### PR TITLE
[Misc] Fix the shutdown logic of Mooncake Backend

### DIFF
--- a/mooncake-ep/include/mooncake_backend.h
+++ b/mooncake-ep/include/mooncake_backend.h
@@ -23,7 +23,7 @@ class MooncakeBackend final : public ::c10d::Backend {
                     c10::intrusive_ptr<MooncakeBackendOptions> options,
                     bool isCpu = false);
 
-    ~MooncakeBackend() override;
+    ~MooncakeBackend() override = default;
 
     const std::string getBackendName() const override;
 
@@ -55,6 +55,8 @@ class MooncakeBackend final : public ::c10d::Backend {
 
     c10::intrusive_ptr<c10d::Work> barrier(
         const c10d::BarrierOptions& opts) override;
+
+    void shutdown() override;
 
     static void setHostIp(const std::string& hostIp) { hostIp_ = hostIp; }
 


### PR DESCRIPTION
**This PR solves memory leaks that occurs after destroy_process_group.**

While the previous code may not cause errors in current usages, I would still like it to be merged for safety.

The cleanup logic of the MooncakeBackend should be implemented in `shutdown()`

Along with a couple of fixes regarding synchronization