### PR TITLE
[FIX] golang vulnerabilities in P2P store

### DIFF
--- a/mooncake-p2p-store/build.sh
+++ b/mooncake-p2p-store/build.sh
@@ -39,6 +39,7 @@ EXT_LDFLAGS+=" -ltransfer_engine -lstdc++ -lnuma -lglog -libverbs -ljsoncpp -let
 # EXT_LDFLAGS+=" -lhiredis"     // if USE_REDIS is enabled
 # EXT_LDFLAGS+=" -lcurl"        // if USE_HTTP is enabled
 
+go get
 go build -o "$TARGET/p2p-store-example" -ldflags="-extldflags '$EXT_LDFLAGS'" "../example/p2p-store-example.go"
 if [ $? -ne 0 ]; then
     echo "Error: Failed to build the example."

--- a/mooncake-p2p-store/src/p2pstore/go.mod
+++ b/mooncake-p2p-store/src/p2pstore/go.mod
@@ -1,8 +1,8 @@
 module github.com/kvcache-ai/Mooncake/mooncake-p2p-store/src/p2pstore
 
-go 1.21
+go 1.23.0
 
-toolchain go1.23.4
+toolchain go1.24.1
 
 require go.etcd.io/etcd/client/v3 v3.5.15
 
@@ -16,9 +16,9 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
-	golang.org/x/net v0.33.0 // indirect
-	golang.org/x/sys v0.28.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
+	golang.org/x/net v0.36.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/text v0.22.0 // indirect
 	google.golang.org/genproto v0.0.0-20230822172742-b8732ec3820d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect

--- a/mooncake-p2p-store/src/p2pstore/transfer_engine.go
+++ b/mooncake-p2p-store/src/p2pstore/transfer_engine.go
@@ -43,7 +43,7 @@ func NewTransferEngine(metadataConnString string,
 	defer C.free(unsafe.Pointer(metadataConnStringCStr))
 	defer C.free(unsafe.Pointer(localServerNameCStr))
 	defer C.free(unsafe.Pointer(localIpAddressCStr))
-	native_engine := C.createTransferEngine(metadataConnStringCStr, localServerNameCStr, localIpAddressCStr, C.uint64_t(rpcPort))
+	native_engine := C.createTransferEngine(metadataConnStringCStr, localServerNameCStr, localIpAddressCStr, C.uint64_t(rpcPort), 0)
 	if native_engine == nil {
 		return nil, ErrTransferEngine
 	}

--- a/mooncake-transfer-engine/example/http-metadata-server/go.mod
+++ b/mooncake-transfer-engine/example/http-metadata-server/go.mod
@@ -26,9 +26,9 @@ require (
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
-	golang.org/x/net v0.33.0 // indirect
-	golang.org/x/sys v0.28.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
+	golang.org/x/net v0.36.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/text v0.22.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Fix golang vulnerabilities in P2P store. Update the version of `golang.org/x/net`. 