### PR TITLE
[Bugfix]Fix 'invalid argument' error when setting QP state to INIT vi…

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -355,10 +355,35 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const std::string &peer_gid,
         return ERR_INVALID_ARGUMENT;
     auto &qp = qp_list_[qp_index];
 
-    // Any state -> RESET (removed)
-    // Modifying the QP to RESET is not necessary here, as it is already in the
-    // RESET state. This avoids the 'invalid argument' issue on some RDMA
+    // Any state -> RESET
+    // Query the status, and if current state is not reset
+    // Set the status as IBV_QPS_RESET.
+    // This avoids the 'invalid argument' issue on some RDMA
     // devices, such as the Intel E810.
+
+    // 1. Query QP State
+	ibv_qp_attr cur_attr;
+	ibv_qp_init_attr init_attr;    
+	int cur_state = IBV_QPS_ERR;
+	if (ibv_query_qp(qp, &cur_attr, IBV_QP_STATE, &init_attr) == 0) {
+	    cur_state = cur_attr.qp_state;
+	} else {
+	    PLOG(WARNING) << "[Handshake] ibv_query_qp failed, proceed to RESET anyway";
+	}
+	
+	// 2. If current state is not reset
+	if (cur_state != IBV_QPS_RESET) {
+	    ibv_qp_attr attr{};
+	    attr.qp_state = IBV_QPS_RESET;
+	    int ret = ibv_modify_qp(qp, &attr, IBV_QP_STATE);
+	    if (ret) {
+	        std::string message = "Failed to modify QP to RESET";
+	        PLOG(ERROR) << "[Handshake] " << message;
+	        if (reply_msg) *reply_msg = message + ": " + strerror(errno);
+	        return ERR_ENDPOINT;
+	    }
+	}
+    
     ibv_qp_attr attr;
     int ret;
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -355,17 +355,12 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const std::string &peer_gid,
         return ERR_INVALID_ARGUMENT;
     auto &qp = qp_list_[qp_index];
 
-    // Any state -> RESET
+    // Any state -> RESET (removed)
+    // Modifying the QP to RESET is not necessary here, as it is already in the
+    // RESET state. This avoids the 'invalid argument' issue on some RDMA
+    // devices, such as the Intel E810.
     ibv_qp_attr attr;
-    memset(&attr, 0, sizeof(attr));
-    attr.qp_state = IBV_QPS_RESET;
-    int ret = ibv_modify_qp(qp, &attr, IBV_QP_STATE);
-    if (ret) {
-        std::string message = "Failed to modify QP to RESET";
-        PLOG(ERROR) << "[Handshake] " << message;
-        if (reply_msg) *reply_msg = message + ": " + strerror(errno);
-        return ERR_ENDPOINT;
-    }
+    int ret;
 
     // RESET -> INIT
     memset(&attr, 0, sizeof(attr));


### PR DESCRIPTION
This PR fix the issue as below:
When using the Intel E810 RDMA NIC, calling the **ibv_modify_qp** function to change the QP state to **INIT** results in an **'Invalid argument (22)'** error.

The error might be caused by the QP already being in the **RESET** state, and setting it to **RESET** again could lead to an internal state inconsistency. 

The solution is to remove the step that sets the QP to **RESET**.
