### PR TITLE
[TE FIX] Updating the outstanding work request counting when closing a QP

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -77,13 +77,19 @@ int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
 
 int RdmaEndPoint::deconstruct() {
     for (size_t i = 0; i < qp_list_.size(); ++i) {
-        if (wr_depth_list_[i] != 0)
-            LOG(WARNING)
-                << "Outstanding work requests found, CQ will not be generated";
-
         if (ibv_destroy_qp(qp_list_[i])) {
             PLOG(ERROR) << "Failed to destroy QP";
             return ERR_ENDPOINT;
+        }
+        // After destroying QP, the wr_depth_list_ won't change
+        bool displayed = false;
+        if (wr_depth_list_[i] != 0) {
+            if (!displayed) {
+                LOG(WARNING)
+                    << "Outstanding work requests found, CQ will not be generated";
+                displayed = true;
+            }
+            __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
         }
     }
     qp_list_.clear();
@@ -218,18 +224,23 @@ void RdmaEndPoint::disconnect() {
 }
 
 void RdmaEndPoint::disconnectUnlocked() {
-    for (size_t i = 0; i < qp_list_.size(); ++i) {
-        if (wr_depth_list_[i] != 0)
-            LOG(WARNING) << "Outstanding work requests will be dropped";
-    }
     ibv_qp_attr attr;
     memset(&attr, 0, sizeof(attr));
     attr.qp_state = IBV_QPS_RESET;
     for (size_t i = 0; i < qp_list_.size(); ++i) {
         int ret = ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE);
         if (ret) PLOG(ERROR) << "Failed to modify QP to RESET";
+        // After resetting QP, the wr_depth_list_ won't change
+        bool displayed = false;
+        if (wr_depth_list_[i] != 0) {
+            if (!displayed) {
+                LOG(WARNING)
+                    << "Outstanding work requests found, CQ will not be generated";
+                displayed = true;
+            }
+            __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
+        }
     }
-    for (size_t i = 0; i < qp_list_.size(); ++i) wr_depth_list_[i] = 0;
     status_.store(UNCONNECTED, std::memory_order_release);
 }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -90,6 +90,7 @@ int RdmaEndPoint::deconstruct() {
                 displayed = true;
             }
             __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
+            wr_depth_list_[i] = 0;
         }
     }
     qp_list_.clear();
@@ -239,6 +240,7 @@ void RdmaEndPoint::disconnectUnlocked() {
                 displayed = true;
             }
             __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
+            wr_depth_list_[i] = 0;
         }
     }
     status_.store(UNCONNECTED, std::memory_order_release);


### PR DESCRIPTION
In the previous implementation, we missed to update the `cq_outstanding` variable, which may block further operations b y other endpoints