### PR TITLE
Fixed cachelib_memory_allocator dependency.

### DIFF
--- a/mooncake-store/benchmarks/CMakeLists.txt
+++ b/mooncake-store/benchmarks/CMakeLists.txt
@@ -1,3 +1,3 @@
 # Add allocator benchmark executable
 add_executable(allocator_bench allocator_bench.cpp)
-target_link_libraries(allocator_bench PRIVATE mooncake_store)
+target_link_libraries(allocator_bench PRIVATE cachelib_memory_allocator mooncake_store)

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 # The cache_allocator library
 include_directories(${Python3_INCLUDE_DIRS})
 add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
-target_link_libraries(mooncake_store PUBLIC transfer_engine ${ETCD_WRAPPER_LIB} glog::glog gflags::gflags  
+target_link_libraries(mooncake_store PUBLIC transfer_engine cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog::glog gflags::gflags  
     ${EXTRA_LIBS}
 )
 if (STORE_USE_ETCD)


### PR DESCRIPTION
Without this patch, the compilation fails with:
```[ 99%] Built target store
/usr/bin/ld: ../src/libmooncake_store.so: undefined reference to `facebook::cachelib::SlabAllocator::~SlabAllocator()'
/usr/bin/ld: ../src/libmooncake_store.so: undefined reference to `facebook::cachelib::MemoryAllocator::addPool(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned long, std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> > const&, bool)'
/usr/bin/ld: ../src/libmooncake_store.so: undefined reference to `facebook::cachelib::MemoryAllocator::allocate(signed char, unsigned int)'
/usr/bin/ld: ../src/libmooncake_store.so: undefined reference to `facebook::cachelib::MemoryAllocator::free(void*)'
/usr/bin/ld: ../src/libmooncake_store.so: undefined reference to `facebook::cachelib::MemoryAllocator::MemoryAllocator(facebook::cachelib::MemoryAllocator::Config, void*, unsigned long, void*, unsigned long)'
/usr/bin/ld: ../src/libmooncake_store.so: undefined reference to `facebook::cachelib::MemoryAllocator::generateAllocSizes(double, unsigned int, unsigned int, bool)'
collect2: error: ld returned 1 exit status
make[2]: *** [mooncake-store/benchmarks/CMakeFiles/allocator_bench.dir/build.make:108: mooncake-store/benchmarks/allocator_bench] Error 1
make[1]: *** [CMakeFiles/Makefile2:1952: mooncake-store/benchmarks/CMakeFiles/allocator_bench.dir/all] Error 2
make: *** [Makefile:146: all] Error 2```