### PR TITLE
feat(store): support transfer engine p2phandshake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,6 @@ jobs:
         python ./bootstrap_server.py &
       shell: bash
 
-    # Removed external Master startup; tests launch in-proc Master themselves.
-
     - name: Test (in build env)
       run: |
         cd build
@@ -100,8 +98,6 @@ jobs:
         ldconfig -v || echo "always continue"
         MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 make test -j ARGS="-V"
       shell: bash
-
-    # Removed external Master shutdown; no longer started in CI.
 
     - name: Generate Python version tag
       id: generate_tag_build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,7 @@ jobs:
         python ./bootstrap_server.py &
       shell: bash
 
-    - name: Start Mooncake Master
-      run: |
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-        # Set a small kv lease ttl to make the test faster.
-        # Must be consistent with the client test parameters.
-        mooncake_master --default_kv_lease_ttl=500 &
-      shell: bash
+    # Removed external Master startup; tests launch in-proc Master themselves.
 
     - name: Test (in build env)
       run: |
@@ -107,10 +101,7 @@ jobs:
         MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 make test -j ARGS="-V"
       shell: bash
 
-    - name: Stop Mooncake Master Service
-      run: |
-        pkill mooncake_master || true
-      shell: bash
+    # Removed external Master shutdown; no longer started in CI.
 
     - name: Generate Python version tag
       id: generate_tag_build

--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -40,13 +40,13 @@ store = MooncakeDistributedStore()
 
 # 2. Setup with all required parameters
 store.setup(
-    "localhost:12345",           # Your node's address
+    "localhost",           # Your node's address
     "http://localhost:8080/metadata",    # HTTP metadata server
     512*1024*1024,          # 512MB segment size
     128*1024*1024,          # 128MB local buffer
     "tcp",                             # Use TCP (RDMA for high performance)
     "",                            # Empty for TCP, specify device for RDMA
-    "localhost:50051"        # Master service
+    "localhost"        # Master service
 )
 
 # 3. Store data
@@ -57,6 +57,31 @@ data = store.get("hello_key")
 print(data.decode())  # Output: Hello, Mooncake Store!
 
 # 5. Clean up
+store.close()
+```
+
+Mooncake selects available ports internally at `setup() `, so you do not need to fix specific port numbers in these examples. Internally, ports are chosen from a dynamic range (currently 12300–14300).
+
+#### P2P Hello World (preview)
+
+The following setup uses the new P2P handshake and does not require an HTTP metadata server. This feature is not released yet; use only if you’re testing the latest code.
+
+```python
+from mooncake.store import MooncakeDistributedStore
+
+store = MooncakeDistributedStore()
+store.setup(
+    "localhost",           # Your node's ip address
+    "P2PHANDSHAKE",              # P2P handshake (no HTTP metadata)
+    512*1024*1024,                # 512MB segment size
+    128*1024*1024,                # 128MB local buffer
+    "tcp",                       # Use TCP (RDMA for high performance)
+    "",                          # Empty for TCP, specify device for RDMA
+    "localhost:50051"           # Master service
+)
+
+store.put("hello_key", b"Hello, Mooncake Store!")
+print(store.get("hello_key").decode())
 store.close()
 ```
 
@@ -74,7 +99,7 @@ from mooncake.store import MooncakeDistributedStore
 
 # 1. Initialize
 store = MooncakeDistributedStore()
-store.setup("localhost:12345",
+store.setup("localhost",
             "http://localhost:8080/metadata",
             512*1024*1024,
             128*1024*1024,
@@ -128,7 +153,7 @@ from mooncake.store import MooncakeDistributedStore
 
 # Initialize store
 store = MooncakeDistributedStore()
-store.setup("localhost:12345", "http://localhost:8080/metadata", 512*1024*1024, 128*1024*1024, "tcp", "", "localhost:50051")
+store.setup("localhost", "http://localhost:8080/metadata", 512*1024*1024, 128*1024*1024, "tcp", "", "localhost:50051")
 
 # Create a large buffer
 buffer = np.zeros(100 * 1024 * 1024, dtype=np.uint8)  # 100MB buffer
@@ -164,7 +189,7 @@ from mooncake.store import MooncakeDistributedStore
 
 # Initialize store with RDMA protocol for maximum performance
 store = MooncakeDistributedStore()
-store.setup("localhost:12345", "http://localhost:8080/metadata", 512*1024*1024, 16*1024*1024, "tcp", "", "localhost:50051")
+store.setup("localhost", "http://localhost:8080/metadata", 512*1024*1024, 16*1024*1024, "tcp", "", "localhost:50051")
 
 # Create data to store
 original_data = np.random.randn(1000, 1000).astype(np.float32)
@@ -283,7 +308,7 @@ config.with_soft_pin = True  # Keep this object in memory longer
 config = ReplicateConfig()
 
 # Preferred replica location ("host:port")
-config.preferred_segment = "node1_ip:12345"    # pin to node1
+config.preferred_segment = "localhost:12345"     # pin to a specific machine
 
 # Alternatively, pin to the local host
 config.preferred_segment = self.get_hostname()
@@ -307,7 +332,7 @@ from mooncake.store import MooncakeDistributedStore
 
 # Initialize (same as zero-copy)
 store = MooncakeDistributedStore()
-store.setup("localhost:12345", "http://localhost:8080/metadata", 512*1024*1024, 128*1024*1024, "tcp", "", "localhost:50051")
+store.setup("localhost", "http://localhost:8080/metadata", 512*1024*1024, 128*1024*1024, "tcp", "", "localhost:50051")
 
 # Simple put/get (automatic memory management)
 data = b"Hello, World!" * 1000  # ~13KB
@@ -364,7 +389,7 @@ export MC_MS_AUTO_DISC=0
 python - <<'PY'
 from mooncake.store import MooncakeDistributedStore as S
 s = S()
-s.setup("localhost:12345", "http://localhost:8080/metadata", 512*1024*1024, 128*1024*1024, "rdma", "mlx5_0,mlx5_1", "localhost:50051")
+s.setup("localhost", "http://localhost:8080/metadata", 512*1024*1024, 128*1024*1024, "rdma", "mlx5_0,mlx5_1", "localhost:50051")
 PY
 
 # Keep auto-discovery but limit to specific NICs
@@ -432,7 +457,7 @@ def setup(
 ```
 
 **Parameters:**
-- `local_hostname` (str): **Required**. Local hostname and port (e.g., "localhost:12345")
+- `local_hostname` (str): **Required**. Local hostname and port (e.g., "localhost" or "localhost:12345")
 - `metadata_server` (str): **Required**. Metadata server address (e.g., "http://localhost:8080/metadata")
 - `global_segment_size` (int): Memory segment size in bytes for mounting (default: 16MB = 16777216)
 - `local_buffer_size` (int): Local buffer size in bytes (default: 1GB = 1073741824)
