### PR TITLE
[Store] Zero copy for Mooncake store get_tensor API

### DIFF
--- a/mooncake-store/include/client_buffer.hpp
+++ b/mooncake-store/include/client_buffer.hpp
@@ -98,6 +98,17 @@ std::vector<Slice> split_into_slices(BufferHandle& handle);
 uint64_t calculate_total_size(const Replica::Descriptor& replica);
 
 /**
+ * @brief Allocate slices from a buffer pointer based on replica descriptor
+ * @param slices Output vector to store the allocated slices
+ * @param replica The replica descriptor defining the slice structure
+ * @param buffer The buffer pointer to allocate slices from
+ * @return 0 on success, non-zero on error
+ */
+int allocateSlices(std::vector<Slice>& slices,
+                   const Replica::Descriptor& replica,
+                   char* buffer);
+
+/**
  * @brief Allocate slices from a buffer handle based on replica descriptor
  * @param slices Output vector to store the allocated slices
  * @param replica The replica descriptor defining the slice structure

--- a/mooncake-store/include/pybind_client.h
+++ b/mooncake-store/include/pybind_client.h
@@ -273,6 +273,9 @@ class PyClient {
         const std::vector<std::span<const char>> &values,
         const ReplicateConfig &config = ReplicateConfig{});
 
+    tl::expected<char*, ErrorCode> get_allocated_internal(
+        const std::string &key, uint64_t& data_length);
+
     tl::expected<void, ErrorCode> remove_internal(const std::string &key);
 
     tl::expected<long, ErrorCode> removeByRegex_internal(

--- a/mooncake-store/include/pybind_client.h
+++ b/mooncake-store/include/pybind_client.h
@@ -273,8 +273,8 @@ class PyClient {
         const std::vector<std::span<const char>> &values,
         const ReplicateConfig &config = ReplicateConfig{});
 
-    tl::expected<char*, ErrorCode> get_allocated_internal(
-        const std::string &key, uint64_t& data_length);
+    tl::expected<char *, ErrorCode> get_allocated_internal(
+        const std::string &key, uint64_t &data_length);
 
     tl::expected<void, ErrorCode> remove_internal(const std::string &key);
 

--- a/mooncake-store/src/client_buffer.cpp
+++ b/mooncake-store/src/client_buffer.cpp
@@ -78,8 +78,7 @@ uint64_t calculate_total_size(const Replica::Descriptor& replica) {
 }
 
 int allocateSlices(std::vector<Slice>& slices,
-                   const Replica::Descriptor& replica,
-                   char* buffer) {
+                   const Replica::Descriptor& replica, char* buffer) {
     uint64_t offset = 0;
     if (replica.is_memory_replica() == false) {
         // For disk-based replica, split into slices based on file size
@@ -106,8 +105,8 @@ int allocateSlices(std::vector<Slice>& slices,
 int allocateSlices(std::vector<Slice>& slices,
                    const Replica::Descriptor& replica,
                    BufferHandle& buffer_handle) {
-    return allocateSlices(
-        slices, replica, static_cast<char*>(buffer_handle.ptr()));
+    return allocateSlices(slices, replica,
+                          static_cast<char*>(buffer_handle.ptr()));
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -1140,7 +1140,7 @@ tl::expected<char *, ErrorCode> PyClient::get_allocated_internal(
     auto unregister_result =
         unregister_buffer_internal(reinterpret_cast<void *>(data_ptr));
     if (!unregister_result) {
-        LOG(WARNING) << "Failed to unregister buffer after put_tensor";
+        LOG(WARNING) << "Failed to unregister buffer";
     }
 
     if (!get_result) {

--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -1125,6 +1125,7 @@ tl::expected<char*, ErrorCode> PyClient::get_allocated_internal(
         reinterpret_cast<void *>(data_ptr), total_length);
     if (!register_result) {
         LOG(ERROR) << "Failed to register buffer";
+        delete[] data_ptr;
         return tl::unexpected(register_result.error());
     }
 

--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -1091,8 +1091,8 @@ int PyClient::put_from_with_metadata(const std::string &key, void *buffer,
     return 0;
 }
 
-tl::expected<char*, ErrorCode> PyClient::get_allocated_internal(
-    const std::string &key, uint64_t& data_length) {
+tl::expected<char *, ErrorCode> PyClient::get_allocated_internal(
+    const std::string &key, uint64_t &data_length) {
     // Query object info first
     auto query_result = client_->Query(key);
     if (!query_result) {
@@ -1138,7 +1138,7 @@ tl::expected<char*, ErrorCode> PyClient::get_allocated_internal(
 
     // unregister the buffer for whatever cases
     auto unregister_result =
-            unregister_buffer_internal(reinterpret_cast<void *>(data_ptr));
+        unregister_buffer_internal(reinterpret_cast<void *>(data_ptr));
     if (!unregister_result) {
         LOG(WARNING) << "Failed to unregister buffer after put_tensor";
     }


### PR DESCRIPTION
Fix #799

To realize zero copy, we allocated a new buffer after getting the total length. The buffer is registered directly to transfer engine to read data directly into the buffer. The buffer is returned with ownership transferred to the caller. It will be used to create the tensor. For any error cases, the buffer needs to be freed until it is used for tensor (numpy array).