### PR TITLE
[Store] Fix CI bugs & Improve log output & Refactor TE Initialization

### DIFF
--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -283,6 +283,7 @@ class Client {
         const std::string& local_hostname,
         const std::string& metadata_connstring, const std::string& protocol,
         const std::optional<std::string>& device_names);
+    void InitTransferSubmitter();
     ErrorCode TransferData(const Replica::Descriptor& replica_descriptor,
                            std::vector<Slice>& slices,
                            TransferRequest::OpCode op_code);
@@ -361,7 +362,6 @@ class Client {
 
     // Client identification
     UUID client_id_;
-    bool te_initialized_{false};
 };
 
 }  // namespace mooncake

--- a/mooncake-store/src/client.cpp
+++ b/mooncake-store/src/client.cpp
@@ -243,10 +243,9 @@ ErrorCode Client::InitTransferEngine(
     } else {
         // Enable auto-discover for RDMA if no devices are specified
         if (protocol == "rdma" && !device_names.has_value()) {
-            LOG(INFO)
-                << "Set auto discovery ON by default for RDMA protocol, "
-                    "since no "
-                    "device names provided";
+            LOG(INFO) << "Set auto discovery ON by default for RDMA protocol, "
+                         "since no "
+                         "device names provided";
             auto_discover = true;
         }
     }
@@ -261,28 +260,25 @@ ErrorCode Client::InitTransferEngine(
     }
 
     if (auto_discover) {
-        LOG(INFO)
-            << "Transfer engine auto discovery is enabled for protocol: "
-            << protocol;
+        LOG(INFO) << "Transfer engine auto discovery is enabled for protocol: "
+                  << protocol;
         auto filters = get_auto_discover_filters(auto_discover);
         transfer_engine_->setWhitelistFilters(std::move(filters));
     } else {
-        LOG(INFO)
-            << "Transfer engine auto discovery is disabled for protocol: "
-            << protocol;
+        LOG(INFO) << "Transfer engine auto discovery is disabled for protocol: "
+                  << protocol;
 
         Transport* transport = nullptr;
 
         if (protocol == "rdma") {
             if (!device_names.has_value() || device_names->empty()) {
-                LOG(ERROR)
-                    << "RDMA protocol requires device names when auto "
-                        "discovery is disabled";
+                LOG(ERROR) << "RDMA protocol requires device names when auto "
+                              "discovery is disabled";
                 return ErrorCode::INVALID_PARAMS;
             }
 
             LOG(INFO) << "Using specified RDMA devices: "
-                        << device_names.value();
+                      << device_names.value();
 
             std::vector<std::string> devices =
                 splitString(device_names.value(), ',', /*skip_empty=*/true);
@@ -292,15 +288,14 @@ ErrorCode Client::InitTransferEngine(
             if (topology) {
                 topology->discover(devices);
                 LOG(INFO) << "Topology discovery complete with specified "
-                                "devices. Found "
-                            << topology->getHcaList().size() << " HCAs";
+                             "devices. Found "
+                          << topology->getHcaList().size() << " HCAs";
             }
 
             transport = transfer_engine_->installTransport("rdma", nullptr);
             if (!transport) {
-                LOG(ERROR)
-                    << "Failed to install RDMA transport with specified "
-                        "devices";
+                LOG(ERROR) << "Failed to install RDMA transport with specified "
+                              "devices";
                 return ErrorCode::INTERNAL_ERROR;
             }
         } else if (protocol == "tcp") {
@@ -310,12 +305,10 @@ ErrorCode Client::InitTransferEngine(
             }
 
             try {
-                transport =
-                    transfer_engine_->installTransport("tcp", nullptr);
+                transport = transfer_engine_->installTransport("tcp", nullptr);
             } catch (std::exception& e) {
-                LOG(ERROR)
-                    << "tcp_transport_install_failed error_message=\""
-                    << e.what() << "\"";
+                LOG(ERROR) << "tcp_transport_install_failed error_message=\""
+                           << e.what() << "\"";
                 return ErrorCode::INTERNAL_ERROR;
             }
 
@@ -332,9 +325,8 @@ ErrorCode Client::InitTransferEngine(
                 transport =
                     transfer_engine_->installTransport("ascend", nullptr);
             } catch (std::exception& e) {
-                LOG(ERROR)
-                    << "ascend_transport_install_failed error_message=\""
-                    << e.what() << "\"";
+                LOG(ERROR) << "ascend_transport_install_failed error_message=\""
+                           << e.what() << "\"";
                 return ErrorCode::INTERNAL_ERROR;
             }
 
@@ -399,14 +391,15 @@ std::optional<std::shared_ptr<Client>> Client::Create(
     if (transfer_engine == nullptr) {
         client->transfer_engine_ = std::make_shared<TransferEngine>();
         err = client->InitTransferEngine(local_hostname, metadata_connstring,
-            protocol, device_names);
+                                         protocol, device_names);
         if (err != ErrorCode::OK) {
-        LOG(ERROR) << "Failed to initialize transfer engine";
-        return std::nullopt;
-}
+            LOG(ERROR) << "Failed to initialize transfer engine";
+            return std::nullopt;
+        }
     } else {
         client->transfer_engine_ = transfer_engine;
-        LOG(INFO) << "Use existing transfer engine instance. Skip its initialization.";
+        LOG(INFO) << "Use existing transfer engine instance. Skip its "
+                     "initialization.";
     }
 
     client->InitTransferSubmitter();

--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -1215,8 +1215,8 @@ std::vector<int> PyClient::batch_put_from_multi_buffers(
 
     auto duration_call = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - start);
-    LOG(INFO) << "batch_put_from_multi_buffers: " << duration_call.count()
-              << "us";
+    VLOG(1) << "batch_put_from_multi_buffers: " << duration_call.count()
+              << " us";
     return results;
 }
 
@@ -1273,8 +1273,8 @@ std::vector<int> PyClient::batch_get_into_multi_buffers(
     }
     auto duration_call = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - start);
