### PR TITLE
[Store] Cancel all negative ret val

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -396,22 +396,22 @@ class MooncakeStorePyWrapper {
                                       const pybind11::list &tensors_list) {
         if (!is_client_initialized()) {
             LOG(ERROR) << "Client is not initialized";
-            return std::vector<int>(
-                keys.size(), to_py_ret(ErrorCode::INVALID_PARAMS));
+            return std::vector<int>(keys.size(),
+                                    to_py_ret(ErrorCode::INVALID_PARAMS));
         }
 
         if (use_dummy_client_) {
             LOG(ERROR) << "batch_put_tensor is not supported for dummy client "
                           "now";
-            return std::vector<int>(
-                keys.size(), to_py_ret(ErrorCode::INVALID_PARAMS));
+            return std::vector<int>(keys.size(),
+                                    to_py_ret(ErrorCode::INVALID_PARAMS));
         }
 
         if (keys.size() != tensors_list.size()) {
             LOG(ERROR) << "Keys and tensors list size mismatch. keys="
                        << keys.size() << ", tensors=" << tensors_list.size();
-            return std::vector<int>(
-                keys.size(), to_py_ret(ErrorCode::INVALID_PARAMS));
+            return std::vector<int>(keys.size(),
+                                    to_py_ret(ErrorCode::INVALID_PARAMS));
         }
 
         if (keys.empty()) {


### PR DESCRIPTION

## Description

The ErrorCode is already a negative value, so there’s no need to negate it again. 

Cancel all negtive ret val. Add to_py_ret func to handle return error code

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
