### PR TITLE
[BugFix] Prevent SIGSEGV when SliceBuffer is destroyed after DistributedObjectStore::close()

### DIFF
--- a/mooncake-integration/store/store_py.h
+++ b/mooncake-integration/store/store_py.h
@@ -92,6 +92,7 @@ class SliceBuffer {
     void *buffer_;
     uint64_t size_;
     bool use_allocator_free_;  // Flag to control deallocation method
+    std::shared_ptr<mooncake::SimpleAllocator> allocator_;  // Hold allocator reference to ensure lifetime
 };
 
 class DistributedObjectStore {
@@ -279,7 +280,7 @@ class DistributedObjectStore {
 
    public:
     std::shared_ptr<mooncake::Client> client_ = nullptr;
-    std::unique_ptr<mooncake::SimpleAllocator> client_buffer_allocator_ =
+    std::shared_ptr<mooncake::SimpleAllocator> client_buffer_allocator_ =
         nullptr;
     struct SegmentDeleter {
         void operator()(void *ptr) {


### PR DESCRIPTION
### Background

Python users can write:

```python
buf = store.get_buffer("key")
store.close()
# buf may be used or garbage-collected later
```

`store.close()` calls `client_buffer_allocator_.reset()`, destroying the
underlying `SimpleAllocator` immediately.  
Any remaining `SliceBuffer` instances still point into that allocator; when
their destructors invoke `allocator_->deallocate()` the `this` pointer is
nullptr, leading to a segmentation fault.

### Fix

1. **Lifetime management**
   * Convert `DistributedObjectStore::client_buffer_allocator_` from
     `std::unique_ptr` to `std::shared_ptr`.
   * Create it with `std::make_shared` inside `setup()`.
   * `SliceBuffer` captures its own `std::shared_ptr<SimpleAllocator>` so the
     allocator stays alive until every `SliceBuffer` is destroyed.

2. **Code clean-up**
   * Add a defensive nullptr check in `SliceBuffer` destructor.



Please review! 🙂