### PR TITLE
feat[Store]: Introduce shm helper for dummy

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -554,6 +554,17 @@ class MooncakeStorePyWrapper {
     }
 };
 
+class MooncakeHostMemAllocatorPyWrapper {
+   public:
+    // Only support ShmHelper for now
+    ShmHelper *shm_helper_ = nullptr;
+
+    MooncakeHostMemAllocatorPyWrapper() {
+        shm_helper_ = ShmHelper::getInstance();
+    }
+    ~MooncakeHostMemAllocatorPyWrapper() { shm_helper_ = nullptr; }
+};
+
 PYBIND11_MODULE(store, m) {
     // Define the ReplicateConfig class
     py::class_<ReplicateConfig>(m, "ReplicateConfig")
@@ -658,6 +669,25 @@ PYBIND11_MODULE(store, m) {
                 );
             }
         });
+
+    py::class_<MooncakeHostMemAllocatorPyWrapper>(m, "MooncakeHostMemAllocator")
+        .def(py::init<>())
+        .def("alloc",
+             [](MooncakeHostMemAllocatorPyWrapper &self, size_t size) {
+                 py::gil_scoped_release release;
+                 void *ptr = self.shm_helper_->allocate(size);
+                 return reinterpret_cast<uintptr_t>(ptr);
+             })
+        .def("free",
+             [](MooncakeHostMemAllocatorPyWrapper &self, uintptr_t ptr) {
+                 py::gil_scoped_release release;
+                 if (ptr != reinterpret_cast<uintptr_t>(
+                                self.shm_helper_->get_base_addr())) {
+                     LOG(ERROR) << "Invalid pointer passed to free";
+                     return -1;
+                 }
+                 return self.shm_helper_->cleanup();
+             });
 
     // Create a wrapper that exposes DistributedObjectStore with Python-specific
     // methods

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -7,6 +7,33 @@
 
 namespace mooncake {
 
+class ShmHelper {
+   public:
+    static ShmHelper *getInstance();
+
+    void *allocate(size_t size);
+
+    int cleanup();
+
+    int get_fd() const { return shm_fd_; }
+
+    void *get_base_addr() const { return shm_base_addr_; }
+
+    size_t get_size() const { return shm_size_; }
+
+    ShmHelper(const ShmHelper &) = delete;
+    ShmHelper &operator=(const ShmHelper &) = delete;
+
+   private:
+    ShmHelper();
+    ~ShmHelper();
+
+    int shm_fd_ = -1;
+    void *shm_base_addr_ = nullptr;
+    size_t shm_size_ = 0;
+    static std::mutex shm_mutex_;
+};
+
 class DummyClient : public PyClient {
    public:
     DummyClient();
@@ -179,7 +206,7 @@ class DummyClient : public PyClient {
     std::string client_addr_param_ GUARDED_BY(connect_mutex_);
 
     // For shared memory management
-    std::string shm_name_;
+    ShmHelper *shm_helper_ = nullptr;
     int shm_fd_ = -1;
     void *shm_base_addr_ = nullptr;
     size_t shm_size_ = 0;

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -21,7 +21,6 @@ struct ShmRegisterRequest {
     uint64_t dummy_base_addr;
     uint64_t shm_size;
     uint64_t local_buffer_size;
-    char shm_name[256];
 };
 
 // Python-specific wrapper class for client interface

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -305,9 +305,11 @@ class RealClient : public PyClient {
 
     // Share mem management for dummy client
     // Modified: map_shm_internal now takes fd instead of just name
-    tl::expected<void, ErrorCode> map_shm_internal(
-        int fd, const std::string &shm_name, uint64_t shm_base_addr,
-        size_t shm_size, size_t local_buffer_size, const UUID &client_id);
+    tl::expected<void, ErrorCode> map_shm_internal(int fd,
+                                                   uint64_t shm_base_addr,
+                                                   size_t shm_size,
+                                                   size_t local_buffer_size,
+                                                   const UUID &client_id);
 
     tl::expected<void, ErrorCode> unmap_shm_internal(const UUID &client_id);
 

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -15,13 +15,78 @@
 
 namespace mooncake {
 
+std::mutex ShmHelper::shm_mutex_;
+
 static int memfd_create_wrapper(const char* name, unsigned int flags) {
 #ifdef __NR_memfd_create
     return syscall(__NR_memfd_create, name, flags);
 #else
-    errno = ENOSYS;
-    return -1;
+    return -1;  // Or appropriate fallback/error
 #endif
+}
+
+ShmHelper* ShmHelper::getInstance() {
+    static ShmHelper instance;
+    return &instance;
+}
+
+ShmHelper::ShmHelper() {}
+
+ShmHelper::~ShmHelper() { cleanup(); }
+
+int ShmHelper::cleanup() {
+    if (shm_fd_ != -1) {
+        close(shm_fd_);
+        shm_fd_ = -1;
+    }
+    if (shm_base_addr_) {
+        if (munmap(shm_base_addr_, shm_size_) == -1) {
+            LOG(ERROR) << "Failed to unmap shared memory: " << strerror(errno);
+            shm_base_addr_ = nullptr;
+            return -1;
+        }
+        shm_base_addr_ = nullptr;
+    }
+    shm_size_ = 0;
+    return 0;
+}
+
+void* ShmHelper::allocate(size_t size) {
+    std::lock_guard<std::mutex> lock(shm_mutex_);
+    if (shm_fd_ != -1) {
+        throw std::runtime_error("Shared memory has already been allocated.");
+    }
+
+    shm_size_ = size;
+
+    // Create memfd
+    shm_fd_ = memfd_create_wrapper("mooncake_shm", MFD_CLOEXEC);
+    if (shm_fd_ == -1) {
+        throw std::runtime_error("Failed to create anonymous shared memory: " +
+                                 std::string(strerror(errno)));
+    }
+
+    // Set size
+    if (ftruncate(shm_fd_, shm_size_) == -1) {
+        close(shm_fd_);
+        shm_fd_ = -1;
+        shm_size_ = 0;
+        throw std::runtime_error("Failed to set shared memory size: " +
+                                 std::string(strerror(errno)));
+    }
+
+    // Map memory
+    shm_base_addr_ = mmap(nullptr, shm_size_, PROT_READ | PROT_WRITE,
+                          MAP_SHARED, shm_fd_, 0);
+    if (shm_base_addr_ == MAP_FAILED) {
+        close(shm_fd_);
+        shm_fd_ = -1;
+        shm_size_ = 0;
+        throw std::runtime_error("Failed to map shared memory: " +
+                                 std::string(strerror(errno)));
+    }
+
+    return shm_base_addr_;
 }
 
 static int send_fd(int socket, int fd, void* data, size_t data_len) {
@@ -209,8 +274,6 @@ int DummyClient::register_shm_via_ipc() {
     req.dummy_base_addr = reinterpret_cast<uintptr_t>(shm_base_addr_);
     req.shm_size = shm_size_;
     req.local_buffer_size = local_buffer_size_;
-    strncpy(req.shm_name, shm_name_.c_str(), sizeof(req.shm_name) - 1);
-    req.shm_name[sizeof(req.shm_name) - 1] = '\0';
 
     if (send_fd(sock_fd, shm_fd_, &req, sizeof(req)) < 0) {
         LOG(ERROR) << "Failed to send FD to RealClient: " << strerror(errno);
@@ -246,43 +309,41 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
         return -1;
     }
 
-    shm_name_ = "mooncake_shm_" + std::to_string(client_id_.first) + "_" +
-                std::to_string(client_id_.second);
-    shm_size_ = local_buffer_size + mem_pool_size;
+    shm_helper_ = ShmHelper::getInstance();
+    shm_fd_ = shm_helper_->get_fd();
+    if (shm_fd_ == -1) {
+        // Allocate shared memory if not already allocated
+        shm_size_ = local_buffer_size + mem_pool_size;
+        try {
+            shm_base_addr_ = shm_helper_->allocate(shm_size_);
+        } catch (const std::exception& e) {
+            LOG(ERROR) << "Failed to allocate shared memory: " << e.what();
+            return -1;
+        }
+        shm_fd_ = shm_helper_->get_fd();
+    } else {
+        // Shared memory already allocated, just get the base address and size
+        shm_base_addr_ = shm_helper_->get_base_addr();
+        shm_size_ = shm_helper_->get_size();
+        size_t requested_size = local_buffer_size + mem_pool_size;
+        if (shm_size_ != requested_size) {
+            LOG(ERROR) << "Shared memory size mismatch: existing size ("
+                       << shm_size_ << ") does not match requested size ("
+                       << requested_size << ")";
+            return -1;
+        }
+    }
+
     local_buffer_size_ = local_buffer_size;
     ipc_socket_path_ = ipc_socket_path;
-
-    // Use memfd_create instead of shm_open for anonymous shared memory
-    shm_fd_ = memfd_create_wrapper(shm_name_.c_str(), MFD_CLOEXEC);
-    if (shm_fd_ == -1) {
-        LOG(ERROR) << "Failed to create anonymous shared memory: "
-                   << strerror(errno);
-        return -1;
-    }
-
-    // Set the size of the shared memory object
-    if (ftruncate(shm_fd_, shm_size_) == -1) {
-        LOG(ERROR) << "Failed to set shared memory size: " << strerror(errno);
-        close(shm_fd_);
-        return -1;
-    }
-
-    // Map shared memory into the process's address space
-    shm_base_addr_ = mmap(nullptr, shm_size_, PROT_READ | PROT_WRITE,
-                          MAP_SHARED, shm_fd_, 0);
-    if (shm_base_addr_ == MAP_FAILED) {
-        LOG(ERROR) << "Failed to map shared memory: " << strerror(errno);
-        close(shm_fd_);
-        return -1;
-    }
 
     // Attempt registration
     if (register_shm_via_ipc() != 0) {
         LOG(ERROR) << "Failed to register SHM via IPC";
-        munmap(shm_base_addr_, shm_size_);
-        close(shm_fd_);
+        // We do not cleanup here, as the shm_helper_ is still valid
         shm_fd_ = -1;
         shm_base_addr_ = nullptr;
+        shm_size_ = 0;
         return -1;
     }
 
@@ -294,21 +355,9 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
 
 int DummyClient::tearDownAll() {
     unregister_shm();
-    if (shm_base_addr_ != nullptr) {
-        if (munmap(shm_base_addr_, shm_size_) == -1) {
-            LOG(ERROR) << "Failed to unmap shared memory: " << shm_name_
-                       << ", error: " << strerror(errno);
-            return -1;
-        }
-        shm_base_addr_ = nullptr;
-        shm_size_ = 0;
-        // Dummy client unlinks shm in setup after real client mmap
-    }
-
-    if (shm_fd_ >= 0) {
-        close(shm_fd_);
-        shm_fd_ = -1;
-    }
+    shm_fd_ = -1;
+    shm_base_addr_ = nullptr;
+    shm_size_ = 0;
 
     if (ping_running_) {
         ping_running_ = false;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -672,8 +672,10 @@ int64_t RealClient::getSize(const std::string &key) {
 }
 
 tl::expected<void, ErrorCode> RealClient::map_shm_internal(
-    int fd, const std::string &shm_name, uint64_t dummy_base_addr,
-    size_t shm_size, size_t local_buffer_size, const UUID &client_id) {
+    int fd, uint64_t dummy_base_addr, size_t shm_size, size_t local_buffer_size,
+    const UUID &client_id) {
+    std::string shm_name = "mooncake_shm_" + std::to_string(client_id.first) +
+                           "_" + std::to_string(client_id.second);
     std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);
     if (shm_contexts_.count(client_id)) {
         LOG(INFO) << "client_id=" << client_id
@@ -792,8 +794,7 @@ tl::expected<void, ErrorCode> RealClient::register_shm_buffer_internal(
     uint64_t real_base_addr = dummy_base_addr + context.shm_addr_offset;
     if (context.registered_buffers.count(real_base_addr)) {
         LOG(ERROR) << "Buffer with base address (real: " << real_base_addr
-                   << ") "
-                   << " , (dummy: " << dummy_base_addr << ") "
+                   << ") " << " , (dummy: " << dummy_base_addr << ") "
                    << " is already registered for client_id=" << client_id;
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -831,8 +832,7 @@ tl::expected<size_t, ErrorCode> RealClient::unregister_shm_buffer_internal(
     } else {
         LOG(ERROR)
             << "Failed to find registered buffer with base address (real: "
-            << real_base_addr << ") "
-            << " , (dummy: " << dummy_base_addr
+            << real_base_addr << ") " << " , (dummy: " << dummy_base_addr
             << ") for client_id=" << client_id << ";";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -1917,9 +1917,8 @@ void RealClient::ipc_server_func() {
             status = -1;
         } else {
             UUID client_id = {req.client_id_first, req.client_id_second};
-            auto ret = map_shm_internal(fd, req.shm_name, req.dummy_base_addr,
-                                        req.shm_size, req.local_buffer_size,
-                                        client_id);
+            auto ret = map_shm_internal(fd, req.dummy_base_addr, req.shm_size,
+                                        req.local_buffer_size, client_id);
             if (!ret) {
                 status = toInt(ret.error());
                 // FD is closed inside map_shm_internal


### PR DESCRIPTION
## Description

Split shm alloc logic into a helper class.
Thus, the APP like SGLang can directly use this helper to create share mem.

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [ ] Transfer Engine
    - [x] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
