### PR TITLE
feat: Optimize pybind11 interface with zero-copy path handling 

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -579,7 +579,7 @@ PYBIND11_MODULE(store, m) {
                 // Return the consolidated pointer as an integer for Python
                 return reinterpret_cast<uintptr_t>(self.consolidated_ptr());
             },
-            py::call_guard<py::gil_scoped_acquire>());
+            py::call_guard<py::gil_scoped_release>());
 
     // Define the DistributedObjectStore class
     py::class_<DistributedObjectStore>(m, "MooncakeDistributedStore")

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -96,10 +96,7 @@ void ResourceTracker::signalHandler(int signal) {
     raise(signal);
 }
 
-void ResourceTracker::exitHandler() {
-    LOG(INFO) << "Process exiting, cleaning up resources";
-    getInstance().cleanupAllResources();
-}
+void ResourceTracker::exitHandler() { getInstance().cleanupAllResources(); }
 
 static bool isPortAvailable(int port) {
     int sock = socket(AF_INET, SOCK_STREAM, 0);
@@ -127,7 +124,6 @@ static int getRandomAvailablePort(int min_port = 12300, int max_port = 14300) {
 
     for (int attempts = 0; attempts < 10; attempts++) {
         int port = dis(gen);
-        std::cout << "port is " << port << std::endl;
         if (isPortAvailable(port)) {
             return port;
         }
@@ -431,12 +427,169 @@ int64_t DistributedObjectStore::getSize(const std::string &key) {
     return total_size;
 }
 
+// SliceBuffer implementation
+SliceBuffer::SliceBuffer(DistributedObjectStore &store,
+                         std::vector<mooncake::Slice> slices,
+                         uint64_t total_size)
+    : store_(store), slices_(std::move(slices)), total_size_(total_size) {}
+
+SliceBuffer::~SliceBuffer() {
+    if (consolidated_buffer_) {
+        delete[] consolidated_buffer_;
+        consolidated_buffer_ = nullptr;
+    }
+
+    // Free all slices
+    store_.freeSlices(slices_);
+}
+
+void *SliceBuffer::ptr() const {
+    if (slices_.empty()) {
+        return nullptr;
+    }
+    return slices_[0].ptr;
+}
+
+uint64_t SliceBuffer::size() const { return total_size_; }
+
+bool SliceBuffer::is_contiguous() const {
+    return slices_.size() == 1 || consolidated_buffer_ != nullptr;
+}
+
+void *SliceBuffer::consolidated_ptr() {
+    // If we already have a consolidated buffer, return it
+    if (consolidated_buffer_) {
+        return consolidated_buffer_;
+    }
+
+    // If there's only one slice, just return its pointer
+    if (slices_.size() == 1) {
+        return slices_[0].ptr;
+    }
+
+    // Otherwise, create a consolidated buffer
+    consolidated_buffer_ = new char[total_size_];
+    uint64_t offset = 0;
+    for (const auto &slice : slices_) {
+        memcpy(consolidated_buffer_ + offset, slice.ptr, slice.size);
+        offset += slice.size;
+    }
+
+    return consolidated_buffer_;
+}
+
+const std::vector<mooncake::Slice> &SliceBuffer::slices() const {
+    return slices_;
+}
+
+// Implementation of get_buffer method
+std::shared_ptr<SliceBuffer> DistributedObjectStore::get_buffer(
+    const std::string &key) {
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return nullptr;
+    }
+
+    mooncake::Client::ObjectInfo object_info;
+    std::vector<Slice> slices;
+    uint64_t total_length = 0;
+    ErrorCode error_code;
+    std::shared_ptr<SliceBuffer> result = nullptr;
+
+    // Query the object info
+    error_code = client_->Query(key, object_info);
+    if (error_code != ErrorCode::OK) {
+        LOG(ERROR) << "Query failed for key: " << key
+                   << " with error: " << toString(error_code);
+        return nullptr;
+    }
+
+    // Allocate slices for the object
+    int ret = allocateSlices(slices, object_info, total_length);
+    if (ret) {
+        LOG(ERROR) << "Failed to allocate slices for key: " << key;
+        return nullptr;
+    }
+
+    // Get the object data
+    error_code = client_->Get(key, object_info, slices);
+    if (error_code != ErrorCode::OK) {
+        // Free slices on error
+        freeSlices(slices);
+        LOG(ERROR) << "Get failed for key: " << key
+                   << " with error: " << toString(error_code);
+        return nullptr;
+    }
+
+    // Create the SliceBuffer
+    result =
+        std::make_shared<SliceBuffer>(*this, std::move(slices), total_length);
+    return result;
+}
+
 PYBIND11_MODULE(store, m) {
+    // Define the SliceBuffer class
+    py::class_<SliceBuffer, std::shared_ptr<SliceBuffer>>(m, "SliceBuffer",
+                                                          py::buffer_protocol())
+        .def("ptr",
+             [](const SliceBuffer &self) {
+                 // Return the pointer as an integer for Python
+                 return reinterpret_cast<uintptr_t>(self.ptr());
+             })
+        .def("size", &SliceBuffer::size)
+        .def("is_contiguous", &SliceBuffer::is_contiguous)
+        .def_buffer([](SliceBuffer &self) -> py::buffer_info {
+            if (!self.is_contiguous()) {
+                void *consolidated_data = self.consolidated_ptr();
+                return py::buffer_info(
+                    consolidated_data, /* Pointer to buffer */
+                    sizeof(char),      /* Size of one scalar */
+                    py::format_descriptor<char>::
+                        format(), /* Python struct-style format descriptor */
+                    1,            /* Number of dimensions */
+                    {(size_t)self.size()}, /* Buffer dimensions */
+                    {sizeof(char)} /* Strides (in bytes) for each index */
+                );
+            } else if (self.size() > 0) {
+                return py::buffer_info(
+                    self.ptr(),   /* Pointer to buffer */
+                    sizeof(char), /* Size of one scalar */
+                    py::format_descriptor<char>::
+                        format(), /* Python struct-style format descriptor */
+                    1,            /* Number of dimensions */
+                    {(size_t)self.size()}, /* Buffer dimensions */
+                    {sizeof(char)} /* Strides (in bytes) for each index */
+                );
+            } else {
+                // Empty buffer
+                return py::buffer_info(
+                    nullptr,      /* Pointer to buffer */
+                    sizeof(char), /* Size of one scalar */
+                    py::format_descriptor<char>::
+                        format(),  /* Python struct-style format descriptor */
+                    1,             /* Number of dimensions */
+                    {0},           /* Buffer dimensions */
+                    {sizeof(char)} /* Strides (in bytes) for each index */
+                );
+            }
+        })
+        .def(
+            "consolidated_ptr",
+            [](SliceBuffer &self) {
+                // Return the consolidated pointer as an integer for Python
+                return reinterpret_cast<uintptr_t>(self.consolidated_ptr());
+            },
+            py::call_guard<py::gil_scoped_acquire>());
+
+    // Define the DistributedObjectStore class
     py::class_<DistributedObjectStore>(m, "MooncakeDistributedStore")
         .def(py::init<>())
         .def("setup", &DistributedObjectStore::setup)
         .def("init_all", &DistributedObjectStore::initAll)
-        .def("get", &DistributedObjectStore::get)  // Removed call_guard
+        .def("get", &DistributedObjectStore::get)
+        .def("get_buffer", &DistributedObjectStore::get_buffer,
+             py::call_guard<py::gil_scoped_release>(),
+             py::return_value_policy::take_ownership)
         .def("put", &DistributedObjectStore::put,
              py::call_guard<py::gil_scoped_release>())
         .def("remove", &DistributedObjectStore::remove,

--- a/mooncake-integration/store/store_py.h
+++ b/mooncake-integration/store/store_py.h
@@ -15,6 +15,7 @@ class DistributedObjectStore;
 
 // Forward declarations
 class SliceGuard;
+class SliceBuffer;
 
 // Global resource tracker to handle cleanup on abnormal termination
 class ResourceTracker {
@@ -49,10 +50,70 @@ class ResourceTracker {
     std::unordered_set<DistributedObjectStore *> instances_;
 };
 
+/**
+ * @brief A class that holds allocated slices and provides a contiguous view of
+ * the data This class is responsible for freeing the slices when it's destroyed
+ * (RAII)
+ */
+class SliceBuffer {
+   public:
+    /**
+     * @brief Construct a new SliceBuffer object
+     * @param store Reference to the DistributedObjectStore that owns the
+     * allocator
+     * @param slices Vector of slices that contain the data
+     * @param total_size Total size of the data across all slices
+     */
+    SliceBuffer(DistributedObjectStore &store,
+                std::vector<mooncake::Slice> slices, uint64_t total_size);
+
+    /**
+     * @brief Destructor that frees all slices
+     */
+    ~SliceBuffer();
+
+    /**
+     * @brief Get a pointer to the data
+     * @return void* Pointer to the data (first slice if multiple slices)
+     */
+    void *ptr() const;
+
+    /**
+     * @brief Get the size of the data
+     * @return uint64_t Size of the data in bytes
+     */
+    uint64_t size() const;
+
+    /**
+     * @brief Get a contiguous buffer containing all the data
+     * @return void* Pointer to the contiguous buffer (caller must NOT free
+     * this)
+     */
+    void *consolidated_ptr();
+
+    /**
+     * @brief Check if the data is stored in a single slice
+     * @return true if data is in a single slice, false otherwise
+     */
+    bool is_contiguous() const;
+
+    /**
+     * @brief Get the raw slices
+     * @return const std::vector<mooncake::Slice>& Reference to the slices
+     */
+    const std::vector<mooncake::Slice> &slices() const;
+
+   private:
+    DistributedObjectStore &store_;
+    std::vector<mooncake::Slice> slices_;
+    uint64_t total_size_;
+    char *consolidated_buffer_ = nullptr;
+};
+
 class DistributedObjectStore {
    public:
-    friend class SliceGuard;  // Allow SliceContainer to access private
-                              // members
+    friend class SliceGuard;   // Allow SliceGuard to access private members
+    friend class SliceBuffer;  // Allow SliceBuffer to access private members
     DistributedObjectStore();
     ~DistributedObjectStore();
 
@@ -70,6 +131,14 @@ class DistributedObjectStore {
     int put(const std::string &key, const std::string &value);
 
     pybind11::bytes get(const std::string &key);
+
+    /**
+     * @brief Get a buffer containing the data for a key
+     * @param key Key to get data for
+     * @return std::shared_ptr<SliceBuffer> Buffer containing the data, or
+     * nullptr if error
+     */
+    std::shared_ptr<SliceBuffer> get_buffer(const std::string &key);
 
     int remove(const std::string &key);
 

--- a/mooncake-integration/store/store_py.h
+++ b/mooncake-integration/store/store_py.h
@@ -128,7 +128,10 @@ class DistributedObjectStore {
     int initAll(const std::string &protocol, const std::string &device_name,
                 size_t mount_segment_size = 1024 * 1024 * 16);  // Default 16MB
 
-    int put(const std::string &key, const std::string &value);
+    int put(const std::string &key, std::span<const char> value);
+
+    int put_parts(const std::string &key,
+                  std::vector<std::span<const char>> values);
 
     pybind11::bytes get(const std::string &key);
 
@@ -166,6 +169,12 @@ class DistributedObjectStore {
     int allocateSlices(std::vector<mooncake::Slice> &slices,
                        const mooncake::Client::ObjectInfo &object_info,
                        uint64_t &length);
+
+    int allocateSlices(std::vector<mooncake::Slice> &slices,
+                       std::span<const char> value);
+
+    int allocateSlicesPacked(std::vector<mooncake::Slice> &slices,
+                             const std::vector<std::span<const char>> &parts);
 
     char *exportSlices(const std::vector<mooncake::Slice> &slices,
                        uint64_t length);

--- a/mooncake-store/tests/test_distributed_object_store.py
+++ b/mooncake-store/tests/test_distributed_object_store.py
@@ -18,7 +18,7 @@ class TestClass:
         struct.pack_into("i", buffer, 0, self.version)
         struct.pack_into("3i", buffer, 4, *self.shape)
         
-    def seralize_into(self):
+    def serialize_into(self):
         version_bytes = struct.pack("i", self.version)
         shape_bytes = struct.pack("3i", *self.shape)
         return (version_bytes, shape_bytes)
@@ -181,7 +181,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         # Clean up
         self.assertEqual(self.store.remove(key), 0)
         
-        (version_bytes, shape_bytes) = test_object.seralize_into()
+        (version_bytes, shape_bytes) = test_object.serialize_into()
         self.assertEqual(self.store.put_parts(key, version_bytes, shape_bytes),0)
         
         retrieved_buffer = self.store.get_buffer(key)


### PR DESCRIPTION
Directly return the internal buffer to the upper-level caller, instead of constructing a Python bytes object by copying.

performance result

### TCP
main

```
Concurrent Stress Test Results:
Total threads: 8
Operations per thread: 100
Total operations: 800
Data block size: 1.00MB
Total data processed: 0.78GB
Put duration: 0.70 seconds
Get duration: 0.43 seconds
System Put throughput: 1149.84 ops/sec
System Get throughput: 1845.99 ops/sec
System Put bandwidth: 1.12 GB/sec
System Get bandwidth: 1.80 GB/sec
```

pr

```
Concurrent Stress Test Results:
Total threads: 8
Operations per thread: 100
Total operations: 800
Data block size: 1.00MB
Total data processed: 0.78GB
Put duration: 0.71 seconds
Get duration: 0.29 seconds
System Put throughput: 1131.98 ops/sec
System Get throughput: 2728.87 ops/sec
System Put bandwidth: 1.11 GB/sec
System Get bandwidth: 2.66 GB/sec
```

### RDMA
main
```
Concurrent Stress Test Results:
Total threads: 8
Operations per thread: 100
Total operations: 800
Data block size: 5.00MB
Total data processed: 3.91GB
Put duration: 1.32 seconds
Get duration: 2.59 seconds
System Put throughput: 605.09 ops/sec
System Get throughput: 308.60 ops/sec
System Put bandwidth: 2.95 GB/sec
System Get bandwidth: 1.51 GB/sec
```
pr
```
Concurrent Stress Test Results:
Total threads: 8
Operations per thread: 100
Total operations: 800
Data block size: 5.00MB
Total data processed: 3.91GB
Put duration: 0.39 seconds
Get duration: 0.35 seconds
System Put throughput: 2062.64 ops/sec
System Get throughput: 2284.94 ops/sec
System Put bandwidth: 10.07 GB/sec
System Get bandwidth: 11.16 GB/sec
```