### PR TITLE
[TransferEngine] Conditionally enable SO_REUSEADDR in handshake daemon

### DIFF
--- a/mooncake-transfer-engine/include/transfer_metadata_plugin.h
+++ b/mooncake-transfer-engine/include/transfer_metadata_plugin.h
@@ -43,7 +43,8 @@ struct HandShakePlugin {
     using OnReceiveCallBack =
         std::function<int(const Json::Value &, Json::Value &)>;
 
-    virtual int startDaemon(uint16_t listen_port, int sockfd) = 0;
+    virtual int startDaemon(uint16_t listen_port, int sockfd,
+                            bool reuse_addr) = 0;
 
     // Connect to peer endpoint, and wait for receiving
     // peer endpoint's attributes


### PR DESCRIPTION
## Summary
Enable SO_REUSEADDR for the handshake listener when appropriate to reduce bind failures during rapid restarts or legacy port reuse.

## Changes
- API: HandShakePlugin::startDaemon now accepts a new parameter `bool reuse_addr`.
- transfer_metadata.cpp:
  - In P2P handshake mode, call `startDaemon(..., /*reuse_addr=*/true)`.
  - For non-P2P, derive `reuse_addr` from env `MC_LEGACY_RPC_PORT_BINDING`.
- transfer_metadata_plugin.cpp:
  - If `reuse_addr` is true, set `SO_REUSEADDR` on the listener socket.

## Motivation
Avoid "address already in use" errors on restarts or when legacy port binding semantics are needed, improving robustness of metadata handshake.

## Behavior & Compatibility
- Runtime behavior unchanged by default; `SO_REUSEADDR` is enabled only in P2P mode or when `MC_LEGACY_RPC_PORT_BINDING` is set.
- Compile-time breaking change for custom HandShakePlugin implementations (signature updated). Implementations must add the `reuse_addr` parameter.

## Notes
- Env toggle: `MC_LEGACY_RPC_PORT_BINDING` to force reuse in non-P2P mode.
