### PR TITLE
[Store] Python store API supports batch operation

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -564,7 +564,7 @@ std::vector<pybind11::bytes> DistributedObjectStore::get_batch(
     std::unordered_set<std::string> seen;
     for (const auto &key : keys) {
         if (!seen.insert(key).second) {
-            LOG(ERROR) << "Duplicate key not supportted for Batch API, key: "
+            LOG(ERROR) << "Duplicate key not supported for Batch API, key: "
                        << key;
             return {kNullString};
         }

--- a/mooncake-integration/store/store_py.h
+++ b/mooncake-integration/store/store_py.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include <csignal>
 #include <mutex>
@@ -112,11 +113,15 @@ class DistributedObjectStore {
 
     int put(const std::string &key, std::span<const char> value);
 
+    int put_batch(const std::unordered_map<std::string, std::span<const char>> &batches);
+
     int put_parts(const std::string &key,
                   std::vector<std::span<const char>> values);
 
     pybind11::bytes get(const std::string &key);
 
+    std::vector<pybind11::bytes> get_batch(
+        const std::vector<std::string> &keys);
     /**
      * @brief Get a buffer containing the data for a key
      * @param key Key to get data for
@@ -139,6 +144,14 @@ class DistributedObjectStore {
     int isExist(const std::string &key);
 
     /**
+     * @brief Check if a batch of objects exists
+     * @param keys Key to check
+     * @return Map of keys to booleans
+     */
+    std::unordered_map<std::string, bool> BatchIsExist(
+        const std::vector<std::string> &keys);
+
+    /**
      * @brief Get the size of an object
      * @param key Key of the object
      * @return Size of the object in bytes, or -1 if error or object doesn't
@@ -159,6 +172,19 @@ class DistributedObjectStore {
 
     int allocateSlicesPacked(std::vector<mooncake::Slice> &slices,
                              const std::vector<std::span<const char>> &parts);
+
+    int allocateBatchedSlices(
+        const std::vector<std::string> &keys,
+        std::unordered_map<std::string, std::vector<mooncake::Slice>>
+            &batched_slices,
+        const mooncake::Client::BatchObjectInfo &batched_object_info,
+        std::unordered_map<std::string, uint64_t> &str_length_map);
+
+    int allocateBatchedSlices(
+        std::vector<std::string> &keys,
+        const std::unordered_map<std::string, std::span<const char>> &batches,
+        std::unordered_map<std::string, std::vector<mooncake::Slice>>
+            &batched_slices);
 
     char *exportSlices(const std::vector<mooncake::Slice> &slices,
                        uint64_t length);

--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -191,6 +191,14 @@ class Client {
      */
     ErrorCode IsExist(const std::string& key);
 
+    /**
+     * @brief Checks if a batch of objects exist
+     * @param keys Keys to check
+     * @return existence map, true if exists, false if not
+     */
+    std::unordered_map<std::string, ErrorCode> BatchIsExist(
+        const std::vector<std::string>& keys);
+
    private:
     /**
      * @brief Private constructor to enforce creation through Create() method

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -42,6 +42,14 @@ class MasterClient {
         const std::string& object_key);
 
     /**
+     * @brief Checks if a batch of objects exist
+     * @param object_keys Keys to query
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] BatchExistKeyResponse BatchExistKey(
+        const std::vector<std::string>& object_keys);
+
+    /**
      * @brief Gets object metadata without transferring data
      * @param object_key Key to query
      * @param object_info Output parameter for object metadata

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -118,6 +118,13 @@ class MasterService {
     ErrorCode ExistKey(const std::string& key);
 
     /**
+     * @brief Check if an batch of objects exist
+     * @return existence map, key is the object name, value is the error code
+     */
+    std::unordered_map<std::string, ErrorCode> BatchExistKey(
+        const std::vector<std::string>& key);
+
+    /**
      * @brief Fetch all keys
      * @return ErrorCode::OK if exists
      */

--- a/mooncake-store/proto/master.proto
+++ b/mooncake-store/proto/master.proto
@@ -47,6 +47,11 @@ message BatchSliceLength {
   repeated uint64 slice_lengths = 2;
 }
 
+message ExistencePair {
+  required string key = 1;
+  required int32 status_code = 2
+}
+
 // Request to check key existence.
 message ExistKeyRequest {
   required string key = 1; // Object key.
@@ -56,6 +61,17 @@ message ExistKeyRequest {
 message ExistKeyResponse {
   required int32 status_code = 1; // Status.
 }
+
+// Request to check key existence.
+message BatchExistKeyRequest {
+  repeated string key = 1; // Object key.
+}
+// Response to check key existence.
+message BatchExistKeyResponse {
+  repeated ExistencePair existence_pair = 1;
+  required int32 status_code = 2; // Status.
+}
+
 
 // Request to get replica list.
 message GetReplicaListRequest {
@@ -222,4 +238,7 @@ service MasterService {
 
   // Check existence of a key.
   rpc ExistKey(ExistKeyRequest) returns (ExistKeyResponse);
+
+  // Check existence of a batch of keys.
+  rpc BatchExistKey(BatchExistKeyRequest) returns (BatchExistKeyResponse);
 }

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -628,6 +628,14 @@ ErrorCode Client::IsExist(const std::string& key) {
     return response.error_code;
 }
 
+std::unordered_map<std::string, ErrorCode> Client::BatchIsExist(
+    const std::vector<std::string>& keys) {
+    const auto& [existence_map, error_code] =
+        master_client_.BatchExistKey(keys);
+    return error_code == ErrorCode::OK ? existence_map
+                                       : decltype(existence_map){};
+}
+
 ErrorCode Client::TransferData(
     const std::vector<AllocatedBuffer::Descriptor>& handles,
     std::vector<Slice>& slices, TransferRequest::OpCode op_code) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -170,6 +170,15 @@ ErrorCode MasterService::ExistKey(const std::string& key) {
     return ErrorCode::OK;
 }
 
+std::unordered_map<std::string, ErrorCode> MasterService::BatchExistKey(
+    const std::vector<std::string>& keys) {
+    std::unordered_map<std::string, ErrorCode> result;
+    for (const auto& key : keys) {
+        result.emplace(key, ExistKey(key));
+    }
+    return result;
+}
+
 ErrorCode MasterService::GetAllKeys(std::vector<std::string> & all_keys) {
     all_keys.clear();
     for(int i = 0; i < kNumShards; i++) {

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -424,6 +424,26 @@ TEST_F(ClientIntegrationTest, BatchPutGetOperations) {
 
     start = std::chrono::high_resolution_clock::now();
     for (int i = 0; i < batch_sz; i++) {
+        test_client_->IsExist(keys[i]);
+    }
+    end = std::chrono::high_resolution_clock::now();
+    LOG(INFO) << "Time taken for single IsExist: "
+              << std::chrono::duration_cast<std::chrono::microseconds>(end -
+                                                                       start)
+                     .count()
+              << "us";
+    start = std::chrono::high_resolution_clock::now();
+    std::unordered_map<std::string, ErrorCode> batched_existence =
+        test_client_->BatchIsExist(keys);
+    end = std::chrono::high_resolution_clock::now();
+    LOG(INFO) << "Time taken for BatchIsExist: "
+              << std::chrono::duration_cast<std::chrono::microseconds>(end -
+                                                                       start)
+                     .count()
+              << "us";
+
+    start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < batch_sz; i++) {
         std::vector<Slice> slices;
         target_buffer =
             client_buffer_allocator_->allocate(test_data_list[i].size());


### PR DESCRIPTION
This PR introduces batch APIs (put_batch, get_batch, is_batch_exist) in the Python module to accelerate data transfer. These APIs are concurrently utilized in the Mooncake store implementation as the L3 cache in SGLang.
Related [PR](https://github.com/sgl-project/sglang/pull/7211) in sglang