### PR TITLE
[CI/Build] Mooncake-common/common.cmake: Add link flag of pthread

### DIFF
--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -149,6 +149,3 @@ set(GFLAGS_USE_TARGET_NAMESPACE "true")
 find_package(yaml-cpp REQUIRED)
 find_package(gflags REQUIRED)
 find_package(yalantinglibs CONFIG REQUIRED)
-
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)

--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -149,3 +149,6 @@ set(GFLAGS_USE_TARGET_NAMESPACE "true")
 find_package(yaml-cpp REQUIRED)
 find_package(gflags REQUIRED)
 find_package(yalantinglibs CONFIG REQUIRED)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)

--- a/mooncake-common/tests/CMakeLists.txt
+++ b/mooncake-common/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(default_config_test default_config_test.cpp)
 target_link_libraries(default_config_test PUBLIC
     mooncake_common 
-    Threads::Threads
     gtest
+    pthread PUBLIC
 )
 add_test(NAME default_config_test COMMAND default_config_test)

--- a/mooncake-common/tests/CMakeLists.txt
+++ b/mooncake-common/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(default_config_test default_config_test.cpp)
 target_link_libraries(default_config_test PUBLIC
     mooncake_common 
+    Threads::Threads
     gtest
 )
 add_test(NAME default_config_test COMMAND default_config_test)


### PR DESCRIPTION
On my ubuntu 20.04, there is a link error for missing pthread link flag when building
`mooncake-common/tests/CMakeFiles/default_config_test.dir/default_config_test.cpp.o`
Add a link flag in cmake files to fix it.



<img width="2223" height="735" alt="image" src="https://github.com/user-attachments/assets/55e4a941-9e8e-4b03-be89-4b61dd2ea2b5" />

