### PR TITLE
feat(store): Add largest free region filtering for allocation

### DIFF
--- a/mooncake-store/include/allocator.h
+++ b/mooncake-store/include/allocator.h
@@ -2,6 +2,7 @@
 #define BUFFER_ALLOCATOR_H
 
 #include <atomic>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -14,6 +15,10 @@ using facebook::cachelib::MemoryAllocator;
 using facebook::cachelib::PoolId;
 
 namespace mooncake {
+
+// Constant for unknown free space in allocators that don't track it precisely
+static constexpr size_t kAllocatorUnknownFreeSpace =
+    std::numeric_limits<size_t>::max();
 
 /**
  * @brief Status of a buffer in the system
@@ -124,6 +129,17 @@ class BufferAllocatorBase {
     virtual size_t capacity() const = 0;
     virtual size_t size() const = 0;
     virtual std::string getSegmentName() const = 0;
+
+    /**
+     * Returns the largest free region available in this allocator.
+     * For CacheLib allocators, this returns kAllocatorUnknownFreeSpace as an
+     * approximation. For OffsetAllocator, this returns the actual largest free
+     * region.
+     *
+     * Note: This is a best-effort estimate used for filtering. The actual
+     * allocation may still fail due to race conditions or fragmentation.
+     */
+    virtual size_t getLargestFreeRegion() const = 0;
 };
 
 /**
@@ -164,6 +180,15 @@ class CachelibBufferAllocator
     size_t size() const override { return cur_size_.load(); }
     std::string getSegmentName() const override { return segment_name_; }
 
+    /**
+     * For CacheLib, return kAllocatorUnknownFreeSpace as we don't have exact
+     * free region info. This ensures CacheLib allocators are always considered
+     * for allocation.
+     */
+    size_t getLargestFreeRegion() const override {
+        return kAllocatorUnknownFreeSpace;
+    }
+
    private:
     // metadata
     const std::string segment_name_;
@@ -200,6 +225,11 @@ class OffsetBufferAllocator
     size_t capacity() const override { return total_size_; }
     size_t size() const override { return cur_size_.load(); }
     std::string getSegmentName() const override { return segment_name_; }
+
+    /**
+     * Returns the actual largest free region from the offset allocator.
+     */
+    size_t getLargestFreeRegion() const override;
 
    private:
     // metadata

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -221,6 +221,25 @@ void OffsetBufferAllocator::deallocate(AllocatedBuffer* handle) {
     }
 }
 
