### PR TITLE
gitmodules: use full path instead of relative path.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "extern/pybind11"]
 	path = extern/pybind11
-	url = ../../pybind/pybind11
+	url = https://github.com/pybind/pybind11.git
 	branch = stable


### PR DESCRIPTION
It will be more friendly when people forked in a private repo instead of github.