### PR TITLE
[Store]: Add option to use jemalloc in mooncake store master

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,7 +20,11 @@ RUN apt-get install -y libibverbs-dev \
     protobuf-compiler-grpc \
     pybind11-dev \
     libcurl4-openssl-dev \
-    libhiredis-dev
+    libhiredis-dev \
+    libyaml-cpp-dev \
+    libjemalloc-dev \
+    pkg-config \
+    patchelf
 
 RUN wget https://go.dev/dl/go1.22.12.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go1.22.12.linux-amd64.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,11 @@ if (STORE_USE_ETCD)
   add_compile_definitions(STORE_USE_ETCD)
 endif()
 
+option(STORE_USE_JEMALLOC "Use jemalloc in mooncake store master" OFF)
+if (STORE_USE_JEMALLOC)
+  add_compile_definitions(STORE_USE_JEMALLOC)
+endif()
+
 add_subdirectory(mooncake-common)
 include_directories(mooncake-common/etcd)
 include_directories(mooncake-common/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,6 @@ if (STORE_USE_ETCD)
 endif()
 
 option(STORE_USE_JEMALLOC "Use jemalloc in mooncake store master" OFF)
-if (STORE_USE_JEMALLOC)
-  add_compile_definitions(STORE_USE_JEMALLOC)
-endif()
 
 add_subdirectory(mooncake-common)
 include_directories(mooncake-common/etcd)

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -120,6 +120,7 @@ SYSTEM_PACKAGES="build-essential \
                   protobuf-compiler-grpc \
                   libcurl4-openssl-dev \
                   libhiredis-dev \
+                  libjemalloc-dev \
                   pkg-config \
                   patchelf"
 

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -50,13 +50,27 @@ endif()
 
 # Master binary
 add_executable(mooncake_master master.cpp)
+
+set(MASTER_EXTRA_INCS "")
+set(MASTER_EXTRA_LIBS "")
+
+if (STORE_USE_JEMALLOC)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(JEMALLOC REQUIRED jemalloc)
+    list(APPEND MASTER_EXTRA_INCS ${JEMALLOC_INCLUDE_DIRS})
+    list(APPEND MASTER_EXTRA_LIBS ${JEMALLOC_STATIC_LIBRARIES})
+endif()
+
+target_include_directories(mooncake_master PRIVATE ${MASTER_EXTRA_INCS})
 target_link_libraries(mooncake_master PRIVATE
     mooncake_store
     cachelib_memory_allocator
     pthread
     mooncake_common
     ${ETCD_WRAPPER_LIB}
+    ${MASTER_EXTRA_LIBS}
 )
+
 if (STORE_USE_ETCD)
     add_dependencies(mooncake_master build_etcd_wrapper)
 endif()

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -51,8 +51,8 @@ endif()
 # Master binary
 add_executable(mooncake_master master.cpp)
 
-set(MASTER_EXTRA_INCS "")
-set(MASTER_EXTRA_LIBS "")
+set(MASTER_EXTRA_INCS)
+set(MASTER_EXTRA_LIBS)
 
 if (STORE_USE_JEMALLOC)
     find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
With more tests and analysis, we found that the root cause of #834 is serious memory fragmentation.

Insertion and deletion of metadata in Mooncake Master are accompanied by allocation and deallocation of small memory objects (typically hundreds of bytes). With large amount of metadata being inserted and removed, the memory space of Master gets seriously fragmented, resulting in unexpected memory consumption.

Using a more modern memory allocator (i.e. [jemalloc](https://jemalloc.net/)) can effectively alleviate this problem. Here is a comparision between the default libc allocator and jemalloc:

Test script:

```bash
#!/bin/bash

# Specify the file path to store the result.
output_file=$1

top -b -n 1 -w 512 | grep mooncake_master >> $output_file
for ((i=0; i<10; i++)); do
    python3 mooncake-store/tests/stress_cluster_benchmark.py \
        --role=prefill --metadata-server=P2PHANDSHAKE --protocol=rdma \
        --device-name=mlx5_bond_0 --local-hostname=127.0.0.1:8081 \
        --local-buffer-size=1024 --global-segment-size=32768 \
        --max-requests=33554432 --value-length=1024 --batch-size=4096 \
        --wait-time=0
    # Sleep for a while to let master calm down.
    sleep 30
    top -b -n 1 -w 512 | grep mooncake_master >> $output_file
done
```

Test results:

| Round | glibc malloc mem usage | glibc malloc performance | jemalloc mem usage | jemalloc performance |
|:-:|:-:|:-:|:-:|:-:|
|0| 37760 | - | 22468 | - |
|1| 9.3g  | 126.98 MB/s |  7.6g | 134.65 MB/s |
|2| 18.4g | 132.49 MB/s |  7.8g | 143.53 MB/s |
|3| 18.4g | 137.45 MB/s | 14.9g | 150.32 MB/s |
|4| 18.4g | 148.84 MB/s | 14.9g | 140.36 MB/s |
|5| 18.4g | 135.92 MB/s | 14.8g | 145.69 MB/s |
|6| 18.4g | 152.01 MB/s |  7.9g | 142.08 MB/s |
|7| 18.4g | 148.36 MB/s |  7.7g | 144.45 MB/s |
|8| 18.4g | 148.53 MB/s | 14.8g | 139.66 MB/s |
|9| 18.4g | 140.32 MB/s | 15.0g | 146.60 MB/s |
|10| 18.4g | 140.91 MB/s | 14.9g | 140.92 MB/s |