+size_t OffsetBufferAllocator::getLargestFreeRegion() const {
+    if (!offset_allocator_) {
+        return 0;
+    }
+
+    try {
+        auto report = offset_allocator_->storageReport();
+        return report.largestFreeRegion;
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to get storage report: " << e.what()
+                   << " segment=" << segment_name_;
+        return 0;
+    } catch (...) {
+        LOG(ERROR) << "Unknown error getting storage report"
+                   << " segment=" << segment_name_;
+        return 0;
+    }
+}
+
 SimpleAllocator::SimpleAllocator(size_t size) {
     LOG(INFO) << "initializing_simple_allocator size=" << size;
 

--- a/mooncake-store/tests/allocation_strategy_test.cpp
+++ b/mooncake-store/tests/allocation_strategy_test.cpp
@@ -12,20 +12,34 @@
 
 namespace mooncake {
 
+// Size units for better readability
+static constexpr size_t MB = 1024 * 1024;
+
+// Base class for non-parameterized tests
 class AllocationStrategyTest : public ::testing::Test {
    protected:
     void SetUp() override {
         strategy_ = std::make_unique<RandomAllocationStrategy>();
     }
 
+    std::unique_ptr<RandomAllocationStrategy> strategy_;
+};
+
+// Parameterized test class for allocator type variations
+class AllocationStrategyParameterizedTest
+    : public ::testing::TestWithParam<BufferAllocatorType> {
+   protected:
+    void SetUp() override {
+        strategy_ = std::make_unique<RandomAllocationStrategy>();
+        allocator_type_ = GetParam();
+    }
+
     // Helper function to create a BufferAllocator for testing
     std::shared_ptr<BufferAllocatorBase> CreateTestAllocator(
         const std::string& segment_name, size_t base_offset,
-        BufferAllocatorType allocator_type) {
+        size_t size = 64 * MB) {
         const size_t base = 0x100000000ULL + base_offset;  // 4GB + offset
-        const size_t size =
-            1024 * 1024 * 64;  // 64MB (for multiple slabs in cachelib)
-        switch (allocator_type) {
+        switch (allocator_type_) {
             case BufferAllocatorType::CACHELIB:
                 return std::make_shared<CachelibBufferAllocator>(segment_name,
                                                                  base, size);
@@ -37,13 +51,54 @@ class AllocationStrategyTest : public ::testing::Test {
         }
     }
 
-    std::vector<BufferAllocatorType> allocator_types_ = {
-        BufferAllocatorType::CACHELIB, BufferAllocatorType::OFFSET};
+    BufferAllocatorType allocator_type_;
+    std::unique_ptr<RandomAllocationStrategy> strategy_;
+};
+
+// Instantiate parameterized tests for all allocator types
+INSTANTIATE_TEST_SUITE_P(
+    AllAllocatorTypes, AllocationStrategyParameterizedTest,
+    ::testing::Values(BufferAllocatorType::CACHELIB,
+                      BufferAllocatorType::OFFSET),
+    [](const ::testing::TestParamInfo<BufferAllocatorType>& info) {
+        switch (info.param) {
+            case BufferAllocatorType::CACHELIB:
+                return "Cachelib";
+            case BufferAllocatorType::OFFSET:
+                return "Offset";
+            default:
+                return "Unknown";
+        }
+    });
+
+// Unit test class for testing individual functions
+class AllocationStrategyUnitTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        strategy_ = std::make_unique<RandomAllocationStrategy>();
+    }
+
+    // Helper function to create test allocators
+    std::shared_ptr<BufferAllocatorBase> CreateTestAllocator(
+        const std::string& segment_name, size_t base_offset,
+        BufferAllocatorType type, size_t size = 64 * MB) {
+        const size_t base = 0x100000000ULL + base_offset;  // 4GB + offset
+        switch (type) {
+            case BufferAllocatorType::CACHELIB:
+                return std::make_shared<CachelibBufferAllocator>(segment_name,
+                                                                 base, size);
+            case BufferAllocatorType::OFFSET:
+                return std::make_shared<OffsetBufferAllocator>(segment_name,
+                                                               base, size);
+            default:
+                throw std::invalid_argument("Invalid allocator type");
+        }
+    }
 
     std::unique_ptr<RandomAllocationStrategy> strategy_;
 };
 
-// Test basic functionality with empty allocators map
+// Test basic functionality with empty allocators map (non-parameterized)
 TEST_F(AllocationStrategyTest, EmptyAllocatorsMap) {
     std::unordered_map<std::string,
                        std::vector<std::shared_ptr<BufferAllocatorBase>>>
@@ -58,7 +113,7 @@ TEST_F(AllocationStrategyTest, EmptyAllocatorsMap) {
     EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
 }
 
-// Test preferred segment behavior with empty allocators
+// Test preferred segment behavior with empty allocators (non-parameterized)
 TEST_F(AllocationStrategyTest, PreferredSegmentWithEmptyAllocators) {
     std::unordered_map<std::string,
                        std::vector<std::shared_ptr<BufferAllocatorBase>>>
@@ -74,301 +129,277 @@ TEST_F(AllocationStrategyTest, PreferredSegmentWithEmptyAllocators) {
 }
 
 // Test preferred segment allocation when available
-TEST_F(AllocationStrategyTest, PreferredSegmentAllocation) {
-    for (const auto& allocator_type : allocator_types_) {
-        auto allocator1 = CreateTestAllocator("segment1", 0, allocator_type);
-        auto allocator2 =
-            CreateTestAllocator("preferred", 0x10000000ULL, allocator_type);
+TEST_P(AllocationStrategyParameterizedTest, PreferredSegmentAllocation) {
+    auto allocator1 = CreateTestAllocator("segment1", 0);
+    auto allocator2 = CreateTestAllocator("preferred", 0x10000000ULL);
 
-        std::unordered_map<std::string,
-                           std::vector<std::shared_ptr<BufferAllocatorBase>>>
-            allocators_by_name;
-        std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
 
-        allocators_by_name["segment1"].push_back(allocator1);
-        allocators_by_name["preferred"].push_back(allocator2);
-        allocators.push_back(allocator1);
-        allocators.push_back(allocator2);
+    allocators_by_name["segment1"].push_back(allocator1);
+    allocators_by_name["preferred"].push_back(allocator2);
+    allocators.push_back(allocator1);
+    allocators.push_back(allocator2);
 
-        ReplicateConfig config{1, false, "preferred"};
-        std::vector<size_t> slice_sizes = {1024};
+    ReplicateConfig config{1, false, "preferred"};
+    std::vector<size_t> slice_sizes = {1024};
 
-        auto result = strategy_->Allocate(allocators, allocators_by_name,
-                                          slice_sizes, config);
-        ASSERT_TRUE(result.has_value());
-        EXPECT_EQ(result.value().size(), 1);
-        ASSERT_FALSE(result.value().empty());
+    auto result = strategy_->Allocate(allocators, allocators_by_name,
+                                      slice_sizes, config);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().size(), 1);
+    ASSERT_FALSE(result.value().empty());
 
-        const auto& replica = result.value()[0];
-        auto descriptor = replica.get_descriptor();
-        ASSERT_TRUE(descriptor.is_memory_replica());
-        const auto& mem_desc = descriptor.get_memory_descriptor();
-        ASSERT_EQ(mem_desc.buffer_descriptors.size(), 1);
-        EXPECT_EQ(mem_desc.buffer_descriptors[0].segment_name_, "preferred");
-        EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 1024);
-    }
+    const auto& replica = result.value()[0];
+    auto descriptor = replica.get_descriptor();
+    ASSERT_TRUE(descriptor.is_memory_replica());
+    const auto& mem_desc = descriptor.get_memory_descriptor();
+    ASSERT_EQ(mem_desc.buffer_descriptors.size(), 1);
+    EXPECT_EQ(mem_desc.buffer_descriptors[0].segment_name_, "preferred");
+    EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 1024);
 }
 
 // Test fallback to random allocation when preferred segment doesn't exist
-TEST_F(AllocationStrategyTest, PreferredSegmentNotFound) {
-    for (const auto& allocator_type : allocator_types_) {
-        auto allocator1 = CreateTestAllocator("segment1", 0, allocator_type);
-        auto allocator2 =
-            CreateTestAllocator("segment2", 0x10000000ULL, allocator_type);
+TEST_P(AllocationStrategyParameterizedTest, PreferredSegmentNotFound) {
+    auto allocator1 = CreateTestAllocator("segment1", 0);
+    auto allocator2 = CreateTestAllocator("segment2", 0x10000000ULL);
 
-        std::unordered_map<std::string,
-                           std::vector<std::shared_ptr<BufferAllocatorBase>>>
-            allocators_by_name;
-        std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
 
-        allocators_by_name["segment1"].push_back(allocator1);
-        allocators_by_name["segment2"].push_back(allocator2);
-        allocators.push_back(allocator1);
-        allocators.push_back(allocator2);
+    allocators_by_name["segment1"].push_back(allocator1);
+    allocators_by_name["segment2"].push_back(allocator2);
+    allocators.push_back(allocator1);
+    allocators.push_back(allocator2);
 
-        ReplicateConfig config{1, false, "nonexistent"};
-        std::vector<size_t> slice_sizes = {1024};
+    ReplicateConfig config{1, false, "nonexistent"};
+    std::vector<size_t> slice_sizes = {1024};
 
-        auto result = strategy_->Allocate(allocators, allocators_by_name,
-                                          slice_sizes, config);
-        ASSERT_TRUE(result.has_value());
-        EXPECT_EQ(result.value().size(), 1);
+    auto result = strategy_->Allocate(allocators, allocators_by_name,
+                                      slice_sizes, config);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().size(), 1);
 
-        const auto& replica = result.value()[0];
-        auto descriptor = replica.get_descriptor();
-        ASSERT_TRUE(descriptor.is_memory_replica());
-        const auto& mem_desc = descriptor.get_memory_descriptor();
-        ASSERT_EQ(mem_desc.buffer_descriptors.size(), 1);
-        std::string segment_name = mem_desc.buffer_descriptors[0].segment_name_;
-        EXPECT_TRUE(segment_name == "segment1" || segment_name == "segment2");
-        EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 1024);
-    }
+    const auto& replica = result.value()[0];
+    auto descriptor = replica.get_descriptor();
+    ASSERT_TRUE(descriptor.is_memory_replica());
+    const auto& mem_desc = descriptor.get_memory_descriptor();
+    ASSERT_EQ(mem_desc.buffer_descriptors.size(), 1);
+    std::string segment_name = mem_desc.buffer_descriptors[0].segment_name_;
+    EXPECT_TRUE(segment_name == "segment1" || segment_name == "segment2");
+    EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 1024);
 }
 
 // Test multiple slices allocation
