### PR TITLE
[Misc] Add Issue Template in Github

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -1,0 +1,44 @@
+name: "🐞 Bug Report"
+description: "Create a bug report to help us improve"
+title: "[Bug]: "
+labels: ["bug"]
+
+body:
+- type: textarea
+  attributes:
+    label: Describe your environment
+    description: >
+      Include details about your environment such as:
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description: >
+      A clear and concise description of what the bug is.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: >
+      Provide a list of steps to reproduce the bug.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    description: >
+      Describe what you expected to happen.
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!
+- type: checkboxes
+  id: before_submit
+  attributes:
+    label: Before submitting a new issue...
+    options:
+      - label: Make sure you already searched for relevant issues and read the [documentation](https://kvcache-ai.github.io/Mooncake/)

--- a/.github/ISSUE_TEMPLATE/2.usage.yml
+++ b/.github/ISSUE_TEMPLATE/2.usage.yml
@@ -1,0 +1,32 @@
+name: "🔧 Usage"
+description: "Questions about Mooncake's usage or best practices"
+title: "[Usage]: "
+labels: ["usage"]
+body:
+- type: textarea
+  attributes:
+    label: Describe your usage question
+    description: >
+      A clear and concise description of your question about using the repo.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Provide context
+    description: >
+      Include any relevant context or examples that might help us understand your question.
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!
+- type: checkboxes
+  id: before_submit
+  attributes:
+    label: Before submitting a new issue...
+    options:
+      - label: Make sure you already searched for relevant issues and read the [documentation](https://kvcache-ai.github.io/Mooncake/)
+
+
+    

--- a/.github/ISSUE_TEMPLATE/3.performance_dicussion.yml
+++ b/.github/ISSUE_TEMPLATE/3.performance_dicussion.yml
@@ -1,0 +1,22 @@
+name: "⚙️ Preformance discussions"
+description: "Questions about Mooncake's performance"
+title: "[Performance]: "
+labels: ["performance"]
+body:
+- type: textarea
+  attributes:
+    label: Describe your performance question
+    description: >
+      A clear and concise description of your question about performance.
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!
+- type: checkboxes
+  id: before_submit
+  attributes:
+    label: Before submitting a new issue...
+    options:
+      - label: Make sure you already searched for relevant issues and read the [documentation](https://kvcache-ai.github.io/Mooncake/)

--- a/.github/ISSUE_TEMPLATE/4.feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/4.feature_request.yml
@@ -1,0 +1,22 @@
+name: "🚀 Feature Request"
+description: "Suggest a new feature or improvement for Mooncake"
+title: "[Feature Request]: "
+labels: ["feature-request"]
+body:
+- type: textarea
+  attributes:
+    label: Describe your feature request
+    description: >
+      A clear and concise description of the feature you'd like to see.
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!
+- type: checkboxes
+  id: before_submit
+  attributes:
+    label: Before submitting a new issue...
+    options:
+      - label: Make sure you already searched for relevant issues and read the [documentation](https://kvcache-ai.github.io/Mooncake/)

--- a/.github/ISSUE_TEMPLATE/5.RFC.yml
+++ b/.github/ISSUE_TEMPLATE/5.RFC.yml
@@ -1,0 +1,26 @@
+name: "💬 RFC"
+description: "Request for Comments"
+title: "[RFC]: "
+labels: ["RFC"]
+
+body:
+- type: textarea
+  attributes:
+    label: Motivation
+    description: >
+      A clear and concise description of the motivation behind this RFC.
+- type: textarea
+  attributes:
+    label: Changes proposed
+    description: >
+      A clear and concise description of the changes proposed in this RFC.
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!
+- type: checkboxes
+  id: before_submit
+  attributes:
+    label: Before submitting a new issue...
+    options:
+      - label: Make sure you already searched for relevant issues and read the [documentation](https://kvcache-ai.github.io/Mooncake/)

--- a/.github/ISSUE_TEMPLATE/6.documentation.yml
+++ b/.github/ISSUE_TEMPLATE/6.documentation.yml
@@ -1,0 +1,26 @@
+name: "📚 Documentation"
+description: "Report issues or suggest improvements for Mooncake's documentation"
+title: "[Documentation]: "
+labels: ["documentation"]
+body:
+- type: textarea
+  attributes:
+    label: errors or unclear descriptions you have encountered in the documentation
+    description: >
+      Please provide any specific errors or unclear descriptions you have encountered in the documentation.
+
+- type: textarea
+  attributes:
+    label: Changes proposed
+    description: >
+     How to improve the documentation based on your experience.
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!
+- type: checkboxes
+  id: before_submit
+  attributes:
+    label: Before submitting a new issue...
+    options:
+      - label: Make sure you already searched for relevant issues and read the [documentation](https://kvcache-ai.github.io/Mooncake/)

--- a/.github/ISSUE_TEMPLATE/7.installation.yml
+++ b/.github/ISSUE_TEMPLATE/7.installation.yml
@@ -1,0 +1,20 @@
+name: "🛠️ Installation"
+description: "Report issues or suggest improvements for Mooncake's installation process"
+title: "[Installation]: "
+labels: ["installation"]
+body:
+- type: textarea
+  attributes:
+    label: Installation errors
+    description: >
+      Describe any errors or issues you encountered during the installation of Mooncake.
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!
+- type: checkboxes
+  id: before_submit
+  attributes:
+    label: Before submitting a new issue...
+    options:
+      - label: Make sure you already searched for relevant issues and read the [documentation](https://kvcache-ai.github.io/Mooncake/)

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://kvcache-ai.github.io/Mooncake/
+    about: Ask questions and discuss with other vLLM community members


### PR DESCRIPTION
Based on the [github issue template tutorial](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) and the taxonomy of the [vllm issue template](https://github.com/vllm-project/vllm/tree/main/.github/ISSUE_TEMPLATE), I exported and labeled the open issues of the mooncake community, see [this table](https://airtable.com/appbJ0k8FJwYl46bK/shrMGqLcypyY4Wjjb), and got the following issue classification:

```shell
.
├── 1.bug_report.yml
├── 2.usage.yml
├── 3.performance_dicussion.yml
├── 4.feature_request.yml
├── 5.RFC.yml
├── 6.documentation.yml
├── 7.installation.yml
└── config.yaml
```