### PR TITLE
[CI] Fix Release build_wheel.sh to make python 3.8 auditwheel happy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+    branches: [ "fix_py38" ]
 
 env:
   SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches: [ "fix_py38" ]
 
 env:
   SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,6 +125,7 @@ jobs:
           files: mooncake-wheel/dist-release/*.whl
 
       - name: Publish package to PyPI
+        if: github.repository == 'kvcache-ai/Mooncake'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: mooncake-wheel/dist-release/

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -179,6 +179,9 @@ if [ "$PYTHON_VERSION" = "3.8" ]; then
         done
     done
 
+    # Manually fix for libcuda since it needs libcuda.so.1 but I didn't get it.
+    EXCLUDE_OPTS="${EXCLUDE_OPTS} --exclude libcuda.so.1 "
+
     echo "Running auditwheel with exclude options: $EXCLUDE_OPTS"
     auditwheel repair ${OUTPUT_DIR}/*.whl $EXCLUDE_OPTS -w ${REPAIRED_DIR}/ --plat ${PLATFORM_TAG}
 else

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -87,82 +87,178 @@ else
     exit 1
 fi
 
-echo "Repairing wheel with auditwheel for platform: $PLATFORM_TAG"
-python -m build --wheel --outdir ${OUTPUT_DIR}
-auditwheel repair ${OUTPUT_DIR}/*.whl \
---exclude libcurl.so* \
---exclude libibverbs.so* \
---exclude libnuma.so* \
---exclude libstdc++.so* \
---exclude libgcc_s.so* \
---exclude libc.so* \
---exclude libnghttp2.so* \
---exclude libidn2.so* \
---exclude librtmp.so* \
---exclude libssh.so* \
---exclude libpsl.so* \
---exclude libssl.so* \
---exclude libcrypto.so* \
---exclude libgssapi_krb5.so* \
---exclude libldap.so* \
---exclude liblber.so* \
---exclude libbrotlidec.so* \
---exclude libz.so* \
---exclude libnl-route-3.so* \
---exclude libnl-3.so* \
---exclude libm.so* \
---exclude liblzma.so* \
---exclude libunistring.so* \
---exclude libgnutls.so* \
---exclude libhogweed.so* \
---exclude libnettle.so* \
---exclude libgmp.so* \
---exclude libkrb5.so* \
---exclude libk5crypto.so* \
---exclude libcom_err.so* \
---exclude libkrb5support.so* \
---exclude libsasl2.so* \
---exclude libbrotlicommon.so* \
---exclude libp11-kit.so* \
---exclude libtasn1.so* \
---exclude libkeyutils.so* \
---exclude libresolv.so* \
---exclude libffi.so* \
---exclude libcuda.so* \
---exclude libcudart.so* \
---exclude libascendcl.so* \
---exclude libhccl.so* \
---exclude libmsprofiler.so* \
---exclude libgert.so* \
---exclude libascendcl_impl.so* \
---exclude libge_executor.so* \
---exclude libascend_dump.so* \
---exclude libgraph.so* \
---exclude libruntime.so* \
---exclude libascend_watchdog.so* \
---exclude libprofapi.so* \
---exclude liberror_manager.so* \
---exclude libascendalog.so* \
---exclude libc_sec.so* \
---exclude libhccl_alg.so* \
---exclude libhccl_plf.so* \
---exclude libascend_protobuf.so* \
---exclude libhybrid_executor.so* \
---exclude libdavinci_executor.so* \
---exclude libge_common.so* \
---exclude libge_common_base.so* \
---exclude liblowering.so* \
---exclude libregister.so* \
---exclude libexe_graph.so* \
---exclude libmmpa.so* \
---exclude libplatform.so* \
---exclude libgraph_base.so* \
---exclude libruntime_common.so* \
---exclude libqos_manager.so* \
---exclude libascend_trace.so* \
---exclude libmetadef*.so \
---exclude libadxl*.so \
--w ${REPAIRED_DIR}/ --plat ${PLATFORM_TAG}
+if [ "$PYTHON_VERSION" = "3.8" ]; then
+    echo "Repairing wheel with auditwheel for platform: $PLATFORM_TAG"
+    python -m build --wheel --outdir ${OUTPUT_DIR}
+
+    echo "python 3.8 auditwheel does not support wild-cards..."
+    PATTERNS=(
+        "libcurl.so*"
+        "libibverbs.so*"
+        "libnuma.so*"
+        "libstdc++.so*"
+        "libgcc_s.so*"
+        "libc.so*"
+        "libnghttp2.so*"
+        "libidn2.so*"
+        "librtmp.so*" 
+        "libssh.so*"
+        "libpsl.so*"
+        "libssl.so*"
+        "libcrypto.so*"
+        "libgssapi_krb5.so*" 
+        "libldap.so*"
+        "liblber.so*"
+        "libbrotlidec.so*"
+        "libz.so*" 
+        "libnl-route-3.so*"
+        "libnl-3.so*"
+        "libm.so*"
+        "liblzma.so*" 
+        "libunistring.so*"
+        "libgnutls.so*"
+        "libhogweed.so*"
+        "libnettle.so*"
+        "libgmp.so*"
+        "libkrb5.so*"
+        "libk5crypto.so*"
+        "libcom_err.so*"
+        "libkrb5support.so*"
+        "libsasl2.so*" 
+        "libbrotlicommon.so*"
+        "libp11-kit.so*"
+        "libtasn1.so*"
+        "libkeyutils.so*"
+        "libresolv.so*"
+        "libffi.so*"
+        "libcuda.so*"
+        "libcudart.so*"
+        "libascendcl.so*"
+        "libhccl.so*"
+        "libmsprofiler.so*"
+        "libgert.so*"
+        "libascendcl_impl.so*"
+        "libge_executor.so*"
+        "libascend_dump.so*"
+        "libgraph.so*"
+        "libruntime.so*"
+        "libascend_watchdog.so*"
+        "libprofapi.so*"
+        "liberror_manager.so*"
+        "libascendalog.so*"
+        "libc_sec.so*"
+        "libhccl_alg.so*"
+        "libhccl_plf.so*"
+        "libascend_protobuf.so*"
+        "libhybrid_executor.so*"
+        "libdavinci_executor.so*"
+        "libge_common.so*"
+        "libge_common_base.so*" 
+        "liblowering.so*"
+        "libregister.so*"
+        "libexe_graph.so*"
+        "libmmpa.so*" 
+        "libplatform.so*"
+        "libgraph_base.so*"
+        "libruntime_common.so*"
+        "libqos_manager.so*"
+        "libascend_trace.so*"
+        "libmetadef*.so"
+        "libadxl*.so"
+    )
+
+    for pattern in "${PATTERNS[@]}"; do
+        for libpath in /usr/local/cuda* /usr/local/cuda-12.8/lib* /usr/lib* /usr/local/lib* /lib*; do
+            if [ -d "$libpath" ]; then
+                for lib in $(find $libpath -name "$pattern" 2>/dev/null); do
+                    # Get just the filename
+                    libname=$(basename "$lib")
+                    EXCLUDE_OPTS="${EXCLUDE_OPTS} --exclude $libname "
+                done
+            fi
+        done
+    done
+
+    echo "Running auditwheel with exclude options: $EXCLUDE_OPTS"
+    auditwheel repair ${OUTPUT_DIR}/*.whl $EXCLUDE_OPTS -w ${REPAIRED_DIR}/ --plat ${PLATFORM_TAG}
+else
+    echo "Repairing wheel with auditwheel for platform: $PLATFORM_TAG"
+    python -m build --wheel --outdir ${OUTPUT_DIR}
+    auditwheel repair ${OUTPUT_DIR}/*.whl \
+    --exclude libcurl.so* \
+    --exclude libibverbs.so* \
+    --exclude libnuma.so* \
+    --exclude libstdc++.so* \
+    --exclude libgcc_s.so* \
+    --exclude libc.so* \
+    --exclude libnghttp2.so* \
+    --exclude libidn2.so* \
+    --exclude librtmp.so* \
+    --exclude libssh.so* \
+    --exclude libpsl.so* \
+    --exclude libssl.so* \
+    --exclude libcrypto.so* \
+    --exclude libgssapi_krb5.so* \
+    --exclude libldap.so* \
+    --exclude liblber.so* \
+    --exclude libbrotlidec.so* \
+    --exclude libz.so* \
+    --exclude libnl-route-3.so* \
+    --exclude libnl-3.so* \
+    --exclude libm.so* \
+    --exclude liblzma.so* \
+    --exclude libunistring.so* \
+    --exclude libgnutls.so* \
+    --exclude libhogweed.so* \
+    --exclude libnettle.so* \
+    --exclude libgmp.so* \
+    --exclude libkrb5.so* \
+    --exclude libk5crypto.so* \
+    --exclude libcom_err.so* \
+    --exclude libkrb5support.so* \
+    --exclude libsasl2.so* \
+    --exclude libbrotlicommon.so* \
+    --exclude libp11-kit.so* \
+    --exclude libtasn1.so* \
+    --exclude libkeyutils.so* \
+    --exclude libresolv.so* \
+    --exclude libffi.so* \
+    --exclude libcuda.so* \
+    --exclude libcudart.so* \
+    --exclude libascendcl.so* \
+    --exclude libhccl.so* \
+    --exclude libmsprofiler.so* \
+    --exclude libgert.so* \
+    --exclude libascendcl_impl.so* \
+    --exclude libge_executor.so* \
+    --exclude libascend_dump.so* \
+    --exclude libgraph.so* \
+    --exclude libruntime.so* \
+    --exclude libascend_watchdog.so* \
+    --exclude libprofapi.so* \
+    --exclude liberror_manager.so* \
+    --exclude libascendalog.so* \
+    --exclude libc_sec.so* \
+    --exclude libhccl_alg.so* \
+    --exclude libhccl_plf.so* \
+    --exclude libascend_protobuf.so* \
+    --exclude libhybrid_executor.so* \
+    --exclude libdavinci_executor.so* \
+    --exclude libge_common.so* \
+    --exclude libge_common_base.so* \
+    --exclude liblowering.so* \
+    --exclude libregister.so* \
+    --exclude libexe_graph.so* \
+    --exclude libmmpa.so* \
+    --exclude libplatform.so* \
+    --exclude libgraph_base.so* \
+    --exclude libruntime_common.so* \
+    --exclude libqos_manager.so* \
+    --exclude libascend_trace.so* \
+    --exclude libmetadef*.so \
+    --exclude libadxl*.so \
+    -w ${REPAIRED_DIR}/ --plat ${PLATFORM_TAG}
+fi
 
 
 # Replace original wheel with repaired wheel


### PR DESCRIPTION
Hello! From the release log in your actions, Python 3.8 was failed due to 

```
ValueError: Cannot repair wheel, because required library "libcuda.so.1" could not be located
```

After investigation, I believed that this was due to python 3.8 do not have auditwheels that capable of `--exclude` shared libraries with wildcards. You can refer to the PR https://github.com/pypa/auditwheel/pull/508#issue-2450955901 here.

It can be seen that Release for 6.2.0 is only suitable for python>=3.9.

<img width="192" height="161" alt="截屏2025-09-03 20 39 21" src="https://github.com/user-attachments/assets/df0eb37a-f1d4-4228-917e-c85e647bdd17" />

<img width="989" height="447" alt="截屏2025-09-03 20 38 30" src="https://github.com/user-attachments/assets/c86cb923-88b9-43fb-b52e-ebd12acb4e9d" />

And in your log, your auditwheel has a version of 6.1.0 in python 3.8 which does not support wild-card.

<img width="1082" height="252" alt="截屏2025-09-03 20 40 26" src="https://github.com/user-attachments/assets/08ddf1bf-da03-4434-b12e-9a58bcf9ed74" />

It can be seen that all  jobs have done except publish to PYPI. And it seems working well!

<img width="877" height="284" alt="截屏2025-09-03 20 42 08" src="https://github.com/user-attachments/assets/5355441e-eff4-4581-af4a-1935cf305990" />

<img width="880" height="263" alt="截屏2025-09-03 20 42 53" src="https://github.com/user-attachments/assets/ef6232cf-8cfe-4fc7-b894-e0a1b115bc1e" />

