### PR TITLE
[Misc] (Mooncake Backend) Early break if a rank failure can be determined through ping message

### DIFF
--- a/mooncake-ep/include/mooncake_worker.cuh
+++ b/mooncake-ep/include/mooncake_worker.cuh
@@ -71,6 +71,8 @@ class MooncakeWorker {
    private:
     static constexpr size_t kNumTasks_ = 4;
 
+    static constexpr size_t kPingTimeoutMicroseconds_ = 100;
+
     bool running_ = false;
 
     Task *tasks_, *tasks_device_;


### PR DESCRIPTION
Under previous implementation, rank failure detection could be slow, as in most cases, such failures can only be detected when the RDMA transfer fails after retrying several times.

This PR adds an early verification through ping messages to detect rank failures more quickly, approximately 4s -> 0.2s.