### PR TITLE
[mooncake-store]: prevent orphaned bucket data files from leaking dis…

### DIFF
--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -400,8 +400,7 @@ class BucketIdGenerator {
 
 class BucketStorageBackend {
    public:
-    BucketStorageBackend(const std::string& storage_filepath,
-                         bool enable_orphan_cleanup = false);
+    BucketStorageBackend(const std::string& storage_filepath);
 
     /**
      * @brief Offload objects in batches
@@ -538,8 +537,5 @@ class BucketStorageBackend {
         object_bucket_map_;
     std::map<int64_t, std::shared_ptr<BucketMetadata>> GUARDED_BY(
         mutex_) buckets_;
-        
-    // Flag to enable automatic orphan cleanup
-    bool enable_orphan_cleanup_;
 };
 }  // namespace mooncake


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Add cleanup mechanism for bucket data files that are left orphaned when the process crashes between writing the data file and its metadata file.

Problem:
- BucketStorageBackend writes data file first, then .meta file
- If crash/failure occurs between these steps, data file is orphaned
- Init() only scans .meta files, never discovers orphans
- Orphaned files accumulate indefinitely, leaking disk space

Solution:
- Add immediate cleanup in WriteBucket() when metadata write fails
- Add orphan detection during Init() to clean up past crashes
- Make cleanup opt-in (disabled by default) via constructor flag
- Identify orphans by: numeric filename, no extension, no .meta pair

Changes:
- BucketStorageBackend: Add enable_orphan_cleanup parameter (default: false)
- WriteBucket(): Clean up data file if StoreBucketMetadata() fails
- Init(): Scan for and remove orphaned data files when enabled
- Add comprehensive test coverage for orphan cleanup

Issue link: https://github.com/kvcache-ai/Mooncake/issues/1139

## Type of Change

* Types
  - [X] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [x] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

- OrphanedDataFileCleanup: Creates valid bucket, manually orphans files, verifies cleanup
- Tests cleanup enabled vs disabled (default behavior)
- Validates valid buckets preserved during orphan cleanup
- Tests file count reduction after cleanup

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
