### PR TITLE
Allow customizing RPC port range

### DIFF
--- a/doc/en/transfer-engine.md
+++ b/doc/en/transfer-engine.md
@@ -443,3 +443,5 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_ENABLE_DEST_DEVICE_AFFINITY` Enable device affinity for RDMA performance optimization. When enabled, Transfer Engine will prioritize communication with remote NICs that have the same name as local NICs to reduce QP count and improve network performance in rail-optimized topologies. The default value is false
 - `MC_FORCE_MNNVL` Force to use Multi-Node NVLink as the active transport regardless whether RDMA devices are installed.
 - `MC_FORCE_TCP` Force to use TCP as the active transport regardless whether RDMA devices are installed.
+- `MC_MIN_PRC_PORT` Specifies the minimum port number for RPC service. The default value is 15000.
+- `MC_MAX_PRC_PORT` Specifies the maximum port number for RPC service. The default value is 17000.

--- a/doc/zh/transfer-engine.md
+++ b/doc/zh/transfer-engine.md
@@ -413,3 +413,5 @@ int init(const std::string &metadata_conn_string,
 - `MC_ENABLE_DEST_DEVICE_AFFINITY` 启用设备亲和性以优化 RDMA 性能。启用后，Transfer Engine 将优先选择和本地网卡同名的远端网卡进行通信，以减少 QP 数量并改善 Rail-optimized 拓扑中的网络性能。默认值为 false
 - `MC_FORCE_MNNVL` 强制使用 Multi-Node NVLink 作为主要传输方式，无论是否安装了有效的 RDMA 网卡
 - `MC_FORCE_TCP` 强制使用 TCP 作为主要传输方式，无论是否安装了有效的 RDMA 网卡
+- `MC_MIN_PRC_PORT` 指定 RPC 服务使用的最小端口号。默认值为 15000。
+- `MC_MAX_PRC_PORT` 指定 RPC 服务使用的最大端口号。默认值为 17000。

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -45,6 +45,8 @@ struct GlobalConfig {
     int log_level = google::INFO;
     bool trace = false;
     int64_t slice_timeout = -1;
+    uint16_t rpc_min_port = 15000;
+    uint16_t rpc_max_port = 17000;
     bool use_ipv6 = false;
     size_t fragment_limit = 16384;
     bool enable_dest_device_affinity = false;

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -239,6 +239,26 @@ void loadGlobalConfig(GlobalConfig &config) {
         }
     }
 
+    const char *min_port_env = std::getenv("MC_MIN_PRC_PORT");
+    if (min_port_env) {
+        int val = atoi(min_port_env);
+        if (val > 0 && val < 65536)
+            config.rpc_min_port = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_PRC_MIN_PORT";
+    }
+
+    const char *max_port_env = std::getenv("MC_MAX_PRC_PORT");
+    if (max_port_env) {
+        int val = atoi(max_port_env);
+        if (val > 0 && val < 65536)
+            config.rpc_max_port = val;
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_PRC_MAX_PORT";
+    }
+
     if (std::getenv("MC_USE_IPV6")) {
         config.use_ipv6 = true;
     }

--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -1111,8 +1111,8 @@ std::vector<std::string> findLocalIpAddresses() {
 uint16_t findAvailableTcpPort(int &sockfd) {
     static std::random_device rand_gen;
     std::uniform_int_distribution rand_dist;
-    const int min_port = 15000;
-    const int max_port = 17000;
+    const int min_port = globalConfig().rpc_min_port;
+    const int max_port = globalConfig().rpc_max_port;
     const int max_attempts = 500;
     bool use_ipv6 = globalConfig().use_ipv6;
 


### PR DESCRIPTION
Some servers restrict the allowed port range. It is better not to hardcode the PRC port range.