### PR TITLE
[CI] Avoid Running Deploy Workflow on Forked Repositories

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   # Build and deploy job
   build-and-deploy:
+    if: github.repository == 'ykwd/Mooncake'
     environment:
       name: github-pages
       url: https://kvcache-ai.github.io/Mooncake/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,8 @@ concurrency:
 jobs:
   # Build and deploy job
   build-and-deploy:
-    if: github.repository == 'ykwd/Mooncake'
+    # Avoid running this workflow on forked repositories
+    if: github.repository == 'kvcache-ai/Mooncake'
     environment:
       name: github-pages
       url: https://kvcache-ai.github.io/Mooncake/


### PR DESCRIPTION
As forked repositories do not have access to the https://kvcache-ai.github.io/Mooncake/, this workflow will always fail.