### PR TITLE
[TransferEngine]: remove SO_REUSEADDR in findAvailableTcpPort

### DIFF
--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -1133,13 +1133,6 @@ uint16_t findAvailableTcpPort(int &sockfd) {
             continue;
         }
 
-        int on = 1;
-        if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on))) {
-            close(sockfd);
-            sockfd = -1;
-            continue;
-        }
-
         if (use_ipv6) {
             sockaddr_in6 bind_address;
             memset(&bind_address, 0, sizeof(sockaddr_in6));


### PR DESCRIPTION
SO_REUSEADDR indicates that the port could be bind multiple times, that's unexpected.