### PR TITLE
[TransferEngine] initiator_test script: make it works with P2PHANDSHAKE.

### DIFF
--- a/mooncake-wheel/tests/transfer_engine_initiator_test.py
+++ b/mooncake-wheel/tests/transfer_engine_initiator_test.py
@@ -23,7 +23,7 @@ class TestVLLMAdaptorTransfer(unittest.TestCase):
             raise RuntimeError(f"Initialization failed with code {ret}")
 
         if cls.metadata_server == "P2PHANDSHAKE":
-            cls.initiator_server_name = cls.initiator_server_name.split(":")[0] + ":" + str(cls.adaptor.get_rpc_port())
+            cls.initiator_server_name = cls.initiator_server_name.rpartition(':')[0] + ":" + str(cls.adaptor.get_rpc_port())
 
 
     def test_random_write_circle_times(self):


### PR DESCRIPTION
WIth this PR, we could do test with P2PHANDSHAKE, i.e.
```
MC_METADATA_SERVER=P2PHANDSHAKE TARGET_SERVER_NAME=$LOCALIP:12345 PROTOCOL=rdma python3 target.py

TARGET_SERVER_NAME=$TARGETIPPORT INITIATOR_SERVER_NAME=$LOCALIP:12347 MC_METADATA_SERVER=P2PHANDSHAKE PROTOCOL=rdma python3 initiator_test.py
```