### PR TITLE
Fix TCP Transport Handshake Daemon Initialization

### DIFF
--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -60,6 +60,8 @@ class TcpTransport : public Transport {
                 std::shared_ptr<TransferMetadata> meta,
                 std::shared_ptr<Topology> topo);
 
+    int startHandshakeDaemon();
+
     int allocateLocalSegmentID(int tcp_data_port);
 
     int registerLocalMemory(void *addr, size_t length,

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -273,6 +273,12 @@ TcpTransport::~TcpTransport() {
     metadata_->removeSegmentDesc(local_server_name_);
 }
 
+int TcpTransport::startHandshakeDaemon() {
+    return metadata_->startHandshakeDaemon(nullptr,
+                                           metadata_->localRpcMeta().rpc_port,
+                                           metadata_->localRpcMeta().sockfd);
+}
+
 int TcpTransport::install(std::string &local_server_name,
                           std::shared_ptr<TransferMetadata> meta,
                           std::shared_ptr<Topology> topo) {
@@ -289,6 +295,12 @@ int TcpTransport::install(std::string &local_server_name,
     int ret = allocateLocalSegmentID(tcp_port);
     if (ret) {
         LOG(ERROR) << "TcpTransport: cannot allocate local segment";
+        return -1;
+    }
+
+    ret = startHandshakeDaemon();
+    if (ret) {
+        LOG(ERROR) << "TcpTransport: cannot start handshake daemon";
         return -1;
     }
 


### PR DESCRIPTION
# Problem

TCP transport was missing handshake daemon initialization during installation, preventing the RPC port from listening for incoming connections. This caused peer notify messages to be undeliverable, breaking inter-node communication. 

Target's log
**Note that currently only the log is being printed; port listening has not actually begun.**
```
I0916 20:18:13.510746 21264 transfer_engine.cpp:114] Transfer Engine RPC using new RPC mapping, listening on 172.17.0.2:50475
```

Initiator's log
```
E0916 20:18:28.652805 21322 transfer_metadata_plugin.cpp:819] SocketHandShakePlugin: connect()172.17.0.2:50475: Connection refused [111]
```
# Solution

- Add startHandshakeDaemon() method to TcpTransport class, which is similar to RDMATransport but does not register the on_receive_handshake callback function
- Initialize handshake daemon during transport installation process
