### PR TITLE
[TransferEngine] Add shared memory transport and refactor metadata format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ if (NOT USE_ETCD AND NOT USE_REDIS AND NOT USE_HTTP)
 endif()
 
 add_subdirectory(mooncake-transfer-engine)
+add_subdirectory(mooncake-ngxl-exp)
 
 include_directories(mooncake-transfer-engine/include)
 

--- a/mooncake-ngxl-exp/CMakeLists.txt
+++ b/mooncake-ngxl-exp/CMakeLists.txt
@@ -1,0 +1,5 @@
+include_directories(include)
+add_subdirectory(include)
+add_subdirectory(src)
+add_subdirectory(tests)
+add_subdirectory(example)

--- a/mooncake-ngxl-exp/README.md
+++ b/mooncake-ngxl-exp/README.md
@@ -1,0 +1,4 @@
+# Mooncake Next-Generation Transfer Engine (NGXL)
+
+This directory contains Mooncake Next-Generation Transfer Engine (NGXL), and the APIs are UNSTABLE.
+Caution if you want to use it in production.

--- a/mooncake-ngxl-exp/example/CMakeLists.txt
+++ b/mooncake-ngxl-exp/example/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(ngxl_bench transfer_engine_bench.cpp)
+target_link_libraries(ngxl_bench PUBLIC ngxl)
+
+add_executable(ngxl_memory_pool memory_pool.cpp)
+target_link_libraries(ngxl_memory_pool PUBLIC ngxl)

--- a/mooncake-ngxl-exp/example/http-metadata-server/go.mod
+++ b/mooncake-ngxl-exp/example/http-metadata-server/go.mod
@@ -1,0 +1,34 @@
+module github.com/kvcache-ai/Mooncake/mooncake-transfer-engine/example/http-metadata-server
+
+go 1.22.9
+
+require github.com/gin-gonic/gin v1.10.0
+
+require (
+	github.com/bytedance/sonic v1.11.6 // indirect
+	github.com/bytedance/sonic/loader v0.1.1 // indirect
+	github.com/cloudwego/base64x v0.1.4 // indirect
+	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.20.0 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ugorji/go/codec v1.2.12 // indirect
+	golang.org/x/arch v0.8.0 // indirect
+	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/net v0.36.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/text v0.22.0 // indirect
+	google.golang.org/protobuf v1.34.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/mooncake-ngxl-exp/example/http-metadata-server/main.go
+++ b/mooncake-ngxl-exp/example/http-metadata-server/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"flag"
+	"net/http"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+)
+
+const jsonContentType = "application/json; charset=utf-8"
+
+type MetadataStore struct {
+	store sync.Map
+}
+
+var (
+	metadataStore = MetadataStore{}
+)
+
+func (m *MetadataStore) Get(key string) ([]byte, bool) {
+	value, ok := m.store.Load(key)
+	if !ok {
+		return nil, false
+	}
+	return value.([]byte), true
+}
+
+func (m *MetadataStore) Set(key string, value []byte) {
+	m.store.Store(key, value)
+}
+
+func (m *MetadataStore) Delete(key string) {
+	m.store.Delete(key)
+}
+
+func getQueryKey(c *gin.Context) string {
+	return c.Request.URL.Query().Get("key")
+}
+
+func getMetadata(c *gin.Context) {
+	key := getQueryKey(c)
+	value, ok := metadataStore.Get(key)
+	if !ok {
+		c.Data(http.StatusNotFound, jsonContentType, []byte(`metadata not found`))
+		return
+	}
+	c.Data(http.StatusOK, jsonContentType, value)
+}
+
+func putMetadata(c *gin.Context) {
+	key := getQueryKey(c)
+	value, err := c.GetRawData()
+	if err != nil {
+		c.Data(http.StatusBadRequest, jsonContentType, []byte(`invalid request`))
+		return
+	}
+	metadataStore.Set(key, value)
+	c.Data(http.StatusOK, jsonContentType, []byte(`metadata updated`))
+}
+
+func deleteMetadata(c *gin.Context) {
+	key := getQueryKey(c)
+	metadataStore.Delete(key)
+	c.Data(http.StatusOK, jsonContentType, []byte(`metadata deleted`))
+}
+
+func main() {
+	address := flag.String("addr", ":8080", "HTTP server address (default :8080)")
+	flag.Parse()
+
+	r := gin.Default()
+
+	r.GET("/metadata", getMetadata)
+	r.PUT("/metadata", putMetadata)
+	r.DELETE("/metadata", deleteMetadata)
+
+	r.Run(*address)
+}

--- a/mooncake-ngxl-exp/example/memory_pool.cpp
+++ b/mooncake-ngxl-exp/example/memory_pool.cpp
@@ -1,0 +1,114 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <sys/time.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+
+#include "transfer_engine.h"
+#include "transport/transport.h"
+
+#define NR_SOCKETS (1)
+#define BASE_ADDRESS_HINT (0x40000000000)
+
+static std::string getHostname() {
+    char hostname[256];
+    if (gethostname(hostname, 256)) {
+        PLOG(ERROR) << "Failed to get hostname";
+        return "";
+    }
+    return hostname;
+}
+
+DEFINE_string(local_server_name, getHostname(),
+              "Local server name for segment discovery");
+DEFINE_string(metadata_server, "192.168.3.77:2379", "etcd server host address");
+DEFINE_string(device_name, "mlx5_2", "Device name to use");
+DEFINE_string(nic_priority_matrix, "",
+              "Path to NIC priority matrix file (Advanced)");
+
+using namespace mooncake;
+
+static void *allocateMemoryPool(size_t size, int socket_id) {
+    void *start_addr;
+    start_addr = mmap((void *)BASE_ADDRESS_HINT, size, PROT_READ | PROT_WRITE,
+                      MAP_ANON | MAP_PRIVATE, -1, 0);
+    if (start_addr != (void *)BASE_ADDRESS_HINT) {
+        PLOG(ERROR) << "Failed to allocate memory on specified address";
+        exit(1);
+    }
+    return start_addr;
+}
+
+static void freeMemoryPool(void *addr, size_t size) { munmap(addr, size); }
+
+std::string loadNicPriorityMatrix() {
+    if (!FLAGS_nic_priority_matrix.empty()) {
+        std::ifstream file(FLAGS_nic_priority_matrix);
+        if (file.is_open()) {
+            std::string content((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+            file.close();
+            return content;
+        }
+    }
+    return "{\"cpu:0\": [[\"" + FLAGS_device_name + "\"], []], " +
+           "\"cpu:1\": [[\"" + FLAGS_device_name + "\"], []]}";
+}
+
+int target() {
+    auto nic_priority_matrix = loadNicPriorityMatrix();
+
+    const size_t dram_buffer_size = 1ull << 30;
+    // disable topology auto discovery for testing.
+    auto engine = std::make_unique<TransferEngine>(false);
+
+    void **args = (void **)malloc(2 * sizeof(void *));
+    args[0] = (void *)nic_priority_matrix.c_str();
+    args[1] = nullptr;
+
+    const std::string &connectable_name = FLAGS_local_server_name;
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
+                 connectable_name.c_str(), 12345);
+    engine->installTransport("rdma", args);
+
+    LOG_ASSERT(engine);
+
+    void *addr[2] = {nullptr};
+    for (int i = 0; i < NR_SOCKETS; ++i) {
+        addr[i] = allocateMemoryPool(dram_buffer_size, i);
+        int rc = engine->registerLocalMemory(addr[i], dram_buffer_size,
+                                             "cpu:" + std::to_string(i));
+        LOG_ASSERT(!rc);
+    }
+
+    while (true) sleep(1);
+
+    for (int i = 0; i < NR_SOCKETS; ++i) {
+        engine->unregisterLocalMemory(addr[i]);
+        freeMemoryPool(addr[i], dram_buffer_size);
+    }
+
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+    return target();
+}

--- a/mooncake-ngxl-exp/example/transfer_engine_bench.cpp
+++ b/mooncake-ngxl-exp/example/transfer_engine_bench.cpp
@@ -1,0 +1,427 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <sys/time.h>
+
+#include <signal.h>
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <unordered_map>
+
+#include "common/base/status.h"
+#include "transfer_engine.h"
+#include "transport/transport.h"
+
+#ifdef USE_CUDA
+#include <bits/stdint-uintn.h>
+#include <cuda_runtime.h>
+
+#ifdef USE_NVMEOF
+#include <cufile.h>
+#endif
+
+#include <cassert>
+
+static void checkCudaError(cudaError_t result, const char *message) {
+    if (result != cudaSuccess) {
+        LOG(ERROR) << message << " (Error code: " << result << " - "
+                   << cudaGetErrorString(result) << ")" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+#endif
+
+const static int NR_SOCKETS =
+    numa_available() == 0 ? numa_num_configured_nodes() : 1;
+
+static std::string getHostname();
+
+DEFINE_string(local_server_name, getHostname(),
+              "Local server name for segment discovery");
+DEFINE_string(metadata_server, "192.168.3.77:2379", "etcd server host address");
+DEFINE_string(mode, "initiator",
+              "Running mode: initiator or target. Initiator node read/write "
+              "data blocks from target node");
+DEFINE_string(operation, "read", "Operation type: read or write");
+
+DEFINE_string(protocol, "rdma", "Transfer protocol: rdma|tcp");
+
+DEFINE_string(device_name, "mlx5_2",
+              "Device name to use, valid if protocol=rdma");
+DEFINE_string(nic_priority_matrix, "",
+              "Path to RDMA NIC priority matrix file (Advanced)");
+
+DEFINE_string(segment_id, "192.168.3.76", "Segment ID to access data");
+DEFINE_uint64(buffer_size, 1ull << 30, "total size of data buffer");
+DEFINE_int32(batch_size, 128, "Batch size");
+DEFINE_uint64(block_size, 4096, "Block size for each transfer request");
+DEFINE_int32(duration, 10, "Test duration in seconds");
+DEFINE_int32(threads, 4, "Task submission threads");
+DEFINE_bool(auto_discovery, false, "Enable auto discovery");
+DEFINE_string(report_unit, "GB", "Report unit: GB|GiB|Gb|MB|MiB|Mb|KB|KiB|Kb");
+DEFINE_uint32(report_precision, 2, "Report precision");
+
+#ifdef USE_CUDA
+DEFINE_bool(use_vram, true, "Allocate memory from GPU VRAM");
+DEFINE_int32(gpu_id, 0, "GPU ID to use");
+#endif
+
+using namespace mooncake;
+
+static std::string getHostname() {
+    char hostname[256];
+    if (gethostname(hostname, 256)) {
+        PLOG(ERROR) << "Failed to get hostname";
+        return "";
+    }
+    return hostname;
+}
+
+static void *allocateMemoryPool(size_t size, int socket_id,
+                                bool from_vram = false) {
+#ifdef USE_CUDA
+    if (from_vram) {
+        int gpu_id = FLAGS_gpu_id;
+        void *d_buf;
+        checkCudaError(cudaSetDevice(gpu_id), "Failed to set device");
+        checkCudaError(cudaMalloc(&d_buf, size),
+                       "Failed to allocate device memory");
+        return d_buf;
+    }
+#endif
+    return numa_alloc_onnode(size, socket_id);
+}
+
+static void freeMemoryPool(void *addr, size_t size) {
+#ifdef USE_CUDA
+    // check pointer on GPU
+    cudaPointerAttributes attributes;
+    checkCudaError(cudaPointerGetAttributes(&attributes, addr),
+                   "Failed to get pointer attributes");
+
+    if (attributes.type == cudaMemoryTypeDevice) {
+        cudaFree(addr);
+    } else if (attributes.type == cudaMemoryTypeHost ||
+               attributes.type == cudaMemoryTypeUnregistered) {
+        numa_free(addr, size);
+    } else {
+        LOG(ERROR) << "Unknown memory type, " << addr << " " << attributes.type;
+    }
+#else
+    numa_free(addr, size);
+#endif
+}
+
+const static std::unordered_map<std::string, uint64_t> RATE_UNIT_MP = {
+    {"GB", 1000ull * 1000ull * 1000ull},
+    {"GiB", 1ull << 30},
+    {"Gb", 1000ull * 1000ull * 1000ull / 8},
+    {"MB", 1000ull * 1000ull},
+    {"MiB", 1ull << 20},
+    {"Mb", 1000ull * 1000ull / 8},
+    {"KB", 1000ull},
+    {"KiB", 1ull << 10},
+    {"Kb", 1000ull / 8}};
+
+static inline std::string calculateRate(uint64_t data_bytes, double duration) {
+    if (std::fabs(duration) < 1e-10) {
+        LOG(ERROR) << "Invalid args: duration shouldn't be 0";
+        return "";
+    }
+    if (!RATE_UNIT_MP.count(FLAGS_report_unit)) {
+        LOG(WARNING) << "Invalid flag: report_unit only support "
+                        "GB|GiB|Gb|MB|MiB|Mb|KB|KiB|Kb, not support "
+                     << FLAGS_report_unit
+                     << " . Now use GB(default) as report_unit";
+        FLAGS_report_unit = "GB";
+    }
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(FLAGS_report_precision)
+        << 1.0 * data_bytes / duration / RATE_UNIT_MP.at(FLAGS_report_unit)
+        << " " << FLAGS_report_unit << "/s";
+    return oss.str();
+}
+
+volatile bool running = true;
+std::atomic<size_t> total_batch_count(0);
+
+Status initiatorWorker(TransferEngine *engine, SegmentID segment_id, int thread_id,
+                    void *addr) {
+    bindToSocket(thread_id % NR_SOCKETS);
+    TransferRequest::OpCode opcode;
+    if (FLAGS_operation == "read")
+        opcode = TransferRequest::READ;
+    else if (FLAGS_operation == "write")
+        opcode = TransferRequest::WRITE;
+    else {
+        LOG(ERROR) << "Unsupported operation: must be 'read' or 'write'";
+        exit(EXIT_FAILURE);
+    }
+
+    auto segment_desc = engine->getMetadata()->getSegmentDescByID(segment_id);
+    if (!segment_desc) {
+        LOG(ERROR) << "Unable to get target segment ID, please recheck";
+        exit(EXIT_FAILURE);
+    }
+    uint64_t remote_base =
+        (uint64_t)segment_desc->memory.buffers[thread_id % NR_SOCKETS].addr;
+
+    size_t batch_count = 0;
+    while (running) {
+        auto batch_id = engine->allocateBatchID(FLAGS_batch_size);
+        Status s;
+        std::vector<TransferRequest> requests;
+        for (int i = 0; i < FLAGS_batch_size; ++i) {
+            TransferRequest entry;
+            entry.opcode = opcode;
+            entry.length = FLAGS_block_size;
+            entry.source = (uint8_t *)(addr) +
+                           FLAGS_block_size * (i * FLAGS_threads + thread_id);
+            entry.target_id = segment_id;
+            entry.target_offset =
+                remote_base +
+                FLAGS_block_size * (i * FLAGS_threads + thread_id);
+            requests.emplace_back(entry);
+        }
+
+        s = engine->submitTransfer(batch_id, requests);
+        LOG_ASSERT(s.ok());
+        for (int task_id = 0; task_id < FLAGS_batch_size; ++task_id) {
+            bool completed = false;
+            TransferStatus status;
+            while (!completed) {
+                Status s = engine->getTransferStatus(batch_id, task_id, status);
+                LOG_ASSERT(s.ok());
+                if (status.s == TransferStatusEnum::COMPLETED)
+                    completed = true;
+                else if (status.s == TransferStatusEnum::FAILED) {
+                    LOG(INFO) << "FAILED";
+                    completed = true;
+                    exit(EXIT_FAILURE);
+                }
+            }
+        }
+
+        s = engine->freeBatchID(batch_id);
+        LOG_ASSERT(s.ok());
+        batch_count++;
+    }
+    LOG(INFO) << "Worker " << thread_id << " stopped!";
+    total_batch_count.fetch_add(batch_count);
+    return Status::OK();
+}
+
+std::string formatDeviceNames(const std::string &device_names) {
+    std::stringstream ss(device_names);
+    std::string item;
+    std::vector<std::string> tokens;
+    while (getline(ss, item, ',')) {
+        tokens.push_back(item);
+    }
+
+    std::string formatted;
+    for (size_t i = 0; i < tokens.size(); ++i) {
+        formatted += "\"" + tokens[i] + "\"";
+        if (i < tokens.size() - 1) {
+            formatted += ",";
+        }
+    }
+    return formatted;
+}
+
+std::string loadNicPriorityMatrix() {
+    if (!FLAGS_nic_priority_matrix.empty()) {
+        std::ifstream file(FLAGS_nic_priority_matrix);
+        if (file.is_open()) {
+            std::string content((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+            file.close();
+            return content;
+        }
+    }
+    // Build JSON Data
+    auto device_names = formatDeviceNames(FLAGS_device_name);
+    return "{\"cpu:0\": [[" + device_names +
+           "], []], "
+           " \"cpu:1\": [[" +
+           device_names +
+           "], []], "
+           " \"cuda:0\": [[" +
+           device_names + "], []]}";
+}
+
+int initiator() {
+    // disable topology auto discovery for testing.
+    auto engine = std::make_unique<TransferEngine>(FLAGS_auto_discovery);
+
+    auto hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
+                 hostname_port.first.c_str(), hostname_port.second);
+
+    if (!FLAGS_auto_discovery) {
+        Transport *xport = nullptr;
+        if (FLAGS_protocol == "rdma") {
+            auto nic_priority_matrix = loadNicPriorityMatrix();
+            void **args = (void **)malloc(2 * sizeof(void *));
+            args[0] = (void *)nic_priority_matrix.c_str();
+            args[1] = nullptr;
+            xport = engine->installTransport("rdma", args);
+        } else if (FLAGS_protocol == "tcp") {
+            xport = engine->installTransport("tcp", nullptr);
+        } else {
+            LOG(ERROR) << "Unsupported protocol";
+        }
+        LOG_ASSERT(xport);
+    }
+
+    std::vector<void *> addr(NR_SOCKETS, nullptr);
+    int buffer_num = NR_SOCKETS;
+
+#ifdef USE_CUDA
+    buffer_num = FLAGS_use_vram ? 1 : NR_SOCKETS;
+    if (FLAGS_use_vram) LOG(INFO) << "VRAM is used";
+    for (int i = 0; i < buffer_num; ++i) {
+        addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
+        std::string name_prefix = FLAGS_use_vram ? "cuda:" : "cpu:";
+        int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
+                                             name_prefix + std::to_string(i));
+        LOG_ASSERT(!rc);
+    }
+#else
+    for (int i = 0; i < buffer_num; ++i) {
+        addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
+        int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
+                                             "cpu:" + std::to_string(i));
+        LOG_ASSERT(!rc);
+    }
+#endif
+
+    auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
+
+    std::thread workers[FLAGS_threads];
+
+    struct timeval start_tv, stop_tv;
+    gettimeofday(&start_tv, nullptr);
+
+    for (int i = 0; i < FLAGS_threads; ++i)
+        workers[i] = std::thread(initiatorWorker, engine.get(), segment_id, i,
+                                 addr[i % buffer_num]);
+
+    sleep(FLAGS_duration);
+    running = false;
+
+    for (int i = 0; i < FLAGS_threads; ++i) workers[i].join();
+
+    gettimeofday(&stop_tv, nullptr);
+    auto duration = (stop_tv.tv_sec - start_tv.tv_sec) +
+                    (stop_tv.tv_usec - start_tv.tv_usec) / 1000000.0;
+    auto batch_count = total_batch_count.load();
+
+    LOG(INFO) << "numa node num: " << NR_SOCKETS;
+
+    LOG(INFO) << "Test completed: duration " << std::fixed
+              << std::setprecision(2) << duration << ", batch count "
+              << batch_count << ", throughput "
+              << calculateRate(
+                     batch_count * FLAGS_batch_size * FLAGS_block_size,
+                     duration);
+
+    for (int i = 0; i < buffer_num; ++i) {
+        engine->unregisterLocalMemory(addr[i]);
+        freeMemoryPool(addr[i], FLAGS_buffer_size);
+    }
+
+    return 0;
+}
+
+volatile bool target_running = true;
+
+void signalHandler(int signum) {
+    LOG(INFO) << "Received signal " << signum << ", stopping target server...";
+    target_running = false;  
+}
+
+int target() {
+    signal(SIGINT, signalHandler);
+    signal(SIGTERM, signalHandler);
+
+    // disable topology auto discovery for testing.
+    auto engine = std::make_unique<TransferEngine>(FLAGS_auto_discovery);
+
+    auto hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
+                 hostname_port.first.c_str(), hostname_port.second);
+
+    if (!FLAGS_auto_discovery) {
+        if (FLAGS_protocol == "rdma") {
+            auto nic_priority_matrix = loadNicPriorityMatrix();
+            void **args = (void **)malloc(2 * sizeof(void *));
+            args[0] = (void *)nic_priority_matrix.c_str();
+            args[1] = nullptr;
+            engine->installTransport("rdma", args);
+        } else if (FLAGS_protocol == "tcp") {
+            engine->installTransport("tcp", nullptr);
+        } else {
+            LOG(ERROR) << "Unsupported protocol";
+        }
+    }
+
+    std::vector<void *> addr(NR_SOCKETS, nullptr);
+    for (int i = 0; i < NR_SOCKETS; ++i) {
+        addr[i] = allocateMemoryPool(FLAGS_buffer_size, i);
+        memset(addr[i], 'x', FLAGS_buffer_size);
+        int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
+                                             "cpu:" + std::to_string(i));
+        LOG_ASSERT(!rc);
+    }
+
+    LOG(INFO) << "numa node num: " << NR_SOCKETS;
+
+    while (target_running) sleep(1);
+    for (int i = 0; i < NR_SOCKETS; ++i) {
+        engine->unregisterLocalMemory(addr[i]);
+        freeMemoryPool(addr[i], FLAGS_buffer_size);
+    }
+
+    return 0;
+}
+
+void check_total_buffer_size() {
+    uint64_t require_size = FLAGS_block_size * FLAGS_batch_size * FLAGS_threads;
+    if (FLAGS_buffer_size < require_size) {
+        FLAGS_buffer_size = require_size;
+        LOG(WARNING) << "Invalid flag: buffer size is samller than "
+                        "require_size, adjust to "
+                     << require_size;
+    }
+}
+
+int main(int argc, char **argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+    check_total_buffer_size();
+
+    if (FLAGS_mode == "initiator")
+        return initiator();
+    else if (FLAGS_mode == "target")
+        return target();
+
+    LOG(ERROR) << "Unsupported mode: must be 'initiator' or 'target'";
+    exit(EXIT_FAILURE);
+}

--- a/mooncake-ngxl-exp/include/CMakeLists.txt
+++ b/mooncake-ngxl-exp/include/CMakeLists.txt
@@ -1,0 +1,1 @@
+install(FILES transfer_engine_c.h DESTINATION include)

--- a/mooncake-ngxl-exp/include/common.h
+++ b/mooncake-ngxl-exp/include/common.h
@@ -1,0 +1,363 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <glog/logging.h>
+#include <numa.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdint>
+#include <ctime>
+#include <thread>
+
+#include "error.h"
+
+#if defined(__x86_64__)
+#include <immintrin.h>
+#define PAUSE() _mm_pause()
+#else
+#define PAUSE()
+#endif
+
+#define likely(x) __glibc_likely(x)
+#define unlikely(x) __glibc_unlikely(x)
+
+namespace mooncake {
+const static int LOCAL_SEGMENT_ID = 0;
+
+static inline int bindToSocket(int socket_id) {
+    if (unlikely(numa_available() < 0)) {
+        LOG(ERROR) << "The platform does not support NUMA";
+        return ERR_NUMA;
+    }
+    cpu_set_t cpu_set;
+    CPU_ZERO(&cpu_set);
+    if (socket_id < 0 || socket_id >= numa_num_configured_nodes())
+        socket_id = 0;
+    struct bitmask *cpu_list = numa_allocate_cpumask();
+    numa_node_to_cpus(socket_id, cpu_list);
+    int nr_possible_cpus = numa_num_possible_cpus();
+    int nr_cpus = 0;
+    for (int cpu = 0; cpu < nr_possible_cpus; ++cpu) {
+        if (numa_bitmask_isbitset(cpu_list, cpu) &&
+            numa_bitmask_isbitset(numa_all_cpus_ptr, cpu)) {
+            CPU_SET(cpu, &cpu_set);
+            nr_cpus++;
+        }
+    }
+    numa_free_cpumask(cpu_list);
+    if (nr_cpus == 0) return 0;
+    if (pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpu_set)) {
+        LOG(ERROR) << "Failed to set socket affinity";
+        return ERR_NUMA;
+    }
+    return 0;
+}
+
+static inline int64_t getCurrentTimeInNano() {
+    const int64_t kNanosPerSecond = 1000 * 1000 * 1000;
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts)) {
+        PLOG(ERROR) << "Failed to read real-time lock";
+        return ERR_CLOCK;
+    }
+    return (int64_t{ts.tv_sec} * kNanosPerSecond + int64_t{ts.tv_nsec});
+}
+
+uint16_t getDefaultHandshakePort();
+
+static inline std::pair<std::string, uint16_t> parseHostNameWithPort(
+    const std::string &server_name) {
+    uint16_t port = getDefaultHandshakePort();
+    auto pos = server_name.find(':');
+    if (pos == server_name.npos) return std::make_pair(server_name, port);
+    auto trimmed_server_name = server_name.substr(0, pos);
+    auto port_str = server_name.substr(pos + 1);
+    int val = std::atoi(port_str.c_str());
+    if (val <= 0 || val > 65535)
+        LOG(WARNING) << "Illegal port number in " << server_name
+                     << ". Use default port " << port << " instead";
+    else
+        port = (uint16_t)val;
+    return std::make_pair(trimmed_server_name, port);
+}
+
+static inline ssize_t writeFully(int fd, const void *buf, size_t len) {
+    char *pos = (char *)buf;
+    size_t nbytes = len;
+    while (nbytes) {
+        ssize_t rc = write(fd, pos, nbytes);
+        if (rc < 0 && (errno == EAGAIN || errno == EINTR))
+            continue;
+        else if (rc < 0) {
+            PLOG(ERROR) << "Socket write failed";
+            return rc;
+        } else if (rc == 0) {
+            LOG(WARNING) << "Socket write incompleted: expected " << len
+                         << " bytes, actual " << len - nbytes << " bytes";
+            return len - nbytes;
+        }
+        pos += rc;
+        nbytes -= rc;
+    }
+    return len;
+}
+
+static inline ssize_t readFully(int fd, void *buf, size_t len) {
+    char *pos = (char *)buf;
+    size_t nbytes = len;
+    while (nbytes) {
+        ssize_t rc = read(fd, pos, nbytes);
+        if (rc < 0 && (errno == EAGAIN || errno == EINTR))
+            continue;
+        else if (rc < 0) {
+            PLOG(ERROR) << "Socket read failed";
+            return rc;
+        } else if (rc == 0) {
+            LOG(WARNING) << "Socket read incompleted: expected " << len
+                         << " bytes, actual " << len - nbytes << " bytes";
+            return len - nbytes;
+        }
+        pos += rc;
+        nbytes -= rc;
+    }
+    return len;
+}
+
+static inline int writeString(int fd, const std::string &str) {
+    uint64_t length = str.size();
+    if (writeFully(fd, &length, sizeof(length)) != (ssize_t)sizeof(length))
+        return ERR_SOCKET;
+    if (writeFully(fd, str.data(), length) != (ssize_t)length)
+        return ERR_SOCKET;
+    return 0;
+}
+
+static inline std::string readString(int fd) {
+    const static size_t kMaxLength = 1ull << 20;
+    uint64_t length = 0;
+    if (readFully(fd, &length, sizeof(length)) != (ssize_t)sizeof(length))
+        return "";
+    if (length > kMaxLength) return "";
+    std::string str;
+    std::vector<char> buffer(length);
+    if (readFully(fd, buffer.data(), length) != (ssize_t)length) return "";
+
+    str.assign(buffer.data(), length);
+    return str;
+}
+
+const static std::string NIC_PATH_DELIM = "@";
+static inline const std::string getServerNameFromNicPath(
+    const std::string &nic_path) {
+    size_t pos = nic_path.find(NIC_PATH_DELIM);
+    if (pos == nic_path.npos) return "";
+    return nic_path.substr(0, pos);
+}
+
+static inline const std::string getNicNameFromNicPath(
+    const std::string &nic_path) {
+    size_t pos = nic_path.find(NIC_PATH_DELIM);
+    if (pos == nic_path.npos) return "";
+    return nic_path.substr(pos + 1);
+}
+
+static inline const std::string MakeNicPath(const std::string &server_name,
+                                            const std::string &nic_name) {
+    return server_name + NIC_PATH_DELIM + nic_name;
+}
+
+static inline bool overlap(const void *a, size_t a_len, const void *b,
+                           size_t b_len) {
+    return (a >= b && a < (char *)b + b_len) ||
+           (b >= a && b < (char *)a + a_len);
+}
+
+class RWSpinlock {
+    union RWTicket {
+        constexpr RWTicket() : whole(0) {}
+        uint64_t whole;
+        uint32_t readWrite;
+        struct {
+            uint16_t write;
+            uint16_t read;
+            uint16_t users;
+        };
+    } ticket;
+
+   private:
+    static void asm_volatile_memory() { asm volatile("" ::: "memory"); }
+
+    template <class T>
+    static T load_acquire(T *addr) {
+        T t = *addr;
+        asm_volatile_memory();
+        return t;
+    }
+
+    template <class T>
+    static void store_release(T *addr, T v) {
+        asm_volatile_memory();
+        *addr = v;
+    }
+
+   public:
+    RWSpinlock() {}
+
+    RWSpinlock(RWSpinlock const &) = delete;
+    RWSpinlock &operator=(RWSpinlock const &) = delete;
+
+    void lock() { writeLockNice(); }
+
+    bool tryLock() {
+        RWTicket t;
+        uint64_t old = t.whole = load_acquire(&ticket.whole);
+        if (t.users != t.write) return false;
+        ++t.users;
+        return __sync_bool_compare_and_swap(&ticket.whole, old, t.whole);
+    }
+
+    void writeLockAggressive() {
+        uint32_t count = 0;
+        uint16_t val = __sync_fetch_and_add(&ticket.users, 1);
+        while (val != load_acquire(&ticket.write)) {
+            PAUSE();
+            if (++count > 1000) std::this_thread::yield();
+        }
+    }
+
+    void writeLockNice() {
+        uint32_t count = 0;
+        while (!tryLock()) {
+            PAUSE();
+            if (++count > 1000) std::this_thread::yield();
+        }
+    }
+
+    void unlockAndLockShared() {
+        uint16_t val = __sync_fetch_and_add(&ticket.read, 1);
+        (void)val;
+    }
+
+    void unlock() {
+        RWTicket t;
+        t.whole = load_acquire(&ticket.whole);
+        ++t.read;
+        ++t.write;
+        store_release(&ticket.readWrite, t.readWrite);
+    }
+
+    void lockShared() {
+        uint_fast32_t count = 0;
+        while (!tryLockShared()) {
+            PAUSE();
+            if (++count > 1000) std::this_thread::yield();
+        }
+    }
+
+    bool tryLockShared() {
+        RWTicket t, old;
+        old.whole = t.whole = load_acquire(&ticket.whole);
+        old.users = old.read;
+        ++t.read;
+        ++t.users;
+        return __sync_bool_compare_and_swap(&ticket.whole, old.whole, t.whole);
+    }
+
+    void unlockShared() { __sync_fetch_and_add(&ticket.write, 1); }
+
+   public:
+    struct WriteGuard {
+        WriteGuard(RWSpinlock &lock) : lock(lock) { lock.lock(); }
+
+        WriteGuard(const WriteGuard &) = delete;
+
+        WriteGuard &operator=(const WriteGuard &) = delete;
+
+        ~WriteGuard() { lock.unlock(); }
+
+        RWSpinlock &lock;
+    };
+
+    struct ReadGuard {
+        ReadGuard(RWSpinlock &lock) : lock(lock) { lock.lockShared(); }
+
+        ReadGuard(const ReadGuard &) = delete;
+
+        ReadGuard &operator=(const ReadGuard &) = delete;
+
+        ~ReadGuard() { lock.unlockShared(); }
+
+        RWSpinlock &lock;
+    };
+
+   private:
+    const static int64_t kExclusiveLock = INT64_MIN / 2;
+
+    std::atomic<int64_t> lock_;
+    uint64_t padding_[15];
+};
+
+class TicketLock {
+   public:
+    TicketLock() : next_ticket_(0), now_serving_(0) {}
+
+    void lock() {
+        int my_ticket = next_ticket_.fetch_add(1, std::memory_order_relaxed);
+        while (now_serving_.load(std::memory_order_acquire) != my_ticket) {
+            std::this_thread::yield();
+        }
+    }
+
+    void unlock() { now_serving_.fetch_add(1, std::memory_order_release); }
+
+   private:
+    std::atomic<int> next_ticket_;
+    std::atomic<int> now_serving_;
+    uint64_t padding_[14];
+};
+
+class SimpleRandom {
+   public:
+    SimpleRandom(uint32_t seed) : current(seed) {}
+
+    static SimpleRandom &Get() {
+        static std::atomic<uint64_t> g_incr_val(0);
+        thread_local SimpleRandom g_random(getCurrentTimeInNano() +
+                                           g_incr_val.fetch_add(1));
+        return g_random;
+    }
+
+    // 生成下一个伪随机数
+    uint32_t next() {
+        current = (a * current + c) % m;
+        return current;
+    }
+
+    uint32_t next(uint32_t max) { return next() % max; }
+
+   private:
+    uint32_t current;
+    static const uint32_t a = 1664525;
+    static const uint32_t c = 1013904223;
+    static const uint32_t m = 0xFFFFFFFF;
+};
+}  // namespace mooncake
+
+#endif  // COMMON_H

--- a/mooncake-ngxl-exp/include/common/base/status.h
+++ b/mooncake-ngxl-exp/include/common/base/status.h
@@ -1,0 +1,283 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The design of this code is adapted from the RocksDB project with some
+// modifications.
+// https://github.com/facebook/rocksdb/blob/main/include/rocksdb/status.h
+
+#ifndef STATUS_H
+#define STATUS_H
+
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace mooncake {
+
+class Status final {
+ public:
+  // The code of the status.
+  enum class Code : uint16_t {
+    kOk = 0,
+    kInvalidArgument = 1,
+    kTooManyRequests = 2,
+    kAddressNotRegistered = 3,
+    kBatchBusy = 4,
+    kDeviceNotFound = 6,
+    kAddressOverlapped = 7,
+    kDns = 101,
+    kSocket = 102,
+    kMalformedJson = 103,
+    kRejectHandshake = 104,
+    kMetadata = 200,
+    kEndpoint = 201,
+    kContext = 202,
+    kNuma = 300,
+    kClock = 301,
+    kMemory = 302,
+    kNotImplmented = 999,
+    kMaxCode
+  };
+
+  // Builds an OK Status.
+  Status() = default;
+
+  ~Status() { delete[] message_; }
+
+  // Constructs a Status object containing a status code and message.
+  // If 'code == Code::kOk', 'msg' is ignored and an object identical to an OK
+  // status is constructed.
+  Status(Code code, std::string_view message);
+
+  Status(const Status& s);
+  Status& operator=(const Status& s);
+  Status(Status&& s);
+  Status& operator=(Status&& s);
+
+  // Returns the stored status code.
+  Code code() const { return code_; }
+
+  // Return the error message (if any).
+  std::string_view message() const {
+    if (message_) {
+      return message_;
+    } else {
+      return std::string_view();
+    }
+  }
+
+  // Returns true if the Status is OK.
+  [[nodiscard]] bool ok() const { return Code::kOk == code_; }
+
+  // Returns true iff the status indicates an InvalidArgument error.
+  [[nodiscard]] bool IsInvalidArgument() const {
+    return Code::kInvalidArgument == code_;
+  }
+
+  // Returns true iff the status indicates a TooManyRequests error.
+  [[nodiscard]] bool IsTooManyRequests() const {
+    return Code::kTooManyRequests == code_;
+  }
+
+  // Returns true iff the status indicates an AddressNotRegistered error.
+  [[nodiscard]] bool IsAddressNotRegistered() const {
+    return Code::kAddressNotRegistered == code_;
+  }
+
+  // Returns true iff the status indicates a BatchBusy error.
+  [[nodiscard]] bool IsBatchBusy() const {
+    return Code::kBatchBusy == code_;
+  }
+
+  // Returns true iff the status indicates an DeviceNotFound error.
+  [[nodiscard]] bool IsDeviceNotFound() const {
+    return Code::kDeviceNotFound == code_;
+  }
+
+  // Returns true iff the status indicates an AddressOverlapped error.
+  [[nodiscard]] bool IsAddressOverlapped() const {
+    return Code::kAddressOverlapped == code_;
+  }
+
+  // Returns true iff the status indicates a dns error.
+  [[nodiscard]] bool IsDns() const {
+    return Code::kDns == code_;
+  }
+
+  // Returns true iff the status indicates an Socket error.
+  [[nodiscard]] bool IsSocket() const {
+    return Code::kSocket == code_;
+  }
+
+  // Returns true iff the status indicates a MalformedJson error.
+  [[nodiscard]] bool IsMalformedJson() const {
+    return Code::kMalformedJson == code_;
+  }
+
+  // Returns true iff the status indicates a RejectHandshake error.
+  [[nodiscard]] bool IsRejectHandshake() const {
+    return Code::kRejectHandshake == code_;
+  }
+
+  // Returns true iff the status indicates a Metadata error.
+  [[nodiscard]] bool IsMetadata() const {
+    return Code::kMetadata == code_;
+  }
+
+  // Returns true iff the status indicates an Endpoint error.
+  [[nodiscard]] bool IsEndpoint() const {
+    return Code::kEndpoint == code_;
+  }
+
+  // Returns true iff the status indicates a Context error.
+  [[nodiscard]] bool IsContext() const {
+    return Code::kContext == code_;
+  }
+
+  // Returns true iff the status indicates a Numa error.
+  [[nodiscard]] bool IsNuma() const {
+    return Code::kNuma == code_;
+  }
+
+  // Returns true iff the status indicates a Clock error.
+  [[nodiscard]] bool IsClock() const {
+    return Code::kClock == code_;
+  }
+
+  // Returns true iff the status indicates a Memory error.
+  [[nodiscard]] bool IsMemory() const {
+    return Code::kMemory == code_;
+  }
+
+  // Returns true iff the status indicates a NotImplmented error.
+  [[nodiscard]] bool IsNotImplmented() const {
+    return Code::kNotImplmented == code_;
+  }
+
+  // Return a combination of the error code name and message.
+  std::string ToString() const;
+
+  bool operator==(const Status& s) const;
+  bool operator!=(const Status& s) const;
+
+  // Return a status of an appropriate type.
+  static Status OK() { return Status(); }
+  static Status InvalidArgument(std::string_view msg) {
+    return Status(Code::kInvalidArgument, msg);
+  }
+  static Status TooManyRequests(std::string_view msg) {
+    return Status(Code::kTooManyRequests, msg);
+  }
+  static Status AddressNotRegistered(std::string_view msg) {
+    return Status(Code::kAddressNotRegistered, msg);
+  }
+  static Status BatchBusy(std::string_view msg) {
+    return Status(Code::kBatchBusy, msg);
+  }
+  static Status DeviceNotFound(std::string_view msg) {
+    return Status(Code::kDeviceNotFound, msg);
+  }
+  static Status AddressOverlapped(std::string_view msg) {
+    return Status(Code::kAddressOverlapped, msg);
+  }
+  static Status Dns(std::string_view msg) {
+    return Status(Code::kDns, msg);
+  }
+  static Status Socket(std::string_view msg) {
+    return Status(Code::kSocket, msg);
+  }
+  static Status MalformedJson(std::string_view msg) {
+    return Status(Code::kMalformedJson, msg);
+  }
+  static Status RejectHandshake(std::string_view msg) {
+    return Status(Code::kRejectHandshake, msg);
+  }
+  static Status Metadata(std::string_view msg) {
+    return Status(Code::kMetadata, msg);
+  }
+  static Status Endpoint(std::string_view msg) {
+    return Status(Code::kEndpoint, msg);
+  }
+  static Status Context(std::string_view msg) {
+    return Status(Code::kContext, msg);
+  }
+  static Status Numa(std::string_view msg) {
+    return Status(Code::kNuma, msg);
+  }
+  static Status Clock(std::string_view msg) {
+    return Status(Code::kClock, msg);
+  }
+  static Status Memory(std::string_view msg) {
+    return Status(Code::kMemory, msg);
+  }
+  static Status NotImplmented(std::string_view msg) {
+    return Status(Code::kNotImplmented, msg);
+  }
+
+  // Return a human-readable name of the 'code'.
+  static std::string_view CodeToString(Code code);
+
+ private:
+  // Return a copy of the message 'msg'.
+  static const char* CopyMessage(const char* msg);
+
+  // The code of the status.
+  Code code_ = Code::kOk;
+  // The error message of the status. Refer to the Status definition in RocksDB,
+  // we don't use 'std::string' type message but 'const char*' type one for the
+  // performance considerations. A memory allocation in the std::string
+  // construction could be avoid for the most cases that the Status is OK. And
+  // the total size of 'message_' is only 8 bytes on a x86-64 platform, while
+  // the size of a uninitialized strings with SSO (Small String Optimization)
+  // will be 24 to 32 bytes big, excluding the dynamically allocated memory.
+  const char* message_ = nullptr;
+};
+
+inline Status::Status(const Status& s) : code_(s.code_) {
+  message_ = (s.message_ == nullptr) ? nullptr : CopyMessage(s.message_);
+}
+
+inline Status& Status::operator=(const Status& s) {
+  if (this != &s) {
+    code_ = s.code_;
+    delete[] message_;
+    message_ = (s.message_ == nullptr) ? nullptr : CopyMessage(s.message_);
+  }
+  return *this;
+}
+
+inline Status::Status(Status&& s) : Status() { *this = std::move(s); }
+
+inline Status& Status::operator=(Status&& s) {
+  if (this != &s) {
+    code_ = std::move(s.code_);
+    s.code_ = Code::kOk;
+    delete[] message_;
+    message_ = nullptr;
+    std::swap(message_, s.message_);
+  }
+  return *this;
+}
+
+// Prints a human-readable representation name of the 'code' to 'os'.
+std::ostream& operator<<(std::ostream& os, Status::Code code);
+
+// Prints a human-readable representation of 's' to 'os'.
+std::ostream& operator<<(std::ostream& os, const Status& s);
+
+}  // namespace mooncake
+
+#endif  // STATUS_H

--- a/mooncake-ngxl-exp/include/config.h
+++ b/mooncake-ngxl-exp/include/config.h
@@ -1,0 +1,57 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <glog/logging.h>
+#include <infiniband/verbs.h>
+#include <jsoncpp/json/json.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
+namespace mooncake {
+struct GlobalConfig {
+    size_t num_cq_per_ctx = 1;
+    size_t num_comp_channels_per_ctx = 1;
+    uint8_t port = 1;
+    int gid_index = 0;
+    size_t max_cqe = 4096;
+    int max_ep_per_ctx = 256;
+    size_t num_qp_per_ep = 2;
+    size_t max_sge = 4;
+    size_t max_wr = 256;
+    size_t max_inline = 64;
+    ibv_mtu mtu_length = IBV_MTU_4096;
+    uint16_t handshake_port = 12001;
+    int workers_per_ctx = 2;
+    bool verbose = false;
+    size_t slice_size = 65536;
+    int retry_cnt = 8;
+};
+
+void loadGlobalConfig(GlobalConfig &config);
+
+void dumpGlobalConfig();
+
+void updateGlobalConfig(ibv_device_attr &device_attr);
+
+GlobalConfig &globalConfig();
+
+uint16_t getDefaultHandshakePort();
+}  // namespace mooncake
+
+#endif  // CONFIG_H

--- a/mooncake-ngxl-exp/include/error.h
+++ b/mooncake-ngxl-exp/include/error.h
@@ -1,0 +1,40 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ERROR_H
+#define ERROR_H
+
+#define ERR_INVALID_ARGUMENT (-1)
+#define ERR_TOO_MANY_REQUESTS (-2)
+#define ERR_ADDRESS_NOT_REGISTERED (-3)
+#define ERR_BATCH_BUSY (-4)
+#define ERR_DEVICE_NOT_FOUND (-6)
+#define ERR_ADDRESS_OVERLAPPED (-7)
+#define ERR_NOT_LOCAL_SEGMENT_OR_SHM (-8)
+
+#define ERR_DNS (-101)
+#define ERR_SOCKET (-102)
+#define ERR_MALFORMED_JSON (-103)
+#define ERR_REJECT_HANDSHAKE (-104)
+
+#define ERR_METADATA (-200)
+#define ERR_ENDPOINT (-201)
+#define ERR_CONTEXT (-202)
+
+#define ERR_NUMA (-300)
+#define ERR_CLOCK (-301)
+#define ERR_MEMORY (-302)
+#define ERR_NOT_IMPLEMENTED (-303)
+
+#endif  // ERROR_H

--- a/mooncake-ngxl-exp/include/memory_location.h
+++ b/mooncake-ngxl-exp/include/memory_location.h
@@ -1,0 +1,40 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEMORY_LOCATION_H
+#define MEMORY_LOCATION_H
+
+#include <glog/logging.h>
+
+#include <memory>
+
+#include "common.h"
+
+const int pagesize = 4096;
+
+namespace mooncake {
+struct MemoryLocationEntry {
+    uint64_t start;
+    size_t len;
+    std::string location;
+};
+
+// Get CPU numa node id
+// TODO: support getting cuda device id from unified address.
+const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
+                                                         size_t len);
+
+}  // namespace mooncake
+
+#endif  // MEMORY_LOCATION_H

--- a/mooncake-ngxl-exp/include/multi_transport.h
+++ b/mooncake-ngxl-exp/include/multi_transport.h
@@ -1,0 +1,66 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MULTI_TRANSPORT_H_
+#define MULTI_TRANSPORT_H_
+
+#include <unordered_map>
+
+#include "transport/transport.h"
+
+namespace mooncake {
+class MultiTransport {
+   public:
+    using BatchID = Transport::BatchID;
+    using TransferRequest = Transport::TransferRequest;
+    using TransferStatus = Transport::TransferStatus;
+    using BatchDesc = Transport::BatchDesc;
+
+    const static BatchID INVALID_BATCH_ID = Transport::INVALID_BATCH_ID;
+
+    MultiTransport(std::shared_ptr<TransferMetadata> metadata,
+                   std::string &local_server_name);
+
+    ~MultiTransport();
+
+    BatchID allocateBatchID(size_t batch_size);
+
+    Status freeBatchID(BatchID batch_id);
+
+    Status submitTransfer(BatchID batch_id,
+                       const std::vector<TransferRequest> &entries);
+
+    Status getTransferStatus(BatchID batch_id, size_t task_id,
+                          TransferStatus &status);
+
+    Transport *installTransport(const std::string &proto,
+                                std::shared_ptr<Topology> topo);
+
+    Transport *getTransport(const std::string &proto);
+
+    std::vector<Transport *> listTransports();
+
+   private:
+    Transport *selectTransport(const TransferRequest &entry);
+
+   private:
+    std::shared_ptr<TransferMetadata> metadata_;
+    std::string local_server_name_;
+    std::map<std::string, std::shared_ptr<Transport>> transport_map_;
+    RWSpinlock batch_desc_lock_;
+    std::unordered_map<BatchID, std::shared_ptr<BatchDesc>> batch_desc_set_;
+};
+}  // namespace mooncake
+
+#endif  // MULTI_TRANSPORT_H_

--- a/mooncake-ngxl-exp/include/segment.h
+++ b/mooncake-ngxl-exp/include/segment.h
@@ -1,0 +1,84 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SEGMENT_H
+#define SEGMENT_H
+
+#include <glog/logging.h>
+#include <jsoncpp/json/json.h>
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include "common.h"
+#include "common/base/status.h"
+#include "topology.h"
+
+namespace mooncake {
+struct BufferAttr {
+    std::string location;
+    uint64_t addr;
+    uint64_t length;
+    std::vector<uint32_t> lkey;  // for rdma
+    std::vector<uint32_t> rkey;  // for rdma
+    std::string shm_path;        // for shm
+};
+
+struct RdmaAttr {
+    std::string name;
+    uint16_t lid;
+    std::string gid;
+};
+
+struct TcpAttr {
+    std::string ip_or_hostname;
+    uint16_t port;
+};
+
+using SegmentID = uint64_t;
+const static SegmentID LocalSegmentID = (uint64_t)(0);
+const static SegmentID InvalidSegmentID = (uint64_t)(-1);
+enum SegmentType { MemoryKind, CufileKind, UnknownKind };
+
+struct SegmentDesc {
+    std::string name;
+    SegmentType type;
+    struct Memory {
+        Topology topology;
+        std::vector<BufferAttr> buffers;
+        std::vector<RdmaAttr> rdma;
+        TcpAttr tcp;
+    } memory;
+    struct Cufile {
+        std::string relative_path;
+        uint64_t length;
+    } cufile;
+
+    Status addBuffer(const BufferAttr &attr);
+    Status removeBuffer(void *addr);
+};
+
+struct SegmentDescUtils {
+    static Json::Value encode(const SegmentDesc &attr);
+
+    static int decode(Json::Value segmentJSON, SegmentDesc &attr);
+};
+}  // namespace mooncake
+
+#endif  // SEGMENT_H

--- a/mooncake-ngxl-exp/include/segment_cache.h
+++ b/mooncake-ngxl-exp/include/segment_cache.h
@@ -1,0 +1,72 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SEGMENT_CACHE_H
+#define SEGMENT_CACHE_H
+
+#include "common/base/status.h"
+#include "segment.h"
+
+namespace mooncake {
+class SegmentCache {
+   public:
+    using SegmentDescRef = std::shared_ptr<SegmentDesc>;
+
+    struct Callbacks {
+        std::function<SegmentDescRef(const std::string &)> on_get_segment_desc;
+        std::function<Status(SegmentDescRef)> on_put_segment_desc;
+        std::function<Status(const std::string &)> on_delete_segment_desc;
+    };
+
+    SegmentCache(Callbacks callbacks, const std::string &local_segment_name);
+
+    ~SegmentCache();
+
+    SegmentCache(const SegmentCache &) = delete;
+
+    SegmentCache &operator=(const SegmentCache &) = delete;
+
+    SegmentID open(const std::string &segment_name);
+
+    Status close(SegmentID segment_id);
+
+    const SegmentDescRef get(SegmentID segment_id, bool direct = false);
+
+    SegmentDescRef getLocal();
+
+    Status setAndFlushLocal(SegmentDescRef &&segment);
+
+    Status flushLocal();
+
+    Status destroyLocal();
+
+    Status invalidateAll();
+
+   private:
+    struct SegmentEntry {
+        std::string name;
+        SegmentDescRef ref;
+        int ref_cnt;
+        bool dirty;
+    };
+
+    RWSpinlock segment_lock_;
+    std::unordered_map<SegmentID, SegmentEntry> segment_entry_map_;
+    std::unordered_map<std::string, SegmentID> segment_name_to_id_map_;
+    std::atomic<SegmentID> next_segment_id_;
+    Callbacks callbacks_;
+};
+}  // namespace mooncake
+
+#endif  // SEGMENT_CACHE_H

--- a/mooncake-ngxl-exp/include/topology.h
+++ b/mooncake-ngxl-exp/include/topology.h
@@ -1,0 +1,100 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TOPOLOGY_H
+#define TOPOLOGY_H
+
+#include <glog/logging.h>
+#include <jsoncpp/json/json.h>
+#include <netdb.h>
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include "common.h"
+
+namespace mooncake {
+struct TopologyEntry {
+    std::string name;
+    std::vector<std::string> preferred_hca;
+    std::vector<std::string> avail_hca;
+
+    Json::Value toJson() const {
+        Json::Value matrix(Json::arrayValue);
+        Json::Value hca_list(Json::arrayValue);
+        for (auto &hca : preferred_hca) {
+            hca_list.append(hca);
+        }
+        matrix.append(hca_list);
+        hca_list.clear();
+        for (auto &hca : avail_hca) {
+            hca_list.append(hca);
+        }
+        matrix.append(hca_list);
+        return matrix;
+    }
+};
+
+using TopologyMatrix =
+    std::unordered_map<std::string /* storage type */, TopologyEntry>;
+
+class Topology {
+   public:
+    Topology();
+
+    ~Topology();
+
+    bool empty() const;
+
+    void clear();
+
+    int discover();
+
+    int parse(const std::string &topology_json);
+
+    int disableDevice(const std::string &device_name);
+
+    std::string toString() const;
+
+    Json::Value toJson() const;
+
+    int selectDevice(const std::string &location_hint, int retry_count = 0);
+
+    TopologyMatrix getMatrix() const { return matrix_; }
+
+    const std::vector<std::string> &getHcaList() const { return hca_list_; }
+
+   private:
+    int resolve();
+
+   private:
+    TopologyMatrix matrix_;
+    std::vector<std::string> hca_list_;
+
+    struct ResolvedTopologyEntry {
+        std::vector<int> preferred_hca;
+        std::vector<int> avail_hca;
+    };
+    std::unordered_map<std::string /* storage type */, ResolvedTopologyEntry>
+        resolved_matrix_;
+};
+
+}  // namespace mooncake
+
+#endif  // TOPOLOGY_H

--- a/mooncake-ngxl-exp/include/transfer_engine.h
+++ b/mooncake-ngxl-exp/include/transfer_engine.h
@@ -1,0 +1,127 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MULTI_TRANSFER_ENGINE_H_
+#define MULTI_TRANSFER_ENGINE_H_
+
+#include <asm-generic/errno-base.h>
+#include <bits/stdint-uintn.h>
+#include <limits.h>
+#include <string.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "multi_transport.h"
+#include "transfer_metadata.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+using TransferRequest = Transport::TransferRequest;
+using TransferStatus = Transport::TransferStatus;
+using TransferStatusEnum = Transport::TransferStatusEnum;
+using SegmentID = Transport::SegmentID;
+using BatchID = Transport::BatchID;
+using BufferEntry = Transport::BufferEntry;
+
+class TransferEngine {
+   public:
+    TransferEngine(bool auto_discover = false)
+        : metadata_(nullptr),
+          local_topology_(std::make_shared<Topology>()),
+          auto_discover_(auto_discover) {}
+
+    ~TransferEngine() { freeEngine(); }
+
+    int init(const std::string &metadata_conn_string,
+             const std::string &local_server_name,
+             const std::string &ip_or_host_name, uint64_t rpc_port = 12345);
+
+    int freeEngine();
+
+    // Only for testing.
+    Transport *installTransport(const std::string &proto, void **args);
+
+    int uninstallTransport(const std::string &proto);
+
+    SegmentID openSegment(const std::string &segment_name);
+
+    int closeSegment(SegmentID handle);
+
+    int registerLocalMemory(void *addr, size_t length,
+                            const std::string &location,
+                            bool remote_accessible = true,
+                            bool update_metadata = true);
+
+    int unregisterLocalMemory(void *addr, bool update_metadata = true);
+
+    int registerLocalMemoryBatch(const std::vector<BufferEntry> &buffer_list,
+                                 const std::string &location);
+
+    int unregisterLocalMemoryBatch(const std::vector<void *> &addr_list);
+
+    BatchID allocateBatchID(size_t batch_size) {
+        return multi_transports_->allocateBatchID(batch_size);
+    }
+
+    Status freeBatchID(BatchID batch_id) {
+        return multi_transports_->freeBatchID(batch_id);
+    }
+
+    Status submitTransfer(BatchID batch_id,
+                          const std::vector<TransferRequest> &entries) {
+        return multi_transports_->submitTransfer(batch_id, entries);
+    }
+
+    Status getTransferStatus(BatchID batch_id, size_t task_id,
+                             TransferStatus &status) {
+        return multi_transports_->getTransferStatus(batch_id, task_id, status);
+    }
+
+    int syncSegmentCache(const std::string &segment_name = "") {
+        return metadata_->syncSegmentCache(segment_name);
+    }
+
+    std::shared_ptr<TransferMetadata> getMetadata() { return metadata_; }
+
+    bool checkOverlap(void *addr, uint64_t length);
+
+   private:
+    struct MemoryRegion {
+        void *addr;
+        uint64_t length;
+        std::string location;
+        bool remote_accessible;
+    };
+
+    std::shared_ptr<TransferMetadata> metadata_;
+    std::string local_server_name_;
+    std::shared_ptr<MultiTransport> multi_transports_;
+    std::shared_mutex mutex_;
+    std::vector<MemoryRegion> local_memory_regions_;
+    std::shared_ptr<Topology> local_topology_;
+    // Discover topology and install transports automatically when it's true.
+    // Set it to false only for testing.
+    bool auto_discover_;
+};
+}  // namespace mooncake
+
+#endif

--- a/mooncake-ngxl-exp/include/transfer_engine_c.h
+++ b/mooncake-ngxl-exp/include/transfer_engine_c.h
@@ -1,0 +1,144 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRANSFER_ENGINE_C
+#define TRANSFER_ENGINE_C
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#define segment_handle_t int32_t
+#define segment_id_t int32_t
+#define batch_id_t uint64_t
+#define LOCAL_SEGMENT (0)
+#define INVALID_BATCH UINT64_MAX
+
+#define OPCODE_READ (0)
+#define OPCODE_WRITE (1)
+
+struct transfer_request {
+    int opcode;
+    void *source;
+    segment_id_t target_id;
+    uint64_t target_offset;
+    uint64_t length;
+};
+
+typedef struct transfer_request transfer_request_t;
+
+#define STATUS_WAITING (0)
+#define STATUS_PENDING (1)
+#define STATUS_INVALID (2)
+#define STATUS_CANNELED (3)
+#define STATUS_COMPLETED (4)
+#define STATUS_TIMEOUT (5)
+#define STATUS_FAILED (6)
+
+struct transfer_status {
+    int status;
+    uint64_t transferred_bytes;
+};
+
+struct segment_desc {
+    int type;  // RDMA / NVMeoF
+    union {
+        struct {
+            void *addr;
+            uint64_t size;
+            const char *location;
+        } rdma;
+        struct {
+            const char *file_path;
+            const char *subsystem_name;
+            const char *proto;
+            const char *ip;
+            uint64_t port;
+            // maybe more needed for mount
+        } nvmeof;
+    } desc_;
+};
+
+typedef struct transfer_status transfer_status_t;
+
+struct buffer_entry {
+    void *addr;
+    size_t length;
+};
+typedef struct buffer_entry buffer_entry_t;
+
+typedef struct segment_desc segment_desc_t;
+typedef void *transfer_engine_t;
+typedef void *transport_t;
+
+/*
+ * All memory pointed to by the "char *" parameters will not be used
+ * after the C function returns.
+ * This means that the caller can free the memory pointed to by "char *"
+ * parameters, after the call is completed.
+ * All the C functions here follow this convention.
+*/
+
+transfer_engine_t createTransferEngine(const char *metadata_conn_string,
+                                       const char *local_server_name,
+                                       const char *ip_or_host_name,
+                                       uint64_t rpc_port,
+                                       int auto_discover);
+
+transport_t installTransport(transfer_engine_t engine, const char *proto,
+                             void **args);
+
+int uninstallTransport(transfer_engine_t engine, const char *proto);
+
+segment_id_t openSegment(transfer_engine_t engine, const char *segment_name);
+
+segment_id_t openSegmentNoCache(transfer_engine_t engine, const char *segment_name);
+
+int closeSegment(transfer_engine_t engine, segment_id_t segment_id);
+
+void destroyTransferEngine(transfer_engine_t engine);
+
+int registerLocalMemory(transfer_engine_t engine, void *addr, size_t length,
+                        const char *location, int remote_accessible);
+
+int unregisterLocalMemory(transfer_engine_t engine, void *addr);
+
+int registerLocalMemoryBatch(transfer_engine_t engine,
+                             buffer_entry_t *buffer_list, size_t buffer_len,
+                             const char *location);
+
+int unregisterLocalMemoryBatch(transfer_engine_t engine, void **addr_list,
+                               size_t addr_len);
+
+batch_id_t allocateBatchID(transfer_engine_t engine, size_t batch_size);
+
+int submitTransfer(transfer_engine_t engine, batch_id_t batch_id,
+                   struct transfer_request *entries, size_t count);
+
+int getTransferStatus(transfer_engine_t engine,
+                      batch_id_t batch_id, size_t task_id,
+                      struct transfer_status *status);
+
+int freeBatchID(transfer_engine_t engine, batch_id_t batch_id);
+
+int syncSegmentCache(transfer_engine_t engine);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // TRANSFER_ENGINE_C

--- a/mooncake-ngxl-exp/include/transfer_metadata.h
+++ b/mooncake-ngxl-exp/include/transfer_metadata.h
@@ -1,0 +1,116 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRANSFER_METADATA
+#define TRANSFER_METADATA
+
+#include <glog/logging.h>
+#include <jsoncpp/json/json.h>
+#include <netdb.h>
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include "common.h"
+#include "topology.h"
+#include "segment_cache.h"
+
+namespace mooncake {
+struct MetadataStoragePlugin;
+struct HandShakePlugin;
+
+class TransferMetadata {
+   public:
+    using SegmentID = uint64_t;
+
+    struct RpcMetaDesc {
+        std::string ip_or_host_name;
+        uint16_t rpc_port;
+    };
+
+    struct HandShakeDesc {
+        std::string local_nic_path;
+        std::string peer_nic_path;
+        std::vector<uint32_t> qp_num;
+        std::string reply_msg;  // on error
+    };
+
+    SegmentCache::SegmentDescRef getSegmentDesc(const std::string &segment_name);
+
+    Status putSegmentDesc(SegmentCache::SegmentDescRef segment);
+
+    Status deleteSegmentDesc(const std::string &segment_name);
+
+   public:
+    TransferMetadata(const std::string &conn_string, const std::string &local_segment_name = "");
+
+    ~TransferMetadata();
+
+    std::shared_ptr<SegmentDesc> getSegmentDescByName(
+        const std::string &segment_name, bool force_update = false);
+
+    std::shared_ptr<SegmentDesc> getSegmentDescByID(SegmentID segment_id,
+                                                    bool force_update = false);
+
+    int updateLocalSegmentDesc();
+
+    SegmentID getSegmentID(const std::string &segment_name);
+
+    int syncSegmentCache(const std::string &segment_name);
+
+    int addLocalMemoryBuffer(const BufferAttr &buffer_desc,
+                             bool update_metadata);
+
+    int removeLocalMemoryBuffer(void *addr, bool update_metadata);
+
+    std::shared_ptr<SegmentDesc> getLocalSegment();
+
+    int setLocalSegment(std::shared_ptr<SegmentDesc> &&desc);
+
+    int addRpcMetaEntry(const std::string &server_name, RpcMetaDesc &desc);
+
+    int removeRpcMetaEntry(const std::string &server_name);
+
+    int getRpcMetaEntry(const std::string &server_name, RpcMetaDesc &desc);
+
+    const RpcMetaDesc &localRpcMeta() const { return local_rpc_meta_; }
+
+    using OnReceiveHandShake = std::function<int(const HandShakeDesc &peer_desc,
+                                                 HandShakeDesc &local_desc)>;
+    int startHandshakeDaemon(OnReceiveHandShake on_receive_handshake,
+                             uint16_t listen_port);
+
+    int sendHandshake(const std::string &peer_server_name,
+                      const HandShakeDesc &local_desc,
+                      HandShakeDesc &peer_desc);
+
+   private:
+
+    RWSpinlock rpc_meta_lock_;
+    std::unordered_map<std::string, RpcMetaDesc> rpc_meta_map_;
+    RpcMetaDesc local_rpc_meta_;
+
+    std::shared_ptr<SegmentCache> cache_;
+    std::shared_ptr<HandShakePlugin> handshake_plugin_;
+    std::shared_ptr<MetadataStoragePlugin> storage_plugin_;
+};
+
+}  // namespace mooncake
+
+#endif  // TRANSFER_METADATA

--- a/mooncake-ngxl-exp/include/transfer_metadata_plugin.h
+++ b/mooncake-ngxl-exp/include/transfer_metadata_plugin.h
@@ -1,0 +1,57 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRANSFER_METADATA_PLUGIN
+#define TRANSFER_METADATA_PLUGIN
+
+#include "transfer_metadata.h"
+
+namespace mooncake {
+struct MetadataStoragePlugin {
+    static std::shared_ptr<MetadataStoragePlugin> Create(
+        const std::string &conn_string);
+
+    MetadataStoragePlugin() {}
+    virtual ~MetadataStoragePlugin() {}
+
+    virtual bool get(const std::string &key, Json::Value &value) = 0;
+    virtual bool set(const std::string &key, const Json::Value &value) = 0;
+    virtual bool remove(const std::string &key) = 0;
+};
+
+struct HandShakePlugin {
+    static std::shared_ptr<HandShakePlugin> Create(
+        const std::string &conn_string);
+
+    HandShakePlugin() {}
+    virtual ~HandShakePlugin() {}
+
+    // When accept a new connection, this function will be called.
+    // The first param represents peer endpoint's attributes, while
+    // the second param represents local endpoint's attributes
+    using OnReceiveCallBack =
+        std::function<int(const Json::Value &, Json::Value &)>;
+
+    virtual int startDaemon(OnReceiveCallBack on_recv_callback,
+                            uint16_t listen_port) = 0;
+
+    // Connect to peer endpoint, and wait for receiving
+    // peer endpoint's attributes
+    virtual int send(std::string ip_or_host_name, uint16_t rpc_port,
+                     const Json::Value &local, Json::Value &peer) = 0;
+};
+
+}  // namespace mooncake
+
+#endif  // TRANSFER_METADATA_PLUGIN

--- a/mooncake-ngxl-exp/include/transport/nvmeof_transport/cufile_context.h
+++ b/mooncake-ngxl-exp/include/transport/nvmeof_transport/cufile_context.h
@@ -1,0 +1,90 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CUFILE_CONTEXT_H_
+#define CUFILE_CONTEXT_H_
+
+#include <cufile.h>
+#include <fcntl.h>
+#include <glog/logging.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+#include <string>
+#include <system_error>
+
+static inline const char *GetCuErrorString(CUresult curesult) {
+    const char *descp = "";
+    if (cuGetErrorName(curesult, &descp) != CUDA_SUCCESS)
+        descp = "unknown cuda error";
+    return descp;
+}
+
+static std::string cuFileGetErrorString(int status) {
+    status = std::abs(status);
+    return IS_CUFILE_ERR(status) ? std::string(CUFILE_ERRSTR(status))
+                                 : std::string(std::strerror(status));
+}
+
+static std::string cuFileGetErrorString(CUfileError_t status) {
+    std::string errStr = cuFileGetErrorString(static_cast<int>(status.err));
+    if (IS_CUDA_ERR(status))
+        errStr.append(".").append(GetCuErrorString(status.cu_err));
+    return errStr;
+}
+
+#define CUFILE_CHECK(e)                                                       \
+    do {                                                                      \
+        if (e.err != CU_FILE_SUCCESS) {                                       \
+            throw std::runtime_error("Error Code: " + std::to_string(e.err) + \
+                                     " " + cuFileGetErrorString(e) + " @ " +  \
+                                     __FILE__ + ":" +                         \
+                                     std::to_string(__LINE__));               \
+            assert(false);                                                    \
+        }                                                                     \
+    } while (0)
+
+class CuFileContext {
+    CUfileHandle_t handle = NULL;
+    CUfileDescr_t desc;
+
+   public:
+    CUfileHandle_t getHandle() const { return handle; }
+
+    /// Create a GDS segment from file name. Return NULL on error.
+    explicit CuFileContext(const char *filename) {
+        int fd = open(filename, O_RDWR | O_DIRECT, 0664);
+        LOG(INFO) << "open " << filename << " get " << fd;
+        memset(&desc, 0, sizeof(desc));
+        desc.type = CU_FILE_HANDLE_TYPE_OPAQUE_FD;
+        desc.handle.fd = fd;
+        CUFILE_CHECK(cuFileHandleRegister(&handle, &desc));
+    }
+
+    CuFileContext(const CuFileContext &) = delete;
+    CuFileContext &operator=(const CuFileContext &) = delete;
+
+    ~CuFileContext() {
+        if (handle) {
+            cuFileHandleDeregister(handle);
+        }
+        if (desc.handle.fd) {
+            close(desc.handle.fd);
+        }
+    }
+};
+
+#endif

--- a/mooncake-ngxl-exp/include/transport/nvmeof_transport/cufile_desc_pool.h
+++ b/mooncake-ngxl-exp/include/transport/nvmeof_transport/cufile_desc_pool.h
@@ -1,0 +1,71 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CUFILE_DESC_POOL_H_
+#define CUFILE_DESC_POOL_H_
+
+#include <cufile.h>
+
+#include <atomic>
+#include <bitset>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+#include "transfer_engine.h"
+
+namespace mooncake {
+class CUFileDescPool {
+   public:
+    explicit CUFileDescPool();
+    ~CUFileDescPool();
+
+    CUFileDescPool(const CUFileDescPool &) = delete;
+    CUFileDescPool &operator=(const CUFileDescPool &) = delete;
+    CUFileDescPool(CUFileDescPool &&) = delete;
+
+    int allocCUfileDesc(size_t batch_size);  // ret: (desc_idx, start_idx)
+    
+    int pushParams(int idx, CUfileIOParams_t &io_params);
+
+    int submitBatch(int idx);
+
+    CUfileIOEvents_t getTransferStatus(int idx, int slice_id);
+
+    int getSliceNum(int idx);
+
+    int freeCUfileDesc(int idx);
+
+   private:
+    static const size_t MAX_NR_CUFILE_DESC = 16;
+    static const size_t MAX_CUFILE_BATCH_SIZE = 128;
+    thread_local static int thread_index;
+    static std::atomic<int> index_counter;
+    // 1. indicates whether a file descriptor is available
+    std::atomic<uint64_t> occupied_[MAX_NR_CUFILE_DESC];
+    // 2. cufile desc array
+    CUfileBatchHandle_t handle_[MAX_NR_CUFILE_DESC];
+    // 3. start idx
+    int start_idx_[MAX_NR_CUFILE_DESC];
+    // 4. IO Params and IO Status
+    std::vector<CUfileIOParams_t> io_params_[MAX_NR_CUFILE_DESC];
+    std::vector<CUfileIOEvents_t> io_events_[MAX_NR_CUFILE_DESC];
+
+    RWSpinlock mutex_;
+};
+
+}  // namespace mooncake
+
+#endif

--- a/mooncake-ngxl-exp/include/transport/nvmeof_transport/nvmeof_transport.h
+++ b/mooncake-ngxl-exp/include/transport/nvmeof_transport/nvmeof_transport.h
@@ -1,0 +1,108 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NVMEOF_TRANSPORT_H_
+#define NVMEOF_TRANSPORT_H_
+
+#include <bits/stdint-uintn.h>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "cufile_context.h"
+#include "cufile_desc_pool.h"
+#include "transfer_metadata.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+class NVMeoFTransport : public Transport {
+   public:
+    NVMeoFTransport();
+
+    ~NVMeoFTransport();
+
+    BatchID allocateBatchID(size_t batch_size) override;
+
+    Status submitTransfer(BatchID batch_id,
+                          const std::vector<TransferRequest> &entries) override;
+
+    Status getTransferStatus(BatchID batch_id, size_t task_id,
+                             TransferStatus &status) override;
+
+    Status freeBatchID(BatchID batch_id) override;
+
+   private:
+    struct NVMeoFBatchDesc {
+        size_t desc_idx_;
+        std::vector<TransferStatus> transfer_status;
+        std::vector<std::pair<uint64_t, uint64_t>>
+            task_to_slices;  // task id -> (slice_begin, slice_num)
+        // unsigned nr_completed;
+    };
+
+    struct pair_hash {
+        template <class T1, class T2>
+        std::size_t operator()(const std::pair<T1, T2> &pair) const {
+            auto hash1 = std::hash<T1>{}(pair.first);
+            auto hash2 = std::hash<T2>{}(pair.second);
+            return hash1 ^ hash2;
+        }
+    };
+
+    int install(std::string &local_server_name,
+                std::shared_ptr<TransferMetadata> meta,
+                std::shared_ptr<Topology> topo) override;
+
+    int registerLocalMemory(void *addr, size_t length,
+                            const std::string &location, bool remote_accessible,
+                            bool update_metadata) override;
+
+    int unregisterLocalMemory(void *addr,
+                              bool update_metadata = false) override;
+
+    int registerLocalMemoryBatch(
+        const std::vector<Transport::BufferEntry> &buffer_list,
+        const std::string &location) override {
+        return 0;
+    }
+
+    int unregisterLocalMemoryBatch(
+        const std::vector<void *> &addr_list) override {
+        return 0;
+    }
+
+    void addSliceToTask(void *source_addr, uint64_t slice_len,
+                        uint64_t target_start, TransferRequest::OpCode op,
+                        TransferTask &task, const char *file_path);
+
+    void addSliceToCUFileBatch(void *source_addr, uint64_t file_offset,
+                               uint64_t slice_len, uint64_t desc_id,
+                               TransferRequest::OpCode op, CUfileHandle_t fh);
+
+    const char *getName() const override { return "nvmeof"; }
+
+    std::unordered_map<std::pair<SegmentID, uint64_t>,
+                       std::shared_ptr<CuFileContext>, pair_hash>
+        segment_to_context_;
+    std::vector<std::thread> workers_;
+
+    std::shared_ptr<CUFileDescPool> desc_pool_;
+    RWSpinlock context_lock_;
+};
+}  // namespace mooncake
+
+#endif

--- a/mooncake-ngxl-exp/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-ngxl-exp/include/transport/rdma_transport/endpoint_store.h
@@ -1,0 +1,115 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ENDPOINT_STORE_H_
+#define ENDPOINT_STORE_H_
+
+#include <infiniband/verbs.h>
+
+#include <atomic>
+#include <memory>
+#include <optional>
+
+#include "rdma_context.h"
+#include "rdma_endpoint.h"
+
+using namespace mooncake;
+
+namespace mooncake {
+// TODO: this can be implemented in std::concept from c++20
+/* TODO: A better abstraction may be used to reduce redundant codes,
+for example, make "cache eviction policy" a abstract class. Currently,
+cache data structure and eviction policy are put in the same class, for
+different eviction policy may need different data structure
+(e.g. lock-free queue for FIFO) for better performance
+*/
+class EndpointStore {
+   public:
+    virtual std::shared_ptr<RdmaEndPoint> getEndpoint(
+        const std::string &peer_nic_path) = 0;
+    virtual std::shared_ptr<RdmaEndPoint> insertEndpoint(
+        const std::string &peer_nic_path, RdmaContext *context) = 0;
+    virtual int deleteEndpoint(const std::string &peer_nic_path) = 0;
+    virtual void evictEndpoint() = 0;
+    virtual void reclaimEndpoint() = 0;
+    virtual size_t getSize() = 0;
+
+    virtual int destroyQPs() = 0;
+    virtual int disconnectQPs() = 0;
+};
+
+// FIFO
+class FIFOEndpointStore : public EndpointStore {
+   public:
+    FIFOEndpointStore(size_t max_size) : max_size_(max_size) {}
+    std::shared_ptr<RdmaEndPoint> getEndpoint(
+        const std::string &peer_nic_path) override;
+    std::shared_ptr<RdmaEndPoint> insertEndpoint(
+        const std::string &peer_nic_path, RdmaContext *context) override;
+    int deleteEndpoint(const std::string &peer_nic_path) override;
+    void evictEndpoint() override;
+    void reclaimEndpoint() override;
+    size_t getSize() override;
+
+    int destroyQPs() override;
+    int disconnectQPs() override;
+
+   private:
+    RWSpinlock endpoint_map_lock_;
+    std::unordered_map<std::string, std::shared_ptr<RdmaEndPoint>>
+        endpoint_map_;
+    std::unordered_map<std::string, std::list<std::string>::iterator> fifo_map_;
+    std::list<std::string> fifo_list_;
+
+    std::unordered_set<std::shared_ptr<RdmaEndPoint>> waiting_list_;
+
+    size_t max_size_;
+};
+
+// NSDI 24, similar to clock with quick demotion
+class SIEVEEndpointStore : public EndpointStore {
+   public:
+    SIEVEEndpointStore(size_t max_size)
+        : waiting_list_len_(0), max_size_(max_size) {}
+    std::shared_ptr<RdmaEndPoint> getEndpoint(
+        const std::string &peer_nic_path) override;
+    std::shared_ptr<RdmaEndPoint> insertEndpoint(
+        const std::string &peer_nic_path, RdmaContext *context) override;
+    int deleteEndpoint(const std::string &peer_nic_path) override;
+    void evictEndpoint() override;
+    void reclaimEndpoint() override;
+    size_t getSize() override;
+
+    int destroyQPs() override;
+    int disconnectQPs() override;
+
+   private:
+    RWSpinlock endpoint_map_lock_;
+    // The bool represents visited
+    std::unordered_map<
+        std::string, std::pair<std::shared_ptr<RdmaEndPoint>, std::atomic_bool>>
+        endpoint_map_;
+    std::unordered_map<std::string, std::list<std::string>::iterator> fifo_map_;
+    std::list<std::string> fifo_list_;
+
+    std::optional<std::list<std::string>::iterator> hand_;
+
+    std::unordered_set<std::shared_ptr<RdmaEndPoint>> waiting_list_;
+    std::atomic<int> waiting_list_len_;
+
+    size_t max_size_;
+};
+}  // namespace mooncake
+
+#endif

--- a/mooncake-ngxl-exp/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-ngxl-exp/include/transport/rdma_transport/rdma_context.h
@@ -1,0 +1,181 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RDMA_CONTEXT_H
+#define RDMA_CONTEXT_H
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <infiniband/verbs.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include "common.h"
+#include "rdma_transport.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+
+class RdmaEndPoint;
+class RdmaTransport;
+class WorkerPool;
+class EndpointStore;
+
+struct RdmaCq {
+    RdmaCq() : native(nullptr), outstanding(0) {}
+    ibv_cq *native;
+    volatile int outstanding;
+};
+
+// RdmaContext represents the set of resources controlled by each local NIC,
+// including Memory Region, CQ, EndPoint (QPs), etc.
+class RdmaContext {
+   public:
+    RdmaContext(RdmaTransport &engine, const std::string &device_name);
+
+    ~RdmaContext();
+
+    int construct(size_t num_cq_list = 1, size_t num_comp_channels = 1,
+                  uint8_t port = 1, int gid_index = 0, size_t max_cqe = 4096,
+                  int max_endpoints = 256);
+
+   private:
+    int deconstruct();
+
+   public:
+    // Memory Region Management
+    int registerMemoryRegion(void *addr, size_t length, int access);
+
+    int unregisterMemoryRegion(void *addr);
+
+    uint32_t rkey(void *addr);
+
+    uint32_t lkey(void *addr);
+
+   public:
+    bool active() const { return active_; }
+
+    void set_active(bool flag) { active_ = flag; }
+
+   public:
+    // EndPoint Management
+    std::shared_ptr<RdmaEndPoint> endpoint(const std::string &peer_nic_path);
+
+    int deleteEndpoint(const std::string &peer_nic_path);
+
+    int disconnectAllEndpoints();
+
+   public:
+    // Device name, such as `mlx5_3`
+    std::string deviceName() const { return device_name_; }
+
+    // NIC Path, such as `192.168.3.76@mlx5_3`
+    std::string nicPath() const;
+
+   public:
+    uint16_t lid() const { return lid_; }
+
+    std::string gid() const;
+
+    int gidIndex() const { return gid_index_; }
+
+    ibv_context *context() const { return context_; }
+
+    RdmaTransport &engine() const { return engine_; }
+
+    ibv_pd *pd() const { return pd_; }
+
+    uint8_t portNum() const { return port_; }
+
+    int activeSpeed() const { return active_speed_; }
+
+    ibv_mtu activeMTU() const { return active_mtu_; }
+
+    ibv_comp_channel *compChannel();
+
+    int compVector();
+
+    int eventFd() const { return event_fd_; }
+
+    ibv_cq *cq();
+
+    volatile int *cqOutstandingCount(int cq_index) {
+        return &cq_list_[cq_index].outstanding;
+    }
+
+    int cqCount() const { return cq_list_.size(); }
+
+    int poll(int num_entries, ibv_wc *wc, int cq_index = 0);
+
+    int socketId();
+
+   private:
+    int openRdmaDevice(const std::string &device_name, uint8_t port,
+                       int gid_index);
+
+    int joinNonblockingPollList(int event_fd, int data_fd);
+
+    int getBestGidIndex(const std::string &device_name,
+                        struct ibv_context *context, ibv_port_attr &port_attr,
+                        uint8_t port);
+
+   public:
+    int submitPostSend(const std::vector<Transport::Slice *> &slice_list);
+
+   private:
+    const std::string device_name_;
+    RdmaTransport &engine_;
+
+    ibv_context *context_ = nullptr;
+    ibv_pd *pd_ = nullptr;
+    int event_fd_ = -1;
+
+    size_t num_comp_channel_ = 0;
+    ibv_comp_channel **comp_channel_ = nullptr;
+
+    uint8_t port_ = 0;
+    uint16_t lid_ = 0;
+    int gid_index_ = -1;
+    int active_speed_ = -1;
+    ibv_mtu active_mtu_;
+    ibv_gid gid_;
+
+    RWSpinlock memory_regions_lock_;
+    std::vector<ibv_mr *> memory_region_list_;
+    std::vector<RdmaCq> cq_list_;
+
+    std::shared_ptr<EndpointStore> endpoint_store_;
+
+    std::vector<std::thread> background_thread_;
+    std::atomic<bool> threads_running_;
+
+    std::atomic<int> next_comp_channel_index_;
+    std::atomic<int> next_comp_vector_index_;
+    std::atomic<int> next_cq_list_index_;
+
+    std::shared_ptr<WorkerPool> worker_pool_;
+
+    volatile bool active_;
+};
+
+}  // namespace mooncake
+
+#endif  // RDMA_CONTEXT_H

--- a/mooncake-ngxl-exp/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-ngxl-exp/include/transport/rdma_transport/rdma_endpoint.h
@@ -1,0 +1,133 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RDMA_ENDPOINT_H
+#define RDMA_ENDPOINT_H
+
+#include <queue>
+
+#include "rdma_context.h"
+
+namespace mooncake {
+
+// RdmaEndPoint represents all QP connections between the local NIC1 (identified
+// by its RdmaContext) and the remote NIC2 (identified by peer_nic_path).
+// 1. After construct, resources are allocated without specifying the peers.
+// 2. Handshake information needs to be exchanged with remote RdmaEndPoint.
+//    - Local side calls the setupConnectionsByActive() function, passing in the
+//    peer_nic_path of the remote side
+//      peer_nic_path := peer_server_name@nic_name, e.g. 192.168.3.76@mlx5_3,
+//      which can be obtained from RdmaContext::nicPath() on the remote side
+//    - Remote side calls the setupConnectionsByPassive() function in its RPC
+//    service.
+//   After above steps, the RdmaEndPoint state is set to CONNECTED
+//
+// If the user initiates a disconnect() call or an error is detected internally,
+// the connection is closed and the RdmaEndPoint state is set to UNCONNECTED.
+// The handshake can be restarted at this point.
+class RdmaEndPoint {
+   public:
+    enum Status {
+        INITIALIZING,
+        UNCONNECTED,
+        CONNECTED,
+    };
+
+   public:
+    RdmaEndPoint(RdmaContext &context);
+
+    ~RdmaEndPoint();
+
+    int construct(ibv_cq *cq, size_t num_qp_list = 2, size_t max_sge = 4,
+                  size_t max_wr = 256, size_t max_inline = 64);
+
+   private:
+    int deconstruct();
+
+   public:
+    void setPeerNicPath(const std::string &peer_nic_path);
+
+    int setupConnectionsByActive();
+
+    int setupConnectionsByActive(const std::string &peer_nic_path) {
+        setPeerNicPath(peer_nic_path);
+        return setupConnectionsByActive();
+    }
+
+    using HandShakeDesc = TransferMetadata::HandShakeDesc;
+    int setupConnectionsByPassive(const HandShakeDesc &peer_desc,
+                                  HandShakeDesc &local_desc);
+
+    bool hasOutstandingSlice() const;
+
+    bool active() const { return active_; }
+
+    void set_active(bool flag) { active_ = flag; }
+
+   public:
+    bool connected() const {
+        return status_.load(std::memory_order_relaxed) == CONNECTED;
+    }
+
+    // Interrupts the connection, which can be triggered by user or by internal
+    // error. Use setupConnectionsByActive or setupConnectionsByPassive to
+    // reconnect
+    void disconnect();
+
+    // Destroy QPs before CQs (in RDMA Context)
+    int destroyQP();
+
+   private:
+    void disconnectUnlocked();
+
+   public:
+    const std::string toString() const;
+
+   public:
+    // Submit some work requests to HW
+    // Submitted tasks (success/failed) are removed in slice_list
+    // Failed tasks (which must be submitted) are inserted in failed_slice_list
+    int submitPostSend(std::vector<Transport::Slice *> &slice_list,
+                       std::vector<Transport::Slice *> &failed_slice_list);
+
+   private:
+    std::vector<uint32_t> qpNum() const;
+
+    int doSetupConnection(const std::string &peer_gid, uint16_t peer_lid,
+                          std::vector<uint32_t> peer_qp_num_list,
+                          std::string *reply_msg = nullptr);
+
+    int doSetupConnection(int qp_index, const std::string &peer_gid,
+                          uint16_t peer_lid, uint32_t peer_qp_num,
+                          std::string *reply_msg = nullptr);
+
+   private:
+    RdmaContext &context_;
+    std::atomic<Status> status_;
+
+    RWSpinlock lock_;
+    std::vector<ibv_qp *> qp_list_;
+
+    std::string peer_nic_path_;
+
+    volatile int *wr_depth_list_;
+    int max_wr_depth_;
+
+    volatile bool active_;
+    volatile int *cq_outstanding_;
+};
+
+}  // namespace mooncake
+
+#endif  // RDMA_ENDPOINT_H

--- a/mooncake-ngxl-exp/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-ngxl-exp/include/transport/rdma_transport/rdma_transport.h
@@ -1,0 +1,113 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRANSFER_ENGINE
+#define TRANSFER_ENGINE
+
+#include <infiniband/verbs.h>
+
+#include <atomic>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "topology.h"
+#include "transfer_metadata.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+
+class RdmaContext;
+class RdmaEndPoint;
+class TransferMetadata;
+class WorkerPool;
+
+class RdmaTransport : public Transport {
+    friend class RdmaContext;
+    friend class RdmaEndPoint;
+    friend class WorkerPool;
+
+    using HandShakeDesc = TransferMetadata::HandShakeDesc;
+
+   public:
+    RdmaTransport();
+
+    ~RdmaTransport();
+
+    int install(std::string &local_server_name,
+                std::shared_ptr<TransferMetadata> meta,
+                std::shared_ptr<Topology> topo) override;
+
+    const char *getName() const override { return "rdma"; }
+
+    int registerLocalMemory(void *addr, size_t length,
+                            const std::string &location, bool remote_accessible,
+                            bool update_metadata) override;
+
+    int unregisterLocalMemory(void *addr, bool update_metadata = true) override;
+
+    int registerLocalMemoryBatch(const std::vector<BufferEntry> &buffer_list,
+                                 const std::string &location) override;
+
+    int unregisterLocalMemoryBatch(
+        const std::vector<void *> &addr_list) override;
+
+    Status submitTransferTask(
+        const std::vector<TransferRequest *> &request_list,
+        const std::vector<TransferTask *> &task_list) override;
+
+    SegmentID getSegmentID(const std::string &segment_name);
+
+   private:
+    int allocateLocalSegmentID();
+
+   public:
+    int onSetupRdmaConnections(const HandShakeDesc &peer_desc,
+                               HandShakeDesc &local_desc);
+
+    int sendHandshake(const std::string &peer_server_name,
+                      const HandShakeDesc &local_desc,
+                      HandShakeDesc &peer_desc) {
+        return metadata_->sendHandshake(peer_server_name, local_desc,
+                                        peer_desc);
+    }
+
+   private:
+    int initializeRdmaResources();
+
+    int startHandshakeDaemon(std::string &local_server_name);
+
+   public:
+    static int selectDevice(SegmentDesc *desc, uint64_t offset, size_t length,
+                            int &buffer_id, int &device_id, int retry_cnt = 0);
+
+   private:
+    std::vector<std::shared_ptr<RdmaContext>> context_list_;
+    std::shared_ptr<Topology> local_topology_;
+};
+
+using TransferRequest = Transport::TransferRequest;
+using TransferStatus = Transport::TransferStatus;
+using TransferStatusEnum = Transport::TransferStatusEnum;
+using SegmentID = Transport::SegmentID;
+using BatchID = Transport::BatchID;
+
+}  // namespace mooncake
+
+#endif  // TRANSFER_ENGINE

--- a/mooncake-ngxl-exp/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-ngxl-exp/include/transport/rdma_transport/worker_pool.h
@@ -1,0 +1,73 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WORKER_H
+#define WORKER_H
+
+#include <queue>
+#include <unordered_set>
+
+#include "rdma_context.h"
+
+namespace mooncake {
+class WorkerPool {
+   public:
+    WorkerPool(RdmaContext &context, int numa_socket_id = 0);
+
+    ~WorkerPool();
+
+    // Add slices to queue, called by Transport
+    int submitPostSend(const std::vector<Transport::Slice *> &slice_list);
+
+   private:
+    void performPostSend(int thread_id);
+
+    void performPollCq(int thread_id);
+
+    void redispatch(std::vector<Transport::Slice *> &slice_list, int thread_id);
+
+    void transferWorker(int thread_id);
+
+    void monitorWorker();
+
+    int doProcessContextEvents();
+
+   private:
+    RdmaContext &context_;
+    const int numa_socket_id_;
+
+    std::vector<std::thread> worker_thread_;
+    std::atomic<bool> workers_running_;
+    std::atomic<int> suspended_flag_;
+
+    std::atomic<int> redispatch_counter_;
+
+    std::mutex cond_mutex_;
+    std::condition_variable cond_var_;
+
+    using SliceList = std::vector<Transport::Slice *>;
+
+    const static int kShardCount = 8;
+    std::unordered_map<std::string, SliceList> slice_queue_[kShardCount];
+    std::atomic<uint64_t> slice_queue_count_[kShardCount];
+    TicketLock slice_queue_lock_[kShardCount];
+
+    std::vector<std::unordered_map<std::string, SliceList>>
+        collective_slice_queue_;
+
+    std::atomic<uint64_t> submitted_slice_count_, processed_slice_count_;
+};
+}  // namespace mooncake
+
+#endif  // WORKER_H

--- a/mooncake-ngxl-exp/include/transport/shm_transport/shm_transport.h
+++ b/mooncake-ngxl-exp/include/transport/shm_transport/shm_transport.h
@@ -1,0 +1,119 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SHM_TRANSPORT_H_
+#define SHM_TRANSPORT_H_
+
+#include <boost/asio.hpp>
+#include <boost/thread.hpp>
+#include <functional>
+#include <iostream>
+#include <queue>
+
+#include "transfer_metadata.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+class TransferMetadata;
+
+class ThreadPool {
+   public:
+    ThreadPool(size_t threadCount)
+        : ioService_(),
+          work_(boost::asio::make_work_guard(ioService_)),
+          stopped_(false) {
+        for (size_t i = 0; i < threadCount; ++i) {
+            threads_.create_thread(
+                boost::bind(&boost::asio::io_service::run, &ioService_));
+        }
+    }
+
+    ~ThreadPool() { stop(); }
+
+    void submit(std::function<void()> task) {
+        ioService_.post(std::move(task));
+    }
+
+    void stop() {
+        if (!stopped_) {
+            stopped_ = true;
+            ioService_.stop();
+            threads_.join_all();
+        }
+    }
+
+   private:
+    boost::asio::io_service ioService_;
+    boost::asio::executor_work_guard<boost::asio::io_service::executor_type>
+        work_;
+    boost::thread_group threads_;
+    bool stopped_;
+};
+
+class ShmTransport : public Transport {
+   public:
+    ShmTransport();
+
+    ~ShmTransport();
+
+    Status submitTransferTask(
+        const std::vector<TransferRequest *> &request_list,
+        const std::vector<TransferTask *> &task_list) override;
+
+   private:
+    int install(std::string &local_server_name,
+                std::shared_ptr<TransferMetadata> metadata,
+                std::shared_ptr<Topology> topology);
+
+    void startTransfer(Slice *slice);
+
+    int registerLocalMemory(void *addr, size_t length,
+                            const std::string &location, bool remote_accessible,
+                            bool update_metadata);
+
+    int unregisterLocalMemory(void *addr, bool update_metadata = false);
+
+    int registerLocalMemoryBatch(
+        const std::vector<Transport::BufferEntry> &buffer_list,
+        const std::string &location);
+
+    int unregisterLocalMemoryBatch(
+        const std::vector<void *> &addr_list) override;
+
+    void *allocateLocalMemory(size_t length, const std::string &location);
+
+    int deallocateLocalMemory(void *addr);
+
+    void *createSharedMemory(const std::string &path, size_t size);
+
+    int relocateSharedMemoryAddress(uint64_t &dest_addr, uint64_t length, uint64_t target_id);
+
+    const char *getName() const override { return "shm"; }
+
+   private:
+    std::atomic_bool running_;
+    ThreadPool thread_pool_;
+
+    struct OpenedShmEntry {
+        int shm_fd;
+        void *shm_addr;
+        uint64_t length;
+    };
+
+    std::unordered_map<void *, std::string> created_entries_;
+    std::unordered_map<uint64_t, OpenedShmEntry> remap_entries_;
+};
+}  // namespace mooncake
+
+#endif

--- a/mooncake-ngxl-exp/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-ngxl-exp/include/transport/tcp_transport/tcp_transport.h
@@ -1,0 +1,82 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TCP_TRANSPORT_H_
+#define TCP_TRANSPORT_H_
+
+#include <infiniband/verbs.h>
+
+#include <atomic>
+#include <boost/asio.hpp>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "transfer_metadata.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+class TransferMetadata;
+class TcpContext;
+
+class TcpTransport : public Transport {
+   public:
+    TcpTransport();
+
+    ~TcpTransport();
+
+    Status submitTransferTask(
+        const std::vector<TransferRequest *> &request_list,
+        const std::vector<TransferTask *> &task_list) override;
+
+   private:
+    int install(std::string &local_server_name,
+                std::shared_ptr<TransferMetadata> meta,
+                std::shared_ptr<Topology> topo);
+
+    int allocateLocalSegmentID();
+
+    int registerLocalMemory(void *addr, size_t length,
+                            const std::string &location, bool remote_accessible,
+                            bool update_metadata);
+
+    int unregisterLocalMemory(void *addr, bool update_metadata = false);
+
+    int registerLocalMemoryBatch(
+        const std::vector<Transport::BufferEntry> &buffer_list,
+        const std::string &location);
+
+    int unregisterLocalMemoryBatch(
+        const std::vector<void *> &addr_list) override;
+
+    void worker();
+
+    void startTransfer(Slice *slice);
+
+    const char *getName() const override { return "tcp"; }
+
+   private:
+    TcpAttr tcp_attr_;
+    TcpContext *context_;
+    std::atomic_bool running_;
+    std::thread thread_;
+};
+}  // namespace mooncake
+
+#endif

--- a/mooncake-ngxl-exp/include/transport/transport.h
+++ b/mooncake-ngxl-exp/include/transport/transport.h
@@ -1,0 +1,200 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRANSPORT_H_
+#define TRANSPORT_H_
+
+#include <bits/stdint-uintn.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "common/base/status.h"
+#include "transfer_metadata.h"
+
+namespace mooncake {
+class TransferMetadata;
+
+class Transport {
+    friend class TransferEngine;
+    friend class MultiTransport;
+
+   public:
+    using SegmentID = uint64_t;
+
+    using BatchID = uint64_t;
+    const static BatchID INVALID_BATCH_ID = UINT64_MAX;
+
+    struct TransferRequest {
+        enum OpCode { READ, WRITE };
+
+        OpCode opcode;
+        void *source;
+        SegmentID target_id;
+        uint64_t target_offset;
+        size_t length;
+    };
+
+    enum TransferStatusEnum {
+        WAITING,
+        PENDING,
+        INVALID,
+        CANNELED,
+        COMPLETED,
+        TIMEOUT,
+        FAILED
+    };
+
+    struct TransferStatus {
+        TransferStatusEnum s;
+        size_t transferred_bytes;
+    };
+
+    struct TransferTask;
+
+    struct Slice {
+        enum SliceStatus { PENDING, POSTED, SUCCESS, TIMEOUT, FAILED };
+
+        void *source_addr;
+        size_t length;
+        TransferRequest::OpCode opcode;
+        SegmentID target_id;
+        std::string peer_nic_path;
+        SliceStatus status;
+        TransferTask *task;
+
+        union {
+            struct {
+                uint64_t dest_addr;
+                uint32_t source_lkey;
+                uint32_t dest_rkey;
+                int rkey_index;
+                volatile int *qp_depth;
+                uint32_t retry_cnt;
+                uint32_t max_retry_cnt;
+            } rdma;
+            struct {
+                void *dest_addr;
+            } local;
+            struct {
+                uint64_t dest_addr;
+            } tcp;
+            struct {
+                const char *file_path;
+                uint64_t start;
+                uint64_t length;
+                uint64_t buffer_id;
+            } nvmeof;
+        };
+
+       public:
+        void markSuccess() {
+            status = Slice::SUCCESS;
+            __sync_fetch_and_add(&task->transferred_bytes, length);
+            __sync_fetch_and_add(&task->success_slice_count, 1);
+        }
+
+        void markFailed() {
+            status = Slice::FAILED;
+            __sync_fetch_and_add(&task->failed_slice_count, 1);
+        }
+    };
+
+    struct TransferTask {
+        volatile uint64_t slice_count = 0;
+        volatile uint64_t success_slice_count = 0;
+        volatile uint64_t failed_slice_count = 0;
+        volatile uint64_t transferred_bytes = 0;
+        volatile bool is_finished = false;
+        uint64_t total_bytes = 0;
+    };
+
+    struct BatchDesc {
+        BatchID id;
+        size_t batch_size;
+        std::vector<TransferTask> task_list;
+        void *context;  // for transport implementers.
+    };
+
+   public:
+    virtual ~Transport() {}
+
+    /// @brief Submit a batch of transfer requests to the batch.
+    /// @return The number of successfully submitted transfers on success. If
+    /// that number is less than nr, errno is set.
+    virtual Status submitTransferTask(
+        const std::vector<TransferRequest *> &request_list,
+        const std::vector<TransferTask *> &task_list) {
+        return Status::NotImplmented(
+            "Transport::submitTransferTask is not implemented");
+    }
+
+    std::shared_ptr<TransferMetadata> &meta() { return metadata_; }
+
+    struct BufferEntry {
+        void *addr;
+        size_t length;
+    };
+
+   protected:
+    virtual int install(std::string &local_server_name,
+                        std::shared_ptr<TransferMetadata> meta,
+                        std::shared_ptr<Topology> topo);
+
+    std::string local_server_name_;
+    std::shared_ptr<TransferMetadata> metadata_;
+
+    RWSpinlock batch_desc_lock_;
+    std::unordered_map<BatchID, std::shared_ptr<BatchDesc>> batch_desc_set_;
+
+   private:
+    virtual int registerLocalMemory(void *addr, size_t length,
+                                    const std::string &location,
+                                    bool remote_accessible,
+                                    bool update_metadata = true) = 0;
+
+    virtual int unregisterLocalMemory(void *addr,
+                                      bool update_metadata = true) = 0;
+
+    virtual int registerLocalMemoryBatch(
+        const std::vector<BufferEntry> &buffer_list,
+        const std::string &location) {
+        for (auto &entry : buffer_list) {
+            int rc =
+                registerLocalMemory(entry.addr, entry.length, location, true);
+            if (rc) return rc;
+        }
+        return 0;
+    }
+
+    virtual int unregisterLocalMemoryBatch(
+        const std::vector<void *> &addr_list) {
+        for (auto &entry : addr_list) {
+            int rc = unregisterLocalMemory(entry);
+            if (rc) return rc;
+        }
+        return 0;
+    }
+
+    virtual const char *getName() const = 0;
+};
+}  // namespace mooncake
+
+#endif  // TRANSPORT_H_

--- a/mooncake-ngxl-exp/scripts/mount.py
+++ b/mooncake-ngxl-exp/scripts/mount.py
@@ -1,0 +1,86 @@
+# Copyright 2024 KVCache.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import etcd3
+import sys
+import json
+import os
+import socket
+import subprocess
+
+def discover_nvmeof_targets(nqn, transport, traddr, trsvcid):
+    """Discover NVMe-oF targets."""
+    cmd = f"nvme discover -t {transport} -a {traddr} -s {trsvcid}"
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Discovery failed: {result.stderr}")
+        return None
+    print(f"Discovered NVMe-oF targets:\n{result.stdout}")
+    return result.stdout
+
+def connect_nvmeof_target(nqn, transport, traddr, trsvcid):
+    """Connect to NVMe-oF target."""
+    cmd = f"nvme connect -t {transport} -n {nqn} -a {traddr} -s {trsvcid}"
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Connection failed: {result.stderr}")
+        return None
+    print(f"Connected to NVMe-oF target:\n{result.stdout}")
+    return result.stdout
+
+def mount_nvme_device(device, mount_point):
+    """Mount the NVMe device to a specific mount point."""
+    os.makedirs(mount_point, exist_ok=True)
+    cmd = f"mount {device} {mount_point}"
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Mount failed: {result.stderr}")
+        return None
+    print(f"Mounted {device} on {mount_point}")
+    return mount_point
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        print("Usage: python mount.py <etcd_host> <segment_name> <file_path> <local_path>")
+        sys.exit(1)
+
+    os.environ.pop("HTTP_PROXY", None)
+    os.environ.pop("HTTPS_PROXY", None)
+    os.environ.pop("http_proxy", None)
+    os.environ.pop("https_proxy", None)
+    etcd_host = sys.argv[1]
+    segment_name = sys.argv[2]
+    file_path = sys.argv[3]
+    local_path = sys.argv[4]
+
+    local_server_name = socket.gethostname()
+
+    etcd = etcd3.client(host=etcd_host, port=2379)
+    value, _ = etcd.get(segment_name)
+
+    segment = json.loads(value)
+    buffers = segment["buffers"]
+    print(buffers)
+
+    buffer = next((b for b in buffers if b["file_path"] == file_path), None)
+    buffer['local_path_map'][local_server_name] = local_path
+
+    etcd.put(segment_name, json.dumps(segment))
+    print(etcd.get(segment_name)[0])
+
+    etcd.put(segment_name, json.dumps(segment))
+    print(etcd.get(segment_name)[0])
+
+  # TODO: mount the buffer to local_path, currently users should mount buffers manually
+

--- a/mooncake-ngxl-exp/scripts/register.py
+++ b/mooncake-ngxl-exp/scripts/register.py
@@ -1,0 +1,59 @@
+# Copyright 2024 KVCache.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import etcd3
+import sys
+import json
+import os
+import socket
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: python mount.py <etcd_server> <segment_name> <file_path> ...")
+        sys.exit(1)
+
+    os.environ.pop("HTTP_PROXY", None)
+    os.environ.pop("HTTPS_PROXY", None)
+    os.environ.pop("http_proxy", None)
+    os.environ.pop("https_proxy", None)
+    etcd_server = sys.argv[1]
+    segment_name = "nvmeof/" + sys.argv[2]
+    files = sys.argv[3:]
+    local_server_name = socket.gethostname()
+
+    etcd_host = sys.argv[1]
+    files = sys.argv[2:]
+
+    server_name = socket.gethostname()
+    print(server_name)
+    segment_name = "mooncake/nvmeof/" + server_name
+    print(segment_name)
+
+    etcd = etcd3.client(host=etcd_host, port=2379)
+
+    value = {}
+    value['server_name'] = server_name
+    value['protocol'] = "nvmeof"
+    value['buffers'] = []
+    for file in files:
+      # TODO: check file path existence
+      buffer = {}
+      buffer['length'] = os.path.getsize(file)
+      buffer['file_path'] = file
+      buffer['local_path_map'] = {}
+      value['buffers'].append(buffer)
+    
+    print(json.dumps(value))
+    etcd.put(segment_name, json.dumps(value))
+

--- a/mooncake-ngxl-exp/src/CMakeLists.txt
+++ b/mooncake-ngxl-exp/src/CMakeLists.txt
@@ -1,0 +1,42 @@
+file(GLOB ENGINE_SOURCES "*.cpp")
+add_subdirectory(common)
+add_subdirectory(transport)
+
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+add_library(ngxl ${ENGINE_SOURCES} $<TARGET_OBJECTS:ngxl_common> $<TARGET_OBJECTS:ngxl_transport>)
+if (BUILD_SHARED_LIBS)
+  install(TARGETS ngxl DESTINATION lib)
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GRPCPP REQUIRED grpc++)
+pkg_check_modules(GRPC REQUIRED grpc)
+
+add_compile_definitions(ngxl PUBLIC MOONCAKE_USE_ETCD)
+if (USE_ETCD)
+  if (USE_STATIC_ETCD_CPP_API)
+    target_link_libraries(ngxl PUBLIC etcd-cpp-api-core protobuf ${GRPC_LDFLAGS} ${GRPCPP_LDFLAGS})
+  else()
+    target_link_libraries(ngxl PUBLIC etcd-cpp-api)
+  endif()
+endif()
+if (USE_REDIS)
+  target_link_libraries(ngxl PUBLIC hiredis)
+endif()
+if (USE_HTTP)
+  find_package(CURL REQUIRED)
+  target_link_libraries(ngxl PUBLIC ${CURL_LIBRARIES})
+endif()
+target_link_libraries(
+  ngxl PUBLIC
+  ngxl_common ngxl_transport rdma_ngxl_transport ibverbs glog gflags pthread jsoncpp numa boost_thread
+)
+
+if (USE_CUDA)
+  target_include_directories(ngxl PRIVATE /usr/local/cuda/include)
+  target_link_libraries(ngxl PUBLIC cuda cudart rt)
+  if (USE_NVMEOF)
+    target_link_libraries(ngxl PUBLIC nvmeof_transport cufile)
+  endif()
+endif()

--- a/mooncake-ngxl-exp/src/common/CMakeLists.txt
+++ b/mooncake-ngxl-exp/src/common/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB COMMON_SOURCES "*.cpp")
+
+add_subdirectory(base)
+add_library(ngxl_common ${XPORT_SOURCES} $<TARGET_OBJECTS:ngxl_common_base>)

--- a/mooncake-ngxl-exp/src/common/base/CMakeLists.txt
+++ b/mooncake-ngxl-exp/src/common/base/CMakeLists.txt
@@ -1,0 +1,2 @@
+file(GLOB COMMON_BASE_SOURCES "*.cpp")
+add_library(ngxl_common_base OBJECT ${COMMON_BASE_SOURCES})

--- a/mooncake-ngxl-exp/src/common/base/status.cpp
+++ b/mooncake-ngxl-exp/src/common/base/status.cpp
@@ -1,0 +1,125 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The design of this code is adapted from the RocksDB project with some
+// modifications.
+// https://github.com/facebook/rocksdb/blob/main/util/status.cc
+
+#include "common/base/status.h"
+
+#include <cstring>
+
+#include "glog/logging.h"
+
+namespace mooncake {
+
+Status::Status(Status::Code code, std::string_view message)
+    : code_(code) {
+  if (code != Code::kOk) {
+    // Only store the message when it is not empty.
+    if (!message.empty()) {
+      const size_t len = message.size();
+      // +1 for null terminator
+      char* const result = new char[len + 1];
+      memcpy(result, message.data(), len);
+      result[len] = '\0';
+      message_ = result;
+    }
+  }
+}
+
+std::string Status::ToString() const {
+  if (ok()) {
+    return "OK";
+  } else {
+    return std::string(CodeToString(code())) + ": " + std::string(message());
+  }
+}
+
+std::string_view Status::CodeToString(Status::Code code) {
+  switch (code) {
+    case Code::kOk:
+      return "OK";
+    case Code::kInvalidArgument:
+      return "InvalidArgument";
+    case Code::kTooManyRequests:
+      return "TooManyRequests";
+    case Code::kAddressNotRegistered:
+      return "AddressNotRegistered";
+    case Code::kBatchBusy:
+      return "BatchBusy";
+    case Code::kDeviceNotFound:
+      return "DeviceNotFound";
+    case Code::kAddressOverlapped:
+      return "AddressOverlapped";
+    case Code::kDns:
+      return "Dns";
+    case Code::kSocket:
+      return "Socket";
+    case Code::kMalformedJson:
+      return "MalformedJson";
+    case Code::kRejectHandshake:
+      return "RejectHandshake";
+    case Code::kMetadata:
+      return "Metadata";
+    case Code::kEndpoint:
+      return "Endpoint";
+    case Code::kContext:
+      return "Context";
+    case Code::kNuma:
+      return "Numa";
+    case Code::kClock:
+      return "Clock";
+    case Code::kMemory:
+      return "Memory";
+    case Code::kNotImplmented:
+      return "NotImplmented";
+    default:
+      LOG(ERROR) << "Unknown code: " << static_cast<uint16_t>(code);
+      return "UnknownCode";
+  }
+}
+
+const char* Status::CopyMessage(const char* msg) {
+  // +1 for the null terminator
+  const size_t len = std::strlen(msg) + 1;
+  return std::strncpy(new char[len], msg, len);
+}
+
+bool Status::operator==(const Status& s) const {
+  // Compare the code.
+  if (code_ != s.code_) {
+    return false;
+  }
+  // Compare the message content.
+  if (message_ == nullptr && s.message_ == nullptr) {
+    return true;
+  }
+  if (message_ != nullptr && s.message_ != nullptr) {
+    return strcmp(message_, s.message_) == 0;
+  }
+  return false;
+}
+
+bool Status::operator!=(const Status& s) const { return !(*this == s); }
+
+std::ostream& operator<<(std::ostream& os, Status::Code code) {
+  return os << Status::CodeToString(code);
+}
+
+std::ostream& operator<<(std::ostream& os, const Status& s) {
+  return os << s.ToString();
+}
+
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/config.cpp
+++ b/mooncake-ngxl-exp/src/config.cpp
@@ -1,0 +1,239 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "config.h"
+
+namespace mooncake {
+void loadGlobalConfig(GlobalConfig &config) {
+    const char *num_cq_per_ctx_env = std::getenv("MC_NUM_CQ_PER_CTX");
+    if (num_cq_per_ctx_env) {
+        int val = atoi(num_cq_per_ctx_env);
+        if (val > 0 && val < 256)
+            config.num_cq_per_ctx = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_NUM_CQ_PER_CTX";
+    }
+
+    const char *num_comp_channels_per_ctx_env =
+        std::getenv("MC_NUM_COMP_CHANNELS_PER_CTX");
+    if (num_comp_channels_per_ctx_env) {
+        int val = atoi(num_comp_channels_per_ctx_env);
+        if (val > 0 && val < 256)
+            config.num_comp_channels_per_ctx = val;
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_NUM_COMP_CHANNELS_PER_CTX";
+    }
+
+    const char *port_env = std::getenv("MC_IB_PORT");
+    if (port_env) {
+        int val = atoi(port_env);
+        if (val >= 0 && val < 256)
+            config.port = uint8_t(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable MC_IB_PORT";
+    }
+
+    const char *gid_index_env = std::getenv("MC_GID_INDEX");
+    if (!gid_index_env) gid_index_env = std::getenv("NCCL_IB_GID_INDEX");
+
+    if (gid_index_env) {
+        int val = atoi(gid_index_env);
+        if (val >= 0 && val < 256)
+            config.gid_index = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_GID_INDEX";
+    }
+
+    const char *max_cqe_per_ctx_env = std::getenv("MC_MAX_CQE_PER_CTX");
+    if (max_cqe_per_ctx_env) {
+        size_t val = atoi(max_cqe_per_ctx_env);
+        if (val > 0 && val <= UINT16_MAX)
+            config.max_cqe = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_MAX_CQE_PER_CTX";
+    }
+
+    const char *max_ep_per_ctx_env = std::getenv("MC_MAX_EP_PER_CTX");
+    if (max_ep_per_ctx_env) {
+        size_t val = atoi(max_ep_per_ctx_env);
+        if (val > 0 && val <= UINT16_MAX)
+            config.max_ep_per_ctx = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_MAX_EP_PER_CTX";
+    }
+
+    const char *num_qp_per_ep_env = std::getenv("MC_NUM_QP_PER_EP");
+    if (num_qp_per_ep_env) {
+        int val = atoi(num_qp_per_ep_env);
+        if (val > 0 && val < 256)
+            config.num_qp_per_ep = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_NUM_QP_PER_EP";
+    }
+
+    const char *max_sge_env = std::getenv("MC_MAX_SGE");
+    if (max_sge_env) {
+        size_t val = atoi(max_sge_env);
+        if (val > 0 && val <= UINT16_MAX)
+            config.max_sge = val;
+        else
+            LOG(WARNING) << "Ignore value from environment variable MC_MAX_SGE";
+    }
+
+    const char *max_wr_env = std::getenv("MC_MAX_WR");
+    if (max_wr_env) {
+        size_t val = atoi(max_wr_env);
+        if (val > 0 && val <= UINT16_MAX)
+            config.max_wr = val;
+        else
+            LOG(WARNING) << "Ignore value from environment variable MC_MAX_WR";
+    }
+
+    const char *max_inline_env = std::getenv("MC_MAX_INLINE");
+    if (max_inline_env) {
+        size_t val = atoi(max_inline_env);
+        if (val <= UINT16_MAX)
+            config.max_inline = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_MAX_INLINE";
+    }
+
+    const char *mtu_length_env = std::getenv("MC_MTU");
+    if (mtu_length_env) {
+        size_t val = atoi(mtu_length_env);
+        if (val == 512)
+            config.mtu_length = IBV_MTU_512;
+        else if (val == 1024)
+            config.mtu_length = IBV_MTU_1024;
+        else if (val == 2048)
+            config.mtu_length = IBV_MTU_2048;
+        else if (val == 4096)
+            config.mtu_length = IBV_MTU_4096;
+        else {
+            LOG(ERROR) << "Ignore value from environment variable MC_MTU, it "
+                          "should be 512|1024|2048|4096";
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    const char *handshake_port_env = std::getenv("MC_HANDSHAKE_PORT");
+    if (handshake_port_env) {
+        int val = atoi(handshake_port_env);
+        if (val > 0 && val < 65536)
+            config.handshake_port = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_HANDSHAKE_PORT";
+    }
+
+    const char *workers_per_ctx_env = std::getenv("MC_WORKERS_PER_CTX");
+    if (workers_per_ctx_env) {
+        size_t val = atoi(workers_per_ctx_env);
+        if (val > 0 && val <= 8)
+            config.workers_per_ctx = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_WORKERS_PER_CTX";
+    }
+
+    const char *slice_size_env = std::getenv("MC_SLICE_SIZE");
+    if (slice_size_env) {
+        size_t val = atoi(slice_size_env);
+        if (val > 0)
+            config.slice_size = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_SLICE_SIZE";
+    }
+
+    const char *retry_cnt_env = std::getenv("MC_RETRY_CNT");
+    if (retry_cnt_env) {
+        size_t val = atoi(retry_cnt_env);
+        if (val > 0 && val < 128)
+            config.retry_cnt = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_RETRY_CNT";
+    }
+
+    const char *verbose_env = std::getenv("MC_VERBOSE");
+    if (verbose_env) {
+        config.verbose = true;
+    }
+}
+
+std::string mtuLengthToString(ibv_mtu mtu) {
+    if (mtu == IBV_MTU_512)
+        return "IBV_MTU_512";
+    else if (mtu == IBV_MTU_1024)
+        return "IBV_MTU_1024";
+    else if (mtu == IBV_MTU_2048)
+        return "IBV_MTU_2048";
+    else if (mtu == IBV_MTU_4096)
+        return "IBV_MTU_4096";
+    else
+        return "UNKNOWN";
+}
+
+void updateGlobalConfig(ibv_device_attr &device_attr) {
+    auto &config = globalConfig();
+    if (config.max_ep_per_ctx * config.num_qp_per_ep >
+        (size_t)device_attr.max_qp)
+        config.max_ep_per_ctx = device_attr.max_qp / config.num_qp_per_ep;
+    if (config.num_cq_per_ctx > (size_t)device_attr.max_cq)
+        config.num_cq_per_ctx = device_attr.max_cq;
+    if (config.max_wr > (size_t)device_attr.max_qp_wr)
+        config.max_wr = device_attr.max_qp_wr;
+    if (config.max_sge > (size_t)device_attr.max_sge)
+        config.max_sge = device_attr.max_sge;
+    if (config.max_cqe > (size_t)device_attr.max_cqe)
+        config.max_cqe = device_attr.max_cqe;
+}
+
+void dumpGlobalConfig() {
+    auto &config = globalConfig();
+    LOG(INFO) << "=== GlobalConfig ===";
+    LOG(INFO) << "num_cq_per_ctx = " << config.num_cq_per_ctx;
+    LOG(INFO) << "num_comp_channels_per_ctx = "
+              << config.num_comp_channels_per_ctx;
+    LOG(INFO) << "port = " << config.port;
+    LOG(INFO) << "gid_index = " << config.gid_index;
+    LOG(INFO) << "max_cqe = " << config.max_cqe;
+    LOG(INFO) << "max_ep_per_ctx = " << config.max_ep_per_ctx;
+    LOG(INFO) << "num_qp_per_ep = " << config.num_qp_per_ep;
+    LOG(INFO) << "max_sge = " << config.max_sge;
+    LOG(INFO) << "max_wr = " << config.max_wr;
+    LOG(INFO) << "max_inline = " << config.max_inline;
+    LOG(INFO) << "mtu_length = " << mtuLengthToString(config.mtu_length);
+    LOG(INFO) << "verbose = " << (config.verbose ? "true" : "false");
+}
+
+GlobalConfig &globalConfig() {
+    static GlobalConfig config;
+    static std::once_flag g_once_flag;
+    std::call_once(g_once_flag, []() { loadGlobalConfig(config); });
+    return config;
+}
+
+uint16_t getDefaultHandshakePort() {
+    return globalConfig().handshake_port;
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/memory_location.cpp
+++ b/mooncake-ngxl-exp/src/memory_location.cpp
@@ -1,0 +1,67 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "memory_location.h"
+
+namespace mooncake {
+
+uintptr_t alignPage(uintptr_t address) { return address & ~(pagesize - 1); }
+
+std::string genCpuNodeName(int node) {
+    if (node >= 0) return "cpu:" + std::to_string(node);
+
+    // use "*" when failed to get the numa node.
+    return "*";
+}
+
+const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
+                                                         size_t len) {
+    std::vector<MemoryLocationEntry> entries;
+
+    // start and end address may not be page aligned.
+    uintptr_t aligned_start = alignPage((uintptr_t)start);
+    int n = (uintptr_t(start) - aligned_start + len + pagesize - 1) / pagesize;
+    void **pages = (void **)malloc(sizeof(void *) * n);
+    int *status = (int *)malloc(sizeof(int) * n);
+
+    for (int i = 0; i < n; i++) {
+        pages[i] = (void *)((char *)aligned_start + i * pagesize);
+    }
+
+    int rc = numa_move_pages(0, n, pages, nullptr, status, 0);
+    if (rc != 0) {
+        PLOG(WARNING) << "Failed to get NUMA node, addr: " << start
+                      << ", len: " << len;
+        entries.push_back({(uint64_t)start, len, "*"});
+        return entries;
+    }
+
+    int node = status[0];
+    uint64_t start_addr = (uint64_t)start;
+    uint64_t new_start_addr;
+    for (int i = 1; i < n; i++) {
+        if (status[i] != node) {
+            new_start_addr = alignPage((uint64_t)start) + i * pagesize;
+            entries.push_back({start_addr, size_t(new_start_addr - start_addr),
+                               genCpuNodeName(node)});
+            start_addr = new_start_addr;
+            node = status[i];
+        }
+    }
+    entries.push_back(
+        {start_addr, (uint64_t)start + len - start_addr, genCpuNodeName(node)});
+    return entries;
+}
+
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/multi_transport.cpp
+++ b/mooncake-ngxl-exp/src/multi_transport.cpp
@@ -1,0 +1,201 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "multi_transport.h"
+
+#include "transport/rdma_transport/rdma_transport.h"
+#include "transport/tcp_transport/tcp_transport.h"
+#include "transport/shm_transport/shm_transport.h"
+#include "transport/transport.h"
+#ifdef USE_NVMEOF
+#include "transport/nvmeof_transport/nvmeof_transport.h"
+#endif
+
+namespace mooncake {
+MultiTransport::MultiTransport(std::shared_ptr<TransferMetadata> metadata,
+                               std::string &local_server_name)
+    : metadata_(metadata), local_server_name_(local_server_name) {
+    // ...
+}
+
+MultiTransport::~MultiTransport() {
+    // ...
+}
+
+MultiTransport::BatchID MultiTransport::allocateBatchID(size_t batch_size) {
+    auto batch_desc = new BatchDesc();
+    if (!batch_desc) return ERR_MEMORY;
+    batch_desc->id = BatchID(batch_desc);
+    batch_desc->batch_size = batch_size;
+    batch_desc->task_list.reserve(batch_size);
+    batch_desc->context = NULL;
+#ifdef CONFIG_USE_BATCH_DESC_SET
+    batch_desc_lock_.lock();
+    batch_desc_set_[batch_desc->id] = batch_desc;
+    batch_desc_lock_.unlock();
+#endif
+    return batch_desc->id;
+}
+
+Status MultiTransport::freeBatchID(BatchID batch_id) {
+    auto &batch_desc = *((BatchDesc *)(batch_id));
+    const size_t task_count = batch_desc.task_list.size();
+    for (size_t task_id = 0; task_id < task_count; task_id++) {
+        if (!batch_desc.task_list[task_id].is_finished) {
+            LOG(ERROR) << "BatchID cannot be freed until all tasks are done";
+            return Status::BatchBusy(
+                "BatchID cannot be freed until all tasks are done");        }
+    }
+    delete &batch_desc;
+#ifdef CONFIG_USE_BATCH_DESC_SET
+    RWSpinlock::WriteGuard guard(batch_desc_lock_);
+    batch_desc_set_.erase(batch_id);
+#endif
+    return Status::OK();
+}
+
+Status MultiTransport::submitTransfer(
+    BatchID batch_id, const std::vector<TransferRequest> &entries) {
+    auto &batch_desc = *((BatchDesc *)(batch_id));
+    if (batch_desc.task_list.size() + entries.size() > batch_desc.batch_size) {
+        LOG(ERROR) << "MultiTransport: Exceed the limitation of batch capacity";
+        return Status::TooManyRequests(
+            "Exceed the limitation of batch capacity");
+    }
+
+    size_t task_id = batch_desc.task_list.size();
+    batch_desc.task_list.resize(task_id + entries.size());
+    struct SubmitTasks {
+        std::vector<TransferRequest *> request_list;
+        std::vector<Transport::TransferTask *> task_list;
+    };
+    std::unordered_map<Transport *, SubmitTasks> submit_tasks;
+    for (auto &request : entries) {
+        auto transport = selectTransport(request);
+        if (!transport) {
+            return Status::InvalidArgument(
+                "SelectTransport failed for SegmentID: " +
+                std::to_string(request.target_id));
+        }
+        auto &task = batch_desc.task_list[task_id];
+        ++task_id;
+        submit_tasks[transport].request_list.push_back(
+            (TransferRequest *)&request);
+        submit_tasks[transport].task_list.push_back(&task);
+    }
+    for (auto &entry : submit_tasks) {
+        auto status = entry.first->submitTransferTask(entry.second.request_list,
+                                                  entry.second.task_list);
+        if (!status.ok()) {
+            LOG(ERROR) << "MultiTransport: Failed to submit transfer task to "
+                       << entry.first->getName();
+            return status;
+        }
+    }
+    return Status::OK();
+}
+
+Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
+                                      TransferStatus &status) {
+    auto &batch_desc = *((BatchDesc *)(batch_id));
+    const size_t task_count = batch_desc.task_list.size();
+    if (task_id >= task_count) {
+        return Status::InvalidArgument(
+            "MultiTransport: task id is equal to or larger than task_count");
+    }
+    auto &task = batch_desc.task_list[task_id];
+    status.transferred_bytes = task.transferred_bytes;
+    uint64_t success_slice_count = task.success_slice_count;
+    uint64_t failed_slice_count = task.failed_slice_count;
+    if (success_slice_count + failed_slice_count == task.slice_count) {
+        if (failed_slice_count) {
+            status.s = Transport::TransferStatusEnum::FAILED;
+        } else {
+            status.s = Transport::TransferStatusEnum::COMPLETED;
+        }
+        task.is_finished = true;
+    } else {
+        status.s = Transport::TransferStatusEnum::WAITING;
+    }
+    return Status::OK();
+}
+
+Transport *MultiTransport::installTransport(const std::string &proto,
+                                            std::shared_ptr<Topology> topo) {
+    Transport *transport = nullptr;
+    if (std::string(proto) == "rdma") {
+        transport = new RdmaTransport();
+    } else if (std::string(proto) == "tcp") {
+        transport = new TcpTransport();
+    } else if (std::string(proto) == "shm") {
+        transport = new ShmTransport();
+    }
+#ifdef USE_NVMEOF
+    else if (std::string(proto) == "nvmeof") {
+        transport = new NVMeoFTransport();
+    }
+#endif
+
+    if (!transport) {
+        LOG(ERROR) << "MultiTransport: Failed to initialize transport "
+                   << proto;
+        return nullptr;
+    }
+
+    if (transport->install(local_server_name_, metadata_, topo)) {
+        return nullptr;
+    }
+
+    transport_map_[proto] = std::shared_ptr<Transport>(transport);
+    return transport;
+}
+
+Transport *MultiTransport::selectTransport(const TransferRequest &entry) {
+    if (entry.target_id == LOCAL_SEGMENT_ID && transport_map_.count("shm"))
+        return transport_map_["shm"].get();
+    auto target_segment_desc = metadata_->getSegmentDescByID(entry.target_id);
+    if (!target_segment_desc) {
+        LOG(ERROR) << "MultiTransport: Incorrect target segment id "
+                   << entry.target_id;
+        return nullptr;
+    }
+    auto proto = "";
+    if (target_segment_desc->type == MemoryKind) {
+        proto = target_segment_desc->memory.rdma.empty() ? "tcp" : "rdma";
+    } else if (target_segment_desc->type == CufileKind) {
+        proto = "nvmeof";
+    } else {
+        LOG(ERROR) << "Unknown segment type";
+        return nullptr;
+    }
+    if (!transport_map_.count(proto)) {
+        LOG(ERROR) << "MultiTransport: Transport " << proto << " not installed";
+        return nullptr;
+    }
+    return transport_map_[proto].get();
+}
+
+Transport *MultiTransport::getTransport(const std::string &proto) {
+    if (!transport_map_.count(proto)) return nullptr;
+    return transport_map_[proto].get();
+}
+
+std::vector<Transport *> MultiTransport::listTransports() {
+    std::vector<Transport *> transport_list;
+    for (auto &entry : transport_map_)
+        transport_list.push_back(entry.second.get());
+    return transport_list;
+}
+
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/segment.cpp
+++ b/mooncake-ngxl-exp/src/segment.cpp
@@ -1,0 +1,160 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "segment.h"
+
+namespace mooncake {
+static inline const std::string toString(SegmentType type) {
+    if (type == MemoryKind)
+        return "memory";
+    else if (type == CufileKind)
+        return "cufile";
+    else
+        return "unknown";
+}
+
+static inline SegmentType parseSegmentType(const std::string &type) {
+    if (type == "memory")
+        return MemoryKind;
+    else if (type == "cufile")
+        return CufileKind;
+    else
+        return UnknownKind;
+}
+
+Json::Value SegmentDescUtils::encode(const SegmentDesc &attr) {
+    try {
+        Json::Value segmentJSON;
+        segmentJSON["name"] = attr.name;
+        segmentJSON["type"] = toString(attr.type);
+        if (attr.type == MemoryKind) {
+            segmentJSON["topology"] = attr.memory.topology.toJson();
+            Json::Value buffersJSON(Json::arrayValue);
+            for (const auto &buffer : attr.memory.buffers) {
+                Json::Value bufferJSON;
+                bufferJSON["location"] = buffer.location;
+                bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
+                bufferJSON["length"] = static_cast<Json::UInt64>(buffer.length);
+                Json::Value rkeyJSON(Json::arrayValue);
+                if (!buffer.rkey.empty()) {
+                    for (auto &entry : buffer.rkey) rkeyJSON.append(entry);
+                    bufferJSON["rkey"] = rkeyJSON;
+                }
+                if (!buffer.shm_path.empty())
+                    bufferJSON["shm_path"] = buffer.shm_path;
+                buffersJSON.append(bufferJSON);
+            }
+            if (!buffersJSON.empty()) segmentJSON["buffers"] = buffersJSON;
+
+            Json::Value rdmaJSON(Json::arrayValue);
+            for (const auto &entry : attr.memory.rdma) {
+                Json::Value entryJSON;
+                entryJSON["name"] = entry.name;
+                entryJSON["lid"] = entry.lid;
+                entryJSON["gid"] = entry.gid;
+                rdmaJSON.append(entryJSON);
+            }
+            if (!rdmaJSON.empty()) segmentJSON["rdma"] = rdmaJSON;
+
+            if (!attr.memory.tcp.ip_or_hostname.empty()) {
+                Json::Value tcpJSON;
+                tcpJSON["ip_or_hostname"] = attr.memory.tcp.ip_or_hostname;
+                tcpJSON["port"] = static_cast<Json::UInt>(attr.memory.tcp.port);
+                segmentJSON["tcp"] = tcpJSON;
+            }
+        }
+        return segmentJSON;
+    } catch (...) {
+        Json::Value segmentJSON;
+        return segmentJSON;
+    }
+}
+
+int SegmentDescUtils::decode(Json::Value segmentJSON, SegmentDesc &attr) {
+    try {
+        attr.name = segmentJSON["name"].asString();
+        attr.type = parseSegmentType(segmentJSON["type"].asString());
+        if (attr.type == MemoryKind) {
+            int ret = attr.memory.topology.parse(
+                segmentJSON["topology"].toStyledString());
+            if (ret) return ret;
+            if (segmentJSON.isMember("buffers")) {
+                for (const auto &bufferJSON : segmentJSON["buffers"]) {
+                    BufferAttr buffer;
+                    buffer.location = bufferJSON["location"].asString();
+                    buffer.addr = bufferJSON["addr"].asUInt64();
+                    buffer.length = bufferJSON["length"].asUInt64();
+                    if (bufferJSON.isMember("shm_path"))
+                        buffer.shm_path = bufferJSON["shm_path"].asString();
+                    if (bufferJSON.isMember("rkey"))
+                        for (const auto &rkeyJSON : bufferJSON["rkey"])
+                            buffer.rkey.push_back(rkeyJSON.asUInt());
+                    if (buffer.location.empty() || !buffer.addr ||
+                        !buffer.length || buffer.rkey.empty()) {
+                        return ERR_MALFORMED_JSON;
+                    }
+                    attr.memory.buffers.push_back(buffer);
+                }
+            }
+            if (segmentJSON.isMember("rdma")) {
+                for (const auto &rdmaJSON : segmentJSON["rdma"]) {
+                    RdmaAttr rdma;
+                    rdma.name = rdmaJSON["name"].asString();
+                    rdma.lid = rdmaJSON["lid"].asUInt();
+                    rdma.gid = rdmaJSON["gid"].asString();
+                    if (rdma.name.empty() || rdma.gid.empty()) {
+                        return ERR_MALFORMED_JSON;
+                    }
+                    attr.memory.rdma.push_back(rdma);
+                }
+            }
+            if (segmentJSON.isMember("tcp")) {
+                auto &tcpJSON = segmentJSON["tcp"];
+                attr.memory.tcp.ip_or_hostname =
+                    tcpJSON["ip_or_hostname"].asString();
+                attr.memory.tcp.port = uint16_t(tcpJSON["port"].asUInt());
+            }
+        } else if (attr.type == CufileKind) {
+            if (segmentJSON.isMember("cufile")) {
+                auto &cufileJSON = segmentJSON["cufile"];
+                attr.cufile.relative_path =
+                    cufileJSON["relative_path"].asString();
+                attr.cufile.length = cufileJSON["length"].asUInt64();
+            }
+        } else {
+            return ERR_MALFORMED_JSON;
+        }
+        return 0;
+    } catch (...) {
+        return ERR_MALFORMED_JSON;
+    }
+}
+
+Status SegmentDesc::addBuffer(const BufferAttr &attr) {
+    if (type != MemoryKind) return Status::InvalidArgument("unsupported type");
+    memory.buffers.push_back(attr);
+    return Status::OK();
+}
+
+Status SegmentDesc::removeBuffer(void *addr) {
+    if (type != MemoryKind) return Status::InvalidArgument("unsupported type");
+    for (auto iter = memory.buffers.begin(); iter != memory.buffers.end(); ++iter) {
+        if (iter->addr == (uint64_t)addr) {
+            memory.buffers.erase(iter);
+            return Status::OK();
+        }
+    }
+    return Status::AddressNotRegistered("address not registered");
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/segment_cache.cpp
+++ b/mooncake-ngxl-exp/src/segment_cache.cpp
@@ -1,0 +1,134 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "segment_cache.h"
+
+namespace mooncake {
+SegmentCache::SegmentCache(Callbacks callbacks,
+                           const std::string &local_segment_name)
+    : next_segment_id_(1), callbacks_(std::move(callbacks)) {
+    auto &entry = segment_entry_map_[LocalSegmentID];
+    segment_name_to_id_map_[local_segment_name] = LocalSegmentID;
+    entry.ref = std::make_shared<SegmentDesc>();
+    entry.name = entry.ref->name = local_segment_name;
+    entry.ref->type = MemoryKind;
+    entry.ref_cnt = 1;
+    entry.dirty = true;
+    flushLocal();
+}
+
+SegmentCache::~SegmentCache() { destroyLocal(); }
+
+SegmentID SegmentCache::open(const std::string &segment_name) {
+    RWSpinlock::WriteGuard guard(segment_lock_);
+    if (segment_name_to_id_map_.count(segment_name)) {
+        auto id = segment_name_to_id_map_[segment_name];
+        auto &entry = segment_entry_map_[id];
+        entry.ref_cnt++;
+        return id;
+    }
+    auto segment = callbacks_.on_get_segment_desc(segment_name);
+    if (!segment || segment->name != segment_name) {
+        return InvalidSegmentID;
+    }
+    auto id = next_segment_id_.fetch_add(1);
+    segment_name_to_id_map_[segment_name] = id;
+    segment_entry_map_[id].ref = segment;
+    segment_entry_map_[id].ref_cnt = 1;
+    segment_entry_map_[id].dirty = false;
+    return id;
+}
+
+Status SegmentCache::close(SegmentID segment_id) {
+    RWSpinlock::WriteGuard guard(segment_lock_);
+    if (!segment_entry_map_.count(segment_id)) {
+        return Status::InvalidArgument("invalid segment id");
+    }
+    auto &entry = segment_entry_map_[segment_id];
+    if (entry.ref_cnt > 1)
+        entry.ref_cnt--;
+    else {
+        segment_entry_map_.erase(segment_id);
+        segment_name_to_id_map_.erase(entry.name);
+    }
+    return Status::OK();
+}
+
+SegmentCache::SegmentDescRef SegmentCache::getLocal() {
+    RWSpinlock::ReadGuard guard(segment_lock_);
+    auto &entry = segment_entry_map_[LocalSegmentID];
+    entry.dirty = true;
+    return entry.ref;
+}
+
+Status SegmentCache::setAndFlushLocal(SegmentDescRef &&segment) {
+    {
+        RWSpinlock::ReadGuard guard(segment_lock_);
+        auto &entry = segment_entry_map_[LocalSegmentID];
+        segment_name_to_id_map_[segment->name] = LocalSegmentID;
+        entry.dirty = true;
+        entry.ref = std::move(segment);
+    }
+    return flushLocal();
+}
+
+const SegmentCache::SegmentDescRef SegmentCache::get(SegmentID segment_id,
+                                                     bool direct) {
+    RWSpinlock::ReadGuard guard(segment_lock_);
+    if (!segment_entry_map_.count(segment_id)) {
+        return nullptr;
+    }
+    auto &entry = segment_entry_map_.at(segment_id);
+    if (!direct) return entry.ref;
+    auto segment = callbacks_.on_get_segment_desc(entry.name);
+    if (!segment || segment->name != entry.name) {
+        return nullptr;
+    }
+    entry.ref = std::move(segment);
+    return entry.ref;
+}
+
+Status SegmentCache::flushLocal() {
+    RWSpinlock::ReadGuard guard(segment_lock_);
+    auto &entry = segment_entry_map_[LocalSegmentID];
+    if (entry.dirty) {
+        auto status = callbacks_.on_put_segment_desc(entry.ref);
+        if (status != Status::OK()) return status;
+        entry.dirty = false;
+    }
+    return Status::OK();
+}
+
+Status SegmentCache::destroyLocal() {
+    RWSpinlock::WriteGuard guard(segment_lock_);
+    if (!segment_entry_map_.count(LocalSegmentID)) {
+        return Status::OK();
+    }
+    auto &entry = segment_entry_map_[LocalSegmentID];
+    segment_entry_map_.erase(LocalSegmentID);
+    segment_name_to_id_map_.erase(entry.name);
+    return callbacks_.on_delete_segment_desc(entry.name);
+}
+
+Status SegmentCache::invalidateAll() {
+    RWSpinlock::WriteGuard guard(segment_lock_);
+    for (auto &name_id_pair : segment_name_to_id_map_) {
+        if (name_id_pair.second == LocalSegmentID) continue;
+        auto &entry = segment_entry_map_[name_id_pair.second];
+        auto segment = callbacks_.on_get_segment_desc(name_id_pair.first);
+        entry.ref = std::move(segment);
+    }
+    return Status::OK();
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/topology.cpp
+++ b/mooncake-ngxl-exp/src/topology.cpp
@@ -1,0 +1,317 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <glog/logging.h>
+#include <jsoncpp/json/json.h>
+
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#ifdef USE_CUDA
+#include <cuda_runtime.h>
+#endif
+
+#include <ctype.h>
+#include <dirent.h>
+#include <infiniband/verbs.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "topology.h"
+
+namespace mooncake {
+struct InfinibandDevice {
+    std::string name;
+    std::string pci_bus_id;
+    int numa_node;
+};
+
+static std::vector<InfinibandDevice> listInfiniBandDevices() {
+    int num_devices = 0;
+    std::vector<InfinibandDevice> devices;
+
+    struct ibv_device **device_list = ibv_get_device_list(&num_devices);
+    if (!device_list || num_devices <= 0) {
+        LOG(WARNING) << "No IB devices found";
+        return {};
+    }
+
+    for (int i = 0; i < num_devices; ++i) {
+        std::string device_name = ibv_get_device_name(device_list[i]);
+
+        char path[PATH_MAX + 32];
+        char resolved_path[PATH_MAX];
+        // Get the PCI bus id for the infiniband device. Note that
+        // "/sys/class/infiniband/mlx5_X/" is a symlink to
+        // "/sys/devices/pciXXXX:XX/XXXX:XX:XX.X/infiniband/mlx5_X/".
+        snprintf(path, sizeof(path), "/sys/class/infiniband/%s/../..",
+                 device_name.c_str());
+        if (realpath(path, resolved_path) == NULL) {
+            PLOG(ERROR) << "Failed to parse realpath";
+            continue;
+        }
+        std::string pci_bus_id = basename(resolved_path);
+
+        int numa_node = -1;
+        snprintf(path, sizeof(path), "%s/numa_node", resolved_path);
+        std::ifstream(path) >> numa_node;
+
+        devices.push_back(InfinibandDevice{.name = std::move(device_name),
+                                           .pci_bus_id = std::move(pci_bus_id),
+                                           .numa_node = numa_node});
+    }
+    return devices;
+}
+
+static std::vector<TopologyEntry> discoverCpuTopology(
+    const std::vector<InfinibandDevice> &all_hca) {
+    DIR *dir = opendir("/sys/devices/system/node");
+    struct dirent *entry;
+    std::vector<TopologyEntry> topology;
+
+    if (dir == NULL) {
+        PLOG(WARNING) << "Failed to open /sys/devices/system/node";
+        return {};
+    }
+    while ((entry = readdir(dir))) {
+        const char *prefix = "node";
+        if (entry->d_type != DT_DIR ||
+            strncmp(entry->d_name, prefix, strlen(prefix)) != 0) {
+            continue;
+        }
+        int node_id = atoi(entry->d_name + strlen(prefix));
+        std::vector<std::string> preferred_hca;
+        std::vector<std::string> avail_hca;
+        // an HCA connected to the same cpu NUMA node is preferred
+        for (const auto &hca : all_hca) {
+            if (hca.numa_node == node_id) {
+                preferred_hca.push_back(hca.name);
+            } else {
+                avail_hca.push_back(hca.name);
+            }
+        }
+        topology.push_back(
+            TopologyEntry{.name = "cpu:" + std::to_string(node_id),
+                          .preferred_hca = std::move(preferred_hca),
+                          .avail_hca = std::move(avail_hca)});
+    }
+    (void)closedir(dir);
+    return topology;
+}
+
+#ifdef USE_CUDA
+
+static int getPciDistance(const char *bus1, const char *bus2) {
+    char buf[PATH_MAX];
+    char path1[PATH_MAX];
+    char path2[PATH_MAX];
+    snprintf(buf, sizeof(buf), "/sys/bus/pci/devices/%s", bus1);
+    if (realpath(buf, path1) == NULL) {
+        return -1;
+    }
+    snprintf(buf, sizeof(buf), "/sys/bus/pci/devices/%s", bus2);
+    if (realpath(buf, path2) == NULL) {
+        return -1;
+    }
+
+    char *ptr1 = path1;
+    char *ptr2 = path2;
+    while (*ptr1 && *ptr1 == *ptr2) {
+        ptr1++;
+        ptr2++;
+    }
+    int distance = 0;
+    for (; *ptr1; ptr1++) {
+        distance += (*ptr1 == '/');
+    }
+    for (; *ptr2; ptr2++) {
+        distance += (*ptr2 == '/');
+    }
+
+    return distance;
+}
+
+static std::vector<TopologyEntry> discoverCudaTopology(
+    const std::vector<InfinibandDevice> &all_hca) {
+    std::vector<TopologyEntry> topology;
+    int device_count;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess) {
+        device_count = 0;
+    }
+    for (int i = 0; i < device_count; i++) {
+        char pci_bus_id[20];
+        if (cudaDeviceGetPCIBusId(pci_bus_id, sizeof(pci_bus_id), i) !=
+            cudaSuccess) {
+            continue;
+        }
+        for (char *ch = pci_bus_id; (*ch = tolower(*ch)); ch++);
+
+        std::vector<std::string> preferred_hca;
+        std::vector<std::string> avail_hca;
+        for (const auto &hca : all_hca) {
+            // FIXME: currently we only identify the NICs connected to the same
+            // PCIe switch/RC with GPU as preferred.
+            if (getPciDistance(hca.pci_bus_id.c_str(), pci_bus_id) == 0) {
+                preferred_hca.push_back(hca.name);
+            } else {
+                avail_hca.push_back(hca.name);
+            }
+        }
+        topology.push_back(
+            TopologyEntry{.name = "cuda:" + std::to_string(i),
+                          .preferred_hca = std::move(preferred_hca),
+                          .avail_hca = std::move(avail_hca)});
+    }
+    return topology;
+}
+
+#endif  // USE_CUDA
+
+Topology::Topology() {}
+
+Topology::~Topology() {}
+
+bool Topology::empty() const { return matrix_.empty(); }
+
+void Topology::clear() {
+    matrix_.clear();
+    hca_list_.clear();
+    resolved_matrix_.clear();
+}
+
+int Topology::discover() {
+    matrix_.clear();
+    auto all_hca = listInfiniBandDevices();
+    for (auto &ent : discoverCpuTopology(all_hca)) {
+        matrix_[ent.name] = ent;
+    }
+#ifdef USE_CUDA
+    for (auto &ent : discoverCudaTopology(all_hca)) {
+        matrix_[ent.name] = ent;
+    }
+#endif
+    return resolve();
+}
+
+int Topology::parse(const std::string &topology_json) {
+    std::set<std::string> rnic_set;
+    Json::Value root;
+    Json::Reader reader;
+
+    if (topology_json.empty() || !reader.parse(topology_json, root)) {
+        LOG(ERROR) << "Topology: malformed json format: " << topology_json;
+        return ERR_MALFORMED_JSON;
+    }
+
+    matrix_.clear();
+    for (const auto &key : root.getMemberNames()) {
+        const Json::Value &value = root[key];
+        if (value.isArray() && value.size() == 2) {
+            TopologyEntry topo_entry;
+            topo_entry.name = key;
+            for (const auto &array : value[0]) {
+                auto device_name = array.asString();
+                topo_entry.preferred_hca.push_back(device_name);
+            }
+            for (const auto &array : value[1]) {
+                auto device_name = array.asString();
+                topo_entry.avail_hca.push_back(device_name);
+            }
+            matrix_[key] = topo_entry;
+        } else {
+            LOG(ERROR) << "Topology: malformed json format";
+            return ERR_MALFORMED_JSON;
+        }
+    }
+
+    return resolve();
+}
+
+std::string Topology::toString() const {
+    Json::Value value(Json::objectValue);
+    for (auto &entry : matrix_) {
+        value[entry.first] = entry.second.toJson();
+    }
+    return value.toStyledString();
+}
+
+Json::Value Topology::toJson() const {
+    Json::Value root;
+    Json::Reader reader;
+    reader.parse(toString(), root);
+    return root;
+}
+
+int Topology::selectDevice(const std::string &location_hint, int retry_count) {
+    std::string location = location_hint;
+    if (resolved_matrix_.count(location_hint) == 0) location = "*";
+    if (resolved_matrix_.count(location) == 0) return ERR_DEVICE_NOT_FOUND;
+    auto &entry = resolved_matrix_[location];
+    if (retry_count == 0) {
+        int rand_value = SimpleRandom::Get().next();
+        if (!entry.preferred_hca.empty())
+            return entry.preferred_hca[rand_value % entry.preferred_hca.size()];
+        else
+            return entry.avail_hca[rand_value % entry.avail_hca.size()];
+    } else {
+        size_t index = (retry_count - 1) %
+                       (entry.preferred_hca.size() + entry.avail_hca.size());
+        if (index < entry.preferred_hca.size())
+            return entry.preferred_hca[index];
+        else {
+            index -= entry.preferred_hca.size();
+            return entry.avail_hca[index];
+        }
+    }
+    return 0;
+}
+
+int Topology::resolve() {
+    std::map<std::string, int> hca_id_map;
+    int next_hca_map_index = 0;
+    for (auto &entry : matrix_) {
+        for (auto &hca : entry.second.preferred_hca) {
+            if (!hca_id_map.count(hca)) {
+                hca_list_.push_back(hca);
+                hca_id_map[hca] = next_hca_map_index;
+                next_hca_map_index++;
+
+                // "*" means any device
+                resolved_matrix_["*"].preferred_hca.push_back(hca_id_map[hca]);
+            }
+            resolved_matrix_[entry.first].preferred_hca.push_back(
+                hca_id_map[hca]);
+        }
+        for (auto &hca : entry.second.avail_hca) {
+            if (!hca_id_map.count(hca)) {
+                hca_list_.push_back(hca);
+                hca_id_map[hca] = next_hca_map_index;
+                next_hca_map_index++;
+
+                // "*" means any device
+                resolved_matrix_["*"].preferred_hca.push_back(hca_id_map[hca]);
+            }
+            resolved_matrix_[entry.first].avail_hca.push_back(hca_id_map[hca]);
+        }
+    }
+    return 0;
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transfer_engine.cpp
+++ b/mooncake-ngxl-exp/src/transfer_engine.cpp
@@ -1,0 +1,198 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transfer_engine.h"
+
+#include "transport/transport.h"
+
+namespace mooncake {
+
+int TransferEngine::init(const std::string &metadata_conn_string,
+                         const std::string &local_server_name,
+                         const std::string &ip_or_host_name,
+                         uint64_t rpc_port) {
+    local_server_name_ = local_server_name;
+    metadata_ = std::make_shared<TransferMetadata>(metadata_conn_string, local_server_name_);
+    multi_transports_ =
+        std::make_shared<MultiTransport>(metadata_, local_server_name_);
+
+    TransferMetadata::RpcMetaDesc desc;
+    desc.ip_or_host_name = ip_or_host_name;
+    desc.rpc_port = rpc_port;
+    int ret = metadata_->addRpcMetaEntry(local_server_name_, desc);
+    if (ret) return ret;
+
+    if (auto_discover_) {
+        // discover topology automatically
+        local_topology_->discover();
+
+        if (local_topology_->getHcaList().size() > 0) {
+            // only install RDMA transport when there is at least one HCA
+            multi_transports_->installTransport("rdma", local_topology_);
+        } else {
+            multi_transports_->installTransport("tcp", nullptr);
+        }
+        // TODO: install other transports automatically
+    }
+
+    return 0;
+}
+
+int TransferEngine::freeEngine() {
+    if (metadata_) {
+        metadata_->removeRpcMetaEntry(local_server_name_);
+        metadata_.reset();
+    }
+    return 0;
+}
+
+// Only for testing
+Transport *TransferEngine::installTransport(const std::string &proto,
+                                            void **args) {
+    Transport *transport = multi_transports_->getTransport(proto);
+    if (transport) {
+        LOG(INFO) << "Transport " << proto << " already installed";
+        return transport;
+    }
+
+    if (args != nullptr && args[0] != nullptr) {
+        const std::string nic_priority_matrix = static_cast<char *>(args[0]);
+        int ret = local_topology_->parse(nic_priority_matrix);
+        if (ret) {
+            LOG(ERROR) << "Failed to parse NIC priority matrix";
+            return nullptr;
+        }
+    }
+
+    transport = multi_transports_->installTransport(proto, local_topology_);
+    if (!transport) return nullptr;
+
+    // Since installTransport() is only called once during initialization
+    // and is not expected to be executed concurrently, we do not acquire a
+    // shared lock here. If future modifications allow installTransport() to be
+    // invoked concurrently, a std::shared_lock<std::shared_mutex> should be
+    // added to ensure thread safety.
+    for (auto &entry : local_memory_regions_) {
+        int ret = transport->registerLocalMemory(
+            entry.addr, entry.length, entry.location, entry.remote_accessible);
+        if (ret < 0) return nullptr;
+    }
+    return transport;
+}
+
+int TransferEngine::uninstallTransport(const std::string &proto) { return 0; }
+
+Transport::SegmentID TransferEngine::openSegment(
+    const std::string &segment_name) {
+    if (segment_name.empty()) return ERR_INVALID_ARGUMENT;
+    std::string trimmed_segment_name = segment_name;
+    while (!trimmed_segment_name.empty() && trimmed_segment_name[0] == '/')
+        trimmed_segment_name.erase(0, 1);
+    if (trimmed_segment_name.empty()) return ERR_INVALID_ARGUMENT;
+    return metadata_->getSegmentID(trimmed_segment_name);
+}
+
+int TransferEngine::closeSegment(Transport::SegmentID handle) { return 0; }
+
+bool TransferEngine::checkOverlap(void *addr, uint64_t length) {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    for (auto &local_memory_region : local_memory_regions_) {
+        if (overlap(addr, length, local_memory_region.addr,
+                    local_memory_region.length)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int TransferEngine::registerLocalMemory(void *addr, size_t length,
+                                        const std::string &location,
+                                        bool remote_accessible,
+                                        bool update_metadata) {
+    if (checkOverlap(addr, length)) {
+        LOG(ERROR)
+            << "Transfer Engine does not support overlapped memory region";
+        return ERR_ADDRESS_OVERLAPPED;
+    }
+    for (auto transport : multi_transports_->listTransports()) {
+        int ret = transport->registerLocalMemory(
+            addr, length, location, remote_accessible, update_metadata);
+        if (ret < 0) return ret;
+    }
+
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    local_memory_regions_.push_back(
+        {addr, length, location, remote_accessible});
+    return 0;
+}
+
+int TransferEngine::unregisterLocalMemory(void *addr, bool update_metadata) {
+    for (auto &transport : multi_transports_->listTransports()) {
+        int ret = transport->unregisterLocalMemory(addr, update_metadata);
+        if (ret) return ret;
+    }
+
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    for (auto it = local_memory_regions_.begin();
+         it != local_memory_regions_.end(); ++it) {
+        if (it->addr == addr) {
+            local_memory_regions_.erase(it);
+            break;
+        }
+    }
+    return 0;
+}
+
+int TransferEngine::registerLocalMemoryBatch(
+    const std::vector<BufferEntry> &buffer_list, const std::string &location) {
+    for (auto &buffer : buffer_list) {
+        if (checkOverlap(buffer.addr, buffer.length)) {
+            LOG(ERROR)
+                << "Transfer Engine does not support overlapped memory region";
+            return ERR_ADDRESS_OVERLAPPED;
+        }
+    }
+    for (auto transport : multi_transports_->listTransports()) {
+        int ret = transport->registerLocalMemoryBatch(buffer_list, location);
+        if (ret < 0) return ret;
+    }
+
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    for (auto &buffer : buffer_list) {
+        local_memory_regions_.push_back(
+            {buffer.addr, buffer.length, location, true});
+    }
+    return 0;
+}
+
+int TransferEngine::unregisterLocalMemoryBatch(
+    const std::vector<void *> &addr_list) {
+    for (auto transport : multi_transports_->listTransports()) {
+        int ret = transport->unregisterLocalMemoryBatch(addr_list);
+        if (ret < 0) return ret;
+    }
+
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    for (auto &addr : addr_list) {
+        for (auto it = local_memory_regions_.begin();
+             it != local_memory_regions_.end(); ++it) {
+            if (it->addr == addr) {
+                local_memory_regions_.erase(it);
+                break;
+            }
+        }
+    }
+    return 0;
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transfer_engine_c.cpp
+++ b/mooncake-ngxl-exp/src/transfer_engine_c.cpp
@@ -1,0 +1,155 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transfer_engine_c.h"
+
+#include <cstdint>
+#include <memory>
+
+#include "transfer_engine.h"
+#include "transport/transport.h"
+
+using namespace mooncake;
+
+transfer_engine_t createTransferEngine(const char *metadata_conn_string,
+                                       const char *local_server_name,
+                                       const char *ip_or_host_name,
+                                       uint64_t rpc_port,
+                                       int auto_discover) {
+    TransferEngine *native = new TransferEngine(auto_discover);
+    int ret = native->init(metadata_conn_string, local_server_name,
+                           ip_or_host_name, rpc_port);
+    if (ret) {
+        delete native;
+        return nullptr;
+    }
+    return (transfer_engine_t)native;
+}
+
+transport_t installTransport(transfer_engine_t engine, const char *proto,
+                             void **args) {
+    TransferEngine *native = (TransferEngine *)engine;
+    return (transport_t)native->installTransport(proto, args);
+}
+
+int uninstallTransport(transfer_engine_t engine, const char *proto) {
+    TransferEngine *native = (TransferEngine *)engine;
+    return native->uninstallTransport(proto);
+}
+
+void destroyTransferEngine(transfer_engine_t engine) {
+    TransferEngine *native = (TransferEngine *)engine;
+    delete native;
+}
+
+segment_id_t openSegment(transfer_engine_t engine, const char *segment_name) {
+    TransferEngine *native = (TransferEngine *)engine;
+    return native->openSegment(segment_name);
+}
+
+segment_id_t openSegmentNoCache(transfer_engine_t engine, const char *segment_name) {
+    TransferEngine *native = (TransferEngine *)engine;
+    int rc = native->syncSegmentCache(segment_name);
+    if (rc) return rc;
+    return native->openSegment(segment_name);
+}
+
+int closeSegment(transfer_engine_t engine, segment_id_t segment_id) {
+    TransferEngine *native = (TransferEngine *)engine;
+    return native->closeSegment(segment_id);
+}
+
+int registerLocalMemory(transfer_engine_t engine, void *addr, size_t length,
+                        const char *location, int remote_accessible) {
+    TransferEngine *native = (TransferEngine *)engine;
+    return native->registerLocalMemory(addr, length, location,
+                                       remote_accessible, true);
+}
+
+int unregisterLocalMemory(transfer_engine_t engine, void *addr) {
+    TransferEngine *native = (TransferEngine *)engine;
+    return native->unregisterLocalMemory(addr);
+}
+
+int registerLocalMemoryBatch(transfer_engine_t engine,
+                             buffer_entry_t *buffer_list, size_t buffer_len,
+                             const char *location) {
+    TransferEngine *native = (TransferEngine *)engine;
+    std::vector<BufferEntry> native_buffer_list;
+    for (size_t i = 0; i < buffer_len; ++i) {
+        BufferEntry entry;
+        entry.addr = buffer_list[i].addr;
+        entry.length = buffer_list[i].length;
+        native_buffer_list.push_back(entry);
+    }
+    return native->registerLocalMemoryBatch(native_buffer_list, location);
+}
+
+int unregisterLocalMemoryBatch(transfer_engine_t engine, void **addr_list,
+                               size_t addr_len) {
+    TransferEngine *native = (TransferEngine *)engine;
+    std::vector<void *> native_addr_list;
+    for (size_t i = 0; i < addr_len; ++i)
+        native_addr_list.push_back(addr_list[i]);
+    return native->unregisterLocalMemoryBatch(native_addr_list);
+}
+
+batch_id_t allocateBatchID(transfer_engine_t engine, size_t batch_size) {
+    TransferEngine *native = (TransferEngine *)engine;
+    return (batch_id_t)native->allocateBatchID(batch_size);
+}
+
+int submitTransfer(transfer_engine_t engine, batch_id_t batch_id,
+                   struct transfer_request *entries,
+                   size_t count) {
+    TransferEngine *native = (TransferEngine *)engine;
+    std::vector<Transport::TransferRequest> native_entries;
+    native_entries.resize(count);
+    for (size_t index = 0; index < count; index++) {
+        native_entries[index].opcode =
+            (Transport::TransferRequest::OpCode)entries[index].opcode;
+        native_entries[index].source = entries[index].source;
+        native_entries[index].target_id = entries[index].target_id;
+        native_entries[index].target_offset = entries[index].target_offset;
+        native_entries[index].length = entries[index].length;
+    }
+    Status s =
+        native->submitTransfer((Transport::BatchID)batch_id, native_entries);
+    return (int)s.code();
+}
+
+int getTransferStatus(transfer_engine_t engine,
+                      batch_id_t batch_id, size_t task_id,
+                      struct transfer_status *status) {
+    TransferEngine *native = (TransferEngine *)engine;
+    Transport::TransferStatus native_status;
+    Status s = native->getTransferStatus((Transport::BatchID)batch_id,
+                                                    task_id, native_status);
+    if (s.ok()) {
+        status->status = (int)native_status.s;
+        status->transferred_bytes = native_status.transferred_bytes;
+    }
+    return (int)s.code();
+}
+
+int freeBatchID(transfer_engine_t engine, batch_id_t batch_id) {
+    TransferEngine *native = (TransferEngine *)engine;
+    Status s = native->freeBatchID(batch_id);
+    return (int)s.code();
+}
+
+int syncSegmentCache(transfer_engine_t engine) {
+    TransferEngine *native = (TransferEngine *)engine;
+    return native->syncSegmentCache();
+}

--- a/mooncake-ngxl-exp/src/transfer_metadata.cpp
+++ b/mooncake-ngxl-exp/src/transfer_metadata.cpp
@@ -1,0 +1,257 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transfer_metadata.h"
+
+#include <jsoncpp/json/value.h>
+
+#include <cassert>
+#include <set>
+
+#include "common.h"
+#include "config.h"
+#include "error.h"
+#include "transfer_metadata_plugin.h"
+
+namespace mooncake {
+
+const static std::string kCommonKeyPrefix = "mooncake_ngxl/";
+const static std::string kSegmentPrefix = kCommonKeyPrefix + "segments/";
+const static std::string kRpcMetaPrefix = kCommonKeyPrefix + "rpc_meta/";
+
+struct TransferHandshakeUtil {
+    static Json::Value encode(const TransferMetadata::HandShakeDesc &desc) {
+        Json::Value root;
+        root["local_nic_path"] = desc.local_nic_path;
+        root["peer_nic_path"] = desc.peer_nic_path;
+        Json::Value qpNums(Json::arrayValue);
+        for (const auto &qp : desc.qp_num) qpNums.append(qp);
+        root["qp_num"] = qpNums;
+        root["reply_msg"] = desc.reply_msg;
+        return root;
+    }
+
+    static int decode(Json::Value root, TransferMetadata::HandShakeDesc &desc) {
+        Json::Reader reader;
+        desc.local_nic_path = root["local_nic_path"].asString();
+        desc.peer_nic_path = root["peer_nic_path"].asString();
+        for (const auto &qp : root["qp_num"])
+            desc.qp_num.push_back(qp.asUInt());
+        desc.reply_msg = root["reply_msg"].asString();
+        if (globalConfig().verbose) {
+            LOG(INFO) << "TransferHandshakeUtil::decode: local_nic_path "
+                      << desc.local_nic_path << " peer_nic_path "
+                      << desc.peer_nic_path << " qp_num count "
+                      << desc.qp_num.size();
+        }
+        return 0;
+    }
+};
+
+TransferMetadata::TransferMetadata(const std::string &conn_string,
+                                   const std::string &local_segment_name) {
+    handshake_plugin_ = HandShakePlugin::Create(conn_string);
+    storage_plugin_ = MetadataStoragePlugin::Create(conn_string);
+    if (!handshake_plugin_ || !storage_plugin_) {
+        LOG(ERROR) << "Unable to create metadata plugins with conn string "
+                   << conn_string;
+    }
+    SegmentCache::Callbacks callbacks;
+    callbacks.on_get_segment_desc = std::bind(&TransferMetadata::getSegmentDesc,
+                                              this, std::placeholders::_1);
+    callbacks.on_put_segment_desc = std::bind(&TransferMetadata::putSegmentDesc,
+                                              this, std::placeholders::_1);
+    callbacks.on_delete_segment_desc = std::bind(
+        &TransferMetadata::deleteSegmentDesc, this, std::placeholders::_1);
+    cache_ = std::make_shared<SegmentCache>(callbacks, local_segment_name);
+}
+
+TransferMetadata::~TransferMetadata() {
+    cache_.reset();
+    handshake_plugin_.reset();
+    storage_plugin_.reset();
+}
+
+SegmentCache::SegmentDescRef TransferMetadata::getSegmentDesc(
+    const std::string &segment_name) {
+    Json::Value segmentJSON;
+    if (!storage_plugin_->get(kSegmentPrefix + segment_name, segmentJSON)) {
+        LOG(ERROR) << "Failed to get segment attr for " << segment_name;
+        return nullptr;
+    }
+    auto desc = std::make_shared<SegmentDesc>();
+    int ret = SegmentDescUtils::decode(segmentJSON, *desc.get());
+    if (ret) {
+        LOG(ERROR) << "Failed to decode segment attr json for " << segment_name;
+        return nullptr;
+    }
+    return desc;
+}
+
+Status TransferMetadata::putSegmentDesc(SegmentCache::SegmentDescRef segment) {
+    Json::Value segmentJSON = SegmentDescUtils::encode(*segment);
+    auto segment_name = segment->name;
+    if (segmentJSON.empty()) {
+        LOG(ERROR) << "Failed to encode segment attr json for " << segment_name;
+        return Status::Metadata("failed to encode segment attr");
+    }
+    if (!storage_plugin_->set(kSegmentPrefix + segment_name, segmentJSON)) {
+        LOG(ERROR) << "Failed to set segment attr for " << segment_name;
+        return Status::Metadata("failed to set segment attr");
+    }
+    return Status::OK();
+}
+
+Status TransferMetadata::deleteSegmentDesc(const std::string &segment_name) {
+    if (!storage_plugin_->remove(kSegmentPrefix + segment_name)) {
+        LOG(ERROR) << "Failed to delete segment attr for " << segment_name;
+        return Status::Metadata("failed to set segment attr");
+    }
+    return Status::OK();
+}
+
+int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
+    auto segment_id = cache_->open(segment_name);
+    if (segment_id == InvalidSegmentID) return ERR_INVALID_ARGUMENT;
+    cache_->get(segment_id, true);
+    cache_->close(segment_id);
+    return 0;
+}
+
+std::shared_ptr<SegmentDesc> TransferMetadata::getSegmentDescByName(
+    const std::string &segment_name, bool force_update) {
+    SegmentID segment_id = cache_->open(segment_name);
+    if (segment_id == InvalidSegmentID) return nullptr;
+    return cache_->get(segment_id, force_update);
+}
+
+std::shared_ptr<SegmentDesc> TransferMetadata::getSegmentDescByID(
+    SegmentID segment_id, bool force_update) {
+    return cache_->get(segment_id, force_update);
+}
+
+TransferMetadata::SegmentID TransferMetadata::getSegmentID(
+    const std::string &segment_name) {
+    return cache_->open(segment_name);
+}
+
+int TransferMetadata::updateLocalSegmentDesc() {
+    Status status = cache_->flushLocal();
+    return (int)status.code();
+}
+
+std::shared_ptr<SegmentDesc> TransferMetadata::getLocalSegment() {
+    return cache_->getLocal();
+}
+
+int TransferMetadata::setLocalSegment(std::shared_ptr<SegmentDesc> &&desc) {
+    Status status = cache_->setAndFlushLocal(std::move(desc));
+    return (int)status.code();
+}
+
+int TransferMetadata::addLocalMemoryBuffer(const BufferAttr &buffer_desc,
+                                           bool update_metadata) {
+    Status status = cache_->getLocal()->addBuffer(buffer_desc);
+    if (status != Status::OK()) return (int)status.code();
+    if (update_metadata) return (int)cache_->flushLocal().code();
+    return 0;
+}
+
+int TransferMetadata::removeLocalMemoryBuffer(void *addr,
+                                              bool update_metadata) {
+    Status status = cache_->getLocal()->removeBuffer(addr);
+    if (status != Status::OK()) return (int)status.code();
+    if (update_metadata) return (int)cache_->flushLocal().code();
+    return 0;
+}
+
+int TransferMetadata::addRpcMetaEntry(const std::string &server_name,
+                                      RpcMetaDesc &desc) {
+    Json::Value rpcMetaJSON;
+    rpcMetaJSON["ip_or_host_name"] = desc.ip_or_host_name;
+    rpcMetaJSON["rpc_port"] = static_cast<Json::UInt64>(desc.rpc_port);
+    if (!storage_plugin_->set(kRpcMetaPrefix + server_name, rpcMetaJSON)) {
+        LOG(ERROR) << "Failed to set location of " << server_name;
+        return ERR_METADATA;
+    }
+    local_rpc_meta_ = desc;
+    return 0;
+}
+
+int TransferMetadata::removeRpcMetaEntry(const std::string &server_name) {
+    if (!storage_plugin_->remove(kRpcMetaPrefix + server_name)) {
+        LOG(ERROR) << "Failed to remove location of " << server_name;
+        return ERR_METADATA;
+    }
+    return 0;
+}
+
+int TransferMetadata::getRpcMetaEntry(const std::string &server_name,
+                                      RpcMetaDesc &desc) {
+    {
+        RWSpinlock::ReadGuard guard(rpc_meta_lock_);
+        if (rpc_meta_map_.count(server_name)) {
+            desc = rpc_meta_map_[server_name];
+            return 0;
+        }
+    }
+    RWSpinlock::WriteGuard guard(rpc_meta_lock_);
+    Json::Value rpcMetaJSON;
+    if (!storage_plugin_->get(kRpcMetaPrefix + server_name, rpcMetaJSON)) {
+        LOG(ERROR) << "Failed to find location of " << server_name;
+        return ERR_METADATA;
+    }
+    desc.ip_or_host_name = rpcMetaJSON["ip_or_host_name"].asString();
+    desc.rpc_port = (uint16_t)rpcMetaJSON["rpc_port"].asUInt();
+    rpc_meta_map_[server_name] = desc;
+    return 0;
+}
+
+int TransferMetadata::startHandshakeDaemon(
+    OnReceiveHandShake on_receive_handshake, uint16_t listen_port) {
+    return handshake_plugin_->startDaemon(
+        [on_receive_handshake](const Json::Value &peer,
+                               Json::Value &local) -> int {
+            HandShakeDesc local_desc, peer_desc;
+            TransferHandshakeUtil::decode(peer, peer_desc);
+            int ret = on_receive_handshake(peer_desc, local_desc);
+            if (ret) return ret;
+            local = TransferHandshakeUtil::encode(local_desc);
+            return 0;
+        },
+        listen_port);
+}
+
+int TransferMetadata::sendHandshake(const std::string &peer_server_name,
+                                    const HandShakeDesc &local_desc,
+                                    HandShakeDesc &peer_desc) {
+    RpcMetaDesc peer_location;
+    if (getRpcMetaEntry(peer_server_name, peer_location)) {
+        return ERR_METADATA;
+    }
+    auto local = TransferHandshakeUtil::encode(local_desc);
+    Json::Value peer;
+    int ret = handshake_plugin_->send(peer_location.ip_or_host_name,
+                                      peer_location.rpc_port, local, peer);
+    if (ret) return ret;
+    TransferHandshakeUtil::decode(peer, peer_desc);
+    if (!peer_desc.reply_msg.empty()) {
+        LOG(ERROR) << "Handshake rejected by " << peer_server_name << ": "
+                   << peer_desc.reply_msg;
+        return ERR_METADATA;
+    }
+    return 0;
+}
+
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transfer_metadata_plugin.cpp
+++ b/mooncake-ngxl-exp/src/transfer_metadata_plugin.cpp
@@ -1,0 +1,616 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transfer_metadata_plugin.h"
+
+#include <arpa/inet.h>
+#include <bits/stdint-uintn.h>
+#include <jsoncpp/json/value.h>
+#include <netdb.h>
+#include <sys/socket.h>
+
+#ifdef USE_REDIS
+#include <hiredis/hiredis.h>
+#endif
+
+#ifdef USE_HTTP
+#include <curl/curl.h>
+#endif
+
+#ifdef USE_ETCD
+#include <etcd/SyncClient.hpp>
+#endif  // USE_ETCD
+
+#include <cassert>
+#include <set>
+
+#include "common.h"
+#include "config.h"
+#include "error.h"
+
+namespace mooncake {
+#ifdef USE_REDIS
+struct RedisStoragePlugin : public MetadataStoragePlugin {
+    RedisStoragePlugin(const std::string &metadata_uri)
+        : client_(nullptr), metadata_uri_(metadata_uri) {
+        auto hostname_port = parseHostNameWithPort(metadata_uri);
+        client_ =
+            redisConnect(hostname_port.first.c_str(), hostname_port.second);
+        if (!client_ || client_->err) {
+            LOG(ERROR) << "RedisStoragePlugin: unable to connect "
+                       << metadata_uri_ << ": " << client_->errstr;
+            client_ = nullptr;
+        }
+    }
+
+    virtual ~RedisStoragePlugin() {}
+
+    virtual bool get(const std::string &key, Json::Value &value) {
+        Json::Reader reader;
+        redisReply *resp =
+            (redisReply *)redisCommand(client_, "GET %s", key.c_str());
+        if (!resp) {
+            LOG(ERROR) << "RedisStoragePlugin: unable to get " << key
+                       << " from " << metadata_uri_;
+            return false;
+        }
+        auto json_file = std::string(resp->str);
+        freeReplyObject(resp);
+        if (!reader.parse(json_file, value)) return false;
+        if (globalConfig().verbose)
+            LOG(INFO) << "RedisStoragePlugin: get: key=" << key
+                      << ", value=" << json_file;
+        return true;
+    }
+
+    virtual bool set(const std::string &key, const Json::Value &value) {
+        Json::FastWriter writer;
+        const std::string json_file = writer.write(value);
+        if (globalConfig().verbose)
+            LOG(INFO) << "RedisStoragePlugin: set: key=" << key
+                      << ", value=" << json_file;
+        redisReply *resp = (redisReply *)redisCommand(
+            client_, "SET %s %s", key.c_str(), json_file.c_str());
+        if (!resp) {
+            LOG(ERROR) << "RedisStoragePlugin: unable to put " << key
+                       << " from " << metadata_uri_;
+            return false;
+        }
+        freeReplyObject(resp);
+        return true;
+    }
+
+    virtual bool remove(const std::string &key) {
+        redisReply *resp =
+            (redisReply *)redisCommand(client_, "DEL %s", key.c_str());
+        if (!resp) {
+            LOG(ERROR) << "RedisStoragePlugin: unable to remove " << key
+                       << " from " << metadata_uri_;
+            return false;
+        }
+        freeReplyObject(resp);
+        return true;
+    }
+
+    redisContext *client_;
+    const std::string metadata_uri_;
+};
+#endif  // USE_REDIS
+
+#ifdef USE_HTTP
+struct HTTPStoragePlugin : public MetadataStoragePlugin {
+    HTTPStoragePlugin(const std::string &metadata_uri)
+        : client_(nullptr), metadata_uri_(metadata_uri) {
+        curl_global_init(CURL_GLOBAL_ALL);
+        client_ = curl_easy_init();
+        if (!client_) {
+            LOG(ERROR) << "Cannot allocate CURL objects";
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    virtual ~HTTPStoragePlugin() {
+        curl_easy_cleanup(client_);
+        curl_global_cleanup();
+    }
+
+    static size_t writeCallback(void *contents, size_t size, size_t nmemb,
+                                std::string *userp) {
+        userp->append(static_cast<char *>(contents), size * nmemb);
+        return size * nmemb;
+    }
+
+    std::string encodeUrl(const std::string &key) {
+        char *newkey = curl_easy_escape(client_, key.c_str(), key.size());
+        std::string encodedKey(newkey);
+        std::string url = metadata_uri_ + "?key=" + encodedKey;
+        curl_free(newkey);
+        return url;
+    }
+
+    virtual bool get(const std::string &key, Json::Value &value) {
+        curl_easy_reset(client_);
+        curl_easy_setopt(client_, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
+
+        std::string url = encodeUrl(key);
+        curl_easy_setopt(client_, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(client_, CURLOPT_WRITEFUNCTION, writeCallback);
+
+        // get response body
+        std::string readBuffer;
+        curl_easy_setopt(client_, CURLOPT_WRITEDATA, &readBuffer);
+        CURLcode res = curl_easy_perform(client_);
+        if (res != CURLE_OK) {
+            LOG(ERROR) << "Error from http client, GET " << url
+                       << " error: " << curl_easy_strerror(res);
+            return false;
+        }
+
+        // Get the HTTP response code
+        long responseCode;
+        curl_easy_getinfo(client_, CURLINFO_RESPONSE_CODE, &responseCode);
+        if (responseCode != 200) {
+            LOG(ERROR) << "Unexpected code in http response, GET " << url
+                       << " response code: " << responseCode
+                       << " response body: " << readBuffer;
+            return false;
+        }
+
+        if (globalConfig().verbose)
+            LOG(INFO) << "Get segment desc, key=" << key
+                      << ", value=" << readBuffer;
+
+        Json::Reader reader;
+        if (!reader.parse(readBuffer, value)) return false;
+        return true;
+    }
+
+    virtual bool set(const std::string &key, const Json::Value &value) {
+        curl_easy_reset(client_);
+        curl_easy_setopt(client_, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
+
+        Json::FastWriter writer;
+        const std::string json_file = writer.write(value);
+        if (globalConfig().verbose)
+            LOG(INFO) << "Put segment desc, key=" << key
+                      << ", value=" << json_file;
+
+        std::string url = encodeUrl(key);
+        curl_easy_setopt(client_, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(client_, CURLOPT_WRITEFUNCTION, writeCallback);
+        curl_easy_setopt(client_, CURLOPT_POSTFIELDS, json_file.c_str());
+        curl_easy_setopt(client_, CURLOPT_POSTFIELDSIZE, json_file.size());
+        curl_easy_setopt(client_, CURLOPT_CUSTOMREQUEST, "PUT");
+
+        // get response body
+        std::string readBuffer;
+        curl_easy_setopt(client_, CURLOPT_WRITEDATA, &readBuffer);
+
+        // set content-type to application/json
+        struct curl_slist *headers = NULL;
+        headers = curl_slist_append(headers, "Content-Type: application/json");
+        curl_easy_setopt(client_, CURLOPT_HTTPHEADER, headers);
+        CURLcode res = curl_easy_perform(client_);
+        curl_slist_free_all(headers);  // Free headers
+        if (res != CURLE_OK) {
+            LOG(ERROR) << "Error from http client, PUT " << url
+                       << " error: " << curl_easy_strerror(res);
+            return false;
+        }
+
+        // Get the HTTP response code
+        long responseCode;
+        curl_easy_getinfo(client_, CURLINFO_RESPONSE_CODE, &responseCode);
+        if (responseCode != 200) {
+            LOG(ERROR) << "Unexpected code in http response, PUT " << url
+                       << " response code: " << responseCode
+                       << " response body: " << readBuffer;
+            return false;
+        }
+
+        return true;
+    }
+
+    virtual bool remove(const std::string &key) {
+        curl_easy_reset(client_);
+        curl_easy_setopt(client_, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
+
+        if (globalConfig().verbose)
+            LOG(INFO) << "Remove segment desc, key=" << key;
+
+        std::string url = encodeUrl(key);
+        curl_easy_setopt(client_, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(client_, CURLOPT_WRITEFUNCTION, writeCallback);
+        curl_easy_setopt(client_, CURLOPT_CUSTOMREQUEST, "DELETE");
+
+        // get response body
+        std::string readBuffer;
+        curl_easy_setopt(client_, CURLOPT_WRITEDATA, &readBuffer);
+        CURLcode res = curl_easy_perform(client_);
+        if (res != CURLE_OK) {
+            LOG(ERROR) << "Error from http client, DELETE " << url
+                       << " error: " << curl_easy_strerror(res);
+            return false;
+        }
+
+        // Get the HTTP response code
+        long responseCode;
+        curl_easy_getinfo(client_, CURLINFO_RESPONSE_CODE, &responseCode);
+        if (responseCode != 200) {
+            LOG(ERROR) << "Unexpected code in http response, DELETE " << url
+                       << " response code: " << responseCode
+                       << " response body: " << readBuffer;
+            return false;
+        }
+        return true;
+    }
+
+    CURL *client_;
+    const std::string metadata_uri_;
+};
+#endif  // USE_HTTP
+
+#ifdef USE_ETCD
+struct EtcdStoragePlugin : public MetadataStoragePlugin {
+    EtcdStoragePlugin(const std::string &metadata_uri)
+        : client_(metadata_uri), metadata_uri_(metadata_uri) {}
+
+    virtual ~EtcdStoragePlugin() {}
+
+    virtual bool get(const std::string &key, Json::Value &value) {
+        Json::Reader reader;
+        auto resp = client_.get(key);
+        if (!resp.is_ok()) {
+            LOG(ERROR) << "EtcdStoragePlugin: unable to get " << key << " from "
+                       << metadata_uri_ << ": " << resp.error_message();
+            return false;
+        }
+        auto json_file = resp.value().as_string();
+        if (!reader.parse(json_file, value)) return false;
+        if (globalConfig().verbose)
+            LOG(INFO) << "EtcdStoragePlugin: get: key=" << key
+                      << ", value=" << json_file;
+        return true;
+    }
+
+    virtual bool set(const std::string &key, const Json::Value &value) {
+        Json::FastWriter writer;
+        const std::string json_file = writer.write(value);
+        if (globalConfig().verbose)
+            LOG(INFO) << "EtcdStoragePlugin: set: key=" << key
+                      << ", value=" << json_file;
+        auto resp = client_.put(key, json_file);
+        if (!resp.is_ok()) {
+            LOG(ERROR) << "EtcdStoragePlugin: unable to set " << key << " from "
+                       << metadata_uri_ << ": " << resp.error_message();
+            return false;
+        }
+        return true;
+    }
+
+    virtual bool remove(const std::string &key) {
+        auto resp = client_.rm(key);
+        if (!resp.is_ok()) {
+            LOG(ERROR) << "EtcdStoragePlugin: unable to delete " << key
+                       << " from " << metadata_uri_ << ": "
+                       << resp.error_message();
+            return false;
+        }
+        return true;
+    }
+
+    etcd::SyncClient client_;
+    const std::string metadata_uri_;
+};
+#endif  // USE_ETCD
+
+std::pair<std::string, std::string> parseConnectionString(
+    const std::string &conn_string) {
+    std::pair<std::string, std::string> result;
+    std::string proto = "etcd";
+    std::string domain;
+    std::size_t pos = conn_string.find("://");
+
+    if (pos != std::string::npos) {
+        proto = conn_string.substr(0, pos);
+        domain = conn_string.substr(pos + 3);
+    } else {
+        domain = conn_string;
+    }
+
+    result.first = proto;
+    result.second = domain;
+    return result;
+}
+
+std::shared_ptr<MetadataStoragePlugin> MetadataStoragePlugin::Create(
+    const std::string &conn_string) {
+    auto parsed_conn_string = parseConnectionString(conn_string);
+#ifdef USE_ETCD
+    if (parsed_conn_string.first == "etcd") {
+        return std::make_shared<EtcdStoragePlugin>(parsed_conn_string.second);
+    }
+#endif  // USE_ETCD
+
+#ifdef USE_REDIS
+    if (parsed_conn_string.first == "redis") {
+        return std::make_shared<RedisStoragePlugin>(parsed_conn_string.second);
+    }
+#endif  // USE_REDIS
+
+#ifdef USE_HTTP
+    if (parsed_conn_string.first == "http" ||
+        parsed_conn_string.first == "https") {
+        return std::make_shared<HTTPStoragePlugin>(
+            conn_string);  // including prefix
+    }
+#endif  // USE_HTTP
+
+    LOG(FATAL) << "Unable to find metadata storage plugin "
+               << parsed_conn_string.first;
+    return nullptr;
+}
+
+static inline const std::string getNetworkAddress(struct sockaddr *addr) {
+    if (addr->sa_family == AF_INET) {
+        struct sockaddr_in *sock_addr = (struct sockaddr_in *)addr;
+        char ip[INET_ADDRSTRLEN];
+        if (inet_ntop(addr->sa_family, &(sock_addr->sin_addr), ip,
+                      INET_ADDRSTRLEN) != NULL)
+            return std::string(ip) + ":" +
+                   std::to_string(ntohs(sock_addr->sin_port));
+    } else if (addr->sa_family == AF_INET6) {
+        struct sockaddr_in6 *sock_addr = (struct sockaddr_in6 *)addr;
+        char ip[INET6_ADDRSTRLEN];
+        if (inet_ntop(addr->sa_family, &(sock_addr->sin6_addr), ip,
+                      INET6_ADDRSTRLEN) != NULL)
+            return std::string(ip) + ":" +
+                   std::to_string(ntohs(sock_addr->sin6_port));
+    }
+    PLOG(ERROR) << "Failed to parse socket address";
+    return "";
+}
+
+struct SocketHandShakePlugin : public HandShakePlugin {
+    SocketHandShakePlugin() : listener_running_(false), listen_fd_(-1) {}
+
+    void closeListen() {
+        if (listen_fd_ >= 0) {
+            LOG(INFO) << "SocketHandShakePlugin: closing listen socket";
+            close(listen_fd_);
+            listen_fd_ = -1;
+        }
+    }
+
+    virtual ~SocketHandShakePlugin() {
+        closeListen();
+        if (listener_running_) {
+            listener_running_ = false;
+            listener_.join();
+        }
+    }
+
+    virtual int startDaemon(OnReceiveCallBack on_recv_callback,
+                            uint16_t listen_port) {
+        sockaddr_in bind_address;
+        int on = 1;
+        memset(&bind_address, 0, sizeof(sockaddr_in));
+        bind_address.sin_family = AF_INET;
+        bind_address.sin_port = htons(listen_port);
+        bind_address.sin_addr.s_addr = INADDR_ANY;
+
+        listen_fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (listen_fd_ < 0) {
+            PLOG(ERROR) << "SocketHandShakePlugin: socket()";
+            return ERR_SOCKET;
+        }
+
+        struct timeval timeout;
+        timeout.tv_sec = 1;
+        timeout.tv_usec = 0;
+        if (setsockopt(listen_fd_, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+                       sizeof(timeout))) {
+            PLOG(ERROR) << "SocketHandShakePlugin: setsockopt(SO_RCVTIMEO)";
+            closeListen();
+            return ERR_SOCKET;
+        }
+
+        if (setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on))) {
+            PLOG(ERROR) << "SocketHandShakePlugin: setsockopt(SO_REUSEADDR)";
+            closeListen();
+            return ERR_SOCKET;
+        }
+
+        if (bind(listen_fd_, (sockaddr *)&bind_address, sizeof(sockaddr_in)) <
+            0) {
+            PLOG(ERROR) << "SocketHandShakePlugin: bind (port " << listen_port
+                        << ")";
+            closeListen();
+            return ERR_SOCKET;
+        }
+
+        if (listen(listen_fd_, 5)) {
+            PLOG(ERROR) << "SocketHandShakePlugin: listen()";
+            closeListen();
+            return ERR_SOCKET;
+        }
+
+        listener_running_ = true;
+        listener_ = std::thread([this, on_recv_callback]() {
+            while (listener_running_) {
+                sockaddr_in addr;
+                socklen_t addr_len = sizeof(sockaddr_in);
+                int conn_fd = accept(listen_fd_, (sockaddr *)&addr, &addr_len);
+                if (conn_fd < 0) {
+                    if (errno != EWOULDBLOCK)
+                        PLOG(ERROR) << "SocketHandShakePlugin: accept()";
+                    continue;
+                }
+
+                if (addr.sin_family != AF_INET && addr.sin_family != AF_INET6) {
+                    LOG(ERROR) << "SocketHandShakePlugin: unsupported socket "
+                                  "type, should be AF_INET or AF_INET6";
+                    close(conn_fd);
+                    continue;
+                }
+
+                struct timeval timeout;
+                timeout.tv_sec = 60;
+                timeout.tv_usec = 0;
+                if (setsockopt(conn_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+                               sizeof(timeout))) {
+                    PLOG(ERROR)
+                        << "SocketHandShakePlugin: setsockopt(SO_RCVTIMEO)";
+                    close(conn_fd);
+                    continue;
+                }
+
+                auto peer_hostname =
+                    getNetworkAddress((struct sockaddr *)&addr);
+                if (globalConfig().verbose)
+                    LOG(INFO) << "SocketHandShakePlugin: new connection: "
+                              << peer_hostname.c_str();
+
+                Json::Value local, peer;
+                Json::Reader reader;
+                if (!reader.parse(readString(conn_fd), peer)) {
+                    LOG(ERROR) << "SocketHandShakePlugin: failed to receive "
+                                  "handshake message: "
+                                  "malformed json format, check tcp connection";
+                    close(conn_fd);
+                    continue;
+                }
+
+                on_recv_callback(peer, local);
+                int ret = writeString(conn_fd, Json::FastWriter{}.write(local));
+                if (ret) {
+                    LOG(ERROR) << "SocketHandShakePlugin: failed to send "
+                                  "handshake message: "
+                                  "malformed json format, check tcp connection";
+                    close(conn_fd);
+                    continue;
+                }
+
+                close(conn_fd);
+            }
+            return;
+        });
+
+        return 0;
+    }
+
+    virtual int send(std::string ip_or_host_name, uint16_t rpc_port,
+                     const Json::Value &local, Json::Value &peer) {
+        struct addrinfo hints;
+        struct addrinfo *result, *rp;
+        memset(&hints, 0, sizeof(hints));
+        hints.ai_family = AF_INET;
+        hints.ai_socktype = SOCK_STREAM;
+
+        char service[16];
+        sprintf(service, "%u", rpc_port);
+        if (getaddrinfo(ip_or_host_name.c_str(), service, &hints, &result)) {
+            PLOG(ERROR)
+                << "SocketHandShakePlugin: failed to get IP address of peer "
+                   "server "
+                << ip_or_host_name << ":" << rpc_port
+                << ", check DNS and /etc/hosts, or use IPv4 address instead";
+            return ERR_DNS;
+        }
+
+        int ret = 0;
+        for (rp = result; rp; rp = rp->ai_next) {
+            ret = doSend(rp, local, peer);
+            if (ret == 0) {
+                freeaddrinfo(result);
+                return 0;
+            }
+            if (ret == ERR_MALFORMED_JSON) {
+                return ret;
+            }
+        }
+
+        freeaddrinfo(result);
+        return ret;
+    }
+
+    int doSend(struct addrinfo *addr, const Json::Value &local,
+               Json::Value &peer) {
+        if (globalConfig().verbose)
+            LOG(INFO) << "SocketHandShakePlugin: connecting "
+                      << getNetworkAddress(addr->ai_addr);
+
+        int on = 1;
+        int conn_fd =
+            socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+        if (conn_fd == -1) {
+            PLOG(ERROR) << "SocketHandShakePlugin: socket()";
+            return ERR_SOCKET;
+        }
+        if (setsockopt(conn_fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on))) {
+            PLOG(ERROR) << "SocketHandShakePlugin: setsockopt(SO_REUSEADDR)";
+            close(conn_fd);
+            return ERR_SOCKET;
+        }
+
+        struct timeval timeout;
+        timeout.tv_sec = 60;
+        timeout.tv_usec = 0;
+        if (setsockopt(conn_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+                       sizeof(timeout))) {
+            PLOG(ERROR) << "SocketHandShakePlugin: setsockopt(SO_RCVTIMEO)";
+            close(conn_fd);
+            return ERR_SOCKET;
+        }
+
+        if (connect(conn_fd, addr->ai_addr, addr->ai_addrlen)) {
+            PLOG(ERROR) << "SocketHandShakePlugin: connect()"
+                        << getNetworkAddress(addr->ai_addr);
+            close(conn_fd);
+            return ERR_SOCKET;
+        }
+
+        int ret = writeString(conn_fd, Json::FastWriter{}.write(local));
+        if (ret) {
+            LOG(ERROR)
+                << "SocketHandShakePlugin: failed to send handshake message: "
+                   "malformed json format, check tcp connection";
+            close(conn_fd);
+            return ret;
+        }
+
+        Json::Reader reader;
+        if (!reader.parse(readString(conn_fd), peer)) {
+            LOG(ERROR) << "SocketHandShakePlugin: failed to receive handshake "
+                          "message: "
+                          "malformed json format, check tcp connection";
+            close(conn_fd);
+            return ERR_MALFORMED_JSON;
+        }
+
+        close(conn_fd);
+        return 0;
+    }
+
+    std::atomic<bool> listener_running_;
+    std::thread listener_;
+    int listen_fd_;
+};
+
+std::shared_ptr<HandShakePlugin> HandShakePlugin::Create(
+    const std::string &conn_string) {
+    return std::make_shared<SocketHandShakePlugin>();
+}
+
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transport/CMakeLists.txt
+++ b/mooncake-ngxl-exp/src/transport/CMakeLists.txt
@@ -1,0 +1,15 @@
+file(GLOB XPORT_SOURCES "*.cpp")
+
+add_subdirectory(rdma_transport)
+add_library(ngxl_transport OBJECT ${XPORT_SOURCES} $<TARGET_OBJECTS:rdma_ngxl_transport>)
+
+add_subdirectory(tcp_transport)
+target_sources(ngxl_transport PUBLIC $<TARGET_OBJECTS:tcp_ngxl_transport>)
+
+add_subdirectory(shm_transport)
+target_sources(ngxl_transport PUBLIC $<TARGET_OBJECTS:shm_ngxl_transport>)
+
+if (USE_NVMEOF)
+  add_subdirectory(nvmeof_transport)
+  target_sources(ngxl_transport PUBLIC $<TARGET_OBJECTS:nvmeof_ngxl_transport>)
+endif()

--- a/mooncake-ngxl-exp/src/transport/nvmeof_transport/CMakeLists.txt
+++ b/mooncake-ngxl-exp/src/transport/nvmeof_transport/CMakeLists.txt
@@ -1,0 +1,5 @@
+file(GLOB NVMEOF_SOURCES "*.cpp")
+
+add_library(nvmeof_ngxl_transport OBJECT ${NVMEOF_SOURCES})
+target_include_directories(nvmeof_ngxl_transport PUBLIC "/usr/local/cuda/include")
+# target_link_libraries(nvmeof_ngxl_transport PUBLIC ngxl_transport)

--- a/mooncake-ngxl-exp/src/transport/nvmeof_transport/cufile_context.cpp
+++ b/mooncake-ngxl-exp/src/transport/nvmeof_transport/cufile_context.cpp
@@ -1,0 +1,19 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef USE_NVMEOF
+
+// TBD
+
+#endif

--- a/mooncake-ngxl-exp/src/transport/nvmeof_transport/cufile_desc_pool.cpp
+++ b/mooncake-ngxl-exp/src/transport/nvmeof_transport/cufile_desc_pool.cpp
@@ -1,0 +1,106 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/nvmeof_transport/cufile_desc_pool.h"
+
+#include <bits/stdint-uintn.h>
+
+#include <atomic>
+#include <cstddef>
+#include <mutex>
+
+#include "cufile.h"
+#include "transfer_engine.h"
+#include "transport/nvmeof_transport/cufile_context.h"
+
+namespace mooncake {
+thread_local int CUFileDescPool::thread_index = -1;
+std::atomic<int> CUFileDescPool::index_counter(0);
+
+CUFileDescPool::CUFileDescPool() {
+    for (size_t i = 0; i < MAX_NR_CUFILE_DESC; ++i) {
+        handle_[i] = NULL;
+        io_params_[i].reserve(MAX_CUFILE_BATCH_SIZE);
+        io_events_[i].resize(MAX_CUFILE_BATCH_SIZE);
+        start_idx_[i] = 0;
+        occupied_[i].store(0, std::memory_order_relaxed);
+        CUFILE_CHECK(cuFileBatchIOSetUp(&handle_[i], MAX_CUFILE_BATCH_SIZE));
+    }
+}
+
+CUFileDescPool::~CUFileDescPool() {
+    for (size_t i = 0; i < MAX_NR_CUFILE_DESC; ++i) {
+        cuFileBatchIODestroy(handle_[i]);
+    }
+}
+
+int CUFileDescPool::allocCUfileDesc(size_t batch_size) {
+    if (batch_size > MAX_CUFILE_BATCH_SIZE) {
+        LOG(ERROR) << "Batch Size Exceeds Max CUFile Batch Size";
+        return -1;
+    }
+    if (thread_index == -1) {
+        thread_index = index_counter.fetch_add(1);
+    }
+
+    int idx = thread_index % MAX_NR_CUFILE_DESC;
+    uint64_t old = 0;
+    if (!occupied_[idx].compare_exchange_strong(old, thread_index)) {
+        LOG(INFO) << "No Batch Descriptor Available ";
+        return -1;
+    }
+    return idx;
+}
+
+int CUFileDescPool::pushParams(int idx, CUfileIOParams_t &io_params) {
+    auto &params = io_params_[idx];
+    if (params.size() >= params.capacity()) {
+        return -1;
+    }
+    params.push_back(io_params);
+    return 0;
+}
+
+int CUFileDescPool::submitBatch(int idx) {
+    auto &params = io_params_[idx];
+    // LOG(INFO) << "submit " << idx;
+    CUFILE_CHECK(cuFileBatchIOSubmit(handle_[idx],
+                                     params.size() - start_idx_[idx],
+                                     params.data() + start_idx_[idx], 0));
+    start_idx_[idx] = params.size();
+    return 0;
+}
+
+CUfileIOEvents_t CUFileDescPool::getTransferStatus(int idx, int slice_id) {
+    unsigned nr = io_params_[idx].size();
+    // TODO: optimize this & fix start
+    CUFILE_CHECK(cuFileBatchIOGetStatus(handle_[idx], 0, &nr,
+                                        io_events_[idx].data(), NULL));
+    return io_events_[idx][slice_id];
+}
+
+int CUFileDescPool::getSliceNum(int idx) {
+    auto &params = io_params_[idx];
+    return params.size();
+}
+
+int CUFileDescPool::freeCUfileDesc(int idx) {
+    occupied_[idx].store(0, std::memory_order_relaxed);
+    io_params_[idx].clear();
+    start_idx_[idx] = 0;
+    // memset(io_events_[idx].data(), 0, io_events_[idx].size() *
+    // sizeof(CUfileIOEvents_t));
+    return 0;
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-ngxl-exp/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -1,0 +1,265 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/nvmeof_transport/nvmeof_transport.h"
+
+#include <bits/stdint-uintn.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <memory>
+
+#include "common.h"
+#include "transfer_engine.h"
+#include "transfer_metadata.h"
+#include "transport/nvmeof_transport/cufile_context.h"
+#include "transport/nvmeof_transport/cufile_desc_pool.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+NVMeoFTransport::NVMeoFTransport() {
+    CUFILE_CHECK(cuFileDriverOpen());
+    desc_pool_ = std::make_shared<CUFileDescPool>();
+}
+
+NVMeoFTransport::~NVMeoFTransport() {}
+
+Transport::TransferStatusEnum from_cufile_transfer_status(
+    CUfileStatus_t status) {
+    switch (status) {
+        case CUFILE_WAITING:
+            return Transport::WAITING;
+        case CUFILE_PENDING:
+            return Transport::PENDING;
+        case CUFILE_INVALID:
+            return Transport::INVALID;
+        case CUFILE_CANCELED:
+            return Transport::CANNELED;
+        case CUFILE_COMPLETE:
+            return Transport::COMPLETED;
+        case CUFILE_TIMEOUT:
+            return Transport::TIMEOUT;
+        case CUFILE_FAILED:
+            return Transport::FAILED;
+        default:
+            return Transport::FAILED;
+    }
+}
+
+NVMeoFTransport::BatchID NVMeoFTransport::allocateBatchID(size_t batch_size) {
+    auto nvmeof_desc = new NVMeoFBatchDesc();
+    auto batch_id = Transport::allocateBatchID(batch_size);
+    auto &batch_desc = *((BatchDesc *)(batch_id));
+    nvmeof_desc->desc_idx_ = desc_pool_->allocCUfileDesc(batch_size);
+    nvmeof_desc->transfer_status.reserve(batch_size);
+    nvmeof_desc->task_to_slices.reserve(batch_size);
+    batch_desc.context = nvmeof_desc;
+    return batch_id;
+}
+
+int NVMeoFTransport::getTransferStatus(BatchID batch_id, size_t task_id,
+                                       TransferStatus &status) {
+    auto &batch_desc = *((BatchDesc *)(batch_id));
+    auto &task = batch_desc.task_list[task_id];
+    auto &nvmeof_desc = *((NVMeoFBatchDesc *)(batch_desc.context));
+    // LOG(DEBUG) << "get t n " << nr;
+    // 1. get task -> id map
+    TransferStatus transfer_status = {.s = Transport::PENDING,
+                                      .transferred_bytes = 0};
+    auto [slice_id, slice_num] = nvmeof_desc.task_to_slices[task_id];
+    for (size_t i = slice_id; i < slice_id + slice_num; ++i) {
+        // LOG(INFO) << "task " << task_id << " i " << i << " upper bound " <<
+        // slice_num;
+        auto event =
+            desc_pool_->getTransferStatus(nvmeof_desc.desc_idx_, slice_id);
+        transfer_status.s = from_cufile_transfer_status(event.status);
+        // TODO(FIXME): what to do if multi slices have different status?
+        if (transfer_status.s == COMPLETED) {
+            transfer_status.transferred_bytes += event.ret;
+        } else {
+            break;
+        }
+    }
+    if (transfer_status.s == COMPLETED) {
+        task.is_finished = true;
+    }
+    status = transfer_status;
+    return 0;
+}
+
+int NVMeoFTransport::submitTransfer(
+    BatchID batch_id, const std::vector<TransferRequest> &entries) {
+    auto &batch_desc = *((BatchDesc *)(batch_id));
+    auto &nvmeof_desc = *((NVMeoFBatchDesc *)(batch_desc.context));
+
+    if (batch_desc.task_list.size() + entries.size() > batch_desc.batch_size)
+        return -1;
+
+    size_t task_id = batch_desc.task_list.size();
+    size_t slice_id = desc_pool_->getSliceNum(nvmeof_desc.desc_idx_);
+    batch_desc.task_list.resize(task_id + entries.size());
+    std::unordered_map<SegmentID, std::shared_ptr<SegmentDesc>>
+        segment_desc_map;
+    // segment_desc_map[LOCAL_SEGMENT_ID] =
+    // getSegmentDescByID(LOCAL_SEGMENT_ID);
+    for (auto &request : entries) {
+        TransferTask &task = batch_desc.task_list[task_id];
+        auto target_id = request.target_id;
+
+        if (!segment_desc_map.count(target_id)) {
+            segment_desc_map[target_id] =
+                metadata_->getSegmentDescByID(target_id);
+            assert(segment_desc_map[target_id] != nullptr);
+        }
+
+        auto &desc = segment_desc_map.at(target_id);
+        // LOG(INFO) << "desc " << desc->name << " " << desc->protocol;
+        assert(desc->protocol == "nvmeof");
+        // TODO: solving iterator invalidation due to vector resize
+        // Handle File Offset
+        uint32_t buffer_id = 0;
+        uint64_t segment_start = request.target_offset;
+        uint64_t segment_end = request.target_offset + request.length;
+        uint64_t current_offset = 0;
+        for (auto &buffer_desc : desc->nvmeof_buffers) {
+            bool is_overlap = overlap(
+                (void *)segment_start, request.length, (void *)current_offset,
+                buffer_desc
+                    .length);  // this buffer intersects with user's target
+            if (is_overlap) {
+                // 1. get_slice_start
+                uint64_t slice_start = std::max(segment_start, current_offset);
+                // 2. slice_end
+                uint64_t slice_end =
+                    std::min(segment_end, current_offset + buffer_desc.length);
+                // 3. init slice and put into TransferTask
+                const char *file_path =
+                    buffer_desc.local_path_map[local_server_name_].c_str();
+                void *source_addr =
+                    (char *)request.source + slice_start - segment_start;
+                uint64_t file_offset = slice_start - current_offset;
+                uint64_t slice_len = slice_end - slice_start;
+                addSliceToTask(source_addr, slice_len, file_offset,
+                               request.opcode, task, file_path);
+                // 4. get cufile handle
+                auto buf_key = std::make_pair(target_id, buffer_id);
+                CUfileHandle_t fh;
+                {
+                    // TODO: upgrade
+                    RWSpinlock::WriteGuard guard(context_lock_);
+                    if (!segment_to_context_.count(buf_key)) {
+                        segment_to_context_[buf_key] =
+                            std::make_shared<CuFileContext>(file_path);
+                    }
+                    fh = segment_to_context_.at(buf_key)->getHandle();
+                }
+                // 5. add cufile request
+                addSliceToCUFileBatch(source_addr, file_offset, slice_len,
+                                      nvmeof_desc.desc_idx_, request.opcode,
+                                      fh);
+            }
+            ++buffer_id;
+            current_offset += buffer_desc.length;
+        }
+
+        nvmeof_desc.transfer_status.push_back(
+            TransferStatus{.s = PENDING, .transferred_bytes = 0});
+        nvmeof_desc.task_to_slices.push_back({slice_id, task.slice_count});
+        ++task_id;
+        slice_id += task.slice_count;
+    }
+
+    desc_pool_->submitBatch(nvmeof_desc.desc_idx_);
+    // LOG(INFO) << "submit nr " << slice_id << " start " << start_slice_id;
+    return 0;
+}
+
+int NVMeoFTransport::freeBatchID(BatchID batch_id) {
+    auto &batch_desc = *((BatchDesc *)(batch_id));
+    auto &nvmeof_desc = *((NVMeoFBatchDesc *)(batch_desc.context));
+    int desc_idx = nvmeof_desc.desc_idx_;
+    int rc = Transport::freeBatchID(batch_id);
+    if (rc < 0) {
+        return -1;
+    }
+    desc_pool_->freeCUfileDesc(desc_idx);
+    return 0;
+}
+
+int NVMeoFTransport::install(std::string &local_server_name,
+                             std::shared_ptr<TransferMetadata> meta,
+                             std::shared_ptr<Topology> topo) {
+    return Transport::install(local_server_name, meta, topo);
+}
+
+int NVMeoFTransport::registerLocalMemory(void *addr, size_t length,
+                                         const std::string &location,
+                                         bool remote_accessible,
+                                         bool update_metadata) {
+    (void)remote_accessible;
+    (void)update_metadata;
+    CUFILE_CHECK(cuFileBufRegister(addr, length, 0));
+    return 0;
+}
+
+int NVMeoFTransport::unregisterLocalMemory(void *addr, bool update_metadata) {
+    (void)update_metadata;
+    CUFILE_CHECK(cuFileBufDeregister(addr));
+    return 0;
+}
+
+void NVMeoFTransport::addSliceToTask(void *source_addr, uint64_t slice_len,
+                                     uint64_t target_start,
+                                     TransferRequest::OpCode op,
+                                     TransferTask &task,
+                                     const char *file_path) {
+    if (!source_addr || !file_path) {
+        LOG(ERROR) << "Invalid source_addr or file_path";
+        return;
+    }
+    Slice *slice = new Slice();
+    slice->source_addr = (char *)source_addr;
+    slice->length = slice_len;
+    slice->opcode = op;
+    slice->nvmeof.file_path = file_path;
+    slice->nvmeof.start = target_start;
+    slice->task = &task;
+    slice->status = Slice::PENDING;
+    task.total_bytes += slice->length;
+    task.slice_count += 1;
+}
+
+void NVMeoFTransport::addSliceToCUFileBatch(
+    void *source_addr, uint64_t file_offset, uint64_t slice_len,
+    uint64_t desc_id, TransferRequest::OpCode op, CUfileHandle_t fh) {
+    CUfileIOParams_t params;
+    params.mode = CUFILE_BATCH;
+    params.opcode =
+        op == Transport::TransferRequest::READ ? CUFILE_READ : CUFILE_WRITE;
+    params.cookie = (void *)0;
+    params.u.batch.devPtr_base = source_addr;
+    params.u.batch.devPtr_offset = 0;
+    params.u.batch.file_offset = file_offset;
+    params.u.batch.size = slice_len;
+    params.fh = fh;
+    // LOG(INFO) << "params " << "base " << request.source << " offset " <<
+    // request.target_offset << " length " << request.length;
+    desc_pool_->pushParams(desc_id, params);
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transport/rdma_transport/CMakeLists.txt
+++ b/mooncake-ngxl-exp/src/transport/rdma_transport/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB RDMA_SOURCES "*.cpp")
+
+add_library(rdma_ngxl_transport OBJECT ${RDMA_SOURCES})
+# target_link_libraries(rdma_ngxl_transport PUBLIC ngxl_transport)

--- a/mooncake-ngxl-exp/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-ngxl-exp/src/transport/rdma_transport/endpoint_store.cpp
@@ -1,0 +1,229 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_transport/endpoint_store.h"
+
+#include <glog/logging.h>
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+#include "config.h"
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_transport/rdma_endpoint.h"
+
+namespace mooncake {
+std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::getEndpoint(
+    const std::string &peer_nic_path) {
+    RWSpinlock::ReadGuard guard(endpoint_map_lock_);
+    auto iter = endpoint_map_.find(peer_nic_path);
+    if (iter != endpoint_map_.end()) return iter->second;
+    return nullptr;
+}
+
+std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::insertEndpoint(
+    const std::string &peer_nic_path, RdmaContext *context) {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    if (endpoint_map_.find(peer_nic_path) != endpoint_map_.end()) {
+        LOG(INFO) << "Endpoint " << peer_nic_path
+                  << " already exists in FIFOEndpointStore";
+        return endpoint_map_[peer_nic_path];
+    }
+    auto endpoint = std::make_shared<RdmaEndPoint>(*context);
+    if (!endpoint) {
+        LOG(ERROR) << "Failed to allocate memory for RdmaEndPoint";
+        return nullptr;
+    }
+    auto &config = globalConfig();
+    int ret =
+        endpoint->construct(context->cq(), config.num_qp_per_ep, config.max_sge,
+                            config.max_wr, config.max_inline);
+    if (ret) return nullptr;
+
+    while (this->getSize() >= max_size_) evictEndpoint();
+
+    endpoint->setPeerNicPath(peer_nic_path);
+    endpoint_map_[peer_nic_path] = endpoint;
+    fifo_list_.push_back(peer_nic_path);
+    auto it = fifo_list_.end();
+    fifo_map_[peer_nic_path] = --it;
+    return endpoint;
+}
+
+int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    auto iter = endpoint_map_.find(peer_nic_path);
+    if (iter != endpoint_map_.end()) {
+        waiting_list_.insert(iter->second);
+        iter->second->set_active(false);
+        endpoint_map_.erase(iter);
+        auto fifo_iter = fifo_map_[peer_nic_path];
+        fifo_list_.erase(fifo_iter);
+        fifo_map_.erase(peer_nic_path);
+    }
+    return 0;
+}
+
+void FIFOEndpointStore::evictEndpoint() {
+    if (fifo_list_.empty()) return;
+    std::string victim = fifo_list_.front();
+    fifo_list_.pop_front();
+    fifo_map_.erase(victim);
+    LOG(INFO) << victim << " evicted";
+    waiting_list_.insert(endpoint_map_[victim]);
+    endpoint_map_.erase(victim);
+    return;
+}
+
+void FIFOEndpointStore::reclaimEndpoint() {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    std::vector<std::shared_ptr<RdmaEndPoint>> to_delete;
+    for (auto &endpoint : waiting_list_)
+        if (!endpoint->hasOutstandingSlice()) to_delete.push_back(endpoint);
+    for (auto &endpoint : to_delete) waiting_list_.erase(endpoint);
+}
+
+size_t FIFOEndpointStore::getSize() { return endpoint_map_.size(); }
+
+int FIFOEndpointStore::destroyQPs() {
+    for (auto &kv : endpoint_map_) {
+        kv.second->destroyQP();
+    }
+    return 0;
+}
+
+int FIFOEndpointStore::disconnectQPs() {
+    for (auto &kv : endpoint_map_) {
+        kv.second->disconnect();
+    }
+    return 0;
+}
+
+std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::getEndpoint(
+    const std::string &peer_nic_path) {
+    RWSpinlock::ReadGuard guard(endpoint_map_lock_);
+    auto iter = endpoint_map_.find(peer_nic_path);
+    if (iter != endpoint_map_.end()) {
+        iter->second.second.store(
+            true, std::memory_order_relaxed);  // This is safe within read lock
+                                               // because of idempotence
+        return iter->second.first;
+    }
+    // LOG(INFO) << "Endpoint " << peer_nic_path << " not found in
+    // SIEVEEndpointStore";
+    return nullptr;
+}
+
+std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::insertEndpoint(
+    const std::string &peer_nic_path, RdmaContext *context) {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    if (endpoint_map_.find(peer_nic_path) != endpoint_map_.end()) {
+        LOG(INFO) << "Endpoint " << peer_nic_path
+                  << " already exists in SIEVEEndpointStore";
+        return endpoint_map_[peer_nic_path].first;
+    }
+    auto endpoint = std::make_shared<RdmaEndPoint>(*context);
+    if (!endpoint) {
+        LOG(ERROR) << "Failed to allocate memory for RdmaEndPoint";
+        return nullptr;
+    }
+    auto &config = globalConfig();
+    int ret =
+        endpoint->construct(context->cq(), config.num_qp_per_ep, config.max_sge,
+                            config.max_wr, config.max_inline);
+    if (ret) return nullptr;
+
+    while (this->getSize() >= max_size_) evictEndpoint();
+
+    endpoint->setPeerNicPath(peer_nic_path);
+    endpoint_map_[peer_nic_path] = std::make_pair(endpoint, false);
+    fifo_list_.push_front(peer_nic_path);
+    fifo_map_[peer_nic_path] = fifo_list_.begin();
+    return endpoint;
+}
+
+int SIEVEEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    auto iter = endpoint_map_.find(peer_nic_path);
+    if (iter != endpoint_map_.end()) {
+        waiting_list_len_++;
+        iter->second.first->set_active(false);
+        waiting_list_.insert(iter->second.first);
+        endpoint_map_.erase(iter);
+        auto fifo_iter = fifo_map_[peer_nic_path];
+        if (hand_.has_value() && hand_.value() == fifo_iter) {
+            fifo_iter == fifo_list_.begin() ? hand_ = std::nullopt
+                                            : hand_ = std::prev(fifo_iter);
+        }
+        fifo_list_.erase(fifo_iter);
+        fifo_map_.erase(peer_nic_path);
+    }
+    return 0;
+}
+
+void SIEVEEndpointStore::evictEndpoint() {
+    if (fifo_list_.empty()) {
+        return;
+    }
+    auto o = hand_.has_value() ? hand_.value() : --fifo_list_.end();
+    std::string victim;
+    while (true) {
+        victim = *o;
+        if (endpoint_map_[victim].second.load(std::memory_order_relaxed)) {
+            endpoint_map_[victim].second.store(false,
+                                               std::memory_order_relaxed);
+            o = (o == fifo_list_.begin() ? --fifo_list_.end() : std::prev(o));
+        } else {
+            break;
+        }
+    }
+    hand_ = (o == fifo_list_.begin() ? --fifo_list_.end() : std::prev(o));
+    fifo_list_.erase(o);
+    fifo_map_.erase(victim);
+    LOG(INFO) << victim << " evicted";
+    auto victim_instance = endpoint_map_[victim].first;
+    victim_instance->set_active(false);
+    waiting_list_len_++;
+    waiting_list_.insert(victim_instance);
+    endpoint_map_.erase(victim);
+    return;
+}
+
+void SIEVEEndpointStore::reclaimEndpoint() {
+    if (waiting_list_len_.load(std::memory_order_relaxed) == 0) return;
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    std::vector<std::shared_ptr<RdmaEndPoint>> to_delete;
+    for (auto &endpoint : waiting_list_)
+        if (!endpoint->hasOutstandingSlice()) to_delete.push_back(endpoint);
+    for (auto &endpoint : to_delete) waiting_list_.erase(endpoint);
+    waiting_list_len_ -= to_delete.size();
+}
+
+int SIEVEEndpointStore::destroyQPs() {
+    for (auto &endpoint : waiting_list_) endpoint->destroyQP();
+    for (auto &kv : endpoint_map_) kv.second.first->destroyQP();
+    return 0;
+}
+
+int SIEVEEndpointStore::disconnectQPs() {
+    for (auto &endpoint : waiting_list_) endpoint->disconnect();
+    for (auto &kv : endpoint_map_) kv.second.first->disconnect();
+    return 0;
+}
+
+size_t SIEVEEndpointStore::getSize() { return endpoint_map_.size(); }
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-ngxl-exp/src/transport/rdma_transport/rdma_context.cpp
@@ -1,0 +1,509 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_transport/rdma_context.h"
+
+#include <fcntl.h>
+#include <sys/epoll.h>
+
+#include <atomic>
+#include <cassert>
+#include <fstream>
+#include <memory>
+#include <thread>
+
+#include "config.h"
+#include "transport/rdma_transport/endpoint_store.h"
+#include "transport/rdma_transport/rdma_endpoint.h"
+#include "transport/rdma_transport/rdma_transport.h"
+#include "transport/rdma_transport/worker_pool.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+static int isNullGid(union ibv_gid *gid) {
+    for (int i = 0; i < 16; ++i) {
+        if (gid->raw[i] != 0) return 0;
+    }
+    return 1;
+}
+
+RdmaContext::RdmaContext(RdmaTransport &engine, const std::string &device_name)
+    : device_name_(device_name),
+      engine_(engine),
+      next_comp_channel_index_(0),
+      next_comp_vector_index_(0),
+      next_cq_list_index_(0),
+      worker_pool_(nullptr),
+      active_(true) {
+    static std::once_flag g_once_flag;
+    auto fork_init = []() {
+        int ret = ibv_fork_init();
+        if (ret) PLOG(ERROR) << "RDMA context setup failed: fork compatibility";
+    };
+    std::call_once(g_once_flag, fork_init);
+}
+
+RdmaContext::~RdmaContext() {
+    if (context_) deconstruct();
+}
+
+int RdmaContext::construct(size_t num_cq_list, size_t num_comp_channels,
+                           uint8_t port, int gid_index, size_t max_cqe,
+                           int max_endpoints) {
+    endpoint_store_ = std::make_shared<SIEVEEndpointStore>(max_endpoints);
+    if (openRdmaDevice(device_name_, port, gid_index)) {
+        LOG(ERROR) << "Failed to open device " << device_name_ << " on port "
+                   << port << " with GID " << gid_index;
+        return ERR_CONTEXT;
+    }
+
+    pd_ = ibv_alloc_pd(context_);
+    if (!pd_) {
+        PLOG(ERROR) << "Failed to allocate new protection domain on device "
+                    << device_name_;
+        return ERR_CONTEXT;
+    }
+
+    num_comp_channel_ = num_comp_channels;
+    comp_channel_ = new ibv_comp_channel *[num_comp_channels];
+    for (size_t i = 0; i < num_comp_channels; ++i) {
+        comp_channel_[i] = ibv_create_comp_channel(context_);
+        if (!comp_channel_[i]) {
+            PLOG(ERROR) << "Failed to create completion channel on device "
+                        << device_name_;
+            return ERR_CONTEXT;
+        }
+    }
+
+    event_fd_ = epoll_create1(0);
+    if (event_fd_ < 0) {
+        PLOG(ERROR) << "Failed to create epoll";
+        return ERR_CONTEXT;
+    }
+
+    if (joinNonblockingPollList(event_fd_, context_->async_fd)) {
+        LOG(ERROR) << "Failed to register context async fd to epoll";
+        close(event_fd_);
+        return ERR_CONTEXT;
+    }
+
+    for (size_t i = 0; i < num_comp_channel_; ++i)
+        if (joinNonblockingPollList(event_fd_, comp_channel_[i]->fd)) {
+            LOG(ERROR) << "Failed to register completion channel " << i
+                       << " to epoll";
+            close(event_fd_);
+            return ERR_CONTEXT;
+        }
+
+    cq_list_.resize(num_cq_list);
+    for (size_t i = 0; i < num_cq_list; ++i) {
+        auto cq =
+            ibv_create_cq(context_, max_cqe,
+                          (void *)&cq_list_[i].outstanding /* CQ context */,
+                          compChannel(), compVector());
+        if (!cq) {
+            PLOG(ERROR) << "Failed to create completion queue";
+            close(event_fd_);
+            return ERR_CONTEXT;
+        }
+        cq_list_[i].native = cq;
+    }
+
+    worker_pool_ = std::make_shared<WorkerPool>(*this, socketId());
+
+    LOG(INFO) << "RDMA device: " << context_->device->name << ", LID: " << lid_
+              << ", GID: (GID_Index " << gid_index_ << ") " << gid();
+
+    return 0;
+}
+
+int RdmaContext::socketId() {
+    std::string path =
+        "/sys/class/infiniband/" + device_name_ + "/device/numa_node";
+    std::ifstream file(path);
+    if (file.is_open()) {
+        int socket_id;
+        file >> socket_id;
+        file.close();
+        return socket_id;
+    } else {
+        return 0;
+    }
+}
+
+int RdmaContext::deconstruct() {
+    worker_pool_.reset();
+
+    endpoint_store_->destroyQPs();
+
+    for (auto &entry : memory_region_list_) {
+        int ret = ibv_dereg_mr(entry);
+        if (ret) {
+            PLOG(ERROR) << "Failed to unregister memory region";
+        }
+    }
+    memory_region_list_.clear();
+
+    for (size_t i = 0; i < cq_list_.size(); ++i) {
+        int ret = ibv_destroy_cq(cq_list_[i].native);
+        if (ret) {
+            PLOG(ERROR) << "Failed to destroy completion queue";
+        }
+    }
+    cq_list_.clear();
+
+    if (event_fd_ >= 0) {
+        if (close(event_fd_)) LOG(ERROR) << "Failed to close epoll fd";
+        event_fd_ = -1;
+    }
+
+    if (comp_channel_) {
+        for (size_t i = 0; i < num_comp_channel_; ++i)
+            if (comp_channel_[i])
+                if (ibv_destroy_comp_channel(comp_channel_[i]))
+                    LOG(ERROR) << "Failed to destroy completion channel";
+        delete[] comp_channel_;
+        comp_channel_ = nullptr;
+    }
+
+    if (pd_) {
+        if (ibv_dealloc_pd(pd_))
+            PLOG(ERROR) << "Failed to deallocate protection domain";
+        pd_ = nullptr;
+    }
+
+    if (context_) {
+        if (ibv_close_device(context_))
+            PLOG(ERROR) << "Failed to close device context";
+        context_ = nullptr;
+    }
+
+    if (globalConfig().verbose)
+        LOG(INFO) << "Release resources of RDMA device: " << device_name_;
+
+    return 0;
+}
+
+int RdmaContext::registerMemoryRegion(void *addr, size_t length, int access) {
+    ibv_mr *mr = ibv_reg_mr(pd_, addr, length, access);
+    if (!mr) {
+        PLOG(ERROR) << "Failed to register memory " << addr;
+        return ERR_CONTEXT;
+    }
+
+    RWSpinlock::WriteGuard guard(memory_regions_lock_);
+    memory_region_list_.push_back(mr);
+
+    if (globalConfig().verbose) {
+        LOG(INFO) << "Memory region: " << addr << " -- "
+                  << (void *)((uintptr_t)addr + length)
+                  << ", Device name: " << device_name_ << ", Length: " << length
+                  << " (" << length / 1024 / 1024 << " MB)"
+                  << ", Permission: " << access << std::hex
+                  << ", LKey: " << mr->lkey << ", RKey: " << mr->rkey;
+    }
+
+    return 0;
+}
+
+int RdmaContext::unregisterMemoryRegion(void *addr) {
+    RWSpinlock::WriteGuard guard(memory_regions_lock_);
+    bool has_removed;
+    do {
+        has_removed = false;
+        for (auto iter = memory_region_list_.begin();
+             iter != memory_region_list_.end(); ++iter) {
+            if ((*iter)->addr <= addr &&
+                addr < (char *)((*iter)->addr) + (*iter)->length) {
+                if (ibv_dereg_mr(*iter)) {
+                    LOG(ERROR) << "Failed to unregister memory " << addr;
+                    return ERR_CONTEXT;
+                }
+                memory_region_list_.erase(iter);
+                has_removed = true;
+                break;
+            }
+        }
+    } while (has_removed);
+    return 0;
+}
+
+uint32_t RdmaContext::rkey(void *addr) {
+    RWSpinlock::ReadGuard guard(memory_regions_lock_);
+    for (auto iter = memory_region_list_.begin();
+         iter != memory_region_list_.end(); ++iter)
+        if ((*iter)->addr <= addr &&
+            addr < (char *)((*iter)->addr) + (*iter)->length)
+            return (*iter)->rkey;
+
+    LOG(ERROR) << "Address " << addr << " rkey not found for " << deviceName();
+    return 0;
+}
+
+uint32_t RdmaContext::lkey(void *addr) {
+    RWSpinlock::ReadGuard guard(memory_regions_lock_);
+    for (auto iter = memory_region_list_.begin();
+         iter != memory_region_list_.end(); ++iter)
+        if ((*iter)->addr <= addr &&
+            addr < (char *)((*iter)->addr) + (*iter)->length)
+            return (*iter)->lkey;
+
+    LOG(ERROR) << "Address " << addr << " lkey not found for " << deviceName();
+    return 0;
+}
+
+std::shared_ptr<RdmaEndPoint> RdmaContext::endpoint(
+    const std::string &peer_nic_path) {
+    if (!active_) {
+        LOG(ERROR) << "Endpoint is not active";
+        return nullptr;
+    }
+
+    if (peer_nic_path.empty()) {
+        LOG(ERROR) << "Invalid peer NIC path";
+        return nullptr;
+    }
+
+    auto endpoint = endpoint_store_->getEndpoint(peer_nic_path);
+    if (endpoint) {
+        return endpoint;
+    } else {
+        auto endpoint = endpoint_store_->insertEndpoint(peer_nic_path, this);
+        return endpoint;
+    }
+
+    endpoint_store_->reclaimEndpoint();
+    return nullptr;
+}
+
+int RdmaContext::disconnectAllEndpoints() {
+    return endpoint_store_->disconnectQPs();
+}
+
+int RdmaContext::deleteEndpoint(const std::string &peer_nic_path) {
+    return endpoint_store_->deleteEndpoint(peer_nic_path);
+}
+
+std::string RdmaContext::nicPath() const {
+    return MakeNicPath(engine_.local_server_name_, device_name_);
+}
+
+std::string RdmaContext::gid() const {
+    std::string gid_str;
+    char buf[16] = {0};
+    const static size_t kGidLength = 16;
+    for (size_t i = 0; i < kGidLength; ++i) {
+        sprintf(buf, "%02x", gid_.raw[i]);
+        gid_str += i == 0 ? buf : std::string(":") + buf;
+    }
+
+    return gid_str;
+}
+
+ibv_cq *RdmaContext::cq() {
+    int index = (next_cq_list_index_++) % cq_list_.size();
+    return cq_list_[index].native;
+}
+
+ibv_comp_channel *RdmaContext::compChannel() {
+    int index = (next_comp_channel_index_++) % num_comp_channel_;
+    return comp_channel_[index];
+}
+
+int RdmaContext::compVector() {
+    return (next_comp_vector_index_++) % context_->num_comp_vectors;
+}
+
+static inline int ipv6_addr_v4mapped(const struct in6_addr *a) {
+    return ((a->s6_addr32[0] | a->s6_addr32[1]) |
+            (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL ||
+           /* IPv4 encoded multicast addresses */
+           (a->s6_addr32[0] == htonl(0xff0e0000) &&
+            ((a->s6_addr32[1] | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL));
+}
+
+int RdmaContext::getBestGidIndex(const std::string &device_name,
+                                 struct ibv_context *context,
+                                 ibv_port_attr &port_attr, uint8_t port) {
+    int gid_index = 0, i;
+    struct ibv_gid_entry gid_entry;
+
+    for (i = 0; i < port_attr.gid_tbl_len; i++) {
+        if (ibv_query_gid_ex(context, port, i, &gid_entry, 0)) {
+            PLOG(ERROR) << "Failed to query GID " << i << " on "
+                        << device_name << "/" << port;
+            continue; // if gid is invalid ibv_query_gid_ex() will return !0
+        }
+        if ((ipv6_addr_v4mapped((struct in6_addr *)gid_entry.gid.raw) &&
+            gid_entry.gid_type == IBV_GID_TYPE_ROCE_V2)
+            || gid_entry.gid_type == IBV_GID_TYPE_IB) {
+            gid_index = i;
+            break;
+        }
+    }
+    return gid_index;
+}
+
+int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
+                                int gid_index) {
+    int num_devices = 0;
+    struct ibv_context *context = nullptr;
+    struct ibv_device **devices = ibv_get_device_list(&num_devices);
+    if (!devices || num_devices <= 0) {
+        LOG(ERROR) << "ibv_get_device_list failed";
+        return ERR_DEVICE_NOT_FOUND;
+    }
+
+    for (int i = 0; i < num_devices; ++i) {
+        if (device_name != ibv_get_device_name(devices[i])) continue;
+
+        context = ibv_open_device(devices[i]);
+        if (!context) {
+            LOG(ERROR) << "ibv_open_device(" << device_name << ") failed";
+            ibv_free_device_list(devices);
+            return ERR_CONTEXT;
+        }
+
+        ibv_port_attr attr;
+        int ret = ibv_query_port(context, port, &attr);
+        if (ret) {
+            PLOG(ERROR) << "Failed to query port " << port << " on "
+                        << device_name;
+            if (ibv_close_device(context)) {
+                PLOG(ERROR) << "ibv_close_device(" << device_name << ") failed";
+            }
+            ibv_free_device_list(devices);
+            return ERR_CONTEXT;
+        }
+
+        if (attr.state != IBV_PORT_ACTIVE) {
+            LOG(WARNING) << "Device " << device_name << " port not active";
+            if (ibv_close_device(context)) {
+                PLOG(ERROR) << "ibv_close_device(" << device_name << ") failed";
+            }
+            ibv_free_device_list(devices);
+            return ERR_CONTEXT;
+        }
+
+        ibv_device_attr device_attr;
+        ret = ibv_query_device(context, &device_attr);
+        if (ret) {
+            PLOG(WARNING) << "Failed to query attributes on " << device_name;
+            if (ibv_close_device(context)) {
+                PLOG(ERROR) << "ibv_close_device(" << device_name << ") failed";
+            }
+            ibv_free_device_list(devices);
+            return ERR_CONTEXT;
+        }
+
+        ibv_port_attr port_attr;
+        ret = ibv_query_port(context, port, &port_attr);
+        if (ret) {
+            PLOG(WARNING) << "Failed to query port attributes on "
+                          << device_name << "/" << port;
+            if (ibv_close_device(context)) {
+                PLOG(ERROR) << "ibv_close_device(" << device_name << ") failed";
+            }
+            ibv_free_device_list(devices);
+            return ERR_CONTEXT;
+        }
+
+        updateGlobalConfig(device_attr);
+        if (gid_index == 0) {
+            int ret = getBestGidIndex(device_name, context, port_attr, port);
+            if (ret >= 0) {
+                LOG(INFO) << "Find best gid index: " << ret << " on "
+                          << device_name << "/" << port;
+                gid_index = ret;
+            }
+        }
+
+        ret = ibv_query_gid(context, port, gid_index, &gid_);
+        if (ret) {
+            PLOG(ERROR) << "Failed to query GID " << gid_index << " on "
+                        << device_name << "/" << port;
+            if (ibv_close_device(context)) {
+                PLOG(ERROR) << "ibv_close_device(" << device_name << ") failed";
+            }
+            ibv_free_device_list(devices);
+            return ERR_CONTEXT;
+        }
+
+#ifndef CONFIG_SKIP_NULL_GID_CHECK
+        if (isNullGid(&gid_)) {
+            LOG(WARNING) << "GID is NULL, please check your GID index by "
+                            "specifying MC_GID_INDEX";
+            if (ibv_close_device(context)) {
+                PLOG(ERROR) << "ibv_close_device(" << device_name << ") failed";
+            }
+            ibv_free_device_list(devices);
+            return ERR_CONTEXT;
+        }
+#endif  // CONFIG_SKIP_NULL_GID_CHECK
+
+        context_ = context;
+        port_ = port;
+        lid_ = attr.lid;
+        active_mtu_ = attr.active_mtu;
+        active_speed_ = attr.active_speed;
+        gid_index_ = gid_index;
+
+        ibv_free_device_list(devices);
+        return 0;
+    }
+
+    ibv_free_device_list(devices);
+    LOG(ERROR) << "No matched device found: " << device_name;
+    return ERR_DEVICE_NOT_FOUND;
+}
+
+int RdmaContext::joinNonblockingPollList(int event_fd, int data_fd) {
+    epoll_event event;
+    memset(&event, 0, sizeof(epoll_event));
+
+    int flags = fcntl(data_fd, F_GETFL, 0);
+    if (flags == -1) {
+        PLOG(ERROR) << "Failed to get file descriptor flags";
+        return ERR_CONTEXT;
+    }
+    if (fcntl(data_fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+        PLOG(ERROR) << "Failed to set file descriptor nonblocking";
+        return ERR_CONTEXT;
+    }
+
+    event.events = EPOLLIN | EPOLLET;
+    event.data.fd = data_fd;
+    if (epoll_ctl(event_fd, EPOLL_CTL_ADD, event.data.fd, &event)) {
+        PLOG(ERROR) << "Failed to register file descriptor to epoll";
+        return ERR_CONTEXT;
+    }
+
+    return 0;
+}
+
+int RdmaContext::poll(int num_entries, ibv_wc *wc, int cq_index) {
+    int nr_poll = ibv_poll_cq(cq_list_[cq_index].native, num_entries, wc);
+    if (nr_poll < 0) {
+        LOG(ERROR) << "Failed to poll CQ " << cq_index << " of device "
+                   << device_name_;
+        return ERR_CONTEXT;
+    }
+    return nr_poll;
+}
+
+int RdmaContext::submitPostSend(
+    const std::vector<Transport::Slice *> &slice_list) {
+    return worker_pool_->submitPostSend(slice_list);
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-ngxl-exp/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -1,0 +1,411 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_transport/rdma_endpoint.h"
+
+#include <glog/logging.h>
+
+#include <cassert>
+#include <cstddef>
+
+#include "config.h"
+
+namespace mooncake {
+const static uint8_t MAX_HOP_LIMIT = 16;
+const static uint8_t TIMEOUT = 14;
+const static uint8_t RETRY_CNT = 7;
+
+RdmaEndPoint::RdmaEndPoint(RdmaContext &context)
+    : context_(context),
+      status_(INITIALIZING),
+      active_(true),
+      cq_outstanding_(nullptr) {}
+
+RdmaEndPoint::~RdmaEndPoint() {
+    if (!qp_list_.empty()) deconstruct();
+}
+
+int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
+                            size_t max_sge_per_wr, size_t max_wr_depth,
+                            size_t max_inline_bytes) {
+    if (status_.load(std::memory_order_relaxed) != INITIALIZING) {
+        LOG(ERROR) << "Endpoint has already been constructed";
+        return ERR_ENDPOINT;
+    }
+
+    qp_list_.resize(num_qp_list);
+    cq_outstanding_ = (volatile int *)cq->cq_context;
+
+    max_wr_depth_ = (int)max_wr_depth;
+    wr_depth_list_ = new volatile int[num_qp_list];
+    if (!wr_depth_list_) {
+        LOG(ERROR) << "Failed to allocate memory for work request depth list";
+        return ERR_MEMORY;
+    }
+    for (size_t i = 0; i < num_qp_list; ++i) {
+        wr_depth_list_[i] = 0;
+        ibv_qp_init_attr attr;
+        memset(&attr, 0, sizeof(attr));
+        attr.send_cq = cq;
+        attr.recv_cq = cq;
+        attr.sq_sig_all = false;
+        attr.qp_type = IBV_QPT_RC;
+        attr.cap.max_send_wr = attr.cap.max_recv_wr = max_wr_depth;
+        attr.cap.max_send_sge = attr.cap.max_recv_sge = max_sge_per_wr;
+        attr.cap.max_inline_data = max_inline_bytes;
+        qp_list_[i] = ibv_create_qp(context_.pd(), &attr);
+        if (!qp_list_[i]) {
+            PLOG(ERROR) << "Failed to create QP";
+            return ERR_ENDPOINT;
+        }
+    }
+
+    status_.store(UNCONNECTED, std::memory_order_relaxed);
+    return 0;
+}
+
+int RdmaEndPoint::deconstruct() {
+    for (size_t i = 0; i < qp_list_.size(); ++i) {
+        if (wr_depth_list_[i] != 0)
+            LOG(WARNING)
+                << "Outstanding work requests found, CQ will not be generated";
+
+        if (ibv_destroy_qp(qp_list_[i])) {
+            PLOG(ERROR) << "Failed to destroy QP";
+            return ERR_ENDPOINT;
+        }
+    }
+    qp_list_.clear();
+    delete[] wr_depth_list_;
+    return 0;
+}
+
+int RdmaEndPoint::destroyQP() { return deconstruct(); }
+
+void RdmaEndPoint::setPeerNicPath(const std::string &peer_nic_path) {
+    RWSpinlock::WriteGuard guard(lock_);
+    if (connected()) {
+        LOG(WARNING) << "Previous connection will be discarded";
+        disconnectUnlocked();
+    }
+    peer_nic_path_ = peer_nic_path;
+}
+
+int RdmaEndPoint::setupConnectionsByActive() {
+    RWSpinlock::WriteGuard guard(lock_);
+    if (connected()) {
+        LOG(INFO) << "Connection has been established";
+        return 0;
+    }
+    HandShakeDesc local_desc, peer_desc;
+    local_desc.local_nic_path = context_.nicPath();
+    local_desc.peer_nic_path = peer_nic_path_;
+    local_desc.qp_num = qpNum();
+
+    auto peer_server_name = getServerNameFromNicPath(peer_nic_path_);
+    auto peer_nic_name = getNicNameFromNicPath(peer_nic_path_);
+    if (peer_server_name.empty() || peer_nic_name.empty()) {
+        LOG(ERROR) << "Parse peer nic path failed: " << peer_nic_path_;
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    int rc = context_.engine().sendHandshake(peer_server_name, local_desc,
+                                             peer_desc);
+    if (rc) return rc;
+
+    if (peer_desc.local_nic_path != peer_nic_path_ ||
+        peer_desc.peer_nic_path != local_desc.local_nic_path) {
+        LOG(ERROR) << "Invalid argument: received packet mismatch";
+        return ERR_REJECT_HANDSHAKE;
+    }
+
+    auto segment_desc =
+        context_.engine().meta()->getSegmentDescByName(peer_server_name);
+    if (segment_desc) {
+        for (auto &nic : segment_desc->memory.rdma)
+            if (nic.name == peer_nic_name)
+                return doSetupConnection(nic.gid, nic.lid, peer_desc.qp_num);
+    }
+    LOG(ERROR) << "Peer NIC " << peer_nic_name << " not found in "
+               << peer_server_name;
+    return ERR_DEVICE_NOT_FOUND;
+}
+
+int RdmaEndPoint::setupConnectionsByPassive(const HandShakeDesc &peer_desc,
+                                            HandShakeDesc &local_desc) {
+    RWSpinlock::WriteGuard guard(lock_);
+    if (connected()) {
+        LOG(WARNING) << "Re-establish connection: " << toString();
+        disconnectUnlocked();
+    }
+
+    peer_nic_path_ = peer_desc.local_nic_path;
+    if (peer_desc.peer_nic_path != context_.nicPath()) {
+        local_desc.reply_msg = "Invalid argument: peer nic path inconsistency";
+        LOG(ERROR) << local_desc.reply_msg;
+        return ERR_REJECT_HANDSHAKE;
+    }
+
+    auto peer_server_name = getServerNameFromNicPath(peer_nic_path_);
+    auto peer_nic_name = getNicNameFromNicPath(peer_nic_path_);
+    if (peer_server_name.empty() || peer_nic_name.empty()) {
+        local_desc.reply_msg = "Parse peer nic path failed: " + peer_nic_path_;
+        LOG(ERROR) << local_desc.reply_msg;
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    local_desc.local_nic_path = context_.nicPath();
+    local_desc.peer_nic_path = peer_nic_path_;
+    local_desc.qp_num = qpNum();
+
+    auto segment_desc =
+        context_.engine().meta()->getSegmentDescByName(peer_server_name);
+    if (segment_desc) {
+        for (auto &nic : segment_desc->memory.rdma)
+            if (nic.name == peer_nic_name)
+                return doSetupConnection(nic.gid, nic.lid, peer_desc.qp_num,
+                                         &local_desc.reply_msg);
+    }
+    local_desc.reply_msg =
+        "Peer nic not found in that server: " + peer_nic_path_;
+    LOG(ERROR) << local_desc.reply_msg;
+    return ERR_DEVICE_NOT_FOUND;
+}
+
+void RdmaEndPoint::disconnect() {
+    RWSpinlock::WriteGuard guard(lock_);
+    disconnectUnlocked();
+}
+
+void RdmaEndPoint::disconnectUnlocked() {
+    for (size_t i = 0; i < qp_list_.size(); ++i) {
+        if (wr_depth_list_[i] != 0)
+            LOG(WARNING) << "Outstanding work requests will be dropped";
+    }
+    ibv_qp_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RESET;
+    for (size_t i = 0; i < qp_list_.size(); ++i) {
+        int ret = ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE);
+        if (ret) PLOG(ERROR) << "Failed to modify QP to RESET";
+    }
+    peer_nic_path_.clear();
+    for (size_t i = 0; i < qp_list_.size(); ++i) wr_depth_list_[i] = 0;
+    status_.store(UNCONNECTED, std::memory_order_release);
+}
+
+const std::string RdmaEndPoint::toString() const {
+    auto status = status_.load(std::memory_order_relaxed);
+    if (status == CONNECTED)
+        return "EndPoint: local " + context_.nicPath() + ", peer " +
+               peer_nic_path_;
+    else
+        return "EndPoint: local " + context_.nicPath() + " (unconnected)";
+}
+
+bool RdmaEndPoint::hasOutstandingSlice() const {
+    if (active_) return true;
+    for (size_t i = 0; i < qp_list_.size(); i++)
+        if (wr_depth_list_[i] != 0) return true;
+    return false;
+}
+
+int RdmaEndPoint::submitPostSend(
+    std::vector<Transport::Slice *> &slice_list,
+    std::vector<Transport::Slice *> &failed_slice_list) {
+    RWSpinlock::WriteGuard guard(lock_);
+    int qp_index = SimpleRandom::Get().next(qp_list_.size());
+    int wr_count = std::min(max_wr_depth_ - wr_depth_list_[qp_index],
+                            (int)slice_list.size());
+    wr_count =
+        std::min(int(globalConfig().max_cqe) - *cq_outstanding_, wr_count);
+    if (wr_count <= 0) return 0;
+
+    ibv_send_wr wr_list[wr_count], *bad_wr = nullptr;
+    ibv_sge sge_list[wr_count];
+    memset(wr_list, 0, sizeof(ibv_send_wr) * wr_count);
+    for (int i = 0; i < wr_count; ++i) {
+        auto slice = slice_list[i];
+        auto &sge = sge_list[i];
+        sge.addr = (uint64_t)slice->source_addr;
+        sge.length = slice->length;
+        sge.lkey = slice->rdma.source_lkey;
+
+        auto &wr = wr_list[i];
+        wr.wr_id = (uint64_t)slice;
+        wr.opcode = slice->opcode == Transport::TransferRequest::READ
+                        ? IBV_WR_RDMA_READ
+                        : IBV_WR_RDMA_WRITE;
+        wr.num_sge = 1;
+        wr.sg_list = &sge;
+        wr.send_flags = IBV_SEND_SIGNALED;
+        wr.next = (i + 1 == wr_count) ? nullptr : &wr_list[i + 1];
+        wr.imm_data = 0;
+        wr.wr.rdma.remote_addr = slice->rdma.dest_addr;
+        wr.wr.rdma.rkey = slice->rdma.dest_rkey;
+        slice->status = Transport::Slice::POSTED;
+        slice->rdma.qp_depth = &wr_depth_list_[qp_index];
+        // if (globalConfig().verbose)
+        // {
+        //     LOG(INFO) << "WR: local addr " << slice->source_addr
+        //               << " remote addr " << slice->rdma.dest_addr
+        //               << " rkey " << slice->rdma.dest_rkey;
+        // }
+    }
+    __sync_fetch_and_add(&wr_depth_list_[qp_index], wr_count);
+    __sync_fetch_and_add(cq_outstanding_, wr_count);
+    int rc = ibv_post_send(qp_list_[qp_index], wr_list, &bad_wr);
+    if (rc) {
+        PLOG(ERROR) << "Failed to ibv_post_send";
+        while (bad_wr) {
+            int i = bad_wr - wr_list;
+            failed_slice_list.push_back(slice_list[i]);
+            __sync_fetch_and_sub(&wr_depth_list_[qp_index], 1);
+            __sync_fetch_and_sub(cq_outstanding_, 1);
+            bad_wr = bad_wr->next;
+        }
+    }
+    slice_list.erase(slice_list.begin(), slice_list.begin() + wr_count);
+    return 0;
+}
+
+std::vector<uint32_t> RdmaEndPoint::qpNum() const {
+    std::vector<uint32_t> ret;
+    for (int qp_index = 0; qp_index < (int)qp_list_.size(); ++qp_index)
+        ret.push_back(qp_list_[qp_index]->qp_num);
+    return ret;
+}
+
+int RdmaEndPoint::doSetupConnection(const std::string &peer_gid,
+                                    uint16_t peer_lid,
+                                    std::vector<uint32_t> peer_qp_num_list,
+                                    std::string *reply_msg) {
+    if (qp_list_.size() != peer_qp_num_list.size()) {
+        std::string message =
+            "QP count mismatch in peer and local endpoints, check "
+            "MC_MAX_EP_PER_CTX";
+        LOG(ERROR) << "[Handshake] " << message;
+        if (reply_msg) *reply_msg = message;
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    for (int qp_index = 0; qp_index < (int)qp_list_.size(); ++qp_index) {
+        int ret = doSetupConnection(qp_index, peer_gid, peer_lid,
+                                    peer_qp_num_list[qp_index], reply_msg);
+        if (ret) return ret;
+    }
+
+    status_.store(CONNECTED, std::memory_order_relaxed);
+    return 0;
+}
+
+int RdmaEndPoint::doSetupConnection(int qp_index, const std::string &peer_gid,
+                                    uint16_t peer_lid, uint32_t peer_qp_num,
+                                    std::string *reply_msg) {
+    if (qp_index < 0 || qp_index > (int)qp_list_.size())
+        return ERR_INVALID_ARGUMENT;
+    auto &qp = qp_list_[qp_index];
+
+    // Any state -> RESET
+    ibv_qp_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RESET;
+    int ret = ibv_modify_qp(qp, &attr, IBV_QP_STATE);
+    if (ret) {
+        std::string message = "Failed to modify QP to RESET";
+        PLOG(ERROR) << "[Handshake] " << message;
+        if (reply_msg) *reply_msg = message + ": " + strerror(errno);
+        return ERR_ENDPOINT;
+    }
+
+    // RESET -> INIT
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_INIT;
+    attr.port_num = context_.portNum();
+    attr.pkey_index = 0;
+    attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+                           IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_ATOMIC;
+    ret = ibv_modify_qp(
+        qp, &attr,
+        IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS);
+    if (ret) {
+        std::string message =
+            "Failed to modify QP to INIT, check local context port num";
+        PLOG(ERROR) << "[Handshake] " << message;
+        if (reply_msg) *reply_msg = message + ": " + strerror(errno);
+        return ERR_ENDPOINT;
+    }
+
+    // INIT -> RTR
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTR;
+    attr.path_mtu = context_.activeMTU();
+    if (globalConfig().mtu_length < attr.path_mtu)
+        attr.path_mtu = globalConfig().mtu_length;
+    ibv_gid peer_gid_raw;
+    std::istringstream iss(peer_gid);
+    for (int i = 0; i < 16; ++i) {
+        int value;
+        iss >> std::hex >> value;
+        peer_gid_raw.raw[i] = static_cast<uint8_t>(value);
+        if (i < 15) iss.ignore(1, ':');
+    }
+    attr.ah_attr.grh.dgid = peer_gid_raw;
+    // TODO gidIndex and portNum must fetch from REMOTE
+    attr.ah_attr.grh.sgid_index = context_.gidIndex();
+    attr.ah_attr.grh.hop_limit = MAX_HOP_LIMIT;
+    attr.ah_attr.dlid = peer_lid;
+    attr.ah_attr.sl = 0;
+    attr.ah_attr.src_path_bits = 0;
+    attr.ah_attr.static_rate = 0;
+    attr.ah_attr.is_global = 1;
+    attr.ah_attr.port_num = context_.portNum();
+    attr.dest_qp_num = peer_qp_num;
+    attr.rq_psn = 0;
+    attr.max_dest_rd_atomic = 16;
+    attr.min_rnr_timer = 12;  // 12 in previous implementation
+    ret = ibv_modify_qp(qp, &attr,
+                        IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_MIN_RNR_TIMER |
+                            IBV_QP_AV | IBV_QP_MAX_DEST_RD_ATOMIC |
+                            IBV_QP_DEST_QPN | IBV_QP_RQ_PSN);
+    if (ret) {
+        std::string message =
+            "Failed to modify QP to RTR, check mtu, gid, peer lid, peer qp num";
+        PLOG(ERROR) << "[Handshake] " << message;
+        if (reply_msg) *reply_msg = message + ": " + strerror(errno);
+        return ERR_ENDPOINT;
+    }
+
+    // RTR -> RTS
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTS;
+    attr.timeout = TIMEOUT;
+    attr.retry_cnt = RETRY_CNT;
+    attr.rnr_retry = 7;  // or 7,RNR error
+    attr.sq_psn = 0;
+    attr.max_rd_atomic = 16;
+    ret = ibv_modify_qp(qp, &attr,
+                        IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
+                            IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
+                            IBV_QP_MAX_QP_RD_ATOMIC);
+    if (ret) {
+        std::string message = "Failed to modify QP to RTS";
+        PLOG(ERROR) << "[Handshake] " << message;
+        if (reply_msg) *reply_msg = message + ": " + strerror(errno);
+        return ERR_ENDPOINT;
+    }
+
+    return 0;
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-ngxl-exp/src/transport/rdma_transport/rdma_transport.cpp
@@ -1,0 +1,335 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_transport/rdma_transport.h"
+
+#include <glog/logging.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+
+#include <cassert>
+#include <cstddef>
+#include <future>
+#include <set>
+
+#include "common.h"
+#include "config.h"
+#include "memory_location.h"
+#include "topology.h"
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_transport/rdma_endpoint.h"
+
+namespace mooncake {
+RdmaTransport::RdmaTransport() {}
+
+RdmaTransport::~RdmaTransport() {
+#ifdef CONFIG_USE_BATCH_DESC_SET
+    for (auto &entry : batch_desc_set_) delete entry.second;
+    batch_desc_set_.clear();
+#endif
+    batch_desc_set_.clear();
+    context_list_.clear();
+}
+
+int RdmaTransport::install(std::string &local_server_name,
+                           std::shared_ptr<TransferMetadata> metadata,
+                           std::shared_ptr<Topology> topology) {
+    if (topology == nullptr) {
+        LOG(ERROR) << "RdmaTransport: missing topology";
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    metadata_ = metadata;
+    local_server_name_ = local_server_name;
+    local_topology_ = topology;
+
+    auto ret = initializeRdmaResources();
+    if (ret) {
+        LOG(ERROR) << "RdmaTransport: cannot initialize RDMA resources";
+        return ret;
+    }
+
+    ret = allocateLocalSegmentID();
+    if (ret) {
+        LOG(ERROR) << "Transfer engine cannot be initialized: cannot "
+                      "allocate local segment";
+        return ret;
+    }
+
+    ret = startHandshakeDaemon(local_server_name);
+    if (ret) {
+        LOG(ERROR) << "RdmaTransport: cannot start handshake daemon";
+        return ret;
+    }
+
+    ret = metadata_->updateLocalSegmentDesc();
+    if (ret) {
+        LOG(ERROR) << "RdmaTransport: cannot publish segments";
+        return ret;
+    }
+
+    return 0;
+}
+
+int RdmaTransport::registerLocalMemory(void *addr, size_t length,
+                                       const std::string &location,
+                                       bool remote_accessible,
+                                       bool update_metadata) {
+    (void)remote_accessible;
+    BufferAttr buffer_desc;
+    const static int access_rights = IBV_ACCESS_LOCAL_WRITE |
+                                     IBV_ACCESS_REMOTE_WRITE |
+                                     IBV_ACCESS_REMOTE_READ;
+    for (auto &context : context_list_) {
+        int ret = context->registerMemoryRegion(addr, length, access_rights);
+        if (ret) return ret;
+        buffer_desc.lkey.push_back(context->lkey(addr));
+        buffer_desc.rkey.push_back(context->rkey(addr));
+    }
+
+    // Get the memory location automatically after registered MR(pinned),
+    // when the name is "*".
+    if (location == "*") {
+        const std::vector<MemoryLocationEntry> entries =
+            getMemoryLocation(addr, length);
+        for (auto &entry : entries) {
+            buffer_desc.location = entry.location;
+            buffer_desc.addr = entry.start;
+            buffer_desc.length = entry.len;
+            int rc =
+                metadata_->addLocalMemoryBuffer(buffer_desc, update_metadata);
+            if (rc) return rc;
+        }
+    } else {
+        buffer_desc.location = location;
+        buffer_desc.addr = (uint64_t)addr;
+        buffer_desc.length = length;
+        int rc = metadata_->addLocalMemoryBuffer(buffer_desc, update_metadata);
+
+        if (rc) return rc;
+    }
+
+    return 0;
+}
+
+int RdmaTransport::unregisterLocalMemory(void *addr, bool update_metadata) {
+    int rc = metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+    if (rc) return rc;
+
+    for (auto &context : context_list_) context->unregisterMemoryRegion(addr);
+
+    return 0;
+}
+
+int RdmaTransport::allocateLocalSegmentID() {
+    std::shared_ptr<SegmentDesc> desc;
+    desc = metadata_->getLocalSegment();
+    if (!desc) {
+        desc = std::make_shared<SegmentDesc>();
+        if (!desc) return ERR_MEMORY;
+        desc->name = local_server_name_;
+        desc->type = MemoryKind;
+    }
+    if (!desc->memory.rdma.empty()) return ERR_INVALID_ARGUMENT;
+    for (auto &entry : context_list_) {
+        RdmaAttr rdma;
+        rdma.name = entry->deviceName();
+        rdma.lid = entry->lid();
+        rdma.gid = entry->gid();
+        desc->memory.rdma.push_back(rdma);
+    }
+    desc->memory.topology = *(local_topology_.get());
+    return metadata_->setLocalSegment(std::move(desc));
+}
+
+int RdmaTransport::registerLocalMemoryBatch(
+    const std::vector<RdmaTransport::BufferEntry> &buffer_list,
+    const std::string &location) {
+    std::vector<std::future<int>> results;
+    for (auto &buffer : buffer_list) {
+        results.emplace_back(
+            std::async(std::launch::async, [this, buffer, location]() -> int {
+                return registerLocalMemory(buffer.addr, buffer.length, location,
+                                           true, false);
+            }));
+    }
+
+    for (size_t i = 0; i < buffer_list.size(); ++i) {
+        if (results[i].get()) {
+            LOG(WARNING) << "RdmaTransport: Failed to register memory: addr "
+                         << buffer_list[i].addr << " length "
+                         << buffer_list[i].length;
+        }
+    }
+
+    return metadata_->updateLocalSegmentDesc();
+}
+
+int RdmaTransport::unregisterLocalMemoryBatch(
+    const std::vector<void *> &addr_list) {
+    std::vector<std::future<int>> results;
+    for (auto &addr : addr_list) {
+        results.emplace_back(
+            std::async(std::launch::async, [this, addr]() -> int {
+                return unregisterLocalMemory(addr, false);
+            }));
+    }
+
+    for (size_t i = 0; i < addr_list.size(); ++i) {
+        if (results[i].get())
+            LOG(WARNING) << "RdmaTransport: Failed to unregister memory: addr "
+                         << addr_list[i];
+    }
+
+    return metadata_->updateLocalSegmentDesc();
+}
+
+Status RdmaTransport::submitTransferTask(
+    const std::vector<TransferRequest *> &request_list,
+    const std::vector<TransferTask *> &task_list) {
+    std::unordered_map<std::shared_ptr<RdmaContext>, std::vector<Slice *>>
+        slices_to_post;
+    auto local_segment_desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    const size_t kBlockSize = globalConfig().slice_size;
+    const int kMaxRetryCount = globalConfig().retry_cnt;
+    for (size_t index = 0; index < request_list.size(); ++index) {
+        auto &request = *request_list[index];
+        auto &task = *task_list[index];
+        for (uint64_t offset = 0; offset < request.length;
+             offset += kBlockSize) {
+            auto slice = new Slice();
+            slice->source_addr = (char *)request.source + offset;
+            slice->length = std::min(request.length - offset, kBlockSize);
+            slice->opcode = request.opcode;
+            slice->rdma.dest_addr = request.target_offset + offset;
+            slice->rdma.retry_cnt = 0;
+            slice->rdma.max_retry_cnt = kMaxRetryCount;
+            slice->task = &task;
+            slice->target_id = request.target_id;
+            slice->status = Slice::PENDING;
+
+            int buffer_id = -1, device_id = -1, retry_cnt = 0;
+            while (retry_cnt < kMaxRetryCount) {
+                if (selectDevice(local_segment_desc.get(),
+                                 (uint64_t)slice->source_addr, slice->length,
+                                 buffer_id, device_id, retry_cnt++))
+                    continue;
+                auto &context = context_list_[device_id];
+                if (!context->active()) continue;
+                slice->rdma.source_lkey =
+                    local_segment_desc->memory.buffers[buffer_id]
+                        .lkey[device_id];
+                slices_to_post[context].push_back(slice);
+                task.total_bytes += slice->length;
+                // task.slices.push_back(slice);
+                task.slice_count += 1;
+                break;
+            }
+            if (device_id < 0) {
+                LOG(ERROR)
+                    << "RdmaTransport: Address not registered by any device(s) "
+                    << slice->source_addr;
+                return Status::AddressNotRegistered(
+                    "RdmaTransport: not registered by any device(s), address: "
+                    + std::to_string(
+                        reinterpret_cast<uintptr_t>(slice->source_addr)));
+            }
+        }
+    }
+    for (auto &entry : slices_to_post)
+        entry.first->submitPostSend(entry.second);
+    return Status::OK();
+}
+
+RdmaTransport::SegmentID RdmaTransport::getSegmentID(
+    const std::string &segment_name) {
+    return metadata_->getSegmentID(segment_name);
+}
+
+int RdmaTransport::onSetupRdmaConnections(const HandShakeDesc &peer_desc,
+                                          HandShakeDesc &local_desc) {
+    auto local_nic_name = getNicNameFromNicPath(peer_desc.peer_nic_path);
+    if (local_nic_name.empty()) return ERR_INVALID_ARGUMENT;
+
+    std::shared_ptr<RdmaContext> context;
+    int index = 0;
+    for (auto &entry : local_topology_->getHcaList()) {
+        if (entry == local_nic_name) {
+            context = context_list_[index];
+            break;
+        }
+        index++;
+    }
+    if (!context) return ERR_INVALID_ARGUMENT;
+
+#ifdef CONFIG_ERDMA
+    if (context->deleteEndpoint(peer_desc.local_nic_path)) return ERR_ENDPOINT;
+#endif
+
+    auto endpoint = context->endpoint(peer_desc.local_nic_path);
+    if (!endpoint) return ERR_ENDPOINT;
+    return endpoint->setupConnectionsByPassive(peer_desc, local_desc);
+}
+
+int RdmaTransport::initializeRdmaResources() {
+    if (local_topology_->empty()) {
+        LOG(ERROR) << "RdmaTransport: No available RNIC";
+        return ERR_DEVICE_NOT_FOUND;
+    }
+
+    std::vector<int> device_speed_list;
+    for (auto &device_name : local_topology_->getHcaList()) {
+        auto context = std::make_shared<RdmaContext>(*this, device_name);
+        if (!context) return ERR_MEMORY;
+
+        auto &config = globalConfig();
+        int ret = context->construct(config.num_cq_per_ctx,
+                                     config.num_comp_channels_per_ctx,
+                                     config.port, config.gid_index,
+                                     config.max_cqe, config.max_ep_per_ctx);
+        if (ret) return ret;
+        device_speed_list.push_back(context->activeSpeed());
+        context_list_.push_back(context);
+    }
+
+    return 0;
+}
+
+int RdmaTransport::startHandshakeDaemon(std::string &local_server_name) {
+    return metadata_->startHandshakeDaemon(
+        std::bind(&RdmaTransport::onSetupRdmaConnections, this,
+                  std::placeholders::_1, std::placeholders::_2),
+        metadata_->localRpcMeta().rpc_port);
+}
+
+// According to the request desc, offset and length information, find proper
+// buffer_id and device_id as output.
+// Return 0 if successful, ERR_ADDRESS_NOT_REGISTERED otherwise.
+int RdmaTransport::selectDevice(SegmentDesc *desc, uint64_t offset,
+                                size_t length, int &buffer_id, int &device_id,
+                                int retry_count) {
+    for (buffer_id = 0; buffer_id < (int)desc->memory.buffers.size();
+         ++buffer_id) {
+        auto &buffer_desc = desc->memory.buffers[buffer_id];
+        if (buffer_desc.addr > offset ||
+            offset + length > buffer_desc.addr + buffer_desc.length)
+            continue;
+        device_id = desc->memory.topology.selectDevice(buffer_desc.location,
+                                                       retry_count);
+        if (device_id >= 0) return 0;
+    }
+
+    return ERR_ADDRESS_NOT_REGISTERED;
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-ngxl-exp/src/transport/rdma_transport/worker_pool.cpp
@@ -1,0 +1,438 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_transport/worker_pool.h"
+
+#include <sys/epoll.h>
+
+#include <cassert>
+
+#include "config.h"
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_transport/rdma_endpoint.h"
+#include "transport/rdma_transport/rdma_transport.h"
+
+#ifdef USE_CUDA
+#include <cuda_runtime.h>
+#endif  // USE_CUDA
+
+// Experimental: Per-thread SegmentDesc & EndPoint Caches
+// #define CONFIG_CACHE_SEGMENT_DESC
+// #define CONFIG_CACHE_ENDPOINT
+
+namespace mooncake {
+
+const static int kTransferWorkerCount = globalConfig().workers_per_ctx;
+
+WorkerPool::WorkerPool(RdmaContext &context, int numa_socket_id)
+    : context_(context),
+      numa_socket_id_(numa_socket_id),
+      workers_running_(true),
+      suspended_flag_(0),
+      redispatch_counter_(0),
+      submitted_slice_count_(0),
+      processed_slice_count_(0) {
+    for (int i = 0; i < kShardCount; ++i)
+        slice_queue_count_[i].store(0, std::memory_order_relaxed);
+    collective_slice_queue_.resize(kTransferWorkerCount);
+    for (int i = 0; i < kTransferWorkerCount; ++i)
+        worker_thread_.emplace_back(
+            std::thread(std::bind(&WorkerPool::transferWorker, this, i)));
+    worker_thread_.emplace_back(
+        std::thread(std::bind(&WorkerPool::monitorWorker, this)));
+}
+
+WorkerPool::~WorkerPool() {
+    if (workers_running_) {
+        cond_var_.notify_all();
+        workers_running_.store(false);
+        for (auto &entry : worker_thread_) entry.join();
+    }
+}
+
+int WorkerPool::submitPostSend(
+    const std::vector<Transport::Slice *> &slice_list) {
+#ifdef CONFIG_CACHE_SEGMENT_DESC
+    thread_local uint64_t tl_last_cache_ts = getCurrentTimeInNano();
+    thread_local std::unordered_map<SegmentID,
+                                    std::shared_ptr<SegmentDesc>>
+        segment_desc_map;
+    uint64_t current_ts = getCurrentTimeInNano();
+
+    if (current_ts - tl_last_cache_ts > 1000000000) {
+        segment_desc_map.clear();
+        tl_last_cache_ts = current_ts;
+    }
+
+    for (auto &slice : slice_list) {
+        auto target_id = slice->target_id;
+        if (!segment_desc_map.count(target_id)) {
+            segment_desc_map[target_id] =
+                context_.engine().meta()->getSegmentDescByID(target_id);
+            if (!segment_desc_map[target_id]) {
+                segment_desc_map.clear();
+                LOG(ERROR) << "Cannot get target segment description #"
+                           << target_id;
+                return ERR_INVALID_ARGUMENT;
+            }
+        }
+    }
+#else
+    std::unordered_map<SegmentID, std::shared_ptr<SegmentDesc>>
+        segment_desc_map;
+    for (auto &slice : slice_list) {
+        auto target_id = slice->target_id;
+        if (!segment_desc_map.count(target_id))
+            segment_desc_map[target_id] =
+                context_.engine().meta()->getSegmentDescByID(target_id);
+        if (!segment_desc_map[target_id]) {
+            LOG(ERROR) << "Cannot get target segment #" << target_id;
+            return ERR_INVALID_ARGUMENT;
+        }
+    }
+#endif  // CONFIG_CACHE_SEGMENT_DESC
+
+    SliceList slice_list_map[kShardCount];
+    uint64_t submitted_slice_count = 0;
+    for (auto &slice : slice_list) {
+        auto &peer_segment_desc = segment_desc_map[slice->target_id];
+        int buffer_id, device_id;
+        if (RdmaTransport::selectDevice(peer_segment_desc.get(),
+                                        slice->rdma.dest_addr, slice->length,
+                                        buffer_id, device_id)) {
+            LOG(WARNING) << "Reselect remote NIC for address "
+                         << (void *)slice->rdma.dest_addr << " on segment #"
+                         << slice->target_id;
+            peer_segment_desc = context_.engine().meta()->getSegmentDescByID(
+                slice->target_id, true);
+            if (!peer_segment_desc) {
+                LOG(ERROR) << "Cannot get target segment #" << slice->target_id;
+                slice->markFailed();
+                continue;
+            }
+            if (RdmaTransport::selectDevice(
+                    peer_segment_desc.get(), slice->rdma.dest_addr,
+                    slice->length, buffer_id, device_id)) {
+                LOG(ERROR) << "Failed to select remote NIC for address "
+                           << (void *)slice->rdma.dest_addr << " on segment #"
+                           << slice->target_id;
+                slice->markFailed();
+                continue;
+            }
+        }
+        slice->rdma.dest_rkey =
+            peer_segment_desc->memory.buffers[buffer_id].rkey[device_id];
+        auto peer_nic_path =
+            MakeNicPath(peer_segment_desc->name,
+                        peer_segment_desc->memory.rdma[device_id].name);
+        slice->peer_nic_path = peer_nic_path;
+        int shard_id = (slice->target_id * 10007 + device_id) % kShardCount;
+        slice_list_map[shard_id].push_back(slice);
+        submitted_slice_count++;
+    }
+
+    for (int shard_id = 0; shard_id < kShardCount; ++shard_id) {
+        if (slice_list_map[shard_id].empty()) continue;
+        slice_queue_lock_[shard_id].lock();
+        for (auto &slice : slice_list_map[shard_id])
+            slice_queue_[shard_id][slice->peer_nic_path].push_back(slice);
+        slice_queue_count_[shard_id].fetch_add(slice_list_map[shard_id].size(),
+                                               std::memory_order_relaxed);
+        slice_queue_lock_[shard_id].unlock();
+    }
+
+    submitted_slice_count_.fetch_add(submitted_slice_count,
+                                     std::memory_order_relaxed);
+    if (suspended_flag_.load(std::memory_order_relaxed)) cond_var_.notify_all();
+
+    return 0;
+}
+
+void WorkerPool::performPostSend(int thread_id) {
+    auto &local_slice_queue = collective_slice_queue_[thread_id];
+    for (int shard_id = thread_id; shard_id < kShardCount;
+         shard_id += kTransferWorkerCount) {
+        if (slice_queue_count_[shard_id].load(std::memory_order_relaxed) == 0)
+            continue;
+
+        slice_queue_lock_[shard_id].lock();
+        for (auto &entry : slice_queue_[shard_id]) {
+            for (auto &slice : entry.second)
+                local_slice_queue[entry.first].push_back(slice);
+            entry.second.clear();
+        }
+        slice_queue_count_[shard_id].store(0, std::memory_order_relaxed);
+        slice_queue_lock_[shard_id].unlock();
+    }
+
+    // Redispatch slices to other endpoints, for temporary failures
+    thread_local int tl_redispatch_counter = 0;
+    if (tl_redispatch_counter <
+        redispatch_counter_.load(std::memory_order_relaxed)) {
+        tl_redispatch_counter =
+            redispatch_counter_.load(std::memory_order_relaxed);
+        auto local_slice_queue_clone = local_slice_queue;
+        local_slice_queue.clear();
+        for (auto &entry : local_slice_queue_clone)
+            redispatch(entry.second, thread_id);
+        return;
+    }
+
+#ifdef CONFIG_CACHE_ENDPOINT
+    thread_local uint64_t tl_last_cache_ts = getCurrentTimeInNano();
+    thread_local std::unordered_map<std::string, std::shared_ptr<RdmaEndPoint>>
+        endpoint_map;
+    uint64_t current_ts = getCurrentTimeInNano();
+    if (current_ts - tl_last_cache_ts > 1000000000) {
+        endpoint_map.clear();
+        tl_last_cache_ts = current_ts;
+    }
+#endif
+
+    SliceList failed_slice_list;
+    for (auto &entry : local_slice_queue) {
+        if (entry.second.empty()) continue;
+
+        if (entry.second[0]->target_id == LOCAL_SEGMENT_ID) {
+            for (auto &slice : entry.second) {
+                LOG_ASSERT(slice->target_id == LOCAL_SEGMENT_ID);
+#ifdef USE_CUDA
+                if (slice->opcode == TransferRequest::READ)
+                    cudaMemcpy(slice->source_addr,
+                               (void *)slice->rdma.dest_addr, slice->length,
+                               cudaMemcpyDefault);
+                else
+                    cudaMemcpy((void *)slice->rdma.dest_addr,
+                               slice->source_addr, slice->length,
+                               cudaMemcpyDefault);
+#else
+                if (slice->opcode == TransferRequest::READ)
+                    memcpy(slice->source_addr, (void *)slice->rdma.dest_addr,
+                           slice->length);
+                else
+                    memcpy((void *)slice->rdma.dest_addr, slice->source_addr,
+                           slice->length);
+#endif
+                slice->markSuccess();
+            }
+            processed_slice_count_.fetch_add(entry.second.size());
+            entry.second.clear();
+            continue;
+        }
+
+#ifdef USE_FAKE_POST_SEND
+        for (auto &slice : entry.second) slice->markSuccess();
+        processed_slice_count_.fetch_add(entry.second.size());
+        entry.second.clear();
+#else
+#ifdef CONFIG_CACHE_ENDPOINT
+        auto &endpoint = endpoint_map[entry.first];
+        if (endpoint == nullptr || !endpoint->active())
+            endpoint = context_.endpoint(entry.first);
+#else
+        auto endpoint = context_.endpoint(entry.first);
+#endif
+        if (!endpoint) {
+            LOG(ERROR) << "Worker: Cannot allocate endpoint: " << entry.first;
+            for (auto &slice : entry.second) failed_slice_list.push_back(slice);
+            entry.second.clear();
+            continue;
+        }
+        if (!endpoint->connected() && endpoint->setupConnectionsByActive()) {
+            LOG(ERROR) << "Worker: Cannot make connection for endpoint: "
+                       << entry.first;
+            for (auto &slice : entry.second) failed_slice_list.push_back(slice);
+            entry.second.clear();
+            continue;
+        }
+        endpoint->submitPostSend(entry.second, failed_slice_list);
+#endif
+    }
+
+    if (!failed_slice_list.empty()) {
+        for (auto &slice : failed_slice_list) slice->rdma.retry_cnt++;
+        redispatch(failed_slice_list, thread_id);
+    }
+}
+
+void WorkerPool::performPollCq(int thread_id) {
+    int processed_slice_count = 0;
+    const static size_t kPollCount = 64;
+    std::unordered_map<volatile int *, int> qp_depth_set;
+    for (int cq_index = thread_id; cq_index < context_.cqCount();
+         cq_index += kTransferWorkerCount) {
+        ibv_wc wc[kPollCount];
+        int nr_poll = context_.poll(kPollCount, wc, cq_index);
+        if (nr_poll < 0) {
+            LOG(ERROR) << "Worker: Failed to poll completion queues";
+            continue;
+        }
+
+        for (int i = 0; i < nr_poll; ++i) {
+            Transport::Slice *slice = (Transport::Slice *)wc[i].wr_id;
+            assert(slice);
+            if (qp_depth_set.count(slice->rdma.qp_depth))
+                qp_depth_set[slice->rdma.qp_depth]++;
+            else
+                qp_depth_set[slice->rdma.qp_depth] = 1;
+            // __sync_fetch_and_sub(slice->rdma.qp_depth, 1);
+            if (wc[i].status != IBV_WC_SUCCESS) {
+                LOG(ERROR) << "Worker: Process failed for slice (opcode: "
+                           << slice->opcode
+                           << ", source_addr: " << slice->source_addr
+                           << ", length: " << slice->length
+                           << ", dest_addr: " << slice->rdma.dest_addr
+                           << ", local_nic: " << context_.deviceName()
+                           << ", peer_nic: " << slice->peer_nic_path
+                           << ", dest_rkey: " << slice->rdma.dest_rkey
+                           << ", retry_cnt: " << slice->rdma.retry_cnt
+                           << "): " << ibv_wc_status_str(wc[i].status);
+                context_.deleteEndpoint(slice->peer_nic_path);
+                slice->rdma.retry_cnt++;
+                if (slice->rdma.retry_cnt >= slice->rdma.max_retry_cnt) {
+                    slice->markFailed();
+                    processed_slice_count_++;
+                } else {
+                    collective_slice_queue_[thread_id][slice->peer_nic_path]
+                        .push_back(slice);
+                    redispatch_counter_++;
+                    // std::vector<RdmaTransport::Slice *> slice_list { slice };
+                    // redispatch(slice_list, thread_id);
+                }
+            } else {
+                slice->markSuccess();
+                processed_slice_count++;
+            }
+        }
+        if (nr_poll)
+            __sync_fetch_and_sub(context_.cqOutstandingCount(cq_index),
+                                 nr_poll);
+    }
+
+    for (auto &entry : qp_depth_set)
+        __sync_fetch_and_sub(entry.first, entry.second);
+
+    if (processed_slice_count)
+        processed_slice_count_.fetch_add(processed_slice_count);
+}
+
+void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
+                            int thread_id) {
+    std::unordered_map<SegmentID, std::shared_ptr<SegmentDesc>>
+        segment_desc_map;
+    for (auto &slice : slice_list) {
+        auto target_id = slice->target_id;
+        if (!segment_desc_map.count(target_id)) {
+            segment_desc_map[target_id] =
+                context_.engine().meta()->getSegmentDescByID(target_id, true);
+        }
+    }
+
+    for (auto &slice : slice_list) {
+        if (slice->rdma.retry_cnt == slice->rdma.max_retry_cnt) {
+            slice->markFailed();
+            processed_slice_count_++;
+        } else {
+            auto &peer_segment_desc = segment_desc_map[slice->target_id];
+            int buffer_id, device_id;
+            if (!peer_segment_desc ||
+                RdmaTransport::selectDevice(peer_segment_desc.get(),
+                                            slice->rdma.dest_addr,
+                                            slice->length, buffer_id, device_id,
+                                            slice->rdma.retry_cnt)) {
+                slice->markFailed();
+                processed_slice_count_++;
+                continue;
+            }
+            slice->rdma.dest_rkey =
+                peer_segment_desc->memory.buffers[buffer_id].rkey[device_id];
+            auto peer_nic_path =
+                MakeNicPath(peer_segment_desc->name,
+                            peer_segment_desc->memory.rdma[device_id].name);
+            slice->peer_nic_path = peer_nic_path;
+            collective_slice_queue_[thread_id][peer_nic_path].push_back(slice);
+        }
+    }
+}
+
+void WorkerPool::transferWorker(int thread_id) {
+    bindToSocket(numa_socket_id_);
+    const static uint64_t kWaitPeriodInNano = 100000000;  // 100ms
+    uint64_t last_wait_ts = getCurrentTimeInNano();
+    while (workers_running_.load(std::memory_order_relaxed)) {
+        auto processed_slice_count =
+            processed_slice_count_.load(std::memory_order_relaxed);
+        auto submitted_slice_count =
+            submitted_slice_count_.load(std::memory_order_relaxed);
+        if (processed_slice_count == submitted_slice_count) {
+            uint64_t curr_wait_ts = getCurrentTimeInNano();
+            if (curr_wait_ts - last_wait_ts > kWaitPeriodInNano) {
+                std::unique_lock<std::mutex> lock(cond_mutex_);
+                suspended_flag_.fetch_add(1);
+                cond_var_.wait_for(lock, std::chrono::seconds(1));
+                suspended_flag_.fetch_sub(1);
+                last_wait_ts = curr_wait_ts;
+            }
+            continue;
+        }
+        performPostSend(thread_id);
+#ifndef USE_FAKE_POST_SEND
+        performPollCq(thread_id);
+#endif
+    }
+}
+
+int WorkerPool::doProcessContextEvents() {
+    ibv_async_event event;
+    if (ibv_get_async_event(context_.context(), &event) < 0) return ERR_CONTEXT;
+    LOG(WARNING) << "Worker: Received context async event "
+                 << ibv_event_type_str(event.event_type) << " for context "
+                 << context_.deviceName();
+    if (event.event_type == IBV_EVENT_DEVICE_FATAL ||
+        event.event_type == IBV_EVENT_CQ_ERR ||
+        event.event_type == IBV_EVENT_WQ_FATAL ||
+        event.event_type == IBV_EVENT_PORT_ERR ||
+        event.event_type == IBV_EVENT_LID_CHANGE) {
+        context_.set_active(false);
+        context_.disconnectAllEndpoints();
+        LOG(INFO) << "Worker: Context " << context_.deviceName()
+                  << " is now inactive";
+    } else if (event.event_type == IBV_EVENT_PORT_ACTIVE) {
+        context_.set_active(true);
+        LOG(INFO) << "Worker: Context " << context_.deviceName()
+                  << " is now active";
+    }
+    ibv_ack_async_event(&event);
+    return 0;
+}
+
+void WorkerPool::monitorWorker() {
+    bindToSocket(numa_socket_id_);
+    while (workers_running_) {
+        struct epoll_event event;
+        int num_events = epoll_wait(context_.eventFd(), &event, 1, 100);
+        if (num_events < 0) {
+            PLOG(ERROR) << "Worker: epoll_wait()";
+            continue;
+        }
+
+        if (num_events == 0) continue;
+
+        if (!(event.events & EPOLLIN)) continue;
+
+        if (event.data.fd == context_.context()->async_fd)
+            doProcessContextEvents();
+    }
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transport/shm_transport/CMakeLists.txt
+++ b/mooncake-ngxl-exp/src/transport/shm_transport/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB SHM_SOURCES "*.cpp")
+
+add_library(shm_ngxl_transport OBJECT ${SHM_SOURCES})

--- a/mooncake-ngxl-exp/src/transport/shm_transport/shm_transport.cpp
+++ b/mooncake-ngxl-exp/src/transport/shm_transport/shm_transport.cpp
@@ -1,0 +1,228 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/shm_transport/shm_transport.h"
+
+#include <bits/stdint-uintn.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <memory>
+
+#include "common.h"
+#include "transfer_engine.h"
+#include "transfer_metadata.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+const static size_t kDefaultThreadPoolSize = 4;
+const static std::string kShmPathPrefix = "/dev/shm/mooncake/";
+
+static inline std::string generateShmPath(const std::string &segment_name) {
+    static std::atomic<int> buffer_index(0);
+    auto path_prefix = kShmPathPrefix + segment_name;
+    return path_prefix + "/" + std::to_string(buffer_index.fetch_add(1));
+}
+
+ShmTransport::ShmTransport() : thread_pool_(kDefaultThreadPoolSize) {}
+
+ShmTransport::~ShmTransport() {
+    for (auto &entry : remap_entries_) {
+        munmap(entry.second.shm_addr, entry.second.length);
+        close(entry.second.shm_fd);
+    }
+    for (auto &entry : created_entries_) deallocateLocalMemory(entry.first);
+    remap_entries_.clear();
+}
+
+int ShmTransport::install(std::string &local_server_name,
+                          std::shared_ptr<TransferMetadata> metadata,
+                          std::shared_ptr<Topology> topology) {
+    metadata_ = metadata;
+    local_server_name_ = local_server_name;
+    return 0;
+}
+
+Status ShmTransport::submitTransferTask(
+    const std::vector<TransferRequest *> &request_list,
+    const std::vector<TransferTask *> &task_list) {
+    for (size_t index = 0; index < request_list.size(); ++index) {
+        auto &request = *request_list[index];
+        auto &task = *task_list[index];
+        uint64_t dest_addr = request.target_offset;
+        if (request.target_id != LOCAL_SEGMENT_ID) {
+            int rc = relocateSharedMemoryAddress(dest_addr, request.length,
+                                                 request.target_id);
+            if (rc) return Status::Memory("memory not registered as mmap");
+        }
+        task.total_bytes = request.length;
+        auto slice = new Slice();
+        slice->source_addr = (char *)request.source;
+        slice->local.dest_addr = (char *)dest_addr;
+        slice->length = request.length;
+        slice->opcode = request.opcode;
+        slice->task = &task;
+        slice->target_id = request.target_id;
+        slice->status = Slice::PENDING;
+        task.slice_count += 1;
+        startTransfer(slice);
+    }
+    return Status::OK();
+}
+
+void ShmTransport::startTransfer(Slice *slice) {
+    thread_pool_.submit([slice]() {
+#ifdef USE_CUDA
+        if (slice->opcode == TransferRequest::READ)
+            cudaMemcpy(slice->source_addr, (void *)slice->local.dest_addr,
+                       slice->length, cudaMemcpyDefault);
+        else
+            cudaMemcpy((void *)slice->local.dest_addr, slice->source_addr,
+                       slice->length, cudaMemcpyDefault);
+#else
+        if (slice->opcode == TransferRequest::READ)
+            memcpy(slice->source_addr, (void *)slice->local.dest_addr,
+                   slice->length);
+        else
+            memcpy((void *)slice->local.dest_addr, slice->source_addr,
+                   slice->length);
+#endif
+        slice->markSuccess();
+    });
+}
+
+int ShmTransport::registerLocalMemory(void *addr, size_t length,
+                                      const std::string &location,
+                                      bool remote_accessible,
+                                      bool update_metadata) {
+    LOG(WARNING) << "Not supported to register an existing memory region";
+    return ERR_NOT_IMPLEMENTED;
+}
+
+int ShmTransport::unregisterLocalMemory(void *addr, bool update_metadata) {
+    return metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+}
+
+void *ShmTransport::allocateLocalMemory(size_t length,
+                                        const std::string &location) {
+    auto shm_path = generateShmPath(local_server_name_);
+    auto addr = createSharedMemory(shm_path, length);
+    if (!addr) return nullptr;
+    BufferAttr attr;
+    attr.addr = (uint64_t)addr;
+    attr.length = length;
+    attr.location = location;
+    attr.shm_path = shm_path;
+    int rc = metadata_->addLocalMemoryBuffer(attr, true);
+    return rc ? nullptr : addr;
+}
+
+int ShmTransport::deallocateLocalMemory(void *addr) {
+    if (!created_entries_.count(addr)) {
+        LOG(ERROR) << "requested address not found";
+        return ERR_INVALID_ARGUMENT;
+    }
+    auto shm_path = created_entries_[addr].c_str();
+    created_entries_.erase(addr);
+    int rc = unregisterLocalMemory(addr);
+    if (rc) return rc;
+    rc = unlink(shm_path);
+    if (rc) {
+        PLOG(ERROR) << "unlink failed";
+        return ERR_MEMORY;
+    }
+    return 0;
+}
+
+void *ShmTransport::createSharedMemory(const std::string &path, size_t size) {
+    int shm_fd = shm_open(path.c_str(), O_CREAT | O_RDWR, 0644);
+    if (shm_fd == -1) {
+        PLOG(ERROR) << "Failed to open shared memory file";
+        return nullptr;
+    }
+
+    if (ftruncate64(shm_fd, size) == -1) {
+        PLOG(ERROR) << "Failed to truncate shared memory file";
+        close(shm_fd);
+        return nullptr;
+    }
+
+    void *mapped_addr =
+        mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+    if (mapped_addr == MAP_FAILED) {
+        PLOG(ERROR) << "Failed to map shared memory file";
+        close(shm_fd);
+        return nullptr;
+    }
+
+    close(shm_fd);
+    return mapped_addr;
+}
+
+int ShmTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
+                                              uint64_t length,
+                                              uint64_t target_id) {
+    auto desc = metadata_->getSegmentDescByID(target_id);
+    int index = 0;
+    for (auto &entry : desc->memory.buffers) {
+        if (!entry.shm_path.empty() && entry.addr <= dest_addr &&
+            dest_addr + length <= entry.addr + entry.length) {
+            if (!remap_entries_.count(entry.addr)) {
+                int shm_fd = shm_open(entry.shm_path.c_str(), O_RDWR, 0644);
+                if (shm_fd < 0) {
+                    PLOG(ERROR) << "Failed to open shared memory file: "
+                                << entry.shm_path;
+                    return ERR_MEMORY;
+                }
+                auto shm_addr = mmap(nullptr, length, PROT_READ | PROT_WRITE,
+                                     MAP_SHARED, shm_fd, 0);
+                if (shm_addr == MAP_FAILED) {
+                    PLOG(ERROR) << "Failed to map shared memory file: "
+                                << entry.shm_path;
+                    close(shm_fd);
+                    return ERR_MEMORY;
+                }
+                OpenedShmEntry shm_entry;
+                shm_entry.shm_fd = shm_fd;
+                shm_entry.shm_addr = shm_addr;
+                shm_entry.length = length;
+                remap_entries_[entry.addr] = shm_entry;
+            }
+            auto shm_addr = remap_entries_[entry.addr].shm_addr;
+            dest_addr = dest_addr - entry.addr + ((uint64_t)shm_addr);
+            return 0;
+        }
+        index++;
+    }
+    return ERR_INVALID_ARGUMENT;
+}
+
+int ShmTransport::registerLocalMemoryBatch(
+    const std::vector<Transport::BufferEntry> &buffer_list,
+    const std::string &location) {
+    for (auto &buffer : buffer_list)
+        registerLocalMemory(buffer.addr, buffer.length, location, true, false);
+    return metadata_->updateLocalSegmentDesc();
+}
+
+int ShmTransport::unregisterLocalMemoryBatch(
+    const std::vector<void *> &addr_list) {
+    for (auto &addr : addr_list) unregisterLocalMemory(addr, false);
+    return metadata_->updateLocalSegmentDesc();
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transport/tcp_transport/CMakeLists.txt
+++ b/mooncake-ngxl-exp/src/transport/tcp_transport/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB TCP_SOURCES "*.cpp")
+
+add_library(tcp_ngxl_transport OBJECT ${TCP_SOURCES})

--- a/mooncake-ngxl-exp/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-ngxl-exp/src/transport/tcp_transport/tcp_transport.cpp
@@ -1,0 +1,339 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/tcp_transport/tcp_transport.h"
+
+#include <bits/stdint-uintn.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <memory>
+
+#include "common.h"
+#include "transfer_engine.h"
+#include "transfer_metadata.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+using tcpsocket = boost::asio::ip::tcp::socket;
+const static size_t kDefaultBufferSize = 65536;
+
+struct SessionHeader {
+    uint64_t size;
+    uint64_t addr;
+    uint8_t opcode;
+};
+
+struct Session : public std::enable_shared_from_this<Session> {
+    explicit Session(tcpsocket socket) : socket_(std::move(socket)) {}
+
+    tcpsocket socket_;
+    SessionHeader header_;
+    uint64_t total_transferred_bytes_;
+    char *local_buffer_;
+    std::function<void(TransferStatusEnum)> on_finalize_;
+    std::mutex session_mutex_;
+
+    void initiate(void *buffer, uint64_t dest_addr, size_t size,
+                  TransferRequest::OpCode opcode) {
+        session_mutex_.lock();
+        local_buffer_ = (char *)buffer;
+        header_.addr = htole64(dest_addr);
+        header_.size = htole64(size);
+        header_.opcode = (uint8_t)opcode;
+        total_transferred_bytes_ = 0;
+        writeHeader();
+    }
+
+    void onAccept() {
+        session_mutex_.lock();
+        total_transferred_bytes_ = 0;
+        readHeader();
+    }
+
+   private:
+    void writeHeader() {
+        // LOG(INFO) << "writeHeader";
+        auto self(shared_from_this());
+        boost::asio::async_write(
+            socket_, boost::asio::buffer(&header_, sizeof(SessionHeader)),
+            [this, self](const boost::system::error_code &ec, std::size_t len) {
+                if (ec || len != sizeof(SessionHeader)) {
+                    if (on_finalize_) on_finalize_(TransferStatusEnum::FAILED);
+                    session_mutex_.unlock();
+                    return;
+                }
+                if (header_.opcode == (uint8_t)TransferRequest::WRITE)
+                    writeBody();
+                else
+                    readBody();
+            });
+    }
+
+    void readHeader() {
+        // LOG(INFO) << "readHeader";
+        auto self(shared_from_this());
+        boost::asio::async_read(
+            socket_, boost::asio::buffer(&header_, sizeof(SessionHeader)),
+            [this, self](const boost::system::error_code &ec, std::size_t len) {
+                if (ec || len != sizeof(SessionHeader)) {
+                    if (on_finalize_) on_finalize_(TransferStatusEnum::FAILED);
+                    session_mutex_.unlock();
+                    return;
+                }
+
+                local_buffer_ = (char *)(le64toh(header_.addr));
+                if (header_.opcode == (uint8_t)TransferRequest::WRITE)
+                    readBody();
+                else
+                    writeBody();
+            });
+    }
+
+    void writeBody() {
+        // LOG(INFO) << "writeBody";
+        auto self(shared_from_this());
+        uint64_t size = le64toh(header_.size);
+        char *addr = local_buffer_;
+
+        size_t buffer_size =
+            std::min(kDefaultBufferSize, size - total_transferred_bytes_);
+        if (buffer_size == 0) {
+            if (on_finalize_) on_finalize_(TransferStatusEnum::COMPLETED);
+            session_mutex_.unlock();
+            return;
+        }
+
+        boost::asio::async_write(
+            socket_,
+            boost::asio::buffer(addr + total_transferred_bytes_, buffer_size),
+            [this, addr, self](const boost::system::error_code &ec,
+                               std::size_t transferred_bytes) {
+                if (ec) {
+                    if (on_finalize_) on_finalize_(TransferStatusEnum::FAILED);
+                    session_mutex_.unlock();
+                    return;
+                }
+                total_transferred_bytes_ += transferred_bytes;
+                writeBody();
+            });
+    }
+
+    void readBody() {
+        // LOG(INFO) << "readBody";
+        auto self(shared_from_this());
+        uint64_t size = le64toh(header_.size);
+        char *addr = local_buffer_;
+
+        size_t buffer_size =
+            std::min(kDefaultBufferSize, size - total_transferred_bytes_);
+        if (buffer_size == 0) {
+            if (on_finalize_) on_finalize_(TransferStatusEnum::COMPLETED);
+            session_mutex_.unlock();
+            return;
+        }
+
+        boost::asio::async_read(
+            socket_,
+            boost::asio::buffer(addr + total_transferred_bytes_, buffer_size),
+            [this, addr, self](const boost::system::error_code &ec,
+                               std::size_t transferred_bytes) {
+                if (ec) {
+                    if (on_finalize_) on_finalize_(TransferStatusEnum::FAILED);
+                    session_mutex_.unlock();
+                    return;
+                }
+                total_transferred_bytes_ += transferred_bytes;
+                readBody();
+            });
+    }
+};
+
+struct TcpContext {
+    TcpContext(short port)
+        : acceptor(io_context, boost::asio::ip::tcp::endpoint(
+                                   boost::asio::ip::tcp::v4(), port)) {}
+
+    void doAccept() {
+        acceptor.async_accept(
+            [this](boost::system::error_code ec, tcpsocket socket) {
+                if (!ec)
+                    std::make_shared<Session>(std::move(socket))->onAccept();
+                doAccept();
+            });
+    }
+
+    boost::asio::io_context io_context;
+    boost::asio::ip::tcp::acceptor acceptor;
+};
+
+TcpTransport::TcpTransport() : context_(nullptr), running_(false) {
+    // TODO
+}
+
+TcpTransport::~TcpTransport() {
+    if (running_) {
+        running_ = false;
+        context_->io_context.stop();
+        thread_.join();
+    }
+
+    if (context_) {
+        delete context_;
+        context_ = nullptr;
+    }
+}
+
+int TcpTransport::install(std::string &local_server_name,
+                          std::shared_ptr<TransferMetadata> metadata,
+                          std::shared_ptr<Topology> topology) {
+    metadata_ = metadata;
+    local_server_name_ = local_server_name;
+
+    int ret = allocateLocalSegmentID();
+    if (ret) {
+        LOG(ERROR) << "TcpTransport: cannot allocate local segment";
+        return -1;
+    }
+
+    ret = metadata_->updateLocalSegmentDesc();
+    if (ret) {
+        LOG(ERROR) << "TcpTransport: cannot publish segments, "
+                      "check the availability of metadata storage";
+        return -1;
+    }
+
+    context_ = new TcpContext(tcp_attr_.port);
+    running_ = true;
+    thread_ = std::thread(&TcpTransport::worker, this);
+    return 0;
+}
+
+int TcpTransport::allocateLocalSegmentID() {
+    std::shared_ptr<SegmentDesc> desc;
+    desc = metadata_->getLocalSegment();
+    if (!desc) {
+        desc = std::make_shared<SegmentDesc>();
+        if (!desc) return ERR_MEMORY;
+        desc->name = local_server_name_;
+        desc->type = MemoryKind;
+    }
+    if (!desc->memory.tcp.ip_or_hostname.empty()) return ERR_INVALID_ARGUMENT;
+    tcp_attr_.ip_or_hostname = metadata_->localRpcMeta().ip_or_host_name;
+    tcp_attr_.port = metadata_->localRpcMeta().rpc_port;
+    desc->memory.tcp = tcp_attr_;
+    return metadata_->setLocalSegment(std::move(desc));
+}
+
+int TcpTransport::registerLocalMemory(void *addr, size_t length,
+                                      const std::string &location,
+                                      bool remote_accessible,
+                                      bool update_metadata) {
+    (void)remote_accessible;
+    BufferAttr buffer_desc;
+    buffer_desc.location = "*";  // unspecified
+    buffer_desc.addr = (uint64_t)addr;
+    buffer_desc.length = length;
+    return metadata_->addLocalMemoryBuffer(buffer_desc, update_metadata);
+}
+
+int TcpTransport::unregisterLocalMemory(void *addr, bool update_metadata) {
+    return metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+}
+
+int TcpTransport::registerLocalMemoryBatch(
+    const std::vector<Transport::BufferEntry> &buffer_list,
+    const std::string &location) {
+    for (auto &buffer : buffer_list)
+        registerLocalMemory(buffer.addr, buffer.length, location, true, false);
+    return metadata_->updateLocalSegmentDesc();
+}
+
+int TcpTransport::unregisterLocalMemoryBatch(
+    const std::vector<void *> &addr_list) {
+    for (auto &addr : addr_list) unregisterLocalMemory(addr, false);
+    return metadata_->updateLocalSegmentDesc();
+}
+
+Status TcpTransport::submitTransferTask(
+    const std::vector<TransferRequest *> &request_list,
+    const std::vector<TransferTask *> &task_list) {
+    for (size_t index = 0; index < request_list.size(); ++index) {
+        auto &request = *request_list[index];
+        auto &task = *task_list[index];
+        task.total_bytes = request.length;
+        auto slice = new Slice();
+        slice->source_addr = (char *)request.source;
+        slice->length = request.length;
+        slice->opcode = request.opcode;
+        slice->tcp.dest_addr = request.target_offset;
+        slice->task = &task;
+        slice->target_id = request.target_id;
+        slice->status = Slice::PENDING;
+        task.slice_count += 1;
+        startTransfer(slice);
+    }
+    return Status::OK();
+}
+
+void TcpTransport::worker() {
+    while (running_) {
+        try {
+            context_->doAccept();
+            context_->io_context.run();
+        } catch (std::exception &e) {
+            LOG(ERROR) << "TcpTransport: exception: " << e.what();
+        }
+    }
+}
+
+void TcpTransport::startTransfer(Slice *slice) {
+    try {
+        boost::asio::ip::tcp::resolver resolver(context_->io_context);
+        boost::asio::ip::tcp::socket socket(context_->io_context);
+        auto desc = metadata_->getSegmentDescByID(slice->target_id);
+        if (!desc) {
+            slice->markFailed();
+            return;
+        }
+
+        TransferMetadata::RpcMetaDesc meta_entry;
+        if (metadata_->getRpcMetaEntry(desc->name, meta_entry)) {
+            slice->markFailed();
+            return;
+        }
+
+        auto endpoint_iterator = resolver.resolve(
+            boost::asio::ip::tcp::v4(), meta_entry.ip_or_host_name,
+            std::to_string(meta_entry.rpc_port));
+        boost::asio::connect(socket, endpoint_iterator);
+        auto session = std::make_shared<Session>(std::move(socket));
+        session->on_finalize_ = [slice](TransferStatusEnum status) {
+            if (status == TransferStatusEnum::COMPLETED)
+                slice->markSuccess();
+            else
+                slice->markFailed();
+        };
+        session->initiate(slice->source_addr, slice->tcp.dest_addr,
+                          slice->length, slice->opcode);
+    } catch (std::exception &e) {
+        LOG(ERROR) << "TcpTransport: ASIO exception: " << e.what();
+        slice->markFailed();
+    }
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/src/transport/transport.cpp
+++ b/mooncake-ngxl-exp/src/transport/transport.cpp
@@ -1,0 +1,28 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/transport.h"
+
+#include "error.h"
+#include "transfer_engine.h"
+
+namespace mooncake {
+int Transport::install(std::string &local_server_name,
+                       std::shared_ptr<TransferMetadata> meta,
+                       std::shared_ptr<Topology> topo) {
+    local_server_name_ = local_server_name;
+    metadata_ = meta;
+    return 0;
+}
+}  // namespace mooncake

--- a/mooncake-ngxl-exp/tests/CMakeLists.txt
+++ b/mooncake-ngxl-exp/tests/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_executable(ngxl_rdma_transport_test rdma_transport_test.cpp)
+target_link_libraries(ngxl_rdma_transport_test PUBLIC ngxl)
+# add_test(NAME ngxl_rdma_transport_test COMMAND ngxl_rdma_transport_test)
+
+add_executable(ngxl_transport_uint_test transport_uint_test.cpp)
+target_link_libraries(ngxl_transport_uint_test PUBLIC ngxl gtest gtest_main )
+add_test(NAME ngxl_transport_uint_test COMMAND ngxl_transport_uint_test)
+
+add_executable(ngxl_rdma_transport_test2 rdma_transport_test2.cpp)
+target_link_libraries(ngxl_rdma_transport_test2 PUBLIC ngxl gtest gtest_main )
+# add_test(NAME ngxl_rdma_transport_test2 COMMAND ngxl_rdma_transport_test2)
+
+add_executable(ngxl_tcp_transport_test tcp_transport_test.cpp)
+target_link_libraries(ngxl_tcp_transport_test PUBLIC ngxl gtest gtest_main )
+add_test(NAME ngxl_tcp_transport_test COMMAND ngxl_tcp_transport_test)
+
+add_executable(ngxl_transfer_metadata_test transfer_metadata_test.cpp)
+target_link_libraries(ngxl_transfer_metadata_test PUBLIC ngxl gtest gtest_main)
+add_test(NAME ngxl_transfer_metadata_test COMMAND ngxl_transfer_metadata_test)
+
+add_executable(ngxl_topology_test topology_test.cpp)
+target_link_libraries(ngxl_topology_test PUBLIC ngxl gtest gtest_main)
+add_test(NAME ngxl_topology_test COMMAND ngxl_topology_test)
+
+add_executable(ngxl_memory_location_test memory_location_test.cpp)
+target_link_libraries(ngxl_memory_location_test PUBLIC ngxl gtest gtest_main)
+add_test(NAME ngxl_memory_location_test COMMAND ngxl_memory_location_test)

--- a/mooncake-ngxl-exp/tests/memory_location_test.cpp
+++ b/mooncake-ngxl-exp/tests/memory_location_test.cpp
@@ -1,0 +1,125 @@
+#include "memory_location.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <numa.h>
+#include <numaif.h>
+#include <sys/mman.h>
+
+TEST(MemoryLocationTest, MallocSimpleNode0) {
+    int size = 4096 * 10;
+    void *addr = numa_alloc_onnode(size, 0);
+    ASSERT_NE(addr, nullptr);
+
+    auto entries = mooncake::getMemoryLocation(addr, size);
+    ASSERT_EQ(entries.size(), static_cast<size_t>(1));
+
+    // check the memory location, no node before page fault
+    EXPECT_EQ(entries[0].start, reinterpret_cast<uint64_t>(addr));
+    EXPECT_EQ(entries[0].location, "*");
+    EXPECT_EQ(entries[0].len, static_cast<size_t>(size));
+
+    // trigger page fault
+    memset(addr, 0, size);
+
+    entries = mooncake::getMemoryLocation(addr, size);
+    ASSERT_EQ(entries.size(), static_cast<size_t>(1));
+
+    // check the memory location, node 0 after page fault
+    EXPECT_EQ(entries[0].start, reinterpret_cast<uint64_t>(addr));
+    EXPECT_EQ(entries[0].location, "cpu:0");
+    EXPECT_EQ(entries[0].len, static_cast<size_t>(size));
+
+    numa_free(addr, size);
+}
+
+TEST(MemoryLocationTest, MallocSimpleNodeLargest) {
+    int node = numa_max_node();
+    LOG(INFO) << "node: " << node;
+
+    std::string location = "cpu:" + std::to_string(node);
+
+    int size = 4096 * 10;
+    void *addr = numa_alloc_onnode(size, node);
+    ASSERT_NE(addr, nullptr);
+
+    // trigger page fault
+    memset(addr, 0, size);
+
+    auto entries = mooncake::getMemoryLocation(addr, size);
+    ASSERT_EQ(entries.size(), static_cast<size_t>(1));
+
+    // check the memory location
+    EXPECT_EQ(entries[0].start, reinterpret_cast<uint64_t>(addr));
+    EXPECT_EQ(entries[0].location, location);
+    EXPECT_EQ(entries[0].len, static_cast<size_t>(size));
+
+    numa_free(addr, size);
+}
+
+TEST(MemoryLocationTest, MallocMultipleNodes) {
+    int nodea = 0;
+    int nodeb = numa_max_node();
+    LOG(INFO) << "node a: " << nodea << " node b: " << nodeb;
+
+    std::string locationa = "cpu:" + std::to_string(nodea);
+    std::string locationb = "cpu:" + std::to_string(nodeb);
+
+    int size = 4096 * 10;
+    void *addr = numa_alloc_onnode(size, nodea);
+    ASSERT_NE(addr, nullptr);
+    ASSERT_EQ((uint64_t)addr % 4096, static_cast<uint64_t>(0));  // page aligned
+
+    // trigger page fault
+    memset(addr, 0, size);
+
+    int rc;
+
+    // move first two pages & last one page to nodeb
+    void *pages[3] = {addr, (void *)((uint64_t)addr + 4096),
+                      (void *)((uint64_t)addr + 4096 * 9)};
+    int nodes[3] = {nodeb, nodeb, nodeb};
+    int status[3];
+    rc = numa_move_pages(0, 3, pages, nodes, status, MPOL_MF_MOVE);
+    if (rc != 0) {
+        PLOG(ERROR) << "numa_move_pages failed, rc: " << rc;
+    }
+    ASSERT_EQ(rc, 0);
+
+    // not page aligned
+    void *start = (void *)((uint64_t)addr + 1024 * 2);
+
+    auto entries = mooncake::getMemoryLocation(start, size - 1024 * 4);
+
+    if (nodea == nodeb) {
+        // only one numa node
+        ASSERT_EQ(entries.size(), static_cast<size_t>(1));
+
+        // check the first memory location
+        EXPECT_EQ(entries[0].start, reinterpret_cast<uint64_t>(start));
+        EXPECT_EQ(entries[0].location, locationa);
+        EXPECT_EQ(entries[0].len, static_cast<size_t>(size - 1024 * 4));
+
+    } else {
+        ASSERT_EQ(entries.size(), static_cast<size_t>(3));
+
+        // check the first memory location
+        EXPECT_EQ(entries[0].start, reinterpret_cast<uint64_t>(start));
+        EXPECT_EQ(entries[0].location, locationb);
+        EXPECT_EQ(entries[0].len, static_cast<size_t>(4096 * 2 - 1024 * 2));
+
+        // check the second memory location
+        EXPECT_EQ(entries[1].start,
+            reinterpret_cast<uint64_t>(addr) + 4096 * 2);
+        EXPECT_EQ(entries[1].location, locationa);
+        EXPECT_EQ(entries[1].len, static_cast<size_t>(4096 * 7));
+
+        // check the third memory location
+        EXPECT_EQ(entries[2].start,
+            reinterpret_cast<uint64_t>(addr) + 4096 * 9);
+        EXPECT_EQ(entries[2].location, locationb);
+        EXPECT_EQ(entries[2].len, static_cast<size_t>(4096 - 1024 * 2));
+    }
+
+    numa_free(addr, size);
+}

--- a/mooncake-ngxl-exp/tests/rdma_transport_test.cpp
+++ b/mooncake-ngxl-exp/tests/rdma_transport_test.cpp
@@ -1,0 +1,334 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// How to run:
+// etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls
+// http://10.0.0.1:2379
+// ./rdma_transport_test --mode=target  --metadata_server=127.0.0.1:2379
+//   --local_server_name=127.0.0.2:12345 --device_name=erdma_0
+// ./rdma_transport_test --metadata_server=127.0.0.1:2379
+//   --segment_id=127.0.0.2:12345 --local_server_name=127.0.0.3:12346
+//   --device_name=erdma_1
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <sys/time.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+
+#include "transfer_engine.h"
+#include "transport/transport.h"
+
+#ifdef USE_CUDA
+#include <bits/stdint-uintn.h>
+#include <cuda_runtime.h>
+
+#ifdef USE_NVMEOF
+#include <cufile.h>
+#endif
+
+#include <cassert>
+
+static void checkCudaError(cudaError_t result, const char *message) {
+    if (result != cudaSuccess) {
+        LOG(ERROR) << message << " (Error code: " << result << " - "
+                   << cudaGetErrorString(result) << ")" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+#endif
+
+#define NR_SOCKETS (1)
+
+static std::string getHostname();
+
+DEFINE_string(local_server_name, getHostname(),
+              "Local server name for segment discovery");
+DEFINE_string(metadata_server, "192.168.3.77:2379", "etcd server host address");
+DEFINE_string(mode, "initiator",
+              "Running mode: initiator or target. Initiator node read/write "
+              "data blocks from target node");
+DEFINE_string(operation, "read", "Operation type: read or write");
+
+DEFINE_string(protocol, "rdma", "Transfer protocol: rdma|tcp");
+
+DEFINE_string(device_name, "mlx5_2",
+              "Device name to use, valid if protocol=rdma");
+DEFINE_string(nic_priority_matrix, "",
+              "Path to RDMA NIC priority matrix file (Advanced)");
+
+DEFINE_string(segment_id, "192.168.3.76", "Segment ID to access data");
+
+#ifdef USE_CUDA
+DEFINE_bool(use_vram, true, "Allocate memory from GPU VRAM");
+DEFINE_int32(gpu_id, 0, "GPU ID to use");
+#endif
+
+using namespace mooncake;
+
+static std::string getHostname() {
+    char hostname[256];
+    if (gethostname(hostname, 256)) {
+        PLOG(ERROR) << "Failed to get hostname";
+        return "";
+    }
+    return hostname;
+}
+
+static void *allocateMemoryPool(size_t size, int socket_id,
+                                bool from_vram = false) {
+#ifdef USE_CUDA
+    if (from_vram) {
+        int gpu_id = FLAGS_gpu_id;
+        void *d_buf;
+        checkCudaError(cudaSetDevice(gpu_id), "Failed to set device");
+        checkCudaError(cudaMalloc(&d_buf, size),
+                       "Failed to allocate device memory");
+        return d_buf;
+    }
+#endif
+    return numa_alloc_onnode(size, socket_id);
+}
+
+static void freeMemoryPool(void *addr, size_t size) {
+#ifdef USE_CUDA
+    // check pointer on GPU
+    cudaPointerAttributes attributes;
+    checkCudaError(cudaPointerGetAttributes(&attributes, addr),
+                   "Failed to get pointer attributes");
+
+    if (attributes.type == cudaMemoryTypeDevice) {
+        cudaFree(addr);
+    } else if (attributes.type == cudaMemoryTypeHost) {
+        numa_free(addr, size);
+    } else {
+        LOG(ERROR) << "Unknown memory type";
+    }
+#else
+    numa_free(addr, size);
+#endif
+}
+
+int initiatorWorker(TransferEngine *engine, SegmentID segment_id, int thread_id,
+                    void *addr) {
+    bindToSocket(0);
+    auto segment_desc = engine->getMetadata()->getSegmentDescByID(segment_id);
+    uint64_t remote_base = (uint64_t)segment_desc->memory.buffers[0].addr;
+    const size_t kDataLength = 4096000;
+    {
+        LOG(INFO) << "Stage 1: Write Data";
+        for (size_t offset = 0; offset < kDataLength; ++offset)
+            *((char *)(addr) + offset) = 'a' + lrand48() % 26;
+
+        LOG(INFO) << "Write Data: " << std::string((char *)(addr), 16) << "...";
+
+        auto batch_id = engine->allocateBatchID(1);
+        Status s;
+
+        TransferRequest entry;
+        entry.opcode = TransferRequest::WRITE;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr);
+        entry.target_id = segment_id;
+        entry.target_offset = remote_base;
+        s = engine->submitTransfer(batch_id, {entry});
+        LOG_ASSERT(s.ok());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            LOG_ASSERT(s.ok());
+            if (status.s == TransferStatusEnum::COMPLETED)
+                completed = true;
+            else if (status.s == TransferStatusEnum::FAILED) {
+                LOG(INFO) << "FAILED";
+                completed = true;
+            }
+        }
+        s = engine->freeBatchID(batch_id);
+        LOG_ASSERT(s.ok());
+    }
+
+    {
+        LOG(INFO) << "Stage 2: Read Data";
+        auto batch_id = engine->allocateBatchID(1);
+        Status s;
+
+        TransferRequest entry;
+        entry.opcode = TransferRequest::READ;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr) + kDataLength;
+        entry.target_id = segment_id;
+        entry.target_offset = remote_base;
+        s = engine->submitTransfer(batch_id, {entry});
+        LOG_ASSERT(s.ok());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            LOG_ASSERT(s.ok());
+            if (status.s == TransferStatusEnum::COMPLETED)
+                completed = true;
+            else if (status.s == TransferStatusEnum::FAILED) {
+                LOG(INFO) << "FAILED";
+                completed = true;
+            }
+        }
+        s = engine->freeBatchID(batch_id);
+        LOG_ASSERT(s.ok());
+    }
+
+    int ret =
+        memcmp((uint8_t *)(addr), (uint8_t *)(addr) + kDataLength, kDataLength);
+    LOG(INFO) << "Read Data: " << std::string((char *)(addr) + kDataLength, 16)
+              << "...";
+    LOG(INFO) << "Compare: " << (ret == 0 ? "OK" : "FAILED");
+
+    return 0;
+}
+
+std::string formatDeviceNames(const std::string &device_names) {
+    std::stringstream ss(device_names);
+    std::string item;
+    std::vector<std::string> tokens;
+    while (getline(ss, item, ',')) {
+        tokens.push_back(item);
+    }
+
+    std::string formatted;
+    for (size_t i = 0; i < tokens.size(); ++i) {
+        formatted += "\"" + tokens[i] + "\"";
+        if (i < tokens.size() - 1) {
+            formatted += ",";
+        }
+    }
+    return formatted;
+}
+
+std::string loadNicPriorityMatrix() {
+    if (!FLAGS_nic_priority_matrix.empty()) {
+        std::ifstream file(FLAGS_nic_priority_matrix);
+        if (file.is_open()) {
+            std::string content((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+            file.close();
+            return content;
+        }
+    }
+    // Build JSON Data
+    auto device_names = formatDeviceNames(FLAGS_device_name);
+    return "{\"cpu:0\": [[" + device_names +
+           "], []], "
+           " \"cpu:1\": [[" +
+           device_names +
+           "], []], "
+           " \"cuda:0\": [[" +
+           device_names + "], []]}";
+}
+
+int initiator() {
+    const size_t ram_buffer_size = 1ull << 30;
+    // disable topology auto discovery for testing.
+    auto engine = std::make_unique<TransferEngine>(false);
+
+    auto hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
+                 hostname_port.first.c_str(), hostname_port.second);
+
+    Transport *xport = nullptr;
+    if (FLAGS_protocol == "rdma") {
+        auto nic_priority_matrix = loadNicPriorityMatrix();
+        void **args = (void **)malloc(2 * sizeof(void *));
+        args[0] = (void *)nic_priority_matrix.c_str();
+        args[1] = nullptr;
+        xport = engine->installTransport("rdma", args);
+    } else if (FLAGS_protocol == "tcp") {
+        xport = engine->installTransport("tcp", nullptr);
+    } else if (FLAGS_protocol == "nvmeof") {
+        xport = engine->installTransport("nvmeof", nullptr);
+    } else {
+        LOG(ERROR) << "Unsupported protocol";
+    }
+
+    LOG_ASSERT(xport);
+
+    void *addr = nullptr;
+#ifdef USE_CUDA
+    addr = allocateMemoryPool(ram_buffer_size, 0, FLAGS_use_vram);
+    int rc = engine->registerLocalMemory(addr, ram_buffer_size,
+                                         FLAGS_use_vram ? "cuda:0" : "cpu:0");
+    LOG_ASSERT(!rc);
+#else
+    addr = allocateMemoryPool(ram_buffer_size, 0, false);
+    int rc = engine->registerLocalMemory(addr, ram_buffer_size, "*");
+    LOG_ASSERT(!rc);
+#endif
+
+    auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
+    std::thread workers(initiatorWorker, engine.get(), segment_id, 0, addr);
+    workers.join();
+    engine->unregisterLocalMemory(addr);
+    freeMemoryPool(addr, ram_buffer_size);
+    return 0;
+}
+
+int target() {
+    const size_t ram_buffer_size = 1ull << 30;
+    // disable topology auto discovery for testing.
+    auto engine = std::make_unique<TransferEngine>(false);
+
+    auto hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
+                 hostname_port.first.c_str(), hostname_port.second);
+
+    if (FLAGS_protocol == "rdma") {
+        auto nic_priority_matrix = loadNicPriorityMatrix();
+        void **args = (void **)malloc(2 * sizeof(void *));
+        args[0] = (void *)nic_priority_matrix.c_str();
+        args[1] = nullptr;
+        engine->installTransport("rdma", args);
+    } else if (FLAGS_protocol == "tcp") {
+        engine->installTransport("tcp", nullptr);
+    } else if (FLAGS_protocol == "nvmeof") {
+        engine->installTransport("nvmeof", nullptr);
+    } else {
+        LOG(ERROR) << "Unsupported protocol";
+    }
+
+    void *addr = nullptr;
+    addr = allocateMemoryPool(ram_buffer_size, 0);
+    int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+    LOG_ASSERT(!rc);
+
+    while (true) sleep(1);
+
+    engine->unregisterLocalMemory(addr);
+    freeMemoryPool(addr, ram_buffer_size);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+
+    if (FLAGS_mode == "initiator")
+        return initiator();
+    else if (FLAGS_mode == "target")
+        return target();
+
+    LOG(ERROR) << "Unsupported mode: must be 'initiator' or 'target'";
+    exit(EXIT_FAILURE);
+}

--- a/mooncake-ngxl-exp/tests/rdma_transport_test2.cpp
+++ b/mooncake-ngxl-exp/tests/rdma_transport_test2.cpp
@@ -1,0 +1,258 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <sys/time.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+
+#include "transfer_engine.h"
+#include "transport/transport.h"
+
+using namespace mooncake;
+
+namespace mooncake {
+
+static std::string getHostname() {
+    char hostname[256];
+    if (gethostname(hostname, 256)) {
+        PLOG(ERROR) << "Failed to get hostname";
+        return "";
+    }
+    return hostname;
+}
+
+DEFINE_string(local_server_name, getHostname(),
+              "Local server name for segment discovery");
+DEFINE_string(metadata_server, "127.0.0.1:2379", "etcd server host address");
+DEFINE_string(mode, "initiator",
+              "Running mode: initiator or target. Initiator node read/write "
+              "data blocks from target node");
+DEFINE_string(operation, "read", "Operation type: read or write");
+
+DEFINE_string(protocol, "rdma", "Transfer protocol: rdma|tcp");
+
+DEFINE_string(device_name, "erdma_1",
+              "Device name to use, valid if protocol=rdma");
+DEFINE_string(nic_priority_matrix, "",
+              "Path to RDMA NIC priority matrix file (Advanced)");
+
+DEFINE_string(segment_id, "127.0.0.2", "Segment ID to access data");
+
+std::string formatDeviceNames(const std::string &device_names) {
+    std::stringstream ss(device_names);
+    std::string item;
+    std::vector<std::string> tokens;
+    while (getline(ss, item, ',')) {
+        tokens.push_back(item);
+    }
+
+    std::string formatted;
+    for (size_t i = 0; i < tokens.size(); ++i) {
+        formatted += "\"" + tokens[i] + "\"";
+        if (i < tokens.size() - 1) {
+            formatted += ",";
+        }
+    }
+    return formatted;
+}
+
+std::string loadNicPriorityMatrix() {
+    if (!FLAGS_nic_priority_matrix.empty()) {
+        std::ifstream file(FLAGS_nic_priority_matrix);
+        if (file.is_open()) {
+            std::string content((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+            file.close();
+            return content;
+        }
+    }
+    // Build JSON Data
+    auto device_names = formatDeviceNames(FLAGS_device_name);
+    return "{\"cpu:0\": [[" + device_names +
+           "], []], "
+           " \"cpu:1\": [[" +
+           device_names +
+           "], []], "
+           " \"cuda:0\": [[" +
+           device_names + "], []]}";
+}
+
+static void *allocateMemoryPool(size_t size, int socket_id,
+                                bool from_vram = false) {
+    return numa_alloc_onnode(size, socket_id);
+}
+
+static void freeMemoryPool(void *addr, size_t size) { numa_free(addr, size); }
+
+class RDMATransportTest : public ::testing::Test {
+   public:
+    std::shared_ptr<mooncake::TransferMetadata> metadata_client;
+    void *addr = nullptr;
+    std::pair<std::string, uint16_t> hostname_port;
+    std::unique_ptr<mooncake::TransferEngine> engine;
+    const size_t ram_buffer_size = 1ull << 30;
+    Transport *xport;
+    std::string nic_priority_matrix;
+    void **args;
+    mooncake::Transport::SegmentID segment_id;
+    std::shared_ptr<SegmentDesc> segment_desc;
+    uint64_t remote_base;
+
+   protected:
+    void SetUp() override {
+        static int offset = 0;
+        LOG(INFO) << "HERE \n";
+        google::InitGoogleLogging("RDMATransportTest");
+        FLAGS_logtostderr = 1;
+        // disable topology auto discovery for testing.
+        engine = std::make_unique<TransferEngine>(false);
+        hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
+        engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
+                     hostname_port.first.c_str(),
+                     hostname_port.second + offset++);
+        xport = nullptr;
+        nic_priority_matrix = loadNicPriorityMatrix();
+        args = (void **)malloc(2 * sizeof(void *));
+        args[0] = (void *)nic_priority_matrix.c_str();
+        args[1] = nullptr;
+        xport = engine->installTransport("rdma", args);
+        ASSERT_NE(xport, nullptr);
+        addr = allocateMemoryPool(ram_buffer_size, 0, false);
+        int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+        ASSERT_EQ(rc, 0);
+        segment_id = engine->openSegment(FLAGS_segment_id.c_str());
+        bindToSocket(0);
+        segment_desc = engine->getMetadata()->getSegmentDescByID(segment_id);
+        remote_base = (uint64_t)segment_desc->memory.buffers[0].addr;
+    }
+
+    void TearDown() override {
+        google::ShutdownGoogleLogging();
+        engine->unregisterLocalMemory(addr);
+        freeMemoryPool(addr, ram_buffer_size);
+    }
+};
+
+TEST_F(RDMATransportTest, MultiWrite) {
+    const size_t kDataLength = 4096000;
+    int times = 10;
+    while (times--) {
+        for (size_t offset = 0; offset < kDataLength; ++offset)
+            *((char *)(addr) + offset) = 'a' + lrand48() % 26;
+        auto batch_id = engine->allocateBatchID(1);
+        Status s;
+        TransferRequest entry;
+        entry.opcode = TransferRequest::WRITE;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr);
+        entry.target_id = segment_id;
+        entry.target_offset = remote_base;
+        s = engine->submitTransfer(batch_id, {entry});
+        LOG_ASSERT(s.ok());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            ASSERT_EQ(s, Status::OK());
+            if (status.s == TransferStatusEnum::COMPLETED)
+                completed = true;
+            else if (status.s == TransferStatusEnum::FAILED) {
+                LOG(INFO) << "FAILED";
+                completed = true;
+            }
+        }
+        s = engine->freeBatchID(batch_id);
+        ASSERT_EQ(s, Status::OK());
+    }
+}
+
+TEST_F(RDMATransportTest, MultipleRead) {
+    const size_t kDataLength = 4096000;
+    int times = 10;
+    while (times--) {
+        for (size_t offset = 0; offset < kDataLength; ++offset)
+            *((char *)(addr) + offset) = 'a' + lrand48() % 26;
+
+        auto batch_id = engine->allocateBatchID(1);
+        Status s;
+        TransferRequest entry;
+        entry.opcode = TransferRequest::WRITE;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr);
+        entry.target_id = segment_id;
+        entry.target_offset = remote_base;
+        s = engine->submitTransfer(batch_id, {entry});
+        LOG_ASSERT(s.ok());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            ASSERT_EQ(s, Status::OK());
+            if (status.s == TransferStatusEnum::COMPLETED)
+                completed = true;
+            else if (status.s == TransferStatusEnum::FAILED) {
+                LOG(INFO) << "FAILED";
+                completed = true;
+            }
+        }
+        s = engine->freeBatchID(batch_id);
+        ASSERT_EQ(s, Status::OK());
+    }
+    times = 10;
+    while (times--) {
+        auto batch_id = engine->allocateBatchID(1);
+        int ret = 0;
+        TransferRequest entry;
+        entry.opcode = TransferRequest::READ;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr) + kDataLength;
+        entry.target_id = segment_id;
+        entry.target_offset = remote_base;
+        Status s;
+        s = engine->submitTransfer(batch_id, {entry});
+        ASSERT_EQ(s, Status::OK());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            ASSERT_EQ(s, Status::OK());
+            if (status.s == TransferStatusEnum::COMPLETED)
+                completed = true;
+            else if (status.s == TransferStatusEnum::FAILED) {
+                completed = true;
+            }
+        }
+        s = engine->freeBatchID(batch_id);
+        ASSERT_EQ(s, Status::OK());
+        ret = memcmp((uint8_t *)(addr), (uint8_t *)(addr) + kDataLength,
+                     kDataLength);
+        ASSERT_EQ(ret, 0);
+    }
+    engine->unregisterLocalMemory(addr);
+    freeMemoryPool(addr, ram_buffer_size);
+}
+
+}  // namespace mooncake
+
+int main(int argc, char **argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-ngxl-exp/tests/tcp_transport_test.cpp
+++ b/mooncake-ngxl-exp/tests/tcp_transport_test.cpp
@@ -1,0 +1,349 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <sys/time.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+
+#ifdef USE_CUDA
+#include <bits/stdint-uintn.h>
+#include <cuda_runtime.h>
+
+#ifdef USE_NVMEOF
+#include <cufile.h>
+#endif
+
+#include <cassert>
+
+#include "common/base/status.h"
+
+static void checkCudaError(cudaError_t result, const char *message) {
+    if (result != cudaSuccess) {
+        LOG(ERROR) << message << " (Error code: " << result << " - "
+                   << cudaGetErrorString(result) << ")" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+#endif
+
+#include "transfer_engine.h"
+#include "transport/transport.h"
+
+#ifdef USE_CUDA
+DEFINE_int32(gpu_id, 0, "GPU ID to use");
+#endif
+
+using namespace mooncake;
+
+namespace mooncake {
+
+class TCPTransportTest : public ::testing::Test {
+   public:
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("TCPTransportTest");
+        FLAGS_logtostderr = 1;
+
+        const char *env = std::getenv("MC_METADATA_SERVER");
+        if (env)
+            metadata_server = env;
+        else
+            metadata_server = metadata_server;
+        LOG(INFO) << "metadata_server: " << metadata_server;
+
+        env = std::getenv("MC_LOCAL_SERVER_NAME");
+        if (env)
+            local_server_name = env;
+        else
+            local_server_name = "127.0.0.2:12345";
+        LOG(INFO) << "local_server_name: " << local_server_name;
+    }
+
+    void TearDown() override {
+        // 清理 glog
+        google::ShutdownGoogleLogging();
+    }
+
+    std::string metadata_server;
+    std::string local_server_name;
+};
+
+static void *allocateMemoryPool(size_t size, int socket_id,
+                                bool from_vram = false) {
+    return numa_alloc_onnode(size, socket_id);
+}
+
+TEST_F(TCPTransportTest, GetTcpTest) {
+    // disable topology auto discovery for testing.
+    auto engine = std::make_unique<TransferEngine>(false);
+    auto hostname_port = parseHostNameWithPort(local_server_name);
+    auto rc = engine->init(metadata_server, local_server_name,
+                           hostname_port.first.c_str(), hostname_port.second);
+    LOG_ASSERT(rc == 0);
+    Transport *xport = nullptr;
+    xport = engine->installTransport("tcp", nullptr);
+    LOG_ASSERT(xport != nullptr);
+}
+
+TEST_F(TCPTransportTest, Writetest) {
+    const size_t kDataLength = 4096000;
+    void *addr = nullptr;
+    const size_t ram_buffer_size = 1ull << 30;
+    // disable topology auto discovery for testing.
+    auto engine = std::make_unique<TransferEngine>(false);
+    auto hostname_port = parseHostNameWithPort(local_server_name);
+    auto rc = engine->init(metadata_server, local_server_name,
+                           hostname_port.first.c_str(), hostname_port.second);
+    LOG_ASSERT(rc == 0);
+    Transport *xport = nullptr;
+    xport = engine->installTransport("tcp", nullptr);
+    LOG_ASSERT(xport != nullptr);
+
+    addr = allocateMemoryPool(ram_buffer_size, 0, false);
+    rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+    LOG_ASSERT(!rc);
+
+    for (size_t offset = 0; offset < kDataLength; ++offset)
+        *((char *)(addr) + offset) = 'a' + lrand48() % 26;
+    auto batch_id = engine->allocateBatchID(1);
+    Status s;
+    auto segment_id = engine->openSegment(local_server_name);
+    TransferRequest entry;
+    auto segment_desc = engine->getMetadata()->getSegmentDescByID(segment_id);
+    uint64_t remote_base = (uint64_t)segment_desc->memory.buffers[0].addr;
+    entry.opcode = TransferRequest::WRITE;
+    entry.length = kDataLength;
+    entry.source = (uint8_t *)(addr);
+    entry.target_id = segment_id;
+    entry.target_offset = remote_base;
+    s = engine->submitTransfer(batch_id, {entry});
+    LOG_ASSERT(s.ok());
+    bool completed = false;
+    TransferStatus status;
+    while (!completed) {
+        Status s = engine->getTransferStatus(batch_id, 0, status);
+        ASSERT_EQ(s, Status::OK());
+        LOG_ASSERT(status.s != TransferStatusEnum::FAILED);
+        if (status.s == TransferStatusEnum::COMPLETED) completed = true;
+    }
+    s = engine->freeBatchID(batch_id);
+    ASSERT_EQ(s, Status::OK());
+}
+
+TEST_F(TCPTransportTest, WriteAndReadtest) {
+    const size_t kDataLength = 4096000;
+    void *addr = nullptr;
+    const size_t ram_buffer_size = 1ull << 30;
+    // disable topology auto discovery for testing.
+    auto engine = std::make_unique<TransferEngine>(false);
+    auto hostname_port = parseHostNameWithPort(local_server_name);
+    engine->init(metadata_server, local_server_name,
+                 hostname_port.first.c_str(), hostname_port.second);
+    Transport *xport = nullptr;
+    xport = engine->installTransport("tcp", nullptr);
+    LOG_ASSERT(xport != nullptr);
+
+    addr = allocateMemoryPool(ram_buffer_size, 0, false);
+    int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+    LOG_ASSERT(!rc);
+    for (size_t offset = 0; offset < kDataLength; ++offset)
+        *((char *)(addr) + offset) = 'a' + lrand48() % 26;
+
+    auto segment_id = engine->openSegment(local_server_name);
+    auto segment_desc = engine->getMetadata()->getSegmentDescByID(segment_id);
+    uint64_t remote_base = (uint64_t)segment_desc->memory.buffers[0].addr;
+    {
+        auto batch_id = engine->allocateBatchID(1);
+        Status s;
+        TransferRequest entry;
+        entry.opcode = TransferRequest::WRITE;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr);
+        entry.target_id = segment_id;
+        entry.target_offset = remote_base;
+        s = engine->submitTransfer(batch_id, {entry});
+        LOG_ASSERT(s.ok());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            ASSERT_EQ(s, Status::OK());
+            LOG_ASSERT(status.s != TransferStatusEnum::FAILED);
+            if (status.s == TransferStatusEnum::COMPLETED) completed = true;
+        }
+        s = engine->freeBatchID(batch_id);
+        ASSERT_EQ(s, Status::OK());
+    }
+
+    {
+        auto batch_id = engine->allocateBatchID(1);
+        Status s;
+
+        TransferRequest entry;
+        entry.opcode = TransferRequest::READ;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr) + kDataLength;
+        entry.target_id = segment_id;
+        entry.target_offset = remote_base;
+        s = engine->submitTransfer(batch_id, {entry});
+        LOG_ASSERT(s.ok());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            LOG_ASSERT(s.ok());
+            if (status.s == TransferStatusEnum::COMPLETED) completed = true;
+            LOG_ASSERT(status.s != TransferStatusEnum::FAILED);
+        }
+        s = engine->freeBatchID(batch_id);
+        LOG_ASSERT(s.ok());
+    }
+    LOG_ASSERT(0 == memcmp((uint8_t *)(addr), (uint8_t *)(addr) + kDataLength,
+                           kDataLength));
+}
+
+TEST_F(TCPTransportTest, WriteAndRead2test) {
+    const size_t kDataLength = 4096000;
+    void *addr = nullptr;
+    const size_t ram_buffer_size = 1ull << 30;
+    // disable topology auto discovery for testing.
+    auto engine = std::make_unique<TransferEngine>(false);
+    auto hostname_port = parseHostNameWithPort(local_server_name);
+    engine->init(metadata_server, local_server_name,
+                 hostname_port.first.c_str(), hostname_port.second);
+    Transport *xport = nullptr;
+    xport = engine->installTransport("tcp", nullptr);
+    LOG_ASSERT(xport != nullptr);
+
+    addr = allocateMemoryPool(ram_buffer_size, 0, false);
+    int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+    LOG_ASSERT(!rc);
+    for (size_t offset = 0; offset < kDataLength; ++offset)
+        *((char *)(addr) + offset) = 'a' + lrand48() % 26;
+
+    auto segment_id = engine->openSegment(local_server_name);
+    auto segment_desc = engine->getMetadata()->getSegmentDescByID(segment_id);
+    uint64_t remote_base = (uint64_t)segment_desc->memory.buffers[0].addr;
+
+    {
+        auto batch_id = engine->allocateBatchID(1);
+        Status s;
+        TransferRequest entry;
+        entry.opcode = TransferRequest::WRITE;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr);
+        entry.target_id = segment_id;
+        entry.target_offset = remote_base;
+        s = engine->submitTransfer(batch_id, {entry});
+        LOG_ASSERT(s.ok());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            ASSERT_EQ(s, Status::OK());
+            LOG_ASSERT(status.s != TransferStatusEnum::FAILED);
+            if (status.s == TransferStatusEnum::COMPLETED) completed = true;
+        }
+        s = engine->freeBatchID(batch_id);
+        ASSERT_EQ(s, Status::OK());
+    }
+
+    {
+        auto batch_id = engine->allocateBatchID(1);
+        Status s;
+        TransferRequest entry;
+        entry.opcode = TransferRequest::READ;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr) + kDataLength;
+        entry.target_id = segment_id;
+        entry.target_offset = remote_base;
+        s = engine->submitTransfer(batch_id, {entry});
+        LOG_ASSERT(s.ok());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            LOG_ASSERT(s.ok());
+            if (status.s == TransferStatusEnum::COMPLETED) completed = true;
+            LOG_ASSERT(status.s != TransferStatusEnum::FAILED);
+        }
+        s = engine->freeBatchID(batch_id);
+        LOG_ASSERT(s.ok());
+    }
+    LOG_ASSERT(0 == memcmp((uint8_t *)(addr), (uint8_t *)(addr) + kDataLength,
+                           kDataLength));
+
+    for (size_t offset = 0; offset < kDataLength; ++offset)
+        *((char *)(addr) + offset) = 'a' + lrand48() % 26;
+    {
+        auto batch_id = engine->allocateBatchID(1);
+        Status s;
+        TransferRequest entry;
+        entry.opcode = TransferRequest::WRITE;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr);
+        entry.target_id = segment_id;
+        entry.target_offset = remote_base;
+        s = engine->submitTransfer(batch_id, {entry});
+        LOG_ASSERT(s.ok());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            ASSERT_EQ(s, Status::OK());
+            LOG_ASSERT(status.s != TransferStatusEnum::FAILED);
+            if (status.s == TransferStatusEnum::COMPLETED) completed = true;
+        }
+        s = engine->freeBatchID(batch_id);
+        ASSERT_EQ(s, Status::OK());
+    }
+
+    {
+        auto batch_id = engine->allocateBatchID(1);
+        Status s;
+        TransferRequest entry;
+        entry.opcode = TransferRequest::READ;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr) + kDataLength;
+        entry.target_id = segment_id;
+        entry.target_offset = remote_base;
+        s = engine->submitTransfer(batch_id, {entry});
+        LOG_ASSERT(s.ok());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            LOG_ASSERT(s.ok());
+            if (status.s == TransferStatusEnum::COMPLETED) completed = true;
+            LOG_ASSERT(status.s != TransferStatusEnum::FAILED);
+        }
+        s = engine->freeBatchID(batch_id);
+        LOG_ASSERT(s.ok());
+    }
+    LOG_ASSERT(0 == memcmp((uint8_t *)(addr), (uint8_t *)(addr) + kDataLength,
+                           kDataLength));
+}
+
+}  // namespace mooncake
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-ngxl-exp/tests/topology_test.cpp
+++ b/mooncake-ngxl-exp/tests/topology_test.cpp
@@ -1,0 +1,111 @@
+#include "topology.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "transfer_metadata.h"
+
+TEST(ToplogyTest, GetTopologyMatrix) {
+    mooncake::Topology topology;
+    topology.discover();
+    std::string json_str = topology.toString();
+    LOG(INFO) << json_str;
+    topology.clear();
+    topology.parse(json_str);
+    ASSERT_EQ(topology.toString(), json_str);
+}
+
+TEST(ToplogyTest, TestEmpty) {
+    mooncake::Topology topology;
+    std::string json_str =
+        "{\"cpu:0\" : [[\"erdma_0\"],[\"erdma_1\"]],\"cpu:1\" "
+        ": [[\"erdma_1\"],[\"erdma_0\"]]}";
+    topology.clear();
+    topology.parse(json_str);
+    ASSERT_TRUE(!topology.empty());
+}
+
+TEST(ToplogyTest, TestHcaList) {
+    mooncake::Topology topology;
+    std::string json_str =
+        "{\"cpu:0\" : [[\"erdma_0\"],[\"erdma_0\"]],\"cpu:1\" "
+        ": [[\"erdma_0\"],[\"erdma_0\"]]}";
+    topology.clear();
+    topology.parse(json_str);
+    ASSERT_EQ(topology.getHcaList().size(), static_cast<size_t>(1));
+    std::set<std::string> HcaList = {"erdma_0"};
+    for (auto &hca : topology.getHcaList()) {
+        ASSERT_TRUE(HcaList.count(hca));
+    }
+}
+
+TEST(ToplogyTest, TestHcaListSize) {
+    mooncake::Topology topology;
+    std::string json_str =
+        "{\"cpu:0\" : [[\"erdma_0\"],[\"erdma_1\"]],\"cpu:1\" "
+        ": [[\"erdma_2\"],[\"erdma_3\"]]}";
+    topology.clear();
+    topology.parse(json_str);
+    ASSERT_EQ(topology.getHcaList().size(), static_cast<size_t>(4));
+}
+
+TEST(ToplogyTest, TestHcaList2) {
+    mooncake::Topology topology;
+    std::string json_str =
+        "{\"cpu:0\" : [[\"erdma_0\"],[\"erdma_1\"]],\"cpu:1\" "
+        ": [[\"erdma_1\"],[\"erdma_0\"]]}";
+    topology.clear();
+    topology.parse(json_str);
+    ASSERT_EQ(topology.getHcaList().size(), static_cast<size_t>(2));
+    std::set<std::string> HcaList = {"erdma_0", "erdma_1"};
+    for (auto &hca : topology.getHcaList()) {
+        ASSERT_TRUE(HcaList.count(hca));
+    }
+}
+
+TEST(ToplogyTest, TestMatrix) {
+    mooncake::Topology topology;
+    std::string json_str = "{\"cpu:0\" : [[\"erdma_0\"],[\"erdma_1\"]]}";
+    topology.clear();
+    topology.parse(json_str);
+    auto matrix = topology.getMatrix();
+    ASSERT_TRUE(matrix.size() == 1);
+    ASSERT_TRUE(matrix.count("cpu:0"));
+}
+
+TEST(ToplogyTest, TestSelectDevice) {
+    mooncake::Topology topology;
+    std::string json_str = "{\"cpu:0\" : [[\"erdma_0\"],[\"erdma_1\"]]}";
+    topology.clear();
+    topology.parse(json_str);
+    std::set<int> items = {0, 1};
+    int device;
+    device = topology.selectDevice("cpu:0", 2);
+    ASSERT_TRUE(items.count(device));
+    items.erase(device);
+    device = topology.selectDevice("cpu:0", 1);
+    ASSERT_TRUE(items.count(device));
+    items.erase(device);
+    ASSERT_TRUE(items.empty());
+}
+
+TEST(ToplogyTest, TestSelectDeviceAny) {
+    mooncake::Topology topology;
+    std::string json_str = "{\"cpu:0\" : [[\"erdma_0\"],[\"erdma_1\"]]}";
+    topology.clear();
+    topology.parse(json_str);
+    std::set<int> items = {0, 1};
+    int device;
+    device = topology.selectDevice("*", 2);
+    ASSERT_TRUE(items.count(device));
+    items.erase(device);
+    device = topology.selectDevice("*", 1);
+    ASSERT_TRUE(items.count(device));
+    items.erase(device);
+    ASSERT_TRUE(items.empty());
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-ngxl-exp/tests/transfer_metadata_test.cpp
+++ b/mooncake-ngxl-exp/tests/transfer_metadata_test.cpp
@@ -1,0 +1,124 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transfer_metadata.h"
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <sys/time.h>
+
+#include <cstdlib>
+
+#include "transport/transport.h"
+
+using namespace mooncake;
+
+namespace mooncake {
+
+class TransferMetadataTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        // initialize glog
+        google::InitGoogleLogging("TransferMetadataTest");
+        FLAGS_logtostderr = 1;  // output to stdout
+
+        const char* env = std::getenv("MC_METADATA_SERVER");
+        if (env)
+            metadata_server = env;
+        else
+            metadata_server = metadata_server;
+        LOG(INFO) << "metadata_server: " << metadata_server;
+
+        env = std::getenv("MC_LOCAL_SERVER_NAME");
+        if (env)
+            local_server_name = env;
+        else
+            local_server_name = "127.0.0.2:12345";
+        LOG(INFO) << "local_server_name: " << local_server_name;
+
+        metadata_client = std::make_unique<TransferMetadata>(metadata_server, local_server_name);
+    }
+    void TearDown() override {
+        // clean up glog
+        google::ShutdownGoogleLogging();
+    }
+    std::unique_ptr<TransferMetadata> metadata_client;
+    std::string metadata_server;
+    std::string local_server_name;
+};
+
+// add and search LocalSegmentMeta
+TEST_F(TransferMetadataTest, LocalSegmentTest) {
+    auto segment_des = std::make_shared<SegmentDesc>();
+    std::string segment_name = local_server_name;
+    segment_des->type = MemoryKind;
+    segment_des->name = segment_name;
+    int re = metadata_client->setLocalSegment(std::move(segment_des));
+    ASSERT_EQ(re, 0);
+    auto des = metadata_client->getSegmentDescByName(segment_name);
+    ASSERT_EQ(des->name, segment_name);
+    des = metadata_client->getSegmentDescByID(LOCAL_SEGMENT_ID, false);
+    ASSERT_EQ(des->name, segment_name);
+    auto id = metadata_client->getSegmentID(segment_name);
+    ASSERT_EQ(id, LOCAL_SEGMENT_ID);
+}
+
+// add and remove LocalMemoryBufferMeta
+TEST_F(TransferMetadataTest, LocalMemoryBufferTest) {
+    auto segment_des = std::make_shared<SegmentDesc>();
+    segment_des->name = local_server_name;
+    segment_des->type = MemoryKind;
+    int re = metadata_client->setLocalSegment(std::move(segment_des));
+    ASSERT_EQ(re, 0);
+    uint64_t addr = 0;
+    for (int i = 0; i < 10; ++i) {
+        BufferAttr buffer_des;
+        buffer_des.addr = addr + i * 2048;
+        buffer_des.length = 1024;
+        re = metadata_client->addLocalMemoryBuffer(buffer_des, false);
+        ASSERT_EQ(re, 0);
+    }
+    addr = 1000;
+    re = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
+    ASSERT_EQ(re, -ERR_ADDRESS_NOT_REGISTERED);
+    for (int i = 9; i > 0; --i) {
+        addr = i * 2048;
+        re = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
+        ASSERT_EQ(re, 0);
+    }
+}
+
+// add, get and remove RPCMetaEntryMeta
+TEST_F(TransferMetadataTest, RpcMetaEntryTest) {
+    auto hostname_port = parseHostNameWithPort(local_server_name);
+    TransferMetadata::RpcMetaDesc desc;
+    desc.ip_or_host_name = hostname_port.first.c_str();
+    desc.rpc_port = hostname_port.second;
+    int re = metadata_client->addRpcMetaEntry("test_server", desc);
+    ASSERT_EQ(re, 0);
+    TransferMetadata::RpcMetaDesc desc1;
+    re = metadata_client->getRpcMetaEntry("test_server", desc1);
+    ASSERT_EQ(desc.ip_or_host_name, desc1.ip_or_host_name);
+    ASSERT_EQ(desc.rpc_port, desc1.rpc_port);
+    re = metadata_client->removeRpcMetaEntry("test_server");
+    ASSERT_EQ(re, 0);
+}
+
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-ngxl-exp/tests/transport_uint_test.cpp
+++ b/mooncake-ngxl-exp/tests/transport_uint_test.cpp
@@ -1,0 +1,179 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <sys/time.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+
+#include "transfer_engine.h"
+#include "transport/transport.h"
+
+using namespace mooncake;
+
+namespace mooncake {
+
+class TransportTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("TransportTest");
+        FLAGS_logtostderr = 1;
+    }
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+};
+
+static int CreateTempFile() {
+    char temp_filename[] = "/tmp/testfileXXXXXX";
+    int fd = mkstemp(temp_filename);
+    if (fd == -1) {
+        return -1;
+    }
+    unlink(temp_filename);
+    return fd;
+}
+
+int CreateTempFileWithContent(const char* content) {
+    char temp_filename[] = "/tmp/testfileXXXXXX";
+    int fd = mkstemp(temp_filename);
+    if (fd == -1) {
+        return -1;
+    }
+    unlink(temp_filename);
+
+    ssize_t nbytes = write(fd, content, strlen(content));
+    (void)nbytes;
+    lseek(fd, 0, SEEK_SET);
+
+    return fd;
+}
+
+TEST_F(TransportTest, parseHostNameWithPortTest) {
+    std::string local_server_name = "0.0.0.0:1234";
+    auto res = parseHostNameWithPort(local_server_name);
+    ASSERT_EQ(res.first, "0.0.0.0");
+    ASSERT_EQ(res.second, 1234);
+
+    local_server_name = "1.2.3.4:111111";
+    res = parseHostNameWithPort(local_server_name);
+    ASSERT_EQ(res.first, "1.2.3.4");
+    ASSERT_EQ(res.second, 12001);
+}
+
+TEST_F(TransportTest, WriteSuccess) {
+    int fd = CreateTempFile();
+    ASSERT_NE(fd, -1) << "Failed to create temporary file";
+
+    const char* testData = "Hello, World!";
+    size_t testDataLen = strlen(testData);
+
+    ssize_t result = writeFully(fd, testData, testDataLen);
+    EXPECT_EQ(result, static_cast<ssize_t>(testDataLen));
+
+    char buffer[256] = {0};
+    ssize_t nbytes = lseek(fd, 0, SEEK_SET);
+    (void)nbytes;
+    nbytes = read(fd, buffer, testDataLen);
+    (void)nbytes;
+    EXPECT_STREQ(buffer, testData);
+
+    close(fd);
+}
+
+TEST_F(TransportTest, WriteInvalidFD) {
+    const char* testData = "Hello, World!";
+    size_t testDataLen = strlen(testData);
+
+    ssize_t result = writeFully(-1, testData, testDataLen);
+    ASSERT_EQ(result, -1);
+    ASSERT_EQ(errno, EBADF);
+}
+
+TEST_F(TransportTest, PartialWrite) {
+    int fd = CreateTempFile();
+    ASSERT_NE(fd, -1) << "Failed to create temporary file";
+
+    const char* testData = "Hello, World!";
+    size_t testDataLen = strlen(testData);
+
+    ssize_t result = writeFully(fd, testData, testDataLen / 2);
+
+    ASSERT_EQ(result, static_cast<ssize_t>(testDataLen / 2));
+
+    char buffer[256] = {0};
+    lseek(fd, 0, SEEK_SET);
+    ssize_t nbytes = read(fd, buffer, result);
+    (void)nbytes;
+    ASSERT_EQ(strncmp(buffer, testData, result), 0);
+    close(fd);
+}
+
+TEST_F(TransportTest, ReadSuccess) {
+    const char* testData = "Hello, World!";
+    int fd = CreateTempFileWithContent(testData);
+    ASSERT_NE(fd, -1) << "Failed to create temporary file";
+
+    char buffer[256] = {0};
+    ssize_t bytesRead = readFully(fd, buffer, sizeof(buffer));
+
+    EXPECT_EQ(bytesRead, static_cast<ssize_t>(strlen(testData)));
+    EXPECT_STREQ(buffer, testData);
+
+    close(fd);
+}
+
+TEST_F(TransportTest, ReadInvalidFD) {
+    char buffer[256] = {0};
+    ssize_t bytesRead = readFully(-1, buffer, sizeof(buffer));
+    EXPECT_EQ(bytesRead, -1);
+    EXPECT_EQ(errno, EBADF);
+}
+
+TEST_F(TransportTest, PartialRead) {
+    const char* testData = "Hello, World!";
+    int fd = CreateTempFileWithContent(testData);
+    ASSERT_NE(fd, -1) << "Failed to create temporary file";
+
+    char buffer[256] = {0};
+    size_t half_len = strlen(testData) / 2;
+    ssize_t bytesRead = readFully(fd, buffer, half_len);
+
+    EXPECT_EQ(bytesRead, static_cast<ssize_t>(half_len));
+    EXPECT_EQ(strncmp(buffer, testData, half_len), 0);
+
+    close(fd);
+}
+
+TEST_F(TransportTest, ReadEmptyFile) {
+    int fd = CreateTempFileWithContent("");
+    ASSERT_NE(fd, -1) << "Failed to create temporary file";
+
+    char buffer[256] = {0};
+    ssize_t bytesRead = readFully(fd, buffer, sizeof(buffer));
+
+    EXPECT_EQ(bytesRead, static_cast<ssize_t>(0));
+
+    close(fd);
+}
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
According to issue #162, we recreate a pull request based on #134 #147. All modified code is in `mooncake-ngxl` directory.

---
This patch is the first stage of Transfer Engine's code refactoring.

Regarding that in many AI data centers, there are multiple link between two storage medias, we want Transfer Engine to use optimal link to reach higher throughput. E.g., two processes in one machine may use shared memory or nvlink transports.

But the current implementation requires to use EITHER rdma or TCP, which is not suitable for extension. Also, there are many dead code in the transport code. So I plan to refact the metadata & transport impl code to make Transfer Engine more organizable.

Overally, this patch changes the following things:

Metadata format, see mooncake-transfer-engine/include/segment.h, we also extract some code for coding & decoding segment desc in the seperte file.
We uniform terms SegmentID and SegmentHandle. In the future, we will remove the term local_server_name and replace it with local_segment_name to avoid ambiguous.
Add shared memory transports, currently only enable local-to-local data transfer, the remaining part will be fixed at stage 2
Remove dead code