### PR TITLE
[TransferEngine] Remove Unused Parameters in `TransferEngine::init`

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -101,17 +101,8 @@ int TransferEnginePy::initializeExt(const char *local_hostname,
     auto device_name_safe = device_name ? std::string(device_name) : "";
     auto device_filter = buildDeviceFilter(device_name_safe);
     engine_ = std::make_unique<TransferEngine>(true, device_filter);
-    if (getenv("MC_LEGACY_RPC_PORT_BINDING")) {
-        auto hostname_port = parseHostNameWithPort(local_hostname);
-        int ret =
-            engine_->init(conn_string, local_hostname,
-                          hostname_port.first.c_str(), hostname_port.second);
-        if (ret) return -1;
-    } else {
-        // the last two params are unused
-        int ret = engine_->init(conn_string, local_hostname, "", 0);
-        if (ret) return -1;
-    }
+    int ret = engine_->init(conn_string, local_hostname);
+    if (ret) return -1;
 
     free_list_.resize(kSlabSizeKBTabLen);
     doBuddyAllocate(kMaxClassId);

--- a/mooncake-integration/vllm/vllm_adaptor.cpp
+++ b/mooncake-integration/vllm/vllm_adaptor.cpp
@@ -87,7 +87,7 @@ int VLLMAdaptor::initializeExt(const char *local_hostname,
     // TODO: remove `false` in the feature, it's for keep same API in vllm.
     engine_ = std::make_unique<TransferEngine>(false);
     // the last two params are unused
-    int ret = engine_->init(conn_string, local_hostname, "", 0);
+    int ret = engine_->init(conn_string, local_hostname);
     if (ret) return -1;
 
     xport_ = nullptr;

--- a/mooncake-p2p-store/src/p2pstore/core.go
+++ b/mooncake-p2p-store/src/p2pstore/core.go
@@ -60,8 +60,7 @@ func NewP2PStore(metadataConnString string, localServerName string, nicPriorityM
 		return nil, err
 	}
 
-	localIpAddressCStr, rpcPort := parseServerName(localServerName)
-	transfer, err := NewTransferEngine(metadataConnString, localServerName, localIpAddressCStr, rpcPort)
+	transfer, err := NewTransferEngine(metadataConnString, localServerName)
 	if err != nil {
 		metadata.Close()
 		return nil, err

--- a/mooncake-p2p-store/src/p2pstore/transfer_engine.go
+++ b/mooncake-p2p-store/src/p2pstore/transfer_engine.go
@@ -33,17 +33,12 @@ type TransferEngine struct {
 	engine C.transfer_engine_t
 }
 
-func NewTransferEngine(metadataConnString string,
-	localServerName string,
-	localIpAddress string,
-	rpcPort int) (*TransferEngine, error) {
+func NewTransferEngine(metadataConnString string, localServerName string) (*TransferEngine, error) {
 	metadataConnStringCStr := C.CString(metadataConnString)
 	localServerNameCStr := C.CString(localServerName)
-	localIpAddressCStr := C.CString(localIpAddress)
 	defer C.free(unsafe.Pointer(metadataConnStringCStr))
 	defer C.free(unsafe.Pointer(localServerNameCStr))
-	defer C.free(unsafe.Pointer(localIpAddressCStr))
-	native_engine := C.createTransferEngine(metadataConnStringCStr, localServerNameCStr, localIpAddressCStr, C.uint64_t(rpcPort), 0)
+	native_engine := C.createTransferEngine(metadataConnStringCStr, localServerNameCStr, 0)
 	if native_engine == nil {
 		return nil, ErrTransferEngine
 	}

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -115,8 +115,7 @@ ErrorCode Client::InitTransferEngine(const std::string& local_hostname,
         get_auto_discover_filters(auto_discover));
 
     auto [hostname, port] = parseHostNameWithPort(local_hostname);
-    int rc = transfer_engine_.init(metadata_connstring, local_hostname,
-                                   hostname, port);
+    int rc = transfer_engine_.init(metadata_connstring, local_hostname);
     CHECK_EQ(rc, 0) << "Failed to initialize transfer engine";
 
     Transport* transport = nullptr;

--- a/mooncake-transfer-engine/example/memory_pool.cpp
+++ b/mooncake-transfer-engine/example/memory_pool.cpp
@@ -75,9 +75,7 @@ int target() {
     args[0] = (void *)nic_priority_matrix.c_str();
     args[1] = nullptr;
 
-    const std::string &connectable_name = FLAGS_local_server_name;
-    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
-                 connectable_name.c_str(), 12345);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str());
     engine->installTransport("rdma", args);
 
     LOG_ASSERT(engine);

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -260,10 +260,7 @@ std::string loadNicPriorityMatrix() {
 int initiator() {
     // disable topology auto discovery for testing.
     auto engine = std::make_unique<TransferEngine>(FLAGS_auto_discovery);
-
-    auto hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
-    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
-                 hostname_port.first.c_str(), hostname_port.second);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str());
 
     if (!FLAGS_auto_discovery) {
         Transport *xport = nullptr;
@@ -354,10 +351,7 @@ int target() {
 
     // disable topology auto discovery for testing.
     auto engine = std::make_unique<TransferEngine>(FLAGS_auto_discovery);
-
-    auto hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
-    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
-                 hostname_port.first.c_str(), hostname_port.second);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str());
 
     if (!FLAGS_auto_discovery) {
         if (FLAGS_protocol == "rdma") {

--- a/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
@@ -261,10 +261,7 @@ std::string loadNicPriorityMatrix() {
 int initiator() {
     // disable topology auto discovery for testing.
     auto engine = std::make_unique<TransferEngine>(FLAGS_auto_discovery);
-
-    auto hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
-    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
-                 hostname_port.first.c_str(), hostname_port.second);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str());
 
     if (!FLAGS_auto_discovery) {
         Transport *xport = nullptr;

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -78,9 +78,7 @@ class TransferEngine {
     }
 
     int init(const std::string &metadata_conn_string,
-             const std::string &local_server_name,
-             const std::string &ip_or_host_name = "",
-             uint64_t rpc_port = 12345);
+             const std::string &local_server_name);
 
     int freeEngine();
 

--- a/mooncake-transfer-engine/include/transfer_engine_c.h
+++ b/mooncake-transfer-engine/include/transfer_engine_c.h
@@ -94,7 +94,7 @@ typedef void *transport_t;
 */
 
 transfer_engine_t createTransferEngine(const char *metadata_conn_string,
-                                       const char *local_server_name
+                                       const char *local_server_name,
                                        int auto_discover);
 
 int getLocalIpAndPort(transfer_engine_t engine, char *buf_out, size_t buf_len);

--- a/mooncake-transfer-engine/include/transfer_engine_c.h
+++ b/mooncake-transfer-engine/include/transfer_engine_c.h
@@ -94,9 +94,7 @@ typedef void *transport_t;
 */
 
 transfer_engine_t createTransferEngine(const char *metadata_conn_string,
-                                       const char *local_server_name,
-                                       const char *ip_or_host_name,
-                                       uint64_t rpc_port,
+                                       const char *local_server_name
                                        int auto_discover);
 
 int getLocalIpAndPort(transfer_engine_t engine, char *buf_out, size_t buf_len);

--- a/mooncake-transfer-engine/rust/src/transfer_engine.rs
+++ b/mooncake-transfer-engine/rust/src/transfer_engine.rs
@@ -76,13 +76,7 @@ impl TransferEngine {
             CString::new(local_server_name).map_err(|_| anyhow!("CString::new failed"))?;
 
         let engine = unsafe {
-            bindings::createTransferEngine(
-                metadata_uri_c.as_ptr(),
-                local_server_name_c.as_ptr(),
-                local_server_name_c.as_ptr(),
-                rpc_port,
-                0, // disable auto_discover
-            )
+            bindings::createTransferEngine(metadata_uri_c.as_ptr(), local_server_name_c.as_ptr())
         };
         if engine.is_null() {
             bail!("Failed to create TransferEngine")

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -38,13 +38,9 @@ static std::string loadTopologyJsonFile(const std::string &path) {
 }
 
 int TransferEngine::init(const std::string &metadata_conn_string,
-                         const std::string &local_server_name,
-                         const std::string &ip_or_host_name,
-                         uint64_t rpc_port) {
+                         const std::string &local_server_name) {
     LOG(INFO) << "Transfer Engine starting. Server: " << local_server_name
-              << ", Metadata: " << metadata_conn_string
-              << ", ip_or_host_name: " << ip_or_host_name
-              << ", rpc_port: " << rpc_port;
+              << ", Metadata: " << metadata_conn_string;
 
     local_server_name_ = local_server_name;
     TransferMetadata::RpcMetaDesc desc;
@@ -73,7 +69,6 @@ int TransferEngine::init(const std::string &metadata_conn_string,
         }
     } else {
         rpc_binding_method = "new RPC mapping";
-        (void)(ip_or_host_name);
         auto *ip_address = getenv("MC_TCP_BIND_ADDRESS");
         if (ip_address)
             desc.ip_or_host_name = ip_address;
@@ -89,7 +84,6 @@ int TransferEngine::init(const std::string &metadata_conn_string,
 
         // In the new rpc port mapping, it is randomly selected to prevent
         // port conflict
-        (void)(rpc_port);
         desc.rpc_port = findAvailableTcpPort(desc.sockfd);
         if (desc.rpc_port == 0) {
             LOG(ERROR) << "not valid port for serving local TCP service";

--- a/mooncake-transfer-engine/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_c.cpp
@@ -24,12 +24,9 @@ using namespace mooncake;
 
 transfer_engine_t createTransferEngine(const char *metadata_conn_string,
                                        const char *local_server_name,
-                                       const char *ip_or_host_name,
-                                       uint64_t rpc_port,
                                        int auto_discover) {
     TransferEngine *native = new TransferEngine(auto_discover);
-    int ret = native->init(metadata_conn_string, local_server_name,
-                           ip_or_host_name, rpc_port);
+    int ret = native->init(metadata_conn_string, local_server_name);
     if (ret) {
         delete native;
         return nullptr;

--- a/mooncake-transfer-engine/tests/nvmeof_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/nvmeof_transport_test.cpp
@@ -76,10 +76,7 @@ class NVMeofTransportTest : public ::testing::Test {
         FLAGS_logtostderr = 1;
         // disable topology auto discovery for testing.
         engine = std::make_unique<TransferEngine>(false);
-        hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
-        engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
-                     hostname_port.first.c_str(),
-                     hostname_port.second + offset++);
+        engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str());
         xport = nullptr;
         args = (void **)malloc(2 * sizeof(void *));
         args[0] = nullptr;

--- a/mooncake-transfer-engine/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test.cpp
@@ -234,10 +234,7 @@ int initiator() {
     const size_t ram_buffer_size = 1ull << 30;
     // disable topology auto discovery for testing.
     auto engine = std::make_unique<TransferEngine>(false);
-
-    auto hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
-    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
-                 hostname_port.first.c_str(), hostname_port.second);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str());
 
     Transport *xport = nullptr;
     if (FLAGS_protocol == "rdma") {
@@ -280,10 +277,7 @@ int target() {
     const size_t ram_buffer_size = 1ull << 30;
     // disable topology auto discovery for testing.
     auto engine = std::make_unique<TransferEngine>(false);
-
-    auto hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
-    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
-                 hostname_port.first.c_str(), hostname_port.second);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str());
 
     if (FLAGS_protocol == "rdma") {
         auto nic_priority_matrix = loadNicPriorityMatrix();

--- a/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
@@ -108,7 +108,6 @@ class RDMATransportTest : public ::testing::Test {
 
    protected:
     void SetUp() override {
-        static int offset = 0;
         LOG(INFO) << "HERE \n";
         google::InitGoogleLogging("RDMATransportTest");
         FLAGS_logtostderr = 1;

--- a/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
@@ -97,7 +97,6 @@ class RDMATransportTest : public ::testing::Test {
    public:
     std::shared_ptr<mooncake::TransferMetadata> metadata_client;
     void *addr = nullptr;
-    std::pair<std::string, uint16_t> hostname_port;
     std::unique_ptr<mooncake::TransferEngine> engine;
     const size_t ram_buffer_size = 1ull << 30;
     Transport *xport;
@@ -115,10 +114,7 @@ class RDMATransportTest : public ::testing::Test {
         FLAGS_logtostderr = 1;
         // disable topology auto discovery for testing.
         engine = std::make_unique<TransferEngine>(false);
-        hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
-        engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
-                     hostname_port.first.c_str(),
-                     hostname_port.second + offset++);
+        engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str());
         xport = nullptr;
         nic_priority_matrix = loadNicPriorityMatrix();
         args = (void **)malloc(2 * sizeof(void *));

--- a/mooncake-transfer-engine/tests/tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_transport_test.cpp
@@ -93,9 +93,7 @@ static void *allocateMemoryPool(size_t size, int socket_id,
 TEST_F(TCPTransportTest, GetTcpTest) {
     // disable topology auto discovery for testing.
     auto engine = std::make_unique<TransferEngine>(false);
-    auto hostname_port = parseHostNameWithPort(local_server_name);
-    auto rc = engine->init(metadata_server, local_server_name,
-                           hostname_port.first.c_str(), hostname_port.second);
+    auto rc = engine->init(metadata_server, local_server_name);
     LOG_ASSERT(rc == 0);
     Transport *xport = nullptr;
     xport = engine->installTransport("tcp", nullptr);
@@ -108,9 +106,7 @@ TEST_F(TCPTransportTest, Writetest) {
     const size_t ram_buffer_size = 1ull << 30;
     // disable topology auto discovery for testing.
     auto engine = std::make_unique<TransferEngine>(false);
-    auto hostname_port = parseHostNameWithPort(local_server_name);
-    auto rc = engine->init(metadata_server, local_server_name,
-                           hostname_port.first.c_str(), hostname_port.second);
+    auto rc = engine->init(metadata_server, local_server_name);
     LOG_ASSERT(rc == 0);
     Transport *xport = nullptr;
     xport = engine->installTransport("tcp", nullptr);
@@ -153,9 +149,7 @@ TEST_F(TCPTransportTest, WriteAndReadtest) {
     const size_t ram_buffer_size = 1ull << 30;
     // disable topology auto discovery for testing.
     auto engine = std::make_unique<TransferEngine>(false);
-    auto hostname_port = parseHostNameWithPort(local_server_name);
-    engine->init(metadata_server, local_server_name,
-                 hostname_port.first.c_str(), hostname_port.second);
+    engine->init(metadata_server, local_server_name);
     Transport *xport = nullptr;
     xport = engine->installTransport("tcp", nullptr);
     LOG_ASSERT(xport != nullptr);
@@ -225,9 +219,7 @@ TEST_F(TCPTransportTest, WriteAndRead2test) {
     const size_t ram_buffer_size = 1ull << 30;
     // disable topology auto discovery for testing.
     auto engine = std::make_unique<TransferEngine>(false);
-    auto hostname_port = parseHostNameWithPort(local_server_name);
-    engine->init(metadata_server, local_server_name,
-                 hostname_port.first.c_str(), hostname_port.second);
+    engine->init(metadata_server, local_server_name);
     Transport *xport = nullptr;
     xport = engine->installTransport("tcp", nullptr);
     LOG_ASSERT(xport != nullptr);


### PR DESCRIPTION
`TransferEngine::init` takes four arguments: `metadata_conn_string`, `local_server_name`, `ip_or_host_name`, and `rpc_port`, but `ip_or_host_name` and `rpc_port` are never used. In fact, `init` gets info from `local_server_name`, environment variables, or the global config.

I suggest removing these two parameters because they only introduce confusion, e.g., `rpc_port` is provided, but the transfer engine actually uses another port specified in the global config.
