### PR TITLE
[TransferEngine] fix segfault when create cq failed

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -156,6 +156,8 @@ int RdmaContext::deconstruct() {
     memory_region_list_.clear();
 
     for (size_t i = 0; i < cq_list_.size(); ++i) {
+        if (!cq_list_[i].native) continue;
+
         int ret = ibv_destroy_cq(cq_list_[i].native);
         if (ret) {
             PLOG(ERROR) << "Failed to destroy completion queue";


### PR DESCRIPTION
got such error message when rdma nic broken:
```
E0620 17:20:15.656373   293 rdma_context.cpp:116] Failed to create completion queue: Cannot allocate memory [12]
W0620 17:20:15.657889   293 rdma_transport.cpp:423] Disable device mlx5_bond_3
Fatal Python error: Segmentation fault
```