### PR TITLE
[TransferEngine] Fix retry logics in RDMA worker

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -76,6 +76,12 @@ class RdmaEndPoint {
     void set_active(bool flag) { 
         RWSpinlock::WriteGuard guard(lock_);
         active_ = flag; 
+        if (!flag) inactive_time_ = getCurrentTimeInNano();
+    }
+
+    double inactiveTime() {
+        if (active_) return 0.0;
+        return (getCurrentTimeInNano() - inactive_time_) / 1000000000.0;
     }
 
    public:
@@ -129,6 +135,7 @@ class RdmaEndPoint {
 
     volatile bool active_;
     volatile int *cq_outstanding_;
+    volatile uint64_t inactive_time_;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -228,7 +228,8 @@ void WorkerPool::performPostSend(int thread_id) {
             continue;
         }
         if (!endpoint->active()) {
-            context_.deleteEndpoint(entry.first);
+            if (endpoint->inactiveTime() > 1.0)
+                context_.deleteEndpoint(entry.first); // enable for re-establishation
             for (auto &slice : entry.second) failed_slice_list.push_back(slice);
             entry.second.clear();
             continue;


### PR DESCRIPTION
1.  When retry_cnt > max_retry_cnt, the loop infiniately may be executed
2. When disabling a endpoint, we allow it to be re-created after one-second grace period. 