### PR TITLE
[Store][Feature] KV Event Publisher System Declaration

### DIFF
--- a/docs/source/design/kv-event/mooncake_event_subscriber_guide.md
+++ b/docs/source/design/kv-event/mooncake_event_subscriber_guide.md
@@ -1,0 +1,430 @@
+# KV Event Subscriber Guide
+
+This document provides guidance for developers who wish to subscribe to KV cache events in the Mooncake system. It focuses on the message schema and deserialization methods needed to properly handle events sent by the event publisher.
+
+---
+
+## Event Types & Meanings
+
+Before diving into the technical schema, it's important to understand what each event type represents and when they are triggered in the Mooncake system.
+
+### Event Overview Table
+
+| Event Type | Trigger Condition | Purpose | Key Characteristics |
+|------------|-------------------|---------|---------------------|
+| **BlockStoreEvent** | First storage of KV cache block | Initial block creation with metadata | ✅ contains `StoreEventInfo` metadata<br>✅ Represents initial creation<br>✅ Generated during `Put` operations |
+| **BlockUpdateEvent** | Replica management operations (copy/remove/migrate) | Track replica distribution changes | ❌ No `StoreEventInfo` metadata<br>✅ Focuses on replica locations<br>✅ Internal system operations |
+| **RemoveAllEvent** | System-wide cache clearance | Signal cache invalidation | ❌ No additional fields<br>✅ System-wide invalidation<br>✅ Maintenance operations |
+
+### Event Type Quick Reference
+
+#### 🏗️ BlockStoreEvent - Storage Event
+
+```mermaid
+graph LR
+    A[Put Operation] --> B[BlockStoreEvent]
+    B --> C[Contains Metadata]
+    C --> D[Downstream Processing]
+```
+
+#### 🔄 BlockUpdateEvent - Replica Event  
+
+```mermaid
+graph LR
+    A[Replica Operation] --> B[BlockUpdateEvent]
+    B --> C[Replica Location Changes]
+    C --> D[Downstream Processing]
+```
+
+#### 🧹 RemoveAllEvent - Clearance Event
+
+```mermaid
+graph LR
+    A[System Maintenance] --> B[RemoveAllEvent]
+    B --> C[Cache Invalidation]
+    C --> D[Downstream Processing]
+```
+
+### Field Definitions at a Glance
+
+#### Core Event Fields
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mooncake_key` | `std::string` | ✅ All events | Unique identifier for cached object |
+| `replicas` | Nested array | ✅ BlockStore/Update | Replica locations: `[type, location]` |
+
+#### `StoreEventInfo` Fields (`BlockStoreEvent` only)
+
+When processing `BlockStoreEvent`events, pay special attention to the StoreEventInfo fields which are appended to the event. **These fields have specific default values that indicate when they are not set**:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `model_name` | `std::string` | `""` | Model identifier |
+| `block_size` | `uint32_t` | `0` | Block size in bytes |
+| `block_hash` | `std::string` | `""` | Current block hash |
+| `parent_block_hash` | `std::string` | `""` | Parent block hash |
+| `token_ids` | `std::vector<uint32_t>` | `[]` | Token ID sequence |
+
+---
+
+## Event Message Schema
+
+The KV event system uses ZeroMQ (ZMQ) for message transport and MessagePack for serialization. Events are sent as multipart ZMQ messages containing three components:
+
+### ZMQ Message Structure
+
+Each event message consists of 3 ZMQ message parts:
+
+```plainText
+1. topic Part: Contains the topic string (default: "mooncake")
+2. Sequence Number Part: 8-byte big-endian unsigned integer representing the sequence number
+3. Payload Part: MessagePack-serialized event batch data
+```
+
+### Event Batch Schema
+
+The payload part contains a serialized `EventBatch`object with the following structure:
+
+```typescript
+[
+    ts, // First element: Timestamp (double) - seconds since UNIX epoch
+    [              // Second element: Event list (array)
+        [event1_data], // Event 1
+        [event2_data], // Event 2
+        ... // Additional events
+    ]
+]
+```
+
+Each event in the batch is a serialized event object that begins with an event type identifier string followed by its specific data fields.
+
+### Event Types Schema
+
+There are three main event types supported by the system:
+
+#### Schema
+
+```typescript
+// Event triggered on the first storage occurrence - contains 8 fields
+BlockStoreEvent {
+    "BlockStoreEvent",           // Event type identifier, string type
+    std::string mooncake_key,    // Mooncake key
+    [                            // Replica location list (nested arrays)
+        ["memory", "transport_endpoint"],     // Memory replica
+        ["disk", "file_path"],                // Disk replica  
+        ["local_disk", "transport_endpoint"]  // Local disk replica
+    ],
+    std::string model_name,         // Model name
+    uint32_t block_size,            // Block size
+    std::string block_hash,         // Current block hash
+    std::string parent_block_hash,  // Parent block hash
+    std::vector<uint32_t> token_ids // Token ID sequence
+}
+
+// Contains all internal Mooncake system operations - contains 3 fields
+BlockUpdateEvent {
+    "BlockUpdateEvent",           // Event type identifier
+    std::string mooncake_key,
+    [                             // Replica location list
+        ["memory", "transport_endpoint"],
+        ["disk", "file_path"],
+        ["local_disk", "transport_endpoint"]
+    ]
+}
+
+// Event for clearing all KV Cache in Mooncake - contains 1 field
+RemoveAllEvent {
+    "RemoveAllEvent"             // Event type identifier
+}
+```
+
+#### Example
+
+```typescript
+// BlockStoreEvent
+[
+    "BlockStoreEvent", // Event type identifier
+    "key_12345",       // mooncake key
+    [                  // Replica location list (nested arrays)
+        ["memory", "tcp://192.168.1.10:6000"],    // Memory type location
+        ["disk", "/data/blocks/block_12345.bin"], // Disk type location
+        ["local_disk", "tcp://192.168.1.10:7000"]     // Local disk type location
+    ],
+    "llama2-7b",       // Model name
+    512,               // block size
+    "0x41234125",      // Current block hash
+    "0x51512342",      // Parent block hash
+    [1,2,3,4,5]        // Token id list
+]
+
+// BlockUpdateEvent
+[
+    "BlockUpdateEvent", // Event type identifier
+    "key_12345",       // mooncake key
+    [                  // Replica location list (nested arrays)
+        ["memory", "tcp://192.168.1.10:6000"],    // Memory type location
+    ],
+]
+
+// RemoveAllEvent
+[
+    "RemoveAllEvent"   // Event type identifier
+]
+```
+
+---
+
+## Deserialization Steps
+
+To properly deserialize events from the KV event system, follow these steps:
+
+1. **Receive the multipart message**: Use `zmq::recv_multipart`or equivalent to receive all 3 parts of the message.
+2. **Extract the topic**: The first part contains the topic string.
+3. **Extract and convert the sequence number**: The second part contains an 8-byte big-endian unsigned integer. On little-endian systems, convert it using `be64toh()`or equivalent function.
+4. **Deserialize the payload**: The third part contains MessagePack-serialized data. Deserialize it to get the `EventBatch`.
+5. **Process individual events**: Iterate through the events in the batch and handle each according to its type identifier (the first element in each event array).
+
+## Required Libraries
+
+- **ZeroMQ library**: For receiving multipart messages
+- **MessagePack library**: For deserializing the payload
+- **Byte order conversion functions**: For converting sequence numbers between big-endian and host byte order
+
+---
+
+## Event Batch Timestamp Handling
+
+The event batch timestamp field `ts` is a double-precision floating-point number representing seconds since the UNIX epoch (January 1, 1970). When deserializing, convert this timestamp appropriately:
+
+<details>
+<summary>Click to expand: Python example</summary>
+
+```python
+import datetime
+
+# Python example
+timestamp = event_batch[0]  # double type seconds
+dt = datetime.datetime.fromtimestamp(timestamp)
+print(f"Event batch timestamp: {dt}")
+```
+
+</details>
+
+
+<details>
+<summary>Click to expand: GoLang example</summary>
+
+```go
+// Go example
+timestamp := eventBatch[0].(float64)
+t := time.Unix(int64(timestamp), 0)
+fmt.Printf("Event batch timestamp: %v\n", t)
+```
+
+</details>
+
+---
+
+## Python Example
+
+Here's a Python example showing how to subscribe to and deserialize KV events:
+
+<details>
+<summary>Click to expand: Python example</summary>
+
+```python
+def deserialize_block_store_event(event_array):
+    if len(event_array) < 8:
+        raise ValueError("Invalid BlockStoreEvent array length")
+    
+    # Extract fields by fixed position
+    event_type = event_array[0]  # "BlockStoreEvent"
+    mooncake_key = event_array[1]
+    replicas = event_array[2]  # Nested array of replica locations
+    model_name = event_array[3] # Could be an empty string
+    block_size = event_array[4] # Could be an empty string
+    block_hash = event_array[5] # Could be an empty string
+    parent_block_hash = event_array[6] # Could be an empty string
+    token_ids = event_array[7] # Could be an empty string
+    
+    # Handle default values according to StoreEventInfo specifications
+    if model_name == "":
+        # Model name not set, use default or skip processing
+        model_name = "unknown"
+    
+    if block_size == 0:
+        # Invalid block size, may indicate an error
+        raise ValueError("Invalid block size: 0")
+    
+    if block_hash == "":
+        # block_hash is not set, use None to indicate missing value
+        block_hash = None
+    
+    if parent_block_hash == "":
+        # No parent block (root block), handle appropriately
+        parent_block_hash = None
+    
+    return {
+        "type": event_type,
+        "mooncake_key": mooncake_key,
+        "replicas": replicas,
+        "model_name": model_name,
+        "block_size": block_size,
+        "block_hash": block_hash,
+        "parent_block_hash": parent_block_hash,
+        "token_ids": token_ids
+    }
+
+def process_replica_locations(replicas):
+    """Process nested replica location arrays"""
+    replica_info = []
+    for replica in replicas:
+        if len(replica) != 2:
+            continue
+        replica_type = replica[0]  # "memory", "disk", or "local_disk"
+        location = replica[1]       # Endpoint or file path
+        replica_info.append({"type": replica_type, "location": location})
+    return replica_info
+```
+
+</details>
+
+## GoLang Example
+
+Here's a Go example showing how to subscribe to and deserialize KV events:
+
+<details>
+<summary>Click to expand: GoLang example</summary>
+
+```go
+func deserializeBlockStoreEvent(eventSlice []interface{}) (map[string]interface{}, error) {
+    if len(eventSlice) < 8 {
+        return nil, fmt.Errorf("invalid BlockStoreEvent array length: %d", len(eventSlice))
+    }
+    
+    result := make(map[string]interface{})
+    
+    // Extract fields by fixed position
+    result["type"] = eventSlice[0].(string)
+    result["mooncake_key"] = eventSlice[1].(string)
+    result["replicas"] = eventSlice[2]
+    result["model_name"] = eventSlice[3].(string)
+    
+    // Handle block_size with proper type assertion
+    if blockSize, ok := eventSlice[4].(uint32); ok {
+        result["block_size"] = blockSize
+        if blockSize == 0 {
+            return nil, fmt.Errorf("invalid block size: 0")
+        }
+    } else {
+        return nil, fmt.Errorf("invalid block_size type")
+    }
+    
+    // block_hash field handling with default value check
+    blockHash := eventSlice[5].(string)
+    if blockHash == "" {
+        result["block_hash"] = nil // Indicates missing value
+    } else {
+        result["block_hash"] = blockHash
+    }
+    
+    // parent_block_hash field handling
+    parentBlockHash := eventSlice[6].(string)
+    if parentBlockHash == "" {
+        result["parent_block_hash"] = nil // No parent block
+    } else {
+        result["parent_block_hash"] = parentBlockHash
+    }
+    
+    result["token_ids"] = eventSlice[7]
+    
+    return result, nil
+}
+
+func processReplicas(replicas interface{}) ([]map[string]string, error) {
+    // Process nested replica arrays
+    replicaSlice, ok := replicas.([]interface{})
+    if !ok {
+        return nil, fmt.Errorf("invalid replicas type")
+    }
+    
+    var replicaInfo []map[string]string
+    for _, replica := range replicaSlice {
+        replicaArr, ok := replica.([]interface{})
+        if !ok || len(replicaArr) != 2 {
+            continue
+        }
+        
+        replicaType, ok1 := replicaArr[0].(string)
+        location, ok2 := replicaArr[1].(string)
+        if ok1 && ok2 {
+            replicaInfo = append(replicaInfo, map[string]string{
+                "type":     replicaType,
+                "location": location,
+            })
+        }
+    }
+    return replicaInfo, nil
+}
+```
+
+</details>
+
+---
+
+## Replay Functionality
+
+The KV event system supports replay functionality, allowing subscribers to request historical events. To implement replay:
+
+1. **Send replay request**: Send a 3-part ZMQ message to the replay endpoint:
+   - Part 1: Client identifier (any data that identifies your client)
+   - Part 2: Empty frame
+   - Part 3: Starting sequence number (8-byte big-endian unsigned integer)
+
+2. **Receive replay events**: The system will send historical events starting from the requested sequence number. Each replayed event is sent as a regular ZMQ multipart message.
+
+3. **Replay end marker**: When all available historical events have been sent, the system sends a special end marker message containing the magic sequence `0xFFFFFFFFFFFFFFFF` (8 bytes of 0xFF).
+
+4. **Handle replay completion**: Upon receiving the end marker, you know that the replay session has completed.
+
+5. **Important considerations**: 
+   - Replayed events may be older than real-time events already processed
+   - Implement duplicate detection if needed
+   - Replay buffer size is limited by the system configuration
+
+Example replay request handling:
+
+<details>
+<summary>Click to expand: Python example</summary>
+
+```python
+def send_replay_request(socket, start_seq):
+    """Send replay request to the replay endpoint"""
+    client_id = b"my_client_001"  # Your client identifier
+    empty_frame = b""             # Empty frame
+    seq_be = start_seq.to_bytes(8, byteorder='big')  # Big-endian sequence
+    
+    messages = [client_id, empty_frame, seq_be]
+    socket.send_multipart(messages)
+
+def handle_replay_message(messages):
+    """Handle incoming replay message"""
+    if len(messages) == 4:
+        client_id = messages[0]
+        empty_frame = messages[1]
+        seq_be = messages[2]
+        payload = messages[3]
+        
+        # Check for end marker
+        if payload == b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF':
+            print("Replay session completed")
+            return None
+        
+        # Process regular replay event
+        seq = int.from_bytes(seq_be, byteorder='big')
+        return deserialize_payload(payload)
+    
+    return None
+```
+
+</details>

--- a/docs/source/design/kv-event/mooncake_event_system_developer_manual.md
+++ b/docs/source/design/kv-event/mooncake_event_system_developer_manual.md
@@ -1,0 +1,459 @@
+# Mooncake Event System Developer Manual
+## 1. System Overview
+KVEventSystem is an asynchronous event processing system based on the publish-subscribe pattern. It encapsulates the complex logic of event publishing, consumption, and queue management using the Facade Pattern, providing a concise and unified interface for upper-layer applications.
+
+### 1.1 Core Features
+
+- **Asynchronous Event Publishing**: Supports publishing various types of events in a non-blocking manner.
+- **Batch Processing**: Automatically batches and merges events to optimize network transmission efficiency.
+- **Reliable Transmission**: Built-in retry mechanisms and queue buffering ensure no event loss.
+- **Real-time Monitoring**: Provides detailed runtime statistical information.
+- **Flexible Configuration**: Performance and reliability can be adjusted through configuration parameters.
+
+### 1.2 Architecture Design
+#### 1.2.1 Architecture Logic Diagram
+
+```mermaid
+graph TD
+    ApplicationLayer[API call site] -->|invoke interface<br>publish KVEvent| KVEventProducer
+    IR[indexer/router]
+    
+    subgraph KVEventSystem
+        KVEventProducer -->|enqueue| KVEventQueue
+        subgraph KVEventConsumer
+            ZMQ
+        end
+        KVEventQueue -->|dequeue| KVEventConsumer
+    end
+    ZMQ -->|event batch serialization<br>ZMQ network transmission| IR
+```
+
+#### 1.2.2 Class Relationship Diagram
+
+```mermaid
+classDiagram
+    %% Event Class Hierarchy
+    class KVCacheEvent {
+        <<interface>>
+        +pack(msgpack::packer~msgpack::sbuffer~) void
+        +type_tag() string_view
+    }
+    
+    KVCacheEvent <|-- BlockStoreEvent
+    KVCacheEvent <|-- BlockUpdateEvent
+    KVCacheEvent <|-- RemoveAllEvent
+    
+    %% Core Components
+    class KVEventProducer {
+        -shared_ptr~KVEventQueue~ event_queue_
+        -unique_ptr~ThreadPool~ enqueue_pool_ : enqueue worker(1)
+        
+        +publish~Event, Args...~(args) future~bool~
+        +publish_event_async(KVEventPtr) future~bool~
+        +shutdown() void
+    }
+    
+    class KVEventConsumer {
+        -zmq::context_t context_
+        -shared_ptr~KVEventQueue~ event_queue_
+        -jthread publisher_thread_
+        
+        +KVEventConsumer(shared_ptr~KVEventQueue~, Config)
+        +shutdown() void
+        +is_running() bool
+    }
+    
+    class ThreadSafeQueue~T~ {
+        <<alias KVEventQueue>>
+    }
+    
+    %% Facade Class
+    class KVEventSystem {
+        -shared_ptr~KVEventQueue~ event_queue_
+        
+        +KVEventSystem(const KVEventPublisherConfig&)
+        +~KVEventSystem()
+        +shutdown() void
+        +is_running() bool
+        +publish~Event, Args...~(args) future~bool~
+    }
+    
+    %% Configuration and Event Classes
+    class KVEventPublisherConfig {
+    }
+    class StoreEventInfo {
+    }
+    class EventBatch {
+        +serialize() msgpack::sbuffer
+    }
+    
+    %% Relationships
+    KVEventSystem --> KVEventPublisherConfig : reads
+    KVEventSystem --> KVEventProducer : contains
+    KVEventSystem --> KVEventConsumer : contains
+    KVEventSystem --> ThreadSafeQueue~KVEventPtr~ : contains
+    
+    KVEventProducer --> ThreadSafeQueue~KVEventPtr~ : enqueues
+    KVEventConsumer --> ThreadSafeQueue~KVEventPtr~ : dequeues
+    
+    KVEventProducer --> KVCacheEvent : creates
+    BlockStoreEvent --> StoreEventInfo : contains
+    KVCacheEvent <.. EventBatch : aggregates
+    EventBatch <.. KVEventConsumer : serialize & publish
+```
+
+#### 1.2.3 Data Flow Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant App as APICallSite
+    participant ES as KVEventSystem
+    participant EP as KVEventProducer
+    participant TSQ as ThreadSafeQueue
+    participant ZMQ as KVEventConsumer
+    participant Network as ZeroMQNetwork
+    
+    App->>ES: 1. publish<KVEvent>(...)
+    ES->>EP: 2. publish<KVEvent>(...)
+    EP->>TSQ: 3. push(event)<br>(create KVCacheEvent object)
+    Note over TSQ: KVEvent Buffer
+    ZMQ->>TSQ: 4. peek_batch()
+    ZMQ->>ZMQ: 5. batch processing
+    ZMQ->>Network: 6. ZeroMQ Publish
+    Network-->>ZMQ: 7. Publish confirmation
+    ZMQ-->>TSQ: 8. pop_batch()
+    ES-->>App: 9. return future
+
+    Note over App,Network: Asynchronous processing flow
+```
+
+------
+
+## 2. Key Class Interface Declarations
+### 2.1 Event Classes (kv_event.hpp)
+#### Event Class Relationships
+
+| Class Name         | Parent Class   | Key Fields                                     | Description                                   |
+| ------------------ | -------------- | ---------------------------------------------- | --------------------------------------------- |
+| `KVCacheEvent`     | -              | No fields                                      | Abstract base class, defines event interface  |
+| `StoreEventInfo`   | -              | All fields                                     | Container for additional data of store events |
+| `BlockStoreEvent`  | `KVCacheEvent` | `mooncake_key`, `replicas`, `store_event_info` | Block storage event                           |
+| `BlockUpdateEvent` | `KVCacheEvent` | `mooncake_key`, `replicas`                     | Block update event                            |
+| `RemoveAllEvent`   | `KVCacheEvent` | No fields                                      | Clear all cache event                         |
+
+**UML Class Diagram**:
+
+```mermaid
+classDiagram
+    %% Event Class Hierarchy
+    class KVCacheEvent {
+        <<abstract>>
+        +pack(msgpack::packer~msgpack::sbuffer~& pk) void
+        +type_tag() string_view
+    }
+    
+    KVCacheEvent <|-- BlockStoreEvent
+    KVCacheEvent <|-- BlockUpdateEvent
+    KVCacheEvent <|-- RemoveAllEvent
+    
+    %% StoreEventInfo Structure
+    class StoreEventInfo {
+        +std::string model_name
+        +uint32_t block_size
+        +std::string block_hash
+        +std::string parent_block_hash
+        +std::vector~uint32_t~ token_ids
+    }
+    
+    %% BlockStoreEvent Class
+    class BlockStoreEvent {
+        +std::string mooncake_key
+        +std::vector~Replica::Descriptor~ replicas
+        +StoreEventInfo store_event_info
+        +BlockStoreEvent(key, replica_list, info)
+        +pack(pk) void
+        +type_tag() string_view
+    }
+    
+    %% BlockUpdateEvent Class
+    class BlockUpdateEvent {
+        +std::string mooncake_key
+        +std::vector~Replica::Descriptor~ replicas
+        +BlockUpdateEvent(key, replica_list)
+        +pack(pk) void
+        +type_tag() string_view
+    }
+    
+    %% RemoveAllEvent Class
+    class RemoveAllEvent {
+        +RemoveAllEvent()
+        +pack(pk) void
+        +type_tag() string_view
+    }
+
+    %% Relationships
+    BlockStoreEvent *-- StoreEventInfo : contains
+
+```
+
+------
+
+#### Event Class Types
+##### Event Base Class: `KVCacheEvent`
+
+> The **abstract base class** for all KV cache events, defining the **unified interface** for event serialization and type identification. It uses the abstract base class pattern to provide a unified event processing interface. All concrete event types must inherit from this class and implement the interface methods.
+
+```c++
+struct KVCacheEvent {
+    virtual void pack(msgpack::packer<msgpack::sbuffer>& pk) const = 0;  // Serialization method
+    virtual std::string_view type_tag() const = 0;  // Type identification method
+}
+```
+
+**Explanation**
+
+| Method Name | Return Type        | Parameters                              | Description                                                  |
+| ----------- | ------------------ | --------------------------------------- | ------------------------------------------------------------ |
+| `pack`      | `void`             | `msgpack::packer<msgpack::sbuffer>& pk` | Pure virtual function, serializes the event into MessagePack format. Derived classes must implement this method to provide type-specific serialization logic. |
+| `type_tag`  | `std::string_view` | None                                    | Pure virtual function, returns a string view of the event type identifier, used for type identification during deserialization. |
+
+------
+
+##### Store Event Pass-Through Meta Data Structure: `StoreEventInfo`
+
+> The `StoreEventInfo`struct is used to carry business metadata for KV cache storage events. All fields in this structure are optional; which fields to populate should be determined by the specific business scenario of the upper-layer cache-aware component (such as indexer or router). The Mooncake system acts only as a transparent pipeline for transmitting these fields and will not perform any business logic validation or interpretation of their content.
+
+```c++
+struct StoreEventInfo {
+    std::string model_name{""};
+    uint32_t block_size{0};
+    std::string block_hash{""};
+    std::string parent_block_hash{""};
+    std::vector token_ids{};
+};
+```
+
+**Explanation**
+
+| Field Name          | Type                    | Default Value | Constraints/Explanation                                   |
+| ------------------- | ----------------------- | ------------- | --------------------------------------------------------- |
+| `model_name`        | `std::string`           | `""`          | Model name identifier, empty indicates not set            |
+| `block_size`        | `uint32_t`              | `0`           | Block size (bytes), 0 indicates invalid value             |
+| `block_hash`        | `std::string`           | `""`          | Hash of the current block, used for unique identification |
+| `parent_block_hash` | `std::string`           | `""`          | Parent block hash, used for dependency chain              |
+| `token_ids`         | `std::vector<uint32_t>` | Empty vector  | Token ID sequence, can be empty                           |
+
+------
+
+##### Storage Event Structure: `BlockStoreEvent`
+> Event type triggered when a KV cache block is stored for the first time, typically containing the additional storage information `StoreEventInfo`that needs to be passed.
+
+```c++
+struct BlockStoreEvent {
+    std::string mooncake_key;
+    std::vector<Replica::Descriptor> replicas;
+    StoreEventInfo store_event_info;
+}
+```
+
+**Explanation**
+| Field Name         | Type                               | Default Value (set by constructor) | Constraints/Explanation                      |
+| ------------------ | ---------------------------------- | ---------------------------------- | -------------------------------------------- |
+| `mooncake_key`     | `std::string`                      | N/A                                | Unique identifier of the cached `ObjectMetadata` in the `MasterService` |
+| `replicas`         | `std::vector<Replica::Descriptor>` | N/A                                | List of replica descriptors containing replica location and type information |
+| `store_event_info` | `StoreEventInfo`                   | N/A                                | Additional information required for KVCache-aware algorithms |
+
+> The `mooncake_key` field represents the primary key of the cached object in the distributed KV cache system. In the implementation, this value may originate from method parameters (e.g., the key parameter in `PutEnd` method) or from `it->first` when iterating through metadata maps (where it is an iterator over `std::unordered_map<std::string, ObjectMetadata>` in `MasterService::metadata_shards_`).
+
+**Event Format Example**
+
+```javascript
+[
+    "BlockStoreEvent", // Event type identifier
+    "key_001",       // mooncake key
+    [                  // Replica location list
+        ["memory", "tcp://192.168.1.10:6000"],    // Memory type location
+        ["disk", "/data/blocks/block_12345.bin"], // Disk type location
+    ],
+    "llama2-7b",       // Model name
+    512,               // block size
+    "0x41234125",      // Current block hash
+    "0x51512342",      // Parent block hash
+    [1,2,3,4,5]        // Token id list
+]
+```
+
+------
+
+##### Replica Change Event Structure: `BlockUpdateEvent`
+> Event type triggered by any replica update operation other than storage events, including copy/eviction/migration.
+
+```c++
+struct BlockUpdateEvent {
+    std::string mooncake_key;
+    std::vector<Replica::Descriptor> replicas;
+}
+```
+
+**Explanation**
+| Field Name     | Type                               | Default Value | Constraints/Explanation                         |
+| -------------- | ---------------------------------- | ------------- | ----------------------------------------------- |
+| `mooncake_key` | `std::string`                      | N/A           | Unique identifier of the cached `ObjectMetadata` in the `MasterService` |
+| `replicas`     | `std::vector<Replica::Descriptor>` | N/A           | List of replica descriptors containing replica location and type information     |
+
+**Event Format Example**
+```javascript
+[
+    "BlockUpdateEvent", // Event type identifier
+    "key_12345",       // mooncake key
+    [                  // Global replica location list
+        ["memory", "tcp://192.168.1.10:6000"],
+        ["memory", "tcp://192.168.1.11:5001"],
+        ["disk", "/data/blocks/block_12345.bin"],
+    ],
+]
+```
+------
+##### Clear All Cache Event Structure: `RemoveAllEvent`
+> Event triggered to clear all caches in Mooncake-Store.
+```c++
+RemoveAllEvent {
+}
+```
+
+**Explanation**: *This event has no fields, identified only by its type tag.*
+**Event Format Example**
+```javascript
+[
+    "RemoveAllEvent"
+]
+```
+
+------
+
+#### Serialization-Related Types
+##### Event Batch Structure: `EventBatch`
+> Used to batch serialize events for transmission, thereby reducing network overhead and improving throughput, while timestamps ensure event ordering.
+
+```c++
+struct EventBatch {
+    double ts;
+    std::vector<std::shared_ptr<KVCacheEvent>> events;
+}
+
+```
+
+**Explanation**
+
+| Field Name | Type                                         | Default Value (set by constructor) | Constraints/Explanation                                      |
+| ---------- | -------------------------------------------- | ---------------------------------- | ------------------------------------------------------------ |
+| `ts`       | `double`                                     | N/A                                | Timestamp of batch creation, using Unix timestamp (seconds since 1970-01-01 00:00:00 UTC, floating-point), used by the receiver to process batches in chronological order. |
+| `events`   | `std::vector<std::shared_ptr<KVCacheEvent>>` | N/A                                | Array of event pointers, can contain any event object derived from `KVCacheEvent`. Events in the batch are serialized and processed in array order. |
+
+**Event Batch Format Example**
+The event batch is serialized as an array containing two elements:
+- The first element is the timestamp (floating-point number)
+- The second element is an array of events, where each event is its corresponding type's serialized array.
+
+```javascript
+[
+    170000000.123, // Element 1: Timestamp (double)
+    [              // Element 2: Event list (array)
+        [           // Event 1: BlockStoreEvent
+            "BlockStoreEvent",
+            "key_001",
+            [
+                ["memory", "tcp://192.168.1.10:6000"],
+                ["disk", "/data/blocks/block_12345.bin"]
+            ],
+            "llama2-7b",
+            512,
+            "0x41234125",
+            "0x51512342",
+            [1, 2, 3, 4, 5]
+        ],
+        [           // Event 2: BlockUpdateEvent
+            "BlockUpdateEvent",
+            "key_12345",
+            [
+                ["memory", "tcp://192.168.1.10:6000"],
+                ["memory", "tcp://192.168.1.11:5001"],
+                ["disk", "/data/blocks/block_12345.bin"]
+            ]
+        ],
+        [           // Event 3: RemoveAllEvent
+            "RemoveAllEvent"
+        ]
+    ]
+]
+
+```
+
+------
+
+### 2.2 Event System Facade Class (kv_event_system.h)
+#### 2.2.1 Configuration Item Descriptions
+
+| Category               | Parameter Name                        | Corresponding Field in `KVEventPublisherConfig` Structure | Type          | Default Value     | Description                                                  |
+| ---------------------- | ------------------------------------- | --------------------------------------------------------- | ------------- | ----------------- | ------------------------------------------------------------ |
+| **Basic Switch**       | `enable_kv_event_publish`             | None (system switch)                                      | `bool`        | `false`           | Master switch for event publishing functionality. System starts event publishing only when set to `true`. |
+| **Network Config**     | `kv_event_publisher_endpoint`         | `endpoint`                                                | `std::string` | `"tcp://*:19997"` | ZeroMQ bind address, supports `tcp://`and `ipc://`protocols. |
+|                        | `kv_event_publisher_replay_endpoint`  | `replay_endpoint`                                         | `std::string` | `""`              | Replay endpoint address. Empty value disables replay functionality. |
+|                        | `kv_event_publisher_topic`            | `topic`                                                   | `std::string` | `"mooncake"`      | Message topic.                                               |
+| **Performance Config** | `kv_event_publisher_hwm`              | `hwm`                                                     | `int`         | `100000`          | ZeroMQ high-water mark, controls memory buffer size.         |
+|                        | `kv_event_publisher_send_interval_ms` | `send_interval`                                           | `uint32_t`    | `0`               | Send interval (milliseconds), 0 means no delay.              |
+|                        | `kv_event_publisher_max_batch_size`   | `max_batch_size`                                          | `uint32_t`    | `50`              | Maximum batch size, affects throughput and latency.          |
+| **Advanced Config**    | `kv_event_publisher_auto_port`        | `auto_port`                                               | `bool`        | `true`            | Automatic port switching, automatically tries other ports if the port is occupied. |
+
+#### 2.2.2 Event Publishing Interface
+##### Generic Publishing Method
+```c++
+// Template method, supports all event types derived from KVCacheEvent
+template <DerivedFromKVCacheEvent Event, typename... Args>
+std::future<bool> publish(Args&&... args);
+```
+##### Publishing Different Types of Events
+
+```c++
+// 1. Publish block storage event
+system.publish<BlockStoreEvent>(
+    "key_001",
+    replica_list,
+    store_info
+);
+
+// 2. Publish block update event
+system.publish<BlockUpdateEvent>(
+    "key_001",
+    updated_replicas
+);
+
+// 3. Publish clear all event
+system.publish<RemoveAllEvent>();
+
+// 4. Custom event (must inherit from KVCacheEvent)
+class CustomEvent : public KVCacheEvent { /* ... */ };
+system.publish<CustomEvent>(arg1, arg2);
+
+```
+
+------
+
+## 3. Python API Integration
+
+Since only the `BlockStoreEvent` requires the introduction of field information defined in `StoreEventInfo` passed from the inference engine side, a new default parameter (i.e., the optional parameter `store_event_infos`) has been added only to the interfaces related to `put` operations.
+
+> Currently, only the `batch_put_from_multi_buffers` interface has been adapted accordingly. Other interfaces related to `put` operations will also need adaptation subsequently.
+
+### `StoreEventInfo` Type
+
+**Purpose**
+The `StoreEventInfo` struct is used to carry business metadata for KV cache storage events. All fields in this structure are optional; which fields to populate should be determined by the specific business scenario of the upper-layer cache-aware component (such as indexer or router). The Mooncake system acts only as a transparent pipeline for transmitting these fields and will not perform any business logic validation or interpretation of their content.
+
+For detailed API specification, please refer to the Python API Reference documentation: [mooncake-store.md](https://github.com/OpenMooncake/Mooncake/blob/main/docs/source/python-api-reference/mooncake-store.md).
+
+### `batch_put_from_multi_buffers` Interface
+
+The `batch_put_from_multi_buffers` interface has been enhanced to support passing `StoreEventInfo` objects via the optional `store_event_infos` parameter. This allows KV cache storage events to carry additional metadata that can be consumed by downstream components.
+
+For detailed API specification and usage examples, please refer to the Python API Reference documentation: [mooncake-store.md](https://github.com/OpenMooncake/Mooncake/blob/main/docs/source/python-api-reference/mooncake-store.md).

--- a/mooncake-store/include/kv_event/kv_event.hpp
+++ b/mooncake-store/include/kv_event/kv_event.hpp
@@ -1,0 +1,222 @@
+#pragma once
+
+#ifndef MOONCAKE_KV_EVENT_H
+#define MOONCAKE_KV_EVENT_H
+
+#include "replica.h"
+
+#include <msgpack.hpp>
+
+#include <atomic>
+#include <vector>
+#include <memory>
+#include <string>
+#include <chrono>
+
+namespace mooncake {
+
+/**
+ * @brief Base class for KV cache events
+ * Defines the interface that all KV cache events must implement for msgpack
+ * serialization Uses the Abstract Base Class pattern to provide a uniform event
+ * handling interface
+ */
+class KVCacheEvent {
+   public:
+    virtual ~KVCacheEvent() = default;
+
+    /**
+     * @brief Serialize the event to msgpack format
+     * @param pk Reference to msgpack packer
+     * Derived classes must implement this method to provide type-specific
+     * serialization logic
+     */
+    virtual void pack(msgpack::packer<msgpack::sbuffer>& pk) const = 0;
+
+    /**
+     * @brief Get the event type identifier
+     * @return String view of the event type
+     * Used for event type identification during deserialization
+     */
+    virtual std::string_view type_tag() const = 0;
+};
+
+/**
+ * @brief Additional Information when a KV Cache Store Event happens
+ * Contains metadata required for KVCache-aware algorithm
+ */
+struct StoreEventInfo {
+    std::string model_name{""};
+    uint32_t block_size{0};
+    std::string block_hash{""};
+    std::string parent_block_hash{""};
+    std::vector<uint32_t> token_ids{};
+
+    YLT_REFL(StoreEventInfo, model_name, block_size, block_hash,
+             parent_block_hash, token_ids);
+};
+
+/**
+ * @brief Block storage event
+ * Event triggered when KV cache is stored for the first time
+ * Contains StoreEventInfo
+ */
+class BlockStoreEvent : public KVCacheEvent {
+   public:
+    // data stored in Mooncake
+    std::string mooncake_key;
+    std::vector<Replica::Descriptor> replicas;
+    StoreEventInfo store_event_info;
+
+    static constexpr size_t kFieldCount{8};
+
+    BlockStoreEvent(std::string key,
+                    std::vector<Replica::Descriptor> replica_list,
+                    const StoreEventInfo& info)
+        : mooncake_key(std::move(key)),
+          replicas(std::move(replica_list)),
+          store_event_info(info) {}
+
+    void pack(msgpack::packer<msgpack::sbuffer>& pk) const override {
+        pk.pack_array(kFieldCount);
+
+        pk.pack(type_tag());
+        pk.pack(mooncake_key);
+        pk.pack_array(replicas.size());
+        for (const auto& replica : replicas) {
+            if (replica.is_memory_replica()) {
+                pk.pack_array(2);
+                pk.pack("memory");
+                pk.pack(replica.get_memory_descriptor()
+                            .buffer_descriptor.transport_endpoint_);
+            } else if (replica.is_disk_replica()) {
+                pk.pack_array(2);
+                pk.pack("disk");
+                pk.pack(replica.get_disk_descriptor().file_path);
+            } else if (replica.is_local_disk_replica()) {
+                pk.pack_array(2);
+                pk.pack("local_disk");
+                pk.pack(replica.get_local_disk_descriptor().transport_endpoint);
+            } else {
+                throw std::runtime_error(
+                    "Unknown replica type in BlockStoreEvent");
+            }
+        }
+
+        pk.pack(store_event_info.model_name);
+        pk.pack(store_event_info.block_size);
+        pk.pack(store_event_info.block_hash);
+        pk.pack(store_event_info.parent_block_hash);
+        pk.pack(store_event_info.token_ids);
+    }
+
+    std::string_view type_tag() const override { return "BlockStoreEvent"; }
+};
+
+/**
+ * @brief Block update event
+ * Used for replica management operations within Mooncake-Store:
+ * 1. Replica copy
+ * 2. Replica removal
+ * 3. Replica migration
+ */
+class BlockUpdateEvent : public KVCacheEvent {
+   public:
+    std::string mooncake_key;
+    std::vector<Replica::Descriptor> replicas;
+    static constexpr size_t kFieldCount{3};
+
+    BlockUpdateEvent(std::string key,
+                     std::vector<Replica::Descriptor> replica_list)
+        : mooncake_key(std::move(key)), replicas(std::move(replica_list)) {}
+
+    void pack(msgpack::packer<msgpack::sbuffer>& pk) const override {
+        pk.pack_array(kFieldCount);
+
+        pk.pack(type_tag());
+        pk.pack(mooncake_key);
+        pk.pack_array(replicas.size());
+        for (const auto& replica : replicas) {
+            if (replica.is_memory_replica()) {
+                pk.pack_array(2);
+                pk.pack("memory");
+                pk.pack(replica.get_memory_descriptor()
+                            .buffer_descriptor.transport_endpoint_);
+            } else if (replica.is_disk_replica()) {
+                pk.pack_array(2);
+                pk.pack("disk");
+                pk.pack(replica.get_disk_descriptor().file_path);
+            } else if (replica.is_local_disk_replica()) {
+                pk.pack_array(2);
+                pk.pack("local_disk");
+                pk.pack(replica.get_local_disk_descriptor().transport_endpoint);
+            } else {
+                throw std::runtime_error(
+                    "Unknown replica type in BlockUpdateEvent");
+            }
+        }
+    }
+
+    std::string_view type_tag() const override { return "BlockUpdateEvent"; }
+};
+
+/**
+ * @brief Remove all event
+ * Special event that instructs receivers to clear all cached data
+ */
+class RemoveAllEvent : public KVCacheEvent {
+   public:
+    static constexpr size_t kFieldCount{1};
+
+    RemoveAllEvent() = default;
+
+    void pack(msgpack::packer<msgpack::sbuffer>& pk) const override {
+        pk.pack_array(kFieldCount);
+        pk.pack(type_tag());
+    }
+
+    std::string_view type_tag() const override { return "RemoveAllEvent"; }
+};
+
+/**
+ * @brief Event batch
+ * Packages multiple events into a batch for transmission to improve network
+ * efficiency Includes timestamp for receivers to process events in
+ * chronological order
+ */
+class EventBatch {
+   public:
+    double ts;
+    std::vector<std::shared_ptr<KVCacheEvent>> events;
+    static constexpr size_t kFieldCount{2};
+
+    EventBatch(std::vector<std::shared_ptr<KVCacheEvent>> evts)
+        : ts(get_current_time()), events(std::move(evts)) {}
+
+    // [ts, events]
+    msgpack::sbuffer serialize() const {
+        msgpack::sbuffer buffer;
+        msgpack::packer<msgpack::sbuffer> pk(buffer);
+
+        pk.pack_array(kFieldCount);
+
+        pk.pack(ts);
+
+        pk.pack_array(events.size());
+        for (const auto& event : events) {
+            event->pack(pk);
+        }
+
+        return buffer;
+    }
+
+   private:
+    static double get_current_time() {
+        auto now = std::chrono::system_clock::now();
+        return std::chrono::duration<double>(now.time_since_epoch()).count();
+    }
+};
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_KV_EVENT_H

--- a/mooncake-store/include/kv_event/kv_event_consumer.h
+++ b/mooncake-store/include/kv_event/kv_event_consumer.h
@@ -1,0 +1,220 @@
+#pragma once
+
+#ifndef MOONCAKE_KV_EVENT_CONSUMER_H
+#define MOONCAKE_KV_EVENT_CONSUMER_H
+
+#include "kv_event/kv_event.hpp"
+#include "kv_event/kv_event_types.h"
+
+#include <zmq.hpp>
+#include <zmq_addon.hpp>
+
+#include <future>
+#include <memory>
+#include <optional>
+#include <algorithm>
+
+namespace mooncake {
+
+class KVEventSystem;
+
+/**
+ * @brief ZeroMQ event consumer
+ * Consumes events from the event queue and publishes them via ZeroMQ
+ * Supports event batch processing and replay functionality
+ */
+class KVEventConsumer {
+   public:
+    /**
+     * @brief Consumer configuration structure
+     */
+    struct Config {
+        // Network endpoint configuration
+        std::string endpoint{"tcp://*:19997"};
+        std::optional<std::string> replay_endpoint = std::nullopt;
+
+        // Performance configuration
+        size_t buffer_steps{10000};  // Replay buffer size
+        int hwm{100000};             // ZeroMQ high-water mark
+        std::chrono::milliseconds send_interval{0};
+
+        // Batching configuration
+        size_t max_batch_size{50};  // Maximum event batch size
+        std::chrono::milliseconds pop_timeout{100};
+
+        // Message configuration
+        std::string topic{"mooncake"};
+
+        // Auto-port switching configuration
+        bool auto_port{true};  // Whether to enable auto-port switching
+        size_t max_port_attempts{10};
+    };
+
+    /**
+     * @brief Consumer statistics
+     */
+    struct Stats {
+        size_t total_events{0};
+        size_t total_batches{0};
+
+        size_t failed_events{0};
+        size_t replay_requests{0};
+
+        double success_rate{0.0};
+        double events_per_batch{0.0};
+
+        /**
+         * @brief Check if any events have been processed
+         * @return true if at least one event has been received, false otherwise
+         */
+        bool has_data() const { return total_events > 0; }
+
+        void calculate_derived_metrics();
+
+        friend std::ostream& operator<<(std::ostream& os, const Stats& stats);
+    };
+
+    /**
+     * @brief Constructor
+     * @param event_queue Shared event queue
+     * @param config Consumer configuration
+     * Initializes ZeroMQ context, publishing thread and configures the shared
+     * queue
+     */
+    explicit KVEventConsumer(const std::shared_ptr<KVEventQueue> event_queue,
+                             const Config& config);
+
+    /**
+     * @brief Destructor
+     * Automatically calls shutdown() to ensure resource release
+     */
+    ~KVEventConsumer();
+
+    // Prohibit copy and move operations
+    KVEventConsumer(const KVEventConsumer&) = delete;
+    KVEventConsumer& operator=(const KVEventConsumer&) = delete;
+    KVEventConsumer(KVEventConsumer&&) = delete;
+    KVEventConsumer& operator=(KVEventConsumer&&) = delete;
+
+    /**
+     * @brief Gracefully shutdown the consumer
+     * 1. Stop accepting new events
+     * 2. Stop publishing thread
+     * 3. Close all network connections
+     */
+    void shutdown();
+
+    /**
+     * @brief Get current statistics
+     * @return Stats object containing all performance metrics
+     * Note: Frequent calls may impact performance
+     */
+    Stats get_stats() const;
+
+    /**
+     * @brief Check if consumer is running
+     * @return true if consumer is active, false if shutdown
+     */
+    bool is_running() const noexcept {
+        return running_.load(std::memory_order_acquire);
+    };
+
+   private:
+    /**
+     * @brief Replay buffer entry
+     * Stores recently transmitted events with their sequence numbers to support
+     * replay for late subscribers
+     */
+    struct ReplayEntry {
+        uint64_t seq;              // Sequence number for ordering
+        msgpack::sbuffer payload;  // Serialized event data
+
+        ReplayEntry(uint64_t s, msgpack::sbuffer p)
+            : seq(s), payload(std::move(p)) {}
+    };
+
+    /**
+     * @brief Thread-specific resources
+     * Contains all resources required by the publishing thread to ensure thread
+     * safety
+     */
+    struct ThreadResources {
+        std::unique_ptr<zmq::socket_t> pub_socket;
+        std::unique_ptr<zmq::socket_t> replay_socket;
+        std::deque<ReplayEntry> replay_buffer;
+        uint64_t next_seq = 0;
+
+        /**
+         * @brief Constructor
+         * @param ctx ZeroMQ context
+         * @param config Consumer configuration
+         */
+        explicit ThreadResources(zmq::context_t& ctx, const Config& config);
+    };
+
+    /**
+     * @brief Publishing thread main function
+     * @param stop_token Stop token for cooperative thread cancellation
+     * Continuous event processing workflow:
+     * 1. Check and service replay requests
+     * 2. Wait for configured send interval
+     * 3. Batch events (up to max_batch_size)
+     * 4. Serialize batches and send via ZeroMQ
+     * 5. Update replay buffer
+     * 6. Fulfill promises for successfully transmitted events
+     */
+    void publisher_thread(std::stop_token stop_token);
+
+    /**
+     * @brief Set up ZeroMQ sockets
+     * @param resources Thread resources reference
+     * @throws std::runtime_error if socket setup fails
+     * Performs automatic port selection based on configuration
+     */
+    void setup_sockets(ThreadResources& resources);
+
+    /**
+     * @brief Service replay requests
+     * @param resources Thread resources
+     * Handles replay requests:
+     * 1. Reads requested starting sequence number
+     * 2. Sends all buffered events with equal or higher sequence numbers
+     * 3. Sends an end marker
+     * Processes only one request per call to avoid blocking the main publishing
+     * loop
+     */
+    void service_replay(ThreadResources& resources);
+
+    /**
+     * @brief Handle errors during publishing operations
+     * @param e Exception that was caught
+     * @param context Description of where the error occurred
+     * Logs error details and implements brief sleep to prevent tight error
+     * loops
+     */
+    void handle_error(const std::exception& e, const std::string& context);
+
+    // Graceful shutdown timeout in seconds
+    static constexpr double SHUTDOWN_TIMEOUT = 2.0;
+
+    // Magic sequence number indicating end of replay transmission
+    static constexpr std::array<uint8_t, 8> END_SEQ = {0xFF, 0xFF, 0xFF, 0xFF,
+                                                       0xFF, 0xFF, 0xFF, 0xFF};
+
+    Config config_;
+    zmq::context_t context_;
+
+    std::shared_ptr<KVEventQueue> event_queue_;
+    std::jthread publisher_thread_;  // Publishing thread
+    std::atomic<bool> running_{false};
+
+    std::atomic<size_t> total_events_{0};
+    std::atomic<size_t> total_batches_{0};
+
+    std::atomic<size_t> failed_events_{0};
+    std::atomic<size_t> replay_requests_{0};
+};  // class KVEventConsumer
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_KV_EVENT_CONSUMER_H

--- a/mooncake-store/include/kv_event/kv_event_producer.h
+++ b/mooncake-store/include/kv_event/kv_event_producer.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#ifndef MOONCAKE_KV_EVENT_PRODUCER_H
+#define MOONCAKE_KV_EVENT_PRODUCER_H
+
+#include "kv_event/kv_event.hpp"
+#include "kv_event/kv_event_types.h"
+#include "thread_pool.h"
+
+#include <future>
+#include <memory>
+
+namespace mooncake {
+
+class KVEventSystem;
+
+/**
+ * @brief Event producer
+ * Responsible for creating events and asynchronously pushing them to the event
+ * queue
+ */
+class KVEventProducer {
+   public:
+    /**
+     * @brief Producer configuration structure
+     */
+    struct Config {
+        size_t enqueue_thread_pool_size{
+            1};  // Number of enqueue thread pool workers
+        std::chrono::milliseconds enqueue_timeout{
+            10};                         // Enqueue timeout duration
+        size_t enqueue_max_retries{10};  // Maximum enqueue retry attempts
+    };
+
+    /**
+     * @brief Producer statistics
+     */
+    struct Stats {
+        size_t events_created{0};
+        size_t enqueue_failed{0};
+        double success_rate{0.0};
+
+        size_t store_event{0};
+        size_t update_event{0};
+        size_t remove_all_event{0};
+
+        bool has_data() const { return events_created > 0; };
+
+        void calculate_derived_metrics();
+
+        friend std::ostream& operator<<(std::ostream& os, const Stats& stats);
+    };
+
+    /**
+     * @brief Constructor
+     * @param event_queue Shared event queue
+     * @param config Producer configuration
+     * Initializes thread pool and configures the shared queue
+     */
+    explicit KVEventProducer(const std::shared_ptr<KVEventQueue> event_queue,
+                             const Config& config);
+
+    /**
+     * @brief Destructor
+     * Automatically calls shutdown() to ensure thread pool is properly closed
+     */
+    ~KVEventProducer();
+
+    // Prohibit copy and move operations
+    KVEventProducer(const KVEventProducer&) = delete;
+    KVEventProducer& operator=(const KVEventProducer&) = delete;
+    KVEventProducer(KVEventProducer&&) = delete;
+    KVEventProducer& operator=(KVEventProducer&&) = delete;
+
+    bool is_running() const noexcept {
+        return running_.load(std::memory_order_acquire);
+    };
+
+    /**
+     * @brief Increment counter based on event type
+     * @tparam Event Event type
+     */
+    template <DerivedFromKVCacheEvent Event>
+    void increment_event_count() {
+        if constexpr (std::is_same_v<Event, BlockStoreEvent>) {
+            store_event_.fetch_add(1, std::memory_order_relaxed);
+        } else if constexpr (std::is_same_v<Event, BlockUpdateEvent>) {
+            update_event_.fetch_add(1, std::memory_order_relaxed);
+        } else if constexpr (std::is_same_v<Event, RemoveAllEvent>) {
+            remove_all_event_.fetch_add(1, std::memory_order_relaxed);
+        } else {
+            static_assert(std::is_same_v<Event, void>,
+                          "Unknown event type! Please add handling for this "
+                          "event type in Stats::increment_event_count()");
+        }
+        events_created_.fetch_add(1, std::memory_order_relaxed);
+    };
+
+    /**
+     * @brief Publish an event
+     * @tparam Event Event type, must derive from KVCacheEvent
+     * @tparam Args Event constructor parameter types
+     * @param args Arguments passed to the event constructor
+     * @return std::future<bool> Future containing the publication result
+     * Creates and enqueues events asynchronously
+     */
+    template <DerivedFromKVCacheEvent Event, typename... Args>
+    std::future<bool> publish(Args&&... args) {
+        if (!is_running()) {
+            auto promise = std::make_shared<std::promise<bool>>();
+            promise->set_value(false);
+            return promise->get_future();
+        }
+
+        auto event = std::make_shared<Event>(std::forward<Args>(args)...);
+        increment_event_count<Event>();
+        return publish_event_async(std::move(event));
+    };
+
+    /**
+     * @brief Asynchronously publish a pre-created event object
+     * @param event Shared pointer to event
+     * @return std::future<bool> Future containing the publication result
+     * Submits the event to the thread pool for enqueuing operation
+     */
+    std::future<bool> publish_event_async(KVEventPtr event);
+
+    /**
+     * @brief Get the event queue
+     * @return Shared pointer to the event queue
+     */
+    std::shared_ptr<KVEventQueue> get_queue() const { return event_queue_; };
+
+    /**
+     * @brief Get statistics
+     * @return Producer statistics
+     */
+    Stats get_stats() const;
+
+    /**
+     * @brief Stop the producer
+     * Shuts down thread pool and stops accepting new events
+     */
+    void shutdown();
+
+   private:
+    Config config_;
+
+    std::atomic<bool> running_{false};
+    std::shared_ptr<KVEventQueue> event_queue_;
+    std::unique_ptr<ThreadPool> enqueue_pool_;  // Enqueuing thread pool
+
+    std::atomic<size_t> events_created_{0};
+    std::atomic<size_t> enqueue_failed_{0};
+
+    std::atomic<size_t> store_event_{0};
+    std::atomic<size_t> update_event_{0};
+    std::atomic<size_t> remove_all_event_{0};
+};
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_KV_EVENT_PRODUCER_H

--- a/mooncake-store/include/kv_event/kv_event_publisher_config.h
+++ b/mooncake-store/include/kv_event/kv_event_publisher_config.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#ifndef MOONCAKE_KV_EVENT_PUBLISHER_CONFIG_H
+#define MOONCAKE_KV_EVENT_PUBLISHER_CONFIG_H
+
+#include <string>
+#include <atomic>
+#include <chrono>
+#include <optional>
+
+namespace mooncake {
+
+struct KVEventPublisherConfig {
+    // Network endpoint configuration
+    std::string endpoint{"tcp://*:19997"};
+    std::optional<std::string> replay_endpoint = std::nullopt;
+
+    // Performance configuration
+    size_t buffer_steps{10000};  // Replay buffer size
+    int hwm{100000};             // ZeroMQ high-water mark
+    size_t max_queue_size{100000};
+    std::chrono::milliseconds send_interval{0};
+
+    // Batching configuration
+    size_t max_batch_size{50};  // Maximum event batch size
+    std::chrono::milliseconds batch_timeout{200};
+    std::chrono::milliseconds pop_timeout{100};
+
+    // Thread pool configuration
+    size_t enqueue_thread_pool_size{1};
+    std::chrono::milliseconds enqueue_timeout{10};
+    size_t enqueue_max_retries = 10;
+
+    // Message configuration
+    std::string topic{"mooncake"};
+
+    // Auto-port switching configuration
+    bool auto_port{true};  // Whether to enable auto-port switching
+    size_t max_port_attempts{10};
+
+    // Validate configuration validity
+    bool validate() const noexcept;
+};
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_KV_EVENT_PUBLISHER_CONFIG_H

--- a/mooncake-store/include/kv_event/kv_event_system.h
+++ b/mooncake-store/include/kv_event/kv_event_system.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#ifndef MOONCAKE_KV_EVENT_SYSTEM_H
+#define MOONCAKE_KV_EVENT_SYSTEM_H
+
+#include "kv_event/kv_event.hpp"
+#include "kv_event/kv_event_publisher_config.h"
+#include "kv_event/kv_event_types.h"
+
+#include <future>
+#include <atomic>
+#include <memory>
+
+namespace mooncake {
+
+class KVEventProducer;
+class KVEventConsumer;
+
+/**
+ * @brief Event system facade class
+ * Provides a simplified interface for using the event system's
+ * publish/subscribe functionality Implements the Facade pattern to hide complex
+ * interactions between producers and consumers
+ */
+class KVEventSystem {
+   public:
+    /**
+     * @brief Constructor
+     * @param config System configuration parameters
+     * Initializes event queue, producer, and consumer, and starts the event
+     * processing pipeline
+     */
+    explicit KVEventSystem(
+        const KVEventPublisherConfig& config = KVEventPublisherConfig{});
+
+    /**
+     * @brief Destructor
+     * Automatically calls shutdown() to ensure proper resource release
+     */
+    ~KVEventSystem();
+
+    // Disable copy and move operations to ensure singleton-like behavior
+    KVEventSystem(const KVEventSystem&) = delete;
+    KVEventSystem& operator=(const KVEventSystem&) = delete;
+    KVEventSystem(KVEventSystem&&) = delete;
+    KVEventSystem& operator=(KVEventSystem&&) = delete;
+
+    /**
+     * @brief Stop the event system
+     * Gracefully shuts down producer and consumer, ensuring all events are
+     * processed
+     */
+    void shutdown();
+
+    /**
+     * @brief Check if the system is running
+     * @return System running status
+     */
+    bool is_running() const noexcept {
+        return running_.load(std::memory_order_acquire);
+    };
+
+    /**
+     * @brief Generic event publishing interface
+     * @tparam Event Event type, must derive from KVCacheEvent
+     * @tparam Args Event constructor parameter types
+     * @param args Arguments passed to the event constructor
+     * @return Future containing the publication result (true for success, false
+     * for failure)
+     */
+    template <DerivedFromKVCacheEvent Event, typename... Args>
+    std::future<bool> publish(Args&&... args) {
+        return producer_->publish<Event>(std::forward<Args>(args)...);
+    };
+
+    /**
+     * @brief Queue statistics structure
+     * Monitors event queue status for performance tuning and capacity planning
+     */
+    struct QueueStats {
+        size_t queue_remain_events =
+            0;                      // Number of pending events in the queue
+        size_t queue_capacity = 0;  // Total queue capacity
+
+        friend std::ostream& operator<<(std::ostream& os,
+                                        const QueueStats& stats);
+    };
+
+    /**
+     * @brief Complete system statistics
+     * Aggregates statistics from producer, consumer, and queue
+     */
+    struct Stats {
+        KVEventProducer::Stats producer_stats;
+        KVEventConsumer::Stats consumer_stats;
+        QueueStats event_queue_stats;
+
+        double success_rate{0.0};
+
+        bool has_data() const;
+        void calculate_derived_metrics();
+
+        friend std::ostream& operator<<(std::ostream& os, const Stats& stats);
+    };
+
+    /**
+     * @brief Get complete system statistics
+     * @return Stats object containing all statistical information
+     * Note: Frequent calls may impact performance
+     */
+    Stats get_stats() const;
+
+    /**
+     * @brief Get producer statistics
+     * @return Producer statistics
+     */
+    KVEventProducer::Stats get_producer_stats() const {
+        return producer_->get_stats();
+    };
+
+    /**
+     * @brief Get consumer statistics
+     * @return Consumer statistics
+     */
+    KVEventConsumer::Stats get_consumer_stats() const {
+        return consumer_->get_stats();
+    };
+
+    /**
+     * @brief Get queue statistics
+     * @return Queue statistics
+     */
+    QueueStats get_queue_stats() const;
+
+    /**
+     * @brief Get internal producer instance
+     * @return Shared pointer to event producer
+     * Used for advanced usage to directly access producer interface
+     */
+    std::shared_ptr<KVEventProducer> get_producer() const { return producer_; };
+
+    /**
+     * @brief Get internal consumer instance
+     * @return Shared pointer to event consumer
+     * Used for advanced usage to directly access consumer interface
+     */
+    std::shared_ptr<KVEventConsumer> get_publisher() const {
+        return consumer_;
+    };
+
+   private:
+    KVEventPublisherConfig config_;
+    std::shared_ptr<KVEventQueue> event_queue_;
+    std::shared_ptr<KVEventProducer> producer_;
+    std::shared_ptr<KVEventConsumer> consumer_;
+    std::atomic<bool> running_{false};
+};
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_KV_EVENT_SYSTEM_H

--- a/mooncake-store/include/kv_event/kv_event_types.h
+++ b/mooncake-store/include/kv_event/kv_event_types.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#ifndef MOONCAKE_KV_EVENT_TYPES_H
+#define MOONCAKE_KV_EVENT_TYPES_H
+
+#include "kv_event/kv_event.hpp"
+#include "thread_safe_queue.h"
+
+#include <future>
+#include <memory>
+#include <optional>
+#include <type_traits>
+
+namespace mooncake {
+
+/**
+ * @brief Type trait concept for events derived from KVCacheEvent
+ * Ensures compile-time type checking for event types used in templates
+ */
+template <typename Event>
+concept DerivedFromKVCacheEvent = std::is_base_of_v<KVCacheEvent, Event>;
+
+/**
+ * @brief Type alias for KVCacheEvent shared pointer
+ * Standardized pointer type for event objects throughout the system
+ */
+using KVEventPtr = std::shared_ptr<KVCacheEvent>;
+
+/**
+ * @brief Structure representing an item in the event queue
+ * Combines an event with its associated promise for notification of
+ * transmission completion The promise is fulfilled by the consumer when the
+ * event is successfully published
+ */
+struct QueuedItem {
+    KVEventPtr event;  // Shared pointer to the event
+    std::shared_ptr<std::promise<bool>>
+        promise;  // Promise to notify publishing result
+};
+
+/**
+ * @brief Type alias for thread-safe event queue
+ * Queue element is optional to support sentinel values for shutdown signaling
+ * Uses ThreadSafeQueue implementation with configurable capacity
+ */
+using KVEventQueue = ThreadSafeQueue<std::optional<QueuedItem>>;
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_KV_EVENT_TYPES_H

--- a/mooncake-store/include/kv_event_publisher.h
+++ b/mooncake-store/include/kv_event_publisher.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifndef MOONCAKE_KV_EVENT_PUBLISHER_H
+#define MOONCAKE_KV_EVENT_PUBLISHER_H
+
+#include "kv_event/kv_event.hpp"
+#include "kv_event/kv_event_types.h"
+#include "kv_event/kv_event_publisher_config.h"
+#include "kv_event/kv_event_producer.h"
+#include "kv_event/kv_event_consumer.h"
+#include "kv_event/kv_event_system.h"
+
+#endif  // MOONCAKE_KV_EVENT_PUBLISHER_H

--- a/mooncake-store/include/thread_pool.h
+++ b/mooncake-store/include/thread_pool.h
@@ -1,4 +1,7 @@
-// ThreadPool.h
+#pragma once
+
+#ifndef MOONCAKE_THREAD_POOL_H
+#define MOONCAKE_THREAD_POOL_H
 
 #include <vector>
 #include <queue>
@@ -7,6 +10,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <atomic>
+
 namespace mooncake {
 /**
  * @class ThreadPool
@@ -67,3 +71,5 @@ void ThreadPool::enqueue(F&& f, Args&&... args) {
     condition.notify_one();  ///< Wake one waiting worker
 }
 }  // namespace mooncake
+
+#endif  // MOONCAKE_THREAD_POOL_H

--- a/mooncake-store/include/thread_safe_queue.h
+++ b/mooncake-store/include/thread_safe_queue.h
@@ -1,0 +1,564 @@
+#pragma once
+
+#ifndef MOONCAKE_THREAD_SAFE_QUEUE_H
+#define MOONCAKE_THREAD_SAFE_QUEUE_H
+
+#include <deque>
+#include <mutex>
+#include <condition_variable>
+#include <chrono>
+#include <optional>
+#include <atomic>
+#include <vector>
+#include <type_traits>
+
+namespace mooncake {
+/**
+ * @brief Thread-safe queue implementation with bounded capacity and shutdown
+ * mechanism
+ *
+ * This template class provides a producer-consumer queue that can be safely
+ * accessed from multiple threads. It supports both blocking and timeout-based
+ * operations, and includes a shutdown mechanism to gracefully terminate waiting
+ * threads.
+ *
+ * Optimized for MPSC (Multiple Producers, Single Consumer) scenarios with
+ * atomic size tracking to reduce lock contention.
+ *
+ * @note Type T must be nothrow move constructible or copy constructible
+ *       for exception safety in batch operations. Uses std::deque as the
+ *       underlying container to support efficient random access for
+ *       peek operations.
+ *
+ * @tparam T Type of elements stored in the queue
+ */
+template <typename T>
+class ThreadSafeQueue {
+    // Static assertion for exception safety requirements
+    static_assert(
+        std::is_nothrow_move_constructible_v<T> ||
+            std::is_copy_constructible_v<T>,
+        "Type T must be nothrow move constructible or copy constructible "
+        "for exception safety in batch operations");
+
+   public:
+    /**
+     * @brief Construct a new ThreadSafeQueue with specified maximum capacity
+     * @param max_size Maximum number of elements the queue can hold
+     */
+    explicit ThreadSafeQueue(size_t max_size = 100000) : max_size_(max_size) {}
+
+    /**
+     * @brief Push an item into the queue (blocking)
+     * @param item Item to be pushed
+     * @return true if item was successfully pushed, false if queue is shutdown
+     */
+    bool push(T item);
+
+    /**
+     * @brief Push an item into the queue with timeout
+     * @param item Item to be pushed
+     * @param timeout Maximum time to wait for push operation
+     * @return true if item was successfully pushed, false on timeout or
+     * shutdown
+     */
+    bool push(T item, std::chrono::milliseconds timeout);
+
+    /**
+     * @brief Attempt to push an item into the queue without blocking
+     *
+     * This method attempts to push an item immediately without waiting.
+     * It returns immediately with the result of the attempt.
+     *
+     * @param item Item to be pushed
+     * @return true if item was successfully pushed, false if queue is full or
+     * shutdown
+     */
+    bool try_push(T item);
+
+    /**
+     * @brief Pop an item from the queue (blocking)
+     * @return std::optional containing the popped item, or std::nullopt if
+     * queue is shutdown
+     */
+    std::optional<T> pop();
+
+    /**
+     * @brief Pop an item from the queue with timeout
+     * @param timeout Maximum time to wait for pop operation
+     * @return std::optional containing the popped item, or std::nullopt on
+     * timeout or shutdown
+     */
+    std::optional<T> pop(std::chrono::milliseconds timeout);
+
+    /**
+     * @brief Batch pop items from the queue
+     * @param max_batch_size Maximum number of items to pop
+     * @param timeout Maximum time to wait for at least one item
+     * @return Vector of popped items, std::nullopt if timeout or shutdown
+     */
+    std::optional<std::vector<T>> pop_batch(size_t max_batch_size,
+                                            std::chrono::milliseconds timeout);
+
+    /**
+     * @brief Non-blocking batch pop
+     * @param max_batch_size Maximum number of items to pop
+     * @return Vector of popped items, empty if queue is empty
+     */
+    std::optional<std::vector<T>> try_pop_batch(size_t max_batch_size);
+
+    /**
+     * @brief Get the first max_batch_size elements from the queue without
+     * removing them
+     *
+     * This method returns a copy of the first max_batch_size elements in the
+     * queue without popping. The operation is thread-safe and efficient due to
+     * the use of std::deque as the underlying container, which supports random
+     * access.
+     *
+     * In MPSC scenarios, producers are only blocked for the minimal time
+     * needed to create a copy of the required elements.
+     *
+     * @param max_batch_size Number of elements to retrieve. If
+     * max_batch_size=0, returns std::nullopt.
+     * @return std::optional<std::vector<T>> containing the first max_batch_size
+     * elements, or std::nullopt if the queue is empty
+     */
+    std::optional<std::vector<T>> peek_batch(size_t max_batch_size) const;
+
+    /**
+     * @brief Get elements at specific positions in the queue without removing
+     * them
+     *
+     * This method returns copies of elements at the specified positions
+     * without removing them. Positions are 0-based from the front of the queue.
+     * The operation is thread-safe and efficient with std::deque.
+     *
+     * @param positions Vector of 0-based positions to peek
+     * @return std::vector<std::optional<T>> containing the elements at the
+     *         requested positions, with nullopt for invalid positions
+     */
+    std::vector<std::optional<T>> peek_at(
+        const std::vector<size_t>& positions) const;
+
+    /**
+     * @brief Check if the queue is empty
+     * @return true if queue contains no elements, false otherwise
+     */
+    bool empty() const;
+
+    /**
+     * @brief Get approximate queue size without locking
+     *
+     * This method provides fast size approximation using atomic operations.
+     * In MPSC scenarios, this provides good accuracy with minimal contention.
+     *
+     * @return Approximate number of elements in the queue
+     */
+    size_t size_approx() const {
+        // Use relaxed memory order as this is an approximate value
+        return approximate_size_.load(std::memory_order_acquire);
+    }
+
+    /**
+     * @brief Get the exact number of elements in the queue
+     *
+     * This method acquires a lock to get the exact size of the queue.
+     * It is safe to call this method after shutdown.
+     *
+     * @return Exact number of elements in the queue
+     */
+    size_t size() const;
+
+    /**
+     * @brief Get the maximum capacity of the queue
+     *
+     * This method returns the maximum number of elements the queue can hold.
+     * The value is set during construction and remains constant throughout
+     * the lifetime of the queue.
+     *
+     * @return Maximum capacity of the queue
+     */
+    size_t capacity() const { return max_size_; }
+
+    /**
+     * @brief Shutdown the queue and wake up all waiting threads
+     *
+     * After shutdown, all push operations will fail immediately, while pop
+     * operations will continue to return remaining elements until the queue is
+     * empty.
+     */
+    void shutdown();
+
+    /**
+     * @brief Check if the queue has been shutdown
+     * @return true if queue is shutdown, false otherwise
+     */
+    bool is_shutdown() const;
+
+    /**
+     * @brief Check if the queue is full
+     * @return true if queue is at maximum capacity, false otherwise
+     */
+    bool is_full() const;
+
+   private:
+    // Helper methods for batch operations
+    template <bool UseCopy>
+    std::vector<T> batch_pop_impl(size_t max_batch_size, size_t original_size,
+                                  bool& was_full);
+
+    // Helper to check if we should proceed with push operation
+    bool should_proceed_with_push() const {
+        // For push operations, we should not proceed if shutdown
+        return !shutdown_.load(std::memory_order_acquire);
+    }
+
+   private:
+    mutable std::mutex mutex_;
+    std::condition_variable not_empty_;
+    std::condition_variable not_full_;
+    std::deque<T> deque_;
+    size_t max_size_;
+    std::atomic<bool> shutdown_{false};
+    std::atomic<size_t> approximate_size_{0};
+};
+
+// Implementation
+template <typename T>
+bool ThreadSafeQueue<T>::push(T item) {
+    if (!should_proceed_with_push()) {
+        return false;
+    }
+
+    std::unique_lock lock(mutex_);
+    not_full_.wait(lock, [this] {
+        return deque_.size() < max_size_ ||
+               shutdown_.load(std::memory_order_acquire);
+    });
+
+    if (shutdown_.load(std::memory_order_acquire)) {
+        return false;
+    }
+
+    bool was_empty = deque_.empty();
+    deque_.push_back(std::move(item));
+    approximate_size_.fetch_add(1, std::memory_order_release);
+    lock.unlock();
+
+    if (was_empty) {
+        not_empty_.notify_one();
+    }
+    return true;
+}
+
+template <typename T>
+bool ThreadSafeQueue<T>::push(T item, std::chrono::milliseconds timeout) {
+    if (!should_proceed_with_push()) {
+        return false;
+    }
+
+    std::unique_lock lock(mutex_);
+    if (!not_full_.wait_for(lock, timeout, [this] {
+            return deque_.size() < max_size_ ||
+                   shutdown_.load(std::memory_order_acquire);
+        })) {
+        return false;
+    }
+
+    if (shutdown_.load(std::memory_order_acquire)) {
+        return false;
+    }
+
+    bool was_empty = deque_.empty();
+    deque_.push_back(std::move(item));
+    approximate_size_.fetch_add(1, std::memory_order_release);
+    lock.unlock();
+
+    if (was_empty) {
+        not_empty_.notify_one();
+    }
+    return true;
+}
+
+template <typename T>
+bool ThreadSafeQueue<T>::try_push(T item) {
+    if (!should_proceed_with_push()) {
+        return false;
+    }
+
+    if (approximate_size_.load(std::memory_order_acquire) >= max_size_) {
+        return false;
+    }
+
+    std::unique_lock lock(mutex_, std::try_to_lock);
+
+    if (!lock.owns_lock() || shutdown_.load(std::memory_order_acquire)) {
+        return false;
+    }
+
+    if (deque_.size() >= max_size_) {
+        return false;
+    }
+
+    bool was_empty = deque_.empty();
+    deque_.push_back(std::move(item));
+    approximate_size_.fetch_add(1, std::memory_order_release);
+    lock.unlock();
+
+    if (was_empty) {
+        not_empty_.notify_one();
+    }
+
+    return true;
+}
+
+template <typename T>
+std::optional<T> ThreadSafeQueue<T>::pop() {
+    std::unique_lock lock(mutex_);
+    not_empty_.wait(lock, [this] {
+        return !deque_.empty() || shutdown_.load(std::memory_order_acquire);
+    });
+
+    if (deque_.empty()) {
+        return std::nullopt;
+    }
+
+    bool was_full = (deque_.size() == max_size_);
+    T item = std::move(deque_.front());
+    deque_.pop_front();
+    approximate_size_.fetch_sub(1, std::memory_order_release);
+    lock.unlock();
+
+    if (was_full) {
+        not_full_.notify_one();
+    }
+    return item;
+}
+
+template <typename T>
+std::optional<T> ThreadSafeQueue<T>::pop(std::chrono::milliseconds timeout) {
+    std::unique_lock lock(mutex_);
+    if (!not_empty_.wait_for(lock, timeout, [this] {
+            return !deque_.empty() || shutdown_.load(std::memory_order_acquire);
+        })) {
+        return std::nullopt;
+    }
+
+    if (deque_.empty()) {
+        return std::nullopt;
+    }
+
+    bool was_full = (deque_.size() == max_size_);
+    T item = std::move(deque_.front());
+    deque_.pop_front();
+    approximate_size_.fetch_sub(1, std::memory_order_release);
+    lock.unlock();
+
+    if (was_full) {
+        not_full_.notify_one();
+    }
+    return item;
+}
+
+template <typename T>
+template <bool UseCopy>
+std::vector<T> ThreadSafeQueue<T>::batch_pop_impl(size_t max_batch_size,
+                                                  size_t original_size,
+                                                  bool& was_full) {
+    const size_t count = std::min(max_batch_size, original_size);
+    was_full = (original_size == max_size_);
+
+    if (count == 0) {
+        return {};
+    }
+
+    std::vector<T> batch;
+    batch.reserve(count);
+
+    auto begin = deque_.begin();
+    auto end = begin;
+    std::advance(end, count);
+
+    if constexpr (UseCopy) {
+        batch.insert(batch.end(), begin, end);
+    } else {
+        batch.insert(batch.end(), std::make_move_iterator(begin),
+                     std::make_move_iterator(end));
+    }
+
+    approximate_size_.fetch_sub(count, std::memory_order_release);
+
+    deque_.erase(begin, end);
+    return batch;
+}
+
+template <typename T>
+std::optional<std::vector<T>> ThreadSafeQueue<T>::pop_batch(
+    size_t max_batch_size, std::chrono::milliseconds timeout) {
+    if (max_batch_size == 0) {
+        return std::nullopt;
+    }
+
+    std::unique_lock lock(mutex_);
+
+    if (!not_empty_.wait_for(lock, timeout, [this] {
+            return !deque_.empty() || shutdown_.load(std::memory_order_acquire);
+        })) {
+        return std::nullopt;
+    }
+
+    if (deque_.empty()) {
+        return std::nullopt;
+    }
+
+    const size_t original_size = deque_.size();
+    bool was_full = false;
+
+    std::vector<T> batch;
+    if constexpr (std::is_nothrow_move_constructible_v<T>) {
+        batch = batch_pop_impl<false>(max_batch_size, original_size, was_full);
+    } else {
+        batch = batch_pop_impl<true>(max_batch_size, original_size, was_full);
+    }
+
+    lock.unlock();
+
+    if (was_full) {
+        not_full_.notify_all();
+    }
+
+    if (!batch.empty()) {
+        return batch;
+    }
+
+    return std::nullopt;
+}
+
+template <typename T>
+std::optional<std::vector<T>> ThreadSafeQueue<T>::try_pop_batch(
+    size_t max_batch_size) {
+    if (max_batch_size == 0) {
+        return std::nullopt;
+    }
+
+    std::unique_lock lock(mutex_);
+
+    if (deque_.empty()) {
+        return std::nullopt;
+    }
+
+    const size_t original_size = deque_.size();
+    bool was_full = false;
+
+    std::vector<T> batch;
+    if constexpr (std::is_nothrow_move_constructible_v<T>) {
+        batch = batch_pop_impl<false>(max_batch_size, original_size, was_full);
+    } else {
+        batch = batch_pop_impl<true>(max_batch_size, original_size, was_full);
+    }
+
+    lock.unlock();
+
+    if (was_full) {
+        not_full_.notify_all();
+    }
+
+    if (!batch.empty()) {
+        return batch;
+    }
+
+    return std::nullopt;
+}
+
+template <typename T>
+std::optional<std::vector<T>> ThreadSafeQueue<T>::peek_batch(
+    size_t max_batch_size) const {
+    if (max_batch_size == 0) {
+        return std::nullopt;
+    }
+
+    if (approximate_size_.load(std::memory_order_acquire) == 0) {
+        return std::nullopt;
+    }
+
+    std::unique_lock lock(mutex_);
+
+    if (deque_.empty()) {
+        return std::nullopt;
+    }
+
+    const size_t count = std::min(max_batch_size, deque_.size());
+
+    return std::make_optional<std::vector<T>>(deque_.begin(),
+                                              deque_.begin() + count);
+}
+
+template <typename T>
+std::vector<std::optional<T>> ThreadSafeQueue<T>::peek_at(
+    const std::vector<size_t>& positions) const {
+    std::vector<std::optional<T>> result;
+
+    std::unique_lock lock(mutex_);
+
+    if (deque_.empty()) {
+        result.resize(positions.size());
+        return result;
+    }
+
+    const size_t deque_size = deque_.size();
+
+    result.reserve(positions.size());
+
+    for (size_t pos : positions) {
+        if (pos < deque_size) {
+            result.emplace_back(deque_[pos]);
+        } else {
+            result.emplace_back(std::nullopt);
+        }
+    }
+
+    return result;
+}
+
+template <typename T>
+size_t ThreadSafeQueue<T>::size() const {
+    std::lock_guard lock(mutex_);
+    return deque_.size();
+}
+
+template <typename T>
+bool ThreadSafeQueue<T>::empty() const {
+    if (approximate_size_.load(std::memory_order_acquire) > 0) {
+        return false;
+    }
+
+    std::lock_guard lock(mutex_);
+    return deque_.empty();
+}
+
+template <typename T>
+void ThreadSafeQueue<T>::shutdown() {
+    shutdown_.store(true, std::memory_order_release);
+
+    {
+        std::lock_guard lock(mutex_);
+        not_empty_.notify_all();
+        not_full_.notify_all();
+    }
+}
+
+template <typename T>
+bool ThreadSafeQueue<T>::is_shutdown() const {
+    return shutdown_.load(std::memory_order_acquire);
+}
+
+template <typename T>
+bool ThreadSafeQueue<T>::is_full() const {
+    std::lock_guard lock(mutex_);
+    return deque_.size() >= max_size_;
+}
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_THREAD_SAFE_QUEUE_H


### PR DESCRIPTION
## Description
motivation: [[RFC]: Mooncake-Conductor: Design and Implementation of a Global Scheduler Module for KV-Cache-Centric Disaggregated Architecture #977](https://github.com/kvcache-ai/Mooncake/issues/977)

Add a kv event publish system: it consists of events and an asynchronous sender, a kv event publisher based on ZMQ. Co-work with @Liziqi-77  @yejj710 

**This is a declaration part PR for the new system**

## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [x] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?


I'll add 2 new UTs: kv_event_publisher_test and thread_safe_queue_test

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
