### PR TITLE
feat(client): add client ID and heartbeat functionality

### DIFF
--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -92,15 +92,24 @@ class MasterClient {
      * @return ErrorCode indicating success/failure
      */
     [[nodiscard]] MountSegmentResponse MountSegment(
-        const std::string& segment_name, const void* buffer, size_t size);
+        const ClientID& client_id, const std::string& segment_name,
+        const void* buffer, size_t size);
 
     /**
      * @brief Unregisters a memory segment from master
+     * @param client_id Unique identifier of the client
      * @param segment_name Name which is used to register the segment
      * @return ErrorCode indicating success/failure
      */
     [[nodiscard]] UnmountSegmentResponse UnmountSegment(
-        const std::string& segment_name);
+        const ClientID& client_id, const std::string& segment_name);
+
+    /**
+     * @brief Sends a heartbeat to the master to indicate client is alive
+     * @param client_id Unique identifier of the client
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] HeartbeatResponse Heartbeat(const ClientID& client_id);
 
    private:
     coro_rpc_client client_;

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -30,6 +30,7 @@ using ObjectKey = std::string;
 using Version = uint64_t;
 using SegmentId = int64_t;
 using TaskID = int64_t;
+using ClientID = std::string;  // Unique identifier for clients
 using BufHandleList = std::vector<std::shared_ptr<AllocatedBuffer>>;
 // using ReplicaList = std::vector<ReplicaInfo>;
 using ReplicaList = std::unordered_map<uint32_t, Replica>;

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -52,6 +52,8 @@ int main(int argc, char* argv[]) {
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::UnmountSegment>(
         &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::Heartbeat>(
+        &wrapped_master_service);
 
     // Metric reporting is now handled by WrappedMasterService
 

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -47,7 +47,6 @@ class ClientIntegrationTest : public ::testing::Test {
     }
 
     static void TearDownTestSuite() {
-        CleanupSegment();
         CleanupClient();
         google::ShutdownGoogleLogging();
     }
@@ -92,13 +91,6 @@ class ClientIntegrationTest : public ::testing::Test {
     static void CleanupClient() {
         if (client_) {
             client_.reset();  // Release the client
-        }
-    }
-
-    static void CleanupSegment() {
-        if (client_->UnmountSegment("localhost:17812", segment_ptr_) !=
-            ErrorCode::OK) {
-            LOG(ERROR) << "Failed to unmount segment";
         }
     }
 


### PR DESCRIPTION
The primary change in this PR is the generation of a unique identifier, ClientId, for each client based on their UUID. Building upon the ClientId, we have extended the RPC services of the Master, introducing a heartbeat interface and a background monitoring thread. Clients that experience a heartbeat timeout will have their associated resources — currently segments — released accordingly.

Recently, there have been significant changes to the master, including support for the metric system, eviction mechanisms, and heartbeat with the client.

The following tasks are planned for the future and will not be included in this PR, as it has already grown quite large:

- [ ] Once eviction support is available, we need to collaborate with the GC module to consider a refactor, gc is to support VLLM’s drop-select semantics.
- [ ] As new features are added, more configurations are being exposed; we need to update the documentation accordingly.
- [ ] We must develop more comprehensive and clearly categorized tests. As the brain of the entire store, the master’s correctness and performance define the system’s limits. It is crucial that we dedicate extra effort to ensure it evolves in the right direction.