### PR TITLE
feat[Store]: add multi shm support for dummy and real client

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1062,12 +1062,7 @@ PYBIND11_MODULE(store, m) {
         .def("free",
              [](MooncakeHostMemAllocatorPyWrapper &self, uintptr_t ptr) {
                  py::gil_scoped_release release;
-                 if (ptr != reinterpret_cast<uintptr_t>(
-                                self.shm_helper_->get_base_addr())) {
-                     LOG(ERROR) << "Invalid pointer passed to free";
-                     return -1;
-                 }
-                 return self.shm_helper_->cleanup();
+                 return self.shm_helper_->free(reinterpret_cast<void *>(ptr));
              });
 
     // Create a wrapper that exposes DistributedObjectStore with Python-specific

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -4,22 +4,35 @@
 
 #include "pyclient.h"
 #include "real_client.h"
+#include <memory>
 
 namespace mooncake {
 
 class ShmHelper {
    public:
+    struct ShmSegment {
+        int fd = -1;
+        void *base_addr = nullptr;
+        size_t size = 0;
+        std::string name;
+        bool registered = false;
+        bool is_local = false;
+    };
+
     static ShmHelper *getInstance();
 
     void *allocate(size_t size);
+    int free(void *addr);
 
-    int cleanup();
+    bool cleanup();
 
-    int get_fd() const { return shm_fd_; }
+    // Get the shm that contains the given address
+    // Returns a shared_ptr to ensure the segment remains valid
+    std::shared_ptr<ShmSegment> get_shm(void *addr);
 
-    void *get_base_addr() const { return shm_base_addr_; }
-
-    size_t get_size() const { return shm_size_; }
+    const std::vector<std::shared_ptr<ShmSegment>> &get_shms() const {
+        return shms_;
+    }
 
     ShmHelper(const ShmHelper &) = delete;
     ShmHelper &operator=(const ShmHelper &) = delete;
@@ -28,9 +41,7 @@ class ShmHelper {
     ShmHelper();
     ~ShmHelper();
 
-    int shm_fd_ = -1;
-    void *shm_base_addr_ = nullptr;
-    size_t shm_size_ = 0;
+    std::vector<std::shared_ptr<ShmSegment>> shms_;
     static std::mutex shm_mutex_;
 };
 
@@ -62,7 +73,7 @@ class DummyClient : public PyClient {
         return -1;
     }
 
-    int64_t alloc_from_mem_pool(size_t size);
+    uint64_t alloc_from_mem_pool(size_t size);
 
     int put(const std::string &key, std::span<const char> value,
             const ReplicateConfig &config = ReplicateConfig{});
@@ -140,7 +151,8 @@ class DummyClient : public PyClient {
    private:
     ErrorCode connect(const std::string &server_address);
 
-    int register_shm_via_ipc();
+    int register_shm_via_ipc(const ShmHelper::ShmSegment *shm,
+                             bool is_local = false);
 
     /**
      * @brief Generic RPC invocation helper for single-result operations
@@ -207,11 +219,6 @@ class DummyClient : public PyClient {
 
     // For shared memory management
     ShmHelper *shm_helper_ = nullptr;
-    int shm_fd_ = -1;
-    void *shm_base_addr_ = nullptr;
-    size_t shm_size_ = 0;
-    size_t registered_size_ = 0;
-    size_t local_buffer_size_ = 0;
     std::string ipc_socket_path_;
 
     // For high availability

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -15,13 +15,14 @@
 
 namespace mooncake {
 
+#define MOONCAKE_SHM_NAME "mooncake_shm"
 // Protocol structure for IPC registration
 struct ShmRegisterRequest {
     uint64_t client_id_first;
     uint64_t client_id_second;
     uint64_t dummy_base_addr;
     uint64_t shm_size;
-    uint64_t local_buffer_size;
+    bool is_local_buffer;
 };
 
 // Python-specific wrapper class for client interface
@@ -44,7 +45,7 @@ class PyClient {
                         const std::string &device_name,
                         size_t mount_segment_size) = 0;
 
-    virtual int64_t alloc_from_mem_pool(size_t size) = 0;
+    virtual uint64_t alloc_from_mem_pool(size_t size) = 0;
 
     virtual int put(const std::string &key, std::span<const char> value,
                     const ReplicateConfig &config = ReplicateConfig{}) = 0;

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -35,59 +35,97 @@ ShmHelper::ShmHelper() {}
 
 ShmHelper::~ShmHelper() { cleanup(); }
 
-int ShmHelper::cleanup() {
-    if (shm_fd_ != -1) {
-        close(shm_fd_);
-        shm_fd_ = -1;
-    }
-    if (shm_base_addr_) {
-        if (munmap(shm_base_addr_, shm_size_) == -1) {
-            LOG(ERROR) << "Failed to unmap shared memory: " << strerror(errno);
-            shm_base_addr_ = nullptr;
-            return -1;
+bool ShmHelper::cleanup() {
+    std::lock_guard<std::mutex> lock(shm_mutex_);
+    bool ret = true;
+    for (auto& shm : shms_) {
+        if (shm->fd != -1) {
+            close(shm->fd);
+            shm->fd = -1;
         }
-        shm_base_addr_ = nullptr;
+        if (shm->base_addr) {
+            if (munmap(shm->base_addr, shm->size) == -1) {
+                LOG(ERROR) << "Failed to unmap shared memory: "
+                           << strerror(errno);
+                ret = false;
+            }
+            shm->base_addr = nullptr;
+        }
     }
-    shm_size_ = 0;
-    return 0;
+    shms_.clear();
+    return ret;
 }
 
 void* ShmHelper::allocate(size_t size) {
     std::lock_guard<std::mutex> lock(shm_mutex_);
-    if (shm_fd_ != -1) {
-        throw std::runtime_error("Shared memory has already been allocated.");
-    }
-
-    shm_size_ = size;
 
     // Create memfd
-    shm_fd_ = memfd_create_wrapper("mooncake_shm", MFD_CLOEXEC);
-    if (shm_fd_ == -1) {
+    int fd = memfd_create_wrapper(MOONCAKE_SHM_NAME, MFD_CLOEXEC);
+    if (fd == -1) {
         throw std::runtime_error("Failed to create anonymous shared memory: " +
                                  std::string(strerror(errno)));
     }
 
     // Set size
-    if (ftruncate(shm_fd_, shm_size_) == -1) {
-        close(shm_fd_);
-        shm_fd_ = -1;
-        shm_size_ = 0;
+    if (ftruncate(fd, size) == -1) {
+        close(fd);
         throw std::runtime_error("Failed to set shared memory size: " +
                                  std::string(strerror(errno)));
     }
 
     // Map memory
-    shm_base_addr_ = mmap(nullptr, shm_size_, PROT_READ | PROT_WRITE,
-                          MAP_SHARED, shm_fd_, 0);
-    if (shm_base_addr_ == MAP_FAILED) {
-        close(shm_fd_);
-        shm_fd_ = -1;
-        shm_size_ = 0;
+    void* base_addr =
+        mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (base_addr == MAP_FAILED) {
+        close(fd);
         throw std::runtime_error("Failed to map shared memory: " +
                                  std::string(strerror(errno)));
     }
 
-    return shm_base_addr_;
+    auto shm = std::make_shared<ShmSegment>();
+    shm->fd = fd;
+    shm->base_addr = base_addr;
+    shm->size = size;
+    shm->name = MOONCAKE_SHM_NAME;
+    shm->registered = false;
+    shms_.push_back(shm);
+
+    return base_addr;
+}
+
+std::shared_ptr<ShmHelper::ShmSegment> ShmHelper::get_shm(void* addr) {
+    std::lock_guard<std::mutex> lock(shm_mutex_);
+    for (auto& shm : shms_) {
+        if (addr >= shm->base_addr &&
+            reinterpret_cast<uint8_t*>(addr) <
+                reinterpret_cast<uint8_t*>(shm->base_addr) + shm->size) {
+            return shm;
+        }
+    }
+    return nullptr;
+}
+
+int ShmHelper::free(void* addr) {
+    std::lock_guard<std::mutex> lock(shm_mutex_);
+    for (auto it = shms_.begin(); it != shms_.end(); ++it) {
+        if ((*it)->base_addr == addr) {
+            if ((*it)->fd != -1) {
+                close((*it)->fd);
+            }
+            if ((*it)->base_addr &&
+                munmap((*it)->base_addr, (*it)->size) == -1) {
+                LOG(ERROR) << "Failed to unmap shared memory during free: "
+                           << strerror(errno);
+                return -1;
+            }
+            LOG(INFO) << "Freed shared memory at " << addr
+                      << ", size: " << (*it)->size;
+            shms_.erase(it);
+            return 0;
+        }
+    }
+    LOG(ERROR) << "Attempted to free unknown shared memory address: " << addr;
+    return -1;
 }
 
 static int send_fd(int socket, int fd, void* data, size_t data_len) {
@@ -234,8 +272,9 @@ ErrorCode DummyClient::connect(const std::string& server_address) {
     return ErrorCode::OK;
 }
 
-int DummyClient::register_shm_via_ipc() {
-    if (shm_fd_ < 0) {
+int DummyClient::register_shm_via_ipc(const ShmHelper::ShmSegment* shm,
+                                      bool is_local) {
+    if (shm->fd < 0) {
         LOG(ERROR) << "Invalid shm_fd during IPC registration";
         return -1;
     }
@@ -272,11 +311,11 @@ int DummyClient::register_shm_via_ipc() {
     ShmRegisterRequest req;
     req.client_id_first = client_id_.first;
     req.client_id_second = client_id_.second;
-    req.dummy_base_addr = reinterpret_cast<uintptr_t>(shm_base_addr_);
-    req.shm_size = shm_size_;
-    req.local_buffer_size = local_buffer_size_;
+    req.dummy_base_addr = reinterpret_cast<uintptr_t>(shm->base_addr);
+    req.shm_size = shm->size;
+    req.is_local_buffer = is_local;
 
-    if (send_fd(sock_fd, shm_fd_, &req, sizeof(req)) < 0) {
+    if (send_fd(sock_fd, shm->fd, &req, sizeof(req)) < 0) {
         LOG(ERROR) << "Failed to send FD to RealClient: " << strerror(errno);
         close(sock_fd);
         return -1;
@@ -297,13 +336,15 @@ int DummyClient::register_shm_via_ipc() {
         return -1;
     }
 
-    LOG(INFO) << "Successfully registered SHM via IPC";
+    LOG(INFO) << "Successfully registered SHM via IPC, base: "
+              << shm->base_addr;
     return 0;
 }
 
 int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                              const std::string& server_address,
                              const std::string& ipc_socket_path) {
+    void* base_addr = nullptr;
     ErrorCode err = connect(server_address);
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "Failed to connect to real client";
@@ -311,42 +352,31 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
     }
 
     shm_helper_ = ShmHelper::getInstance();
-    shm_fd_ = shm_helper_->get_fd();
-    if (shm_fd_ == -1) {
-        // Allocate shared memory if not already allocated
-        shm_size_ = local_buffer_size + mem_pool_size;
-        try {
-            shm_base_addr_ = shm_helper_->allocate(shm_size_);
-        } catch (const std::exception& e) {
-            LOG(ERROR) << "Failed to allocate shared memory: " << e.what();
-            return -1;
-        }
-        shm_fd_ = shm_helper_->get_fd();
-    } else {
-        // Shared memory already allocated, just get the base address and size
-        shm_base_addr_ = shm_helper_->get_base_addr();
-        shm_size_ = shm_helper_->get_size();
-        size_t requested_size = local_buffer_size + mem_pool_size;
-        if (shm_size_ != requested_size) {
-            LOG(ERROR) << "Shared memory size mismatch: existing size ("
-                       << shm_size_ << ") does not match requested size ("
-                       << requested_size << ")";
-            return -1;
-        }
-    }
-
-    local_buffer_size_ = local_buffer_size;
-    ipc_socket_path_ = ipc_socket_path;
-
-    // Attempt registration
-    if (register_shm_via_ipc() != 0) {
-        LOG(ERROR) << "Failed to register SHM via IPC";
-        // We do not cleanup here, as the shm_helper_ is still valid
-        shm_fd_ = -1;
-        shm_base_addr_ = nullptr;
-        shm_size_ = 0;
+    try {
+        base_addr = shm_helper_->allocate(local_buffer_size);
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to allocate shared memory: " << e.what();
         return -1;
     }
+
+    ipc_socket_path_ = ipc_socket_path;
+
+    // Attempt registration for the primary segment
+    auto local_buffer_shm = shm_helper_->get_shm(base_addr);
+    if (!local_buffer_shm) {
+        LOG(ERROR) << "Failed to get shm segment for base address";
+        shm_helper_->free(base_addr);
+        return -1;
+    }
+
+    if (register_shm_via_ipc(local_buffer_shm.get(), true) != 0) {
+        LOG(ERROR) << "Failed to register SHM via IPC";
+        // Register failed, cleanup
+        shm_helper_->free(local_buffer_shm->base_addr);
+        return -1;
+    }
+    local_buffer_shm->registered = true;
+    local_buffer_shm->is_local = true;
 
     ping_running_ = true;
     ping_thread_ = std::thread([this]() mutable { this->ping_thread_main(); });
@@ -356,9 +386,6 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
 
 int DummyClient::tearDownAll() {
     unregister_shm();
-    shm_fd_ = -1;
-    shm_base_addr_ = nullptr;
-    shm_size_ = 0;
 
     if (ping_running_) {
         ping_running_ = false;
@@ -380,47 +407,71 @@ int DummyClient::register_buffer(void* buffer, size_t size) {
         LOG(ERROR) << "Invalid buffer pointer";
         return -1;
     }
-    if (shm_base_addr_ == nullptr) {
-        LOG(ERROR) << "Shared memory is not registered";
+    // Find which shm this buffer belongs to
+    auto shm = shm_helper_->get_shm(buffer);
+    if (!shm) {
+        LOG(ERROR) << "Buffer is not in any registered shared memory";
         return -1;
     }
-    if (buffer < shm_base_addr_ ||
-        reinterpret_cast<uint8_t*>(buffer) + static_cast<uint64_t>(size) >
-            reinterpret_cast<uint8_t*>(shm_base_addr_) + shm_size_) {
-        LOG(ERROR) << "Buffer to register is out of shared memory bounds";
+    // Check bounds
+    if (reinterpret_cast<uint8_t*>(buffer) !=
+            reinterpret_cast<uint8_t*>(shm->base_addr) ||
+        size != shm->size) {
+        LOG(ERROR)
+            << "Invalid buffer address or size for registration: Buffer addr: "
+            << buffer << ", need addr: " << shm->base_addr
+            << ", buffer size: " << size << ", need size: " << shm->size;
         return -1;
     }
-    auto ret = invoke_rpc<&RealClient::register_shm_buffer_internal, void>(
-        reinterpret_cast<uint64_t>(buffer), static_cast<uint64_t>(size),
-        client_id_);
-    if (ret.has_value()) {
-        registered_size_ += size;
+
+    // If this shm is not registered with RealClient yet, do it now
+    if (!shm->registered) {
+        if (register_shm_via_ipc(shm.get(), shm->is_local) != 0) {
+            LOG(ERROR) << "Failed to implicitly register new SHM via IPC";
+            return -1;
+        }
+        shm->registered = true;
     }
-    return to_py_ret(ret);
+
+    return 0;
 }
 
 int DummyClient::unregister_buffer(void* buffer) {
-    auto ret = invoke_rpc<&RealClient::unregister_shm_buffer_internal, size_t>(
+    if (buffer == nullptr) {
+        LOG(ERROR) << "Invalid buffer pointer";
+        return -1;
+    }
+
+    auto shm = shm_helper_->get_shm(buffer);
+    if (!shm) {
+        LOG(ERROR) << "Buffer is not in any registered shared memory";
+        return -1;
+    }
+    if (!shm->registered) {
+        LOG(ERROR) << "Buffer is not registered with RealClient";
+        return -1;
+    }
+    if (reinterpret_cast<uint8_t*>(buffer) !=
+        reinterpret_cast<uint8_t*>(shm->base_addr)) {
+        LOG(ERROR) << "Invalid buffer address for unregistration";
+        return -1;
+    }
+    auto ret = invoke_rpc<&RealClient::unregister_shm_buffer_internal, void>(
         reinterpret_cast<uint64_t>(buffer), client_id_);
     if (ret.has_value()) {
-        registered_size_ -= ret.value();
-        return 0;
+        shm->registered = false;
     }
     return to_py_ret(ret);
 }
 
-int64_t DummyClient::alloc_from_mem_pool(size_t size) {
-    // TODO: using offset allocation strategy later
-    if (shm_base_addr_ == nullptr) {
-        LOG(ERROR) << "Shared memory is not registered";
-        return -1;
+uint64_t DummyClient::alloc_from_mem_pool(size_t size) {
+    try {
+        void* addr = shm_helper_->allocate(size);
+        return reinterpret_cast<uint64_t>(addr);
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to allocate from mem pool: " << e.what();
+        return 0;
     }
-    if (registered_size_ + local_buffer_size_ + size > shm_size_) {
-        LOG(ERROR) << "Not enough space in shared memory";
-        return -1;
-    }
-    return reinterpret_cast<int64_t>(shm_base_addr_) +
-           static_cast<int64_t>(registered_size_);
 }
 
 int DummyClient::put(const std::string& key, std::span<const char> value,
@@ -659,12 +710,27 @@ void DummyClient::ping_thread_main() {
 
             // Reconnection Loop
             while (ping_running_) {
-                // 1. Try to register SHM via IPC (this is critical if
-                // RealClient restarted)
-                if (register_shm_via_ipc() == 0) {
-                    LOG(INFO) << "Re-registered SHM via IPC successfully";
+                // Re-register ALL shms
+                bool all_registered = true;
+                const auto& shms = shm_helper_->get_shms();
+                for (const auto& shm_ptr : shms) {
+                    if (shm_ptr->registered) {
+                        if (register_shm_via_ipc(shm_ptr.get(),
+                                                 shm_ptr->is_local) != 0) {
+                            LOG(WARNING)
+                                << "Failed to re-register shared memory "
+                                   "during reconnection";
+                            all_registered = false;
+                            break;
+                        }
+                    }
+                }
 
-                    // 2. Try to validate RPC connection
+                if (all_registered) {
+                    LOG(INFO)
+                        << "Re-registered all shared memorys successfully";
+
+                    // Try to validate RPC connection
                     // Even if register_shm_via_ipc succeeded, we should check
                     // if RPC is responsive
                     auto check_rpc =

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -219,7 +219,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
 
     // If global_segment_size is 0, skip mount segment;
     // If global_segment_size is larger than max_mr_size, split to multiple
-    // segments.
+    // mapped_shms.
     auto max_mr_size = globalConfig().max_mr_size;     // Max segment size
     uint64_t total_glbseg_size = global_segment_size;  // For logging
     uint64_t current_glbseg_size = 0;                  // For logging
@@ -333,13 +333,20 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
     while (shm_it != shm_contexts_.end()) {
         auto &context = shm_it->second;
         context.client_buffer_allocator.reset();
-        if (context.shm_buffer) {
-            // Memory mapped from memfd needs munmap
-            if (munmap(context.shm_buffer, context.shm_size) != 0) {
-                LOG(ERROR) << "Failed to unmap shm buffer: " << strerror(errno);
+
+        // Iterate over all mapped_shms to unmap them
+        for (auto &seg : context.mapped_shms) {
+            if (seg.shm_buffer) {
+                // Memory mapped from memfd needs munmap
+                if (munmap(seg.shm_buffer, seg.shm_size) != 0) {
+                    LOG(ERROR) << "Failed to unmap shm: " << seg.shm_name
+                               << ", error: " << strerror(errno);
+                }
+                seg.shm_buffer = nullptr;
             }
-            context.shm_buffer = nullptr;
         }
+        context.mapped_shms.clear();
+
         shm_it = shm_contexts_.erase(shm_it);
     }
     return {};
@@ -684,15 +691,26 @@ int64_t RealClient::getSize(const std::string &key) {
 }
 
 tl::expected<void, ErrorCode> RealClient::map_shm_internal(
-    int fd, uint64_t dummy_base_addr, size_t shm_size, size_t local_buffer_size,
+    int fd, uint64_t dummy_base_addr, size_t shm_size, bool is_local_buffer,
     const UUID &client_id) {
-    std::string shm_name = "mooncake_shm_" + std::to_string(client_id.first) +
-                           "_" + std::to_string(client_id.second);
+    std::stringstream addr_stream;
+    addr_stream << "0x" << std::hex << dummy_base_addr;
+
+    std::string shm_name =
+        std::string(MOONCAKE_SHM_NAME) + "_" + std::to_string(client_id.first) +
+        "_" + std::to_string(client_id.second) + "_" + addr_stream.str();
     std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);
-    if (shm_contexts_.count(client_id)) {
-        LOG(INFO) << "client_id=" << client_id
-                  << ", shm already mapped (idempotent success)";
-        return {};
+
+    // Check if client context exists, create if not
+    auto &context = shm_contexts_[client_id];
+
+    // Check if this shm is already mapped
+    for (const auto &shm : context.mapped_shms) {
+        if (shm.dummy_base_addr == static_cast<uintptr_t>(dummy_base_addr)) {
+            LOG(INFO) << "Segment already mapped: " << shm_name;
+            if (fd >= 0) close(fd);
+            return {};
+        }
     }
 
     if (fd < 0) {
@@ -709,54 +727,42 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal(
         close(fd);
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
-    LOG(INFO) << "Shared memory mapped successfully from fd: " << fd
-              << ", name: " << shm_name
-              << ", size: " << byte_size_to_string(shm_size)
-              << ", local buffer size: "
-              << byte_size_to_string(local_buffer_size);
 
-    // We can close the FD after mmap (or caller closes it).
-    // In IPC flow, we received a copy, we should close it after mapping.
-    close(fd);
+    close(fd);  // Close FD after mapping
 
-    ShmContext context;
-    context.shm_addr_offset = reinterpret_cast<uintptr_t>(shm_buffer) -
-                              reinterpret_cast<uintptr_t>(dummy_base_addr);
-    context.shm_name = shm_name;
-    context.shm_size = shm_size;
-    context.local_buffer_size = local_buffer_size;
-    context.shm_buffer = shm_buffer;
+    MappedShm shm;
+    shm.shm_name = shm_name;
+    shm.shm_buffer = shm_buffer;
+    shm.shm_size = shm_size;
+    shm.dummy_base_addr = static_cast<uintptr_t>(dummy_base_addr);
+    shm.shm_addr_offset = reinterpret_cast<uintptr_t>(shm_buffer) -
+                          reinterpret_cast<uintptr_t>(dummy_base_addr);
 
     if (shm_size > 0) {
         auto result = client_->RegisterLocalMemory(
-            context.shm_buffer, shm_size, kWildcardLocation, false, true);
+            shm.shm_buffer, shm_size, kWildcardLocation, false, true);
         if (!result.has_value()) {
-            LOG(ERROR) << "Failed to register memory: "
-                       << toString(result.error());
-            // Cleanup
+            LOG(ERROR) << "Failed to register memory";
             munmap(shm_buffer, shm_size);
             return tl::unexpected(result.error());
         }
-        LOG(INFO) << "Registered shared memory successfully: " << shm_name
-                  << ", size: " << byte_size_to_string(shm_size);
-    } else {
-        LOG(INFO) << "Shm buffer size is 0, skip registering memory";
     }
 
-    // We assume shm_buffer_ and shm_size_ are already set by
-    // map_shm_internal. Create client buffer allocator on the shared
-    // memory. Note: We use the latter part of the shared memory for client
-    // buffer, the front part is used for registered memory.
-    context.client_buffer_allocator = ClientBufferAllocator::create(
-        reinterpret_cast<void *>(
-            reinterpret_cast<uintptr_t>(context.shm_buffer) + shm_size -
-            local_buffer_size),
-        local_buffer_size, this->protocol);
-    LOG(INFO)
-        << "Client buffer allocator created on shared memory successfully, "
-        << "size: " << byte_size_to_string(local_buffer_size);
+    if (is_local_buffer) {
+        if (context.client_buffer_allocator) {
+            LOG(ERROR) << "A local buffer is already mapped for this "
+                          "client shared memory.";
+            munmap(shm_buffer, shm_size);
+            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+        }
+        context.client_buffer_allocator =
+            ClientBufferAllocator::create(shm_buffer, shm_size, this->protocol);
+    }
 
-    shm_contexts_.emplace(client_id, std::move(context));
+    context.mapped_shms.push_back(std::move(shm));
+
+    LOG(INFO) << "Mapped new shared memory: " << shm_name
+              << ", size: " << shm_size;
     return {};
 }
 
@@ -771,62 +777,27 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
 
     auto &context = it->second;
     context.client_buffer_allocator.reset();
-    if (context.total_registered_size > 0) {
-        LOG(WARNING)
-            << "There are still registered buffers when unmapping shm, size: "
-            << context.total_registered_size;
-    }
-    if (context.shm_buffer) {
-        client_->unregisterLocalMemory(context.shm_buffer, context.shm_size);
-        if (munmap(context.shm_buffer, context.shm_size) == -1) {
-            LOG(ERROR) << "Failed to unmap shared memory: " << context.shm_name
-                       << ", error: " << strerror(errno);
-            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
-        }
-        LOG(INFO) << "Shared memory unmapped successfully: "
-                  << context.shm_name;
-        // Note: We do not shm_unlink here, as the creator of the shared
-        // memory is responsible for unlinking it.
-    }
 
+    for (auto &shm : context.mapped_shms) {
+        if (shm.shm_buffer) {
+            auto rc =
+                client_->unregisterLocalMemory(shm.shm_buffer, shm.shm_size);
+            if (!rc) {
+                LOG(ERROR) << "Failed to unregister memory";
+                munmap(shm.shm_buffer, shm.shm_size);
+                context.mapped_shms.clear();
+                shm_contexts_.erase(it);
+                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+            }
+            munmap(shm.shm_buffer, shm.shm_size);
+        }
+    }
+    context.mapped_shms.clear();
     shm_contexts_.erase(it);
     return {};
 }
 
-tl::expected<void, ErrorCode> RealClient::register_shm_buffer_internal(
-    uint64_t dummy_base_addr, size_t registered_size, const UUID &client_id) {
-    std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);
-    auto it = shm_contexts_.find(client_id);
-    if (it == shm_contexts_.end()) {
-        LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-    }
-    auto &context = it->second;
-
-    uint64_t real_base_addr = dummy_base_addr + context.shm_addr_offset;
-    if (context.registered_buffers.count(real_base_addr)) {
-        LOG(ERROR) << "Buffer with base address (real: " << real_base_addr
-                   << ") " << " , (dummy: " << dummy_base_addr << ") "
-                   << " is already registered for client_id=" << client_id;
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-    }
-    if (registered_size + context.total_registered_size +
-            context.local_buffer_size >
-        context.shm_size) {
-        LOG(ERROR)
-            << "Not enough shared memory to register buffer for client_id="
-            << client_id << ", requested size: " << registered_size
-            << ", used size: "
-            << context.total_registered_size + context.local_buffer_size
-            << ", shm size: " << context.shm_size;
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-    }
-    context.registered_buffers.emplace(real_base_addr, registered_size);
-    context.total_registered_size += registered_size;
-    return {};
-}
-
-tl::expected<size_t, ErrorCode> RealClient::unregister_shm_buffer_internal(
+tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
     uint64_t dummy_base_addr, const UUID &client_id) {
     std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
@@ -836,19 +807,51 @@ tl::expected<size_t, ErrorCode> RealClient::unregister_shm_buffer_internal(
     }
     auto &context = it->second;
 
-    uint64_t real_base_addr = dummy_base_addr + context.shm_addr_offset;
-    auto buffer_it = context.registered_buffers.find(real_base_addr);
-    if (buffer_it != context.registered_buffers.end()) {
-        context.total_registered_size -= buffer_it->second;
-        context.registered_buffers.erase(buffer_it);
-    } else {
-        LOG(ERROR)
-            << "Failed to find registered buffer with base address (real: "
-            << real_base_addr << ") " << " , (dummy: " << dummy_base_addr
-            << ") for client_id=" << client_id << ";";
-        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    // Find the shm corresponding to this dummy address
+    auto shm_it = context.mapped_shms.end();
+    for (auto sit = context.mapped_shms.begin();
+         sit != context.mapped_shms.end(); ++sit) {
+        if (dummy_base_addr == sit->dummy_base_addr) {
+            shm_it = sit;
+            break;
+        }
     }
-    return buffer_it->second;
+
+    if (shm_it == context.mapped_shms.end()) {
+        std::stringstream addr_stream;
+        addr_stream << "0x" << std::hex << dummy_base_addr;
+        LOG(ERROR) << "Share memory not found for dummy address: "
+                   << addr_stream.str() << " (client_id: " << client_id << ")";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    // Unmap and clean up the shm
+    if (shm_it->shm_buffer) {
+        // Unregister from transfer engine if it was registered
+        if (shm_it->shm_size > 0) {
+            // Matching the usage in unmap_shm_internal
+            auto res = client_->unregisterLocalMemory(shm_it->shm_buffer,
+                                                      shm_it->shm_size);
+            if (!res) {
+                LOG(WARNING)
+                    << "Failed to unregister local memory for shared memory: "
+                    << shm_it->shm_name << ", error: " << toString(res.error());
+            }
+        }
+
+        if (munmap(shm_it->shm_buffer, shm_it->shm_size) != 0) {
+            LOG(ERROR) << "Failed to munmap shared memory: " << shm_it->shm_name
+                       << ", error: " << strerror(errno);
+        } else {
+            LOG(INFO) << "Unmapped and cleaned up shared memory: "
+                      << shm_it->shm_name << ", size: " << shm_it->shm_size;
+        }
+    }
+
+    // Remove shm from list
+    context.mapped_shms.erase(shm_it);
+
+    return {};
 }
 
 // Implementation of get_buffer_internal method
@@ -952,7 +955,21 @@ RealClient::get_buffer_info_dummy_helper(const std::string &key,
     }
     uint64_t buffer_base = reinterpret_cast<uint64_t>(buffer_handle->ptr());
     size_t buffer_size = buffer_handle->size();
-    return std::make_tuple(buffer_base - context.shm_addr_offset, buffer_size);
+
+    for (const auto &shm : context.mapped_shms) {
+        uint64_t shm_start = reinterpret_cast<uint64_t>(shm.shm_buffer);
+        uint64_t shm_end = shm_start + shm.shm_size;
+
+        if (buffer_base >= shm_start && buffer_base < shm_end) {
+            // Convert real address to dummy address.
+            return std::make_tuple(buffer_base - shm.shm_addr_offset,
+                                   buffer_size);
+        }
+    }
+
+    LOG(ERROR) << "Buffer allocated at " << buffer_base
+               << " not found in any shared memory for client " << client_id;
+    return tl::unexpected(ErrorCode::INTERNAL_ERROR);
 }
 
 // Implementation of batch_get_buffer_internal method
@@ -1197,10 +1214,38 @@ RealClient::batch_put_from_dummy_helper(
 
     std::vector<void *> buffers;
     buffers.reserve(dummy_buffers.size());
+    const MappedShm *last_hit_shm = nullptr;
 
-    for (auto dummy_buffer : dummy_buffers) {
-        buffers.push_back(
-            reinterpret_cast<void *>(dummy_buffer + context.shm_addr_offset));
+    for (size_t i = 0; i < dummy_buffers.size(); ++i) {
+        uint64_t dummy_addr = dummy_buffers[i];
+        size_t size = sizes[i];
+        bool found = false;
+
+        if (last_hit_shm && dummy_addr >= last_hit_shm->dummy_base_addr &&
+            dummy_addr + size <=
+                last_hit_shm->dummy_base_addr + last_hit_shm->shm_size) {
+            buffers.push_back(reinterpret_cast<void *>(
+                dummy_addr + last_hit_shm->shm_addr_offset));
+            found = true;
+        } else {
+            for (const auto &shm : context.mapped_shms) {
+                if (dummy_addr >= shm.dummy_base_addr &&
+                    dummy_addr + size <= shm.dummy_base_addr + shm.shm_size) {
+                    buffers.push_back(reinterpret_cast<void *>(
+                        dummy_addr + shm.shm_addr_offset));
+                    found = true;
+                    last_hit_shm = &shm;
+                    break;
+                }
+            }
+        }
+
+        if (!found) {
+            LOG(ERROR) << "Dummy buffer at " << dummy_addr
+                       << " not found in any mapped shared memory";
+            return std::vector<tl::expected<void, ErrorCode>>(
+                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+        }
     }
     return batch_put_from_internal(keys, buffers, sizes, config);
 }
@@ -1336,9 +1381,40 @@ RealClient::batch_get_into_dummy_helper(
 
     std::vector<void *> buffers;
     buffers.reserve(dummy_buffers.size());
-    for (auto dummy_buffer : dummy_buffers) {
-        buffers.push_back(
-            reinterpret_cast<void *>(dummy_buffer + context.shm_addr_offset));
+    const MappedShm *last_hit_shm = nullptr;
+
+    for (size_t i = 0; i < dummy_buffers.size(); ++i) {
+        uint64_t dummy_addr = dummy_buffers[i];
+        size_t size = sizes[i];
+        bool found = false;
+
+        if (last_hit_shm && dummy_addr >= last_hit_shm->dummy_base_addr &&
+            dummy_addr + size <=
+                last_hit_shm->dummy_base_addr + last_hit_shm->shm_size) {
+            buffers.push_back(reinterpret_cast<void *>(
+                dummy_addr + last_hit_shm->shm_addr_offset));
+            found = true;
+        } else {
+            for (const auto &shm : context.mapped_shms) {
+                if (dummy_addr >= shm.dummy_base_addr &&
+                    dummy_addr + size <= shm.dummy_base_addr + shm.shm_size) {
+                    buffers.push_back(reinterpret_cast<void *>(
+                        dummy_addr + shm.shm_addr_offset));
+                    found = true;
+                    last_hit_shm = &shm;
+                    break;
+                }
+            }
+        }
+
+        if (!found) {
+            LOG(ERROR) << "Dummy buffer at " << dummy_addr << " (size " << size
+                       << ") "
+                       << "not found in any mapped shared memory for client "
+                       << client_id;
+            return std::vector<tl::expected<int64_t, ErrorCode>>(
+                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+        }
     }
     return batch_get_into_internal(keys, buffers, sizes);
 }
@@ -1799,7 +1875,7 @@ void RealClient::dummy_client_monitor_func() {
         // Update the client status to NEED_REMOUNT
         if (!expired_clients.empty()) {
             for (auto &client_id : expired_clients) {
-                // Unmap shm segments associated with this client
+                // Unmap mapped_shms associated with this client
                 unmap_shm_internal(client_id);
             }
         }
@@ -1930,7 +2006,7 @@ void RealClient::ipc_server_func() {
         } else {
             UUID client_id = {req.client_id_first, req.client_id_second};
             auto ret = map_shm_internal(fd, req.dummy_base_addr, req.shm_size,
-                                        req.local_buffer_size, client_id);
+                                        req.is_local_buffer, client_id);
             if (!ret) {
                 status = toInt(ret.error());
                 // FD is closed inside map_shm_internal

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -38,8 +38,6 @@ void RegisterClientRpcService(coro_rpc::coro_rpc_server &server,
         &real_client);
     server.register_handler<&RealClient::map_shm_internal>(&real_client);
     server.register_handler<&RealClient::unmap_shm_internal>(&real_client);
-    server.register_handler<&RealClient::register_shm_buffer_internal>(
-        &real_client);
     server.register_handler<&RealClient::unregister_shm_buffer_internal>(
         &real_client);
     server.register_handler<&RealClient::service_ready_internal>(&real_client);


### PR DESCRIPTION
## Description

Now that dummy can only alloc one share mem buffer. This PR add multi shm support.

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [ ] Transfer Engine
    - [x] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
