### PR TITLE
[do not merge]: add g++ flags for (#571) to allow proper arm build

### DIFF
--- a/mooncake-transfer-engine/nvlink-allocator/build.sh
+++ b/mooncake-transfer-engine/nvlink-allocator/build.sh
@@ -11,7 +11,7 @@ mkdir -p "$OUTPUT_DIR"
 
 CPP_FILE=$(dirname $(readlink -f $0))/nvlink_allocator.cpp  # get cpp file path, under same dir with this script
 
-g++ "$CPP_FILE" -o "$OUTPUT_DIR/nvlink_allocator.so" --shared -fPIC -lcuda -lcudart -I/usr/local/cuda/include
+g++ "$CPP_FILE" -o "$OUTPUT_DIR/nvlink_allocator.so" --shared -fPIC -lcuda -I/usr/local/cuda/include
 
 if [ $? -eq 0 ]; then
     echo "Successfully built nvlink_allocator.so in $OUTPUT_DIR"


### PR DESCRIPTION
Forked off of #572 and added proper g++ compilation. Proper building for GB200 looks like

```bash
git clone https://github.com/ishandhanani/Mooncake.git
cd Mooncake
git checkout ishan/pr-571-diff-build
bash dependencies.sh -y
mkdir -p build
cd build
cmake .. -DUSE_MNNVL=ON
make -j
make install
```

And then you should use `MC_FORCE_MNNVL=1`