### PR TITLE
[TE] Add early mem backend detection method in NVLINK_allocator

### DIFF
--- a/mooncake-integration/allocator.py
+++ b/mooncake-integration/allocator.py
@@ -4,21 +4,24 @@ import os
 import threading
 from importlib import resources
 from typing import Dict, Final, Optional
+from enum import IntEnum
 
 from torch import device as torch_device
 from torch.cuda.memory import CUDAPluggableAllocator
 
 logger = logging.getLogger(__name__)
 
-MEMORY_BACKEND_USE_CUDAMALLOC = 0
-MEMORY_BACKEND_USE_CUMEMCREATE = 1
-MEMORY_BACKEND_UNKNOWN = -1
+
+class MemoryBackend(IntEnum):
+    USE_CUDAMALLOC = 0
+    USE_CUMEMCREATE = 1
+    UNKNOWN = -1
 
 
 class NVLinkAllocator:
     _instances: Dict[torch_device, CUDAPluggableAllocator] = {}
     _lock: Final = threading.Lock()
-    _supports_fabric: int = MEMORY_BACKEND_UNKNOWN
+    _supports_fabric: int = MemoryBackend.UNKNOWN
     _probe_done: bool = False
 
     @classmethod
@@ -65,9 +68,9 @@ class NVLinkAllocator:
             # Use device 0 for probing
             dev_id = 0
             supported_type = probe_func(dev_id)
-            if supported_type == MEMORY_BACKEND_USE_CUDAMALLOC:
+            if supported_type == MemoryBackend.USE_CUDAMALLOC:
                 logger.info(f"Use CudaMalloc fallback")
-            elif supported_type == MEMORY_BACKEND_USE_CUMEMCREATE:
+            elif supported_type == MemoryBackend.USE_CUMEMCREATE:
                 logger.info(f"Supports Fabric Memory")
             else:
                 logger.info("Unknown Backend error")

--- a/mooncake-integration/allocator.py
+++ b/mooncake-integration/allocator.py
@@ -105,7 +105,7 @@ class NVLinkAllocator:
             cls._probe_done = True
 
     @classmethod
-    def detect_mem_bankend(cls) -> int:
+    def detect_mem_backend(cls) -> int:
         """Public API: check if fabric memory is supported."""
         if not cls._probe_done:
             cls._initialize_probe()

--- a/mooncake-integration/allocator.py
+++ b/mooncake-integration/allocator.py
@@ -49,7 +49,7 @@ class NVLinkAllocator:
             )
 
     @classmethod
