### PR TITLE
[TransferEngine] build: support on rpm based distros

### DIFF
--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories("../mooncake-store/include/cachelib_memory_allocator")
 include_directories("../mooncake-store/include/cachelib_memory_allocator/include")
 include_directories("../mooncake-store/include/cachelib_memory_allocator/fake_include")
 
+include_directories("/usr/include/jsoncpp")
 
 pybind11_add_module(mooncake_vllm_adaptor ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
     vllm/vllm_adaptor.cpp 

--- a/mooncake-store/CMakeLists.txt
+++ b/mooncake-store/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include/mooncake-store/proto/
     ${CMAKE_CURRENT_SOURCE_DIR}/include/
     ${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-transfer-engine/include
+    /usr/include/jsoncpp
 )
 
 # Add subdirectories

--- a/mooncake-transfer-engine/CMakeLists.txt
+++ b/mooncake-transfer-engine/CMakeLists.txt
@@ -65,7 +65,7 @@ if (NOT GLOBAL_CONFIG)
 
 endif() # GLOBAL_CONFIG
 
-include_directories(include)
+include_directories(include /usr/include/jsoncpp)
 add_subdirectory(include)
 add_subdirectory(src)
 

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -17,7 +17,7 @@
 
 #include <glog/logging.h>
 #include <infiniband/verbs.h>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/mooncake-transfer-engine/include/topology.h
+++ b/mooncake-transfer-engine/include/topology.h
@@ -16,7 +16,7 @@
 #define TOPOLOGY_H
 
 #include <glog/logging.h>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 #include <netdb.h>
 
 #include <atomic>

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -16,7 +16,7 @@
 #define TRANSFER_METADATA
 
 #include <glog/logging.h>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 #include <netdb.h>
 
 #include <atomic>

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <glog/logging.h>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 #include <fstream>
 #include <iostream>

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -14,7 +14,7 @@
 
 #include "transfer_metadata.h"
 
-#include <jsoncpp/json/value.h>
+#include <json/value.h>
 
 #include <cassert>
 #include <set>

--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -17,7 +17,7 @@
 #include <arpa/inet.h>
 #include <bits/stdint-uintn.h>
 #include <ifaddrs.h>
-#include <jsoncpp/json/value.h>
+#include <json/value.h>
 #include <net/if.h>
 #include <netdb.h>
 #include <sys/socket.h>


### PR DESCRIPTION
RPM based distros like RHEL or Fedora, jsoncpp header files are at /usr/include, while deb based distros like debian or ubuntu such header files are at /usr/include/jsoncpp

To support building on both distro families, let's include <json/json.h> instead of <jsoncpp/json/json.h> and add /usr/include/jsoncpp to include path as well.