### PR TITLE
fix: correctly cleanup local buffer allocation

### DIFF
--- a/mooncake-integration/store/store_py.h
+++ b/mooncake-integration/store/store_py.h
@@ -243,12 +243,6 @@ class DistributedObjectStore {
             &replica_lists,
         std::unordered_map<std::string, uint64_t> &str_length_map);
 
-    int allocateBatchedSlices(
-        const std::vector<std::string> &keys,
-        const std::vector<std::span<const char>> &values,
-        std::unordered_map<std::string, std::vector<mooncake::Slice>>
-            &batched_slices);
-
     char *exportSlices(const std::vector<mooncake::Slice> &slices,
                        uint64_t length);
 


### PR DESCRIPTION
1. release slice correctly, put batch uses RAII slice, get batch still need release slices manually
2. obligatory acquiring gil before accessing py object, compatible with later version of Python