### PR TITLE
[Store] Add retry logic for auto port binding in client setup

### DIFF
--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -194,7 +194,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         client_ = *client_opt;
     } else {
         // Auto port binding with retry on metadata registration failure
-        const int kMaxRetries = GetEnvOr<int>("MC_STORE_CLIENT_SETUP_RETRIES", 20);
+        const int kMaxRetries =
+            GetEnvOr<int>("MC_STORE_CLIENT_SETUP_RETRIES", 20);
         bool success = false;
 
         for (int retry = 0; retry < kMaxRetries; ++retry) {


### PR DESCRIPTION
## Description

fix this issue https://github.com/sgl-project/sglang/issues/13395

This PR adds a retry mechanism for automatic port binding during client initialization in `RealClient::setup_internal()`. When multiple clients start simultaneously on the same host, they may encounter port conflicts or metadata registration failures. This change improves reliability by automatically retrying with different ports.


## Problem

In high-concurrency scenarios (e.g., multiple workers starting at the same time), the current implementation may fail to create a client due to:

1. **Port binding race conditions**: Multiple processes may try to bind the same auto-assigned port
2. **Metadata registration conflicts**: Even if port binding succeeds locally, metadata server registration may fail if another client has already registered with the same `hostname:port`
3. **Stale metadata after unclean shutdown**: When a Mooncake client exits (crashes or terminates unexpectedly), it does not unregister its port from the metadata service. Upon restart, the client may be assigned the same port that is still registered in the metadata service from the previous session, causing registration failure due to duplicate `hostname:port` entries.

The original code would fail immediately without any retry, causing service startup failures in distributed deployments.

## Solution

- **Separate handling for user-specified vs auto-assigned ports**:
  - If user explicitly specifies a port (e.g., `hostname:8080`), the behavior remains unchanged (no retry)
  - If port is auto-assigned, implement retry logic with up to 20 attempts

- **Retry mechanism**:
  - On each retry, release the current port and acquire a new one
  - Attempt to create the client with the new port
  - Log warnings for each failed attempt and success info on completion

- **Code restructuring**:
  - Moved `device_name` initialization before the port binding logic for cleaner code flow
  - Added clear separation between user-specified port path and auto-binding path

## Changes

- `mooncake-store/src/real_client.cpp`: Modified `setup_internal()` function

## Type of Change

* Types
  - [√] Bug fix
  - [√ ] New feature
    - [√ ] Transfer Engine
    - [√ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
