### PR TITLE
[TE] feat:ascend direct transport support async transfer

### DIFF
--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -61,6 +61,7 @@ struct GlobalConfig {
     int ib_traffic_class = -1;
     // ib_pci_relaxed_ordering_mode: 0: off, 1: on if supported, 2: auto
     int ib_pci_relaxed_ordering_mode = 0;
+    bool ascend_use_fabric_mem = false;
 };
 
 struct RpcCommunicatorConfig {

--- a/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.h
+++ b/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.h
@@ -77,7 +77,7 @@ class AscendDirectTransport : public Transport {
    private:
     int allocateLocalSegmentID();
 
-    void workerThread();
+    void queryThread();
 
     void processSliceList(const std::vector<Slice *> &slice_list);
 
@@ -94,15 +94,15 @@ class AscendDirectTransport : public Transport {
                            aclrtMemcpyKind kind, size_t batch_num,
                            size_t slice_index) const;
 
-    void copyWithSync(TransferRequest::OpCode opcode,
-                      const std::vector<Slice *> &slice_list,
-                      aclrtMemcpyKind kind);
+    static void copyWithSync(TransferRequest::OpCode opcode,
+                             const std::vector<Slice *> &slice_list,
+                             aclrtMemcpyKind kind);
 
     void copyWithAsync(TransferRequest::OpCode opcode,
                        const std::vector<Slice *> &slice_list,
                        aclrtMemcpyKind kind);
 
-    uint16_t findAdxlListenPort() const;
+    uint16_t findAdxlListenPort();
 
    private:
     int InitAdxlEngine();
@@ -112,6 +112,16 @@ class AscendDirectTransport : public Transport {
     int disconnect(const std::string &target_adxl_engine_name,
                    int32_t timeout_in_millis, bool force = false);
 
+    void TransferWithAsync(const std::string &target_adxl_engine_name,
+                           adxl::TransferOp operation,
+                           const std::vector<Slice *> &slice_list,
+                           const std::vector<adxl::TransferOpDesc> &op_descs);
+
+    template <class F, class... Args>
+    void enqueue(F &&f, Args &&...args);
+
+    void submitSlices(std::vector<Slice *> &slice_list);
+
     std::atomic_bool running_;
     std::unique_ptr<adxl::AdxlEngine> adxl_;
     std::map<void *, adxl::MemHandle> addr_to_mem_handle_;
@@ -120,12 +130,6 @@ class AscendDirectTransport : public Transport {
     // Connection management for segment connections
     std::set<std::string> connected_segments_;
     std::mutex connection_mutex_;
-
-    // Async processing related members (similar to hccl_transport)
-    std::thread worker_thread_;
-    std::queue<std::vector<Slice *>> slice_queue_;
-    std::mutex queue_mutex_;
-    std::condition_variable queue_cv_;
 
     int32_t device_logic_id_{};
     aclrtContext rt_context_{nullptr};
@@ -137,6 +141,21 @@ class AscendDirectTransport : public Transport {
     int32_t base_port_ = 20000;
     std::unordered_set<SegmentID> need_update_metadata_segs_;
     bool use_short_connection_{false};
+
+    // add for async transfer
+    std::thread query_thread_;
+    std::queue<std::vector<Slice *>> query_slice_queue_;
+    std::mutex query_mutex_;
+    std::condition_variable query_cv_;
+    int64_t transfer_timeout_in_nano_;
+    bool use_async_transfer_{false};
+
+    // add for thread pool
+    std::vector<std::thread> workers_;         ///< Worker thread pool
+    std::queue<std::function<void()>> tasks_;  ///< Task queue
+    std::mutex thread_pool_queue_mutex_;       ///< Protects task queue access
+    std::condition_variable
+        thread_pool_condition_;  ///< Synchronizes task assignment
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -144,6 +144,8 @@ class Transport {
             } hccl;
             struct {
                 uint64_t dest_addr;
+                void *handle;
+                int64_t start_time;
             } ascend_direct;
         };
 

--- a/mooncake-transfer-engine/src/transport/ascend_transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/CMakeLists.txt
@@ -8,6 +8,18 @@ else ()
 endif ()
 
 if (USE_ASCEND_DIRECT)
+    set(ADXL_HEADER_PATH "${ASCEND_INCLUDE_DIR}/adxl/adxl_engine.h")
+    if(EXISTS "${ADXL_HEADER_PATH}")
+        file(READ "${ADXL_HEADER_PATH}" ADXL_CONTENT)
+        if("${ADXL_CONTENT}" MATCHES "Status TransferAsync")
+            message(STATUS "Check TransferAsync method exist.")
+            add_compile_definitions(EXIST_ADXL_ASYNC_METHOD)
+        else()
+            message(STATUS "TransferAsync method is not exist.")
+        endif()
+    else()
+        message(WARNING "Ascend direct header file is not exist")
+    endif()
     add_library(ascend_transport SHARED ${ASCEND_SOURCES})
     find_library(
             FOUND_METADEF

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
@@ -36,9 +36,13 @@
 
 namespace mooncake {
 namespace {
-constexpr size_t kMemcpyBatchLimit = 4096;
+constexpr size_t kMemcpyBatchLimit = 4096U;
 constexpr int32_t kMaxAdxlConnectRetries = 3;
+constexpr int64_t kMillisToNano = 1000000;
+constexpr size_t kThreadPoolSize = 8U;
+constexpr size_t kSyncThreadPoolSize = 8U;
 }  // namespace
+
 AscendDirectTransport::AscendDirectTransport() : running_(false) {}
 
 AscendDirectTransport::~AscendDirectTransport() {
@@ -46,10 +50,16 @@ AscendDirectTransport::~AscendDirectTransport() {
 
     // Stop worker thread
     running_ = false;
-    queue_cv_.notify_all();
+    query_cv_.notify_all();
 
-    if (worker_thread_.joinable()) {
-        worker_thread_.join();
+    if (query_thread_.joinable()) {
+        query_thread_.join();
+    }
+
+    // stop thread pool
+    thread_pool_condition_.notify_all();
+    for (std::thread &worker : workers_) {
+        if (worker.joinable()) worker.join();
     }
 
     // Disconnect all connections
@@ -68,18 +78,6 @@ AscendDirectTransport::~AscendDirectTransport() {
         }
         connected_segments_.clear();
     }
-
-    // Deregister all memory
-    std::lock_guard<std::mutex> mem_handle_lock(mem_handle_mutex_);
-    for (const auto &[addr, mem_handle] : addr_to_mem_handle_) {
-        auto status = adxl_->DeregisterMem(mem_handle);
-        if (status != adxl::SUCCESS) {
-            LOG(ERROR) << "Failed to deregister memory at address " << addr;
-        } else {
-            LOG(INFO) << "Deregistered memory at address " << addr;
-        }
-    }
-    addr_to_mem_handle_.clear();
     adxl_->Finalize();
 }
 
@@ -125,7 +123,30 @@ int AscendDirectTransport::install(std::string &local_server_name,
     }
     // Start worker thread
     running_ = true;
-    worker_thread_ = std::thread(&AscendDirectTransport::workerThread, this);
+    query_thread_ = std::thread(&AscendDirectTransport::queryThread, this);
+    size_t thread_pool_size =
+        use_async_transfer_ ? kThreadPoolSize : kSyncThreadPoolSize;
+    // add thread pool
+    for (size_t i = 0; i < thread_pool_size; ++i) {
+        workers_.emplace_back([this] {
+            while (true) {
+                std::function<void()> task;
+                {
+                    std::unique_lock<std::mutex> lock(
+                        this->thread_pool_queue_mutex_);
+                    this->thread_pool_condition_.wait(lock, [this] {
+                        return !this->running_ || !this->tasks_.empty();
+                    });
+
+                    if (!this->running_ && this->tasks_.empty()) return;
+
+                    task = std::move(this->tasks_.front());
+                    this->tasks_.pop();
+                }
+                task();
+            }
+        });
+    }
     return 0;
 }
 
@@ -158,17 +179,40 @@ int AscendDirectTransport::InitAdxlEngine() {
             LOG(INFO) << "Set RdmaServiceLevel to:" << rdma_sl;
         }
     }
+    // check set async transfer
+    char *use_async = std::getenv("ASCEND_USE_ASYNC_TRANSFER");
+    if (use_async) {
+#ifndef EXIST_ADXL_ASYNC_METHOD
+        LOG(ERROR) << "ASCEND_USE_ASYNC_TRANSFER is set, but async transfer is "
+                      "not available, please upgrade cann package.";
+        return -1;
+#endif
+        LOG(INFO) << "Use async transfer";
+        use_async_transfer_ = true;
+    }
     // set default buffer pool
-    options["adxl.BufferPool"] = "4:8";
-    use_buffer_pool_ = true;
+    options["adxl.BufferPool"] = "0:0";
+    use_buffer_pool_ = false;
     char *buffer_pool = std::getenv("ASCEND_BUFFER_POOL");
     if (buffer_pool) {
         options["adxl.BufferPool"] = buffer_pool;
-        LOG(INFO) << "Set adxl.BufferPool to:" << buffer_pool;
-        if (std::strcmp(buffer_pool, "0:0") == 0) {
-            LOG(INFO) << "Cancel buffer pool.";
-            use_buffer_pool_ = false;
+        if (std::strcmp(buffer_pool, "0:0") != 0) {
+            LOG(INFO) << "Set adxl.BufferPool to:" << buffer_pool;
+            use_buffer_pool_ = true;
+            if (use_async_transfer_) {
+                LOG(ERROR) << "Buffer pool mode do not support async transfer.";
+                return -1;
+            }
         }
+    }
+    if (globalConfig().ascend_use_fabric_mem) {
+        if (use_buffer_pool_) {
+            LOG(ERROR) << "Buffer pool and fabric mem mode can not be enabled "
+                          "simultaneously.";
+            return -1;
+        }
+        options["EnableUseFabricMem"] = "1";
+        LOG(INFO) << "Fabric mem mode is enabled.";
     }
     std::string engine_name_str =
         (globalConfig().use_ipv6 ? ("[" + host_ip + "]") : host_ip) + ":" +
@@ -182,7 +226,7 @@ int AscendDirectTransport::InitAdxlEngine() {
     }
     LOG(INFO) << "Success to initialize adxl engine:"
               << adxl_engine_name.GetString()
-              << " with device_id:" << device_logic_id_;
+              << " with device_id:" << device_logic_id_ << ", pid:" << getpid();
     char *connect_timeout_str = std::getenv("ASCEND_CONNECT_TIMEOUT");
     if (connect_timeout_str) {
         std::optional<int32_t> connect_timeout =
@@ -212,7 +256,47 @@ int AscendDirectTransport::InitAdxlEngine() {
                       << use_short_connection_;
         }
     }
+    transfer_timeout_in_nano_ = transfer_timeout_ * kMillisToNano;
     return 0;
+}
+
+template <class F, class... Args>
+void AscendDirectTransport::enqueue(F &&f, Args &&...args) {
+    auto task = std::make_shared<std::function<void()>>(
+        [f = std::forward<F>(f),
+         ... args = std::forward<Args>(args)]() mutable {
+            std::invoke(f, args...);
+        });
+    {
+        std::unique_lock<std::mutex> lock(thread_pool_queue_mutex_);
+        if (!running_) {
+            throw std::runtime_error("enqueue on stopped ThreadPool");
+        }
+        tasks_.emplace([task] { (*task)(); });
+    }
+    thread_pool_condition_.notify_one();  ///< Wake one waiting worker
+}
+
+void AscendDirectTransport::submitSlices(std::vector<Slice *> &slice_list) {
+    std::unordered_map<SegmentID, std::vector<Slice *>> seg_to_slices;
+    for (auto slice : slice_list) {
+        seg_to_slices[slice->target_id].push_back(slice);
+    }
+    for (auto &[seg_id, slices] : seg_to_slices) {
+        enqueue([this, moved_slices = std::move(slices)] {
+            static thread_local bool context_set = false;
+            if (!context_set) {
+                auto ret = aclrtSetCurrentContext(rt_context_);
+                if (ret) {
+                    LOG(ERROR)
+                        << "Call aclrtSetCurrentContext failed, ret: " << ret;
+                    return;
+                }
+                context_set = true;
+            }
+            processSliceList(moved_slices);
+        });
+    }
 }
 
 Status AscendDirectTransport::submitTransfer(
@@ -248,12 +332,7 @@ Status AscendDirectTransport::submitTransfer(
         __sync_fetch_and_add(&task.slice_count, 1);
         slice_list.push_back(slice);
     }
-
-    std::unique_lock<std::mutex> lock(queue_mutex_);
-    slice_queue_.push(slice_list);
-    lock.unlock();
-    queue_cv_.notify_one();
-
+    submitSlices(slice_list);
     return Status::OK();
 }
 
@@ -282,11 +361,7 @@ Status AscendDirectTransport::submitTransferTask(
         slice_list.push_back(slice);
     }
 
-    std::unique_lock<std::mutex> lock(queue_mutex_);
-    slice_queue_.push(slice_list);
-    lock.unlock();
-    queue_cv_.notify_one();
-
+    submitSlices(slice_list);
     return Status::OK();
 }
 
@@ -371,7 +446,7 @@ int AscendDirectTransport::registerLocalMemory(void *addr, size_t length,
     adxl::MemHandle mem_handle;
     auto adxl_ret = adxl_->RegisterMem(mem_desc, mem_type, mem_handle);
     if (adxl_ret != adxl::SUCCESS) {
-        LOG(ERROR) << "adxl_ret:" << adxl_ret << ".";
+        LOG(ERROR) << "Register mem ret:" << adxl_ret << ".";
         return -1;
     }
     std::lock_guard<std::mutex> lock(mem_handle_mutex_);
@@ -465,7 +540,18 @@ int AscendDirectTransport::allocateLocalSegmentID() {
     return 0;
 }
 
-uint16_t AscendDirectTransport::findAdxlListenPort() const {
+uint16_t AscendDirectTransport::findAdxlListenPort() {
+    char *adxl_base_port = std::getenv("ASCEND_BASE_PORT");
+    if (adxl_base_port) {
+        try {
+            int32_t base_port = std::stoi(adxl_base_port);
+            base_port_ = base_port;
+            LOG(INFO) << "Set base port to:" << base_port;
+        } catch (const std::exception &e) {
+            LOG(WARNING) << "ASCEND_BASE_PORT is not valid, value:"
+                         << adxl_base_port;
+        }
+    }
     int32_t dev_id = device_logic_id_;
     char *rt_visible_devices = std::getenv("ASCEND_RT_VISIBLE_DEVICES");
     if (rt_visible_devices) {
@@ -490,8 +576,8 @@ uint16_t AscendDirectTransport::findAdxlListenPort() const {
     }
     static std::random_device rand_gen;
     std::uniform_int_distribution rand_dist;
-    const int min_port = base_port_ + dev_id * 1000;
-    const int max_port = base_port_ + (dev_id + 1) * 1000;
+    const int min_port = base_port_ + dev_id * 100;
+    const int max_port = base_port_ + (dev_id + 1) * 100;
     LOG(INFO) << "Find available between " << min_port << " and " << max_port;
     const int max_attempts = 500;
     bool use_ipv6 = globalConfig().use_ipv6;
@@ -539,38 +625,96 @@ uint16_t AscendDirectTransport::findAdxlListenPort() const {
     return 0;
 }
 
-void AscendDirectTransport::workerThread() {
-    LOG(INFO) << "AscendDirectTransport worker thread started";
-    auto ret = aclrtSetCurrentContext(rt_context_);
-    if (ret) {
-        LOG(ERROR) << "Call aclrtSetCurrentContext failed, ret: " << ret;
-        return;
-    }
+void AscendDirectTransport::queryThread() {
+#ifdef EXIST_ADXL_ASYNC_METHOD
+    LOG(INFO) << "AscendDirectTransport query thread started";
+    std::vector<std::vector<Slice *>> pending_batches;
     while (running_) {
-        std::vector<Slice *> slice_list;
         {
-            std::unique_lock<std::mutex> lock(queue_mutex_);
-            queue_cv_.wait(
-                lock, [this] { return !running_ || !slice_queue_.empty(); });
+            std::unique_lock<std::mutex> lock(query_mutex_);
+            if (pending_batches.empty()) {
+                query_cv_.wait(lock, [this] {
+                    return !running_ || !query_slice_queue_.empty();
+                });
+            }
             if (!running_) {
                 break;
             }
-            slice_list = std::move(slice_queue_.front());
-            slice_queue_.pop();
+            while (!query_slice_queue_.empty()) {
+                pending_batches.emplace_back(
+                    std::move(query_slice_queue_.front()));
+                query_slice_queue_.pop();
+            }
         }
-        if (slice_list.empty()) {
-            LOG(ERROR) << "AscendDirectTransport: empty transfer request batch";
+
+        if (pending_batches.empty()) {
             continue;
         }
-        std::unordered_map<SegmentID, std::vector<Slice *>> seg_to_slices;
-        for (auto slice : slice_list) {
-            seg_to_slices[slice->target_id].push_back(slice);
+
+        auto it = pending_batches.begin();
+        while (it != pending_batches.end()) {
+            auto &slice_list = *it;
+            if (slice_list.empty()) {
+                it = pending_batches.erase(it);
+                continue;
+            }
+            auto handle = static_cast<adxl::TransferReq>(
+                slice_list[0]->ascend_direct.handle);
+            adxl::TransferStatus task_status;
+            auto ret = adxl_->GetTransferStatus(handle, task_status);
+            if (ret != adxl::SUCCESS ||
+                task_status == adxl::TransferStatus::FAILED) {
+                LOG(ERROR) << "Get transfer status failed, ret: " << ret;
+                for (auto &slice : slice_list) {
+                    slice->markFailed();
+                }
+                it = pending_batches.erase(it);
+            } else if (task_status == adxl::TransferStatus::COMPLETED) {
+                auto now = getCurrentTimeInNano();
+                auto duration = now - slice_list[0]->ascend_direct.start_time;
+                auto target_segment_desc =
+                    metadata_->getSegmentDescByID(slice_list[0]->target_id);
+                if (target_segment_desc) {
+                    auto target_adxl_engine_name =
+                        (globalConfig().use_ipv6
+                             ? ("[" + target_segment_desc->rank_info.hostIp +
+                                "]")
+                             : target_segment_desc->rank_info.hostIp) +
+                        ":" +
+                        std::to_string(target_segment_desc->rank_info.hostPort);
+                    VLOG(1) << "Transfer to " << target_adxl_engine_name
+                            << " time: " << duration / 1000 << "us";
+                }
+                for (auto &slice : slice_list) {
+                    slice->markSuccess();
+                }
+                it = pending_batches.erase(it);
+            } else {
+                auto now = getCurrentTimeInNano();
+                if (now - slice_list[0]->ascend_direct.start_time >
+                    transfer_timeout_in_nano_) {
+                    LOG(ERROR)
+                        << "Transfer timeout, you can increase the timeout "
+                           "duration to reduce "
+                           "the failure rate by configuring "
+                           "the ASCEND_TRANSFER_TIMEOUT environment variable.";
+                    for (auto &slice : slice_list) {
+                        slice->markFailed();
+                    }
+                    it = pending_batches.erase(it);
+                } else {
+                    ++it;
+                }
+            }
         }
-        for (auto &[seg_id, slices] : seg_to_slices) {
-            processSliceList(slices);
+
+        if (!pending_batches.empty()) {
+            // Avoid busy loop
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
         }
     }
-    LOG(INFO) << "AscendDirectTransport worker thread stopped";
+    LOG(INFO) << "AscendDirectTransport query thread stopped";
+#endif
 }
 
 void AscendDirectTransport::processSliceList(
@@ -643,17 +787,21 @@ void AscendDirectTransport::connectAndTransfer(
         op_desc.len = slice->length;
         op_descs.emplace_back(op_desc);
     }
+    if (use_async_transfer_) {
+        return TransferWithAsync(target_adxl_engine_name, operation, slice_list,
+                                 op_descs);
+    }
     auto status = adxl_->TransferSync(target_adxl_engine_name.c_str(),
                                       operation, op_descs, transfer_timeout_);
     if (status == adxl::SUCCESS) {
         for (auto &slice : slice_list) {
             slice->markSuccess();
         }
-        LOG(INFO) << "Transfer to:" << target_adxl_engine_name << ", cost: "
-                  << std::chrono::duration_cast<std::chrono::microseconds>(
-                         std::chrono::steady_clock::now() - start)
-                         .count()
-                  << " us";
+        VLOG(1) << "Transfer to:" << target_adxl_engine_name << ", cost: "
+                << std::chrono::duration_cast<std::chrono::microseconds>(
+                       std::chrono::steady_clock::now() - start)
+                       .count()
+                << " us";
         if (use_short_connection_) {
             disconnect(target_adxl_engine_name, connect_timeout_);
         }
@@ -684,6 +832,41 @@ void AscendDirectTransport::connectAndTransfer(
         disconnect(target_adxl_engine_name, 1000);
         need_update_metadata_segs_.emplace(slice_list[0]->target_id);
     }
+}
+
+void AscendDirectTransport::TransferWithAsync(
+    const std::string &target_adxl_engine_name, adxl::TransferOp operation,
+    const std::vector<Slice *> &slice_list,
+    const std::vector<adxl::TransferOpDesc> &op_descs) {
+#ifdef EXIST_ADXL_ASYNC_METHOD
+    auto start_time = getCurrentTimeInNano();
+    for (auto &slice : slice_list) {
+        slice->ascend_direct.start_time = start_time;
+    }
+    adxl::TransferReq req_handle;
+    auto status =
+        adxl_->TransferAsync(target_adxl_engine_name.c_str(), operation,
+                             op_descs, adxl::TransferArgs(), req_handle);
+    if (status == adxl::SUCCESS) {
+        for (auto &slice : slice_list) {
+            slice->ascend_direct.handle = req_handle;
+        }
+        {
+            std::unique_lock<std::mutex> lock(query_mutex_);
+            query_slice_queue_.push(slice_list);
+        }
+        query_cv_.notify_one();
+    } else {
+        LOG(ERROR) << "Transfer slice failed with status: " << status;
+        for (auto &slice : slice_list) {
+            slice->markFailed();
+        }
+        // the connection is probably broken.
+        // set small timeout to just release local res.
+        disconnect(target_adxl_engine_name, 1000);
+        need_update_metadata_segs_.emplace(slice_list[0]->target_id);
+    }
+#endif
 }
 
 void AscendDirectTransport::localCopy(TransferRequest::OpCode opcode,


### PR DESCRIPTION
## Description

In cann 8.5.0, adxl support async transfer, so, this PR add async transfer feature to transfer engine.

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [x] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

1. compile in diffrent cann version.
2. test with vllm-ascend.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
