### PR TITLE
[TransferEngine] Suppress gtest type cast compile warning and fix some trivial bugs

### DIFF
--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -48,12 +48,13 @@ static inline int bindToSocket(int socket_id) {
     }
     cpu_set_t cpu_set;
     CPU_ZERO(&cpu_set);
-    int num_nodes = numa_num_configured_nodes();
-    if (socket_id < 0 || socket_id >= num_nodes) socket_id = 0;
+    if (socket_id < 0 || socket_id >= numa_num_configured_nodes())
+        socket_id = 0;
     struct bitmask *cpu_list = numa_allocate_cpumask();
     numa_node_to_cpus(socket_id, cpu_list);
+    int nr_possible_cpus = numa_num_possible_cpus();
     int nr_cpus = 0;
-    for (int cpu = 0; cpu < numa_num_possible_cpus(); ++cpu) {
+    for (int cpu = 0; cpu < nr_possible_cpus; ++cpu) {
         if (numa_bitmask_isbitset(cpu_list, cpu) &&
             numa_bitmask_isbitset(numa_all_cpus_ptr, cpu)) {
             CPU_SET(cpu, &cpu_set);

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -113,7 +113,6 @@ class RdmaTransport : public Transport {
 
    private:
     std::vector<std::shared_ptr<RdmaContext>> context_list_;
-    std::atomic<SegmentID> next_segment_id_;
     std::shared_ptr<Topology> local_topology_;
 };
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -31,7 +31,7 @@
 #include "transport/rdma_transport/rdma_endpoint.h"
 
 namespace mooncake {
-RdmaTransport::RdmaTransport() : next_segment_id_(1) {}
+RdmaTransport::RdmaTransport() {}
 
 RdmaTransport::~RdmaTransport() {
 #ifdef CONFIG_USE_BATCH_DESC_SET

--- a/mooncake-transfer-engine/tests/memory_location_test.cpp
+++ b/mooncake-transfer-engine/tests/memory_location_test.cpp
@@ -12,23 +12,23 @@ TEST(MemoryLocationTest, MallocSimpleNode0) {
     ASSERT_NE(addr, nullptr);
 
     auto entries = mooncake::getMemoryLocation(addr, size);
-    ASSERT_EQ(entries.size(), 1);
+    ASSERT_EQ(entries.size(), static_cast<size_t>(1));
 
     // check the memory location, no node before page fault
-    EXPECT_EQ(entries[0].start, (uint64_t)addr);
+    EXPECT_EQ(entries[0].start, reinterpret_cast<uint64_t>(addr));
     EXPECT_EQ(entries[0].location, "*");
-    EXPECT_EQ(entries[0].len, size);
+    EXPECT_EQ(entries[0].len, static_cast<size_t>(size));
 
     // trigger page fault
     memset(addr, 0, size);
 
     entries = mooncake::getMemoryLocation(addr, size);
-    ASSERT_EQ(entries.size(), 1);
+    ASSERT_EQ(entries.size(), static_cast<size_t>(1));
 
     // check the memory location, node 0 after page fault
-    EXPECT_EQ(entries[0].start, (uint64_t)addr);
+    EXPECT_EQ(entries[0].start, reinterpret_cast<uint64_t>(addr));
     EXPECT_EQ(entries[0].location, "cpu:0");
-    EXPECT_EQ(entries[0].len, size);
+    EXPECT_EQ(entries[0].len, static_cast<size_t>(size));
 
     numa_free(addr, size);
 }
@@ -47,12 +47,12 @@ TEST(MemoryLocationTest, MallocSimpleNodeLargest) {
     memset(addr, 0, size);
 
     auto entries = mooncake::getMemoryLocation(addr, size);
-    ASSERT_EQ(entries.size(), 1);
+    ASSERT_EQ(entries.size(), static_cast<size_t>(1));
 
     // check the memory location
-    EXPECT_EQ(entries[0].start, (uint64_t)addr);
+    EXPECT_EQ(entries[0].start, reinterpret_cast<uint64_t>(addr));
     EXPECT_EQ(entries[0].location, location);
-    EXPECT_EQ(entries[0].len, size);
+    EXPECT_EQ(entries[0].len, static_cast<size_t>(size));
 
     numa_free(addr, size);
 }
@@ -68,7 +68,7 @@ TEST(MemoryLocationTest, MallocMultipleNodes) {
     int size = 4096 * 10;
     void *addr = numa_alloc_onnode(size, nodea);
     ASSERT_NE(addr, nullptr);
-    ASSERT_EQ((uint64_t)addr % 4096, 0);  // page aligned
+    ASSERT_EQ((uint64_t)addr % 4096, static_cast<uint64_t>(0));  // page aligned
 
     // trigger page fault
     memset(addr, 0, size);
@@ -93,30 +93,32 @@ TEST(MemoryLocationTest, MallocMultipleNodes) {
 
     if (nodea == nodeb) {
         // only one numa node
-        ASSERT_EQ(entries.size(), 1);
+        ASSERT_EQ(entries.size(), static_cast<size_t>(1));
 
         // check the first memory location
-        EXPECT_EQ(entries[0].start, (uint64_t)start);
+        EXPECT_EQ(entries[0].start, reinterpret_cast<uint64_t>(start));
         EXPECT_EQ(entries[0].location, locationa);
-        EXPECT_EQ(entries[0].len, size - 1024 * 4);
+        EXPECT_EQ(entries[0].len, static_cast<size_t>(size - 1024 * 4));
 
     } else {
-        ASSERT_EQ(entries.size(), 3);
+        ASSERT_EQ(entries.size(), static_cast<size_t>(3));
 
         // check the first memory location
-        EXPECT_EQ(entries[0].start, (uint64_t)start);
+        EXPECT_EQ(entries[0].start, reinterpret_cast<uint64_t>(start));
         EXPECT_EQ(entries[0].location, locationb);
-        EXPECT_EQ(entries[0].len, 4096 * 2 - 1024 * 2);
+        EXPECT_EQ(entries[0].len, static_cast<size_t>(4096 * 2 - 1024 * 2));
 
         // check the second memory location
-        EXPECT_EQ(entries[1].start, (uint64_t)addr + 4096 * 2);
+        EXPECT_EQ(entries[1].start,
+            reinterpret_cast<uint64_t>(addr) + 4096 * 2);
         EXPECT_EQ(entries[1].location, locationa);
-        EXPECT_EQ(entries[1].len, 4096 * 7);
+        EXPECT_EQ(entries[1].len, static_cast<size_t>(4096 * 7));
 
         // check the third memory location
-        EXPECT_EQ(entries[2].start, (uint64_t)addr + 4096 * 9);
+        EXPECT_EQ(entries[2].start,
+            reinterpret_cast<uint64_t>(addr) + 4096 * 9);
         EXPECT_EQ(entries[2].location, locationb);
-        EXPECT_EQ(entries[2].len, 4096 - 1024 * 2);
+        EXPECT_EQ(entries[2].len, static_cast<size_t>(4096 - 1024 * 2));
     }
 
     numa_free(addr, size);

--- a/mooncake-transfer-engine/tests/topology_test.cpp
+++ b/mooncake-transfer-engine/tests/topology_test.cpp
@@ -32,7 +32,7 @@ TEST(ToplogyTest, TestHcaList) {
         ": [[\"erdma_0\"],[\"erdma_0\"]]}";
     topology.clear();
     topology.parse(json_str);
-    ASSERT_EQ(topology.getHcaList().size(), 1);
+    ASSERT_EQ(topology.getHcaList().size(), static_cast<size_t>(1));
     std::set<std::string> HcaList = {"erdma_0"};
     for (auto &hca : topology.getHcaList()) {
         ASSERT_TRUE(HcaList.count(hca));
@@ -46,7 +46,7 @@ TEST(ToplogyTest, TestHcaListSize) {
         ": [[\"erdma_2\"],[\"erdma_3\"]]}";
     topology.clear();
     topology.parse(json_str);
-    ASSERT_EQ(topology.getHcaList().size(), 4);
+    ASSERT_EQ(topology.getHcaList().size(), static_cast<size_t>(4));
 }
 
 TEST(ToplogyTest, TestHcaList2) {
@@ -56,7 +56,7 @@ TEST(ToplogyTest, TestHcaList2) {
         ": [[\"erdma_1\"],[\"erdma_0\"]]}";
     topology.clear();
     topology.parse(json_str);
-    ASSERT_EQ(topology.getHcaList().size(), 2);
+    ASSERT_EQ(topology.getHcaList().size(), static_cast<size_t>(2));
     std::set<std::string> HcaList = {"erdma_0", "erdma_1"};
     for (auto &hca : topology.getHcaList()) {
         ASSERT_TRUE(HcaList.count(hca));

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -84,7 +84,7 @@ TEST_F(TransportTest, WriteSuccess) {
     size_t testDataLen = strlen(testData);
 
     ssize_t result = writeFully(fd, testData, testDataLen);
-    EXPECT_EQ(result, testDataLen);
+    EXPECT_EQ(result, static_cast<ssize_t>(testDataLen));
 
     char buffer[256] = {0};
     ssize_t nbytes = lseek(fd, 0, SEEK_SET);
@@ -114,7 +114,7 @@ TEST_F(TransportTest, PartialWrite) {
 
     ssize_t result = writeFully(fd, testData, testDataLen / 2);
 
-    ASSERT_EQ(result, testDataLen / 2);
+    ASSERT_EQ(result, static_cast<ssize_t>(testDataLen / 2));
 
     char buffer[256] = {0};
     lseek(fd, 0, SEEK_SET);
@@ -132,7 +132,7 @@ TEST_F(TransportTest, ReadSuccess) {
     char buffer[256] = {0};
     ssize_t bytesRead = readFully(fd, buffer, sizeof(buffer));
 
-    EXPECT_EQ(bytesRead, strlen(testData));
+    EXPECT_EQ(bytesRead, static_cast<ssize_t>(strlen(testData)));
     EXPECT_STREQ(buffer, testData);
 
     close(fd);
@@ -154,7 +154,7 @@ TEST_F(TransportTest, PartialRead) {
     size_t half_len = strlen(testData) / 2;
     ssize_t bytesRead = readFully(fd, buffer, half_len);
 
-    EXPECT_EQ(bytesRead, half_len);
+    EXPECT_EQ(bytesRead, static_cast<ssize_t>(half_len));
     EXPECT_EQ(strncmp(buffer, testData, half_len), 0);
 
     close(fd);
@@ -167,7 +167,7 @@ TEST_F(TransportTest, ReadEmptyFile) {
     char buffer[256] = {0};
     ssize_t bytesRead = readFully(fd, buffer, sizeof(buffer));
 
-    EXPECT_EQ(bytesRead, 0);
+    EXPECT_EQ(bytesRead, static_cast<ssize_t>(0));
 
     close(fd);
 }


### PR DESCRIPTION
Suppress gtest compile warning and fix some trivial bugs.