### PR TITLE
[Bugfix] fix the gid choice of IB device: only choose IBV_GID_TYPE_ROCE_V2 now

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -337,25 +337,15 @@ int RdmaContext::getBestGidIndex(const std::string &device_name,
                                  struct ibv_context *context,
                                  ibv_port_attr &port_attr, uint8_t port) {
     int gid_index = 0, i;
-    union ibv_gid temp_gid, temp_gid_rival;
-    int is_ipv4, is_ipv4_rival;
+    struct ibv_gid_entry gid_entry;
 
-    if (ibv_query_gid(context, port, gid_index, &temp_gid)) {
-        PLOG(ERROR) << "Failed to query GID " << gid_index << " on "
-                    << device_name << "/" << port;
-        return -1;
-    }
-    is_ipv4 = ipv6_addr_v4mapped((struct in6_addr *)temp_gid.raw);
-
-    for (i = 1; i < port_attr.gid_tbl_len; i++) {
-        if (ibv_query_gid(context, port, i, &temp_gid_rival)) {
-            PLOG(ERROR) << "Failed to query GID " << i << " on " << device_name
-                        << "/" << port;
-            return -1;
+    for (i = 0; i < port_attr.gid_tbl_len; i++) {
+        if (ibv_query_gid_ex(context, port, i, &gid_entry, 0)) {
+            PLOG(ERROR) << "Failed to query GID " << i << " on "
+                        << device_name << "/" << port;
+            continue; // if gid is invalid ibv_query_gid_ex() will return !0
         }
-        is_ipv4_rival =
-            ipv6_addr_v4mapped((struct in6_addr *)temp_gid_rival.raw);
-        if (is_ipv4_rival && !is_ipv4) {
+        if (ipv6_addr_v4mapped((struct in6_addr *)gid_entry.gid.raw) && gid_entry.gid_type == IBV_GID_TYPE_ROCE_V2) {
             gid_index = i;
             break;
         }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -345,9 +345,9 @@ int RdmaContext::getBestGidIndex(const std::string &device_name,
                         << device_name << "/" << port;
             continue; // if gid is invalid ibv_query_gid_ex() will return !0
         }
-        if (ipv6_addr_v4mapped((struct in6_addr *)gid_entry.gid.raw) &&
-            (gid_entry.gid_type == IBV_GID_TYPE_IB ||
-             gid_entry.gid_type == IBV_GID_TYPE_ROCE_V2)) {
+        if ((ipv6_addr_v4mapped((struct in6_addr *)gid_entry.gid.raw) &&
+            gid_entry.gid_type == IBV_GID_TYPE_ROCE_V2)
+            || gid_entry.gid_type == IBV_GID_TYPE_IB) {
             gid_index = i;
             break;
         }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -345,7 +345,9 @@ int RdmaContext::getBestGidIndex(const std::string &device_name,
                         << device_name << "/" << port;
             continue; // if gid is invalid ibv_query_gid_ex() will return !0
         }
-        if (ipv6_addr_v4mapped((struct in6_addr *)gid_entry.gid.raw) && gid_entry.gid_type == IBV_GID_TYPE_ROCE_V2) {
+        if (ipv6_addr_v4mapped((struct in6_addr *)gid_entry.gid.raw) &&
+            (gid_entry.gid_type == IBV_GID_TYPE_IB ||
+             gid_entry.gid_type == IBV_GID_TYPE_ROCE_V2)) {
             gid_index = i;
             break;
         }


### PR DESCRIPTION
In the function `RdmaContext::getBestGidIndex`, we select the first GID with an IPv4-mapped address without considering the GID type.

Since the connection is now TCP-based, it requires the type of GID to be RoCEv2. 

Selecting a RoCEv1 GID will result in an error due to the poor connection:
```
E0219 16:52:31.208603 273373 worker_pool.cpp:281] Worker: Process failed for slice (opcode: 0, source_addr: 0x7f593802c000, length: 4096, dest_addr: 140622732378112, local_nic: mlx5_bond_0, peer_nic: x.x.x.x:12345@mlx5_bond_2, dest_rkey: 1568428, retry_cnt: 0): transport retry counter exceeded
E0219 16:52:31.208797 273373 worker_pool.cpp:281] Worker: Process failed for slice (opcode: 0, source_addr: 0x7f593800c000, length: 4096, dest_addr: 140622732247040, local_nic: mlx5_bond_0, peer_nic: x.x.x.x:12345@mlx5_bond_3, dest_rkey: 1587190, retry_cnt: 0): transport retry counter exceeded
```

Meanwhile, I also removed some code that appeared to be unnecessary.