### PR TITLE
fix(memory): Prevent integer overflow in getMemoryLocation for large memory regions

### DIFF
--- a/mooncake-transfer-engine/src/memory_location.cpp
+++ b/mooncake-transfer-engine/src/memory_location.cpp
@@ -56,11 +56,11 @@ const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
 
     // start and end address may not be page aligned.
     uintptr_t aligned_start = alignPage((uintptr_t)start);
-    int n = (uintptr_t(start) - aligned_start + len + pagesize - 1) / pagesize;
+    long long n = (uintptr_t(start) - aligned_start + len + pagesize - 1) / pagesize;
     void **pages = (void **)malloc(sizeof(void *) * n);
     int *status = (int *)malloc(sizeof(int) * n);
 
-    for (int i = 0; i < n; i++) {
+    for (long long i = 0; i < n; i++) {
         pages[i] = (void *)((char *)aligned_start + i * pagesize);
     }
 
@@ -77,7 +77,7 @@ const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
     int node = status[0];
     uint64_t start_addr = (uint64_t)start;
     uint64_t new_start_addr;
-    for (int i = 1; i < n; i++) {
+    for (long long i = 1; i < n; i++) {
         if (status[i] != node) {
             new_start_addr = alignPage((uint64_t)start) + i * pagesize;
             entries.push_back({start_addr, size_t(new_start_addr - start_addr),


### PR DESCRIPTION
#### What's the motivation for the change?

The `getMemoryLocation` function in `memory_location.cpp` has a potential integer overflow bug when processing large memory allocations (i.e., with a `len` greater than 2GB).

In the original implementation, the total number of pages `n` and the loop counter `i` are both of type `int`. When calculating page addresses inside the loops, the expression `i * pagesize` is performed using integer arithmetic.

```cpp
// Buggy lines in the original code
pages[i] = (void *)((char *)aligned_start + i * pagesize);
// and
new_start_addr = alignPage((uint64_t)start) + i * pagesize;
```

If the total memory size `len` is large enough to make `i * pagesize` exceed `INT_MAX`, the multiplication will overflow before being added to the `uint64_t` base address. This results in an incorrect address calculation and leads to erroneous NUMA node mapping for large memory blocks.

#### What does this PR do?

This PR fixes the integer overflow vulnerability by changing the data types of the page count variable `n` and the loop iterator `i` from `int` to `long long`.

By promoting these variables to `long long`, the multiplication `i * pagesize` is performed using 64-bit arithmetic, which prevents the overflow and ensures that the address calculation is correct even for memory regions far exceeding 2GB. This makes the memory location tracking more robust for large-scale workloads.

#### How was this change tested?

This change can be verified by running `getMemoryLocation` on a memory buffer with a size (`len`) greater than `INT_MAX` (e.g., 3GB).

  * **Before fix:** The address calculation would be incorrect due to overflow.
  * **After fix:** The function correctly processes the entire memory range and returns accurate NUMA location entries.

This ensures the logic holds for large memory allocations, which is the primary scenario this fix targets.