### PR TITLE
[TE/HIP] Add stream and event pools for async transfer operations

### DIFF
--- a/mooncake-transfer-engine/include/transport/hip_transport/event_pool.h
+++ b/mooncake-transfer-engine/include/transport/hip_transport/event_pool.h
@@ -1,0 +1,62 @@
+// Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EVENT_POOL_H_
+#define EVENT_POOL_H_
+
+#include <hip/hip_runtime.h>
+
+#include <mutex>
+#include <queue>
+#include <unordered_map>
+
+namespace mooncake {
+
+// EventPool manages a pool of HIP events per device for async operations
+class EventPool {
+   public:
+    explicit EventPool(int num_events_per_device);
+    ~EventPool();
+
+    // Disable copy (to prevent double-free of HIP resources)
+    EventPool(const EventPool &) = delete;
+    EventPool &operator=(const EventPool &) = delete;
+
+    // Disable move (std::mutex is not movable)
+    EventPool(EventPool &&) = delete;
+    EventPool &operator=(EventPool &&) = delete;
+
+    // Get an event from the pool (creates new ones if pool is empty)
+    hipEvent_t getEvent(int device_id);
+
+    // Return an event to the pool for reuse
+    void putEvent(hipEvent_t event, int device_id);
+
+   private:
+    bool initializeEventsForDevice(int device_id);
+
+    // Helper function to create a single event for a device
+    hipEvent_t createEventForDevice(int device_id);
+
+    // Helper function to create an event assuming device is already set
+    hipEvent_t createEvent();
+
+    int num_events_per_device_;
+    std::mutex mutex_;
+    std::unordered_map<int, std::queue<hipEvent_t>> event_pools_;
+};
+
+}  // namespace mooncake
+
+#endif  // EVENT_POOL_H_

--- a/mooncake-transfer-engine/include/transport/hip_transport/stream_pool.h
+++ b/mooncake-transfer-engine/include/transport/hip_transport/stream_pool.h
@@ -1,0 +1,54 @@
+// Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STREAM_POOL_H_
+#define STREAM_POOL_H_
+
+#include <hip/hip_runtime.h>
+
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace mooncake {
+
+// StreamPool manages a pool of HIP streams per device for async operations
+class StreamPool {
+   public:
+    explicit StreamPool(int num_streams_per_device);
+    ~StreamPool();
+
+    // Disable copy (to prevent double-free of HIP resources)
+    StreamPool(const StreamPool &) = delete;
+    StreamPool &operator=(const StreamPool &) = delete;
+
+    // Disable move (std::mutex is not movable)
+    StreamPool(StreamPool &&) = delete;
+    StreamPool &operator=(StreamPool &&) = delete;
+
+    // Get next stream for a device in round-robin fashion
+    hipStream_t getNextStream(int device_id);
+
+   private:
+    bool initializeStreamsForDevice(int device_id);
+
+    int num_streams_per_device_;
+    std::mutex mutex_;
+    std::unordered_map<int, std::vector<hipStream_t>> streams_;
+    std::unordered_map<int, int> current_stream_idx_;
+};
+
+}  // namespace mooncake
+
+#endif  // STREAM_POOL_H_

