### PR TITLE
feat(store): add client heartbeat support for non ha mode

### DIFF
--- a/doc/en/mooncake-store.md
+++ b/doc/en/mooncake-store.md
@@ -44,7 +44,8 @@ Mooncake store supports two deployment methods to accommodate different availabi
 1. **Default mode**: In this mode, the master service consists of a single master node, which simplifies deployment but introduces a single point of failure. If the master crashes or becomes unreachable, the system cannot continue to serve requests until it is restored.
 2. **High availability mode (unstable)**: This mode enhances fault tolerance by running the master service as a cluster of multiple master nodes coordinated through an etcd cluster. The master nodes use etcd to elect a leader, which is responsible for handling client requests.
 If the current leader fails or becomes partitioned from the network, the remaining master nodes automatically perform a new leader election, ensuring continuous availability.
-The leader monitors the health of all client nodes through periodic heartbeats. If a client crashes or becomes unreachable, the leader quickly detects the failure and takes appropriate action. When a client node recovers or reconnects, it can automatically rejoin the cluster without manual intervention.
+
+In both modes, the leader monitors the health of all client nodes through periodic heartbeats. If a client crashes or becomes unreachable, the leader quickly detects the failure and takes appropriate action. When a client node recovers or reconnects, it can automatically rejoin the cluster without manual intervention.
 
 ## Client C++ API
 

--- a/doc/zh/mooncake-store.md
+++ b/doc/zh/mooncake-store.md
@@ -46,9 +46,9 @@ Mooncake Store 的主要特性包括：
 
 Mooncake Store 支持两种部署方式，以满足不同的可用性需求：
 1. **默认模式**：在该模式下，master service 由单个 master 节点组成，部署方式较为简单，但存在单点故障的问题。如果 master 崩溃或无法访问，系统将无法继续提供服务，直到 master 恢复为止。
-2. **高可用模式（不稳定）**：在该模式下 master service 以多个 master 节点组成集群，并借助 etcd 集群进行协调，从而提升系统的容错能力。多个 master 节点使用 etcd 进行 leader 选举，由 leader 负责处理客户端请求。
-如果当前的 leader 崩溃或发生网络故障，其余 master 节点将自动进行新的 leader 选举，以确保服务的持续可用性。
-leader 通过定期心跳监控所有 client 节点的健康状态。如果某个 client 崩溃或无法访问，leader 能迅速检测到故障并采取相应措施。当 client 恢复或重新连接后，会自动重新加入集群，无需人工干预。
+2. **高可用模式（不稳定）**：在该模式下 master service 以多个 master 节点组成集群，并借助 etcd 集群进行协调，从而提升系统的容错能力。多个 master 节点使用 etcd 进行 leader 选举，由 leader 负责处理客户端请求。如果当前的 leader 崩溃或发生网络故障，其余 master 节点将自动进行新的 leader 选举，以确保服务的持续可用性。
+
+在两种模式下，leader 都会通过定期心跳监控所有 client 节点的健康状态。如果某个 client 崩溃或无法访问，leader 能迅速检测到故障并采取相应措施。当 client 恢复或重新连接后，会自动重新加入集群，无需人工干预。
 
 ## Client C++ API
 

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -44,7 +44,8 @@ Mooncake store supports two deployment methods to accommodate different availabi
 1. **Default mode**: In this mode, the master service consists of a single master node, which simplifies deployment but introduces a single point of failure. If the master crashes or becomes unreachable, the system cannot continue to serve requests until it is restored.
 2. **High availability mode (unstable)**: This mode enhances fault tolerance by running the master service as a cluster of multiple master nodes coordinated through an etcd cluster. The master nodes use etcd to elect a leader, which is responsible for handling client requests.
 If the current leader fails or becomes partitioned from the network, the remaining master nodes automatically perform a new leader election, ensuring continuous availability.
-The leader monitors the health of all client nodes through periodic heartbeats. If a client crashes or becomes unreachable, the leader quickly detects the failure and takes appropriate action. When a client node recovers or reconnects, it can automatically rejoin the cluster without manual intervention.
+
+In both modes, the leader monitors the health of all client nodes through periodic heartbeats. If a client crashes or becomes unreachable, the leader quickly detects the failure and takes appropriate action. When a client node recovers or reconnects, it can automatically rejoin the cluster without manual intervention.
 
 ## Client C++ API
 

