### PR TITLE
[MooncakeStore]Provide cache aware interface for scheduler

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -118,6 +118,26 @@ class MasterService {
     ErrorCode ExistKey(const std::string& key);
 
     /**
+     * @brief Fetch all keys
+     * @return ErrorCode::OK if exists
+     */
+    ErrorCode GetAllKeys(std::vector<std::string> & all_keys);
+
+    /**
+     * @brief Fetch all segments, each node has a unique real client with fixed segment
+     * name : segment name, preferred format : {ip}:{port}, bad format : localhost:{port}
+     * @return ErrorCode::OK if exists
+     */
+    ErrorCode GetAllSegments(std::vector<std::string> & all_segments);
+
+    /**
+     * @brief Query a segment's capacity and used size in bytes.
+     * Conductor should use these information to schedule new requests. 
+     * @return ErrorCode::OK if exists
+     */
+    ErrorCode QuerySegments(const std::string & segment, size_t & used, size_t & capacity);
+
+    /**
      * @brief Get list of replicas for an object
      * @param[out] replica_list Vector to store replica information
      * @return ErrorCode::OK on success, ErrorCode::REPLICA_IS_NOT_READY if not

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -6,6 +6,8 @@
 #include <ylt/coro_http/coro_http_client.hpp>
 #include <ylt/coro_http/coro_http_server.hpp>
 #include <ylt/reflection/user_reflect_macro.hpp>
+#include <ylt/struct_json/json_reader.h>
+#include <ylt/struct_json/json_writer.h>
 
 #include "master_metric_manager.h"
 #include "master_service.h"
@@ -116,6 +118,79 @@ class WrappedMasterService {
                     MasterMetricManager::instance().get_summary_string();
                 resp.add_header("Content-Type", "text/plain; version=0.0.4");
                 resp.set_status_and_content(status_type::ok, summary);
+            });
+
+        // Endpoint for query a key's location
+        http_server_.set_http_handler<GET>(
+            "/query_key",
+            [&](coro_http_request& req, coro_http_response& resp) {
+                auto key = req.get_query_value("key");
+                GetReplicaListResponse response;
+                response = GetReplicaList(std::string(key));
+                resp.add_header("Content-Type", "text/plain; version=0.0.4");
+                std::string ss = "";
+                for(size_t i = 0; i < response.replica_list.size(); i++) {
+                    for(const auto& handle : response.replica_list[i].buffer_descriptors) {
+                        std::string tmp = "";
+                        struct_json::to_json(handle, tmp);
+                        ss += tmp;
+                        ss += "\n";
+                    }
+                }
+                resp.set_status_and_content(status_type::ok, ss);
+            });
+
+        // Endpoint for query all keys
+        http_server_.set_http_handler<GET>(
+            "/get_all_keys",
+            [&](coro_http_request& req, coro_http_response& resp) {
+                resp.add_header("Content-Type", "text/plain; version=0.0.4");
+                std::string ss = "";
+                std::vector<std::string>  all_keys;
+                master_service_.GetAllKeys(all_keys);
+                for(const auto & key : all_keys) {
+                    ss += key;
+                    ss += "\n";
+                }
+                resp.set_status_and_content(status_type::ok, ss);
+            });
+
+        // Endpoint for query all segments
+        http_server_.set_http_handler<GET>(
+            "/get_all_segments",
+            [&](coro_http_request& req, coro_http_response& resp) {
+                resp.add_header("Content-Type", "text/plain; version=0.0.4");
+                std::string ss = "";
+                std::vector<std::string>  all_segments;
+                master_service_.GetAllSegments(all_segments);
+                for(const auto & segment: all_segments) {
+                    ss += segment;
+                    ss += "\n";
+                }
+                resp.set_status_and_content(status_type::ok, ss);
+            });
+
+        // Endpoint for query segment details
+        http_server_.set_http_handler<GET>(
+            "/query_segment",
+            [&](coro_http_request& req, coro_http_response& resp) {
+                auto segment = req.get_query_value("segment");
+                resp.add_header("Content-Type", "text/plain; version=0.0.4");
+                std::string ss = "";
+                size_t used = 0, capacity = 0;
+                if(master_service_.QuerySegments(std::string(segment), used, capacity) 
+                   == ErrorCode::OK) {
+                    ss += segment;
+                    ss += "\n";
+                    ss += "Used(bytes): ";
+                    ss += std::to_string(used);
+                    ss += "\nCapacity(bytes) : ";
+                    ss += std::to_string(capacity);
+                    ss += "\n";
+                    resp.set_status_and_content(status_type::ok, ss);
+                } else {
+                    resp.set_status_and_content(status_type::not_found, ss);
+                }
             });
 
         // Health check endpoint

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -168,6 +168,47 @@ ErrorCode MasterService::ExistKey(const std::string& key) {
     return ErrorCode::OK;
 }
 
+ErrorCode MasterService::GetAllKeys(std::vector<std::string> & all_keys) {
+    all_keys.clear();
+    for(int i = 0; i < kNumShards; i++) {
+        for(const auto& item : metadata_shards_[i].metadata) {
+            all_keys.push_back(item.first);
+        }
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode MasterService::GetAllSegments(std::vector<std::string> & all_segments) {
+    all_segments.clear();
+    std::shared_lock<std::shared_mutex> alloc_lock(
+        buffer_allocator_manager_->GetMutex());
+    const auto& allocators = buffer_allocator_manager_->GetAllocators();
+    for(auto & allocator : allocators) {
+        all_segments.push_back(allocator.first);
+    }
+    alloc_lock.unlock();
+    return ErrorCode::OK;
+}
+
+ErrorCode MasterService::QuerySegments(const std::string & segment,
+                                       size_t & used,
+                                       size_t & capacity) {
+    std::shared_lock<std::shared_mutex> alloc_lock(
+        buffer_allocator_manager_->GetMutex());
+    const auto& allocators = buffer_allocator_manager_->GetAllocators();
+    auto it = allocators.find(segment);
+    if (it != allocators.end()) {
+        auto& allocator = it -> second;
+        capacity = allocator -> capacity();
+        used = allocator -> size();
+    } else {
+        VLOG(1) << "### DEBUG ### MasterService::QuerySegments(" << segment << ") not found!";
+        return ErrorCode::AVAILABLE_SEGMENT_EMPTY;
+    }
+    alloc_lock.unlock();
+    return ErrorCode::OK;
+}
+
 ErrorCode MasterService::GetReplicaList(
     const std::string& key, std::vector<Replica::Descriptor>& replica_list) {
     MetadataAccessor accessor(this, key);


### PR DESCRIPTION
For detailed discuss, please check this  [RFC](https://github.com/kvcache-ai/Mooncake/issues/381)

Here are some examples:
```
# curl localhost:9003/get_all_keys
12638900504727518832_12489051952825107803
17704606561907141142_15702553452409431093
...
#  curl -s localhost:9003/query_key?key=17704606561907141142_15702553452409431093 | jq
{
  "segment_name_": "192.168.1.105:16384",
  "size_": 65536,
  "buffer_address_": 139903195893632,
  "status_": 1
}
```
