### PR TITLE
[Bugfix] YAML CPP has inline impl in header file which will cause linking error

### DIFF
--- a/mooncake-common/include/default_config.h
+++ b/mooncake-common/include/default_config.h
@@ -5,7 +5,7 @@
 #else
 #include <json/json.h>  // CentOS
 #endif
-#include <yaml-cpp/node/node.h>
+#include <yaml-cpp/yaml.h>
 
 #include <cstdint>
 #include <string>

--- a/mooncake-common/src/default_config.cpp
+++ b/mooncake-common/src/default_config.cpp
@@ -8,7 +8,6 @@
 #include <json/value.h>  // CentOS
 #endif
 
-#include <yaml-cpp/node/node.h>
 #include <yaml-cpp/yaml.h>
 
 #include <cstdint>


### PR DESCRIPTION
As titled. Please refer to https://github.com/jbeder/yaml-cpp/issues/554 and its subsequent follow up solution in https://github.com/Jmeyer1292/robot_cal_tools/issues/102. 

Thank you! Please let me know if there is anything else I need to fill out for good PR etiquette.