--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -320,7 +320,7 @@ class Client {
     MasterViewHelper master_view_helper_;
     std::thread ping_thread_;
     std::atomic<bool> ping_running_{false};
-    void PingThreadFunc();
+    void PingThreadMain(bool is_ha_mode, std::string current_master_address);
 
     // Client identification
     UUID client_id_;

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <string>
+#include <ylt/util/tl/expected.hpp>
 
 #include "types.h"
 
@@ -171,5 +172,11 @@ class AutoPortBinder {
     int socket_fd_;
     int port_;
 };
+
+// HTTP utility: simple GET, returns body on 200, otherwise error code
+tl::expected<std::string, int> httpGet(const std::string& url);
+
+// Network utility: obtain an available TCP port on loopback by binding to 0
+int getFreeTcpPort();
 
 }  // namespace mooncake

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -202,14 +202,31 @@ ErrorCode Client::ConnectToMaster(const std::string& master_server_entry) {
             return err;
         }
 
-        // Start Ping thread to monitor master view changes and remount segments
-        // if needed
+        // Start ping thread to monitor master health and trigger remount if
+        // needed.
         ping_running_ = true;
-        ping_thread_ = std::thread(&Client::PingThreadFunc, this);
+        bool is_ha_mode = true;
+        std::string current_master_address = master_address;
+        ping_thread_ = std::thread([this, is_ha_mode,
+                                    current_master_address]() mutable {
+            this->PingThreadMain(is_ha_mode, std::move(current_master_address));
+        });
 
         return ErrorCode::OK;
     } else {
-        return master_client_.Connect(master_server_entry);
+        auto err = master_client_.Connect(master_server_entry);
+        if (err != ErrorCode::OK) {
+            return err;
+        }
+        // Non-HA mode also enables heartbeat/ping
+        ping_running_ = true;
+        bool is_ha_mode = false;
+        std::string current_master_address = master_server_entry;
+        ping_thread_ = std::thread([this, is_ha_mode,
+                                    current_master_address]() mutable {
+            this->PingThreadMain(is_ha_mode, std::move(current_master_address));
+        });
+        return ErrorCode::OK;
     }
 }
 
@@ -1314,7 +1331,8 @@ ErrorCode Client::TransferRead(const Replica::Descriptor& replica_descriptor,
     return TransferData(replica_descriptor, slices, TransferRequest::READ);
 }
 
