### PR TITLE
fix(transfer_engine): Add notify callback registration in RPC metadata handling

### DIFF
--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -616,7 +616,7 @@ int TransferMetadata::addRpcMetaEntry(const std::string &server_name,
             [this](const Json::Value &peer, Json::Value &local) -> int {
                 return receivePeerNotify(peer, local);
             });
-        
+
         int rc = handshake_plugin_->startDaemon(desc.rpc_port, desc.sockfd);
         if (rc != 0) {
             return rc;


### PR DESCRIPTION
If the registration for the Notify callback function is not added in the addRpcMetaEntry function, the P2PHANDSHAKE method will not work. An example is the [testing program for the NIXL backend Mooncake integration plugin](https://github.com/ai-dynamo/nixl/blob/main/test/unit/plugins/mooncake/mooncake_backend_test.cpp).

```
I1025 16:48:45.144167 87366 transfer_metadata_plugin.cpp:752] SocketHandShakePlugin: received handshake message of type 2, json string length: 38, json string content: {"name":"Agent1","notify_msg":"test"}
I1025 16:48:45.144309 87366 transfer_metadata_plugin.cpp:778] SocketHandShakePlugin: [RECEIVER] Before callback, local is empty
I1025 16:48:45.144345 87366 transfer_metadata_plugin.cpp:780] SocketHandShakePlugin: [RECEIVER] After callback, local content: null
I1025 16:48:45.144373 87366 transfer_metadata_plugin.cpp:790] SocketHandShakePlugin: [RECEIVER] Sending reply, type=2, json length=5, content: null
I1025 16:48:45.144551 87363 transfer_metadata_plugin.cpp:1035] SocketHandShakePlugin: [SENDER] Received reply, type=2, json length=5, content: null
I1025 16:48:45.144593 87363 transfer_metadata_plugin.cpp:1047] SocketHandShakePlugin: received notify message: null
E1025 16:48:45.144726 87363 transfer_metadata.cpp:745] Notify rejected by 192.168.0.27:16430:
```

