### PR TITLE
[Bugfix] GetReplicaList does not grant a lease when GC is enabled

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -301,15 +301,9 @@ auto MasterService::GetReplicaList(std::string_view key)
         replica_list.emplace_back(replica.get_descriptor());
     }
 
-    // Only mark for GC if enabled
-    if (enable_gc_) {
-        MarkForGC(std::string(key),
-                  1000);  // After 1 second, the object will be removed
-    } else {
-        // Grant a lease to the object so it will not be removed
-        // when the client is reading it.
-        metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
-    }
+    // Grant a lease to the object so it will not be removed
+    // when the client is reading it.
+    metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
 
     return replica_list;
 }


### PR DESCRIPTION
Documentation quote:
```
To avoid data conflicts, a per-object lease will be granted whenever an ExistKey request or a GetReplicaListRequest request succeeds. An object is guaranteed to be protected from Remove request, RemoveAll request and Eviction task until its lease expires. The default lease TTL is 5 seconds and is configurable via a startup parameter of master_service.
```

Observed behavior:
* PutEnd sets lease=0 (is this expected?). With GC enabled, GetReplicaList marks the object for GC instead of granting a lease
* Example: after PUT, the object can exist indefinitely; the first GET immediately schedules it for deletion and it disappears, instead of receiving a lease as the docs specify