### PR TITLE
[Refactor] Replace rpc logic with MasterClient in Client class

### DIFF
--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -1,18 +1,14 @@
 #pragma once
 
-#include <grpcpp/grpcpp.h>
-
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "master.grpc.pb.h"
+#include "master_client.h"
 #include "transfer_engine.h"
 #include "types.h"
 
 namespace mooncake {
-
-static const std::string kDefaultMasterAddress = "localhost:50051";
 
 /**
  * @brief Client for interacting with the mooncake distributed object store
@@ -157,7 +153,7 @@ class Client {
 
     // Core components
     std::unique_ptr<TransferEngine> transfer_engine_;
-    std::unique_ptr<mooncake_store::MasterService::Stub> master_stub_;
+    std::unique_ptr<MasterClient> master_client_;
 
     std::unordered_map<std::string, void*> mounted_segments_;
 

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <grpcpp/grpcpp.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "master.grpc.pb.h"
+#include "types.h"
+
+namespace mooncake {
+
+static const std::string kDefaultMasterAddress = "localhost:50051";
+
+/**
+ * @brief Client for interacting with the mooncake master service
+ */
+class MasterClient {
+   public:
+    MasterClient();
+    ~MasterClient();
+
+    MasterClient(const MasterClient&) = delete;
+    MasterClient& operator=(const MasterClient&) = delete;
+
+    /**
+     * @brief Connects to the master service
+     * @param master_addr Master service address (IP:Port)
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] ErrorCode Connect(
+        const std::string& master_addr = kDefaultMasterAddress);
+
+    /**
+     * @brief Gets object metadata without transferring data
+     * @param object_key Key to query
+     * @param object_info Output parameter for object metadata
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] ErrorCode GetReplicaList(
+        const std::string& object_key,
+        mooncake_store::GetReplicaListResponse& object_info) const;
+
+    /**
+     * @brief Starts a put operation
+     * @param key Object key
+     * @param slice_lengths Vector of slice lengths
+     * @param value_length Total value length
+     * @param config Replication configuration
+     * @param start_response Output parameter for put start response
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] ErrorCode PutStart(
+        const std::string& key, const std::vector<size_t>& slice_lengths,
+        size_t value_length, const ReplicateConfig& config,
+        mooncake_store::PutStartResponse& start_response) const;
+
+    /**
+     * @brief Ends a put operation
+     * @param key Object key
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] ErrorCode PutEnd(const std::string& key) const;
+
+    /**
+     * @brief Revokes a put operation
+     * @param key Object key
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] ErrorCode PutRevoke(const std::string& key) const;
+
+    /**
+     * @brief Removes an object and all its replicas
+     * @param key Key to remove
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] ErrorCode Remove(const std::string& key) const;
+
+    /**
+     * @brief Registers a segment to master for allocation
+     * @param segment_name hostname:port of the segment
+     * @param buffer Buffer address of the segment
+     * @param size Size of the segment in bytes
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] ErrorCode MountSegment(const std::string& segment_name,
+                                         const void* buffer, size_t size) const;
+
+    /**
+     * @brief Unregisters a memory segment from master
+     * @param segment_name Name which is used to register the segment
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] ErrorCode UnmountSegment(
+        const std::string& segment_name) const;
+
+    /**
+     * @brief Checks if an object exists
+     * @param key Key to check
+     * @return ErrorCode::OK if exists, ErrorCode::OBJECT_NOT_FOUND if not
+     * exists, other ErrorCode for errors
+     */
+    [[nodiscard]] ErrorCode IsExist(const std::string& key) const;
+
+   private:
+    // Template method: Execute RPC call and handle results
+    template <typename Req, typename Res, typename... Builders>
+    [[nodiscard]] ErrorCode ExecuteRpc(
+        const std::string& rpc_name,
+        grpc::Status (mooncake_store::MasterService::Stub::*method)(
+            grpc::ClientContext*, const Req&, Res*),
+        Res& response, Builders&&... builders) const;
+
+    std::unique_ptr<mooncake_store::MasterService::Stub> master_stub_{nullptr};
+};
+
+}  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(cachelib_memory_allocator)
 set(CACHE_ALLOCATOR_SOURCES
     allocator.cpp
     client.cpp
+    master_client.cpp
     master.pb.cpp
     master.grpc.pb.cpp
     master_service.cpp

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -18,34 +18,13 @@ namespace mooncake {
     return slice_size;
 }
 
-template <typename RequestType, typename ResponseType>
-ErrorCode LogAndCheckRpcStatus(grpc::Status status,
-                               const ResponseType& response,
-                               const std::string& rpc_name,
-                               const RequestType& request) {
-    VLOG(1) << rpc_name << ": rpc_request=" << request.ShortDebugString();
-
-    if (!status.ok()) {
-        LOG(ERROR) << rpc_name << ": rpc error, code: " << status.error_code()
-                   << ", message: " << status.error_message();
-        return ErrorCode::RPC_FAIL;
-    }
-
-    VLOG(1) << rpc_name << ": status_code=" << response.status_code();
-    return fromInt(response.status_code());
-}
-
-Client::Client() : transfer_engine_(nullptr), master_stub_(nullptr) {}
+Client::Client() : transfer_engine_(nullptr), master_client_(nullptr) {}
 
 Client::~Client() = default;
 
 ErrorCode Client::ConnectToMaster(const std::string& master_addr) {
-    auto channel =
-        grpc::CreateChannel(master_addr, grpc::InsecureChannelCredentials());
-    master_stub_ = mooncake_store::MasterService::NewStub(channel);
-    CHECK(master_stub_) << "Failed to create master service stub";
-    LOG(INFO) << "master_service_stub_created=true master_addr=" << master_addr;
-    return ErrorCode::OK;
+    master_client_ = std::make_unique<MasterClient>();
+    return master_client_->Connect(master_addr);
 }
 
 ErrorCode Client::InitTransferEngine(const std::string& local_hostname,
@@ -126,28 +105,7 @@ ErrorCode Client::Get(const std::string& object_key,
 
 ErrorCode Client::Query(const std::string& object_key,
                         ObjectInfo& object_info) const {
-    // Get replica list from master
-    mooncake_store::GetReplicaListRequest request;
-    request.set_key(object_key);
-    grpc::ClientContext context;
-
-    grpc::Status status =
-        master_stub_->GetReplicaList(&context, request, &object_info);
-    ErrorCode err =
-        LogAndCheckRpcStatus(status, object_info, "GetReplicaList", request);
-    if (err != ErrorCode::OK) {
-        return err;
-    }
-
-    VLOG(1) << "GetReplicaList: replica_count="
-            << object_info.replica_list_size();
-
-    if (object_info.replica_list().empty()) {
-        LOG(INFO) << "object_not_found key=" << object_key;
-        return ErrorCode::OBJECT_NOT_FOUND;
-    }
-
-    return ErrorCode::OK;
+    return master_client_->GetReplicaList(object_key, object_info);
 }
 
 ErrorCode Client::Get(const std::string& object_key,
@@ -186,43 +144,24 @@ ErrorCode Client::Get(const std::string& object_key,
 
 ErrorCode Client::Put(const ObjectKey& key, std::vector<Slice>& slices,
                       const ReplicateConfig& config) {
-    // Start put operation
-    mooncake_store::PutStartRequest start_request;
-    start_request.set_key(key);
-
+    // Prepare slice lengths
+    std::vector<size_t> slice_lengths;
     size_t slice_size = 0;
     for (size_t i = 0; i < slices.size(); ++i) {
-        start_request.add_slice_lengths(slices[i].size);
+        slice_lengths.push_back(slices[i].size);
         slice_size += slices[i].size;
     }
-    start_request.set_value_length(slice_size);
 
-    auto* replica_config = start_request.mutable_config();
-    replica_config->set_replica_num(config.replica_num);
-
+    // Start put operation
     mooncake_store::PutStartResponse start_response;
-    grpc::ClientContext start_context;
-
-    grpc::Status status =
-        master_stub_->PutStart(&start_context, start_request, &start_response);
-    ErrorCode err =
-        LogAndCheckRpcStatus(status, start_response, "PutStart", start_request);
+    ErrorCode err = master_client_->PutStart(key, slice_lengths, slice_size,
+                                             config, start_response);
     if (err != ErrorCode::OK) {
         if (err == ErrorCode::OBJECT_ALREADY_EXISTS) {
             LOG(INFO) << "object_alredy_exists key=" << key;
             return ErrorCode::OK;
         }
         return err;
-    }
-
-    VLOG(1) << "PutStart: replica_count=" << start_response.replica_list_size();
-
-    for (const auto& replica : start_response.replica_list()) {
-        for (const auto& handle : replica.handles()) {
-            VLOG(1) << "handle: buffer=" << handle.buffer()
-                    << " size=" << handle.size()
-                    << " segment_name=" << handle.segment_name();
-        }
     }
 
     // Transfer data using allocated handles from all replicas
@@ -235,50 +174,21 @@ ErrorCode Client::Put(const ObjectKey& key, std::vector<Slice>& slices,
         ErrorCode transfer_err = TransferWrite(handles, slices);
         if (transfer_err != ErrorCode::OK) {
             // Revoke put operation
-            mooncake_store::PutRevokeRequest revoke_request;
-            revoke_request.set_key(key);
-            mooncake_store::PutRevokeResponse revoke_response;
-            grpc::ClientContext revoke_context;
-            status = master_stub_->PutRevoke(&revoke_context, revoke_request,
-                                             &revoke_response);
-            LogAndCheckRpcStatus(status, revoke_response, "PutRevoke",
-                                 revoke_request);
-            VLOG(1) << "PutRevoke: status_code="
-                    << revoke_response.status_code();
+            auto revoke_err = master_client_->PutRevoke(key);
+            if (revoke_err != ErrorCode::OK) {
+                LOG(ERROR) << "Failed to revoke put operation";
+                return revoke_err;
+            }
             return transfer_err;
         }
     }
 
     // End put operation
-    mooncake_store::PutEndRequest end_request;
-    end_request.set_key(key);
-
-    mooncake_store::PutEndResponse end_response;
-    grpc::ClientContext end_context;
-
-    status = master_stub_->PutEnd(&end_context, end_request, &end_response);
-    err = LogAndCheckRpcStatus(status, end_response, "PutEnd", end_request);
-    if (err != ErrorCode::OK) {
-        return err;
-    }
-    VLOG(1) << "PutEnd: status_code=" << end_response.status_code();
-
-    return ErrorCode::OK;
+    return master_client_->PutEnd(key);
 }
 
 ErrorCode Client::Remove(const ObjectKey& key) const {
-    mooncake_store::RemoveRequest request;
-    request.set_key(key);
-
-    mooncake_store::RemoveResponse response;
-    grpc::ClientContext context;
-
-    grpc::Status status = master_stub_->Remove(&context, request, &response);
-    ErrorCode err = LogAndCheckRpcStatus(status, response, "Remove", request);
-    if (err != ErrorCode::OK) {
-        return err;
-    }
-    return ErrorCode::OK;
+    return master_client_->Remove(key);
 }
 
 ErrorCode Client::MountSegment(const std::string& segment_name,
@@ -290,13 +200,6 @@ ErrorCode Client::MountSegment(const std::string& segment_name,
         return ErrorCode::INVALID_PARAMS;
     }
 
-    mooncake_store::MountSegmentRequest request;
-    request.set_segment_name(segment_name);
-    request.set_buffer(reinterpret_cast<uint64_t>(buffer));
-    request.set_size(size);
-    mooncake_store::MountSegmentResponse response;
-    grpc::ClientContext context;
-
     int rc = transfer_engine_->registerLocalMemory((void*)buffer, size, "cpu:0",
                                                    true, true);
     if (rc != 0) {
@@ -305,10 +208,7 @@ ErrorCode Client::MountSegment(const std::string& segment_name,
         return ErrorCode::INVALID_PARAMS;
     }
 
-    grpc::Status status =
-        master_stub_->MountSegment(&context, request, &response);
-    ErrorCode err =
-        LogAndCheckRpcStatus(status, response, "MountSegment", request);
+    ErrorCode err = master_client_->MountSegment(segment_name, buffer, size);
     if (err != ErrorCode::OK) {
         return err;
     }
@@ -317,14 +217,7 @@ ErrorCode Client::MountSegment(const std::string& segment_name,
 }
 
 ErrorCode Client::UnmountSegment(const std::string& segment_name, void* addr) {
-    mooncake_store::UnmountSegmentRequest request;
-    request.set_segment_name(segment_name);
-    mooncake_store::UnmountSegmentResponse response;
-    grpc::ClientContext context;
-    grpc::Status status =
-        master_stub_->UnmountSegment(&context, request, &response);
-    ErrorCode err =
-        LogAndCheckRpcStatus(status, response, "UnmountSegment", request);
+    ErrorCode err = master_client_->UnmountSegment(segment_name);
     if (err != ErrorCode::OK) {
         return err;
     }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -1,0 +1,154 @@
+#include "master_client.h"
+
+#include <glog/logging.h>
+
+#include <chrono>
+#include <cstdint>
+
+namespace mooncake {
+
+// Template member method for executing RPC calls and handling results
+template <typename Req, typename Res, typename... Builders>
+ErrorCode MasterClient::ExecuteRpc(
+    const std::string& rpc_name,
+    grpc::Status (mooncake_store::MasterService::Stub::*method)(
+        grpc::ClientContext*, const Req&, Res*),
+    Res& response, Builders&&... builders) const {
+    // Build the request object
+    Req request;
+    (builders(request), ...);  // Use fold expression to apply all builders
+
+    // Log request start
+    auto start_time = std::chrono::steady_clock::now();
+    VLOG(1) << "[MasterClient] operation=RPC_START method=" << rpc_name
+            << " request=" << request.ShortDebugString();
+
+    // Execute RPC call
+    grpc::ClientContext context;
+    auto status = (master_stub_.get()->*method)(&context, request, &response);
+
+    // Calculate elapsed time
+    auto end_time = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
+                        end_time - start_time)
+                        .count();
+
+    // Handle errors
+    if (!status.ok()) {
+        LOG(ERROR) << "[MasterClient] operation=RPC_FAIL method=" << rpc_name
+                   << " grpc_code=" << status.error_code()
+                   << " latency_us=" << duration << " error_message=\""
+                   << status.error_message() << "\"";
+        return ErrorCode::RPC_FAIL;
+    }
+
+    // Log successful response
+    VLOG(1) << "[MasterClient] operation=RPC_DONE method=" << rpc_name
+            << " latency_us=" << duration
+            << " status_code=" << response.status_code();
+
+    // Convert and return error code
+    return fromInt(response.status_code());
+}
+
+MasterClient::MasterClient() : master_stub_(nullptr) {}
+
+MasterClient::~MasterClient() = default;
+
+ErrorCode MasterClient::Connect(const std::string& master_addr) {
+    auto channel =
+        grpc::CreateChannel(master_addr, grpc::InsecureChannelCredentials());
+    master_stub_ = mooncake_store::MasterService::NewStub(channel);
+    if (!master_stub_) {
+        LOG(ERROR) << "[MasterClient] operation=CONNECT status=FAILED "
+                      "error_message=\"Failed to create master service stub\"";
+        return ErrorCode::RPC_FAIL;
+    }
+    LOG(INFO)
+        << "[MasterClient] operation=CONNECT status=SUCCESS master_addr=\""
+        << master_addr << "\"";
+    return ErrorCode::OK;
+}
+
+ErrorCode MasterClient::GetReplicaList(
+    const std::string& object_key,
+    mooncake_store::GetReplicaListResponse& object_info) const {
+    auto err = ExecuteRpc(
+        "GetReplicaList", &mooncake_store::MasterService::Stub::GetReplicaList,
+        object_info, [&](auto& req) { req.set_key(object_key); });
+
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+
+    CHECK(object_info.replica_list().empty() == false);
+
+    return ErrorCode::OK;
+}
+
+ErrorCode MasterClient::PutStart(
+    const std::string& key, const std::vector<size_t>& slice_lengths,
+    size_t value_length, const ReplicateConfig& config,
+    mooncake_store::PutStartResponse& start_response) const {
+    return ExecuteRpc("PutStart",
+                      &mooncake_store::MasterService::Stub::PutStart,
+                      start_response, [&](auto& req) {
+                          req.set_key(key);
+                          req.set_value_length(value_length);
+                          for (const auto& length : slice_lengths) {
+                              req.add_slice_lengths(length);
+                          }
+                          auto* replica_config = req.mutable_config();
+                          replica_config->set_replica_num(config.replica_num);
+                      });
+}
+
+ErrorCode MasterClient::PutEnd(const std::string& key) const {
+    mooncake_store::PutEndResponse response;
+
+    return ExecuteRpc("PutEnd", &mooncake_store::MasterService::Stub::PutEnd,
+                      response, [&](auto& req) { req.set_key(key); });
+}
+
+ErrorCode MasterClient::PutRevoke(const std::string& key) const {
+    mooncake_store::PutRevokeResponse response;
+
+    return ExecuteRpc("PutRevoke",
+                      &mooncake_store::MasterService::Stub::PutRevoke, response,
+                      [&](auto& req) { req.set_key(key); });
+}
+
+ErrorCode MasterClient::Remove(const std::string& key) const {
+    mooncake_store::RemoveResponse response;
+
+    return ExecuteRpc("Remove", &mooncake_store::MasterService::Stub::Remove,
+                      response, [&](auto& req) { req.set_key(key); });
+}
+
+ErrorCode MasterClient::MountSegment(const std::string& segment_name,
+                                     const void* buffer, size_t size) const {
+    mooncake_store::MountSegmentResponse response;
+
+    return ExecuteRpc("MountSegment",
+                      &mooncake_store::MasterService::Stub::MountSegment,
+                      response, [&](auto& req) {
+                          req.set_segment_name(segment_name);
+                          req.set_buffer(reinterpret_cast<uintptr_t>(buffer));
+                          req.set_size(size);
+                      });
+}
+
+ErrorCode MasterClient::UnmountSegment(const std::string& segment_name) const {
+    mooncake_store::UnmountSegmentResponse response;
+
+    return ExecuteRpc(
+        "UnmountSegment", &mooncake_store::MasterService::Stub::UnmountSegment,
+        response, [&](auto& req) { req.set_segment_name(segment_name); });
+}
+
+ErrorCode MasterClient::IsExist(const std::string& key) const {
+    mooncake_store::GetReplicaListResponse object_info;
+    return GetReplicaList(key, object_info);
+}
+
+}  // namespace mooncake


### PR DESCRIPTION
Abstracting the RPC logic with the Master Service into the MasterClient streamlines the Client module. 

Further code reorganization within the Client module will follow.