### PR TITLE
feat(store): add `get_hostname` method for py bindings

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -997,6 +997,10 @@ int DistributedObjectStore::get_into(const std::string &key, void *buffer,
     return static_cast<int>(total_size);
 }
 
+std::string DistributedObjectStore::get_hostname() const {
+    return local_hostname;
+}
+
 std::vector<int> DistributedObjectStore::batch_put_from(
     const std::vector<std::string> &keys, const std::vector<void *> &buffers,
     const std::vector<size_t> &sizes, const ReplicateConfig &config) {
@@ -1473,7 +1477,8 @@ PYBIND11_MODULE(store, m) {
                 return self.put_batch(keys, spans, config);
             },
             py::arg("keys"), py::arg("values"),
-            py::arg("config") = ReplicateConfig{});
+            py::arg("config") = ReplicateConfig{})
+        .def("get_hostname", &DistributedObjectStore::get_hostname);
 }
 
 }  // namespace mooncake

--- a/mooncake-integration/store/store_py.h
+++ b/mooncake-integration/store/store_py.h
@@ -183,6 +183,8 @@ class DistributedObjectStore {
                   const std::vector<std::span<const char>> &values,
                   const ReplicateConfig &config = ReplicateConfig{});
 
+    [[nodiscard]] std::string get_hostname() const;
+
     pybind11::bytes get(const std::string &key);
 
     std::vector<pybind11::bytes> get_batch(

--- a/mooncake-wheel/tests/test_distributed_object_store.py
+++ b/mooncake-wheel/tests/test_distributed_object_store.py
@@ -63,6 +63,14 @@ class TestDistributedObjectStore(unittest.TestCase):
         self.assertEqual(self.store.put(key, test_data), 0)
         retrieved_data = self.store.get(key)
         self.assertEqual(retrieved_data, test_data)
+            
+    def test_basic_get_hostname(self):
+        # No port is set in the config, so it should pick a random one between 12300 and 14300
+        hostname = self.store.get_hostname()
+        self.assertTrue(hostname.startswith("localhost:"))
+        port = int(hostname.split(":")[1])
+        self.assertTrue(12300 <= port <= 14300)
+
 
     def test_basic_put_get_exist_operations(self):
         """Test basic Put/Get/Exist operations through the Python interface."""


### PR DESCRIPTION
Right now, our Python binding only takes an IP address and randomly selects a port to generate the hostname.

We should expose an interface to allow Python users to retrieve the generated client hostname after it's created.

The main use case for this is to better support `preferred_segment` usage, especially since the `ReplicateConfig` is now user-defined and we don't provide a default value for `preferred_segment` anymore.