### PR TITLE
[Build] feature: start the Mooncake master server through Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,27 @@
 # Base Image from Alibaba Cloud AC2
 FROM ac2-registry.cn-hangzhou.cr.aliyuncs.com/ac2/pytorch-ubuntu:2.3.0-cuda12.1.1-ubuntu22.04
 
+WORKDIR /app
+
+COPY . .
+
+ENV GOROOT=/usr/local/go
+ENV PATH=$GOROOT/bin:$PATH
+
+RUN apt update \
+     && apt install -y unzip wget cmake git sudo \
+     && pip install pybind11
+
 # Execute installation in the container
-RUN  apt update
-RUN  apt install -y unzip wget cmake git sudo
-RUN  pip install pybind11
-RUN  wget https://github.com/kvcache-ai/Mooncake/archive/refs/heads/main.zip
-RUN  unzip main.zip
-RUN  cd Mooncake-main && bash dependencies.sh && mkdir build && cd build \
-       && cmake .. && make -j && make install
+RUN bash dependencies.sh \
+     && apt autoremove -y \
+     && apt clean -y \
+     && rm -rf /tmp/* /var/tmp/* \
+     && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
+     && find /var/cache -type f -delete
+
+RUN if [ -d "build" ]; then rm -rf build; fi \
+     && mkdir build && cd build \
+     && cmake .. && make -j && make install
+
+CMD ["mooncake_master"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN bash dependencies.sh \
      && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
      && find /var/cache -type f -delete
 
-RUN if [ -d "build" ]; then rm -rf build; fi \
+RUN rm -rf build || true \
      && mkdir build && cd build \
      && cmake .. && make -j && make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,3 @@ RUN if [ -d "build" ]; then rm -rf build; fi \
      && mkdir build && cd build \
      && cmake .. && make -j && make install
 
-CMD ["mooncake_master"]


### PR DESCRIPTION
This pr has optimized the building process of the Dockerfile and fixed the potential issues in the original building method:
1. In the original method of using `wget https://github.com/kvcache-ai/Mooncake/archive/refs/heads/main.zip`, after downloading and unzipping, the project will lack the `.git` file. As a result, during the `bash dependencies.sh` stage, the submodule cannot be found.
2. The `RUN` commands have been combined and the cache has been deleted to reduce the size of the image.
3. It is now allowed to directly start the mooncake_master_server through the container.