### PR TITLE
[TransferEngine] Fix QP leak in EndPointStore

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -37,10 +37,10 @@ different eviction policy may need different data structure
 class EndpointStore {
    public:
     virtual std::shared_ptr<RdmaEndPoint> getEndpoint(
-        const std::string &peer_nic_path) = 0;
+        const std::string& peer_nic_path) = 0;
     virtual std::shared_ptr<RdmaEndPoint> insertEndpoint(
-        const std::string &peer_nic_path, RdmaContext *context) = 0;
-    virtual int deleteEndpoint(const std::string &peer_nic_path) = 0;
+        const std::string& peer_nic_path, RdmaContext* context) = 0;
+    virtual int deleteEndpoint(const std::string& peer_nic_path) = 0;
     virtual void evictEndpoint() = 0;
     virtual void reclaimEndpoint() = 0;
     virtual void reclaimEndpointUnlocked() = 0;
@@ -58,10 +58,10 @@ class FIFOEndpointStore : public EndpointStore {
    public:
     FIFOEndpointStore(size_t max_size) : max_size_(max_size) {}
     std::shared_ptr<RdmaEndPoint> getEndpoint(
-        const std::string &peer_nic_path) override;
+        const std::string& peer_nic_path) override;
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
-        const std::string &peer_nic_path, RdmaContext *context) override;
-    int deleteEndpoint(const std::string &peer_nic_path) override;
+        const std::string& peer_nic_path, RdmaContext* context) override;
+    int deleteEndpoint(const std::string& peer_nic_path) override;
     void evictEndpoint() override;
     void reclaimEndpoint() override;
     void reclaimEndpointUnlocked() override;
