### PR TITLE
[Store][FIX] fix issue that the preferred segments not working when put

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -428,6 +428,8 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
         std::vector<std::string> preferred_segments;
         if (!config.preferred_segment.empty()) {
             preferred_segments.push_back(config.preferred_segment);
+        } else if (!config.preferred_segments.empty()) {
+            preferred_segments = config.preferred_segments;
         }
 
         auto allocation_result = allocation_strategy_->Allocate(


### PR DESCRIPTION
## Description

The previous pr https://github.com/kvcache-ai/Mooncake/pull/1148 introduce the `preferred_segments` in the `ReplicateConfig`, but this is not working for `put` api.

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

- unit test

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
