### PR TITLE
Fix Handshake Daemon Initialization Order

### DIFF
--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -672,11 +672,6 @@ int TransferMetadata::getRpcMetaEntry(const std::string &server_name,
 
 int TransferMetadata::startHandshakeDaemon(
     OnReceiveHandShake on_receive_handshake, uint16_t listen_port, int sockfd) {
-    int rc = handshake_plugin_->startDaemon(listen_port, sockfd);
-    if (rc != 0) {
-        return rc;
-    }
-
     handshake_plugin_->registerOnConnectionCallBack(
         [on_receive_handshake](const Json::Value &peer,
                                Json::Value &local) -> int {
@@ -693,6 +688,11 @@ int TransferMetadata::startHandshakeDaemon(
         [this](const Json::Value &peer, Json::Value &local) -> int {
             return receivePeerNotify(peer, local);
         });
+
+    int rc = handshake_plugin_->startDaemon(listen_port, sockfd);
+    if (rc != 0) {
+        return rc;
+    }
     return 0;
 }
 


### PR DESCRIPTION
# Summary
Fixes incorrect initialization sequence in `startHandshakeDaemon()` by moving the daemon start call after callback registrations.

# Changes

- Before: Daemon started before registering callbacks

- After: Callbacks registered first, then daemon started

# Why
The original order could cause race conditions where the daemon becomes active before callbacks are properly set up, potentially leading to missed or improperly handled handshake events.