### PR TITLE
[Transfer Engine] fix metadata server connection string builder in vllm intergation

### DIFF
--- a/mooncake-integration/vllm/vllm_adaptor.cpp
+++ b/mooncake-integration/vllm/vllm_adaptor.cpp
@@ -77,8 +77,10 @@ int VLLMAdaptor::initializeExt(const char *local_hostname,
                                const char *metadata_server,
                                const char *protocol, const char *device_name,
                                const char *metadata_type) {
-    auto conn_string =
-        std::string(metadata_type) + "://" + std::string(metadata_server);
+    std::string conn_string = metadata_server;
+    if (conn_string.find("://") == std::string::npos)
+        conn_string =
+            std::string(metadata_type) + "://" + std::string(metadata_server);
 
     engine_ = std::make_unique<TransferEngine>();
     auto hostname_port = parseHostNameWithPort(local_hostname);


### PR DESCRIPTION
Mooncake supports vllm integration with etcd/redis/http as metadata service. You can change it in mooncake.json 
```
{
  "prefill_url": "192.168.0.137:13003",
  "decode_url": "192.168.0.139:13003",
  "metadata_server": "192.168.0.139:2379", # you can add protocol prefix like "etcd://", "redis://" or "http://"
  "protocol": "rdma", # if you use protocol prefix in metadata_server, this field is ignored
  "device_name": "erdma_0"
}
```
