### PR TITLE
fixed initall function

### DIFF
--- a/doc/en/mooncake-store-preview.md
+++ b/doc/en/mooncake-store-preview.md
@@ -406,9 +406,9 @@ Initializes storage configuration and network parameters.
 
 ---
 
-### initAll
+### init_all
 ```python
-def initAll(
+def init_all(
     self,
     protocol: str,
     device_name: str,

--- a/doc/zh/mooncake-store-preview.md
+++ b/doc/zh/mooncake-store-preview.md
@@ -418,9 +418,9 @@ def setup(
 
 ---
 
-### initAll
+### init_all
 ```python
-def initAll(
+def init_all(
     self,
     protocol: str,
     device_name: str,


### PR DESCRIPTION
In the python interfaces of mooncake store, the initAll() is a C++ function, after its converted to python with pybind, its name should be init_all()
![image](https://github.com/user-attachments/assets/3d95eaa8-bd27-4754-acbd-66d901919fff)
