### PR TITLE
[TransferEngine] optimization: remove request_list parameter from submitTransferTask

### DIFF
--- a/mooncake-transfer-engine/include/transport/nvlink_transport/nvlink_transport.h
+++ b/mooncake-transfer-engine/include/transport/nvlink_transport/nvlink_transport.h
@@ -41,7 +41,6 @@ class NvlinkTransport : public Transport {
                           const std::vector<TransferRequest>& entries) override;
 
     Status submitTransferTask(
-        const std::vector<TransferRequest*>& request_list,
         const std::vector<TransferTask*>& task_list) override;
 
     Status getTransferStatus(BatchID batch_id, size_t task_id,

--- a/mooncake-transfer-engine/include/transport/nvmeof_transport/nvmeof_transport.h
+++ b/mooncake-transfer-engine/include/transport/nvmeof_transport/nvmeof_transport.h
@@ -46,7 +46,6 @@ class NVMeoFTransport : public Transport {
     BatchID allocateBatchID(size_t batch_size) override;
 
     Status submitTransferTask(
-        const std::vector<TransferRequest *> &request_list,
         const std::vector<TransferTask *> &task_list) override;
 
     Status submitTransfer(BatchID batch_id,

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -77,7 +77,6 @@ class RdmaTransport : public Transport {
                           const std::vector<TransferRequest> &entries) override;
 
     Status submitTransferTask(
-        const std::vector<TransferRequest *> &request_list,
         const std::vector<TransferTask *> &task_list) override;
 
     Status getTransferStatus(BatchID batch_id,

--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -50,7 +50,6 @@ class TcpTransport : public Transport {
                           const std::vector<TransferRequest> &entries) override;
 
     Status submitTransferTask(
-        const std::vector<TransferRequest *> &request_list,
         const std::vector<TransferTask *> &task_list) override;
 
     Status getTransferStatus(BatchID batch_id, size_t task_id,

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -198,6 +198,8 @@ class Transport {
         uint64_t total_bytes = 0;
         BatchID batch_id = 0;
 
+        // record the origin request
+        const TransferRequest *request = nullptr;
         // record the slice list for freeing objects
         std::vector<Slice *> slice_list;
         ~TransferTask() {
@@ -230,7 +232,6 @@ class Transport {
         BatchID batch_id, const std::vector<TransferRequest> &entries) = 0;
 
     virtual Status submitTransferTask(
-        const std::vector<TransferRequest *> &request_list,
         const std::vector<TransferTask *> &task_list) {
         return Status::NotImplemented(
             "Transport::submitTransferTask is not implemented");

--- a/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
@@ -165,11 +165,12 @@ Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
 }
 
 Status NvlinkTransport::submitTransferTask(
-    const std::vector<TransferRequest *> &request_list,
     const std::vector<TransferTask *> &task_list) {
-    for (size_t index = 0; index < request_list.size(); ++index) {
-        auto &request = *request_list[index];
+    for (size_t index = 0; index < task_list.size(); ++index) {
+        assert(task_list[index]);
         auto &task = *task_list[index];
+        assert(task.request);
+        auto &request = *task.request;
         uint64_t dest_addr = request.target_offset;
         if (request.target_id != LOCAL_SEGMENT_ID) {
             int rc = relocateSharedMemoryAddress(dest_addr, request.length,

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -263,7 +263,6 @@ Status RdmaTransport::submitTransfer(
 }
 
 Status RdmaTransport::submitTransferTask(
-    const std::vector<TransferRequest *> &request_list,
     const std::vector<TransferTask *> &task_list) {
     std::unordered_map<std::shared_ptr<RdmaContext>, std::vector<Slice *>>
         slices_to_post;
@@ -274,11 +273,12 @@ Status RdmaTransport::submitTransferTask(
     const size_t kFragmentSize = globalConfig().fragment_limit;
     const size_t kSubmitWatermark = globalConfig().max_wr * globalConfig().num_qp_per_ep;
     uint64_t nr_slices;
-    for (size_t index = 0; index < request_list.size(); ++index) {
-        assert(request_list[index] && task_list[index]);
-        auto &request = *request_list[index];
+    for (size_t index = 0; index < task_list.size(); ++index) {
+        assert(task_list[index]);
         auto &task = *task_list[index];
         nr_slices = 0;
+        assert(task.request);
+        auto &request = *task.request;
         for (uint64_t offset = 0; offset < request.length;
              offset += kBlockSize) {
             Slice *slice = getSliceCache().allocate();

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -347,11 +347,12 @@ Status TcpTransport::submitTransfer(
 }
 
 Status TcpTransport::submitTransferTask(
-    const std::vector<TransferRequest *> &request_list,
     const std::vector<TransferTask *> &task_list) {
-    for (size_t index = 0; index < request_list.size(); ++index) {
-        auto &request = *request_list[index];
+    for (size_t index = 0; index < task_list.size(); ++index) {
+        assert(task_list[index]);
         auto &task = *task_list[index];
+        assert(task.request);
+        auto &request = *task.request;
         task.total_bytes = request.length;
         Slice *slice = getSliceCache().allocate();
         slice->source_addr = (char *)request.source;


### PR DESCRIPTION
I didn't think it was necessary to use the request_list parameter in the function `submitTransferTask`, so I removed it and stored the request reference in TransferTask instead of passing a separate request_list parameter. I think this helps to reduce the complexity of the code and the cost of reading it.

I don't know if my understanding is wrong or not, please don't hesitate to comment if I'm wrong!
