### PR TITLE
Fix deleting buffer that doesn't belong to us

### DIFF
--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -160,7 +160,9 @@ struct Session : public std::enable_shared_from_this<Session> {
             [this, addr, dram_buffer, self](const asio::error_code &ec,
                                             std::size_t transferred_bytes) {
 #ifdef USE_CUDA
+            if (isCudaMemory(addr)) {
                 delete[] dram_buffer;
+            }
 #endif
                 if (ec) {
                     LOG(ERROR)

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -160,9 +160,9 @@ struct Session : public std::enable_shared_from_this<Session> {
             [this, addr, dram_buffer, self](const asio::error_code &ec,
                                             std::size_t transferred_bytes) {
 #ifdef USE_CUDA
-            if (isCudaMemory(addr)) {
-                delete[] dram_buffer;
-            }
+                if (isCudaMemory(addr)) {
+                    delete[] dram_buffer;
+                }
 #endif
                 if (ec) {
                     LOG(ERROR)


### PR DESCRIPTION
Currently when using CUDA with TCP it assumes that we allocated a new buffer in line 152, it's not always the case and we can free memory that doesn't belong to us causing a segfault later