### PR TITLE
 [FEATURE] Support mounting multiple segments under the same segment_name

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,7 +22,7 @@ jobs:
     - name: make
       run: |
         cd build
-        make -j
+        sudo make install -j
       shell: bash
     - name: start-metadata-server
       run: |
@@ -31,10 +31,21 @@ jobs:
         go mod tidy && go build -o http-metadata-server .
         ./http-metadata-server --addr=:8090 &
       shell: bash
+    - name: start-mooncake-master
+      run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        mooncake_master --enable_gc=false &
+      shell: bash
     - name: test
       run: |
         cd build
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
         ldconfig -v || echo "always continue"
         MC_METADATA_SERVER=http://127.0.0.1:8090/metadata make test -j ARGS="-V"
+      shell: bash
+    - name: mooncake store python test
+      run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        cd mooncake-store/tests
+        MC_METADATA_SERVER=http://127.0.0.1:8090/metadata python3 test_distributed_object_store.py
       shell: bash

--- a/doc/en/mooncake-store-preview.md
+++ b/doc/en/mooncake-store-preview.md
@@ -246,6 +246,7 @@ The storage node (Client) allocates a segment of memory and, after calling `Tran
 ```protobuf
 message UnmountSegmentRequest {
   required string segment_name = 1;  // Storage segment name used during mounting
+  required uint64 buffer = 2;        // Starting address of the space
 }
 
 message UnMountSegmentResponse {
@@ -271,7 +272,8 @@ The storage node (Client) registers the storage segment space with the Master Se
 - UnmountSegment
 
 ```C++
-ErrorCode UnmountSegment(const std::string& segment_name);
+ErrorCode UnmountSegment(const std::string& segment_name,
+                         uint64_t buffer);
 ```
 
 The storage node (Client) unregisters the storage segment space with the Master Service.
@@ -345,11 +347,12 @@ AllocationStrategy is used in conjunction with the Master Service and the underl
 
 ```C++
 virtual std::shared_ptr<BufHandle> Allocate(
-        const std::unordered_map<std::string, std::shared_ptr<BufferAllocator>>& allocators,
+        const std::unordered_map<AllocatorKey, std::shared_ptr<BufferAllocator>,
+                                 AllocatorKeyHash>& allocators,
         size_t objectSize) = 0;
 ```
 
-- Input: The list of available storage segments and the size of the space to be allocated.
+- Input: The list of available storage segments (AllocatorKey is the combination of segment name and starting address), and the size of the space to be allocated.
 - Output: Returns a successful allocation handle BufHandle.
 
 #### Implementation Strategies

--- a/doc/zh/mooncake-store-preview.md
+++ b/doc/zh/mooncake-store-preview.md
@@ -252,6 +252,7 @@ message MountSegmentResponse {
 ```protobuf
 message UnmountSegmentRequest {
   required string segment_name = 1;  // 挂载时的存储段名称
+  required uint64 buffer = 2;        // 挂载时的起始地址
 }
 
 message UnMountSegmentResponse {
@@ -278,7 +279,8 @@ ErrorCode MountSegment(uint64_t buffer,
 - UnmountSegment
 
 ```C++
-ErrorCode UnmountSegment(const std::string& segment_name);
+ErrorCode UnmountSegment(const std::string& segment_name,
+                         uint64_t buffer);
 ```
 
 存储节点(Client)向`Master Service`注销存储段空间。
@@ -356,11 +358,12 @@ AllocationStrategy 与`Master Service`和底层模块 `BufferAllocator` 配合�
 
 ```C++
 virtual std::shared_ptr<BufHandle> Allocate(
-        const std::unordered_map<std::string, std::shared_ptr<BufferAllocator>>& allocators,
+        const std::unordered_map<AllocatorKey, std::shared_ptr<BufferAllocator>,
+                                 AllocatorKeyHash>& allocators,
         size_t objectSize) = 0;
 ```
 
-输入：当前可用的存储段列表，以及所需分配的空间大小。
+输入：当前可用的存储段列表(AllocatorKey是存储段名称和起始地址的组合)，以及所需分配的空间大小。
 输出：返回分配成功的存储空间句柄`BufHandle`。
 
 #### 具体实现策略

--- a/mooncake-integration/vllm/distributed_object_store.cpp
+++ b/mooncake-integration/vllm/distributed_object_store.cpp
@@ -296,7 +296,7 @@ int DistributedObjectStore::put(const std::string &key,
     if (ret) return ret;
     ErrorCode error_code = client_->Put(std::string(key), slices, config);
     freeSlices(slices);
-    if (error_code != ErrorCode::OK) return 1;
+    if (error_code != ErrorCode::OK) return toInt(error_code);
     return 0;
 }
 
@@ -343,7 +343,7 @@ int DistributedObjectStore::remove(const std::string &key) {
         return 1;
     }
     ErrorCode error_code = client_->Remove(key);
-    if (error_code != ErrorCode::OK) return 1;
+    if (error_code != ErrorCode::OK) return toInt(error_code);
     return 0;
 }
 
@@ -355,7 +355,7 @@ int DistributedObjectStore::isExist(const std::string &key) {
     ErrorCode err = client_->IsExist(key);
     if (err == ErrorCode::OK) return 1;                // Yes
     if (err == ErrorCode::OBJECT_NOT_FOUND) return 0;  // No
-    return -1;                                         // Error
+    return toInt(err);                                 // Error
 }
 
 int64_t DistributedObjectStore::getSize(const std::string &key) {
@@ -368,7 +368,7 @@ int64_t DistributedObjectStore::getSize(const std::string &key) {
     ErrorCode error_code = client_->Query(key, object_info);
 
     if (error_code != ErrorCode::OK) {
-        return -1;  // Error or object doesn't exist
+        return toInt(error_code);
     }
 
     // Calculate total size from all replicas' handles

--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -159,7 +159,9 @@ class Client {
     std::unique_ptr<TransferEngine> transfer_engine_;
     std::unique_ptr<mooncake_store::MasterService::Stub> master_stub_;
 
-    std::unordered_map<std::string, void*> mounted_segments_;
+    std::mutex mounted_segments_mutex_;  // Protects the following map
+    std::unordered_map<std::string, std::unordered_set<uint64_t>>
+        mounted_segments_;  // Segment name -> set of starting addresses
 
     // Configuration
     std::string local_hostname_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -81,13 +81,12 @@ class MasterService {
     // Comparator for GC tasks priority queue
     struct GCTaskComparator {
         bool operator()(GCTask* a, GCTask* b) const {
-            return a->deletion_time >
-                   b->deletion_time;  // 最小堆，最早过期的优先级最高
+            return a->deletion_time > b->deletion_time;
         }
     };
 
    public:
-    MasterService();
+    MasterService(bool enable_gc = true);
     ~MasterService();
 
     /**
@@ -191,6 +190,7 @@ class MasterService {
     boost::lockfree::queue<GCTask*> gc_queue_{kGCQueueSize};
     std::thread gc_thread_;
     std::atomic<bool> gc_running_{false};
+    bool enable_gc_{true};  // Flag to enable/disable garbage collection
     static constexpr uint64_t kGCThreadSleepMs =
         10;  // 10 ms sleep between GC checks
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -52,13 +52,14 @@ class BufferAllocatorManager {
      * @return ErrorCode::OK on success, ErrorCode::INVALID_PARAMS if segment
      * not found
      */
-    ErrorCode RemoveSegment(const std::string& segment_name);
+    ErrorCode RemoveSegment(const std::string& segment_name, uint64_t buffer);
 
     /**
      * @brief Get the map of buffer allocators
      * @note Caller must hold the mutex while accessing the map
      */
-    const std::unordered_map<std::string, std::shared_ptr<BufferAllocator>>&
+    const std::unordered_map<AllocatorKey, std::shared_ptr<BufferAllocator>,
+                             AllocatorKeyHash>&
     GetAllocators() const {
         return buf_allocators_;
     }
@@ -72,7 +73,8 @@ class BufferAllocatorManager {
     // Protects the buffer allocator map (BufferAllocator is thread-safe by
     // itself)
     mutable std::shared_mutex allocator_mutex_;
-    std::unordered_map<std::string, std::shared_ptr<BufferAllocator>>
+    std::unordered_map<AllocatorKey, std::shared_ptr<BufferAllocator>,
+                       AllocatorKeyHash>
         buf_allocators_;
 };
 
@@ -99,10 +101,12 @@ class MasterService {
 
     /**
      * @brief Unmount a memory segment
+     * @param segment_name Name of the segment to unmount
+     * @param buffer Memory address of the buffer to unmount
      * @return ErrorCode::OK on success, ErrorCode::INVALID_PARAMS if segment
      * not found
      */
-    ErrorCode UnmountSegment(const std::string& segment_name);
+    ErrorCode UnmountSegment(const std::string& segment_name, uint64_t buffer);
 
     /**
      * @brief Get list of replicas for an object

--- a/mooncake-store/proto/master.proto
+++ b/mooncake-store/proto/master.proto
@@ -108,6 +108,7 @@ message MountSegmentResponse {
 // Request to unmount a segment
 message UnmountSegmentRequest {
     required string segment_name = 1; // Segment name.
+    required uint64 buffer = 2;       // Memory address.
 }
 
 // Response to unmount a segment

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -17,6 +17,7 @@
 // Define command line flags
 DEFINE_int32(port, 50051, "Port for master service to listen on");
 DEFINE_int32(max_threads, 4, "Maximum number of threads to use");
+DEFINE_bool(enable_gc, true, "Enable garbage collection");
 
 namespace mooncake {
 
@@ -258,8 +259,12 @@ int main(int argc, char* argv[]) {
             return 1;
         }
 
-        // Create master service instance
-        auto master_service = std::make_shared<mooncake::MasterService>();
+        // Create master service instance with GC flag
+        auto master_service =
+            std::make_shared<mooncake::MasterService>(FLAGS_enable_gc);
+
+        LOG(INFO) << "Garbage collection: "
+                  << (FLAGS_enable_gc ? "enabled" : "disabled");
 
         // Initialize gRPC server
         std::string server_address = "0.0.0.0:" + std::to_string(FLAGS_port);

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -227,8 +227,8 @@ class MasterServiceImpl final : public mooncake_store::MasterService::Service {
         grpc::ServerContext* context,
         const mooncake_store::UnmountSegmentRequest* request,
         mooncake_store::UnmountSegmentResponse* response) override {
-        ErrorCode error_code =
-            master_service_->UnmountSegment(request->segment_name());
+        ErrorCode error_code = master_service_->UnmountSegment(
+            request->segment_name(), request->buffer());
         response->set_status_code(toInt(error_code));
         return grpc::Status::OK;
     }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -28,9 +28,12 @@ ErrorCode BufferAllocatorManager::AddSegment(const std::string& segment_name,
                                              uint64_t base, uint64_t size) {
     std::unique_lock<std::shared_mutex> lock(allocator_mutex_);
 
+    // Create composite key
+    AllocatorKey key(segment_name, base);
+
     // Check if segment already exists
-    if (buf_allocators_.find(segment_name) != buf_allocators_.end()) {
-        LOG(WARNING) << "segment_name=" << segment_name
+    if (buf_allocators_.find(key) != buf_allocators_.end()) {
+        LOG(WARNING) << "segment_name=" << segment_name << ", buffer=" << base
                      << ", error=segment_already_exists";
         return ErrorCode::INVALID_PARAMS;
     }
@@ -45,22 +48,26 @@ ErrorCode BufferAllocatorManager::AddSegment(const std::string& segment_name,
     VLOG(1) << "segment_name=" << segment_name << ", base=" << base
             << ", size=" << size << ", allocator_ptr=" << allocator.get()
             << ", action=register_buffer";
-    buf_allocators_[segment_name] = std::move(allocator);
+    buf_allocators_[key] = std::move(allocator);
     return ErrorCode::OK;
 }
 
-ErrorCode BufferAllocatorManager::RemoveSegment(
-    const std::string& segment_name) {
+ErrorCode BufferAllocatorManager::RemoveSegment(const std::string& segment_name,
+                                                uint64_t buffer) {
     std::unique_lock<std::shared_mutex> lock(allocator_mutex_);
 
-    auto it = buf_allocators_.find(segment_name);
+    // Create composite key
+    AllocatorKey key(segment_name, buffer);
+
+    auto it = buf_allocators_.find(key);
     if (it == buf_allocators_.end()) {
-        LOG(WARNING) << "segment_name=" << segment_name
+        LOG(WARNING) << "segment_name=" << segment_name << ", buffer=" << buffer
                      << ", error=segment_not_found";
         return ErrorCode::INVALID_PARAMS;
     }
 
-    VLOG(1) << "segment_name=" << segment_name << ", action=unregister_buffer";
+    VLOG(1) << "segment_name=" << segment_name << ", buffer=" << buffer
+            << ", action=unregister_buffer";
     // Remove buffer allocator
     buf_allocators_.erase(it);
     return ErrorCode::OK;
@@ -109,9 +116,11 @@ ErrorCode MasterService::MountSegment(uint64_t buffer, uint64_t size,
     return buffer_allocator_manager_->AddSegment(segment_name, buffer, size);
 }
 
-ErrorCode MasterService::UnmountSegment(const std::string& segment_name) {
-    VLOG(1) << "segment_name=" << segment_name << ", action=unmount_segment";
-    return buffer_allocator_manager_->RemoveSegment(segment_name);
+ErrorCode MasterService::UnmountSegment(const std::string& segment_name,
+                                        uint64_t buffer) {
+    VLOG(1) << "segment_name=" << segment_name << ", buffer=" << buffer
+            << ", action=unmount_segment";
+    return buffer_allocator_manager_->RemoveSegment(segment_name, buffer);
 }
 
 ErrorCode MasterService::GetReplicaList(

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -1,9 +1,10 @@
 add_executable(buffer_allocator_test buffer_allocator_test.cpp)
 target_link_libraries(buffer_allocator_test PUBLIC cache_allocator cachelib_memory_allocator gtest gtest_main pthread)
-
+add_test(NAME buffer_allocator_test COMMAND buffer_allocator_test)
 
 add_executable(master_service_test master_service_test.cpp)
 target_link_libraries(master_service_test PUBLIC cache_allocator cachelib_memory_allocator glog gtest gtest_main pthread)
+add_test(NAME master_service_test COMMAND master_service_test)
 
 add_executable(client_integration_test client_integration_test.cpp)
 target_link_libraries(client_integration_test PUBLIC 
@@ -17,6 +18,7 @@ target_link_libraries(client_integration_test PUBLIC
     gtest_main 
     pthread
 )
+add_test(NAME client_integration_test COMMAND client_integration_test)
 
 add_executable(stress_workload_test stress_workload_test.cpp)
 target_link_libraries(stress_workload_test PUBLIC 

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -547,3 +547,8 @@ TEST_F(MasterServiceTest, CleanupStaleHandlesTest) {
 }
 
 }  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -53,16 +53,18 @@ TEST_F(MasterServiceTest, MountUnmountSegment) {
         service_->MountSegment(kBufferAddress, kSegmentSize, segment_name));
 
     // Test unmounting the segment.
-    EXPECT_EQ(ErrorCode::OK, service_->UnmountSegment(segment_name));
+    EXPECT_EQ(ErrorCode::OK,
+              service_->UnmountSegment(segment_name, kBufferAddress));
 
     // Test unmounting a non-existent segment (should fail).
     EXPECT_EQ(ErrorCode::INVALID_PARAMS,
-              service_->UnmountSegment("non_existent"));
+              service_->UnmountSegment("non_existent", kBufferAddress));
 
     // Test remounting after unmount.
     EXPECT_EQ(ErrorCode::OK, service_->MountSegment(
                                  kBufferAddress, kSegmentSize, segment_name));
-    EXPECT_EQ(ErrorCode::OK, service_->UnmountSegment(segment_name));
+    EXPECT_EQ(ErrorCode::OK,
+              service_->UnmountSegment(segment_name, kBufferAddress));
 }
 
 TEST_F(MasterServiceTest, RandomMountUnmountSegment) {
@@ -84,7 +86,8 @@ TEST_F(MasterServiceTest, RandomMountUnmountSegment) {
         EXPECT_EQ(
             ErrorCode::OK,
             service_->MountSegment(kBufferAddress, kSegmentSize, segment_name));
-        EXPECT_EQ(ErrorCode::OK, service_->UnmountSegment(segment_name));
+        EXPECT_EQ(ErrorCode::OK,
+                  service_->UnmountSegment(segment_name, kBufferAddress));
     }
 }
 
@@ -106,7 +109,7 @@ TEST_F(MasterServiceTest, ConcurrentMountUnmount) {
                 if (service_->MountSegment(buffer, size, segment_name) ==
                     ErrorCode::OK) {
                     EXPECT_EQ(ErrorCode::OK,
-                              service_->UnmountSegment(segment_name));
+                              service_->UnmountSegment(segment_name, buffer));
                     success_count++;
                 }
             }
@@ -514,7 +517,7 @@ TEST_F(MasterServiceTest, CleanupStaleHandlesTest) {
     ASSERT_EQ(1, retrieved_replicas.size());
 
     // Unmount the segment
-    ASSERT_EQ(ErrorCode::OK, service_->UnmountSegment(segment_name));
+    ASSERT_EQ(ErrorCode::OK, service_->UnmountSegment(segment_name, buffer));
 
     // Try to get the object - it should be automatically removed since the
     // replica is invalid
@@ -540,7 +543,7 @@ TEST_F(MasterServiceTest, CleanupStaleHandlesTest) {
               service_->GetReplicaList(key2, retrieved_replicas));
 
     // Unmount the segment
-    ASSERT_EQ(ErrorCode::OK, service_->UnmountSegment(segment_name));
+    ASSERT_EQ(ErrorCode::OK, service_->UnmountSegment(segment_name, buffer));
 
     // Try to remove the object that should already be cleaned up
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, service_->Remove(key2));


### PR DESCRIPTION
Supported mounting multiple segments for the same client.

Taking it a step further, we might consider modifying the segment management interface on the client side, such as removing the `segment_name` parameter from the interface (since the segment name is fixed once the client is inited).

Going even further, the client should ideally be stateless, and perhaps `MountSegment` should return a handle whose ownership is managed by the user.

To keep this PR concise, the discussions will not be implemented in this PR.