### PR TITLE
feat(store): modernize thread handling with std::jthread and stop_token

### DIFF
--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -251,9 +251,8 @@ class Client {
 
     // For high availability
     MasterViewHelper master_view_helper_;
-    std::thread ping_thread_;
-    std::atomic<bool> ping_running_{false};
-    void PingThreadFunc();
+    std::jthread ping_thread_;
+    void PingThreadFunc(std::stop_token stop_token);
 
     // Client identification
     UUID client_id_;

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -250,9 +250,9 @@ class MemcpyWorkerPool {
     void submitTask(MemcpyTask task);
 
    private:
-    void workerThread();
+    void workerThread(std::stop_token stop_token);
 
-    std::vector<std::thread> workers_;
+    std::vector<std::jthread> workers_;
     std::queue<MemcpyTask> task_queue_;
     std::mutex queue_mutex_;
     std::condition_variable queue_cv_;


### PR DESCRIPTION
- Replace std::thread with std::jthread in Client::ping_thread_ and MemcpyWorkerPool::workers_
- Update thread functions to accept std::stop_token parameter for cooperative cancellation
- Remove manual thread joining logic as std::jthread handles this automatically
- Eliminate ping_running_ atomic flag in favor of stop_token mechanism
- Improve thread shutdown safety and resource management