### PR TITLE
[Doc] Add pypi install guide in the build doc

### DIFF
--- a/doc/en/build.md
+++ b/doc/en/build.md
@@ -1,6 +1,11 @@
 # Build Guide
 
-This document describes how to build Mooncake.
+This document describes how to build Mooncake from source.
+
+- Note: we have prebuild the pypi wheel for Ubuntu 22.04/24.04, you can simply install mooncake with pip/pip3.
+   ```bash
+   pip3 install mooncake-transfer-engine --upgrade
+   ```
 
 ## Automatic
 

--- a/doc/zh/build.md
+++ b/doc/zh/build.md
@@ -1,6 +1,11 @@
 # 编译指南
 
-本文档叙述了 Mooncake 框架的编译方法。
+本文档叙述了 Mooncake 框架的源码编译安装方法。
+
+- 注意: 我们已经为 Ubuntu 22.04/24.04 预先构建了 pypi 安装包，您可以使用 pip/pip3 以更简单的方式安装和使用 mooncake。
+   ```bash
+   pip3 install mooncake-transfer-engine --upgrade
+   ```
 
 ## 自动安装
 


### PR DESCRIPTION
Since we are redirecting people to this build doc when they are running e2e sglang/vllm tests without mooncake, I suppose we should inform the users that they can simply use pip install when they are using Ubuntu.