### PR TITLE
[Misc] For Mooncake Backend, skip transferring to non-active ranks

### DIFF
--- a/mooncake-ep/src/mooncake_worker_thread.cpp
+++ b/mooncake-ep/src/mooncake_worker_thread.cpp
@@ -100,8 +100,8 @@ void MooncakeWorker::startWorker() {
                             if (!group->activeRanks[j]) {
                                 continue;
                             }
-                            group->engine->getTransferStatus(task.batchID, task_id,
-                                                             status);
+                            group->engine->getTransferStatus(task.batchID,
+                                                             task_id, status);
                             ++task_id;
                             if (group->activeRanks[j] &&
                                 status.s != TransferStatusEnum::COMPLETED) {


### PR DESCRIPTION
Previously, during collective communication, a process may transfer data to its peer, even if it already knows the peer is offline.

Although it is essentially a no-op, it would produce loads of warnings, which was annoying.