-TEST_F(AllocationStrategyTest, MultipleSlicesAllocation) {
-    for (const auto& allocator_type : allocator_types_) {
-        auto allocator1 = CreateTestAllocator("segment1", 0, allocator_type);
-        auto allocator2 =
-            CreateTestAllocator("segment2", 0x10000000ULL, allocator_type);
+TEST_P(AllocationStrategyParameterizedTest, MultipleSlicesAllocation) {
+    auto allocator1 = CreateTestAllocator("segment1", 0);
+    auto allocator2 = CreateTestAllocator("segment2", 0x10000000ULL);
 
-        std::unordered_map<std::string,
-                           std::vector<std::shared_ptr<BufferAllocatorBase>>>
-            allocators_by_name;
-        std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
 
-        allocators_by_name["segment1"].push_back(allocator1);
-        allocators_by_name["segment2"].push_back(allocator2);
-        allocators.push_back(allocator1);
-        allocators.push_back(allocator2);
+    allocators_by_name["segment1"].push_back(allocator1);
+    allocators_by_name["segment2"].push_back(allocator2);
+    allocators.push_back(allocator1);
+    allocators.push_back(allocator2);
 
-        ReplicateConfig config{1, false, ""};
-        std::vector<size_t> slice_sizes = {1024, 2048, 512};
+    ReplicateConfig config{1, false, ""};
+    std::vector<size_t> slice_sizes = {1024, 2048, 512};
 
-        auto result = strategy_->Allocate(allocators, allocators_by_name,
-                                          slice_sizes, config);
-        ASSERT_TRUE(result.has_value());
-        EXPECT_EQ(result.value().size(), 1);
+    auto result = strategy_->Allocate(allocators, allocators_by_name,
+                                      slice_sizes, config);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().size(), 1);
 
-        const auto& replica = result.value()[0];
-        auto descriptor = replica.get_descriptor();
-        ASSERT_TRUE(descriptor.is_memory_replica());
-        const auto& mem_desc = descriptor.get_memory_descriptor();
-        ASSERT_EQ(mem_desc.buffer_descriptors.size(), 3);
-        EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 1024);
-        EXPECT_EQ(mem_desc.buffer_descriptors[1].size_, 2048);
-        EXPECT_EQ(mem_desc.buffer_descriptors[2].size_, 512);
-    }
+    const auto& replica = result.value()[0];
+    auto descriptor = replica.get_descriptor();
+    ASSERT_TRUE(descriptor.is_memory_replica());
+    const auto& mem_desc = descriptor.get_memory_descriptor();
+    ASSERT_EQ(mem_desc.buffer_descriptors.size(), 3);
+    EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 1024);
+    EXPECT_EQ(mem_desc.buffer_descriptors[1].size_, 2048);
+    EXPECT_EQ(mem_desc.buffer_descriptors[2].size_, 512);
 }
 
 // Test multiple replicas allocation
