### PR TITLE
Refactor(store): Enable the transfer engine to autonomously detect

### DIFF
--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -45,7 +45,6 @@ class Client {
     static std::optional<std::shared_ptr<Client>> Create(
         const std::string& local_hostname,
         const std::string& metadata_connstring, const std::string& protocol,
-        void** protocol_args,
         const std::string& master_server_entry = kDefaultMasterAddress);
 
     /**
@@ -249,8 +248,7 @@ class Client {
     ErrorCode ConnectToMaster(const std::string& master_server_entry);
     ErrorCode InitTransferEngine(const std::string& local_hostname,
                                  const std::string& metadata_connstring,
-                                 const std::string& protocol,
-                                 void** protocol_args);
+                                 const std::string& protocol);
     ErrorCode TransferData(const Replica::Descriptor& replica,
                            std::vector<Slice>& slices,
                            TransferRequest::OpCode op_code);

--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -35,7 +35,8 @@ class Client {
      * @param local_hostname Local host address (IP:Port)
      * @param metadata_connstring Connection string for metadata service
      * @param protocol Transfer protocol ("rdma" or "tcp")
-     * @param protocol_args Protocol-specific arguments
+     * @param device_names Comma-separated RDMA device names (if protocol is
+     *        "rdma" and auto_discover is false)
      * @param master_server_entry The entry of master server (IP:Port of master
      *        address for non-HA mode, etcd://IP:Port;IP:Port;...;IP:Port for
      *        HA mode)
@@ -45,6 +46,7 @@ class Client {
     static std::optional<std::shared_ptr<Client>> Create(
         const std::string& local_hostname,
         const std::string& metadata_connstring, const std::string& protocol,
+        const std::optional<std::string>& device_names = std::nullopt,
         const std::string& master_server_entry = kDefaultMasterAddress);
 
     /**
@@ -246,9 +248,10 @@ class Client {
      * @brief Internal helper functions for initialization and data transfer
      */
     ErrorCode ConnectToMaster(const std::string& master_server_entry);
-    ErrorCode InitTransferEngine(const std::string& local_hostname,
-                                 const std::string& metadata_connstring,
-                                 const std::string& protocol);
+    ErrorCode InitTransferEngine(
+        const std::string& local_hostname,
+        const std::string& metadata_connstring, const std::string& protocol,
+        const std::optional<std::string>& device_names);
     ErrorCode TransferData(const Replica::Descriptor& replica,
                            std::vector<Slice>& slices,
                            TransferRequest::OpCode op_code);

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -98,8 +98,6 @@ std::string expected_to_str(const tl::expected<T, ErrorCode>& expected) {
 */
 void* allocate_buffer_allocator_memory(size_t total_size);
 
-void** rdma_args(const std::string& device_name);
-
 [[nodiscard]] inline std::string byte_size_to_string(uint64_t bytes) {
     const double KB = 1024.0;
     const double MB = KB * 1024.0;

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -125,6 +125,21 @@ void* allocate_buffer_allocator_memory(size_t total_size);
     return oss.str();
 }
 
+// String utility functions
+
+/**
+ * @brief Split a string by delimiter into a vector of strings
+ * @param str The string to split
+ * @param delimiter The delimiter to split by (default is comma)
+ * @param trim_spaces Whether to trim leading/trailing spaces from each token
+ * @param keep_empty Whether to keep empty tokens in the result
+ * @return Vector of split strings
+ */
+std::vector<std::string> splitString(const std::string& str,
+                                     char delimiter = ',',
+                                     bool trim_spaces = true,
+                                     bool keep_empty = false);
+
 // Network utility functions
 
 /**

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -104,7 +104,7 @@ static bool get_auto_discover() {
             return true;
         }
     }
-    return false;
+    return true;
 }
 
 static inline void ltrim(std::string& s) {
@@ -208,8 +208,7 @@ ErrorCode Client::ConnectToMaster(const std::string& master_server_entry) {
 
 ErrorCode Client::InitTransferEngine(const std::string& local_hostname,
                                      const std::string& metadata_connstring,
-                                     const std::string& protocol,
-                                     void** protocol_args) {
+                                     const std::string& protocol) {
     // get auto_discover and filters from env
     bool auto_discover = get_auto_discover();
     transfer_engine_.setAutoDiscover(auto_discover);
@@ -227,11 +226,11 @@ ErrorCode Client::InitTransferEngine(const std::string& local_hostname,
     Transport* transport = nullptr;
     if (protocol == "rdma") {
         LOG(INFO) << "transport_type=rdma";
-        transport = transfer_engine_.installTransport("rdma", protocol_args);
+        transport = transfer_engine_.installTransport("rdma", nullptr);
     } else if (protocol == "tcp") {
         LOG(INFO) << "transport_type=tcp";
         try {
-            transport = transfer_engine_.installTransport("tcp", protocol_args);
+            transport = transfer_engine_.installTransport("tcp", nullptr);
         } catch (std::exception& e) {
             LOG(ERROR) << "tcp_transport_install_failed error_message=\""
                        << e.what() << "\"";
@@ -256,8 +255,7 @@ ErrorCode Client::InitTransferEngine(const std::string& local_hostname,
 
 std::optional<std::shared_ptr<Client>> Client::Create(
     const std::string& local_hostname, const std::string& metadata_connstring,
-    const std::string& protocol, void** protocol_args,
-    const std::string& master_server_entry) {
+    const std::string& protocol, const std::string& master_server_entry) {
     auto client = std::shared_ptr<Client>(
         new Client(local_hostname, metadata_connstring));
 
@@ -290,7 +288,7 @@ std::optional<std::shared_ptr<Client>> Client::Create(
 
     // Initialize transfer engine
     err = client->InitTransferEngine(local_hostname, metadata_connstring,
-                                     protocol, protocol_args);
+                                     protocol);
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "Failed to initialize transfer engine";
         return std::nullopt;

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -102,6 +102,13 @@ static bool get_auto_discover() {
         if (iv == 1) {
             LOG(INFO) << "auto discovery set by env MC_MS_AUTO_DISC";
             return true;
+        } else if (iv == 0) {
+            LOG(INFO) << "auto discovery not set by env MC_MS_AUTO_DISC";
+            return false;
+        } else {
+            LOG(WARNING)
+                << "invalid MC_MS_AUTO_DISC value: " << ev_ad
+                << ", should be 0 or 1, using default: auto discovery not set";
         }
     }
     return true;
@@ -206,14 +213,13 @@ ErrorCode Client::ConnectToMaster(const std::string& master_server_entry) {
     }
 }
 
-ErrorCode Client::InitTransferEngine(const std::string& local_hostname,
-                                     const std::string& metadata_connstring,
-                                     const std::string& protocol) {
+ErrorCode Client::InitTransferEngine(
+    const std::string& local_hostname, const std::string& metadata_connstring,
+    const std::string& protocol,
+    const std::optional<std::string>& device_names) {
     // get auto_discover and filters from env
     bool auto_discover = get_auto_discover();
     transfer_engine_.setAutoDiscover(auto_discover);
-    transfer_engine_.setWhitelistFilters(
-        get_auto_discover_filters(auto_discover));
 
     auto [hostname, port] = parseHostNameWithPort(local_hostname);
     int rc = transfer_engine_.init(metadata_connstring, local_hostname,
@@ -223,26 +229,67 @@ ErrorCode Client::InitTransferEngine(const std::string& local_hostname,
         return ErrorCode::INTERNAL_ERROR;
     }
 
-    Transport* transport = nullptr;
-    if (protocol == "rdma") {
-        LOG(INFO) << "transport_type=rdma";
-        transport = transfer_engine_.installTransport("rdma", nullptr);
-    } else if (protocol == "tcp") {
-        LOG(INFO) << "transport_type=tcp";
-        try {
-            transport = transfer_engine_.installTransport("tcp", nullptr);
-        } catch (std::exception& e) {
-            LOG(ERROR) << "tcp_transport_install_failed error_message=\""
-                       << e.what() << "\"";
-            return ErrorCode::INTERNAL_ERROR;
-        }
+    if (auto_discover) {
+        LOG(INFO) << "Transfer engine auto discovery is enabled for protocol: "
+                  << protocol;
+        auto filters = get_auto_discover_filters(auto_discover);
+        transfer_engine_.setWhitelistFilters(std::move(filters));
     } else {
-        LOG(ERROR) << "unsupported_protocol protocol=" << protocol;
-        return ErrorCode::INVALID_PARAMS;
-    }
-    if (!transport) {
-        LOG(ERROR) << "Failed to install transport";
-        return ErrorCode::INTERNAL_ERROR;
+        LOG(INFO) << "Transfer engine auto discovery is disabled for protocol: "
+                  << protocol;
+
+        Transport* transport = nullptr;
+
+        if (protocol == "rdma") {
+            if (!device_names.has_value() || device_names->empty()) {
+                LOG(ERROR) << "RDMA protocol requires device names when auto "
+                              "discovery is disabled";
+                return ErrorCode::INVALID_PARAMS;
+            }
+
+            LOG(INFO) << "Using specified RDMA devices: "
+                      << device_names.value();
+
+            std::vector<std::string> devices =
+                splitString(device_names.value(), ',', /*skip_empty=*/true);
+
+            // Manually discover topology with specified devices only
+            auto topology = transfer_engine_.getLocalTopology();
+            if (topology) {
+                topology->discover(devices);
+                LOG(INFO) << "Topology discovery complete with specified "
+                             "devices. Found "
+                          << topology->getHcaList().size() << " HCAs";
+            }
+
+            transport = transfer_engine_.installTransport("rdma", nullptr);
+            if (!transport) {
+                LOG(ERROR) << "Failed to install RDMA transport with specified "
+                              "devices";
+                return ErrorCode::INTERNAL_ERROR;
+            }
+        } else if (protocol == "tcp") {
+            if (device_names.has_value()) {
+                LOG(WARNING)
+                    << "TCP protocol does not use device names, ignoring";
+            }
+
+            try {
+                transport = transfer_engine_.installTransport("tcp", nullptr);
+            } catch (std::exception& e) {
+                LOG(ERROR) << "tcp_transport_install_failed error_message=\""
+                           << e.what() << "\"";
+                return ErrorCode::INTERNAL_ERROR;
+            }
+
+            if (!transport) {
+                LOG(ERROR) << "Failed to install TCP transport";
+                return ErrorCode::INTERNAL_ERROR;
+            }
+        } else {
+            LOG(ERROR) << "unsupported_protocol protocol=" << protocol;
+            return ErrorCode::INVALID_PARAMS;
+        }
     }
 
     // Initialize TransferSubmitter after transfer engine is ready
