### PR TITLE
refactor(store_py): Replace function with AutoPortBinder RAII class 

### DIFF
--- a/mooncake-store/include/pybind_client.h
+++ b/mooncake-store/include/pybind_client.h
@@ -7,6 +7,7 @@
 
 #include "client.h"
 #include "client_buffer.hpp"
+#include "utils.h"
 
 namespace mooncake {
 
@@ -288,6 +289,7 @@ class PyClient {
 
     std::shared_ptr<mooncake::Client> client_ = nullptr;
     std::shared_ptr<ClientBufferAllocator> client_buffer_allocator_ = nullptr;
+    std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
 
     struct SegmentDeleter {
         void operator()(void *ptr) {

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -120,12 +120,27 @@ void** rdma_args(const std::string& device_name);
  */
 bool isPortAvailable(int port);
 
-/**
- * @brief Get a random available port in the specified range
- * @param min_port Minimum port number (default: 12300)
- * @param max_port Maximum port number (default: 14300)
- * @return Available port number, or -1 if no port found after 10 attempts
- */
-int getRandomAvailablePort(int min_port = 12300, int max_port = 14300);
+// Simple RAII class for automatically binding to an available port
+// The socket is bound during construction and released during destruction
+class AutoPortBinder {
+   public:
+    // Constructs binder and attempts to bind to an available port in range
+    // [min_port, max_port] After successful construction, the port is bound and
+    // reserved until destruction
+    AutoPortBinder(int min_port = 12300, int max_port = 14300);
+    ~AutoPortBinder();
+
+    // Non-copyable, non-movable
+    AutoPortBinder(const AutoPortBinder&) = delete;
+    AutoPortBinder& operator=(const AutoPortBinder&) = delete;
+    AutoPortBinder(AutoPortBinder&&) = delete;
+    AutoPortBinder& operator=(AutoPortBinder&&) = delete;
+
+    int getPort() const { return port_; }
+
+   private:
+    int socket_fd_;
+    int port_;
+};
 
 }  // namespace mooncake

--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -100,13 +100,13 @@ tl::expected<void, ErrorCode> PyClient::setup_internal(
     std::string hostname = local_hostname;
     size_t colon_pos = hostname.find(":");
     if (colon_pos == std::string::npos) {
-        // Get a random available port
-        int port = getRandomAvailablePort();
+        // Create port binder to hold a port
+        port_binder_ = std::make_unique<AutoPortBinder>();
+        int port = port_binder_->getPort();
         if (port < 0) {
-            LOG(ERROR) << "Failed to find available port";
+            LOG(ERROR) << "Failed to bind available port";
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
-        // Combine hostname with port
         this->local_hostname = hostname + ":" + std::to_string(port);
     } else {
         this->local_hostname = local_hostname;
@@ -210,6 +210,7 @@ tl::expected<void, ErrorCode> PyClient::tearDownAll_internal() {
     // Reset all resources
     client_.reset();
     client_buffer_allocator_.reset();
+    port_binder_.reset();
     segment_ptrs_.clear();
     local_hostname = "";
     device_name = "";

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -9,6 +9,62 @@
 #include <random>
 
 namespace mooncake {
+
+bool isPortAvailable(int port) {
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) return false;
+
+    int opt = 1;
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = htons(port);
+
+    bool available = (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    close(sock);
+    return available;
+}
+
+// AutoPortBinder implementation
+AutoPortBinder::AutoPortBinder(int min_port, int max_port)
+    : socket_fd_(-1), port_(-1) {
+    static std::random_device rand_gen;
+    std::mt19937 gen(rand_gen());
+    std::uniform_int_distribution<> rand_dist(min_port, max_port);
+
+    for (int attempt = 0; attempt < 20; ++attempt) {
+        int port = rand_dist(gen);
+
+        socket_fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (socket_fd_ < 0) continue;
+
+        int opt = 1;
+        setsockopt(socket_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+        sockaddr_in addr = {};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = INADDR_ANY;
+        addr.sin_port = htons(port);
+
+        if (bind(socket_fd_, (sockaddr *)&addr, sizeof(addr)) == 0) {
+            port_ = port;
+            break;
+        } else {
+            close(socket_fd_);
+            socket_fd_ = -1;
+        }
+    }
+}
+
+AutoPortBinder::~AutoPortBinder() {
+    if (socket_fd_ >= 0) {
+        close(socket_fd_);
+    }
+}
+
 void *allocate_buffer_allocator_memory(size_t total_size) {
     const size_t alignment = facebook::cachelib::Slab::kSize;
     // Ensure total_size is a multiple of alignment
@@ -49,43 +105,6 @@ void **rdma_args(const std::string &device_name) {
     args[0] = (void *)nic_priority_matrix.c_str();
     args[1] = nullptr;
     return args;
-}
-
-bool isPortAvailable(int port) {
-    int sock = socket(AF_INET, SOCK_STREAM, 0);
-    if (sock < 0) return false;
-
-    int opt = 1;
-    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-
-    struct sockaddr_in addr;
-    memset(&addr, 0, sizeof(addr));
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = INADDR_ANY;
-    addr.sin_port = htons(port);
-
-    bool available = (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0);
-    close(sock);
-    return available;
-}
-
-int getRandomAvailablePort(int min_port, int max_port) {
-    // Handle invalid range
-    if (min_port > max_port) {
-        std::swap(min_port, max_port);
-    }
-
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<> dis(min_port, max_port);
-
-    for (int attempts = 0; attempts < 10; attempts++) {
-        int port = dis(gen);
-        if (isPortAvailable(port)) {
-            return port;
-        }
-    }
-    return -1;  // Failed to find available port
 }
 
 }  // namespace mooncake


### PR DESCRIPTION
This PR primarily addresses potential random port selection issues #736 

In reality, `TrasnferEngine` doesn't use the port we provide. The port we select functions more as an "identifier" for different clients, allowing them to maintain distinct keys in the transfer metadata.


I'll refactor the `TransferEngine` construction logic later. Since we're behind on some API versions, we need to adjust for newer usage patterns and update the documentation.
