### PR TITLE
[TE/Topology] Enhance PCI distance calculation by considering NUMA node affinity

### DIFF
--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -196,7 +196,8 @@ static std::vector<TopologyEntry> discoverCudaTopology(
                 sameNuma_hca.push_back(hca);
             }
         }
-        const auto &candidate_preferred_hca = sameNuma_hca.empty() ? all_hca : sameNuma_hca;
+        const auto &candidate_preferred_hca =
+            sameNuma_hca.empty() ? all_hca : sameNuma_hca;
 
         for (const auto &hca : candidate_preferred_hca) {
             int distance = getPciDistance(hca.pci_bus_id.c_str(), pci_bus_id);


### PR DESCRIPTION
## Description
During performance testing in sglang, we identified a significant performance degradation when using HCA devices that are not on the same NUMA node as the target GPU for transmitting KV cache data.

Given a topology like:
```text
Machine
  Package L#0
    NUMANode L#0 
    HostBridge
      PCIBridge
        PCI xx:xx.x (Ethernet)
          OpenFabrics "mlx5_0"
    HostBridge
	  PCIBridge
		PCI xx:xx.x (GPU0)
  Package L#1
    NUMANode L#1 
    HostBridge
      PCIBridge
        PCI xx:xx.x (Ethernet)
          OpenFabrics "mlx5_1"
    HostBridge
	  PCIBridge
		PCI xx:xx.x (GPU1)
```
The current PCI distance calculation method incorrectly identifies both mlx5_0 and mlx5_1 as preferred HCAs for GPU0. In reality, mlx5_1 and GPU0 reside on different NUMA nodes (L#1 vs L#0), leading to 3x-5x increased transmission latency under high concurrency when cross-NUMA HCA devices are used.
This PR enhances the PCI distance calculation method to incorporate NUMA node affinity.

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [x] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?
Output comparison from `transfer_engine_topology_dump`:
Before:
```
Local topology:  {
        "cpu:0" : 
        [
                [
                        "mlx5_0"
      
                ],
                [
                        "mlx5_1"
                ]
        ],
        "cpu:1" : 
        [
                [
                        "mlx5_1"      
                ],
                [
                        "mlx5_0"
                ]
        ],
        "musa:0" : 
        [
                [
                        "mlx5_0",
						"mlx5_1"
                ]
                []
        ],
        "musa:1" : 
        [
                [
                        "mlx5_0",
                        "mlx5_1"
                ],
                []
        ]
}
```
After:
```
Local topology:  {
        "cpu:0" : 
        [
                [
                        "mlx5_0"
      
                ],
                [
                        "mlx5_1"
                ]
        ],
        "cpu:1" : 
        [
                [
                        "mlx5_1"      
                ],
                [
                        "mlx5_0"
                ]
        ],
        "musa:0" : 
        [
                [
                        "mlx5_0"
			
                ]
                [       
                         "mlx5_1"
                ]
        ],
        "musa:1" : 
        [
                [
                        "mlx5_1"
                ],
                [
                        "mlx5_0"
                ]
        ]
}
```
<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
