### PR TITLE
refactor(offset-allocator): add memory allocation metrics tracking

### DIFF
--- a/mooncake-store/include/offset_allocator/offset_allocator.hpp
+++ b/mooncake-store/include/offset_allocator/offset_allocator.hpp
@@ -49,7 +49,8 @@ class OffsetAllocationHandle {
    public:
     // Constructor for valid allocation
     OffsetAllocationHandle(std::shared_ptr<OffsetAllocator> allocator,
-                     OffsetAllocation allocation, uint64_t base, uint64_t size);
+                           OffsetAllocation allocation, uint64_t base,
+                           uint64_t size);
 
     // Move constructor
     OffsetAllocationHandle(OffsetAllocationHandle&& other) noexcept;
@@ -84,6 +85,18 @@ class OffsetAllocationHandle {
     uint64_t requested_size;
 };
 
+struct OffsetAllocatorMetrics {
+    uint64_t allocated_size_;       // Total bytes currently allocated
+    uint64_t allocated_num_;        // Number of active allocations
+    uint64_t largest_free_region_;  // Size of largest contiguous free region
+    uint64_t total_free_space_;     // Total free space available
+    const uint64_t capacity;        // Total capacity of the allocator
+};
+
+// Stream output operator for OffsetAllocatorMetrics
+std::ostream& operator<<(std::ostream& os,
+                         const OffsetAllocatorMetrics& metrics);
+
 // Wrapper class for __Allocator, it 1) supports thread-safe allocation and
 // deallocation, 2) supports creating a buffer or allocating a memory region
 // that is larger than the largest bin size (3.75GB). The __allocator class is
@@ -96,7 +109,8 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
    public:
     // Factory method to create shared_ptr<OffsetAllocator>
     static std::shared_ptr<OffsetAllocator> create(uint64_t base, size_t size,
-                                             uint32 maxAllocs = 128 * 1024);
+                                                   uint32 maxAllocs = 128 *
+                                                                      1024);
 
     // Disable copy constructor and copy assignment
     OffsetAllocator(const OffsetAllocator&) = delete;
@@ -121,64 +135,77 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
     [[nodiscard]]
     OffsetAllocStorageReportFull storageReportFull() const;
 
+    // Get comprehensive metrics including fragmentation analysis (thread-safe)
+    [[nodiscard]]
+    OffsetAllocatorMetrics get_metrics() const;
+
    private:
     friend class OffsetAllocationHandle;
 
     // Internal method for Handle to free allocation (thread-safe)
-    void freeAllocation(const OffsetAllocation& allocation);
+    void freeAllocation(const OffsetAllocation& allocation, uint64_t size);
+
+    // Internal method to get metrics without locking (caller must hold m_mutex)
+    [[nodiscard]]
+    OffsetAllocatorMetrics get_metrics_internal() const;
 
     std::unique_ptr<__Allocator> m_allocator GUARDED_BY(m_mutex);
     const uint64_t m_base;
     // The real offset and size of the allocated memory need to be multiplied by
     // m_multiplier
     const uint64_t m_multiplier;
+    const uint64_t m_capacity;
     mutable Mutex m_mutex;
