### PR TITLE
[TransferEngine] Refactor TE Return Value - part 2

### DIFF
--- a/mooncake-integration/vllm/vllm_adaptor.cpp
+++ b/mooncake-integration/vllm/vllm_adaptor.cpp
@@ -87,9 +87,9 @@ int VLLMAdaptor::initializeExt(const char *local_hostname,
     // TODO: remove `false` in the feature, it's for keep same API in vllm.
     engine_ = std::make_unique<TransferEngine>(false);
     auto hostname_port = parseHostNameWithPort(local_hostname);
-    int ret = engine_->init(conn_string, local_hostname,
-                            hostname_port.first.c_str(), hostname_port.second);
-    if (ret) return -1;
+    auto s = engine_->init(conn_string, local_hostname,
+                           hostname_port.first.c_str(), hostname_port.second);
+    if (!s.ok()) return -1;
 
     xport_ = nullptr;
     if (strcmp(protocol, "rdma") == 0) {
@@ -116,8 +116,8 @@ int VLLMAdaptor::initializeExt(const char *local_hostname,
 char *VLLMAdaptor::allocateRawBuffer(size_t capacity) {
     auto buffer = malloc(capacity);
     if (!buffer) return nullptr;
-    int ret = engine_->registerLocalMemory(buffer, capacity, "cpu:0");
-    if (ret) {
+    auto s = engine_->registerLocalMemory(buffer, capacity, "cpu:0");
+    if (!s.ok()) {
         free(buffer);
         return nullptr;
     }
@@ -201,12 +201,12 @@ int VLLMAdaptor::transferSync(const char *target_hostname, uintptr_t buffer,
     entry.target_id = handle;
     entry.target_offset = peer_buffer_address;
 
-    Status s = engine_->submitTransfer(batch_id, {entry});
+    auto s = engine_->submitTransfer(batch_id, {entry});
     if (!s.ok()) return -1;
 
     TransferStatus status;
     while (true) {
-        Status s = engine_->getTransferStatus(batch_id, 0, status);
+        auto s = engine_->getTransferStatus(batch_id, 0, status);
         LOG_ASSERT(s.ok());
         if (status.s == TransferStatusEnum::COMPLETED) {
             engine_->freeBatchID(batch_id);
@@ -220,12 +220,16 @@ int VLLMAdaptor::transferSync(const char *target_hostname, uintptr_t buffer,
 
 int VLLMAdaptor::expRegisterMemory(uintptr_t buffer_addr, size_t capacity) {
     char *buffer = reinterpret_cast<char *>(buffer_addr);
-    return engine_->registerLocalMemory(buffer, capacity, "cpu:0");
+    auto s = engine_->registerLocalMemory(buffer, capacity, "cpu:0");
+    if (!s.ok()) return -1;
+    return 0;
 }
 
 int VLLMAdaptor::expUnregisterMemory(uintptr_t buffer_addr) {
     char *buffer = reinterpret_cast<char *>(buffer_addr);
-    return engine_->unregisterLocalMemory(buffer);
+    auto s = engine_->unregisterLocalMemory(buffer);
+    if (!s.ok()) return -1;
+    return 0;
 }
 
 namespace py = pybind11;

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -57,9 +57,9 @@ ErrorCode Client::InitTransferEngine(const std::string& local_hostname,
     CHECK(transfer_engine_) << "Failed to create transfer engine";
 
     auto [hostname, port] = parseHostNameWithPort(local_hostname);
-    int rc = transfer_engine_->init(metadata_connstring, local_hostname,
+    auto s = transfer_engine_->init(metadata_connstring, local_hostname,
                                     hostname, port);
-    CHECK_EQ(rc, 0) << "Failed to initialize transfer engine";
+    CHECK_EQ(s, Status::OK()) << "Failed to initialize transfer engine";
     Transport* transport = nullptr;
     if (protocol == "rdma") {
         LOG(INFO) << "transport_type=rdma";
@@ -284,11 +284,13 @@ ErrorCode Client::MountSegment(const std::string& segment_name,
     mooncake_store::MountSegmentResponse response;
     grpc::ClientContext context;
 
-    int rc = transfer_engine_->registerLocalMemory((void*)buffer, size, "cpu:0",
-                                                   true, true);
-    if (rc != 0) {
+    auto s = transfer_engine_->registerLocalMemory((void*)buffer,
+                                                        size, "cpu:0",
+                                                        true, true);
+    if (!s.ok()) {
         LOG(ERROR) << "register_local_memory_failed segment_name="
-                   << segment_name;
+                   << segment_name << " : "
+                   << s.message();
         return ErrorCode::INVALID_PARAMS;
     }
 
@@ -316,11 +318,11 @@ ErrorCode Client::UnmountSegment(const std::string& segment_name,
     if (err != ErrorCode::OK) {
         return err;
     }
-    int rc = transfer_engine_->unregisterLocalMemory(addr);
-    if (rc != 0) {
+    auto s = transfer_engine_->unregisterLocalMemory(addr);
+    if (!s.ok()) {
         LOG(ERROR) << "Failed to unregister transfer buffer with transfer "
                       "engine ret is "
-                   << rc;
+                   << s.message();
         return ErrorCode::INVALID_PARAMS;
     }
     mounted_segments_.erase(segment_name);
@@ -331,16 +333,16 @@ ErrorCode Client::RegisterLocalMemory(void* addr, size_t length,
                                       const std::string& location,
                                       bool remote_accessible,
                                       bool update_metadata) {
-    if (this->transfer_engine_->registerLocalMemory(
-            addr, length, location, remote_accessible, update_metadata) != 0) {
+    if (!(this->transfer_engine_->registerLocalMemory(
+            addr, length, location, remote_accessible, update_metadata)).ok()) {
         return ErrorCode::INVALID_PARAMS;
     }
     return ErrorCode::OK;
 }
 
 ErrorCode Client::unregisterLocalMemory(void* addr, bool update_metadata) {
-    if (this->transfer_engine_->unregisterLocalMemory(addr, update_metadata) !=
-        0) {
+    if (!(this->transfer_engine_->unregisterLocalMemory(
+            addr, update_metadata)).ok()) {
         return ErrorCode::INVALID_PARAMS;
     }
     return ErrorCode::OK;

--- a/mooncake-transfer-engine/example/memory_pool.cpp
+++ b/mooncake-transfer-engine/example/memory_pool.cpp
@@ -93,9 +93,9 @@ int target() {
     void *addr[2] = {nullptr};
     for (int i = 0; i < NR_SOCKETS; ++i) {
         addr[i] = allocateMemoryPool(dram_buffer_size, i);
-        int rc = engine->registerLocalMemory(addr[i], dram_buffer_size,
+        auto s = engine->registerLocalMemory(addr[i], dram_buffer_size,
                                              "cpu:" + std::to_string(i));
-        LOG_ASSERT(!rc);
+        LOG_ASSERT(s.ok());
     }
 
     while (true) sleep(1);

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -306,9 +306,9 @@ int initiator() {
 #else
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
-        int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
+        auto s = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
                                              "cpu:" + std::to_string(i));
-        LOG_ASSERT(!rc);
+        LOG_ASSERT(s.ok());
     }
 #endif
 
@@ -376,9 +376,9 @@ int target() {
     for (int i = 0; i < NR_SOCKETS; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i);
         memset(addr[i], 'x', FLAGS_buffer_size);
-        int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
+        auto s = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
                                              "cpu:" + std::to_string(i));
-        LOG_ASSERT(!rc);
+        LOG_ASSERT(s.ok());
     }
 
     LOG(INFO) << "numa node num: " << NR_SOCKETS;

--- a/mooncake-transfer-engine/include/topology.h
+++ b/mooncake-transfer-engine/include/topology.h
@@ -28,6 +28,7 @@
 #include <unordered_map>
 
 #include "common.h"
+#include "common/base/status.h"
 
 namespace mooncake {
 struct TopologyEntry {
@@ -74,7 +75,8 @@ class Topology {
 
     Json::Value toJson() const;
 
-    int selectDevice(const std::string storage_type, int retry_count = 0);
+    Status selectDevice(const std::string storage_type, int *device_id,
+                        int retry_count = 0);
 
     TopologyMatrix getMatrix() const { return matrix_; }
 

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -52,11 +52,11 @@ class TransferEngine {
 
     ~TransferEngine() { freeEngine(); }
 
-    int init(const std::string &metadata_conn_string,
-             const std::string &local_server_name,
-             const std::string &ip_or_host_name, uint64_t rpc_port = 12345);
+    Status init(const std::string &metadata_conn_string,
+                const std::string &local_server_name,
+                const std::string &ip_or_host_name, uint64_t rpc_port = 12345);
 
-    int freeEngine();
+    void freeEngine();
 
     // Only for testing.
     Transport *installTransport(const std::string &proto, void **args);
@@ -67,17 +67,17 @@ class TransferEngine {
 
     int closeSegment(SegmentHandle handle);
 
-    int registerLocalMemory(void *addr, size_t length,
-                            const std::string &location,
-                            bool remote_accessible = true,
-                            bool update_metadata = true);
+    Status registerLocalMemory(void *addr, size_t length,
+                               const std::string &location,
+                               bool remote_accessible = true,
+                               bool update_metadata = true);
 
-    int unregisterLocalMemory(void *addr, bool update_metadata = true);
+    Status unregisterLocalMemory(void *addr, bool update_metadata = true);
 
-    int registerLocalMemoryBatch(const std::vector<BufferEntry> &buffer_list,
-                                 const std::string &location);
+    Status registerLocalMemoryBatch(const std::vector<BufferEntry> &buffer_list,
+                                    const std::string &location);
 
-    int unregisterLocalMemoryBatch(const std::vector<void *> &addr_list);
+    Status unregisterLocalMemoryBatch(const std::vector<void *> &addr_list);
 
     BatchID allocateBatchID(size_t batch_size) {
         return multi_transports_->allocateBatchID(batch_size);

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -28,6 +28,7 @@
 #include <unordered_map>
 
 #include "common.h"
+#include "common/base/status.h"
 #include "topology.h"
 
 namespace mooncake {
@@ -93,9 +94,9 @@ class TransferMetadata {
     std::shared_ptr<SegmentDesc> getSegmentDescByID(SegmentID segment_id,
                                                     bool force_update = false);
 
-    int updateLocalSegmentDesc(SegmentID segment_id = LOCAL_SEGMENT_ID);
+    Status updateLocalSegmentDesc(SegmentID segment_id = LOCAL_SEGMENT_ID);
 
-    int updateSegmentDesc(const std::string &segment_name,
+    Status updateSegmentDesc(const std::string &segment_name,
                           const SegmentDesc &desc);
 
     std::shared_ptr<SegmentDesc> getSegmentDesc(
@@ -105,30 +106,32 @@ class TransferMetadata {
 
     int syncSegmentCache(const std::string &segment_name);
 
-    int removeSegmentDesc(const std::string &segment_name);
+    Status removeSegmentDesc(const std::string &segment_name);
 
-    int addLocalMemoryBuffer(const BufferDesc &buffer_desc,
-                             bool update_metadata);
+    Status addLocalMemoryBuffer(const BufferDesc &buffer_desc,
+                                bool update_metadata);
 
-    int removeLocalMemoryBuffer(void *addr, bool update_metadata);
+    Status removeLocalMemoryBuffer(void *addr, bool update_metadata);
 
-    int addLocalSegment(SegmentID segment_id, const std::string &segment_name,
-                        std::shared_ptr<SegmentDesc> &&desc);
+    Status addLocalSegment(SegmentID segment_id,
+                           const std::string &segment_name,
+                           std::shared_ptr<SegmentDesc> &&desc);
 
-    int addRpcMetaEntry(const std::string &server_name, RpcMetaDesc &desc);
+    Status addRpcMetaEntry(const std::string &server_name, RpcMetaDesc &desc);
 
-    int removeRpcMetaEntry(const std::string &server_name);
+    Status removeRpcMetaEntry(const std::string &server_name);
 
-    int getRpcMetaEntry(const std::string &server_name, RpcMetaDesc &desc);
+    Status getRpcMetaEntry(const std::string &server_name, RpcMetaDesc &desc);
 
     const RpcMetaDesc &localRpcMeta() const { return local_rpc_meta_; }
 
-    using OnReceiveHandShake = std::function<int(const HandShakeDesc &peer_desc,
-                                                 HandShakeDesc &local_desc)>;
-    int startHandshakeDaemon(OnReceiveHandShake on_receive_handshake,
-                             uint16_t listen_port);
+    using OnReceiveHandShake =
+        std::function<Status(const HandShakeDesc &peer_desc,
+                             HandShakeDesc &local_desc)>;
+    Status startHandshakeDaemon(OnReceiveHandShake on_receive_handshake,
+                                uint16_t listen_port);
 
-    int sendHandshake(const std::string &peer_server_name,
+    Status sendHandshake(const std::string &peer_server_name,
                       const HandShakeDesc &local_desc,
                       HandShakeDesc &peer_desc);
 

--- a/mooncake-transfer-engine/include/transfer_metadata_plugin.h
+++ b/mooncake-transfer-engine/include/transfer_metadata_plugin.h
@@ -41,15 +41,15 @@ struct HandShakePlugin {
     // The first param represents peer endpoint's attributes, while
     // the second param represents local endpoint's attributes
     using OnReceiveCallBack =
-        std::function<int(const Json::Value &, Json::Value &)>;
+        std::function<Status(const Json::Value &, Json::Value &)>;
 
-    virtual int startDaemon(OnReceiveCallBack on_recv_callback,
-                            uint16_t listen_port) = 0;
+    virtual Status startDaemon(OnReceiveCallBack on_recv_callback,
+                               uint16_t listen_port) = 0;
 
     // Connect to peer endpoint, and wait for receiving
     // peer endpoint's attributes
-    virtual int send(std::string ip_or_host_name, uint16_t rpc_port,
-                     const Json::Value &local, Json::Value &peer) = 0;
+    virtual Status send(std::string ip_or_host_name, uint16_t rpc_port,
+                        const Json::Value &local, Json::Value &peer) = 0;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/cxl_transport/cxl_transport.h
+++ b/mooncake-transfer-engine/include/transport/cxl_transport/cxl_transport.h
@@ -55,26 +55,27 @@ class CxlTransport : public Transport {
     Status freeBatchID(BatchID batch_id) override;
 
    private:
-    int install(std::string &local_server_name,
-                std::shared_ptr<TransferMetadata> meta,
-                std::shared_ptr<Topology> topo) override;
+    Status install(std::string &local_server_name,
+                   std::shared_ptr<TransferMetadata> meta,
+                   std::shared_ptr<Topology> topo) override;
 
-    int registerLocalMemory(void *addr, size_t length,
-                            const std::string &location, bool remote_accessible,
-                            bool update_metadata) override;
+    Status registerLocalMemory(void *addr, size_t length,
+                               const std::string &location,
+                               bool remote_accessible,
+                               bool update_metadata) override;
 
-    int unregisterLocalMemory(void *addr,
-                              bool update_metadata = false) override;
+    Status unregisterLocalMemory(void *addr,
+                                 bool update_metadata = false) override;
 
-    int registerLocalMemoryBatch(
+    Status registerLocalMemoryBatch(
         const std::vector<Transport::BufferEntry> &buffer_list,
         const std::string &location) override {
-        return 0;
+        return Status::OK();
     }
 
-    int unregisterLocalMemoryBatch(
+    Status unregisterLocalMemoryBatch(
         const std::vector<void *> &addr_list) override {
-        return 0;
+        return Status::OK();
     }
 
     const char *getName() const override { return "cxl"; }

--- a/mooncake-transfer-engine/include/transport/nvmeof_transport/nvmeof_transport.h
+++ b/mooncake-transfer-engine/include/transport/nvmeof_transport/nvmeof_transport.h
@@ -63,26 +63,27 @@ class NVMeoFTransport : public Transport {
         }
     };
 
-    int install(std::string &local_server_name,
-                std::shared_ptr<TransferMetadata> meta,
-                std::shared_ptr<Topology> topo) override;
+    Status install(std::string &local_server_name,
+                   std::shared_ptr<TransferMetadata> meta,
+                   std::shared_ptr<Topology> topo) override;
 
-    int registerLocalMemory(void *addr, size_t length,
-                            const std::string &location, bool remote_accessible,
-                            bool update_metadata) override;
+    Status registerLocalMemory(void *addr, size_t length,
+                               const std::string &location,
+                               bool remote_accessible,
+                               bool update_metadata) override;
 
-    int unregisterLocalMemory(void *addr,
-                              bool update_metadata = false) override;
+    Status unregisterLocalMemory(void *addr,
+                                 bool update_metadata = false) override;
 
-    int registerLocalMemoryBatch(
+    Status registerLocalMemoryBatch(
         const std::vector<Transport::BufferEntry> &buffer_list,
         const std::string &location) override {
-        return 0;
+        return Status::OK();
     }
 
-    int unregisterLocalMemoryBatch(
+    Status unregisterLocalMemoryBatch(
         const std::vector<void *> &addr_list) override {
-        return 0;
+        return Status::OK();
     }
 
     void addSliceToTask(void *source_addr, uint64_t slice_len,

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -53,18 +53,18 @@ class RdmaContext {
 
     ~RdmaContext();
 
-    int construct(size_t num_cq_list = 1, size_t num_comp_channels = 1,
-                  uint8_t port = 1, int gid_index = 0, size_t max_cqe = 4096,
-                  int max_endpoints = 256);
+    Status construct(size_t num_cq_list = 1, size_t num_comp_channels = 1,
+                     uint8_t port = 1, int gid_index = 0, size_t max_cqe = 4096,
+                     int max_endpoints = 256);
 
    private:
     int deconstruct();
 
    public:
     // Memory Region Management
-    int registerMemoryRegion(void *addr, size_t length, int access);
+    Status registerMemoryRegion(void *addr, size_t length, int access);
 
-    int unregisterMemoryRegion(void *addr);
+    Status unregisterMemoryRegion(void *addr);
 
     uint32_t rkey(void *addr);
 
@@ -128,17 +128,17 @@ class RdmaContext {
     int socketId();
 
    private:
-    int openRdmaDevice(const std::string &device_name, uint8_t port,
-                       int gid_index);
+    Status openRdmaDevice(const std::string &device_name, uint8_t port,
+                          int gid_index);
 
-    int joinNonblockingPollList(int event_fd, int data_fd);
+    Status joinNonblockingPollList(int event_fd, int data_fd);
 
     int getBestGidIndex(const std::string &device_name,
                         struct ibv_context *context, ibv_port_attr &port_attr,
                         uint8_t port);
 
    public:
-    int submitPostSend(const std::vector<Transport::Slice *> &slice_list);
+    Status submitPostSend(const std::vector<Transport::Slice *> &slice_list);
 
    private:
     const std::string device_name_;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -38,7 +38,7 @@ namespace mooncake {
 // The handshake can be restarted at this point.
 class RdmaEndPoint {
    public:
-    enum Status {
+    enum EndPointStatus {
         INITIALIZING,
         UNCONNECTED,
         CONNECTED,
@@ -49,8 +49,8 @@ class RdmaEndPoint {
 
     ~RdmaEndPoint();
 
-    int construct(ibv_cq *cq, size_t num_qp_list = 2, size_t max_sge = 4,
-                  size_t max_wr = 256, size_t max_inline = 64);
+    Status construct(ibv_cq *cq, size_t num_qp_list = 2, size_t max_sge = 4,
+                     size_t max_wr = 256, size_t max_inline = 64);
 
    private:
     int deconstruct();
@@ -58,16 +58,16 @@ class RdmaEndPoint {
    public:
     void setPeerNicPath(const std::string &peer_nic_path);
 
-    int setupConnectionsByActive();
+    Status setupConnectionsByActive();
 
-    int setupConnectionsByActive(const std::string &peer_nic_path) {
+    Status setupConnectionsByActive(const std::string &peer_nic_path) {
         setPeerNicPath(peer_nic_path);
         return setupConnectionsByActive();
     }
 
     using HandShakeDesc = TransferMetadata::HandShakeDesc;
-    int setupConnectionsByPassive(const HandShakeDesc &peer_desc,
-                                  HandShakeDesc &local_desc);
+    Status setupConnectionsByPassive(const HandShakeDesc &peer_desc,
+                                     HandShakeDesc &local_desc);
 
     bool hasOutstandingSlice() const;
 
@@ -98,23 +98,23 @@ class RdmaEndPoint {
     // Submit some work requests to HW
     // Submitted tasks (success/failed) are removed in slice_list
     // Failed tasks (which must be submitted) are inserted in failed_slice_list
-    int submitPostSend(std::vector<Transport::Slice *> &slice_list,
-                       std::vector<Transport::Slice *> &failed_slice_list);
+    Status submitPostSend(std::vector<Transport::Slice *> &slice_list,
+                          std::vector<Transport::Slice *> &failed_slice_list);
 
    private:
     std::vector<uint32_t> qpNum() const;
 
-    int doSetupConnection(const std::string &peer_gid, uint16_t peer_lid,
-                          std::vector<uint32_t> peer_qp_num_list,
-                          std::string *reply_msg = nullptr);
+    Status doSetupConnection(const std::string &peer_gid, uint16_t peer_lid,
+                             std::vector<uint32_t> peer_qp_num_list,
+                             std::string *reply_msg = nullptr);
 
-    int doSetupConnection(int qp_index, const std::string &peer_gid,
-                          uint16_t peer_lid, uint32_t peer_qp_num,
-                          std::string *reply_msg = nullptr);
+    Status doSetupConnection(int qp_index, const std::string &peer_gid,
+                             uint16_t peer_lid, uint32_t peer_qp_num,
+                             std::string *reply_msg = nullptr);
 
    private:
     RdmaContext &context_;
-    std::atomic<Status> status_;
+    std::atomic<EndPointStatus> status_;
 
     RWSpinlock lock_;
     std::vector<ibv_qp *> qp_list_;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -53,28 +53,30 @@ class RdmaTransport : public Transport {
 
     ~RdmaTransport();
 
-    int install(std::string &local_server_name,
-                std::shared_ptr<TransferMetadata> meta,
-                std::shared_ptr<Topology> topo) override;
+    Status install(std::string &local_server_name,
+                   std::shared_ptr<TransferMetadata> meta,
+                   std::shared_ptr<Topology> topo) override;
 
     const char *getName() const override { return "rdma"; }
 
-    int registerLocalMemory(void *addr, size_t length,
-                            const std::string &location, bool remote_accessible,
-                            bool update_metadata) override;
+    Status registerLocalMemory(void *addr, size_t length,
+                               const std::string &location,
+                               bool remote_accessible,
+                               bool update_metadata) override;
 
-    int unregisterLocalMemory(void *addr, bool update_metadata = true) override;
+    Status unregisterLocalMemory(void *addr,
+                                 bool update_metadata = true) override;
 
-    int registerLocalMemoryBatch(const std::vector<BufferEntry> &buffer_list,
-                                 const std::string &location) override;
+    Status registerLocalMemoryBatch(const std::vector<BufferEntry> &buffer_list,
+                                    const std::string &location) override;
 
-    int unregisterLocalMemoryBatch(
+    Status unregisterLocalMemoryBatch(
         const std::vector<void *> &addr_list) override;
 
     // TRANSFER
 
     Status submitTransfer(BatchID batch_id,
-                       const std::vector<TransferRequest> &entries) override;
+                          const std::vector<TransferRequest> &entries) override;
 
     Status submitTransferTask(
         const std::vector<TransferRequest *> &request_list,
@@ -89,27 +91,28 @@ class RdmaTransport : public Transport {
     SegmentID getSegmentID(const std::string &segment_name);
 
    private:
-    int allocateLocalSegmentID();
+    Status allocateLocalSegmentID();
 
    public:
-    int onSetupRdmaConnections(const HandShakeDesc &peer_desc,
-                               HandShakeDesc &local_desc);
+    Status onSetupRdmaConnections(const HandShakeDesc &peer_desc,
+                                  HandShakeDesc &local_desc);
 
-    int sendHandshake(const std::string &peer_server_name,
-                      const HandShakeDesc &local_desc,
-                      HandShakeDesc &peer_desc) {
+    Status sendHandshake(const std::string &peer_server_name,
+                         const HandShakeDesc &local_desc,
+                         HandShakeDesc &peer_desc) {
         return metadata_->sendHandshake(peer_server_name, local_desc,
                                         peer_desc);
     }
 
    private:
-    int initializeRdmaResources();
+    Status initializeRdmaResources();
 
-    int startHandshakeDaemon(std::string &local_server_name);
+    Status startHandshakeDaemon(std::string &local_server_name);
 
    public:
-    static int selectDevice(SegmentDesc *desc, uint64_t offset, size_t length,
-                            int &buffer_id, int &device_id, int retry_cnt = 0);
+    static Status selectDevice(SegmentDesc *desc, uint64_t offset,
+                               size_t length, int &buffer_id, int &device_id,
+                               int retry_cnt = 0);
 
    private:
     std::vector<std::shared_ptr<RdmaContext>> context_list_;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -28,7 +28,7 @@ class WorkerPool {
     ~WorkerPool();
 
     // Add slices to queue, called by Transport
-    int submitPostSend(const std::vector<Transport::Slice *> &slice_list);
+    Status submitPostSend(const std::vector<Transport::Slice *> &slice_list);
 
    private:
     void performPostSend(int thread_id);

--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -57,23 +57,24 @@ class TcpTransport : public Transport {
                           TransferStatus &status) override;
 
    private:
-    int install(std::string &local_server_name,
-                std::shared_ptr<TransferMetadata> meta,
-                std::shared_ptr<Topology> topo);
+    Status install(std::string &local_server_name,
+                   std::shared_ptr<TransferMetadata> meta,
+                   std::shared_ptr<Topology> topo);
 
-    int allocateLocalSegmentID();
+    Status allocateLocalSegmentID();
 
-    int registerLocalMemory(void *addr, size_t length,
-                            const std::string &location, bool remote_accessible,
-                            bool update_metadata);
+    Status registerLocalMemory(void *addr, size_t length,
+                               const std::string &location,
+                               bool remote_accessible,
+                               bool update_metadata);
 
-    int unregisterLocalMemory(void *addr, bool update_metadata = false);
+    Status unregisterLocalMemory(void *addr, bool update_metadata = false);
 
-    int registerLocalMemoryBatch(
+    Status registerLocalMemoryBatch(
         const std::vector<Transport::BufferEntry> &buffer_list,
         const std::string &location);
 
-    int unregisterLocalMemoryBatch(
+    Status unregisterLocalMemoryBatch(
         const std::vector<void *> &addr_list) override;
 
     void worker();

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -184,9 +184,9 @@ class Transport {
     };
 
    protected:
-    virtual int install(std::string &local_server_name,
-                        std::shared_ptr<TransferMetadata> meta,
-                        std::shared_ptr<Topology> topo);
+    virtual Status install(std::string &local_server_name,
+                           std::shared_ptr<TransferMetadata> meta,
+                           std::shared_ptr<Topology> topo);
 
     std::string local_server_name_;
     std::shared_ptr<TransferMetadata> metadata_;
@@ -195,19 +195,19 @@ class Transport {
     std::unordered_map<BatchID, std::shared_ptr<BatchDesc>> batch_desc_set_;
 
    private:
-    virtual int registerLocalMemory(void *addr, size_t length,
-                                    const std::string &location,
-                                    bool remote_accessible,
-                                    bool update_metadata = true) = 0;
+    virtual Status registerLocalMemory(void *addr, size_t length,
+                                       const std::string &location,
+                                       bool remote_accessible,
+                                       bool update_metadata = true) = 0;
 
-    virtual int unregisterLocalMemory(void *addr,
-                                      bool update_metadata = true) = 0;
+    virtual Status unregisterLocalMemory(void *addr,
+                                         bool update_metadata = true) = 0;
 
-    virtual int registerLocalMemoryBatch(
+    virtual Status registerLocalMemoryBatch(
         const std::vector<BufferEntry> &buffer_list,
         const std::string &location) = 0;
 
-    virtual int unregisterLocalMemoryBatch(
+    virtual Status unregisterLocalMemoryBatch(
         const std::vector<void *> &addr_list) = 0;
 
     virtual const char *getName() const = 0;

--- a/mooncake-transfer-engine/rust/src/transfer_engine.rs
+++ b/mooncake-transfer-engine/rust/src/transfer_engine.rs
@@ -108,7 +108,7 @@ impl TransferEngine {
         let ret = unsafe {
             bindings::registerLocalMemory(self.engine, addr, length, location_c.as_ptr(), 1)
         };
-        if ret < 0 {
+        if ret != 0 {
             bail!("Failed to register local memory")
         } else {
             Ok(())
@@ -117,7 +117,7 @@ impl TransferEngine {
 
     pub fn unregister_local_memory(&self, addr: *mut c_void) -> Result<()> {
         let ret = unsafe { bindings::unregisterLocalMemory(self.engine, addr) };
-        if ret < 0 {
+        if ret != 0 {
             bail!("Failed to unregister local memory")
         } else {
             Ok(())
@@ -146,7 +146,7 @@ impl TransferEngine {
                 location_c.as_ptr(),
             )
         };
-        if ret < 0 {
+        if ret != 0 {
             bail!("Failed to register local memory")
         } else {
             Ok(())
@@ -159,7 +159,7 @@ impl TransferEngine {
         let ret = unsafe {
             bindings::unregisterLocalMemoryBatch(self.engine, addr_list.as_mut_ptr(), addr_len)
         };
-        if ret < 0 {
+        if ret != 0 {
             bail!("Failed to unregister local memory")
         } else {
             Ok(())

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -150,7 +150,8 @@ Transport *MultiTransport::installTransport(const std::string &proto,
         return nullptr;
     }
 
-    if (transport->install(local_server_name_, metadata_, topo)) {
+    Status status = transport->install(local_server_name_, metadata_, topo);
+    if (!status.ok()) {
         return nullptr;
     }
 

--- a/mooncake-transfer-engine/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_c.cpp
@@ -28,9 +28,9 @@ transfer_engine_t createTransferEngine(const char *metadata_conn_string,
                                        uint64_t rpc_port,
                                        int auto_discover) {
     TransferEngine *native = new TransferEngine(auto_discover);
-    int ret = native->init(metadata_conn_string, local_server_name,
+    Status s = native->init(metadata_conn_string, local_server_name,
                            ip_or_host_name, rpc_port);
-    if (ret) {
+    if (!s.ok()) {
         delete native;
         return nullptr;
     }
@@ -73,13 +73,16 @@ int closeSegment(transfer_engine_t engine, segment_id_t segment_id) {
 int registerLocalMemory(transfer_engine_t engine, void *addr, size_t length,
                         const char *location, int remote_accessible) {
     TransferEngine *native = (TransferEngine *)engine;
-    return native->registerLocalMemory(addr, length, location,
-                                       remote_accessible, true);
+    Status s =
+        native->registerLocalMemory(addr, length, location,
+                                    remote_accessible, true);
+    return (int)s.code();
 }
 
 int unregisterLocalMemory(transfer_engine_t engine, void *addr) {
     TransferEngine *native = (TransferEngine *)engine;
-    return native->unregisterLocalMemory(addr);
+    Status s = native->unregisterLocalMemory(addr);
+    return (int)s.code();
 }
 
 int registerLocalMemoryBatch(transfer_engine_t engine,
@@ -93,7 +96,8 @@ int registerLocalMemoryBatch(transfer_engine_t engine,
         entry.length = buffer_list[i].length;
         native_buffer_list.push_back(entry);
     }
-    return native->registerLocalMemoryBatch(native_buffer_list, location);
+    Status s = native->registerLocalMemoryBatch(native_buffer_list, location);
+    return (int)s.code();
 }
 
 int unregisterLocalMemoryBatch(transfer_engine_t engine, void **addr_list,
@@ -102,7 +106,8 @@ int unregisterLocalMemoryBatch(transfer_engine_t engine, void **addr_list,
     std::vector<void *> native_addr_list;
     for (size_t i = 0; i < addr_len; ++i)
         native_addr_list.push_back(addr_list[i]);
-    return native->unregisterLocalMemoryBatch(native_addr_list);
+    Status s = native->unregisterLocalMemoryBatch(native_addr_list);
+    return (int)s.code();
 }
 
 batch_id_t allocateBatchID(transfer_engine_t engine, size_t batch_size) {

--- a/mooncake-transfer-engine/src/transport/cxl_transport/cxl_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/cxl_transport/cxl_transport.cpp
@@ -43,30 +43,30 @@ CxlTransport::BatchID CxlTransport::allocateBatchID(size_t batch_size) {
 
 Status CxlTransport::getTransferStatus(BatchID batch_id, size_t task_id,
                                     TransferStatus &status) {
-    return 0;
+    return Status::OK();
 }
 
 Status CxlTransport::submitTransfer(BatchID batch_id,
                                  const std::vector<TransferRequest> &entries) {
-    return 0;
+    return Status::OK();
 }
 
-int CxlTransport::freeBatchID(BatchID batch_id) { return 0; }
+Status CxlTransport::freeBatchID(BatchID batch_id) { return Status::OK(); }
 
-int CxlTransport::install(std::string &local_server_name,
-                          std::shared_ptr<TransferMetadata> meta,
-                          std::shared_ptr<Topology> topo) {
-    return 0;
+Status CxlTransport::install(std::string &local_server_name,
+                             std::shared_ptr<TransferMetadata> meta,
+                             std::shared_ptr<Topology> topo) {
+    return Status::OK();
 }
 
-int CxlTransport::registerLocalMemory(void *addr, size_t length,
-                                      const string &location,
-                                      bool remote_accessible,
-                                      bool update_metadata) {
-    return 0;
+Status CxlTransport::registerLocalMemory(void *addr, size_t length,
+                                         const string &location,
+                                         bool remote_accessible,
+                                         bool update_metadata) {
+    return Status::OK();
 }
 
-int CxlTransport::unregisterLocalMemory(void *addr, bool update_metadata) {
-    return 0;
+Status CxlTransport::unregisterLocalMemory(void *addr, bool update_metadata) {
+    return Status::OK();
 }
 }  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -49,10 +49,10 @@ std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::insertEndpoint(
         return nullptr;
     }
     auto &config = globalConfig();
-    int ret =
+    auto status =
         endpoint->construct(context->cq(), config.num_qp_per_ep, config.max_sge,
                             config.max_wr, config.max_inline);
-    if (ret) return nullptr;
+    if (!status.ok()) return nullptr;
 
     while (this->getSize() >= max_size_) evictEndpoint();
 
@@ -142,10 +142,10 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::insertEndpoint(
         return nullptr;
     }
     auto &config = globalConfig();
-    int ret =
+    auto status =
         endpoint->construct(context->cq(), config.num_qp_per_ep, config.max_sge,
                             config.max_wr, config.max_inline);
-    if (ret) return nullptr;
+    if (!status.ok()) return nullptr;
 
     while (this->getSize() >= max_size_) evictEndpoint();
 

--- a/mooncake-transfer-engine/src/transport/transport.cpp
+++ b/mooncake-transfer-engine/src/transport/transport.cpp
@@ -51,11 +51,11 @@ Status Transport::freeBatchID(BatchID batch_id) {
     return Status::OK();
 }
 
-int Transport::install(std::string &local_server_name,
-                       std::shared_ptr<TransferMetadata> meta,
-                       std::shared_ptr<Topology> topo) {
+Status Transport::install(std::string &local_server_name,
+                          std::shared_ptr<TransferMetadata> meta,
+                          std::shared_ptr<Topology> topo) {
     local_server_name_ = local_server_name;
     metadata_ = meta;
-    return 0;
+    return Status::OK();
 }
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test.cpp
@@ -269,13 +269,14 @@ int initiator() {
     void *addr = nullptr;
 #ifdef USE_CUDA
     addr = allocateMemoryPool(ram_buffer_size, 0, FLAGS_use_vram);
-    int rc = engine->registerLocalMemory(addr, ram_buffer_size,
-                                         FLAGS_use_vram ? "cuda:0" : "cpu:0");
-    LOG_ASSERT(!rc);
+    auto status = engine->registerLocalMemory(addr, ram_buffer_size,
+                                              FLAGS_use_vram ?
+                                                "cuda:0" : "cpu:0");
+    LOG_ASSERT(status.ok());
 #else
     addr = allocateMemoryPool(ram_buffer_size, 0, false);
-    int rc = engine->registerLocalMemory(addr, ram_buffer_size, "*");
-    LOG_ASSERT(!rc);
+    auto status = engine->registerLocalMemory(addr, ram_buffer_size, "*");
+    LOG_ASSERT(status.ok());
 #endif
 
     auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
@@ -311,8 +312,8 @@ int target() {
 
     void *addr = nullptr;
     addr = allocateMemoryPool(ram_buffer_size, 0);
-    int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
-    LOG_ASSERT(!rc);
+    auto status = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+    LOG_ASSERT(status.ok());
 
     while (true) sleep(1);
 

--- a/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
@@ -135,8 +135,8 @@ class RDMATransportTest : public ::testing::Test {
         xport = engine->installTransport("rdma", args);
         ASSERT_NE(xport, nullptr);
         addr = allocateMemoryPool(ram_buffer_size, 0, false);
-        int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
-        ASSERT_EQ(rc, 0);
+        auto status = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+        ASSERT_TRUE(status.ok());
         segment_id = engine->openSegment(FLAGS_segment_id.c_str());
         bindToSocket(0);
         segment_desc = engine->getMetadata()->getSegmentDescByID(segment_id);

--- a/mooncake-transfer-engine/tests/topology_test.cpp
+++ b/mooncake-transfer-engine/tests/topology_test.cpp
@@ -80,11 +80,11 @@ TEST(ToplogyTest, TestSelectDevice) {
     topology.parse(json_str);
     std::set<int> items = {0, 1};
     int device;
-    device = topology.selectDevice("cpu:0", 2);
-    ASSERT_TRUE(items.count(device));
+    auto s = topology.selectDevice("cpu:0", &device, 2);
+    ASSERT_TRUE(s.ok());
     items.erase(device);
-    device = topology.selectDevice("cpu:0", 1);
-    ASSERT_TRUE(items.count(device));
+    s = topology.selectDevice("cpu:0", &device, 1);
+    ASSERT_TRUE(s.ok());
     items.erase(device);
     ASSERT_TRUE(items.empty());
 }
@@ -96,10 +96,10 @@ TEST(ToplogyTest, TestSelectDeviceAny) {
     topology.parse(json_str);
     std::set<int> items = {0, 1};
     int device;
-    device = topology.selectDevice("*", 2);
-    ASSERT_TRUE(items.count(device));
+    auto s = topology.selectDevice("*", &device, 2);
+    ASSERT_TRUE(s.ok());
     items.erase(device);
-    device = topology.selectDevice("*", 1);
+    s = topology.selectDevice("*", &device, 1);
     ASSERT_TRUE(items.count(device));
     items.erase(device);
     ASSERT_TRUE(items.empty());

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -66,9 +66,9 @@ TEST_F(TransferMetadataTest, LocalSegmentTest) {
     segment_des->protocol = "rdma";
     TransferMetadata::SegmentID segment_id = 1111111;
     std::string segment_name = "test_segment";
-    int re = metadata_client->addLocalSegment(segment_id, segment_name,
-                                              std::move(segment_des));
-    ASSERT_EQ(re, 0);
+    auto status = metadata_client->addLocalSegment(segment_id, segment_name,
+                                                   std::move(segment_des));
+    ASSERT_TRUE(status.ok());
     auto des = metadata_client->getSegmentDescByName(segment_name);
     ASSERT_EQ(des, segment_des);
     des = metadata_client->getSegmentDescByID(segment_id, false);
@@ -82,24 +82,24 @@ TEST_F(TransferMetadataTest, LocalMemoryBufferTest) {
     auto segment_des = std::make_shared<TransferMetadata::SegmentDesc>();
     segment_des->name = "test_localMemery";
     segment_des->protocol = "rdma";
-    int re = metadata_client->addLocalSegment(
+    auto s = metadata_client->addLocalSegment(
         LOCAL_SEGMENT_ID, "test_local_segment", std::move(segment_des));
-    ASSERT_EQ(re, 0);
+    ASSERT_TRUE(s.ok());
     uint64_t addr = 0;
     for (int i = 0; i < 10; ++i) {
         TransferMetadata::BufferDesc buffer_des;
         buffer_des.addr = addr + i * 2048;
         buffer_des.length = 1024;
-        re = metadata_client->addLocalMemoryBuffer(buffer_des, false);
-        ASSERT_EQ(re, 0);
+        auto s = metadata_client->addLocalMemoryBuffer(buffer_des, false);
+        ASSERT_TRUE(s.ok());
     }
     addr = 1000;
-    re = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
-    ASSERT_EQ(re, ERR_ADDRESS_NOT_REGISTERED);
+    s = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
+    ASSERT_TRUE(s.IsAddressNotRegistered());
     for (int i = 9; i > 0; --i) {
         addr = i * 2048;
-        re = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
-        ASSERT_EQ(re, 0);
+        auto s = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
+        ASSERT_TRUE(s.ok());
     }
 }
 
@@ -109,14 +109,14 @@ TEST_F(TransferMetadataTest, RpcMetaEntryTest) {
     TransferMetadata::RpcMetaDesc desc;
     desc.ip_or_host_name = hostname_port.first.c_str();
     desc.rpc_port = hostname_port.second;
-    int re = metadata_client->addRpcMetaEntry("test_server", desc);
-    ASSERT_EQ(re, 0);
+    auto s = metadata_client->addRpcMetaEntry("test_server", desc);
+    ASSERT_TRUE(s.ok());
     TransferMetadata::RpcMetaDesc desc1;
-    re = metadata_client->getRpcMetaEntry("test_server", desc1);
+    s = metadata_client->getRpcMetaEntry("test_server", desc1);
     ASSERT_EQ(desc.ip_or_host_name, desc1.ip_or_host_name);
     ASSERT_EQ(desc.rpc_port, desc1.rpc_port);
-    re = metadata_client->removeRpcMetaEntry("test_server");
-    ASSERT_EQ(re, 0);
+    s = metadata_client->removeRpcMetaEntry("test_server");
+    ASSERT_TRUE(s.ok());
 }
 
 }  // namespace mooncake


### PR DESCRIPTION
This PR refactors most functions within the TransferEngine to use more descriptive and structured return types (e.g., Status, StatusOr<T>), replacing ambiguous or less informative return values such as int, bool, or void.

This is a follow up PR of [PR125](https://github.com/kvcache-ai/Mooncake/pull/125). The **motivations** are as follows:

- Improve code readability and maintainability
- Enable better error propagation and diagnostics
- Make debugging easier by providing explicit error messages and context