-TEST_F(AllocationStrategyTest, MultipleReplicasAllocation) {
-    for (const auto& allocator_type : allocator_types_) {
-        auto allocator1 = CreateTestAllocator("segment1", 0, allocator_type);
-        auto allocator2 =
-            CreateTestAllocator("segment2", 0x10000000ULL, allocator_type);
-        auto allocator3 =
-            CreateTestAllocator("segment3", 0x20000000ULL, allocator_type);
+TEST_P(AllocationStrategyParameterizedTest, MultipleReplicasAllocation) {
+    auto allocator1 = CreateTestAllocator("segment1", 0);
+    auto allocator2 = CreateTestAllocator("segment2", 0x10000000ULL);
+    auto allocator3 = CreateTestAllocator("segment3", 0x20000000ULL);
 
-        std::unordered_map<std::string,
-                           std::vector<std::shared_ptr<BufferAllocatorBase>>>
-            allocators_by_name;
-        std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
 
-        allocators_by_name["segment1"].push_back(allocator1);
-        allocators_by_name["segment2"].push_back(allocator2);
-        allocators_by_name["segment3"].push_back(allocator3);
-        allocators.push_back(allocator1);
-        allocators.push_back(allocator2);
-        allocators.push_back(allocator3);
+    allocators_by_name["segment1"].push_back(allocator1);
+    allocators_by_name["segment2"].push_back(allocator2);
+    allocators_by_name["segment3"].push_back(allocator3);
+    allocators.push_back(allocator1);
+    allocators.push_back(allocator2);
+    allocators.push_back(allocator3);
 
-        ReplicateConfig config{3, false, ""};  // Request 3 replicas
-        std::vector<size_t> slice_sizes = {1024, 2048};
+    ReplicateConfig config{3, false, ""};  // Request 3 replicas
+    std::vector<size_t> slice_sizes = {1024, 2048};
 
-        auto result = strategy_->Allocate(allocators, allocators_by_name,
-                                          slice_sizes, config);
-        ASSERT_TRUE(result.has_value());
-        EXPECT_EQ(result.value().size(), 3);
+    auto result = strategy_->Allocate(allocators, allocators_by_name,
+                                      slice_sizes, config);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().size(), 3);
 
-        // Check each replica has all slices
-        for (const auto& replica : result.value()) {
-            auto descriptor = replica.get_descriptor();
-            ASSERT_TRUE(descriptor.is_memory_replica());
-            const auto& mem_desc = descriptor.get_memory_descriptor();
-            ASSERT_EQ(mem_desc.buffer_descriptors.size(), 2);
-            EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 1024);
-            EXPECT_EQ(mem_desc.buffer_descriptors[1].size_, 2048);
-        }
+    // Check each replica has all slices
+    for (const auto& replica : result.value()) {
+        auto descriptor = replica.get_descriptor();
+        ASSERT_TRUE(descriptor.is_memory_replica());
+        const auto& mem_desc = descriptor.get_memory_descriptor();
+        ASSERT_EQ(mem_desc.buffer_descriptors.size(), 2);
+        EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 1024);
+        EXPECT_EQ(mem_desc.buffer_descriptors[1].size_, 2048);
+    }
 
