### PR TITLE
feat(transfer_engine_bench): Add multi-GPU support 

### DIFF
--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -321,6 +321,8 @@ int initiator() {
             LOG(INFO) << "GPU ID is specified or failed to get GPU count, use " << FLAGS_gpu_id << " GPU";
             buffer_num = 1;
         }
+    } else {
+        LOG(INFO) << "DRAM is used, numa node num: " << NR_SOCKETS;
     }
     addr.resize(buffer_num);
     for (int i = 0; i < buffer_num; ++i) {
@@ -344,6 +346,7 @@ int initiator() {
         LOG_ASSERT(!rc);
     }
 #else
+    LOG(INFO) << "DRAM is used, numa node num: " << NR_SOCKETS;
     addr.resize(buffer_num);
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
@@ -374,9 +377,6 @@ int initiator() {
                     (stop_tv.tv_usec - start_tv.tv_usec) / 1000000.0;
     auto batch_count = total_batch_count.load();
 
-    if (!FLAGS_use_vram) {
-        LOG(INFO) << "numa node num: " << NR_SOCKETS;
-    }
 
     LOG(INFO) << "Test completed: duration " << std::fixed
               << std::setprecision(2) << duration << ", batch count "
@@ -441,6 +441,8 @@ int target() {
                       << FLAGS_gpu_id << " GPU";
             buffer_num = 1;
         }
+    } else {
+        LOG(INFO) << "DRAM is used, numa node num: " << NR_SOCKETS;
     }
     addr.resize(buffer_num);
     for (int i = 0; i < buffer_num; ++i) {
@@ -464,6 +466,7 @@ int target() {
         LOG_ASSERT(!rc);
     }
 #else
+    LOG(INFO) << "DRAM is used, numa node num: " << NR_SOCKETS;
     addr.resize(buffer_num);
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
@@ -472,10 +475,6 @@ int target() {
         LOG_ASSERT(!rc);
     }
 #endif
-
-    if (!FLAGS_use_vram) {
-        LOG(INFO) << "numa node num: " << NR_SOCKETS;
-    }
 
     while (target_running) sleep(1);
     for (int i = 0; i < buffer_num; ++i) {

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -355,7 +355,7 @@ int initiator() {
 
     auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
 
-    std::thread workers[FLAGS_threads];
+    std::vector<std::thread> workers(FLAGS_threads);
 
     struct timeval start_tv, stop_tv;
     gettimeofday(&start_tv, nullptr);

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -54,12 +54,10 @@ static void checkCudaError(cudaError_t result, const char *message) {
 }
 #endif
 
-#ifdef USE_CUDA
-const static int NR_SOCKETS = 4;
-#else
 const static int NR_SOCKETS =
     numa_available() == 0 ? numa_num_configured_nodes() : 1;
-#endif
+
+static int buffer_num = NR_SOCKETS;
 
 DEFINE_string(local_server_name, mooncake::getHostname(),
               "Local server name for segment discovery");
@@ -88,17 +86,23 @@ DEFINE_uint32(report_precision, 2, "Report precision");
 
 #ifdef USE_CUDA
 DEFINE_bool(use_vram, true, "Allocate memory from GPU VRAM");
-DEFINE_int32(gpu_id, 0, "GPU ID to use");
+DEFINE_int32(gpu_id, 0, "GPU ID to use, -1 for all GPUs");
 #endif
 
 using namespace mooncake;
 
-static void *allocateMemoryPool(size_t size, int socket_id,
+static void *allocateMemoryPool(size_t size, int buffer_id,
                                 bool from_vram = false) {
 #ifdef USE_CUDA
     if (from_vram) {
-        int gpu_id = FLAGS_gpu_id;
+        int gpu_id;
+        if (FLAGS_gpu_id == -1) {
+            gpu_id = buffer_id;
+        } else {
+            gpu_id = FLAGS_gpu_id;
+        }
         void *d_buf;
+        LOG(INFO) << "Allocating memory on GPU " << gpu_id;
         checkCudaError(cudaSetDevice(gpu_id), "Failed to set device");
 #ifdef USE_MNNVL
         d_buf = mooncake::NvlinkTransport::allocatePinnedLocalMemory(size);
@@ -109,7 +113,7 @@ static void *allocateMemoryPool(size_t size, int socket_id,
         return d_buf;
     }
 #endif
-    return numa_alloc_onnode(size, socket_id);
+    return numa_alloc_onnode(size, buffer_id);
 }
 
 static void freeMemoryPool(void *addr, size_t size) {
@@ -192,7 +196,7 @@ Status initiatorWorker(TransferEngine *engine, SegmentID segment_id,
         exit(EXIT_FAILURE);
     }
     uint64_t remote_base =
-        (uint64_t)segment_desc->buffers[thread_id % NR_SOCKETS].addr;
+        (uint64_t)segment_desc->buffers[thread_id % buffer_num].addr;
 
     size_t batch_count = 0;
     while (running) {
@@ -305,21 +309,42 @@ int initiator() {
         LOG_ASSERT(xport);
     }
 
-    std::vector<void *> addr(NR_SOCKETS, nullptr);
-    int buffer_num = NR_SOCKETS;
-
+    std::vector<void *> addr;
 #ifdef USE_CUDA
-    if (FLAGS_use_vram) LOG(INFO) << "VRAM is used";
+    if (FLAGS_use_vram) {
+        int gpu_num;
+        LOG(INFO) << "VRAM is used";
+        if (FLAGS_gpu_id == -1 && cudaGetDeviceCount(&gpu_num) == cudaSuccess) {
+            LOG(INFO) << "GPU ID is not specified, found " << gpu_num << " GPUs to use";
+            buffer_num = gpu_num;
+        } else {
+            LOG(INFO) << "GPU ID is specified or failed to get GPU count, use " << FLAGS_gpu_id << " GPU";
+            buffer_num = 1;
+        }
+    }
+    addr.resize(buffer_num);
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
-        std::string name_prefix = FLAGS_use_vram ? "cuda:" : "cpu:";
-        int name_postfix = FLAGS_use_vram ? FLAGS_gpu_id : i;
+        std::string name_prefix;
+        int name_suffix;
+        if (FLAGS_use_vram) {
+            name_prefix = "cuda:";
+            if (FLAGS_gpu_id == -1) {
+                name_suffix = i;
+            } else {
+                name_suffix = FLAGS_gpu_id;
+            }
+        } else {
+            name_prefix = "cpu:";
+            name_suffix = i;
+        }
         int rc = engine->registerLocalMemory(
             addr[i], FLAGS_buffer_size,
-            name_prefix + std::to_string(name_postfix));
+            name_prefix + std::to_string(name_suffix));
         LOG_ASSERT(!rc);
     }
 #else
+    addr.resize(buffer_num);
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
         int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
@@ -349,7 +374,9 @@ int initiator() {
                     (stop_tv.tv_usec - start_tv.tv_usec) / 1000000.0;
     auto batch_count = total_batch_count.load();
 
-    LOG(INFO) << "numa node num: " << NR_SOCKETS;
+    if (!FLAGS_use_vram) {
+        LOG(INFO) << "numa node num: " << NR_SOCKETS;
+    }
 
     LOG(INFO) << "Test completed: duration " << std::fixed
               << std::setprecision(2) << duration << ", batch count "
@@ -400,21 +427,44 @@ int target() {
         }
     }
 
-    std::vector<void *> addr(NR_SOCKETS, nullptr);
-    int buffer_num = NR_SOCKETS;
-
+    std::vector<void *> addr;
 #ifdef USE_CUDA
-    if (FLAGS_use_vram) LOG(INFO) << "VRAM is used";
+    if (FLAGS_use_vram) {
+        int gpu_num;
+        LOG(INFO) << "VRAM is used";
+        if (FLAGS_gpu_id == -1 && cudaGetDeviceCount(&gpu_num) == cudaSuccess) {
+            LOG(INFO) << "GPU ID is not specified, found " << gpu_num
+                      << " GPUs to use";
+            buffer_num = gpu_num;
+        } else {
+            LOG(INFO) << "GPU ID is specified or failed to get GPU count, use "
+                      << FLAGS_gpu_id << " GPU";
+            buffer_num = 1;
+        }
+    }
+    addr.resize(buffer_num);
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
-        std::string name_prefix = FLAGS_use_vram ? "cuda:" : "cpu:";
-        int name_postfix = FLAGS_use_vram ? FLAGS_gpu_id : i;
+        std::string name_prefix;
+        int name_suffix;
+        if (FLAGS_use_vram) {
+            name_prefix = "cuda:";
+            if (FLAGS_gpu_id == -1) {
+                name_suffix = i;
+            } else {
+                name_suffix = FLAGS_gpu_id;
+            }
+        } else {
+            name_prefix = "cpu:";
+            name_suffix = i;
+        }
         int rc = engine->registerLocalMemory(
             addr[i], FLAGS_buffer_size,
-            name_prefix + std::to_string(name_postfix));
+            name_prefix + std::to_string(name_suffix));
         LOG_ASSERT(!rc);
     }
 #else
+    addr.resize(buffer_num);
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
         int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
@@ -423,7 +473,9 @@ int target() {
     }
 #endif
 
-    LOG(INFO) << "numa node num: " << NR_SOCKETS;
+    if (!FLAGS_use_vram) {
+        LOG(INFO) << "numa node num: " << NR_SOCKETS;
+    }
 
     while (target_running) sleep(1);
     for (int i = 0; i < buffer_num; ++i) {

--- a/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
@@ -291,10 +291,10 @@ int initiator() {
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
         std::string name_prefix = FLAGS_use_vram ? "cuda:" : "cpu:";
-        int name_postfix = FLAGS_use_vram ? FLAGS_gpu_id : i;
+        int name_suffix = FLAGS_use_vram ? FLAGS_gpu_id : i;
         int rc = engine->registerLocalMemory(
             addr[i], FLAGS_buffer_size,
-            name_prefix + std::to_string(name_postfix));
+            name_prefix + std::to_string(name_suffix));
         LOG_ASSERT(!rc);
     }
 #else

--- a/mooncake-transfer-engine/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test.cpp
@@ -260,9 +260,9 @@ int initiator() {
 #ifdef USE_CUDA
     addr = allocateMemoryPool(ram_buffer_size, 0, FLAGS_use_vram);
     std::string name_prefix = FLAGS_use_vram ? "cuda:" : "cpu:";
-    int name_postfix = FLAGS_use_vram ? FLAGS_gpu_id : 0;
+    int name_suffix = FLAGS_use_vram ? FLAGS_gpu_id : 0;
     int rc = engine->registerLocalMemory(
-        addr, ram_buffer_size, name_prefix + std::to_string(name_postfix));
+        addr, ram_buffer_size, name_prefix + std::to_string(name_suffix));
     LOG_ASSERT(!rc);
 #else
     addr = allocateMemoryPool(ram_buffer_size, 0, false);


### PR DESCRIPTION
# Summary

This PR enhances the mooncake transfer engine benchmark to support multi-GPU configurations and improves memory allocation logic for better performance demonstration.

# Change

- Added support for using all available GPUs: When gpu_id=-1, the benchmark now automatically detects and utilizes all available GPUs
- Dynamic buffer allocation: The number of buffers now scales with the number of GPUs when using VRAM
- Enhanced logging: Added detailed logging for GPU memory allocation to aid in debugging and monitoring

# Usage

- Single GPU: --gpu_id=0 (existing behavior)
- Multi-GPU: --gpu_id=-1 (**new feature - uses all available GPUs**)

# Testing Result

The changes maintain full backward compatibility with existing single-GPU configurations while enabling multi-GPU scenarios for enhanced performance testing. I have test the performance with the below command:

- target:

```
./transfer_engine_bench --mode=target --metadata_server=redis://${redis_ip}:${redis_port} --local_server_name=${local_ip} --use_vram=true --block_size=$((1*1024*1024)) --threads=16 --auto_discovery --gpu_id=-1
```

- initiator:

```
./transfer_engine_bench --metadata_server=redis://${redis_ip}:${redis_port} --local_server_name=${local_ip} segment_id=${target_ip} --block_size=$((1*1024*1024)) --operation=write --duration=30 --threads=16 --auto_discovery --use_vram=true --gpu_id=-1
```

And the result show that **When allocating memory from eight H20 GPUs simultaneously (which is the purpose of this PR), the Mooncake Transfer Engine can fully utilize the bandwidth of eight 400Gbps RDMA NIC**
<img width="672" height="31" alt="Clipboard_Screenshot_1753502699" src="https://github.com/user-attachments/assets/84c0968d-d19e-478b-96fb-061a6c093fa5" />
