### PR TITLE
[Store] Check if Connecting Master Fails

### DIFF
--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -46,7 +46,7 @@ store.setup(
     128*1024*1024,          # 128MB local buffer
     "tcp",                             # Use TCP (RDMA for high performance)
     "",                            # Leave empty; Mooncake auto-picks RDMA devices when needed
-    "localhost"        # Master service
+    "localhost:50051"        # Master service
 )
 
 # 3. Store data

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -80,6 +80,8 @@ class WrappedMasterService {
 
     tl::expected<PingResponse, ErrorCode> Ping(const UUID& client_id);
 
+    tl::expected<bool, ErrorCode> ServiceReady();
+
    private:
     MasterService master_service_;
     std::thread metric_report_thread_;

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -80,7 +80,7 @@ class WrappedMasterService {
 
     tl::expected<PingResponse, ErrorCode> Ping(const UUID& client_id);
 
-    tl::expected<bool, ErrorCode> ServiceReady();
+    tl::expected<void, ErrorCode> ServiceReady();
 
    private:
     MasterService master_service_;

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -14,8 +14,6 @@
 #include "types.h"
 #include "utils/scoped_vlog_timer.h"
 
-#include <source_location>
-
 namespace mooncake {
 
 template <auto Method>
@@ -116,6 +114,11 @@ struct RpcNameTraits<&WrappedMasterService::GetFsdir> {
     static constexpr const char* value = "GetFsdir";
 };
 
+template <>
+struct RpcNameTraits<&WrappedMasterService::ServiceReady> {
+    static constexpr const char* value = "ServiceReady";
+};
+
 template <auto ServiceMethod, typename ReturnType, typename... Args>
 tl::expected<ReturnType, ErrorCode> MasterClient::invoke_rpc(Args&&... args) {
     auto pool = client_accessor_.GetClientPool();
@@ -209,19 +212,25 @@ ErrorCode MasterClient::Connect(const std::string& master_addr) {
     ScopedVLogTimer timer(1, "MasterClient::Connect");
     timer.LogRequest("master_addr=", master_addr);
 
-    auto location = std::source_location::current();
-    auto name = location.function_name();
-    LOG(INFO) << "Connecting to master at " << master_addr << " from " << name;
-
     MutexLocker lock(&connect_mutex_);
     if (client_addr_param_ != master_addr) {
-        lock.unlock();
-        // add a new client pool to client pools.
+        // WARNING: The existing client pool cannot be erased. So if there are a
+        // lot of different addresses, there will be resource leak problems.
         auto client_pool = client_pools_->at(master_addr);
-        lock.lock();
-        client_addr_param_ = master_addr;
-        lock.unlock();
         client_accessor_.SetClientPool(client_pool);
+        client_addr_param_ = master_addr;
+    }
+    auto pool = client_accessor_.GetClientPool();
+    // The client pool does not have native connection check method, so we need
+    // to use custom ServiceReady API.
+    auto result = invoke_rpc<&WrappedMasterService::ServiceReady, bool>();
+    if (!result.has_value()) {
+        timer.LogResponse("error_code=", result.error());
+        return result.error();
+    }
+    if (!result.value()) {
+        timer.LogResponse("error_code=", ErrorCode::RPC_FAIL);
+        return ErrorCode::RPC_FAIL;
     }
     timer.LogResponse("error_code=", ErrorCode::OK);
     return ErrorCode::OK;

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -223,14 +223,10 @@ ErrorCode MasterClient::Connect(const std::string& master_addr) {
     auto pool = client_accessor_.GetClientPool();
     // The client pool does not have native connection check method, so we need
     // to use custom ServiceReady API.
-    auto result = invoke_rpc<&WrappedMasterService::ServiceReady, bool>();
+    auto result = invoke_rpc<&WrappedMasterService::ServiceReady, void>();
     if (!result.has_value()) {
         timer.LogResponse("error_code=", result.error());
         return result.error();
-    }
-    if (!result.value()) {
-        timer.LogResponse("error_code=", ErrorCode::RPC_FAIL);
-        return ErrorCode::RPC_FAIL;
     }
     timer.LogResponse("error_code=", ErrorCode::OK);
     return ErrorCode::OK;

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -527,6 +527,11 @@ tl::expected<PingResponse, ErrorCode> WrappedMasterService::Ping(
     return result;
 }
 
+tl::expected<bool, ErrorCode> WrappedMasterService::ServiceReady() {
+    // Simply return true to indicate the service is ready
+    return true;
+}
+
 void RegisterRpcService(
     coro_rpc::coro_rpc_server& server,
     mooncake::WrappedMasterService& wrapped_master_service) {
@@ -569,6 +574,8 @@ void RegisterRpcService(
     server.register_handler<&mooncake::WrappedMasterService::GetFsdir>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchExistKey>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::ServiceReady>(
         &wrapped_master_service);
 }
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -527,9 +527,8 @@ tl::expected<PingResponse, ErrorCode> WrappedMasterService::Ping(
     return result;
 }
 
-tl::expected<bool, ErrorCode> WrappedMasterService::ServiceReady() {
-    // Simply return true to indicate the service is ready
-    return true;
+tl::expected<void, ErrorCode> WrappedMasterService::ServiceReady() {
+    return {};
 }
 
 void RegisterRpcService(


### PR DESCRIPTION
1. WARNING: The existing client pool cannot be erased. So if there are a lot of different addresses, there will be resource leak problems.
2. When creating a new client pool using the at interface of pools, there is no return value indicating whether the connection was successful. Currently, our workaround is to create a dedicated API on the remote server to test connectivity. 

Related issue: https://github.com/alibaba/yalantinglibs/issues/1078