### PR TITLE
[FIX] Fix build error of stress_workload_test.cpp

### DIFF
--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -23,13 +23,13 @@ pybind11_add_module(mooncake_vllm_adaptor ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
 )
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
- set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
- 
- set_target_properties(mooncake_vllm_adaptor PROPERTIES
-     INSTALL_RPATH "$ORIGIN/lib_so"
-     BUILD_RPATH "$ORIGIN/lib_so"
-     SKIP_BUILD_RPATH FALSE
- )
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+
+set_target_properties(mooncake_vllm_adaptor PROPERTIES
+    INSTALL_RPATH "$ORIGIN/lib_so"
+    BUILD_RPATH "$ORIGIN/lib_so"
+    SKIP_BUILD_RPATH FALSE
+)
  
 
 target_link_libraries(mooncake_vllm_adaptor PUBLIC 

--- a/mooncake-store/tests/stress_workload_test.cpp
+++ b/mooncake-store/tests/stress_workload_test.cpp
@@ -1,3 +1,4 @@
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <numa.h>


### PR DESCRIPTION
There is a build error in stress_workload_test.cpp. It looks like that gflags header is missing.
![image](https://github.com/user-attachments/assets/1311c5a0-1bfb-4c58-8a53-8b1540f428ac)