--- a/mooncake-transfer-engine/src/transport/hip_transport/event_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/event_pool.cpp
@@ -1,0 +1,113 @@
+// Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/hip_transport/event_pool.h"
+
+#include <glog/logging.h>
+
+namespace mooncake {
+
+EventPool::EventPool(int num_events_per_device)
+    : num_events_per_device_(num_events_per_device) {
+    if (num_events_per_device_ == 0) {
+        num_events_per_device_ = 1;
+    }
+}
+
+EventPool::~EventPool() {
+    for (auto &device_entry : event_pools_) {
+        while (!device_entry.second.empty()) {
+            hipEvent_t event = device_entry.second.front();
+            device_entry.second.pop();
+            if (event != nullptr) {
+                (void)hipEventDestroy(event);
+            }
+        }
+    }
+}
+
+hipEvent_t EventPool::getEvent(int device_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Initialize event pool for this device if not done yet
+    if (event_pools_.find(device_id) == event_pools_.end()) {
+        event_pools_[device_id] = std::queue<hipEvent_t>();
+        if (!initializeEventsForDevice(device_id)) {
+            return nullptr;
+        }
+    }
+
+    auto &pool = event_pools_[device_id];
+
+    // If pool is empty, create a new event on demand
+    if (pool.empty()) {
+        return createEventForDevice(device_id);
+    }
+
+    hipEvent_t event = pool.front();
+    pool.pop();
+    return event;
+}
+
+void EventPool::putEvent(hipEvent_t event, int device_id) {
+    if (event == nullptr) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    event_pools_[device_id].push(event);
+}
+
+hipEvent_t EventPool::createEvent() {
+    hipEvent_t event;
+    hipError_t err = hipEventCreateWithFlags(&event, hipEventDisableTiming);
+    if (err != hipSuccess) {
+        LOG(ERROR) << "EventPool: Failed to create event: "
+                   << hipGetErrorString(err);
+        return nullptr;
+    }
+    return event;
+}
+
+hipEvent_t EventPool::createEventForDevice(int device_id) {
+    hipError_t err = hipSetDevice(device_id);
+    if (err != hipSuccess) {
+        LOG(ERROR) << "EventPool: Failed to set device " << device_id << ": "
+                   << hipGetErrorString(err);
+        return nullptr;
+    }
+
+    return createEvent();
+}
+
+bool EventPool::initializeEventsForDevice(int device_id) {
+    hipError_t err = hipSetDevice(device_id);
+    if (err != hipSuccess) {
+        LOG(ERROR) << "EventPool: Failed to set device " << device_id << ": "
+                   << hipGetErrorString(err);
+        return false;
+    }
+
+    auto &pool = event_pools_[device_id];
+    for (int i = 0; i < num_events_per_device_; ++i) {
+        hipEvent_t event = createEvent();
+        if (event == nullptr) {
+            return false;
+        }
+        pool.push(event);
+    }
+    return true;
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/hip_transport/stream_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/stream_pool.cpp
@@ -1,0 +1,92 @@
+// Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/hip_transport/stream_pool.h"
+
+#include <glog/logging.h>
+
+namespace mooncake {
+
+StreamPool::StreamPool(int num_streams_per_device)
+    : num_streams_per_device_(num_streams_per_device) {
+    if (num_streams_per_device_ == 0) {
+        num_streams_per_device_ = 1;
+    }
+}
+
+StreamPool::~StreamPool() {
+    for (auto &device_entry : streams_) {
+        for (auto stream : device_entry.second) {
+            if (stream != nullptr) {
+                (void)hipStreamDestroy(stream);
+            }
+        }
+    }
+}
+
+hipStream_t StreamPool::getNextStream(int device_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Initialize streams for this device if not done yet
+    if (streams_.find(device_id) == streams_.end()) {
+        if (!initializeStreamsForDevice(device_id)) {
+            return nullptr;
+        }
+    }
+
+    auto &device_streams = streams_[device_id];
+    if (device_streams.empty()) {
+        return nullptr;
+    }
+
+    // Round-robin selection
+    auto &current_idx = current_stream_idx_[device_id];
+    hipStream_t stream = device_streams[current_idx];
+    current_idx = (current_idx + 1) % (int)device_streams.size();
+
+    return stream;
+}
+
+bool StreamPool::initializeStreamsForDevice(int device_id) {
+    hipError_t err = hipSetDevice(device_id);
+    if (err != hipSuccess) {
+        LOG(ERROR) << "StreamPool: Failed to set device " << device_id << ": "
+                   << hipGetErrorString(err);
+        return false;
+    }
+
+    std::vector<hipStream_t> device_streams;
+    device_streams.reserve(num_streams_per_device_);
+
+    for (int i = 0; i < num_streams_per_device_; ++i) {
+        hipStream_t stream;
+        err = hipStreamCreateWithFlags(&stream, hipStreamNonBlocking);
+        if (err != hipSuccess) {
+            LOG(ERROR) << "StreamPool: Failed to create stream for device "
+                       << device_id << ": " << hipGetErrorString(err);
+            // Clean up already created streams
+            for (auto s : device_streams) {
+                (void)hipStreamDestroy(s);
+            }
+            return false;
+        }
+        device_streams.push_back(stream);
+    }
+
+    streams_[device_id] = std::move(device_streams);
+    current_stream_idx_[device_id] = 0;
+    return true;
+}
+
+}  // namespace mooncake


### PR DESCRIPTION
## Description
(AI assist)

This PR improves hip transport performance by using streams/events and enabling asynchronous data transfers across multiple streams. Each transfer in a batch executes on a separate stream, allowing multiple transfers to run concurrently on the GPU.

### Changes:
- Add StreamPool class to manage reusable HIP streams per device
- Add EventPool class to manage reusable HIP events per device
- Refactor HipTransport to use async transfers with stream/event pools
- Add support for configurable pool sizes via environment variables:
  * MC_HIP_NUM_STREAMS (default: 64)
  * MC_HIP_NUM_EVENTS (default: 64)

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [x] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

Ran transfer_engine_bench and transfer_engine_validator on the nodes with AMG GPU. Performance was checked by running transfer_engine_bench with different values of -batch_size parameter. 

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
