### PR TITLE
[Store]: Add OffsetAllocator disk backend with lock-striped metadata + refcounted extents.

### DIFF
--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -10,7 +10,6 @@
 #include "file_interface.h"
 #include "mutex.h"
 #include "offset_allocator/offset_allocator.hpp"
-#include "offset_allocator/offset_allocator.hpp"
 #include "types.h"
 
 namespace mooncake {

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -1,7 +1,6 @@
 #include "file_storage.h"
 
 #include <memory>
-#include <unordered_set>
 #include <vector>
 
 #include "storage_backend.h"


### PR DESCRIPTION
## Description

Introduce a new StorageBackendType::kOffsetAllocator backend that stores
all objects in a single data file (kv_cache.data) and manages free space
with OffsetAllocator.

**Concurrency model (new backend only):**
1. Metadata is sharded into 1024 stripes (SharedMutex + unordered_map)
    using hash(key) & (N-1) to reduce contention.
2. Values are referenced via shared_ptr<RefCountedAllocationHandle> so
     readers can drop locks before I/O while preventing reuse-after-free of
     extents during in-flight reads.
3. Quota accounting uses atomics (total_size_, total_keys_) to avoid
    global aggregation across shards.
4. Record format: [u32 key_len][u32 value_len][key_bytes][value_bytes].
5. Persistence v1: none (truncate on init; restart begins empty).

**Tests:**
Extend unit tests to cover new backend and fix cleanup to remove
leftover directories.
## Type of Change

* Types
  - [ ] Bug fix
  - [X] New feature
    - [ ] Transfer Engine
    - [X] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?
StorageBackendTest.*

## Checklist

- [X] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [X] I have added tests to prove my changes are effective.
