### PR TITLE
Fix: add missing include path for cuda_alike.h in mooncake-transfer-engine/nvlink-allocator/build.sh

### DIFF
--- a/mooncake-transfer-engine/nvlink-allocator/build.sh
+++ b/mooncake-transfer-engine/nvlink-allocator/build.sh
@@ -32,7 +32,7 @@ if [ $# -ge 2 ]; then
 fi
 
 # Add include directory for cuda_alike.h (relative to build.sh location)
-SCRIPT_DIR=$(dirname $(readlink -f $0))
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 INCLUDE_LIST="${INCLUDE_LIST:+${INCLUDE_LIST} }${SCRIPT_DIR}/../include"
 
 # Process include directories into flags


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
`mooncake-transfer-engine/nvlink-allocator/build.sh` can be run directly without being invoked by `cmake`. So, adding the include directory of `cuda_alike.h` is necessary.

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

Build passed on `musa`.

```bash
cd mooncake-transfer-engine/nvlink-allocator && bash build.sh --use-mcc ../../build/mooncake-transfer-engine/nvlink-allocator/
```

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
