### PR TITLE
[Store][Feature]task add rpc_only protocol

### DIFF
--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -431,6 +431,12 @@ std::optional<std::shared_ptr<Client>> Client::Create(
         }
     }
 
+    // this only performs RPC calls
+    if (protocol == "rpc_only") {
+        LOG(INFO) << "Use rpc only. Skip initializing transfer engine.";
+        return client;
+    }
+
     // Initialize transfer engine
     if (transfer_engine == nullptr) {
         client->transfer_engine_ = std::make_shared<TransferEngine>();


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes. Link to any relevant issues. -->
Currently in Mooncake Integration with LMCache, we utilize Lookup Server/Lookup Client mechanic for looking up prefix cache hit; However, we can also setup a MooncakeStore client in the scheduler process by setting both local and global segment sizes to 0 to achieve the same result.

In this case, initializing a Transfer Engine is not needed, since the only task of the client object is to call the_exist() function. We propose to add another protocol "rpc_only" for MooncakeStore that immedietly returns when initializing Transfer Engine. 
[ISSUES #1172](https://github.com/kvcache-ai/Mooncake/issues/1172)

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [ ] Transfer Engine
    - [x] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