+
+    // Lightweight metrics maintained during allocation/deallocation
+    uint64_t m_allocated_size GUARDED_BY(m_mutex) = 0;
+    uint64_t m_allocated_num GUARDED_BY(m_mutex) = 0;
 
     // Private constructor - use create() factory method instead
     OffsetAllocator(uint64_t base, size_t size, uint32 maxAllocs = 128 * 1024);
 };
 
 class __Allocator {
-    public:
-     __Allocator(uint32 size, uint32 maxAllocs = 128 * 1024);
-     __Allocator(__Allocator&& other);
-     ~__Allocator();
-     void reset();
- 
-     OffsetAllocation allocate(uint32 size);
-     void free(OffsetAllocation allocation);
- 
-     uint32 allocationSize(OffsetAllocation allocation) const;
-     OffsetAllocStorageReport storageReport() const;
-     OffsetAllocStorageReportFull storageReportFull() const;
- 
-    private:
-     uint32 insertNodeIntoBin(uint32 size, uint32 dataOffset);
-     void removeNodeFromBin(uint32 nodeIndex);
- 
-     struct Node {
-         static constexpr NodeIndex unused = 0xffffffff;
- 
-         uint32 dataOffset = 0;
-         uint32 dataSize = 0;
-         NodeIndex binListPrev = unused;
-         NodeIndex binListNext = unused;
-         NodeIndex neighborPrev = unused;
-         NodeIndex neighborNext = unused;
-         bool used = false;  // TODO: Merge as bit flag
-     };
- 
-     uint32 m_size;
-     uint32 m_maxAllocs;
-     uint32 m_freeStorage;
- 
-     uint32 m_usedBinsTop;
-     uint8 m_usedBins[NUM_TOP_BINS];
-     NodeIndex m_binIndices[NUM_LEAF_BINS];
- 
-     Node* m_nodes;
-     NodeIndex* m_freeNodes;
-     uint32 m_freeOffset;
- };
+   public:
+    __Allocator(uint32 size, uint32 maxAllocs = 128 * 1024);
+    __Allocator(__Allocator&& other);
+    ~__Allocator();
+    void reset();
+
+    OffsetAllocation allocate(uint32 size);
+    void free(OffsetAllocation allocation);
+
+    uint32 allocationSize(OffsetAllocation allocation) const;
+    OffsetAllocStorageReport storageReport() const;
+    OffsetAllocStorageReportFull storageReportFull() const;
+
+   private:
+    uint32 insertNodeIntoBin(uint32 size, uint32 dataOffset);
+    void removeNodeFromBin(uint32 nodeIndex);
+
+    struct Node {
+        static constexpr NodeIndex unused = 0xffffffff;
+
+        uint32 dataOffset = 0;
+        uint32 dataSize = 0;
+        NodeIndex binListPrev = unused;
+        NodeIndex binListNext = unused;
+        NodeIndex neighborPrev = unused;
+        NodeIndex neighborNext = unused;
+        bool used = false;  // TODO: Merge as bit flag
+    };
+
+    uint32 m_size;
+    uint32 m_maxAllocs;
+    uint32 m_freeStorage;
+
+    uint32 m_usedBinsTop;
+    uint8 m_usedBins[NUM_TOP_BINS];
+    NodeIndex m_binIndices[NUM_LEAF_BINS];
+
+    Node* m_nodes;
+    NodeIndex* m_freeNodes;
+    uint32 m_freeOffset;
+};
 
 }  // namespace mooncake::offset_allocator

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -84,4 +84,31 @@ void* allocate_buffer_allocator_memory(size_t total_size);
 
 void** rdma_args(const std::string& device_name);
 
+[[nodiscard]] inline std::string byte_size_to_string(uint64_t bytes) {
+    const double KB = 1024.0;
+    const double MB = KB * 1024.0;
+    const double GB = MB * 1024.0;
+    const double TB = GB * 1024.0;
+
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2);
+
+    if (bytes >= static_cast<uint64_t>(TB)) {
+        oss << bytes / TB << " TB";
+    } else if (bytes >= static_cast<uint64_t>(GB)) {
+        oss << bytes / GB << " GB";
+    } else if (bytes >= static_cast<uint64_t>(MB)) {
+        oss << bytes / MB << " MB";
+    } else if (bytes >= static_cast<uint64_t>(KB)) {
+        oss << bytes / KB << " KB";
+    } else {
+        // Less than 1 KB, don't use fixed point
+        oss.unsetf(std::ios::fixed);
+        oss << bytes << " B";
+        return oss.str();
+    }
+
+    return oss.str();
+}
+
 }  // namespace mooncake

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -4,6 +4,8 @@
 #include <sstream>  // For string building during serialization
 #include <vector>   // Required by histogram serialization
 
+#include "utils.h"
+
 namespace mooncake {
 
 // --- Singleton Instance ---
@@ -22,13 +24,13 @@ MasterMetricManager::MasterMetricManager()
                       "Total capacity across all mounted segments"),
       key_count_("master_key_count",
                  "Total number of keys managed by the master"),
-      soft_pin_key_count_("master_soft_pin_key_count",
-                          "Total number of soft-pinned keys managed by the master"),
+      soft_pin_key_count_(
+          "master_soft_pin_key_count",
+          "Total number of soft-pinned keys managed by the master"),
       // Initialize Histogram (4KB, 64KB, 256KB, 1MB, 4MB, 16MB, 64MB)
-      value_size_distribution_("master_value_size_bytes",
-                               "Distribution of object value sizes",
-                               {4096, 65536, 262144, 1048576, 4194304,
-                                16777216, 67108864}),
+      value_size_distribution_(
+          "master_value_size_bytes", "Distribution of object value sizes",
+          {4096, 65536, 262144, 1048576, 4194304, 16777216, 67108864}),
       // Initialize cluster metrics
       active_clients_("master_active_clients",
                       "Total number of active clients"),
@@ -52,20 +54,18 @@ MasterMetricManager::MasterMetricManager()
       get_replica_list_failures_(
           "master_get_replica_list_failures_total",
           "Total number of failed GetReplicaList requests"),
