### PR TITLE
feat(store): add batch exist support for master

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -2,6 +2,7 @@
 
 #include <netinet/in.h>
 #include <pybind11/gil.h>  // For GIL management
+#include <pybind11/stl.h>
 #include <sys/socket.h>
 #include <unistd.h>
 

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -494,6 +494,48 @@ int DistributedObjectStore::isExist(const std::string &key) {
     return toInt(err);                                 // Error
 }
 
+std::vector<int> DistributedObjectStore::batchIsExist(
+    const std::vector<std::string> &keys) {
+    std::vector<int> results;
+
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        results.resize(keys.size(), -1);  // Fill with error codes
+        return results;
+    }
+
+    if (keys.empty()) {
+        LOG(WARNING) << "Empty keys vector provided to batchIsExist";
+        return results;  // Return empty vector
+    }
+
+    std::vector<ErrorCode> exist_results;
+    ErrorCode batch_err = client_->BatchIsExist(keys, exist_results);
+
+    results.resize(keys.size());
+
+    if (batch_err != ErrorCode::OK) {
+        LOG(ERROR) << "BatchIsExist operation failed with error: "
+                   << toString(batch_err);
+        // Fill all results with error code
+        std::fill(results.begin(), results.end(), toInt(batch_err));
+        return results;
+    }
+
+    // Convert ErrorCode results to int results
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (exist_results[i] == ErrorCode::OK) {
+            results[i] = 1;  // Exists
+        } else if (exist_results[i] == ErrorCode::OBJECT_NOT_FOUND) {
+            results[i] = 0;  // Does not exist
+        } else {
+            results[i] = toInt(exist_results[i]);  // Error
+        }
+    }
+
+    return results;
+}
+
 int64_t DistributedObjectStore::getSize(const std::string &key) {
     if (!client_) {
         LOG(ERROR) << "Client is not initialized";
@@ -775,6 +817,10 @@ PYBIND11_MODULE(store, m) {
              py::call_guard<py::gil_scoped_release>())
         .def("is_exist", &DistributedObjectStore::isExist,
              py::call_guard<py::gil_scoped_release>())
+        .def("batch_is_exist", &DistributedObjectStore::batchIsExist,
+             py::call_guard<py::gil_scoped_release>(), py::arg("keys"),
+             "Check if multiple objects exist. Returns list of results: 1 if "
+             "exists, 0 if not exists, -1 if error")
         .def("close", &DistributedObjectStore::tearDownAll)
         .def("get_size", &DistributedObjectStore::getSize,
              py::call_guard<py::gil_scoped_release>())

--- a/mooncake-integration/store/store_py.h
+++ b/mooncake-integration/store/store_py.h
@@ -165,6 +165,14 @@ class DistributedObjectStore {
     int isExist(const std::string &key);
 
     /**
+     * @brief Check if multiple objects exist
+     * @param keys Vector of keys to check
+     * @return Vector of existence results: 1 if exists, 0 if not exists, -1 if
+     * error
+     */
+    std::vector<int> batchIsExist(const std::vector<std::string> &keys);
+
+    /**
      * @brief Get the size of an object
      * @param key Key of the object
      * @return Size of the object in bytes, or -1 if error or object doesn't

--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -1,18 +1,18 @@
 #pragma once
 
+#include <boost/functional/hash.hpp>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
 #include <vector>
-#include <boost/functional/hash.hpp>
 
+#include "ha_helper.h"
 #include "master_client.h"
 #include "rpc_service.h"
 #include "transfer_engine.h"
 #include "transfer_task.h"
 #include "types.h"
-#include "ha_helper.h"
 
 namespace mooncake {
 
@@ -189,6 +189,15 @@ class Client {
      * exists, other ErrorCode for errors
      */
     ErrorCode IsExist(const std::string& key);
+
+    /**
+     * @brief Checks if multiple objects exist
+     * @param keys Vector of keys to check
+     * @param exist_results Output vector of existence results for each key
+     * @return ErrorCode indicating success/failure of the batch operation
+     */
+    ErrorCode BatchIsExist(const std::vector<std::string>& keys,
+                           std::vector<ErrorCode>& exist_results);
 
    private:
     /**

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -38,8 +38,15 @@ class MasterClient {
      * @param object_key Key to query
      * @return ErrorCode indicating exist or not
      */
-    [[nodiscard]] ExistKeyResponse ExistKey(
-        const std::string& object_key);
+    [[nodiscard]] ExistKeyResponse ExistKey(const std::string& object_key);
+
+    /**
+     * @brief Checks if multiple objects exist
+     * @param object_keys Vector of keys to query
+     * @return BatchExistResponse containing existence status for each key
+     */
+    [[nodiscard]] BatchExistResponse BatchExistKey(
+        const std::vector<std::string>& object_keys);
 
     /**
      * @brief Gets object metadata without transferring data
@@ -136,8 +143,8 @@ class MasterClient {
      * @param client_id The uuid of the client
      * @return ErrorCode indicating success/failure
      */
-    [[nodiscard]] MountSegmentResponse MountSegment(
-        const Segment& segment, const UUID& client_id);
+    [[nodiscard]] MountSegmentResponse MountSegment(const Segment& segment,
+                                                    const UUID& client_id);
 
     /**
      * @brief Re-mount segments, invoked when the client is the first time to
@@ -157,8 +164,8 @@ class MasterClient {
      * @param client_id The uuid of the client
      * @return ErrorCode indicating success/failure
      */
-    [[nodiscard]] UnmountSegmentResponse UnmountSegment(
-        const UUID& segment_id, const UUID& client_id);
+    [[nodiscard]] UnmountSegmentResponse UnmountSegment(const UUID& segment_id,
+                                                        const UUID& client_id);
 
     /**
      * @brief Pings master to check its availability

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -105,6 +105,8 @@ class MasterService {
      */
     ErrorCode ExistKey(const std::string& key);
 
+    std::vector<ErrorCode> BatchExistKey(const std::vector<std::string>& keys);
+
     /**
      * @brief Fetch all keys
      * @return ErrorCode::OK if exists

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -97,6 +97,11 @@ struct PingResponse {
 };
 YLT_REFL(PingResponse, view_version, error_code)
 
+struct BatchExistResponse {
+    std::vector<ErrorCode> exist_responses;
+};
+YLT_REFL(BatchExistResponse, exist_responses)
+
 constexpr uint64_t kMetricReportIntervalSeconds = 10;
 
 class WrappedMasterService {
@@ -270,6 +275,15 @@ class WrappedMasterService {
             MasterMetricManager::instance().inc_exist_key_failures();
         }
 
+        timer.LogResponseJson(response);
+        return response;
+    }
+
+    BatchExistResponse BatchExistKey(const std::vector<std::string>& keys) {
+        ScopedVLogTimer timer(1, "BatchExistKey");
+        timer.LogRequest("keys_count=", keys.size());
+
+        BatchExistResponse response{master_service_.BatchExistKey(keys)};
         timer.LogResponseJson(response);
         return response;
     }
@@ -462,7 +476,8 @@ class WrappedMasterService {
         return response;
     }
 
-    MountSegmentResponse MountSegment(const Segment& segment, const UUID& client_id) {
+    MountSegmentResponse MountSegment(const Segment& segment,
+                                      const UUID& client_id) {
         ScopedVLogTimer timer(1, "MountSegment");
         timer.LogRequest("base=", segment.base, ", size=", segment.size,
                          ", segment_name=", segment.name, ", id=", segment.id);
@@ -504,7 +519,8 @@ class WrappedMasterService {
         return response;
     }
 
-    UnmountSegmentResponse UnmountSegment(const UUID& segment_id, const UUID& client_id) {
+    UnmountSegmentResponse UnmountSegment(const UUID& segment_id,
+                                          const UUID& client_id) {
         ScopedVLogTimer timer(1, "UnmountSegment");
         timer.LogRequest("segment_id=", segment_id);
 
@@ -512,7 +528,8 @@ class WrappedMasterService {
         MasterMetricManager::instance().inc_unmount_segment_requests();
 
         UnmountSegmentResponse response;
-        response.error_code = master_service_.UnmountSegment(segment_id, client_id);
+        response.error_code =
+            master_service_.UnmountSegment(segment_id, client_id);
 
         // Track failures if needed
         if (response.error_code != ErrorCode::OK) {
@@ -580,6 +597,8 @@ inline void RegisterRpcService(
     server.register_handler<&mooncake::WrappedMasterService::UnmountSegment>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::Ping>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::BatchExistKey>(
         &wrapped_master_service);
 }
 

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -43,8 +43,8 @@ Client::~Client() {
     }
 
     for (auto& segment : segments_to_unmount) {
-        auto err_code = UnmountSegment(reinterpret_cast<void*>(segment.base),
-                                       segment.size);
+        auto err_code =
+            UnmountSegment(reinterpret_cast<void*>(segment.base), segment.size);
         if (err_code != ErrorCode::OK) {
             LOG(ERROR) << "Failed to unmount segment: " << toString(err_code);
         }
@@ -148,8 +148,7 @@ ErrorCode Client::ConnectToMaster(const std::string& master_server_entry) {
         // Start Ping thread to monitor master view changes and remount segments
         // if needed
         ping_running_ = true;
-        ping_thread_ =
-            std::thread(&Client::PingThreadFunc, this);
+        ping_thread_ = std::thread(&Client::PingThreadFunc, this);
 
         return ErrorCode::OK;
     } else {
@@ -212,7 +211,7 @@ std::optional<std::shared_ptr<Client>> Client::Create(
 
     // Initialize transfer engine
     err = client->InitTransferEngine(local_hostname, metadata_connstring,
-                                    protocol, protocol_args);
+                                     protocol, protocol_args);
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "Failed to initialize transfer engine";
         return std::nullopt;
@@ -581,8 +580,7 @@ ErrorCode Client::MountSegment(const void* buffer, size_t size) {
     Segment segment(generate_uuid(), local_hostname_,
                     reinterpret_cast<uintptr_t>(buffer), size);
 
-    ErrorCode err =
-        master_client_.MountSegment(segment, client_id_).error_code;
+    ErrorCode err = master_client_.MountSegment(segment, client_id_).error_code;
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "mount_segment_to_master_failed base=" << buffer
                    << " size=" << size << ", error=" << err;
@@ -658,6 +656,42 @@ ErrorCode Client::unregisterLocalMemory(void* addr, bool update_metadata) {
 ErrorCode Client::IsExist(const std::string& key) {
     auto response = master_client_.ExistKey(key);
     return response.error_code;
+}
+
+ErrorCode Client::BatchIsExist(const std::vector<std::string>& keys,
+                               std::vector<ErrorCode>& exist_results) {
+    // Check for duplicate keys
+    std::unordered_set<std::string> seen;
+    for (const auto& key : keys) {
+        if (!seen.insert(key).second) {
+            LOG(ERROR) << "Duplicate key not supported for Batch API, key: "
+                       << key;
+            return ErrorCode::INVALID_PARAMS;
+        }
+    }
+
+    auto response = master_client_.BatchExistKey(keys);
+
+    // Resize the output vector to match the number of keys
+    exist_results.resize(keys.size());
+
+    // Check if we got the expected number of responses
+    if (response.exist_responses.size() != keys.size()) {
+        LOG(ERROR) << "BatchExistKey response size mismatch. Expected: "
+                   << keys.size()
+                   << ", Got: " << response.exist_responses.size();
+        // Fill with RPC_FAIL error codes
+        std::fill(exist_results.begin(), exist_results.end(),
+                  ErrorCode::RPC_FAIL);
+        return ErrorCode::RPC_FAIL;
+    }
+
+    // Copy the error codes from the response
+    for (size_t i = 0; i < keys.size(); ++i) {
+        exist_results[i] = response.exist_responses[i];
+    }
+
+    return ErrorCode::OK;
 }
 
 ErrorCode Client::TransferData(

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -660,20 +660,8 @@ ErrorCode Client::IsExist(const std::string& key) {
 
 ErrorCode Client::BatchIsExist(const std::vector<std::string>& keys,
                                std::vector<ErrorCode>& exist_results) {
-    // Check for duplicate keys
-    std::unordered_set<std::string> seen;
-    for (const auto& key : keys) {
-        if (!seen.insert(key).second) {
-            LOG(ERROR) << "Duplicate key not supported for Batch API, key: "
-                       << key;
-            return ErrorCode::INVALID_PARAMS;
-        }
-    }
-
-    auto response = master_client_.BatchExistKey(keys);
-
-    // Resize the output vector to match the number of keys
     exist_results.resize(keys.size());
+    auto response = master_client_.BatchExistKey(keys);
 
     // Check if we got the expected number of responses
     if (response.exist_responses.size() != keys.size()) {
@@ -686,10 +674,7 @@ ErrorCode Client::BatchIsExist(const std::vector<std::string>& keys,
         return ErrorCode::RPC_FAIL;
     }
 
-    // Copy the error codes from the response
-    for (size_t i = 0; i < keys.size(); ++i) {
-        exist_results[i] = response.exist_responses[i];
-    }
+    exist_results = response.exist_responses;
 
     return ErrorCode::OK;
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -223,6 +223,16 @@ ErrorCode MasterService::ExistKey(const std::string& key) {
     return ErrorCode::OK;
 }
 
+std::vector<ErrorCode> MasterService::BatchExistKey(
+    const std::vector<std::string>& keys) {
+    std::vector<ErrorCode> results;
+    results.reserve(keys.size());
+    for (const auto& key : keys) {
+        results.push_back(ExistKey(key));
+    }
+    return results;
+}
+
 ErrorCode MasterService::GetAllKeys(std::vector<std::string>& all_keys) {
     all_keys.clear();
     for (size_t i = 0; i < kNumShards; i++) {
@@ -295,10 +305,10 @@ ErrorCode MasterService::PutStart(
     const std::string& key, uint64_t value_length,
     const std::vector<uint64_t>& slice_lengths, const ReplicateConfig& config,
     std::vector<Replica::Descriptor>& replica_list) {
-    if (config.replica_num == 0 || value_length == 0) {
+    if (config.replica_num == 0 || value_length == 0 || key.empty()) {
         LOG(ERROR) << "key=" << key << ", replica_num=" << config.replica_num
                    << ", value_length=" << value_length
-                   << ", error=invalid_params";
+                   << ", key_size=" << key.size() << ", error=invalid_params";
         return ErrorCode::INVALID_PARAMS;
     }
 

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -120,7 +120,7 @@ class ClientIntegrationTest : public ::testing::Test {
         // Unmount test client segment first
         if (test_client_ && test_client_segment_ptr_) {
             if (test_client_->UnmountSegment(test_client_segment_ptr_,
-                                            test_client_ram_buffer_size_) !=
+                                             test_client_ram_buffer_size_) !=
                 ErrorCode::OK) {
                 LOG(ERROR) << "Failed to unmount test client segment";
             }
@@ -135,9 +135,8 @@ class ClientIntegrationTest : public ::testing::Test {
     }
 
     static void CleanupSegment() {
-        if (segment_provider_client_->UnmountSegment(segment_ptr_,
-                                                    ram_buffer_size_) !=
-            ErrorCode::OK) {
+        if (segment_provider_client_->UnmountSegment(
+                segment_ptr_, ram_buffer_size_) != ErrorCode::OK) {
             LOG(ERROR) << "Failed to unmount segment";
         }
     }
@@ -470,6 +469,78 @@ TEST_F(ClientIntegrationTest, BatchPutGetOperations) {
                   0);
         client_buffer_allocator_->deallocate(
             target_batched_slices[keys[i]][0].ptr, test_data_list[i].size());
+    }
+}
+
+// Test batch IsExist operations through the client
+TEST_F(ClientIntegrationTest, BatchIsExistOperations) {
+    int batch_size = 50;
+    std::vector<std::string> keys;
+    std::vector<std::string> test_data_list;
+    std::unordered_map<std::string, std::vector<Slice>> batched_slices;
+
+    // Create test keys and data
+    for (int i = 0; i < batch_size; i++) {
+        keys.push_back("test_key_batch_exist_" + std::to_string(i));
+        test_data_list.push_back("test_data_" + std::to_string(i));
+    }
+
+    // Put only the first half of the keys
+    void* buffer = nullptr;
+    for (int i = 0; i < batch_size / 2; i++) {
+        std::vector<Slice> slices;
+        buffer = client_buffer_allocator_->allocate(test_data_list[i].size());
+        memcpy(buffer, test_data_list[i].data(), test_data_list[i].size());
+        slices.emplace_back(Slice{buffer, test_data_list[i].size()});
+        batched_slices.emplace(keys[i], slices);
+    }
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    // Put the first half of keys
+    std::vector<std::string> existing_keys(keys.begin(),
+                                           keys.begin() + batch_size / 2);
+    ASSERT_EQ(test_client_->BatchPut(existing_keys, batched_slices, config),
+              ErrorCode::OK);
+
+    // Test BatchIsExist with mixed existing and non-existing keys
+    std::vector<ErrorCode> exist_results;
+    ASSERT_EQ(test_client_->BatchIsExist(keys, exist_results), ErrorCode::OK);
+
+    // Verify results
+    ASSERT_EQ(keys.size(), exist_results.size());
+
+    // First half should exist
+    for (int i = 0; i < batch_size / 2; i++) {
+        EXPECT_EQ(ErrorCode::OK, exist_results[i])
+            << "Key " << keys[i]
+            << " should exist but got error: " << toString(exist_results[i]);
+    }
+
+    // Second half should not exist
+    for (int i = batch_size / 2; i < batch_size; i++) {
+        EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, exist_results[i])
+            << "Key " << keys[i]
+            << " should not exist but got: " << toString(exist_results[i]);
+    }
+
+    // Test with empty keys vector
+    std::vector<std::string> empty_keys;
+    std::vector<ErrorCode> empty_results;
+    ASSERT_EQ(test_client_->BatchIsExist(empty_keys, empty_results),
+              ErrorCode::OK);
+    ASSERT_EQ(empty_results.size(), 0);
+
+    // Clean up
+    for (int i = 0; i < batch_size / 2; i++) {
+        client_buffer_allocator_->deallocate(batched_slices[keys[i]][0].ptr,
+                                             test_data_list[i].size());
+    }
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(FLAGS_default_kv_lease_ttl));
+    for (int i = 0; i < batch_size / 2; i++) {
+        ASSERT_EQ(test_client_->Remove(keys[i]), ErrorCode::OK);
     }
 }
 

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -26,7 +26,7 @@ class MasterServiceTest : public ::testing::Test {
 };
 
 std::string GenerateKeyForSegment(const std::unique_ptr<MasterService>& service,
-                                 const std::string& segment_name) {
+                                  const std::string& segment_name) {
     static std::atomic<uint64_t> counter(0);
 
     while (true) {
@@ -35,12 +35,12 @@ std::string GenerateKeyForSegment(const std::unique_ptr<MasterService>& service,
 
         // Check if the key already exists.
         if (service->ExistKey(key) == ErrorCode::OK) {
-            continue; // Retry if the key already exists
+            continue;  // Retry if the key already exists
         }
 
         // Attempt to put the key.
         ErrorCode code = service->PutStart(key, 1024, {1024},
-                                         {.replica_num=1}, replica_list);
+                                           {.replica_num = 1}, replica_list);
 
         if (code == ErrorCode::OBJECT_ALREADY_EXISTS) {
             continue;  // Retry if the key already exists
@@ -50,7 +50,8 @@ std::string GenerateKeyForSegment(const std::unique_ptr<MasterService>& service,
                                      std::to_string(static_cast<int>(code)));
         }
         service->PutEnd(key);
-        if (replica_list[0].buffer_descriptors[0].segment_name_ == segment_name) {
+        if (replica_list[0].buffer_descriptors[0].segment_name_ ==
+            segment_name) {
             return key;
         }
         // Clean up failed attempt
@@ -67,7 +68,8 @@ TEST_F(MasterServiceTest, MountUnmountSegment) {
     constexpr size_t kSegmentSize = 1024 * 1024 * 16;
     // Define the name of the test segment.
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, kBufferAddress, kSegmentSize);
+    Segment segment(generate_uuid(), segment_name, kBufferAddress,
+                    kSegmentSize);
     UUID client_id = generate_uuid();
 
     // Test invalid parameters.
@@ -101,16 +103,17 @@ TEST_F(MasterServiceTest, MountUnmountSegment) {
     EXPECT_EQ(ErrorCode::OK, service_->MountSegment(segment, client_id));
 
     // Test mounting the same segment again (idempotent request should succeed).
-    EXPECT_EQ(ErrorCode::OK,
-              service_->MountSegment(segment, client_id));
+    EXPECT_EQ(ErrorCode::OK, service_->MountSegment(segment, client_id));
 
     // Test unmounting the segment.
     EXPECT_EQ(ErrorCode::OK, service_->UnmountSegment(segment.id, client_id));
 
-    // Test unmounting the same segment again (idempotent request should succeed).
+    // Test unmounting the same segment again (idempotent request should
+    // succeed).
     EXPECT_EQ(ErrorCode::OK, service_->UnmountSegment(segment.id, client_id));
 
-    // Test unmounting a non-existent segment (idempotent request should succeed).
+    // Test unmounting a non-existent segment (idempotent request should
+    // succeed).
     UUID non_existent_id = generate_uuid();
     EXPECT_EQ(ErrorCode::OK,
               service_->UnmountSegment(non_existent_id, client_id));
@@ -137,12 +140,13 @@ TEST_F(MasterServiceTest, RandomMountUnmountSegment) {
         int random_number = dis(gen);
         // Define the size of the segment (16MB).
         size_t kSegmentSize = 1024 * 1024 * 16 * random_number;
-        
+
         Segment segment(segment_id, segment_name, kBufferAddress, kSegmentSize);
 
         // Test remounting after unmount.
         EXPECT_EQ(ErrorCode::OK, service_->MountSegment(segment, client_id));
-        EXPECT_EQ(ErrorCode::OK, service_->UnmountSegment(segment.id, client_id));
+        EXPECT_EQ(ErrorCode::OK,
+                  service_->UnmountSegment(segment.id, client_id));
     }
 }
 
@@ -188,10 +192,10 @@ TEST_F(MasterServiceTest, PutStartInvalidParams) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
-    
+
     Segment segment(generate_uuid(), segment_name, buffer, size);
     UUID client_id = generate_uuid();
-    
+
     ASSERT_EQ(ErrorCode::OK, service_->MountSegment(segment, client_id));
 
     std::string key = "test_key";
@@ -394,7 +398,8 @@ TEST_F(MasterServiceTest, RandomRemoveObject) {
 
 TEST_F(MasterServiceTest, RemoveAll) {
     const uint64_t kv_lease_ttl = 50;
-    std::unique_ptr<MasterService> service_(new MasterService(false, kv_lease_ttl));
+    std::unique_ptr<MasterService> service_(
+        new MasterService(false, kv_lease_ttl));
     // Mount segment and put 10 objects
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 16;
@@ -682,28 +687,33 @@ TEST_F(MasterServiceTest, ConcurrentWriteAndRemoveAll) {
     for (int i = 0; i < num_threads; ++i) {
         writers.emplace_back([&, i]() {
             for (int j = 0; j < objects_per_thread; ++j) {
-                std::string key = "key_" + std::to_string(i) + "_" + std::to_string(j);
+                std::string key =
+                    "key_" + std::to_string(i) + "_" + std::to_string(j);
                 std::vector<uint64_t> slice_lengths = {1024};
                 ReplicateConfig config;
                 config.replica_num = 1;
                 std::vector<Replica::Descriptor> replica_list;
 
-                if (service_->PutStart(key, 1024, slice_lengths, config, replica_list) == ErrorCode::OK &&
+                if (service_->PutStart(key, 1024, slice_lengths, config,
+                                       replica_list) == ErrorCode::OK &&
                     service_->PutEnd(key) == ErrorCode::OK) {
                     success_writes++;
                 }
 
                 // Random sleep to increase concurrency complexity
-                std::this_thread::sleep_for(std::chrono::milliseconds(rand() % 10));
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(rand() % 10));
             }
         });
     }
 
     // RemoveAll thread
     std::thread remove_thread([&]() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(50)); // Let some writes start
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(50));  // Let some writes start
         long removed = service_->RemoveAll();
-        LOG(INFO) << "Removed " << removed << " objects during concurrent writes";
+        LOG(INFO) << "Removed " << removed
+                  << " objects during concurrent writes";
         ASSERT_GT(removed, 0);
         remove_all_done = true;
         total_removed.fetch_add(removed);
@@ -728,9 +738,10 @@ TEST_F(MasterServiceTest, ConcurrentWriteAndRemoveAll) {
 }
 
 TEST_F(MasterServiceTest, ConcurrentReadAndRemoveAll) {
-    // set a large kv_lease_ttl so the granted lease will not quickly expire 
+    // set a large kv_lease_ttl so the granted lease will not quickly expire
     const uint64_t kv_lease_ttl = 200;
-    std::unique_ptr<MasterService> service_(new MasterService(false, kv_lease_ttl));
+    std::unique_ptr<MasterService> service_(
+        new MasterService(false, kv_lease_ttl));
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 256;  // 256MB for concurrent testing
     std::string segment_name = "concurrent_segment";
@@ -747,7 +758,8 @@ TEST_F(MasterServiceTest, ConcurrentReadAndRemoveAll) {
         config.replica_num = 1;
         std::vector<Replica::Descriptor> replica_list;
 
-        ASSERT_EQ(ErrorCode::OK, service_->PutStart(key, 1024, slice_lengths, config, replica_list));
+        ASSERT_EQ(ErrorCode::OK, service_->PutStart(key, 1024, slice_lengths,
+                                                    config, replica_list));
         ASSERT_EQ(ErrorCode::OK, service_->PutEnd(key));
     }
 
@@ -761,21 +773,25 @@ TEST_F(MasterServiceTest, ConcurrentReadAndRemoveAll) {
             std::vector<Replica::Descriptor> replica_list;
             for (int j = 0; j < num_objects; ++j) {
                 std::string key = "pre_key_" + std::to_string(j);
-                if (service_->GetReplicaList(key, replica_list) == ErrorCode::OK) {
+                if (service_->GetReplicaList(key, replica_list) ==
+                    ErrorCode::OK) {
                     success_reads++;
                 }
 
                 // Random sleep to increase concurrency complexity
-                std::this_thread::sleep_for(std::chrono::milliseconds(rand() % 5));
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(rand() % 5));
             }
         });
     }
 
     // RemoveAll thread
     std::thread remove_thread([&]() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10)); // Let some reads start
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(10));  // Let some reads start
         long removed = service_->RemoveAll();
-        LOG(INFO) << "Removed " << removed << " objects during concurrent reads";
+        LOG(INFO) << "Removed " << removed
+                  << " objects during concurrent reads";
         remove_all_done = true;
     });
 
@@ -799,14 +815,16 @@ TEST_F(MasterServiceTest, ConcurrentReadAndRemoveAll) {
     std::vector<Replica::Descriptor> replica_list;
     for (int i = 0; i < num_objects; ++i) {
         std::string key = "pre_key_" + std::to_string(i);
-        EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, service_->GetReplicaList(key, replica_list));
+        EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND,
+                  service_->GetReplicaList(key, replica_list));
     }
 }
 
 TEST_F(MasterServiceTest, ConcurrentRemoveAllOperations) {
     std::unique_ptr<MasterService> service_(new MasterService());
     constexpr size_t buffer = 0x300000000;
-    constexpr size_t size = 1024 * 1024 * 16 * 100;  // 256MB for concurrent testing
+    constexpr size_t size =
+        1024 * 1024 * 16 * 100;  // 256MB for concurrent testing
     std::string segment_name = "concurrent_segment";
     Segment segment(generate_uuid(), segment_name, buffer, size);
     UUID client_id = generate_uuid();
@@ -821,7 +839,8 @@ TEST_F(MasterServiceTest, ConcurrentRemoveAllOperations) {
         config.replica_num = 1;
         std::vector<Replica::Descriptor> replica_list;
 
-        ASSERT_EQ(ErrorCode::OK, service_->PutStart(key, 1024, slice_lengths, config, replica_list));
+        ASSERT_EQ(ErrorCode::OK, service_->PutStart(key, 1024, slice_lengths,
+                                                    config, replica_list));
         ASSERT_EQ(ErrorCode::OK, service_->PutEnd(key));
     }
 
@@ -849,7 +868,8 @@ TEST_F(MasterServiceTest, ConcurrentRemoveAllOperations) {
     std::vector<Replica::Descriptor> replica_list;
     for (int i = 0; i < num_objects; ++i) {
         std::string key = "pre_key_" + std::to_string(i);
-        EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, service_->GetReplicaList(key, replica_list));
+        EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND,
+                  service_->GetReplicaList(key, replica_list));
     }
 }
 
@@ -884,29 +904,28 @@ TEST_F(MasterServiceTest, UnmountSegmentImmediateCleanup) {
               service_->GetReplicaList(key1, retrieved));
 
     // Verify objects in segment2 is still there
-    ASSERT_EQ(ErrorCode::OK,
-              service_->GetReplicaList(key2, retrieved));
+    ASSERT_EQ(ErrorCode::OK, service_->GetReplicaList(key2, retrieved));
 
     // Verify put key1 will put into segment2 rather than segment1
     ASSERT_EQ(ErrorCode::OK, service_->PutStart(key1, 1024, slice_lengths,
                                                 config, replica_list));
     ASSERT_EQ(ErrorCode::OK, service_->PutEnd(key1));
-    ASSERT_EQ(ErrorCode::OK,
-              service_->GetReplicaList(key1, retrieved));
-    ASSERT_EQ(replica_list[0].buffer_descriptors[0].segment_name_, segment2.name);
+    ASSERT_EQ(ErrorCode::OK, service_->GetReplicaList(key1, retrieved));
+    ASSERT_EQ(replica_list[0].buffer_descriptors[0].segment_name_,
+              segment2.name);
 }
 
 TEST_F(MasterServiceTest, UnmountSegmentPerformance) {
     std::unique_ptr<MasterService> service_(new MasterService());
     constexpr size_t kBufferAddress = 0x300000000;
-    constexpr size_t kSegmentSize = 1024 * 1024 * 256; // 256MB
+    constexpr size_t kSegmentSize = 1024 * 1024 * 256;  // 256MB
     std::string segment_name = "perf_test_segment";
-    Segment segment(generate_uuid(), segment_name, kBufferAddress, kSegmentSize);
+    Segment segment(generate_uuid(), segment_name, kBufferAddress,
+                    kSegmentSize);
     UUID client_id = generate_uuid();
 
     // Mount a segment for testing
-    ASSERT_EQ(ErrorCode::OK,
-              service_->MountSegment(segment, client_id));
+    ASSERT_EQ(ErrorCode::OK, service_->MountSegment(segment, client_id));
 
     // Create 10000 keys for testing
     constexpr int kNumKeys = 1000;
@@ -928,8 +947,9 @@ TEST_F(MasterServiceTest, UnmountSegmentPerformance) {
     EXPECT_EQ(ErrorCode::OK, service_->UnmountSegment(segment.id, client_id));
     auto unmount_end = std::chrono::steady_clock::now();
 
-    auto unmount_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-        unmount_end - unmount_start);
+    auto unmount_duration =
+        std::chrono::duration_cast<std::chrono::milliseconds>(unmount_end -
+                                                              unmount_start);
 
     // Unmount operation should be very fast, so we set 1s limit
     EXPECT_LE(unmount_duration.count(), 1000)
@@ -944,8 +964,9 @@ TEST_F(MasterServiceTest, UnmountSegmentPerformance) {
     }
 
     // Output performance report
-    auto total_create_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-        create_end - start);
+    auto total_create_duration =
+        std::chrono::duration_cast<std::chrono::milliseconds>(create_end -
+                                                              start);
     std::cout << "\nPerformance Metrics:\n"
               << "Keys created: " << kNumKeys << "\n"
               << "Creation time: " << total_create_duration.count() << "ms\n"
@@ -954,15 +975,15 @@ TEST_F(MasterServiceTest, UnmountSegmentPerformance) {
 
 TEST_F(MasterServiceTest, RemoveLeasedObject) {
     const uint64_t kv_lease_ttl = 50;
-    std::unique_ptr<MasterService> service_(new MasterService(false, kv_lease_ttl));
+    std::unique_ptr<MasterService> service_(
+        new MasterService(false, kv_lease_ttl));
     // Mount segment and put an object
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
     Segment segment(generate_uuid(), segment_name, buffer, size);
     UUID client_id = generate_uuid();
-    ASSERT_EQ(ErrorCode::OK,
-              service_->MountSegment(segment, client_id));
+    ASSERT_EQ(ErrorCode::OK, service_->MountSegment(segment, client_id));
 
     std::string key = "test_key";
     std::vector<uint64_t> slice_lengths = {1024};
@@ -1017,15 +1038,15 @@ TEST_F(MasterServiceTest, RemoveLeasedObject) {
 
 TEST_F(MasterServiceTest, RemoveAllLeasedObject) {
     const uint64_t kv_lease_ttl = 50;
-    std::unique_ptr<MasterService> service_(new MasterService(false, kv_lease_ttl));
+    std::unique_ptr<MasterService> service_(
+        new MasterService(false, kv_lease_ttl));
     // Mount segment and put 10 objects, with 5 of them having lease
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
     Segment segment(generate_uuid(), segment_name, buffer, size);
     UUID client_id = generate_uuid();
-    ASSERT_EQ(ErrorCode::OK,
-              service_->MountSegment(segment, client_id));
+    ASSERT_EQ(ErrorCode::OK, service_->MountSegment(segment, client_id));
     for (int i = 0; i < 10; ++i) {
         std::string key = "test_key" + std::to_string(i);
         std::vector<uint64_t> slice_lengths = {1024};
@@ -1056,7 +1077,8 @@ TEST_F(MasterServiceTest, RemoveAllLeasedObject) {
 TEST_F(MasterServiceTest, EvictObject) {
     // set a large kv_lease_ttl so the granted lease will not quickly expire
     const uint64_t kv_lease_ttl = 2000;
-    std::unique_ptr<MasterService> service_(new MasterService(false, kv_lease_ttl));
+    std::unique_ptr<MasterService> service_(
+        new MasterService(false, kv_lease_ttl));
     // Mount a segment that can hold about 1024 * 16 objects.
     // As the eviction is processed separately for each shard,
     // we need to fill each shard with enough objects to thoroughly
@@ -1067,8 +1089,7 @@ TEST_F(MasterServiceTest, EvictObject) {
     std::string segment_name = "test_segment";
     Segment segment(generate_uuid(), segment_name, buffer, size);
     UUID client_id = generate_uuid();
-    ASSERT_EQ(ErrorCode::OK,
-              service_->MountSegment(segment, client_id));
+    ASSERT_EQ(ErrorCode::OK, service_->MountSegment(segment, client_id));
 
     // Verify if we can put objects more than the segment can hold
     int success_puts = 0;
@@ -1078,8 +1099,8 @@ TEST_F(MasterServiceTest, EvictObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         std::vector<Replica::Descriptor> replica_list;
-        if (ErrorCode::OK == service_->PutStart(key, object_size,
-            slice_lengths, config, replica_list)) {
+        if (ErrorCode::OK == service_->PutStart(key, object_size, slice_lengths,
+                                                config, replica_list)) {
             ASSERT_EQ(ErrorCode::OK, service_->PutEnd(key));
             success_puts++;
         } else {
@@ -1095,15 +1116,15 @@ TEST_F(MasterServiceTest, EvictObject) {
 TEST_F(MasterServiceTest, TryEvictLeasedObject) {
     // set a large kv_lease_ttl so the granted lease will not quickly expire
     const uint64_t kv_lease_ttl = 500;
-    std::unique_ptr<MasterService> service_(new MasterService(false, kv_lease_ttl));
+    std::unique_ptr<MasterService> service_(
+        new MasterService(false, kv_lease_ttl));
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 16;
     constexpr size_t object_size = 1024 * 1024;
     std::string segment_name = "test_segment";
     Segment segment(generate_uuid(), segment_name, buffer, size);
     UUID client_id = generate_uuid();
-    ASSERT_EQ(ErrorCode::OK,
-              service_->MountSegment(segment, client_id));
+    ASSERT_EQ(ErrorCode::OK, service_->MountSegment(segment, client_id));
 
     // Verify leased object will not be evicted.
     int success_puts = 0;
@@ -1115,11 +1136,12 @@ TEST_F(MasterServiceTest, TryEvictLeasedObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         std::vector<Replica::Descriptor> replica_list;
-        if (ErrorCode::OK == service_->PutStart(key, object_size,
-            slice_lengths, config, replica_list)) {
+        if (ErrorCode::OK == service_->PutStart(key, object_size, slice_lengths,
+                                                config, replica_list)) {
             ASSERT_EQ(ErrorCode::OK, service_->PutEnd(key));
             // the object is leased
-            ASSERT_EQ(ErrorCode::OK, service_->GetReplicaList(key, replica_list));
+            ASSERT_EQ(ErrorCode::OK,
+                      service_->GetReplicaList(key, replica_list));
             leased_keys.push_back(key);
             success_puts++;
         } else {
@@ -1137,6 +1159,45 @@ TEST_F(MasterServiceTest, TryEvictLeasedObject) {
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
     service_->RemoveAll();
+}
+
+TEST_F(MasterServiceTest, BatchExistKeyTest) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+
+    // Mount a segment
+    constexpr size_t buffer = 0x300000000;
+    constexpr size_t size = 1024 * 1024 * 128;
+    std::string segment_name = "test_segment";
+    Segment segment(generate_uuid(), segment_name, buffer, size);
+    UUID client_id = generate_uuid();
+    ASSERT_EQ(ErrorCode::OK, service_->MountSegment(segment, client_id));
+
+    int test_object_num = 10;
+    std::vector<std::string> test_keys;
+    for (int i = 0; i < test_object_num; ++i) {
+        test_keys.push_back("test_key" + std::to_string(i));
+        ReplicateConfig config;
+        config.replica_num = 1;
+        std::vector<uint64_t> slice_lengths = {1024};
+        std::vector<Replica::Descriptor> replica_list;
+        ASSERT_EQ(ErrorCode::OK,
+                  service_->PutStart(test_keys[i], 1024, slice_lengths, config,
+                                     replica_list));
+        ASSERT_EQ(ErrorCode::OK, service_->PutEnd(test_keys[i]));
+    }
+
+    // Test individual ExistKey calls to verify the underlying functionality
+    for (int i = 0; i < test_object_num; ++i) {
+        EXPECT_EQ(ErrorCode::OK, service_->ExistKey(test_keys[i]));
+    }
+
+    // Tets batch
+    test_keys.push_back("non_existent_key");
+    auto exist_resp = service_->BatchExistKey(test_keys);
+    for (int i = 0; i < test_object_num; ++i) {
+        ASSERT_EQ(ErrorCode::OK, exist_resp[i]);
+    }
+    ASSERT_EQ(ErrorCode::OBJECT_NOT_FOUND, exist_resp[test_object_num]);
 }
 
 }  // namespace mooncake::test

--- a/mooncake-wheel/tests/test_distributed_object_store.py
+++ b/mooncake-wheel/tests/test_distributed_object_store.py
@@ -82,6 +82,47 @@ class TestDistributedObjectStore(unittest.TestCase):
         time.sleep(DEFAULT_KV_LEASE_TTL / 1000)
         self.assertEqual(self.store.remove(key), 0)
 
+    def test_batch_is_exist_operations(self):
+        """Test batch is_exist operations through the Python interface."""
+        batch_size = 20
+        test_data = b"Hello, Batch World!"
+
+        # Create test keys
+        keys = [f"test_batch_exist_key_{i}" for i in range(batch_size)]
+
+        # Put only the first half of the keys
+        existing_keys = keys[:batch_size // 2]
+        for key in existing_keys:
+            self.assertEqual(self.store.put(key, test_data), 0)
+
+        # Test batch_is_exist with mixed existing and non-existing keys
+        results = self.store.batch_is_exist(keys)
+
+        # Verify results
+        self.assertEqual(len(results), len(keys))
+
+        # First half should exist (result = 1)
+        for i in range(batch_size // 2):
+            self.assertEqual(results[i], 1, f"Key {keys[i]} should exist but got {results[i]}")
+
+        # Second half should not exist (result = 0)
+        for i in range(batch_size // 2, batch_size):
+            self.assertEqual(results[i], 0, f"Key {keys[i]} should not exist but got {results[i]}")
+
+        # Test with empty keys list
+        empty_results = self.store.batch_is_exist([])
+        self.assertEqual(len(empty_results), 0)
+
+        # Test with single key
+        single_result = self.store.batch_is_exist([existing_keys[0]])
+        self.assertEqual(len(single_result), 1)
+        self.assertEqual(single_result[0], 1)
+
+        # Test with non-existent key
+        non_existent_result = self.store.batch_is_exist(["non_existent_key"])
+        self.assertEqual(len(non_existent_result), 1)
+        self.assertEqual(non_existent_result[0], 0)
+        
         # Get after remove should return empty bytes
         self.assertLess(self.store.get_size(key), 0)
         empty_data = self.store.get(key)

--- a/mooncake-wheel/tests/test_distributed_object_store.py
+++ b/mooncake-wheel/tests/test_distributed_object_store.py
@@ -123,29 +123,12 @@ class TestDistributedObjectStore(unittest.TestCase):
         self.assertEqual(len(non_existent_result), 1)
         self.assertEqual(non_existent_result[0], 0)
         
-        # Get after remove should return empty bytes
-        self.assertLess(self.store.get_size(key), 0)
-        empty_data = self.store.get(key)
-        self.assertEqual(empty_data, b"")
-
-        # Test isExist functionality
-        test_data_2 = b"Testing exists!"
-        key_2 = "test_exist_key"
-        
-        # Should not exist initially
-        self.assertLess(self.store.get_size(key_2), 0)
-        self.assertEqual(self.store.is_exist(key_2), 0)
-        
-        # Should exist after put
-        self.assertEqual(self.store.put(key_2, test_data_2), 0)
-        self.assertEqual(self.store.is_exist(key_2), 1)
-        self.assertEqual(self.store.get_size(key_2), len(test_data_2))
-        
-        # Should not exist after remove
+        # Clean up
         time.sleep(DEFAULT_KV_LEASE_TTL / 1000)
-        self.assertEqual(self.store.remove(key_2), 0)
-        self.assertLess(self.store.get_size(key_2), 0)
-        self.assertEqual(self.store.is_exist(key_2), 0)
+        for key in existing_keys:
+            self.assertEqual(self.store.remove(key), 0)
+        
+
     
     def test_zero_copy_operations(self):
         """Test zero-copy get_into and put_from operations."""


### PR DESCRIPTION
This change is in preparation for future optimizations like https://github.com/LMCache/LMCache/issues/891. The LMCache scheduler often checks the existence of many keys at once, and using this new interface can significantly reduce latency for those lookups.

Upcoming TODO:

Add support for meta-only clients (which don't need to interact with the actual data).