### PR TITLE
Fix segfault in Mooncake TCP transfer under high concurrency by enabling socket reuse

### DIFF
--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -453,6 +453,10 @@ void TcpTransport::startTransfer(Slice *slice) {
     try {
         asio::ip::tcp::resolver resolver(context_->io_context);
         asio::ip::tcp::socket socket(context_->io_context);
+
+        socket.open(asio::ip::tcp::v4());
+        socket.set_option(asio::socket_base::reuse_address(true));
+
         auto desc = metadata_->getSegmentDescByID(slice->target_id);
         if (!desc) {
             LOG(ERROR) << "TcpTransport::startTransfer failed to get segment "


### PR DESCRIPTION
In the current Mooncake KVCache transfer implementation over TCP, each transfer uses a short-lived connection. Under high concurrency, such as running some bencemarks, this leads to:

Rapid accumulation of TIME_WAIT sockets
Exhaustion of ephemeral ports (Cannot assign requested address)
Eventually, Boost.Asio fails to create new sockets, causing a segmentation fault or crash due to unhandled bad_descriptor errors
Solution:
Enable reuse_address(true) on the client socket after explicitly opening it, which allows the kernel to reuse local addresses in TIME_WAIT state