### PR TITLE
[BugFix] Zero Size RDMA Mem Register

### DIFF
--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -222,7 +222,10 @@ ErrorCode Client::InitTransferEngine(const std::string& local_hostname,
         LOG(ERROR) << "unsupported_protocol protocol=" << protocol;
         return ErrorCode::INVALID_PARAMS;
     }
-    CHECK(transport) << "Failed to install transport";
+    if (!transport) {
+        LOG(ERROR) << "Failed to install transport";
+        return ErrorCode::INTERNAL_ERROR;
+    }
 
     // Initialize TransferSubmitter after transfer engine is ready
     transfer_submitter_ = std::make_unique<TransferSubmitter>(
@@ -406,7 +409,15 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchGet(
     const std::vector<std::string>& object_keys,
     const std::vector<std::vector<Replica::Descriptor>>& replica_lists,
     std::unordered_map<std::string, std::vector<Slice>>& slices) {
-    CHECK(transfer_submitter_) << "TransferSubmitter not initialized";
+    if (!transfer_submitter_) {
+        LOG(ERROR) << "TransferSubmitter not initialized";
+        std::vector<tl::expected<void, ErrorCode>> results;
+        results.reserve(object_keys.size());
+        for (size_t i = 0; i < object_keys.size(); ++i) {
+            results.emplace_back(tl::unexpected(ErrorCode::INTERNAL_ERROR));
+        }
+        return results;
+    }
 
     // Validate input size consistency
     if (replica_lists.size() != object_keys.size()) {
@@ -655,7 +666,13 @@ void Client::StartBatchPut(std::vector<PutOperation>& ops,
 }
 
 void Client::SubmitTransfers(std::vector<PutOperation>& ops) {
-    CHECK(transfer_submitter_) << "TransferSubmitter not initialized";
+    if (!transfer_submitter_) {
+        LOG(ERROR) << "TransferSubmitter not initialized";
+        for (auto& op : ops) {
+            op.SetError(ErrorCode::INTERNAL_ERROR, "TransferSubmitter not initialized");
+        }
+        return;
+    }
 
     for (auto& op : ops) {
         // Skip operations that already failed in previous stages
@@ -1126,7 +1143,10 @@ void Client::PutToLocalFile(const std::string& key,
 ErrorCode Client::TransferData(const Replica::Descriptor& replica_descriptor,
                                std::vector<Slice>& slices,
                                TransferRequest::OpCode op_code) {
-    CHECK(transfer_submitter_) << "TransferSubmitter not initialized";
+    if (!transfer_submitter_) {
+        LOG(ERROR) << "TransferSubmitter not initialized";
+        return ErrorCode::INTERNAL_ERROR;
+    }
 
     auto future =
         transfer_submitter_->submit(replica_descriptor, slices, op_code);

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -325,7 +325,10 @@ void TransferEngineOperationState::wait_for_completion() {
 
 TransferFuture::TransferFuture(std::shared_ptr<OperationState> state)
     : state_(std::move(state)) {
-    CHECK(state_) << "TransferFuture requires valid state";
+    if (!state_) {
+        LOG(ERROR) << "TransferFuture requires valid state";
+        throw std::invalid_argument("TransferFuture requires valid state");
+    }
 }
 
 bool TransferFuture::isReady() const { return state_->is_completed(); }
@@ -354,7 +357,10 @@ TransferSubmitter::TransferSubmitter(TransferEngine& engine,
       local_hostname_(local_hostname),
       memcpy_pool_(std::make_unique<MemcpyWorkerPool>()),
       fileread_pool_(std::make_unique<FilereadWorkerPool>(backend)) {
-    CHECK(!local_hostname_.empty()) << "Local hostname cannot be empty";
+    if (local_hostname_.empty()) {
+        LOG(ERROR) << "Local hostname cannot be empty";
+        throw std::invalid_argument("Local hostname cannot be empty");
+    }
 
     // Read MC_STORE_MEMCPY environment variable, default to false (disabled)
     const char* env_value = std::getenv("MC_STORE_MEMCPY");


### PR DESCRIPTION
While integrating `mooncake-store` with `sglang`, we identified several bugs and design flaws. To make the review process easier, we will address them through a series of smaller PRs.

This PR includes two changes:

1. **Fix setup failure when `local_buffer_size` is zero**
   The root cause is that registering an RDMA memory region with a size of zero using `ibv_reg_mr()` leads to undefined behavior. In our testing, this registration succeeds on `ibp6s`, but fails on `erdma`.

2. **Replace `CHECK` statements with explicit error handling**
   This improves robustness and provides better control over failure scenarios, especially in production environments.
