### PR TITLE
feat(store): add duplicate rpc_meta key check and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,19 @@ jobs:
         bash build.sh --ci-build ../../build/mooncake-transfer-engine/nvlink-allocator/
       shell: bash
 
+    - name: Start Metadata Server
+      run: |
+        cd mooncake-transfer-engine/example/http-metadata-server-python
+        pip install aiohttp
+        python ./bootstrap_server.py &
+      shell: bash
+
     - name: Start Mooncake Master
       run: |
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
         # Set a small kv lease ttl to make the test faster.
         # Must be consistent with the client test parameters.
-        mooncake_master --default_kv_lease_ttl=500 --enable_http_metadata_server=1 &
+        mooncake_master --default_kv_lease_ttl=500 &
       shell: bash
 
     - name: Test (in build env)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,19 +84,12 @@ jobs:
         bash build.sh --ci-build ../../build/mooncake-transfer-engine/nvlink-allocator/
       shell: bash
 
-    - name: Start Metadata Server
-      run: |
-        cd mooncake-transfer-engine/example/http-metadata-server-python
-        pip install aiohttp
-        python ./bootstrap_server.py &
-      shell: bash
-
     - name: Start Mooncake Master
       run: |
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
         # Set a small kv lease ttl to make the test faster.
         # Must be consistent with the client test parameters.
-        mooncake_master --default_kv_lease_ttl=500 &
+        mooncake_master --default_kv_lease_ttl=500 --enable_http_metadata_server=1 &
       shell: bash
 
     - name: Test (in build env)

--- a/mooncake-store/src/http_metadata_server.cpp
+++ b/mooncake-store/src/http_metadata_server.cpp
@@ -56,6 +56,13 @@ void HttpMetadataServer::init_server() {
             std::string body(req.get_body());
             {
                 std::lock_guard<std::mutex> lock(store_mutex_);
+                if (key.find("rpc_meta") != std::string::npos &&
+                    store_.find(std::string(key)) != store_.end()) {
+                    resp.set_status_and_content(
+                        status_type::bad_request,
+                        "Duplicate rpc_meta key not allowed");
+                    return;
+                }
                 store_[std::string(key)] = body;
             }
 

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -65,6 +65,20 @@ TEST_F(PyClientTest, ConstructorAndSetup) {
     // Verify hostname
     std::string hostname = py_client_->get_hostname();
     EXPECT_EQ(hostname, "localhost:17813");
+
+    // Same local hostname should fail
+    auto new_client = std::make_unique<PyClient>();
+    int second_setup_result = new_client->setup(
+        "localhost:17813",                   // local_hostname
+        FLAGS_transfer_engine_metadata_url,  // metadata_server
+        16 * 1024 * 1024,                    // global_segment_size (16MB)
+        16 * 1024 * 1024,                    // local_buffer_size (16MB)
+        FLAGS_protocol,                      // protocol
+        FLAGS_device_name,                   // rdma_devices
+        "localhost:50051"                    // master_server_addr
+    );
+    EXPECT_NE(second_setup_result, 0)
+        << "Second setup should fail due to already initialized client";
 }
 
 // Test basic Put and Get operations

--- a/mooncake-transfer-engine/example/http-metadata-server-python/bootstrap_server.py
+++ b/mooncake-transfer-engine/example/http-metadata-server-python/bootstrap_server.py
@@ -50,6 +50,9 @@ class KVBootstrapServer:
     async def _handle_put(self, key, request):
         data = await request.read()
         async with self.lock:
+            if key.find("rpc_meta") != -1 and key in self.store:
+                return web.Response(text='Duplicate rpc_meta key not allowed', status=400,
+                                  content_type='application/json')
             self.store[key] = data
         return web.Response(text='metadata updated', status=200,
                           content_type='application/json')

--- a/mooncake-wheel/mooncake/http_metadata_server.py
+++ b/mooncake-wheel/mooncake/http_metadata_server.py
@@ -86,6 +86,9 @@ class KVBootstrapServer:
         """Handle PUT requests."""
         data = await request.read()
         async with self.lock:
+            if key.find("rpc_meta") != -1 and key in self.store:
+                return web.Response(text='Duplicate rpc_meta key not allowed', status=400,
+                                  content_type='application/json')
             self.store[key] = data
         return web.Response(text='metadata updated', status=200,
                           content_type='application/json')


### PR DESCRIPTION
On the main branch, identical hostnames can be set up without triggering any errors. However, this may later disrupt data transfer—such as A's metadata being overwritten by B's—which results in all transfers to A failing due to corrupted or incorrect metadata.

We can address and fix this issue.