### PR TITLE
[EP] Fix the tensorSize of the barrier op

### DIFF
--- a/mooncake-ep/src/mooncake_backend.cpp
+++ b/mooncake-ep/src/mooncake_backend.cpp
@@ -14,6 +14,7 @@ constexpr const char* SYNC_OP_ERROR_MSG = "Expecting async op but got sync op.";
 constexpr const char* REDUCE_OP_ERROR_MSG = "Only support SUM.";
 constexpr const char* SPARSE_ERROR_MSG = "Sparse op not supported.";
 constexpr const char* REDUCE_DTYPE_ERROR_MSG = "Unsupported reduce dtype: ";
+constexpr int kBarrierDummyTensorSize = 1;
 
 std::string MooncakeBackend::hostIp_ = "127.0.0.1";
 TransferEngine MooncakeBackend::engine_ = TransferEngine(true);
@@ -469,8 +470,10 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::barrier(
     const c10d::BarrierOptions& opts) {
     TORCH_CHECK(isCpu_, "Barrier is available only for CPU.")
     return worker_.putTaskCpu(
-        c10d::OpType::BARRIER, 1, 0, &meta_, [=](void*, size_t, size_t) {},
-        [=](void*, size_t, size_t) {});
+        // a non-zero tensorSize is required to ensure the worker task for the
+        // barrier is created
+        c10d::OpType::BARRIER, kBarrierDummyTensorSize, 0, &meta_,
+        [=](void*, size_t, size_t) {}, [=](void*, size_t, size_t) {});
 }
 
 void MooncakeBackend::shutdown() {

--- a/mooncake-wheel/tests/test_mooncake_backend_cpu.py
+++ b/mooncake-wheel/tests/test_mooncake_backend_cpu.py
@@ -26,6 +26,10 @@ def worker(rank, world_size, results, collective):
         dist.all_gather(gathered, tensor)
         results[rank] = [t.item() for t in gathered]
 
+    elif collective == "barrier":
+        dist.barrier()
+        results[rank] = "ok"
+
     else:
         raise ValueError(f"Unsupported collective: {collective}")
 
@@ -65,6 +69,9 @@ class TestMooncakeBackend(unittest.TestCase):
     def test_allgather(self):
         # Expected gather = [0, 1, 2, 3]
         self._spawn_and_check("all_gather", lambda size: list(range(size)))
+
+    def test_barrier(self):
+        self._spawn_and_check("barrier", lambda size: "ok")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Previously, the tensorSize of the barrier op was set to 0, causing the entire collective communication to be skipped.

This PR changes the tensorSize to 1.

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

SGLang end-to-end test passes.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
