### PR TITLE
[Fix] Store Metrics-related Bugs

### DIFF
--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -20,36 +20,36 @@ class MasterMetricManager {
     MasterMetricManager& operator=(MasterMetricManager&&) = delete;
 
     // Storage Metrics
-    void inc_allocated_size(int64_t val = 1.0);
-    void dec_allocated_size(int64_t val = 1.0);
-    void inc_total_capacity(int64_t val = 1.0);
-    void dec_total_capacity(int64_t val = 1.0);
+    void inc_allocated_size(int64_t val = 1);
+    void dec_allocated_size(int64_t val = 1);
+    void inc_total_capacity(int64_t val = 1);
+    void dec_total_capacity(int64_t val = 1);
     double get_global_used_ratio(void);
 
     // Key/Value Metrics
-    void inc_key_count(int64_t val = 1.0);
-    void dec_key_count(int64_t val = 1.0);
+    void inc_key_count(int64_t val = 1);
+    void dec_key_count(int64_t val = 1);
     void observe_value_size(int64_t size);
 
     // Operation Statistics (Counters)
-    void inc_put_start_requests(int64_t val = 1.0);
-    void inc_put_start_failures(int64_t val = 1.0);
-    void inc_put_end_requests(int64_t val = 1.0);
-    void inc_put_end_failures(int64_t val = 1.0);
-    void inc_put_revoke_requests(int64_t val = 1.0);
-    void inc_put_revoke_failures(int64_t val = 1.0);
-    void inc_get_replica_list_requests(int64_t val = 1.0);
-    void inc_get_replica_list_failures(int64_t val = 1.0);
-    void inc_exist_key_requests(int64_t val = 1.0);
-    void inc_exist_key_failures(int64_t val = 1.0);
-    void inc_remove_requests(int64_t val = 1.0);
-    void inc_remove_failures(int64_t val = 1.0);
-    void inc_remove_all_requests(int64_t val = 1.0);
-    void inc_remove_all_failures(int64_t val = 1.0);
-    void inc_mount_segment_requests(int64_t val = 1.0);
-    void inc_mount_segment_failures(int64_t val = 1.0);
-    void inc_unmount_segment_requests(int64_t val = 1.0);
-    void inc_unmount_segment_failures(int64_t val = 1.0);
+    void inc_put_start_requests(int64_t val = 1);
+    void inc_put_start_failures(int64_t val = 1);
+    void inc_put_end_requests(int64_t val = 1);
+    void inc_put_end_failures(int64_t val = 1);
+    void inc_put_revoke_requests(int64_t val = 1);
+    void inc_put_revoke_failures(int64_t val = 1);
+    void inc_get_replica_list_requests(int64_t val = 1);
+    void inc_get_replica_list_failures(int64_t val = 1);
+    void inc_exist_key_requests(int64_t val = 1);
+    void inc_exist_key_failures(int64_t val = 1);
+    void inc_remove_requests(int64_t val = 1);
+    void inc_remove_failures(int64_t val = 1);
+    void inc_remove_all_requests(int64_t val = 1);
+    void inc_remove_all_failures(int64_t val = 1);
+    void inc_mount_segment_requests(int64_t val = 1);
+    void inc_mount_segment_failures(int64_t val = 1);
+    void inc_unmount_segment_requests(int64_t val = 1);
+    void inc_unmount_segment_failures(int64_t val = 1);
 
     // Eviction Metrics
     void inc_eviction_success(int64_t key_count, int64_t size);
@@ -76,32 +76,32 @@ class MasterMetricManager {
     // --- Metric Members ---
 
     // Storage Metrics
-    ylt::metric::gauge_d allocated_size_;  // Use update for gauge
-    ylt::metric::gauge_d total_capacity_;  // Use update for gauge
+    ylt::metric::gauge_t allocated_size_;  // Use update for gauge
+    ylt::metric::gauge_t total_capacity_;  // Use update for gauge
 
     // Key/Value Metrics
-    ylt::metric::gauge_d key_count_;
-    ylt::metric::histogram_d value_size_distribution_;
+    ylt::metric::gauge_t key_count_;
+    ylt::metric::histogram_t value_size_distribution_;
 
     // Operation Statistics
-    ylt::metric::counter_d put_start_requests_;
-    ylt::metric::counter_d put_start_failures_;
-    ylt::metric::counter_d put_end_requests_;
-    ylt::metric::counter_d put_end_failures_;
-    ylt::metric::counter_d put_revoke_requests_;
-    ylt::metric::counter_d put_revoke_failures_;
-    ylt::metric::counter_d get_replica_list_requests_;
-    ylt::metric::counter_d get_replica_list_failures_;
-    ylt::metric::counter_d exist_key_requests_;
-    ylt::metric::counter_d exist_key_failures_;
-    ylt::metric::counter_d remove_requests_;
-    ylt::metric::counter_d remove_failures_;
-    ylt::metric::counter_d remove_all_requests_;
-    ylt::metric::counter_d remove_all_failures_;
-    ylt::metric::counter_d mount_segment_requests_;
-    ylt::metric::counter_d mount_segment_failures_;
-    ylt::metric::counter_d unmount_segment_requests_;
-    ylt::metric::counter_d unmount_segment_failures_;
+    ylt::metric::counter_t put_start_requests_;
+    ylt::metric::counter_t put_start_failures_;
+    ylt::metric::counter_t put_end_requests_;
+    ylt::metric::counter_t put_end_failures_;
+    ylt::metric::counter_t put_revoke_requests_;
+    ylt::metric::counter_t put_revoke_failures_;
+    ylt::metric::counter_t get_replica_list_requests_;
+    ylt::metric::counter_t get_replica_list_failures_;
+    ylt::metric::counter_t exist_key_requests_;
+    ylt::metric::counter_t exist_key_failures_;
+    ylt::metric::counter_t remove_requests_;
+    ylt::metric::counter_t remove_failures_;
+    ylt::metric::counter_t remove_all_requests_;
+    ylt::metric::counter_t remove_all_failures_;
+    ylt::metric::counter_t mount_segment_requests_;
+    ylt::metric::counter_t mount_segment_failures_;
+    ylt::metric::counter_t unmount_segment_requests_;
+    ylt::metric::counter_t unmount_segment_failures_;
 
     // Eviction Metrics
     ylt::metric::counter_t eviction_success_;

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -31,10 +31,6 @@ class MasterMetricManager {
     void dec_key_count(int64_t val = 1.0);
     void observe_value_size(int64_t size);
 
-    // Eviction Metrics
-    void inc_eviction_success(int64_t key_count, int64_t size);
-    void inc_eviction_fail(); // not a single object is evicted
-
     // Operation Statistics (Counters)
     void inc_put_start_requests(int64_t val = 1.0);
     void inc_put_start_failures(int64_t val = 1.0);
@@ -54,6 +50,10 @@ class MasterMetricManager {
     void inc_mount_segment_failures(int64_t val = 1.0);
     void inc_unmount_segment_requests(int64_t val = 1.0);
     void inc_unmount_segment_failures(int64_t val = 1.0);
+
+    // Eviction Metrics
+    void inc_eviction_success(int64_t key_count, int64_t size);
+    void inc_eviction_fail(); // not a single object is evicted
 
     // --- Serialization ---
     /**
@@ -83,12 +83,6 @@ class MasterMetricManager {
     ylt::metric::gauge_d key_count_;
     ylt::metric::histogram_d value_size_distribution_;
 
-    // Eviction Metrics
-    ylt::metric::counter_t eviction_success_;
-    ylt::metric::counter_t eviction_attempts_;
-    ylt::metric::counter_t evicted_key_count_;
-    ylt::metric::counter_t evicted_size_;
-
     // Operation Statistics
     ylt::metric::counter_d put_start_requests_;
     ylt::metric::counter_d put_start_failures_;
@@ -108,6 +102,12 @@ class MasterMetricManager {
     ylt::metric::counter_d mount_segment_failures_;
     ylt::metric::counter_d unmount_segment_requests_;
     ylt::metric::counter_d unmount_segment_failures_;
+
+    // Eviction Metrics
+    ylt::metric::counter_t eviction_success_;
+    ylt::metric::counter_t eviction_attempts_;
+    ylt::metric::counter_t evicted_key_count_;
+    ylt::metric::counter_t evicted_size_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -24,12 +24,15 @@ class MasterMetricManager {
     void dec_allocated_size(int64_t val = 1);
     void inc_total_capacity(int64_t val = 1);
     void dec_total_capacity(int64_t val = 1);
+    int64_t get_allocated_size();
+    int64_t get_total_capacity();
     double get_global_used_ratio(void);
 
     // Key/Value Metrics
     void inc_key_count(int64_t val = 1);
     void dec_key_count(int64_t val = 1);
     void observe_value_size(int64_t size);
+    int64_t get_key_count();
 
     // Operation Statistics (Counters)
     void inc_put_start_requests(int64_t val = 1);
@@ -51,9 +54,35 @@ class MasterMetricManager {
     void inc_unmount_segment_requests(int64_t val = 1);
     void inc_unmount_segment_failures(int64_t val = 1);
 
+    // Operation Statistics Getters
+    int64_t get_put_start_requests();
+    int64_t get_put_start_failures();
+    int64_t get_put_end_requests();
+    int64_t get_put_end_failures();
+    int64_t get_put_revoke_requests();
+    int64_t get_put_revoke_failures();
+    int64_t get_get_replica_list_requests();
+    int64_t get_get_replica_list_failures();
+    int64_t get_exist_key_requests();
+    int64_t get_exist_key_failures();
+    int64_t get_remove_requests();
+    int64_t get_remove_failures();
+    int64_t get_remove_all_requests();
+    int64_t get_remove_all_failures();
+    int64_t get_mount_segment_requests();
+    int64_t get_mount_segment_failures();
+    int64_t get_unmount_segment_requests();
+    int64_t get_unmount_segment_failures();
+
     // Eviction Metrics
     void inc_eviction_success(int64_t key_count, int64_t size);
     void inc_eviction_fail(); // not a single object is evicted
+
+    // Eviction Metrics Getters
+    int64_t get_eviction_success();
+    int64_t get_eviction_attempts();
+    int64_t get_evicted_key_count();
+    int64_t get_evicted_size();
 
     // --- Serialization ---
     /**

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -16,6 +16,7 @@ AllocatedBuffer::~AllocatedBuffer() {
         VLOG(1) << "buf_handle_deallocated segment_name=" << segment_name_
                 << " size=" << size_;
     } else {
+        MasterMetricManager::instance().dec_allocated_size(size_);
         LOG(WARNING) << "allocator=expired_or_null in buf_handle_destructor";
     }
 }

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -99,6 +99,14 @@ void MasterMetricManager::dec_total_capacity(int64_t val) {
     total_capacity_.dec(val);
 }
 
+int64_t MasterMetricManager::get_allocated_size() {
+    return allocated_size_.value();
+}
+
+int64_t MasterMetricManager::get_total_capacity() {
+    return total_capacity_.value();
+}
+
 double MasterMetricManager::get_global_used_ratio(void) {
     double allocated = allocated_size_.value();
     double capacity = total_capacity_.value();
@@ -114,6 +122,10 @@ void MasterMetricManager::dec_key_count(int64_t val) { key_count_.dec(val); }
 
 void MasterMetricManager::observe_value_size(int64_t size) {
     value_size_distribution_.observe(size);
+}
+
+int64_t MasterMetricManager::get_key_count() {
+    return key_count_.value();
 }
 
 // Operation Statistics (Counters)
@@ -172,6 +184,78 @@ void MasterMetricManager::inc_unmount_segment_failures(int64_t val) {
     unmount_segment_failures_.inc(val);
 }
 
+int64_t MasterMetricManager::get_put_start_requests() {
+    return put_start_requests_.value();
+}
+
+int64_t MasterMetricManager::get_put_start_failures() {
+    return put_start_failures_.value();
+}
+
+int64_t MasterMetricManager::get_put_end_requests() {
+    return put_end_requests_.value();
+}
+
+int64_t MasterMetricManager::get_put_end_failures() {
+    return put_end_failures_.value();
+}
+
+int64_t MasterMetricManager::get_put_revoke_requests() {
+    return put_revoke_requests_.value();
+}
+
+int64_t MasterMetricManager::get_put_revoke_failures() {
+    return put_revoke_failures_.value();
+}
+
+int64_t MasterMetricManager::get_get_replica_list_requests() {
+    return get_replica_list_requests_.value();
+}
+
+int64_t MasterMetricManager::get_get_replica_list_failures() {
+    return get_replica_list_failures_.value();
+}
+
+int64_t MasterMetricManager::get_exist_key_requests() {
+    return exist_key_requests_.value();
+}
+
+int64_t MasterMetricManager::get_exist_key_failures() {
+    return exist_key_failures_.value();
+}
+
+int64_t MasterMetricManager::get_remove_requests() {
+    return remove_requests_.value();
+}
+
+int64_t MasterMetricManager::get_remove_failures() {
+    return remove_failures_.value();
+}
+
+int64_t MasterMetricManager::get_remove_all_requests() {
+    return remove_all_requests_.value();
+}
+
+int64_t MasterMetricManager::get_remove_all_failures() {
+    return remove_all_failures_.value();
+}
+
+int64_t MasterMetricManager::get_mount_segment_requests() {
+    return mount_segment_requests_.value();
+}
+
+int64_t MasterMetricManager::get_mount_segment_failures() {
+    return mount_segment_failures_.value();
+}
+
+int64_t MasterMetricManager::get_unmount_segment_requests() {
+    return unmount_segment_requests_.value();
+}
+
+int64_t MasterMetricManager::get_unmount_segment_failures() {
+    return unmount_segment_failures_.value();
+}
+
 // Eviction Metrics
 void MasterMetricManager::inc_eviction_success(int64_t key_count, int64_t size) {
     evicted_key_count_.inc(key_count);
@@ -182,6 +266,22 @@ void MasterMetricManager::inc_eviction_success(int64_t key_count, int64_t size) 
 
 void MasterMetricManager::inc_eviction_fail() {
     eviction_attempts_.inc();
+}
+
+int64_t MasterMetricManager::get_eviction_success() {
+    return eviction_success_.value();
+}
+
+int64_t MasterMetricManager::get_eviction_attempts() {
+    return eviction_attempts_.value();
+}
+
+int64_t MasterMetricManager::get_evicted_key_count() {
+    return evicted_key_count_.value();
+}
+
+int64_t MasterMetricManager::get_evicted_size() {
+    return evicted_size_.value();
 }
 
 // --- Serialization ---
@@ -256,29 +356,29 @@ std::string MasterMetricManager::get_summary_string() {
     };
 
     // --- Get current values ---
-    double allocated = allocated_size_.value();
-    double capacity = total_capacity_.value();
-    double keys = key_count_.value();
+    int64_t allocated = allocated_size_.value();
+    int64_t capacity = total_capacity_.value();
+    int64_t keys = key_count_.value();
 
     // Request counters
-    double exist_keys = exist_key_requests_.value();
-    double exist_key_fails = exist_key_failures_.value();
-    double put_starts = put_start_requests_.value();
-    double put_start_fails = put_start_failures_.value();
-    double put_ends = put_end_requests_.value();
-    double put_end_fails = put_end_failures_.value();
-    double get_replicas = get_replica_list_requests_.value();
-    double get_replica_fails = get_replica_list_failures_.value();
-    double removes = remove_requests_.value();
-    double remove_fails = remove_failures_.value();
-    double remove_all = remove_all_requests_.value();
-    double remove_all_fails = remove_all_failures_.value();
+    int64_t exist_keys = exist_key_requests_.value();
+    int64_t exist_key_fails = exist_key_failures_.value();
+    int64_t put_starts = put_start_requests_.value();
+    int64_t put_start_fails = put_start_failures_.value();
+    int64_t put_ends = put_end_requests_.value();
+    int64_t put_end_fails = put_end_failures_.value();
+    int64_t get_replicas = get_replica_list_requests_.value();
+    int64_t get_replica_fails = get_replica_list_failures_.value();
+    int64_t removes = remove_requests_.value();
+    int64_t remove_fails = remove_failures_.value();
+    int64_t remove_all = remove_all_requests_.value();
+    int64_t remove_all_fails = remove_all_failures_.value();
 
     // Eviction counters
-    uint64_t eviction_success = eviction_success_.value();
-    uint64_t eviction_attempts = eviction_attempts_.value();
-    uint64_t evicted_key_count = evicted_key_count_.value();
-    uint64_t evicted_size = evicted_size_.value();
+    int64_t eviction_success = eviction_success_.value();
+    int64_t eviction_attempts = eviction_attempts_.value();
+    int64_t evicted_key_count = evicted_key_count_.value();
+    int64_t evicted_size = evicted_size_.value();
 
     // --- Format the summary string ---
     ss << "Storage: " << format_bytes(allocated) << " / "

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -25,8 +25,8 @@ MasterMetricManager::MasterMetricManager()
       // Initialize Histogram (4KB, 64KB, 256KB, 1MB, 4MB, 16MB, 64MB)
       value_size_distribution_("master_value_size_bytes",
                                "Distribution of object value sizes",
-                               {4096.0, 65536.0, 262144.0, 1048576.0, 4194304.0,
-                                16777216.0, 67108864.0}),
+                               {4096, 65536, 262144, 1048576, 4194304,
+                                16777216, 67108864}),
       // Initialize Request Counters
       put_start_requests_("master_put_start_requests_total",
                           "Total number of PutStart requests received"),
@@ -287,22 +287,17 @@ std::string MasterMetricManager::get_summary_string() {
         ss << " (" << std::fixed << std::setprecision(1)
            << (allocated / capacity * 100.0) << "%)";
     }
-    ss << " | Keys: " << static_cast<int64_t>(keys);
+    ss << " | Keys: " << keys;
 
     // Request summary - focus on the most important metrics
     ss << " | Requests (Success/Total): ";
     ss << "Put="
-       << static_cast<int64_t>(put_starts - put_start_fails + put_ends -
-                               put_end_fails)
-       << "/" << static_cast<int64_t>(put_starts + put_ends) << ", ";
-    ss << "Get=" << static_cast<int64_t>(get_replicas - get_replica_fails)
-       << "/" << static_cast<int64_t>(get_replicas) << ", ";
-    ss << "Exist=" << static_cast<int64_t>(exist_keys - exist_key_fails)
-       << "/" << static_cast<int64_t>(exist_keys) << ", ";
-    ss << "Del=" << static_cast<int64_t>(removes - remove_fails) << "/"
-       << static_cast<int64_t>(removes) << ", ";
-    ss << "DelAll=" << static_cast<int64_t>(remove_all - remove_all_fails) << "/"
-       << static_cast<int64_t>(remove_all);
+       << put_starts - put_start_fails + put_ends - put_end_fails
+       << "/" << put_starts + put_ends << ", ";
+    ss << "Get=" << get_replicas - get_replica_fails << "/" << get_replicas << ", ";
+    ss << "Exist=" << exist_keys - exist_key_fails << "/" << exist_keys << ", ";
+    ss << "Del=" << removes - remove_fails << "/" << removes << ", ";
+    ss << "DelAll=" << remove_all - remove_all_fails << "/" << remove_all;
 
     // Eviction summary
     ss << " | Eviction: "

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -128,10 +128,10 @@ ErrorCode MasterService::UnmountSegment(const std::string& segment_name) {
                     break;
                 }
             }
-
             // Remove the object if it has no valid replicas
             if (has_invalid || CleanupStaleHandles(it->second)) {
                 it = shard.metadata.erase(it);
+                MasterMetricManager::instance().dec_key_count(1);
             } else {
                 ++it;
             }

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -21,6 +21,17 @@ target_link_libraries(client_integration_test PUBLIC
 )
 add_test(NAME client_integration_test COMMAND client_integration_test)
 
+add_executable(master_metrics_test master_metrics_test.cpp)
+target_link_libraries(master_metrics_test PUBLIC
+    mooncake_store
+    cachelib_memory_allocator
+    glog
+    gtest
+    gtest_main
+    pthread
+)
+add_test(NAME master_metrics_test COMMAND master_metrics_test)
+
 add_executable(stress_workload_test stress_workload_test.cpp)
 target_link_libraries(stress_workload_test PUBLIC 
     mooncake_store 

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -1,0 +1,164 @@
+#include "master_service.h"
+#include "rpc_service.h"
+#include "types.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <memory>
+#include <random>
+#include <thread>
+#include <vector>
+
+namespace mooncake::test {
+
+class MasterMetricsTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("MasterMetricsTest");
+        FLAGS_logtostderr = true;
+    }
+
+    std::vector<Replica::Descriptor> replica_list;
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+};
+
+TEST_F(MasterMetricsTest, InitialStatusTest) {
+    auto& metrics = MasterMetricManager::instance();
+
+    // Storage Metrics
+    ASSERT_EQ(metrics.get_allocated_size(), 0);
+    ASSERT_EQ(metrics.get_total_capacity(),0);
+    ASSERT_DOUBLE_EQ(metrics.get_global_used_ratio(), 0.0);
+
+    // Key/Value Metrics
+    ASSERT_EQ(metrics.get_key_count(), 0);
+
+    // Operation Statistics
+    ASSERT_EQ(metrics.get_put_start_requests(), 0);
+    ASSERT_EQ(metrics.get_put_start_failures(), 0);
+    ASSERT_EQ(metrics.get_put_end_requests(), 0);
+    ASSERT_EQ(metrics.get_put_end_failures(), 0);
+    ASSERT_EQ(metrics.get_put_revoke_requests(), 0);
+    ASSERT_EQ(metrics.get_put_revoke_failures(), 0);
+    ASSERT_EQ(metrics.get_get_replica_list_requests(), 0);
+    ASSERT_EQ(metrics.get_get_replica_list_failures(), 0);
+    ASSERT_EQ(metrics.get_exist_key_requests(), 0);
+    ASSERT_EQ(metrics.get_exist_key_failures(), 0);
+    ASSERT_EQ(metrics.get_remove_requests(), 0);
+    ASSERT_EQ(metrics.get_remove_failures(), 0);
+    ASSERT_EQ(metrics.get_remove_all_requests(), 0);
+    ASSERT_EQ(metrics.get_remove_all_failures(), 0);
+    ASSERT_EQ(metrics.get_mount_segment_requests(), 0);
+    ASSERT_EQ(metrics.get_mount_segment_failures(), 0);
+    ASSERT_EQ(metrics.get_unmount_segment_requests(), 0);
+    ASSERT_EQ(metrics.get_unmount_segment_failures(), 0);
+
+    // Eviction Metrics
+    ASSERT_EQ(metrics.get_eviction_success(), 0);
+    ASSERT_EQ(metrics.get_eviction_attempts(), 0);
+    ASSERT_EQ(metrics.get_evicted_key_count(), 0);
+    ASSERT_EQ(metrics.get_evicted_size(), 0);
+}
+
+TEST_F(MasterMetricsTest, BasicRequestTest) {
+    const uint64_t default_kv_lease_ttl = 100;
+    auto& metrics = MasterMetricManager::instance();
+    // Use a wrapped master service to test the metrics manager
+    WrappedMasterService service_(
+        false, default_kv_lease_ttl, true);
+
+    constexpr size_t kBufferAddress = 0x300000000;
+    constexpr size_t kSegmentSize = 1024 * 1024 * 16;
+    std::string segment_name = "test_segment";
+    std::string key = "test_key";
+    uint64_t value_length = 1024;
+    std::vector<uint64_t> slice_lengths = {value_length};
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    // Test MountSegment request
+    ASSERT_EQ(ErrorCode::OK,
+            service_.MountSegment(kBufferAddress, kSegmentSize, segment_name).error_code);
+    ASSERT_EQ(metrics.get_allocated_size(), 0);
+    ASSERT_EQ(metrics.get_total_capacity(), kSegmentSize);
+    ASSERT_DOUBLE_EQ(metrics.get_global_used_ratio(), 0.0);
+    ASSERT_EQ(metrics.get_mount_segment_requests(), 1);
+    ASSERT_EQ(metrics.get_mount_segment_failures(), 0);
+
+    // Test PutStart and PutRevoke request
+    ASSERT_EQ(ErrorCode::OK,
+              service_.PutStart(key, value_length, slice_lengths, config).error_code);
+    ASSERT_EQ(metrics.get_key_count(), 1);
+    ASSERT_EQ(metrics.get_allocated_size(), value_length);
+    ASSERT_EQ(metrics.get_put_start_requests(), 1);
+    ASSERT_EQ(metrics.get_put_start_failures(), 0);
+    ASSERT_EQ(ErrorCode::OK, service_.PutRevoke(key).error_code);
+    ASSERT_EQ(metrics.get_key_count(), 0);
+    ASSERT_EQ(metrics.get_allocated_size(), 0);
+    ASSERT_EQ(metrics.get_put_revoke_requests(), 1);
+    ASSERT_EQ(metrics.get_put_revoke_failures(), 0);
+
+    // Test PutStart and PutEnd request
+    ASSERT_EQ(ErrorCode::OK,
+              service_.PutStart(key, value_length, slice_lengths, config).error_code);
+    ASSERT_EQ(metrics.get_key_count(), 1);
+    ASSERT_EQ(metrics.get_allocated_size(), value_length);
+    ASSERT_EQ(metrics.get_put_start_requests(), 2);
+    ASSERT_EQ(metrics.get_put_start_failures(), 0);
+    ASSERT_EQ(ErrorCode::OK, service_.PutEnd(key).error_code);
+    ASSERT_EQ(metrics.get_key_count(), 1);
+    ASSERT_EQ(metrics.get_allocated_size(), value_length);
+    ASSERT_EQ(metrics.get_put_end_requests(), 1);
+    ASSERT_EQ(metrics.get_put_end_failures(), 0);
+
+    // Test ExistKey request
+    ASSERT_EQ(ErrorCode::OK, service_.ExistKey(key).error_code);
+    ASSERT_EQ(metrics.get_exist_key_requests(), 1);
+    ASSERT_EQ(metrics.get_exist_key_failures(), 0);
+
+    // Test GetReplicaList request
+    ASSERT_EQ(ErrorCode::OK, service_.GetReplicaList(key).error_code);
+    ASSERT_EQ(metrics.get_get_replica_list_requests(), 1);
+    ASSERT_EQ(metrics.get_get_replica_list_failures(), 0);
+
+    // Test Remove request
+    std::this_thread::sleep_for(std::chrono::milliseconds(default_kv_lease_ttl));
+    ASSERT_EQ(ErrorCode::OK, service_.Remove(key).error_code);
+    ASSERT_EQ(metrics.get_remove_requests(), 1);
+    ASSERT_EQ(metrics.get_remove_failures(), 0);
+    ASSERT_EQ(metrics.get_key_count(), 0);
+    ASSERT_EQ(metrics.get_allocated_size(), 0);
+
+    // Test RemoveAll request
+    ASSERT_EQ(ErrorCode::OK,
+              service_.PutStart(key, value_length, slice_lengths, config).error_code);
+    ASSERT_EQ(ErrorCode::OK, service_.PutEnd(key).error_code);
+    ASSERT_EQ(metrics.get_key_count(), 1);
+    ASSERT_EQ(1, service_.RemoveAll().removed_count);
+    ASSERT_EQ(metrics.get_remove_all_requests(), 1);
+    ASSERT_EQ(metrics.get_remove_all_failures(), 0);
+    ASSERT_EQ(metrics.get_key_count(), 0);
+    ASSERT_EQ(metrics.get_allocated_size(), 0);
+
+    // Test UnmountSegment request
+    ASSERT_EQ(ErrorCode::OK,
+              service_.PutStart(key, value_length, slice_lengths, config).error_code);
+    ASSERT_EQ(ErrorCode::OK, service_.PutEnd(key).error_code);
+    ASSERT_EQ(ErrorCode::OK, service_.UnmountSegment(segment_name).error_code);
+    ASSERT_EQ(metrics.get_unmount_segment_requests(), 1);
+    ASSERT_EQ(metrics.get_unmount_segment_failures(), 0);
+    ASSERT_EQ(metrics.get_key_count(), 0);
+    ASSERT_EQ(metrics.get_allocated_size(), 0);
+    ASSERT_EQ(metrics.get_total_capacity(), 0);
+    ASSERT_DOUBLE_EQ(metrics.get_global_used_ratio(), 0.0);
+}
+
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
1. The eviction-related metrics are calculated but do not add to the output string.
2. When unmounting a segment, keys are removed, but the corresponding metrics do not change.
3. Adjust the position of some eviction metrics code blocks to make code ordering consistent.