### PR TITLE
[TransferEngine] Refine std::bind with absl::bind_front

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -58,4 +58,13 @@ echo "*** Download and installing [golang-1.22] ***"
 wget https://go.dev/dl/go1.22.10.linux-amd64.tar.gz
 sudo tar -C /usr/local -xzf go1.22.10.linux-amd64.tar.gz
 
+echo "*** Download and installing [abseil-cpp] ***"
+cd ${REPO_ROOT}/thirdparties
+git clone ${GITHUB_PROXY}/abseil/abseil-cpp.git
+cd abseil-cpp
+mkdir -p build
+cd build
+cmake ..
+make -j$(nproc) && sudo make install
+
 echo "*** Dependencies Installed! ***"

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -23,6 +23,7 @@
 #include <future>
 #include <set>
 
+#include "absl/functional/bind_front.h"
 #include "common.h"
 #include "config.h"
 #include "memory_location.h"
@@ -408,9 +409,10 @@ int RdmaTransport::initializeRdmaResources() {
 }
 
 int RdmaTransport::startHandshakeDaemon(std::string &local_server_name) {
+    // Using absl::bind_front instead of std::bind.
+    // https://abseil.io/tips/108
     return metadata_->startHandshakeDaemon(
-        std::bind(&RdmaTransport::onSetupRdmaConnections, this,
-                  std::placeholders::_1, std::placeholders::_2),
+        absl::bind_front(&RdmaTransport::onSetupRdmaConnections, this),
         metadata_->localRpcMeta().rpc_port);
 }
 


### PR DESCRIPTION
Replace std::bind with absl::bind_front for better performance and readability.