### PR TITLE
[TransferEngine]: fix compilation warning

### DIFF
--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -133,7 +133,7 @@ class Transport {
             __sync_fetch_and_add(&task->failed_slice_count, 1);
         }
 
-        volatile uint64_t ts;
+        volatile int64_t ts;
     };
 
     struct ThreadLocalSliceCache {

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "multi_transport.h"
+#include <string>
 
 #include "config.h"
 #include "transport/rdma_transport/rdma_transport.h"
@@ -223,7 +224,7 @@ Status MultiTransport::selectTransport(const TransferRequest &entry,
     auto target_segment_desc = metadata_->getSegmentDescByID(entry.target_id);
     if (!target_segment_desc) {
         return Status::InvalidArgument("Invalid target segment ID " +
-                                       entry.target_id);
+                                       std::to_string(entry.target_id));
     }
     auto proto = target_segment_desc->protocol;
     if (!transport_map_.count(proto)) {

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -203,7 +203,7 @@ int TransferEngine::sendNotify(SegmentID target_id,
     auto desc = metadata_->getSegmentDescByID(target_id);
     Transport::NotifyDesc peer_desc;
     int ret = metadata_->sendNotify(desc->name, notify_msg, peer_desc);
-    return 0;
+    return ret;
 }
 
 Transport::SegmentHandle TransferEngine::openSegment(

--- a/mooncake-transfer-engine/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_c.cpp
@@ -146,6 +146,9 @@ int submitTransferWithNotify(transfer_engine_t engine, batch_id_t batch_id,
                              notify_msg_t notify_msg) {
     uint64_t target_id = entries[0].target_id;
     int rc = submitTransfer(engine, batch_id, entries, count);
+    if (rc) {
+        return rc;
+    }
     // notify
     TransferEngine *native = (TransferEngine *)engine;
     TransferMetadata::NotifyDesc notify;


### PR DESCRIPTION
1: warning: comparison of integer expressions of different signedness: ‘long int’ and ‘long unsigned int’
` if (ts > 0 && current_ts > ts &&current_ts - ts > kPacketDeliveryTimeout)`
2:warning: unused variable ‘ret’ [-Wunused-variable] `int ret = metadata_->sendNotify(desc->name, notify_msg, peer_desc);`
3: warning: unused variable ‘rc’ [-Wunused-variable] ` int rc = submitTransfer(engine, batch_id, entries, count)`