### PR TITLE
fix bug in async apis in python, the batch_id's dtype is int64_t, not int

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -328,7 +328,7 @@ int TransferEnginePy::transferSync(const char *target_hostname,
     return -1;
 }
 
-int TransferEnginePy::transferSubmitWrite(const char *target_hostname,
+int64_t TransferEnginePy::transferSubmitWrite(const char *target_hostname,
                                           uintptr_t buffer,
                                           uintptr_t peer_buffer_address,
                                           size_t length) {
@@ -356,7 +356,7 @@ int TransferEnginePy::transferSubmitWrite(const char *target_hostname,
     return batch_id;
 }
 
-int TransferEnginePy::transferCheckStatus(int batch_id) {
+int TransferEnginePy::transferCheckStatus(int64_t batch_id) {
     pybind11::gil_scoped_release release;
     TransferStatus status;
     Status s = engine_->getTransferStatus(batch_id, 0, status);

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -64,10 +64,10 @@ class TransferEnginePy {
     int transferSyncWrite(const char *target_hostname, uintptr_t buffer,
                           uintptr_t peer_buffer_address, size_t length);
 
-    int transferSubmitWrite(const char *target_hostname, uintptr_t buffer,
+    int64_t transferSubmitWrite(const char *target_hostname, uintptr_t buffer,
                             uintptr_t peer_buffer_address, size_t length);
 
-    int transferCheckStatus(int batch_id);
+    int transferCheckStatus(int64_t batch_id);
 
     int transferSyncRead(const char *target_hostname, uintptr_t buffer,
                          uintptr_t peer_buffer_address, size_t length);


### PR DESCRIPTION
fix bug in async apis in python, the batch_id's dtype is int64_t, not int