### PR TITLE
[EP] Replace _mm_pause() with PAUSE() macro

### DIFF
--- a/mooncake-ep/src/mooncake_worker_thread.cpp
+++ b/mooncake-ep/src/mooncake_worker_thread.cpp
@@ -19,7 +19,7 @@ void MooncakeWorker::startWorker() {
         clock::time_point activeTime[kNumTasks_];
         TransferMetadata::NotifyDesc msg{"ping", "ping"};
         while (running_) {
-            _mm_pause();
+            PAUSE();
             for (size_t i = 0; i < kNumTasks_; ++i) {
                 auto &task = tasks_[i];
                 if (!task.active) {


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Should fix #1242

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
