### PR TITLE
[TransferEngine] Fix memory leak problem in ThreadLocalSliceCache

### DIFF
--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -156,7 +156,6 @@ class Transport {
             }
             auto slice = lazy_delete_slices_[tail_ % kLazyDeleteSliceCapacity];
             tail_++;
-            new (slice) Slice();
             return slice;
         }
 


### PR DESCRIPTION
We found that `new (slice) Slice()` introduces memory leak. After allocating slice objects, user code will reinitialize the structure. So it's safe to remove this line.