### PR TITLE
chore: use git submodule to manage pybind11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         sudo apt update -y
         sudo bash -x dependencies.sh -y
         pip install build setuptools wheel
+        git submodule update --init
         mkdir build
         cd build
         cmake .. -DUSE_HTTP=ON

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
         run: |
           sudo apt update -y
           sudo bash -x dependencies.sh -y
+          git submodule update --init
           mkdir build
           cd build
           cmake .. -DUSE_HTTP=ON

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "extern/pybind11"]
+	path = extern/pybind11
+	url = ../../pybind/pybind11
+	branch = stable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,17 +42,13 @@ option(WITH_STORE "build mooncake store library and sample code" ON)
 option(WITH_P2P_STORE "build p2p store library and sample code" OFF)
 option(WITH_RUST_EXAMPLE "build the Rust interface and sample code for the transfer engine" OFF)
 
-find_package(Python3 REQUIRED Interpreter Development)
-find_package(pybind11 REQUIRED)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extern/pybind11)
 set(PYTHON_EXECUTABLE "python3")
 execute_process(
     COMMAND ${PYTHON_EXECUTABLE} -c "import sys; print(sys.path[-1])"
     OUTPUT_VARIABLE PYTHON_SYS_PATH
 )
 string(STRIP ${PYTHON_SYS_PATH} PYTHON_SYS_PATH)
-
-set(PYBIND11_FINDPYTHON ON)
-find_package(pybind11 CONFIG REQUIRED)
 
 if (USE_CUDA)
   add_compile_definitions(USE_CUDA)
@@ -101,7 +97,6 @@ include_directories(mooncake-transfer-engine/include)
 
 if (WITH_STORE)
   message(STATUS "Mooncake Store will be build")
-  find_package(pybind11 CONFIG REQUIRED)
   add_subdirectory(mooncake-store)
   include_directories(mooncake-store/include)
 endif()

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -116,7 +116,6 @@ SYSTEM_PACKAGES="build-essential \
                   libgrpc++-dev \
                   libprotobuf-dev \
                   protobuf-compiler-grpc \
-                  pybind11-dev \
                   libcurl4-openssl-dev \
                   libhiredis-dev \
                   pkg-config \

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -17,8 +17,6 @@ include_directories("../mooncake-store/include/cachelib_memory_allocator/include
 include_directories("../mooncake-store/include/cachelib_memory_allocator/fake_include")
 
 
-set(PYBIND11_FINDPYTHON ON)
-find_package(pybind11 CONFIG REQUIRED) 
 pybind11_add_module(mooncake_vllm_adaptor ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
     vllm/vllm_adaptor.cpp 
     vllm/distributed_object_store.cpp


### PR DESCRIPTION
Because the version of pybind11 automatically installed by Ubuntu 22.04 is relatively outdated and offers limited support for Python 3.12, use CMake to retrieve a more recent version of pybind11.