### PR TITLE
[TransferEngine] Add whitelist to the auto topology detection

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -15,11 +15,7 @@
 #include "transfer_engine_py.h"
 
 #include <cassert>
-
-#ifdef USE_CUDA
-#include <bits/stdint-uintn.h>
-#include <cuda_runtime.h>
-#endif
+#include <fstream>
 
 TransferEnginePy::TransferEnginePy() {}
 
@@ -33,22 +29,14 @@ TransferEnginePy::~TransferEnginePy() {
     large_buffer_list_.clear();
 }
 
-std::string formatDeviceNames(const std::string &device_names) {
+std::vector<std::string> buildDeviceFilter(const std::string &device_names) {
     std::stringstream ss(device_names);
     std::string item;
     std::vector<std::string> tokens;
     while (getline(ss, item, ',')) {
         tokens.push_back(item);
     }
-
-    std::string formatted;
-    for (size_t i = 0; i < tokens.size(); ++i) {
-        formatted += "\"" + tokens[i] + "\"";
-        if (i < tokens.size() - 1) {
-            formatted += ",";
-        }
-    }
-    return formatted;
+    return tokens;
 }
 
 std::pair<std::string, std::string> parseConnectionString(
@@ -99,14 +87,12 @@ int TransferEnginePy::initializeExt(const char *local_hostname,
                                     const char *protocol,
                                     const char *device_name,
                                     const char *metadata_type) {
+    (void)(protocol);
     std::string conn_string = buildConnString(metadata_type, metadata_server);
 
-    auto_discovery_ = false;
-    if (device_name == nullptr || strlen(device_name) == 0) {
-        auto_discovery_ = true;
-    }
-
-    engine_ = std::make_unique<TransferEngine>(auto_discovery_);
+    auto device_name_safe = device_name ? std::string(device_name) : "";
+    auto device_filter = buildDeviceFilter(device_name_safe);
+    engine_ = std::make_unique<TransferEngine>(true, device_filter);
     if (getenv("MC_LEGACY_RPC_PORT_BINDING")) {
         auto hostname_port = parseHostNameWithPort(local_hostname);
         int ret =
@@ -117,28 +103,6 @@ int TransferEnginePy::initializeExt(const char *local_hostname,
         // the last two params are unused
         int ret = engine_->init(conn_string, local_hostname, "", 0);
         if (ret) return -1;
-    }
-
-    if (!auto_discovery_) {
-        xport_ = nullptr;
-        if (strcmp(protocol, "rdma") == 0) {
-            auto device_names = formatDeviceNames(device_name);
-            std::string nic_priority_matrix = "{\"cpu:0\": [[" + device_names +
-                                              "], []],"
-                                              "\"cuda:0\": [[" +
-                                              device_names + "], []]}";
-            void **args = (void **)malloc(2 * sizeof(void *));
-            args[0] = (void *)nic_priority_matrix.c_str();
-            args[1] = nullptr;
-            xport_ = engine_->installTransport("rdma", args);
-        } else if (strcmp(protocol, "tcp") == 0) {
-            xport_ = engine_->installTransport("tcp", nullptr);
-        } else {
-            LOG(ERROR) << "Unsupported protocol";
-            return -1;
-        }
-
-        if (!xport_) return -1;
     }
 
     free_list_.resize(kSlabSizeKBTabLen);
@@ -337,18 +301,6 @@ int TransferEnginePy::transferSync(const char *target_hostname,
 
 int TransferEnginePy::registerMemory(uintptr_t buffer_addr, size_t capacity) {
     char *buffer = reinterpret_cast<char *>(buffer_addr);
-    if (!auto_discovery_) {
-        std::string location = "cpu:0";
-#ifdef USE_CUDA
-        // check pointer on GPU
-        cudaPointerAttributes attributes;
-        cudaPointerGetAttributes(&attributes, buffer);
-        if (attributes.type == cudaMemoryTypeDevice) {
-            location = "cuda:0";
-        }
-#endif
-        return engine_->registerLocalMemory(buffer, capacity, location);
-    }
     return engine_->registerLocalMemory(buffer, capacity);
 }
 

--- a/mooncake-transfer-engine/include/topology.h
+++ b/mooncake-transfer-engine/include/topology.h
@@ -64,7 +64,12 @@ class Topology {
 
     void clear();
 
-    int discover();
+    int discover() {
+        std::vector<std::string> filter;
+        return discover(filter);
+    }
+
+    int discover(const std::vector<std::string> &filter);
 
     int parse(const std::string &topology_json);
 

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -51,6 +51,12 @@ class TransferEngine {
           local_topology_(std::make_shared<Topology>()),
           auto_discover_(auto_discover) {}
 
+    TransferEngine(bool auto_discover, const std::vector<std::string> &filter)
+        : metadata_(nullptr),
+          local_topology_(std::make_shared<Topology>()),
+          auto_discover_(auto_discover),
+          filter_(filter) {}
+
     ~TransferEngine() { freeEngine(); }
 
     int init(const std::string &metadata_conn_string,
@@ -126,6 +132,7 @@ class TransferEngine {
     // Discover topology and install transports automatically when it's true.
     // Set it to false only for testing.
     bool auto_discover_;
+    std::vector<std::string> filter_;
 };
 }  // namespace mooncake
 

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -288,6 +288,8 @@ int Topology::selectDevice(const std::string storage_type, int retry_count) {
 }
 
 int Topology::resolve() {
+    resolved_matrix_.clear();
+    hca_list_.clear();
     std::map<std::string, int> hca_id_map;
     int next_hca_map_index = 0;
     for (auto &entry : matrix_) {
@@ -316,5 +318,20 @@ int Topology::resolve() {
         }
     }
     return 0;
+}
+
+int Topology::disableDevice(const std::string &device_name) {
+    for (auto &record : matrix_) {
+        auto &preferred_hca = record.second.preferred_hca;
+        auto preferred_hca_iter =
+            std::find(preferred_hca.begin(), preferred_hca.end(), device_name);
+        if (preferred_hca_iter != preferred_hca.end())
+            preferred_hca.erase(preferred_hca_iter);
+        auto &avail_hca = record.second.avail_hca;
+        auto avail_hca_iter =
+            std::find(avail_hca.begin(), avail_hca.end(), device_name);
+        if (avail_hca_iter != avail_hca.end()) avail_hca.erase(avail_hca_iter);
+    }
+    return resolve();
 }
 }  // namespace mooncake

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -17,7 +17,20 @@
 #include "transfer_metadata_plugin.h"
 #include "transport/transport.h"
 
+#include <fstream>
+
 namespace mooncake {
+static std::string loadTopologyJsonFile(const std::string &path) {
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return "";
+    }
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    std::string content = buffer.str();
+    file.close();
+    return content;
+}
 
 int TransferEngine::init(const std::string &metadata_conn_string,
                          const std::string &local_server_name,
@@ -83,7 +96,19 @@ int TransferEngine::init(const std::string &metadata_conn_string,
 
     if (auto_discover_) {
         // discover topology automatically
-        local_topology_->discover();
+        if (getenv("MC_CUSTOM_TOPO_JSON")) {
+            auto path = getenv("MC_CUSTOM_TOPO_JSON");
+            auto topo_json = loadTopologyJsonFile(path);
+            if (!topo_json.empty())
+                local_topology_->parse(topo_json);
+            else {
+                LOG(WARNING) << "Unable to read custom topology file from "
+                             << path << ", fall back to auto-detect";
+                local_topology_->discover(filter_);
+            }
+        } else {
+            local_topology_->discover(filter_);
+        }
 
         if (local_topology_->getHcaList().size() > 0) {
             // only install RDMA transport when there is at least one HCA


### PR DESCRIPTION
When user specify the `device_name` in the init function, the auto topology detection algorithm will use only the device listed. If a device failed to open, it will be removed from the topology internally.