### PR TITLE
TCP transport support ipv6

### DIFF
--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -503,9 +503,8 @@ void TcpTransport::startTransfer(Slice *slice) {
             slice->markFailed();
             return;
         }
-        auto endpoint_iterator =
-            resolver.resolve(meta_entry.ip_or_host_name,
-                             std::to_string(desc->tcp_data_port));
+        auto endpoint_iterator = resolver.resolve(
+            meta_entry.ip_or_host_name, std::to_string(desc->tcp_data_port));
         asio::connect(socket, endpoint_iterator);
         auto session = std::make_shared<Session>(std::move(socket));
         session->on_finalize_ = [slice](TransferStatusEnum status) {


### PR DESCRIPTION
## Description
https://github.com/vllm-project/vllm-ascend/issues/4103 use tcp transport with error `E20251112 17:02:55.861567 33158 tcp_transport.cpp:480] TcpTransport::startTransfer encountered an ASIO exception. Slice details - source_addr: 0x12d11ac40000, length: 32768, opcode: 0, target_id: 1. Exception: resolve: Host not found (authoritative)
`