### PR TITLE
[TE] Fix notifs problems in C wrapper

### DIFF
--- a/mooncake-transfer-engine/include/transfer_engine_c.h
+++ b/mooncake-transfer-engine/include/transfer_engine_c.h
@@ -146,6 +146,8 @@ int submitTransferWithNotify(transfer_engine_t engine, batch_id_t batch_id,
 
 notify_msg_t *getNotifsFromEngine(transfer_engine_t engine, int *size);
 
+int freeNotifsMsgBuf(notify_msg_t *msg, int size);
+
 int genNotifyInEngine(transfer_engine_t engine, uint64_t target_id,
                       notify_msg_t notify_msg);
 

--- a/mooncake-transfer-engine/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_c.cpp
@@ -143,17 +143,23 @@ int submitTransfer(transfer_engine_t engine, batch_id_t batch_id,
 int submitTransferWithNotify(transfer_engine_t engine, batch_id_t batch_id,
                              struct transfer_request *entries, size_t count,
                              notify_msg_t notify_msg) {
-    uint64_t target_id = entries[0].target_id;
-    int rc = submitTransfer(engine, batch_id, entries, count);
-    if (rc) {
-        return rc;
-    }
-    // notify
     TransferEngine *native = (TransferEngine *)engine;
-    TransferMetadata::NotifyDesc notify;
-    notify.name = notify_msg.name;
-    notify.notify_msg = notify_msg.msg;
-    return native->sendNotifyByID((SegmentID)target_id, notify);
+    std::vector<Transport::TransferRequest> native_entries;
+    native_entries.resize(count);
+    for (size_t index = 0; index < count; index++) {
+        native_entries[index].opcode =
+            (Transport::TransferRequest::OpCode)entries[index].opcode;
+        native_entries[index].source = entries[index].source;
+        native_entries[index].target_id = entries[index].target_id;
+        native_entries[index].target_offset = entries[index].target_offset;
+        native_entries[index].length = entries[index].length;
+    }
+    TransferMetadata::NotifyDesc native_notify_msg;
+    native_notify_msg.name = notify_msg.name;
+    native_notify_msg.notify_msg = notify_msg.msg;
+    Status s = native->submitTransferWithNotify(
+        (Transport::BatchID)batch_id, native_entries, native_notify_msg);
+    return (int)s.code();
 }
 
 int getTransferStatus(transfer_engine_t engine, batch_id_t batch_id,
@@ -176,12 +182,29 @@ notify_msg_t *getNotifsFromEngine(transfer_engine_t engine, int *size) {
     *size = notifies_desc.size();
     notify_msg_t *notifies =
         (notify_msg_t *)malloc(*size * sizeof(notify_msg_t));
+    memset(notifies, 0, *size * sizeof(notify_msg_t));
     for (int i = 0; i < *size; i++) {
-        notifies[i].name = const_cast<char *>(notifies_desc[i].name.c_str());
-        notifies[i].msg =
-            const_cast<char *>(notifies_desc[i].notify_msg.c_str());
+        notifies[i].name = new char[notifies_desc[i].name.size() + 1];
+        notifies[i].msg = new char[notifies_desc[i].notify_msg.size() + 1];
+        if (!notifies[i].name || !notifies[i].msg) {
+            freeNotifsMsgBuf(notifies, *size);
+            return nullptr;
+        }
+        strncpy(notifies[i].name, notifies_desc[i].name.c_str(),
+                notifies_desc[i].name.size());
+        strncpy(notifies[i].msg, notifies_desc[i].notify_msg.c_str(),
+                notifies_desc[i].name.size());
     }
     return notifies;
+}
+
+int freeNotifsMsgBuf(notify_msg_t *msg, int size) {
+    for (int i = 0; i < size; i++) {
+        if (msg[i].name) free(msg[i].name);
+        if (msg[i].msg) free(msg[i].msg);
+    }
+    free(msg);
+    return 0;
 }
 
 int genNotifyInEngine(transfer_engine_t engine, uint64_t target_id,

--- a/mooncake-transfer-engine/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_c.cpp
@@ -184,8 +184,8 @@ notify_msg_t *getNotifsFromEngine(transfer_engine_t engine, int *size) {
         (notify_msg_t *)malloc(*size * sizeof(notify_msg_t));
     memset(notifies, 0, *size * sizeof(notify_msg_t));
     for (int i = 0; i < *size; i++) {
-        notifies[i].name = new char[notifies_desc[i].name.size() + 1];
-        notifies[i].msg = new char[notifies_desc[i].notify_msg.size() + 1];
+        notifies[i].name = malloc(notifies_desc[i].name.size() + 1);
+        notifies[i].msg = malloc(notifies_desc[i].notify_msg.size() + 1);
         if (!notifies[i].name || !notifies[i].msg) {
             freeNotifsMsgBuf(notifies, *size);
             return nullptr;


### PR DESCRIPTION
Trying to fix problems in #769 #770. 

NB. After merging this PR, the NIXL plugin should use `freeNotifsMsgBuf` instead of `free` in the following code snipple. @haobayuxi 

https://github.com/ai-dynamo/nixl/blob/787dd7b5d074d0ba0755e6c50cc21fdb330114c3/src/plugins/mooncake/mooncake_backend.cpp#L328