### PR TITLE
[store|proto]: Add ExistKey rpc as implementation of IsExist

### DIFF
--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -34,6 +34,14 @@ class MasterClient {
         const std::string& master_addr = kDefaultMasterAddress);
 
     /**
+     * @brief Checks if an object exists
+     * @param object_key Key to query
+     * @return ErrorCode indicating exist or not
+     */
+    [[nodiscard]] ExistKeyResponse ExistKey(
+        const std::string& object_key);
+
+    /**
      * @brief Gets object metadata without transferring data
      * @param object_key Key to query
      * @param object_info Output parameter for object metadata

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -39,6 +39,8 @@ class MasterMetricManager {
     void inc_put_revoke_failures(int64_t val = 1.0);
     void inc_get_replica_list_requests(int64_t val = 1.0);
     void inc_get_replica_list_failures(int64_t val = 1.0);
+    void inc_exist_key_requests(int64_t val = 1.0);
+    void inc_exist_key_failures(int64_t val = 1.0);
     void inc_remove_requests(int64_t val = 1.0);
     void inc_remove_failures(int64_t val = 1.0);
     void inc_mount_segment_requests(int64_t val = 1.0);
@@ -83,6 +85,8 @@ class MasterMetricManager {
     ylt::metric::counter_d put_revoke_failures_;
     ylt::metric::counter_d get_replica_list_requests_;
     ylt::metric::counter_d get_replica_list_failures_;
+    ylt::metric::counter_d exist_key_requests_;
+    ylt::metric::counter_d exist_key_failures_;
     ylt::metric::counter_d remove_requests_;
     ylt::metric::counter_d remove_failures_;
     ylt::metric::counter_d mount_segment_requests_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -105,6 +105,12 @@ class MasterService {
     ErrorCode UnmountSegment(const std::string& segment_name);
 
     /**
+     * @brief Check if an object exists
+     * @return ErrorCode::OK if exists, otherwise return other ErrorCode
+     */
+    ErrorCode ExistKey(const std::string& key);
+
+    /**
      * @brief Get list of replicas for an object
      * @param[out] replica_list Vector to store replica information
      * @return ErrorCode::OK on success, ErrorCode::REPLICA_IS_NOT_READY if not

--- a/mooncake-store/proto/master.proto
+++ b/mooncake-store/proto/master.proto
@@ -32,6 +32,16 @@ message ReplicaInfo {
   required ReplicaStatus status = 2 [default = UNDEFINED]; // Replica status.
 }
 
+// Request to check key existence.
+message ExistKeyRequest {
+  required string key = 1; // Object key.
+}
+
+// Response to check key existence.
+message ExistKeyResponse {
+  required int32 status_code = 1; // Status.
+}
+
 // Request to get replica list.
 message GetReplicaListRequest {
   required string key = 1; // Object key.
@@ -137,4 +147,7 @@ service MasterService {
 
   // Unmount a segment.
   rpc UnmountSegment(UnmountSegmentRequest) returns (UnmountSegmentResponse);
+
+  // Check existence of a key.
+  rpc ExistKey(ExistKeyRequest) returns (ExistKeyResponse);
 }

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -363,8 +363,8 @@ ErrorCode Client::unregisterLocalMemory(void* addr, bool update_metadata) {
 }
 
 ErrorCode Client::IsExist(const std::string& key) {
-    ObjectInfo object_info;
-    return Query(key, object_info);
+    auto response = master_client_.ExistKey(key);
+    return response.error_code;
 }
 
 ErrorCode Client::TransferData(

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -36,6 +36,8 @@ int main(int argc, char* argv[]) {
 
     mooncake::WrappedMasterService wrapped_master_service(
         FLAGS_enable_gc, FLAGS_enable_metric_reporting, FLAGS_metrics_port);
+    server.register_handler<&mooncake::WrappedMasterService::ExistKey>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::GetReplicaList>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::PutStart>(

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -46,6 +46,12 @@ MasterMetricManager::MasterMetricManager()
       get_replica_list_failures_(
           "master_get_replica_list_failures_total",
           "Total number of failed GetReplicaList requests"),
+      exist_key_requests_(
+          "master_exist_key_requests_total",
+          "Total number of ExistKey requests received"),
+      exist_key_failures_(
+          "master_exist_key_failures_total",
+          "Total number of failed ExistKey requests"),
       remove_requests_("master_remove_requests_total",
                        "Total number of Remove requests received"),
       remove_failures_("master_remove_failures_total",
@@ -87,6 +93,12 @@ void MasterMetricManager::observe_value_size(int64_t size) {
 }
 
 // Operation Statistics (Counters)
+void MasterMetricManager::inc_exist_key_requests(int64_t val) {
+    exist_key_requests_.inc(val);
+}
+void MasterMetricManager::inc_exist_key_failures(int64_t val) {
+    exist_key_failures_.inc(val);
+}
 void MasterMetricManager::inc_put_start_requests(int64_t val) {
     put_start_requests_.inc(val);
 }
@@ -153,6 +165,8 @@ std::string MasterMetricManager::serialize_metrics() {
     serialize_metric(value_size_distribution_);
 
     // Serialize Counters
+    serialize_metric(exist_key_requests_);
+    serialize_metric(exist_key_failures_);
     serialize_metric(put_start_requests_);
     serialize_metric(put_start_failures_);
     serialize_metric(put_end_requests_);
@@ -197,6 +211,8 @@ std::string MasterMetricManager::get_summary_string() {
     double keys = key_count_.value();
 
     // Request counters
+    double exist_keys = exist_key_requests_.value();
+    double exist_key_fails = exist_key_failures_.value();
     double put_starts = put_start_requests_.value();
     double put_start_fails = put_start_failures_.value();
     double put_ends = put_end_requests_.value();
@@ -223,6 +239,8 @@ std::string MasterMetricManager::get_summary_string() {
        << "/" << static_cast<int64_t>(put_starts + put_ends) << ", ";
     ss << "Get=" << static_cast<int64_t>(get_replicas - get_replica_fails)
        << "/" << static_cast<int64_t>(get_replicas) << ", ";
+    ss << "Exist=" << static_cast<int64_t>(exist_keys - exist_key_fails)
+       << "/" << static_cast<int64_t>(exist_keys) << ", ";
     ss << "Del=" << static_cast<int64_t>(removes - remove_fails) << "/"
        << static_cast<int64_t>(removes);
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -111,6 +111,26 @@ ErrorCode MasterService::UnmountSegment(const std::string& segment_name) {
     return buffer_allocator_manager_->RemoveSegment(segment_name);
 }
 
+ErrorCode MasterService::ExistKey(const std::string& key) {
+    MetadataAccessor accessor(this, key);
+    if (!accessor.Exists()) {
+        VLOG(1) << "key=" << key << ", info=object_not_found";
+        return ErrorCode::OBJECT_NOT_FOUND;
+    }
+
+    auto& metadata = accessor.Get();
+    for (const auto& replica : metadata.replicas) {
+        auto status = replica.status();
+        if (status != ReplicaStatus::COMPLETE) {
+            LOG(WARNING) << "key=" << key << ", status=" << status
+                         << ", error=replica_not_ready";
+            return ErrorCode::REPLICA_IS_NOT_READY;
+        }
+    }
+
+    return ErrorCode::OK;
+}
+
 ErrorCode MasterService::GetReplicaList(
     const std::string& key, std::vector<Replica::Descriptor>& replica_list) {
     MetadataAccessor accessor(this, key);


### PR DESCRIPTION
# Motivation
As the existing implementation of `isExist` leverage to the `getReplicationList`, there are some affects.
1. The `getReplicationList` return all replications info to the client, but client never used it, it is a waste behavior and harmful for performance.
2. The exists operations are considered as `get replication` operation, so the metrics can be confused, and the gc after 1s is triggered by the `get replication` operation too.

So I add a new true `isExist` rpc between `client` and `master`. 

# How to test
1. Run vllm + lmcache + mooncake store
  - start mooncake master
```shell
mooncake_master -max_threads 64 -v=1 -metrics_port=8081
```
  - prepare lmcache.yaml
```yaml
chunk_size: 256
local_device: "cpu"
remote_url: "mooncakestore:/localhost:50051/"
remote_serde: "naive"
pipelined_backend: False
local_cpu: False
max_local_cpu_size: 10
```

  - prepare mooncake.json
```json
{
    "local_hostname": "localhost",
    "metadata_server": "etcd://localhost:2379",
    "protocol": "rdma",
    "device_name": "mlx5_1",
    "master_server_address": "localhost:50051"
}
```
  - install lmcache
```console
# You may need to build lmcache pip wheel by your self before lmcache team release next version.
pip install lmcache
```
  - start vllm
```shell
MC_LOG_LEVEL=TRACE MC_TE_METRIC_INTERVAL_SECONDS=1 \
MOONCAKE_CONFIG_PATH=./mooncake.json \
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
VLLM_MLA_DISABLE=0 VLLM_USE_V1=0 LMCACHE_CONFIG_FILE=./lmcache.yaml \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 2 \
           --kv-transfer-config '{"kv_connector":"LMCacheConnector","kv_role":"kv_both","kv_parallel_size":2}'
```

2. Execute curl test twice
```Shell
curl http://localhost:8000/v1/chat/completions     -H "Content-Type: application/json"     -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "hi hi hi hi hi hi hi hi hi hi 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255 256"}],
    "max_tokens": 60,
    "temperature": 0
    }'
```
3. Check the Metrics
  - By curl : 
```shell
curl -s http://localhost:8081/metrics |grep -v \#|grep exist
master_exist_key_requests_total 72.000000
master_exist_key_failures_total 40.000000
```
  - By grafana :
<img width="1856" alt="image" src="https://github.com/user-attachments/assets/1e4105a9-4fd6-4d5f-81f8-52545d178f63" />