-    def _probe_fabric_memory_support(cls, so_path: str) -> int:
+    def _probe_fabric_memory_support(cls, so_path: str) -> MemoryBackend:
         """
         Probe whether the system supports fabric memory by calling a C++ function
         that attempts cuMemCreate with CU_MEM_HANDLE_TYPE_FABRIC.
@@ -81,10 +81,10 @@ class NVLinkAllocator:
                 "Symbol 'mc_probe_fabric_support' not found in nvlink_allocator.so. "
                 "Assuming fabric memory is NOT supported (you may need to update the library)."
             )
-            return False
+            return MemoryBackend.USE_CUDAMALLOC
         except Exception as e:
             logger.warning(f"Failed to probe fabric memory support: {e}")
-            return False
+            return MemoryBackend.USE_CUDAMALLOC
 
     @classmethod
     def _initialize_probe(cls):

--- a/mooncake-integration/allocator.py
+++ b/mooncake-integration/allocator.py
@@ -1,3 +1,5 @@
+import ctypes
+import logging
 import os
 import threading
 from importlib import resources
@@ -6,10 +8,18 @@ from typing import Dict, Final, Optional
 from torch import device as torch_device
 from torch.cuda.memory import CUDAPluggableAllocator
 
+logger = logging.getLogger(__name__)
+
+MEMORY_BACKEND_USE_CUDAMALLOC = 0
+MEMORY_BACKEND_USE_CUMEMCREATE = 1
+MEMORY_BACKEND_UNKNOWN = -1
+
 
 class NVLinkAllocator:
     _instances: Dict[torch_device, CUDAPluggableAllocator] = {}
     _lock: Final = threading.Lock()
+    _supports_fabric: int = MEMORY_BACKEND_UNKNOWN
+    _probe_done: bool = False
 
     @classmethod
     def _get_so_path(cls) -> str:
@@ -36,6 +46,69 @@ class NVLinkAllocator:
             )
 
     @classmethod
+    def _probe_fabric_memory_support(cls, so_path: str) -> int:
+        """
+        Probe whether the system supports fabric memory by calling a C++ function
+        that attempts cuMemCreate with CU_MEM_HANDLE_TYPE_FABRIC.
+        We assume the shared library exports a symbol like:
+            extern "C" MemoryBackendType mc_probe_fabric_support(int device_id);
+        """
+        try:
+
+            lib = ctypes.CDLL(so_path)
+
+            # Try to get the probe function
+            probe_func = lib.mc_probe_fabric_support
+            probe_func.argtypes = [ctypes.c_int]
+            probe_func.restype = ctypes.c_int
+
+            # Use device 0 for probing
+            dev_id = 0
+            supported_type = probe_func(dev_id)
+            if supported_type == MEMORY_BACKEND_USE_CUDAMALLOC:
+                logger.info(f"Use CudaMalloc fallback")
+            elif supported_type == MEMORY_BACKEND_USE_CUMEMCREATE:
+                logger.info(f"Supports Fabric Memory")
+            else:
+                logger.info("Unknown Backend error")
+            return supported_type
+
+        except AttributeError:
+            logger.warning(
+                "Symbol 'mc_probe_fabric_support' not found in nvlink_allocator.so. "
+                "Assuming fabric memory is NOT supported (you may need to update the library)."
+            )
+            return False
+        except Exception as e:
+            logger.warning(f"Failed to probe fabric memory support: {e}")
+            return False
+
+    @classmethod
+    def _initialize_probe(cls):
+        """Lazy initialization of fabric support detection."""
+        with cls._lock:
+            if cls._probe_done:
+                return
+
+            so_path = None
+            try:
+                so_path = cls._get_so_path()
+                # First try dedicated probe function
+                cls._supports_fabric = cls._probe_fabric_memory_support(so_path)
+            except Exception as e:
+                logger.error(f"Critical error during fabric memory probe setup: {e}")
+                cls._supports_fabric = -1
+
+            cls._probe_done = True
+
+    @classmethod
+    def detect_mem_bankend(cls) -> int:
+        """Public API: check if fabric memory is supported."""
+        if not cls._probe_done:
+            cls._initialize_probe()
+        return cls._supports_fabric
+
+    @classmethod
     def get_allocator(cls, device: torch_device) -> CUDAPluggableAllocator:
         with cls._lock:
             if device not in cls._instances:
@@ -58,11 +131,11 @@ class BarexAllocator:
             "/usr/lib/libaccl_barex.so",  # Ubuntu [deb]
             "/usr/lib64/libaccl_barex.so",  # AliOS [rpm]
         ]
-        
+
         for path in possible_paths:
             if os.path.exists(path):
                 return path
-        
+
         # Try to locate in mooncake package installation
         try:
             # Attempt to locate package resource
@@ -82,7 +155,7 @@ class BarexAllocator:
                 return so_path
         except (ImportError, FileNotFoundError, TypeError):
             pass
-        
+
         raise ImportError(
             "BarexAllocator requires libaccl_barex.so to be installed. "
             "Please install the barex library or ensure it's in the system path."
@@ -94,6 +167,8 @@ class BarexAllocator:
             if device not in cls._instances:
                 so_path = cls._get_so_path()
                 cls._instances[device] = CUDAPluggableAllocator(
-                    so_path, "u2mm_alloc_wrapper_with_stream", "u2mm_free_wrapper_with_stream"
+                    so_path,
+                    "u2mm_alloc_wrapper_with_stream",
+                    "u2mm_free_wrapper_with_stream",
                 )
             return cls._instances[device]


### PR DESCRIPTION
Add early detection method for sglang NVLINK_allocator to avoid CuMemCreate

Use enumerate type to indicate mem backend type

format check use pre-commit

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [x] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

This PR introduces a method called mc_probe_fabric_support() in nvlink_allocator.cpp along with corresponding API allocator.py which can be used by other framework integrating Mooncake such as SGlang for early detection.

<img width="869" height="916" alt="image" src="https://github.com/user-attachments/assets/966683e3-ca76-4527-965a-c895e1b20da3" />
<img width="1006" height="639" alt="image" src="https://github.com/user-attachments/assets/89eee0aa-6672-4515-b8bd-21350b2ba4d3" />


## Checklist

- [x] I have performed a self-review of my own code.

- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
