### PR TITLE
Reduced build-with-ep workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,6 @@ jobs:
         sub-packages: '["nvcc", "nvrtc-dev"]'
         non-cuda-sub-packages: '["libcusparse-dev", "libcublas-dev", "libcusolver-dev"]'
 
-
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
 


### PR DESCRIPTION
In CI process "build-with-ep" workflow, there will be a possibility of running out of disk space.
So I made some changes:
1. restrict SCCACHE_CACHE_SIZE to 2GB
2. removed some CUDA packages
3. change torch installation to --no-cache
