### PR TITLE
[EP] Avoid server name collision during EP backend init

### DIFF
--- a/mooncake-ep/src/mooncake_backend.cpp
+++ b/mooncake-ep/src/mooncake_backend.cpp
@@ -164,9 +164,7 @@ MooncakeBackend::MooncakeBackend(
         // Avoid server name collision.
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
-    store->set("server_name_" + std::to_string(backendIndex_) + "_" +
-                   std::to_string(rank_),
-               localServerName);
+    store->set(serverNameKey, localServerName);
 
     int backendIndex = backendIndex_;
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
