### PR TITLE
feat(client): Add client-side metrics for transfer and RPC operations

### DIFF
--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 #include <ylt/util/tl/expected.hpp>
 
@@ -196,6 +197,16 @@ class Client {
     std::vector<tl::expected<bool, ErrorCode>> BatchIsExist(
         const std::vector<std::string>& keys);
 
+    // For human-readable metrics
+    std::string summary_metrics() { return metrics_.summary_metrics(); }
+
+    // For Prometheus-style metrics
+    std::string serialize_metrics() {
+        std::string str;
+        metrics_.serialize(str);
+        return str;
+    }
+
    private:
     /**
      * @brief Private constructor to enforce creation through Create() method
@@ -255,6 +266,9 @@ class Client {
     std::vector<tl::expected<void, ErrorCode>> CollectResults(
         const std::vector<PutOperation>& ops);
 
+    // Client-side metrics
+    ClientMetric metrics_;
+
     // Core components
     TransferEngine transfer_engine_;
     MasterClient master_client_;
@@ -278,6 +292,17 @@ class Client {
     std::thread ping_thread_;
     std::atomic<bool> ping_running_{false};
     void PingThreadFunc();
+
+    // Metrics reporting thread
+    std::jthread metrics_reporting_thread_;
+    std::atomic<bool> should_stop_metrics_thread_{false};
+    bool metrics_enabled_{false};            // Default to disabled
+    uint64_t metrics_interval_seconds_{10};  // Default to 10 seconds
+
+    // Helper methods for metrics reporting thread management
+    void InitializeMetricsConfig();
+    void StartMetricsReportingThread();
+    void StopMetricsReportingThread();
 
     // Client identification
     UUID client_id_;

--- a/mooncake-store/include/client_metric.h
+++ b/mooncake-store/include/client_metric.h
@@ -249,7 +249,7 @@ struct ClientMetric {
      *         nullptr if disabled
      *
      * Environment variables:
-     * - MC_STORE_CLIENT_METRIC: Enable/disable metrics (enabled by default, 
+     * - MC_STORE_CLIENT_METRIC: Enable/disable metrics (enabled by default,
      *   set to 0/false to disable)
      * - MC_STORE_CLIENT_METRIC_INTERVAL: Reporting interval in seconds
      *   (default: 0, 0 = collect but don't report)

--- a/mooncake-store/include/client_metric.h
+++ b/mooncake-store/include/client_metric.h
@@ -1,0 +1,257 @@
+#pragma once
+
+#include <vector>
+#include <sstream>
+#include <ylt/metric/counter.hpp>
+#include <ylt/metric/histogram.hpp>
+#include <ylt/metric/summary.hpp>
+#include "utils.h"
+
+namespace mooncake {
+
+// latency bucket is in microsecond
+// Tuned for RDMA: fine-grained in <1ms, with ms-scale tail up to 1s
+const std::vector<double> kLatencyBucket = {
+    // sub-ms to 1ms region
+    125, 150, 200, 250, 300, 400, 500, 750, 1000,
+    // ms-level tail for batch/occasional spikes
+    1500, 2000, 3000, 5000, 7000, 15000, 20000,
+    // safeguards for long tails
+    50000, 100000, 200000, 500000, 1000000};
+
+struct TransferMetric {
+    ylt::metric::counter_t total_read_bytes{"mooncake_transfer_read_bytes",
+                                            "Total bytes read"};
+    ylt::metric::counter_t total_write_bytes{"mooncake_transfer_write_bytes",
+                                             "Total bytes written"};
+    ylt::metric::histogram_t batch_put_latency_us{
+        "mooncake_transfer_batch_put_latency",
+        "Batch Put transfer latency (us)", kLatencyBucket};
+    ylt::metric::histogram_t batch_get_latency_us{
+        "mooncake_transfer_batch_get_latency",
+        "Batch Get transfer latency (us)", kLatencyBucket};
+    ylt::metric::histogram_t get_latency_us{"mooncake_transfer_get_latency",
+                                            "Get transfer latency (us)",
+                                            kLatencyBucket};
+    ylt::metric::histogram_t put_latency_us{"mooncake_transfer_put_latency",
+                                            "Put transfer latency (us)",
+                                            kLatencyBucket};
+
+    void serialize(std::string& str) {
+        total_read_bytes.serialize(str);
+        total_write_bytes.serialize(str);
+        batch_put_latency_us.serialize(str);
+        batch_get_latency_us.serialize(str);
+        get_latency_us.serialize(str);
+        put_latency_us.serialize(str);
+    }
+
+    std::string summary_metrics() {
+        std::stringstream ss;
+        ss << "=== Transfer Metrics Summary ===\n";
+
+        // Bytes transferred
+        auto read_bytes = total_read_bytes.value();
+        auto write_bytes = total_write_bytes.value();
+        ss << "Total Read: " << byte_size_to_string(read_bytes) << "\n";
+        ss << "Total Write: " << byte_size_to_string(write_bytes) << "\n";
+
+        // Latency summaries
+        ss << "\n=== Latency Summary (microseconds) ===\n";
+        ss << "Get: " << format_latency_summary(get_latency_us) << "\n";
+        ss << "Put: " << format_latency_summary(put_latency_us) << "\n";
+        ss << "Batch Get: " << format_latency_summary(batch_get_latency_us)
+           << "\n";
+        ss << "Batch Put: " << format_latency_summary(batch_put_latency_us)
+           << "\n";
+
+        return ss.str();
+    }
+
+   private:
+    std::string format_latency_summary(ylt::metric::histogram_t& hist) {
+        // Access the internal sum and bucket counts
+        auto sum_ptr =
+            const_cast<ylt::metric::histogram_t&>(hist).get_bucket_counts();
+        if (sum_ptr.empty()) {
+            return "No data";
+        }
+
+        // Calculate total count from all buckets
+        int64_t total_count = 0;
+        for (auto& bucket : sum_ptr) {
+            total_count += bucket->value();
+        }
+
+        if (total_count == 0) {
+            return "No data";
+        }
+
+        // Get sum from the histogram's internal sum gauge
+        // Note: We need to access the private sum_ member, which requires
+        // friendship or reflection For now, let's use a simpler approach
+        // showing just count
+        std::stringstream ss;
+        ss << "count=" << total_count;
+
+        // Find P95
+        int64_t p95_target = (total_count * 95) / 100;
+        int64_t cumulative = 0;
+        double p95_bucket = 0;
+
+        for (size_t i = 0; i < sum_ptr.size() && i < kLatencyBucket.size();
+             i++) {
+            cumulative += sum_ptr[i]->value();
+            if (cumulative >= p95_target && p95_bucket == 0) {
+                p95_bucket = kLatencyBucket[i];
+                break;
+            }
+        }
+
+        if (p95_bucket > 0) {
+            ss << ", p95<" << p95_bucket << "μs";
+        }
+
+        // Find max bucket (highest bucket with data)
+        double max_bucket = 0;
+        for (size_t i = sum_ptr.size(); i > 0; i--) {
+            size_t idx = i - 1;
+            if (idx < kLatencyBucket.size() && sum_ptr[idx]->value() > 0) {
+                max_bucket = kLatencyBucket[idx];
+                break;
+            }
+        }
+
+        if (max_bucket > 0) {
+            ss << ", max<" << max_bucket << "μs";
+        }
+
+        return ss.str();
+    }
+};
+
+struct MasterClientMetric {
+    std::array<std::string, 1> rpc_names = {"rpc_name"};
+
+    MasterClientMetric()
+        : rpc_count("mooncake_client_rpc_count",
+                    "Total number of RPC calls made by the client", rpc_names),
+          rpc_latency("mooncake_client_rpc_latency",
+                      "Latency of RPC calls made by the client (in us)",
+                      kLatencyBucket, rpc_names) {}
+
+    ylt::metric::dynamic_counter_1t rpc_count;
+    ylt::metric::dynamic_histogram_1t rpc_latency;
+    void serialize(std::string& str) {
+        rpc_count.serialize(str);
+        rpc_latency.serialize(str);
+    }
+
+    std::string summary_metrics() {
+        std::stringstream ss;
+        ss << "=== RPC Metrics Summary ===\n";
+
+        // For dynamic metrics, we need to check if there are any labels with
+        // data
+        if (rpc_count.label_value_count() == 0) {
+            ss << "No RPC calls recorded\n";
+            return ss.str();
+        }
+
+        // Get all available RPC names from the dynamic metrics
+        // We'll iterate through all possible RPC names instead of using a fixed
+        // list
+        std::vector<std::string> all_rpc_names = {"GetReplicaList",
+                                                  "PutStart",
+                                                  "PutEnd",
+                                                  "PutRevoke",
+                                                  "ExistKey",
+                                                  "Remove",
+                                                  "RemoveAll",
+                                                  "MountSegment",
+                                                  "UnmountSegment",
+                                                  "GetFsdir",
+                                                  "BatchGetReplicaList",
+                                                  "BatchPutStart",
+                                                  "BatchPutEnd",
+                                                  "BatchPutRevoke"};
+
+        bool found_any = false;
+        for (const auto& rpc_name : all_rpc_names) {
+            std::array<std::string, 1> label_array = {rpc_name};
+
+            // Check if this RPC has any data by trying to access bucket counts
+            auto bucket_counts = rpc_latency.get_bucket_counts();
+            int64_t total_count = 0;
+            for (auto& bucket : bucket_counts) {
+                total_count += bucket->value(label_array);
+            }
+
+            // Skip RPCs with zero count
+            if (total_count == 0) continue;
+
+            found_any = true;
+            ss << rpc_name << ": count=" << total_count;
+
+            // Find P95
+            int64_t p95_target = (total_count * 95) / 100;
+            int64_t cumulative = 0;
+            double p95_bucket = 0;
+
+            for (size_t i = 0;
+                 i < bucket_counts.size() && i < kLatencyBucket.size(); i++) {
+                cumulative += bucket_counts[i]->value(label_array);
+                if (cumulative >= p95_target && p95_bucket == 0) {
+                    p95_bucket = kLatencyBucket[i];
+                    break;
+                }
+            }
+
+            if (p95_bucket > 0) {
+                ss << ", p95<" << p95_bucket << "μs";
+            }
+
+            // Find max bucket (highest bucket with data)
+            double max_bucket = 0;
+            for (size_t i = bucket_counts.size(); i > 0; i--) {
+                size_t idx = i - 1;
+                if (idx < kLatencyBucket.size() &&
+                    bucket_counts[idx]->value(label_array) > 0) {
+                    max_bucket = kLatencyBucket[idx];
+                    break;
+                }
+            }
+
+            if (max_bucket > 0) {
+                ss << ", max<" << max_bucket << "μs";
+            }
+
+            ss << "\n";
+        }
+
+        if (!found_any) {
+            ss << "No RPC calls recorded\n";
+        }
+
+        return ss.str();
+    }
+};
+
+struct ClientMetric {
+    TransferMetric transfer_metric;
+    MasterClientMetric master_client_metric;
+    void serialize(std::string& str) {
+        transfer_metric.serialize(str);
+        master_client_metric.serialize(str);
+    }
+
+    std::string summary_metrics() {
+        std::stringstream ss;
+        ss << "Client Metrics Summary\n";
+        ss << transfer_metric.summary_metrics();
+        ss << "\n";
+        ss << master_client_metric.summary_metrics();
+        return ss.str();
+    }
+};
+};  // namespace mooncake

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -17,7 +17,7 @@ static const std::string kDefaultMasterAddress = "localhost:50051";
  */
 class MasterClient {
    public:
-    MasterClient(MasterClientMetric& metrics) : metrics_(metrics) {}
+    MasterClient(MasterClientMetric* metrics = nullptr) : metrics_(metrics) {}
     ~MasterClient();
 
     MasterClient(const MasterClient&) = delete;
@@ -233,7 +233,7 @@ class MasterClient {
     RpcClientAccessor client_accessor_;
 
     // Metrics for tracking RPC operations
-    MasterClientMetric& metrics_;
+    MasterClientMetric* metrics_;
 
     // Mutex to insure the Connect function is atomic.
     mutable Mutex connect_mutex_;

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -352,7 +352,7 @@ class TransferSubmitter {
     explicit TransferSubmitter(TransferEngine& engine,
                                const std::string& local_hostname,
                                std::shared_ptr<StorageBackend>& backend,
-                               TransferMetric& transfer_metric);
+                               TransferMetric* transfer_metric = nullptr);
 
     /**
      * @brief Submit an asynchronous transfer operation
@@ -377,7 +377,7 @@ class TransferSubmitter {
     std::unique_ptr<MemcpyWorkerPool> memcpy_pool_;
     std::unique_ptr<FilereadWorkerPool> fileread_pool_;
     bool memcpy_enabled_;
-    TransferMetric& transfer_metric_;
+    TransferMetric* transfer_metric_;
 
     /**
      * @brief Select the optimal transfer strategy

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <mutex>
@@ -16,6 +17,9 @@
 #include "transport/transport.h"
 #include "types.h"
 #include "storage_backend.h"
+
+#include "ylt/metric/counter.hpp"
+#include "ylt/metric/histogram.hpp"
 
 namespace mooncake {
 
@@ -44,6 +48,23 @@ inline std::ostream& operator<<(std::ostream& os,
             return os << "UNKNOWN";
     }
 }
+
+// latency bucket is in microsecond
+// 50us ~ 1000ms
+const std::vector<double> kLatencyBucket = {
+    100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 10000, 100000, 1000000};
+
+struct TransferMetric {
+    ylt::metric::counter_t total_read_bytes{"mooncake_transfer_read_bytes",
+                                            "Total bytes read"};
+    ylt::metric::counter_t total_write_bytes{"mooncake_transfer_write_bytes",
+                                             "Total bytes written"};
+    ylt::metric::histogram_t read_latency{"mooncake_transfer_read_latency",
+                                          "Read latency (us)", kLatencyBucket};
+    ylt::metric::histogram_t write_latency{"mooncake_transfer_write_latency",
+                                           "Write latency (us)",
+                                           kLatencyBucket};
+};
 
 /**
  * @brief Abstract base class for operation state management

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MOONCAKE_STORE_SOURCES
     allocator.cpp
     master_service.cpp
     client.cpp
+    client_metric.cpp
     types.cpp
     master_client.cpp
     utils.cpp

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -38,8 +38,8 @@ namespace mooncake {
 Client::Client(const std::string& local_hostname,
                const std::string& metadata_connstring,
                const std::string& storage_root_dir)
-    : metrics_(),
-      master_client_(metrics_.master_client_metric),
+    : metrics_(ClientMetric::Create()),
+      master_client_(metrics_ ? &metrics_->master_client_metric : nullptr),
       local_hostname_(local_hostname),
       metadata_connstring_(metadata_connstring),
       storage_root_dir_(storage_root_dir),
@@ -47,15 +47,19 @@ Client::Client(const std::string& local_hostname,
     client_id_ = generate_uuid();
     LOG(INFO) << "client_id=" << client_id_;
 
-    // Initialize and start metrics reporting thread
-    InitializeMetricsConfig();
-    StartMetricsReportingThread();
+    if (metrics_) {
+        if (metrics_->GetReportingInterval() > 0) {
+            LOG(INFO) << "Client metrics enabled with reporting thread started (interval: " 
+                      << metrics_->GetReportingInterval() << "s)";
+        } else {
+            LOG(INFO) << "Client metrics enabled but reporting disabled (interval=0)";
+        }
+    } else {
+        LOG(INFO) << "Client metrics disabled (set MC_STORE_CLIENT_METRIC=1 to enable)";
+    }
 }
 
 Client::~Client() {
-    // Stop metrics reporting thread first
-    StopMetricsReportingThread();
-
     // Make a copy of mounted_segments_ to avoid modifying while iterating
     std::vector<Segment> segments_to_unmount;
     {
@@ -244,7 +248,7 @@ ErrorCode Client::InitTransferEngine(const std::string& local_hostname,
     // Initialize TransferSubmitter after transfer engine is ready
     transfer_submitter_ = std::make_unique<TransferSubmitter>(
         transfer_engine_, local_hostname, storage_backend_,
-        metrics_.transfer_metric);
+        metrics_ ? &metrics_->transfer_metric : nullptr);
 
     return ErrorCode::OK;
 }
@@ -417,7 +421,9 @@ tl::expected<void, ErrorCode> Client::Get(
     auto us_get = std::chrono::duration_cast<std::chrono::microseconds>(
                       std::chrono::steady_clock::now() - t0_get)
                       .count();
-    metrics_.transfer_metric.get_latency_us.observe(us_get);
+    if (metrics_) {
+        metrics_->transfer_metric.get_latency_us.observe(us_get);
+    }
 
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "transfer_read_failed key=" << object_key;
@@ -515,7 +521,9 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchGet(
     auto us_batch_get = std::chrono::duration_cast<std::chrono::microseconds>(
                             std::chrono::steady_clock::now() - t0_batch_get)
                             .count();
-    metrics_.transfer_metric.batch_get_latency_us.observe(us_batch_get);
+    if (metrics_) {
+        metrics_->transfer_metric.batch_get_latency_us.observe(us_batch_get);
+    }
 
     VLOG(1) << "BatchGet completed for " << object_keys.size() << " keys";
     return results;
@@ -562,7 +570,9 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
     auto us_put = std::chrono::duration_cast<std::chrono::microseconds>(
                       std::chrono::steady_clock::now() - t0_put)
                       .count();
-    metrics_.transfer_metric.put_latency_us.observe(us_put);
+    if (metrics_) {
+        metrics_->transfer_metric.put_latency_us.observe(us_put);
+    }
 
     // End put operation
     auto end_result = master_client_.PutEnd(key);
@@ -973,7 +983,9 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchPut(
     auto us = std::chrono::duration_cast<std::chrono::microseconds>(
                   std::chrono::steady_clock::now() - t0)
                   .count();
-    metrics_.transfer_metric.batch_put_latency_us.observe(us);
+    if (metrics_) {
+        metrics_->transfer_metric.batch_put_latency_us.observe(us);
+    }
 
     FinalizeBatchPut(ops);
     BatchPuttoLocalFile(ops);
@@ -1344,97 +1356,6 @@ ErrorCode Client::FindFirstCompleteReplica(
 
     // No complete replica found
     return ErrorCode::INVALID_REPLICA;
-}
-
-static std::string toLower(const std::string& str) {
-    std::string result = str;
-    std::transform(result.begin(), result.end(), result.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
-    return result;
-}
-
-void Client::InitializeMetricsConfig() {
-    // Check if metrics reporting is enabled via environment variable
-    const char* metric_env = std::getenv("MC_STORE_METRIC_REPORT");
-    if (metric_env) {
-        std::string value = toLower(metric_env);
-        metrics_enabled_ = (value == "1" || value == "true" || value == "yes" ||
-                            value == "on" || value == "enable");
-        LOG(INFO) << "Client metrics reporting "
-                  << (metrics_enabled_ ? "enabled" : "disabled")
-                  << " via MC_STORE_METRIC_REPORT=" << metric_env;
-    }
-
-    // Check for custom metrics interval
-    const char* interval_env = std::getenv("MC_STORE_METRIC_REPORT_INTERVAL");
-    if (interval_env) {
-        try {
-            uint64_t interval = std::stoull(interval_env);
-            if (interval > 0) {
-                metrics_interval_seconds_ = interval;
-                LOG(INFO) << "Client metrics interval set to "
-                          << metrics_interval_seconds_
-                          << "s via MC_CLIENT_METRIC_INTERVAL";
-            } else {
-                LOG(WARNING)
-                    << "Invalid metrics interval: " << interval_env
-                    << ", using default: " << metrics_interval_seconds_;
-            }
-        } catch (const std::exception& e) {
-            LOG(WARNING) << "Failed to parse MC_STORE_METRIC_REPORT_INTERVAL: "
-                         << interval_env
-                         << ", using default: " << metrics_interval_seconds_
-                         << "s via MC_STORE_METRIC_REPORT_INTERVAL";
-        }
-    } else {
-        LOG(WARNING) << "Invalid metrics interval: " << interval_env
-                     << ", using default: " << metrics_interval_seconds_;
-    }
-}
-
-void Client::StartMetricsReportingThread() {
-    // Only start the metrics thread if metrics are enabled
-    if (!metrics_enabled_) {
-        LOG(INFO) << "Client metrics reporting is disabled (set "
-                     "MC_STORE_METRIC_REPORT=1 to enable)";
-        return;
-    }
-
-    should_stop_metrics_thread_ = false;
-    metrics_reporting_thread_ = std::jthread([this](
-                                                 std::stop_token stop_token) {
-        LOG(INFO) << "Client metrics reporting thread started (interval: "
-                  << metrics_interval_seconds_ << "s)";
-
-        while (!stop_token.stop_requested() && !should_stop_metrics_thread_) {
-            // Sleep for the interval, checking periodically for stop signal
-            for (uint64_t i = 0;
-                 i < metrics_interval_seconds_ &&
-                 !stop_token.stop_requested() && !should_stop_metrics_thread_;
-                 ++i) {
-                std::this_thread::sleep_for(std::chrono::seconds(1));
-            }
-
-            if (stop_token.stop_requested() || should_stop_metrics_thread_) {
-                break;  // Exit if stopped during sleep
-            }
-
-            // Print metrics summary
-            std::string summary = summary_metrics();
-            LOG(INFO) << "Client Metrics Report:\n" << summary;
-        }
-        LOG(INFO) << "Client metrics reporting thread stopped";
-    });
-}
-
-void Client::StopMetricsReportingThread() {
-    should_stop_metrics_thread_ = true;  // Signal the thread to stop
-    if (metrics_reporting_thread_.joinable()) {
-        LOG(INFO) << "Waiting for client metrics reporting thread to join...";
-        metrics_reporting_thread_.request_stop();
-        metrics_reporting_thread_.join();  // Wait for the thread to finish
-        LOG(INFO) << "Client metrics reporting thread joined";
-    }
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -1381,7 +1381,14 @@ void Client::InitializeMetricsConfig() {
                     << ", using default: " << metrics_interval_seconds_;
             }
         } catch (const std::exception& e) {
-            LOG(WARNING) << "Failed to parse MC_CLIENT_METRIC_INTERVAL: "
+                          << "s via MC_STORE_METRIC_REPORT_INTERVAL";
+            } else {
+                LOG(WARNING)
+                    << "Invalid metrics interval: " << interval_env
+                    << ", using default: " << metrics_interval_seconds_;
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "Failed to parse MC_STORE_METRIC_REPORT_INTERVAL: "
                          << interval_env
                          << ", using default: " << metrics_interval_seconds_;
         }

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -49,13 +49,16 @@ Client::Client(const std::string& local_hostname,
 
     if (metrics_) {
         if (metrics_->GetReportingInterval() > 0) {
-            LOG(INFO) << "Client metrics enabled with reporting thread started (interval: " 
+            LOG(INFO) << "Client metrics enabled with reporting thread started "
+                         "(interval: "
                       << metrics_->GetReportingInterval() << "s)";
         } else {
-            LOG(INFO) << "Client metrics enabled but reporting disabled (interval=0)";
+            LOG(INFO)
+                << "Client metrics enabled but reporting disabled (interval=0)";
         }
     } else {
-        LOG(INFO) << "Client metrics disabled (set MC_STORE_CLIENT_METRIC=1 to enable)";
+        LOG(INFO) << "Client metrics disabled (set MC_STORE_CLIENT_METRIC=1 to "
+                     "enable)";
     }
 }
 

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -1381,17 +1381,14 @@ void Client::InitializeMetricsConfig() {
                     << ", using default: " << metrics_interval_seconds_;
             }
         } catch (const std::exception& e) {
-                          << "s via MC_STORE_METRIC_REPORT_INTERVAL";
-            } else {
-                LOG(WARNING)
-                    << "Invalid metrics interval: " << interval_env
-                    << ", using default: " << metrics_interval_seconds_;
-            }
-        } catch (const std::exception& e) {
             LOG(WARNING) << "Failed to parse MC_STORE_METRIC_REPORT_INTERVAL: "
                          << interval_env
-                         << ", using default: " << metrics_interval_seconds_;
+                         << ", using default: " << metrics_interval_seconds_
+                         << "s via MC_STORE_METRIC_REPORT_INTERVAL";
         }
+    } else {
+        LOG(WARNING) << "Invalid metrics interval: " << interval_env
+                     << ", using default: " << metrics_interval_seconds_;
     }
 }
 

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -1399,7 +1399,7 @@ void Client::StartMetricsReportingThread() {
     // Only start the metrics thread if metrics are enabled
     if (!metrics_enabled_) {
         LOG(INFO) << "Client metrics reporting is disabled (set "
-                     "MC_CLIENT_METRIC=1 to enable)";
+                     "MC_STORE_METRIC_REPORT=1 to enable)";
         return;
     }
 

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -1362,7 +1362,7 @@ void Client::InitializeMetricsConfig() {
                             value == "on" || value == "enable");
         LOG(INFO) << "Client metrics reporting "
                   << (metrics_enabled_ ? "enabled" : "disabled")
-                  << " via MC_CLIENT_METRIC=" << metric_env;
+                  << " via MC_STORE_METRIC_REPORT=" << metric_env;
     }
 
     // Check for custom metrics interval

--- a/mooncake-store/src/client_metric.cpp
+++ b/mooncake-store/src/client_metric.cpp
@@ -1,0 +1,133 @@
+#include "client_metric.h"
+
+#include <glog/logging.h>
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cstdlib>
+#include <thread>
+
+namespace mooncake {
+
+namespace {
+
+std::string toLower(const std::string& str) {
+    std::string result = str;
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return result;
+}
+
+bool parseMetricsEnabled() {
+    const char* metric_env = std::getenv("MC_STORE_CLIENT_METRIC");
+    if (!metric_env) {
+        return true;
+    }
+    std::string value = toLower(metric_env);
+    return (value == "1" || value == "true" || value == "yes" ||
+            value == "on" || value == "enable");
+}
+
+uint64_t parseMetricsInterval() {
+    const char* interval_env = std::getenv("MC_STORE_CLIENT_METRIC_INTERVAL");
+    if (!interval_env) {
+        // Default to disabled
+        return 0;
+    }
+
+    try {
+        uint64_t interval = std::stoull(interval_env);
+        if (interval == 0) {
+            LOG(INFO) << "Client metrics reporting disabled (interval=0) via "
+                         "MC_STORE_CLIENT_METRIC_INTERVAL";
+        } else {
+            LOG(INFO) << "Client metrics interval set to " << interval
+                      << "s via MC_STORE_CLIENT_METRIC_INTERVAL";
+        }
+        return interval;
+    } catch (const std::exception& e) {
+        LOG(WARNING) << "Failed to parse MC_STORE_CLIENT_METRIC_INTERVAL: "
+                     << interval_env << ", disabling metrics reporting";
+        return 0;
+    }
+}
+
+}  // anonymous namespace
+
+ClientMetric::ClientMetric(uint64_t interval_seconds)
+    : should_stop_metrics_thread_(false),
+      metrics_interval_seconds_(interval_seconds) {
+    if (metrics_interval_seconds_ > 0) {
+        StartMetricsReportingThread();
+    }
+}
+
+ClientMetric::~ClientMetric() { StopMetricsReportingThread(); }
+
+std::unique_ptr<ClientMetric> ClientMetric::Create() {
+    if (!parseMetricsEnabled()) {
+        LOG(INFO) << "Client metrics disabled (set MC_STORE_CLIENT_METRIC=0 to "
+                     "disable)";
+        return nullptr;
+    }
+
+    uint64_t interval = parseMetricsInterval();
+
+    LOG(INFO) << "Client metrics enabled (default enabled)";
+
+    return std::make_unique<ClientMetric>(interval);
+}
+
+void ClientMetric::serialize(std::string& str) {
+    transfer_metric.serialize(str);
+    master_client_metric.serialize(str);
+}
+
+std::string ClientMetric::summary_metrics() {
+    std::stringstream ss;
+    ss << "Client Metrics Summary\n";
+    ss << transfer_metric.summary_metrics();
+    ss << "\n";
+    ss << master_client_metric.summary_metrics();
+    return ss.str();
+}
+
+void ClientMetric::StartMetricsReportingThread() {
+    should_stop_metrics_thread_ = false;
+    metrics_reporting_thread_ = std::jthread([this](
+                                                 std::stop_token stop_token) {
+        LOG(INFO) << "Client metrics reporting thread started (interval: "
+                  << metrics_interval_seconds_ << "s)";
+
+        while (!stop_token.stop_requested() && !should_stop_metrics_thread_) {
+            // Sleep for the interval, checking periodically for stop signal
+            for (uint64_t i = 0;
+                 i < metrics_interval_seconds_ &&
+                 !stop_token.stop_requested() && !should_stop_metrics_thread_;
+                 ++i) {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
+
+            if (stop_token.stop_requested() || should_stop_metrics_thread_) {
+                break;  // Exit if stopped during sleep
+            }
+
+            // Print metrics summary
+            std::string summary = summary_metrics();
+            LOG(INFO) << "Client Metrics Report:\n" << summary;
+        }
+        LOG(INFO) << "Client metrics reporting thread stopped";
+    });
+}
+
+void ClientMetric::StopMetricsReportingThread() {
+    should_stop_metrics_thread_ = true;  // Signal the thread to stop
+    if (metrics_reporting_thread_.joinable()) {
+        LOG(INFO) << "Waiting for client metrics reporting thread to join...";
+        metrics_reporting_thread_.request_stop();
+        metrics_reporting_thread_.join();  // Wait for the thread to finish
+        LOG(INFO) << "Client metrics reporting thread joined";
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -14,10 +14,97 @@
 #include "types.h"
 #include "utils/scoped_vlog_timer.h"
 
+#include <source_location>
+
 namespace mooncake {
 
-using namespace coro_rpc;
-using namespace async_simple::coro;
+template <auto Method>
+struct RpcNameTraits;
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::ExistKey> {
+    static constexpr const char* value = "ExistKey";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::BatchExistKey> {
+    static constexpr const char* value = "BatchExistKey";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::GetReplicaList> {
+    static constexpr const char* value = "GetReplicaList";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::BatchGetReplicaList> {
+    static constexpr const char* value = "BatchGetReplicaList";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::PutStart> {
+    static constexpr const char* value = "PutStart";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::BatchPutStart> {
+    static constexpr const char* value = "BatchPutStart";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::PutEnd> {
+    static constexpr const char* value = "PutEnd";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::BatchPutEnd> {
+    static constexpr const char* value = "BatchPutEnd";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::PutRevoke> {
+    static constexpr const char* value = "PutRevoke";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::BatchPutRevoke> {
+    static constexpr const char* value = "BatchPutRevoke";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::Remove> {
+    static constexpr const char* value = "Remove";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::RemoveAll> {
+    static constexpr const char* value = "RemoveAll";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::MountSegment> {
+    static constexpr const char* value = "MountSegment";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::ReMountSegment> {
+    static constexpr const char* value = "ReMountSegment";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::UnmountSegment> {
+    static constexpr const char* value = "UnmountSegment";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::Ping> {
+    static constexpr const char* value = "Ping";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::GetFsdir> {
+    static constexpr const char* value = "GetFsdir";
+};
 
 template <auto ServiceMethod, typename ReturnType, typename... Args>
 tl::expected<ReturnType, ErrorCode> MasterClient::invoke_rpc(Args&&... args) {
@@ -27,15 +114,26 @@ tl::expected<ReturnType, ErrorCode> MasterClient::invoke_rpc(Args&&... args) {
         return tl::make_unexpected(ErrorCode::RPC_FAIL);
     }
 
+    // Increment RPC counter
+    metrics_.rpc_count.inc({RpcNameTraits<ServiceMethod>::value});
+
+    auto start_time = std::chrono::steady_clock::now();
     auto request_result =
         client->send_request<ServiceMethod>(std::forward<Args>(args)...);
-    return coro::syncAwait(
-        [&]() -> coro::Lazy<tl::expected<ReturnType, ErrorCode>> {
+
+    return async_simple::coro::syncAwait(
+        [&]() -> async_simple::coro::Lazy<tl::expected<ReturnType, ErrorCode>> {
             auto result = co_await co_await request_result;
             if (!result) {
                 LOG(ERROR) << "RPC call failed: " << result.error().msg;
                 co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
             }
+            auto end_time = std::chrono::steady_clock::now();
+            auto latency =
+                std::chrono::duration_cast<std::chrono::microseconds>(
+                    end_time - start_time);
+            metrics_.rpc_latency.observe({RpcNameTraits<ServiceMethod>::value},
+                                         latency.count());
             co_return result->result();
         }());
 }
@@ -50,10 +148,14 @@ std::vector<tl::expected<ResultType, ErrorCode>> MasterClient::invoke_batch_rpc(
             input_size, tl::make_unexpected(ErrorCode::RPC_FAIL));
     }
 
+    // Increment RPC counter
+    metrics_.rpc_count.inc({RpcNameTraits<ServiceMethod>::value});
+
     auto request_result =
         client->send_request<ServiceMethod>(std::forward<Args>(args)...);
-    return coro::syncAwait(
-        [&]() -> coro::Lazy<std::vector<tl::expected<ResultType, ErrorCode>>> {
+    return async_simple::coro::syncAwait(
+        [&]() -> async_simple::coro::Lazy<
+                  std::vector<tl::expected<ResultType, ErrorCode>>> {
             auto result = co_await co_await request_result;
             if (!result) {
                 LOG(ERROR) << "Batch RPC call failed: " << result.error().msg;
@@ -76,10 +178,15 @@ ErrorCode MasterClient::Connect(const std::string& master_addr) {
     ScopedVLogTimer timer(1, "MasterClient::Connect");
     timer.LogRequest("master_addr=", master_addr);
 
+    auto location = std::source_location::current();
+    auto name = location.function_name();
+    LOG(INFO) << "Connecting to master at " << master_addr << " from " << name;
+
     MutexLocker lock(&connect_mutex_);
     if (client_addr_param_ == master_addr) {
         auto client = client_accessor_.GetClient();
-        auto result = coro::syncAwait(client->connect(master_addr));
+        auto result =
+            async_simple::coro::syncAwait(client->connect(master_addr));
         if (result.val() != 0) {
             LOG(ERROR) << "Failed to connect to master: " << result.message();
             timer.LogResponse("error_code=", ErrorCode::RPC_FAIL);
@@ -91,8 +198,9 @@ ErrorCode MasterClient::Connect(const std::string& master_addr) {
         // Once connected to address A, the coro_rpc_client does not support
         // connect to a new address B. So we need to create a new
         // coro_rpc_client if the address is different from the current one.
-        auto client = std::make_shared<coro_rpc_client>();
-        auto result = coro::syncAwait(client->connect(master_addr));
+        auto client = std::make_shared<coro_rpc::coro_rpc_client>();
+        auto result =
+            async_simple::coro::syncAwait(client->connect(master_addr));
         if (result.val() != 0) {
             LOG(ERROR) << "Failed to connect to master: " << result.message();
             timer.LogResponse("error_code=", ErrorCode::RPC_FAIL);

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -5,8 +5,6 @@
 #include <algorithm>
 #include <cstdlib>
 
-#include "utils.h"
-
 namespace mooncake {
 
 // ============================================================================
@@ -357,7 +355,7 @@ TransferStrategy TransferFuture::strategy() const {
 TransferSubmitter::TransferSubmitter(TransferEngine& engine,
                                      const std::string& local_hostname,
                                      std::shared_ptr<StorageBackend>& backend,
-                                     TransferMetric& transfer_metric)
+                                     TransferMetric* transfer_metric)
     : engine_(engine),
       local_hostname_(local_hostname),
       memcpy_pool_(std::make_unique<MemcpyWorkerPool>()),
@@ -614,10 +612,15 @@ void TransferSubmitter::updateTransferMetrics(
         total_bytes += slice.size;
     }
 
+    if (transfer_metric_ == nullptr) {
+        return;
+    }
+
     if (op_code == Transport::TransferRequest::READ) {
-        transfer_metric_.total_read_bytes.inc(total_bytes);
+        transfer_metric_->total_read_bytes.inc(total_bytes);
+
     } else if (op_code == Transport::TransferRequest::WRITE) {
-        transfer_metric_.total_write_bytes.inc(total_bytes);
+        transfer_metric_->total_write_bytes.inc(total_bytes);
     }
 }
 

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -136,4 +136,15 @@ target_link_libraries(pybind_client_test PUBLIC
 )
 add_test(NAME pybind_client_test COMMAND pybind_client_test)
 
+add_executable(client_metrics_test client_metrics_test.cpp)
+target_link_libraries(client_metrics_test PUBLIC
+    mooncake_store
+    cachelib_memory_allocator
+    glog
+    gtest
+    gtest_main
+    pthread
+)
+add_test(NAME client_metrics_test COMMAND client_metrics_test)
+
 add_subdirectory(e2e)

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -1,0 +1,176 @@
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <string>
+
+#include "client_metric.h"
+
+namespace mooncake::test {
+
+class ClientMetricsTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("ClientMetricsTest");
+        FLAGS_logtostderr = true;
+    }
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+};
+
+TEST_F(ClientMetricsTest, TransferMetricsSummaryTest) {
+    TransferMetric metrics;
+
+    // Test empty metrics
+    std::string summary = metrics.summary_metrics();
+    EXPECT_TRUE(summary.find("Total Read: 0 B") != std::string::npos);
+    EXPECT_TRUE(summary.find("Total Write: 0 B") != std::string::npos);
+    EXPECT_TRUE(summary.find("Get: No data") != std::string::npos);
+    EXPECT_TRUE(summary.find("Put: No data") != std::string::npos);
+
+    // Add some data
+    metrics.total_read_bytes.inc(1024);              // 1KB
+    metrics.total_write_bytes.inc(2 * 1024 * 1024);  // 2MB
+
+    // Add latency observations
+    metrics.get_latency_us.observe(150);  // 150 microseconds
+    metrics.get_latency_us.observe(200);  // 200 microseconds
+    metrics.get_latency_us.observe(300);  // 300 microseconds
+
+    metrics.put_latency_us.observe(500);  // 500 microseconds
+    metrics.put_latency_us.observe(750);  // 750 microseconds
+
+    summary = metrics.summary_metrics();
+
+    // Check byte formatting
+    EXPECT_TRUE(summary.find("Total Read: 1.00 KB") != std::string::npos);
+    EXPECT_TRUE(summary.find("Total Write: 2.00 MB") != std::string::npos);
+
+    // Check latency summaries
+    EXPECT_TRUE(summary.find("Get: count=3") != std::string::npos);
+    EXPECT_TRUE(summary.find("Put: count=2") != std::string::npos);
+
+    // Check percentiles are present
+    EXPECT_TRUE(summary.find("p50<") != std::string::npos);
+    EXPECT_TRUE(summary.find("p95<") != std::string::npos);
+
+    std::cout << "Transfer Metrics Summary:\n" << summary << std::endl;
+}
+
+TEST_F(ClientMetricsTest, MasterClientMetricsSummaryTest) {
+    MasterClientMetric metrics;
+
+    // Test empty metrics
+    std::string summary = metrics.summary_metrics();
+    EXPECT_TRUE(summary.find("No RPC calls recorded") != std::string::npos);
+
+    // Add some RPC calls
+    std::array<std::string, 1> get_replica_label = {"GetReplicaList"};
+    std::array<std::string, 1> mount_segment_label = {"MountSegment"};
+    std::array<std::string, 1> unmount_segment_label = {"UnmountSegment"};
+
+    // Simulate RPC calls
+    metrics.rpc_count.inc(get_replica_label);
+    metrics.rpc_count.inc(get_replica_label);
+    metrics.rpc_count.inc(mount_segment_label);
+    metrics.rpc_count.inc(unmount_segment_label);
+
+    // Add latency observations
+    metrics.rpc_latency.observe(get_replica_label, 200);  // 200 microseconds
+    metrics.rpc_latency.observe(get_replica_label, 250);  // 250 microseconds
+    metrics.rpc_latency.observe(mount_segment_label, 37789);   // 37.789 ms
+    metrics.rpc_latency.observe(unmount_segment_label, 7536);  // 7.536 ms
+
+    summary = metrics.summary_metrics();
+
+    // Check that RPC calls are recorded
+    EXPECT_TRUE(summary.find("GetReplicaList: count=2") != std::string::npos);
+    EXPECT_TRUE(summary.find("MountSegment: count=1") != std::string::npos);
+    EXPECT_TRUE(summary.find("UnmountSegment: count=1") != std::string::npos);
+
+    // Check percentiles are present for RPCs with data
+    EXPECT_TRUE(summary.find("p50<") != std::string::npos);
+    EXPECT_TRUE(summary.find("p95<") != std::string::npos);
+
+    std::cout << "Master Client Metrics Summary:\n" << summary << std::endl;
+}
+
+TEST_F(ClientMetricsTest, ClientMetricsSummaryTest) {
+    ClientMetric metrics;
+
+    // Add some transfer data
+    metrics.transfer_metric.total_read_bytes.inc(5 * 1024 * 1024);    // 5MB
+    metrics.transfer_metric.total_write_bytes.inc(10 * 1024 * 1024);  // 10MB
+
+    metrics.transfer_metric.batch_get_latency_us.observe(1500);  // 1.5ms
+    metrics.transfer_metric.batch_put_latency_us.observe(2000);  // 2ms
+
+    // Add some RPC data
+    std::array<std::string, 1> exist_key_label = {"ExistKey"};
+    metrics.master_client_metric.rpc_count.inc(exist_key_label);
+    metrics.master_client_metric.rpc_latency.observe(exist_key_label, 180);
+
+    std::string summary = metrics.summary_metrics();
+
+    // Should contain both transfer and RPC metrics
+    EXPECT_TRUE(summary.find("Transfer Metrics Summary") != std::string::npos);
+    EXPECT_TRUE(summary.find("RPC Metrics Summary") != std::string::npos);
+    EXPECT_TRUE(summary.find("Total Read: 5.00 MB") != std::string::npos);
+    EXPECT_TRUE(summary.find("Total Write: 10.00 MB") != std::string::npos);
+    EXPECT_TRUE(summary.find("ExistKey: count=1") != std::string::npos);
+
+    std::cout << "Full Client Metrics Summary:\n" << summary << std::endl;
+}
+
+TEST_F(ClientMetricsTest, ByteFormattingTest) {
+    TransferMetric metrics;
+
+    // Test different byte sizes
+    metrics.total_read_bytes.inc(512);  // 512 B
+    std::string summary = metrics.summary_metrics();
+    EXPECT_TRUE(summary.find("512.00 B") != std::string::npos);
+
+    metrics.total_read_bytes.inc(1024 - 512);  // Total 1024 B = 1 KB
+    summary = metrics.summary_metrics();
+    EXPECT_TRUE(summary.find("1.00 KB") != std::string::npos);
+
+    metrics.total_read_bytes.inc(1024 * 1024 - 1024);  // Total 1 MB
+    summary = metrics.summary_metrics();
+    EXPECT_TRUE(summary.find("1.00 MB") != std::string::npos);
+
+    metrics.total_read_bytes.inc(1024LL * 1024 * 1024 -
+                                 1024 * 1024);  // Total 1 GB
+    summary = metrics.summary_metrics();
+    EXPECT_TRUE(summary.find("1.00 GB") != std::string::npos);
+}
+
+TEST_F(ClientMetricsTest, CompareWithSerializedMetrics) {
+    ClientMetric metrics;
+
+    // Add some data
+    metrics.transfer_metric.total_read_bytes.inc(1024 * 1024);
+    metrics.transfer_metric.get_latency_us.observe(200);
+
+    std::array<std::string, 1> get_replica_label = {"GetReplicaList"};
+    metrics.master_client_metric.rpc_count.inc(get_replica_label);
+    metrics.master_client_metric.rpc_latency.observe(get_replica_label, 250);
+
+    // Get both summary and full serialized metrics
+    std::string summary = metrics.summary_metrics();
+    std::string serialized;
+    metrics.serialize(serialized);
+
+    std::cout << "\n=== Summary Metrics ===" << std::endl;
+    std::cout << summary << std::endl;
+
+    std::cout << "\n=== Full Serialized Metrics ===" << std::endl;
+    std::cout << serialized << std::endl;
+
+    // Summary should be much shorter and more readable
+    EXPECT_LT(summary.length(), serialized.length());
+    EXPECT_TRUE(summary.find("count=") != std::string::npos);
+    EXPECT_TRUE(summary.find("p50<") != std::string::npos ||
+                summary.find("No data") != std::string::npos);
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -51,8 +51,8 @@ TEST_F(ClientMetricsTest, TransferMetricsSummaryTest) {
     EXPECT_TRUE(summary.find("Put: count=2") != std::string::npos);
 
     // Check percentiles are present
-    EXPECT_TRUE(summary.find("p50<") != std::string::npos);
     EXPECT_TRUE(summary.find("p95<") != std::string::npos);
+    EXPECT_TRUE(summary.find("max<") != std::string::npos);
 
     std::cout << "Transfer Metrics Summary:\n" << summary << std::endl;
 }
@@ -89,8 +89,8 @@ TEST_F(ClientMetricsTest, MasterClientMetricsSummaryTest) {
     EXPECT_TRUE(summary.find("UnmountSegment: count=1") != std::string::npos);
 
     // Check percentiles are present for RPCs with data
-    EXPECT_TRUE(summary.find("p50<") != std::string::npos);
     EXPECT_TRUE(summary.find("p95<") != std::string::npos);
+    EXPECT_TRUE(summary.find("max<") != std::string::npos);
 
     std::cout << "Master Client Metrics Summary:\n" << summary << std::endl;
 }
@@ -128,7 +128,7 @@ TEST_F(ClientMetricsTest, ByteFormattingTest) {
     // Test different byte sizes
     metrics.total_read_bytes.inc(512);  // 512 B
     std::string summary = metrics.summary_metrics();
-    EXPECT_TRUE(summary.find("512.00 B") != std::string::npos);
+    EXPECT_TRUE(summary.find("512 B") != std::string::npos);
 
     metrics.total_read_bytes.inc(1024 - 512);  // Total 1024 B = 1 KB
     summary = metrics.summary_metrics();
@@ -169,7 +169,9 @@ TEST_F(ClientMetricsTest, CompareWithSerializedMetrics) {
     // Summary should be much shorter and more readable
     EXPECT_LT(summary.length(), serialized.length());
     EXPECT_TRUE(summary.find("count=") != std::string::npos);
-    EXPECT_TRUE(summary.find("p50<") != std::string::npos ||
+    EXPECT_TRUE(summary.find("p95<") != std::string::npos ||
+                summary.find("No data") != std::string::npos);
+    EXPECT_TRUE(summary.find("max<") != std::string::npos ||
                 summary.find("No data") != std::string::npos);
 }
 


### PR DESCRIPTION
In this PR, we introduce client side support for both transfer and RPC-related metrics.

We provide interface support: Prometheus-style and human-readable formats. Additionally, we've implemented a background thread for metric printing (disabled by default).

```
I20250812 17:07:51.023622 117228 client.cpp:1417] Client Metrics Report:
Client Metrics Summary
=== Transfer Metrics Summary ===
Total Read: 5.00 MB
Total Write: 5.00 MB

=== Latency Summary (microseconds) ===
Get: count=103, p95<250μs, max<15000μs
Put: count=4, p95<1500μs, max<15000μs
Batch Get: count=1, p95<125μs, max<15000μs
Batch Put: count=3, p95<5000μs, max<20000μs

=== RPC Metrics Summary ===
GetReplicaList: count=104, p95<150μs, max<200μs
PutStart: count=5, p95<250μs, max<250μs
PutEnd: count=4, p95<200μs, max<1500μs
Remove: count=29, p95<300μs, max<400μs
MountSegment: count=1, p95<125μs, max<7000μs
GetFsdir: count=1, p95<125μs, max<250μs
BatchGetReplicaList: count=1, p95<125μs, max<300μs
BatchPutStart: count=3, p95<250μs, max<500μs
BatchPutEnd: count=3, p95<150μs, max<200μs
```