### PR TITLE
[TransferEngine] only dump metadata on the last selectDevice failure

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -116,14 +116,14 @@ int WorkerPool::submitPostSend(
                 continue;
             }
 
-            context_.engine().meta()->dumpMetadataContent(
-                peer_segment_desc->name, slice->rdma.dest_addr,
-                slice->length);
-
             if (RdmaTransport::selectDevice(
                     peer_segment_desc.get(), slice->rdma.dest_addr,
                     slice->length, buffer_id, device_id)) {
                 slice->markFailed();
+
+                context_.engine().meta()->dumpMetadataContent(
+                    peer_segment_desc->name, slice->rdma.dest_addr,
+                    slice->length);
                 continue;
             }
         }


### PR DESCRIPTION
We selectDevice() according to peer segment desc, and will force update segmeng desc if this fails, then try selectDevice() for the second time, which normally succeeds.

But currently we dump metadata content on first selectDevice() failure, which is mostly like a transient failure. So let's dump metadata only on the last selectDevice() failure.