### PR TITLE
Optimize  to accelerate the large batch transfer operation

### DIFF
--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -91,6 +91,7 @@ class Transport {
         std::string peer_nic_path;
         SliceStatus status;
         TransferTask *task;
+        bool from_cache;
 
         union {
             struct {
@@ -154,12 +155,18 @@ class Transport {
         }
 
         Slice *allocate() {
+            Slice *slice;
+
             if (head_ - tail_ == 0) {
                 allocated_++;
-                return new Slice();
+                slice = new Slice();
+                slice->from_cache = false;
+            } else {
+                slice = lazy_delete_slices_[tail_ % kLazyDeleteSliceCapacity];
+                tail_++;
+                slice->from_cache = true;
             }
-            auto slice = lazy_delete_slices_[tail_ % kLazyDeleteSliceCapacity];
-            tail_++;
+
             return slice;
         }
 


### PR DESCRIPTION
- Motivation
In scenarios such as cases mentioned in #499 , where transfers involve a large batch size (thousands or more), but each chunk within the batch is relatively small (tens to hundreds of KiB), a substantial number of slices and work requests must be generated for the transfer. The current implementation introduces non-negligible latency due to the following issue:
  - In `RdmaTransport::submitTransferTask`, all slices must be allocated before posting to `RdmaContext::submitPostSend`. When there are many requests, the volume of slices can overwhelm the `ThreadLocalSliceCache`, causing page faults and delaying transfer initiation.
  - The `TransferRequest` length may not be a multiple of `GlobalConfig::slice_size`, leading to smaller final slices. Each slice becomes a separate work request, and when many small slices are created, overhead increases, reducing throughput.
- Modification
  - Submit the slice_list when the number of slices allocated by the `new` operator reaches a predefined watermark, even if there are still pending requests to be processed in `RdmaTransport::submitTransfer`Task.
  - Merge the final slice with the previous slice if its size is below a specified threshold.
- Result
Run the Python [script](https://gist.github.com/ssssnow/37f17c9815cd26c3337ceae2729397cb) provided by #499 
Since the modification occurs with `RdmaTransport::submitTransferTask`, two results have been merged for comparison as follow
```bash
============================================================================================
SUMMARY
============================================================================================
Test Case            wo-opt(s)      wo-opt(GB/s)   w-opt(GB/s)    w-opt(GB/s)    Speedup   
--------------------------------------------------------------------------------------------
200MB/5000chunks     0.008          27.921         0.007          32.471         16.29%    
200MB/10000chunks    0.011          19.145         0.008          24.819         29.63%    
300MB/8000chunks     0.012          26.849         0.010          32.463         20.90%    
400MB/10000chunks    0.015          27.521         0.013          33.013         19.95%    
500MB/15000chunks    0.021          25.069         0.017          30.392         21.23%    
600MB/12000chunks    0.021          30.130         0.018          34.885         15.78%    
700MB/20000chunks    0.029          25.571         0.024          31.191         21.97%    
700MB/10000chunks    0.025          29.294         0.019          38.352         30.91%    

Average Speedup: 22.08%
Maximum Speedup: 30.91%
Average Batch Throughput: 32.198 GB/s
Average Non-Batch Throughput: 26.438 GB/s
```
Result shows that the modification achieves 20%~30% boost in throughput.