### PR TITLE
refactor(rpc_service): separate implementation into cpp file

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -10,6 +10,7 @@
 #include <random>
 
 #include "types.h"
+#include "utils.h"
 
 namespace py = pybind11;
 
@@ -1260,17 +1261,16 @@ int DistributedObjectStore::put_from(const std::string &key, void *buffer,
 }
 
 template <typename T>
-py::array create_typed_array(char* exported_data, size_t total_length) {
-    py::capsule free_when_done(exported_data, [](void* p) { delete[] static_cast<T*>(p); });
-    
-    return py::array_t<T>(
-                {static_cast<ssize_t>(total_length/sizeof(T))},
-                (T*)exported_data,
-                free_when_done
-            );
+py::array create_typed_array(char *exported_data, size_t total_length) {
+    py::capsule free_when_done(exported_data,
+                               [](void *p) { delete[] static_cast<T *>(p); });
+
+    return py::array_t<T>({static_cast<ssize_t>(total_length / sizeof(T))},
+                          (T *)exported_data, free_when_done);
 }
 
-pybind11::object DistributedObjectStore::get_tensor(const std::string &key, const std::string dtype) {
+pybind11::object DistributedObjectStore::get_tensor(const std::string &key,
+                                                    const std::string dtype) {
     if (!client_) {
         LOG(ERROR) << "Client is not initialized";
         return pybind11::none();
@@ -1278,7 +1278,7 @@ pybind11::object DistributedObjectStore::get_tensor(const std::string &key, cons
 
     try {
         // Import torch module
-        
+
         // Query object info first
         // Step 1: Get object info
         auto query_result = client_->Query(key);
@@ -1303,11 +1303,11 @@ pybind11::object DistributedObjectStore::get_tensor(const std::string &key, cons
         }
 
         // Get the object data
-        auto get_result  = client_->Get(key, guard.slices());
+        auto get_result = client_->Get(key, guard.slices());
         if (!get_result) {
             py::gil_scoped_acquire acquire_gil;
             LOG(ERROR) << "Get failed for key: " << key
-                    << " with error: " << toString(get_result.error());
+                       << " with error: " << toString(get_result.error());
             return pybind11::none();
         }
 
@@ -1320,29 +1320,33 @@ pybind11::object DistributedObjectStore::get_tensor(const std::string &key, cons
 
         // Convert bytes to tensor using torch.from_numpy
 
-        py::object py_buffer = py::memoryview::from_memory(exported_data, total_length);
+        py::object py_buffer =
+            py::memoryview::from_memory(exported_data, total_length);
         pybind11::object np_array;
-        if(dtype=="float32") {
+        if (dtype == "float32") {
             np_array = create_typed_array<float>(exported_data, total_length);
-        }else if(dtype=="float64") {
+        } else if (dtype == "float64") {
             np_array = create_typed_array<double>(exported_data, total_length);
-        }else if(dtype=="int8") {
+        } else if (dtype == "int8") {
             np_array = create_typed_array<int8_t>(exported_data, total_length);
-        }else if(dtype=="uint8") {
+        } else if (dtype == "uint8") {
             np_array = create_typed_array<uint8_t>(exported_data, total_length);
-        }else if(dtype=="int16") {
+        } else if (dtype == "int16") {
             np_array = create_typed_array<int16_t>(exported_data, total_length);
-        }else if(dtype=="uint16") {
-            np_array = create_typed_array<uint16_t>(exported_data, total_length);
-        }else if(dtype=="int32") {
+        } else if (dtype == "uint16") {
+            np_array =
+                create_typed_array<uint16_t>(exported_data, total_length);
+        } else if (dtype == "int32") {
             np_array = create_typed_array<int32_t>(exported_data, total_length);
-        }else if(dtype=="uint32") {
-            np_array = create_typed_array<uint32_t>(exported_data, total_length);
-        }else if(dtype=="int64") {
+        } else if (dtype == "uint32") {
+            np_array =
+                create_typed_array<uint32_t>(exported_data, total_length);
+        } else if (dtype == "int64") {
             np_array = create_typed_array<int64_t>(exported_data, total_length);
-        }else if(dtype=="uint64") {
-            np_array = create_typed_array<uint64_t>(exported_data, total_length);
-        }else if(dtype=="bool") {
+        } else if (dtype == "uint64") {
+            np_array =
+                create_typed_array<uint64_t>(exported_data, total_length);
+        } else if (dtype == "bool") {
             np_array = create_typed_array<bool>(exported_data, total_length);
         }
 
@@ -1355,7 +1359,8 @@ pybind11::object DistributedObjectStore::get_tensor(const std::string &key, cons
     }
 }
 
-int DistributedObjectStore::put_tensor(const std::string &key, pybind11::object tensor) {
+int DistributedObjectStore::put_tensor(const std::string &key,
+                                       pybind11::object tensor) {
     if (!client_) {
         LOG(ERROR) << "Client is not initialized";
         return -1;
@@ -1364,7 +1369,10 @@ int DistributedObjectStore::put_tensor(const std::string &key, pybind11::object 
     try {
         // Import torch module
         // Check if the object is a tensor
-        if (!(tensor.attr("__class__").attr("__name__").cast<std::string>().find("Tensor") != std::string::npos)) {
+        if (!(tensor.attr("__class__")
+                  .attr("__name__")
+                  .cast<std::string>()
+                  .find("Tensor") != std::string::npos)) {
             LOG(ERROR) << "Input is not a PyTorch tensor";
             return -1;
         }
@@ -1374,10 +1382,11 @@ int DistributedObjectStore::put_tensor(const std::string &key, pybind11::object 
         size_t element_size = tensor.attr("element_size")().cast<size_t>();
         size_t buffer_size = numel * element_size;
 
-        this->register_buffer(reinterpret_cast<void*>(data_ptr), buffer_size);
+        this->register_buffer(reinterpret_cast<void *>(data_ptr), buffer_size);
         // Use put_from for direct memory access (zero-copy)
-        int result = this->put_from(key, reinterpret_cast<void*>(data_ptr), buffer_size);
-        this->unregister_buffer(reinterpret_cast<void*>(data_ptr));
+        int result = this->put_from(key, reinterpret_cast<void *>(data_ptr),
+                                    buffer_size);
+        this->unregister_buffer(reinterpret_cast<void *>(data_ptr));
         return result;
     } catch (const pybind11::error_already_set &e) {
         LOG(ERROR) << "Failed to access tensor data: " << e.what();
@@ -1459,10 +1468,10 @@ PYBIND11_MODULE(store, m) {
         .def("close", &DistributedObjectStore::tearDownAll)
         .def("get_size", &DistributedObjectStore::getSize,
              py::call_guard<py::gil_scoped_release>())
-        .def("get_tensor", &DistributedObjectStore::get_tensor,
-             py::arg("key"), py::arg("dtype"), "Get a PyTorch tensor from the store")
-        .def("put_tensor", &DistributedObjectStore::put_tensor,
-             py::arg("key"), py::arg("tensor"), "Put a PyTorch tensor into the store")
+        .def("get_tensor", &DistributedObjectStore::get_tensor, py::arg("key"),
+             py::arg("dtype"), "Get a PyTorch tensor from the store")
+        .def("put_tensor", &DistributedObjectStore::put_tensor, py::arg("key"),
+             py::arg("tensor"), "Put a PyTorch tensor into the store")
         .def(
             "register_buffer",
             [](DistributedObjectStore &self, uintptr_t buffer_ptr,

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -1,26 +1,19 @@
 #pragma once
-#include <ylt/struct_json/json_reader.h>
-#include <ylt/struct_json/json_writer.h>
 
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <thread>
-#include <ylt/coro_http/coro_http_client.hpp>
 #include <ylt/coro_http/coro_http_server.hpp>
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
-#include <ylt/reflection/user_reflect_macro.hpp>
 #include <ylt/util/tl/expected.hpp>
 
-#include "master_metric_manager.h"
 #include "master_service.h"
-#include "rpc_helper.h"
 #include "types.h"
-#include "utils/scoped_vlog_timer.h"
 
 namespace mooncake {
 
-constexpr uint64_t kMetricReportIntervalSeconds = 10;
+extern const uint64_t kMetricReportIntervalSeconds;
 
 class WrappedMasterService {
    public:
@@ -36,481 +29,59 @@ class WrappedMasterService {
         ViewVersionId view_version = 0,
         int64_t client_live_ttl_sec = DEFAULT_CLIENT_LIVE_TTL_SEC,
         bool enable_ha = false,
-        const std::string& cluster_id = DEFAULT_CLUSTER_ID)
-        : master_service_(enable_gc, default_kv_lease_ttl,
-                          default_kv_soft_pin_ttl,
-                          allow_evict_soft_pinned_objects, eviction_ratio,
-                          eviction_high_watermark_ratio, view_version,
-                          client_live_ttl_sec, enable_ha, cluster_id),
-          http_server_(4, http_port),
-          metric_report_running_(enable_metric_reporting) {
-        // Initialize HTTP server for metrics
-        init_http_server();
+        const std::string& cluster_id = DEFAULT_CLUSTER_ID);
 
-        // Set the config for metric reporting
-        MasterMetricManager::instance().set_enable_ha(enable_ha);
+    ~WrappedMasterService();
 
-        // Start metric reporting thread if enabled
-        if (enable_metric_reporting) {
-            metric_report_thread_ = std::thread([this]() {
-                while (metric_report_running_) {
-                    std::string metrics_summary =
-                        MasterMetricManager::instance().get_summary_string();
-                    LOG(INFO) << "Master Metrics: " << metrics_summary;
-                    std::this_thread::sleep_for(
-                        std::chrono::seconds(kMetricReportIntervalSeconds));
-                }
-            });
-        }
-    }
+    void init_http_server();
 
-    ~WrappedMasterService() {
-        metric_report_running_ = false;
-        if (metric_report_thread_.joinable()) {
-            metric_report_thread_.join();
-        }
-        // Stop HTTP server
-        http_server_.stop();
-    }
-
-    // Initialize and start the HTTP server
-    void init_http_server() {
-        using namespace coro_http;
-
-        // Endpoint for Prometheus metrics
-        http_server_.set_http_handler<GET>(
-            "/metrics", [](coro_http_request& req, coro_http_response& resp) {
-                std::string metrics =
-                    MasterMetricManager::instance().serialize_metrics();
-                resp.add_header("Content-Type", "text/plain; version=0.0.4");
-                resp.set_status_and_content(status_type::ok, std::move(metrics));
-            });
-
-        // Endpoint for human-readable metrics summary
-        http_server_.set_http_handler<GET>(
-            "/metrics/summary",
-            [](coro_http_request& req, coro_http_response& resp) {
-                std::string summary =
-                    MasterMetricManager::instance().get_summary_string();
-                resp.add_header("Content-Type", "text/plain; version=0.0.4");
-                resp.set_status_and_content(status_type::ok, std::move(summary));
-            });
-
-        // Endpoint for query a key's location
-        http_server_.set_http_handler<GET>(
-            "/query_key",
-            [&](coro_http_request& req, coro_http_response& resp) {
-                auto key = req.get_query_value("key");
-                auto get_result = GetReplicaList(std::string(key));
-                resp.add_header("Content-Type", "text/plain; version=0.0.4");
-                if (get_result) {
-                    std::string ss = "";
-                    for (size_t i = 0; i < get_result.value().size(); i++) {
-                        if (get_result.value()[i].is_memory_replica()) {
-                            auto& memory_descriptors =
-                                get_result.value()[i].get_memory_descriptor();
-                            for (const auto& handle :
-                                 memory_descriptors.buffer_descriptors) {
-                                std::string tmp = "";
-                                struct_json::to_json(handle, tmp);
-                                ss += tmp;
-                                ss += "\n";
-                            }
-                        }
-                    }
-                    resp.set_status_and_content(status_type::ok, std::move(ss));
-                } else {
-                    resp.set_status_and_content(status_type::not_found,
-                                                toString(get_result.error()));
-                }
-            });
-
-        // Endpoint for query all keys
-        http_server_.set_http_handler<GET>(
-            "/get_all_keys",
-            [&](coro_http_request& req, coro_http_response& resp) {
-                resp.add_header("Content-Type", "text/plain; version=0.0.4");
-
-                auto result = master_service_.GetAllKeys();
-                if (result) {
-                    std::string ss = "";
-                    auto keys = result.value();
-                    for (const auto& key : keys) {
-                        ss += key;
-                        ss += "\n";
-                    }
-                    resp.set_status_and_content(status_type::ok, std::move(ss));
-                } else {
-                    resp.set_status_and_content(
-                        status_type::internal_server_error,
-                        "Failed to get all keys");
-                }
-            });
-
-        // Endpoint for query all segments
-        http_server_.set_http_handler<GET>(
-            "/get_all_segments",
-            [&](coro_http_request& req, coro_http_response& resp) {
-                resp.add_header("Content-Type", "text/plain; version=0.0.4");
-                auto result = master_service_.GetAllSegments();
-                if (result) {
-                    std::string ss = "";
-                    auto segments = result.value();
-                    for (const auto& segment_name : segments) {
-                        ss += segment_name;
-                        ss += "\n";
-                    }
-                    resp.set_status_and_content(status_type::ok, std::move(ss));
-                } else {
-                    resp.set_status_and_content(
-                        status_type::internal_server_error,
-                        "Failed to get all segments");
-                }
-            });
-
-        // Endpoint for query segment details
-        http_server_.set_http_handler<GET>(
-            "/query_segment",
-            [&](coro_http_request& req, coro_http_response& resp) {
-                auto segment = req.get_query_value("segment");
-                resp.add_header("Content-Type", "text/plain; version=0.0.4");
-                auto result =
-                    master_service_.QuerySegments(std::string(segment));
-
-                if (result) {
-                    std::string ss = "";
-                    auto [used, capacity] = result.value();
-                    ss += segment;
-                    ss += "\n";
-                    ss += "Used(bytes): ";
-                    ss += std::to_string(used);
-                    ss += "\nCapacity(bytes) : ";
-                    ss += std::to_string(capacity);
-                    ss += "\n";
-                    resp.set_status_and_content(status_type::ok, std::move(ss));
-                } else {
-                    resp.set_status_and_content(
-                        status_type::internal_server_error,
-                        "Failed to query segment");
-                }
-            });
-
-        // Health check endpoint
-        http_server_.set_http_handler<GET>(
-            "/health", [](coro_http_request& req, coro_http_response& resp) {
-                resp.add_header("Content-Type", "text/plain; version=0.0.4");
-                resp.set_status_and_content(status_type::ok, "OK");
-            });
-
-        // Start the HTTP server asynchronously
-        http_server_.async_start();
-        LOG(INFO) << "HTTP metrics server started on port "
-                  << http_server_.port();
-    }
-
-    tl::expected<bool, ErrorCode> ExistKey(const std::string& key) {
-        return execute_rpc(
-            "ExistKey", [&] { return master_service_.ExistKey(key); },
-            [&](auto& timer) { timer.LogRequest("key=", key); },
-            [] { MasterMetricManager::instance().inc_exist_key_requests(); },
-            [] { MasterMetricManager::instance().inc_exist_key_failures(); });
-    }
+    tl::expected<bool, ErrorCode> ExistKey(const std::string& key);
 
     std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
-        const std::vector<std::string>& keys) {
-        ScopedVLogTimer timer(1, "BatchExistKey");
-        timer.LogRequest("keys_count=", keys.size());
-        MasterMetricManager::instance().inc_batch_exist_key_requests();
-
-        auto result = master_service_.BatchExistKey(keys);
-
-        // Count failures and log errors
-        size_t failure_count = 0;
-        for (size_t i = 0; i < result.size(); ++i) {
-            if (!result[i].has_value()) {
-                failure_count++;
-                LOG(ERROR) << "BatchExistKey failed for key[" << i << "] '"
-                           << keys[i] << "': " << toString(result[i].error());
-            }
-        }
-        MasterMetricManager::instance().inc_batch_exist_key_failures(
-            failure_count);
-
-        timer.LogResponse("total=", result.size(),
-                          ", success=", result.size() - failure_count,
-                          ", failures=", failure_count);
-        return result;
-    }
+        const std::vector<std::string>& keys);
 
     tl::expected<std::vector<Replica::Descriptor>, ErrorCode> GetReplicaList(
-        const std::string& key) {
-        return execute_rpc(
-            "GetReplicaList",
-            [&] { return master_service_.GetReplicaList(key); },
-            [&](auto& timer) { timer.LogRequest("key=", key); },
-            [] {
-                MasterMetricManager::instance().inc_get_replica_list_requests();
-            },
-            [] {
-                MasterMetricManager::instance().inc_get_replica_list_failures();
-            });
-    }
+        const std::string& key);
 
     std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-    BatchGetReplicaList(const std::vector<std::string>& keys) {
-        ScopedVLogTimer timer(1, "BatchGetReplicaList");
-        timer.LogRequest("keys_count=", keys.size());
-        MasterMetricManager::instance().inc_batch_get_replica_list_requests();
-
-        std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-            results;
-        results.reserve(keys.size());
-
-        for (const auto& key : keys) {
-            results.emplace_back(master_service_.GetReplicaList(key));
-        }
-
-        // Count failures and log errors
-        size_t failure_count = 0;
-        for (size_t i = 0; i < results.size(); ++i) {
-            if (!results[i].has_value()) {
-                failure_count++;
-                LOG(ERROR) << "BatchGetReplicaList failed for key[" << i
-                           << "] '" << keys[i]
-                           << "': " << toString(results[i].error());
-            }
-        }
-        MasterMetricManager::instance().inc_batch_get_replica_list_failures(
-            failure_count);
-
-        timer.LogResponse("total=", results.size(),
-                          ", success=", results.size() - failure_count,
-                          ", failures=", failure_count);
-        return results;
-    }
+    BatchGetReplicaList(const std::vector<std::string>& keys);
 
     tl::expected<std::vector<Replica::Descriptor>, ErrorCode> PutStart(
         const std::string& key, const std::vector<uint64_t>& slice_lengths,
-        const ReplicateConfig& config) {
-        return execute_rpc(
-            "PutStart",
-            [&] {
-                return master_service_.PutStart(key, slice_lengths, config);
-            },
-            [&](auto& timer) {
-                timer.LogRequest("key=", key,
-                                 ", slice_lengths=", slice_lengths.size());
-            },
-            [&] { MasterMetricManager::instance().inc_put_start_requests(); },
-            [] { MasterMetricManager::instance().inc_put_start_failures(); });
-    }
+        const ReplicateConfig& config);
 
-    tl::expected<void, ErrorCode> PutEnd(const std::string& key) {
-        return execute_rpc(
-            "PutEnd", [&] { return master_service_.PutEnd(key); },
-            [&](auto& timer) { timer.LogRequest("key=", key); },
-            [] { MasterMetricManager::instance().inc_put_end_requests(); },
-            [] { MasterMetricManager::instance().inc_put_end_failures(); });
-    }
+    tl::expected<void, ErrorCode> PutEnd(const std::string& key);
 
-    tl::expected<void, ErrorCode> PutRevoke(const std::string& key) {
-        return execute_rpc(
-            "PutRevoke", [&] { return master_service_.PutRevoke(key); },
-            [&](auto& timer) { timer.LogRequest("key=", key); },
-            [] { MasterMetricManager::instance().inc_put_revoke_requests(); },
-            [] { MasterMetricManager::instance().inc_put_revoke_failures(); });
-    }
+    tl::expected<void, ErrorCode> PutRevoke(const std::string& key);
 
     std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
     BatchPutStart(const std::vector<std::string>& keys,
                   const std::vector<std::vector<uint64_t>>& slice_lengths,
-                  const ReplicateConfig& config) {
-        ScopedVLogTimer timer(1, "BatchPutStart");
-        timer.LogRequest("keys_count=", keys.size());
-        MasterMetricManager::instance().inc_batch_put_start_requests();
-
-        std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-            results;
-        results.reserve(keys.size());
-
-        for (size_t i = 0; i < keys.size(); ++i) {
-            results.emplace_back(
-                master_service_.PutStart(keys[i], slice_lengths[i], config));
-        }
-
-        // Count failures and log errors
-        size_t failure_count = 0;
-        for (size_t i = 0; i < results.size(); ++i) {
-            if (!results[i].has_value()) {
-                failure_count++;
-                LOG(ERROR) << "BatchPutStart failed for key[" << i << "] '"
-                           << keys[i] << "': " << toString(results[i].error());
-            }
-        }
-        MasterMetricManager::instance().inc_batch_put_start_failures(
-            failure_count);
-
-        timer.LogResponse("total=", results.size(),
-                          ", success=", results.size() - failure_count,
-                          ", failures=", failure_count);
-        return results;
-    }
+                  const ReplicateConfig& config);
 
     std::vector<tl::expected<void, ErrorCode>> BatchPutEnd(
-        const std::vector<std::string>& keys) {
-        ScopedVLogTimer timer(1, "BatchPutEnd");
-        timer.LogRequest("keys_count=", keys.size());
-        MasterMetricManager::instance().inc_batch_put_end_requests();
-
-        std::vector<tl::expected<void, ErrorCode>> results;
-        results.reserve(keys.size());
-
-        for (const auto& key : keys) {
-            results.emplace_back(master_service_.PutEnd(key));
-        }
-
-        // Count failures and log errors
-        size_t failure_count = 0;
-        for (size_t i = 0; i < results.size(); ++i) {
-            if (!results[i].has_value()) {
-                failure_count++;
-                LOG(ERROR) << "BatchPutEnd failed for key[" << i << "] '"
-                           << keys[i] << "': " << toString(results[i].error());
-            }
-        }
-        MasterMetricManager::instance().inc_batch_put_end_failures(
-            failure_count);
-
-        timer.LogResponse("total=", results.size(),
-                          ", success=", results.size() - failure_count,
-                          ", failures=", failure_count);
-        return results;
-    }
+        const std::vector<std::string>& keys);
 
     std::vector<tl::expected<void, ErrorCode>> BatchPutRevoke(
-        const std::vector<std::string>& keys) {
-        ScopedVLogTimer timer(1, "BatchPutRevoke");
-        timer.LogRequest("keys_count=", keys.size());
-        MasterMetricManager::instance().inc_batch_put_revoke_requests();
+        const std::vector<std::string>& keys);
 
-        std::vector<tl::expected<void, ErrorCode>> results;
-        results.reserve(keys.size());
+    tl::expected<void, ErrorCode> Remove(const std::string& key);
 
-        for (const auto& key : keys) {
-            results.emplace_back(master_service_.PutRevoke(key));
-        }
-
-        // Count failures and log errors
-        size_t failure_count = 0;
-        for (size_t i = 0; i < results.size(); ++i) {
-            if (!results[i].has_value()) {
-                failure_count++;
-                LOG(ERROR) << "BatchPutRevoke failed for key[" << i << "] '"
-                           << keys[i] << "': " << toString(results[i].error());
-            }
-        }
-        MasterMetricManager::instance().inc_batch_put_revoke_failures(
-            failure_count);
-
-        timer.LogResponse("total=", results.size(),
-                          ", success=", results.size() - failure_count,
-                          ", failures=", failure_count);
-        return results;
-    }
-
-    tl::expected<void, ErrorCode> Remove(const std::string& key) {
-        return execute_rpc(
-            "Remove", [&] { return master_service_.Remove(key); },
-            [&](auto& timer) { timer.LogRequest("key=", key); },
-            [] { MasterMetricManager::instance().inc_remove_requests(); },
-            [] { MasterMetricManager::instance().inc_remove_failures(); });
-    }
-
-    long RemoveAll() {
-        ScopedVLogTimer timer(1, "RemoveAll");
-        timer.LogRequest("action=remove_all_objects");
-        MasterMetricManager::instance().inc_remove_all_requests();
-        long result = master_service_.RemoveAll();
-        timer.LogResponse("items_removed=", result);
-        return result;
-    }
+    long RemoveAll();
 
     tl::expected<void, ErrorCode> MountSegment(const Segment& segment,
-                                               const UUID& client_id) {
-        return execute_rpc(
-            "MountSegment",
-            [&] { return master_service_.MountSegment(segment, client_id); },
-            [&](auto& timer) {
-                timer.LogRequest("base=", segment.base, ", size=", segment.size,
-                                 ", segment_name=", segment.name,
-                                 ", id=", segment.id);
-            },
-            [] {
-                MasterMetricManager::instance().inc_mount_segment_requests();
-            },
-            [] {
-                MasterMetricManager::instance().inc_mount_segment_failures();
-            });
-    }
+                                               const UUID& client_id);
 
     tl::expected<void, ErrorCode> ReMountSegment(
-        const std::vector<Segment>& segments, const UUID& client_id) {
-        return execute_rpc(
-            "ReMountSegment",
-            [&] { return master_service_.ReMountSegment(segments, client_id); },
-            [&](auto& timer) {
-                timer.LogRequest("segments_count=", segments.size(),
-                                 ", client_id=", client_id);
-            },
-            [] {
-                MasterMetricManager::instance().inc_remount_segment_requests();
-            },
-            [] {
-                MasterMetricManager::instance().inc_remount_segment_failures();
-            });
-    }
+        const std::vector<Segment>& segments, const UUID& client_id);
 
     tl::expected<void, ErrorCode> UnmountSegment(const UUID& segment_id,
-                                                 const UUID& client_id) {
-        return execute_rpc(
-            "UnmountSegment",
-            [&] {
-                return master_service_.UnmountSegment(segment_id, client_id);
-            },
-            [&](auto& timer) {
-                timer.LogRequest("segment_id=", segment_id,
-                                 ", client_id=", client_id);
-            },
-            [] {
-                MasterMetricManager::instance().inc_unmount_segment_requests();
-            },
-            [] {
-                MasterMetricManager::instance().inc_unmount_segment_failures();
-            });
-    }
+                                                 const UUID& client_id);
 
-    tl::expected<std::string, ErrorCode> GetFsdir() {
-        ScopedVLogTimer timer(1, "GetFsdir");
-        timer.LogRequest("action=get_fsdir");
-
-        auto result = master_service_.GetFsdir();
-
-        timer.LogResponseExpected(result);
-        return result;
-    }
+    tl::expected<std::string, ErrorCode> GetFsdir();
 
     tl::expected<std::pair<ViewVersionId, ClientStatus>, ErrorCode> Ping(
-        const UUID& client_id) {
-        ScopedVLogTimer timer(1, "Ping");
-        timer.LogRequest("client_id=", client_id);
-
-        MasterMetricManager::instance().inc_ping_requests();
-
-        auto result = master_service_.Ping(client_id);
-
-        timer.LogResponseExpected(result);
-        return result;
-    }
+        const UUID& client_id);
 
    private:
     MasterService master_service_;
@@ -519,44 +90,8 @@ class WrappedMasterService {
     std::atomic<bool> metric_report_running_;
 };
 
-inline void RegisterRpcService(
+void RegisterRpcService(
     coro_rpc::coro_rpc_server& server,
-    mooncake::WrappedMasterService& wrapped_master_service) {
-    server.register_handler<&mooncake::WrappedMasterService::ExistKey>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::GetReplicaList>(
-        &wrapped_master_service);
-    server
-        .register_handler<&mooncake::WrappedMasterService::BatchGetReplicaList>(
-            &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::PutStart>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::PutEnd>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::PutRevoke>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::BatchPutStart>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::BatchPutEnd>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::BatchPutRevoke>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::Remove>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::RemoveAll>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::MountSegment>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::ReMountSegment>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::UnmountSegment>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::Ping>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::GetFsdir>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::BatchExistKey>(
-        &wrapped_master_service);
-}
+    mooncake::WrappedMasterService& wrapped_master_service);
 
 }  // namespace mooncake

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <chrono>
 #include <cstdint>
 #include <thread>
 #include <ylt/coro_http/coro_http_server.hpp>
@@ -90,8 +89,7 @@ class WrappedMasterService {
     std::atomic<bool> metric_report_running_;
 };
 
-void RegisterRpcService(
-    coro_rpc::coro_rpc_server& server,
-    mooncake::WrappedMasterService& wrapped_master_service);
+void RegisterRpcService(coro_rpc::coro_rpc_server& server,
+                        mooncake::WrappedMasterService& wrapped_master_service);
 
 }  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(MOONCAKE_STORE_SOURCES
     transfer_task.cpp
     etcd_helper.cpp
     ha_helper.cpp
+    rpc_service.cpp
 )
 
 # The cache_allocator library

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1,0 +1,534 @@
+#include "rpc_service.h"
+
+#include <ylt/struct_json/json_reader.h>
+#include <ylt/struct_json/json_writer.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <thread>
+#include <ylt/coro_http/coro_http_client.hpp>
+#include <ylt/coro_http/coro_http_server.hpp>
+#include <ylt/coro_rpc/coro_rpc_server.hpp>
+#include <ylt/reflection/user_reflect_macro.hpp>
+#include <ylt/util/tl/expected.hpp>
+
+#include "master_metric_manager.h"
+#include "master_service.h"
+#include "rpc_helper.h"
+#include "types.h"
+#include "utils/scoped_vlog_timer.h"
+
+namespace mooncake {
+
+const uint64_t kMetricReportIntervalSeconds = 10;
+
+WrappedMasterService::WrappedMasterService(
+    bool enable_gc, uint64_t default_kv_lease_ttl,
+    uint64_t default_kv_soft_pin_ttl,
+    bool allow_evict_soft_pinned_objects,
+    bool enable_metric_reporting, uint16_t http_port,
+    double eviction_ratio,
+    double eviction_high_watermark_ratio,
+    ViewVersionId view_version,
+    int64_t client_live_ttl_sec,
+    bool enable_ha,
+    const std::string& cluster_id)
+    : master_service_(enable_gc, default_kv_lease_ttl,
+                      default_kv_soft_pin_ttl,
+                      allow_evict_soft_pinned_objects, eviction_ratio,
+                      eviction_high_watermark_ratio, view_version,
+                      client_live_ttl_sec, enable_ha, cluster_id),
+      http_server_(4, http_port),
+      metric_report_running_(enable_metric_reporting) {
+    init_http_server();
+
+    MasterMetricManager::instance().set_enable_ha(enable_ha);
+
+    if (enable_metric_reporting) {
+        metric_report_thread_ = std::thread([this]() {
+            while (metric_report_running_) {
+                std::string metrics_summary =
+                    MasterMetricManager::instance().get_summary_string();
+                LOG(INFO) << "Master Metrics: " << metrics_summary;
+                std::this_thread::sleep_for(
+                    std::chrono::seconds(kMetricReportIntervalSeconds));
+            }
+        });
+    }
+}
+
+WrappedMasterService::~WrappedMasterService() {
+    metric_report_running_ = false;
+    if (metric_report_thread_.joinable()) {
+        metric_report_thread_.join();
+    }
+    http_server_.stop();
+}
+
+void WrappedMasterService::init_http_server() {
+    using namespace coro_http;
+
+    http_server_.set_http_handler<GET>(
+        "/metrics", [](coro_http_request& req, coro_http_response& resp) {
+            std::string metrics =
+                MasterMetricManager::instance().serialize_metrics();
+            resp.add_header("Content-Type", "text/plain; version=0.0.4");
+            resp.set_status_and_content(status_type::ok, std::move(metrics));
+        });
+
+    http_server_.set_http_handler<GET>(
+        "/metrics/summary",
+        [](coro_http_request& req, coro_http_response& resp) {
+            std::string summary =
+                MasterMetricManager::instance().get_summary_string();
+            resp.add_header("Content-Type", "text/plain; version=0.0.4");
+            resp.set_status_and_content(status_type::ok, std::move(summary));
+        });
+
+    http_server_.set_http_handler<GET>(
+        "/query_key",
+        [&](coro_http_request& req, coro_http_response& resp) {
+            auto key = req.get_query_value("key");
+            auto get_result = GetReplicaList(std::string(key));
+            resp.add_header("Content-Type", "text/plain; version=0.0.4");
+            if (get_result) {
+                std::string ss = "";
+                for (size_t i = 0; i < get_result.value().size(); i++) {
+                    if (get_result.value()[i].is_memory_replica()) {
+                        auto& memory_descriptors =
+                            get_result.value()[i].get_memory_descriptor();
+                        for (const auto& handle :
+                             memory_descriptors.buffer_descriptors) {
+                            std::string tmp = "";
+                            struct_json::to_json(handle, tmp);
+                            ss += tmp;
+                            ss += "\n";
+                        }
+                    }
+                }
+                resp.set_status_and_content(status_type::ok, std::move(ss));
+            } else {
+                resp.set_status_and_content(status_type::not_found,
+                                            toString(get_result.error()));
+            }
+        });
+
+    http_server_.set_http_handler<GET>(
+        "/get_all_keys",
+        [&](coro_http_request& req, coro_http_response& resp) {
+            resp.add_header("Content-Type", "text/plain; version=0.0.4");
+
+            auto result = master_service_.GetAllKeys();
+            if (result) {
+                std::string ss = "";
+                auto keys = result.value();
+                for (const auto& key : keys) {
+                    ss += key;
+                    ss += "\n";
+                }
+                resp.set_status_and_content(status_type::ok, std::move(ss));
+            } else {
+                resp.set_status_and_content(
+                    status_type::internal_server_error,
+                    "Failed to get all keys");
+            }
+        });
+
+    http_server_.set_http_handler<GET>(
+        "/get_all_segments",
+        [&](coro_http_request& req, coro_http_response& resp) {
+            resp.add_header("Content-Type", "text/plain; version=0.0.4");
+            auto result = master_service_.GetAllSegments();
+            if (result) {
+                std::string ss = "";
+                auto segments = result.value();
+                for (const auto& segment_name : segments) {
+                    ss += segment_name;
+                    ss += "\n";
+                }
+                resp.set_status_and_content(status_type::ok, std::move(ss));
+            } else {
+                resp.set_status_and_content(
+                    status_type::internal_server_error,
+                    "Failed to get all segments");
+            }
+        });
+
+    http_server_.set_http_handler<GET>(
+        "/query_segment",
+        [&](coro_http_request& req, coro_http_response& resp) {
+            auto segment = req.get_query_value("segment");
+            resp.add_header("Content-Type", "text/plain; version=0.0.4");
+            auto result =
+                master_service_.QuerySegments(std::string(segment));
+
+            if (result) {
+                std::string ss = "";
+                auto [used, capacity] = result.value();
+                ss += segment;
+                ss += "\n";
+                ss += "Used(bytes): ";
+                ss += std::to_string(used);
+                ss += "\nCapacity(bytes) : ";
+                ss += std::to_string(capacity);
+                ss += "\n";
+                resp.set_status_and_content(status_type::ok, std::move(ss));
+            } else {
+                resp.set_status_and_content(
+                    status_type::internal_server_error,
+                    "Failed to query segment");
+            }
+        });
+
+    http_server_.set_http_handler<GET>(
+        "/health", [](coro_http_request& req, coro_http_response& resp) {
+            resp.add_header("Content-Type", "text/plain; version=0.0.4");
+            resp.set_status_and_content(status_type::ok, "OK");
+        });
+
+    http_server_.async_start();
+    LOG(INFO) << "HTTP metrics server started on port "
+              << http_server_.port();
+}
+
+tl::expected<bool, ErrorCode> WrappedMasterService::ExistKey(const std::string& key) {
+    return execute_rpc(
+        "ExistKey", [&] { return master_service_.ExistKey(key); },
+        [&](auto& timer) { timer.LogRequest("key=", key); },
+        [] { MasterMetricManager::instance().inc_exist_key_requests(); },
+        [] { MasterMetricManager::instance().inc_exist_key_failures(); });
+}
+
+std::vector<tl::expected<bool, ErrorCode>> WrappedMasterService::BatchExistKey(
+    const std::vector<std::string>& keys) {
+    ScopedVLogTimer timer(1, "BatchExistKey");
+    timer.LogRequest("keys_count=", keys.size());
+    MasterMetricManager::instance().inc_batch_exist_key_requests();
+
+    auto result = master_service_.BatchExistKey(keys);
+
+    size_t failure_count = 0;
+    for (size_t i = 0; i < result.size(); ++i) {
+        if (!result[i].has_value()) {
+            failure_count++;
+            LOG(ERROR) << "BatchExistKey failed for key[" << i << "] '"
+                       << keys[i] << "': " << toString(result[i].error());
+        }
+    }
+    MasterMetricManager::instance().inc_batch_exist_key_failures(
+        failure_count);
+
+    timer.LogResponse("total=", result.size(),
+                      ", success=", result.size() - failure_count,
+                      ", failures=", failure_count);
+    return result;
+}
+
+tl::expected<std::vector<Replica::Descriptor>, ErrorCode> WrappedMasterService::GetReplicaList(
+    const std::string& key) {
+    return execute_rpc(
+        "GetReplicaList",
+        [&] { return master_service_.GetReplicaList(key); },
+        [&](auto& timer) { timer.LogRequest("key=", key); },
+        [] {
+            MasterMetricManager::instance().inc_get_replica_list_requests();
+        },
+        [] {
+            MasterMetricManager::instance().inc_get_replica_list_failures();
+        });
+}
+
+std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+WrappedMasterService::BatchGetReplicaList(const std::vector<std::string>& keys) {
+    ScopedVLogTimer timer(1, "BatchGetReplicaList");
+    timer.LogRequest("keys_count=", keys.size());
+    MasterMetricManager::instance().inc_batch_get_replica_list_requests();
+
+    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+        results;
+    results.reserve(keys.size());
+
+    for (const auto& key : keys) {
+        results.emplace_back(master_service_.GetReplicaList(key));
+    }
+
+    size_t failure_count = 0;
+    for (size_t i = 0; i < results.size(); ++i) {
+        if (!results[i].has_value()) {
+            failure_count++;
+            LOG(ERROR) << "BatchGetReplicaList failed for key[" << i
+                       << "] '" << keys[i]
+                       << "': " << toString(results[i].error());
+        }
+    }
+    MasterMetricManager::instance().inc_batch_get_replica_list_failures(
+        failure_count);
+
+    timer.LogResponse("total=", results.size(),
+                      ", success=", results.size() - failure_count,
+                      ", failures=", failure_count);
+    return results;
+}
+
+tl::expected<std::vector<Replica::Descriptor>, ErrorCode> WrappedMasterService::PutStart(
+    const std::string& key, const std::vector<uint64_t>& slice_lengths,
+    const ReplicateConfig& config) {
+    return execute_rpc(
+        "PutStart",
+        [&] {
+            return master_service_.PutStart(key, slice_lengths, config);
+        },
+        [&](auto& timer) {
+            timer.LogRequest("key=", key,
+                             ", slice_lengths=", slice_lengths.size());
+        },
+        [&] { MasterMetricManager::instance().inc_put_start_requests(); },
+        [] { MasterMetricManager::instance().inc_put_start_failures(); });
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::PutEnd(const std::string& key) {
+    return execute_rpc(
+        "PutEnd", [&] { return master_service_.PutEnd(key); },
+        [&](auto& timer) { timer.LogRequest("key=", key); },
+        [] { MasterMetricManager::instance().inc_put_end_requests(); },
+        [] { MasterMetricManager::instance().inc_put_end_failures(); });
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::PutRevoke(const std::string& key) {
+    return execute_rpc(
+        "PutRevoke", [&] { return master_service_.PutRevoke(key); },
+        [&](auto& timer) { timer.LogRequest("key=", key); },
+        [] { MasterMetricManager::instance().inc_put_revoke_requests(); },
+        [] { MasterMetricManager::instance().inc_put_revoke_failures(); });
+}
+
+std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+WrappedMasterService::BatchPutStart(const std::vector<std::string>& keys,
+              const std::vector<std::vector<uint64_t>>& slice_lengths,
+              const ReplicateConfig& config) {
+    ScopedVLogTimer timer(1, "BatchPutStart");
+    timer.LogRequest("keys_count=", keys.size());
+    MasterMetricManager::instance().inc_batch_put_start_requests();
+
+    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+        results;
+    results.reserve(keys.size());
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results.emplace_back(
+            master_service_.PutStart(keys[i], slice_lengths[i], config));
+    }
+
+    size_t failure_count = 0;
+    for (size_t i = 0; i < results.size(); ++i) {
+        if (!results[i].has_value()) {
+            failure_count++;
+            LOG(ERROR) << "BatchPutStart failed for key[" << i << "] '"
+                       << keys[i] << "': " << toString(results[i].error());
+        }
+    }
+    MasterMetricManager::instance().inc_batch_put_start_failures(
+        failure_count);
+
+    timer.LogResponse("total=", results.size(),
+                      ", success=", results.size() - failure_count,
+                      ", failures=", failure_count);
+    return results;
+}
+
+std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchPutEnd(
+    const std::vector<std::string>& keys) {
+    ScopedVLogTimer timer(1, "BatchPutEnd");
+    timer.LogRequest("keys_count=", keys.size());
+    MasterMetricManager::instance().inc_batch_put_end_requests();
+
+    std::vector<tl::expected<void, ErrorCode>> results;
+    results.reserve(keys.size());
+
+    for (const auto& key : keys) {
+        results.emplace_back(master_service_.PutEnd(key));
+    }
+
+    size_t failure_count = 0;
+    for (size_t i = 0; i < results.size(); ++i) {
+        if (!results[i].has_value()) {
+            failure_count++;
+            LOG(ERROR) << "BatchPutEnd failed for key[" << i << "] '"
+                       << keys[i] << "': " << toString(results[i].error());
+        }
+    }
+    MasterMetricManager::instance().inc_batch_put_end_failures(
+        failure_count);
+
+    timer.LogResponse("total=", results.size(),
+                      ", success=", results.size() - failure_count,
+                      ", failures=", failure_count);
+    return results;
+}
+
+std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchPutRevoke(
+    const std::vector<std::string>& keys) {
+    ScopedVLogTimer timer(1, "BatchPutRevoke");
+    timer.LogRequest("keys_count=", keys.size());
+    MasterMetricManager::instance().inc_batch_put_revoke_requests();
+
+    std::vector<tl::expected<void, ErrorCode>> results;
+    results.reserve(keys.size());
+
+    for (const auto& key : keys) {
+        results.emplace_back(master_service_.PutRevoke(key));
+    }
+
+    size_t failure_count = 0;
+    for (size_t i = 0; i < results.size(); ++i) {
+        if (!results[i].has_value()) {
+            failure_count++;
+            LOG(ERROR) << "BatchPutRevoke failed for key[" << i << "] '"
+                       << keys[i] << "': " << toString(results[i].error());
+        }
+    }
+    MasterMetricManager::instance().inc_batch_put_revoke_failures(
+        failure_count);
+
+    timer.LogResponse("total=", results.size(),
+                      ", success=", results.size() - failure_count,
+                      ", failures=", failure_count);
+    return results;
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::Remove(const std::string& key) {
+    return execute_rpc(
+        "Remove", [&] { return master_service_.Remove(key); },
+        [&](auto& timer) { timer.LogRequest("key=", key); },
+        [] { MasterMetricManager::instance().inc_remove_requests(); },
+        [] { MasterMetricManager::instance().inc_remove_failures(); });
+}
+
+long WrappedMasterService::RemoveAll() {
+    ScopedVLogTimer timer(1, "RemoveAll");
+    timer.LogRequest("action=remove_all_objects");
+    MasterMetricManager::instance().inc_remove_all_requests();
+    long result = master_service_.RemoveAll();
+    timer.LogResponse("items_removed=", result);
+    return result;
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::MountSegment(const Segment& segment,
+                                           const UUID& client_id) {
+    return execute_rpc(
+        "MountSegment",
+        [&] { return master_service_.MountSegment(segment, client_id); },
+        [&](auto& timer) {
+            timer.LogRequest("base=", segment.base, ", size=", segment.size,
+                             ", segment_name=", segment.name,
+                             ", id=", segment.id);
+        },
+        [] {
+            MasterMetricManager::instance().inc_mount_segment_requests();
+        },
+        [] {
+            MasterMetricManager::instance().inc_mount_segment_failures();
+        });
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::ReMountSegment(
+    const std::vector<Segment>& segments, const UUID& client_id) {
+    return execute_rpc(
+        "ReMountSegment",
+        [&] { return master_service_.ReMountSegment(segments, client_id); },
+        [&](auto& timer) {
+            timer.LogRequest("segments_count=", segments.size(),
+                             ", client_id=", client_id);
+        },
+        [] {
+            MasterMetricManager::instance().inc_remount_segment_requests();
+        },
+        [] {
+            MasterMetricManager::instance().inc_remount_segment_failures();
+        });
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::UnmountSegment(const UUID& segment_id,
+                                             const UUID& client_id) {
+    return execute_rpc(
+        "UnmountSegment",
+        [&] {
+            return master_service_.UnmountSegment(segment_id, client_id);
+        },
+        [&](auto& timer) {
+            timer.LogRequest("segment_id=", segment_id,
+                             ", client_id=", client_id);
+        },
+        [] {
+            MasterMetricManager::instance().inc_unmount_segment_requests();
+        },
+        [] {
+            MasterMetricManager::instance().inc_unmount_segment_failures();
+        });
+}
+
+tl::expected<std::string, ErrorCode> WrappedMasterService::GetFsdir() {
+    ScopedVLogTimer timer(1, "GetFsdir");
+    timer.LogRequest("action=get_fsdir");
+
+    auto result = master_service_.GetFsdir();
+
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<std::pair<ViewVersionId, ClientStatus>, ErrorCode> WrappedMasterService::Ping(
+    const UUID& client_id) {
+    ScopedVLogTimer timer(1, "Ping");
+    timer.LogRequest("client_id=", client_id);
+
+    MasterMetricManager::instance().inc_ping_requests();
+
+    auto result = master_service_.Ping(client_id);
+
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+void RegisterRpcService(
+    coro_rpc::coro_rpc_server& server,
+    mooncake::WrappedMasterService& wrapped_master_service) {
+    server.register_handler<&mooncake::WrappedMasterService::ExistKey>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::GetReplicaList>(
+        &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::BatchGetReplicaList>(
+            &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::PutStart>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::PutEnd>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::PutRevoke>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::BatchPutStart>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::BatchPutEnd>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::BatchPutRevoke>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::Remove>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::RemoveAll>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::MountSegment>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::ReMountSegment>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::UnmountSegment>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::Ping>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::GetFsdir>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::BatchExistKey>(
+        &wrapped_master_service);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -25,17 +25,11 @@ const uint64_t kMetricReportIntervalSeconds = 10;
 
 WrappedMasterService::WrappedMasterService(
     bool enable_gc, uint64_t default_kv_lease_ttl,
-    uint64_t default_kv_soft_pin_ttl,
-    bool allow_evict_soft_pinned_objects,
-    bool enable_metric_reporting, uint16_t http_port,
-    double eviction_ratio,
-    double eviction_high_watermark_ratio,
-    ViewVersionId view_version,
-    int64_t client_live_ttl_sec,
-    bool enable_ha,
-    const std::string& cluster_id)
-    : master_service_(enable_gc, default_kv_lease_ttl,
-                      default_kv_soft_pin_ttl,
+    uint64_t default_kv_soft_pin_ttl, bool allow_evict_soft_pinned_objects,
+    bool enable_metric_reporting, uint16_t http_port, double eviction_ratio,
+    double eviction_high_watermark_ratio, ViewVersionId view_version,
+    int64_t client_live_ttl_sec, bool enable_ha, const std::string& cluster_id)
+    : master_service_(enable_gc, default_kv_lease_ttl, default_kv_soft_pin_ttl,
                       allow_evict_soft_pinned_objects, eviction_ratio,
                       eviction_high_watermark_ratio, view_version,
                       client_live_ttl_sec, enable_ha, cluster_id),
@@ -87,8 +81,7 @@ void WrappedMasterService::init_http_server() {
         });
 
     http_server_.set_http_handler<GET>(
-        "/query_key",
-        [&](coro_http_request& req, coro_http_response& resp) {
+        "/query_key", [&](coro_http_request& req, coro_http_response& resp) {
             auto key = req.get_query_value("key");
             auto get_result = GetReplicaList(std::string(key));
             resp.add_header("Content-Type", "text/plain; version=0.0.4");
@@ -115,8 +108,7 @@ void WrappedMasterService::init_http_server() {
         });
 
     http_server_.set_http_handler<GET>(
-        "/get_all_keys",
-        [&](coro_http_request& req, coro_http_response& resp) {
+        "/get_all_keys", [&](coro_http_request& req, coro_http_response& resp) {
             resp.add_header("Content-Type", "text/plain; version=0.0.4");
 
             auto result = master_service_.GetAllKeys();
@@ -129,9 +121,8 @@ void WrappedMasterService::init_http_server() {
                 }
                 resp.set_status_and_content(status_type::ok, std::move(ss));
             } else {
-                resp.set_status_and_content(
-                    status_type::internal_server_error,
-                    "Failed to get all keys");
+                resp.set_status_and_content(status_type::internal_server_error,
+                                            "Failed to get all keys");
             }
         });
 
@@ -149,9 +140,8 @@ void WrappedMasterService::init_http_server() {
                 }
                 resp.set_status_and_content(status_type::ok, std::move(ss));
             } else {
-                resp.set_status_and_content(
-                    status_type::internal_server_error,
-                    "Failed to get all segments");
+                resp.set_status_and_content(status_type::internal_server_error,
+                                            "Failed to get all segments");
             }
         });
 
@@ -160,8 +150,7 @@ void WrappedMasterService::init_http_server() {
         [&](coro_http_request& req, coro_http_response& resp) {
             auto segment = req.get_query_value("segment");
             resp.add_header("Content-Type", "text/plain; version=0.0.4");
-            auto result =
-                master_service_.QuerySegments(std::string(segment));
+            auto result = master_service_.QuerySegments(std::string(segment));
 
             if (result) {
                 std::string ss = "";
@@ -175,9 +164,8 @@ void WrappedMasterService::init_http_server() {
                 ss += "\n";
                 resp.set_status_and_content(status_type::ok, std::move(ss));
             } else {
-                resp.set_status_and_content(
-                    status_type::internal_server_error,
-                    "Failed to query segment");
+                resp.set_status_and_content(status_type::internal_server_error,
+                                            "Failed to query segment");
             }
         });
 
@@ -188,11 +176,11 @@ void WrappedMasterService::init_http_server() {
         });
 
     http_server_.async_start();
-    LOG(INFO) << "HTTP metrics server started on port "
-              << http_server_.port();
+    LOG(INFO) << "HTTP metrics server started on port " << http_server_.port();
 }
 
-tl::expected<bool, ErrorCode> WrappedMasterService::ExistKey(const std::string& key) {
+tl::expected<bool, ErrorCode> WrappedMasterService::ExistKey(
+    const std::string& key) {
     return execute_rpc(
         "ExistKey", [&] { return master_service_.ExistKey(key); },
         [&](auto& timer) { timer.LogRequest("key=", key); },
@@ -216,8 +204,7 @@ std::vector<tl::expected<bool, ErrorCode>> WrappedMasterService::BatchExistKey(
                        << keys[i] << "': " << toString(result[i].error());
         }
     }
-    MasterMetricManager::instance().inc_batch_exist_key_failures(
-        failure_count);
+    MasterMetricManager::instance().inc_batch_exist_key_failures(failure_count);
 
     timer.LogResponse("total=", result.size(),
                       ", success=", result.size() - failure_count,
@@ -225,22 +212,20 @@ std::vector<tl::expected<bool, ErrorCode>> WrappedMasterService::BatchExistKey(
     return result;
 }
 
-tl::expected<std::vector<Replica::Descriptor>, ErrorCode> WrappedMasterService::GetReplicaList(
-    const std::string& key) {
+tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+WrappedMasterService::GetReplicaList(const std::string& key) {
     return execute_rpc(
-        "GetReplicaList",
-        [&] { return master_service_.GetReplicaList(key); },
+        "GetReplicaList", [&] { return master_service_.GetReplicaList(key); },
         [&](auto& timer) { timer.LogRequest("key=", key); },
-        [] {
-            MasterMetricManager::instance().inc_get_replica_list_requests();
-        },
+        [] { MasterMetricManager::instance().inc_get_replica_list_requests(); },
         [] {
             MasterMetricManager::instance().inc_get_replica_list_failures();
         });
 }
 
 std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-WrappedMasterService::BatchGetReplicaList(const std::vector<std::string>& keys) {
+WrappedMasterService::BatchGetReplicaList(
+    const std::vector<std::string>& keys) {
     ScopedVLogTimer timer(1, "BatchGetReplicaList");
     timer.LogRequest("keys_count=", keys.size());
     MasterMetricManager::instance().inc_batch_get_replica_list_requests();
@@ -257,9 +242,8 @@ WrappedMasterService::BatchGetReplicaList(const std::vector<std::string>& keys) 
     for (size_t i = 0; i < results.size(); ++i) {
         if (!results[i].has_value()) {
             failure_count++;
-            LOG(ERROR) << "BatchGetReplicaList failed for key[" << i
-                       << "] '" << keys[i]
-                       << "': " << toString(results[i].error());
+            LOG(ERROR) << "BatchGetReplicaList failed for key[" << i << "] '"
+                       << keys[i] << "': " << toString(results[i].error());
         }
     }
     MasterMetricManager::instance().inc_batch_get_replica_list_failures(
@@ -271,14 +255,13 @@ WrappedMasterService::BatchGetReplicaList(const std::vector<std::string>& keys) 
     return results;
 }
 
-tl::expected<std::vector<Replica::Descriptor>, ErrorCode> WrappedMasterService::PutStart(
-    const std::string& key, const std::vector<uint64_t>& slice_lengths,
-    const ReplicateConfig& config) {
+tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+WrappedMasterService::PutStart(const std::string& key,
+                               const std::vector<uint64_t>& slice_lengths,
+                               const ReplicateConfig& config) {
     return execute_rpc(
         "PutStart",
-        [&] {
-            return master_service_.PutStart(key, slice_lengths, config);
-        },
+        [&] { return master_service_.PutStart(key, slice_lengths, config); },
         [&](auto& timer) {
             timer.LogRequest("key=", key,
                              ", slice_lengths=", slice_lengths.size());
@@ -287,7 +270,8 @@ tl::expected<std::vector<Replica::Descriptor>, ErrorCode> WrappedMasterService::
         [] { MasterMetricManager::instance().inc_put_start_failures(); });
 }
 
-tl::expected<void, ErrorCode> WrappedMasterService::PutEnd(const std::string& key) {
+tl::expected<void, ErrorCode> WrappedMasterService::PutEnd(
+    const std::string& key) {
     return execute_rpc(
         "PutEnd", [&] { return master_service_.PutEnd(key); },
         [&](auto& timer) { timer.LogRequest("key=", key); },
@@ -295,7 +279,8 @@ tl::expected<void, ErrorCode> WrappedMasterService::PutEnd(const std::string& ke
         [] { MasterMetricManager::instance().inc_put_end_failures(); });
 }
 
-tl::expected<void, ErrorCode> WrappedMasterService::PutRevoke(const std::string& key) {
+tl::expected<void, ErrorCode> WrappedMasterService::PutRevoke(
+    const std::string& key) {
     return execute_rpc(
         "PutRevoke", [&] { return master_service_.PutRevoke(key); },
         [&](auto& timer) { timer.LogRequest("key=", key); },
@@ -304,9 +289,10 @@ tl::expected<void, ErrorCode> WrappedMasterService::PutRevoke(const std::string&
 }
 
 std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-WrappedMasterService::BatchPutStart(const std::vector<std::string>& keys,
-              const std::vector<std::vector<uint64_t>>& slice_lengths,
-              const ReplicateConfig& config) {
+WrappedMasterService::BatchPutStart(
+    const std::vector<std::string>& keys,
+    const std::vector<std::vector<uint64_t>>& slice_lengths,
+    const ReplicateConfig& config) {
     ScopedVLogTimer timer(1, "BatchPutStart");
     timer.LogRequest("keys_count=", keys.size());
     MasterMetricManager::instance().inc_batch_put_start_requests();
@@ -328,8 +314,7 @@ WrappedMasterService::BatchPutStart(const std::vector<std::string>& keys,
                        << keys[i] << "': " << toString(results[i].error());
         }
     }
-    MasterMetricManager::instance().inc_batch_put_start_failures(
-        failure_count);
+    MasterMetricManager::instance().inc_batch_put_start_failures(failure_count);
 
     timer.LogResponse("total=", results.size(),
                       ", success=", results.size() - failure_count,
@@ -354,12 +339,11 @@ std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchPutEnd(
     for (size_t i = 0; i < results.size(); ++i) {
         if (!results[i].has_value()) {
             failure_count++;
-            LOG(ERROR) << "BatchPutEnd failed for key[" << i << "] '"
-                       << keys[i] << "': " << toString(results[i].error());
+            LOG(ERROR) << "BatchPutEnd failed for key[" << i << "] '" << keys[i]
+                       << "': " << toString(results[i].error());
         }
     }
-    MasterMetricManager::instance().inc_batch_put_end_failures(
-        failure_count);
+    MasterMetricManager::instance().inc_batch_put_end_failures(failure_count);
 
     timer.LogResponse("total=", results.size(),
                       ", success=", results.size() - failure_count,
@@ -397,7 +381,8 @@ std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchPutRevoke(
     return results;
 }
 
-tl::expected<void, ErrorCode> WrappedMasterService::Remove(const std::string& key) {
+tl::expected<void, ErrorCode> WrappedMasterService::Remove(
+    const std::string& key) {
     return execute_rpc(
         "Remove", [&] { return master_service_.Remove(key); },
         [&](auto& timer) { timer.LogRequest("key=", key); },
@@ -414,8 +399,8 @@ long WrappedMasterService::RemoveAll() {
     return result;
 }
 
-tl::expected<void, ErrorCode> WrappedMasterService::MountSegment(const Segment& segment,
-                                           const UUID& client_id) {
+tl::expected<void, ErrorCode> WrappedMasterService::MountSegment(
+    const Segment& segment, const UUID& client_id) {
     return execute_rpc(
         "MountSegment",
         [&] { return master_service_.MountSegment(segment, client_id); },
@@ -424,12 +409,8 @@ tl::expected<void, ErrorCode> WrappedMasterService::MountSegment(const Segment& 
                              ", segment_name=", segment.name,
                              ", id=", segment.id);
         },
-        [] {
-            MasterMetricManager::instance().inc_mount_segment_requests();
-        },
-        [] {
-            MasterMetricManager::instance().inc_mount_segment_failures();
-        });
+        [] { MasterMetricManager::instance().inc_mount_segment_requests(); },
+        [] { MasterMetricManager::instance().inc_mount_segment_failures(); });
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::ReMountSegment(
@@ -441,31 +422,21 @@ tl::expected<void, ErrorCode> WrappedMasterService::ReMountSegment(
             timer.LogRequest("segments_count=", segments.size(),
                              ", client_id=", client_id);
         },
-        [] {
-            MasterMetricManager::instance().inc_remount_segment_requests();
-        },
-        [] {
-            MasterMetricManager::instance().inc_remount_segment_failures();
-        });
+        [] { MasterMetricManager::instance().inc_remount_segment_requests(); },
+        [] { MasterMetricManager::instance().inc_remount_segment_failures(); });
 }
 
-tl::expected<void, ErrorCode> WrappedMasterService::UnmountSegment(const UUID& segment_id,
-                                             const UUID& client_id) {
+tl::expected<void, ErrorCode> WrappedMasterService::UnmountSegment(
+    const UUID& segment_id, const UUID& client_id) {
     return execute_rpc(
         "UnmountSegment",
-        [&] {
-            return master_service_.UnmountSegment(segment_id, client_id);
-        },
+        [&] { return master_service_.UnmountSegment(segment_id, client_id); },
         [&](auto& timer) {
             timer.LogRequest("segment_id=", segment_id,
                              ", client_id=", client_id);
         },
-        [] {
-            MasterMetricManager::instance().inc_unmount_segment_requests();
-        },
-        [] {
-            MasterMetricManager::instance().inc_unmount_segment_failures();
-        });
+        [] { MasterMetricManager::instance().inc_unmount_segment_requests(); },
+        [] { MasterMetricManager::instance().inc_unmount_segment_failures(); });
 }
 
 tl::expected<std::string, ErrorCode> WrappedMasterService::GetFsdir() {
@@ -478,8 +449,8 @@ tl::expected<std::string, ErrorCode> WrappedMasterService::GetFsdir() {
     return result;
 }
 
-tl::expected<std::pair<ViewVersionId, ClientStatus>, ErrorCode> WrappedMasterService::Ping(
-    const UUID& client_id) {
+tl::expected<std::pair<ViewVersionId, ClientStatus>, ErrorCode>
+WrappedMasterService::Ping(const UUID& client_id) {
     ScopedVLogTimer timer(1, "Ping");
     timer.LogRequest("client_id=", client_id);
 


### PR DESCRIPTION
The header was getting a bit too long, so I went moved the implementation into `rpc_service .cpp` file before it got out of hand. No other changes were made. Feel free to take a look when you have a moment!