### PR TITLE
feat(store): Add multi threading handle page fault during segment allocation

### DIFF
--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -237,11 +237,7 @@ tl::expected<void, ErrorCode> PyClient::setup_internal(
             std::min(max_threads, std::max<size_t>(threads_by_size, 1));
 
         if (threads_by_size < 1 || num_threads == 1) {
-            // Too small to benefit from threading; touch inline.
-            for (size_t offset = 0; offset < segment_size;
-                 offset += page_size) {
-                static_cast<char *>(ptr)[offset] = 0;
-            }
+            // Too small to benefit from threading; Skip
         } else {
             std::vector<std::thread> threads;
             threads.reserve(num_threads);

--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -222,7 +222,6 @@ tl::expected<void, ErrorCode> PyClient::setup_internal(
             LOG(ERROR) << "Failed to allocate segment memory";
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
-
         if (this->protocol == "ascend") {
             ascend_segment_ptrs_.emplace_back(ptr);
         } else {

--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -222,6 +222,52 @@ tl::expected<void, ErrorCode> PyClient::setup_internal(
             LOG(ERROR) << "Failed to allocate segment memory";
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
+        // Prefault/touch pages to ensure backing memory is realized.
+        // - Cap threads by hardware_concurrency.
+        // - Ensure each thread handles at least 10 GiB; otherwise do it inline.
+        long ps = sysconf(_SC_PAGESIZE);
+        const size_t page_size = ps > 0 ? static_cast<size_t>(ps) : 4096;
+        constexpr size_t kMinBytesPerThread =
+            10ULL * 1024 * 1024 * 1024;  // 10 GiB
+        unsigned int hw = std::thread::hardware_concurrency();
+        if (hw == 0) hw = 1;
+        size_t max_threads = static_cast<size_t>(hw);
+        size_t threads_by_size = segment_size / kMinBytesPerThread;  // floor
+        size_t num_threads =
+            std::min(max_threads, std::max<size_t>(threads_by_size, 1));
+
+        if (threads_by_size < 1 || num_threads == 1) {
+            // Too small to benefit from threading; touch inline.
+            for (size_t offset = 0; offset < segment_size;
+                 offset += page_size) {
+                static_cast<char *>(ptr)[offset] = 0;
+            }
+        } else {
+            std::vector<std::thread> threads;
+            threads.reserve(num_threads);
+            for (size_t t = 0; t < num_threads; ++t) {
+                size_t start_offset = (t * segment_size) / num_threads;
+                size_t end_offset = ((t + 1) * segment_size) / num_threads;
+                // Align to page boundaries
+                start_offset =
+                    (start_offset + page_size - 1) & ~(page_size - 1);
+                end_offset = end_offset & ~(page_size - 1);
+                if (start_offset >= end_offset) continue;
+                threads.emplace_back(
+                    [ptr, start_offset, end_offset, page_size]() {
+                        for (size_t offset = start_offset; offset < end_offset;
+                             offset += page_size) {
+                            static_cast<char *>(ptr)[offset] = 0;
+                        }
+                    });
+            }
+            for (auto &thread : threads) {
+                if (thread.joinable()) {
+                    thread.join();
+                }
+            }
+        }
+
         if (this->protocol == "ascend") {
             ascend_segment_ptrs_.emplace_back(ptr);
         } else {

--- a/mooncake-transfer-engine/include/memory_location.h
+++ b/mooncake-transfer-engine/include/memory_location.h
@@ -31,8 +31,12 @@ struct MemoryLocationEntry {
     std::string location;
 };
 
+// If only_first_page is true, only the location of the first page will be
+// returned. Scan all pages may take a long time, so set only_first_page if only
+// the location of the first page is needed.
 const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
-                                                         size_t len);
+                                                         size_t len,
+                                                         bool only_first_page);
 
 const static std::string kWildcardLocation = "*";
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -73,9 +73,14 @@ class RdmaContext {
 
     int unregisterMemoryRegion(void *addr);
 
+    int preTouchMemory(void *addr, size_t length);
+
     uint32_t rkey(void *addr);
 
     uint32_t lkey(void *addr);
+
+   private:
+    int registerMemoryRegionInternal(void *addr, size_t length, int access, MemoryRegionMeta &mrMeta);
 
    public:
     bool active() const { return active_; }

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -80,7 +80,8 @@ class RdmaContext {
     uint32_t lkey(void *addr);
 
    private:
-    int registerMemoryRegionInternal(void *addr, size_t length, int access, MemoryRegionMeta &mrMeta);
+    int registerMemoryRegionInternal(void *addr, size_t length, int access,
+                                     MemoryRegionMeta &mrMeta);
 
    public:
     bool active() const { return active_; }

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -90,7 +90,7 @@ class RdmaTransport : public Transport {
    private:
     int allocateLocalSegmentID();
     
-    void preTouchMemory(void *addr, size_t length);
+    int preTouchMemory(void *addr, size_t length);
 
    public:
     int onSetupRdmaConnections(const HandShakeDesc &peer_desc,

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -89,6 +89,8 @@ class RdmaTransport : public Transport {
 
    private:
     int allocateLocalSegmentID();
+    
+    void preTouchMemory(void *addr, size_t length);
 
    public:
     int onSetupRdmaConnections(const HandShakeDesc &peer_desc,

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -89,7 +89,7 @@ class RdmaTransport : public Transport {
 
    private:
     int allocateLocalSegmentID();
-    
+
     int preTouchMemory(void *addr, size_t length);
 
    public:

--- a/mooncake-transfer-engine/src/memory_location.cpp
+++ b/mooncake-transfer-engine/src/memory_location.cpp
@@ -33,7 +33,8 @@ std::string genGpuNodeName(int node) {
 }
 
 const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
-                                                         size_t len) {
+                                                         size_t len,
+                                                         bool only_first_page) {
     std::vector<MemoryLocationEntry> entries;
 
 #ifdef USE_CUDA
@@ -56,7 +57,7 @@ const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
 
     // start and end address may not be page aligned.
     uintptr_t aligned_start = alignPage((uintptr_t)start);
-    long long n =
+    long long n = only_first_page ? 1 :
         (uintptr_t(start) - aligned_start + len + pagesize - 1) / pagesize;
     void **pages = (void **)malloc(sizeof(void *) * n);
     int *status = (int *)malloc(sizeof(int) * n);

--- a/mooncake-transfer-engine/src/memory_location.cpp
+++ b/mooncake-transfer-engine/src/memory_location.cpp
@@ -57,8 +57,11 @@ const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
 
     // start and end address may not be page aligned.
     uintptr_t aligned_start = alignPage((uintptr_t)start);
-    long long n = only_first_page ? 1 :
-        (uintptr_t(start) - aligned_start + len + pagesize - 1) / pagesize;
+    long long n =
+        only_first_page
+            ? 1
+            : (uintptr_t(start) - aligned_start + len + pagesize - 1) /
+                  pagesize;
     void **pages = (void **)malloc(sizeof(void *) * n);
     int *status = (int *)malloc(sizeof(int) * n);
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -198,7 +198,9 @@ int RdmaContext::deconstruct() {
     return 0;
 }
 
-int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length, int access, MemoryRegionMeta &mrMeta) {
+int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
+                                              int access,
+                                              MemoryRegionMeta &mrMeta) {
     if (length > (size_t)globalConfig().max_mr_size) {
         PLOG(WARNING) << "The buffer length exceeds device max_mr_size, "
                       << "shrink it to " << globalConfig().max_mr_size;
@@ -282,7 +284,8 @@ int RdmaContext::unregisterMemoryRegion(void *addr) {
 
 int RdmaContext::preTouchMemory(void *addr, size_t length) {
     MemoryRegionMeta mrMeta;
-    int ret = registerMemoryRegionInternal(addr, length, IBV_ACCESS_LOCAL_WRITE, mrMeta);
+    int ret = registerMemoryRegionInternal(addr, length, IBV_ACCESS_LOCAL_WRITE,
+                                           mrMeta);
     if (ret != 0) {
         return ret;
     }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -198,14 +198,12 @@ int RdmaContext::deconstruct() {
     return 0;
 }
 
-int RdmaContext::registerMemoryRegion(void *addr, size_t length, int access) {
+int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length, int access, MemoryRegionMeta &mrMeta) {
     if (length > (size_t)globalConfig().max_mr_size) {
         PLOG(WARNING) << "The buffer length exceeds device max_mr_size, "
                       << "shrink it to " << globalConfig().max_mr_size;
         length = (size_t)globalConfig().max_mr_size;
     }
-
-    MemoryRegionMeta mrMeta;
 #if !defined(WITH_NVIDIA_PEERMEM) && defined(USE_CUDA)
     // Implement register memory in a way that does not assume the presence of
     // nvidia-peermem. If memory is on CPU call ibv_reg_mr() as usual. If memory
@@ -246,7 +244,15 @@ int RdmaContext::registerMemoryRegion(void *addr, size_t length, int access) {
         PLOG(ERROR) << "Failed to register memory " << addr;
         return ERR_CONTEXT;
     }
+    return 0;
+}
 
+int RdmaContext::registerMemoryRegion(void *addr, size_t length, int access) {
+    MemoryRegionMeta mrMeta;
+    int ret = registerMemoryRegionInternal(addr, length, access, mrMeta);
+    if (ret != 0) {
+        return ret;
+    }
     RWSpinlock::WriteGuard guard(memory_regions_lock_);
     memory_region_list_.push_back(mrMeta);
     return 0;
@@ -272,6 +278,15 @@ int RdmaContext::unregisterMemoryRegion(void *addr) {
         }
     } while (has_removed);
     return 0;
+}
+
+int RdmaContext::preTouchMemory(void *addr, size_t length) {
+    MemoryRegionMeta mrMeta;
+    int ret = registerMemoryRegionInternal(addr, length, IBV_ACCESS_LOCAL_WRITE, mrMeta);
+    if (ret != 0) {
+        return ret;
+    }
+    return ibv_dereg_mr(mrMeta.mr);
 }
 
 uint32_t RdmaContext::rkey(void *addr) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -149,7 +149,11 @@ int RdmaTransport::registerLocalMemory(void *addr, size_t length,
         
         for (size_t i = 0; i < context_list_.size(); ++i) {
             reg_threads.emplace_back([this, &ret_codes, i, addr, length]() {
+                auto start_time_thread = std::chrono::high_resolution_clock::now();
                 ret_codes[i] = context_list_[i]->registerMemoryRegion(addr, length, access_rights);
+                auto end_time_thread = std::chrono::high_resolution_clock::now();
+                auto duration_thread = std::chrono::duration_cast<std::chrono::milliseconds>(end_time_thread - start_time_thread);
+                LOG(ERROR) << "\tregisterMemoryRegion execution time: " << duration_thread.count() << " ms";
             });
         }
         
@@ -201,7 +205,8 @@ int RdmaTransport::registerLocalMemory(void *addr, size_t length,
     }
     auto end_time2 = std::chrono::high_resolution_clock::now();
     auto duration2 = std::chrono::duration_cast<std::chrono::milliseconds>(end_time2 - end_time);
-    LOG(ERROR) << "metadata_->addLocalMemoryBuffer execution time: " << duration2.count() << " ms";
+    LOG(ERROR) << "getMemoryLocation + addLocalMemoryBuffer execution time: " << duration2.count() << " ms";
+    LOG(ERROR) << "total execution time: " << duration.count() + duration2.count() << " ms";
     return 0;
 }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -228,7 +228,8 @@ int RdmaTransport::registerLocalMemory(void *addr, size_t length,
     auto end_time2 = std::chrono::high_resolution_clock::now();
     auto duration2 = std::chrono::duration_cast<std::chrono::milliseconds>(end_time2 - end_time);
     LOG(ERROR) << "getMemoryLocation + addLocalMemoryBuffer execution time: " << duration2.count() << " ms";
-    LOG(ERROR) << "total execution time: " << std::chrono::duration_cast<std::chrono::milliseconds>(end_time2 - start_time_pre_touch).count() << " ms";
+    LOG(ERROR) << "total execution time: " << std::chrono::duration_cast<std::chrono::milliseconds>(end_time2 - start_time_pre_touch).count() << " ms"
+        << ", size: " << length * 1.0 / (1024 * 1024 * 1024) << " GB";
     return 0;
 }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -144,7 +144,7 @@ int RdmaTransport::registerLocalMemory(void *addr, size_t length,
         addr_maybe_on_device = true;
     }
 #endif
-
+    auto start_time_pre_touch = std::chrono::high_resolution_clock::now();
     bool do_pre_touch =
         context_list_.size() > 0 && std::thread::hardware_concurrency() >= 4 &&
         length >= (size_t)4 * 1024 * 1024 * 1024 && !addr_maybe_on_device;
@@ -228,7 +228,7 @@ int RdmaTransport::registerLocalMemory(void *addr, size_t length,
     auto end_time2 = std::chrono::high_resolution_clock::now();
     auto duration2 = std::chrono::duration_cast<std::chrono::milliseconds>(end_time2 - end_time);
     LOG(ERROR) << "getMemoryLocation + addLocalMemoryBuffer execution time: " << duration2.count() << " ms";
-    LOG(ERROR) << "total execution time: " << std::chrono::duration_cast<std::chrono::milliseconds>(end_time2 - start_time).count() << " ms";
+    LOG(ERROR) << "total execution time: " << std::chrono::duration_cast<std::chrono::milliseconds>(end_time2 - start_time_pre_touch).count() << " ms";
     return 0;
 }
 

--- a/mooncake-transfer-engine/tests/memory_location_test.cpp
+++ b/mooncake-transfer-engine/tests/memory_location_test.cpp
@@ -9,9 +9,10 @@
 TEST(MemoryLocationTest, MallocSimpleNode0) {
     int size = 4096 * 10;
     void *addr = numa_alloc_onnode(size, 0);
+    bool only_first_page = false;
     ASSERT_NE(addr, nullptr);
 
-    auto entries = mooncake::getMemoryLocation(addr, size);
+    auto entries = mooncake::getMemoryLocation(addr, size, only_first_page);
     ASSERT_EQ(entries.size(), static_cast<size_t>(1));
 
     // check the memory location, no node before page fault
@@ -22,7 +23,7 @@ TEST(MemoryLocationTest, MallocSimpleNode0) {
     // trigger page fault
     memset(addr, 0, size);
 
-    entries = mooncake::getMemoryLocation(addr, size);
+    entries = mooncake::getMemoryLocation(addr, size, only_first_page);
     ASSERT_EQ(entries.size(), static_cast<size_t>(1));
 
     // check the memory location, node 0 after page fault
@@ -43,10 +44,12 @@ TEST(MemoryLocationTest, MallocSimpleNodeLargest) {
     void *addr = numa_alloc_onnode(size, node);
     ASSERT_NE(addr, nullptr);
 
+    bool only_first_page = false;
+
     // trigger page fault
     memset(addr, 0, size);
 
-    auto entries = mooncake::getMemoryLocation(addr, size);
+    auto entries = mooncake::getMemoryLocation(addr, size, only_first_page);
     ASSERT_EQ(entries.size(), static_cast<size_t>(1));
 
     // check the memory location
@@ -70,6 +73,8 @@ TEST(MemoryLocationTest, MallocMultipleNodes) {
     ASSERT_NE(addr, nullptr);
     ASSERT_EQ((uint64_t)addr % 4096, static_cast<uint64_t>(0));  // page aligned
 
+    bool only_first_page = false;
+
     // trigger page fault
     memset(addr, 0, size);
 
@@ -89,7 +94,7 @@ TEST(MemoryLocationTest, MallocMultipleNodes) {
     // not page aligned
     void *start = (void *)((uint64_t)addr + 1024 * 2);
 
-    auto entries = mooncake::getMemoryLocation(start, size - 1024 * 4);
+    auto entries = mooncake::getMemoryLocation(start, size - 1024 * 4, only_first_page);
 
     if (nodea == nodeb) {
         // only one numa node

--- a/mooncake-transfer-engine/tests/memory_location_test.cpp
+++ b/mooncake-transfer-engine/tests/memory_location_test.cpp
@@ -94,7 +94,8 @@ TEST(MemoryLocationTest, MallocMultipleNodes) {
     // not page aligned
     void *start = (void *)((uint64_t)addr + 1024 * 2);
 
-    auto entries = mooncake::getMemoryLocation(start, size - 1024 * 4, only_first_page);
+    auto entries =
+        mooncake::getMemoryLocation(start, size - 1024 * 4, only_first_page);
 
     if (nodea == nodeb) {
         // only one numa node


### PR DESCRIPTION
bench mount 180GB segment
main: 74s
this pr: 46s(31s for register RDMA)

A 10GB threshold is necessary. I've tried with 1GB, and having too many threads actually slows things down. 10GB works pretty well in testing.

This will greatly improve the experience for users mounting TB-sized segments, helping them start up much faster.

related issue #848 