### PR TITLE
[CI] Add spell check process to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,11 @@ jobs:
         cd mooncake-store/tests
         MC_METADATA_SERVER=http://127.0.0.1:8090/metadata python3 test_distributed_object_store.py
       shell: bash
+  spell-check:
+    name: Spell Check with Typos
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v4
+    - name: Spell Check Repo
+      uses: crate-ci/typos@v1.30.2

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ In order to install and use Mooncake, some preparation is required.
 - Linux-x86_64 with gcc, g++ (9.4+) and cmake (3.16+).
 - Python (3.10 or above)
 
-In addition, to support more features of Mooncake Transfer Engine, we *recommand* you to install the following components:
+In addition, to support more features of Mooncake Transfer Engine, we *recommend* you to install the following components:
 
 - CUDA 12.1 and above, including NVIDIA GPUDirect Storage Support, if you want to build with `-DUSE_CUDA`. You may install them from [here](https://developer.nvidia.com/cuda-downloads). 
   ```bash

--- a/doc/en/architecture.md
+++ b/doc/en/architecture.md
@@ -5,7 +5,7 @@ Mooncake aims to enhance the inference efficiency of large language models (LLMs
 Mooncake:
 - provides object-level data storage services
 - supports data replication in the cache layer, with a lightweight design due to not guaranteeing high availability
-- ensures the atomicity of object write operations, meaning a `Get` oepration will always read one consistent version, but not necessarily the latest one
+- ensures the atomicity of object write operations, meaning a `Get` operation will always read one consistent version, but not necessarily the latest one
 - supports striping and parallel I/O transfer for larger objects to utilize the aggregated bandwidth of multiple network cards
 - supports multiple modes for flushing slow object storage
 - supports dynamic addition and removal of cache resources

--- a/doc/en/transfer-engine.md
+++ b/doc/en/transfer-engine.md
@@ -58,7 +58,7 @@ The process involves identifying the appropriate local and target NICs based on 
 
 For instance, as illustrated in figure above, to transfer data from buffer 0 (assigned to cpu:0) in the local node to buffer 1 (assigned to cpu:1) in the target node, the engine first identifies the preferred NICs for cpu:0 using the local server's topology matrix and selects one, such as mlx5_1, as the local NIC. Similarly, the target NIC, such as mlx5_3, is selected based on the target memory address. This setup enables establishing an RDMA connection from mlx5_1@local to mlx5_3@target to carry out RDMA read and write operations.
 
-To further maximize bandwidth utilization, if a single request's transfer is internally divided into multiple slices if its length exeeds 16KB. 
+To further maximize bandwidth utilization, if a single request's transfer is internally divided into multiple slices if its length exceeds 16KB. 
 Each slice might use a different path, enabling collaborative work among all RDMA NICs.
 
 ### Endpoint Management

--- a/doc/en/vllm-benchmark-results-v0.1.md
+++ b/doc/en/vllm-benchmark-results-v0.1.md
@@ -204,7 +204,7 @@ P99 ITL (ms):                            2536.78
 ==================================================
 ```
 
-## Short prefill length with varing request rates: input_len=256, qps = 2, 4, 6, 8
+## Short prefill length with varying request rates: input_len=256, qps = 2, 4, 6, 8
 
 ### Non-disaggregated
 ```

--- a/doc/en/vllm-integration-v1.md
+++ b/doc/en/vllm-integration-v1.md
@@ -53,7 +53,7 @@ pip3 install -e .
   - Use `http` as backend: `"http://192.168.0.137:8080/metadata"`
 - "protocol": The protocol to be used for data transmission. ("rdma/tcp")
 - "device_name": The device to be used for data transmission, it is required when "protocol" is set to "rdma". If multiple NIC devices are used, they can be separated by commas such as "erdma_0,erdma_1". Please note that there are no spaces between them.
-- "master_server_address": The IP address and the port of the master deamon process of MooncakeStore.
+- "master_server_address": The IP address and the port of the master daemon process of MooncakeStore.
 ### Prepare configuration file to Run Example over TCP
 
 - Prepare a _**mooncake.json**_ file for both Prefill and Decode instances

--- a/doc/zh/mooncake-store-preview.md
+++ b/doc/zh/mooncake-store-preview.md
@@ -542,7 +542,7 @@ Master service listening on 0.0.0.0:50051
 ### 启动验证程序
 Mooncake Store 提供了多种验证程序，包括基于 C++ 和 Python 等接口形态。下面以 `stress_cluster_benchmark` 为例介绍一下如何运行。
 
-1. 打开 `stress_cluster_benchmar.py`，结合网络情况修改初始化代码，重点是 local_hostname（对应本机 IP 地址）、metadata_server（对应 Transfer Engine 元数据服务）、master_server_address（对应 Master Service 地址及端口）等：
+1. 打开 `stress_cluster_benchmark.py`，结合网络情况修改初始化代码，重点是 local_hostname（对应本机 IP 地址）、metadata_server（对应 Transfer Engine 元数据服务）、master_server_address（对应 Master Service 地址及端口）等：
 ```python
 import os
 import time

--- a/doc/zh/mooncake-store.md
+++ b/doc/zh/mooncake-store.md
@@ -80,7 +80,7 @@ Mooncake Store 采用分层架构设计，架构自顶向下分为：`Distribute
 TaskID DistributedObjectStore::put(ObjectKey key,std::vector<void *> ptrs,std::vector<void *> sizes,ReplicateConfig config)
 ```
 
-用于将指定对象放入到 objectstore 中, 根据`config`中的`replica_num`，调用`ReplicaAlloctor::addOneReplica` 创建对应副本，并通过`TransferEngine` 将数据写入对应节点
+用于将指定对象放入到 objectstore 中, 根据`config`中的`replica_num`，调用`ReplicaAllocator::addOneReplica` 创建对应副本，并通过`TransferEngine` 将数据写入对应节点
 
 2. get 操作
 ```C++

--- a/doc/zh/transfer-engine.md
+++ b/doc/zh/transfer-engine.md
@@ -270,7 +270,7 @@ int unregisterLocalMemory(void *addr);
 
 ### Segment 管理与元数据格式
 
-TranferEngine 提供 `openSegment` 函数，该函数获取一个 `SegmentHandle`，用于后续 `Transport` 的传输。
+TransferEngine 提供 `openSegment` 函数，该函数获取一个 `SegmentHandle`，用于后续 `Transport` 的传输。
 ```cpp
 SegmentHandle openSegment(const std::string& segment_name);
 ```

--- a/mooncake-p2p-store/src/example/p2p-store-example.go
+++ b/mooncake-p2p-store/src/example/p2p-store-example.go
@@ -164,20 +164,20 @@ func doInferencer(ctx context.Context, store *p2pstore.P2PStore, name string) {
 		os.Exit(1)
 	}
 
-	fmt.Println("Object retrival started: name", name)
+	fmt.Println("Object retrieval started: name", name)
 	startTimestamp := time.Now()
 	addrList := []uintptr{uintptr(unsafe.Pointer(&addr[0]))}
 	sizeList := []uint64{uint64(fileSize)}
 	err = store.GetReplica(ctx, name, addrList, sizeList)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Object retrival failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Object retrieval failed: %v\n", err)
 		os.Exit(1)
 	}
 
 	phaseOneTimestamp := time.Now()
 	duration := phaseOneTimestamp.Sub(startTimestamp).Milliseconds()
 
-	fmt.Printf("Object retrival done: duration (ms) %d throughput (GB/s) %.2f\n",
+	fmt.Printf("Object retrieval done: duration (ms) %d throughput (GB/s) %.2f\n",
 		duration,
 		float64(fileSizeMB)/float64(duration))
 

--- a/mooncake-p2p-store/src/p2pstore/core.go
+++ b/mooncake-p2p-store/src/p2pstore/core.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 )
 
-// When the data size larger than MAX_CHUNK_SIZE bytes, we split them into multiple buffers and registered seperately.
+// When the data size larger than MAX_CHUNK_SIZE bytes, we split them into multiple buffers and registered separately.
 // Warning: Memory registration is a SLOW operation.
 // MAX_CHUNK_SIZE must be an integer power of 2.
 // maxShardSize must be an integer power of 2, divisible by MAX_CHUNK_SIZE.

--- a/mooncake-store/include/cachelib_memory_allocator/AllocationClass.h
+++ b/mooncake-store/include/cachelib_memory_allocator/AllocationClass.h
@@ -68,7 +68,7 @@ class AllocationClass {
     }
 
     // Whether the pool is full or free to allocate more in the current state.
-    // This is only a hint and not a gurantee that subsequent allocate will
+    // This is only a hint and not a guarantee that subsequent allocate will
     // fail/succeed.
     bool isFull() const noexcept { return !canAllocate_; }
 
@@ -228,7 +228,7 @@ class AllocationClass {
     // @return  SlabReleaseContext
     //          isReleased == true means the slab is already released
     //          as there was no active allocation to be freed. If not, the
-    //          caller is responsible for ensuring that all active alocations
+    //          caller is responsible for ensuring that all active allocations
     //          returned by getActiveAllocs are freed back and
     //
     // @throw std::invalid_argument if the hint is invalid.
@@ -320,7 +320,7 @@ class AllocationClass {
     void waitUntilAllFreed(const Slab* slab);
 
     // return the allocation's index into the slab. It is the caller's
-    // reponsibility to ensure that the alloc belongs to the slab and is valid.
+    // responsibility to ensure that the alloc belongs to the slab and is valid.
     size_t getAllocIdx(const Slab* slab, void* alloc) const noexcept;
 
     // return the allocation pointer into the slab for a given index.
@@ -425,7 +425,7 @@ class AllocationClass {
 
     // stores the list of outstanding allocations for a given slab. This is
     // created when we start a slab release process and if there are any active
-    // allocaitons need to be marked as free.
+    // allocations need to be marked as free.
     std::unordered_map<uintptr_t, std::vector<bool>> slabReleaseAllocMap_;
 
     // Starting releasing a slab is serialized across threads.
@@ -441,7 +441,7 @@ class AllocationClass {
     // This is needed to avoid other threads from starving for lock.
     static constexpr unsigned int kFreeAllocsPruneSleepMicroSecs = 1000;
 
-    // Numer of allocations ahead to prefetch when iterating over each
+    // Number of allocations ahead to prefetch when iterating over each
     // allocation in a slab.
     static constexpr unsigned int kForEachAllocPrefetchOffset = 16;
 };

--- a/mooncake-store/include/cachelib_memory_allocator/MemoryAllocator.h
+++ b/mooncake-store/include/cachelib_memory_allocator/MemoryAllocator.h
@@ -207,7 +207,7 @@ class MemoryAllocator {
     // Check if the slab has all its active allocations freed.
     //
     // @param ctx context returned by startSlabRelease.
-    // @return    true if all allocs have been freed back to the allcoator
+    // @return    true if all allocs have been freed back to the allocator
     //            false otherwise
     //
     // @throw std::invalid_argument if the pool id or allocation class id

--- a/mooncake-store/include/cachelib_memory_allocator/Slab.h
+++ b/mooncake-store/include/cachelib_memory_allocator/Slab.h
@@ -48,7 +48,7 @@ namespace cachelib {
  * The info about which memory pool and allocation class a slab is being used
  * for is stored in the slab header. The slab header is not located within the
  * slab, but is managed and the mapping of Slab to its header is maintained
- * independantly by the SlabAllocator.
+ * independently by the SlabAllocator.
  */
 
 // identifier for the memory tier
@@ -123,7 +123,7 @@ struct CACHELIB_PACKED_ATTR SlabHeader {
     SlabHeader(PoolId pid, ClassId cid, uint32_t size)
         : poolId(pid), classId(cid), allocSize(size) {}
 
-    // This doesn't reset the flags. That's done explcitly by calling
+    // This doesn't reset the flags. That's done explicitly by calling
     // setFlag/unsetFlag above.
     void resetAllocInfo() {
         poolId = Slab::kInvalidPoolId;

--- a/mooncake-store/include/cachelib_memory_allocator/SlabAllocator.h
+++ b/mooncake-store/include/cachelib_memory_allocator/SlabAllocator.h
@@ -44,7 +44,7 @@ class SlabAllocator {
                 void* slabMemoryStart,
                 size_t slabMemorySize);
 
-  // free up and unmap the mmaped memory if the allocator was created with
+  // free up and unmap the mapped memory if the allocator was created with
   // one.
   ~SlabAllocator();
 
@@ -90,7 +90,7 @@ class SlabAllocator {
   // invalid
   SlabHeader* getSlabHeader(const Slab* const slab) const noexcept;
 
-  // returns ture if ptr points to memory in the slab and the slab is a valid
+  // returns true if ptr points to memory in the slab and the slab is a valid
   // slab, false otherwise.
   bool isMemoryInSlab(const void* ptr, const Slab* slab) const noexcept;
 

--- a/mooncake-store/include/cachelib_memory_allocator/fake_include/folly/logging/xlog.h
+++ b/mooncake-store/include/cachelib_memory_allocator/fake_include/folly/logging/xlog.h
@@ -248,7 +248,7 @@
 
 /**
  * Similar to XLOG(...) except it logs a message if the condition predicate
- * evalutes to true or approximately every @param n invocations
+ * evaluates to true or approximately every @param n invocations
  *
  * The internal counter is process-global and threadsafe but, to
  * to avoid the performance degradation of atomic-rmw operations,
@@ -421,7 +421,7 @@
  * - We want to make sure this macro is safe to use even from inside static
  *   initialization code that runs before main.  We also want to make the log
  *   admittance check as cheap as possible, so that disabled debug logs have
- *   minimal overhead, and can be left in place even in performance senstive
+ *   minimal overhead, and can be left in place even in performance sensitive
  *   code.
  *
  *   In order to do this, we rely on zero-initialization of variables with
@@ -645,7 +645,7 @@
 #ifdef __INCLUDE_LEVEL__
 #define XLOG_IS_IN_HEADER_FILE bool(__INCLUDE_LEVEL__ > 0)
 #else
-// Without __INCLUDE_LEVEL__ we canot tell if we are in a header file or not,
+// Without __INCLUDE_LEVEL__ we cannot tell if we are in a header file or not,
 // and must pessimstically assume we are always in a header file.
 #define XLOG_IS_IN_HEADER_FILE true
 #endif

--- a/mooncake-store/include/cachelib_memory_allocator/include/fmt/os.h
+++ b/mooncake-store/include/cachelib_memory_allocator/include/fmt/os.h
@@ -292,7 +292,7 @@ class file {
   // Possible values for the oflag argument to the constructor.
   enum {
     RDONLY = FMT_POSIX(O_RDONLY),  // Open for reading only.
-    WRONLY = FMT_POSIX(O_WRONLY),  // Open for writing only.
+    WRONGLY = FMT_POSIX(O_WRONLY),  // Open for writing only.
     RDWR = FMT_POSIX(O_RDWR),      // Open for reading and writing.
     CREATE = FMT_POSIX(O_CREAT),   // Create if the file doesn't exist.
     APPEND = FMT_POSIX(O_APPEND),  // Open in append mode.
@@ -375,7 +375,7 @@ struct buffer_size {
 };
 
 struct ostream_params {
-  int oflag = file::WRONLY | file::CREATE | file::TRUNC;
+  int oflag = file::WRONGLY | file::CREATE | file::TRUNC;
   size_t buffer_size = BUFSIZ > 32768 ? BUFSIZ : 32768;
 
   ostream_params() {}
@@ -450,7 +450,7 @@ class FMT_API ostream final : private detail::buffer<char> {
 
   * ``<integer>``: Flags passed to `open
     <https://pubs.opengroup.org/onlinepubs/007904875/functions/open.html>`_
-    (``file::WRONLY | file::CREATE`` by default)
+    (``file::WRONGLY | file::CREATE`` by default)
   * ``buffer_size=<integer>``: Output buffer size
 
   **Example**::

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -30,10 +30,10 @@ BufHandle::~BufHandle() {
     }
 }
 