@@ -90,10 +90,10 @@ class SIEVEEndpointStore : public EndpointStore {
     SIEVEEndpointStore(size_t max_size)
         : waiting_list_len_(0), max_size_(max_size) {}
     std::shared_ptr<RdmaEndPoint> getEndpoint(
-        const std::string &peer_nic_path) override;
+        const std::string& peer_nic_path) override;
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
-        const std::string &peer_nic_path, RdmaContext *context) override;
-    int deleteEndpoint(const std::string &peer_nic_path) override;
+        const std::string& peer_nic_path, RdmaContext* context) override;
+    int deleteEndpoint(const std::string& peer_nic_path) override;
     void evictEndpoint() override;
     void reclaimEndpoint() override;
     void reclaimEndpointUnlocked() override;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -43,6 +43,7 @@ class EndpointStore {
     virtual int deleteEndpoint(const std::string &peer_nic_path) = 0;
     virtual void evictEndpoint() = 0;
     virtual void reclaimEndpoint() = 0;
+    virtual void reclaimEndpointUnlocked() = 0;
     virtual size_t getSize() = 0;
 
     virtual int destroyQPs() = 0;
@@ -63,6 +64,7 @@ class FIFOEndpointStore : public EndpointStore {
     int deleteEndpoint(const std::string &peer_nic_path) override;
     void evictEndpoint() override;
     void reclaimEndpoint() override;
+    void reclaimEndpointUnlocked() override;
     size_t getSize() override;
 
     int destroyQPs() override;
@@ -94,6 +96,7 @@ class SIEVEEndpointStore : public EndpointStore {
     int deleteEndpoint(const std::string &peer_nic_path) override;
     void evictEndpoint() override;
     void reclaimEndpoint() override;
+    void reclaimEndpointUnlocked() override;
     size_t getSize() override;
 
     int destroyQPs() override;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -59,7 +59,7 @@ class RdmaEndPoint {
    public:
     void setPeerNicPath(const std::string &peer_nic_path);
 
-    std::string getPeerNicPath() const { retrun peer_nic_path_; }
+    std::string getPeerNicPath() const { return peer_nic_path_; }
 
     int setupConnectionsByActive();
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -46,31 +46,31 @@ class RdmaEndPoint {
     };
 
    public:
-    RdmaEndPoint(RdmaContext &context);
+    RdmaEndPoint(RdmaContext& context);
 
     ~RdmaEndPoint();
 
-    int construct(ibv_cq *cq, size_t num_qp_list = 2, size_t max_sge = 4,
+    int construct(ibv_cq* cq, size_t num_qp_list = 2, size_t max_sge = 4,
                   size_t max_wr = 256, size_t max_inline = 64);
 
    private:
     int deconstruct();
 
    public:
-    void setPeerNicPath(const std::string &peer_nic_path);
+    void setPeerNicPath(const std::string& peer_nic_path);
 
     std::string getPeerNicPath() const { return peer_nic_path_; }
 
     int setupConnectionsByActive();
 
-    int setupConnectionsByActive(const std::string &peer_nic_path) {
+    int setupConnectionsByActive(const std::string& peer_nic_path) {
         setPeerNicPath(peer_nic_path);
         return setupConnectionsByActive();
     }
 
     using HandShakeDesc = TransferMetadata::HandShakeDesc;
-    int setupConnectionsByPassive(const HandShakeDesc &peer_desc,
-                                  HandShakeDesc &local_desc);
+    int setupConnectionsByPassive(const HandShakeDesc& peer_desc,
+                                  HandShakeDesc& local_desc);
 
     bool hasOutstandingSlice() const;
 
@@ -80,8 +80,7 @@ class RdmaEndPoint {
         RWSpinlock::WriteGuard guard(lock_);
         if (flag) return;
         auto prev_status = status_.exchange(CLOSING);
-        if (prev_status == CONNECTED)
-            inactive_time_ = getCurrentTimeInNano();
+        if (prev_status == CONNECTED) inactive_time_ = getCurrentTimeInNano();
     }
 
     double inactiveTime() {
@@ -112,8 +111,8 @@ class RdmaEndPoint {
     // Submit some work requests to HW
     // Submitted tasks (success/failed) are removed in slice_list
     // Failed tasks (which must be submitted) are inserted in failed_slice_list
-    int submitPostSend(std::vector<Transport::Slice *> &slice_list,
-                       std::vector<Transport::Slice *> &failed_slice_list);
+    int submitPostSend(std::vector<Transport::Slice*>& slice_list,
+                       std::vector<Transport::Slice*>& failed_slice_list);
 
     // Get the number of QPs in this endpoint
     size_t getQPNumber() const;
@@ -121,28 +120,28 @@ class RdmaEndPoint {
    private:
     std::vector<uint32_t> qpNum() const;
 
-    int doSetupConnection(const std::string &peer_gid, uint16_t peer_lid,
+    int doSetupConnection(const std::string& peer_gid, uint16_t peer_lid,
                           std::vector<uint32_t> peer_qp_num_list,
-                          std::string *reply_msg = nullptr);
+                          std::string* reply_msg = nullptr);
 
-    int doSetupConnection(int qp_index, const std::string &peer_gid,
+    int doSetupConnection(int qp_index, const std::string& peer_gid,
                           uint16_t peer_lid, uint32_t peer_qp_num,
-                          std::string *reply_msg = nullptr);
+                          std::string* reply_msg = nullptr);
 
    private:
-    RdmaContext &context_;
+    RdmaContext& context_;
     std::atomic<Status> status_;
 
     RWSpinlock lock_;
-    std::vector<ibv_qp *> qp_list_;
+    std::vector<ibv_qp*> qp_list_;
 
     std::string peer_nic_path_;
 
-    volatile int *wr_depth_list_;
+    volatile int* wr_depth_list_;
     int max_wr_depth_;
 
     // volatile bool active_;
-    volatile int *cq_outstanding_;
+    volatile int* cq_outstanding_;
     volatile uint64_t inactive_time_;
 };
 

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -77,7 +77,7 @@ void loadGlobalConfig(GlobalConfig &config) {
     const char *max_ep_per_ctx_env = std::getenv("MC_MAX_EP_PER_CTX");
     if (max_ep_per_ctx_env) {
         size_t val = atoi(max_ep_per_ctx_env);
-        if (val > 0 && val <= UINT16_MAX)
+        if (val > 0 && val <= UINT32_MAX)
             config.max_ep_per_ctx = val;
         else
             LOG(WARNING)

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -26,16 +26,14 @@ const static uint8_t MAX_HOP_LIMIT = 16;
 const static uint8_t TIMEOUT = 14;
 const static uint8_t RETRY_CNT = 7;
 
-RdmaEndPoint::RdmaEndPoint(RdmaContext &context)
-    : context_(context),
-      status_(INITIALIZING),
-      cq_outstanding_(nullptr) {}
+RdmaEndPoint::RdmaEndPoint(RdmaContext& context)
+    : context_(context), status_(INITIALIZING), cq_outstanding_(nullptr) {}
 
 RdmaEndPoint::~RdmaEndPoint() {
     if (!qp_list_.empty()) deconstruct();
 }
 
-int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
+int RdmaEndPoint::construct(ibv_cq* cq, size_t num_qp_list,
                             size_t max_sge_per_wr, size_t max_wr_depth,
                             size_t max_inline_bytes) {
     if (status_.load(std::memory_order_relaxed) != INITIALIZING) {
@@ -44,7 +42,7 @@ int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
     }
 
     qp_list_.resize(num_qp_list);
-    cq_outstanding_ = (volatile int *)cq->cq_context;
+    cq_outstanding_ = (volatile int*)cq->cq_context;
 
     max_wr_depth_ = (int)max_wr_depth;
     wr_depth_list_ = new volatile int[num_qp_list];
@@ -101,7 +99,7 @@ int RdmaEndPoint::deconstruct() {
 
 int RdmaEndPoint::destroyQP() { return deconstruct(); }
 
-void RdmaEndPoint::setPeerNicPath(const std::string &peer_nic_path) {
+void RdmaEndPoint::setPeerNicPath(const std::string& peer_nic_path) {
     RWSpinlock::WriteGuard guard(lock_);
     if (connected()) {
         LOG(WARNING) << "Previous connection will be discarded";
@@ -122,7 +120,7 @@ int RdmaEndPoint::setupConnectionsByActive() {
         auto segment_desc =
             context_.engine().meta()->getSegmentDescByID(LOCAL_SEGMENT_ID);
         if (segment_desc) {
-            for (auto &nic : segment_desc->devices)
+            for (auto& nic : segment_desc->devices)
                 if (nic.name == context_.deviceName())
                     return doSetupConnection(nic.gid, nic.lid, qpNum());
         }
@@ -166,7 +164,7 @@ int RdmaEndPoint::setupConnectionsByActive() {
     auto segment_desc =
         context_.engine().meta()->getSegmentDescByName(peer_server_name);
     if (segment_desc) {
-        for (auto &nic : segment_desc->devices)
+        for (auto& nic : segment_desc->devices)
             if (nic.name == peer_nic_name)
                 return doSetupConnection(nic.gid, nic.lid, peer_desc.qp_num);
     }
@@ -175,8 +173,8 @@ int RdmaEndPoint::setupConnectionsByActive() {
     return ERR_DEVICE_NOT_FOUND;
 }
 
-int RdmaEndPoint::setupConnectionsByPassive(const HandShakeDesc &peer_desc,
-                                            HandShakeDesc &local_desc) {
+int RdmaEndPoint::setupConnectionsByPassive(const HandShakeDesc& peer_desc,
+                                            HandShakeDesc& local_desc) {
     RWSpinlock::WriteGuard guard(lock_);
     if (connected()) {
         LOG(WARNING) << "Re-establish connection: " << toString();
@@ -209,7 +207,7 @@ int RdmaEndPoint::setupConnectionsByPassive(const HandShakeDesc &peer_desc,
     auto segment_desc =
         context_.engine().meta()->getSegmentDescByName(peer_server_name);
     if (segment_desc) {
-        for (auto &nic : segment_desc->devices)
+        for (auto& nic : segment_desc->devices)
             if (nic.name == peer_nic_name)
                 return doSetupConnection(nic.gid, nic.lid, peer_desc.qp_num,
                                          &local_desc.reply_msg);
@@ -264,8 +262,8 @@ bool RdmaEndPoint::hasOutstandingSlice() const {
 }
 
 int RdmaEndPoint::submitPostSend(
-    std::vector<Transport::Slice *> &slice_list,
-    std::vector<Transport::Slice *> &failed_slice_list) {
+    std::vector<Transport::Slice*>& slice_list,
+    std::vector<Transport::Slice*>& failed_slice_list) {
     RWSpinlock::WriteGuard guard(lock_);
     if (!active()) return 0;
     int qp_index = SimpleRandom::Get().next(qp_list_.size());
@@ -280,12 +278,12 @@ int RdmaEndPoint::submitPostSend(
     memset(wr_list, 0, sizeof(ibv_send_wr) * wr_count);
     for (int i = 0; i < wr_count; ++i) {
         auto slice = slice_list[i];
-        auto &sge = sge_list[i];
+        auto& sge = sge_list[i];
         sge.addr = (uint64_t)slice->source_addr;
         sge.length = slice->length;
         sge.lkey = slice->rdma.source_lkey;
 
-        auto &wr = wr_list[i];
+        auto& wr = wr_list[i];
         wr.wr_id = (uint64_t)slice;
         wr.opcode = slice->opcode == Transport::TransferRequest::READ
                         ? IBV_WR_RDMA_READ
@@ -327,10 +325,10 @@ std::vector<uint32_t> RdmaEndPoint::qpNum() const {
     return ret;
 }
 
-int RdmaEndPoint::doSetupConnection(const std::string &peer_gid,
+int RdmaEndPoint::doSetupConnection(const std::string& peer_gid,
                                     uint16_t peer_lid,
                                     std::vector<uint32_t> peer_qp_num_list,
-                                    std::string *reply_msg) {
+                                    std::string* reply_msg) {
     if (qp_list_.size() != peer_qp_num_list.size()) {
         std::string message =
             "QP count mismatch in peer and local endpoints, connect stopped";
@@ -349,12 +347,12 @@ int RdmaEndPoint::doSetupConnection(const std::string &peer_gid,
     return 0;
 }
 
-int RdmaEndPoint::doSetupConnection(int qp_index, const std::string &peer_gid,
+int RdmaEndPoint::doSetupConnection(int qp_index, const std::string& peer_gid,
                                     uint16_t peer_lid, uint32_t peer_qp_num,
-                                    std::string *reply_msg) {
+                                    std::string* reply_msg) {
     if (qp_index < 0 || qp_index > (int)qp_list_.size())
         return ERR_INVALID_ARGUMENT;
-    auto &qp = qp_list_[qp_index];
+    auto& qp = qp_list_[qp_index];
 
     // Any state -> RESET
     ibv_qp_attr attr;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -333,8 +333,7 @@ int RdmaEndPoint::doSetupConnection(const std::string &peer_gid,
                                     std::string *reply_msg) {
     if (qp_list_.size() != peer_qp_num_list.size()) {
         std::string message =
-            "QP count mismatch in peer and local endpoints, check "
-            "MC_MAX_EP_PER_CTX";
+            "QP count mismatch in peer and local endpoints, connect stopped";
         LOG(ERROR) << "[Handshake] " << message;
         if (reply_msg) *reply_msg = message;
         return ERR_INVALID_ARGUMENT;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -31,7 +31,7 @@ namespace mooncake {
 
 const static int kTransferWorkerCount = globalConfig().workers_per_ctx;
 
-WorkerPool::WorkerPool(RdmaContext &context, int numa_socket_id)
+WorkerPool::WorkerPool(RdmaContext& context, int numa_socket_id)
     : context_(context),
       numa_socket_id_(numa_socket_id),
       workers_running_(true),
@@ -53,12 +53,12 @@ WorkerPool::~WorkerPool() {
     if (workers_running_) {
         cond_var_.notify_all();
         workers_running_.store(false);
-        for (auto &entry : worker_thread_) entry.join();
+        for (auto& entry : worker_thread_) entry.join();
     }
 }
 
 int WorkerPool::submitPostSend(
-    const std::vector<Transport::Slice *> &slice_list) {
+    const std::vector<Transport::Slice*>& slice_list) {
 #ifdef CONFIG_CACHE_SEGMENT_DESC
     thread_local uint64_t tl_last_cache_ts = getCurrentTimeInNano();
     thread_local std::unordered_map<SegmentID,
@@ -71,7 +71,7 @@ int WorkerPool::submitPostSend(
         tl_last_cache_ts = current_ts;
     }
 
-    for (auto &slice : slice_list) {
+    for (auto& slice : slice_list) {
         auto target_id = slice->target_id;
         if (!segment_desc_map.count(target_id)) {
             segment_desc_map[target_id] =
@@ -87,7 +87,7 @@ int WorkerPool::submitPostSend(
 #else
     std::unordered_map<SegmentID, std::shared_ptr<RdmaTransport::SegmentDesc>>
         segment_desc_map;
-    for (auto &slice : slice_list) {
+    for (auto& slice : slice_list) {
         auto target_id = slice->target_id;
         if (!segment_desc_map.count(target_id))
             segment_desc_map[target_id] =
@@ -98,7 +98,7 @@ int WorkerPool::submitPostSend(
     SliceList slice_list_map[kShardCount];
     uint64_t submitted_slice_count = 0;
     thread_local std::unordered_map<int, uint64_t> failed_target_ids;
-    for (auto &slice : slice_list) {
+    for (auto& slice : slice_list) {
         if (failed_target_ids.count(slice->target_id)) {
             auto ts = failed_target_ids[slice->target_id];
             if (getCurrentTimeInNano() - ts < 100000000ull) {
@@ -108,7 +108,7 @@ int WorkerPool::submitPostSend(
                 failed_target_ids.erase(slice->target_id);
             }
         }
-        auto &peer_segment_desc = segment_desc_map[slice->target_id];
+        auto& peer_segment_desc = segment_desc_map[slice->target_id];
         int buffer_id, device_id;
         auto hint = globalConfig().enable_dest_device_affinity
                         ? context_.deviceName()
@@ -154,7 +154,7 @@ int WorkerPool::submitPostSend(
     for (int shard_id = 0; shard_id < kShardCount; ++shard_id) {
         if (slice_list_map[shard_id].empty()) continue;
         slice_queue_lock_[shard_id].lock();
-        for (auto &slice : slice_list_map[shard_id])
+        for (auto& slice : slice_list_map[shard_id])
             slice_queue_[shard_id][slice->peer_nic_path].push_back(slice);
         slice_queue_count_[shard_id].fetch_add(slice_list_map[shard_id].size(),
                                                std::memory_order_relaxed);
@@ -169,15 +169,15 @@ int WorkerPool::submitPostSend(
 }
 
 void WorkerPool::performPostSend(int thread_id) {
-    auto &local_slice_queue = collective_slice_queue_[thread_id];
+    auto& local_slice_queue = collective_slice_queue_[thread_id];
     for (int shard_id = thread_id; shard_id < kShardCount;
          shard_id += kTransferWorkerCount) {
         if (slice_queue_count_[shard_id].load(std::memory_order_relaxed) == 0)
             continue;
 
         slice_queue_lock_[shard_id].lock();
-        for (auto &entry : slice_queue_[shard_id]) {
-            for (auto &slice : entry.second)
+        for (auto& entry : slice_queue_[shard_id]) {
+            for (auto& slice : entry.second)
                 local_slice_queue[entry.first].push_back(slice);
             entry.second.clear();
         }
@@ -193,7 +193,7 @@ void WorkerPool::performPostSend(int thread_id) {
             redispatch_counter_.load(std::memory_order_relaxed);
         auto local_slice_queue_clone = local_slice_queue;
         local_slice_queue.clear();
-        for (auto &entry : local_slice_queue_clone)
+        for (auto& entry : local_slice_queue_clone)
             redispatch(entry.second, thread_id);
         return;
     }
@@ -210,23 +210,22 @@ void WorkerPool::performPostSend(int thread_id) {
 #endif
 
     SliceList failed_slice_list;
-    for (auto &entry : local_slice_queue) {
+    for (auto& entry : local_slice_queue) {
         if (entry.second.empty()) continue;
 
 #ifdef USE_FAKE_POST_SEND
-        for (auto &slice : entry.second) slice->markSuccess();
+        for (auto& slice : entry.second) slice->markSuccess();
         processed_slice_count_.fetch_add(entry.second.size());
         entry.second.clear();
 #else
 #ifdef CONFIG_CACHE_ENDPOINT
-        auto &endpoint = endpoint_map[entry.first];
-        if (endpoint == nullptr)
-            endpoint = context_.endpoint(entry.first);
+        auto& endpoint = endpoint_map[entry.first];
+        if (endpoint == nullptr) endpoint = context_.endpoint(entry.first);
 #else
         auto endpoint = context_.endpoint(entry.first);
 #endif
         if (!endpoint) {
-            for (auto &slice : entry.second) failed_slice_list.push_back(slice);
+            for (auto& slice : entry.second) failed_slice_list.push_back(slice);
             entry.second.clear();
             continue;
         }
@@ -234,15 +233,15 @@ void WorkerPool::performPostSend(int thread_id) {
         //     if (endpoint->inactiveTime() > 1.0)
         //         context_.deleteEndpoint(
         //             entry.first);  // enable for re-establishation
-        //     for (auto &slice : entry.second) failed_slice_list.push_back(slice);
-        //     entry.second.clear();
+        //     for (auto &slice : entry.second)
+        //     failed_slice_list.push_back(slice); entry.second.clear();
         //     continue;
         // }
         if (!endpoint->connected() && endpoint->setupConnectionsByActive()) {
             LOG(ERROR) << "Worker: Cannot make connection for endpoint: "
-                       << entry.first << ", mark it inactive"; 
+                       << entry.first << ", mark it inactive";
             context_.deleteEndpoint(entry.first);
-            for (auto &slice : entry.second) failed_slice_list.push_back(slice);
+            for (auto& slice : entry.second) failed_slice_list.push_back(slice);
             // failed_nr_polls++;
             // if (context_.active() && failed_nr_polls > 32 &&
             //     !success_nr_polls) {
@@ -258,7 +257,7 @@ void WorkerPool::performPostSend(int thread_id) {
     }
 
     if (!failed_slice_list.empty()) {
-        for (auto &slice : failed_slice_list) slice->rdma.retry_cnt++;
+        for (auto& slice : failed_slice_list) slice->rdma.retry_cnt++;
         redispatch(failed_slice_list, thread_id);
     }
 }
@@ -266,7 +265,7 @@ void WorkerPool::performPostSend(int thread_id) {
 void WorkerPool::performPollCq(int thread_id) {
     int processed_slice_count = 0;
     const static size_t kPollCount = 64;
-    std::unordered_map<volatile int *, int> qp_depth_set;
+    std::unordered_map<volatile int*, int> qp_depth_set;
     for (int cq_index = thread_id; cq_index < context_.cqCount();
          cq_index += kTransferWorkerCount) {
         ibv_wc wc[kPollCount];
@@ -277,7 +276,7 @@ void WorkerPool::performPollCq(int thread_id) {
         }
 
         for (int i = 0; i < nr_poll; ++i) {
-            Transport::Slice *slice = (Transport::Slice *)wc[i].wr_id;
+            Transport::Slice* slice = (Transport::Slice*)wc[i].wr_id;
             assert(slice);
             if (qp_depth_set.count(slice->rdma.qp_depth))
                 qp_depth_set[slice->rdma.qp_depth]++;
@@ -295,7 +294,7 @@ void WorkerPool::performPollCq(int thread_id) {
                         << slice->opcode
                         << ", source_addr: " << slice->source_addr
                         << ", length: " << slice->length
-                        << ", dest_addr: " << (void *)slice->rdma.dest_addr
+                        << ", dest_addr: " << (void*)slice->rdma.dest_addr
                         << ", local_nic: " << context_.deviceName()
                         << ", peer_nic: " << slice->peer_nic_path
                         << ", dest_rkey: " << slice->rdma.dest_rkey
@@ -331,18 +330,18 @@ void WorkerPool::performPollCq(int thread_id) {
                                  nr_poll);
     }
 
-    for (auto &entry : qp_depth_set)
+    for (auto& entry : qp_depth_set)
         __sync_fetch_and_sub(entry.first, entry.second);
 
     if (processed_slice_count)
         processed_slice_count_.fetch_add(processed_slice_count);
 }
 
-void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
+void WorkerPool::redispatch(std::vector<Transport::Slice*>& slice_list,
                             int thread_id) {
     std::unordered_map<SegmentID, std::shared_ptr<Transport::SegmentDesc>>
         segment_desc_map;
-    for (auto &slice : slice_list) {
+    for (auto& slice : slice_list) {
         auto target_id = slice->target_id;
         if (!segment_desc_map.count(target_id)) {
             segment_desc_map[target_id] =
@@ -350,12 +349,12 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
         }
     }
 
-    for (auto &slice : slice_list) {
+    for (auto& slice : slice_list) {
         if (slice->rdma.retry_cnt >= slice->rdma.max_retry_cnt) {
             slice->markFailed();
             processed_slice_count_++;
         } else {
-            auto &peer_segment_desc = segment_desc_map[slice->target_id];
+            auto& peer_segment_desc = segment_desc_map[slice->target_id];
             int buffer_id, device_id;
             if (!peer_segment_desc ||
                 RdmaTransport::selectDevice(peer_segment_desc.get(),
@@ -411,7 +410,7 @@ int WorkerPool::doProcessContextEvents() {
                  << ibv_event_type_str(event.event_type) << " for context "
                  << context_.deviceName();
     if (event.event_type == IBV_EVENT_QP_FATAL) {
-        auto endpoint = (RdmaEndPoint *)event.element.qp->qp_context;
+        auto endpoint = (RdmaEndPoint*)event.element.qp->qp_context;
         context_.deleteEndpoint(endpoint->getPeerNicPath());
     } else if (event.event_type == IBV_EVENT_DEVICE_FATAL ||
                event.event_type == IBV_EVENT_CQ_ERR ||

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -229,26 +229,11 @@ void WorkerPool::performPostSend(int thread_id) {
             entry.second.clear();
             continue;
         }
-        // if (!endpoint->active()) {
-        //     if (endpoint->inactiveTime() > 1.0)
-        //         context_.deleteEndpoint(
-        //             entry.first);  // enable for re-establishation
-        //     for (auto &slice : entry.second)
-        //     failed_slice_list.push_back(slice); entry.second.clear();
-        //     continue;
-        // }
         if (!endpoint->connected() && endpoint->setupConnectionsByActive()) {
             LOG(ERROR) << "Worker: Cannot make connection for endpoint: "
                        << entry.first << ", mark it inactive";
             context_.deleteEndpoint(entry.first);
             for (auto& slice : entry.second) failed_slice_list.push_back(slice);
-            // failed_nr_polls++;
-            // if (context_.active() && failed_nr_polls > 32 &&
-            //     !success_nr_polls) {
-            //     LOG(WARNING)
-            //         << "Failed to establish peer endpoints in local RNIC "
-            //         << context_.nicPath() << ", mark it inactive";
-            // }
             entry.second.clear();
             continue;
         }


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Type of Change

* Types
  - [X] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

This patch tries to mitigate problems from EndPoint Store management, including:
- When EP count exceeds a soft limit rather than a hard limit, we evict some unused EPs eagerly.
- Delete RDMA resources immediately when calling deleteEndpoint, if it is OK.
- Make "pending-to-close" as a seperate state along with "handshake" or "connected".

Simple test in local testbed.

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
