### PR TITLE
[MooncakeStore] support batch api

### DIFF
--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -45,11 +45,27 @@ class Client {
     ErrorCode Get(const std::string& object_key, std::vector<Slice>& slices);
 
     /**
+     * @brief Gets object metadata without transferring data
+     * @param object_keys Keys to query
+     * @param slices Output parameter for the retrieved data
+     */
+    ErrorCode BatchGet(
+        const std::vector<std::string>& object_keys,
+        std::unordered_map<std::string, std::vector<Slice>>& slices);
+
+    /**
      * @brief Two-step data retrieval process
      * 1. Query object information
      * 2. Transfer data based on the information
      */
     using ObjectInfo = GetReplicaListResponse;
+
+    /**
+     * @brief Two-step data retrieval process
+     * 1. BatchQuery object information
+     * 2. Transfer data based on the information
+     */
+    using BatchObjectInfo = BatchGetReplicaListResponse;
 
     /**
      * @brief Gets object metadata without transferring data
@@ -58,6 +74,14 @@ class Client {
      * @return ErrorCode indicating success/failure
      */
     ErrorCode Query(const std::string& object_key, ObjectInfo& object_info);
+
+    /**
+     * @brief Batch query object metadata without transferring data
+     * @param object_keys Keys to query
+     * @param object_infos Output parameter for object metadata
+     */
+    ErrorCode BatchQuery(const std::vector<std::string>& object_keys,
+                         BatchObjectInfo& object_infos);
 
     /**
      * @brief Transfers data using pre-queried object information
@@ -70,6 +94,18 @@ class Client {
                   std::vector<Slice>& slices);
 
     /**
+     * @brief Transfers data using pre-queried object information
+     * @param object_keys Keys of the objects
+     * @param object_infos Previously queried object metadata
+     * @param slices Vector of slices to store the data
+     * @return ErrorCode indicating success/failure
+     */
+    ErrorCode BatchGet(
+        const std::vector<std::string>& object_keys,
+        BatchObjectInfo& object_infos,
+        std::unordered_map<std::string, std::vector<Slice>>& slices);
+
+    /**
      * @brief Stores data with replication
      * @param key Object key
      * @param slices Vector of data slices to store
@@ -78,6 +114,17 @@ class Client {
      */
     ErrorCode Put(const ObjectKey& key, std::vector<Slice>& slices,
                   const ReplicateConfig& config);
+
+    /**
+     * @brief Batch put data with replication
+     * @param keys Object keys
+     * @param batched_slices Vector of data slices to store
+     * @param config Replication configuration
+     */
+    ErrorCode BatchPut(
+        const std::vector<ObjectKey>& keys,
+        std::unordered_map<std::string, std::vector<Slice>>& batched_slices,
+        ReplicateConfig& config);
 
     /**
      * @brief Removes an object and all its replicas

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -51,6 +51,15 @@ class MasterClient {
         const std::string& object_key);
 
     /**
+     * @brief Gets object metadata without transferring data
+     * @param object_keys Keys to query
+     * @param object_infos Output parameter for object metadata
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] BatchGetReplicaListResponse BatchGetReplicaList(
+        const std::vector<std::string>& object_keys);
+
+    /**
      * @brief Starts a put operation
      * @param key Object key
      * @param slice_lengths Vector of slice lengths
@@ -64,6 +73,21 @@ class MasterClient {
         size_t value_length, const ReplicateConfig& config);
 
     /**
+     * @brief Starts a batch of put operations for N objects
+     * @param keys Vector of object key
+     * @param value_lengths Vector of total value lengths
+     * @param slice_lengths Vector of vectors of slice lengths
+     * @param config Replication configuration
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] BatchPutStartResponse BatchPutStart(
+        const std::vector<std::string>& keys,
+        const std::unordered_map<std::string, uint64_t>& value_lengths,
+        const std::unordered_map<std::string, std::vector<uint64_t>>&
+            slice_lengths,
+        const ReplicateConfig& config);
+
+    /**
      * @brief Ends a put operation
      * @param key Object key
      * @return ErrorCode indicating success/failure
@@ -71,11 +95,27 @@ class MasterClient {
     [[nodiscard]] PutEndResponse PutEnd(const std::string& key);
 
     /**
+     * @brief Ends a put operation for a batch of objects
+     * @param keys Vector of object keys
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] BatchPutEndResponse BatchPutEnd(
+        const std::vector<std::string>& keys);
+
+    /**
      * @brief Revokes a put operation
      * @param key Object key
      * @return ErrorCode indicating success/failure
      */
     [[nodiscard]] PutRevokeResponse PutRevoke(const std::string& key);
+
+    /**
+     * @brief Revokes a put operation for a batch of objects
+     * @param keys Vector of object keys
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] BatchPutRevokeResponse BatchPutRevoke(
+        const std::vector<std::string>& keys);
 
     /**
      * @brief Removes an object and all its replicas

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -127,6 +127,16 @@ class MasterService {
                              std::vector<Replica::Descriptor>& replica_list);
 
     /**
+     * @brief Get list of replicas for a batch of objects
+     * @param[out] batch_replica_list Vector to store replicas information for
+     * slices
+     */
+    ErrorCode BatchGetReplicaList(
+        const std::vector<std::string>& keys,
+        std::unordered_map<std::string, std::vector<Replica::Descriptor>>&
+            batch_replica_list);
+
+    /**
      * @brief Mark a key for garbage collection after specified delay
      * @param key The key to be garbage collected
      * @param delay_ms Delay in milliseconds before removing the key
@@ -161,11 +171,42 @@ class MasterService {
     ErrorCode PutRevoke(const std::string& key);
 
     /**
+     * @brief Start a batch of put operations for N objects
+     * @param[out] replica_list Vector to store replica information for slices
+     * @return ErrorCode::OK on success, ErrorCode::OBJECT_NOT_FOUND if exists,
+     *         ErrorCode::NO_AVAILABLE_HANDLE if allocation fails,
+     *         ErrorCode::INVALID_PARAMS if slice size is invalid
+     */
+    ErrorCode BatchPutStart(
+        const std::vector<std::string>& keys,
+        const std::unordered_map<std::string, uint64_t>& value_lengths,
+        const std::unordered_map<std::string, std::vector<uint64_t>>&
+            slice_lengths,
+        const ReplicateConfig& config,
+        std::unordered_map<std::string, std::vector<Replica::Descriptor>>&
+            batch_replica_list);
+
+    /**
+     * @brief Complete a batch of put operations
+     * @return ErrorCode::OK on success, ErrorCode::OBJECT_NOT_FOUND if not
+     * found, ErrorCode::INVALID_WRITE if replica status is invalid
+     */
+    ErrorCode BatchPutEnd(const std::vector<std::string>& keys);
+
+    /**
+     * @brief Revoke a batch of put operations
+     * @return ErrorCode::OK on success, ErrorCode::OBJECT_NOT_FOUND if not
+     * found, ErrorCode::INVALID_WRITE if replica status is invalid
+     */
+    ErrorCode BatchPutRevoke(const std::vector<std::string>& keys);
+
+    /**
      * @brief Remove an object and its replicas
      * @return ErrorCode::OK on success, ErrorCode::OBJECT_NOT_FOUND if not
      * found
      */
     ErrorCode Remove(const std::string& key);
+
     /**
      * @brief Remove all objects and their replicas
      * @return return the number of objects removed

--- a/mooncake-store/proto/master.proto
+++ b/mooncake-store/proto/master.proto
@@ -32,6 +32,21 @@ message ReplicaInfo {
   required ReplicaStatus status = 2 [default = UNDEFINED]; // Replica status.
 }
 
+message BatchReplicaInfo {
+  required string key = 1;
+  repeated ReplicaInfo replica_list= 2;
+}
+
+message BatchValueLength {
+  required string key = 1;
+  required uint64 value_lengths = 2;
+}
+
+message BatchSliceLength {
+  required string key = 1;
+  repeated uint64 slice_lengths = 2;
+}
+
 // Request to check key existence.
 message ExistKeyRequest {
   required string key = 1; // Object key.
@@ -51,6 +66,17 @@ message GetReplicaListRequest {
 message GetReplicaListResponse {
   required int32 status_code = 1; // Status.
   repeated ReplicaInfo replica_list = 2; // Replicas.
+}
+
+// Request to get replica list.
+message BatchGetReplicaListRequest {
+  repeated string keys = 1; // Object keys.
+}
+
+// Response to batch get replica lists.
+message BatchGetReplicaListResponse {
+  required int32 status_code = 1; // Status.
+  repeated BatchReplicaInfo batch_replica_list = 2; // Replicas.
 }
 
 // Replication configuration.
@@ -93,6 +119,39 @@ message PutRevokeResponse {
   required int32 status_code = 1; // Status.
 }
 
+// Request to start a BatchPut operation.
+message BatchPutStartRequest {
+  repeated string keys = 1;         // Object keys.
+  repeated BatchValueLength value_lengths = 2; // Total data length.
+  repeated BatchSliceLength slice_lengths = 3; // Length of each slice.
+  required ReplicateConfig config = 4; // Replication config.
+}
+
+message BatchPutStartResponse {
+  required int32 status_code = 1; // Status.
+  repeated BatchReplicaInfo batch_replica_list = 2; // Replicas.
+}
+
+// Request to end a BatchPut operation.
+message BatchPutEndRequest {
+  repeated string key = 1; // Object keys.
+}
+
+// Response to end a BatchPut operation.
+message BatchPutEndResponse {
+  required int32 status_code = 1; // Status.
+}
+
+// Request to revoke a BatchPut operation.
+message BatchPutRevokeRequest {
+  repeated string key = 1; // Object key.
+}
+
+// Response to revoke a BatchPut operation.
+message BatchPutRevokeResponse {
+  required int32 status_code = 1; // Status.
+}
+
 // Request to remove an object.
 message RemoveRequest {
   required string key = 1; // Object key.
@@ -130,6 +189,9 @@ service MasterService {
   // Get replica list.
   rpc GetReplicaList(GetReplicaListRequest) returns (GetReplicaListResponse);
 
+  // BatchGet replica list.
+  rpc BatchGetReplicaList(BatchGetReplicaListRequest) returns (BatchGetReplicaListResponse);
+
   // Start Put operation.
   rpc PutStart(PutStartRequest) returns (PutStartResponse);
 
@@ -138,6 +200,15 @@ service MasterService {
 
   // Revoke Put operation.
   rpc PutRevoke(PutRevokeRequest) returns (PutRevokeResponse);
+
+  // Start Batch Put operation.
+  rpc BatchPutStart(BatchPutStartRequest) returns (BatchPutStartResponse);
+
+  // End Batch Put operation.
+  rpc BatchPutEnd(BatchPutEndRequest) returns (BatchPutEndResponse);
+
+  // Revoke Batch Put operation.
+  rpc BatchPutRevoke(BatchPutRevokeRequest) returns (BatchPutRevokeResponse);
 
   // Remove object.
   rpc Remove(RemoveRequest) returns (RemoveResponse);

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -183,7 +183,7 @@ ErrorCode Client::BatchGet(
     std::unordered_set<std::string> seen;
     for (const auto& key : object_keys) {
         if (!seen.insert(key).second) {
-            LOG(ERROR) << "Duplicate key not supportted for Batch API, key: "
+            LOG(ERROR) << "Duplicate key not supported for Batch API, key: "
                        << key;
             return ErrorCode::INVALID_PARAMS;
         };

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -56,11 +56,19 @@ int main(int argc, char* argv[]) {
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::GetReplicaList>(
         &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::BatchGetReplicaList>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::PutStart>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::PutEnd>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::PutRevoke>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::BatchPutStart>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::BatchPutEnd>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::BatchPutRevoke>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::Remove>(
         &wrapped_master_service);

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -299,6 +299,69 @@ TEST_F(ClientIntegrationTest, LargeAllocateTest) {
     ASSERT_EQ(client_->Remove(key), ErrorCode::OK);
 }
 
+// Test batch Put/Get operations through the client
+TEST_F(ClientIntegrationTest, BatchPutGetOperations) {
+    int batch_sz = 10;
+    std::vector<std::string> keys;
+    std::vector<std::string> test_data_list;
+    std::unordered_map<std::string, std::vector<Slice>> batched_slices;
+    for (int i = 0; i < batch_sz; i++) {
+        keys.push_back("test_key_batch_put_" + std::to_string(i));
+        test_data_list.push_back("test_data_" + std::to_string(i));
+    }
+    void* buffer = nullptr;
+    void* target_buffer = nullptr;
+    for (int i = 0; i < batch_sz; i++) {
+        std::vector<Slice> slices;
+        buffer = client_buffer_allocator_->allocate(test_data_list[i].size());
+        memcpy(buffer, test_data_list[i].data(), test_data_list[i].size());
+        slices.emplace_back(Slice{buffer, test_data_list[i].size()});
+        batched_slices.emplace(keys[i], slices);
+    }
+    // Test Batch Put operation
+    ReplicateConfig config;
+    config.replica_num = 1;
+    ASSERT_EQ(client_->BatchPut(keys, batched_slices, config), ErrorCode::OK);
+
+    // Allocate slice buffers for GetBatch
+    std::unordered_map<std::string, std::vector<Slice>> target_batched_slices;
+    for (int i = 0; i < batch_sz; i++) {
+        std::vector<Slice> target_slices;
+        target_buffer =
+            client_buffer_allocator_->allocate(test_data_list[i].size());
+        target_slices.emplace_back(
+            Slice{target_buffer, test_data_list[i].size()});
+        target_batched_slices.emplace(keys[i], target_slices);
+    }
+
+    ErrorCode error_code = client_->BatchGet(keys, target_batched_slices);
+    ASSERT_EQ(error_code, ErrorCode::OK);
+    for (int i = 0; i < batch_sz; i++) {
+        const auto& slices = target_batched_slices[keys[i]];
+        memcmp(static_cast<char*>(slices[0].ptr), test_data_list[i].data(),
+               test_data_list[i].size());
+        std::cout << "Key: " << keys[i] << std::endl;
+        for (const auto& slice : slices) {
+            std::cout << "Value: "
+                      << std::string(static_cast<char*>(slices[0].ptr),
+                                     slice.size)
+                      << std::endl;
+        }
+    }
+
+    error_code = client_->BatchGet({keys[0], keys[0]}, target_batched_slices);
+    ASSERT_NE(error_code, ErrorCode::OK);
+
+    for (int i = 0; i < batch_sz; i++) {
+        for (auto& slice : target_batched_slices[keys[i]]) {
+            client_buffer_allocator_->deallocate(slice.ptr, slice.size);
+        }
+        for (auto& slice : batched_slices[keys[i]]) {
+            client_buffer_allocator_->deallocate(slice.ptr, slice.size);
+        }
+    }
+}
+
 }  // namespace testing
 
 }  // namespace mooncake


### PR DESCRIPTION
This PR supports to put/get a batch of data in order to reduce master rpc call. It provides BatchPutStart, BatchPutEnd, BatchPutRevode and BatchGet APIs. I am still working on Python Store Batch API and will post it soon.   Related RFC: https://github.com/kvcache-ai/Mooncake/issues/380