### PR TITLE
[CI] Fix a CI BUG in PyClientTest:TestSetupExistTransferEngine

### DIFF
--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -504,7 +504,8 @@ TEST_F(PyClientTest, TestSetupExistTransferEngine) {
 
     // The auto discover has some problems in GitHub CI, so disable it here.
     transfer_engine->setAutoDiscover(false);
-    transfer_engine->init("P2PHANDSHAKE", "localhost:17813"); 
+    auto init_ret = transfer_engine->init("P2PHANDSHAKE", "localhost:17813"); 
+    ASSERT_EQ(init_ret, 0) << "Transfer engine initialization should succeed";
     if (FLAGS_protocol == "tcp") {
         auto transport = transfer_engine->installTransport("tcp", nullptr);
         ASSERT_NE(transport, nullptr) << "Install transport should succeed";

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -498,19 +498,19 @@ TEST_F(PyClientTest, TestSetupExistTransferEngine) {
 
     // Setup the client
     const std::string rdma_devices = (FLAGS_protocol == std::string("rdma"))
-                    ? FLAGS_device_name
-                    : std::string("");
+                                         ? FLAGS_device_name
+                                         : std::string("");
     auto transfer_engine = std::make_shared<TransferEngine>("P2PHANDSHAKE");
 
     // The auto discover has some problems in GitHub CI, so disable it here.
     transfer_engine->setAutoDiscover(false);
-    auto init_ret = transfer_engine->init("P2PHANDSHAKE", "localhost:17813"); 
+    auto init_ret = transfer_engine->init("P2PHANDSHAKE", "localhost:17813");
     ASSERT_EQ(init_ret, 0) << "Transfer engine initialization should succeed";
     if (FLAGS_protocol == "tcp") {
         auto transport = transfer_engine->installTransport("tcp", nullptr);
         ASSERT_NE(transport, nullptr) << "Install transport should succeed";
     } else {
-        ASSERT_TRUE(false) << "Unsupported protocol";
+        ASSERT_TRUE(false) << "Unsupported protocol: " << FLAGS_protocol;
     }
     ASSERT_EQ(
         py_client_->setup("localhost:17813", "P2PHANDSHAKE", 16 * 1024 * 1024,

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -498,10 +498,19 @@ TEST_F(PyClientTest, TestSetupExistTransferEngine) {
 
     // Setup the client
     const std::string rdma_devices = (FLAGS_protocol == std::string("rdma"))
-                                         ? FLAGS_device_name
-                                         : std::string("");
+                    ? FLAGS_device_name
+                    : std::string("");
     auto transfer_engine = std::make_shared<TransferEngine>("P2PHANDSHAKE");
-    transfer_engine->init("P2PHANDSHAKE", "localhost:17813");
+
+    // The auto discover has some problems in GitHub CI, so disable it here.
+    transfer_engine->setAutoDiscover(false);
+    transfer_engine->init("P2PHANDSHAKE", "localhost:17813"); 
+    if (FLAGS_protocol == "tcp") {
+        auto transport = transfer_engine->installTransport("tcp", nullptr);
+        ASSERT_NE(transport, nullptr) << "Install transport should succeed";
+    } else {
+        ASSERT_TRUE(false) << "Unsupported protocol";
+    }
     ASSERT_EQ(
         py_client_->setup("localhost:17813", "P2PHANDSHAKE", 16 * 1024 * 1024,
                           16 * 1024 * 1024, FLAGS_protocol, rdma_devices,


### PR DESCRIPTION
Recently, this bug has occurred very frequently, such as: https://github.com/kvcache-ai/Mooncake/actions/runs/19023355483/job/54322585181

This PR serves as a temporary fix. The root cause is still an issue with TE’s auto-discovery — on the CI server, it can detect the HCA, but fails to detect the NIC, causing TE initialization to fail.  @alogfans do you have any idea about this?