### PR TITLE
[bugfix] fix bfloat16 for get_tensor

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -380,6 +380,8 @@ class MooncakeStorePyWrapper {
                 torch_module().attr("from_numpy")(np_array);
             if (dtype_enum == TensorDtype::BFLOAT16) {
                 tensor = tensor.attr("view")(torch_module().attr("bfloat16"));
+            } else if (dtype_enum == TensorDtype::FLOAT16) {
+                tensor = tensor.attr("view")(torch_module().attr("float16"));
             }
             return tensor;
 
@@ -500,6 +502,9 @@ class MooncakeStorePyWrapper {
                 if (dtype_enum == TensorDtype::BFLOAT16) {
                     tensor =
                         tensor.attr("view")(torch_module().attr("bfloat16"));
+                } else if (dtype_enum == TensorDtype::FLOAT16) {
+                    tensor =
+                        tensor.attr("view")(torch_module().attr("float16"));
                 }
                 results_list.append(tensor);
             }


### PR DESCRIPTION
## Description

Fix for BFloat16 format

## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [x] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
