### PR TITLE
[CI/Build] gate mooncake-store test behind BUILD_UNIT_TESTS option

### DIFF
--- a/mooncake-store/CMakeLists.txt
+++ b/mooncake-store/CMakeLists.txt
@@ -20,5 +20,8 @@ include_directories(
 
 # Add subdirectories
 add_subdirectory(src)
-add_subdirectory(tests)
-add_subdirectory(benchmarks)
+
+if (BUILD_UNIT_TESTS)
+    add_subdirectory(tests)
+    add_subdirectory(benchmarks)
+endif()


### PR DESCRIPTION
This can avoid some unnecessary build time.