### PR TITLE
fix(transfer_engine): replace deprecated Json::Reader 

### DIFF
--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_store_test(pybind_client_test pybind_client_test.cpp)
 add_store_test(client_metrics_test client_metrics_test.cpp)
 add_store_test(serializer_test serializer_test.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
+
 add_subdirectory(e2e)
 
 add_executable(high_availability_test high_availability_test.cpp)

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -264,9 +264,20 @@ int Topology::discover(const std::vector<std::string> &filter) {
 int Topology::parse(const std::string &topology_json) {
     std::set<std::string> rnic_set;
     Json::Value root;
-    Json::Reader reader;
 
-    if (topology_json.empty() || !reader.parse(topology_json, root)) {
+    if (topology_json.empty()) {
+        return ERR_MALFORMED_JSON;
+    }
+
+    // Use thread-safe CharReaderBuilder instead of deprecated Reader
+    Json::CharReaderBuilder builder;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+    std::string errs;
+
+    if (!reader->parse(topology_json.data(),
+                       topology_json.data() + topology_json.size(), &root,
+                       &errs)) {
+        LOG(ERROR) << "Topology::parse: JSON parse error: " << errs;
         return ERR_MALFORMED_JSON;
     }
 
@@ -303,8 +314,17 @@ std::string Topology::toString() const {
 
 Json::Value Topology::toJson() const {
     Json::Value root;
-    Json::Reader reader;
-    reader.parse(toString(), root);
+    std::string json_str = toString();
+
+    // Use thread-safe CharReaderBuilder instead of deprecated Reader
+    Json::CharReaderBuilder builder;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+    std::string errs;
+
+    if (!reader->parse(json_str.data(), json_str.data() + json_str.size(),
+                       &root, &errs)) {
+        LOG(ERROR) << "Topology::toJson: JSON parse error: " << errs;
+    }
     return root;
 }
 

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -314,16 +314,8 @@ std::string Topology::toString() const {
 
 Json::Value Topology::toJson() const {
     Json::Value root;
-    std::string json_str = toString();
-
-    // Use thread-safe CharReaderBuilder instead of deprecated Reader
-    Json::CharReaderBuilder builder;
-    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
-    std::string errs;
-
-    if (!reader->parse(json_str.data(), json_str.data() + json_str.size(),
-                       &root, &errs)) {
-        LOG(ERROR) << "Topology::toJson: JSON parse error: " << errs;
+    for (const auto &pair : matrix_) {
+        root[pair.first] = pair.second.toJson();
     }
     return root;
 }

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -47,7 +47,6 @@ struct TransferNotifyUtil {
     }
 
     static int decode(Json::Value root, TransferMetadata::NotifyDesc &desc) {
-        Json::Reader reader;
         desc.name = root["name"].asString();
         desc.notify_msg = root["notify_msg"].asString();
         return 0;
@@ -67,7 +66,6 @@ struct TransferHandshakeUtil {
     }
 
     static int decode(Json::Value root, TransferMetadata::HandShakeDesc &desc) {
-        Json::Reader reader;
         desc.local_nic_path = root["local_nic_path"].asString();
         desc.peer_nic_path = root["peer_nic_path"].asString();
         for (const auto &qp : root["qp_num"])

--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -49,6 +49,21 @@
 #include "config.h"
 #include "error.h"
 
+// Helper function to parse JSON string using thread-safe CharReaderBuilder
+static bool parseJsonString(const std::string &json_str, Json::Value &value,
+                            std::string *error_msg = nullptr) {
+    Json::CharReaderBuilder builder;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+    std::string errs;
+
+    bool success = reader->parse(
+        json_str.data(), json_str.data() + json_str.size(), &value, &errs);
+    if (!success && error_msg) {
+        *error_msg = errs;
+    }
+    return success;
+}
+
 namespace mooncake {
 #ifdef USE_REDIS
 struct RedisStoragePlugin : public MetadataStoragePlugin {
@@ -118,7 +133,6 @@ struct RedisStoragePlugin : public MetadataStoragePlugin {
         std::lock_guard<std::mutex> lock(access_client_mutex_);
         if (!client_) return false;
 
-        Json::Reader reader;
         redisReply *resp =
             (redisReply *)redisCommand(client_, "GET %s", key.c_str());
         if (!resp) {
@@ -135,7 +149,12 @@ struct RedisStoragePlugin : public MetadataStoragePlugin {
 
         auto json_file = std::string(resp->str);
         freeReplyObject(resp);
-        if (!reader.parse(json_file, value)) return false;
+
+        std::string errs;
+        if (!parseJsonString(json_file, value, &errs)) {
+            LOG(ERROR) << "RedisStoragePlugin: JSON parse error: " << errs;
+            return false;
+        }
         return true;
     }
 
@@ -374,7 +393,6 @@ struct EtcdStoragePlugin : public MetadataStoragePlugin {
     virtual ~EtcdStoragePlugin() {}
 
     virtual bool get(const std::string &key, Json::Value &value) {
-        Json::Reader reader;
         auto resp = client_.get(key);
         if (!resp.is_ok()) {
             LOG(ERROR) << "EtcdStoragePlugin: unable to get " << key << " from "
@@ -382,7 +400,12 @@ struct EtcdStoragePlugin : public MetadataStoragePlugin {
             return false;
         }
         auto json_file = resp.value().as_string();
-        if (!reader.parse(json_file, value)) return false;
+
+        std::string errs;
+        if (!parseJsonString(json_file, value, &errs)) {
+            LOG(ERROR) << "EtcdStoragePlugin: JSON parse error: " << errs;
+            return false;
+        }
         return true;
     }
 
@@ -429,7 +452,6 @@ struct EtcdStoragePlugin : public MetadataStoragePlugin {
     virtual ~EtcdStoragePlugin() { EtcdCloseWrapper(); }
 
     virtual bool get(const std::string &key, Json::Value &value) {
-        Json::Reader reader;
         char *json_data = nullptr;
         auto ret = EtcdGetWrapper((char *)key.c_str(), &json_data, &err_msg_);
         if (ret) {
@@ -446,7 +468,12 @@ struct EtcdStoragePlugin : public MetadataStoragePlugin {
         auto json_file = std::string(json_data);
         // free the memory allocated by EtcdGetWrapper
         free(json_data);
-        if (!reader.parse(json_file, value)) return false;
+
+        std::string errs;
+        if (!parseJsonString(json_file, value, &errs)) {
+            LOG(ERROR) << "EtcdStoragePlugin: JSON parse error: " << errs;
+            return false;
+        }
         return true;
     }
 
@@ -716,16 +743,16 @@ struct SocketHandShakePlugin : public HandShakePlugin {
                     getNetworkAddress((struct sockaddr *)&addr);
 
                 Json::Value local, peer;
-                Json::Reader reader;
 
                 auto [type, json_str] = readString(conn_fd);
-                if (!reader.parse(json_str, peer)) {
-                    LOG(ERROR) << "SocketHandShakePlugin: failed to receive "
-                                  "handshake message, "
-                                  "malformed json format:"
-                               << reader.getFormattedErrorMessages()
-                               << ", json string length: " << json_str.size()
-                               << ", json string content: " << json_str;
+                std::string errs;
+                if (!parseJsonString(json_str, peer, &errs)) {
+                    LOG(ERROR)
+                        << "SocketHandShakePlugin: failed to receive "
+                           "handshake message, "
+                           "malformed json format: "
+                        << errs << ", json string length: " << json_str.size()
+                        << ", json string content: " << json_str;
                     close(conn_fd);
                     continue;
                 }
@@ -906,7 +933,6 @@ struct SocketHandShakePlugin : public HandShakePlugin {
             return ret;
         }
 
-        Json::Reader reader;
         auto [type, json_str] = readString(conn_fd);
         if (type != HandShakeRequestType::Connection) {
             LOG(ERROR)
@@ -915,10 +941,11 @@ struct SocketHandShakePlugin : public HandShakePlugin {
             return ERR_SOCKET;
         }
 
-        if (!reader.parse(json_str, peer)) {
+        std::string errs;
+        if (!parseJsonString(json_str, peer, &errs)) {
             LOG(ERROR) << "SocketHandShakePlugin: failed to receive handshake "
-                          "message: "
-                          "malformed json format, check tcp connection";
+                          "message: malformed json format: "
+                       << errs;
             close(conn_fd);
             return ERR_MALFORMED_JSON;
         }
@@ -981,7 +1008,6 @@ struct SocketHandShakePlugin : public HandShakePlugin {
             return ret;
         }
 
-        Json::Reader reader;
         auto [type, json_str] = readString(conn_fd);
         if (type != HandShakeRequestType::Notify) {
             LOG(ERROR)
@@ -993,10 +1019,11 @@ struct SocketHandShakePlugin : public HandShakePlugin {
         // LOG(INFO) << "SocketHandShakePlugin: received metadata message: "
         //           << json_str;
 
-        if (!reader.parse(json_str, peer_notify)) {
+        std::string errs;
+        if (!parseJsonString(json_str, peer_notify, &errs)) {
             LOG(ERROR) << "SocketHandShakePlugin: failed to receive metadata "
                           "message, malformed json format: "
-                       << reader.getFormattedErrorMessages();
+                       << errs;
             close(conn_fd);
             return ERR_MALFORMED_JSON;
         }
@@ -1023,7 +1050,6 @@ struct SocketHandShakePlugin : public HandShakePlugin {
             return ret;
         }
 
-        Json::Reader reader;
         auto [type, json_str] = readString(conn_fd);
         if (type != HandShakeRequestType::Metadata) {
             LOG(ERROR)
@@ -1035,10 +1061,11 @@ struct SocketHandShakePlugin : public HandShakePlugin {
         // LOG(INFO) << "SocketHandShakePlugin: received metadata message: "
         //           << json_str;
 
-        if (!reader.parse(json_str, peer_metadata)) {
+        std::string errs;
+        if (!parseJsonString(json_str, peer_metadata, &errs)) {
             LOG(ERROR) << "SocketHandShakePlugin: failed to receive metadata "
                           "message, malformed json format: "
-                       << reader.getFormattedErrorMessages();
+                       << errs;
             close(conn_fd);
             return ERR_MALFORMED_JSON;
         }


### PR DESCRIPTION
## Problem

The deprecated `Json::Reader` class uses static global variables internally, causing race conditions and memory corruption in multi-threaded scenarios. This led to intermittent CI crashes with symptoms including:
- Segmentation faults
- Double free or corruption errors  
- JSON parse failures in concurrent tests

## Solution

Replaced all `Json::Reader` usage with the thread-safe `Json::CharReaderBuilder` API across:
- `mooncake-transfer-engine`: transfer_metadata_plugin, transfer_metadata, topology
- `mooncake-common`: default_config

## Testing

Verified the fix resolves the issue:
- ✅ `ConcurrentPutGetWithLeaseTimeOut` test passes consistently (3/3 runs)
- ✅ All basic tests pass without crashes
- ✅ Thread-safe JSON parsing validated

This should eliminate the small probability CI crashes in concurrent scenarios.