### PR TITLE
[Fix] Fix issues with run path and etcd dependency integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
         cp build/mooncake-integration/*.so mooncake-wheel/mooncake
         cp build/mooncake-store/src/mooncake_master mooncake-wheel/mooncake
+        cp thirdparties/etcd-cpp-apiv3/build/src/libetcd-cpp-api.so mooncake-wheel/mooncake/lib_so/
         cd mooncake-wheel
         python -m build
         pip install dist/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
     - name: Build Python wheel
       run: |
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        mkdir mooncake-wheel/mooncake/lib_so/
         cp build/mooncake-integration/*.so mooncake-wheel/mooncake
         cp build/mooncake-store/src/mooncake_master mooncake-wheel/mooncake
         cp thirdparties/etcd-cpp-apiv3/build/src/libetcd-cpp-api.so mooncake-wheel/mooncake/lib_so/

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -19,6 +19,17 @@ pybind11_add_module(mooncake_vllm_adaptor ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
     vllm/vllm_adaptor.cpp 
     vllm/distributed_object_store.cpp
 )
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+ set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+ 
+ set_target_properties(mooncake_vllm_adaptor PROPERTIES
+     INSTALL_RPATH "$ORIGIN/lib_so"
+     BUILD_RPATH "$ORIGIN/lib_so"
+     SKIP_BUILD_RPATH FALSE
+ )
+ 
+
 target_link_libraries(mooncake_vllm_adaptor PUBLIC 
     transfer_engine 
     glog 


### PR DESCRIPTION
- Added `$ORIGIN/lib_so` as a runtime library search path (RUNPATH) to `mooncake_vllm_adaptor`, which has lower precedence than `LD_LIBRARY_PATH`.
- Fixed the issue where the etcd dependency (`libetcd-cpp-api.so`) was hardcoded into the mooncake-wheel.
 