-      exist_key_requests_(
-          "master_exist_key_requests_total",
-          "Total number of ExistKey requests received"),
-      exist_key_failures_(
-          "master_exist_key_failures_total",
-          "Total number of failed ExistKey requests"),
+      exist_key_requests_("master_exist_key_requests_total",
+                          "Total number of ExistKey requests received"),
+      exist_key_failures_("master_exist_key_failures_total",
+                          "Total number of failed ExistKey requests"),
       remove_requests_("master_remove_requests_total",
                        "Total number of Remove requests received"),
       remove_failures_("master_remove_failures_total",
                        "Total number of failed Remove requests"),
       remove_all_requests_("master_remove_all_requests_total",
-                       "Total number of Remove all requests received"),
+                           "Total number of Remove all requests received"),
       remove_all_failures_("master_remove_all_failures_total",
-                       "Total number of failed Remove all requests"),
+                           "Total number of failed Remove all requests"),
 
       mount_segment_requests_("master_mount_segment_requests_total",
                               "Total number of MountSegment requests received"),
@@ -89,34 +89,42 @@ MasterMetricManager::MasterMetricManager()
                      "Total number of failed ping requests"),
 
       // Initialize Batch Request Counters
-      batch_exist_key_requests_("master_batch_exist_key_requests_total",
-                                "Total number of BatchExistKey requests received"),
-      batch_exist_key_failures_("master_batch_exist_key_failures_total",
-                                "Total number of failed BatchExistKey requests"),
-      batch_get_replica_list_requests_("master_batch_get_replica_list_requests_total",
-                                       "Total number of BatchGetReplicaList requests received"),
-      batch_get_replica_list_failures_("master_batch_get_replica_list_failures_total",
-                                       "Total number of failed BatchGetReplicaList requests"),
-      batch_put_start_requests_("master_batch_put_start_requests_total",
-                                "Total number of BatchPutStart requests received"),
-      batch_put_start_failures_("master_batch_put_start_failures_total",
-                                "Total number of failed BatchPutStart requests"),
+      batch_exist_key_requests_(
+          "master_batch_exist_key_requests_total",
+          "Total number of BatchExistKey requests received"),
+      batch_exist_key_failures_(
+          "master_batch_exist_key_failures_total",
+          "Total number of failed BatchExistKey requests"),
+      batch_get_replica_list_requests_(
+          "master_batch_get_replica_list_requests_total",
+          "Total number of BatchGetReplicaList requests received"),
+      batch_get_replica_list_failures_(
+          "master_batch_get_replica_list_failures_total",
+          "Total number of failed BatchGetReplicaList requests"),
+      batch_put_start_requests_(
+          "master_batch_put_start_requests_total",
+          "Total number of BatchPutStart requests received"),
+      batch_put_start_failures_(
+          "master_batch_put_start_failures_total",
+          "Total number of failed BatchPutStart requests"),
       batch_put_end_requests_("master_batch_put_end_requests_total",
                               "Total number of BatchPutEnd requests received"),
       batch_put_end_failures_("master_batch_put_end_failures_total",
                               "Total number of failed BatchPutEnd requests"),
-      batch_put_revoke_requests_("master_batch_put_revoke_requests_total",
-                                 "Total number of BatchPutRevoke requests received"),
-      batch_put_revoke_failures_("master_batch_put_revoke_failures_total",
-                                 "Total number of failed BatchPutRevoke requests"),
+      batch_put_revoke_requests_(
+          "master_batch_put_revoke_requests_total",
+          "Total number of BatchPutRevoke requests received"),
+      batch_put_revoke_failures_(
+          "master_batch_put_revoke_failures_total",
+          "Total number of failed BatchPutRevoke requests"),
 
       // Initialize Eviction Counters
       eviction_success_("master_successful_evictions_total",
-                       "Total number of successful eviction operations"),
+                        "Total number of successful eviction operations"),
       eviction_attempts_("master_attempted_evictions_total",
                          "Total number of attempted eviction operations"),
       evicted_key_count_("master_evicted_key_count",
-                        "Total number of keys evicted"),
+                         "Total number of keys evicted"),
       evicted_size_("master_evicted_size_bytes",
                     "Total bytes of evicted objects") {}
 
