### PR TITLE
[TransferEngine] Add support to force MNNVL transport by MC_FORCE_MNNVL

### DIFF
--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -79,9 +79,9 @@ DEFINE_string(nic_priority_matrix, "",
 DEFINE_string(segment_id, "192.168.3.76", "Segment ID to access data");
 DEFINE_uint64(buffer_size, 1ull << 30, "total size of data buffer");
 DEFINE_int32(batch_size, 128, "Batch size");
-DEFINE_uint64(block_size, 4096, "Block size for each transfer request");
+DEFINE_uint64(block_size, 65536, "Block size for each transfer request");
 DEFINE_int32(duration, 10, "Test duration in seconds");
-DEFINE_int32(threads, 4, "Task submission threads");
+DEFINE_int32(threads, 12, "Task submission threads");
 DEFINE_bool(auto_discovery, false, "Enable auto discovery");
 DEFINE_string(report_unit, "GB", "Report unit: GB|GiB|Gb|MB|MiB|Mb|KB|KiB|Kb");
 DEFINE_uint32(report_precision, 2, "Report precision");


### PR DESCRIPTION
To use MNNVL:
- Ensure that you build the package WITH USE_MNNVL parameter
- Your platform does not install RDMA; or setting environment variable MC_FORCE_MNNVL.