### PR TITLE
refine build with ascend

### DIFF
--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -105,6 +105,10 @@ if (USE_TCP)
 endif()
 
 if (USE_ASCEND)
+  find_package(MPI REQUIRED)
+  if (NOT MPI_FOUND)
+    message(FATAL "MPI package is not found")
+  endif()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOPEN_BUILD_PROJECT ")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DOPEN_BUILD_PROJECT ")
 
@@ -116,7 +120,7 @@ if (USE_ASCEND)
   message(STATUS "Found include directories: ${ASCEND_INCLUDE_DIR}")
 
   add_compile_definitions(USE_ASCEND)
-  include_directories(/usr/local/include /usr/include ${ASCEND_INCLUDE_DIR} /usr/include/jsoncpp)
+  include_directories(/usr/local/include /usr/include ${ASCEND_INCLUDE_DIR} /usr/include/jsoncpp ${MPI_CXX_INCLUDE_DIRS})
   link_directories(${ASCEND_LIB_DIR})
 endif()
 

--- a/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/ascend_transport_c/hccl_transport_mem_c.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/ascend_transport_c/hccl_transport_mem_c.cpp
@@ -512,9 +512,9 @@ int createTransportMem(RankInfo *local_rank_info, RankInfo *remote_rank_info, st
         }
         char *desc = nullptr;
         uint64_t desc_len = 0;
-        ret = HcclMemExport(&buf, &desc, &desc_len);
+        ret = HcclMemGetDesc(&buf, &desc, &desc_len);
         if (ret) {
-            LOG(ERROR) << "HcclMemExport failed, ret:" << ret << " addr: " << g_localMemAddr[i] << " len: " << g_localMemLen[i];
+            LOG(ERROR) << "HcclMemGetDesc failed, ret:" << ret << " addr: " << g_localMemAddr[i] << " len: " << g_localMemLen[i];
             return ret;
         }
         
@@ -870,9 +870,9 @@ int transportMemAccept(RankInfo *local_rank_info) {
         }
         char *desc = nullptr;
         uint64_t desc_len = 0;
-        ret = HcclMemExport(&buf, &desc, &desc_len);
+        ret = HcclMemGetDesc(&buf, &desc, &desc_len);
         if (ret) {
-            LOG(ERROR) << "HcclMemExport failed, ret:" << ret << " addr: " << g_localMemAddr[i] << " len: " << g_localMemLen[i];
+            LOG(ERROR) << "HcclMemGetDesc failed, ret:" << ret << " addr: " << g_localMemAddr[i] << " len: " << g_localMemLen[i];
             return ret;
         }
         


### PR DESCRIPTION
Thanks to PR https://github.com/kvcache-ai/Mooncake/pull/502 for providing support for ascend npu. 
This PR fixes several compile issues and provides an end-to-end compilation commands.

1. `apt purge openmpi-bin libopenmpi-dev` (or `yum remove openmpi opemmpi-dev` for centos)
2. `apt install mpich libmpich-dev` (or `yum install -y mpich mpich-devel` for centos)
3. install the latest **cann 8.2.rc1.alpha003** toolkit and kernels from site https://www.hiascend.com/developer/download/community/result?module=cann
4. `mkdir build && cmake .. -DUSE_ASCEND=ON && make -j`