@@ -158,16 +166,18 @@ double MasterMetricManager::get_global_used_ratio(void) {
 void MasterMetricManager::inc_key_count(int64_t val) { key_count_.inc(val); }
 void MasterMetricManager::dec_key_count(int64_t val) { key_count_.dec(val); }
 
-void MasterMetricManager::inc_soft_pin_key_count(int64_t val) { soft_pin_key_count_.inc(val); }
-void MasterMetricManager::dec_soft_pin_key_count(int64_t val) { soft_pin_key_count_.dec(val); }
+void MasterMetricManager::inc_soft_pin_key_count(int64_t val) {
+    soft_pin_key_count_.inc(val);
+}
+void MasterMetricManager::dec_soft_pin_key_count(int64_t val) {
+    soft_pin_key_count_.dec(val);
+}
 
 void MasterMetricManager::observe_value_size(int64_t size) {
     value_size_distribution_.observe(size);
 }
 
-int64_t MasterMetricManager::get_key_count() {
-    return key_count_.value();
-}
+int64_t MasterMetricManager::get_key_count() { return key_count_.value(); }
 
 int64_t MasterMetricManager::get_soft_pin_key_count() {
     return soft_pin_key_count_.value();
@@ -415,16 +425,15 @@ int64_t MasterMetricManager::get_batch_put_revoke_failures() {
 }
 
 // Eviction Metrics
-void MasterMetricManager::inc_eviction_success(int64_t key_count, int64_t size) {
+void MasterMetricManager::inc_eviction_success(int64_t key_count,
+                                               int64_t size) {
     evicted_key_count_.inc(key_count);
     evicted_size_.inc(size);
     eviction_success_.inc();
     eviction_attempts_.inc();
 }
 
-void MasterMetricManager::inc_eviction_fail() {
-    eviction_attempts_.inc();
-}
+void MasterMetricManager::inc_eviction_fail() { eviction_attempts_.inc(); }
 
 int64_t MasterMetricManager::get_eviction_success() {
     return eviction_success_.value();
@@ -524,22 +533,6 @@ std::string MasterMetricManager::serialize_metrics() {
 std::string MasterMetricManager::get_summary_string() {
     std::stringstream ss;
 
-    // --- Helper lambda for formatting bytes ---
-    auto format_bytes = [](double bytes) -> std::string {
-        std::stringstream byte_ss;
-        byte_ss << std::fixed << std::setprecision(2);
-        if (bytes >= 1024.0 * 1024.0 * 1024.0) {  // GB
-            byte_ss << (bytes / (1024.0 * 1024.0 * 1024.0)) << " GB";
-        } else if (bytes >= 1024.0 * 1024.0) {  // MB
-            byte_ss << (bytes / (1024.0 * 1024.0)) << " MB";
-        } else if (bytes >= 1024.0) {  // KB
-            byte_ss << (bytes / 1024.0) << " KB";
-        } else {
-            byte_ss << bytes << " B";
-        }
-        return byte_ss.str();
-    };
-
     // --- Get current values ---
     int64_t allocated = allocated_size_.value();
     int64_t capacity = total_capacity_.value();
@@ -572,11 +565,11 @@ std::string MasterMetricManager::get_summary_string() {
     int64_t ping_fails = ping_failures_.value();
 
     // --- Format the summary string ---
-    ss << "Storage: " << format_bytes(allocated) << " / "
-       << format_bytes(capacity);
+    ss << "Storage: " << byte_size_to_string(allocated) << " / "
+       << byte_size_to_string(capacity);
     if (capacity > 0) {
         ss << " (" << std::fixed << std::setprecision(1)
-           << ((double) allocated / (double)capacity * 100.0) << "%)";
+           << ((double)allocated / (double)capacity * 100.0) << "%)";
     }
     ss << " | Keys: " << keys << " (soft-pinned: " << soft_pin_keys << ")";
     if (enable_ha_) {
@@ -585,22 +578,24 @@ std::string MasterMetricManager::get_summary_string() {
 
     // Request summary - focus on the most important metrics
     ss << " | Requests (Success/Total): ";
-    ss << "Put="
-       << put_starts - put_start_fails + put_ends - put_end_fails
+    ss << "Put=" << put_starts - put_start_fails + put_ends - put_end_fails
        << "/" << put_starts + put_ends << ", ";
-    ss << "Get=" << get_replicas - get_replica_fails << "/" << get_replicas << ", ";
+    ss << "Get=" << get_replicas - get_replica_fails << "/" << get_replicas
+       << ", ";
     ss << "Exist=" << exist_keys - exist_key_fails << "/" << exist_keys << ", ";
     ss << "Del=" << removes - remove_fails << "/" << removes << ", ";
-    ss << "DelAll=" << remove_all - remove_all_fails << "/" << remove_all << ", ";
+    ss << "DelAll=" << remove_all - remove_all_fails << "/" << remove_all
+       << ", ";
     if (enable_ha_) {
         ss << "Ping=" << ping - ping_fails << "/" << ping << ", ";
     }
 
     // Eviction summary
     ss << " | Eviction: "
-        << "Success/Attempts=" << eviction_success << "/" << eviction_attempts << ", "
-        << "keys=" << evicted_key_count << ", "
-        << "size=" << format_bytes(evicted_size);
+       << "Success/Attempts=" << eviction_success << "/" << eviction_attempts
+       << ", "
+       << "keys=" << evicted_key_count << ", "
+       << "size=" << byte_size_to_string(evicted_size);
 
     return ss.str();
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -12,15 +12,12 @@
 
 namespace mooncake {
 
-MasterService::MasterService(bool enable_gc, uint64_t default_kv_lease_ttl,
-                             uint64_t default_kv_soft_pin_ttl,
-                             bool allow_evict_soft_pinned_objects,
-                             double eviction_ratio,
-                             double eviction_high_watermark_ratio,
-                             ViewVersionId view_version,
-                             int64_t client_live_ttl_sec, bool enable_ha,
-                             const std::string& cluster_id,
-                             BufferAllocatorType memory_allocator)
+MasterService::MasterService(
+    bool enable_gc, uint64_t default_kv_lease_ttl,
+    uint64_t default_kv_soft_pin_ttl, bool allow_evict_soft_pinned_objects,
+    double eviction_ratio, double eviction_high_watermark_ratio,
+    ViewVersionId view_version, int64_t client_live_ttl_sec, bool enable_ha,
+    const std::string& cluster_id, BufferAllocatorType memory_allocator)
     : enable_gc_(enable_gc),
       default_kv_lease_ttl_(default_kv_lease_ttl),
       default_kv_soft_pin_ttl_(default_kv_soft_pin_ttl),
@@ -388,9 +385,6 @@ auto MasterService::PutStart(const std::string& key,
                     allocators, allocators_by_name, chunk_size, config);
 
                 if (!handle) {
-                    LOG(ERROR)
-                        << "key=" << key << ", replica_id=" << i
-                        << ", slice_index=" << j << ", error=allocation_failed";
                     // If the allocation failed, we need to evict some objects
                     // to free up space for future allocations.
                     need_eviction_ = true;

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -657,7 +657,7 @@ std::ostream& operator<<(std::ostream& os,
        << ", free_space="
        << mooncake::byte_size_to_string(metrics.total_free_space_)
        << ", largest_free="
-       << mooncake::byte_size_to_string(metrics.largest_free_region_);
+       << mooncake::byte_size_to_string(metrics.largest_free_region_) << "}";
     return os;
 }
 

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -569,8 +569,8 @@ std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {
         // Log metrics to help understand why allocation failed
         // Note: We're already holding m_mutex, so use internal method
         OffsetAllocatorMetrics metrics = get_metrics_internal();
-        LOG(WARNING) << "OffsetAllocator allocation failed: size=" << size
-                     << ", fake_size=" << fake_size << ", " << metrics;
+        VLOG(1) << "OffsetAllocator allocation failed: size=" << size
+                << ", fake_size=" << fake_size << ", " << metrics;
         return std::nullopt;
     }
 

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -3,8 +3,12 @@
 
 #include "offset_allocator/offset_allocator.hpp"
 
-#include "mutex.h"
+#include <cmath>
+#include <iomanip>
 #include <iostream>
+
+#include "mutex.h"
+#include "utils.h"
 
 #ifdef DEBUG
 #include <assert.h>
@@ -470,20 +474,22 @@ OffsetAllocStorageReportFull __Allocator::storageReportFull() const {
 }
 
 // OffsetAllocationHandle implementation
-OffsetAllocationHandle::OffsetAllocationHandle(std::shared_ptr<OffsetAllocator> allocator,
-                                   OffsetAllocation allocation, uint64_t base,
-                                   uint64_t size)
+OffsetAllocationHandle::OffsetAllocationHandle(
+    std::shared_ptr<OffsetAllocator> allocator, OffsetAllocation allocation,
+    uint64_t base, uint64_t size)
     : m_allocator(std::move(allocator)),
       m_allocation(allocation),
       real_base(base),
       requested_size(size) {}
 
-OffsetAllocationHandle::OffsetAllocationHandle(OffsetAllocationHandle&& other) noexcept
+OffsetAllocationHandle::OffsetAllocationHandle(
+    OffsetAllocationHandle&& other) noexcept
     : m_allocator(std::move(other.m_allocator)),
       m_allocation(other.m_allocation),
       real_base(other.real_base),
       requested_size(other.requested_size) {
-    other.m_allocation = {OffsetAllocation::NO_SPACE, OffsetAllocation::NO_SPACE};
+    other.m_allocation = {OffsetAllocation::NO_SPACE,
+                          OffsetAllocation::NO_SPACE};
     other.real_base = 0;
     other.requested_size = 0;
 }
@@ -494,7 +500,7 @@ OffsetAllocationHandle& OffsetAllocationHandle::operator=(
         // Free current allocation if valid{
         auto allocator = m_allocator.lock();
         if (allocator) {
-            allocator->freeAllocation(m_allocation);
+            allocator->freeAllocation(m_allocation, requested_size);
         }
 
         // Move from other
@@ -504,7 +510,8 @@ OffsetAllocationHandle& OffsetAllocationHandle::operator=(
         requested_size = other.requested_size;
 
         // Reset other
-        other.m_allocation = {OffsetAllocation::NO_SPACE, OffsetAllocation::NO_SPACE};
+        other.m_allocation = {OffsetAllocation::NO_SPACE,
+                              OffsetAllocation::NO_SPACE};
         other.real_base = 0;
         other.requested_size = 0;
     }
@@ -514,7 +521,7 @@ OffsetAllocationHandle& OffsetAllocationHandle::operator=(
 OffsetAllocationHandle::~OffsetAllocationHandle() {
     auto allocator = m_allocator.lock();
     if (allocator) {
-        allocator->freeAllocation(m_allocation);
+        allocator->freeAllocation(m_allocation, requested_size);
     }
 }
 
@@ -527,14 +534,16 @@ static uint64_t calculateMultiplier(size_t size) {
 }
 
 // Thread-safe OffsetAllocator implementation
-std::shared_ptr<OffsetAllocator> OffsetAllocator::create(uint64_t base, size_t size,
-                                             uint32 maxAllocs) {
+std::shared_ptr<OffsetAllocator> OffsetAllocator::create(uint64_t base,
+                                                         size_t size,
+                                                         uint32 maxAllocs) {
     // Use a custom deleter to allow private constructor
-    return std::shared_ptr<OffsetAllocator>(new OffsetAllocator(base, size, maxAllocs));
+    return std::shared_ptr<OffsetAllocator>(
+        new OffsetAllocator(base, size, maxAllocs));
 }
 
 OffsetAllocator::OffsetAllocator(uint64_t base, size_t size, uint32 maxAllocs)
-    : m_base(base), m_multiplier(calculateMultiplier(size)) {
+    : m_base(base), m_multiplier(calculateMultiplier(size)), m_capacity(size) {
     m_allocator = std::make_unique<__Allocator>(size / m_multiplier, maxAllocs);
 }
 
@@ -557,13 +566,22 @@ std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {
 
     OffsetAllocation allocation = m_allocator->allocate(fake_size);
     if (allocation.offset == OffsetAllocation::NO_SPACE) {
+        // Log metrics to help understand why allocation failed
+        // Note: We're already holding m_mutex, so use internal method
+        OffsetAllocatorMetrics metrics = get_metrics_internal();
+        LOG(WARNING) << "OffsetAllocator allocation failed: size=" << size
+                     << ", fake_size=" << fake_size << ", " << metrics;
         return std::nullopt;
     }
 
+    // Update lightweight metrics
+    m_allocated_size += size;
+    m_allocated_num++;
+
     // Use shared_from_this to get a shared_ptr to this OffsetAllocator
     return OffsetAllocationHandle(shared_from_this(), allocation,
-                            m_base + allocation.offset * m_multiplier,
-                            size);
+                                  m_base + allocation.offset * m_multiplier,
+                                  size);
 }
 
 OffsetAllocStorageReport OffsetAllocator::storageReport() const {
@@ -584,17 +602,63 @@ OffsetAllocStorageReportFull OffsetAllocator::storageReportFull() const {
     }
     OffsetAllocStorageReportFull report = m_allocator->storageReportFull();
     for (uint32 i = 0; i < NUM_LEAF_BINS; i++) {
-        report.freeRegions[i] = {.size = report.freeRegions[i].size * m_multiplier,
-                                 .count = report.freeRegions[i].count};
+        report.freeRegions[i] = {
+            .size = report.freeRegions[i].size * m_multiplier,
+            .count = report.freeRegions[i].count};
     }
     return report;
 }
 
-void OffsetAllocator::freeAllocation(const OffsetAllocation& allocation) {
+OffsetAllocatorMetrics OffsetAllocator::get_metrics_internal() const {
+    if (!m_allocator) {
+        return {0, 0, 0, 0, m_capacity};
+    }
+
+    // Get basic storage report
+    OffsetAllocStorageReport basic_report = m_allocator->storageReport();
+    return {
+        m_allocated_size,                               // allocated_size_
+        m_allocated_num,                                // allocated_num_
+        basic_report.largestFreeRegion * m_multiplier,  // largest_free_region_
+        basic_report.totalFreeSpace * m_multiplier,     // total_free_space_
+        m_capacity,                                     // capacity
+    };
+}
+
+OffsetAllocatorMetrics OffsetAllocator::get_metrics() const {
+    MutexLocker guard(&m_mutex);
+    return get_metrics_internal();
+}
+
+void OffsetAllocator::freeAllocation(const OffsetAllocation& allocation,
+                                     uint64_t size) {
     MutexLocker lock(&m_mutex);
     if (m_allocator) {
         m_allocator->free(allocation);
+        // Update lightweight metrics
+        m_allocated_size -= size;
+        m_allocated_num--;
     }
+}
+
+// Stream output operator implementation
+std::ostream& operator<<(std::ostream& os,
+                         const OffsetAllocatorMetrics& metrics) {
+    double utilization =
+        metrics.capacity > 0
+            ? (double)metrics.allocated_size_ / metrics.capacity * 100.0
+            : 0.0;
+    os << "OffsetAllocatorMetrics{"
+       << "allocated=" << mooncake::byte_size_to_string(metrics.allocated_size_)
+       << ", allocs=" << metrics.allocated_num_
+       << ", capacity=" << mooncake::byte_size_to_string(metrics.capacity)
+       << ", utilization=" << std::fixed << std::setprecision(1) << utilization
+       << "%"
+       << ", free_space="
+       << mooncake::byte_size_to_string(metrics.total_free_space_)
+       << ", largest_free="
+       << mooncake::byte_size_to_string(metrics.largest_free_region_);
+    return os;
 }
 
 }  // namespace mooncake::offset_allocator

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -101,4 +101,15 @@ target_link_libraries(offset_allocator_test PUBLIC
 )
 add_test(NAME offset_allocator_test COMMAND offset_allocator_test)
 
+add_executable(utils_test utils_test.cpp)
+target_link_libraries(utils_test PUBLIC
+    mooncake_store
+    cachelib_memory_allocator
+    glog
+    gtest
+    gtest_main
+    pthread
+)
+add_test(NAME utils_test COMMAND utils_test)
+
 add_subdirectory(e2e)

--- a/mooncake-store/tests/offset_allocator_test.cpp
+++ b/mooncake-store/tests/offset_allocator_test.cpp
@@ -1,10 +1,10 @@
+#include "offset_allocator/offset_allocator.hpp"
+
 #include <gtest/gtest.h>
 
 #include <map>
 #include <random>
 #include <vector>
-
-#include "offset_allocator/offset_allocator.hpp"
 
 using namespace mooncake::offset_allocator;
 
@@ -144,6 +144,11 @@ class AllocatorWrapper : public std::enable_shared_from_this<AllocatorWrapper> {
     // Get storage report
     OffsetAllocStorageReport storageReport() const {
         return m_allocator->storageReport();
+    }
+
+    // Get metrics
+    OffsetAllocatorMetrics getMetrics() const {
+        return m_allocator->get_metrics();
     }
 
    private:
@@ -1120,6 +1125,73 @@ TEST_F(OffsetAllocatorTest, BinSystemPageSizeMultiples) {
         EXPECT_EQ(handle->size(), size);
         // Handle will be automatically freed when it goes out of scope
     }
+}
+
+// Test metrics interface functionality
+TEST_F(OffsetAllocatorTest, MetricsInterface) {
+    constexpr uint32 ALLOCATOR_SIZE = 1024 * 1024;  // 1MB
+    constexpr uint32 MAX_ALLOCS = 1000;
+    auto allocator =
+        std::make_shared<AllocatorWrapper>(0, ALLOCATOR_SIZE, MAX_ALLOCS);
+
+    // Test initial metrics - should show empty allocator
+    OffsetAllocatorMetrics initial_metrics = allocator->getMetrics();
+    EXPECT_EQ(initial_metrics.allocated_size_, 0);
+    EXPECT_EQ(initial_metrics.allocated_num_, 0);
+    EXPECT_EQ(initial_metrics.capacity, ALLOCATOR_SIZE);
+    EXPECT_GT(initial_metrics.total_free_space_, 0);
+    EXPECT_GT(initial_metrics.largest_free_region_, 0);
+    EXPECT_EQ(initial_metrics.total_free_space_, ALLOCATOR_SIZE);
+
+    // Allocate some memory and verify metrics update
+    constexpr size_t ALLOC_SIZE_1 = 1024;
+    auto handle1 = allocator->allocate(ALLOC_SIZE_1);
+    ASSERT_TRUE(handle1.has_value());
+
+    OffsetAllocatorMetrics after_first_alloc = allocator->getMetrics();
+    EXPECT_EQ(after_first_alloc.allocated_size_, ALLOC_SIZE_1);
+    EXPECT_EQ(after_first_alloc.allocated_num_, 1);
+    EXPECT_EQ(after_first_alloc.capacity, ALLOCATOR_SIZE);
+    EXPECT_LT(after_first_alloc.total_free_space_,
+              initial_metrics.total_free_space_);
+    EXPECT_EQ(after_first_alloc.total_free_space_,
+              ALLOCATOR_SIZE - ALLOC_SIZE_1);
+
+    // Allocate more memory and verify metrics continue to update
+    constexpr size_t ALLOC_SIZE_2 = 2048;
+    auto handle2 = allocator->allocate(ALLOC_SIZE_2);
+    ASSERT_TRUE(handle2.has_value());
+
+    OffsetAllocatorMetrics after_second_alloc = allocator->getMetrics();
+    EXPECT_EQ(after_second_alloc.allocated_size_, ALLOC_SIZE_1 + ALLOC_SIZE_2);
+    EXPECT_EQ(after_second_alloc.allocated_num_, 2);
+    EXPECT_EQ(after_second_alloc.capacity, ALLOCATOR_SIZE);
+    EXPECT_LT(after_second_alloc.total_free_space_,
+              after_first_alloc.total_free_space_);
+    EXPECT_EQ(after_second_alloc.total_free_space_,
+              ALLOCATOR_SIZE - ALLOC_SIZE_1 - ALLOC_SIZE_2);
+
+    // Free first allocation and verify metrics reflect the change
+    handle1.reset();
+
+    OffsetAllocatorMetrics after_first_free = allocator->getMetrics();
+    EXPECT_EQ(after_first_free.allocated_size_, ALLOC_SIZE_2);
+    EXPECT_EQ(after_first_free.allocated_num_, 1);
+    EXPECT_EQ(after_first_free.capacity, ALLOCATOR_SIZE);
+    EXPECT_GT(after_first_free.total_free_space_,
+              after_second_alloc.total_free_space_);
+    EXPECT_EQ(after_first_free.total_free_space_,
+              ALLOCATOR_SIZE - ALLOC_SIZE_2);
+
+    // Free remaining allocation and verify metrics return to initial state
+    handle2.reset();
+
+    OffsetAllocatorMetrics after_all_free = allocator->getMetrics();
+    EXPECT_EQ(after_all_free.allocated_size_, 0);
+    EXPECT_EQ(after_all_free.allocated_num_, 0);
+    EXPECT_EQ(after_all_free.capacity, ALLOCATOR_SIZE);
+    EXPECT_EQ(after_all_free.total_free_space_, ALLOCATOR_SIZE);
+    EXPECT_EQ(after_all_free.largest_free_region_, ALLOCATOR_SIZE);
 }
 
 int main(int argc, char** argv) {

--- a/mooncake-store/tests/utils_test.cpp
+++ b/mooncake-store/tests/utils_test.cpp
@@ -1,0 +1,20 @@
+#include "utils.h"
+
+#include <gtest/gtest.h>
+
+using namespace mooncake;
+
+TEST(UtilsTest, ByteSizeToString) {
+    EXPECT_EQ(byte_size_to_string(999), "999 B");
+    EXPECT_EQ(byte_size_to_string(2048), "2.00 KB");
+    EXPECT_EQ(byte_size_to_string(5ULL * 1024 * 1024 + 1234), "5.00 MB");
+    EXPECT_EQ(byte_size_to_string(15ULL * 1024 * 1024 * 1024), "15.00 GB");
+    EXPECT_EQ(byte_size_to_string(0), "0 B");
+    EXPECT_EQ(byte_size_to_string(1), "1 B");
+    EXPECT_EQ(byte_size_to_string(1024), "1.00 KB");
+    EXPECT_EQ(byte_size_to_string(1024 * 1024), "1.00 MB");
+    EXPECT_EQ(byte_size_to_string(1024ULL * 1024 * 1024), "1.00 GB");
+    EXPECT_EQ(byte_size_to_string(1024ULL * 1024 * 1024 * 1024), "1.00 TB");
+    EXPECT_EQ(byte_size_to_string(15 * 1024 + 134), "15.13 KB");
+    EXPECT_EQ(byte_size_to_string(15 * 1024 * 1024 + 44048), "15.04 MB");
+}


### PR DESCRIPTION
if allocation failed, it will reports 
```
W20250729 19:47:32.905817 417472 offset_allocator.cpp:580] OffsetAllocator allocation failed: size=943731256, fake_size=14745801, OffsetAllocatorMetrics{allocated=136.08 GB, allocs=186, capacity=143.58 GB, utilization=94.8%, free_space=63.99 MB, largest_free=60.00 MB
```

In the future, we can integrate this with metrics and eviction logic (e.g., using the largest free bin to trigger eviction).