### PR TITLE
[Store] Add ungister_buffer api for Store

### DIFF
--- a/mooncake-integration/store/store_py.h
+++ b/mooncake-integration/store/store_py.h
@@ -116,6 +116,8 @@ class DistributedObjectStore {
 
     int register_buffer(void *buffer, size_t size);
 
+    int unregister_buffer(void *buffer);
+
     /**
      * @brief Get object data directly into a pre-allocated buffer
      * @param key Key of the object to get

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -884,6 +884,9 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchPut(
 
 tl::expected<void, ErrorCode> Client::Remove(const ObjectKey& key) {
     auto result = master_client_.Remove(key);
+    if(storage_backend_) {
+        storage_backend_->RemoveFile(key);
+    }
     if (!result) {
         return tl::unexpected(result.error());
     }
@@ -891,6 +894,9 @@ tl::expected<void, ErrorCode> Client::Remove(const ObjectKey& key) {
 }
 
 tl::expected<long, ErrorCode> Client::RemoveAll() {
+    if(storage_backend_) {
+        storage_backend_->RemoveAll();
+    }
     return master_client_.RemoveAll();
 }
 

--- a/mooncake-wheel/tests/test_distributed_object_store.py
+++ b/mooncake-wheel/tests/test_distributed_object_store.py
@@ -187,6 +187,8 @@ class TestDistributedObjectStore(unittest.TestCase):
 
         # Cleanup
         time.sleep(DEFAULT_KV_LEASE_TTL / 1000)
+        self.assertEqual(self.store.unregister_buffer(buffer_ptr), 0, "Buffer unregistration should succeed")
+        self.assertEqual(self.store.unregister_buffer(small_buffer_ptr), 0)
         self.assertEqual(self.store.remove(key), 0)
 
     def test_batch_get_into_operations(self):
@@ -261,6 +263,7 @@ class TestDistributedObjectStore(unittest.TestCase):
 
         # Cleanup
         time.sleep(DEFAULT_KV_LEASE_TTL / 1000)
+        self.assertEqual(self.store.unregister_buffer(large_buffer_ptr), 0, "Buffer unregistration should succeed")
         for key in keys:
             self.assertEqual(self.store.remove(key), 0)
 
@@ -333,6 +336,7 @@ class TestDistributedObjectStore(unittest.TestCase):
 
         # Cleanup
         time.sleep(DEFAULT_KV_LEASE_TTL / 1000)
+        self.assertEqual(self.store.unregister_buffer(large_buffer_ptr), 0, "Buffer unregistration should succeed")
         for key in keys:
             self.assertEqual(self.store.remove(key), 0)
 

--- a/mooncake-wheel/tests/test_ssd_offload_in_evict.py
+++ b/mooncake-wheel/tests/test_ssd_offload_in_evict.py
@@ -287,6 +287,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         # Phase 3: Cleanup (still using single remove for simplicity)
         # --------------------------
         time.sleep(DEFAULT_KV_LEASE_TTL / 1000)
+        self.assertEqual(self.store.unregister_buffer(large_buffer_ptr), 0, "Buffer unregistration should succeed")
         index = 0
         while index < MAX_REQUESTS:
             key = "k_" + str(index)

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -29,12 +29,12 @@ MC_METADATA_SERVER=http://127.0.0.1:8080/metadata python test_distributed_object
 kill $MASTER_PID || true
 
 # Disabled for now, need to investigate
-# echo "Running with ssd offload in evict tests..."
-# mooncake_master &
-# MASTER_PID=$!
-# sleep 1
-# MC_METADATA_SERVER=http://127.0.0.1:8080/metadata python test_ssd_offload_in_evict.py
-# kill $MASTER_PID || true
+echo "Running with ssd offload in evict tests..."
+mooncake_master &
+MASTER_PID=$!
+sleep 1
+MC_METADATA_SERVER=http://127.0.0.1:8080/metadata python test_ssd_offload_in_evict.py
+kill $MASTER_PID || true
 
 echo "Running CLI entry point tests..."
 python test_cli.py

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -28,13 +28,19 @@ sleep 1
 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata python test_distributed_object_store.py
 kill $MASTER_PID || true
 
-# Disabled for now, need to investigate
-echo "Running with ssd offload in evict tests..."
-mooncake_master &
-MASTER_PID=$!
-sleep 1
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata python test_ssd_offload_in_evict.py
-kill $MASTER_PID || true
+
+# Check if MOONCAKE_STORAGE_ROOT_DIR is set and not empty
+if [ -n "$MOONCAKE_STORAGE_ROOT_DIR" ]; then
+    echo "MOONCAKE_STORAGE_ROOT_DIR is set to: $MOONCAKE_STORAGE_ROOT_DIR"
+    echo "Running with ssd offload in evict tests..."
+    mooncake_master &
+    MASTER_PID=$!
+    sleep 1
+    MC_METADATA_SERVER=http://127.0.0.1:8080/metadata python test_ssd_offload_in_evict.py
+    kill $MASTER_PID || true
+else
+    echo "Skipping test: MOONCAKE_STORAGE_ROOT_DIR environment variable is not set"
+fi
 
 echo "Running CLI entry point tests..."
 python test_cli.py


### PR DESCRIPTION
# PR Content Description  

- **Added Python interface for `unregister_buffer`**:  
  - Currently, the Python interface only provides the `register_buffer` method without a corresponding `unregister` method. To address this, we have added the `unregister` interface, which brings two key benefits:  
    - For upper-layer applications, it allows undoing registered buffers when needed, maintaining operational consistency.  
    - For certain tests, repeated `register_buffer` calls may cause buffer space overlap, leading to test failures. The `unregister` interface helps avoid this issue.  

- **Re-enabled SSD offload in evict test**:  
  - The test was temporarily disabled due to issues caused by a previous PR that turned off some persistent operations. It has now been re-enabled but will only run when testing SSD offload functionality.  

- **Fixed bug in persistent `remove file` operation**:  
  - A previous PR accidentally removed the persistent `remove file` operation, which has now been restored.  