### PR TITLE
[TransferEngine] fix the compilation warnings

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -587,7 +587,7 @@ int TransferEnginePy::batchRegisterMemory(std::vector<uintptr_t> buffer_addresse
     pybind11::gil_scoped_release release;
     auto batch_size = buffer_addresses.size();
     std::vector<BufferEntry> buffers;
-    for (int i = 0; i < batch_size; i ++ ) {
+    for (size_t i = 0; i < batch_size; i ++ ) {
         buffers.push_back(BufferEntry{(void *)buffer_addresses[i], capacities[i]});
     }
     return engine_->registerLocalMemoryBatch(buffers, kWildcardLocation);
@@ -597,7 +597,7 @@ int TransferEnginePy::batchUnregisterMemory(std::vector<uintptr_t> buffer_addres
     pybind11::gil_scoped_release release;
     auto batch_size = buffer_addresses.size();
     std::vector<void *> buffers;
-    for (int i = 0; i < batch_size; i ++ ) {
+    for (size_t i = 0; i < batch_size; i ++ ) {
         buffers.push_back(reinterpret_cast<char *>(buffer_addresses[i]));
     }
     return engine_->unregisterLocalMemoryBatch(buffers);


### PR DESCRIPTION
Fix the compilation warnings below

>  /Mooncake/mooncake-integration/transfer_engine/transfer_engine_py.cpp: In member function 'int TransferEnginePy::batchRegisterMemory(std::vector<long unsigned int>, std::vector<long unsigned int>)':
/Mooncake/mooncake-integration/transfer_engine/transfer_engine_py.cpp:590:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
  590 |     for (int i = 0; i < batch_size; i ++ ) {
      |                     ~~^~~~~~~~~~~~

> /Mooncake/mooncake-integration/transfer_engine/transfer_engine_py.cpp: In member function 'int TransferEnginePy::batchUnregisterMemory(std::vector<long unsigned int>)':
/Mooncake/mooncake-integration/transfer_engine/transfer_engine_py.cpp:600:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
  600 |     for (int i = 0; i < batch_size; i ++ ) {
      |                     ~~^~~~~~~~~~~~ 