### PR TITLE
leave endpoint status unchanged when delete endpoint reference to avoid endpoint deconstruction before CQ being generated

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -67,9 +67,10 @@ std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::insertEndpoint(
 int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     auto iter = endpoint_map_.find(peer_nic_path);
+    // remove endpoint but leaving it status unchanged
+    // in case it is setting up connection or submitting slice
     if (iter != endpoint_map_.end()) {
         waiting_list_.insert(iter->second);
-        iter->second->set_active(false);
         endpoint_map_.erase(iter);
         auto fifo_iter = fifo_map_[peer_nic_path];
         fifo_list_.erase(fifo_iter);


### PR DESCRIPTION
Here is a subtle test case that I constantly get warning, "Outstanding work requests found, CQ will not be generated" and it fails of course.

My test case is based on stress_cluster_benchmark.py and replace line14 - line23 with below code

```
protocol = os.getenv("PROTOCOL", "rdma")
device_name = os.getenv("DEVICE_NAME", "")
# Changed to the local hostname (retrieved by `ip addr`) accordingly
local_hostname = os.getenv("LOCAL_HOSTNAME", "<ip>")
metadata_server = os.getenv("METADATA_ADDR", "<ip>:2379")
global_segment_size = 3200 * 1024 * 1024
local_buffer_size = 512 * 1024 * 1024
master_server_address = os.getenv("MASTER_SERVER", "<ip>:50001")
cls.value_length = 65536 * 2
cls.max_requests = 10
```
Use below env vars when launch:

`"ROLE": "prefill", "MC_MS_AUTO_DISC": "1", "MC_LOG_LEVEL": "TRACE", "MC_MS_FILTERS": "mlx5_0,mlx5_3"`

What it basically does is mlx5_0 and mlx5_3 send data to each other. The endpoint (peer nic: mlx5_3), which is either setting up connection or submitting slice in the first thread, could be deleted and set to inactive when callback "onSetupRdmaConnection" is called in the second thread during passive connecting. It's because mlx5_3 acts as both sender and receiver.  After that, the endpoint will be removed from endpoint_store in reclaimEndpoint which cause number of references to the endpoint reducing to 1 (referenced in method in the first thread only). When the method in the first thread completes, the endpoint gets deconstructed which is the root cause of above warning and failure. 

The PR leaves the endpoint status unchanged when delete endpoint so that it will not be removed from endpoint store. Hopefully, it will not cause other regression.