### PR TITLE
feat(Mooncake Integration): Supply a MooncakeConfig into whl file

### DIFF
--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -17,8 +17,8 @@ class MooncakeConfig:
     Attributes:
         local_hostname (str): The hostname of the local machine.
         metadata_server (str): The address of the metadata server.
-        global_segment_size_bytes (int): The size of each global segment in bytes.
-        local_buffer_size_bytes (int): The size of the local buffer in bytes.
+        global_segment_size (int): The size of each global segment in bytes.
+        local_buffer_size (int): The size of the local buffer in bytes.
         protocol (str): The communication protocol to use.
         device_name (Optional[str]): The name of the device to use.
         master_server_address (str): The address of the master server.
@@ -27,8 +27,8 @@ class MooncakeConfig:
         {
             "local_hostname": "localhost",
             "metadata_server": "localhost:8080",
-            "global_segment_size_bytes": 3355443200,
-            "local_buffer_size_bytes": 1073741824,
+            "global_segment_size": 3355443200,
+            "local_buffer_size": 1073741824,
             "protocol": "tcp",
             "device_name": "",
             "master_server_address": "localhost:8081"
@@ -36,8 +36,8 @@ class MooncakeConfig:
     """
     local_hostname: str
     metadata_server: str
-    global_segment_size_bytes: int
-    local_buffer_size_bytes: int
+    global_segment_size: int
+    local_buffer_size: int
     protocol: str
     device_name: Optional[str]
     master_server_address: str
@@ -58,10 +58,10 @@ class MooncakeConfig:
         return MooncakeConfig(
             local_hostname=config.get("local_hostname"),
             metadata_server=config.get("metadata_server"),
-            global_segment_size_bytes=config.get("global_segment_size_bytes",
-                                                 DEFAULT_GLOBAL_SEGMENT_SIZE),
-            local_buffer_size_bytes=config.get("local_buffer_size_bytes",
-                                               DEFAULT_LOCAL_BUFFER_SIZE),
+            global_segment_size=config.get("global_segment_size",
+                                           DEFAULT_GLOBAL_SEGMENT_SIZE),
+            local_buffer_size=config.get("local_buffer_size",
+                                         DEFAULT_LOCAL_BUFFER_SIZE),
             protocol=config.get("protocol", "tcp"),
             device_name=config.get("device_name", ""),
             master_server_address=config.get("master_server_address"),

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Mooncake Configuration
+"""
+import json
+import os
+from dataclasses import dataclass
+
+@dataclass
+class MooncakeConfig:
+    local_hostname: str
+    metadata_server: str
+    global_segment_size: int
+    local_buffer_size: int
+    protocol: str
+    device_name: str
+    master_server_address: str
+
+    @staticmethod
+    def from_file(file_path: str) -> 'MooncakeConfig':
+        """Load the config from a JSON file."""
+        with open(file_path) as fin:
+            config = json.load(fin)
+        return MooncakeConfig(
+            local_hostname=config.get("local_hostname"),
+            metadata_server=config.get("metadata_server"),
+            global_segment_size=config.get("global_segment_size", 3355443200),
+            local_buffer_size=config.get("local_buffer_size", 1073741824),
+            protocol=config.get("protocol", "tcp"),
+            device_name=config.get("device_name", ""),
+            master_server_address=config.get("master_server_address"),
+        )
+
+    @staticmethod
+    def load_from_env() -> 'MooncakeConfig':
+        """Load config from a file specified in the environment variable."""
+        config_file_path = os.getenv('MOONCAKE_CONFIG_PATH')
+        if config_file_path is None:
+            raise ValueError(
+                "The environment variable 'MOONCAKE_CONFIG_PATH' is not set.")
+        return MooncakeConfig.from_file(config_file_path)

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -5,15 +5,41 @@ Mooncake Configuration
 import json
 import os
 from dataclasses import dataclass
+from typing import Optional
+
+DEFAULT_GLOBAL_SEGMENT_SIZE = 3355443200  # 3.125 GiB
+DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
 
 @dataclass
 class MooncakeConfig:
+    """The configuration class for Mooncake.
+
+    Attributes:
+        local_hostname (str): The hostname of the local machine.
+        metadata_server (str): The address of the metadata server.
+        global_segment_size_bytes (int): The size of each global segment in bytes.
+        local_buffer_size_bytes (int): The size of the local buffer in bytes.
+        protocol (str): The communication protocol to use.
+        device_name (Optional[str]): The name of the device to use.
+        master_server_address (str): The address of the master server.
+
+    Example of configuration file:
+        {
+            "local_hostname": "localhost",
+            "metadata_server": "localhost:8080",
+            "global_segment_size_bytes": 3355443200,
+            "local_buffer_size_bytes": 1073741824,
+            "protocol": "tcp",
+            "device_name": "",
+            "master_server_address": "localhost:8081"
+        }
+    """
     local_hostname: str
     metadata_server: str
-    global_segment_size: int
-    local_buffer_size: int
+    global_segment_size_bytes: int
+    local_buffer_size_bytes: int
     protocol: str
-    device_name: str
+    device_name: Optional[str]
     master_server_address: str
 
     @staticmethod
@@ -21,11 +47,21 @@ class MooncakeConfig:
         """Load the config from a JSON file."""
         with open(file_path) as fin:
             config = json.load(fin)
+        required_fields = [
+            "local_hostname",
+            "metadata_server",
+            "master_server_address",
+        ]
+        for field in required_fields:
+            if field not in config:
+                raise ValueError(f"Missing required config field: {field}")
         return MooncakeConfig(
             local_hostname=config.get("local_hostname"),
             metadata_server=config.get("metadata_server"),
-            global_segment_size=config.get("global_segment_size", 3355443200),
-            local_buffer_size=config.get("local_buffer_size", 1073741824),
+            global_segment_size_bytes=config.get("global_segment_size_bytes",
+                                                 DEFAULT_GLOBAL_SEGMENT_SIZE),
+            local_buffer_size_bytes=config.get("local_buffer_size_bytes",
+                                               DEFAULT_LOCAL_BUFFER_SIZE),
             protocol=config.get("protocol", "tcp"),
             device_name=config.get("device_name", ""),
             master_server_address=config.get("master_server_address"),

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -1,0 +1,94 @@
+import json
+import os
+import tempfile
+import unittest
+
+from ..mooncake.mooncake_config import MooncakeConfig, DEFAULT_GLOBAL_SEGMENT_SIZE, DEFAULT_LOCAL_BUFFER_SIZE
+
+class TestMooncakeConfig(unittest.TestCase):
+    def setUp(self):
+        # Create temporary directory
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.config_file = os.path.join(self.temp_dir.name, "config.json")
+
+        # Valid configuration
+        self.valid_config = {
+            "local_hostname": "localhost",
+            "metadata_server": "localhost:8080",
+            "master_server_address": "localhost:8081",
+            "global_segment_size_bytes": 3355443200,
+            "local_buffer_size_bytes": 1073741824,
+            "protocol": "tcp",
+            "device_name": "eth0"
+        }
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def write_config(self, config_data):
+        """Write configuration to file"""
+        with open(self.config_file, 'w') as f:
+            json.dump(config_data, f)
+
+    def test_load_valid_config(self):
+        """Test loading valid configuration"""
+        self.write_config(self.valid_config)
+        config = MooncakeConfig.from_file(self.config_file)
+
+        self.assertEqual(config.local_hostname, "localhost")
+        self.assertEqual(config.metadata_server, "localhost:8080")
+        self.assertEqual(config.master_server_address, "localhost:8081")
+        self.assertEqual(config.global_segment_size_bytes, 3355443200)
+        self.assertEqual(config.local_buffer_size_bytes, 1073741824)
+        self.assertEqual(config.protocol, "tcp")
+        self.assertEqual(config.device_name, "eth0")
+
+    def test_load_with_default_values(self):
+        """Test loading configuration with default values"""
+        minimal_config = {
+            "local_hostname": "localhost",
+            "metadata_server": "localhost:8080",
+            "master_server_address": "localhost:8081"
+        }
+        self.write_config(minimal_config)
+        config = MooncakeConfig.from_file(self.config_file)
+
+        self.assertEqual(config.global_segment_size_bytes, DEFAULT_GLOBAL_SEGMENT_SIZE)
+        self.assertEqual(config.local_buffer_size_bytes, DEFAULT_LOCAL_BUFFER_SIZE)
+        self.assertEqual(config.protocol, "tcp")
+        self.assertEqual(config.device_name, "")
+
+    def test_missing_required_field(self):
+        """Test missing required field"""
+        for field in ["local_hostname", "metadata_server", "master_server_address"]:
+            with self.subTest(field=field):
+                invalid_config = self.valid_config.copy()
+                invalid_config.pop(field)
+                self.write_config(invalid_config)
+
+                with self.assertRaises(ValueError) as cm:
+                    MooncakeConfig.from_file(self.config_file)
+                self.assertIn(f"Missing required config field: {field}", str(cm.exception))
+
+    def test_load_from_env(self):
+        """Test loading configuration from environment variable"""
+        self.write_config(self.valid_config)
+
+        # Set environment variable
+        os.environ['MOONCAKE_CONFIG_PATH'] = self.config_file
+
+        try:
+            config = MooncakeConfig.load_from_env()
+            self.assertEqual(config.local_hostname, "localhost")
+        finally:
+            # Clean up environment variable
+            del os.environ['MOONCAKE_CONFIG_PATH']
+
+    def test_load_from_env_missing(self):
+        """Test loading configuration from environment variable when not set"""
+        with self.assertRaises(ValueError) as cm:
+            MooncakeConfig.load_from_env()
+        self.assertIn("The environment variable 'MOONCAKE_CONFIG_PATH' is not set", str(cm.exception))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -16,8 +16,8 @@ class TestMooncakeConfig(unittest.TestCase):
             "local_hostname": "localhost",
             "metadata_server": "localhost:8080",
             "master_server_address": "localhost:8081",
-            "global_segment_size_bytes": 3355443200,
-            "local_buffer_size_bytes": 1073741824,
+            "global_segment_size": 3355443200,
+            "local_buffer_size": 1073741824,
             "protocol": "tcp",
             "device_name": "eth0"
         }
@@ -38,8 +38,8 @@ class TestMooncakeConfig(unittest.TestCase):
         self.assertEqual(config.local_hostname, "localhost")
         self.assertEqual(config.metadata_server, "localhost:8080")
         self.assertEqual(config.master_server_address, "localhost:8081")
-        self.assertEqual(config.global_segment_size_bytes, 3355443200)
-        self.assertEqual(config.local_buffer_size_bytes, 1073741824)
+        self.assertEqual(config.global_segment_size, 3355443200)
+        self.assertEqual(config.local_buffer_size, 1073741824)
         self.assertEqual(config.protocol, "tcp")
         self.assertEqual(config.device_name, "eth0")
 
@@ -53,8 +53,8 @@ class TestMooncakeConfig(unittest.TestCase):
         self.write_config(minimal_config)
         config = MooncakeConfig.from_file(self.config_file)
 
-        self.assertEqual(config.global_segment_size_bytes, DEFAULT_GLOBAL_SEGMENT_SIZE)
-        self.assertEqual(config.local_buffer_size_bytes, DEFAULT_LOCAL_BUFFER_SIZE)
+        self.assertEqual(config.global_segment_size, DEFAULT_GLOBAL_SEGMENT_SIZE)
+        self.assertEqual(config.local_buffer_size, DEFAULT_LOCAL_BUFFER_SIZE)
         self.assertEqual(config.protocol, "tcp")
         self.assertEqual(config.device_name, "")
 

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import unittest
 
-from ..mooncake.mooncake_config import MooncakeConfig, DEFAULT_GLOBAL_SEGMENT_SIZE, DEFAULT_LOCAL_BUFFER_SIZE
+from mooncake.mooncake_config import MooncakeConfig, DEFAULT_GLOBAL_SEGMENT_SIZE, DEFAULT_LOCAL_BUFFER_SIZE
 
 class TestMooncakeConfig(unittest.TestCase):
     def setUp(self):

--- a/scripts/test_installation.sh
+++ b/scripts/test_installation.sh
@@ -39,6 +39,9 @@ cp -r mooncake-wheel/tests test_env/
 cd test_env
 python tests/test_import_structure.py
 
+echo "Running mooncake config test..."
+python tests/test_mooncake_config.py
+
 echo "Verifying mooncake_master entry point..."
 # Check if the mooncake_master entry point is installed and executable
 which mooncake_master || { echo "ERROR: mooncake_master entry point not found!"; exit 1; }


### PR DESCRIPTION
# Motivation

There are 3 existing place need the `MooncakeConfig`, so I propose to abstract it into the whl file which supplied by mooncake.

- https://github.com/vllm-project/vllm/blob/376786fac1fc50e8d788a39a91fa28d1709ad48b/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py#L29
- https://github.com/LMCache/LMCache/blob/702fba782d0fa4940c31f970e1aef481cdb9010a/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py#L40
- https://github.com/kvcache-ai/Mooncake/pull/328/commits/deb89b2075926adc5f74d1adbd4e2acccbc47a71#diff-fd59ce035f5508afc145b7b7c8d4def42344b2df64445e31d6283aadfebc0789R12