### PR TITLE
fix(store): fix memory leak in client_integration_test.cpp

### DIFF
--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -142,6 +142,14 @@ class ClientIntegrationTest : public ::testing::Test {
         if (segment_provider_client_) {
             segment_provider_client_.reset();
         }
+
+        // Free segment memory
+        if (test_client_segment_ptr_) {
+            free(test_client_segment_ptr_);
+        }
+        if (segment_ptr_) {
+            free(segment_ptr_);
+        }
     }
 
     static void CleanupSegment() {


### PR DESCRIPTION
This PR fixes the memory leak in client_integration_test.cpp caused by not freeing allocated segments.