### PR TITLE
[Bugfix] mooncake-common: fix error pointer handling in CGO interfaces​​

### DIFF
--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -19,11 +19,11 @@ var (
 )
 
 //export NewEtcdClient
-func NewEtcdClient(endpoints *C.char, errMsg *C.char) int {
+func NewEtcdClient(endpoints *C.char, errMsg **C.char) int {
 	mutex.Lock()
 	defer mutex.Unlock()
 	if globalClient != nil {
-		errMsg = C.CString("etcd client can be initialized only once")
+		*errMsg = C.CString("etcd client can be initialized only once")
 		return -1
 	}
 
@@ -34,7 +34,7 @@ func NewEtcdClient(endpoints *C.char, errMsg *C.char) int {
 	})
 
 	if err != nil {
-		errMsg = C.CString(err.Error())
+		*errMsg = C.CString(err.Error())
 		return -1
 	}
 
@@ -43,9 +43,9 @@ func NewEtcdClient(endpoints *C.char, errMsg *C.char) int {
 }
 
 //export EtcdPutWrapper
-func EtcdPutWrapper(key *C.char, value *C.char, errMsg *C.char) int {
+func EtcdPutWrapper(key *C.char, value *C.char, errMsg **C.char) int {
 	if globalClient == nil {
-		errMsg = C.CString("etcd client not initialized")
+		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
 	k := C.GoString(key)
@@ -54,16 +54,16 @@ func EtcdPutWrapper(key *C.char, value *C.char, errMsg *C.char) int {
     defer cancel()
 	_, err := globalClient.Put(ctx, k, v)
 	if err != nil {
-		errMsg = C.CString(err.Error())
+		*errMsg = C.CString(err.Error())
 		return -1
 	}
 	return 0
 }
 
 //export EtcdGetWrapper
-func EtcdGetWrapper(key *C.char, value **C.char, errMsg *C.char) int {
+func EtcdGetWrapper(key *C.char, value **C.char, errMsg **C.char) int {
 	if globalClient == nil {
-		errMsg = C.CString("etcd client not initialized")
+		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
 	k := C.GoString(key)
@@ -71,7 +71,7 @@ func EtcdGetWrapper(key *C.char, value **C.char, errMsg *C.char) int {
     defer cancel()
 	resp, err := globalClient.Get(ctx, k)
 	if err != nil {
-		errMsg = C.CString(err.Error())
+		*errMsg = C.CString(err.Error())
 		return -1
 	}
 	if len(resp.Kvs) == 0 {
@@ -84,9 +84,9 @@ func EtcdGetWrapper(key *C.char, value **C.char, errMsg *C.char) int {
 }
 
 //export EtcdDeleteWrapper
-func EtcdDeleteWrapper(key *C.char, errMsg *C.char) int {
+func EtcdDeleteWrapper(key *C.char, errMsg **C.char) int {
 	if globalClient == nil {
-		errMsg = C.CString("etcd client not initialized")
+		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
 	k := C.GoString(key)
@@ -94,7 +94,7 @@ func EtcdDeleteWrapper(key *C.char, errMsg *C.char) int {
     defer cancel()
 	_, err := globalClient.Delete(ctx, k)
 	if err != nil {
-		errMsg = C.CString(err.Error())
+		*errMsg = C.CString(err.Error())
 		return -1
 	}
 	return 0

--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -349,7 +349,7 @@ struct EtcdStoragePlugin : public MetadataStoragePlugin {
 struct EtcdStoragePlugin : public MetadataStoragePlugin {
     EtcdStoragePlugin(const std::string &metadata_uri)
         : metadata_uri_(metadata_uri) {
-        auto ret = NewEtcdClient((char *)metadata_uri_.c_str(), err_msg_);
+        auto ret = NewEtcdClient((char *)metadata_uri_.c_str(), &err_msg_);
         if (ret) {
             LOG(ERROR) << "EtcdStoragePlugin: unable to connect "
                        << metadata_uri_ << ": " << err_msg_;
@@ -364,7 +364,7 @@ struct EtcdStoragePlugin : public MetadataStoragePlugin {
     virtual bool get(const std::string &key, Json::Value &value) {
         Json::Reader reader;
         char *json_data = nullptr;
-        auto ret = EtcdGetWrapper((char *)key.c_str(), &json_data, err_msg_);
+        auto ret = EtcdGetWrapper((char *)key.c_str(), &json_data, &err_msg_);
         if (ret) {
             LOG(ERROR) << "EtcdStoragePlugin: unable to get " << key << " in "
                        << metadata_uri_ << ": " << err_msg_;
@@ -393,7 +393,7 @@ struct EtcdStoragePlugin : public MetadataStoragePlugin {
         Json::FastWriter writer;
         const std::string json_file = writer.write(value);
         auto ret = EtcdPutWrapper((char *)key.c_str(),
-                                  (char *)json_file.c_str(), err_msg_);
+                                  (char *)json_file.c_str(), &err_msg_);
         if (ret) {
             LOG(ERROR) << "EtcdStoragePlugin: unable to set " << key << " in "
                        << metadata_uri_ << ": " << err_msg_;
@@ -409,7 +409,7 @@ struct EtcdStoragePlugin : public MetadataStoragePlugin {
     }
 
     virtual bool remove(const std::string &key) {
-        auto ret = EtcdDeleteWrapper((char *)key.c_str(), err_msg_);
+        auto ret = EtcdDeleteWrapper((char *)key.c_str(), &err_msg_);
         if (ret) {
             LOG(ERROR) << "EtcdStoragePlugin: unable to remove " << key
                        << " in " << metadata_uri_ << ": " << err_msg_;


### PR DESCRIPTION
- Change `errMsg` params to `​**​C.char` in Go wrapper
- Add `&` operator in C++ callsites
- Fixes: error message propagation