### PR TITLE
[TransferEngine] fix: avoid leaking Slice memory in RDMA transport

### DIFF
--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -76,6 +76,8 @@ class Transport {
 
     struct TransferTask;
 
+    // Slice must be allocated on heap, as it will delete self on markSuccess
+    // or markFailed.
     struct Slice {
         enum SliceStatus { PENDING, POSTED, SUCCESS, TIMEOUT, FAILED };
 
@@ -119,11 +121,13 @@ class Transport {
             status = Slice::SUCCESS;
             __sync_fetch_and_add(&task->transferred_bytes, length);
             __sync_fetch_and_add(&task->success_slice_count, 1);
+            delete this;
         }
 
         void markFailed() {
             status = Slice::FAILED;
             __sync_fetch_and_add(&task->failed_slice_count, 1);
+            delete this;
         }
     };
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -244,13 +244,18 @@ Status RdmaTransport::submitTransfer(BatchID batch_id,
                 break;
             }
             if (device_id < 0) {
+                auto source_addr = slice->source_addr;
+                delete slice;
+                for (auto &entry : slices_to_post)
+                    for (auto s : entry.second)
+                        delete s;
                 LOG(ERROR)
                     << "RdmaTransport: Address not registered by any device(s) "
-                    << slice->source_addr;
+                    << source_addr;
                 return Status::AddressNotRegistered(
                     "RdmaTransport: not registered by any device(s), address: "
                     + std::to_string(
-                        reinterpret_cast<uintptr_t>(slice->source_addr)));
+                        reinterpret_cast<uintptr_t>(source_addr)));
             }
         }
     }
@@ -300,13 +305,18 @@ Status RdmaTransport::submitTransferTask(
                 break;
             }
             if (device_id < 0) {
+                auto source_addr = slice->source_addr;
+                delete slice;
+                for (auto &entry : slices_to_post)
+                    for (auto s : entry.second)
+                        delete s;
                 LOG(ERROR)
                     << "RdmaTransport: Address not registered by any device(s) "
-                    << slice->source_addr;
+                    << source_addr;
                 return Status::AddressNotRegistered(
                     "RdmaTransport: not registered by any device(s), address: "
                     + std::to_string(
-                        reinterpret_cast<uintptr_t>(slice->source_addr)));
+                        reinterpret_cast<uintptr_t>(source_addr)));
             }
         }
     }


### PR DESCRIPTION
New slices are created/allocated in submitTransfer() and submitTransferTask(), but they're not freed after transfer, which results in memory leak as processing transfer tasks. I'm seeing memory accumulated in longterm stress testing.

Fix it by deleting such slices in WorkerPool::performPollCq(), after marking slice as done (either failed or success).