### PR TITLE
[TransferEngine] Update software-based timeout mechanism

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -17,7 +17,15 @@
 #include <cassert>
 #include <fstream>
 
-TransferEnginePy::TransferEnginePy() {}
+TransferEnginePy::TransferEnginePy() {
+    const int64_t kNanosPerSecond = 1000 * 1000 * 1000;
+    if (getenv("MC_TRANSFER_TIMEOUT")) {
+        int timeout_sec = std::max(10, atoi(getenv("MC_TRANSFER_TIMEOUT")));
+        transfer_timeout_nsec_ = timeout_sec * kNanosPerSecond;
+    } else {
+        transfer_timeout_nsec_ = 60 * kNanosPerSecond;
+    }
+}
 
 TransferEnginePy::~TransferEnginePy() {
     for (auto &handle : handle_map_) engine_->closeSegment(handle.second);
@@ -252,9 +260,7 @@ int TransferEnginePy::transferSync(const char *target_hostname,
                 completed = true;
             }
             auto current_ts = getCurrentTimeInNano();
-            const int64_t kNanosPerSecond = 1000 * 1000 * 1000;
-            const int64_t timeout =
-                (10 + length / 5000000000) * kNanosPerSecond;
+            const int64_t timeout = transfer_timeout_nsec_ + length; // 1GiB per second
             if (current_ts - start_ts > timeout) {
                 LOG(INFO) << "Sync data transfer timeout, local buffer "
                           << (void *)buffer << " remote buffer "

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -258,6 +258,8 @@ int TransferEnginePy::transferSync(const char *target_hostname,
             } else if (status.s == TransferStatusEnum::FAILED) {
                 engine_->freeBatchID(batch_id);
                 completed = true;
+            } else if (status.s == TransferStatusEnum::TIMEOUT) {
+                completed = true;
             }
             auto current_ts = getCurrentTimeInNano();
             const int64_t timeout = transfer_timeout_nsec_ + length; // 1GiB per second
@@ -315,6 +317,8 @@ int TransferEnginePy::transferCheckStatus(batch_id_t batch_id) {
     } else if (status.s == TransferStatusEnum::FAILED) {
         engine_->freeBatchID(batch_id);
         return -1;
+    } else if (status.s == TransferStatusEnum::TIMEOUT) {
+        return -2;
     } else {
         return 0;
     }

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -20,10 +20,10 @@
 TransferEnginePy::TransferEnginePy() {
     const int64_t kNanosPerSecond = 1000 * 1000 * 1000;
     if (getenv("MC_TRANSFER_TIMEOUT")) {
-        int timeout_sec = std::max(10, atoi(getenv("MC_TRANSFER_TIMEOUT")));
+        int timeout_sec = std::max(5, atoi(getenv("MC_TRANSFER_TIMEOUT")));
         transfer_timeout_nsec_ = timeout_sec * kNanosPerSecond;
     } else {
-        transfer_timeout_nsec_ = 60 * kNanosPerSecond;
+        transfer_timeout_nsec_ = 30 * kNanosPerSecond;
     }
 }
 

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -115,4 +115,6 @@ class TransferEnginePy {
     std::unordered_set<char *> large_buffer_list_;
     std::unordered_map<std::string, Transport::SegmentHandle> handle_map_;
     bool auto_discovery_;
+
+    uint64_t transfer_timeout_nsec_;
 };

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -90,6 +90,7 @@ class Transport {
         std::string peer_nic_path;
         SliceStatus status;
         TransferTask *task;
+        uint64_t ts;
 
         union {
             struct {

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -129,7 +129,7 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
         for (auto &slice : task.slice_list) {
             if (slice->status == Transport::Slice::POSTED && slice->ts > 0 &&
                 current_ts - slice->ts > kPacketDeliveryTimeout) {
-                status.s = Transport::TransferStatusEnum::FAILED;
+                status.s = Transport::TransferStatusEnum::TIMEOUT;
                 return Status::OK();
             }
         }

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -129,7 +129,7 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
         for (auto &slice : task.slice_list) {
             if (slice->status == Transport::Slice::POSTED && slice->ts > 0 &&
                 current_ts - slice->ts > kPacketDeliveryTimeout) {
-                status.s = Transport::TransferStatusEnum::TIMEOUT;
+                status.s = Transport::TransferStatusEnum::FAILED;
                 return Status::OK();
             }
         }

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -255,6 +255,7 @@ void NVMeoFTransport::addSliceToTask(void *source_addr, uint64_t slice_len,
     slice->nvmeof.start = target_start;
     slice->task = &task;
     slice->status = Slice::PENDING;
+    slice->ts = 0;
     task.slice_list.push_back(slice);
     task.total_bytes += slice->length;
     __sync_fetch_and_add(&task.slice_count, 1);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -61,6 +61,7 @@ int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
         attr.recv_cq = cq;
         attr.sq_sig_all = false;
         attr.qp_type = IBV_QPT_RC;
+        attr.qp_context = this;
         attr.cap.max_send_wr = attr.cap.max_recv_wr = max_wr_depth;
         attr.cap.max_send_sge = attr.cap.max_recv_sge = max_sge_per_wr;
         attr.cap.max_inline_data = max_inline_bytes;
@@ -296,6 +297,7 @@ int RdmaEndPoint::submitPostSend(
         wr.imm_data = 0;
         wr.wr.rdma.remote_addr = slice->rdma.dest_addr;
         wr.wr.rdma.rkey = slice->rdma.dest_rkey;
+        slice->ts = getCurrentTimeInNano();
         slice->status = Transport::Slice::POSTED;
         slice->rdma.qp_depth = &wr_depth_list_[qp_index];
     }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -227,6 +227,7 @@ Status RdmaTransport::submitTransfer(
             slice->task = &task;
             slice->target_id = request.target_id;
             slice->status = Slice::PENDING;
+            slice->ts = 0;
             task.slice_list.push_back(slice);
 
             int buffer_id = -1, device_id = -1, retry_cnt = 0;
@@ -289,6 +290,7 @@ Status RdmaTransport::submitTransferTask(
             slice->task = &task;
             slice->target_id = request.target_id;
             slice->status = Slice::PENDING;
+            slice->ts = 0;
             task.slice_list.push_back(slice);
 
             int buffer_id = -1, device_id = -1,

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -337,6 +337,7 @@ Status TcpTransport::submitTransfer(
         slice->task = &task;
         slice->target_id = request.target_id;
         slice->status = Slice::PENDING;
+        slice->ts = 0;
         task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
         startTransfer(slice);
@@ -360,6 +361,7 @@ Status TcpTransport::submitTransferTask(
         slice->task = &task;
         slice->target_id = request.target_id;
         slice->status = Slice::PENDING;
+        slice->ts = 0;
         task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
         startTransfer(slice);


### PR DESCRIPTION
Now supports two kinds of timeout:
1. end-to-end timeout in transferSync, 60 seconds by default. This can be changed using env var `MC_TRANSFER_TIMEOUT`.
2. data transfer timeout, 10 seconds by default. This is similar to RDMA's hardware timeout notification. However, in some environments, the QP will be destroyed so that we cannot poll for notification.