### PR TITLE
Feat: Implement Master Service Metrics System

### DIFF
--- a/mooncake-store/include/allocator.h
+++ b/mooncake-store/include/allocator.h
@@ -6,12 +6,8 @@
 #include <string>
 
 #include "cachelib_memory_allocator/MemoryAllocator.h"
+#include "master_metric_manager.h"
 #include "types.h"
-// Removed ylt metric includes
-// #include "ylt/metric/counter.hpp"
-// #include "ylt/metric/gauge.hpp"
-// #include "ylt/metric/metric_manager.hpp"
-#include "master_metric_manager.h"  // Added
 
 using facebook::cachelib::MemoryAllocator;
 using facebook::cachelib::PoolId;
@@ -42,7 +38,6 @@ namespace mooncake {
  */
 class BufferAllocator : public std::enable_shared_from_this<BufferAllocator> {
    public:
-    // Removed allocated_bytes parameter
     BufferAllocator(std::string segment_name, size_t base, size_t size);
 
     ~BufferAllocator();

--- a/mooncake-store/include/allocator.h
+++ b/mooncake-store/include/allocator.h
@@ -1,11 +1,17 @@
 #ifndef BUFFER_ALLOCATOR_H
 #define BUFFER_ALLOCATOR_H
 
+#include <atomic>
 #include <memory>
 #include <string>
 
 #include "cachelib_memory_allocator/MemoryAllocator.h"
 #include "types.h"
+// Removed ylt metric includes
+// #include "ylt/metric/counter.hpp"
+// #include "ylt/metric/gauge.hpp"
+// #include "ylt/metric/metric_manager.hpp"
+#include "master_metric_manager.h"  // Added
 
 using facebook::cachelib::MemoryAllocator;
 using facebook::cachelib::PoolId;
@@ -36,6 +42,7 @@ namespace mooncake {
  */
 class BufferAllocator : public std::enable_shared_from_this<BufferAllocator> {
    public:
+    // Removed allocated_bytes parameter
     BufferAllocator(std::string segment_name, size_t base, size_t size);
 
     ~BufferAllocator();
@@ -50,11 +57,13 @@ class BufferAllocator : public std::enable_shared_from_this<BufferAllocator> {
 
    private:
     // metadata
-    std::string segment_name_;
-    size_t base_;
-    size_t total_size_;
-    std::atomic<size_t> cur_size_{0};
+    const std::string segment_name_;
+    const size_t base_;
+    const size_t total_size_;
+    std::atomic_size_t cur_size_;
 
+    // metrics - removed allocated_bytes_ member
+    // ylt::metric::gauge_t* allocated_bytes_{nullptr};
     // cachelib
     std::unique_ptr<char[]> header_region_start_;
     size_t header_region_size_;

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <mutex>
-#include <sstream>  // For string formatting
 #include <string>
 
 #include "ylt/metric/counter.hpp"
@@ -90,14 +89,6 @@ class MasterMetricManager {
     ylt::metric::counter_d mount_segment_failures_;
     ylt::metric::counter_d unmount_segment_requests_;
     ylt::metric::counter_d unmount_segment_failures_;
-
-    // GC Statistics
-    ylt::metric::counter_d gc_tasks_added_;
-    ylt::metric::counter_d gc_tasks_processed_;
-    ylt::metric::counter_d gc_remove_failures_;
-
-    // Mutex for thread-safe serialization
-    std::mutex serialization_mutex_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mutex>
+#include <sstream>  // For string formatting
 #include <string>
 
 #include "ylt/metric/counter.hpp"
@@ -22,15 +23,12 @@ class MasterMetricManager {
     // Storage Metrics
     void inc_allocated_size(int64_t val = 1.0);
     void dec_allocated_size(int64_t val = 1.0);
-    void set_allocated_size(int64_t val);  // Use update for gauge
     void inc_total_capacity(int64_t val = 1.0);
     void dec_total_capacity(int64_t val = 1.0);
-    void set_total_capacity(int64_t val);  // Use update for gauge
 
     // Key/Value Metrics
     void inc_key_count(int64_t val = 1.0);
     void dec_key_count(int64_t val = 1.0);
-    void set_key_count(int64_t val);  // Use update for gauge
     void observe_value_size(int64_t size);
 
     // Operation Statistics (Counters)
@@ -56,6 +54,12 @@ class MasterMetricManager {
      */
     std::string serialize_metrics();
 
+    /**
+     * @brief Generates a concise, human-readable summary of key metrics.
+     * @return A string containing the formatted summary.
+     */
+    std::string get_summary_string();
+
    private:
     // --- Private Constructor & Destructor ---
     MasterMetricManager();
@@ -64,12 +68,12 @@ class MasterMetricManager {
     // --- Metric Members ---
 
     // Storage Metrics
-    ylt::metric::gauge_d allocated_size_;
-    ylt::metric::gauge_d total_capacity_;
+    ylt::metric::gauge_d allocated_size_;  // Use update for gauge
+    ylt::metric::gauge_d total_capacity_;  // Use update for gauge
 
     // Key/Value Metrics
     ylt::metric::gauge_d key_count_;
-    ylt::metric::histogram_d value_size_distribution_;  // Example buckets
+    ylt::metric::histogram_d value_size_distribution_;
 
     // Operation Statistics
     ylt::metric::counter_d put_start_requests_;

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <mutex>
+#include <string>
+
+#include "ylt/metric/counter.hpp"
+#include "ylt/metric/gauge.hpp"
+#include "ylt/metric/histogram.hpp"
+
+namespace mooncake {
+
+class MasterMetricManager {
+   public:
+    // --- Singleton Access ---
+    static MasterMetricManager& instance();
+
+    MasterMetricManager(const MasterMetricManager&) = delete;
+    MasterMetricManager& operator=(const MasterMetricManager&) = delete;
+    MasterMetricManager(MasterMetricManager&&) = delete;
+    MasterMetricManager& operator=(MasterMetricManager&&) = delete;
+
+    // Storage Metrics
+    void inc_allocated_size(int64_t val = 1.0);
+    void dec_allocated_size(int64_t val = 1.0);
+    void set_allocated_size(int64_t val);  // Use update for gauge
+    void inc_total_capacity(int64_t val = 1.0);
+    void dec_total_capacity(int64_t val = 1.0);
+    void set_total_capacity(int64_t val);  // Use update for gauge
+
+    // Key/Value Metrics
+    void inc_key_count(int64_t val = 1.0);
+    void dec_key_count(int64_t val = 1.0);
+    void set_key_count(int64_t val);  // Use update for gauge
+    void observe_value_size(int64_t size);
+
+    // Operation Statistics (Counters)
+    void inc_put_start_requests(int64_t val = 1.0);
+    void inc_put_start_failures(int64_t val = 1.0);
+    void inc_put_end_requests(int64_t val = 1.0);
+    void inc_put_end_failures(int64_t val = 1.0);
+    void inc_put_revoke_requests(int64_t val = 1.0);
+    void inc_put_revoke_failures(int64_t val = 1.0);
+    void inc_get_replica_list_requests(int64_t val = 1.0);
+    void inc_get_replica_list_failures(int64_t val = 1.0);
+    void inc_remove_requests(int64_t val = 1.0);
+    void inc_remove_failures(int64_t val = 1.0);
+    void inc_mount_segment_requests(int64_t val = 1.0);
+    void inc_mount_segment_failures(int64_t val = 1.0);
+    void inc_unmount_segment_requests(int64_t val = 1.0);
+    void inc_unmount_segment_failures(int64_t val = 1.0);
+
+    // --- Serialization ---
+    /**
+     * @brief Serializes all managed metrics into Prometheus text format.
+     * @return A string containing the metrics in Prometheus format.
+     */
+    std::string serialize_metrics();
+
+   private:
+    // --- Private Constructor & Destructor ---
+    MasterMetricManager();
+    ~MasterMetricManager() = default;
+
+    // --- Metric Members ---
+
+    // Storage Metrics
+    ylt::metric::gauge_d allocated_size_;
+    ylt::metric::gauge_d total_capacity_;
+
+    // Key/Value Metrics
+    ylt::metric::gauge_d key_count_;
+    ylt::metric::histogram_d value_size_distribution_;  // Example buckets
+
+    // Operation Statistics
+    ylt::metric::counter_d put_start_requests_;
+    ylt::metric::counter_d put_start_failures_;
+    ylt::metric::counter_d put_end_requests_;
+    ylt::metric::counter_d put_end_failures_;
+    ylt::metric::counter_d put_revoke_requests_;
+    ylt::metric::counter_d put_revoke_failures_;
+    ylt::metric::counter_d get_replica_list_requests_;
+    ylt::metric::counter_d get_replica_list_failures_;
+    ylt::metric::counter_d remove_requests_;
+    ylt::metric::counter_d remove_failures_;
+    ylt::metric::counter_d mount_segment_requests_;
+    ylt::metric::counter_d mount_segment_failures_;
+    ylt::metric::counter_d unmount_segment_requests_;
+    ylt::metric::counter_d unmount_segment_failures_;
+
+    // GC Statistics
+    ylt::metric::counter_d gc_tasks_added_;
+    ylt::metric::counter_d gc_tasks_processed_;
+    ylt::metric::counter_d gc_remove_failures_;
+
+    // Mutex for thread-safe serialization
+    std::mutex serialization_mutex_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MOONCAKE_STORE_SOURCES
     types.cpp
     master_client.cpp
     utils.cpp
+    master_metric_manager.cpp
 )
 
 # The cache_allocator library

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -26,9 +26,7 @@ BufferAllocator::BufferAllocator(std::string segment_name, size_t base,
     : segment_name_(segment_name),
       base_(base),
       total_size_(size),
-      cur_size_(0)
-// allocated_bytes_(allocated_bytes) // Removed
-{
+      cur_size_(0) {
     VLOG(1) << "initializing_buffer_allocator segment_name=" << segment_name
             << " base_address=" << reinterpret_cast<void*>(base)
             << " size=" << size;

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -5,6 +5,8 @@
 
 #include <memory>
 
+#include "master_metric_manager.h"
+
 namespace mooncake {
 
 AllocatedBuffer::~AllocatedBuffer() {
@@ -18,9 +20,15 @@ AllocatedBuffer::~AllocatedBuffer() {
     }
 }
 
+// Removed allocated_bytes parameter and member initialization
 BufferAllocator::BufferAllocator(std::string segment_name, size_t base,
                                  size_t size)
-    : segment_name_(segment_name), base_(base), total_size_(size) {
+    : segment_name_(segment_name),
+      base_(base),
+      total_size_(size),
+      cur_size_(0)
+// allocated_bytes_(allocated_bytes) // Removed
+{
     VLOG(1) << "initializing_buffer_allocator segment_name=" << segment_name
             << " base_address=" << reinterpret_cast<void*>(base)
             << " size=" << size;
@@ -74,8 +82,8 @@ std::unique_ptr<AllocatedBuffer> BufferAllocator::allocate(size_t size) {
     }
     VLOG(1) << "allocation_succeeded size=" << size
             << " segment=" << segment_name_ << " address=" << buffer;
-    // Create and return a new BufHandle.
     cur_size_.fetch_add(size);
+    MasterMetricManager::instance().inc_allocated_size(size);
     return std::make_unique<AllocatedBuffer>(shared_from_this(), segment_name_,
                                              buffer, size);
 }
@@ -85,9 +93,12 @@ void BufferAllocator::deallocate(AllocatedBuffer* handle) {
         // Deallocate memory using CacheLib.
         memory_allocator_->free(handle->buffer_ptr_);
         handle->status = BufStatus::UNREGISTERED;
-        cur_size_.fetch_sub(handle->size_);
+        size_t freed_size =
+            handle->size_;  // Store size before handle might become invalid
+        cur_size_.fetch_sub(freed_size);
+        MasterMetricManager::instance().dec_allocated_size(freed_size);
         VLOG(1) << "deallocation_succeeded address=" << handle->buffer_ptr_
-                << " size=" << handle->size_ << " segment=" << segment_name_;
+                << " size=" << freed_size << " segment=" << segment_name_;
     } catch (const std::exception& e) {
         LOG(ERROR) << "deallocation_exception error=" << e.what();
     } catch (...) {

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -1,5 +1,7 @@
 #include <gflags/gflags.h>
 
+#include <chrono>  // For std::chrono
+#include <thread>  // For std::thread
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
 #include <ylt/easylog/record.hpp>
 
@@ -43,6 +45,8 @@ int main(int argc, char* argv[]) {
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::UnmountSegment>(
         &wrapped_master_service);
+
+    // Metric reporting is now handled by WrappedMasterService
 
     return !server.start();
 }

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -15,6 +15,7 @@ DEFINE_int32(port, 50051, "Port for master service to listen on");
 DEFINE_int32(max_threads, 4, "Maximum number of threads to use");
 DEFINE_bool(enable_gc, false, "Enable garbage collection");
 DEFINE_bool(enable_metric_reporting, true, "Enable periodic metric reporting");
+DEFINE_int32(metrics_port, 9003, "Port for HTTP metrics server to listen on");
 
 int main(int argc, char* argv[]) {
     // Initialize gflags
@@ -30,10 +31,11 @@ int main(int argc, char* argv[]) {
     LOG(INFO) << "Master service started on port " << FLAGS_port
               << ", enable_gc=" << FLAGS_enable_gc
               << ", max_threads=" << FLAGS_max_threads
-              << ", enable_metric_reporting=" << FLAGS_enable_metric_reporting;
+              << ", enable_metric_reporting=" << FLAGS_enable_metric_reporting
+              << ", metrics_port=" << FLAGS_metrics_port;
 
     mooncake::WrappedMasterService wrapped_master_service(
-        FLAGS_enable_gc, FLAGS_enable_metric_reporting);
+        FLAGS_enable_gc, FLAGS_enable_metric_reporting, FLAGS_metrics_port);
     server.register_handler<&mooncake::WrappedMasterService::GetReplicaList>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::PutStart>(

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -14,6 +14,7 @@ using namespace async_simple::coro;
 DEFINE_int32(port, 50051, "Port for master service to listen on");
 DEFINE_int32(max_threads, 4, "Maximum number of threads to use");
 DEFINE_bool(enable_gc, false, "Enable garbage collection");
+DEFINE_bool(enable_metric_reporting, true, "Enable periodic metric reporting");
 
 int main(int argc, char* argv[]) {
     // Initialize gflags
@@ -28,9 +29,11 @@ int main(int argc, char* argv[]) {
         /*port=*/FLAGS_port);
     LOG(INFO) << "Master service started on port " << FLAGS_port
               << ", enable_gc=" << FLAGS_enable_gc
-              << ", max_threads=" << FLAGS_max_threads;
+              << ", max_threads=" << FLAGS_max_threads
+              << ", enable_metric_reporting=" << FLAGS_enable_metric_reporting;
 
-    mooncake::WrappedMasterService wrapped_master_service(FLAGS_enable_gc);
+    mooncake::WrappedMasterService wrapped_master_service(
+        FLAGS_enable_gc, FLAGS_enable_metric_reporting);
     server.register_handler<&mooncake::WrappedMasterService::GetReplicaList>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::PutStart>(

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -1,0 +1,224 @@
+#include "master_metric_manager.h"
+
+#include <sstream>  // For string building during serialization
+#include <vector>   // Required by histogram serialization
+
+namespace mooncake {
+
+// --- Singleton Instance ---
+MasterMetricManager& MasterMetricManager::instance() {
+    // Guaranteed to be lazy initialized and thread-safe in C++11+
+    static MasterMetricManager static_instance;
+    return static_instance;
+}
+
+// --- Constructor ---
+MasterMetricManager::MasterMetricManager()
+    // Initialize Gauges
+    : allocated_size_("master_allocated_bytes",
+                      "Total bytes currently allocated across all segments"),
+      total_capacity_("master_total_capacity_bytes",
+                      "Total capacity across all mounted segments"),
+      key_count_("master_key_count",
+                 "Total number of keys managed by the master"),
+      // Initialize Histogram (Example buckets: 1KB, 4KB, 16KB, 64KB, 256KB,
+      // 1MB, 4MB) Buckets should be sorted.
+      value_size_distribution_(
+          "master_value_size_bytes", "Distribution of object value sizes",
+          {1024.0, 4096.0, 16384.0, 65536.0, 262144.0, 1048576.0, 4194304.0}),
+      // Initialize Counters
+      put_start_requests_("master_put_start_requests_total",
+                          "Total number of PutStart requests received"),
+      put_start_failures_("master_put_start_failures_total",
+                          "Total number of failed PutStart requests"),
+      put_end_requests_("master_put_end_requests_total",
+                        "Total number of PutEnd requests received"),
+      put_end_failures_("master_put_end_failures_total",
+                        "Total number of failed PutEnd requests"),
+      put_revoke_requests_("master_put_revoke_requests_total",
+                           "Total number of PutRevoke requests received"),
+      put_revoke_failures_("master_put_revoke_failures_total",
+                           "Total number of failed PutRevoke requests"),
+      get_replica_list_requests_(
+          "master_get_replica_list_requests_total",
+          "Total number of GetReplicaList requests received"),
+      get_replica_list_failures_(
+          "master_get_replica_list_failures_total",
+          "Total number of failed GetReplicaList requests"),
+      remove_requests_("master_remove_requests_total",
+                       "Total number of Remove requests received"),
+      remove_failures_("master_remove_failures_total",
+                       "Total number of failed Remove requests"),
+      mount_segment_requests_("master_mount_segment_requests_total",
+                              "Total number of MountSegment requests received"),
+      mount_segment_failures_("master_mount_segment_failures_total",
+                              "Total number of failed MountSegment requests"),
+      unmount_segment_requests_(
+          "master_unmount_segment_requests_total",
+          "Total number of UnmountSegment requests received"),
+      unmount_segment_failures_(
+          "master_unmount_segment_failures_total",
+          "Total number of failed UnmountSegment requests"),
+      gc_tasks_added_("master_gc_tasks_added_total",
+                      "Total number of tasks added to the GC queue"),
+      gc_tasks_processed_("master_gc_tasks_processed_total",
+                          "Total number of tasks processed by the GC thread"),
+      gc_remove_failures_("master_gc_remove_failures_total",
+                          "Total number of failures during GC key removal") {}
+
+// --- Metric Interface Methods ---
+
+// Storage Metrics
+void MasterMetricManager::inc_allocated_size(int64_t val) {
+    allocated_size_.inc(val);
+}
+void MasterMetricManager::dec_allocated_size(int64_t val) {
+    allocated_size_.dec(val);
+}
+void MasterMetricManager::set_allocated_size(int64_t val) {
+    allocated_size_.update(val);
+}  // Use update for gauge
+void MasterMetricManager::inc_total_capacity(int64_t val) {
+    total_capacity_.inc(val);
+}
+void MasterMetricManager::dec_total_capacity(int64_t val) {
+    total_capacity_.dec(val);
+}
+void MasterMetricManager::set_total_capacity(int64_t val) {
+    total_capacity_.update(val);
+}  // Use update for gauge
+
+// Key/Value Metrics
+void MasterMetricManager::inc_key_count(int64_t val) { key_count_.inc(val); }
+void MasterMetricManager::dec_key_count(int64_t val) { key_count_.dec(val); }
+void MasterMetricManager::set_key_count(int64_t val) {
+    key_count_.update(val);
+}  // Use update for gauge
+void MasterMetricManager::observe_value_size(int64_t size) {
+    value_size_distribution_.observe(size);
+}
+
+// Operation Statistics (Counters)
+void MasterMetricManager::inc_put_start_requests(int64_t val) {
+    put_start_requests_.inc(val);
+}
+void MasterMetricManager::inc_put_start_failures(int64_t val) {
+    put_start_failures_.inc(val);
+}
+void MasterMetricManager::inc_put_end_requests(int64_t val) {
+    put_end_requests_.inc(val);
+}
+void MasterMetricManager::inc_put_end_failures(int64_t val) {
+    put_end_failures_.inc(val);
+}
+void MasterMetricManager::inc_put_revoke_requests(int64_t val) {
+    put_revoke_requests_.inc(val);
+}
+void MasterMetricManager::inc_put_revoke_failures(int64_t val) {
+    put_revoke_failures_.inc(val);
+}
+void MasterMetricManager::inc_get_replica_list_requests(int64_t val) {
+    get_replica_list_requests_.inc(val);
+}
+void MasterMetricManager::inc_get_replica_list_failures(int64_t val) {
+    get_replica_list_failures_.inc(val);
+}
+void MasterMetricManager::inc_remove_requests(int64_t val) {
+    remove_requests_.inc(val);
+}
+void MasterMetricManager::inc_remove_failures(int64_t val) {
+    remove_failures_.inc(val);
+}
+void MasterMetricManager::inc_mount_segment_requests(int64_t val) {
+    mount_segment_requests_.inc(val);
+}
+void MasterMetricManager::inc_mount_segment_failures(int64_t val) {
+    mount_segment_failures_.inc(val);
+}
+void MasterMetricManager::inc_unmount_segment_requests(int64_t val) {
+    unmount_segment_requests_.inc(val);
+}
+void MasterMetricManager::inc_unmount_segment_failures(int64_t val) {
+    unmount_segment_failures_.inc(val);
+}
+
+// --- Serialization ---
+std::string MasterMetricManager::serialize_metrics() {
+    std::lock_guard<std::mutex> lock(serialization_mutex_);
+    std::stringstream ss;
+    std::string
+        temp_str;  // Temporary string for individual metric serialization
+
+    // Serialize Gauges
+    allocated_size_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    total_capacity_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    key_count_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+
+    // Serialize Histogram
+    value_size_distribution_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+
+    // Serialize Counters
+    put_start_requests_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    put_start_failures_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    put_end_requests_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    put_end_failures_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    put_revoke_requests_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    put_revoke_failures_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    get_replica_list_requests_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    get_replica_list_failures_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    remove_requests_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    remove_failures_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    mount_segment_requests_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    mount_segment_failures_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    unmount_segment_requests_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    unmount_segment_failures_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    gc_tasks_added_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    gc_tasks_processed_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+    gc_remove_failures_.serialize(temp_str);
+    ss << temp_str;
+    temp_str.clear();
+
+    return ss.str();
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -5,6 +5,7 @@
 #include <queue>
 #include <shared_mutex>
 
+#include "master_metric_manager.h"
 #include "types.h"
 
 namespace mooncake {
@@ -60,6 +61,7 @@ ErrorCode BufferAllocatorManager::RemoveSegment(
         return ErrorCode::INVALID_PARAMS;
     }
 
+    MasterMetricManager::instance().dec_total_capacity(it->second->capacity());
     buf_allocators_.erase(it);
     return ErrorCode::OK;
 }


### PR DESCRIPTION
This PR introduces a basic metrics system for the `mooncake-store master service` to provide **better observability** into its operation and resource usage.

Key Changes:
* `MasterMetricManager`: A new singleton class (MasterMetricManager) is introduced to centralize the collection and management of all master-related metrics. It utilizes the ylt::metric library.
* An embedded `coro_http_server` is started within `WrappedMasterService`.
Metrics are exposed in Prometheus text format at the `/metrics` endpoint.
A human-readable summary is available at the `/metrics/summary` endpoint.
A basic `/health` check endpoint is also included.

Background Reporting (Optional):
An optional background thread can be enabled to periodically log the metrics summary to the master's log output.

For example
```
╰─ ./mooncake-store/src/mooncake_master                              
WARNING: Logging before InitGoogleLogging() is written to STDERR
I20250428 15:24:11.769802 83289 master.cpp:31] Master service started on port 50051, enable_gc=0, max_threads=4, enable_metric_reporting=1, metrics_port=9003
I20250428 15:24:11.784299 83289 rpc_service.h:118] HTTP metrics server started on port 9003
I20250428 15:24:11.784762 83299 rpc_service.h:69] Master Metrics: Storage: 0.00 B / 0.00 B | Keys: 0 | Requests (Success/Total): Put=0/0, Get=0/0, Del=0/0
I20250428 15:24:15.351261 83305 master_service.cpp:188] key=test_key, info=object_already_exists
I20250428 15:24:21.788318 83299 rpc_service.h:69] Master Metrics: Storage: 0.00 B / 1.00 GB (0.0%) | Keys: 0 | Requests (Success/Total): Put=6/7, Get=2/3, Del=3/3
I20250428 15:24:31.025538 83299 rpc_service.h:69] Master Metrics: Storage: 0.00 B / 1.00 GB (0.0%) | Keys: 0 | Requests (Success/Total): Put=6/7, Get=2/3, Del=3/3
```