### PR TITLE
[TransferEngine] Use RDMA transport to transfer data in local process rapidly

### DIFF
--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -54,7 +54,8 @@ class TransferEngine {
 
     int init(const std::string &metadata_conn_string,
              const std::string &local_server_name,
-             const std::string &ip_or_host_name, uint64_t rpc_port = 12345);
+             const std::string &ip_or_host_name = "", 
+             uint64_t rpc_port = 12345);
 
     int freeEngine();
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -108,6 +108,21 @@ int RdmaEndPoint::setupConnectionsByActive() {
         LOG(INFO) << "Connection has been established";
         return 0;
     }
+
+    // loopback mode
+    if (context_.nicPath() == peer_nic_path_) {
+        auto segment_desc =
+            context_.engine().meta()->getSegmentDescByID(LOCAL_SEGMENT_ID);
+        if (segment_desc) {
+            for (auto &nic : segment_desc->devices)
+                if (nic.name == context_.deviceName())
+                    return doSetupConnection(nic.gid, nic.lid, qpNum());
+        }
+        LOG(ERROR) << "Peer NIC " << context_.deviceName()
+                   << " not found in localhost";
+        return ERR_DEVICE_NOT_FOUND;
+    }
+
     HandShakeDesc local_desc, peer_desc;
     local_desc.local_nic_path = context_.nicPath();
     local_desc.peer_nic_path = peer_nic_path_;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -399,7 +399,6 @@ int RdmaTransport::onSetupRdmaConnections(const HandShakeDesc &peer_desc,
 #ifdef CONFIG_ERDMA
     if (context->deleteEndpoint(peer_desc.local_nic_path)) return ERR_ENDPOINT;
 #endif
-
     auto endpoint = context->endpoint(peer_desc.local_nic_path);
     if (!endpoint) return ERR_ENDPOINT;
     return endpoint->setupConnectionsByPassive(peer_desc, local_desc);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -23,10 +23,6 @@
 #include "transport/rdma_transport/rdma_endpoint.h"
 #include "transport/rdma_transport/rdma_transport.h"
 
-#ifdef USE_CUDA
-#include <cuda_runtime.h>
-#endif  // USE_CUDA
-
 // Experimental: Per-thread SegmentDesc & EndPoint Caches
 // #define CONFIG_CACHE_SEGMENT_DESC
 // #define CONFIG_CACHE_ENDPOINT
@@ -203,33 +199,6 @@ void WorkerPool::performPostSend(int thread_id) {
     SliceList failed_slice_list;
     for (auto &entry : local_slice_queue) {
         if (entry.second.empty()) continue;
-
-        if (entry.second[0]->target_id == LOCAL_SEGMENT_ID) {
-            for (auto &slice : entry.second) {
-                LOG_ASSERT(slice->target_id == LOCAL_SEGMENT_ID);
-#ifdef USE_CUDA
-                if (slice->opcode == TransferRequest::READ)
-                    cudaMemcpy(slice->source_addr,
-                               (void *)slice->rdma.dest_addr, slice->length,
-                               cudaMemcpyDefault);
-                else
-                    cudaMemcpy((void *)slice->rdma.dest_addr,
-                               slice->source_addr, slice->length,
-                               cudaMemcpyDefault);
-#else
-                if (slice->opcode == TransferRequest::READ)
-                    memcpy(slice->source_addr, (void *)slice->rdma.dest_addr,
-                           slice->length);
-                else
-                    memcpy((void *)slice->rdma.dest_addr, slice->source_addr,
-                           slice->length);
-#endif
-                slice->markSuccess();
-            }
-            processed_slice_count_.fetch_add(entry.second.size());
-            entry.second.clear();
-            continue;
-        }
 
 #ifdef USE_FAKE_POST_SEND
         for (auto &slice : entry.second) slice->markSuccess();

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(rdma_transport_test2 rdma_transport_test2.cpp)
 target_link_libraries(rdma_transport_test2 PUBLIC transfer_engine gtest gtest_main )
 # add_test(NAME rdma_transport_test2 COMMAND rdma_transport_test2)
 
+add_executable(rdma_loopback_test rdma_loopback_test.cpp)
+target_link_libraries(rdma_loopback_test PUBLIC transfer_engine gtest gtest_main )
+# add_test(NAME rdma_loopback_test COMMAND rdma_loopback_test)
+
 if (USE_NVMEOF)
     add_executable(nvmeof_transport_test nvmeof_transport_test.cpp)
     target_link_libraries(nvmeof_transport_test PUBLIC transfer_engine gtest gtest_main )

--- a/mooncake-transfer-engine/tests/rdma_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_loopback_test.cpp
@@ -1,0 +1,99 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <sys/time.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+
+#include "transfer_engine.h"
+#include "transport/transport.h"
+
+using namespace mooncake;
+
+namespace mooncake {
+
+DEFINE_string(metadata_server, "127.0.0.1:2379",
+              "central metadata server for transfer engine");
+
+class RDMALoopbackTest : public ::testing::Test {
+   public:
+    void *addr = nullptr;
+    std::pair<std::string, uint16_t> hostname_port;
+    std::unique_ptr<mooncake::TransferEngine> engine;
+    const size_t ram_buffer_size = 1ull << 30;
+
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("RDMALoopbackTest");
+        FLAGS_logtostderr = 1;
+        engine = std::make_unique<TransferEngine>(true);
+        engine->init(FLAGS_metadata_server, "test_node");
+        addr = numa_alloc_onnode(ram_buffer_size, 0);
+        int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+        ASSERT_EQ(rc, 0);
+    }
+
+    void TearDown() override {
+        google::ShutdownGoogleLogging();
+        engine->unregisterLocalMemory(addr);
+        numa_free(addr, ram_buffer_size);
+    }
+};
+
+TEST_F(RDMALoopbackTest, MultiWrite) {
+    const size_t kDataLength = 4096000;
+    int times = 200;
+    while (times--) {
+        for (size_t offset = 0; offset < kDataLength; ++offset)
+            *((char *)(addr) + offset) = 'a' + lrand48() % 26;
+        auto batch_id = engine->allocateBatchID(1);
+        Status s;
+        TransferRequest entry;
+        entry.opcode = TransferRequest::WRITE;
+        entry.length = kDataLength;
+        entry.source = (uint8_t *)(addr);
+        entry.target_id = LOCAL_SEGMENT_ID;
+        entry.target_offset = (uint64_t)addr + kDataLength;
+        s = engine->submitTransfer(batch_id, {entry});
+        LOG_ASSERT(s.ok());
+        bool completed = false;
+        TransferStatus status;
+        while (!completed) {
+            Status s = engine->getTransferStatus(batch_id, 0, status);
+            ASSERT_EQ(s, Status::OK());
+            if (status.s == TransferStatusEnum::COMPLETED)
+                completed = true;
+            else if (status.s == TransferStatusEnum::FAILED) {
+                LOG(INFO) << "FAILED";
+                completed = true;
+            }
+        }
+        s = engine->freeBatchID(batch_id);
+        ASSERT_EQ(s, Status::OK());
+        ASSERT_EQ(0, memcmp(addr, (char *) addr + kDataLength, kDataLength));
+    }
+}
+}  // namespace mooncake
+
+int main(int argc, char **argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
... which is faster than memcpy in many cases