### PR TITLE
Optimizing Throughput for Large Batch Sizes

### DIFF
--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -167,7 +167,8 @@ class TransferEngine {
 #endif
         auto &batch_desc = *((BatchDesc *)(batch_id));
         const size_t task_count = batch_desc.task_list.size();
-        if (result.ok() && status.s == TransferStatusEnum::COMPLETED && task_id == task_count - 1) {
+        if (result.ok() && status.s == TransferStatusEnum::COMPLETED &&
+            task_id == task_count - 1) {
             // when the overall status is COMPLETED
             // send notify
             RWSpinlock::WriteGuard guard(send_notifies_lock_);


### PR DESCRIPTION
## Finding
As shown in the table, when running ./transfer_engine_bench on two H20 servers, the throughput decreases as the batch size increases.

<img width="308" height="164" alt="image" src="https://github.com/user-attachments/assets/544f9c5e-7281-460a-a778-c8f8928580f4" />


## Optimization

We optimize the implementation of getTransferStatus() in transfer_engine.h, reducing the time complexity from O(n²·m) to O(n·m), where n is the batch size.

## Evaluation

### Experiment Setup
2 nodes, with 8 × H20 GPUs per node.
 
```
./transfer_engine_bench --mode=initiator --metadata_server=etcd://etcd_server:port --segment_id=abcd:12345 --operation=read --device_name=mlx5_bond_1 --batch_size=xx --block_size=4096

./transfer_engine_bench --mode=target --metadata_server=etcd://etcd_server:port  --local_server_name=abcd:12345 --operation=read --device_name=mlx5_bond_1  --batch_size=xx --block_size=4096
```

### Performance Evaluation

<img width="453" height="165" alt="image" src="https://github.com/user-attachments/assets/05464129-a9ab-467f-bb54-d34a309ecfd9" />