### PR TITLE
[TransferEngine] fix: add auto_discover in transfer_engine_c

### DIFF
--- a/mooncake-p2p-store/src/p2pstore/transfer_engine.go
+++ b/mooncake-p2p-store/src/p2pstore/transfer_engine.go
@@ -71,7 +71,8 @@ func NewTransferEngine(metadata_uri string, local_server_name string, nic_priori
 	defer C.free(unsafe.Pointer(localServerName))
 	defer C.free(unsafe.Pointer(connectableName))
 
-	native_engine := C.createTransferEngine(metadataUri, localServerName, connectableName, C.uint64_t(rpc_port))
+	auto_discover := 0 // disable auto_discover
+	native_engine := C.createTransferEngine(metadataUri, localServerName, connectableName, C.uint64_t(rpc_port), C.uint64_t(auto_discover))
 	if native_engine == nil {
 		return nil, ErrTransferEngine
 	}

--- a/mooncake-transfer-engine/include/transfer_engine_c.h
+++ b/mooncake-transfer-engine/include/transfer_engine_c.h
@@ -96,7 +96,8 @@ typedef void *transport_t;
 transfer_engine_t createTransferEngine(const char *metadata_conn_string,
                                        const char *local_server_name,
                                        const char *ip_or_host_name,
-                                       uint64_t rpc_port);
+                                       uint64_t rpc_port,
+                                       int auto_discover);
 
 transport_t installTransport(transfer_engine_t engine, const char *proto,
                              void **args);

--- a/mooncake-transfer-engine/rust/src/transfer_engine.rs
+++ b/mooncake-transfer-engine/rust/src/transfer_engine.rs
@@ -81,6 +81,7 @@ impl TransferEngine {
                 local_server_name_c.as_ptr(),
                 local_server_name_c.as_ptr(),
                 rpc_port,
+                0, // disable auto_discover
             )
         };
         if engine.is_null() {

--- a/mooncake-transfer-engine/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_c.cpp
@@ -25,8 +25,9 @@ using namespace mooncake;
 transfer_engine_t createTransferEngine(const char *metadata_conn_string,
                                        const char *local_server_name,
                                        const char *ip_or_host_name,
-                                       uint64_t rpc_port) {
-    TransferEngine *native = new TransferEngine();
+                                       uint64_t rpc_port,
+                                       int auto_discover) {
+    TransferEngine *native = new TransferEngine(auto_discover);
     int ret = native->init(metadata_conn_string, local_server_name,
                            ip_or_host_name, rpc_port);
     if (ret) {


### PR DESCRIPTION
Add the `auto_discover` parameter to transfer_engine_c, according to the changes in PR #73.

cc @alogfans @doujiang24