### PR TITLE
fix(store): the metadata leak after umount segment

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -166,6 +166,12 @@ class MasterService {
     long RemoveAll();
 
 
+    /**
+     * @brief Get the count of keys
+     * @return The count of keys
+     */
+    size_t GetKeyCount() const;
+
    private:
     // GC thread function
     void GCThreadFunc();

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -108,7 +108,34 @@ ErrorCode MasterService::MountSegment(uint64_t buffer, uint64_t size,
 }
 
 ErrorCode MasterService::UnmountSegment(const std::string& segment_name) {
-    return buffer_allocator_manager_->RemoveSegment(segment_name);
+    // 1. Remove the segment from the allocator
+    auto ret = buffer_allocator_manager_->RemoveSegment(segment_name);
+    if (ret != ErrorCode::OK) return ret;
+
+    // 2. Remove the metadata of the related objects
+    for (auto& shard : metadata_shards_) {
+        std::unique_lock lock(shard.mutex);
+        auto it = shard.metadata.begin();
+        while (it != shard.metadata.end()) {
+            // Check if the object has any invalid replicas
+            bool has_invalid = false;
+            for (auto& replica : it->second.replicas) {
+                if (replica.has_invalid_handle()) {
+                    has_invalid = true;
+                    break;
+                }
+            }
+
+            // Remove the object if it has no valid replicas
+            if (has_invalid || CleanupStaleHandles(it->second)) {
+                it = shard.metadata.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    return ErrorCode::OK;
 }
 
 ErrorCode MasterService::ExistKey(const std::string& key) {
@@ -372,6 +399,16 @@ bool MasterService::CleanupStaleHandles(ObjectMetadata& metadata) {
     // Return true if no valid replicas remain after cleanup
     return metadata.replicas.empty();
 }
+
+size_t MasterService::GetKeyCount() const {
+    size_t total = 0;
+    for (const auto& shard : metadata_shards_) {
+        std::unique_lock lock(shard.mutex);
+        total += shard.metadata.size();
+    }
+    return total;
+}
+
 
 void MasterService::GCThreadFunc() {
     VLOG(1) << "action=gc_thread_started";

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -25,6 +25,22 @@ class MasterServiceTest : public ::testing::Test {
     void TearDown() override { google::ShutdownGoogleLogging(); }
 };
 
+std::string GenerateKeyForSegment(const std::unique_ptr<MasterService>& service,
+                                 const std::string& segment_name) {
+    while (true) {
+        std::string key = "key_" + std::to_string(rand());
+        std::vector<Replica::Descriptor> replica_list;
+        service->PutStart(key, 1024, {1024},
+                                                  {.replica_num=1}, replica_list);
+        service->PutEnd(key);
+        if (replica_list[0].buffer_descriptors[0].segment_name_ == segment_name) {
+            return key;
+        }
+        // Clean up failed attempt
+        service->Remove(key);
+    }
+}
+
 TEST_F(MasterServiceTest, MountUnmountSegment) {
     // Create a MasterService instance for testing.
     std::unique_ptr<MasterService> service_(new MasterService());
@@ -759,6 +775,48 @@ TEST_F(MasterServiceTest, ConcurrentRemoveAllOperations) {
         std::string key = "pre_key_" + std::to_string(i);
         EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, service_->GetReplicaList(key, replica_list));
     }
+}
+
+TEST_F(MasterServiceTest, UnmountSegmentImmediateCleanup) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+
+    // Mount two segments for testing
+    constexpr size_t buffer1 = 0x300000000;
+    constexpr size_t buffer2 = 0x400000000;
+    constexpr size_t size = 1024 * 1024 * 16;
+    std::string segment1 = "segment1";
+    std::string segment2 = "segment2";
+
+    ASSERT_EQ(ErrorCode::OK, service_->MountSegment(buffer1, size, segment1));
+    ASSERT_EQ(ErrorCode::OK, service_->MountSegment(buffer2, size, segment2));
+
+    // Create two objects in the two segments
+    std::string key1 = GenerateKeyForSegment(service_, segment1);
+    std::string key2 = GenerateKeyForSegment(service_, segment2);
+    std::vector<uint64_t> slice_lengths = {1024};
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    // Unmount segment1
+    ASSERT_EQ(ErrorCode::OK, service_->UnmountSegment(segment1));
+    // Umount will remove all objects in the segment, include the key1
+    ASSERT_EQ(1, service_->GetKeyCount());
+    // Verify objects in segment1 is gone
+    std::vector<Replica::Descriptor> retrieved;
+    ASSERT_EQ(ErrorCode::OBJECT_NOT_FOUND,
+              service_->GetReplicaList(key1, retrieved));
+
+    // Verify objects in segment2 is still there
+    ASSERT_EQ(ErrorCode::OK,
+              service_->GetReplicaList(key2, retrieved));
+
+    // Verify put key1 will put into segment2 rather than segment1
+    ASSERT_EQ(ErrorCode::OK, service_->PutStart(key1, 1024, slice_lengths,
+                                                config, replica_list));
+    ASSERT_EQ(ErrorCode::OK, service_->PutEnd(key1));
+    ASSERT_EQ(ErrorCode::OK,
+              service_->GetReplicaList(key1, retrieved));
+    ASSERT_EQ(replica_list[0].buffer_descriptors[0].segment_name_, segment2);
 }
 
 }  // namespace mooncake::test


### PR DESCRIPTION
# Description
Although `UnmountSegement` remove the specified segment from buffer_allocator_manager, but the related metadata of objects still exists.

Although `MetadataAccessor` will remove these invalid key in the constructor, but it will still leak if the related keys do not be accessed any more.

So the safe way is remove the related keys in the UnmountSegement function.

# Future work
- It would be better to collect the `UnmountSegement` request and execute it async.