### PR TITLE
[Bugfix] Fixed potential issues that may occur during the CMake build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ if(CCACHE_FOUND AND ENABLE_CCACHE)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif()
 
+add_compile_definitions(GLOG_USE_GLOG_EXPORT)
+
 option(BUILD_EXAMPLES "Build examples" ON)
 
 # unit test

--- a/mooncake-common/etcd/CMakeLists.txt
+++ b/mooncake-common/etcd/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so
-    COMMAND go mod tidy && go build -buildmode=c-shared -o ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so etcd_wrapper.go && cp ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.h ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND bash -c "go mod tidy" && bash -c "go build -buildmode=c-shared -o ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so etcd_wrapper.go" && cp ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.h ${CMAKE_CURRENT_SOURCE_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Building Go shared library"
     DEPENDS etcd_wrapper.go


### PR DESCRIPTION
In this pr, two main issues have been fixed. 
1. Firstly, when building with google-glog 0.7.0, it was necessary to add `add_compile_definitions(GLOG_USE_GLOG_EXPORT)`. Same as this isse: https://github.com/mhx/dwarfs/issues/201.
2. Secondly, when build_etcd_wrapper was being built using make, the shell used was /bin/sh, which led to the inability to find `go` command. Because the previous installation script installed `go` under the .bashrc file.