### PR TITLE
[TransferEngine] Fix SIEVE eviction algorithm for RDMA endpoint store

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -160,7 +160,7 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::insertEndpoint(
     while (this->getSize() >= max_size_) evictEndpoint();
 
     endpoint->setPeerNicPath(peer_nic_path);
-    endpoint_map_[peer_nic_path] = std::make_pair(endpoint, false);
+    endpoint_map_[peer_nic_path] = std::make_pair(endpoint, true);
     fifo_list_.push_front(peer_nic_path);
     fifo_map_[peer_nic_path] = fifo_list_.begin();
     return endpoint;


### PR DESCRIPTION
Currently, this project uses a SIEVE cache eviction algorithm for the RDMA endpoint store. However, this algorithm was originally designed for web caching, under the assumption that most newly inserted elements are cold. Therefore, it employs a "quick demotion" strategy that aggressively evicts newly inserted elements unless they have been visited again.

In the context of RDMA endpoints, however, we can assume that a newly inserted endpoint is likely to be used soon, otherwise there is no need to create it. Thus, we can set the default "visited" field of a newly inserted element to True, giving it a second chance.

In this way, the SIEVE algorithm essentially falls back to the CLOCK eviction algorithm. More advanced alternatives—such as LRU (less scalable due to high metadata maintenance overhead) or S3FIFO (similar to an improved SIEVE with a ghost queue) could also be considered in the future.