### PR TITLE
fix(store): Fix integer overflow in get_into/batch_get_into for values > 4GB

### DIFF
--- a/mooncake-store/include/pybind_client.h
+++ b/mooncake-store/include/pybind_client.h
@@ -118,8 +118,8 @@ class PyClient {
      * @param keys Vector of keys of the objects to get
      * @param buffers Vector of pointers to the pre-allocated buffers
      * @param sizes Vector of sizes of the buffers
-     * @return Vector of integers, where each element is the number of bytes
-     * read on success, or a negative value on error
+     * @return Vector of 64-bit integers, where each element is the number of
+     * bytes read on success, or a negative value on error
      * @note The buffer addresses must be previously registered with
      * register_buffer() for zero-copy operations
      */

--- a/mooncake-store/include/pybind_client.h
+++ b/mooncake-store/include/pybind_client.h
@@ -110,7 +110,7 @@ class PyClient {
      * @note The buffer address must be previously registered with
      * register_buffer() for zero-copy operations
      */
-    int get_into(const std::string &key, void *buffer, size_t size);
+    int64_t get_into(const std::string &key, void *buffer, size_t size);
 
     /**
      * @brief Get object data directly into pre-allocated buffers for multiple
@@ -123,9 +123,9 @@ class PyClient {
      * @note The buffer addresses must be previously registered with
      * register_buffer() for zero-copy operations
      */
-    std::vector<int> batch_get_into(const std::vector<std::string> &keys,
-                                    const std::vector<void *> &buffers,
-                                    const std::vector<size_t> &sizes);
+    std::vector<int64_t> batch_get_into(const std::vector<std::string> &keys,
+                                        const std::vector<void *> &buffers,
+                                        const std::vector<size_t> &sizes);
 
     /**
      * @brief Put object data directly from a pre-allocated buffer

--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -835,7 +835,7 @@ tl::expected<int64_t, ErrorCode> PyClient::get_into_internal(
     return static_cast<int64_t>(total_size);
 }
 
-int PyClient::get_into(const std::string &key, void *buffer, size_t size) {
+int64_t PyClient::get_into(const std::string &key, void *buffer, size_t size) {
     return to_py_ret(get_into_internal(key, buffer, size));
 }
 
@@ -951,11 +951,11 @@ int PyClient::put_from(const std::string &key, void *buffer, size_t size,
     return to_py_ret(put_from_internal(key, buffer, size, config));
 }
 
-std::vector<int> PyClient::batch_get_into(const std::vector<std::string> &keys,
-                                          const std::vector<void *> &buffers,
-                                          const std::vector<size_t> &sizes) {
+std::vector<int64_t> PyClient::batch_get_into(
+    const std::vector<std::string> &keys, const std::vector<void *> &buffers,
+    const std::vector<size_t> &sizes) {
     auto internal_results = batch_get_into_internal(keys, buffers, sizes);
-    std::vector<int> results;
+    std::vector<int64_t> results;
     results.reserve(internal_results.size());
 
     for (const auto &result : internal_results) {

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -305,7 +305,8 @@ TEST_F(PyClientTest, ConcurrentPutGetWithLeaseTimeOut) {
                             key, get_data.data(), slice_size);
                         if (bytes_read > 0) {
                             // Verify the retrieved data matches the put data
-                            ASSERT_EQ(bytes_read, static_cast<int>(slice_size))
+                            ASSERT_EQ(bytes_read,
+                                      static_cast<int64_t>(slice_size))
                                 << "Bytes read should match slice size for "
                                    "thread "
                                 << thread_idx;


### PR DESCRIPTION
## Problem

The `get_into()` and `batch_get_into()` methods had an integer overflow bug when handling values larger than 4GB:

- Both methods returned `int` (32-bit signed integer, max ~2.1GB)
- When the value size exceeded it, integer overflow occurred
- This caused incorrect results to be returned to the caller

## Solution

Changed the return types to use `int64_t` instead of `int`:

- `get_into()`: `int` → `int64_t`
- `batch_get_into()`: `std::vector<int>` → `std::vector<int64_t>`

This allows handling values up to ~9.2 exabytes (2^63 - 1), which is more than sufficient for any realistic use case.

## Changes

### Modified Files

1. **mooncake-store/include/pybind_client.h**
   - Updated `get_into()` return type to `int64_t`
   - Updated `batch_get_into()` return type to `std::vector<int64_t>`

2. **mooncake-store/src/pybind_client.cpp**
   - Updated implementations to match new signatures

3. **mooncake-store/tests/pybind_client_test.cpp**
   - Updated test assertions to use `int64_t`

## Testing

- ✅ All existing unit tests pass
- ✅ Code compiles without errors or warnings
- ✅ Backward compatible for values < 2GB

## Additional Notes

- The internal implementations (`get_into_internal` and `batch_get_into_internal`) already used `int64_t`, so this change aligns the public API with the internal implementation
- Python bindings automatically handle `int64_t` → Python `int` conversion via pybind11
- Searched the entire codebase for similar patterns - no other integer overflow issues found
- Testing with 4GB+ values is not feasible in CI due to memory constraints, but the type change ensures correctness

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author