### PR TITLE
[BugFix] Topology Empty Check Bug

### DIFF
--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -217,7 +217,15 @@ Topology::Topology() {}
 
 Topology::~Topology() {}
 
-bool Topology::empty() const { return matrix_.empty(); }
+bool Topology::empty() const {
+    for (const auto& entry : resolved_matrix_) {
+        if (!entry.second.preferred_hca.empty() ||
+            !entry.second.avail_hca.empty()) {
+            return false;
+        }
+    }
+    return true;
+}
 
 void Topology::clear() {
     matrix_.clear();


### PR DESCRIPTION
In `RdmaTransport::initializeRdmaResources()`, the code currently uses `local_topology_->empty()` to check whether any RDMA devices are available. However, `empty()` only verifies whether the topology matrix has entries, not whether those entries contain valid devices.

There are cases where the topology matrix is non-empty, but both `preferred_hca` and `avail_hca` are empty. This can happen if the input devices are empty or incorrect. In such cases, initialization or installation may incorrectly return success, and memory registration may also succeed. However, data transfer will eventually fail due to the absence of valid RDMA devices.