### PR TITLE
[TransferEngine] bugfix: ensure proper socket closure in destructor

### DIFF
--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -545,11 +545,11 @@ struct SocketHandShakePlugin : public HandShakePlugin {
     }
 
     virtual ~SocketHandShakePlugin() {
-        closeListen();
         if (listener_running_) {
             listener_running_ = false;
             listener_.join();
         }
+        closeListen();
     }
 
     virtual void registerOnConnectionCallBack(OnReceiveCallBack callback) {


### PR DESCRIPTION
This PR attempts to fix race condition in `SocketHandShakePlugin` destructor.

# Problem
The `SocketHandShakePlugin` destructor had a race condition where it would close the listening socket (closeListen()) before stopping the listener thread. This could cause undefined behavior if the listener thread was still running and attempting to use the socket that had just been closed. In the following screenshot `accept` fails because it is using a closed listening socket.
<img width="488" alt="Clipboard_Screenshot_1751003109" src="https://github.com/user-attachments/assets/3c3fece8-52a3-4b00-b1d9-469c0c76691b" />
<img width="589" alt="Clipboard_Screenshot_1751004109" src="https://github.com/user-attachments/assets/a4b7e317-5d68-4cfc-9b9a-7055f3a8b59f" />


# Root Cause
The original destructor order was:

1. `closeListen()` - closes the socket
2. Stop listener thread and join

This created a race condition because the listener thread's main loop continuously calls `accept(listen_fd_, ...)` and other socket operations, which could fail or cause undefined behavior if the socket was closed while the thread was still running. 

# Solution
Reordered the destructor operations to:

1. Stop listener thread and join (ensures thread is completely stopped)
2. `closeListen()` - safely close the socket

This ensures that the listener thread is completely terminated before the socket is closed, eliminating the race condition.




