### PR TITLE
[TransferEngine] clear all transport mems for fast recovery for ascend transport

### DIFF
--- a/mooncake-transfer-engine/include/transport/ascend_transport/hccl_transport/hccl_transport_mem_c.h
+++ b/mooncake-transfer-engine/include/transport/ascend_transport/hccl_transport/hccl_transport_mem_c.h
@@ -100,6 +100,7 @@ extern int initTransportMem(RankInfo *local_rank_info);
 extern void freeTransportMem();
 
 extern int clearTransportMem(RankInfo *remote_rank_info);
+extern int clearTransportMems();
 
 extern int transportMemTask(RankInfo *local_rank_info,
                             RankInfo *remote_rank_info, int op_code,

--- a/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/ascend_transport_c/hccl_transport_mem_c.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/ascend_transport_c/hccl_transport_mem_c.cpp
@@ -300,18 +300,7 @@ int initTransportMem(RankInfo *local_rank_info) {
 }
 
 void freeTransportMem() {
-    for (auto &it : target_key_to_connection_map_) {
-        auto &hccl_ctrl_socket = it.second.hccl_ctrl_socket;
-        if (hccl_ctrl_socket) {
-            hccl_ctrl_socket->Close();
-        }
-        auto &hccl_data_socket = it.second.hccl_data_socket;
-        if (hccl_data_socket) {
-            hccl_data_socket->Close();
-        }
-    }
-    target_key_to_connection_map_.clear();
-
+    clearTransportMems();
     if (vnicServerSocket_) {
         HcclNetCloseDev(vnicNetDevCtx_);
         vnicServerSocket_.reset();
@@ -324,7 +313,6 @@ void freeTransportMem() {
     if (notifyPool_) {
         notifyPool_.reset();
     }
-
     if (g_server_socket_ > 0) {
         close(g_server_socket_);
     }
@@ -757,6 +745,21 @@ int clearTransportMem(RankInfo *remote_rank_info) {
         }
         target_key_to_connection_map_.erase(key_str);
     }
+    return 0;
+}
+
+int clearTransportMems() {
+    for (auto &it : target_key_to_connection_map_) {
+        auto &hccl_ctrl_socket = it.second.hccl_ctrl_socket;
+        if (hccl_ctrl_socket) {
+            hccl_ctrl_socket->Close();
+        }
+        auto &hccl_data_socket = it.second.hccl_data_socket;
+        if (hccl_data_socket) {
+            hccl_data_socket->Close();
+        }
+    }
+    target_key_to_connection_map_.clear();
     return 0;
 }
 

--- a/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/hccl_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/hccl_transport.cpp
@@ -35,6 +35,11 @@ static int getTransferTimeoutMs() {
     return env ? std::stoi(env) : 20000;
 }
 
+static bool getTransferEnableFastRecovery() {
+    static char *env = getenv("ASCEND_TRANSPORT_TRANSFER_ENABLE_FAST_RECOVERY");
+    return env != nullptr && std::string(env) == "1";
+}
+
 HcclTransport::HcclTransport() : running_(-1) {
     // TODO
 }
@@ -68,6 +73,7 @@ void HcclTransport::initiatorLoop(int deviceLogicId, int selfIdx) {
 
     int transfer_max_retry_cnt = getTransferMaxRetryCnt();
     int transfer_timeout_ms = getTransferTimeoutMs();
+    bool transfer_enable_fast_recovery = getTransferEnableFastRecovery();
 
     while (1) {
         auto waitlock = std::chrono::high_resolution_clock::now();
@@ -165,7 +171,11 @@ void HcclTransport::initiatorLoop(int deviceLogicId, int selfIdx) {
                               << inet_ntoa(remote_rank_info_.hostIp)
                               << ", remote devicePhyId: "
                               << remote_rank_info_.devicePhyId;
-                    clearTransportMem(&remote_rank_info_);
+                    if (transfer_enable_fast_recovery) {
+                        clearTransportMems();
+                    } else {
+                        clearTransportMem(&remote_rank_info_);
+                    }
                     continue;
                 }
                 LOG(ERROR) << "Hccl transport failed after "


### PR DESCRIPTION
After the remote target restarts, it is necessary to wait for a 20-second timeout each time before re-establishing connections one by one. When there are a large number of target devices, this process may take an extremely long time, ranging from several minutes to half an hour. To address this issue, an environment variable `ASCEND_TRANSPORT_TRANSFER_ENABLE_FAST_RECOVERY` has been added to support avoiding the one-by-one timeout wait and enabling direct reconnection.