### PR TITLE
[doc] Fix documentation link

### DIFF
--- a/doc/en/mooncake-store.md
+++ b/doc/en/mooncake-store.md
@@ -568,7 +568,7 @@ Note that the HTTP metadata server is designed for single-node deployments and d
 
 ## Mooncake Store Python API
 
-**Complete Python API Documentation**: [https://kvcache-ai.github.io/Mooncake/mooncake-store-api/python-binding.html](https://kvcache-ai.github.io/Mooncake/mooncake-store-api/python-binding.html)
+**Complete Python API Documentation**: [https://kvcache-ai.github.io/Mooncake/python-api-reference/mooncake-store.html](https://kvcache-ai.github.io/Mooncake/python-api-reference/mooncake-store.html)
 
 ## Compilation and Usage
 Mooncake Store is compiled together with other related components (such as the Transfer Engine).

--- a/doc/zh/mooncake-store.md
+++ b/doc/zh/mooncake-store.md
@@ -568,7 +568,7 @@ HTTP 元数据服务器可通过以下参数进行配置：
 
 ## Mooncake Store Python API
 
-**完整的 Python API 文档**: [https://kvcache-ai.github.io/Mooncake/mooncake-store-api/python-binding.html](https://kvcache-ai.github.io/Mooncake/mooncake-store-api/python-binding.html)
+**完整的 Python API 文档**: [https://kvcache-ai.github.io/Mooncake/python-api-reference/mooncake-store.html](https://kvcache-ai.github.io/Mooncake/python-api-reference/mooncake-store.html)
 
 
 ## 编译及使用方法

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -539,7 +539,7 @@ If you need to use 3FS's native API (USRBIO) to achieve high-performance persist
 
 ## Mooncake Store Python API
 
-**Complete Python API Documentation**: [https://kvcache-ai.github.io/Mooncake/mooncake-store-api/python-binding.html](https://kvcache-ai.github.io/Mooncake/mooncake-store-api/python-binding.html)
+**Complete Python API Documentation**: [https://kvcache-ai.github.io/Mooncake/python-api-reference/mooncake-store.html](https://kvcache-ai.github.io/Mooncake/python-api-reference/mooncake-store.html)
 
 ## Compilation and Usage
 Mooncake Store is compiled together with other related components (such as the Transfer Engine).


### PR DESCRIPTION
This PR fixes the link to "Mooncake Store Python API" in the documentation.