### PR TITLE
Revert "implement genNotify interface"

### DIFF
--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -132,18 +132,15 @@ class TransferEngine {
         if (!s.ok()) {
             return s;
         }
-        // store notify
-        RWSpinlock::WriteGuard guard(send_notifies_lock_);
-        notifies_to_send_[batch_id] = std::make_pair(target_id, notify_msg);
+        // notify
+        sendNotify(target_id, notify_msg);
         return s;
     }
 
     int getNotifies(std::vector<TransferMetadata::NotifyDesc> &notifies);
 
-    int sendNotifyByID(SegmentID target_id,
-                       TransferMetadata::NotifyDesc notify_msg);
-
-    int sendNotifyByName(std::string remote_agent,TransferMetadata::NotifyDesc notify_msg);
+    int sendNotify(SegmentID target_id,
+                   TransferMetadata::NotifyDesc notify_msg);
 
     Status getTransferStatus(BatchID batch_id, size_t task_id,
                              TransferStatus &status) {
@@ -156,13 +153,6 @@ class TransferEngine {
             }
         }
 #endif
-        if (result.ok() && status.s == TransferStatusEnum::COMPLETED) {
-            // send notify
-            RWSpinlock::WriteGuard guard(send_notifies_lock_);
-            auto value = notifies_to_send_[batch_id];
-            sendNotifyByID(value.first, value.second);
-            notifies_to_send_.erase(batch_id);
-        }
         return result;
     }
 
@@ -210,10 +200,6 @@ class TransferEngine {
     std::shared_mutex mutex_;
     std::vector<MemoryRegion> local_memory_regions_;
     std::shared_ptr<Topology> local_topology_;
-    RWSpinlock send_notifies_lock_;
-    std::unordered_map<BatchID,
-                       std::pair<SegmentID, TransferMetadata::NotifyDesc>>
-        notifies_to_send_;
     // Discover topology and install transports automatically when it's true.
     // Set it to false only for testing.
     bool auto_discover_;

--- a/mooncake-transfer-engine/include/transfer_engine_c.h
+++ b/mooncake-transfer-engine/include/transfer_engine_c.h
@@ -148,9 +148,6 @@ int submitTransferWithNotify(transfer_engine_t engine, batch_id_t batch_id,
 notify_msg_t* getNotifsFromEngine(transfer_engine_t engine,
               int* size);
 
-int genNotifyInEngine(transfer_engine_t engine, uint64_t target_id,
-              notify_msg_t notify_msg);
-
 int getTransferStatus(transfer_engine_t engine,
                       batch_id_t batch_id, size_t task_id,
                       struct transfer_status *status);

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "multi_transport.h"
-
 #include <string>
 
 #include "config.h"

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -214,21 +214,16 @@ std::string TransferEngine::getLocalIpAndPort() {
            std::to_string(metadata_->localRpcMeta().rpc_port);
 }
 
-int TransferEngine::getNotifies(std::vector<TransferMetadata::NotifyDesc> &notifies) {
+int TransferEngine::getNotifies(
+    std::vector<TransferMetadata::NotifyDesc> &notifies) {
     return metadata_->getNotifies(notifies);
 }
 
-int TransferEngine::sendNotifyByID(SegmentID target_id,
-                                   TransferMetadata::NotifyDesc notify_msg) {
+int TransferEngine::sendNotify(SegmentID target_id,
+                               TransferMetadata::NotifyDesc notify_msg) {
     auto desc = metadata_->getSegmentDescByID(target_id);
     Transport::NotifyDesc peer_desc;
     int ret = metadata_->sendNotify(desc->name, notify_msg, peer_desc);
-    return ret;
-}
-
-int TransferEngine::sendNotifyByName(std::string remote_agent, TransferMetadata::NotifyDesc notify_msg) {
-    Transport::NotifyDesc peer_desc;
-    int ret = metadata_->sendNotify(remote_agent, notify_msg, peer_desc);
     return ret;
 }
 

--- a/mooncake-transfer-engine/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_c.cpp
@@ -146,12 +146,15 @@ int submitTransferWithNotify(transfer_engine_t engine, batch_id_t batch_id,
                              notify_msg_t notify_msg) {
     uint64_t target_id = entries[0].target_id;
     int rc = submitTransfer(engine, batch_id, entries, count);
+    if (rc) {
+        return rc;
+    }
     // notify
     TransferEngine *native = (TransferEngine *)engine;
     TransferMetadata::NotifyDesc notify;
     notify.name = notify_msg.name;
     notify.notify_msg = notify_msg.msg;
-    return native->sendNotifyByID((SegmentID)target_id, notify);
+    return native->sendNotify((SegmentID)target_id, notify);
 }
 
 int getTransferStatus(transfer_engine_t engine,
@@ -180,15 +183,6 @@ notify_msg_t* getNotifsFromEngine(transfer_engine_t engine,
         notifies[i].msg = const_cast<char*>(notifies_desc[i].notify_msg.c_str());
     }
     return notifies;
-}
-
-int genNotifyInEngine(transfer_engine_t engine, uint64_t target_id,
-              notify_msg_t notify_msg) {
-    TransferEngine *native = (TransferEngine *)engine;
-    TransferMetadata::NotifyDesc notify;
-    notify.name.assign(notify_msg.name);
-    notify.notify_msg.assign(notify_msg.msg);
-    return native->sendNotifyByID(target_id, notify);
 }
 
 int freeBatchID(transfer_engine_t engine, batch_id_t batch_id) {


### PR DESCRIPTION
Reverts kvcache-ai/Mooncake#600

This PR introduces a bug:

```bash
[2025-07-16 13:06:59] The server is fired up and ready to roll!
[2025-07-16 13:07:38 TP0] Prefill batch. #new-seq: 1, #new-token: 32, #cached-token: 0, #token: 0, token usage: 0.00, #unbootstrapped-req: 0, #queue-req: 0, #transferring-req: 0, input throughput (token/s): 0.77, timestamp: 2025-07-16T13:07:38.603833
terminate called after throwing an instance of 'std::bad_function_call'
  what():  bad_function_call
Fatal Python error: Aborted

```

Let revert it first.