-        // Check that replicas are on different segments
-        std::set<std::string> used_segments;
-        for (const auto& replica : result.value()) {
-            auto segment_names = replica.get_segment_names();
-            for (const auto& name_ptr : segment_names) {
-                if (name_ptr) {
-                    used_segments.insert(*name_ptr);
-                }
+    // Check that replicas are on different segments
+    std::set<std::string> used_segments;
+    for (const auto& replica : result.value()) {
+        auto segment_names = replica.get_segment_names();
+        for (const auto& name_ptr : segment_names) {
+            if (name_ptr) {
+                used_segments.insert(*name_ptr);
             }
         }
     }
 }
 
 // Test allocation when preferred segment has insufficient space
-TEST_F(AllocationStrategyTest, PreferredSegmentInsufficientSpace) {
-    for (const auto& allocator_type : allocator_types_) {
-        auto allocator1 = CreateTestAllocator("segment1", 0, allocator_type);
-        auto allocator2 =
-            CreateTestAllocator("preferred", 0x10000000ULL, allocator_type);
+TEST_P(AllocationStrategyParameterizedTest, PreferredSegmentInsufficientSpace) {
+    auto allocator1 = CreateTestAllocator("segment1", 0);
+    auto allocator2 = CreateTestAllocator("preferred", 0x10000000ULL);
 
-        std::unordered_map<std::string,
-                           std::vector<std::shared_ptr<BufferAllocatorBase>>>
-            allocators_by_name;
-        std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
 
-        allocators_by_name["segment1"].push_back(allocator1);
-        allocators_by_name["preferred"].push_back(allocator2);
-        allocators.push_back(allocator1);
-        allocators.push_back(allocator2);
+    allocators_by_name["segment1"].push_back(allocator1);
+    allocators_by_name["preferred"].push_back(allocator2);
+    allocators.push_back(allocator1);
+    allocators.push_back(allocator2);
 
-        // First, fill up the preferred allocator
-        ReplicateConfig config{1, false, "preferred"};
-        std::vector<size_t> large_slices = {
-            10 * 1024 * 1024, 10 * 1024 * 1024, 10 * 1024 * 1024,
-            10 * 1024 * 1024, 10 * 1024 * 1024, 10 * 1024 * 1024,
-            3 * 1024 * 1024};  // 63MB out of 64MB
+    // First, fill up the preferred allocator
+    ReplicateConfig config{1, false, "preferred"};
+    std::vector<size_t> large_slices = {10 * 1024 * 1024, 10 * 1024 * 1024,
+                                        10 * 1024 * 1024, 10 * 1024 * 1024,
+                                        10 * 1024 * 1024, 10 * 1024 * 1024,
+                                        3 * 1024 * 1024};  // 63MB out of 64MB
 
-        auto large_result = strategy_->Allocate(allocators, allocators_by_name,
-                                                large_slices, config);
-        ASSERT_TRUE(large_result.has_value());
-        auto large_desc = large_result.value()[0].get_descriptor();
-        ASSERT_TRUE(large_desc.is_memory_replica());
-        EXPECT_EQ(large_desc.get_memory_descriptor()
-                      .buffer_descriptors[0]
-                      .segment_name_,
-                  "preferred");
+    auto large_result = strategy_->Allocate(allocators, allocators_by_name,
+                                            large_slices, config);
+    ASSERT_TRUE(large_result.has_value());
+    auto large_desc = large_result.value()[0].get_descriptor();
+    ASSERT_TRUE(large_desc.is_memory_replica());
+    EXPECT_EQ(
+        large_desc.get_memory_descriptor().buffer_descriptors[0].segment_name_,
+        "preferred");
 
-        // Now try to allocate more than remaining space in preferred segment
-        std::vector<size_t> small_slice = {2 * 1024 * 1024};
-        auto result = strategy_->Allocate(allocators, allocators_by_name,
-                                          small_slice, config);
-        ASSERT_TRUE(result.has_value());
-        auto small_desc = result.value()[0].get_descriptor();
-        ASSERT_TRUE(small_desc.is_memory_replica());
-        const auto& mem_desc = small_desc.get_memory_descriptor();
-        EXPECT_EQ(mem_desc.buffer_descriptors[0].segment_name_, "segment1");
-        EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 2 * 1024 * 1024);
-    }
+    // Now try to allocate more than remaining space in preferred segment
+    std::vector<size_t> small_slice = {2 * 1024 * 1024};
+    auto result = strategy_->Allocate(allocators, allocators_by_name,
+                                      small_slice, config);
+    ASSERT_TRUE(result.has_value());
+    auto small_desc = result.value()[0].get_descriptor();
+    ASSERT_TRUE(small_desc.is_memory_replica());
+    const auto& mem_desc = small_desc.get_memory_descriptor();
+    EXPECT_EQ(mem_desc.buffer_descriptors[0].segment_name_, "segment1");
+    EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 2 * 1024 * 1024);
 }
 
 // Test allocation when all allocators are full