-    LOG(INFO) << "batch_get_into_multi_buffers: " << duration_call.count()
-              << "us";
+    VLOG(1) << "batch_get_into_multi_buffers: " << duration_call.count()
+              << " us";
     return results;
 }
 

--- a/mooncake-store/src/pybind_client.cpp
+++ b/mooncake-store/src/pybind_client.cpp
@@ -1216,7 +1216,7 @@ std::vector<int> PyClient::batch_put_from_multi_buffers(
     auto duration_call = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - start);
     VLOG(1) << "batch_put_from_multi_buffers: " << duration_call.count()
-              << " us";
+            << " us";
     return results;
 }
 
@@ -1274,7 +1274,7 @@ std::vector<int> PyClient::batch_get_into_multi_buffers(
     auto duration_call = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - start);
     VLOG(1) << "batch_get_into_multi_buffers: " << duration_call.count()
-              << " us";
+            << " us";
     return results;
 }
 

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -515,6 +515,13 @@ TEST_F(PyClientTest, TestBatchPutAndGetMultiBuffers) {
 
     std::string test_data(1000, '1');
     std::string dst_data(1000, '0');
+    
+    // Register buffers for zero-copy operations
+    int reg_result_test = py_client_->register_buffer(test_data.data(), test_data.size());
+    ASSERT_EQ(reg_result_test, 0) << "Test data buffer registration should succeed";
+    int reg_result_dst = py_client_->register_buffer(dst_data.data(), dst_data.size());
+    ASSERT_EQ(reg_result_dst, 0) << "Dst data buffer registration should succeed";
+    
     std::vector<std::string> keys;
     std::vector<std::vector<void*>> all_ptrs;
     std::vector<std::vector<void*>> all_dst_ptrs;

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -531,12 +531,10 @@ TEST_F(PyClientTest, TestBatchPutAndGetMultiBuffers) {
     const std::string rdma_devices = (FLAGS_protocol == std::string("rdma"))
                                          ? FLAGS_device_name
                                          : std::string("");
-    auto transfer_engine = std::make_shared<TransferEngine>("P2PHANDSHAKE");
-    transfer_engine->init("P2PHANDSHAKE", "localhost:17813");
     ASSERT_EQ(
         py_client_->setup("localhost:17813", "P2PHANDSHAKE", 16 * 1024 * 1024,
                           16 * 1024 * 1024, FLAGS_protocol, rdma_devices,
-                          master_address_, transfer_engine),
+                          master_address_),
         0);
 
     std::string test_data(1000, '1');

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -582,6 +582,12 @@ TEST_F(PyClientTest, TestBatchPutAndGetMultiBuffers) {
         EXPECT_EQ(result, 100) << "Get operation should succeed";
     }
     EXPECT_EQ(dst_data, test_data) << "Retrieved data should match original";
+
+    // Unregister buffers
+    int unreg_result_test = py_client_->unregister_buffer(test_data.data());
+    ASSERT_EQ(unreg_result_test, 0) << "Test data buffer unregistration should succeed";
+    int unreg_result_dst = py_client_->unregister_buffer(dst_data.data());
+    ASSERT_EQ(unreg_result_dst, 0) << "Dst data buffer unregistration should succeed";
 }
 }  // namespace testing
 

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -531,21 +531,24 @@ TEST_F(PyClientTest, TestBatchPutAndGetMultiBuffers) {
     const std::string rdma_devices = (FLAGS_protocol == std::string("rdma"))
                                          ? FLAGS_device_name
                                          : std::string("");
-    ASSERT_EQ(
-        py_client_->setup("localhost:17813", "P2PHANDSHAKE", 16 * 1024 * 1024,
-                          16 * 1024 * 1024, FLAGS_protocol, rdma_devices,
-                          master_address_),
-        0);
+    ASSERT_EQ(py_client_->setup("localhost:17813", "P2PHANDSHAKE",
+                                16 * 1024 * 1024, 16 * 1024 * 1024,
+                                FLAGS_protocol, rdma_devices, master_address_),
+              0);
 
     std::string test_data(1000, '1');
     std::string dst_data(1000, '0');
-    
+
     // Register buffers for zero-copy operations
-    int reg_result_test = py_client_->register_buffer(test_data.data(), test_data.size());
-    ASSERT_EQ(reg_result_test, 0) << "Test data buffer registration should succeed";
-    int reg_result_dst = py_client_->register_buffer(dst_data.data(), dst_data.size());
-    ASSERT_EQ(reg_result_dst, 0) << "Dst data buffer registration should succeed";
-    
+    int reg_result_test =
+        py_client_->register_buffer(test_data.data(), test_data.size());
+    ASSERT_EQ(reg_result_test, 0)
+        << "Test data buffer registration should succeed";
+    int reg_result_dst =
+        py_client_->register_buffer(dst_data.data(), dst_data.size());
+    ASSERT_EQ(reg_result_dst, 0)
+        << "Dst data buffer registration should succeed";
+
     std::vector<std::string> keys;
     std::vector<std::vector<void*>> all_ptrs;
     std::vector<std::vector<void*>> all_dst_ptrs;
@@ -585,9 +588,11 @@ TEST_F(PyClientTest, TestBatchPutAndGetMultiBuffers) {
 
     // Unregister buffers
     int unreg_result_test = py_client_->unregister_buffer(test_data.data());
-    ASSERT_EQ(unreg_result_test, 0) << "Test data buffer unregistration should succeed";
+    ASSERT_EQ(unreg_result_test, 0)
+        << "Test data buffer unregistration should succeed";
     int unreg_result_dst = py_client_->unregister_buffer(dst_data.data());
-    ASSERT_EQ(unreg_result_dst, 0) << "Dst data buffer unregistration should succeed";
+    ASSERT_EQ(unreg_result_dst, 0)
+        << "Dst data buffer unregistration should succeed";
 }
 }  // namespace testing
 


### PR DESCRIPTION
This pr solves the following issues:

1. In pybind_client_test, there is a test case where the zero copy method is used, but the memory is not registered before, which will fail in rdma env.
2. In pybind_client_test, there are two test cases that will output 30k+ lines of error log, which greatly hinders reading the ci log.
3. In client.cpp, InitTransferSubmitter is put in the same function as InitTransferEngine. Previously, both the init of TE and submitter will be executed. But now the init of TE will be skipped if the TE is passed as a parameter. Now the skipping check is controlled by a private member of client, and this member is only used in this place.