### PR TITLE
[bugfix]Fix 'invalid argument' issue when calling  to modify QP state…

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -355,17 +355,11 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const std::string &peer_gid,
         return ERR_INVALID_ARGUMENT;
     auto &qp = qp_list_[qp_index];
 
-    // Any state -> RESET
+    // Any state -> RESET (removed)
+    // Modifing to RESET is not necessary here because it is already 
+    // and avoid 'invalid argument' issuse on some RDMA devices such as Intel E810.
     ibv_qp_attr attr;
-    memset(&attr, 0, sizeof(attr));
-    attr.qp_state = IBV_QPS_RESET;
-    int ret = ibv_modify_qp(qp, &attr, IBV_QP_STATE);
-    if (ret) {
-        std::string message = "Failed to modify QP to RESET";
-        PLOG(ERROR) << "[Handshake] " << message;
-        if (reply_msg) *reply_msg = message + ": " + strerror(errno);
-        return ERR_ENDPOINT;
-    }
+    int ret;
 
     // RESET -> INIT
     memset(&attr, 0, sizeof(attr));


### PR DESCRIPTION
This PR is to fix the issue as below:
When using the Intel E810 RDMA NIC, calling the **ibv_modify_qp** function to change the QP state to **INIT** results in an '**Invalid argument (22)**' error.
The error might be caused by the QP already being in the **RESET** state, and setting it to **RESET** again could lead to an internal state inconsistency. **The solution is to remove the step that sets the QP to RESET.**