### PR TITLE
[TransferEngine] add option to enable metrics or not

### DIFF
--- a/mooncake-transfer-engine/CMakeLists.txt
+++ b/mooncake-transfer-engine/CMakeLists.txt
@@ -27,6 +27,7 @@ if (NOT GLOBAL_CONFIG)
   option(USE_REDIS "option for enable redis as metadata server" OFF)
   option(USE_HTTP "option for enable http as metadata server" ON)
   option(WITH_RUST_EXAMPLE "build the Rust interface and sample code for the transfer engine" OFF)
+  option(WITH_METRICS "enable metrics and metrics reporting thread" ON)
 
   add_definitions(-DCONFIG_ERDMA)
 
@@ -61,6 +62,11 @@ if (NOT GLOBAL_CONFIG)
 
   if (USE_ETCD)
     message(FATAL_ERROR "Cannot enable USE_ETCD while building transfer engine independently")
+  endif()
+
+  if (WITH_METRICS)
+    add_compile_definitions(WITH_METRICS)
+    message(STATUS "metrics is enabled")
   endif()
 
 endif() # GLOBAL_CONFIG

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -25,15 +25,6 @@
 
 namespace mooncake {
 
-// Helper function to convert string to lowercase for case-insensitive
-// comparison
-static std::string toLower(const std::string &s) {
-    std::string result = s;
-    std::transform(result.begin(), result.end(), result.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
-    return result;
-}
-
 static std::string loadTopologyJsonFile(const std::string &path) {
     std::ifstream file(path);
     if (!file.is_open()) {
@@ -298,6 +289,17 @@ int TransferEngine::unregisterLocalMemoryBatch(
     }
     return 0;
 }
+
+#ifdef WITH_METRICS
+// Helper function to convert string to lowercase for case-insensitive
+// comparison
+static std::string toLower(const std::string &s) {
+    std::string result = s;
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return result;
+}
+
 void TransferEngine::InitializeMetricsConfig() {
     // Check if metrics reporting is enabled via environment variable
     const char *metric_env = getenv("MC_TE_METRIC");
@@ -387,5 +389,6 @@ void TransferEngine::StopMetricsReportingThread() {
         LOG(INFO) << "Metrics reporting thread joined";
     }
 }
+#endif
 
 }  // namespace mooncake


### PR DESCRIPTION
When using transfer engine as a standalone library, the application itself may have metrics framework, so metrics in transfer engine is not needed.

Add WITH_METRICS build option to control metrics, which can be turned off with -DWITH_METRICS=OFF. We could also avoid depending on yalantinglibs in transfer engine.