@@ -255,7 +302,8 @@ ErrorCode Client::InitTransferEngine(const std::string& local_hostname,
 
 std::optional<std::shared_ptr<Client>> Client::Create(
     const std::string& local_hostname, const std::string& metadata_connstring,
-    const std::string& protocol, const std::string& master_server_entry) {
+    const std::string& protocol, const std::optional<std::string>& device_names,
+    const std::string& master_server_entry) {
     auto client = std::shared_ptr<Client>(
         new Client(local_hostname, metadata_connstring));
 
@@ -288,7 +336,7 @@ std::optional<std::shared_ptr<Client>> Client::Create(
 
     // Initialize transfer engine
     err = client->InitTransferEngine(local_hostname, metadata_connstring,
-                                     protocol);
+                                     protocol, device_names);
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "Failed to initialize transfer engine";
         return std::nullopt;

--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -112,10 +112,8 @@ tl::expected<void, ErrorCode> PyClient::setup_internal(
         this->local_hostname = local_hostname;
     }
 
-    void **args = (protocol == "rdma") ? rdma_args(rdma_devices) : nullptr;
-    auto client_opt =
-        mooncake::Client::Create(this->local_hostname, metadata_server,
-                                 protocol, args, master_server_addr);
+    auto client_opt = mooncake::Client::Create(
+        this->local_hostname, metadata_server, protocol, master_server_addr);
     if (!client_opt) {
         LOG(ERROR) << "Failed to create client";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);

--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -112,8 +112,13 @@ tl::expected<void, ErrorCode> PyClient::setup_internal(
         this->local_hostname = local_hostname;
     }
 
-    auto client_opt = mooncake::Client::Create(
-        this->local_hostname, metadata_server, protocol, master_server_addr);
+    std::optional<std::string> device_name =
+        (rdma_devices.empty() ? std::nullopt
+                              : std::make_optional(rdma_devices));
+
+    auto client_opt =
+        mooncake::Client::Create(this->local_hostname, metadata_server,
+                                 protocol, device_name, master_server_addr);
     if (!client_opt) {
         LOG(ERROR) << "Failed to create client";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -5,6 +5,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <boost/algorithm/string.hpp>
 
 #include <random>
 
@@ -89,6 +90,23 @@ std::string formatDeviceNames(const std::string &device_names) {
         }
     }
     return formatted;
+}
+
+std::vector<std::string> splitString(const std::string &str, char delimiter,
+                                     bool trim_spaces, bool keep_empty) {
+    std::vector<std::string> result;
+
+    boost::split(
+        result, str, boost::is_any_of(std::string(1, delimiter)),
+        keep_empty ? boost::token_compress_off : boost::token_compress_on);
+
+    if (trim_spaces) {
+        for (auto &token : result) {
+            boost::trim(token);
+        }
+    }
+
+    return result;
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -91,17 +91,4 @@ std::string formatDeviceNames(const std::string &device_names) {
     return formatted;
 }
 
-static std::string loadNicPriorityMatrix(const std::string &device_name) {
-    auto device_names = formatDeviceNames(device_name);
-    return "{\"cpu:0\": [[" + device_names + "], []]}";
-}
-
-void **rdma_args(const std::string &device_name) {
-    static auto nic_priority_matrix = loadNicPriorityMatrix(device_name);
-    void **args = (void **)malloc(2 * sizeof(void *));
-    args[0] = (void *)nic_priority_matrix.c_str();
-    args[1] = nullptr;
-    return args;
-}
-
 }  // namespace mooncake

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -27,13 +27,10 @@ namespace testing {
 class ClientIntegrationTest : public ::testing::Test {
    protected:
     static std::shared_ptr<Client> CreateClient(const std::string& host_name) {
-        void** args =
-            (FLAGS_protocol == "rdma") ? rdma_args(FLAGS_device_name) : nullptr;
-
         auto client_opt = Client::Create(
             host_name,                           // Local hostname
             FLAGS_transfer_engine_metadata_url,  // Metadata connection string
-            FLAGS_protocol, args,
+            FLAGS_protocol,
             "localhost:50051"  // Master server address
         );
 

--- a/mooncake-store/tests/e2e/client_wrapper.cpp
+++ b/mooncake-store/tests/e2e/client_wrapper.cpp
@@ -25,11 +25,9 @@ ClientTestWrapper::CreateClientWrapper(const std::string& hostname,
                                        const std::string& device_name,
                                        const std::string& master_server_entry,
                                        size_t local_buffer_size) {
-    void** args = (protocol == "rdma") ? rdma_args(device_name) : nullptr;
-
-    auto client_opt = Client::Create(hostname,  // Local hostname
-                                     metadata_connstring, protocol, args,
-                                     master_server_entry);
+    auto client_opt =
+        Client::Create(hostname,  // Local hostname
+                       metadata_connstring, protocol, master_server_entry);
 
     if (!client_opt.has_value()) {
         return std::nullopt;

--- a/mooncake-store/tests/stress_workload_test.cpp
+++ b/mooncake-store/tests/stress_workload_test.cpp
@@ -94,13 +94,10 @@ void cleanup_segment() {
 }
 
 bool initialize_client() {
-    void** args =
-        (FLAGS_protocol == "rdma") ? rdma_args(FLAGS_device_name) : nullptr;
-
     auto client_opt = Client::Create(
         FLAGS_local_hostname,              // Local hostname
         FLAGS_metadata_connection_string,  // Metadata connection string
-        FLAGS_protocol, args, FLAGS_master_address);
+        FLAGS_protocol, FLAGS_master_address);
 
     if (!client_opt.has_value()) {
         LOG(ERROR) << "Failed to create client";

--- a/mooncake-store/tests/utils_test.cpp
+++ b/mooncake-store/tests/utils_test.cpp
@@ -121,6 +121,17 @@ TEST(UtilsTest, AutoPortBinderMultipleInstances) {
     EXPECT_NE(port1, port2);
 }
 
+TEST(UtilsTest, SplitStringBasic) {
+    std::string input = "a, b ,c, d";
+    auto tokens = splitString(input, ',', true, false);
+
+    ASSERT_EQ(tokens.size(), 4);
+    EXPECT_EQ(tokens[0], "a");
+    EXPECT_EQ(tokens[1], "b");
+    EXPECT_EQ(tokens[2], "c");
+    EXPECT_EQ(tokens[3], "d");
+}
+
 TEST(UtilsTest, AutoPortBinderRAII) {
     // Test RAII behavior - port should be released when binder is destroyed
     int port;


### PR DESCRIPTION
If we don't enable this, the topology will default to something like "cpu:0 device xxx," which severely impacts performance in multi-NIC environments.

With this change, TE will automatically detect the topology and use the optimal configuration for data transfer.

Additionally, we might extend support for topology-aware allocation in the master branch, unlocking further performance improvements.

main branch
```
All requests completed
Performance metrics summary:
  Total requests: 900 at 16.0 requests per second
  Average TTFT: 0.64
  P90 TTFT: 4.13
  Median TTFT: 0.56
  Average latency: 0.64
  P90 latency: 0.68
  Median latency: 0.56
  Input token throughput: 35032.53 tokens per second
  Output token throughput: 5.72 tokens per second
  Request Throughput: 5.72 requests per second
  Cache Hit Rate: 0.651540
```

This pr

```
All requests completed
Performance metrics summary:
  Total requests: 900 at 16.0 requests per second
  Average TTFT: 0.54
  P90 TTFT: 0.67
  Median TTFT: 0.56
  Average latency: 0.54
  P90 latency: 0.62
  Median latency: 0.56
  Input token throughput: 41552.95 tokens per second
  Output token throughput: 6.78 tokens per second
  Request Throughput: 6.78 requests per second
  Cache Hit Rate: 0.651449
```