### PR TITLE
refactor(store): remove unused value_length from PutStart functions

### DIFF
--- a/mooncake-integration/store/store_py.h
+++ b/mooncake-integration/store/store_py.h
@@ -9,7 +9,6 @@
 
 #include "allocator.h"
 #include "client.h"
-#include "utils.h"
 
 namespace mooncake {
 
@@ -221,8 +220,7 @@ class DistributedObjectStore {
     int64_t getSize(const std::string &key);
 
    private:
-    int allocateSlices(std::vector<mooncake::Slice> &slices,
-                                           size_t length);
+    int allocateSlices(std::vector<mooncake::Slice> &slices, size_t length);
 
     int allocateSlices(std::vector<mooncake::Slice> &slices,
                        const std::string &value);

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -81,7 +80,7 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
     PutStart(const std::string& key, const std::vector<size_t>& slice_lengths,
-             size_t value_length, const ReplicateConfig& config);
+             const ReplicateConfig& config);
 
     /**
      * @brief Starts a batch of put operations for N objects
@@ -94,7 +93,6 @@ class MasterClient {
     [[nodiscard]] std::vector<
         tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
     BatchPutStart(const std::vector<std::string>& keys,
-                  const std::vector<uint64_t>& value_lengths,
                   const std::vector<std::vector<uint64_t>>& slice_lengths,
                   const ReplicateConfig& config);
 

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -465,15 +465,12 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
                                           const ReplicateConfig& config) {
     // Prepare slice lengths
     std::vector<size_t> slice_lengths;
-    size_t slice_size = 0;
     for (size_t i = 0; i < slices.size(); ++i) {
         slice_lengths.emplace_back(slices[i].size);
-        slice_size += slices[i].size;
     }
 
     // Start put operation
-    auto start_result =
-        master_client_.PutStart(key, slice_lengths, slice_size, config);
+    auto start_result = master_client_.PutStart(key, slice_lengths, config);
     if (!start_result) {
         ErrorCode err = start_result.error();
         if (err == ErrorCode::OBJECT_ALREADY_EXISTS) {
@@ -590,16 +587,13 @@ std::vector<PutOperation> Client::CreatePutOperations(
 void Client::StartBatchPut(std::vector<PutOperation>& ops,
                            const ReplicateConfig& config) {
     std::vector<std::string> keys;
-    std::vector<size_t> value_lengths;
     std::vector<std::vector<uint64_t>> slice_lengths;
 
     keys.reserve(ops.size());
-    value_lengths.reserve(ops.size());
     slice_lengths.reserve(ops.size());
 
     for (const auto& op : ops) {
         keys.emplace_back(op.key);
-        value_lengths.emplace_back(op.value_length);
 
         std::vector<uint64_t> slice_sizes;
         slice_sizes.reserve(op.slices.size());
@@ -609,8 +603,8 @@ void Client::StartBatchPut(std::vector<PutOperation>& ops,
         slice_lengths.emplace_back(std::move(slice_sizes));
     }
 
-    auto start_responses = master_client_.BatchPutStart(keys, value_lengths,
-                                                        slice_lengths, config);
+    auto start_responses =
+        master_client_.BatchPutStart(keys, slice_lengths, config);
 
     // Ensure response size matches request size
     if (start_responses.size() != ops.size()) {
@@ -887,7 +881,7 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchPut(
 
 tl::expected<void, ErrorCode> Client::Remove(const ObjectKey& key) {
     auto result = master_client_.Remove(key);
-    if(storage_backend_) {
+    if (storage_backend_) {
         storage_backend_->RemoveFile(key);
     }
     if (!result) {
@@ -897,7 +891,7 @@ tl::expected<void, ErrorCode> Client::Remove(const ObjectKey& key) {
 }
 
 tl::expected<long, ErrorCode> Client::RemoveAll() {
-    if(storage_backend_) {
+    if (storage_backend_) {
         storage_backend_->RemoveAll();
     }
     return master_client_.RemoveAll();

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -199,10 +199,9 @@ MasterClient::BatchGetReplicaList(const std::vector<std::string>& object_keys) {
 tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
 MasterClient::PutStart(const std::string& key,
                        const std::vector<size_t>& slice_lengths,
-                       size_t value_length, const ReplicateConfig& config) {
+                       const ReplicateConfig& config) {
     ScopedVLogTimer timer(1, "MasterClient::PutStart");
-    timer.LogRequest("key=", key, ", value_length=", value_length,
-                     ", slice_count=", slice_lengths.size());
+    timer.LogRequest("key=", key, ", slice_count=", slice_lengths.size());
 
     auto client = client_accessor_.GetClient();
     if (!client) {
@@ -219,7 +218,7 @@ MasterClient::PutStart(const std::string& key,
     }
 
     auto request_result = client->send_request<&WrappedMasterService::PutStart>(
-        key, value_length, rpc_slice_lengths, config);
+        key, rpc_slice_lengths, config);
     auto result = coro::syncAwait(
         [&]() -> coro::Lazy<
                   tl::expected<std::vector<Replica::Descriptor>, ErrorCode>> {
@@ -238,7 +237,6 @@ MasterClient::PutStart(const std::string& key,
 std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
 MasterClient::BatchPutStart(
     const std::vector<std::string>& keys,
-    const std::vector<uint64_t>& value_lengths,
     const std::vector<std::vector<uint64_t>>& slice_lengths,
     const ReplicateConfig& config) {
     ScopedVLogTimer timer(1, "MasterClient::BatchPutStart");
@@ -256,7 +254,7 @@ MasterClient::BatchPutStart(
 
     auto request_result =
         client->send_request<&WrappedMasterService::BatchPutStart>(
-            keys, value_lengths, slice_lengths, config);
+            keys, slice_lengths, config);
 
     auto result = coro::syncAwait(
         [&]() -> coro::Lazy<std::vector<

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -108,8 +108,7 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     ASSERT_EQ(metrics.get_mount_segment_failures(), 0);
 
     // Test PutStart and PutRevoke request
-    auto put_start_result1 =
-        service_.PutStart(key, value_length, slice_lengths, config);
+    auto put_start_result1 = service_.PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result1.has_value());
     ASSERT_EQ(metrics.get_key_count(), 1);
     ASSERT_EQ(metrics.get_allocated_size(), value_length);
@@ -123,8 +122,7 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     ASSERT_EQ(metrics.get_put_revoke_failures(), 0);
 
     // Test PutStart and PutEnd request
-    auto put_start_result2 =
-        service_.PutStart(key, value_length, slice_lengths, config);
+    auto put_start_result2 = service_.PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result2.has_value());
     ASSERT_EQ(metrics.get_key_count(), 1);
     ASSERT_EQ(metrics.get_allocated_size(), value_length);
@@ -160,8 +158,7 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     ASSERT_EQ(metrics.get_allocated_size(), 0);
 
     // Test RemoveAll request
-    auto put_start_result3 =
-        service_.PutStart(key, value_length, slice_lengths, config);
+    auto put_start_result3 = service_.PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result3.has_value());
     auto put_end_result2 = service_.PutEnd(key);
     ASSERT_TRUE(put_end_result2.has_value());
@@ -173,8 +170,7 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     ASSERT_EQ(metrics.get_allocated_size(), 0);
 
     // Test UnmountSegment request
-    auto put_start_result4 =
-        service_.PutStart(key, value_length, slice_lengths, config);
+    auto put_start_result4 = service_.PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result4.has_value());
     auto put_end_result3 = service_.PutEnd(key);
     ASSERT_TRUE(put_end_result3.has_value());
@@ -205,7 +201,6 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
     UUID client_id = generate_uuid();
 
     std::vector<std::string> keys = {"test_key1", "test_key2", "test_key3"};
-    std::vector<uint64_t> value_lengths = {1024, 2048, 512};
     std::vector<std::vector<uint64_t>> slice_lengths = {{1024}, {2048}, {512}};
     ReplicateConfig config;
     config.replica_num = 1;
@@ -222,7 +217,7 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
 
     // Test BatchPutStart request
     auto batch_put_start_result =
-        service_.BatchPutStart(keys, value_lengths, slice_lengths, config);
+        service_.BatchPutStart(keys, slice_lengths, config);
     ASSERT_EQ(batch_put_start_result.size(), 3);
     ASSERT_EQ(metrics.get_batch_put_start_requests(), 1);
     ASSERT_EQ(metrics.get_batch_put_start_failures(), 0);

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -1298,14 +1298,12 @@ TEST_F(MasterServiceTest, RemoveSoftPinObject) {
     config.with_soft_pin = true;
 
     // Verify soft pin does not block remove
-    ASSERT_TRUE(
-        service_->PutStart(key, 1024, slice_lengths, config).has_value());
+    ASSERT_TRUE(service_->PutStart(key, slice_lengths, config).has_value());
     ASSERT_TRUE(service_->PutEnd(key).has_value());
     EXPECT_TRUE(service_->Remove(key).has_value());
 
     // Verify soft pin does not block RemoveAll
-    ASSERT_TRUE(
-        service_->PutStart(key, 1024, slice_lengths, config).has_value());
+    ASSERT_TRUE(service_->PutStart(key, slice_lengths, config).has_value());
     ASSERT_TRUE(service_->PutEnd(key).has_value());
     EXPECT_EQ(1, service_->RemoveAll());
 }
@@ -1339,10 +1337,9 @@ TEST_F(MasterServiceTest, SoftPinObjectsNotEvictedBeforeOtherObjects) {
             soft_pin_config.replica_num = 1;
             soft_pin_config.with_soft_pin = true;
 
-            ASSERT_TRUE(service_
-                            ->PutStart(pin_key, value_size, slice_lengths,
-                                       soft_pin_config)
-                            .has_value());
+            ASSERT_TRUE(
+                service_->PutStart(pin_key, slice_lengths, soft_pin_config)
+                    .has_value());
             ASSERT_TRUE(service_->PutEnd(pin_key).has_value());
         }
 
@@ -1353,8 +1350,7 @@ TEST_F(MasterServiceTest, SoftPinObjectsNotEvictedBeforeOtherObjects) {
             std::vector<uint64_t> slice_lengths = {value_size};
             ReplicateConfig config;
             config.replica_num = 1;
-            if (service_->PutStart(key, value_size, slice_lengths, config)
-                    .has_value()) {
+            if (service_->PutStart(key, slice_lengths, config).has_value()) {
                 ASSERT_TRUE(service_->PutEnd(key).has_value());
             } else {
                 failed_puts++;
@@ -1402,8 +1398,7 @@ TEST_F(MasterServiceTest, SoftPinObjectsCanBeEvicted) {
         ReplicateConfig config;
         config.replica_num = 1;
         config.with_soft_pin = true;
-        if (service_->PutStart(key, value_size, slice_lengths, config)
-                .has_value()) {
+        if (service_->PutStart(key, slice_lengths, config).has_value()) {
             ASSERT_TRUE(service_->PutEnd(key).has_value());
             success_puts++;
         } else {
@@ -1449,10 +1444,8 @@ TEST_F(MasterServiceTest, SoftPinExtendedOnGet) {
             soft_pin_config.replica_num = 1;
             soft_pin_config.with_soft_pin = true;
 
-            ASSERT_TRUE(service_
-                            ->PutStart(pin_key, value_size, slice_lengths,
-                                       soft_pin_config)
-                            .has_value());
+            ASSERT_TRUE(
+                service_->PutStart(pin_key, slice_lengths, soft_pin_config));
             ASSERT_TRUE(service_->PutEnd(pin_key).has_value());
         }
 
@@ -1472,8 +1465,7 @@ TEST_F(MasterServiceTest, SoftPinExtendedOnGet) {
             std::vector<uint64_t> slice_lengths = {value_size};
             ReplicateConfig config;
             config.replica_num = 1;
-            if (service_->PutStart(key, value_size, slice_lengths, config)
-                    .has_value()) {
+            if (service_->PutStart(key, slice_lengths, config).has_value()) {
                 ASSERT_TRUE(service_->PutEnd(key).has_value());
             } else {
                 failed_puts++;
@@ -1524,8 +1516,7 @@ TEST_F(MasterServiceTest, SoftPinObjectsNotAllowEvict) {
         ReplicateConfig config;
         config.replica_num = 1;
         config.with_soft_pin = true;
-        if (service_->PutStart(key, value_size, slice_lengths, config)
-                .has_value()) {
+        if (service_->PutStart(key, slice_lengths, config).has_value()) {
             ASSERT_TRUE(service_->PutEnd(key).has_value());
             success_keys.push_back(key);
         } else {

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -40,8 +40,7 @@ std::string GenerateKeyForSegment(const std::unique_ptr<MasterService>& service,
         }
 
         // Attempt to put the key.
-        auto put_result =
-            service->PutStart(key, 1024, {1024}, {.replica_num = 1});
+        auto put_result = service->PutStart(key, {1024}, {.replica_num = 1});
         if (put_result.has_value()) {
             replica_list = std::move(put_result.value());
         }
@@ -230,21 +229,16 @@ TEST_F(MasterServiceTest, PutStartInvalidParams) {
 
     // Test invalid replica_num
     config.replica_num = 0;
-    auto put_result1 = service_->PutStart(key, 1024, {1024}, config);
+    auto put_result1 = service_->PutStart(key, {1024}, config);
     EXPECT_FALSE(put_result1.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, put_result1.error());
 
     // Test empty slice_lengths
     config.replica_num = 1;
     std::vector<uint64_t> empty_slices;
-    auto put_result2 = service_->PutStart(key, 1024, empty_slices, config);
+    auto put_result2 = service_->PutStart(key, empty_slices, config);
     EXPECT_FALSE(put_result2.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, put_result2.error());
-
-    // Test slice_lengths sum mismatch
-    auto put_result3 = service_->PutStart(key, 1024, {512}, config);
-    EXPECT_FALSE(put_result3.has_value());
-    EXPECT_EQ(ErrorCode::INVALID_PARAMS, put_result3.error());
 }
 
 TEST_F(MasterServiceTest, PutStartEndFlow) {
@@ -266,8 +260,7 @@ TEST_F(MasterServiceTest, PutStartEndFlow) {
     ReplicateConfig config;
     config.replica_num = 1;
 
-    auto put_start_result =
-        service_->PutStart(key, value_length, slice_lengths, config);
+    auto put_start_result = service_->PutStart(key, slice_lengths, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_FALSE(replica_list.empty());
@@ -315,8 +308,7 @@ TEST_F(MasterServiceTest, RandomPutStartEndFlow) {
     std::uniform_int_distribution<> dis(1, 5);
     int random_number = dis(gen);
     config.replica_num = random_number;
-    auto put_start_result =
-        service_->PutStart(key, value_length, slice_lengths, config);
+    auto put_start_result = service_->PutStart(key, slice_lengths, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_FALSE(replica_list.empty());
@@ -363,8 +355,7 @@ TEST_F(MasterServiceTest, GetReplicaList) {
     std::vector<uint64_t> slice_lengths = {1024};
     ReplicateConfig config;
     config.replica_num = 1;
-    auto put_start_result =
-        service_->PutStart(key, 1024, slice_lengths, config);
+    auto put_start_result = service_->PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto put_end_result = service_->PutEnd(key);
     ASSERT_TRUE(put_end_result.has_value());
@@ -393,8 +384,7 @@ TEST_F(MasterServiceTest, RemoveObject) {
     std::vector<uint64_t> slice_lengths = {1024};
     ReplicateConfig config;
     config.replica_num = 1;
-    auto put_start_result =
-        service_->PutStart(key, 1024, slice_lengths, config);
+    auto put_start_result = service_->PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto put_end_result = service_->PutEnd(key);
     ASSERT_TRUE(put_end_result.has_value());
@@ -435,8 +425,7 @@ TEST_F(MasterServiceTest, RandomRemoveObject) {
         std::vector<uint64_t> slice_lengths = {1024};
         ReplicateConfig config;
         config.replica_num = 1;
-        auto put_start_result =
-            service_->PutStart(key, 1024, slice_lengths, config);
+        auto put_start_result = service_->PutStart(key, slice_lengths, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result = service_->PutEnd(key);
         ASSERT_TRUE(put_end_result.has_value());
@@ -472,8 +461,7 @@ TEST_F(MasterServiceTest, RemoveAll) {
         std::vector<uint64_t> slice_lengths = {1024};
         ReplicateConfig config;
         config.replica_num = 1;
-        auto put_start_result =
-            service_->PutStart(key, 1024, slice_lengths, config);
+        auto put_start_result = service_->PutStart(key, slice_lengths, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result = service_->PutEnd(key);
         ASSERT_TRUE(put_end_result.has_value());
@@ -533,8 +521,7 @@ TEST_F(MasterServiceTest, MultiSliceMultiReplicaFlow) {
     std::vector<Replica::Descriptor> replica_list;
 
     // Test PutStart with multiple slices and replicas
-    auto put_start_result =
-        service_->PutStart(key, total_size, slice_lengths, config);
+    auto put_start_result = service_->PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
 
@@ -636,7 +623,7 @@ TEST_F(MasterServiceTest, ConcurrentGarbageCollectionTest) {
 
                     // Create the object
                     auto put_start_result =
-                        service_->PutStart(key, 1024, slice_lengths, config);
+                        service_->PutStart(key, slice_lengths, config);
                     ASSERT_TRUE(put_start_result.has_value());
                     auto put_end_result = service_->PutEnd(key);
                     ASSERT_TRUE(put_end_result.has_value());
@@ -702,8 +689,7 @@ TEST_F(MasterServiceTest, CleanupStaleHandlesTest) {
     config.replica_num = 1;  // One replica
 
     // Create the object
-    auto put_start_result =
-        service_->PutStart(key, 1024 * 1024, slice_lengths, config);
+    auto put_start_result = service_->PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto put_end_result = service_->PutEnd(key);
     ASSERT_TRUE(put_end_result.has_value());
@@ -730,8 +716,7 @@ TEST_F(MasterServiceTest, CleanupStaleHandlesTest) {
 
     // Create another object
     std::string key2 = "another_segment_object";
-    auto put_start_result2 =
-        service_->PutStart(key2, 1024 * 1024, slice_lengths, config);
+    auto put_start_result2 = service_->PutStart(key2, slice_lengths, config);
     ASSERT_TRUE(put_start_result2.has_value());
     auto put_end_result2 = service_->PutEnd(key2);
     ASSERT_TRUE(put_end_result2.has_value());
@@ -779,7 +764,7 @@ TEST_F(MasterServiceTest, ConcurrentWriteAndRemoveAll) {
                 std::vector<Replica::Descriptor> replica_list;
 
                 auto put_start_result =
-                    service_->PutStart(key, 1024, slice_lengths, config);
+                    service_->PutStart(key, slice_lengths, config);
                 if (put_start_result.has_value()) {
                     auto put_end_result = service_->PutEnd(key);
                     if (put_end_result.has_value()) {
@@ -845,8 +830,7 @@ TEST_F(MasterServiceTest, ConcurrentReadAndRemoveAll) {
         ReplicateConfig config;
         config.replica_num = 1;
 
-        auto put_start_result =
-            service_->PutStart(key, 1024, slice_lengths, config);
+        auto put_start_result = service_->PutStart(key, slice_lengths, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result = service_->PutEnd(key);
         ASSERT_TRUE(put_end_result.has_value());
@@ -927,8 +911,7 @@ TEST_F(MasterServiceTest, ConcurrentRemoveAllOperations) {
         ReplicateConfig config;
         config.replica_num = 1;
 
-        auto put_start_result =
-            service_->PutStart(key, 1024, slice_lengths, config);
+        auto put_start_result = service_->PutStart(key, slice_lengths, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result = service_->PutEnd(key);
         ASSERT_TRUE(put_end_result.has_value());
@@ -1001,8 +984,7 @@ TEST_F(MasterServiceTest, UnmountSegmentImmediateCleanup) {
     ASSERT_TRUE(get_result2.has_value());
 
     // Verify put key1 will put into segment2 rather than segment1
-    auto put_start_result =
-        service_->PutStart(key1, 1024, slice_lengths, config);
+    auto put_start_result = service_->PutStart(key1, slice_lengths, config);
     ASSERT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     auto put_end_result = service_->PutEnd(key1);
@@ -1096,8 +1078,7 @@ TEST_F(MasterServiceTest, RemoveLeasedObject) {
     config.replica_num = 1;
 
     // Verify lease is granted on ExistsKey
-    auto put_start_result =
-        service_->PutStart(key, 1024, slice_lengths, config);
+    auto put_start_result = service_->PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto put_end_result = service_->PutEnd(key);
     ASSERT_TRUE(put_end_result.has_value());
@@ -1111,8 +1092,7 @@ TEST_F(MasterServiceTest, RemoveLeasedObject) {
     EXPECT_TRUE(remove_result2.has_value());
 
     // Verify lease is extended on successive ExistsKey
-    auto put_start_result2 =
-        service_->PutStart(key, 1024, slice_lengths, config);
+    auto put_start_result2 = service_->PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result2.has_value());
     auto put_end_result2 = service_->PutEnd(key);
     ASSERT_TRUE(put_end_result2.has_value());
@@ -1129,8 +1109,7 @@ TEST_F(MasterServiceTest, RemoveLeasedObject) {
     EXPECT_TRUE(remove_result4.has_value());
 
     // Verify lease is granted on GetReplicaList
-    auto put_start_result3 =
-        service_->PutStart(key, 1024, slice_lengths, config);
+    auto put_start_result3 = service_->PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result3.has_value());
     auto put_end_result3 = service_->PutEnd(key);
     ASSERT_TRUE(put_end_result3.has_value());
@@ -1144,8 +1123,7 @@ TEST_F(MasterServiceTest, RemoveLeasedObject) {
     EXPECT_TRUE(remove_result6.has_value());
 
     // Verify lease is extended on successive GetReplicaList
-    auto put_start_result4 =
-        service_->PutStart(key, 1024, slice_lengths, config);
+    auto put_start_result4 = service_->PutStart(key, slice_lengths, config);
     ASSERT_TRUE(put_start_result4.has_value());
     auto put_end_result4 = service_->PutEnd(key);
     ASSERT_TRUE(put_end_result4.has_value());
@@ -1184,8 +1162,7 @@ TEST_F(MasterServiceTest, RemoveAllLeasedObject) {
         std::vector<uint64_t> slice_lengths = {1024};
         ReplicateConfig config;
         config.replica_num = 1;
-        auto put_start_result =
-            service_->PutStart(key, 1024, slice_lengths, config);
+        auto put_start_result = service_->PutStart(key, slice_lengths, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result = service_->PutEnd(key);
         ASSERT_TRUE(put_end_result.has_value());
@@ -1235,8 +1212,7 @@ TEST_F(MasterServiceTest, EvictObject) {
         std::vector<uint64_t> slice_lengths = {object_size};
         ReplicateConfig config;
         config.replica_num = 1;
-        auto put_start_result =
-            service_->PutStart(key, object_size, slice_lengths, config);
+        auto put_start_result = service_->PutStart(key, slice_lengths, config);
         if (put_start_result.has_value()) {
             auto put_end_result = service_->PutEnd(key);
             ASSERT_TRUE(put_end_result.has_value());
@@ -1274,8 +1250,7 @@ TEST_F(MasterServiceTest, TryEvictLeasedObject) {
         std::vector<uint64_t> slice_lengths = {object_size};
         ReplicateConfig config;
         config.replica_num = 1;
-        auto put_start_result =
-            service_->PutStart(key, object_size, slice_lengths, config);
+        auto put_start_result = service_->PutStart(key, slice_lengths, config);
         if (put_start_result.has_value()) {
             auto put_end_result = service_->PutEnd(key);
             ASSERT_TRUE(put_end_result.has_value());
@@ -1323,12 +1298,14 @@ TEST_F(MasterServiceTest, RemoveSoftPinObject) {
     config.with_soft_pin = true;
 
     // Verify soft pin does not block remove
-    ASSERT_TRUE(service_->PutStart(key, 1024, slice_lengths, config).has_value());
+    ASSERT_TRUE(
+        service_->PutStart(key, 1024, slice_lengths, config).has_value());
     ASSERT_TRUE(service_->PutEnd(key).has_value());
     EXPECT_TRUE(service_->Remove(key).has_value());
 
     // Verify soft pin does not block RemoveAll
-    ASSERT_TRUE(service_->PutStart(key, 1024, slice_lengths, config).has_value());
+    ASSERT_TRUE(
+        service_->PutStart(key, 1024, slice_lengths, config).has_value());
     ASSERT_TRUE(service_->PutEnd(key).has_value());
     EXPECT_EQ(1, service_->RemoveAll());
 }
@@ -1362,8 +1339,10 @@ TEST_F(MasterServiceTest, SoftPinObjectsNotEvictedBeforeOtherObjects) {
             soft_pin_config.replica_num = 1;
             soft_pin_config.with_soft_pin = true;
 
-            ASSERT_TRUE(service_->PutStart(pin_key, value_size, slice_lengths,
-                                           soft_pin_config).has_value());
+            ASSERT_TRUE(service_
+                            ->PutStart(pin_key, value_size, slice_lengths,
+                                       soft_pin_config)
+                            .has_value());
             ASSERT_TRUE(service_->PutEnd(pin_key).has_value());
         }
 
@@ -1470,8 +1449,10 @@ TEST_F(MasterServiceTest, SoftPinExtendedOnGet) {
             soft_pin_config.replica_num = 1;
             soft_pin_config.with_soft_pin = true;
 
-            ASSERT_TRUE(service_->PutStart(pin_key, value_size, slice_lengths,
-                                           soft_pin_config).has_value());
+            ASSERT_TRUE(service_
+                            ->PutStart(pin_key, value_size, slice_lengths,
+                                       soft_pin_config)
+                            .has_value());
             ASSERT_TRUE(service_->PutEnd(pin_key).has_value());
         }
 
@@ -1582,7 +1563,7 @@ TEST_F(MasterServiceTest, BatchExistKeyTest) {
         config.replica_num = 1;
         std::vector<uint64_t> slice_lengths = {value_size};
         auto put_start_result =
-            service_->PutStart(test_keys[i], value_size, slice_lengths, config);
+            service_->PutStart(test_keys[i], slice_lengths, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result = service_->PutEnd(test_keys[i]);
         ASSERT_TRUE(put_end_result.has_value());


### PR DESCRIPTION
Since the length of the object's value can be determined from its slices, we can probably remove it.