### PR TITLE
[TransferEngine] build: support build transfer engine independently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
 project(mooncake CXX C)
 
+# indicates cmake is invoked from top-level dir
+set(GLOBAL_CONFIG "true")
+
 option(ENABLE_CCACHE "Whether to open ccache" OFF)
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND AND ENABLE_CCACHE)
@@ -9,7 +12,13 @@ if(CCACHE_FOUND AND ENABLE_CCACHE)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif()
 
-enable_testing()
+option(BUILD_EXAMPLES "Build examples" ON)
+
+# unit test
+option(BUILD_UNIT_TESTS "Build unit tests" ON)
+if (BUILD_UNIT_TESTS)
+  enable_testing()
+endif()
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 20)
@@ -86,7 +95,7 @@ if (USE_ETCD)
 endif()
 
 if (NOT USE_ETCD AND NOT USE_REDIS AND NOT USE_HTTP)
-  message(FATAL_ERROR "Please enable at least one metadata type: USE_ETCD, USE_REDIS, or USE_HTTP")
+  message(STATUS "None of USE_ETCD, USE_REDIS, USE_HTTP is selected, only \"P2PHANDSHAKE\" is supported as metadata server")
 endif()
 
 add_subdirectory(mooncake-common)

--- a/doc/en/build.md
+++ b/doc/en/build.md
@@ -124,8 +124,10 @@ The following options can be used during `cmake ..` to specify whether to compil
 - `-DUSE_CUDA=[ON|OFF]`: Enable GPU Direct RDMA and NVMe-of support
 - `-DUSE_CXL=[ON|OFF]`: Enable CXL support
 - `-DWITH_STORE=[ON|OFF]`: Build Mooncake Store component
-- `-DWITH_P2P_STORE=[ON|OFF]`: Enable Golang support and build P2P Store component, note go 1.22+
+- `-DWITH_P2P_STORE=[ON|OFF]`: Enable Golang support and build P2P Store component, note go 1.23+
 - `-DWITH_WITH_RUST_EXAMPLE=[ON|OFF]`: Enable Rust support
 - `-DUSE_REDIS=[ON|OFF]`: Enable Redis-based metadata service
 - `-DUSE_HTTP=[ON|OFF]`: Enable Http-based metadata service
 - `-DBUILD_SHARED_LIBS=[ON|OFF]`: Build Transfer Engine as shared library, default is OFF
+- `-DBUILD_UNIT_TESTS=[ON|OFF]`: Build unit tests, default is ON
+- `-DBUILD_EXAMPLES=[ON|OFF]`: Build examples, default is ON

--- a/doc/zh/build.md
+++ b/doc/zh/build.md
@@ -113,8 +113,10 @@
 - `-DUSE_CUDA=[ON|OFF]`: 启用 GPU Direct RDMA 及 NVMe-of 支持
 - `-DUSE_CXL=[ON|OFF]`: 启用 CXL 支持
 - `-DWITH_STORE=[ON|OFF]`: 编译 Mooncake Store 组件
-- `-DWITH_P2P_STORE=[ON|OFF]`: 启用 Golang 支持并编译 P2P Store 组件，注意 go 1.22+
+- `-DWITH_P2P_STORE=[ON|OFF]`: 启用 Golang 支持并编译 P2P Store 组件，注意 go 1.23+
 - `-DWITH_WITH_RUST_EXAMPLE=[ON|OFF]`: 启用 Rust 支持
 - `-DUSE_REDIS=[ON|OFF]`: 启用基于 Redis 的元数据服务
 - `-DUSE_HTTP=[ON|OFF]`: 启用基于 Http 的元数据服务
 - `-DBUILD_SHARED_LIBS=[ON|OFF]`: 将 Transfer Engine 编译为共享库，默认为 OFF
+- `-DBUILD_UNIT_TESTS=[ON|OFF]`: 编译单元测试，默认为 ON
+- `-DBUILD_EXAMPLES=[ON|OFF]`: 编译示例程序，默认为 ON

--- a/mooncake-transfer-engine/CMakeLists.txt
+++ b/mooncake-transfer-engine/CMakeLists.txt
@@ -1,8 +1,77 @@
+cmake_minimum_required(VERSION 3.16)
+project(mooncake-transfer-engine)
+
+if (NOT GLOBAL_CONFIG)
+  set(CMAKE_C_STANDARD 99)
+  set(CMAKE_CXX_STANDARD 20)
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Wno-unused-parameter -fPIC")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -Wno-unused-parameter -fPIC")
+
+  set(CMAKE_C_FLAGS_RELEASE "-O3")
+  set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+
+  set(CMAKE_C_FLAGS_DEBUG "-O0")
+  set(CMAKE_CXX_FLAGS_DEBUG "-O0")
+
+  set(CMAKE_BUILD_TYPE "Release")
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+  option(BUILD_UNIT_TESTS "Build uint tests" ON)
+  option(USE_ETCD "Option for enabling etcd as metadata server" OFF)
+  option(USE_ETCD_LEGACY "option for enable etcd based on etcd-cpp-api-v3" OFF)
+  option(USE_CUDA "option for using gpu direct" OFF)
+  option(USE_NVMEOF "option for using NVMe over Fabric" OFF)
+  option(USE_CXL "option for using cxl protocol" OFF)
+  option(USE_REDIS "option for enable redis as metadata server" OFF)
+  option(USE_HTTP "option for enable http as metadata server" ON)
+  option(WITH_RUST_EXAMPLE "build the Rust interface and sample code for the transfer engine" OFF)
+
+  add_definitions(-DCONFIG_ERDMA)
+
+  if (USE_CUDA)
+    add_compile_definitions(USE_CUDA)
+    message(STATUS "CUDA support is enabled")
+
+    if (USE_NVMEOF)
+      add_compile_definitions(USE_NVMEOF)
+      message(STATUS "NVMe-oF support is enabled")
+    endif()
+
+    include_directories(/usr/local/cuda/include)
+    link_directories(/usr/local/cuda/lib /usr/local/cuda/lib64)
+  elseif(USE_NVMEOF)
+    message(FATAL_ERROR "Cannot enable USE_NVMEOF without USE_CUDA")
+  endif()
+
+  if (USE_REDIS)
+    add_compile_definitions(USE_REDIS)
+    message(STATUS "Redis as metadata server support is enabled")
+  endif()
+
+  if (USE_HTTP)
+    add_compile_definitions(USE_HTTP)
+    message(STATUS "Http as metadata server support is enabled")
+  endif()
+
+  if (USE_ETCD)
+    message(FATAL_ERROR "Cannot enable USE_ETCD while building transfer engine independently")
+  endif()
+
+endif() # GLOBAL_CONFIG
+
 include_directories(include)
 add_subdirectory(include)
 add_subdirectory(src)
-add_subdirectory(tests)
-add_subdirectory(example)
+
+if (BUILD_UNIT_TESTS)
+  add_subdirectory(tests)
+endif()
+
+if (BUILD_EXAMPLES)
+  add_subdirectory(example)
+endif()
+
 if (WITH_RUST_EXAMPLE)
   add_subdirectory(rust)
 endif()


### PR DESCRIPTION
In case we want to build transfer engine only, enhance transfer engine CMakeLists.txt to support building transfer engine indepedently. e.g.

```bash
cd mooncake-transfer-engine
mkdir build
cd build
cmake .. -DUSE_REDIS=OFF -DBUILD_UNIT_TESTS=OFF
make -j
```

Also introduce new build options, BUILD_UNIT_TESTS and BUILD_EXAMPLES, and add them to doc.