### PR TITLE
fix(store): add mutex locks for thread-safe metrics retrieval

### DIFF
--- a/mooncake-store/include/offset_allocator/offset_allocator.hpp
+++ b/mooncake-store/include/offset_allocator/offset_allocator.hpp
@@ -173,7 +173,7 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
 
     // Internal method to get metrics without locking (caller must hold m_mutex)
     [[nodiscard]]
-    OffsetAllocatorMetrics get_metrics_internal() const;
+    OffsetAllocatorMetrics get_metrics_internal() const REQUIRES(m_mutex);
 
     std::unique_ptr<__Allocator> m_allocator GUARDED_BY(m_mutex);
     uint64_t m_base;

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -626,6 +626,7 @@ OffsetAllocStorageReportFull OffsetAllocator::storageReportFull() const {
 }
 
 OffsetAllocatorMetrics OffsetAllocator::get_metrics_internal() const {
+    MutexLocker lock(&m_mutex);
     if (!m_allocator) {
         return {0, 0, 0, 0, m_capacity};
     }

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -626,7 +626,6 @@ OffsetAllocStorageReportFull OffsetAllocator::storageReportFull() const {
 }
 
 OffsetAllocatorMetrics OffsetAllocator::get_metrics_internal() const {
-    MutexLocker lock(&m_mutex);
     if (!m_allocator) {
         return {0, 0, 0, 0, m_capacity};
     }

--- a/mooncake-store/tests/offset_allocator_test.cpp
+++ b/mooncake-store/tests/offset_allocator_test.cpp
@@ -1,4 +1,5 @@
 #include "offset_allocator/offset_allocator.hpp"
+#include "mutex.h"
 #include "serializer.h"
 #include "types.h"
 
@@ -297,6 +298,8 @@ class OffsetAllocatorTest : public ::testing::Test {
 
     void assertAllocatorEQ(const std::shared_ptr<OffsetAllocator>& a,
                            const std::shared_ptr<OffsetAllocator>& b) {
+        MutexLocker lock_a(&a->m_mutex);
+        MutexLocker lock_b(&b->m_mutex);
         // Compare basic member variables
         ASSERT_EQ(a->m_base, b->m_base);
         ASSERT_EQ(a->m_multiplier_bits, b->m_multiplier_bits);
@@ -353,6 +356,8 @@ class OffsetAllocatorTest : public ::testing::Test {
     // Compare two allocators bytes by bytes to detect one bit difference.
     bool isAllocatorEqual(const std::shared_ptr<OffsetAllocator>& a,
                           const std::shared_ptr<OffsetAllocator>& b) {
+        MutexLocker lock_a(&a->m_mutex);
+        MutexLocker lock_b(&b->m_mutex);
         // Compare basic member variables
         if (memcmp(&a->m_base, &b->m_base, sizeof(a->m_base)) != 0)
             return false;


### PR DESCRIPTION
fix clang errors like this
```
/data/code/Mooncake/mooncake-store/tests/offset_allocator_test.cpp:322:26: error: reading variable 'm_allocator' requires holding mutex 'a->m_mutex' [-Werror,-Wthread-safety-analysis]
  322 |             ASSERT_EQ(a->m_allocator->m_usedBins[i],
```