### PR TITLE
[Bugfix] fix typos and fix rdma device selection when retry_count != 0

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -23,7 +23,7 @@ namespace mooncake {
 
 // RdmaEndPoint represents all QP connections between the local NIC1 (identified
 // by its RdmaContext) and the remote NIC2 (identified by peer_nic_path).
-// 1. After ctor, resources are allocated without specifying the peers.
+// 1. After construct, resources are allocated without specifying the peers.
 // 2. Handshake information needs to be exchanged with remote RdmaEndPoint.
 //    - Local side calls the setupConnectionsByActive() function, passing in the
 //    peer_nic_path of the remote side

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -126,7 +126,7 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::insertEndpoint(
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     if (endpoint_map_.find(peer_nic_path) != endpoint_map_.end()) {
         LOG(INFO) << "Endpoint " << peer_nic_path
-                  << " already exists in FIFOEndpointStore";
+                  << " already exists in SIEVEEndpointStore";
         return endpoint_map_[peer_nic_path].first;
     }
     auto endpoint = std::make_shared<RdmaEndPoint>(*context);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -376,9 +376,9 @@ int RdmaTransport::selectDevice(SegmentDesc *desc, uint64_t offset,
         } else {
             size_t index = (retry_count - 1) % rnic_list_len;
             if (index < preferred_rnic_list_len)
-                device_id = index;
+                device_id = priority.preferred_rnic_id_list[index];
             else
-                device_id = index - preferred_rnic_list_len;
+                device_id = priority.available_rnic_id_list[index - preferred_rnic_list_len];
         }
 
         return 0;


### PR DESCRIPTION
1. fix typo in ./mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp 
> FIFOEndpointStore -> SIEVEEndpointStore 
2. fix rdma device selection when retry_count != 0, we should get correct device_id from priority_matrix