### PR TITLE
[BugFix] Forbid Register Zero Size Memory

### DIFF
--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -303,6 +303,10 @@ int TransferEngine::registerLocalMemory(void *addr, size_t length,
             << "Transfer Engine does not support overlapped memory region";
         return ERR_ADDRESS_OVERLAPPED;
     }
+    if (length == 0) {
+        LOG(ERROR) << "Transfer Engine does not support zero length memory region";
+        return ERR_INVALID_ARGUMENT;
+    }
     for (auto transport : multi_transports_->listTransports()) {
         int ret = transport->registerLocalMemory(
             addr, length, location, remote_accessible, update_metadata);


### PR DESCRIPTION
Currently, TE (TransferEngine) does not validate whether the memory size is zero during memory registration. This can lead to initialization appearing successful, but later data transfers failing.

Specifically, if `TransferEngine::registerLocalMemory` is called twice within the same process—once with size 0 and once with a non-zero size, with the `location` set as `*`, both memory regions will be registered under the same name. During data transfer, `TransferMetadata::decodeSegmentDesc` will be invoked. Even if only the non-zero-sized memory region is accessed, the logic will still validate both buffers. The zero-sized buffer will fail the validation checks, ultimately causing the data transfer to fail.
