### PR TITLE
[Build] Call find_package() before using external deps

### DIFF
--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -83,3 +83,9 @@ if (WITH_METRICS)
   add_compile_definitions(WITH_METRICS)
   message(STATUS "metrics is enabled")
 endif()
+
+
+set(GFLAGS_USE_TARGET_NAMESPACE "true")
+find_package(gflags REQUIRED)
+find_package(glog REQUIRED)
+find_package(yalantinglibs CONFIG REQUIRED)

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -35,8 +35,8 @@ set_target_properties(mooncake_vllm_adaptor PROPERTIES
 
 target_link_libraries(mooncake_vllm_adaptor PUBLIC 
     transfer_engine 
-    glog 
-    gflags 
+    glog::glog
+    gflags::gflags
     mooncake_store 
     cachelib_memory_allocator
 )
@@ -49,16 +49,16 @@ pybind11_add_module(engine ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
 )
 target_link_libraries(engine PUBLIC 
     transfer_engine 
-    glog 
-    gflags 
+    glog::glog
+    gflags::gflags
 )
 pybind11_add_module(store ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
     store/store_py.cpp 
 )
 target_link_libraries(store PUBLIC 
     transfer_engine 
-    glog 
-    gflags 
+    glog::glog
+    gflags::gflags
     mooncake_store 
     cachelib_memory_allocator
 )

--- a/mooncake-store/CMakeLists.txt
+++ b/mooncake-store/CMakeLists.txt
@@ -9,7 +9,6 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include/mooncake-store/proto/
     ${CMAKE_CURRENT_SOURCE_DIR}/include/
     ${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-transfer-engine/include
-    /usr/include/jsoncpp
 )
 
 # Add subdirectories

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -14,7 +14,7 @@ set(MOONCAKE_STORE_SOURCES
 # The cache_allocator library
 include_directories(${Python3_INCLUDE_DIRS})
 add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
-target_link_libraries(mooncake_store PUBLIC transfer_engine glog gflags)
+target_link_libraries(mooncake_store PUBLIC transfer_engine glog::glog gflags::gflags)
 
 
 # Master binary

--- a/mooncake-transfer-engine/CMakeLists.txt
+++ b/mooncake-transfer-engine/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT GLOBAL_CONFIG)
   include(../mooncake-common/common.cmake)
 endif() # GLOBAL_CONFIG
 
-include_directories(include /usr/include/jsoncpp)
+include_directories(include)
 add_subdirectory(include)
 add_subdirectory(src)
 

--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 target_link_libraries(
     transfer_engine
     PUBLIC
-    base transport rdma_transport ibverbs glog gflags pthread jsoncpp numa
+    base transport rdma_transport ibverbs glog gflags pthread jsoncpp numa yalantinglibs::yalantinglibs
     )
 
 if (USE_CUDA)

--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 target_link_libraries(
     transfer_engine
     PUBLIC
-    base transport rdma_transport ibverbs glog gflags pthread jsoncpp numa yalantinglibs::yalantinglibs
+    base transport rdma_transport ibverbs glog::glog gflags::gflags pthread JsonCpp::JsonCpp numa yalantinglibs::yalantinglibs
     )
 
 if (USE_CUDA)

--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(jsoncpp REQUIRED)
+
 file(GLOB ENGINE_SOURCES "*.cpp")
 add_subdirectory(common)
 add_subdirectory(transport)

--- a/mooncake-transfer-engine/src/transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/CMakeLists.txt
@@ -2,7 +2,7 @@ file(GLOB XPORT_SOURCES "*.cpp")
 
 add_subdirectory(rdma_transport)
 add_library(transport OBJECT ${XPORT_SOURCES} $<TARGET_OBJECTS:rdma_transport>)
-target_link_libraries(transport PRIVATE yalantinglibs::yalantinglibs)
+target_link_libraries(transport PRIVATE JsonCpp::JsonCpp yalantinglibs::yalantinglibs)
 
 if (USE_TCP)
   add_subdirectory(tcp_transport)

--- a/mooncake-transfer-engine/src/transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/CMakeLists.txt
@@ -2,6 +2,7 @@ file(GLOB XPORT_SOURCES "*.cpp")
 
 add_subdirectory(rdma_transport)
 add_library(transport OBJECT ${XPORT_SOURCES} $<TARGET_OBJECTS:rdma_transport>)
+target_link_libraries(transport PRIVATE yalantinglibs::yalantinglibs)
 
 if (USE_TCP)
   add_subdirectory(tcp_transport)

--- a/mooncake-transfer-engine/src/transport/rdma_transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/CMakeLists.txt
@@ -1,4 +1,4 @@
 file(GLOB RDMA_SOURCES "*.cpp")
 
 add_library(rdma_transport OBJECT ${RDMA_SOURCES})
-# target_link_libraries(rdma_transport PUBLIC transport)
+target_link_libraries(rdma_transport PRIVATE JsonCpp::JsonCpp)

--- a/mooncake-transfer-engine/src/transport/tcp_transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/CMakeLists.txt
@@ -1,4 +1,4 @@
 file(GLOB TCP_SOURCES "*.cpp")
 
 add_library(tcp_transport OBJECT ${TCP_SOURCES})
-target_link_libraries(tcp_transport PRIVATE yalantinglibs::yalantinglibs)
+target_link_libraries(tcp_transport PRIVATE JsonCpp::JsonCpp yalantinglibs::yalantinglibs)

--- a/mooncake-transfer-engine/src/transport/tcp_transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/CMakeLists.txt
@@ -1,3 +1,4 @@
 file(GLOB TCP_SOURCES "*.cpp")
 
 add_library(tcp_transport OBJECT ${TCP_SOURCES})
+target_link_libraries(tcp_transport PRIVATE yalantinglibs::yalantinglibs)


### PR DESCRIPTION
Previously, we included headers like glog/logging.h without first checking
if the required packages were installed. This caused build failures at
compilation time rather than at configuration time.

This change implements proper dependency handling by:
- Adding find_package() calls for glog and yanlantinglibs
- Ensuring configuration fails early if dependencies are missing
- Improving error reporting for missing requirements

Users will now get clear configuration-time errors instead of confusing
compilation failures when dependencies aren't satisfied.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>