### PR TITLE
chore: bump version to 0.3.6.post1 in pyproject.toml

### DIFF
--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mooncake-transfer-engine"
-version = "0.3.6"
+version = "0.3.6.post1"
 description = "Python binding of a Mooncake library using pybind11"
 authors = [
     { name = "Mooncake Authors" }


### PR DESCRIPTION
Need a new release to involve #869 to fix GB200 usage.