### PR TITLE
[Bugfix] Add shared and unique lock for local_memory_regions_ (#107)

### DIFF
--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -24,6 +24,8 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -114,6 +116,7 @@ class TransferEngine {
     std::shared_ptr<TransferMetadata> metadata_;
     std::string local_server_name_;
     std::shared_ptr<MultiTransport> multi_transports_;
+    std::shared_mutex mutex_;
     std::vector<MemoryRegion> local_memory_regions_;
     std::shared_ptr<Topology> local_topology_;
     // Discover topology and install transports automatically when it's true.


### PR DESCRIPTION
- Introduced `std::shared_mutex` to protect `local_memory_regions_` from concurrent access.
- Added `std::shared_lock<std::shared_mutex>` for read-only operations:
  - `checkOverlap()` now acquires a shared lock to allow concurrent reads.
- Added `std::unique_lock<std::shared_mutex>` for write operations.
- Updated `installTransport()` with a comment clarifying that locking is not needed, as it is only executed during initialization.
- Ensured that memory region modifications occur within a locked context to prevent race conditions.

Future considerations:
- If `installTransport()` is later used in a concurrent context, a `std::shared_lock<std::shared_mutex>` should be introduced.

Fixes: #107