-BufferAllocator::BufferAllocator(std::string segmetn_name, size_t base,
+BufferAllocator::BufferAllocator(std::string segment_name, size_t base,
                                  size_t size)
-    : segment_name_(segmetn_name), base_(base), total_size_(size) {
-    VLOG(1) << "initializing_buffer_allocator segment_name=" << segmetn_name
+    : segment_name_(segment_name), base_(base), total_size_(size) {
+    VLOG(1) << "initializing_buffer_allocator segment_name=" << segment_name
             << " base_address=" << reinterpret_cast<void*>(base)
             << " size=" << size;
 

--- a/mooncake-store/src/cachelib_memory_allocator/MemoryPool.cpp
+++ b/mooncake-store/src/cachelib_memory_allocator/MemoryPool.cpp
@@ -40,7 +40,7 @@ MemoryPool::MemoryPool(PoolId id,
 void MemoryPool::checkState() const {
   if (id_ < 0) {
     throw std::invalid_argument(
-        fmt::format("Invaild MemoryPool id {}", id_));
+        fmt::format("Invalid MemoryPool id {}", id_));
   }
 
   const size_t currAlloc = currAllocSize_;

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -209,7 +209,7 @@ ErrorCode Client::Put(const ObjectKey& key, std::vector<Slice>& slices,
         LogAndCheckRpcStatus(status, start_response, "PutStart", start_request);
     if (err != ErrorCode::OK) {
         if (err == ErrorCode::OBJECT_ALREADY_EXISTS) {
-            LOG(INFO) << "object_alredy_exists key=" << key;
+            LOG(INFO) << "object_already_exists key=" << key;
             return ErrorCode::OK;
         }
         return err;

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -407,7 +407,7 @@ void check_total_buffer_size() {
     uint64_t require_size = FLAGS_block_size * FLAGS_batch_size * FLAGS_threads;
     if (FLAGS_buffer_size < require_size) {
         FLAGS_buffer_size = require_size;
-        LOG(WARNING) << "Invalid flag: buffer size is samller than "
+        LOG(WARNING) << "Invalid flag: buffer size is smaller than "
                         "require_size, adjust to "
                      << require_size;
     }

--- a/mooncake-transfer-engine/include/common/base/status.h
+++ b/mooncake-transfer-engine/include/common/base/status.h
@@ -48,7 +48,7 @@ class Status final {
     kNuma = 300,
     kClock = 301,
     kMemory = 302,
-    kNotImplmented = 999,
+    kNotImplemented = 999,
     kMaxCode
   };
 
@@ -162,9 +162,9 @@ class Status final {
     return Code::kMemory == code_;
   }
 
-  // Returns true iff the status indicates a NotImplmented error.
-  [[nodiscard]] bool IsNotImplmented() const {
-    return Code::kNotImplmented == code_;
+  // Returns true iff the status indicates a NotImplemented error.
+  [[nodiscard]] bool IsNotImplemented() const {
+    return Code::kNotImplemented == code_;
   }
 
   // Return a combination of the error code name and message.
@@ -223,8 +223,8 @@ class Status final {
   static Status Memory(std::string_view msg) {
     return Status(Code::kMemory, msg);
   }
-  static Status NotImplmented(std::string_view msg) {
-    return Status(Code::kNotImplmented, msg);
+  static Status NotImplemented(std::string_view msg) {
+    return Status(Code::kNotImplemented, msg);
   }
 
   // Return a human-readable name of the 'code'.

--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -47,14 +47,14 @@ class TcpTransport : public Transport {
     ~TcpTransport();
 
     Status submitTransfer(BatchID batch_id,
-                       const std::vector<TransferRequest> &entries) override;
+                          const std::vector<TransferRequest> &entries) override;
 
     Status submitTransferTask(
         const std::vector<TransferRequest *> &request_list,
         const std::vector<TransferTask *> &task_list) override;
 
     Status getTransferStatus(BatchID batch_id, size_t task_id,
-                          TransferStatus &status) override;
+                             TransferStatus &status) override;
 
    private:
     int install(std::string &local_server_name,

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -165,7 +165,7 @@ class Transport {
     virtual Status submitTransferTask(
         const std::vector<TransferRequest *> &request_list,
         const std::vector<TransferTask *> &task_list) {
-        return Status::NotImplmented(
+        return Status::NotImplemented(
             "Transport::submitTransferTask is not implemented");
     }
 

--- a/mooncake-transfer-engine/src/common/base/status.cpp
+++ b/mooncake-transfer-engine/src/common/base/status.cpp
@@ -83,8 +83,8 @@ std::string_view Status::CodeToString(Status::Code code) {
       return "Clock";
     case Code::kMemory:
       return "Memory";
-    case Code::kNotImplmented:
-      return "NotImplmented";
+    case Code::kNotImplemented:
+      return "NotImplemented";
     default:
       LOG(ERROR) << "Unknown code: " << static_cast<uint16_t>(code);
       return "UnknownCode";

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -80,7 +80,7 @@ TEST_F(TransferMetadataTest, LocalSegmentTest) {
 // add and remove LocalMemoryBufferMeta
 TEST_F(TransferMetadataTest, LocalMemoryBufferTest) {
     auto segment_des = std::make_shared<TransferMetadata::SegmentDesc>();
-    segment_des->name = "test_localMemery";
+    segment_des->name = "test_localMemory";
     segment_des->protocol = "rdma";
     int re = metadata_client->addLocalSegment(
         LOCAL_SEGMENT_ID, "test_local_segment", std::move(segment_des));


### PR DESCRIPTION
Future plans include integrating the clang-format process to enforce a consistent code style across the project. Should we also include clang-tidy in the futurer?