-void Client::PingThreadFunc() {
+void Client::PingThreadMain(bool is_ha_mode,
+                            std::string current_master_address) {
     // How many failed pings before getting latest master view from etcd
     const int max_ping_fail_count = 3;
     // How long to wait for next ping after success
@@ -1379,32 +1397,50 @@ void Client::PingThreadFunc() {
             continue;
         }
 
-        // Too many ping failures, we need to check if the master view
-        // has changed
-        LOG(ERROR) << "Failed to ping master for " << ping_fail_count
-                   << " times, try to get latest master view and reconnect";
-        std::string master_address;
-        ViewVersionId next_version = 0;
-        auto err =
-            master_view_helper_.GetMasterView(master_address, next_version);
-        if (err != ErrorCode::OK) {
-            LOG(ERROR) << "Failed to get new master view: " << toString(err);
-            std::this_thread::sleep_for(
-                std::chrono::milliseconds(fail_ping_interval_ms));
-            continue;
-        }
+        // Exceeded ping failure threshold. Reconnect based on mode.
+        if (is_ha_mode) {
+            LOG(ERROR)
+                << "Failed to ping master for " << ping_fail_count
+                << " times; fetching latest master view and reconnecting";
+            std::string master_address;
+            ViewVersionId next_version = 0;
+            auto err =
+                master_view_helper_.GetMasterView(master_address, next_version);
+            if (err != ErrorCode::OK) {
+                LOG(ERROR) << "Failed to get new master view: "
+                           << toString(err);
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(fail_ping_interval_ms));
+                continue;
+            }
 
-        err = master_client_.Connect(master_address);
-        if (err != ErrorCode::OK) {
-            LOG(ERROR) << "Failed to connect to master " << master_address
-                       << ": " << toString(err);
-            std::this_thread::sleep_for(
-                std::chrono::milliseconds(fail_ping_interval_ms));
-            continue;
-        }
+            err = master_client_.Connect(master_address);
+            if (err != ErrorCode::OK) {
+                LOG(ERROR) << "Failed to connect to master " << master_address
+                           << ": " << toString(err);
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(fail_ping_interval_ms));
+                continue;
+            }
 
-        LOG(INFO) << "Reconnected to master " << master_address;
-        ping_fail_count = 0;
+            current_master_address = master_address;
+            LOG(INFO) << "Reconnected to master " << master_address;
+            ping_fail_count = 0;
+        } else {
+            LOG(ERROR) << "Failed to ping master for " << ping_fail_count
+                       << " times (non-HA); reconnecting to "
+                       << current_master_address;
+            auto err = master_client_.Connect(current_master_address);
+            if (err != ErrorCode::OK) {
+                LOG(ERROR) << "Reconnect failed to " << current_master_address
+                           << ": " << toString(err);
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(fail_ping_interval_ms));
+                continue;
+            }
+            LOG(INFO) << "Reconnected to master " << current_master_address;
+            ping_fail_count = 0;
+        }
     }
     // Explicitly wait for the remount segment thread to finish
     if (remount_segment_future.valid()) {

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -9,6 +9,8 @@
 
 #include <random>
 
+#include <ylt/coro_http/coro_http_client.hpp>
+
 namespace mooncake {
 
 bool isPortAvailable(int port) {
@@ -107,6 +109,36 @@ std::vector<std::string> splitString(const std::string &str, char delimiter,
     }
 
     return result;
+}
+
+tl::expected<std::string, int> httpGet(const std::string &url) {
+    coro_http::coro_http_client client;
+    auto res = client.get(url);
+    if (res.status == 200) {
+        return std::string(res.resp_body);
+    }
+    return tl::unexpected(res.status);
+}
+
+int getFreeTcpPort() {
+    int sock = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) return -1;
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(0);
+    if (::bind(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0) {
+        ::close(sock);
+        return -1;
+    }
+    socklen_t len = sizeof(addr);
+    if (::getsockname(sock, reinterpret_cast<sockaddr *>(&addr), &len) != 0) {
+        ::close(sock);
+        return -1;
+    }
+    int port = ntohs(addr.sin_port);
+    ::close(sock);
+    return port;
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -1,38 +1,24 @@
-add_executable(buffer_allocator_test buffer_allocator_test.cpp)
-target_link_libraries(buffer_allocator_test PUBLIC mooncake_store cachelib_memory_allocator gtest gtest_main pthread)
-add_test(NAME buffer_allocator_test COMMAND buffer_allocator_test)
+function(add_store_test name)
+    add_executable(${name} ${ARGN})
+    target_link_libraries(${name} PUBLIC
+        mooncake_store
+        cachelib_memory_allocator
+        ${ETCD_WRAPPER_LIB}
+        glog
+        gtest
+        gtest_main
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+endfunction()
 
-add_executable(allocation_strategy_test allocation_strategy_test.cpp)
-target_link_libraries(allocation_strategy_test PUBLIC mooncake_store cachelib_memory_allocator glog gtest gtest_main pthread)
-add_test(NAME allocation_strategy_test COMMAND allocation_strategy_test)
-
-add_executable(eviction_strategy_test eviction_strategy_test.cpp)
-target_link_libraries(eviction_strategy_test PUBLIC mooncake_store cachelib_memory_allocator glog gtest gtest_main pthread)
-add_test(NAME eviction_strategy_test COMMAND eviction_strategy_test)
-
-add_executable(master_service_test master_service_test.cpp)
-target_link_libraries(master_service_test PUBLIC mooncake_store cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gtest gtest_main pthread)
-add_test(NAME master_service_test COMMAND master_service_test)
-
-add_executable(master_service_ssd_test master_service_ssd_test.cpp)
-target_link_libraries(master_service_ssd_test PUBLIC mooncake_store cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gtest gtest_main pthread)
-add_test(NAME master_service_ssd_test COMMAND master_service_ssd_test)
-
-add_executable(client_integration_test client_integration_test.cpp)
-target_link_libraries(client_integration_test PUBLIC
-    mooncake_store
-    cachelib_memory_allocator
-    ${ETCD_WRAPPER_LIB}
-    glog
-    gtest
-    gtest_main
-    pthread
-)
-add_test(NAME client_integration_test COMMAND client_integration_test)
-
-add_executable(master_metrics_test master_metrics_test.cpp)
-target_link_libraries(master_metrics_test PUBLIC mooncake_store cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gtest gtest_main pthread)
-add_test(NAME master_metrics_test COMMAND master_metrics_test)
+add_store_test(buffer_allocator_test buffer_allocator_test.cpp)
+add_store_test(allocation_strategy_test allocation_strategy_test.cpp)
+add_store_test(eviction_strategy_test eviction_strategy_test.cpp)
+add_store_test(master_service_test master_service_test.cpp)
+add_store_test(master_service_ssd_test master_service_ssd_test.cpp)
+add_store_test(client_integration_test client_integration_test.cpp)
+add_store_test(master_metrics_test master_metrics_test.cpp)
 
 add_executable(high_availability_test high_availability_test.cpp)
 target_link_libraries(high_availability_test PUBLIC mooncake_store cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gtest gtest_main pthread)
@@ -51,115 +37,18 @@ target_link_libraries(stress_workload_test PUBLIC
     pthread
 )
 
-add_executable(posix_file_test posix_file_test.cpp)
-target_link_libraries(posix_file_test PUBLIC
-    mooncake_store
-    cachelib_memory_allocator
-    glog
-    gtest
-    gtest_main
-    pthread
-)
-add_test(NAME posix_file_test COMMAND posix_file_test)
+add_store_test(posix_file_test posix_file_test.cpp)
+add_store_test(thread_pool_test thread_pool_test.cpp)
+add_store_test(transfer_task_test transfer_task_test.cpp)
+add_store_test(segment_test segment_test.cpp)
+add_store_test(offset_allocator_test offset_allocator_test.cpp)
+add_store_test(utils_test utils_test.cpp)
+add_store_test(client_buffer_test client_buffer_test.cpp)
+add_store_test(pybind_client_test pybind_client_test.cpp)
+add_store_test(client_metrics_test client_metrics_test.cpp)
+add_store_test(serializer_test serializer_test.cpp)
 
-add_executable(thread_pool_test thread_pool_test.cpp)
-target_link_libraries(thread_pool_test PUBLIC
-    mooncake_store
-    cachelib_memory_allocator
-    glog
-    gtest
-    gtest_main
-    pthread
-)
-add_test(NAME thread_pool_test COMMAND thread_pool_test)
-
-add_executable(transfer_task_test transfer_task_test.cpp)
-target_link_libraries(transfer_task_test PUBLIC
-    mooncake_store
-    cachelib_memory_allocator
-    glog
-    gtest
-    gtest_main
-    pthread
-)
-add_test(NAME transfer_task_test COMMAND transfer_task_test)
-
-add_executable(segment_test segment_test.cpp)
-target_link_libraries(segment_test PUBLIC
-    mooncake_store
-    cachelib_memory_allocator
-    glog
-    gtest
-    gtest_main
-    pthread
-)
-add_test(NAME segment_test COMMAND segment_test)
-
-add_executable(offset_allocator_test offset_allocator_test.cpp)
-target_link_libraries(offset_allocator_test PUBLIC
-    mooncake_store
-    cachelib_memory_allocator
-    glog
-    gtest
-    gtest_main
-    pthread
-)
-add_test(NAME offset_allocator_test COMMAND offset_allocator_test)
-
-add_executable(utils_test utils_test.cpp)
-target_link_libraries(utils_test PUBLIC
-    mooncake_store
-    cachelib_memory_allocator
-    glog
-    gtest
-    gtest_main
-    pthread
-)
-add_test(NAME utils_test COMMAND utils_test)
-
-add_executable(client_buffer_test client_buffer_test.cpp)
-target_link_libraries(client_buffer_test PUBLIC
-    mooncake_store
-    cachelib_memory_allocator
-    glog
-    gtest
-    gtest_main
-    pthread
-)
-add_test(NAME client_buffer_test COMMAND client_buffer_test)
-
-add_executable(pybind_client_test pybind_client_test.cpp)
-target_link_libraries(pybind_client_test PUBLIC
-    mooncake_store
-    cachelib_memory_allocator
-    ${ETCD_WRAPPER_LIB}
-    glog
-    gtest
-    gtest_main
-    pthread
-)
-add_test(NAME pybind_client_test COMMAND pybind_client_test)
-
-add_executable(client_metrics_test client_metrics_test.cpp)
-target_link_libraries(client_metrics_test PUBLIC
-    mooncake_store
-    cachelib_memory_allocator
-    glog
-    gtest
-    gtest_main
-    pthread
-)
-add_test(NAME client_metrics_test COMMAND client_metrics_test)
-
-add_executable(serializer_test serializer_test.cpp)
-target_link_libraries(serializer_test PUBLIC
-    mooncake_store
-    cachelib_memory_allocator
-    glog
-    gtest
-    gtest_main
-    pthread
-)
-add_test(NAME serializer_test COMMAND serializer_test)
+# New test: non-HA reconnect and remount
+add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
 
 add_subdirectory(e2e)

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -19,6 +19,18 @@ add_store_test(master_service_test master_service_test.cpp)
 add_store_test(master_service_ssd_test master_service_ssd_test.cpp)
 add_store_test(client_integration_test client_integration_test.cpp)
 add_store_test(master_metrics_test master_metrics_test.cpp)
+add_store_test(posix_file_test posix_file_test.cpp)
+add_store_test(thread_pool_test thread_pool_test.cpp)
+add_store_test(transfer_task_test transfer_task_test.cpp)
+add_store_test(segment_test segment_test.cpp)
+add_store_test(offset_allocator_test offset_allocator_test.cpp)
+add_store_test(utils_test utils_test.cpp)
+add_store_test(client_buffer_test client_buffer_test.cpp)
+add_store_test(pybind_client_test pybind_client_test.cpp)
+add_store_test(client_metrics_test client_metrics_test.cpp)
+add_store_test(serializer_test serializer_test.cpp)
+add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
+add_subdirectory(e2e)
 
 add_executable(high_availability_test high_availability_test.cpp)
 target_link_libraries(high_availability_test PUBLIC mooncake_store cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gtest gtest_main pthread)
@@ -36,19 +48,3 @@ target_link_libraries(stress_workload_test PUBLIC
     gflags
     pthread
 )
-
-add_store_test(posix_file_test posix_file_test.cpp)
-add_store_test(thread_pool_test thread_pool_test.cpp)
-add_store_test(transfer_task_test transfer_task_test.cpp)
-add_store_test(segment_test segment_test.cpp)
-add_store_test(offset_allocator_test offset_allocator_test.cpp)
-add_store_test(utils_test utils_test.cpp)
-add_store_test(client_buffer_test client_buffer_test.cpp)
-add_store_test(pybind_client_test pybind_client_test.cpp)
-add_store_test(client_metrics_test client_metrics_test.cpp)
-add_store_test(serializer_test serializer_test.cpp)
-
-# New test: non-HA reconnect and remount
-add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
-
-add_subdirectory(e2e)

--- a/mooncake-store/tests/non_ha_reconnect_test.cpp
+++ b/mooncake-store/tests/non_ha_reconnect_test.cpp
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+#include <glog/logging.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <ylt/coro_rpc/coro_rpc_server.hpp>
+#include <ylt/easylog.hpp>
+#include <ylt/easylog/record.hpp>
+
+#include "client.h"
+#include "utils.h"
+#include "test_server_helpers.h"
+
+namespace mooncake {
+namespace testing {
+
+// Non-HA: client auto-reconnects to master and remounts segments
+TEST(NonHAReconnectTest, ClientAutoReconnectAndRemount) {
+    // Start master (auto-pick ports) and embedded HTTP metadata server
+    InProcMaster master;
+    ASSERT_TRUE(master.Start());
+
+    // Create client (non-HA), mount a segment
+    std::string metadata_url = master.metadata_url();
+    std::string local_hostname = "127.0.0.1:18001";
+    std::string master_addr = master.master_address();
+    auto client_opt = Client::Create(local_hostname, metadata_url, "tcp",
+                                     std::nullopt, master_addr);
+    ASSERT_TRUE(client_opt.has_value());
+    auto client = client_opt.value();
+
+    size_t ram_buffer_size = 16 * 1024 * 1024;  // 16MB
+    void* seg_ptr = allocate_buffer_allocator_memory(ram_buffer_size);
+    ASSERT_NE(seg_ptr, nullptr);
+    auto mount_res = client->MountSegment(seg_ptr, ram_buffer_size);
+    ASSERT_TRUE(mount_res.has_value()) << toString(mount_res.error());
+
+    // Verify segment is visible via helper (expected-based)
+    {
+        auto vis = CheckSegmentVisible(master, local_hostname);
+        if (!vis.has_value()) {
+            LOG(INFO) << "Initial segment not visible: " << vis.error();
+        }
+        ASSERT_TRUE(vis.value()) << "Initial segment not found in master";
+    }
+
+    // Stop master, wait for ping failures to accumulate
+    master.Stop();
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+
+    auto vis_result = CheckSegmentVisible(master, local_hostname);
+    ASSERT_FALSE(vis_result.has_value())
+        << "Segment should not be visible after master stop";
+
+    // Restart master on the same ports
+    ASSERT_TRUE(master.Start(master.rpc_port(), master.http_metrics_port(),
+                             /*enable_http_metadata=*/true,
+                             master.http_metadata_port()));
+
+    // Wait until remount is reflected in master
+    bool found = false;
+    for (int i = 0; i < 30; ++i) {  // up to ~15s
+        auto vis = CheckSegmentVisible(master, local_hostname);
+        if (vis.value()) {
+            LOG(INFO) << "Segment found in master after restart in " << i
+                      << " attempts";
+            found = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+    ASSERT_TRUE(found) << "Client did not reconnect and remount in time";
+
+    // Cleanup
+    auto unmount_res = client->UnmountSegment(seg_ptr, ram_buffer_size);
+    ASSERT_TRUE(unmount_res.has_value()) << toString(unmount_res.error());
+    // Free the aligned memory allocated for the segment to avoid leaks
+    free(seg_ptr);
+}
+
+}  // namespace testing
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    easylog::set_min_severity(easylog::Severity::WARNING);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-store/tests/test_server_helpers.h
+++ b/mooncake-store/tests/test_server_helpers.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <ylt/coro_rpc/coro_rpc_server.hpp>
+
+#include "http_metadata_server.h"
+#include "master_config.h"
+#include "rpc_service.h"
+#include "types.h"
+#include "utils.h"
+#include <ylt/util/tl/expected.hpp>
+#include "utils.h"
+
+namespace mooncake {
+namespace testing {
+
+// Lightweight in-process master server for tests (non-HA).
+// Optionally starts embedded HTTP metadata server for transfer engine.
+class InProcMaster {
+   public:
+    InProcMaster() = default;
+    ~InProcMaster() { Stop(); }
+
+    bool Start(int rpc_port = 0, int http_metrics_port = 0,
+               bool enable_http_metadata = true, int http_metadata_port = 0) {
+        try {
+            // Choose ports if not provided
+            rpc_port_ = rpc_port > 0 ? rpc_port : getFreeTcpPort();
+            http_metrics_port_ =
+                http_metrics_port > 0 ? http_metrics_port : getFreeTcpPort();
+            if (enable_http_metadata) {
+                http_metadata_port_ = http_metadata_port > 0
+                                          ? http_metadata_port
+                                          : getFreeTcpPort();
+            } else {
+                http_metadata_port_ = 0;
+            }
+
+            // Optional HTTP metadata server
+            if (enable_http_metadata) {
+                meta_server_ = std::make_unique<HttpMetadataServer>(
+                    static_cast<uint16_t>(http_metadata_port_), "127.0.0.1");
+                if (!meta_server_->start()) {
+                    return false;
+                }
+            }
+
+            // RPC server + master service
+            server_ = std::make_unique<coro_rpc::coro_rpc_server>(
+                /*thread_num=*/4, /*port=*/rpc_port_, /*address=*/"0.0.0.0",
+                std::chrono::seconds(0), /*tcp_no_delay=*/true);
+            const char* value = std::getenv("MC_RPC_PROTOCOL");
+            if (value && std::string_view(value) == "rdma") {
+                server_->init_ibv();
+            }
+
+            WrappedMasterServiceConfig cfg;
+            cfg.default_kv_lease_ttl = DEFAULT_DEFAULT_KV_LEASE_TTL;
+            cfg.default_kv_soft_pin_ttl = DEFAULT_KV_SOFT_PIN_TTL_MS;
+            cfg.allow_evict_soft_pinned_objects = true;
+            cfg.enable_metric_reporting = false;
+            cfg.eviction_ratio = DEFAULT_EVICTION_RATIO;
+            cfg.eviction_high_watermark_ratio =
+                DEFAULT_EVICTION_HIGH_WATERMARK_RATIO;
+            cfg.view_version = 0;
+            // Use default client_live_ttl_sec to align with production defaults
+            cfg.enable_ha = false;
+            cfg.http_port = static_cast<uint16_t>(http_metrics_port_);
+            cfg.cluster_id = DEFAULT_CLUSTER_ID;
+            cfg.root_fs_dir = DEFAULT_ROOT_FS_DIR;
+            cfg.memory_allocator = BufferAllocatorType::OFFSET;
+
+            wrapped_ = std::make_unique<WrappedMasterService>(cfg);
+            RegisterRpcService(*server_, *wrapped_);
+
+            auto ec = server_->async_start();
+            if (ec.hasResult()) {
+                return false;
+            }
+            // Allow server to bind
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+
+    void Stop() {
+        if (server_) {
+            server_->stop();
+            server_.reset();
+            wrapped_.reset();
+        }
+        if (meta_server_) {
+            meta_server_->stop();
+            meta_server_.reset();
+        }
+    }
+
+    // Accessors
+    int rpc_port() const { return rpc_port_; }
+    int http_metrics_port() const { return http_metrics_port_; }
+    int http_metadata_port() const { return http_metadata_port_; }
+    std::string master_address() const {
+        return std::string("127.0.0.1:") + std::to_string(rpc_port_);
+    }
+    std::string metadata_url() const {
+        if (http_metadata_port_ <= 0) return {};
+        return std::string("http://127.0.0.1:") +
+               std::to_string(http_metadata_port_) + "/metadata";
+    }
+    std::string http_metrics_base() const {
+        return std::string("http://127.0.0.1:") +
+               std::to_string(http_metrics_port_);
+    }
+
+   private:
+    std::unique_ptr<coro_rpc::coro_rpc_server> server_;
+    std::unique_ptr<WrappedMasterService> wrapped_;
+    std::unique_ptr<HttpMetadataServer> meta_server_;
+    int rpc_port_ = 0;
+    int http_metrics_port_ = 0;
+    int http_metadata_port_ = 0;
+};
+
+// Helper: return all segments body or error
+inline tl::expected<std::string, int> GetAllSegments(const InProcMaster& m) {
+    return httpGet(m.http_metrics_base() + "/get_all_segments");
+}
+
+// Helper: check if a client hostname appears in segment list
+inline tl::expected<bool, int> CheckSegmentVisible(
+    const InProcMaster& m, const std::string& local_hostname) {
+    auto r = GetAllSegments(m);
+    if (!r) return tl::unexpected(r.error());
+    const std::string& body = r.value();
+    if (body.empty() || body.find(local_hostname) == std::string::npos) {
+        return false;
+    }
+    return true;
+}
+
+}  // namespace testing
+}  // namespace mooncake


### PR DESCRIPTION
This change extends client functionality to handle master reconnection and segment remounting in non-HA mode, adds corresponding test infrastructure, and improves utility functions for HTTP operations and port allocation.

By the way, we should also re-insert `TransferEngine Metadata` since HTTP metadata is now embedded in the master.

If we don't, other clients won't be able to access it, which could lead to transfer failures and make recovery impossible.

Maybe we can extend the segment definition to include metadata from TransferEngine — but that can be handled in a follow-up PR.


