### PR TITLE
[Enhance] Add an RPATH that takes precedence over LD_LIBRARY_PATH and other paths in the wheel package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,8 @@ jobs:
           cp build/mooncake-integration/*.so mooncake-wheel/mooncake
           cp build/mooncake-store/src/mooncake_master mooncake-wheel/mooncake
           cp thirdparties/etcd-cpp-apiv3/build/src/libetcd-cpp-api.so mooncake-wheel/mooncake/lib_so/
+          patchelf --set-rpath '$ORIGIN/lib_so' --force-rpath mooncake-wheel/mooncake/mooncake_master
+          patchelf --set-rpath '$ORIGIN/lib_so' --force-rpath mooncake-wheel/mooncake/*.so
           python -m build mooncake-wheel/
         env:
           VERSION: ${{ env.VERSION }}

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -34,7 +34,8 @@ sudo apt-get install -y build-essential \
                         pybind11-dev \
                         libcurl4-openssl-dev \
                         libhiredis-dev \
-                        pkg-config
+                        pkg-config \
+                        patchelf
                         
 pip install build setuptools wheel
 echo "*** Download and installing [cpprest sdk] ***"


### PR DESCRIPTION
The default search order now starts with RPATH, followed by LD_LIBRARY_PATH.