### PR TITLE
Support SSD offload and KVCache persistence

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -148,7 +148,8 @@ int DistributedObjectStore::setup(const std::string &local_hostname,
                                   size_t local_buffer_size,
                                   const std::string &protocol,
                                   const std::string &rdma_devices,
-                                  const std::string &master_server_addr) {
+                                  const std::string &master_server_addr,
+                                  const std::string &storage_root_path) {
     this->protocol = protocol;
 
     // Remove port if hostname already contains one
@@ -170,7 +171,8 @@ int DistributedObjectStore::setup(const std::string &local_hostname,
     void **args = (protocol == "rdma") ? rdma_args(rdma_devices) : nullptr;
     auto client_opt =
         mooncake::Client::Create(this->local_hostname, metadata_server,
-                                 protocol, args, master_server_addr);
+                                 protocol, args, master_server_addr,
+                                 storage_root_path);
     if (!client_opt) {
         LOG(ERROR) << "Failed to create client";
         return 1;
@@ -204,14 +206,16 @@ int DistributedObjectStore::setup(const std::string &local_hostname,
 
 int DistributedObjectStore::initAll(const std::string &protocol_,
                                     const std::string &device_name,
-                                    size_t mount_segment_size) {
+                                    size_t mount_segment_size,
+                                    const std::string &storage_root_path) {
     if (client_) {
         LOG(ERROR) << "Client is already initialized";
         return 1;
     }
     uint64_t buffer_allocator_size = 1024 * 1024 * 1024;
     return setup("localhost:12345", "127.0.0.1:2379", mount_segment_size,
-                 buffer_allocator_size, protocol_, device_name);
+                 buffer_allocator_size, protocol_, device_name,
+                 storage_root_path);
 }
 
 int DistributedObjectStore::allocateSlices(std::vector<Slice> &slices,

--- a/mooncake-integration/store/store_py.h
+++ b/mooncake-integration/store/store_py.h
@@ -105,10 +105,12 @@ class DistributedObjectStore {
               size_t local_buffer_size = 1024 * 1024 * 16,
               const std::string &protocol = "tcp",
               const std::string &rdma_devices = "",
-              const std::string &master_server_addr = "127.0.0.1:50051");
+              const std::string &master_server_addr = "127.0.0.1:50051",
+              const std::string &storage_root_path = "");
 
     int initAll(const std::string &protocol, const std::string &device_name,
-                size_t mount_segment_size = 1024 * 1024 * 16);  // Default 16MB
+                size_t mount_segment_size = 1024 * 1024 * 16, // Default 16MB
+                const std::string &storage_root_path = "");
 
     int put(const std::string &key, std::span<const char> value);
 

--- a/mooncake-integration/vllm/distributed_object_store.cpp
+++ b/mooncake-integration/vllm/distributed_object_store.cpp
@@ -143,7 +143,8 @@ int DistributedObjectStore::setup(const std::string &local_hostname,
                                   size_t local_buffer_size,
                                   const std::string &protocol,
                                   const std::string &rdma_devices,
-                                  const std::string &master_server_addr) {
+                                  const std::string &master_server_addr,
+                                  const std::string &storage_root_path) {
     this->protocol = protocol;
 
     // Remove port if hostname already contains one
@@ -165,7 +166,8 @@ int DistributedObjectStore::setup(const std::string &local_hostname,
     void **args = (protocol == "rdma") ? rdma_args(rdma_devices) : nullptr;
     auto client_opt =
         mooncake::Client::Create(this->local_hostname, metadata_server,
-                                 protocol, args, master_server_addr);
+                                 protocol, args, master_server_addr,
+                                 storage_root_path);
     if (!client_opt) {
         LOG(ERROR) << "Failed to create client";
         return 1;
@@ -199,14 +201,16 @@ int DistributedObjectStore::setup(const std::string &local_hostname,
 
 int DistributedObjectStore::initAll(const std::string &protocol_,
                                     const std::string &device_name,
-                                    size_t mount_segment_size) {
+                                    size_t mount_segment_size,
+                                    const std::string &storage_root_path) {
     if (client_) {
         LOG(ERROR) << "Client is already initialized";
         return 1;
     }
     uint64_t buffer_allocator_size = 1024 * 1024 * 1024;
     return setup("localhost:12345", "127.0.0.1:2379", mount_segment_size,
-                 buffer_allocator_size, protocol_, device_name);
+                 buffer_allocator_size, protocol_, device_name,
+                 storage_root_path);
 }
 
 int DistributedObjectStore::allocateSlices(std::vector<Slice> &slices,

--- a/mooncake-integration/vllm/distributed_object_store.h
+++ b/mooncake-integration/vllm/distributed_object_store.h
@@ -57,10 +57,12 @@ class DistributedObjectStore {
               size_t local_buffer_size = 1024 * 1024 * 16,
               const std::string &protocol = "tcp",
               const std::string &rdma_devices = "",
-              const std::string &master_server_addr = "127.0.0.1:50051");
+              const std::string &master_server_addr = "127.0.0.1:50051",
+              const std::string &storage_root_path = "");
 
     int initAll(const std::string &protocol, const std::string &device_name,
-                size_t mount_segment_size = 1024 * 1024 * 16);  // Default 16MB
+                size_t mount_segment_size = 1024 * 1024 * 16, // Default 16MB
+                const std::string &storage_root_path = "");
 
     int put(const std::string &key, const std::string &value);
 

--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -8,6 +8,8 @@
 
 #include "master_client.h"
 #include "rpc_service.h"
+#include "thread_pool.h"
+#include "storage_backend.h"
 #include "transfer_engine.h"
 #include "types.h"
 
@@ -159,6 +161,11 @@ class Client {
         const std::vector<AllocatedBuffer::Descriptor>& handles,
         std::vector<Slice>& slices);
 
+    void SetLocalSSDPath(const std::string& path);
+
+    void SaveToPersistentStorage(
+        const ObjectKey& key, const std::vector<Slice>& slices);
+
     // Core components
     TransferEngine transfer_engine_;
     MasterClient master_client_;
@@ -170,6 +177,11 @@ class Client {
     // Configuration
     const std::string local_hostname_;
     const std::string metadata_connstring_;
+
+    // Persistence
+    std::string local_ssd_path_;
+    ThreadPool background_writer_;
+    std::shared_ptr<StorageBackend> storage_backend_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -36,7 +36,8 @@ class Client {
         const std::string& local_hostname,
         const std::string& metadata_connstring, const std::string& protocol,
         void** protocol_args,
-        const std::string& master_addr = kDefaultMasterAddress);
+        const std::string& master_addr = kDefaultMasterAddress,
+        const std::string& storage_root_path = kDefaultStorageRootPath);
 
     /**
      * @brief Retrieves data for a given key
@@ -141,7 +142,8 @@ class Client {
      * @brief Private constructor to enforce creation through Create() method
      */
     Client(const std::string& local_hostname,
-           const std::string& metadata_connstring);
+           const std::string& metadata_connstring,
+           const std::string& storage_root_path);
 
     /**
      * @brief Internal helper functions for initialization and data transfer
@@ -161,7 +163,7 @@ class Client {
         const std::vector<AllocatedBuffer::Descriptor>& handles,
         std::vector<Slice>& slices);
 
-    void SetLocalSSDPath(const std::string& path);
+    void PrepareStorageRoot(const std::string& path);
 
     void SaveToPersistentStorage(
         const ObjectKey& key, const std::vector<Slice>& slices);
@@ -179,7 +181,7 @@ class Client {
     const std::string metadata_connstring_;
 
     // Persistence
-    std::string local_ssd_path_;
+    std::string storage_root_path_;
     ThreadPool background_writer_;
     std::shared_ptr<StorageBackend> storage_backend_;
 };

--- a/mooncake-store/include/file_storage_backend.h
+++ b/mooncake-store/include/file_storage_backend.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "storage_backend.h"
+#include <string>
+#include <vector>
+#include <mutex>
+#include "types.h"
+
+namespace mooncake {
+
+class FileStorageBackend : public StorageBackend {
+ public:
+  explicit FileStorageBackend(const std::string& root_dir);
+  ErrorCode Write(const ObjectKey& key, const std::vector<Slice>& slices) override;
+  ErrorCode Read(const ObjectKey& key, std::vector<Slice>& slices) override;
+
+ private:
+  std::string SanitizeKey(const ObjectKey& key) const;
+  std::string ResolvePath(const ObjectKey& key) const;
+
+  std::string root_dir_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/local_file.h
+++ b/mooncake-store/include/local_file.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstdlib>
+#include <functional>
+#include <memory>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+
+#include "types.h"
+
+namespace mooncake {
+
+/**
+ * @brief LocalFile class to handle kv cache I/O on file
+ */
+class LocalFile {
+   public:
+    LocalFile(const std::string &file_name, FILE *file,
+        ErrorCode ec = ErrorCode::OK);
+    ~LocalFile();
+
+    /**
+     * @brief Read content from current file to buffer
+     * @param buffer [in] buffer to store the content
+     * @param length [in] length in bytes of content to read
+     * @return ssize_t, the length of content actually read, -1 indicates an error
+     */
+    ssize_t read(void *buffer, size_t length);
+
+    /**
+     * @brief Write content from buffer to current file
+     * @param buffer [in] buffer to write from
+     * @param length [in] length in bytes of content to write
+     * @return ssize_t, the length of content actually write, -1 indicates an error
+     */
+    ssize_t write(const void *buffer, size_t length);
+
+    /**
+     * @brief Read iovcnt buffers from current file into the buffers described by iov
+     * @param iov [in] points to an array of iovec structures, refer to preadv(2)
+     * @param iovcnt [in] count of iovec
+     * @param offset [in] file offset from which to read in bytes
+     * @return ssize_t, the length of content actually read, -1 indicates an error
+     */
+    ssize_t preadv(const iovec *iov, int iovcnt, off_t offset);
+
+    /**
+     * @brief Write content from buffer to current file, file offset is not changed
+     * @param iov [in] buffer to write from
+     * @param iovcnt [in] count of iovec
+     * @param offset [in] file offset from which to write in bytes
+     * @return ssize_t, the length of content actually write, -1 indicates an error
+     */
+    ssize_t pwritev(const iovec *iov, int iovcnt, off_t offset);
+
+    const char *getFileName() const { return file_name_.c_str(); }
+
+    ErrorCode error_code_;
+
+   private:
+    std::string file_name_;
+    FILE *file_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/local_file.h
+++ b/mooncake-store/include/local_file.h
@@ -57,11 +57,12 @@ class LocalFile {
 
     const char *getFileName() const { return file_name_.c_str(); }
 
-    ErrorCode error_code_;
+    ErrorCode error_code() const { return error_code_; }
 
    private:
     std::string file_name_;
     FILE *file_;
+    ErrorCode error_code_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include "types.h"
+
+namespace mooncake {
+
+class StorageBackend {
+ public:
+  virtual ~StorageBackend() = default;
+
+  virtual ErrorCode Write(const ObjectKey& key, const std::vector<Slice>& slices) = 0;
+  virtual ErrorCode Read(const ObjectKey& key, std::vector<Slice>& slices) = 0;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -6,6 +6,7 @@
 
 namespace mooncake {
 
+static const std::string kDefaultStorageRootPath = "";
 class StorageBackend {
  public:
   virtual ~StorageBackend() = default;

--- a/mooncake-store/include/thread_pool.h
+++ b/mooncake-store/include/thread_pool.h
@@ -1,0 +1,108 @@
+#pragma once
+#include <vector>
+#include <queue>
+#include <memory>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <future>
+#include <functional>
+#include <stdexcept>
+
+namespace mooncake {
+
+
+class ThreadPool {
+   public:
+    ThreadPool(size_t);
+    template <class F, class... Args>
+    auto enqueue(F&& f, Args&&... args)
+        -> std::future<typename std::result_of<F(Args...)>::type>;
+    ~ThreadPool();
+    void exit();
+    void clear();
+
+    private:
+    // Need to keep track of threads so we can join them
+    std::vector<std::thread> workers_;
+    std::queue<std::function<void()>> tasks_;
+
+    // Synchronization
+    std::mutex queue_mutex_;
+    std::condition_variable condition_;
+    bool stop_;
+};
+
+// The constructor just launches some amount of workers
+inline ThreadPool::ThreadPool(size_t threads) : stop_(false) {
+    assert(threads >= 1);
+    for (size_t i = 0; i < threads; ++i)
+    workers_.emplace_back([this] {
+        for (;;) {
+            std::function<void()> task;
+            {
+                std::unique_lock<std::mutex> lock(this->queue_mutex_);
+                this->condition_.wait(
+                    lock, [this] {
+                        return this->stop_ || !this->tasks_.empty(); });
+                if (this->stop_ && this->tasks_.empty()) return;
+                task = std::move(this->tasks_.front());
+                this->tasks_.pop();
+            }
+
+            try {
+                task();
+            } catch (const std::exception& e) {
+                // Handle or log the exception
+            } catch (...) {
+                // Handle or log unknown exceptions
+            }
+        }
+    });
+}
+
+// Add new work item to the pool
+template <class F, class... Args>
+auto ThreadPool::enqueue(F&& f, Args&&... args)
+    -> std::future<typename std::result_of<F(Args...)>::type> {
+    using return_type = typename std::result_of<F(Args...)>::type;
+
+    auto task = std::make_shared<std::packaged_task<return_type()> >(
+        std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+
+    std::future<return_type> res = task->get_future();
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+
+        if (stop_) throw std::runtime_error("enqueue on stopped ThreadPool");
+
+        tasks_.emplace([task]() { (*task)(); });
+    }
+    condition_.notify_one();
+    return res;
+}
+
+// the destructor joins all threads
+inline ThreadPool::~ThreadPool() { exit(); }
+
+inline void ThreadPool::clear() {
+    std::unique_lock<std::mutex> lock(queue_mutex_);
+    while (!tasks_.empty()) {
+        tasks_.pop();
+    }
+}
+
+inline void ThreadPool::exit() {
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        stop_ = true;
+    }
+    condition_.notify_all();
+    for (std::thread& worker : workers_) {
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -82,6 +82,7 @@ enum class ErrorCode : int32_t {
     // Persistence errors (Range: -1000 to -1099)
     BAD_FILE = -1000,  ///< Bad file.
     BAD_ARGS = -1001,  ///< Bad arguments.
+    NOT_FOUND = -1002,  ///< Not found.
 };
 
 int32_t toInt(ErrorCode errorCode) noexcept;

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -78,6 +78,10 @@ enum class ErrorCode : int32_t {
 
     // RPC errors (Range: -900 to -999)
     RPC_FAIL = -900,  ///< RPC operation failed.
+
+    // Persistence errors (Range: -1000 to -1099)
+    BAD_FILE = -1000,  ///< Bad file.
+    BAD_ARGS = -1001,  ///< Bad arguments.
 };
 
 int32_t toInt(ErrorCode errorCode) noexcept;

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -9,6 +9,7 @@ set(MOONCAKE_STORE_SOURCES
     master_client.cpp
     utils.cpp
     master_metric_manager.cpp
+    local_file.cpp
 )
 
 # The cache_allocator library

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(MOONCAKE_STORE_SOURCES
     utils.cpp
     master_metric_manager.cpp
     local_file.cpp
+    file_storage_backend.cpp
 )
 
 # The cache_allocator library

--- a/mooncake-store/src/file_storage_backend.cpp
+++ b/mooncake-store/src/file_storage_backend.cpp
@@ -1,0 +1,85 @@
+#include "file_storage_backend.h"
+#include "local_file.h"
+#include <sys/uio.h>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include <glog/logging.h>
+
+namespace mooncake {
+
+FileStorageBackend::FileStorageBackend(const std::string& root_dir)
+    : root_dir_(root_dir) {
+    std::filesystem::create_directories(root_dir_);
+}
+
+std::string FileStorageBackend::SanitizeKey(const ObjectKey& key) const {
+    std::string safe_key = key;
+    std::replace(safe_key.begin(), safe_key.end(), '/', '_');
+    return safe_key;
+}
+
+std::string FileStorageBackend::ResolvePath(const ObjectKey& key) const {
+    std::hash<std::string> hasher;
+    size_t hash = hasher(key);
+
+    std::stringstream ss;
+    ss << std::hex << ((hash >> 16) & 0xFF) << '/' << ((hash >> 8) & 0xFF);
+    std::string prefix = ss.str();
+
+    std::string safe_key = SanitizeKey(key);
+    std::filesystem::path full_dir = std::filesystem::path(root_dir_) / prefix;
+    std::filesystem::create_directories(full_dir);
+    return (full_dir / safe_key).string();
+}
+
+ErrorCode FileStorageBackend::Write(const ObjectKey& key, const std::vector<Slice>& slices) {
+    std::string path = ResolvePath(key);
+    FILE* f = fopen(path.c_str(), "wb");
+    if (!f) {
+        LOG(ERROR) << "Failed to open file for write: " << path;
+        return ErrorCode::BAD_FILE;
+    }
+
+    LocalFile local_file(path, f, ErrorCode::OK);
+    std::vector<iovec> iovs;
+    for (const auto& slice : slices) {
+        iovec io{ slice.ptr, slice.size };
+        iovs.push_back(io);
+    }
+
+    ssize_t ret = local_file.pwritev(iovs.data(), static_cast<int>(iovs.size()), 0);
+    if (ret < 0) {
+        LOG(ERROR) << "pwritev failed for: " << path;
+        return ErrorCode::BAD_FILE;
+    }
+
+    return ErrorCode::OK;
+}
+
+ErrorCode FileStorageBackend::Read(const ObjectKey& key, std::vector<Slice>& slices) {
+    std::string path = ResolvePath(key);
+    FILE* f = fopen(path.c_str(), "rb");
+    if (!f) {
+        LOG(WARNING) << "File not found: " << path;
+        return ErrorCode::NOT_FOUND;
+    }
+
+    LocalFile local_file(path, f, ErrorCode::OK);
+    std::vector<iovec> iovs;
+    for (auto& slice : slices) {
+        iovec io{ slice.ptr, slice.size };
+        iovs.push_back(io);
+    }
+
+    ssize_t ret = local_file.preadv(iovs.data(), static_cast<int>(iovs.size()), 0);
+    if (ret < 0) {
+        LOG(ERROR) << "preadv failed for: " << path;
+        return ErrorCode::BAD_FILE;
+    }
+
+    return ErrorCode::OK;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/local_file.cpp
+++ b/mooncake-store/src/local_file.cpp
@@ -1,0 +1,121 @@
+#include "local_file.h"
+
+#include <string>
+#include <vector>
+
+#include "types.h"
+
+namespace mooncake {
+
+using namespace std;
+
+LocalFile::LocalFile(const string &file_name, FILE *file, ErrorCode ec)
+    : file_name_(file_name), file_(file), error_code_(ec) {}
+
+LocalFile::~LocalFile() {
+    if (file_) {
+        fclose(file_);
+        file_ = nullptr;
+    }
+}
+
+ssize_t LocalFile::read(void *buffer, size_t length) {
+    if (!file_) {
+        error_code_ = ErrorCode::BAD_FILE;
+        return -1;
+    }
+
+    if (length > static_cast<size_t>(std::numeric_limits<ssize_t>::max())) {
+        error_code_ = ErrorCode::BAD_ARGS;
+        return -1;
+    }
+
+    size_t bytes_remaining = length;
+    size_t bytes_read = 0;
+    while (bytes_remaining > 0) {
+        size_t ret = fread(reinterpret_cast<char*>(buffer) + bytes_read,
+                           1, bytes_remaining, file_);
+        if (ret == 0) {
+            if (feof(file_)) {
+                break;
+            }
+            if (ferror(file_)) {
+                error_code_ = ErrorCode::BAD_ARGS;
+                return -1;
+            }
+        }
+        bytes_read += ret;
+        bytes_remaining -= ret;
+    }
+
+    return static_cast<ssize_t>(bytes_read);
+}
+
+ssize_t LocalFile::write(const void *buffer, size_t length) {
+    if (!file_) {
+        error_code_ = ErrorCode::BAD_FILE;
+        return -1;
+    }
+
+    if (length > static_cast<size_t>(std::numeric_limits<ssize_t>::max())) {
+        error_code_ = ErrorCode::BAD_ARGS;
+        return -1;
+    }
+
+    size_t bytes_remaining = length;
+    size_t bytes_written = 0;
+    while (bytes_remaining > 0) {
+        size_t ret = fwrite(
+            reinterpret_cast<const char*>(buffer) + bytes_written,
+            1, bytes_remaining, file_);
+        if (ret == 0) {
+            if (ferror(file_)) {
+                // TODO: convert errno into ErrorCode
+                error_code_ = ErrorCode::BAD_FILE;
+                return -1;
+            }
+            break;
+        }
+        bytes_written += ret;
+        bytes_remaining -= ret;
+    }
+
+    return static_cast<ssize_t>(bytes_written);
+}
+
+ssize_t LocalFile::preadv(const iovec *iov, int iovcnt, off_t offset) {
+    if (!file_) {
+        error_code_ = ErrorCode::BAD_FILE;
+        return -1;
+    }
+
+    int fd = fileno(file_);
+    ssize_t ret = ::preadv(fd, iov, iovcnt, offset);
+    if (ret == -1) {
+        // TODO: convert errno into ErrorCode
+        error_code_ = ErrorCode::BAD_FILE;
+    }
+    return ret;
+}
+
+ssize_t LocalFile::pwritev(const iovec *iov, int iovcnt, off_t offset) {
+    if (!file_) {
+        error_code_ = ErrorCode::BAD_FILE;
+        return -1;
+    }
+
+    if (iov == nullptr || iovcnt <= 0) {
+        error_code_ = ErrorCode::BAD_FILE;
+        return -1;
+    }
+
+    int fd = fileno(file_);
+    auto ret = ::pwritev(fd, iov, iovcnt, offset);
+    if (ret == -1) {
+        // TODO: convert errno into ErrorCode
+        error_code_ = ErrorCode::BAD_FILE;
+    }
+    return ret;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/vllm/distributed_object_store.h
+++ b/mooncake-store/src/vllm/distributed_object_store.h
@@ -22,7 +22,8 @@ class DistributedObjectStore {
               const std::string &master_server_addr = "127.0.0.1:50051");
 
     int initAll(const std::string &protocol, const std::string &device_name,
-                size_t mount_segment_size = 1024 * 1024 * 16);  // Default 16MB
+                size_t mount_segment_size = 1024 * 1024 * 16, // Default 16MB
+                const std::string &storage_root_path);
 
     int put(const std::string &key, const std::string &value);
 

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -48,3 +48,14 @@ target_link_libraries(thread_pool_test PUBLIC
     pthread
 )
 add_test(NAME thread_pool_test COMMAND thread_pool_test)
+
+add_executable(file_storage_backend_test file_storage_backend_test.cpp)
+target_link_libraries(file_storage_backend_test PUBLIC
+    mooncake_store
+    cachelib_memory_allocator
+    glog
+    gtest
+    gtest_main
+    pthread
+)
+add_test(NAME file_storage_backend_test COMMAND file_storage_backend_test)

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -7,22 +7,33 @@ target_link_libraries(master_service_test PUBLIC mooncake_store cachelib_memory_
 add_test(NAME master_service_test COMMAND master_service_test)
 
 add_executable(client_integration_test client_integration_test.cpp)
-target_link_libraries(client_integration_test PUBLIC 
-    mooncake_store 
-    cachelib_memory_allocator 
-    glog 
-    gtest 
-    gtest_main 
+target_link_libraries(client_integration_test PUBLIC
+    mooncake_store
+    cachelib_memory_allocator
+    glog
+    gtest
+    gtest_main
     pthread
 )
 add_test(NAME client_integration_test COMMAND client_integration_test)
 
 add_executable(stress_workload_test stress_workload_test.cpp)
-target_link_libraries(stress_workload_test PUBLIC 
-    mooncake_store 
-    cachelib_memory_allocator 
-    glog 
-    gtest 
-    gtest_main 
+target_link_libraries(stress_workload_test PUBLIC
+    mooncake_store
+    cachelib_memory_allocator
+    glog
+    gtest
+    gtest_main
     pthread
 )
+
+add_executable(local_file_test local_file_test.cpp)
+target_link_libraries(local_file_test PUBLIC
+    mooncake_store
+    cachelib_memory_allocator
+    glog
+    gtest
+    gtest_main
+    pthread
+)
+add_test(NAME local_file_test COMMAND local_file_test)

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -37,3 +37,14 @@ target_link_libraries(local_file_test PUBLIC
     pthread
 )
 add_test(NAME local_file_test COMMAND local_file_test)
+
+add_executable(thread_pool_test thread_pool_test.cpp)
+target_link_libraries(thread_pool_test PUBLIC
+    mooncake_store
+    cachelib_memory_allocator
+    glog
+    gtest
+    gtest_main
+    pthread
+)
+add_test(NAME thread_pool_test COMMAND thread_pool_test)

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -18,6 +18,7 @@ DEFINE_string(device_name, "ibp6s0",
               "Device name to use, valid if protocol=rdma");
 DEFINE_string(transfer_engine_metadata_url, "http://127.0.0.1:8090/metadata",
               "Metadata connection string for transfer engine");
+DEFINE_string(storage_root_path, "", "Storage root path");
 
 namespace mooncake {
 namespace testing {
@@ -72,7 +73,8 @@ class ClientIntegrationTest : public ::testing::Test {
             "localhost:17812",                   // Local hostname
             FLAGS_transfer_engine_metadata_url,  // Metadata connection string
             FLAGS_protocol, args,
-            "localhost:50051"  // Master server address
+            "localhost:50051",  // Master server address
+            FLAGS_storage_root_path
         );
 
         ASSERT_TRUE(client_opt.has_value()) << "Failed to create client";

--- a/mooncake-store/tests/file_storage_backend_test.cpp
+++ b/mooncake-store/tests/file_storage_backend_test.cpp
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+#include "file_storage_backend.h"
+#include <filesystem>
+#include <cstring>
+#include <memory>
+
+namespace mooncake {
+namespace testing {
+
+class FileStorageBackendTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+    test_dir_ = std::filesystem::temp_directory_path() / "fsb_test";
+    std::filesystem::remove_all(test_dir_);
+    std::filesystem::create_directory(test_dir_);
+    backend_ = std::make_unique<FileStorageBackend>(test_dir_.string());
+    }
+
+    void TearDown() override {
+        std::filesystem::remove_all(test_dir_);
+    }
+
+    std::unique_ptr<FileStorageBackend> backend_;
+    std::filesystem::path test_dir_;
+};
+
+TEST_F(FileStorageBackendTest, WriteAndReadSingleKey) {
+    std::string key = "test_key";
+    std::string content = "Mooncake Store SSD Offload!";
+    std::vector<char> buffer(content.begin(), content.end());
+    Slice write_slice{buffer.data(), buffer.size()};
+    std::vector<Slice> slices{write_slice};
+
+    {
+        EXPECT_EQ(backend_->Write(key, slices), ErrorCode::OK);
+    }
+
+    std::vector<char> read_buf(buffer.size(), 0);
+    Slice read_slice{read_buf.data(), read_buf.size()};
+    std::vector<Slice> read_slices{read_slice};
+
+    EXPECT_EQ(backend_->Read(key, read_slices), ErrorCode::OK);
+    EXPECT_EQ(std::memcmp(buffer.data(), read_buf.data(), buffer.size()), 0);
+}
+
+TEST_F(FileStorageBackendTest, WriteAndReadMultipleSlices) {
+    std::string key = "multi_slice_key";
+    std::string content1 = "Tensor1Data";
+    std::string content2 = "Tensor2DataLonger";
+    std::string content3 = "Tensor3DataLongest";
+
+    std::vector<char> buffer1(content1.begin(), content1.end());
+    std::vector<char> buffer2(content2.begin(), content2.end());
+    std::vector<char> buffer3(content3.begin(), content3.end());
+
+    Slice s1{buffer1.data(), buffer1.size()};
+    Slice s2{buffer2.data(), buffer2.size()};
+    Slice s3{buffer3.data(), buffer3.size()};
+    std::vector<Slice> write_slices{s1, s2, s3};
+
+    EXPECT_EQ(backend_->Write(key, write_slices), ErrorCode::OK);
+
+    std::vector<char> read_buf1(buffer1.size(), 0);
+    std::vector<char> read_buf2(buffer2.size(), 0);
+    std::vector<char> read_buf3(buffer3.size(), 0);
+
+    Slice rs1{read_buf1.data(), read_buf1.size()};
+    Slice rs2{read_buf2.data(), read_buf2.size()};
+    Slice rs3{read_buf3.data(), read_buf3.size()};
+    std::vector<Slice> read_slices{rs1, rs2, rs3};
+
+    EXPECT_EQ(backend_->Read(key, read_slices), ErrorCode::OK);
+    EXPECT_EQ(std::memcmp(buffer1.data(), read_buf1.data(), buffer1.size()), 0);
+    EXPECT_EQ(std::memcmp(buffer2.data(), read_buf2.data(), buffer2.size()), 0);
+    EXPECT_EQ(std::memcmp(buffer3.data(), read_buf3.data(), buffer3.size()), 0);
+}
+
+TEST_F(FileStorageBackendTest, ReadNonExistentKey) {
+    std::string key = "nonexistent";
+    std::vector<char> read_buf(10, 0);
+    Slice read_slice{read_buf.data(), read_buf.size()};
+    std::vector<Slice> slices{read_slice};
+
+    EXPECT_EQ(backend_->Read(key, slices), ErrorCode::NOT_FOUND);
+}
+
+}  // namespace testing
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    // Initialize Google's flags library
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+    // Initialize Google Test
+    ::testing::InitGoogleTest(&argc, argv);
+
+    // Run all tests
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-store/tests/local_file_test.cpp
+++ b/mooncake-store/tests/local_file_test.cpp
@@ -1,0 +1,204 @@
+#include <gtest/gtest.h>
+#include <fstream>
+#include <cstdio>
+#include <cerrno>
+#include <vector>
+#include <sys/uio.h>
+
+#include "local_file.h"  // Include the header for LocalFile class
+
+namespace mooncake {
+namespace testing {
+
+class LocalFileTest : public ::testing::Test {
+protected:
+    // Test fixture setup and teardown
+    static void SetUpTestSuite() {
+        // This function will be run before any test cases are executed.
+        // We can initialize shared resources if needed.
+    }
+
+    static void TearDownTestSuite() {
+        // This function will be run after all test cases are executed.
+        // We can release shared resources if needed.
+    }
+
+    void SetUp() override {
+        // This function will be run before each test case.
+        // You can set up individual resources like creating a temporary file.
+    }
+
+    void TearDown() override {
+        // This function will be run after each test case.
+        // Clean up resources after each test.
+    }
+};
+
+TEST_F(LocalFileTest, TestRead) {
+    // Create a temporary file with some content
+    const std::string test_file = "test_file.txt";
+    FILE *file = fopen(test_file.c_str(), "w+");
+    ASSERT_TRUE(file != nullptr);
+
+    const char *test_data = "Hello, world!";
+    fwrite(test_data, 1, strlen(test_data), file);
+    fflush(file);
+    fseek(file, 0, SEEK_SET);  // Go back to the start of the file
+
+    // Create LocalFile object
+    LocalFile local_file(test_file, file);
+
+    // Test normal read
+    char buffer[50];
+    ssize_t bytes_read = local_file.read(buffer, sizeof(buffer) - 1);
+    ASSERT_GE(bytes_read, 0);
+    buffer[bytes_read] = '\0';
+    ASSERT_STREQ(buffer, test_data);
+
+    // Test read with bad file
+    LocalFile bad_file("bad_file.txt", nullptr);
+    bytes_read = bad_file.read(buffer, sizeof(buffer) - 1);
+    ASSERT_EQ(bytes_read, -1);
+    ASSERT_EQ(bad_file.error_code_, ErrorCode::BAD_FILE);
+
+}
+
+TEST_F(LocalFileTest, TestWrite) {
+    // Create a temporary file
+    const std::string test_file = "test_file.txt";
+    FILE *file = fopen(test_file.c_str(), "w+");
+    ASSERT_TRUE(file != nullptr);
+
+    // Create LocalFile object
+    LocalFile local_file(test_file, file);
+
+    // Test normal write
+    const char *write_data = "Hello, GTest!";
+    ssize_t bytes_written = local_file.write(write_data, strlen(write_data));
+    ASSERT_GE(bytes_written, 0);
+    ASSERT_EQ(bytes_written, strlen(write_data));
+
+    // Check if the content was written correctly
+    fseek(file, 0, SEEK_SET);
+    char buffer[50];
+    fread(buffer, 1, bytes_written, file);
+    buffer[bytes_written] = '\0';
+    ASSERT_STREQ(buffer, write_data);
+
+    // Test write with bad file
+    LocalFile bad_file("bad_file.txt", nullptr);
+    bytes_written = bad_file.write(write_data, strlen(write_data));
+    ASSERT_EQ(bytes_written, -1);
+    ASSERT_EQ(bad_file.error_code_, ErrorCode::BAD_FILE);
+
+}
+
+TEST_F(LocalFileTest, TestPreadv) {
+    const std::string test_file = "test_file.txt";
+    FILE *file = fopen(test_file.c_str(), "w+");
+    ASSERT_TRUE(file != nullptr);
+
+    const char *test_data = "Hello, preadv! This is a test for the preadv function. "
+                            "It should handle multiple buffers correctly, even with larger data.";
+    fwrite(test_data, 1, strlen(test_data), file);
+    fflush(file);
+
+    fseek(file, 0, SEEK_SET);
+
+    LocalFile local_file(test_file, file);
+
+    struct iovec iov[3];
+    char buffer1[20], buffer2[20], buffer3[50];
+    iov[0].iov_base = buffer1;
+    iov[0].iov_len = sizeof(buffer1) - 1;
+    std::cout << "iov[0].iov_len=" << iov[0].iov_len << std::endl;
+    iov[1].iov_base = buffer2;
+    iov[1].iov_len = sizeof(buffer2) - 1;
+    iov[2].iov_base = buffer3;
+    iov[2].iov_len = sizeof(buffer3) - 1;
+
+    ssize_t bytes_read = local_file.preadv(iov, 3, 0);
+    ASSERT_GE(bytes_read, 0);
+    std::cout << "bytes_read=" << bytes_read << std::endl;
+
+    buffer1[iov[0].iov_len] = '\0';
+    buffer2[iov[1].iov_len] = '\0';
+    buffer3[iov[2].iov_len] = '\0';
+
+    ASSERT_TRUE(bytes_read > 0);
+    ASSERT_EQ(memcmp(buffer1, iov[0].iov_base, 19), 0);
+    ASSERT_EQ(memcmp(buffer2, iov[1].iov_base, 19), 0);
+    ASSERT_EQ(memcmp(buffer3, iov[2].iov_base, 49), 0);
+
+    bytes_read = local_file.preadv(iov, 3, 500);
+    ASSERT_EQ(bytes_read, 0);
+
+    LocalFile bad_file("bad_file.txt", nullptr);
+    bytes_read = bad_file.preadv(iov, 3, 0);
+    ASSERT_EQ(bytes_read, -1);
+    ASSERT_EQ(bad_file.error_code_, ErrorCode::BAD_FILE);
+}
+
+TEST_F(LocalFileTest, TestPwritev) {
+    const std::string test_file = "test_file.txt";
+    FILE *file = fopen(test_file.c_str(), "w+");
+    ASSERT_TRUE(file != nullptr);
+
+    // Create LocalFile object
+    LocalFile local_file(test_file, file);
+
+    // Prepare the iovec structure for pwritev
+    const char *write_data = "Hello, pwritev!";
+    struct iovec iov[1];
+    iov[0].iov_base = const_cast<char*>(write_data);
+    iov[0].iov_len = strlen(write_data);
+
+    // Test normal pwritev
+    ssize_t bytes_written = local_file.pwritev(iov, 1, 0);
+    ASSERT_GE(bytes_written, 0);
+    ASSERT_EQ(bytes_written, strlen(write_data));
+
+    // Check if the content was written correctly
+    fseek(file, 0, SEEK_SET);
+    char buffer[50];
+    fread(buffer, 1, bytes_written, file);
+    buffer[bytes_written] = '\0';
+    ASSERT_STREQ(buffer, write_data);
+
+    // Test pwritev with bad file
+    LocalFile bad_file("bad_file.txt", nullptr);
+    bytes_written = bad_file.pwritev(iov, 1, 0);
+    ASSERT_EQ(bytes_written, -1);
+    ASSERT_EQ(bad_file.error_code_, ErrorCode::BAD_FILE);
+
+}
+
+// Test error codes
+TEST_F(LocalFileTest, TestErrorCodes) {
+    const std::string test_file = "test_file.txt";
+    FILE *file = fopen(test_file.c_str(), "w+");
+    ASSERT_TRUE(file != nullptr);
+
+    // Create LocalFile object
+    LocalFile local_file(test_file, file);
+
+    // Test error code when file is null
+    LocalFile bad_file("bad_file.txt", nullptr);
+    bad_file.read(nullptr, 0);
+    ASSERT_EQ(bad_file.error_code_, ErrorCode::BAD_FILE);
+
+}
+
+}  // namespace testing
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    // Initialize Google's flags library
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+    // Initialize Google Test
+    ::testing::InitGoogleTest(&argc, argv);
+
+    // Run all tests
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-store/tests/local_file_test.cpp
+++ b/mooncake-store/tests/local_file_test.cpp
@@ -59,7 +59,7 @@ TEST_F(LocalFileTest, TestRead) {
     LocalFile bad_file("bad_file.txt", nullptr);
     bytes_read = bad_file.read(buffer, sizeof(buffer) - 1);
     ASSERT_EQ(bytes_read, -1);
-    ASSERT_EQ(bad_file.error_code_, ErrorCode::BAD_FILE);
+    ASSERT_EQ(bad_file.error_code(), ErrorCode::BAD_FILE);
 
 }
 
@@ -89,7 +89,7 @@ TEST_F(LocalFileTest, TestWrite) {
     LocalFile bad_file("bad_file.txt", nullptr);
     bytes_written = bad_file.write(write_data, strlen(write_data));
     ASSERT_EQ(bytes_written, -1);
-    ASSERT_EQ(bad_file.error_code_, ErrorCode::BAD_FILE);
+    ASSERT_EQ(bad_file.error_code(), ErrorCode::BAD_FILE);
 
 }
 
@@ -136,7 +136,7 @@ TEST_F(LocalFileTest, TestPreadv) {
     LocalFile bad_file("bad_file.txt", nullptr);
     bytes_read = bad_file.preadv(iov, 3, 0);
     ASSERT_EQ(bytes_read, -1);
-    ASSERT_EQ(bad_file.error_code_, ErrorCode::BAD_FILE);
+    ASSERT_EQ(bad_file.error_code(), ErrorCode::BAD_FILE);
 }
 
 TEST_F(LocalFileTest, TestPwritev) {
@@ -169,7 +169,7 @@ TEST_F(LocalFileTest, TestPwritev) {
     LocalFile bad_file("bad_file.txt", nullptr);
     bytes_written = bad_file.pwritev(iov, 1, 0);
     ASSERT_EQ(bytes_written, -1);
-    ASSERT_EQ(bad_file.error_code_, ErrorCode::BAD_FILE);
+    ASSERT_EQ(bad_file.error_code(), ErrorCode::BAD_FILE);
 
 }
 
@@ -185,7 +185,7 @@ TEST_F(LocalFileTest, TestErrorCodes) {
     // Test error code when file is null
     LocalFile bad_file("bad_file.txt", nullptr);
     bad_file.read(nullptr, 0);
-    ASSERT_EQ(bad_file.error_code_, ErrorCode::BAD_FILE);
+    ASSERT_EQ(bad_file.error_code(), ErrorCode::BAD_FILE);
 
 }
 

--- a/mooncake-store/tests/stress_workload_test.cpp
+++ b/mooncake-store/tests/stress_workload_test.cpp
@@ -17,6 +17,7 @@ DEFINE_string(protocol, "rdma", "Transfer protocol: rdma|tcp");
 DEFINE_string(device_name, "ibp6s0",
               "Device name to use, valid if protocol=rdma");
 DEFINE_string(master_address, "localhost:50051", "Address of master server");
+DEFINE_string(storage_root_path, "", "Storage root path");
 
 namespace mooncake {
 namespace testing {
@@ -136,7 +137,8 @@ class ClientIntegrationTest : public ::testing::Test {
         auto client_opt =
             Client::Create("localhost:12345",  // Local hostname
                            "127.0.0.1:2379",   // Metadata connection string
-                           FLAGS_protocol, args, FLAGS_master_address);
+                           FLAGS_protocol, args, FLAGS_master_address,
+                           FLAGS_storage_root_path);
 
         ASSERT_TRUE(client_opt.has_value()) << "Failed to create client";
         client_ = *client_opt;

--- a/mooncake-store/tests/test_distributed_object_store.py
+++ b/mooncake-store/tests/test_distributed_object_store.py
@@ -13,21 +13,21 @@ class TestClass:
     def __init__(self, version=1, shape=(1, 2, 3)):
         self.version = version
         self.shape = shape
-    
+
     def serialize_into(self, buffer):
         struct.pack_into("i", buffer, 0, self.version)
         struct.pack_into("3i", buffer, 4, *self.shape)
-        
+
     def serialize_into(self):
         version_bytes = struct.pack("i", self.version)
         shape_bytes = struct.pack("3i", *self.shape)
         return (version_bytes, shape_bytes)
-        
+
     def deserialize_from(buffer):
         version = struct.unpack_from("i", buffer, 0)[0]
         shape = struct.unpack_from("3i", buffer, 4)
         return TestClass(version, shape)
-         
+
 def get_client(store):
     """Initialize and setup the distributed store client."""
     protocol = os.getenv("PROTOCOL", "tcp")
@@ -37,17 +37,19 @@ def get_client(store):
     global_segment_size = 3200 * 1024 * 1024  # 3200 MB
     local_buffer_size = 512 * 1024 * 1024     # 512 MB
     master_server_address = os.getenv("MASTER_SERVER", "127.0.0.1:50051")
-    
+    storage_root_path = ""
+
     retcode = store.setup(
-        local_hostname, 
-        metadata_server, 
+        local_hostname,
+        metadata_server,
         global_segment_size,
-        local_buffer_size, 
-        protocol, 
+        local_buffer_size,
+        protocol,
         device_name,
-        master_server_address
+        master_server_address,
+        storage_root_path
     )
-    
+
     if retcode:
         raise RuntimeError(f"Failed to setup store client. Return code: {retcode}")
 
@@ -58,24 +60,24 @@ class TestDistributedObjectStore(unittest.TestCase):
         """Initialize the store once for all tests."""
         cls.store = MooncakeDistributedStore()
         get_client(cls.store)
-    
+
     def test_client_tear_down(self):
         """Test client tear down and re-initialization."""
         test_data = b"Hello, World!"
         key = "test_teardown_key"
-        
+
         # Put data and verify teardown clears it
         self.assertEqual(self.store.put(key, test_data), 0)
         self.assertEqual(self.store.close(), 0)
         time.sleep(1)  # Allow time for teardown to complete
-        
+
         # Re-initialize the store
         get_client(self.store)
-        
+
         # Verify data is gone after teardown
         retrieved_data = self.store.get(key)
         self.assertEqual(retrieved_data, b"")
-        
+
         # Verify store is functional after re-initialization
         self.assertEqual(self.store.put(key, test_data), 0)
         retrieved_data = self.store.get(key)
@@ -108,89 +110,89 @@ class TestDistributedObjectStore(unittest.TestCase):
         # Test is_exist functionality
         test_data_2 = b"Testing exists!"
         key_2 = "test_exist_key"
-        
+
         # Should not exist initially
         self.assertLess(self.store.get_size(key_2), 0)
         self.assertEqual(self.store.is_exist(key_2), 0)
-        
+
         # Should exist after put
         self.assertEqual(self.store.put(key_2, test_data_2), 0)
         self.assertEqual(self.store.is_exist(key_2), 1)
         self.assertEqual(self.store.get_size(key_2), len(test_data_2))
-        
+
         # Should not exist after remove
         self.assertEqual(self.store.remove(key_2), 0)
         self.assertLess(self.store.get_size(key_2), 0)
         self.assertEqual(self.store.is_exist(key_2), 0)
-        
+
     def test_large_buffer(self):
         """Test SliceBuffer with large data that might span multiple slices."""
         # Create a large data buffer (10MB)
         size = 20 * 1024 * 1024
         test_data = os.urandom(size)
         key = "test_large_slice_buffer_key"
-        
+
         # Put data
         self.assertEqual(self.store.put(key, test_data), 0)
-        
+
         # Get buffer
         buffer = self.store.get_buffer(key)
         self.assertIsNotNone(buffer)
-        
+
         # Check size
         self.assertEqual(buffer.size(), size)
-        
+
         # Get consolidated pointer
         ptr = buffer.consolidated_ptr()
         self.assertNotEqual(ptr, 0)
-        
+
         # Create a ctypes buffer from the pointer
         c_buffer = (ctypes.c_char * buffer.size()).from_address(ptr)
         retrieved_data = bytes(c_buffer)
-        
+
         # Verify data
         self.assertEqual(retrieved_data, test_data)
-        
+
         # Clean up
         self.assertEqual(self.store.remove(key), 0)
-    
+
     def test_serialization_and_deserialization(self):
         """Test serialization and deserialization of custom objects."""
         test_object = TestClass()
         key = "test_serialization_key"
-        
+
         # Serialize the object into a buffer
         buffer = bytearray(16)  # 16 bytes for the test object
         test_object.serialize_into(buffer)
-        
+
         # Put the serialized data
         self.assertEqual(self.store.put(key, buffer), 0)
-        
+
         # Get the serialized data
         retrieved_buffer = self.store.get_buffer(key)
         retrieved_buffer = memoryview(retrieved_buffer)
         self.assertEqual(len(retrieved_buffer), 16)
-        
+
         # Deserialize the object from the retrieved buffer
         deserialized_object = TestClass.deserialize_from(retrieved_buffer)
-        
+
         # Verify deserialized object
         self.assertEqual(deserialized_object.version, 1)
         self.assertEqual(deserialized_object.shape, (1, 2, 3))
-        
+
         # Clean up
         self.assertEqual(self.store.remove(key), 0)
-        
+
         (version_bytes, shape_bytes) = test_object.serialize_into()
         self.assertEqual(self.store.put_parts(key, version_bytes, shape_bytes),0)
-        
+
         retrieved_buffer = self.store.get_buffer(key)
         retrieved_buffer = memoryview(retrieved_buffer)
         self.assertEqual(len(retrieved_buffer), 16)
         deserialized_object = TestClass.deserialize_from(retrieved_buffer)
         self.assertEqual(deserialized_object.version, 1)
         self.assertEqual(deserialized_object.shape, (1, 2, 3))
-        
+
         self.assertEqual(self.store.remove(key), 0)
 
     def test_concurrent_stress_with_barrier(self):
@@ -198,12 +200,12 @@ class TestDistributedObjectStore(unittest.TestCase):
         NUM_THREADS = 8
         VALUE_SIZE = 5 * 1024 * 1024  # 1MB
         OPERATIONS_PER_THREAD = 100
-        
+
         # Create barriers for synchronization
         start_barrier = threading.Barrier(NUM_THREADS + 1)  # +1 for main thread
         put_barrier = threading.Barrier(NUM_THREADS + 1)    # Barrier after put operations
         get_barrier = threading.Barrier(NUM_THREADS + 1)    # Barrier after get operations
-        
+
         # Statistics for system-wide timing
         system_stats = {
             'put_start': 0,
@@ -212,85 +214,85 @@ class TestDistributedObjectStore(unittest.TestCase):
             'get_end': 0
         }
         thread_exceptions = []
-        
+
         def worker(thread_id):
             try:
                 # Generate test data (1MB)
                 test_data = os.urandom(VALUE_SIZE)
                 thread_keys = [f"key_{thread_id}_{i}" for i in range(OPERATIONS_PER_THREAD)]
-                
+
                 # Wait for all threads to be ready
                 start_barrier.wait()
-                
+
                 # Put operations
                 for key in thread_keys:
                     result = self.store.put(key, test_data)
                     if result != 0:
                         thread_exceptions.append(f"Put operation failed for key {key} with result {result}")
-                
+
                 # Wait for all threads to complete put operations
                 put_barrier.wait()
-                
+
                 # Get operations
                 for key in thread_keys:
                     buffer = self.store.get_buffer(key)
                     assert buffer is not None
                     assert buffer.size() == VALUE_SIZE
-                    
+
                     retrieved_data = memoryview(buffer)
                     if len(retrieved_data) != VALUE_SIZE:
                         thread_exceptions.append(f"Retrieved data size mismatch for key {key}: expected {VALUE_SIZE}, got {len(retrieved_data)}")
-                
+
                 # Wait for all threads to complete get operations
                 get_barrier.wait()
-                
+
                 # Remove all keys
                 for key in thread_keys:
                     result = self.store.remove(key)
                     if result != 0:
                         thread_exceptions.append(f"Remove operation failed for key {key} with result {result}")
-                
+
             except Exception as e:
                 thread_exceptions.append(f"Thread {thread_id} failed: {str(e)}")
-        
+
         # Create and start threads
         threads = []
         for i in range(NUM_THREADS):
             t = threading.Thread(target=worker, args=(i,), name=f"Worker-{i}")
             threads.append(t)
             t.start()
-        
+
         # Wait for all threads to be ready and start the test
         start_barrier.wait()
-        
+
         # Record put start time
         system_stats['put_start'] = time.time()
-        
+
         # Wait for all put operations to complete
         put_barrier.wait()
         system_stats['put_end'] = time.time()
-        
+
         # Record get start time
         system_stats['get_start'] = time.time()
-        
+
         # Wait for all get operations to complete
         get_barrier.wait()
         system_stats['get_end'] = time.time()
-        
+
         # Join all threads
         for t in threads:
             t.join()
-        
+
         # Check for any exceptions in the main thread
         if thread_exceptions:
             self.fail(f"Test failed with the following errors:\n" + "\n".join(thread_exceptions))
-        
+
         # Calculate system-wide statistics
         total_operations = NUM_THREADS * OPERATIONS_PER_THREAD
         put_duration = system_stats['put_end'] - system_stats['put_start']
         get_duration = system_stats['get_end'] - system_stats['get_start']
         total_data_size_gb = (VALUE_SIZE * total_operations) / (1024**3)
-        
+
         print(f"\nConcurrent Stress Test Results:")
         print(f"Total threads: {NUM_THREADS}")
         print(f"Operations per thread: {OPERATIONS_PER_THREAD}")
@@ -332,10 +334,10 @@ class TestDistributedObjectStore(unittest.TestCase):
                          size = random.randint(1, 64 * 1024 * 1024)
                          value = os.urandom(size)
                          key_values[key] = value
-                     
+
                      fuzz_record.append(f"{i}: put {key} [size: {size}]")
                      error_code = self.store.put(key, value)
-                     if error_code == -200: 
+                     if error_code == -200:
                          # The space is not enough, continue to next operation
                          continue
                      elif error_code == 0:
@@ -362,6 +364,6 @@ class TestDistributedObjectStore(unittest.TestCase):
          # Cleanup: ensure all remaining keys are removed
          for key in list(reference.keys()):
              self.store.remove(key)
-             
+
 if __name__ == '__main__':
     unittest.main()

--- a/mooncake-store/tests/thread_pool_test.cpp
+++ b/mooncake-store/tests/thread_pool_test.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "thread_pool.h"
+
+using namespace mooncake;
+
+class ThreadPoolTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+    // Initialize thread pool with desired number of threads
+    thread_pool_ = std::make_shared<ThreadPool>(5); // Example with 5 threads
+    }
+
+    void TearDown() override {
+    // Clean up thread pool
+    thread_pool_->exit();
+    }
+
+    std::shared_ptr<ThreadPool> thread_pool_;
+};
+
+TEST_F(ThreadPoolTest, TaskWithReturnValue) {
+    std::vector<std::future<int>> results;
+
+    std::string file_name1 = "./test_file1";
+    std::string file_name2 = "./test_file2";
+    auto make_task = [&](const std::string& file_name) {
+        return [file_name]() -> int {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            return 42;
+        };
+    };
+
+    // Submit task to thread pool
+    results.emplace_back(thread_pool_->enqueue(make_task(file_name1)));
+    results.emplace_back(thread_pool_->enqueue(make_task(file_name2)));
+
+    // Wait for tasks to complete and check results
+    for (size_t i = 0; i < results.size(); i++) {
+        int result = results[i].get();
+        EXPECT_EQ(result, 42);
+    }
+}

--- a/mooncake-wheel/tests/test_distributed_object_store.py
+++ b/mooncake-wheel/tests/test_distributed_object_store.py
@@ -15,17 +15,19 @@ def get_client(store):
     global_segment_size = 3200 * 1024 * 1024  # 3200 MB
     local_buffer_size = 512 * 1024 * 1024     # 512 MB
     master_server_address = os.getenv("MASTER_SERVER", "127.0.0.1:50051")
-    
+    storage_root_path = ""
+
     retcode = store.setup(
-        local_hostname, 
-        metadata_server, 
+        local_hostname,
+        metadata_server,
         global_segment_size,
-        local_buffer_size, 
-        protocol, 
+        local_buffer_size,
+        protocol,
         device_name,
-        master_server_address
+        master_server_address,
+        storage_root_path
     )
-    
+
     if retcode:
         raise RuntimeError(f"Failed to setup store client. Return code: {retcode}")
 
@@ -36,24 +38,24 @@ class TestDistributedObjectStore(unittest.TestCase):
         """Initialize the store once for all tests."""
         cls.store = MooncakeDistributedStore()
         get_client(cls.store)
-    
+
     def test_client_tear_down(self):
         """Test client tear down and re-initialization."""
         test_data = b"Hello, World!"
         key = "test_teardown_key"
-        
+
         # Put data and verify teardown clears it
         self.assertEqual(self.store.put(key, test_data), 0)
         self.assertEqual(self.store.close(), 0)
         time.sleep(1)  # Allow time for teardown to complete
-        
+
         # Re-initialize the store
         get_client(self.store)
-        
+
         # Verify data is gone after teardown
         retrieved_data = self.store.get(key)
         self.assertEqual(retrieved_data, b"")
-        
+
         # Verify store is functional after re-initialization
         self.assertEqual(self.store.put(key, test_data), 0)
         retrieved_data = self.store.get(key)
@@ -86,16 +88,16 @@ class TestDistributedObjectStore(unittest.TestCase):
         # Test isExist functionality
         test_data_2 = b"Testing exists!"
         key_2 = "test_exist_key"
-        
+
         # Should not exist initially
         self.assertLess(self.store.get_size(key_2), 0)
         self.assertEqual(self.store.is_exist(key_2), 0)
-        
+
         # Should exist after put
         self.assertEqual(self.store.put(key_2, test_data_2), 0)
         self.assertEqual(self.store.is_exist(key_2), 1)
         self.assertEqual(self.store.get_size(key_2), len(test_data_2))
-        
+
         # Should not exist after remove
         self.assertEqual(self.store.remove(key_2), 0)
         self.assertLess(self.store.get_size(key_2), 0)
@@ -106,12 +108,12 @@ class TestDistributedObjectStore(unittest.TestCase):
         NUM_THREADS = 8
         VALUE_SIZE = 1024 * 1024  # 1MB
         OPERATIONS_PER_THREAD = 100
-        
+
         # Create barriers for synchronization
         start_barrier = threading.Barrier(NUM_THREADS + 1)  # +1 for main thread
         put_barrier = threading.Barrier(NUM_THREADS + 1)    # Barrier after put operations
         get_barrier = threading.Barrier(NUM_THREADS + 1)    # Barrier after get operations
-        
+
         # Statistics for system-wide timing
         system_stats = {
             'put_start': 0,
@@ -120,81 +122,81 @@ class TestDistributedObjectStore(unittest.TestCase):
             'get_end': 0
         }
         thread_exceptions = []
-        
+
         def worker(thread_id):
             try:
                 # Generate test data (1MB)
                 test_data = os.urandom(VALUE_SIZE)
                 thread_keys = [f"key_{thread_id}_{i}" for i in range(OPERATIONS_PER_THREAD)]
-                
+
                 # Wait for all threads to be ready
                 start_barrier.wait()
-                
+
                 # Put operations
                 for key in thread_keys:
                     result = self.store.put(key, test_data)
                     self.assertEqual(result, 0, f"Put operation failed for key {key}")
-                
+
                 # Wait for all threads to complete put operations
                 put_barrier.wait()
-                
+
                 # Get operations
                 for key in thread_keys:
                     retrieved_data = self.store.get(key)
-                    self.assertEqual(len(retrieved_data), VALUE_SIZE, 
+                    self.assertEqual(len(retrieved_data), VALUE_SIZE,
                                     f"Retrieved data size mismatch for key {key}")
-                    self.assertEqual(retrieved_data, test_data, 
+                    self.assertEqual(retrieved_data, test_data,
                                     f"Retrieved data content mismatch for key {key}")
-                
+
                 # Wait for all threads to complete get operations
                 get_barrier.wait()
-                
+
                 # Remove all keys
                 for key in thread_keys:
                     self.assertEqual(self.store.remove(key), 0)
-                
-                
+
+
             except Exception as e:
                 thread_exceptions.append(f"Thread {thread_id} failed: {str(e)}")
-        
+
         # Create and start threads
         threads = []
         for i in range(NUM_THREADS):
             t = threading.Thread(target=worker, args=(i,), name=f"Worker-{i}")
             threads.append(t)
             t.start()
-        
+
         # Wait for all threads to be ready and start the test
         start_barrier.wait()
-        
+
         # Record put start time
         system_stats['put_start'] = time.time()
-        
+
         # Wait for all put operations to complete
         put_barrier.wait()
         system_stats['put_end'] = time.time()
-        
+
         # Record get start time
         system_stats['get_start'] = time.time()
-        
+
         # Wait for all get operations to complete
         get_barrier.wait()
         system_stats['get_end'] = time.time()
-        
-        
+
+
         # Join all threads
         for t in threads:
             t.join()
-        
+
         # Check for any exceptions
         self.assertEqual(len(thread_exceptions), 0, "\n".join(thread_exceptions))
-        
+
         # Calculate system-wide statistics
         total_operations = NUM_THREADS * OPERATIONS_PER_THREAD
         put_duration = system_stats['put_end'] - system_stats['put_start']
         get_duration = system_stats['get_end'] - system_stats['get_start']
         total_data_size_gb = (VALUE_SIZE * total_operations) / (1024**3)
-        
+
         print(f"\nConcurrent Stress Test Results:")
         print(f"Total threads: {NUM_THREADS}")
         print(f"Operations per thread: {OPERATIONS_PER_THREAD}")
@@ -236,10 +238,10 @@ class TestDistributedObjectStore(unittest.TestCase):
                          size = random.randint(1, 64 * 1024 * 1024)
                          value = os.urandom(size)
                          key_values[key] = value
-                     
+
                      fuzz_record.append(f"{i}: put {key} [size: {size}]")
                      error_code = self.store.put(key, value)
-                     if error_code == -200: 
+                     if error_code == -200:
                          # The space is not enough, continue to next operation
                          continue
                      elif error_code == 0:
@@ -266,6 +268,6 @@ class TestDistributedObjectStore(unittest.TestCase):
          # Cleanup: ensure all remaining keys are removed
          for key in list(reference.keys()):
              self.store.remove(key)
-             
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Support KVCache Persistence. This PR is Phase 1. (WIP)

Phase 1: Persist to Local NVMe via POSIX 
- In Client Put path, persist KVCache into POSIX file. Each KVCache key contains 3 tensors, pwritev into a file.
- Provide a thread pool scheduler, run in background.
- In Client Get path, if not find key/value in local memory, try to find in local SSD, if local SSD not able to find, return NotFound.

[Note] This is a preliminary implementation which is the agreement @alogfans and I discussed. We also discussed some solutions like ClickHouse MergeTree and LevelDB / RocksDB LSM tree, but eventually we decided to adopt this concise approach for Phase 1. The reason is in the next step we will implement a UserSpace FileSystem in SPDK which is compliant with the interface and would be more efficient.

TODO: When Mooncake restart, scan all the KVCache files and construct a in-memory KVCache file index. When Get is invoked, first check the cache index.
 
Phase 2: Persist to Local NVMe via SPDK

Phase 3: Persist to remote NVMe via NVMeoF