### PR TITLE
[TE/Examples] Memory initialization and HIP cleanup fixes

### DIFF
--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// Modifications Copyright(C) 2025 Advanced Micro Devices, Inc.
-// All rights reserved.
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>

--- a/mooncake-transfer-engine/example/transfer_engine_bench_with_notify.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench_with_notify.cpp
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// Modifications Copyright(C) 2025 Advanced Micro Devices, Inc.
-// All rights reserved.
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>

--- a/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// Modifications Copyright(C) 2025 Advanced Micro Devices, Inc.
-// All rights reserved.
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>

--- a/mooncake-transfer-engine/example/transfer_engine_validator.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_validator.cpp
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// Modifications Copyright(C) 2025 Advanced Micro Devices, Inc.
-// All rights reserved.
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>


### PR DESCRIPTION
## Description

Transfer engine examples changes: 
1. Initialize allocated memory:
    - GPU Driver may optimize transfers for non-initialized memory, while on real applications the memory is always initialized. So, need to initialize the memory in the benchmarks too.
2. Check data at least once in TransferEngineValidator:
    - transfer_engine_validator checks data on random iterations. It may happen that it does not check data at all. So, added checking at least on the first iteration.
3. Directly call freePinnedLocalMemory for HIP:
    - hipMemRetainAllocationHandle fails if memory was allocated using hipMalloc, which is possible inside NvlinkTransport::allocatePinnedLocalMemory. So, call just freePinnedLocalMemory, which will handle how to free.
    - **UPDATE**: Directly call freePinnedLocalMemory for CUDA and MUSA too as suggested by gemini

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [x] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

Ran transfer_engine_bench and transfer_engine_validator on nodes with AMG GPU

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
