### PR TITLE
[TE] support arm arch PAUSE()

### DIFF
--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -40,6 +40,8 @@
 #if defined(__x86_64__)
 #include <immintrin.h>
 #define PAUSE() _mm_pause()
+#elif defined(__aarch64__) || defined(__arm__)
+#define PAUSE() __asm__ __volatile__("yield")
 #else
 #define PAUSE()
 #endif

--- a/mooncake-transfer-engine/tent/include/tent/common/utils/os.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/utils/os.h
@@ -33,6 +33,8 @@
 #if defined(__x86_64__)
 #include <immintrin.h>
 #define PAUSE() _mm_pause()
+#elif defined(__aarch64__) || defined(__arm__)
+#define PAUSE() __asm__ __volatile__("yield")
 #else
 #define PAUSE()
 #endif


### PR DESCRIPTION
## Description

#1313 addresses wheel building for non-Intel architectures but lacks a `mm_pause` replacement.

## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
