### PR TITLE
Optimize QP Selection in `RdmaEndPoint::submitPostSend` for Efficient Work Request Posting

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -271,8 +271,8 @@ int RdmaEndPoint::submitPostSend(
     int qp_index = 0, wr_count = 0;
     for (size_t i = 0; i < qp_list_.size(); i++) {
         int curr_wr_count = std::min(max_wr_depth_ - wr_depth_list_[qp_index],
-                            std::min(std::static_cast<int>(slice_list.size()),
-                                     std::static_cast<int>(globalConfig().max_cqe) - *cq_outstanding_));
+                            std::min(static_cast<int>(slice_list.size()),
+                                     static_cast<int>(globalConfig().max_cqe) - *cq_outstanding_));
 
         if (curr_wr_count > wr_count) {
             wr_count = curr_wr_count;


### PR DESCRIPTION
- Motivation
The current implementation of the `RdmaEndPoint::submitPostSend` function involves a thread acquiring a `WriteGuard` lock before randomly selecting a Queue Pair (QP) from the `qp_list_` using `SimpleRandom::get().next()`. If the chosen QP lacks available space for posting work requests (i.e., `max_wr_depth_ - wr_depth_list_[qp_index] == 0`), the thread must release the lock and exit the function. This process occurs even if other QPs have the capacity to handle work requests, potentially introducing delays in the control plane's work request posting.

- Modifications
Replace the random selection process of QP with a search of QP having maximum available work request slots (`wr_count`) within the `qp_lists_`.