### PR TITLE
[TE/topology]Implement PCIe Root Complex detection for optimal GPU-InfiniBand pairing

### DIFF
--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -271,10 +271,10 @@ static std::vector<TopologyEntry> discoverCudaTopology(
                 sameNuma_hca.push_back(hca);
             }
         }
-        const auto &candidate_preferred_hca = 
-            !samePCIeRoot_hca.empty() ? samePCIeRoot_hca : 
-            !sameNuma_hca.empty() ? sameNuma_hca : 
-            all_hca;
+        const auto &candidate_preferred_hca =
+            !samePCIeRoot_hca.empty() ? samePCIeRoot_hca
+            : !sameNuma_hca.empty()   ? sameNuma_hca
+                                      : all_hca;
 
         for (const auto &hca : candidate_preferred_hca) {
             int distance = getPciDistance(hca.pci_bus_id.c_str(), pci_bus_id);


### PR DESCRIPTION
## Description
This feature identifies and determines whether GPU devices and InfiniBand (IB) devices are located under the same PCIe Root Complex.

1. **PCIe Topology Discovery**
The isSamePcieRootComplex function determines whether two PCI devices are under the same root complex
Uses getCommonParent and isPciRootComplex functions for path analysis
2. **Device Association Optimization**
In the discoverCudaTopology function, prioritizes IB devices that share the same PCIe root with the GPU
Establishes mapping relationships from GPUs to optimal IB devices to optimize data transfer paths
<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [x] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?
I have tested the PCIe root identification functionality using simulated parameters, covering basic functional scenarios and edge cases. However, this feature still requires validation testing in a real hardware environment where GPU and IB devices are located under the same PCIe root complex.
<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