@@ -450,10 +475,10 @@ def setup(
 
 ```python
 # TCP initialization
-store.setup("localhost:12345", "http://localhost:8080/metadata", 1024*1024*1024, 128*1024*1024, "tcp", "", "localhost:50051")
+store.setup("localhost", "http://localhost:8080/metadata", 1024*1024*1024, 128*1024*1024, "tcp", "", "localhost:50051")
 
 # RDMA initialization (devices optional; auto-discovery is default)
-store.setup("localhost:12345", "http://localhost:8080/metadata", 512*1024*1024, 128*1024*1024, "rdma", "", "localhost:50051")
+store.setup("localhost", "http://localhost:8080/metadata", 512*1024*1024, 128*1024*1024, "rdma", "", "localhost:50051")
 ```
 
 </details>

--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -238,7 +238,7 @@ class Client {
         return str;
     }
 
-    std::string GetTransportEndpoint() {
+    [[nodiscard]] std::string GetTransportEndpoint() {
         return transfer_engine_.getLocalIpAndPort();
     }
 

--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -238,6 +238,10 @@ class Client {
         return str;
     }
 
+    std::string GetTransportEndpoint() {
+        return transfer_engine_.getLocalIpAndPort();
+    }
+
    private:
     /**
      * @brief Private constructor to enforce creation through Create() method

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -51,8 +51,8 @@ class MasterService {
      *         be mounted temporarily,
      *         ErrorCode::INTERNAL_ERROR on internal errors.
      */
-    auto MountSegment(const Segment& segment,
-                      const UUID& client_id) -> tl::expected<void, ErrorCode>;
+    auto MountSegment(const Segment& segment, const UUID& client_id)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Re-mount segments, invoked when the client is the first time to
@@ -74,8 +74,8 @@ class MasterService {
      *         ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS if the segment is
      *         currently unmounting.
      */
-    auto UnmountSegment(const UUID& segment_id,
-                        const UUID& client_id) -> tl::expected<void, ErrorCode>;
+    auto UnmountSegment(const UUID& segment_id, const UUID& client_id)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Check if an object exists
@@ -155,8 +155,8 @@ class MasterService {
      * @return ErrorCode::OK on success, ErrorCode::OBJECT_NOT_FOUND if not
      * found, ErrorCode::INVALID_WRITE if replica status is invalid
      */
-    auto PutEnd(const std::string& key,
-                ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
+    auto PutEnd(const std::string& key, ReplicaType replica_type)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Revoke a put operation, replica_type indicates the type of
@@ -164,8 +164,8 @@ class MasterService {
      * @return ErrorCode::OK on success, ErrorCode::OBJECT_NOT_FOUND if not
      * found, ErrorCode::INVALID_WRITE if replica status is invalid
      */
-    auto PutRevoke(const std::string& key,
-                   ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
+    auto PutRevoke(const std::string& key, ReplicaType replica_type)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Complete a batch of put operations

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -51,8 +51,8 @@ class MasterService {
      *         be mounted temporarily,
      *         ErrorCode::INTERNAL_ERROR on internal errors.
      */
-    auto MountSegment(const Segment& segment, const UUID& client_id)
-        -> tl::expected<void, ErrorCode>;
+    auto MountSegment(const Segment& segment,
+                      const UUID& client_id) -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Re-mount segments, invoked when the client is the first time to
@@ -74,8 +74,8 @@ class MasterService {
      *         ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS if the segment is
      *         currently unmounting.
      */
-    auto UnmountSegment(const UUID& segment_id, const UUID& client_id)
-        -> tl::expected<void, ErrorCode>;
+    auto UnmountSegment(const UUID& segment_id,
+                        const UUID& client_id) -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Check if an object exists
@@ -155,8 +155,8 @@ class MasterService {
      * @return ErrorCode::OK on success, ErrorCode::OBJECT_NOT_FOUND if not
      * found, ErrorCode::INVALID_WRITE if replica status is invalid
      */
-    auto PutEnd(const std::string& key, ReplicaType replica_type)
-        -> tl::expected<void, ErrorCode>;
+    auto PutEnd(const std::string& key,
+                ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Revoke a put operation, replica_type indicates the type of
@@ -164,8 +164,8 @@ class MasterService {
      * @return ErrorCode::OK on success, ErrorCode::OBJECT_NOT_FOUND if not
      * found, ErrorCode::INVALID_WRITE if replica status is invalid
      */
-    auto PutRevoke(const std::string& key, ReplicaType replica_type)
-        -> tl::expected<void, ErrorCode>;
+    auto PutRevoke(const std::string& key,
+                   ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Complete a batch of put operations

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -351,7 +351,6 @@ class FilereadWorkerPool {
 class TransferSubmitter {
    public:
     explicit TransferSubmitter(TransferEngine& engine,
-                               const std::string& local_hostname,
                                std::shared_ptr<StorageBackend>& backend,
                                TransferMetric* transfer_metric = nullptr);
 

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -373,7 +373,6 @@ class TransferSubmitter {
 
    private:
     TransferEngine& engine_;
-    const std::string local_hostname_;
     std::unique_ptr<MemcpyWorkerPool> memcpy_pool_;
     std::unique_ptr<FilereadWorkerPool> fileread_pool_;
     bool memcpy_enabled_;

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -168,7 +168,7 @@ const static uint64_t kMaxSliceSize =
  */
 struct Segment {
     UUID id{0, 0};
-    std::string name{};  // Logical segment name used for scheduling / labels
+    std::string name{};  // Logical segment name used for preferred allocation
     uintptr_t base{0};
     size_t size{0};
     // TE p2p endpoint (ip:port) for transport-only addressing

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -168,16 +168,14 @@ const static uint64_t kMaxSliceSize =
  */
 struct Segment {
     UUID id{0, 0};
-    std::string name{};  // The name of the segment, also might be the
-                         // hostname of the server that owns the segment
+    std::string name{};  // Logical segment name used for scheduling / labels
     uintptr_t base{0};
     size_t size{0};
+    // TE p2p endpoint (ip:port) for transport-only addressing
+    std::string te_endpoint{};
     Segment() = default;
-    Segment(const UUID& id, const std::string& name, uintptr_t base,
-            size_t size)
-        : id(id), name(name), base(base), size(size) {}
 };
-YLT_REFL(Segment, id, name, base, size);
+YLT_REFL(Segment, id, name, base, size, te_endpoint);
 
 /**
  * @brief Client status from the master's perspective

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -27,6 +27,10 @@ AllocatedBuffer::Descriptor AllocatedBuffer::get_descriptor() const {
     std::string endpoint;
     if (alloc) {
         endpoint = alloc->getTransportEndpoint();
+    } else {
+        LOG(ERROR) << "allocator=expired_or_null in get_descriptor, where "
+                      "segment_name="
+                   << segment_name_;
     }
     return {static_cast<uint64_t>(size()),
             reinterpret_cast<uintptr_t>(buffer_ptr_), status, endpoint};

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -23,8 +23,13 @@ AllocatedBuffer::~AllocatedBuffer() {
 
 // Implementation of get_descriptor
 AllocatedBuffer::Descriptor AllocatedBuffer::get_descriptor() const {
-    return {segment_name_, static_cast<uint64_t>(size()),
-            reinterpret_cast<uintptr_t>(buffer_ptr_), status};
+    auto alloc = allocator_.lock();
+    std::string endpoint;
+    if (alloc) {
+        endpoint = alloc->getTransportEndpoint();
+    }
+    return {static_cast<uint64_t>(size()),
+            reinterpret_cast<uintptr_t>(buffer_ptr_), status, endpoint};
 }
 
 // Define operator<< using public accessors or get_descriptor if appropriate
@@ -38,11 +43,13 @@ std::ostream& operator<<(std::ostream& os, const AllocatedBuffer& buffer) {
 
 // Removed allocated_bytes parameter and member initialization
 CachelibBufferAllocator::CachelibBufferAllocator(std::string segment_name,
-                                                 size_t base, size_t size)
+                                                 size_t base, size_t size,
+                                                 std::string transport_endpoint)
     : segment_name_(segment_name),
       base_(base),
       total_size_(size),
-      cur_size_(0) {
+      cur_size_(0),
+      transport_endpoint_(std::move(transport_endpoint)) {
     VLOG(1) << "initializing_buffer_allocator segment_name=" << segment_name
             << " base_address=" << reinterpret_cast<void*>(base)
             << " size=" << size;
@@ -123,11 +130,13 @@ void CachelibBufferAllocator::deallocate(AllocatedBuffer* handle) {
 
 // OffsetBufferAllocator implementation
 OffsetBufferAllocator::OffsetBufferAllocator(std::string segment_name,
-                                             size_t base, size_t size)
+                                             size_t base, size_t size,
+                                             std::string transport_endpoint)
     : segment_name_(segment_name),
       base_(base),
       total_size_(size),
-      cur_size_(0) {
+      cur_size_(0),
+      transport_endpoint_(std::move(transport_endpoint)) {
     VLOG(1) << "initializing_offset_buffer_allocator segment_name="
             << segment_name << " base_address=" << reinterpret_cast<void*>(base)
             << " size=" << size;

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -1143,7 +1143,14 @@ tl::expected<void, ErrorCode> Client::MountSegment(const void* buffer,
     segment.name = local_hostname_;
     segment.base = reinterpret_cast<uintptr_t>(buffer);
     segment.size = size;
-    segment.te_endpoint = transfer_engine_.getLocalIpAndPort();
+    // For P2P handshake mode, publish the actual transport endpoint that was
+    // negotiated by the transfer engine. Otherwise, keep the logical hostname
+    // so metadata backends (HTTP/etcd/redis) can resolve the segment by name.
+    if (metadata_connstring_ == P2PHANDSHAKE) {
+        segment.te_endpoint = transfer_engine_.getLocalIpAndPort();
+    } else {
+        segment.te_endpoint = local_hostname_;
+    }
 
     auto mount_result = master_client_.MountSegment(segment, client_id_);
     if (!mount_result) {

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -331,7 +331,7 @@ ErrorCode Client::InitTransferEngine(
     // Keep using logical local_hostname for name-based behaviors; endpoint is
     // used separately where needed.
     transfer_submitter_ = std::make_unique<TransferSubmitter>(
-        transfer_engine_, local_hostname, storage_backend_,
+        transfer_engine_, storage_backend_,
         metrics_ ? &metrics_->transfer_metric : nullptr);
 
     return ErrorCode::OK;

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -50,11 +50,11 @@ ErrorCode ScopedSegmentAccess::MountSegment(const Segment& segment,
         switch (segment_manager_->memory_allocator_) {
             case BufferAllocatorType::CACHELIB:
                 allocator = std::make_shared<CachelibBufferAllocator>(
-                    segment.name, buffer, size);
+                    segment.name, buffer, size, segment.te_endpoint);
                 break;
             case BufferAllocatorType::OFFSET:
                 allocator = std::make_shared<OffsetBufferAllocator>(
-                    segment.name, buffer, size);
+                    segment.name, buffer, size, segment.te_endpoint);
                 break;
             default:
                 LOG(ERROR) << "segment_name=" << segment.name

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -293,7 +293,7 @@ void TransferEngineOperationState::wait_for_completion() {
     }
 
     VLOG(1) << "Starting transfer engine polling for batch " << batch_id_;
-    constexpr int64_t timeout_seconds = 60;
+    constexpr int64_t timeout_seconds = 1;
     constexpr int64_t kOneSecondInNano = 1000 * 1000 * 1000;
 
     const int64_t start_ts = getCurrentTimeInNano();
@@ -588,9 +588,11 @@ bool TransferSubmitter::isLocalTransfer(
     }
 
     if (!local_ep.empty()) {
-        return std::all_of(handles.begin(), handles.end(), [&local_ep](const auto& h) {
-            return !h.transport_endpoint_.empty() && h.transport_endpoint_ == local_ep;
-        });
+        return std::all_of(handles.begin(), handles.end(),
+                           [&local_ep](const auto& h) {
+                               return !h.transport_endpoint_.empty() &&
+                                      h.transport_endpoint_ == local_ep;
+                           });
     }
 
     // Without a local endpoint we cannot prove locality; disable memcpy.

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -359,11 +359,6 @@ TransferSubmitter::TransferSubmitter(TransferEngine& engine,
       memcpy_pool_(std::make_unique<MemcpyWorkerPool>()),
       fileread_pool_(std::make_unique<FilereadWorkerPool>(backend)),
       transfer_metric_(transfer_metric) {
-    if (local_hostname_.empty()) {
-        LOG(ERROR) << "Local hostname cannot be empty";
-        throw std::invalid_argument("Local hostname cannot be empty");
-    }
-
     // Read MC_STORE_MEMCPY environment variable, default to false (disabled)
     const char* env_value = std::getenv("MC_STORE_MEMCPY");
     if (env_value == nullptr) {

--- a/mooncake-store/tests/allocation_strategy_test.cpp
+++ b/mooncake-store/tests/allocation_strategy_test.cpp
@@ -35,6 +35,7 @@ class AllocationStrategyParameterizedTest
     }
 
     // Helper function to create a BufferAllocator for testing
+    // Using segment_name as transport_endpoint for simplicity
     std::shared_ptr<BufferAllocatorBase> CreateTestAllocator(
         const std::string& segment_name, size_t base_offset,
         size_t size = 64 * MB) {

--- a/mooncake-store/tests/allocation_strategy_test.cpp
+++ b/mooncake-store/tests/allocation_strategy_test.cpp
@@ -189,8 +189,7 @@ TEST_P(AllocationStrategyParameterizedTest, PreferredSegmentNotFound) {
     ASSERT_TRUE(descriptor.is_memory_replica());
     const auto& mem_desc = descriptor.get_memory_descriptor();
     ASSERT_EQ(mem_desc.buffer_descriptors.size(), 1);
-    std::string segment_ep =
-        mem_desc.buffer_descriptors[0].transport_endpoint_;
+    std::string segment_ep = mem_desc.buffer_descriptors[0].transport_endpoint_;
     EXPECT_TRUE(segment_ep == "segment1" || segment_ep == "segment2");
     EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 1024);
 }
@@ -303,11 +302,10 @@ TEST_P(AllocationStrategyParameterizedTest, PreferredSegmentInsufficientSpace) {
     ASSERT_TRUE(large_result.has_value());
     auto large_desc = large_result.value()[0].get_descriptor();
     ASSERT_TRUE(large_desc.is_memory_replica());
-    EXPECT_EQ(
-        large_desc.get_memory_descriptor()
-            .buffer_descriptors[0]
-            .transport_endpoint_,
-        "preferred");
+    EXPECT_EQ(large_desc.get_memory_descriptor()
+                  .buffer_descriptors[0]
+                  .transport_endpoint_,
+              "preferred");
 
     // Now try to allocate more than remaining space in preferred segment
     std::vector<size_t> small_slice = {2 * 1024 * 1024};
@@ -317,8 +315,7 @@ TEST_P(AllocationStrategyParameterizedTest, PreferredSegmentInsufficientSpace) {
     auto small_desc = result.value()[0].get_descriptor();
     ASSERT_TRUE(small_desc.is_memory_replica());
     const auto& mem_desc = small_desc.get_memory_descriptor();
-    EXPECT_EQ(mem_desc.buffer_descriptors[0].transport_endpoint_,
-              "segment1");
+    EXPECT_EQ(mem_desc.buffer_descriptors[0].transport_endpoint_, "segment1");
     EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 2 * 1024 * 1024);
 }
 

--- a/mooncake-store/tests/allocation_strategy_test.cpp
+++ b/mooncake-store/tests/allocation_strategy_test.cpp
@@ -41,11 +41,11 @@ class AllocationStrategyParameterizedTest
         const size_t base = 0x100000000ULL + base_offset;  // 4GB + offset
         switch (allocator_type_) {
             case BufferAllocatorType::CACHELIB:
-                return std::make_shared<CachelibBufferAllocator>(segment_name,
-                                                                 base, size);
+                return std::make_shared<CachelibBufferAllocator>(
+                    segment_name, base, size, segment_name);
             case BufferAllocatorType::OFFSET:
-                return std::make_shared<OffsetBufferAllocator>(segment_name,
-                                                               base, size);
+                return std::make_shared<OffsetBufferAllocator>(
+                    segment_name, base, size, segment_name);
             default:
                 throw std::invalid_argument("Invalid allocator type");
         }
@@ -85,11 +85,11 @@ class AllocationStrategyUnitTest : public ::testing::Test {
         const size_t base = 0x100000000ULL + base_offset;  // 4GB + offset
         switch (type) {
             case BufferAllocatorType::CACHELIB:
-                return std::make_shared<CachelibBufferAllocator>(segment_name,
-                                                                 base, size);
+                return std::make_shared<CachelibBufferAllocator>(
+                    segment_name, base, size, segment_name);
             case BufferAllocatorType::OFFSET:
-                return std::make_shared<OffsetBufferAllocator>(segment_name,
-                                                               base, size);
+                return std::make_shared<OffsetBufferAllocator>(
+                    segment_name, base, size, segment_name);
             default:
                 throw std::invalid_argument("Invalid allocator type");
         }
@@ -157,7 +157,7 @@ TEST_P(AllocationStrategyParameterizedTest, PreferredSegmentAllocation) {
     ASSERT_TRUE(descriptor.is_memory_replica());
     const auto& mem_desc = descriptor.get_memory_descriptor();
     ASSERT_EQ(mem_desc.buffer_descriptors.size(), 1);
-    EXPECT_EQ(mem_desc.buffer_descriptors[0].segment_name_, "preferred");
+    EXPECT_EQ(mem_desc.buffer_descriptors[0].transport_endpoint_, "preferred");
     EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 1024);
 }
 
@@ -189,8 +189,9 @@ TEST_P(AllocationStrategyParameterizedTest, PreferredSegmentNotFound) {
     ASSERT_TRUE(descriptor.is_memory_replica());
     const auto& mem_desc = descriptor.get_memory_descriptor();
     ASSERT_EQ(mem_desc.buffer_descriptors.size(), 1);
-    std::string segment_name = mem_desc.buffer_descriptors[0].segment_name_;
-    EXPECT_TRUE(segment_name == "segment1" || segment_name == "segment2");
+    std::string segment_ep =
+        mem_desc.buffer_descriptors[0].transport_endpoint_;
+    EXPECT_TRUE(segment_ep == "segment1" || segment_ep == "segment2");
     EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 1024);
 }
 
@@ -303,7 +304,9 @@ TEST_P(AllocationStrategyParameterizedTest, PreferredSegmentInsufficientSpace) {
     auto large_desc = large_result.value()[0].get_descriptor();
     ASSERT_TRUE(large_desc.is_memory_replica());
     EXPECT_EQ(
-        large_desc.get_memory_descriptor().buffer_descriptors[0].segment_name_,
+        large_desc.get_memory_descriptor()
+            .buffer_descriptors[0]
+            .transport_endpoint_,
         "preferred");
 
     // Now try to allocate more than remaining space in preferred segment
@@ -314,7 +317,8 @@ TEST_P(AllocationStrategyParameterizedTest, PreferredSegmentInsufficientSpace) {
     auto small_desc = result.value()[0].get_descriptor();
     ASSERT_TRUE(small_desc.is_memory_replica());
     const auto& mem_desc = small_desc.get_memory_descriptor();
-    EXPECT_EQ(mem_desc.buffer_descriptors[0].segment_name_, "segment1");
+    EXPECT_EQ(mem_desc.buffer_descriptors[0].transport_endpoint_,
+              "segment1");
     EXPECT_EQ(mem_desc.buffer_descriptors[0].size_, 2 * 1024 * 1024);
 }
 
@@ -399,7 +403,7 @@ TEST_P(AllocationStrategyParameterizedTest, VeryLargeSizeAllocation) {
 // Test empty slice sizes
 TEST_F(AllocationStrategyTest, EmptySliceSizes) {
     auto allocator = std::make_shared<OffsetBufferAllocator>(
-        "segment1", 0x100000000ULL, 64 * MB);
+        "segment1", 0x100000000ULL, 64 * MB, "segment1");
     std::unordered_map<std::string,
                        std::vector<std::shared_ptr<BufferAllocatorBase>>>
         allocators_by_name;
@@ -420,7 +424,7 @@ TEST_F(AllocationStrategyTest, EmptySliceSizes) {
 // Test invalid replication count
 TEST_F(AllocationStrategyTest, InvalidReplicationCount) {
     auto allocator = std::make_shared<OffsetBufferAllocator>(
-        "segment1", 0x100000000ULL, 64 * MB);
+        "segment1", 0x100000000ULL, 64 * MB, "segment1");
     std::unordered_map<std::string,
                        std::vector<std::shared_ptr<BufferAllocatorBase>>>
         allocators_by_name;
@@ -442,9 +446,9 @@ TEST_F(AllocationStrategyTest, InvalidReplicationCount) {
 // count
 TEST_F(AllocationStrategyTest, InsufficientAllocatorsForReplicas) {
     auto allocator1 = std::make_shared<OffsetBufferAllocator>(
-        "segment1", 0x100000000ULL, 64 * MB);
+        "segment1", 0x100000000ULL, 64 * MB, "segment1");
     auto allocator2 = std::make_shared<OffsetBufferAllocator>(
-        "segment2", 0x100000000ULL + 0x10000000ULL, 64 * MB);
+        "segment2", 0x100000000ULL + 0x10000000ULL, 64 * MB, "segment2");
 
     std::unordered_map<std::string,
                        std::vector<std::shared_ptr<BufferAllocatorBase>>>
@@ -481,7 +485,8 @@ TEST_F(AllocationStrategyTest, InsufficientAllocatorsForReplicas) {
     for (const auto& replica : result.value()) {
         auto descriptor = replica.get_descriptor();
         const auto& mem_desc = descriptor.get_memory_descriptor();
-        segment_names.insert(mem_desc.buffer_descriptors[0].segment_name_);
+        segment_names.insert(
+            mem_desc.buffer_descriptors[0].transport_endpoint_);
     }
     EXPECT_EQ(2u, segment_names.size());
 }

--- a/mooncake-store/tests/buffer_allocator_test.cpp
+++ b/mooncake-store/tests/buffer_allocator_test.cpp
@@ -35,20 +35,23 @@ class BufferAllocatorTest : public ::testing::Test {
         const size_t base = 0x100000000ULL + base_offset;  // 4GB + offset
         switch (allocator_type) {
             case BufferAllocatorType::CACHELIB:
-                return std::make_shared<CachelibBufferAllocator>(segment_name,
-                                                                 base, size);
+                return std::make_shared<CachelibBufferAllocator>(
+                    segment_name, base, size, segment_name);
             case BufferAllocatorType::OFFSET:
-                return std::make_shared<OffsetBufferAllocator>(segment_name,
-                                                               base, size);
+                return std::make_shared<OffsetBufferAllocator>(
+                    segment_name, base, size, segment_name);
             default:
                 throw std::invalid_argument("Invalid allocator type");
         }
     }
 
     void VerifyAllocatedBuffer(const AllocatedBuffer& bufHandle,
-                               size_t alloc_size, std::string segment_name) {
+                               size_t alloc_size,
+                               const std::string& segment_name,
+                               const std::string& transport_endpoint) {
         auto descriptor = bufHandle.get_descriptor();
-        EXPECT_EQ(descriptor.segment_name_, segment_name);
+        EXPECT_EQ(bufHandle.getSegmentName(), segment_name);
+        EXPECT_EQ(descriptor.transport_endpoint_, transport_endpoint);
         EXPECT_EQ(descriptor.size_, alloc_size);
         EXPECT_EQ(descriptor.status_, BufStatus::INIT);
         EXPECT_NE(bufHandle.data(), nullptr);
@@ -72,7 +75,8 @@ TEST_F(BufferAllocatorTest, AllocateAndDeallocate) {
         auto descriptor = bufHandle->get_descriptor();
         // Verify allocation success and properties
         ASSERT_NE(bufHandle, nullptr);
-        VerifyAllocatedBuffer(*bufHandle, alloc_size, segment_name);
+        VerifyAllocatedBuffer(*bufHandle, alloc_size, segment_name,
+                              segment_name);
 
         // Release memory
         bufHandle.reset();
@@ -96,7 +100,8 @@ TEST_F(BufferAllocatorTest, AllocateMultiple) {
         for (int i = 0; i < 8; ++i) {
             auto bufHandle = allocator->allocate(alloc_size);
             ASSERT_NE(bufHandle, nullptr);
-            VerifyAllocatedBuffer(*bufHandle, alloc_size, segment_name);
+            VerifyAllocatedBuffer(*bufHandle, alloc_size, segment_name,
+                                  segment_name);
             handles.push_back(std::move(bufHandle));
         }
 
@@ -136,7 +141,8 @@ TEST_F(BufferAllocatorTest, RepeatAllocateAndDeallocate) {
         for (size_t i = 0; i < size / alloc_size * 2; ++i) {
             auto bufHandle = allocator->allocate(alloc_size);
             ASSERT_NE(bufHandle, nullptr);
-            VerifyAllocatedBuffer(*bufHandle, alloc_size, segment_name);
+            VerifyAllocatedBuffer(*bufHandle, alloc_size, segment_name,
+                                  segment_name);
         }
     }
 }
@@ -167,7 +173,8 @@ TEST_F(BufferAllocatorTest, ParallelAllocation) {
                     auto bufHandle = allocator->allocate(alloc_size);
 
                     ASSERT_NE(bufHandle, nullptr);
-                    VerifyAllocatedBuffer(*bufHandle, alloc_size, segment_name);
+                    VerifyAllocatedBuffer(*bufHandle, alloc_size,
+                                          segment_name, segment_name);
                 }
             });
         }

--- a/mooncake-store/tests/buffer_allocator_test.cpp
+++ b/mooncake-store/tests/buffer_allocator_test.cpp
@@ -162,21 +162,21 @@ TEST_F(BufferAllocatorTest, ParallelAllocation) {
         // Create 4 threads, each performing repeated allocation and
         // deallocation for 1 second
         for (int thread_id = 0; thread_id < num_threads; ++thread_id) {
-            threads.emplace_back([this, &allocator, test_duration,
-                                  segment_name]() {
-                auto start_time = std::chrono::steady_clock::now();
+            threads.emplace_back(
+                [this, &allocator, test_duration, segment_name]() {
+                    auto start_time = std::chrono::steady_clock::now();
 
-                while (std::chrono::steady_clock::now() - start_time <
-                       test_duration) {
-                    // Allocate memory of varying sizes
-                    size_t alloc_size = 477;
-                    auto bufHandle = allocator->allocate(alloc_size);
+                    while (std::chrono::steady_clock::now() - start_time <
+                           test_duration) {
+                        // Allocate memory of varying sizes
+                        size_t alloc_size = 477;
+                        auto bufHandle = allocator->allocate(alloc_size);
 
-                    ASSERT_NE(bufHandle, nullptr);
-                    VerifyAllocatedBuffer(*bufHandle, alloc_size,
-                                          segment_name, segment_name);
-                }
-            });
+                        ASSERT_NE(bufHandle, nullptr);
+                        VerifyAllocatedBuffer(*bufHandle, alloc_size,
+                                              segment_name, segment_name);
+                    }
+                });
         }
 
         // Wait for all threads to complete

--- a/mooncake-store/tests/client_buffer_test.cpp
+++ b/mooncake-store/tests/client_buffer_test.cpp
@@ -271,19 +271,19 @@ TEST_F(ClientBufferTest, CalculateTotalSizeMemoryReplica) {
 
     // Add some buffer descriptors with proper initialization
     AllocatedBuffer::Descriptor buf1;
-    buf1.segment_name_ = "test1";
+    buf1.transport_endpoint_ = "test1";
     buf1.size_ = 1024;
     buf1.buffer_address_ = 0x1000;
     buf1.status_ = BufStatus::COMPLETE;
 
     AllocatedBuffer::Descriptor buf2;
-    buf2.segment_name_ = "test2";
+    buf2.transport_endpoint_ = "test2";
     buf2.size_ = 2048;
     buf2.buffer_address_ = 0x2000;
     buf2.status_ = BufStatus::COMPLETE;
 
     AllocatedBuffer::Descriptor buf3;
-    buf3.segment_name_ = "test3";
+    buf3.transport_endpoint_ = "test3";
     buf3.size_ = 512;
     buf3.buffer_address_ = 0x3000;
     buf3.status_ = BufStatus::COMPLETE;

--- a/mooncake-store/tests/client_buffer_test.cpp
+++ b/mooncake-store/tests/client_buffer_test.cpp
@@ -271,19 +271,16 @@ TEST_F(ClientBufferTest, CalculateTotalSizeMemoryReplica) {
 
     // Add some buffer descriptors with proper initialization
     AllocatedBuffer::Descriptor buf1;
-    buf1.transport_endpoint_ = "test1";
     buf1.size_ = 1024;
     buf1.buffer_address_ = 0x1000;
     buf1.status_ = BufStatus::COMPLETE;
 
     AllocatedBuffer::Descriptor buf2;
-    buf2.transport_endpoint_ = "test2";
     buf2.size_ = 2048;
     buf2.buffer_address_ = 0x2000;
     buf2.status_ = BufStatus::COMPLETE;
 
     AllocatedBuffer::Descriptor buf3;
-    buf3.transport_endpoint_ = "test3";
     buf3.size_ = 512;
     buf3.buffer_address_ = 0x3000;
     buf3.status_ = BufStatus::COMPLETE;

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -62,12 +62,13 @@ class ClientIntegrationTest : public ::testing::Test {
         }
         LOG(INFO) << "Default KV lease TTL: " << default_kv_lease_ttl_;
 
-        // Start an in-process non-HA master with embedded HTTP metadata server
-        ASSERT_TRUE(master_.Start());
+        // Start an in-process non-HA master without HTTP metadata server
+        ASSERT_TRUE(master_.Start(/*rpc_port=*/0, /*http_metrics_port=*/0,
+                                  /*http_metadata_port=*/std::nullopt));
         master_address_ = master_.master_address();
         metadata_url_ = master_.metadata_url();
         LOG(INFO) << "Started in-proc master at " << master_address_
-                  << ", metadata_url=" << metadata_url_;
+                  << ", metadata=P2PHANDSHAKE";
 
         InitializeClients();
         InitializeSegment();

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -14,8 +14,7 @@
 #include "test_server_helpers.h"
 
 DEFINE_string(protocol, "tcp", "Transfer protocol: rdma|tcp");
-DEFINE_string(device_name, "",
-              "Device name to use, valid if protocol=rdma");
+DEFINE_string(device_name, "", "Device name to use, valid if protocol=rdma");
 DEFINE_uint64(default_kv_lease_ttl, mooncake::DEFAULT_DEFAULT_KV_LEASE_TTL,
               "Default lease time for kv objects, must be set to the "
               "same as the master's default_kv_lease_ttl");

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -11,12 +11,11 @@
 #include "client.h"
 #include "types.h"
 #include "utils.h"
+#include "test_server_helpers.h"
 
 DEFINE_string(protocol, "tcp", "Transfer protocol: rdma|tcp");
 DEFINE_string(device_name, "ibp6s0",
               "Device name to use, valid if protocol=rdma");
-DEFINE_string(transfer_engine_metadata_url, "http://localhost:8080/metadata",
-              "Metadata connection string for transfer engine");
 DEFINE_uint64(default_kv_lease_ttl, mooncake::DEFAULT_DEFAULT_KV_LEASE_TTL,
               "Default lease time for kv objects, must be set to the "
               "same as the master's default_kv_lease_ttl");
@@ -28,10 +27,11 @@ class ClientIntegrationTest : public ::testing::Test {
    protected:
     static std::shared_ptr<Client> CreateClient(const std::string& host_name) {
         auto client_opt = Client::Create(
-            host_name,                           // Local hostname
-            FLAGS_transfer_engine_metadata_url,  // Metadata connection string
-            FLAGS_protocol,
-            "localhost:50051"  // Master server address
+            host_name,                  // Local hostname
+            "P2PHANDSHAKE",              // Metadata connection string
+            FLAGS_protocol,             // Transfer protocol
+            std::nullopt,               // RDMA device names (auto-discovery)
+            master_address_             // Master server address (non-HA)
         );
 
         EXPECT_TRUE(client_opt.has_value())
@@ -51,12 +51,9 @@ class ClientIntegrationTest : public ::testing::Test {
         // Override flags from environment variables if present
         if (getenv("PROTOCOL")) FLAGS_protocol = getenv("PROTOCOL");
         if (getenv("DEVICE_NAME")) FLAGS_device_name = getenv("DEVICE_NAME");
-        if (getenv("MC_METADATA_SERVER"))
-            FLAGS_transfer_engine_metadata_url = getenv("MC_METADATA_SERVER");
 
         LOG(INFO) << "Protocol: " << FLAGS_protocol
-                  << ", Device name: " << FLAGS_device_name
-                  << ", Metadata URL: " << FLAGS_transfer_engine_metadata_url;
+                  << ", Device name: " << FLAGS_device_name;
 
         if (getenv("DEFAULT_KV_LEASE_TTL")) {
             default_kv_lease_ttl_ = std::stoul(getenv("DEFAULT_KV_LEASE_TTL"));
@@ -65,6 +62,13 @@ class ClientIntegrationTest : public ::testing::Test {
         }
         LOG(INFO) << "Default KV lease TTL: " << default_kv_lease_ttl_;
 
+        // Start an in-process non-HA master with embedded HTTP metadata server
+        ASSERT_TRUE(master_.Start());
+        master_address_ = master_.master_address();
+        metadata_url_ = master_.metadata_url();
+        LOG(INFO) << "Started in-proc master at " << master_address_
+                  << ", metadata_url=" << metadata_url_;
+
         InitializeClients();
         InitializeSegment();
     }
@@ -72,6 +76,7 @@ class ClientIntegrationTest : public ::testing::Test {
     static void TearDownTestSuite() {
         CleanupSegment();
         CleanupClients();
+        master_.Stop();
         google::ShutdownGoogleLogging();
     }
 
@@ -159,6 +164,9 @@ class ClientIntegrationTest : public ::testing::Test {
     static void* test_client_segment_ptr_;
     static size_t test_client_ram_buffer_size_;
     static uint64_t default_kv_lease_ttl_;
+    static InProcMaster master_;
+    static std::string master_address_;
+    static std::string metadata_url_;
 };
 
 // Static members initialization
@@ -172,6 +180,9 @@ std::unique_ptr<SimpleAllocator>
 size_t ClientIntegrationTest::ram_buffer_size_ = 0;
 size_t ClientIntegrationTest::test_client_ram_buffer_size_ = 0;
 uint64_t ClientIntegrationTest::default_kv_lease_ttl_ = 0;
+InProcMaster ClientIntegrationTest::master_;
+std::string ClientIntegrationTest::master_address_;
+std::string ClientIntegrationTest::metadata_url_;
 
 // Test basic Put/Get operations through the client
 TEST_F(ClientIntegrationTest, BasicPutGetOperations) {
@@ -301,8 +312,8 @@ TEST_F(ClientIntegrationTest, LocalPreferredAllocationTest) {
     ASSERT_EQ(replica_list[0]
                   .get_memory_descriptor()
                   .buffer_descriptors[0]
-                  .segment_name_,
-              "localhost:17812");
+                  .transport_endpoint_,
+              segment_provider_client_->GetTransportEndpoint());
 
     auto get_result = test_client_->Get(key, replica_list, slices);
     ASSERT_TRUE(get_result.has_value())
@@ -675,7 +686,7 @@ int main(int argc, char** argv) {
 
     // Initialize Google's flags library
     gflags::ParseCommandLineFlags(&argc, &argv, false);
-
+    easylog::set_min_severity(easylog::Severity::WARNING);
     // Run all tests
     return RUN_ALL_TESTS();
 }

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -14,7 +14,7 @@
 #include "test_server_helpers.h"
 
 DEFINE_string(protocol, "tcp", "Transfer protocol: rdma|tcp");
-DEFINE_string(device_name, "ibp6s0",
+DEFINE_string(device_name, "",
               "Device name to use, valid if protocol=rdma");
 DEFINE_uint64(default_kv_lease_ttl, mooncake::DEFAULT_DEFAULT_KV_LEASE_TTL,
               "Default lease time for kv objects, must be set to the "
@@ -26,13 +26,13 @@ namespace testing {
 class ClientIntegrationTest : public ::testing::Test {
    protected:
     static std::shared_ptr<Client> CreateClient(const std::string& host_name) {
-        auto client_opt = Client::Create(
-            host_name,                  // Local hostname
-            "P2PHANDSHAKE",              // Metadata connection string
-            FLAGS_protocol,             // Transfer protocol
-            std::nullopt,               // RDMA device names (auto-discovery)
-            master_address_             // Master server address (non-HA)
-        );
+        auto client_opt =
+            Client::Create(host_name,       // Local hostname
+                           "P2PHANDSHAKE",  // Metadata connection string
+                           FLAGS_protocol,  // Transfer protocol
+                           std::nullopt,  // RDMA device names (auto-discovery)
+                           master_address_  // Master server address (non-HA)
+            );
 
         EXPECT_TRUE(client_opt.has_value())
             << "Failed to create client with host_name: " << host_name;

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -33,7 +33,12 @@ TEST_F(MasterServiceSSDTest, PutEndBothReplica) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 64;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -80,7 +85,12 @@ TEST_F(MasterServiceSSDTest, PutRevokeDiskReplica) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 64;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -113,7 +123,12 @@ TEST_F(MasterServiceSSDTest, PutRevokeMemoryReplica) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 64;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -144,7 +159,12 @@ TEST_F(MasterServiceSSDTest, PutRevokeBothReplica) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 64;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -174,7 +194,12 @@ TEST_F(MasterServiceSSDTest, RemoveKey) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 64;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -206,7 +231,12 @@ TEST_F(MasterServiceSSDTest, EvictObject) {
     constexpr size_t size = 1024 * 1024 * 16 * 15;
     constexpr size_t object_size = 1024 * 15;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     auto mount_result = service_->MountSegment(segment, client_id);
     ASSERT_TRUE(mount_result.has_value());

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -1384,7 +1384,7 @@ TEST_F(MasterServiceTest, ConcurrentRemoveAllOperations) {
     ASSERT_TRUE(mount_result.has_value());
 
     // Pre-populate with test data
-    constexpr int num_objects = 1000000;
+    constexpr int num_objects = 1000;
     for (int i = 0; i < num_objects; ++i) {
         std::string key = "pre_key_" + std::to_string(i);
         std::vector<uint64_t> slice_lengths = {1024};

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -388,8 +388,7 @@ TEST_F(MasterServiceTest, RandomPutStartEndFlow) {
         Segment segment;
         segment.id = generate_uuid();
         segment.name = "segment_" + std::to_string(i);
-        segment.base =
-            kBaseAddr + static_cast<size_t>(i) * kSegmentSize;
+        segment.base = kBaseAddr + static_cast<size_t>(i) * kSegmentSize;
         segment.size = kSegmentSize;
         segment.te_endpoint = segment.name;
         ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
@@ -1038,8 +1037,7 @@ TEST_F(MasterServiceTest, MultiSliceMultiReplicaFlow) {
         Segment segment;
         segment.id = generate_uuid();
         segment.name = "segment_" + std::to_string(i);
-        segment.base =
-            kBaseAddr + static_cast<size_t>(i) * kSegmentSize;
+        segment.base = kBaseAddr + static_cast<size_t>(i) * kSegmentSize;
         segment.size = kSegmentSize;
         segment.te_endpoint = segment.name;
         ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
@@ -2182,8 +2180,7 @@ TEST_F(MasterServiceTest, PerSliceReplicaSegmentsAreUnique) {
         Segment segment;
         segment.id = generate_uuid();
         segment.name = "segment_" + std::to_string(i);
-        segment.base =
-            kBaseAddr + static_cast<size_t>(i) * kSegmentSize;
+        segment.base = kBaseAddr + static_cast<size_t>(i) * kSegmentSize;
         segment.size = kSegmentSize;
         segment.te_endpoint = segment.name;
         ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -62,7 +62,7 @@ std::string GenerateKeyForSegment(const std::unique_ptr<MasterService>& service,
         if (replica_list[0]
                 .get_memory_descriptor()
                 .buffer_descriptors[0]
-                .segment_name_ == segment_name) {
+                .transport_endpoint_ == segment_name) {
             return key;
         }
         // Clean up failed attempt
@@ -86,8 +86,12 @@ TEST_F(MasterServiceTest, MountUnmountSegmentWithCachelibAllocator) {
     constexpr size_t kSegmentSize = 1024 * 1024 * 16;
     // Define the name of the test segment.
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, kBufferAddress,
-                    kSegmentSize);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = kBufferAddress;
+    segment.size = kSegmentSize;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     // Test invalid parameters.
@@ -163,8 +167,12 @@ TEST_F(MasterServiceTest, MountUnmountSegmentWithOffsetAllocator) {
     constexpr size_t kSegmentSize = 1024 * 1024 * 16;
     // Define the name of the test segment.
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, kBufferAddress,
-                    kSegmentSize);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = kBufferAddress;
+    segment.size = kSegmentSize;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     // Test invalid parameters.
@@ -232,7 +240,12 @@ TEST_F(MasterServiceTest, RandomMountUnmountSegment) {
         // Define the size of the segment (16MB).
         size_t kSegmentSize = 1024 * 1024 * 16 * random_number;
 
-        Segment segment(segment_id, segment_name, kBufferAddress, kSegmentSize);
+        Segment segment;
+        segment.id = segment_id;
+        segment.name = segment_name;
+        segment.base = kBufferAddress;
+        segment.size = kSegmentSize;
+        segment.te_endpoint = segment.name;
 
         // Test remounting after unmount.
         auto mount_result = service_->MountSegment(segment, client_id);
@@ -286,7 +299,12 @@ TEST_F(MasterServiceTest, PutStartInvalidParams) {
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
 
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -315,7 +333,12 @@ TEST_F(MasterServiceTest, PutStartEndFlow) {
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
 
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -362,9 +385,13 @@ TEST_F(MasterServiceTest, RandomPutStartEndFlow) {
     constexpr size_t kSegmentSize = 1024 * 1024 * 16;  // 16MB
     UUID client_id = generate_uuid();
     for (int i = 0; i < 5; ++i) {
-        Segment segment(generate_uuid(), "segment_" + std::to_string(i),
-                        kBaseAddr + static_cast<size_t>(i) * kSegmentSize,
-                        kSegmentSize);
+        Segment segment;
+        segment.id = generate_uuid();
+        segment.name = "segment_" + std::to_string(i);
+        segment.base =
+            kBaseAddr + static_cast<size_t>(i) * kSegmentSize;
+        segment.size = kSegmentSize;
+        segment.te_endpoint = segment.name;
         ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
     }
 
@@ -419,7 +446,12 @@ TEST_F(MasterServiceTest, GetReplicaListByRegex) {
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
 
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -475,7 +507,12 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     auto mount_result = service_->MountSegment(segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
@@ -600,7 +637,12 @@ TEST_F(MasterServiceTest, GetReplicaList) {
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
 
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -629,7 +671,12 @@ TEST_F(MasterServiceTest, RemoveObject) {
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
 
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -666,7 +713,12 @@ TEST_F(MasterServiceTest, RandomRemoveObject) {
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
 
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -707,7 +759,12 @@ TEST_F(MasterServiceTest, RemoveByRegex) {
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
 
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -750,7 +807,12 @@ TEST_F(MasterServiceTest, RemoveByRegexComplex) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment_remove";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     auto mount_result = service_->MountSegment(segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
@@ -926,7 +988,12 @@ TEST_F(MasterServiceTest, RemoveAll) {
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
 
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     auto mount_result = service_->MountSegment(segment, client_id);
@@ -968,9 +1035,13 @@ TEST_F(MasterServiceTest, MultiSliceMultiReplicaFlow) {
     constexpr size_t kSegmentSize = 1024 * 1024 * 64;  // 64MB
     UUID client_id = generate_uuid();
     for (int i = 0; i < 3; ++i) {
-        Segment segment(generate_uuid(), "segment_" + std::to_string(i),
-                        kBaseAddr + static_cast<size_t>(i) * kSegmentSize,
-                        kSegmentSize);
+        Segment segment;
+        segment.id = generate_uuid();
+        segment.name = "segment_" + std::to_string(i);
+        segment.base =
+            kBaseAddr + static_cast<size_t>(i) * kSegmentSize;
+        segment.size = kSegmentSize;
+        segment.te_endpoint = segment.name;
         ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
     }
 
@@ -1061,7 +1132,12 @@ TEST_F(MasterServiceTest, CleanupStaleHandlesTest) {
     constexpr size_t size = 1024 * 1024 * 16;  // 16MB
     std::string segment_name = "test_segment";
 
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     // Mount the segment
@@ -1126,7 +1202,12 @@ TEST_F(MasterServiceTest, ConcurrentWriteAndRemoveAll) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 256;  // 256MB for concurrent testing
     std::string segment_name = "concurrent_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     auto mount_result_concurrent = service_->MountSegment(segment, client_id);
     ASSERT_TRUE(mount_result_concurrent.has_value());
@@ -1206,7 +1287,12 @@ TEST_F(MasterServiceTest, ConcurrentReadAndRemoveAll) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 256;  // 256MB for concurrent testing
     std::string segment_name = "concurrent_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     auto mount_result = service_->MountSegment(segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
@@ -1287,7 +1373,12 @@ TEST_F(MasterServiceTest, ConcurrentRemoveAllOperations) {
     constexpr size_t size =
         1024 * 1024 * 16 * 100;  // 256MB for concurrent testing
     std::string segment_name = "concurrent_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     auto mount_result = service_->MountSegment(segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
@@ -1343,8 +1434,18 @@ TEST_F(MasterServiceTest, UnmountSegmentImmediateCleanup) {
     constexpr size_t buffer2 = 0x400000000;
     constexpr size_t size = 1024 * 1024 * 16;
 
-    Segment segment1(generate_uuid(), "segment1", buffer1, size);
-    Segment segment2(generate_uuid(), "segment2", buffer2, size);
+    Segment segment1;
+    segment1.id = generate_uuid();
+    segment1.name = "segment1";
+    segment1.base = buffer1;
+    segment1.size = size;
+    segment1.te_endpoint = segment1.name;
+    Segment segment2;
+    segment2.id = generate_uuid();
+    segment2.name = "segment2";
+    segment2.base = buffer2;
+    segment2.size = size;
+    segment2.te_endpoint = segment2.name;
     UUID client_id = generate_uuid();
     auto mount_result1 = service_->MountSegment(segment1, client_id);
     ASSERT_TRUE(mount_result1.has_value());
@@ -1384,7 +1485,7 @@ TEST_F(MasterServiceTest, UnmountSegmentImmediateCleanup) {
     ASSERT_EQ(replica_list[0]
                   .get_memory_descriptor()
                   .buffer_descriptors[0]
-                  .segment_name_,
+                  .transport_endpoint_,
               segment2.name);
 }
 
@@ -1397,8 +1498,18 @@ TEST_F(MasterServiceTest, ReadableAfterPartialUnmountWithReplication) {
     constexpr size_t segment_size = 1024 * 1024 * 64;  // 64MB
     constexpr size_t object_size = 1024 * 1024;        // 1MB
 
-    Segment segment1(generate_uuid(), "segment1", buffer1, segment_size);
-    Segment segment2(generate_uuid(), "segment2", buffer2, segment_size);
+    Segment segment1;
+    segment1.id = generate_uuid();
+    segment1.name = "segment1";
+    segment1.base = buffer1;
+    segment1.size = segment_size;
+    segment1.te_endpoint = segment1.name;
+    Segment segment2;
+    segment2.id = generate_uuid();
+    segment2.name = "segment2";
+    segment2.base = buffer2;
+    segment2.size = segment_size;
+    segment2.te_endpoint = segment2.name;
     UUID client_id = generate_uuid();
     auto mount_result1 = service_->MountSegment(segment1, client_id);
     ASSERT_TRUE(mount_result1.has_value());
@@ -1426,7 +1537,7 @@ TEST_F(MasterServiceTest, ReadableAfterPartialUnmountWithReplication) {
         ASSERT_EQ(ReplicaStatus::COMPLETE, rep.status);
         const auto& mem = rep.get_memory_descriptor();
         ASSERT_EQ(1u, mem.buffer_descriptors.size());
-        seg_names.insert(mem.buffer_descriptors[0].segment_name_);
+        seg_names.insert(mem.buffer_descriptors[0].transport_endpoint_);
     }
     ASSERT_EQ(2u, seg_names.size())
         << "Replicas should be on different segments";
@@ -1445,8 +1556,12 @@ TEST_F(MasterServiceTest, UnmountSegmentPerformance) {
     constexpr size_t kBufferAddress = 0x300000000;
     constexpr size_t kSegmentSize = 1024 * 1024 * 256;  // 256MB
     std::string segment_name = "perf_test_segment";
-    Segment segment(generate_uuid(), segment_name, kBufferAddress,
-                    kSegmentSize);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = kBufferAddress;
+    segment.size = kSegmentSize;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
 
     // Mount a segment for testing
@@ -1510,7 +1625,12 @@ TEST_F(MasterServiceTest, RemoveLeasedObject) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     auto mount_result = service_->MountSegment(segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
@@ -1598,7 +1718,12 @@ TEST_F(MasterServiceTest, RemoveAllLeasedObject) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     auto mount_result = service_->MountSegment(segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
@@ -1647,7 +1772,12 @@ TEST_F(MasterServiceTest, EvictObject) {
     constexpr size_t size = 1024 * 1024 * 16 * 15;
     constexpr size_t object_size = 1024 * 15;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     auto mount_result = service_->MountSegment(segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
@@ -1685,7 +1815,12 @@ TEST_F(MasterServiceTest, TryEvictLeasedObject) {
     constexpr size_t size = 1024 * 1024 * 16;
     constexpr size_t object_size = 1024 * 1024;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     auto mount_result = service_->MountSegment(segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
@@ -1741,7 +1876,12 @@ TEST_F(MasterServiceTest, RemoveSoftPinObject) {
     constexpr size_t buffer = 0x300000000;
     constexpr size_t size = 1024 * 1024 * 16;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
 
@@ -1782,7 +1922,12 @@ TEST_F(MasterServiceTest, SoftPinObjectsNotEvictedBeforeOtherObjects) {
     constexpr size_t segment_size = 1024 * 1024 * 16;
     constexpr size_t value_size = 1024 * 1024;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, segment_size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = segment_size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
 
@@ -1852,7 +1997,12 @@ TEST_F(MasterServiceTest, SoftPinObjectsCanBeEvicted) {
     constexpr size_t segment_size = 1024 * 1024 * 16;
     constexpr size_t value_size = 1024 * 1024;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, segment_size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = segment_size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
 
@@ -1901,7 +2051,12 @@ TEST_F(MasterServiceTest, SoftPinExtendedOnGet) {
     constexpr size_t segment_size = 1024 * 1024 * 16;
     constexpr size_t value_size = 1024 * 1024;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, segment_size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = segment_size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
 
@@ -1982,7 +2137,12 @@ TEST_F(MasterServiceTest, SoftPinObjectsNotAllowEvict) {
     constexpr size_t segment_size = 1024 * 1024 * 16;
     constexpr size_t value_size = 1024 * 1024;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, segment_size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = segment_size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
 
@@ -2019,9 +2179,13 @@ TEST_F(MasterServiceTest, PerSliceReplicaSegmentsAreUnique) {
     constexpr size_t kSegmentSize = 1024 * 1024 * 16;  // 16MB
     UUID client_id = generate_uuid();
     for (int i = 0; i < 20; ++i) {
-        Segment segment(generate_uuid(), "segment_" + std::to_string(i),
-                        kBaseAddr + static_cast<size_t>(i) * kSegmentSize,
-                        kSegmentSize);
+        Segment segment;
+        segment.id = generate_uuid();
+        segment.name = "segment_" + std::to_string(i);
+        segment.base =
+            kBaseAddr + static_cast<size_t>(i) * kSegmentSize;
+        segment.size = kSegmentSize;
+        segment.te_endpoint = segment.name;
         ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
     }
 
@@ -2044,7 +2208,7 @@ TEST_F(MasterServiceTest, PerSliceReplicaSegmentsAreUnique) {
             const auto& mem = replica.get_memory_descriptor();
             ASSERT_EQ(slice_lengths.size(), mem.buffer_descriptors.size());
             segment_names.insert(
-                mem.buffer_descriptors[slice_idx].segment_name_);
+                mem.buffer_descriptors[slice_idx].transport_endpoint_);
         }
         EXPECT_EQ(segment_names.size(), config.replica_num)
             << "Duplicate segment found for slice index " << slice_idx;
@@ -2059,7 +2223,12 @@ TEST_F(MasterServiceTest, ReplicationFactorTwoWithSingleSegment) {
     // Mount a single 16MB segment
     constexpr size_t kBaseAddr = 0x300000000;
     constexpr size_t kSegmentSize = 1024 * 1024 * 16;  // 16MB
-    Segment segment(generate_uuid(), "single_segment", kBaseAddr, kSegmentSize);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "single_segment";
+    segment.base = kBaseAddr;
+    segment.size = kSegmentSize;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
 
@@ -2081,7 +2250,8 @@ TEST_F(MasterServiceTest, ReplicationFactorTwoWithSingleSegment) {
     // Verify the replica is properly allocated on the single segment
     auto mem_desc = replicas[0].get_memory_descriptor();
     EXPECT_EQ(1u, mem_desc.buffer_descriptors.size());
-    EXPECT_EQ("single_segment", mem_desc.buffer_descriptors[0].segment_name_);
+    EXPECT_EQ("single_segment",
+              mem_desc.buffer_descriptors[0].transport_endpoint_);
     EXPECT_EQ(1024u, mem_desc.buffer_descriptors[0].size_);
 }
 
@@ -2093,7 +2263,12 @@ TEST_F(MasterServiceTest, BatchExistKeyTest) {
     constexpr size_t size = 1024 * 1024 * 128;
     constexpr size_t value_size = 1024;
     std::string segment_name = "test_segment";
-    Segment segment(generate_uuid(), segment_name, buffer, size);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
     UUID client_id = generate_uuid();
     auto mount_result = service_->MountSegment(segment, client_id);
     ASSERT_TRUE(mount_result.has_value());

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -9,8 +9,7 @@
 #include "test_server_helpers.h"
 
 DEFINE_string(protocol, "tcp", "Transfer protocol: rdma|tcp");
-DEFINE_string(device_name, "",
-              "Device name to use, valid if protocol=rdma");
+DEFINE_string(device_name, "", "Device name to use, valid if protocol=rdma");
 
 namespace mooncake {
 namespace testing {
@@ -58,7 +57,6 @@ class PyClientTest : public ::testing::Test {
 // Static members definition
 mooncake::testing::InProcMaster PyClientTest::master_;
 std::string PyClientTest::master_address_;
-
 
 // Test basic Put and Get operations
 TEST_F(PyClientTest, BasicPutGetOperations) {

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -6,12 +6,11 @@
 #include <string>
 
 #include "pybind_client.h"
+#include "test_server_helpers.h"
 
 DEFINE_string(protocol, "tcp", "Transfer protocol: rdma|tcp");
-DEFINE_string(device_name, "ibp6s0",
+DEFINE_string(device_name, "",
               "Device name to use, valid if protocol=rdma");
-DEFINE_string(transfer_engine_metadata_url, "http://localhost:8080/metadata",
-              "Metadata connection string for transfer engine");
 
 namespace mooncake {
 namespace testing {
@@ -25,15 +24,21 @@ class PyClientTest : public ::testing::Test {
         // Override flags from environment variables if present
         if (getenv("PROTOCOL")) FLAGS_protocol = getenv("PROTOCOL");
         if (getenv("DEVICE_NAME")) FLAGS_device_name = getenv("DEVICE_NAME");
-        if (getenv("MC_METADATA_SERVER"))
-            FLAGS_transfer_engine_metadata_url = getenv("MC_METADATA_SERVER");
 
         LOG(INFO) << "Protocol: " << FLAGS_protocol
                   << ", Device name: " << FLAGS_device_name
-                  << ", Metadata URL: " << FLAGS_transfer_engine_metadata_url;
+                  << ", Metadata: P2PHANDSHAKE";
+        ASSERT_TRUE(master_.Start(/*rpc_port=*/0, /*http_metrics_port=*/0,
+                                  /*http_metadata_port=*/std::nullopt))
+            << "Failed to start in-proc master";
+        master_address_ = master_.master_address();
+        LOG(INFO) << "Started in-proc master at " << master_address_;
     }
 
-    static void TearDownTestSuite() { google::ShutdownGoogleLogging(); }
+    static void TearDownTestSuite() {
+        master_.Stop();
+        google::ShutdownGoogleLogging();
+    }
 
     void SetUp() override { py_client_ = PyClient::create(); }
 
@@ -44,51 +49,27 @@ class PyClientTest : public ::testing::Test {
     }
 
     std::shared_ptr<PyClient> py_client_;
+
+    // In-proc master for tests
+    static mooncake::testing::InProcMaster master_;
+    static std::string master_address_;
 };
 
-// Test PyClient construction and setup
-TEST_F(PyClientTest, ConstructorAndSetup) {
-    ASSERT_TRUE(py_client_ != nullptr);
+// Static members definition
+mooncake::testing::InProcMaster PyClientTest::master_;
+std::string PyClientTest::master_address_;
 
-    // Test setup
-    int setup_result = py_client_->setup(
-        "localhost:17813",                   // local_hostname
-        FLAGS_transfer_engine_metadata_url,  // metadata_server
-        16 * 1024 * 1024,                    // global_segment_size (16MB)
-        16 * 1024 * 1024,                    // local_buffer_size (16MB)
-        FLAGS_protocol,                      // protocol
-        FLAGS_device_name,                   // rdma_devices
-        "localhost:50051"                    // master_server_addr
-    );
-    EXPECT_EQ(setup_result, 0) << "Setup should succeed";
-
-    // Verify hostname
-    std::string hostname = py_client_->get_hostname();
-    EXPECT_EQ(hostname, "localhost:17813");
-
-    // Same local hostname should fail
-    auto new_client = PyClient::create();
-    int second_setup_result = new_client->setup(
-        "localhost:17813",                   // local_hostname
-        FLAGS_transfer_engine_metadata_url,  // metadata_server
-        16 * 1024 * 1024,                    // global_segment_size (16MB)
-        16 * 1024 * 1024,                    // local_buffer_size (16MB)
-        FLAGS_protocol,                      // protocol
-        FLAGS_device_name,                   // rdma_devices
-        "localhost:50051"                    // master_server_addr
-    );
-    EXPECT_NE(second_setup_result, 0)
-        << "Second setup should fail due to already initialized client";
-}
 
 // Test basic Put and Get operations
 TEST_F(PyClientTest, BasicPutGetOperations) {
     // Setup the client
-    ASSERT_EQ(
-        py_client_->setup("localhost:17813", FLAGS_transfer_engine_metadata_url,
-                          16 * 1024 * 1024, 16 * 1024 * 1024, FLAGS_protocol,
-                          FLAGS_device_name, "localhost:50051"),
-        0);
+    const std::string rdma_devices = (FLAGS_protocol == std::string("rdma"))
+                                         ? FLAGS_device_name
+                                         : std::string("");
+    ASSERT_EQ(py_client_->setup("localhost:17813", "P2PHANDSHAKE",
+                                16 * 1024 * 1024, 16 * 1024 * 1024,
+                                FLAGS_protocol, rdma_devices, master_address_),
+              0);
 
     const std::string test_data = "Hello, PyClient!";
     const std::string key = "test_key_pyclient";

--- a/mooncake-store/tests/test_server_helpers.h
+++ b/mooncake-store/tests/test_server_helpers.h
@@ -19,7 +19,8 @@ namespace mooncake {
 namespace testing {
 
 // Lightweight in-process master server for tests (non-HA).
-// Optionally starts embedded HTTP metadata server for transfer engine (default off).
+// Optionally starts embedded HTTP metadata server for transfer engine (default
+// off).
 class InProcMaster {
    public:
     InProcMaster() = default;
@@ -33,10 +34,10 @@ class InProcMaster {
             http_metrics_port_ =
                 http_metrics_port > 0 ? http_metrics_port : getFreeTcpPort();
             http_metadata_port_ = http_metadata_port.has_value()
-                                       ? (http_metadata_port.value() > 0
-                                              ? http_metadata_port.value()
-                                              : getFreeTcpPort())
-                                       : 0;
+                                      ? (http_metadata_port.value() > 0
+                                             ? http_metadata_port.value()
+                                             : getFreeTcpPort())
+                                      : 0;
 
             // Optional HTTP metadata server
             if (http_metadata_port_ > 0) {

--- a/mooncake-store/tests/test_server_helpers.h
+++ b/mooncake-store/tests/test_server_helpers.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <cstdlib>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
-#include <optional>
 
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
 
@@ -58,7 +59,15 @@ class InProcMaster {
             }
 
             WrappedMasterServiceConfig cfg;
-            cfg.default_kv_lease_ttl = DEFAULT_DEFAULT_KV_LEASE_TTL;
+            uint64_t default_kv_lease_ttl = DEFAULT_DEFAULT_KV_LEASE_TTL;
+            if (const char* ttl_env = std::getenv("DEFAULT_KV_LEASE_TTL")) {
+                char* endptr = nullptr;
+                unsigned long parsed = std::strtoul(ttl_env, &endptr, 10);
+                if (endptr != ttl_env && endptr && *endptr == '\0') {
+                    default_kv_lease_ttl = static_cast<uint64_t>(parsed);
+                }
+            }
+            cfg.default_kv_lease_ttl = default_kv_lease_ttl;
             cfg.default_kv_soft_pin_ttl = DEFAULT_KV_SOFT_PIN_TTL_MS;
             cfg.allow_evict_soft_pinned_objects = true;
             cfg.enable_metric_reporting = false;

--- a/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/hccl_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/hccl_transport.cpp
@@ -199,8 +199,7 @@ void HcclTransport::initiatorLoop(int deviceLogicId, int selfIdx) {
                           << ", batch waitlock spent: " << duration_wait.count()
                           << "ms"
                           << ", batch call spent: " << duration_call.count()
-                          << "us"
-                          << ", batch addOpfence spent: "
+                          << "us" << ", batch addOpfence spent: "
                           << duration_addOpfence.count() << "us"
                           << ", batch sync spent: " << duration_sync.count()
                           << "us";

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -90,11 +90,10 @@ struct Session : public std::enable_shared_from_this<Session> {
             socket_, asio::buffer(&header_, sizeof(SessionHeader)),
             [this, self](const asio::error_code &ec, std::size_t len) {
                 if (ec || len != sizeof(SessionHeader)) {
-                    LOG(ERROR)
-                        << "Session::writeHeader failed. Error: "
-                        << ec.message() << " (value: " << ec.value() << ")"
-                        << ", bytes written: " << len
-                        << ", expected: " << sizeof(SessionHeader);
+                    LOG(ERROR) << "Session::writeHeader failed. Error: "
+                               << ec.message() << " (value: " << ec.value()
+                               << ")" << ", bytes written: " << len
+                               << ", expected: " << sizeof(SessionHeader);
                     if (on_finalize_) on_finalize_(TransferStatusEnum::FAILED);
                     session_mutex_.unlock();
                     return;

--- a/mooncake-wheel/tests/test_distributed_object_store.py
+++ b/mooncake-wheel/tests/test_distributed_object_store.py
@@ -636,5 +636,5 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    # Show which test is running
-    unittest.main(verbosity=2)
+    # Show which test is running; stop on first failure
+    unittest.main(verbosity=2, failfast=True)


### PR DESCRIPTION
After this, we no longer rely on any external metadata service — only `Master` is all we need. Also, with this change, TE's lifecycle is tied to the client's, so we don't have to handle metadata re-insertion when client reconnects to master.

For compatibility, we still kept the old metadata URLs for now, but as we roll out new releases, I think we can deprecate them.

still, not sure if this brings side effects in other areas, e.g., performance impact