### PR TITLE
[Bugfix] cpp std::string

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -ex
 
 REPO_ROOT=`pwd`
 GITHUB_PROXY="https://mirror.ghproxy.com/github.com"

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -ex
 
 REPO_ROOT=`pwd`
 GITHUB_PROXY="https://mirror.ghproxy.com/github.com"

--- a/mooncake-transfer-engine/example/memory_pool.cpp
+++ b/mooncake-transfer-engine/example/memory_pool.cpp
@@ -86,7 +86,7 @@ int target() {
     args[0] = (void *)nic_priority_matrix.c_str();
     args[1] = nullptr;
 
-    const string &connectable_name = FLAGS_local_server_name;
+    const std::string &connectable_name = FLAGS_local_server_name;
     engine->init(FLAGS_local_server_name.c_str(), connectable_name.c_str(),
                  12345);
     engine->installOrGetTransport("rdma", args);

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -79,7 +79,7 @@ class TransferEngine {
     Transport *initTransport(const char *proto);
 
     std::vector<Transport *> installed_transports_;
-    string local_server_name_;
+    std::string local_server_name_;
     std::shared_ptr<TransferMetadata> metadata_;
     std::vector<MemoryRegion> local_memory_regions_;
 };

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -118,7 +118,7 @@ class TransferMetadata {
 
     int removeLocalMemoryBuffer(void *addr, bool update_metadata);
 
-    int addLocalSegment(SegmentID segment_id, const string &segment_name,
+    int addLocalSegment(SegmentID segment_id, const std::string &segment_name,
                         std::shared_ptr<SegmentDesc> &&desc);
     
     int addRpcMetaEntry(const std::string &server_name, RpcMetaDesc &desc);

--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -58,7 +58,7 @@ class TcpTransport : public Transport {
 
     int allocateLocalSegmentID();
 
-    int registerLocalMemory(void *addr, size_t length, const string &location,
+    int registerLocalMemory(void *addr, size_t length, const std::string &location,
                             bool remote_accessible, bool update_metadata);
 
     int unregisterLocalMemory(void *addr, bool update_metadata = false);

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -189,7 +189,7 @@ class Transport {
 
    private:
     virtual int registerLocalMemory(void *addr, size_t length,
-                                    const string &location,
+                                    const std::string &location,
                                     bool remote_accessible,
                                     bool update_metadata = true) = 0;
 

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -362,7 +362,7 @@ int TransferMetadata::updateLocalSegmentDesc(uint64_t segment_id) {
 }
 
 int TransferMetadata::addLocalSegment(SegmentID segment_id,
-                                      const string &segment_name,
+                                      const std::string &segment_name,
                                       std::shared_ptr<SegmentDesc> &&desc) {
     RWSpinlock::WriteGuard guard(segment_lock_);
     segment_id_to_desc_map_[segment_id] = desc;

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -239,7 +239,7 @@ int TcpTransport::allocateLocalSegmentID() {
 }
 
 int TcpTransport::registerLocalMemory(void *addr, size_t length,
-                                      const string &location,
+                                      const std::string &location,
                                       bool remote_accessible,
                                       bool update_metadata) {
     (void)remote_accessible;


### PR DESCRIPTION
add missing `std::` to string, otherwise the build will failed.

my env:

```
cmake version 3.31.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

```
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
