### PR TITLE
[Bug] fixed bug of master not using glog actually

### DIFF
--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -1,4 +1,5 @@
 #include <gflags/gflags.h>
+#include <glog/logging.h>
 
 #include <chrono>  // For std::chrono
 #include <memory>  // For std::unique_ptr
@@ -361,6 +362,11 @@ int main(int argc, char* argv[]) {
     easylog::set_min_severity(easylog::Severity::WARN);
     // Initialize gflags
     gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+    if (!FLAGS_log_dir.empty()) {
+        google::InitGoogleLogging(argv[0]);
+    }
+
     // Initialize the master configuration
     mooncake::MasterConfig master_config;
     std::string conf_path = FLAGS_config_path;


### PR DESCRIPTION
## Description

Before modification, when the mooncake master started, it would issue a warning: "Logging before InitGoogleLogging() is written to STDERR". After modification, logs are printed in the glog format, defaulting to the /tmp directory with filenames starting with mooncake_master. Custom log configuration can be achieved by setting the corresponding glog flags during startup.

## Type of Change

* Types
  - [√ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other