### PR TITLE
fix: filter out DOWN network interfaces in findLocalIpAddresses()

### DIFF
--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -867,9 +867,18 @@ std::vector<std::string> findLocalIpAddresses() {
                 continue;
             }
 
+            // Check if interface is UP and RUNNING
+            if (!(ifa->ifa_flags & IFF_UP) || !(ifa->ifa_flags & IFF_RUNNING)) {
+                LOG(INFO) << "Skipping interface " << ifa->ifa_name
+                          << " (not UP or not RUNNING)";
+                continue;
+            }
+
             char host[NI_MAXHOST];
             if (getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), host,
                             NI_MAXHOST, nullptr, 0, NI_NUMERICHOST) == 0) {
+                LOG(INFO) << "Found active interface " << ifa->ifa_name
+                          << " with IP " << host;
                 ips.push_back(host);
             }
         }


### PR DESCRIPTION
🐛 Problem
The findLocalIpAddresses() function in the transfer metadata plugin was incorrectly returning IP addresses from network interfaces that are in DOWN state. This caused connection failures and RPC timeouts when services attempted to bind or connect to these inactive IP addresses.
🔍 Root Cause
The current implementation only filters out the loopback interface (lo) but does not check the interface status flags (IFF_UP and IFF_RUNNING). As a result, it returns IP addresses from all non-loopback interfaces regardless of their operational state.
💡 Solution
Added proper interface status checks to ensure only active network interfaces are considered:
✅ Check IFF_UP flag (interface is administratively up)
✅ Check IFF_RUNNING flag (interface has a valid link/connection)
✅ Add informative logging for skipped and selected interfaces
✅ Maintain existing loopback interface filtering
