### PR TITLE
[Draft] [FEAT]: Support mooncake store  RDMA auto discover

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -167,10 +167,9 @@ int DistributedObjectStore::setup(const std::string &local_hostname,
         this->local_hostname = local_hostname;
     }
 
-    void **args = (protocol == "rdma") ? rdma_args(rdma_devices) : nullptr;
     auto client_opt =
         mooncake::Client::Create(this->local_hostname, metadata_server,
-                                 protocol, args, master_server_addr);
+                                 protocol, rdma_devices, master_server_addr);
     if (!client_opt) {
         LOG(ERROR) << "Failed to create client";
         return 1;

--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -36,6 +36,12 @@ class Client {
         void** protocol_args,
         const std::string& master_addr = kDefaultMasterAddress);
 
+    static std::optional<std::shared_ptr<Client>> Create(
+        const std::string& local_hostname,
+        const std::string& metadata_connstring, const std::string& protocol,
+        const std::string& device_name,
+        const std::string& master_addr = kDefaultMasterAddress);
+
     /**
      * @brief Retrieves data for a given key
      * @param object_key Key to retrieve
@@ -136,10 +142,25 @@ class Client {
 
    private:
     /**
+     * @brief Internal static helper for creating Client instances.
+     */
+    static std::optional<std::shared_ptr<Client>> CreateInternal(
+        const std::string& local_hostname,
+        const std::string& metadata_connstring, const std::string& protocol,
+        void** protocol_args, const std::string& device_name,
+        const std::string& master_addr);
+
+    /**
      * @brief Private constructor to enforce creation through Create() method
      */
     Client(const std::string& local_hostname,
            const std::string& metadata_connstring);
+
+    /**
+     * @brief Private constructor to enforce creation through Create() method
+     */
+    Client(const std::string& local_hostname,
+           const std::string& metadata_connstring, bool auto_discover, std::string device_name);
 
     /**
      * @brief Internal helper functions for initialization and data transfer
@@ -148,7 +169,8 @@ class Client {
     ErrorCode InitTransferEngine(const std::string& local_hostname,
                                  const std::string& metadata_connstring,
                                  const std::string& protocol,
-                                 void** protocol_args);
+                                 void** protocol_args,
+                                 const std::string& device_name);
     ErrorCode TransferData(
         const std::vector<AllocatedBuffer::Descriptor>& handles,
         std::vector<Slice>& slices, TransferRequest::OpCode op_code);


### PR DESCRIPTION
**motivation**
目前transfer engine py可以支持RDMA 设备自动识别。但是store还没有该功能，不利于GDR的支持。

**Modifications**
支持 store 自动识别网卡。 为client 添加了新的 构造函数，兼容老的接口。