### PR TITLE
Bugfix issue 946

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -392,16 +392,16 @@ static inline int ipv6_addr_v4mapped(const struct in6_addr *a) {
             ((a->s6_addr32[1] | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL));
 }
 
-
-static std::string readGidNdev(const std::string &device_name, uint8_t port, int gid_index) {
-    std::string sysfs_path = "/sys/class/infiniband/" + device_name + 
-                             "/ports/" + std::to_string(port) + 
+static std::string readGidNdev(const std::string &device_name, uint8_t port,
+                               int gid_index) {
+    std::string sysfs_path = "/sys/class/infiniband/" + device_name +
+                             "/ports/" + std::to_string(port) +
                              "/gid_attrs/ndevs/" + std::to_string(gid_index);
     std::ifstream file(sysfs_path);
     if (!file.is_open()) {
         return "";
     }
-    
+
     std::string ndev;
     std::getline(file, ndev);
     return ndev;
@@ -420,9 +420,8 @@ int RdmaContext::getBestGidIndex(const std::string &device_name,
                         << "/" << port;
             continue;  // if gid is invalid ibv_query_gid_ex() will return !0
         }
-        
-        if ((ipv6_addr_v4mapped(
-                 (struct in6_addr *)gid_entry.gid.raw) &&
+
+        if ((ipv6_addr_v4mapped((struct in6_addr *)gid_entry.gid.raw) &&
              gid_entry.gid_type == IBV_GID_TYPE_ROCE_V2) ||
             gid_entry.gid_type == IBV_GID_TYPE_IB) {
             // Check if this GID has an associated network device


### PR DESCRIPTION

### 问题描述
当前的 getBestGidIndex() 函数会选择第一个符合条件的 GID（IPv4-mapped + RoCE v2 或 IB 类型）。但在有多个符合条件的 GID 时，可能会选到不属于本机网络接口的 GID。

#### 实际场景：

GID[3]: ::ffff:26.208.8.250, RoCE v2  (不是本机 IP)
GID[7]: ::ffff:26.208.8.252, RoCE v2  (本机 eth1 的 IP)
当前逻辑会选择 GID[3] 并立即返回，但实际应该选择 GID[7]。

###解决方案
我考虑了两种修复方式：
**方式一：从 sysfs 读取网络设备信息（已采用）**
- 读取 /sys/class/infiniband/{dev}/ports/{port}/gid_attrs/ndevs/{index}
- 选择有关联网络设备的 GID（如 "eth1"）
- 参考了 show_gids.sh  https://gist.github.com/aagontuk/6aaee1ef908a0c3341ee0cac7c540fcc  脚本的实现
- 更加通用

**方式二：匹配本机 IP 地址**
- 提取 GID 中的 IPv4 地址
- 通过 getifaddrs() 获取本机所有 IP
- 选择 IP 匹配的 GID
- 更直接但需要额外系统调用

为什么选择方式一
- 与内核子系统对齐，使用与标准工具相同的数据源
- 更通用，不受 IP 配置变化影响
- 实现简单，改动最小
- 性能更好，只需一次文件读取

请求 Review
请帮忙看看这个方案是否有问题，或者有更好的解决方式？

