### PR TITLE
feat(store): add thread safety analysis with clang annotations

### DIFF
--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -15,6 +15,10 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_C_FLAGS_DEBUG "-O0")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0")
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=thread-safety")
+endif()
+
 option(ENABLE_ASAN "enable address sanitizer" OFF)
 
 if (ENABLE_ASAN)

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1,25 +1,23 @@
 #pragma once
 
 #include <atomic>
-#include <boost/lockfree/queue.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/lockfree/queue.hpp>
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <optional>
 
 #include "allocation_strategy.h"
-#include "eviction_strategy.h"
-#include "allocator.h"
-#include "types.h"
+#include "mutex.h"
 #include "segment.h"
-
+#include "types.h"
 
 namespace mooncake {
 // Forward declarations
@@ -47,7 +45,7 @@ struct GCTask {
  * 1. client_mutex_
  * 2. metadata_shards_[shard_idx_].mutex
  * 3. segment_mutex_
-*/
+ */
 class MasterService {
    private:
     // Comparator for GC tasks priority queue
@@ -61,7 +59,8 @@ class MasterService {
     MasterService(bool enable_gc = true,
                   uint64_t default_kv_lease_ttl = DEFAULT_DEFAULT_KV_LEASE_TTL,
                   double eviction_ratio = DEFAULT_EVICTION_RATIO,
-                  double eviction_high_watermark_ratio = DEFAULT_EVICTION_HIGH_WATERMARK_RATIO,
+                  double eviction_high_watermark_ratio =
+                      DEFAULT_EVICTION_HIGH_WATERMARK_RATIO,
                   ViewVersionId view_version = 0,
                   int64_t client_live_ttl_sec = DEFAULT_CLIENT_LIVE_TTL_SEC,
                   bool enable_ha = false);
@@ -83,8 +82,8 @@ class MasterService {
      * connect to the master or the client Ping TTL is expired and need
      * to remount. This function is idempotent. Client should retry if the
      * return code is not ErrorCode::OK.
-     * @return ErrorCode::OK means either all segments are remounted successfully
-     *         or the fail is not solvable by a new remount request.
+     * @return ErrorCode::OK means either all segments are remounted
+     * successfully or the fail is not solvable by a new remount request.
      *         ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS if the segment cannot
      *         be mounted temporarily.
      *         ErrorCode::INTERNAL_ERROR if something temporary error happens.
@@ -110,21 +109,23 @@ class MasterService {
      * @brief Fetch all keys
      * @return ErrorCode::OK if exists
      */
-    ErrorCode GetAllKeys(std::vector<std::string> & all_keys);
+    ErrorCode GetAllKeys(std::vector<std::string>& all_keys);
 
     /**
-     * @brief Fetch all segments, each node has a unique real client with fixed segment
-     * name : segment name, preferred format : {ip}:{port}, bad format : localhost:{port}
+     * @brief Fetch all segments, each node has a unique real client with fixed
+     * segment name : segment name, preferred format : {ip}:{port}, bad format :
+     * localhost:{port}
      * @return ErrorCode::OK if exists
      */
-    ErrorCode GetAllSegments(std::vector<std::string> & all_segments);
+    ErrorCode GetAllSegments(std::vector<std::string>& all_segments);
 
     /**
      * @brief Query a segment's capacity and used size in bytes.
-     * Conductor should use these information to schedule new requests. 
+     * Conductor should use these information to schedule new requests.
      * @return ErrorCode::OK if exists
      */
-    ErrorCode QuerySegments(const std::string & segment, size_t & used, size_t & capacity);
+    ErrorCode QuerySegments(const std::string& segment, size_t& used,
+                            size_t& capacity);
 
     /**
      * @brief Get list of replicas for an object
@@ -222,7 +223,6 @@ class MasterService {
      */
     long RemoveAll();
 
-
     /**
      * @brief Get the count of keys
      * @return The count of keys
@@ -238,7 +238,7 @@ class MasterService {
      *         ping queue is full
      */
     ErrorCode Ping(const UUID& client_id, ViewVersionId& view_version,
-              ClientStatus& client_status);
+                   ClientStatus& client_status);
 
    private:
     // GC thread function
@@ -258,10 +258,11 @@ class MasterService {
         // the Clock's epoch (i.e., time_since_epoch() is zero).
         std::chrono::steady_clock::time_point lease_timeout;
 
-        // Check if there is some replica with a different status than the given value.
-        // If there is, return the status of the first replica that is not equal to
-        // the given value. Otherwise, return false.
-        std::optional<ReplicaStatus> HasDiffRepStatus(ReplicaStatus status) const {
+        // Check if there is some replica with a different status than the given
+        // value. If there is, return the status of the first replica that is
+        // not equal to the given value. Otherwise, return false.
+        std::optional<ReplicaStatus> HasDiffRepStatus(
+            ReplicaStatus status) const {
             for (const auto& replica : replicas) {
                 if (replica.status() != status) {
                     return replica.status();
@@ -270,10 +271,12 @@ class MasterService {
             return {};
         }
 
-        // Grant a lease with timeout as now() + ttl, only update if the new timeout is larger
+        // Grant a lease with timeout as now() + ttl, only update if the new
+        // timeout is larger
         void GrantLease(const uint64_t ttl) {
-            lease_timeout = std::max(lease_timeout,
-                                    std::chrono::steady_clock::now() + std::chrono::milliseconds(ttl));
+            lease_timeout =
+                std::max(lease_timeout, std::chrono::steady_clock::now() +
+                                            std::chrono::milliseconds(ttl));
         }
 
         // Check if the lease has expired
@@ -282,7 +285,7 @@ class MasterService {
         }
 
         // Check if the lease has expired
-        bool IsLeaseExpired(std::chrono::steady_clock::time_point &now) const {
+        bool IsLeaseExpired(std::chrono::steady_clock::time_point& now) const {
             return now >= lease_timeout;
         }
     };
@@ -295,8 +298,9 @@ class MasterService {
 
     // Sharded metadata maps and their mutexes
     struct MetadataShard {
-        mutable std::mutex mutex;
-        std::unordered_map<std::string, ObjectMetadata> metadata;
+        mutable Mutex mutex;
+        std::unordered_map<std::string, ObjectMetadata> metadata
+            GUARDED_BY(mutex);
     };
     std::array<MetadataShard, kNumShards> metadata_shards_;
 
@@ -318,12 +322,13 @@ class MasterService {
         10;  // 10 ms sleep between GC and eviction checks
 
     // Lease related members
-    const uint64_t default_kv_lease_ttl_; // in milliseconds
+    const uint64_t default_kv_lease_ttl_;  // in milliseconds
 
     // Eviction related members
-    std::atomic<bool> need_eviction_{false}; // Set to trigger eviction when not enough space left
-    const double eviction_ratio_; // in range [0.0, 1.0]
-    const double eviction_high_watermark_ratio_; // in range [0.0, 1.0]
+    std::atomic<bool> need_eviction_{
+        false};  // Set to trigger eviction when not enough space left
+    const double eviction_ratio_;                 // in range [0.0, 1.0]
+    const double eviction_high_watermark_ratio_;  // in range [0.0, 1.0]
 
     // Helper class for accessing metadata with automatic locking and cleanup
     class MetadataAccessor {
@@ -332,7 +337,7 @@ class MasterService {
             : service_(service),
               key_(key),
               shard_idx_(service_->getShardIndex(key)),
-              lock_(service_->metadata_shards_[shard_idx_].mutex),
+              lock_(&service_->metadata_shards_[shard_idx_].mutex),
               it_(service_->metadata_shards_[shard_idx_].metadata.find(key)) {
             // Automatically clean up invalid handles
             if (it_ != service_->metadata_shards_[shard_idx_].metadata.end()) {
@@ -344,21 +349,21 @@ class MasterService {
         }
 
         // Check if metadata exists
-        bool Exists() const {
+        bool Exists() const NO_THREAD_SAFETY_ANALYSIS {
             return it_ != service_->metadata_shards_[shard_idx_].metadata.end();
         }
 
         // Get metadata (only call when Exists() is true)
-        ObjectMetadata& Get() { return it_->second; }
+        ObjectMetadata& Get() NO_THREAD_SAFETY_ANALYSIS { return it_->second; }
 
         // Delete current metadata (for PutRevoke or Remove operations)
-        void Erase() {
+        void Erase() NO_THREAD_SAFETY_ANALYSIS {
             service_->metadata_shards_[shard_idx_].metadata.erase(it_);
             it_ = service_->metadata_shards_[shard_idx_].metadata.end();
         }
 
         // Create new metadata (only call when !Exists())
-        ObjectMetadata& Create() {
+        ObjectMetadata& Create() NO_THREAD_SAFETY_ANALYSIS {
             auto result =
                 service_->metadata_shards_[shard_idx_].metadata.emplace(
                     key_, ObjectMetadata());
@@ -370,7 +375,7 @@ class MasterService {
         MasterService* service_;
         std::string key_;
         size_t shard_idx_;
-        std::unique_lock<std::mutex> lock_;
+        MutexLocker lock_;
         std::unordered_map<std::string, ObjectMetadata>::iterator it_;
     };
 
@@ -380,7 +385,8 @@ class MasterService {
 
     // Client related members
     mutable std::shared_mutex client_mutex_;
-    std::unordered_set<UUID, boost::hash<UUID>> ok_client_;  // client with ok status
+    std::unordered_set<UUID, boost::hash<UUID>>
+        ok_client_;  // client with ok status
     void ClientMonitorFunc();
     std::thread client_monitor_thread_;
     std::atomic<bool> client_monitor_running_{false};

--- a/mooncake-store/include/mutex.h
+++ b/mooncake-store/include/mutex.h
@@ -1,0 +1,102 @@
+#ifndef THREAD_SAFETY_ANALYSIS_MUTEX_H
+#define THREAD_SAFETY_ANALYSIS_MUTEX_H
+
+#include <mutex>
+
+// Enable thread safety attributes only with clang.
+// The attributes can be safely erased when compiling with other compilers.
+#if defined(__clang__) && (!defined(SWIG))
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) __attribute__((x))
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE__(x)  // no-op
+#endif
+
+#define CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+
+#define SCOPED_CAPABILITY THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+#define GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+
+#define PT_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
+
+#define ACQUIRED_BEFORE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+
+#define ACQUIRED_AFTER(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+
+#define REQUIRES(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+
+#define ACQUIRE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+
+#define RELEASE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+
+#define EXCLUDES(...) THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+#define ASSERT_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
+
+#define RETURN_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+#define NO_THREAD_SAFETY_ANALYSIS \
+    THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+// Simple mutex implementation using std::mutex for exclusive locking only.
+class CAPABILITY("mutex") Mutex {
+   private:
+    std::mutex mutex_;
+
+   public:
+    // Acquire/lock this mutex exclusively.
+    void lock() ACQUIRE() { mutex_.lock(); }
+
+    // Release/unlock the mutex.
+    void unlock() RELEASE() { mutex_.unlock(); }
+
+    // Try to acquire the mutex. Returns true on success, and false on failure.
+    bool try_lock() TRY_ACQUIRE(true) { return mutex_.try_lock(); }
+
+    // For negative capabilities.
+    const Mutex &operator!() const { return *this; }
+};
+
+// MutexLocker is an RAII class that acquires a mutex in its constructor, and
+// releases it in its destructor.
+class SCOPED_CAPABILITY MutexLocker {
+   private:
+    Mutex *mut;
+    bool locked;
+
+   public:
+    // Acquire mu, implicitly acquire *this and associate it with mu.
+    MutexLocker(Mutex *mu) ACQUIRE(mu) : mut(mu), locked(true) { mu->lock(); }
+
+    // Release *this and all associated mutexes, if they are still held.
+    ~MutexLocker() RELEASE() {
+        if (locked) {
+            mut->unlock();
+        }
+    }
+
+    // Acquire the mutex exclusively.
+    void lock() ACQUIRE() {
+        mut->lock();
+        locked = true;
+    }
+
+    // Try to acquire the mutex exclusively.
+    bool TryLock() TRY_ACQUIRE(true) { return locked = mut->try_lock(); }
+
+    // Release the mutex.
+    void unlock() RELEASE() {
+        mut->unlock();
+        locked = false;
+    }
+};
+
+#endif  // THREAD_SAFETY_ANALYSIS_MUTEX_H

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -583,7 +583,7 @@ bool MasterService::CleanupStaleHandles(ObjectMetadata& metadata) {
 size_t MasterService::GetKeyCount() const {
     size_t total = 0;
     for (const auto& shard : metadata_shards_) {
-        MutexLocker lock(const_cast<Mutex*>(&shard.mutex));
+        MutexLocker lock(&shard.mutex);
         total += shard.metadata.size();
     }
     return total;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -40,7 +40,8 @@ MasterService::MasterService(bool enable_gc, uint64_t default_kv_lease_ttl,
 
     if (enable_ha) {
         client_monitor_running_ = true;
-        client_monitor_thread_ = std::thread(&MasterService::ClientMonitorFunc, this);
+        client_monitor_thread_ =
+            std::thread(&MasterService::ClientMonitorFunc, this);
         VLOG(1) << "action=start_client_monitor_thread";
     }
 }
@@ -151,7 +152,7 @@ ErrorCode MasterService::ReMountSegment(const std::vector<Segment>& segments,
 
 void MasterService::ClearInvalidHandles() {
     for (auto& shard : metadata_shards_) {
-        std::unique_lock lock(shard.mutex);
+        MutexLocker lock(&shard.mutex);
         auto it = shard.metadata.begin();
         while (it != shard.metadata.end()) {
             // Check if the object has any invalid replicas
@@ -222,10 +223,11 @@ ErrorCode MasterService::ExistKey(const std::string& key) {
     return ErrorCode::OK;
 }
 
-ErrorCode MasterService::GetAllKeys(std::vector<std::string> & all_keys) {
+ErrorCode MasterService::GetAllKeys(std::vector<std::string>& all_keys) {
     all_keys.clear();
-    for(size_t i = 0; i < kNumShards; i++) {
-        for(const auto& item : metadata_shards_[i].metadata) {
+    for (size_t i = 0; i < kNumShards; i++) {
+        MutexLocker lock(&metadata_shards_[i].mutex);
+        for (const auto& item : metadata_shards_[i].metadata) {
             all_keys.push_back(item.first);
         }
     }
@@ -326,7 +328,7 @@ ErrorCode MasterService::PutStart(
 
     // Lock the shard and check if object already exists
     size_t shard_idx = getShardIndex(key);
-    std::unique_lock<std::mutex> lock(metadata_shards_[shard_idx].mutex);
+    MutexLocker lock(&metadata_shards_[shard_idx].mutex);
 
     auto it = metadata_shards_[shard_idx].metadata.find(key);
     if (it != metadata_shards_[shard_idx].metadata.end() &&
@@ -343,7 +345,8 @@ ErrorCode MasterService::PutStart(
     std::vector<Replica> replicas;
     replicas.reserve(config.replica_num);
     {
-        ScopedAllocatorAccess allocator_access = segment_manager_.getAllocatorAccess();
+        ScopedAllocatorAccess allocator_access =
+            segment_manager_.getAllocatorAccess();
         auto& allocators = allocator_access.getAllocators();
         auto& allocators_by_name = allocator_access.getAllocatorsByName();
         for (size_t i = 0; i < config.replica_num; ++i) {
@@ -355,13 +358,13 @@ ErrorCode MasterService::PutStart(
                 auto chunk_size = slice_lengths[j];
 
                 // Use the unified allocation strategy with replica config
-                auto handle =
-                    allocation_strategy_->Allocate(allocators, allocators_by_name, chunk_size, config);
+                auto handle = allocation_strategy_->Allocate(
+                    allocators, allocators_by_name, chunk_size, config);
 
                 if (!handle) {
-                    LOG(ERROR) << "key=" << key << ", replica_id=" << i
-                            << ", slice_index=" << j
-                            << ", error=allocation_failed";
+                    LOG(ERROR)
+                        << "key=" << key << ", replica_id=" << i
+                        << ", slice_index=" << j << ", error=allocation_failed";
                     replica_list.clear();
                     // If the allocation failed, we need to evict some objects
                     // to free up space for future allocations.
@@ -375,7 +378,8 @@ ErrorCode MasterService::PutStart(
                 handles.emplace_back(std::move(handle));
             }
 
-            replicas.emplace_back(std::move(handles), ReplicaStatus::PROCESSING);
+            replicas.emplace_back(std::move(handles),
+                                  ReplicaStatus::PROCESSING);
         }
     }
 
@@ -433,7 +437,8 @@ ErrorCode MasterService::BatchPutStart(
     const std::unordered_map<std::string, uint64_t>& value_lengths,
     const std::unordered_map<std::string, std::vector<uint64_t>>& slice_lengths,
     const ReplicateConfig& config,
-    std::unordered_map<std::string, std::vector<Replica::Descriptor>>& batch_replica_list) {
+    std::unordered_map<std::string, std::vector<Replica::Descriptor>>&
+        batch_replica_list) {
     if (config.replica_num == 0 || keys.empty()) {
         LOG(ERROR) << "replica_num=" << config.replica_num
                    << ", keys_size=" << keys.size() << ", error=invalid_params";
@@ -514,7 +519,7 @@ long MasterService::RemoveAll() {
     auto now = std::chrono::steady_clock::now();
 
     for (auto& shard : metadata_shards_) {
-        std::unique_lock lock(shard.mutex);
+        MutexLocker lock(&shard.mutex);
         if (shard.metadata.empty()) {
             continue;
         }
@@ -578,7 +583,7 @@ bool MasterService::CleanupStaleHandles(ObjectMetadata& metadata) {
 size_t MasterService::GetKeyCount() const {
     size_t total = 0;
     for (const auto& shard : metadata_shards_) {
-        std::unique_lock lock(shard.mutex);
+        MutexLocker lock(const_cast<Mutex*>(&shard.mutex));
         total += shard.metadata.size();
     }
     return total;
@@ -683,7 +688,7 @@ void MasterService::BatchEvict(double eviction_ratio) {
     for (size_t i = 0; i < metadata_shards_.size(); i++) {
         auto& shard =
             metadata_shards_[(start_idx + i) % metadata_shards_.size()];
-        std::unique_lock lock(shard.mutex);
+        MutexLocker lock(&shard.mutex);
 
         // object_count must be updated at beginning as it will be used later
         // to compute ideal_evict_num
@@ -764,14 +769,16 @@ void MasterService::ClientMonitorFunc() {
         PodUUID pod_client_id;
         while (client_ping_queue_.pop(pod_client_id)) {
             UUID client_id = {pod_client_id.first, pod_client_id.second};
-            client_ttl[client_id] = now + std::chrono::seconds(client_live_ttl_sec_);
+            client_ttl[client_id] =
+                now + std::chrono::seconds(client_live_ttl_sec_);
         }
 
         // Find out expired clients
         std::vector<UUID> expired_clients;
         for (auto it = client_ttl.begin(); it != client_ttl.end();) {
             if (it->second < now) {
-                LOG(INFO) << "client_id=" << it->first << ", action=client_expired";
+                LOG(INFO) << "client_id=" << it->first
+                          << ", action=client_expired";
                 expired_clients.push_back(it->first);
                 it = client_ttl.erase(it);
             } else {
@@ -815,7 +822,9 @@ void MasterService::ClientMonitorFunc() {
                         } else {
                             LOG(ERROR) << "client_id=" << client_id
                                        << ", segment_name=" << seg.name
-                                       << ", error=prepare_unmount_expired_segment_failed";
+                                       << ", "
+                                          "error=prepare_unmount_expired_"
+                                          "segment_failed";
                         }
                     }
                 }


### PR DESCRIPTION
- Add GUARDED_BY annotations to metadata hash table
- Use MutexLocker instead of std::unique_lock for better thread safety analysis
- Add NO_THREAD_SAFETY_ANALYSIS annotations where needed
- Enable clang thread safety checking in build system
- Fix all thread safety warnings in master service

For example, if  we don't lock the mutex in `getallkeys()`
```cpp
ErrorCode MasterService::GetAllKeys(std::vector<std::string>& all_keys) {
    all_keys.clear();
    for (size_t i = 0; i < kNumShards; i++) {
        for (const auto& item : metadata_shards_[i].metadata) {
            all_keys.push_back(item.first);
        }
    }
    return ErrorCode::OK;
}
```

```
/src/master_service.cpp:229:31: error: reading variable 'metadata' requires holding mutex 'operator[](metadata_shards_, i).mutex' [-Werror,-Wthread-safety-analysis]
        for (const auto& item : metadata_shards_[i].metadata) {
                              ^
/src/master_service.cpp:229:31: error: reading variable 'metadata' requires holding mutex 'operator[](metadata_shards_, i).mutex' [-Werror,-Wthread-safety-analysis]
```