### PR TITLE
[TransferEngine] build: add USE_TCP option to control enable tcp transport or not

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(USE_CUDA "option for using gpu direct" OFF)
 option(USE_NVMEOF "option for using NVMe over Fabric" OFF)
+option(USE_TCP "option for using TCP transport" ON)
 option(USE_CXL "option for using cxl protocol" OFF)
 option(USE_ETCD "option for enable etcd as metadata server" ON)
 option(USE_ETCD_LEGACY "option for enable etcd based on etcd-cpp-api-v3" OFF)
@@ -72,6 +73,10 @@ if (USE_CUDA)
   link_directories(/usr/local/cuda/lib /usr/local/cuda/lib64)
 elseif(USE_NVMEOF)
   message(FATAL_ERROR "Cannot enable USE_NVMEOF without USE_CUDA")
+endif()
+
+if (USE_TCP)
+  add_compile_definitions(USE_TCP)
 endif()
 
 if (USE_REDIS)

--- a/mooncake-transfer-engine/CMakeLists.txt
+++ b/mooncake-transfer-engine/CMakeLists.txt
@@ -22,12 +22,17 @@ if (NOT GLOBAL_CONFIG)
   option(USE_ETCD_LEGACY "option for enable etcd based on etcd-cpp-api-v3" OFF)
   option(USE_CUDA "option for using gpu direct" OFF)
   option(USE_NVMEOF "option for using NVMe over Fabric" OFF)
+  option(USE_TCP "option for using TCP transport" ON)
   option(USE_CXL "option for using cxl protocol" OFF)
   option(USE_REDIS "option for enable redis as metadata server" OFF)
   option(USE_HTTP "option for enable http as metadata server" ON)
   option(WITH_RUST_EXAMPLE "build the Rust interface and sample code for the transfer engine" OFF)
 
   add_definitions(-DCONFIG_ERDMA)
+
+  if (USE_TCP)
+    add_compile_definitions(USE_TCP)
+  endif()
 
   if (USE_CUDA)
     add_compile_definitions(USE_CUDA)

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -15,7 +15,9 @@
 #include "multi_transport.h"
 
 #include "transport/rdma_transport/rdma_transport.h"
+#ifdef USE_TCP
 #include "transport/tcp_transport/tcp_transport.h"
+#endif
 #include "transport/transport.h"
 #ifdef USE_NVMEOF
 #include "transport/nvmeof_transport/nvmeof_transport.h"
@@ -128,9 +130,12 @@ Transport *MultiTransport::installTransport(const std::string &proto,
     Transport *transport = nullptr;
     if (std::string(proto) == "rdma") {
         transport = new RdmaTransport();
-    } else if (std::string(proto) == "tcp") {
+    }
+#ifdef USE_TCP
+    else if (std::string(proto) == "tcp") {
         transport = new TcpTransport();
     }
+#endif
 #ifdef USE_NVMEOF
     else if (std::string(proto) == "nvmeof") {
         transport = new NVMeoFTransport();

--- a/mooncake-transfer-engine/src/transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/CMakeLists.txt
@@ -3,8 +3,10 @@ file(GLOB XPORT_SOURCES "*.cpp")
 add_subdirectory(rdma_transport)
 add_library(transport OBJECT ${XPORT_SOURCES} $<TARGET_OBJECTS:rdma_transport>)
 
-add_subdirectory(tcp_transport)
-target_sources(transport PUBLIC $<TARGET_OBJECTS:tcp_transport>)
+if (USE_TCP)
+  add_subdirectory(tcp_transport)
+  target_sources(transport PUBLIC $<TARGET_OBJECTS:tcp_transport>)
+endif()
 
 if (USE_NVMEOF)
   add_subdirectory(nvmeof_transport)

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -20,9 +20,11 @@ if (USE_NVMEOF)
     # add_test(NAME nvmeof_transport_test COMMAND nvmeof_transport_test)
 endif()
 
+if (USE_TCP)
 add_executable(tcp_transport_test tcp_transport_test.cpp)
 target_link_libraries(tcp_transport_test PUBLIC transfer_engine gtest gtest_main )
 add_test(NAME tcp_transport_test COMMAND tcp_transport_test)
+endif()
 
 add_executable(transfer_metadata_test transfer_metadata_test.cpp)
 target_link_libraries(transfer_metadata_test PUBLIC transfer_engine gtest gtest_main)


### PR DESCRIPTION
It's easier to use only RDMA transport.