### PR TITLE
[TransferEngine]chore: replace slices vector with slice counter

### DIFF
--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -129,12 +129,9 @@ class Transport {
     };
 
     struct TransferTask {
-        ~TransferTask() {
-            for (auto &entry : slices) delete entry;
-            slices.clear();
-        }
 
-        std::vector<Slice *> slices;
+
+        volatile uint64_t slice_count   = 0;
         volatile uint64_t success_slice_count = 0;
         volatile uint64_t failed_slice_count = 0;
         volatile uint64_t transferred_bytes = 0;

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -110,7 +110,7 @@ int MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
     if (success_slice_count + failed_slice_count ==
-        (uint64_t)task.slices.size()) {
+        task.slice_count) {
         if (failed_slice_count) {
             status.s = Transport::TransferStatusEnum::FAILED;
         } else {

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -180,9 +180,9 @@ int NVMeoFTransport::submitTransfer(
 
         nvmeof_desc.transfer_status.push_back(
             TransferStatus{.s = PENDING, .transferred_bytes = 0});
-        nvmeof_desc.task_to_slices.push_back({slice_id, task.slices.size()});
+        nvmeof_desc.task_to_slices.push_back({slice_id, task.slice_count});
         ++task_id;
-        slice_id += task.slices.size();
+        slice_id += task.slice_count;
     }
 
     desc_pool_->submitBatch(nvmeof_desc.desc_idx_);
@@ -229,6 +229,10 @@ void NVMeoFTransport::addSliceToTask(void *source_addr, uint64_t slice_len,
                                      TransferRequest::OpCode op,
                                      TransferTask &task,
                                      const char *file_path) {
+    if (!source_addr || !file_path) {
+        LOG(ERROR) << "Invalid source_addr or file_path";
+        return;
+    }
     Slice *slice = new Slice();
     slice->source_addr = (char *)source_addr;
     slice->length = slice_len;
@@ -238,7 +242,7 @@ void NVMeoFTransport::addSliceToTask(void *source_addr, uint64_t slice_len,
     slice->task = &task;
     slice->status = Slice::PENDING;
     task.total_bytes += slice->length;
-    task.slices.push_back(slice);
+    task.slice_count += 1;
 }
 
 void NVMeoFTransport::addSliceToCUFileBatch(

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -221,7 +221,7 @@ int RdmaTransport::submitTransfer(BatchID batch_id,
                     local_segment_desc->buffers[buffer_id].lkey[device_id];
                 slices_to_post[context].push_back(slice);
                 task.total_bytes += slice->length;
-                task.slices.push_back(slice);
+                task.slice_count++;
                 break;
             }
             if (device_id < 0) {
@@ -273,7 +273,8 @@ int RdmaTransport::submitTransferTask(
                     local_segment_desc->buffers[buffer_id].lkey[device_id];
                 slices_to_post[context].push_back(slice);
                 task.total_bytes += slice->length;
-                task.slices.push_back(slice);
+                // task.slices.push_back(slice);
+                task.slice_count += 1;
                 break;
             }
             if (device_id < 0) {
@@ -300,7 +301,7 @@ int RdmaTransport::getTransferStatus(BatchID batch_id,
         uint64_t success_slice_count = task.success_slice_count;
         uint64_t failed_slice_count = task.failed_slice_count;
         if (success_slice_count + failed_slice_count ==
-            (uint64_t)task.slices.size()) {
+            task.slice_count) {
             if (failed_slice_count)
                 status[task_id].s = TransferStatusEnum::FAILED;
             else
@@ -323,7 +324,7 @@ int RdmaTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
     if (success_slice_count + failed_slice_count ==
-        (uint64_t)task.slices.size()) {
+        task.slice_count) {
         if (failed_slice_count)
             status.s = TransferStatusEnum::FAILED;
         else

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -276,7 +276,7 @@ int TcpTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
     if (success_slice_count + failed_slice_count ==
-        (uint64_t)task.slices.size()) {
+        task.slice_count) {
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;
         } else {
@@ -313,7 +313,7 @@ int TcpTransport::submitTransfer(BatchID batch_id,
         slice->task = &task;
         slice->target_id = request.target_id;
         slice->status = Slice::PENDING;
-        task.slices.push_back(slice);
+        task.slice_count += 1;
         startTransfer(slice);
     }
 
@@ -335,7 +335,7 @@ int TcpTransport::submitTransferTask(
         slice->task = &task;
         slice->target_id = request.target_id;
         slice->status = Slice::PENDING;
-        task.slices.push_back(slice);
+        task.slice_count += 1;
         startTransfer(slice);
     }
     return 0;


### PR DESCRIPTION
Since the slices are solely utilized for counting purposes, replace them with counters to eliminate memory overhead