### PR TITLE
[Misc] Add amd-arozanov as CODEOWNERS for TE hip_transport

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,5 @@
 /mooncake-integration/store @ykwd @stmatengss 
 /mooncake-store @ykwd @stmatengss @XucSh @YiXR
 /mooncake-transfer-engine @alogfans @doujiang24 @chestnut-Q
+/mooncake-transfer-engine/*/transport/hip_transport @alogfans @amd-arozanov
 /mooncake-wheel @ShangmingCai @stmatengss

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,5 +13,5 @@
 /mooncake-integration/store @ykwd @stmatengss 
 /mooncake-store @ykwd @stmatengss @XucSh @YiXR
 /mooncake-transfer-engine @alogfans @doujiang24 @chestnut-Q
-/mooncake-transfer-engine/*/transport/hip_transport @alogfans @amd-arozanov
+/mooncake-transfer-engine/*/transport/hip_transport/ @alogfans @amd-arozanov
 /mooncake-wheel @ShangmingCai @stmatengss


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

@amd-arozanov has contributed 8 pull requests to the Transfer Engine, including several key features in the HIP transport. He has also expressed willingness to continue maintaining the HIP transport going forward. Therefore, I would like to nominate @amd-arozanov as a CODEOWNER for the Transfer Engine HIP transport.

Since merging changes requires approval from at least one CODEOWNER, a backup code owner is also needed. For this role, I would like to nominate @alogfans.

## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
