### PR TITLE
fix nixl bench bug

### DIFF
--- a/mooncake-transfer-engine/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_c.cpp
@@ -191,10 +191,8 @@ notify_msg_t *getNotifsFromEngine(transfer_engine_t engine, int *size) {
             freeNotifsMsgBuf(notifies, *size);
             return nullptr;
         }
-        strncpy(notifies[i].name, notifies_desc[i].name.c_str(),
-                notifies_desc[i].name.size());
-        strncpy(notifies[i].msg, notifies_desc[i].notify_msg.c_str(),
-                notifies_desc[i].name.size());
+        strcpy(notifies[i].name, notifies_desc[i].name.c_str());
+        strcpy(notifies[i].msg, notifies_desc[i].notify_msg.c_str());
     }
     return notifies;
 }


### PR DESCRIPTION
Fix the bug in nixl bench. Using strncpy without handling the boundary. Occasionally, incorrect characters appear at the end. Causing errors in string matching for nixl. So use strcpy instead. The size of char[] is allocated as the string size +1. So use strcpy is fine.