### PR TITLE
[Transfer Engine] Check the buffer size before register

### DIFF
--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -29,6 +29,7 @@ struct GlobalConfig {
     size_t num_comp_channels_per_ctx = 1;
     uint8_t port = 1;
     int gid_index = 0;
+    uint64_t max_mr_size = 0x10000000000;
     size_t max_cqe = 4096;
     int max_ep_per_ctx = 256;
     size_t num_qp_per_ep = 2;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -150,6 +150,7 @@ class RdmaContext {
 
     ibv_context *context_ = nullptr;
     ibv_pd *pd_ = nullptr;
+    uint64_t max_mr_size;
     int event_fd_ = -1;
 
     size_t num_comp_channel_ = 0;

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -222,6 +222,8 @@ void updateGlobalConfig(ibv_device_attr &device_attr) {
         config.max_sge = device_attr.max_sge;
     if (config.max_cqe > (size_t)device_attr.max_cqe)
         config.max_cqe = device_attr.max_cqe;
+    if (config.max_mr_size > device_attr.max_mr_size)
+        config.max_mr_size = device_attr.max_mr_size;
 }
 
 void dumpGlobalConfig() {
@@ -232,6 +234,7 @@ void dumpGlobalConfig() {
               << config.num_comp_channels_per_ctx;
     LOG(INFO) << "port = " << config.port;
     LOG(INFO) << "gid_index = " << config.gid_index;
+    LOG(INFO) << "max_mr_size = " << config.max_mr_size;
     LOG(INFO) << "max_cqe = " << config.max_cqe;
     LOG(INFO) << "max_ep_per_ctx = " << config.max_ep_per_ctx;
     LOG(INFO) << "num_qp_per_ep = " << config.num_qp_per_ep;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -193,6 +193,11 @@ int RdmaContext::deconstruct() {
 }
 
 int RdmaContext::registerMemoryRegion(void *addr, size_t length, int access) {
+    if (length > (size_t)globalConfig().max_mr_size) {
+        PLOG(WARNING) << "The buffer length exceeds device max_mr_size, "
+                      << "shrink it to " << globalConfig().max_mr_size;
+        length = (size_t)globalConfig().max_mr_size;
+    }
     ibv_mr *mr = ibv_reg_mr(pd_, addr, length, access);
     if (!mr) {
         PLOG(ERROR) << "Failed to register memory " << addr;


### PR DESCRIPTION
Now when global_segment_size in mooncake.json is larger than device's max_mr_size, the registration will failed. But the application will still enter a fake normal state, like LMCache. Reduce the buffer length to the maximum value allowed by the device and issue a warning if encountering such scenario.