-TEST_F(AllocationStrategyTest, AllAllocatorsFull) {
-    for (const auto& allocator_type : allocator_types_) {
-        auto allocator1 = CreateTestAllocator("segment1", 0, allocator_type);
-        auto allocator2 =
-            CreateTestAllocator("segment2", 0x10000000ULL, allocator_type);
+TEST_P(AllocationStrategyParameterizedTest, AllAllocatorsFull) {
+    auto allocator1 = CreateTestAllocator("segment1", 0);
+    auto allocator2 = CreateTestAllocator("segment2", 0x10000000ULL);
 
-        std::unordered_map<std::string,
-                           std::vector<std::shared_ptr<BufferAllocatorBase>>>
-            allocators_by_name;
-        std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
 
-        allocators_by_name["segment1"].push_back(allocator1);
-        allocators_by_name["segment2"].push_back(allocator2);
-        allocators.push_back(allocator1);
-        allocators.push_back(allocator2);
+    allocators_by_name["segment1"].push_back(allocator1);
+    allocators_by_name["segment2"].push_back(allocator2);
+    allocators.push_back(allocator1);
+    allocators.push_back(allocator2);
 
-        ReplicateConfig config{1, false, ""};
+    ReplicateConfig config{1, false, ""};
 
-        // Fill up both allocators
-        std::vector<size_t> large_slices = {15 * 1024 * 1024, 15 * 1024 * 1024,
-                                            15 * 1024 * 1024,
-                                            15 * 1024 * 1024};  // 60MB
-        auto result1 = strategy_->Allocate(allocators, allocators_by_name,
-                                           large_slices, config);
-        ASSERT_TRUE(result1.has_value());
-        auto result2 = strategy_->Allocate(allocators, allocators_by_name,
-                                           large_slices, config);
-        ASSERT_TRUE(result2.has_value());
+    // Fill up both allocators
+    std::vector<size_t> large_slices = {15 * 1024 * 1024, 15 * 1024 * 1024,
+                                        15 * 1024 * 1024,
+                                        15 * 1024 * 1024};  // 60MB
+    auto result1 = strategy_->Allocate(allocators, allocators_by_name,
+                                       large_slices, config);
+    ASSERT_TRUE(result1.has_value());
+    auto result2 = strategy_->Allocate(allocators, allocators_by_name,
+                                       large_slices, config);
+    ASSERT_TRUE(result2.has_value());
 
-        // Try to allocate more than remaining space
-        std::vector<size_t> impossible_slice = {
-            5 * 1024 * 1024};  // 5MB (more than remaining)
-        auto result = strategy_->Allocate(allocators, allocators_by_name,
-                                          impossible_slice, config);
-        EXPECT_FALSE(result.has_value());
-        EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
-    }
+    // Try to allocate more than remaining space
+    std::vector<size_t> impossible_slice = {5 * 1024 *
+                                            1024};  // 5MB (more than remaining)
+    auto result = strategy_->Allocate(allocators, allocators_by_name,
+                                      impossible_slice, config);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
 }
 
 // Test allocation with zero size
-TEST_F(AllocationStrategyTest, ZeroSizeAllocation) {
-    for (const auto& allocator_type : allocator_types_) {
-        auto allocator = CreateTestAllocator("segment1", 0, allocator_type);
-        std::unordered_map<std::string,
-                           std::vector<std::shared_ptr<BufferAllocatorBase>>>
-            allocators_by_name;
-        std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
+TEST_P(AllocationStrategyParameterizedTest, ZeroSizeAllocation) {
+    auto allocator = CreateTestAllocator("segment1", 0);
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
 
-        allocators_by_name["segment1"].push_back(allocator);
-        allocators.push_back(allocator);
+    allocators_by_name["segment1"].push_back(allocator);
+    allocators.push_back(allocator);
 
-        ReplicateConfig config{1, false, ""};
-        std::vector<size_t> zero_slice = {0};
+    ReplicateConfig config{1, false, ""};
+    std::vector<size_t> zero_slice = {0};
 
-        auto result = strategy_->Allocate(allocators, allocators_by_name,
-                                          zero_slice, config);
-        EXPECT_FALSE(result.has_value());
-        EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
-    }
+    auto result =
+        strategy_->Allocate(allocators, allocators_by_name, zero_slice, config);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
 }
 
 // Test allocation with very large size
-TEST_F(AllocationStrategyTest, VeryLargeSizeAllocation) {
-    for (const auto& allocator_type : allocator_types_) {
-        auto allocator = CreateTestAllocator("segment1", 0, allocator_type);
-        std::unordered_map<std::string,
-                           std::vector<std::shared_ptr<BufferAllocatorBase>>>
-            allocators_by_name;
-        std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
+TEST_P(AllocationStrategyParameterizedTest, VeryLargeSizeAllocation) {
+    auto allocator = CreateTestAllocator("segment1", 0);
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators;
 
-        allocators_by_name["segment1"].push_back(allocator);
-        allocators.push_back(allocator);
+    allocators_by_name["segment1"].push_back(allocator);
+    allocators.push_back(allocator);
 
-        ReplicateConfig config{1, false, ""};
-        std::vector<size_t> huge_slice = {
-            100 * 1024 * 1024};  // 100MB (larger than 64MB capacity)
+    ReplicateConfig config{1, false, ""};
+    std::vector<size_t> huge_slice = {
+        100 * 1024 * 1024};  // 100MB (larger than 64MB capacity)
 
-        auto result = strategy_->Allocate(allocators, allocators_by_name,
-                                          huge_slice, config);
-        EXPECT_FALSE(result.has_value());
-        EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
-    }
+    auto result =
+        strategy_->Allocate(allocators, allocators_by_name, huge_slice, config);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
 }
 
 // Test empty slice sizes
 TEST_F(AllocationStrategyTest, EmptySliceSizes) {
-    auto allocator =
-        CreateTestAllocator("segment1", 0, BufferAllocatorType::OFFSET);
+    auto allocator = std::make_shared<OffsetBufferAllocator>(
+        "segment1", 0x100000000ULL, 64 * MB);
     std::unordered_map<std::string,
                        std::vector<std::shared_ptr<BufferAllocatorBase>>>
         allocators_by_name;
@@ -388,8 +419,8 @@ TEST_F(AllocationStrategyTest, EmptySliceSizes) {
 
 // Test invalid replication count
 TEST_F(AllocationStrategyTest, InvalidReplicationCount) {
-    auto allocator =
-        CreateTestAllocator("segment1", 0, BufferAllocatorType::OFFSET);
+    auto allocator = std::make_shared<OffsetBufferAllocator>(
+        "segment1", 0x100000000ULL, 64 * MB);
     std::unordered_map<std::string,
                        std::vector<std::shared_ptr<BufferAllocatorBase>>>
         allocators_by_name;
@@ -410,10 +441,10 @@ TEST_F(AllocationStrategyTest, InvalidReplicationCount) {
 // Test best-effort behavior when insufficient allocators for requested replica
 // count
 TEST_F(AllocationStrategyTest, InsufficientAllocatorsForReplicas) {
-    auto allocator1 =
-        CreateTestAllocator("segment1", 0, BufferAllocatorType::OFFSET);
-    auto allocator2 = CreateTestAllocator("segment2", 0x10000000ULL,
-                                          BufferAllocatorType::OFFSET);
+    auto allocator1 = std::make_shared<OffsetBufferAllocator>(
+        "segment1", 0x100000000ULL, 64 * MB);
+    auto allocator2 = std::make_shared<OffsetBufferAllocator>(
+        "segment2", 0x100000000ULL + 0x10000000ULL, 64 * MB);
 
     std::unordered_map<std::string,
                        std::vector<std::shared_ptr<BufferAllocatorBase>>>
@@ -453,6 +484,212 @@ TEST_F(AllocationStrategyTest, InsufficientAllocatorsForReplicas) {
         segment_names.insert(mem_desc.buffer_descriptors[0].segment_name_);
     }
     EXPECT_EQ(2u, segment_names.size());
+}
+
+TEST_F(AllocationStrategyUnitTest,
+       AllocateSingleBuffer_PreferredSegmentNotFound) {
+    auto allocator1 =
+        CreateTestAllocator("segment1", 0, BufferAllocatorType::OFFSET);
+    auto allocator2 = CreateTestAllocator("segment2", 0x10000000ULL,
+                                          BufferAllocatorType::OFFSET);
+
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators = {allocator1,
+                                                                    allocator2};
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    allocators_by_name["segment1"] = {allocator1};
+    allocators_by_name["segment2"] = {allocator2};
+
+    ReplicateConfig config{1, false, "nonexistent"};
+    std::unordered_set<std::string> excluded_segments;
+
+    auto buffer = strategy_->allocateSingleBuffer(
+        allocators, allocators_by_name, 1024, config, excluded_segments);
+
+    ASSERT_TRUE(buffer != nullptr);
+    std::string segment_name = buffer->getSegmentName();
+    EXPECT_TRUE(segment_name == "segment1" || segment_name == "segment2");
+}
+
+TEST_F(AllocationStrategyUnitTest, AllocateSingleBuffer_EmptyPreferredSegment) {
+    auto allocator1 =
+        CreateTestAllocator("segment1", 0, BufferAllocatorType::OFFSET);
+
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators = {allocator1};
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    allocators_by_name["segment1"] = {allocator1};
+
+    ReplicateConfig config{1, false, ""};  // Empty preferred segment
+    std::unordered_set<std::string> excluded_segments;
+
+    auto buffer = strategy_->allocateSingleBuffer(
+        allocators, allocators_by_name, 1024, config, excluded_segments);
+
+    ASSERT_TRUE(buffer != nullptr);
+    EXPECT_EQ(buffer->getSegmentName(), "segment1");
+}
+
+// Test tryRandomAllocate function
+TEST_F(AllocationStrategyUnitTest, TryRandomAllocate_Success) {
+    auto allocator1 =
+        CreateTestAllocator("segment1", 0, BufferAllocatorType::OFFSET);
+    auto allocator2 = CreateTestAllocator("segment2", 0x10000000ULL,
+                                          BufferAllocatorType::OFFSET);
+
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators = {allocator1,
+                                                                    allocator2};
+    std::unordered_set<std::string> excluded_segments;
+
+    auto buffer =
+        strategy_->tryRandomAllocate(allocators, 1024, excluded_segments);
+    ASSERT_TRUE(buffer != nullptr);
+    EXPECT_EQ(buffer->size(), 1024);
+}
+
+TEST_F(AllocationStrategyUnitTest, TryRandomAllocate_AllSegmentsExcluded) {
+    auto allocator1 =
+        CreateTestAllocator("segment1", 0, BufferAllocatorType::OFFSET);
+    auto allocator2 = CreateTestAllocator("segment2", 0x10000000ULL,
+                                          BufferAllocatorType::OFFSET);
+
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators = {allocator1,
+                                                                    allocator2};
+    std::unordered_set<std::string> excluded_segments = {"segment1",
+                                                         "segment2"};
+
+    auto buffer =
+        strategy_->tryRandomAllocate(allocators, 1024, excluded_segments);
+    EXPECT_TRUE(buffer == nullptr);
+}
+
+TEST_F(AllocationStrategyUnitTest, TryRandomAllocate_InsufficientSpace) {
+    auto allocator = CreateTestAllocator(
+        "segment1", 0, BufferAllocatorType::OFFSET, 1024);  // Only 1KB
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators = {allocator};
+    std::unordered_set<std::string> excluded_segments;
+
+    auto buffer = strategy_->tryRandomAllocate(
+        allocators, 2048, excluded_segments);  // Request 2KB
+    EXPECT_TRUE(buffer == nullptr);
+}
+
+// Test allocateSlice function
+TEST_F(AllocationStrategyUnitTest, AllocateSlice_SingleReplica) {
+    auto allocator1 =
+        CreateTestAllocator("segment1", 0, BufferAllocatorType::OFFSET);
+
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators = {allocator1};
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    allocators_by_name["segment1"] = {allocator1};
+
+    ReplicateConfig config{1, false, ""};
+    auto buffers = strategy_->allocateSlice(allocators, allocators_by_name,
+                                            1024, 1, config);
+
+    ASSERT_EQ(buffers.size(), 1);
+    EXPECT_EQ(buffers[0]->size(), 1024);
+    EXPECT_EQ(buffers[0]->getSegmentName(), "segment1");
+}
+
+TEST_F(AllocationStrategyUnitTest, AllocateSlice_MultipleReplicas) {
+    auto allocator1 =
+        CreateTestAllocator("segment1", 0, BufferAllocatorType::OFFSET);
+    auto allocator2 = CreateTestAllocator("segment2", 0x10000000ULL,
+                                          BufferAllocatorType::OFFSET);
+    auto allocator3 = CreateTestAllocator("segment3", 0x20000000ULL,
+                                          BufferAllocatorType::OFFSET);
+
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators = {
+        allocator1, allocator2, allocator3};
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    allocators_by_name["segment1"] = {allocator1};
+    allocators_by_name["segment2"] = {allocator2};
+    allocators_by_name["segment3"] = {allocator3};
+
+    ReplicateConfig config{3, false, ""};
+    auto buffers = strategy_->allocateSlice(allocators, allocators_by_name,
+                                            1024, 3, config);
+
+    ASSERT_EQ(buffers.size(), 3);
+
+    // Verify all buffers have correct size
+    for (const auto& buffer : buffers) {
+        EXPECT_EQ(buffer->size(), 1024);
+    }
+
+    // Verify replicas are on different segments
+    std::unordered_set<std::string> used_segments;
+    for (const auto& buffer : buffers) {
+        used_segments.insert(buffer->getSegmentName());
+    }
+    EXPECT_EQ(used_segments.size(), 3);
+}
+
+TEST_F(AllocationStrategyUnitTest, AllocateSlice_InsufficientAllocators) {
+    auto allocator1 =
+        CreateTestAllocator("segment1", 0, BufferAllocatorType::OFFSET);
+
+    std::vector<std::shared_ptr<BufferAllocatorBase>> allocators = {allocator1};
+    std::unordered_map<std::string,
+                       std::vector<std::shared_ptr<BufferAllocatorBase>>>
+        allocators_by_name;
+    allocators_by_name["segment1"] = {allocator1};
+
+    ReplicateConfig config{3, false,
+                           ""};  // Request 3 replicas but only 1 allocator
+    auto buffers = strategy_->allocateSlice(allocators, allocators_by_name,
+                                            1024, 3, config);
+
+    // Should allocate as many as possible (best-effort)
+    ASSERT_EQ(buffers.size(), 1);
+    EXPECT_EQ(buffers[0]->getSegmentName(), "segment1");
+}
+
+// Test getLargestFreeRegion() filtering logic with fragmented allocators
+TEST_F(AllocationStrategyUnitTest,
+       TryRandomAllocate_LargestFreeRegionFiltering) {
+    // Run the test 10 times to account for randomness
+    for (int run = 0; run < 10; ++run) {
+        // Create two OffsetBufferAllocators with 10MB each
+        auto allocator1 = CreateTestAllocator(
+            "segment1", 0, BufferAllocatorType::OFFSET, 10 * MB);
+        auto allocator2 = CreateTestAllocator(
+            "segment2", 0x10000000ULL, BufferAllocatorType::OFFSET, 10 * MB);
+
+        // Fragment allocator1 heavily - leave only small free regions
+        std::vector<std::unique_ptr<AllocatedBuffer>> fragments1;
+        for (int i = 0; i < 9; ++i) {
+            fragments1.push_back(allocator1->allocate(1 * MB));
+        }
+        // allocator1: 9MB allocated, only 1MB free
+
+        // Leave allocator2 with enough contiguous space
+        auto fragment2 = allocator2->allocate(5 * MB);
+        // allocator2: 5MB allocated, 5MB contiguous free
+
+        std::vector<std::shared_ptr<BufferAllocatorBase>> allocators = {
+            allocator1, allocator2};
+        std::unordered_set<std::string> excluded_segments;
+
+        // Reset retry counter before test
+        strategy_->resetRetryCount();
+
+        auto buffer =
+            strategy_->tryRandomAllocate(allocators, 4 * MB, excluded_segments);
+
+        ASSERT_TRUE(buffer != nullptr) << "Failed on run " << run;
+        EXPECT_EQ(buffer->size(), 4 * MB) << "Failed on run " << run;
+        EXPECT_EQ(buffer->getSegmentName(), "segment2")
+            << "Failed on run " << run;
+        EXPECT_EQ(strategy_->getRetryCount(), 0) << "Failed on run " << run;
+    }
 }
 
 }  // namespace mooncake


### PR DESCRIPTION
The commit introduces two main features:
1. A thread-safe retry counter to track allocation attempts in RandomAllocationStrategy
2. A getLargestFreeRegion() method in BufferAllocatorBase interface that allows filtering allocators by available space, with specific implementations for both Cachelib and Offset allocators

These changes improve allocation reliability and efficiency by enabling better failure tracking and space-aware allocation decisions.