### PR TITLE
[store] Add disk eviction feature

### DIFF
--- a/mooncake-store/include/client.h
+++ b/mooncake-store/include/client.h
@@ -296,7 +296,9 @@ class Client {
      * @brief Prepare and use the storage backend for persisting data
      */
     void PrepareStorageBackend(const std::string& storage_root_dir,
-                               const std::string& fsdir);
+                               const std::string& fsdir,
+                               bool enable_eviction = true,
+                               uint64_t quota_bytes = 0);
 
     void PutToLocalFile(const std::string& object_key,
                         const std::vector<Slice>& slices,

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -211,6 +211,9 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<std::string, ErrorCode> GetFsdir();
 
+    [[nodiscard]] tl::expected<GetStorageConfigResponse, ErrorCode>
+    GetStorageConfig();
+
     /**
      * @brief Pings master to check its availability
      * @return tl::expected<PingResponse, ErrorCode>

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -40,6 +40,10 @@ struct MasterConfig {
 
     uint64_t put_start_discard_timeout_sec;
     uint64_t put_start_release_timeout_sec;
+
+    // Storage backend eviction configuration
+    bool enable_disk_eviction;
+    uint64_t quota_bytes;
 };
 
 class MasterServiceSupervisorConfig {
@@ -71,6 +75,8 @@ class MasterServiceSupervisorConfig {
     BufferAllocatorType memory_allocator = BufferAllocatorType::OFFSET;
     uint64_t put_start_discard_timeout_sec = DEFAULT_PUT_START_DISCARD_TIMEOUT;
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
+    bool enable_disk_eviction = true;
+    uint64_t quota_bytes = 0;
 
     MasterServiceSupervisorConfig() = default;
 
@@ -109,6 +115,8 @@ class MasterServiceSupervisorConfig {
 
         put_start_discard_timeout_sec = config.put_start_discard_timeout_sec;
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
+        enable_disk_eviction = config.enable_disk_eviction;
+        quota_bytes = config.quota_bytes;
 
         validate();
     }
@@ -176,6 +184,8 @@ class WrappedMasterServiceConfig {
     BufferAllocatorType memory_allocator = BufferAllocatorType::OFFSET;
     uint64_t put_start_discard_timeout_sec = DEFAULT_PUT_START_DISCARD_TIMEOUT;
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
+    bool enable_disk_eviction = true;
+    uint64_t quota_bytes = 0;
 
     WrappedMasterServiceConfig() = default;
 
@@ -199,6 +209,8 @@ class WrappedMasterServiceConfig {
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;
         global_file_segment_size = config.global_file_segment_size;
+        enable_disk_eviction = config.enable_disk_eviction;
+        quota_bytes = config.quota_bytes;
 
         // Convert string memory_allocator to BufferAllocatorType enum
         if (config.memory_allocator == "cachelib") {
@@ -234,6 +246,8 @@ class WrappedMasterServiceConfig {
         root_fs_dir = config.root_fs_dir;
         global_file_segment_size = config.global_file_segment_size;
         memory_allocator = config.memory_allocator;
+        enable_disk_eviction = config.enable_disk_eviction;
+        quota_bytes = config.quota_bytes;
         put_start_discard_timeout_sec = config.put_start_discard_timeout_sec;
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
     }
@@ -259,6 +273,8 @@ class MasterServiceConfigBuilder {
     std::string root_fs_dir_ = DEFAULT_ROOT_FS_DIR;
     int64_t global_file_segment_size_ = DEFAULT_GLOBAL_FILE_SEGMENT_SIZE;
     BufferAllocatorType memory_allocator_ = BufferAllocatorType::OFFSET;
+    bool enable_disk_eviction_ = true;
+    uint64_t quota_bytes_ = 0;
     uint64_t put_start_discard_timeout_sec_ = DEFAULT_PUT_START_DISCARD_TIMEOUT;
     uint64_t put_start_release_timeout_sec_ = DEFAULT_PUT_START_RELEASE_TIMEOUT;
 
@@ -362,6 +378,8 @@ class MasterServiceConfig {
     BufferAllocatorType memory_allocator = BufferAllocatorType::OFFSET;
     uint64_t put_start_discard_timeout_sec = DEFAULT_PUT_START_DISCARD_TIMEOUT;
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
+    bool enable_disk_eviction = true;
+    uint64_t quota_bytes = 0;
 
     MasterServiceConfig() = default;
 
@@ -380,6 +398,8 @@ class MasterServiceConfig {
         root_fs_dir = config.root_fs_dir;
         global_file_segment_size = config.global_file_segment_size;
         memory_allocator = config.memory_allocator;
+        enable_disk_eviction = config.enable_disk_eviction;
+        quota_bytes = config.quota_bytes;
         put_start_discard_timeout_sec = config.put_start_discard_timeout_sec;
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
     }
@@ -405,6 +425,8 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     config.memory_allocator = memory_allocator_;
     config.put_start_discard_timeout_sec = put_start_discard_timeout_sec_;
     config.put_start_release_timeout_sec = put_start_release_timeout_sec_;
+    config.enable_disk_eviction = enable_disk_eviction_;
+    config.quota_bytes = quota_bytes_;
     return config;
 }
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -220,6 +220,13 @@ class MasterService {
      */
     tl::expected<std::string, ErrorCode> GetFsdir() const;
 
+    /**
+     * @brief Get storage backend configuration including eviction settings
+     * @return GetStorageConfigResponse containing fsdir, enable_disk_eviction,
+     * and quota_bytes
+     */
+    tl::expected<GetStorageConfigResponse, ErrorCode> GetStorageConfig() const;
+
    private:
     // Resolve the key to a sanitized format for storage
     std::string SanitizeKey(const std::string& key) const;
@@ -537,6 +544,9 @@ class MasterService {
     const std::string root_fs_dir_;
     // global 3fs/nfs segment size
     int64_t global_file_segment_size_;
+    // storage backend eviction configuration
+    const bool enable_disk_eviction_;
+    const uint64_t quota_bytes_;
 
     bool use_disk_replica_{false};
 

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -81,6 +81,8 @@ class WrappedMasterService {
 
     tl::expected<std::string, ErrorCode> GetFsdir();
 
+    tl::expected<GetStorageConfigResponse, ErrorCode> GetStorageConfig();
+
     tl::expected<PingResponse, ErrorCode> Ping(const UUID& client_id);
 
     tl::expected<void, ErrorCode> ServiceReady();

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -40,4 +40,21 @@ struct GetReplicaListResponse {
 };
 YLT_REFL(GetReplicaListResponse, replicas, lease_ttl_ms);
 
+/**
+ * @brief Response structure for GetStorageConfig operation
+ */
+struct GetStorageConfigResponse {
+    std::string fsdir;
+    bool enable_disk_eviction;
+    uint64_t quota_bytes;
+
+    GetStorageConfigResponse() : enable_disk_eviction(true), quota_bytes(0) {}
+    GetStorageConfigResponse(const std::string& fsdir_param,
+                             bool enable_eviction, uint64_t quota)
+        : fsdir(fsdir_param),
+          enable_disk_eviction(enable_eviction),
+          quota_bytes(quota) {}
+};
+YLT_REFL(GetStorageConfigResponse, fsdir, enable_disk_eviction, quota_bytes);
+
 }  // namespace mooncake

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -93,6 +93,11 @@ DEFINE_uint64(put_start_release_timeout_sec,
               mooncake::DEFAULT_PUT_START_RELEASE_TIMEOUT,
               "Timeout for releasing space allocated in uncompleted PutStart "
               "operations");
+DEFINE_bool(enable_disk_eviction, true,
+            "Enable disk eviction feature for storage backend (default: true)");
+DEFINE_uint64(
+    quota_bytes, 0,
+    "Quota for storage backend in bytes (0 = use default 90% of capacity)");
 
 void InitMasterConf(const mooncake::DefaultConfig& default_config,
                     mooncake::MasterConfig& master_config) {
@@ -161,6 +166,11 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetUInt64("put_start_release_timeout_sec",
                              &master_config.put_start_release_timeout_sec,
                              FLAGS_put_start_release_timeout_sec);
+    default_config.GetBool("enable_disk_eviction",
+                           &master_config.enable_disk_eviction,
+                           FLAGS_enable_disk_eviction);
+    default_config.GetUInt64("quota_bytes", &master_config.quota_bytes,
+                             FLAGS_quota_bytes);
 }
 
 void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
@@ -330,6 +340,16 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.put_start_release_timeout_sec =
             FLAGS_put_start_release_timeout_sec;
+    }
+    if ((google::GetCommandLineFlagInfo("enable_disk_eviction", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.enable_disk_eviction = FLAGS_enable_disk_eviction;
+    }
+    if ((google::GetCommandLineFlagInfo("quota_bytes", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.quota_bytes = FLAGS_quota_bytes;
     }
 }
 

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -115,6 +115,11 @@ struct RpcNameTraits<&WrappedMasterService::GetFsdir> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::GetStorageConfig> {
+    static constexpr const char* value = "GetStorageConfig";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::ServiceReady> {
     static constexpr const char* value = "ServiceReady";
 };
@@ -449,6 +454,17 @@ tl::expected<std::string, ErrorCode> MasterClient::GetFsdir() {
     timer.LogRequest("action=get_fsdir");
 
     auto result = invoke_rpc<&WrappedMasterService::GetFsdir, std::string>();
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<GetStorageConfigResponse, ErrorCode>
+MasterClient::GetStorageConfig() {
+    ScopedVLogTimer timer(1, "MasterClient::GetStorageConfig");
+    timer.LogRequest("action=get_storage_config");
+
+    auto result = invoke_rpc<&WrappedMasterService::GetStorageConfig,
+                             GetStorageConfigResponse>();
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -576,6 +576,17 @@ tl::expected<std::string, ErrorCode> WrappedMasterService::GetFsdir() {
     return result;
 }
 
+tl::expected<GetStorageConfigResponse, ErrorCode>
+WrappedMasterService::GetStorageConfig() {
+    ScopedVLogTimer timer(1, "GetStorageConfig");
+    timer.LogRequest("action=get_storage_config");
+
+    auto result = master_service_.GetStorageConfig();
+
+    timer.LogResponseExpected(result);
+    return result;
+}
+
 tl::expected<PingResponse, ErrorCode> WrappedMasterService::Ping(
     const UUID& client_id) {
     ScopedVLogTimer timer(1, "Ping");
@@ -633,6 +644,8 @@ void RegisterRpcService(
     server.register_handler<&mooncake::WrappedMasterService::Ping>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::GetFsdir>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::GetStorageConfig>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchExistKey>(
         &wrapped_master_service);


### PR DESCRIPTION
This pull request introduces a disk eviction mechanism to the StorageBackend. This feature ensures that the storage system can gracefully handle situations where disk space is exhausted by automatically removing older files to make space for new writes, preventing out-of-space errors.

Currently, when the allocated disk quota is fully utilized, any new write operations (StoreObject) will fail with an out-of-space or insufficient space error. This can lead to service disruptions and requires manual intervention to clear up space.
To build a more resilient and self-managing storage system, we need an automated mechanism that can reclaim space when the storage backend is under pressure. This PR addresses this need by implementing a disk eviction strategy.