### PR TITLE
fix(bench): use correct GPU ID in memory registration

### DIFF
--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -313,8 +313,10 @@ int initiator() {
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
         std::string name_prefix = FLAGS_use_vram ? "cuda:" : "cpu:";
-        int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
-                                             name_prefix + std::to_string(i));
+        int name_postfix = FLAGS_use_vram ? FLAGS_gpu_id : i;
+        int rc = engine->registerLocalMemory(
+            addr[i], FLAGS_buffer_size,
+            name_prefix + std::to_string(name_postfix));
         LOG_ASSERT(!rc);
     }
 #else
@@ -406,8 +408,10 @@ int target() {
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
         std::string name_prefix = FLAGS_use_vram ? "cuda:" : "cpu:";
-        int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
-                                             name_prefix + std::to_string(i));
+        int name_postfix = FLAGS_use_vram ? FLAGS_gpu_id : i;
+        int rc = engine->registerLocalMemory(
+            addr[i], FLAGS_buffer_size,
+            name_prefix + std::to_string(name_postfix));
         LOG_ASSERT(!rc);
     }
 #else

--- a/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
@@ -291,8 +291,10 @@ int initiator() {
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
         std::string name_prefix = FLAGS_use_vram ? "cuda:" : "cpu:";
-        int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
-                                             name_prefix + std::to_string(i));
+        int name_postfix = FLAGS_use_vram ? FLAGS_gpu_id : i;
+        int rc = engine->registerLocalMemory(
+            addr[i], FLAGS_buffer_size,
+            name_prefix + std::to_string(name_postfix));
         LOG_ASSERT(!rc);
     }
 #else

--- a/mooncake-transfer-engine/tests/nvlink_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/nvlink_transport_test.cpp
@@ -62,7 +62,8 @@ TEST(NvlinkTransportTest, WriteAndRead) {
     ASSERT_NE(client_transport, nullptr);
 
     void* client_buffer = allocateCudaBuffer(kDataLength * 2, gpu_id);
-    rc = client_engine->registerLocalMemory(client_buffer, kDataLength * 2, "cuda:0");
+    rc = client_engine->registerLocalMemory(client_buffer, kDataLength * 2,
+                                            "cuda:" + std::to_string(gpu_id));
     ASSERT_EQ(rc, 0);
 
     // Write: client -> server

--- a/mooncake-transfer-engine/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test.cpp
@@ -259,8 +259,10 @@ int initiator() {
     void *addr = nullptr;
 #ifdef USE_CUDA
     addr = allocateMemoryPool(ram_buffer_size, 0, FLAGS_use_vram);
-    int rc = engine->registerLocalMemory(addr, ram_buffer_size,
-                                         FLAGS_use_vram ? "cuda:0" : "cpu:0");
+    std::string name_prefix = FLAGS_use_vram ? "cuda:" : "cpu:";
+    int name_postfix = FLAGS_use_vram ? FLAGS_gpu_id : 0;
+    int rc = engine->registerLocalMemory(
+        addr, ram_buffer_size, name_prefix + std::to_string(name_postfix));
     LOG_ASSERT(!rc);
 #else
     addr = allocateMemoryPool(ram_buffer_size, 0, false);


### PR DESCRIPTION
# Summary

This PR fixes inconsistent GPU ID usage in memory registration across test and benchmark files. Previously, some files were using loop index i instead of the configured `FLAGS_gpu_id` for VRAM buffer registration.

# Changes

- transfer_engine_bench.cpp: Use FLAGS_gpu_id for VRAM buffer registration in both initiator and target functions
- transfer_engine_bench_with_retry.cpp: Use FLAGS_gpu_id for VRAM buffer registration in initiator function
- nvlink_transport_test.cpp: Use gpu_id variable instead of hardcoded "cuda:0"
- rdma_transport_test.cpp: Use FLAGS_gpu_id for VRAM buffer registration

# Impact

- Ensures consistent GPU device selection across all test files
- Fixes potential issues where tests might register memory on wrong GPU device
