### PR TITLE
[Transfer Engine] fix: maximum the memory resource limitation

### DIFF
--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -72,7 +72,9 @@ int TransferEngine::init(const std::string &metadata_conn_string,
     std::string rpc_binding_method;
 
     if (!setFilesLimit()) {
-        LOG(WARNING) << "Failed to set file descriptor limit. Continuing initialization, but this may cause issues if too many files are opened.";
+        LOG(WARNING) << "Failed to set file descriptor limit. Continuing "
+                        "initialization, but this may cause issues if too many "
+                        "files are opened.";
     }
     // Set resources to the maximum value
 


### PR DESCRIPTION
We implement it according to https://github.com/NVIDIA/nccl/blob/master/src/bootstrap.cc#L250
It is necessary in a container environment.