### PR TITLE
fix(ci): add id-token permission and unify PyPI token for release

### DIFF
--- a/.github/workflows/release-non-cuda.yaml
+++ b/.github/workflows/release-non-cuda.yaml
@@ -89,6 +89,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -119,5 +120,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: mooncake-wheel/dist-release/
-          password: ${{ secrets.PYPI_API_TOKEN_NON_CUDA }}
+          password: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,6 +108,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION


- Add id-token: write permission to both release workflows to support PyPI Trusted Publishing (OIDC authentication)
- Unify PyPI API token usage: both CUDA and non-CUDA releases now use the same PYPI_API_TOKEN secret instead of separate tokens
- This resolves the "missing or insufficient OIDC token permissions" error during PyPI package publishing