### PR TITLE
add support for asynchronous batch transfer to accelerate transfer operation

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -237,6 +237,22 @@ int TransferEnginePy::batchTransferSyncRead(const char *target_hostname,
                              TransferOpcode::READ);
 }
 
+int TransferEnginePy::batchTransferAsyncWrite(const char *target_hostname,
+                                              const std::vector<uintptr_t> &buffers,
+                                              const std::vector<uintptr_t> &peer_buffer_addresses,
+                                              const std::vector<size_t> &lengths) {
+    return batchTransferAsync(target_hostname, buffers, peer_buffer_addresses, lengths,
+                             TransferOpcode::WRITE);
+}
+
+int TransferEnginePy::batchTransferAsyncRead(const char *target_hostname,
+                                             const std::vector<uintptr_t> &buffers,
+                                             const std::vector<uintptr_t> &peer_buffer_addresses,
+                                             const std::vector<size_t> &lengths) {
+    return batchTransferAsync(target_hostname, buffers, peer_buffer_addresses, lengths,
+                             TransferOpcode::READ);
+}
+
 int TransferEnginePy::transferSync(const char *target_hostname,
                                    uintptr_t buffer,
                                    uintptr_t peer_buffer_address, size_t length,
@@ -395,6 +411,125 @@ int TransferEnginePy::batchTransferSync(const char *target_hostname,
     return -1;
 }
 
+batch_id_t TransferEnginePy::batchTransferAsync(const char *target_hostname,
+                                                const std::vector<uintptr_t>& buffers,
+                                                const std::vector<uintptr_t>& peer_buffer_addresses,
+                                                const std::vector<size_t>& lengths,
+                                                TransferOpcode opcode) {
+    pybind11::gil_scoped_release release;
+    Transport::SegmentHandle handle;
+    {
+        std::lock_guard<std::mutex> guard(mutex_);
+        if (handle_map_.count(target_hostname)) {
+            handle = handle_map_[target_hostname];
+        } else {
+            handle = engine_->openSegment(target_hostname);
+            if (handle == (Transport::SegmentHandle)-1) return -1;
+            handle_map_[target_hostname] = handle;
+        }
+    }
+
+    if (buffers.size() != peer_buffer_addresses.size() || buffers.size() != lengths.size()) {
+        LOG(ERROR) << "buffers, peer_buffer_addresses and lengths have different size";
+        return 0;
+    }
+
+    const int max_retry = engine_->numContexts() + 1;
+    auto batch_size = buffers.size();
+    std::vector<TransferRequest> entries;
+    batch_id_t batch_id = 0;
+    for (size_t i = 0; i < batch_size; ++i) {
+        TransferRequest entry;
+        if (opcode == TransferOpcode::WRITE) {
+            entry.opcode = TransferRequest::WRITE;
+        } else {
+            entry.opcode = TransferRequest::READ;
+        }
+        entry.length = lengths[i];
+        entry.source = (void *)buffers[i];
+        entry.target_id = handle;
+        entry.target_offset = peer_buffer_addresses[i];
+        entry.advise_retry_cnt = 0;
+        entries.push_back(entry);
+    }
+
+    for (int retry = 0; retry < max_retry; ++retry) {
+        batch_id = engine_->allocateBatchID(batch_size);
+        auto batch_desc = reinterpret_cast<BatchDesc *>(batch_id);
+
+        auto start_ts = getCurrentTimeInNano();
+        batch_desc->start_timestamp = start_ts;
+
+        Status s = engine_->submitTransfer(batch_id, entries);
+        if (!s.ok()) {
+            engine_->freeBatchID(batch_id);
+            return 0;
+        } else {
+            break;
+        }
+    }
+
+    return batch_id;
+}
+
+int TransferEnginePy::getBatchTransferStatus(const std::vector<batch_id_t>& batch_ids) {
+    TransferStatus status;
+    std::unordered_map<batch_id_t, int64_t> timeout_table{};
+    for (auto &batch_id : batch_ids) {
+        int64_t total_length = 0;
+        auto batch_desc = reinterpret_cast<BatchDesc *>(batch_id);
+        const size_t task_count = batch_desc->task_list.size();
+
+        for (size_t task_id = 0; task_id < task_count; task_id++) {
+            auto &task = batch_desc->task_list[task_id];
+            for (auto &slice : task.slice_list) {
+                total_length += slice->length;
+            }
+        }
+
+        timeout_table[batch_id] = total_length + transfer_timeout_nsec_;
+    }
+
+    bool failed_or_timeout = false;
+    std::unordered_set<batch_id_t> remove_ids {};
+    while (!timeout_table.empty() && !failed_or_timeout) {
+        for (auto &entry : timeout_table) {
+            auto batch_desc = reinterpret_cast<BatchDesc *>(entry.first);
+            Status s = engine_->getBatchTransferStatus(entry.first, status);
+            LOG_ASSERT(s.ok());
+            if (status.s == TransferStatusEnum::COMPLETED) {
+                engine_->freeBatchID(entry.first);
+                LOG(INFO) << "Batch Transfer completed!";
+                remove_ids.insert(entry.first);
+            } else if (status.s == TransferStatusEnum::FAILED) {
+                failed_or_timeout = true;
+            } else if (status.s == TransferStatusEnum::TIMEOUT) {
+                LOG(INFO) << "Sync data transfer timeout";
+            }
+            auto current_ts = getCurrentTimeInNano();
+            if (current_ts - batch_desc->start_timestamp > entry.second) {
+                LOG(INFO) << "Sync batch data transfer timeout after " 
+                            << current_ts - batch_desc->start_timestamp << "ns";
+                failed_or_timeout = true;
+            }
+        }
+
+        for (auto &remove_id : remove_ids) {
+            timeout_table.erase(remove_id);
+        }
+
+        remove_ids.clear();
+    }
+
+    if (failed_or_timeout) {
+        for (auto &entry : timeout_table) {
+            engine_->freeBatchID(entry.first);
+        }
+    }
+
+    return failed_or_timeout ? -1 : 0;
+}
+
 batch_id_t TransferEnginePy::transferSubmitWrite(const char *target_hostname,
                                                  uintptr_t buffer,
                                                  uintptr_t peer_buffer_address,
@@ -484,8 +619,12 @@ PYBIND11_MODULE(engine, m) {
             .def("transfer_sync_read", &TransferEnginePy::transferSyncRead)
             .def("batch_transfer_sync_write", &TransferEnginePy::batchTransferSyncWrite)
             .def("batch_transfer_sync_read", &TransferEnginePy::batchTransferSyncRead)
+            .def("batch_transfer_async_write", &TransferEnginePy::batchTransferAsyncWrite)
+            .def("batch_transfer_async_read", &TransferEnginePy::batchTransferAsyncRead)
             .def("transfer_sync", &TransferEnginePy::transferSync)
             .def("batch_transfer_sync", &TransferEnginePy::batchTransferSync)
+            .def("batch_transfer_async", &TransferEnginePy::batchTransferAsync)
+            .def("get_batch_transfer_status", &TransferEnginePy::getBatchTransferStatus)
             .def("transfer_submit_write",
                  &TransferEnginePy::transferSubmitWrite)
             .def("transfer_check_status",

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -45,6 +45,9 @@ class TransferEnginePy {
     enum class TransferOpcode { READ = 0, WRITE = 1 };
 
    public:
+    using BatchDesc = Transport::BatchDesc;
+
+   public:
     TransferEnginePy();
 
     ~TransferEnginePy();
@@ -83,6 +86,16 @@ class TransferEnginePy {
                               std::vector<uintptr_t> peer_buffer_addresses,
                               std::vector<size_t> lengths);
 
+    int batchTransferAsyncWrite(const char *target_hostname,
+                                const std::vector<uintptr_t> &buffers,
+                                const std::vector<uintptr_t> &peer_buffer_addresses,
+                                const std::vector<size_t> &lengths);
+
+    int batchTransferAsyncRead(const char *target_hostname,
+                               const std::vector<uintptr_t> &buffers,
+                               const std::vector<uintptr_t> &peer_buffer_addresses,
+                               const std::vector<size_t> &lengths);
+
     int transferSync(const char *target_hostname, uintptr_t buffer,
                      uintptr_t peer_buffer_address, size_t length,
                      TransferOpcode opcode);
@@ -92,6 +105,14 @@ class TransferEnginePy {
                           std::vector<uintptr_t> peer_buffer_addresses,
                           std::vector<size_t> lengths,
                           TransferOpcode opcode);
+
+    batch_id_t batchTransferAsync(const char *target_hostname,
+                          const std::vector<uintptr_t> &buffers,
+                          const std::vector<uintptr_t> &peer_buffer_addresses,
+                          const std::vector<size_t> &lengths,
+                          TransferOpcode opcode);
+    
+    int getBatchTransferStatus(const std::vector<batch_id_t> &batch_ids);
 
     uintptr_t getFirstBufferAddress(const std::string &segment_name);
 

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -201,6 +201,7 @@ class Transport {
         size_t batch_size;
         std::vector<TransferTask> task_list;
         void *context;  // for transport implementers.
+        int64_t start_timestamp;
     };
 
    public:

--- a/mooncake-wheel/tests/transfer_engine_initiator_test.py
+++ b/mooncake-wheel/tests/transfer_engine_initiator_test.py
@@ -131,5 +131,74 @@ class TestVLLMAdaptorTransfer(unittest.TestCase):
 
         print(f"[✓] {circles} rounds of batch_write_read passed, batch size {batch_size}.")
 
+    def test_async_batch_write_read(self):
+        """Test batch_transfer_sync_write and batch_transfer_sync_read for batch write/read consistency."""
+        import random, string
+
+        def generate_random_string(length):
+            chars = string.ascii_letters + string.digits + string.punctuation
+            return ''.join(random.choices(chars, k=length))
+
+        adaptor = self.adaptor
+        batch_size = 100  # Adjust batch size if needed
+        circles = max(2, self.circle // 100)  # Number of batch test rounds
+
+        base_src_addr = adaptor.get_first_buffer_address(self.initiator_server_name)
+        base_dst_addr = adaptor.get_first_buffer_address(self.target_server_name)
+        
+        src_addr_list = []
+        dst_addr_list = []
+        offset_size = 1024  # 1KB offset between each buffer
+        
+        for i in range(batch_size):
+            src_addr_list.append(base_src_addr + i * offset_size)
+            dst_addr_list.append(base_dst_addr + i * offset_size)
+
+        for i in range(circles):
+            # Generate multiple groups of random data
+            data_list = []
+            data_len_list = []
+            for _ in range(batch_size):
+                str_len = random.randint(32, min(128, offset_size))
+                src_data = generate_random_string(str_len).encode('utf-8')
+                data_list.append(src_data)
+                data_len_list.append(len(src_data))
+
+            # Write to local buffers in batch
+            for j in range(batch_size):
+                result = adaptor.write_bytes_to_buffer(src_addr_list[j], data_list[j], data_len_list[j])
+                self.assertEqual(result, 0, f"[{i}-{j}] writeBytesToBuffer failed")
+
+            # Batch write to remote
+            batch_id = adaptor.batch_transfer_async_write(
+                self.target_server_name, src_addr_list, dst_addr_list, data_len_list
+            )
+            self.assertNotEqual(batch_id, 0, f"[{i}] batch_transfer_async_write {batch_id} failed in submitting task(s)")
+
+            result = adaptor.get_batch_transfer_status([batch_id])
+            self.assertEqual(result, 0, f"[{i}] batch {batch_id} failed during transferring")
+
+            # Clear local buffers
+            for j in range(batch_size):
+                clear_data = bytes([0] * data_len_list[j])
+                result = adaptor.write_bytes_to_buffer(src_addr_list[j], clear_data, data_len_list[j])
+                self.assertEqual(result, 0, f"[{i}-{j}] Clear buffer failed")
+
+            # Batch read back from remote
+            batch_id = adaptor.batch_transfer_async_read(
+                self.target_server_name, src_addr_list, dst_addr_list, data_len_list
+            )
+            self.assertNotEqual(batch_id, 0, f"[{i}] batch_transfer_async_read {batch_id} failed in submitting task(s)")
+
+            result = adaptor.get_batch_transfer_status([batch_id])
+            self.assertEqual(result, 0, f"[{i}] batch {batch_id} failed during transferring")
+
+            # Verify data consistency
+            for j in range(batch_size):
+                read_back = adaptor.read_bytes_from_buffer(src_addr_list[j], data_len_list[j])
+                self.assertEqual(read_back, data_list[j], f"[{i}-{j}] Data mismatch in batch read")
+
+        print(f"[✓] {circles} rounds of batch_write_async_read passed, batch size {batch_size}.")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Add Support for Asynchronous Batch Transfer Interface
- Motivation
As mentioned in #499 , the batch transfer operation can greatly accelerate the transfer process. With batch sizes exceeding thousands, Pybind interface overhead becomes substantial, reducing the overall throughput. One intuitive method in resolving this is dividing a large batch of transfer requests into micro-batches and posted them separately. But with current implementation of batch transfer, each micro-batch have to wait for all its tasks to complete, then return, making the division pointless. So this pull request aims to decouple task submission from result polling, allowing Pybind calling overhead to overlap with actual task transfer time.
- Modification
Introduce an asynchronous batch transfer Pybind interface for task submission without immediate result retrieval. A separate querying interface ensures batch completion. These modifications, inspired by issue #557, aim to enhance transfer efficiency and throughput.
- Result
Below are the batch transfer speed results based on a 200*2Gbps RDMA setup,  
```bash
====================================================================================================
SUMMARY
====================================================================================================
Test Case            Batch(s)   Async-Batch(s) Batch(GB/s)  Async-Batch(GB/s) Speedup(%)
----------------------------------------------------------------------------------------------------
200MB/5000chunks     0.006      0.005           32.818       45.644            39.08%
200MB/10000chunks    0.008      0.007           26.136       30.346            16.11%
300MB/8000chunks     0.010      0.007           32.738       46.232            41.22%
400MB/10000chunks    0.012      0.009           33.734       46.734            38.53%
500MB/15000chunks    0.016      0.011           31.831       47.246            48.43%
600MB/12000chunks    0.018      0.013           35.927       47.461            32.10%
700MB/20000chunks    0.022      0.015           32.674       47.848            46.44%
700MB/10000chunks    0.019      0.015           39.001       47.897            22.81%

Average Speedup: 35.59%
Maximum Speedup: 48.43%
Average Batch Throughput: 33.107 GB/s
Average Async-Batch Throughput: 44.926 GB/s
```
Related test has been added to `mooncake-wheel/tests/transfer_engine_initiator_test.py`