### PR TITLE
[TransferEngine] Add Redis password authentication and DB selection via environment variables

### DIFF
--- a/doc/en/transfer-engine.md
+++ b/doc/en/transfer-engine.md
@@ -437,4 +437,5 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_DISABLE_METACACHE` Disable local meta cache to prevent transfer failure due to dynamic memory registrations, which may downgrades the performance
 - `MC_HANDSHAKE_LISTEN_BACKLOG` The backlog size of socket listening for handshaking, default value is 128
 - `MC_LOG_DIR` Specify the directory path for log redirection files. If invalid, log to stderr instead.
-
+- `MC_REDIS_PASSWORD` The password for Redis storage plugin, only takes effect when Redis is specified as the metadata server. If not set, no authentication will be attempted to log in to the Redis.
+- `MC_REDIS_DB_INDEX` The database index for Redis storage plugin, must be an integer between 0 and 255. Only takes effect when Redis is specified as the metadata server. If not set or invalid, the default value is 0.

--- a/doc/zh/transfer-engine.md
+++ b/doc/zh/transfer-engine.md
@@ -407,3 +407,5 @@ int init(const std::string &metadata_conn_string,
 - `MC_LOG_LEVEL` 该选项可以设置成`TRACE`/`INFO`/`WARNING`/`ERROR`（详情见 [glog doc](https://github.com/google/glog/blob/master/docs/logging.md)），则在运行时会输出更详细的日志
 - `MC_HANDSHAKE_LISTEN_BACKLOG` 监听握手连接的 backlog 大小, 默认值 128
 - `MC_LOG_DIR` 该选项指定存放日志重定向文件的目录路径。如果路径无效，glog将回退到向标准错误[stderr]输出日志。
+- `MC_REDIS_PASSWORD` Redis 存储插件的密码，仅在指定 Redis 作为 metadata server 时生效。如果未设置，将不会尝试进行密码认证登录 Redis。
+- `MC_REDIS_DB_INDEX` Redis 存储插件的数据库索引，必须为 0 到 255 之间的整数。仅在指定 Redis 作为 metadata server 时生效。如果未设置或无效，默认值为 0。


### PR DESCRIPTION
Hi, this PR implements configurable Redis authentication and database selection through environment variables:

1. Redis Password Authentication
    * Added support for `MC_REDIS_PASSWORD` environment variable
    * When set: 
    1. Authentication command (AUTH) automatically sent during connection; 
    2. Uses provided password value;
    * When unset:
    1. No authentication attempted; 
    2. Maintains default Redis connection behavior;
2. Database Index Selection
    * Added support for `MC_REDIS_DB_INDEX` environment variable
    * When set: 
    1. SELECT command automatically executed to switch databases; 
    2. Uses provided integer index value (e.g., `MC_REDIS_DB_INDEX`=3)
    * When unset: 
    1. No SELECT command sent; 
    2. Default database (index 0) remains active;