### PR TITLE
fix(master): Fix negative storage size metrics after removeAll

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -333,7 +333,6 @@ long MasterService::RemoveAll() {
         removed_count += object_count;
         // Reset related metrics on successful removed
         MasterMetricManager::instance().dec_key_count(removed_count);
-        MasterMetricManager::instance().dec_allocated_size(total_freed_size);
         shard.metadata.clear();
     }
     VLOG(1) << "action=remove_all_objects" << ", removed_count=" << removed_count


### PR DESCRIPTION
```
I0512 23:15:16.652259  1527 allocator.cpp:16] buf_handle_deallocated segment_name=192.168.100.219:12986 size=11
I0512 23:15:16.652276  1527 master_service.cpp:339] action=remove_all_objects, removed_count=1, total_freed_size=11
I0512 23:15:16.652279  1527 scoped_vlog_timer.h:77] RemoveAll response: {"removed_count":1}, latency=64us

I0512 23:15:26.011116  1521 rpc_service.h:78] Master Metrics: Storage: -11.00 B / 75.02 GB (-0.0%) | Keys: 0 | Requests (Success/Total): Put=2/2, Get=0/0, Exist=0/0, Del=0/0, DelAll=1/1
```

# How to test

- start master
```console
/usr/local/lib/python3.12/dist-packages/mooncake/mooncake_master -max_threads 64 -v=1 -metrics_port=8081
```
- start mooncake-store-service
```
python3 /usr/local/lib/python3.12/dist-packages/mooncake/mooncake_store_service.py --config=./mooncake.json
```
- start test
```
curl -X PUT -H "Content-Type: application/json" -d '{"key":"test1", "value":"sample data"}' http://localhost:8088/api/put
curl -X DELETE http://localhost:8080/api/remove_all
```