### PR TITLE
[Store][Feature]Extract common interfaces of rpc_service and master_client for the P2P architecture

### DIFF
--- a/mooncake-store/benchmarks/master_bench.cpp
+++ b/mooncake-store/benchmarks/master_bench.cpp
@@ -24,7 +24,7 @@
 #include "gflags/gflags.h"
 #include "glog/logging.h"
 
-#include "master_client.h"
+#include "centralized_master_client.h"
 
 // Size units for better readability
 static constexpr size_t KiB = 1024;
@@ -112,7 +112,7 @@ class SegmentClient {
     }
 
    private:
-    mooncake::MasterClient master_client_;
+    mooncake::CentralizedMasterClient master_client_;
     mooncake::Segment segment_;
     std::future<void> remount_future_;
 };
@@ -349,7 +349,7 @@ class BenchClient {
         }
     }
 
-    mooncake::MasterClient master_client_;
+    mooncake::CentralizedMasterClient master_client_;
 
     std::atomic<bool> running_;
     std::vector<std::thread> threads_;

--- a/mooncake-store/include/centralized_client_manager.h
+++ b/mooncake-store/include/centralized_client_manager.h
@@ -5,7 +5,7 @@
 #include "centralized_segment_manager.h"
 
 namespace mooncake {
-class CentralizedClientManager : public ClientManager {
+class CentralizedClientManager final : public ClientManager {
    public:
     CentralizedClientManager(const int64_t client_live_ttl_sec,
                              const BufferAllocatorType memory_allocator_type,

--- a/mooncake-store/include/centralized_master_client.h
+++ b/mooncake-store/include/centralized_master_client.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "master_client.h"
+
+namespace mooncake {
+
+/**
+ * @brief Client for interacting with the mooncake master service
+ */
+class CentralizedMasterClient final : public MasterClient {
+   public:
+    CentralizedMasterClient(const UUID& client_id,
+                            MasterClientMetric* metrics = nullptr)
+        : MasterClient(client_id, metrics) {}
+
+    CentralizedMasterClient(const CentralizedMasterClient&) = delete;
+    CentralizedMasterClient& operator=(const CentralizedMasterClient&) = delete;
+
+    /**
+     * @brief Starts a put operation
+     * @param key Object key
+     * @param batch_slice_lengths Vector of slice lengths
+     * @param value_length Total value length
+     * @param config Replication configuration
+     * @return tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+     * indicating success/failure
+     */
+    [[nodiscard]] tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+    PutStart(const std::string& key,
+             const std::vector<size_t>& batch_slice_lengths,
+             const ReplicateConfig& config);
+
+    /**
+     * @brief Starts a batch of put operations for N objects
+     * @param keys Vector of object key
+     * @param value_lengths Vector of total value lengths
+     * @param slice_lengths Vector of vectors of slice lengths
+     * @param config Replication configuration
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] std::vector<
+        tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+    BatchPutStart(const std::vector<std::string>& keys,
+                  const std::vector<std::vector<uint64_t>>& slice_lengths,
+                  const ReplicateConfig& config);
+
+    /**
+     * @brief Ends a put operation
+     * @param key Object key
+     * @param replica_type Type of replica (memory or disk)
+     * @return tl::expected<void, ErrorCode> indicating success/failure
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> PutEnd(
+        const std::string& key, ReplicaType replica_type);
+
+    /**
+     * @brief Ends a put operation for a batch of objects
+     * @param keys Vector of object keys
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] std::vector<tl::expected<void, ErrorCode>> BatchPutEnd(
+        const std::vector<std::string>& keys);
+
+    /**
+     * @brief Revokes a put operation
+     * @param key Object key
+     * @param replica_type Type of replica (memory or disk)
+     * @return tl::expected<void, ErrorCode> indicating success/failure
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> PutRevoke(
+        const std::string& key, ReplicaType replica_type);
+
+    /**
+     * @brief Revokes a put operation for a batch of objects
+     * @param keys Vector of object keys
+     * @return ErrorCode indicating success/failure
+     */
+    [[nodiscard]] std::vector<tl::expected<void, ErrorCode>> BatchPutRevoke(
+        const std::vector<std::string>& keys);
+
+    /**
+     * @brief Registers a segment to master for allocation
+     * @param segment Segment to register
+     * @return tl::expected<void, ErrorCode> indicating success/failure
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> MountSegment(
+        const Segment& segment);
+
+    /**
+     * @brief Re-mount segments, invoked when the client is the first time to
+     * connect to the master or the client Ping TTL is expired and need
+     * to remount. This function is idempotent. Client should retry if the
+     * return code is not ErrorCode::OK.
+     * @param segments Segments to remount
+     * @return tl::expected<void, ErrorCode> indicating success/failure
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> ReMountSegment(
+        const std::vector<Segment>& segments);
+
+    /**
+     * @brief Gets the cluster ID for the current client to use as subdirectory
+     * name
+     * @return GetClusterIdResponse containing the cluster ID
+     */
+    [[nodiscard]] tl::expected<std::string, ErrorCode> GetFsdir();
+
+    [[nodiscard]] tl::expected<GetStorageConfigResponse, ErrorCode>
+    GetStorageConfig();
+
+    /**
+     * @brief Mounts a local disk segment into the master.
+     * @param enable_offloading If true, enables offloading (write-to-file).
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> MountLocalDiskSegment(
+        const UUID& client_id, bool enable_offloading);
+
+    /**
+     * @brief Heartbeat call to collect object-level statistics and retrieve the
+     * set of non-persisted objects.
+     * @param enable_offloading Indicates whether persistence is enabled for
+     * this segment.
+     */
+    [[nodiscard]] tl::expected<std::unordered_map<std::string, int64_t>,
+                               ErrorCode>
+    OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading);
+
+    /**
+     * @brief Adds multiple new objects to a specified client in batch.
+     * @param keys         A list of object keys (names) that were successfully
+     * offloaded.
+     * @param metadatas    The corresponding metadata for each offloaded object,
+     * including size, storage location, etc.
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> NotifyOffloadSuccess(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        const std::vector<StorageObjectMetadata>& metadatas);
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/centralized_rpc_service.h
+++ b/mooncake-store/include/centralized_rpc_service.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "rpc_service.h"
+
+namespace mooncake {
+
+class WrappedCentralizedMasterService final : public WrappedMasterService {
+   public:
+    WrappedCentralizedMasterService(const WrappedMasterServiceConfig& config);
+
+    tl::expected<std::vector<Replica::Descriptor>, ErrorCode> PutStart(
+        const UUID& client_id, const std::string& key,
+        const uint64_t slice_length, const ReplicateConfig& config);
+
+    tl::expected<void, ErrorCode> PutEnd(const UUID& client_id,
+                                         const std::string& key,
+                                         ReplicaType replica_type);
+
+    tl::expected<void, ErrorCode> PutRevoke(const UUID& client_id,
+                                            const std::string& key,
+                                            ReplicaType replica_type);
+
+    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+    BatchPutStart(const UUID& client_id, const std::vector<std::string>& keys,
+                  const std::vector<uint64_t>& slice_lengths,
+                  const ReplicateConfig& config);
+
+    std::vector<tl::expected<void, ErrorCode>> BatchPutEnd(
+        const UUID& client_id, const std::vector<std::string>& keys);
+
+    std::vector<tl::expected<void, ErrorCode>> BatchPutRevoke(
+        const UUID& client_id, const std::vector<std::string>& keys);
+
+    tl::expected<void, ErrorCode> MountSegment(const Segment& segment,
+                                               const UUID& client_id);
+
+    tl::expected<void, ErrorCode> ReMountSegment(
+        const std::vector<Segment>& segments, const UUID& client_id);
+
+    tl::expected<std::string, ErrorCode> GetFsdir();
+
+    tl::expected<GetStorageConfigResponse, ErrorCode> GetStorageConfig();
+
+    tl::expected<void, ErrorCode> MountLocalDiskSegment(const UUID& client_id,
+                                                        bool enable_offloading);
+
+    tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>
+    OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading);
+
+    tl::expected<void, ErrorCode> NotifyOffloadSuccess(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        const std::vector<StorageObjectMetadata>& metadatas);
+
+   protected:
+    virtual MasterService& GetMasterService() override {
+        return master_service_;
+    }
+
+   private:
+    // TODO: wanyue-wy
+    // rename MasterService to CentralizedMasterService before merge to main
+    // branch
+    MasterService master_service_;
+};
+
+void RegisterCentralizedRpcService(
+    coro_rpc::coro_rpc_server& server,
+    mooncake::WrappedCentralizedMasterService& wrapped_master_service);
+
+}  // namespace mooncake

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -12,7 +12,7 @@
 
 #include "client_metric.h"
 #include "ha_helper.h"
-#include "master_client.h"
+#include "centralized_master_client.h"
 #include "storage_backend.h"
 #include "thread_pool.h"
 #include "transfer_engine.h"
@@ -424,7 +424,7 @@ class Client {
 
     // Core components
     std::shared_ptr<TransferEngine> transfer_engine_;
-    MasterClient master_client_;
+    CentralizedMasterClient master_client_;
     std::unique_ptr<TransferSubmitter> transfer_submitter_;
 
     // Mutex to protect mounted_segments_

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -45,6 +45,8 @@ struct MasterConfig {
     // Storage backend eviction configuration
     bool enable_disk_eviction;
     uint64_t quota_bytes;
+
+    std::string deployment_mode;
 };
 
 class MasterServiceSupervisorConfig {
@@ -79,6 +81,7 @@ class MasterServiceSupervisorConfig {
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
     bool enable_disk_eviction = true;
     uint64_t quota_bytes = 0;
+    DeploymentMode deployment_mode = DeploymentMode::CENTRALIZATION;
 
     MasterServiceSupervisorConfig() = default;
 
@@ -120,6 +123,11 @@ class MasterServiceSupervisorConfig {
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
         enable_disk_eviction = config.enable_disk_eviction;
         quota_bytes = config.quota_bytes;
+        if (config.deployment_mode == "Centralization") {
+            deployment_mode = DeploymentMode::CENTRALIZATION;
+        } else {
+            deployment_mode = DeploymentMode::P2P;
+        }
 
         validate();
     }

--- a/mooncake-store/include/p2p_client_manager.h
+++ b/mooncake-store/include/p2p_client_manager.h
@@ -4,7 +4,7 @@
 #include "p2p_segment_manager.h"
 namespace mooncake {
 // TODO: this class is a tmp placeholder. it will be implemented later
-class P2PClientManager : public ClientManager {
+class P2PClientManager final : public ClientManager {
    public:
     P2PClientManager(const int64_t client_live_ttl_sec);
 

--- a/mooncake-store/include/p2p_rpc_service.h
+++ b/mooncake-store/include/p2p_rpc_service.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "rpc_service.h"
+
+namespace mooncake {
+
+// TODO: wanyue-wy
+class WrappedP2PMasterService final : public WrappedMasterService {
+   public:
+    WrappedP2PMasterService(const WrappedMasterServiceConfig& config);
+
+    ~WrappedP2PMasterService();
+
+    //    private:
+    //     P2PMasterService master_service_;
+};
+
+void RegisterP2PRpcService(
+    coro_rpc::coro_rpc_server& server,
+    mooncake::WrappedP2PMasterService& wrapped_master_service);
+
+}  // namespace mooncake

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -179,6 +179,11 @@ inline std::ostream& operator<<(std::ostream& os,
     return os << toString(errorCode);
 }
 
+enum class DeploymentMode {
+    CENTRALIZATION = 0,
+    P2P,
+};
+
 /**
  * @brief Represents a contiguous memory region
  */

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MOONCAKE_STORE_SOURCES
     client_metric.cpp
     types.cpp
     master_client.cpp
+    centralized_master_client.cpp
     utils.cpp
     master_metric_manager.cpp
     storage_backend.cpp
@@ -23,6 +24,8 @@ set(MOONCAKE_STORE_SOURCES
     etcd_helper.cpp
     ha_helper.cpp
     rpc_service.cpp
+    centralized_rpc_service.cpp
+    p2p_rpc_service.cpp
     offset_allocator.cpp
     posix_file.cpp
     client_buffer.cpp

--- a/mooncake-store/src/centralized_master_client.cpp
+++ b/mooncake-store/src/centralized_master_client.cpp
@@ -1,0 +1,252 @@
+#include "centralized_master_client.h"
+#include "centralized_rpc_service.h"
+#include "utils/scoped_vlog_timer.h"
+
+namespace mooncake {
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::PutStart> {
+    static constexpr const char* value = "PutStart";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::BatchPutStart> {
+    static constexpr const char* value = "BatchPutStart";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::PutEnd> {
+    static constexpr const char* value = "PutEnd";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::BatchPutEnd> {
+    static constexpr const char* value = "BatchPutEnd";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::PutRevoke> {
+    static constexpr const char* value = "PutRevoke";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::BatchPutRevoke> {
+    static constexpr const char* value = "BatchPutRevoke";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::MountSegment> {
+    static constexpr const char* value = "MountSegment";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::ReMountSegment> {
+    static constexpr const char* value = "ReMountSegment";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::GetFsdir> {
+    static constexpr const char* value = "GetFsdir";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::GetStorageConfig> {
+    static constexpr const char* value = "GetStorageConfig";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::MountLocalDiskSegment> {
+    static constexpr const char* value = "MountLocalDiskSegment";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::OffloadObjectHeartbeat> {
+    static constexpr const char* value = "OffloadObjectHeartbeat";
+};
+
+template <>
+struct RpcNameTraits<&WrappedCentralizedMasterService::NotifyOffloadSuccess> {
+    static constexpr const char* value = "NotifyOffloadSuccess";
+};
+
+tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+CentralizedMasterClient::PutStart(const std::string& key,
+                                  const std::vector<size_t>& slice_lengths,
+                                  const ReplicateConfig& config) {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::PutStart");
+    timer.LogRequest("key=", key, ", slice_count=", slice_lengths.size());
+
+    uint64_t total_slice_length = 0;
+    for (const auto& slice_length : slice_lengths) {
+        total_slice_length += slice_length;
+    }
+
+    auto result = invoke_rpc<&WrappedCentralizedMasterService::PutStart,
+                             std::vector<Replica::Descriptor>>(
+        client_id_, key, total_slice_length, config);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+CentralizedMasterClient::BatchPutStart(
+    const std::vector<std::string>& keys,
+    const std::vector<std::vector<uint64_t>>& batch_slice_lengths,
+    const ReplicateConfig& config) {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::BatchPutStart");
+    timer.LogRequest("keys_count=", keys.size());
+
+    std::vector<uint64_t> total_slice_lengths;
+    total_slice_lengths.reserve(batch_slice_lengths.size());
+    for (const auto& slice_lengths : batch_slice_lengths) {
+        uint64_t total_slice_length = 0;
+        for (const auto& slice_length : slice_lengths) {
+            total_slice_length += slice_length;
+        }
+        total_slice_lengths.emplace_back(total_slice_length);
+    }
+
+    auto result =
+        invoke_batch_rpc<&WrappedCentralizedMasterService::BatchPutStart,
+                         std::vector<Replica::Descriptor>>(
+            keys.size(), client_id_, keys, total_slice_lengths, config);
+    timer.LogResponse("result=", result.size(), " operations");
+    return result;
+}
+
+tl::expected<void, ErrorCode> CentralizedMasterClient::PutEnd(
+    const std::string& key, ReplicaType replica_type) {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::PutEnd");
+    timer.LogRequest("key=", key);
+
+    auto result = invoke_rpc<&WrappedCentralizedMasterService::PutEnd, void>(
+        client_id_, key, replica_type);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+std::vector<tl::expected<void, ErrorCode>> CentralizedMasterClient::BatchPutEnd(
+    const std::vector<std::string>& keys) {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::BatchPutEnd");
+    timer.LogRequest("keys_count=", keys.size());
+
+    auto result =
+        invoke_batch_rpc<&WrappedCentralizedMasterService::BatchPutEnd, void>(
+            keys.size(), client_id_, keys);
+    timer.LogResponse("result=", result.size(), " operations");
+    return result;
+}
+
+tl::expected<void, ErrorCode> CentralizedMasterClient::PutRevoke(
+    const std::string& key, ReplicaType replica_type) {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::PutRevoke");
+    timer.LogRequest("key=", key);
+
+    auto result = invoke_rpc<&WrappedCentralizedMasterService::PutRevoke, void>(
+        client_id_, key, replica_type);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+CentralizedMasterClient::BatchPutRevoke(const std::vector<std::string>& keys) {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::BatchPutRevoke");
+    timer.LogRequest("keys_count=", keys.size());
+
+    auto result =
+        invoke_batch_rpc<&WrappedCentralizedMasterService::BatchPutRevoke,
+                         void>(keys.size(), client_id_, keys);
+    timer.LogResponse("result=", result.size(), " operations");
+    return result;
+}
+
+tl::expected<void, ErrorCode> CentralizedMasterClient::MountSegment(
+    const Segment& segment) {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::MountSegment");
+    timer.LogRequest("base=", segment.base, ", size=", segment.size,
+                     ", name=", segment.name, ", id=", segment.id,
+                     ", client_id=", client_id_);
+
+    auto result =
+        invoke_rpc<&WrappedCentralizedMasterService::MountSegment, void>(
+            segment, client_id_);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<void, ErrorCode> CentralizedMasterClient::ReMountSegment(
+    const std::vector<Segment>& segments) {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::ReMountSegment");
+    timer.LogRequest("segments_num=", segments.size(),
+                     ", client_id=", client_id_);
+
+    auto result =
+        invoke_rpc<&WrappedCentralizedMasterService::ReMountSegment, void>(
+            segments, client_id_);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<std::string, ErrorCode> CentralizedMasterClient::GetFsdir() {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::GetFsdir");
+    timer.LogRequest("action=get_fsdir");
+
+    auto result =
+        invoke_rpc<&WrappedCentralizedMasterService::GetFsdir, std::string>();
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<GetStorageConfigResponse, ErrorCode>
+CentralizedMasterClient::GetStorageConfig() {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::GetStorageConfig");
+    timer.LogRequest("action=get_storage_config");
+
+    auto result = invoke_rpc<&WrappedCentralizedMasterService::GetStorageConfig,
+                             GetStorageConfigResponse>();
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<void, ErrorCode> CentralizedMasterClient::MountLocalDiskSegment(
+    const UUID& client_id, bool enable_offloading) {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::MountLocalDiskSegment");
+    timer.LogRequest("client_id=", client_id,
+                     ", enable_offloading=", enable_offloading);
+
+    auto result =
+        invoke_rpc<&WrappedCentralizedMasterService::MountLocalDiskSegment,
+                   void>(client_id, enable_offloading);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>
+CentralizedMasterClient::OffloadObjectHeartbeat(const UUID& client_id,
+                                                bool enable_offloading) {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::OffloadObjectHeartbeat");
+    timer.LogRequest("client_id=", client_id,
+                     ", enable_offloading=", enable_offloading);
+
+    auto result =
+        invoke_rpc<&WrappedCentralizedMasterService::OffloadObjectHeartbeat,
+                   std::unordered_map<std::string, int64_t>>(client_id,
+                                                             enable_offloading);
+    return result;
+}
+
+tl::expected<void, ErrorCode> CentralizedMasterClient::NotifyOffloadSuccess(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    const std::vector<StorageObjectMetadata>& metadatas) {
+    ScopedVLogTimer timer(1, "CentralizedMasterClient::NotifyOffloadSuccess");
+    timer.LogRequest("client_id=", client_id, ", keys_count=", keys.size(),
+                     ", metadatas_count=", metadatas.size());
+
+    auto result =
+        invoke_rpc<&WrappedCentralizedMasterService::NotifyOffloadSuccess,
+                   void>(client_id, keys, metadatas);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/centralized_rpc_service.cpp
+++ b/mooncake-store/src/centralized_rpc_service.cpp
@@ -1,0 +1,346 @@
+#include "centralized_rpc_service.h"
+#include "rpc_helper.h"
+
+namespace mooncake {
+
+WrappedCentralizedMasterService::WrappedCentralizedMasterService(
+    const WrappedMasterServiceConfig& config)
+    : WrappedMasterService(config),
+      master_service_(MasterServiceConfig(config)) {}
+
+tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+WrappedCentralizedMasterService::PutStart(const UUID& client_id,
+                                          const std::string& key,
+                                          const uint64_t slice_length,
+                                          const ReplicateConfig& config) {
+    return execute_rpc(
+        "PutStart",
+        [&] {
+            return master_service_.PutStart(client_id, key, slice_length,
+                                            config);
+        },
+        [&](auto& timer) {
+            timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", slice_length=", slice_length);
+        },
+        [&] { MasterMetricManager::instance().inc_put_start_requests(); },
+        [] { MasterMetricManager::instance().inc_put_start_failures(); });
+}
+
+tl::expected<void, ErrorCode> WrappedCentralizedMasterService::PutEnd(
+    const UUID& client_id, const std::string& key, ReplicaType replica_type) {
+    return execute_rpc(
+        "PutEnd",
+        [&] { return master_service_.PutEnd(client_id, key, replica_type); },
+        [&](auto& timer) {
+            timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", replica_type=", replica_type);
+        },
+        [] { MasterMetricManager::instance().inc_put_end_requests(); },
+        [] { MasterMetricManager::instance().inc_put_end_failures(); });
+}
+
+tl::expected<void, ErrorCode> WrappedCentralizedMasterService::PutRevoke(
+    const UUID& client_id, const std::string& key, ReplicaType replica_type) {
+    return execute_rpc(
+        "PutRevoke",
+        [&] { return master_service_.PutRevoke(client_id, key, replica_type); },
+        [&](auto& timer) {
+            timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", replica_type=", replica_type);
+        },
+        [] { MasterMetricManager::instance().inc_put_revoke_requests(); },
+        [] { MasterMetricManager::instance().inc_put_revoke_failures(); });
+}
+
+std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+WrappedCentralizedMasterService::BatchPutStart(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    const std::vector<uint64_t>& slice_lengths, const ReplicateConfig& config) {
+    ScopedVLogTimer timer(1, "BatchPutStart");
+    const size_t total_keys = keys.size();
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
+    MasterMetricManager::instance().inc_batch_put_start_requests(total_keys);
+
+    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+        results;
+    results.reserve(keys.size());
+
+    if (config.prefer_alloc_in_same_node) {
+        ReplicateConfig new_config = config;
+        for (size_t i = 0; i < keys.size(); ++i) {
+            auto result = master_service_.PutStart(
+                client_id, keys[i], slice_lengths[i], new_config);
+            results.emplace_back(result);
+            if ((i == 0) && result.has_value()) {
+                std::string preferred_segment;
+                for (const auto& replica : result.value()) {
+                    if (replica.is_memory_replica()) {
+                        auto handles =
+                            replica.get_memory_descriptor().buffer_descriptor;
+                        if (!handles.transport_endpoint_.empty()) {
+                            preferred_segment = handles.transport_endpoint_;
+                        }
+                    }
+                }
+                if (!preferred_segment.empty()) {
+                    new_config.preferred_segment = preferred_segment;
+                }
+            }
+        }
+    } else {
+        for (size_t i = 0; i < keys.size(); ++i) {
+            results.emplace_back(master_service_.PutStart(
+                client_id, keys[i], slice_lengths[i], config));
+        }
+    }
+
+    size_t failure_count = 0;
+    int no_available_handle_count = 0;
+    for (size_t i = 0; i < results.size(); ++i) {
+        if (!results[i].has_value()) {
+            failure_count++;
+            auto error = results[i].error();
+            if (error == ErrorCode::OBJECT_ALREADY_EXISTS) {
+                VLOG(1) << "BatchPutStart failed for key[" << i << "] '"
+                        << keys[i] << "': " << toString(error);
+            } else if (error == ErrorCode::NO_AVAILABLE_HANDLE) {
+                no_available_handle_count++;
+            } else {
+                LOG(ERROR) << "BatchPutStart failed for key[" << i << "] '"
+                           << keys[i] << "': " << toString(error);
+            }
+        }
+    }
+
+    if (no_available_handle_count > 0) {
+        LOG(WARNING) << "BatchPutStart failed for " << no_available_handle_count
+                     << " keys" << PUT_NO_SPACE_HELPER_STR;
+    }
+
+    if (failure_count == total_keys) {
+        MasterMetricManager::instance().inc_batch_put_start_failures(
+            failure_count);
+    } else if (failure_count != 0) {
+        MasterMetricManager::instance().inc_batch_put_start_partial_success(
+            failure_count);
+    }
+
+    timer.LogResponse("total=", results.size(),
+                      ", success=", results.size() - failure_count,
+                      ", failures=", failure_count);
+    return results;
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+WrappedCentralizedMasterService::BatchPutEnd(
+    const UUID& client_id, const std::vector<std::string>& keys) {
+    ScopedVLogTimer timer(1, "BatchPutEnd");
+    const size_t total_keys = keys.size();
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
+    MasterMetricManager::instance().inc_batch_put_end_requests(total_keys);
+
+    std::vector<tl::expected<void, ErrorCode>> results;
+    results.reserve(keys.size());
+
+    for (const auto& key : keys) {
+        results.emplace_back(
+            master_service_.PutEnd(client_id, key, ReplicaType::MEMORY));
+    }
+
+    size_t failure_count = 0;
+    for (size_t i = 0; i < results.size(); ++i) {
+        if (!results[i].has_value()) {
+            failure_count++;
+            auto error = results[i].error();
+            LOG(ERROR) << "BatchPutEnd failed for key[" << i << "] '" << keys[i]
+                       << "': " << toString(error);
+        }
+    }
+
+    if (failure_count == total_keys) {
+        MasterMetricManager::instance().inc_batch_put_end_failures(
+            failure_count);
+    } else if (failure_count != 0) {
+        MasterMetricManager::instance().inc_batch_put_end_partial_success(
+            failure_count);
+    }
+
+    timer.LogResponse("total=", results.size(),
+                      ", success=", results.size() - failure_count,
+                      ", failures=", failure_count);
+    return results;
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+WrappedCentralizedMasterService::BatchPutRevoke(
+    const UUID& client_id, const std::vector<std::string>& keys) {
+    ScopedVLogTimer timer(1, "BatchPutRevoke");
+    const size_t total_keys = keys.size();
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
+    MasterMetricManager::instance().inc_batch_put_revoke_requests(total_keys);
+
+    std::vector<tl::expected<void, ErrorCode>> results;
+    results.reserve(keys.size());
+
+    for (const auto& key : keys) {
+        results.emplace_back(
+            master_service_.PutRevoke(client_id, key, ReplicaType::MEMORY));
+    }
+
+    size_t failure_count = 0;
+    for (size_t i = 0; i < results.size(); ++i) {
+        if (!results[i].has_value()) {
+            failure_count++;
+            auto error = results[i].error();
+            LOG(ERROR) << "BatchPutRevoke failed for key[" << i << "] '"
+                       << keys[i] << "': " << toString(error);
+        }
+    }
+
+    if (failure_count == total_keys) {
+        MasterMetricManager::instance().inc_batch_put_revoke_failures(
+            failure_count);
+    } else if (failure_count != 0) {
+        MasterMetricManager::instance().inc_batch_put_revoke_partial_success(
+            failure_count);
+    }
+
+    timer.LogResponse("total=", results.size(),
+                      ", success=", results.size() - failure_count,
+                      ", failures=", failure_count);
+    return results;
+}
+
+tl::expected<void, ErrorCode> WrappedCentralizedMasterService::MountSegment(
+    const Segment& segment, const UUID& client_id) {
+    return execute_rpc(
+        "MountSegment",
+        [&] { return master_service_.MountSegment(segment, client_id); },
+        [&](auto& timer) {
+            timer.LogRequest("base=", segment.base, ", size=", segment.size,
+                             ", segment_name=", segment.name,
+                             ", id=", segment.id);
+        },
+        [] { MasterMetricManager::instance().inc_mount_segment_requests(); },
+        [] { MasterMetricManager::instance().inc_mount_segment_failures(); });
+}
+
+tl::expected<void, ErrorCode> WrappedCentralizedMasterService::ReMountSegment(
+    const std::vector<Segment>& segments, const UUID& client_id) {
+    return execute_rpc(
+        "ReMountSegment",
+        [&] { return master_service_.ReMountSegment(segments, client_id); },
+        [&](auto& timer) {
+            timer.LogRequest("segments_count=", segments.size(),
+                             ", client_id=", client_id);
+        },
+        [] { MasterMetricManager::instance().inc_remount_segment_requests(); },
+        [] { MasterMetricManager::instance().inc_remount_segment_failures(); });
+}
+
+tl::expected<std::string, ErrorCode>
+WrappedCentralizedMasterService::GetFsdir() {
+    ScopedVLogTimer timer(1, "GetFsdir");
+    timer.LogRequest("action=get_fsdir");
+
+    auto result = master_service_.GetFsdir();
+
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<GetStorageConfigResponse, ErrorCode>
+WrappedCentralizedMasterService::GetStorageConfig() {
+    ScopedVLogTimer timer(1, "GetStorageConfig");
+    timer.LogRequest("action=get_storage_config");
+
+    auto result = master_service_.GetStorageConfig();
+
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<void, ErrorCode>
+WrappedCentralizedMasterService::MountLocalDiskSegment(const UUID& client_id,
+                                                       bool enable_offloading) {
+    ScopedVLogTimer timer(1, "MountLocalDiskSegment");
+    timer.LogRequest("action=mount_local_disk_segment");
+    LOG(INFO) << "Mount local disk segment with client id is : " << client_id
+              << ", enable offloading is: " << enable_offloading;
+    auto result =
+        master_service_.MountLocalDiskSegment(client_id, enable_offloading);
+
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<std::unordered_map<std::string, int64_t, std::hash<std::string>>,
+             ErrorCode>
+WrappedCentralizedMasterService::OffloadObjectHeartbeat(
+    const UUID& client_id, bool enable_offloading) {
+    ScopedVLogTimer timer(1, "OffloadObjectHeartbeat");
+    timer.LogRequest("action=offload_object_heartbeat");
+    auto result =
+        master_service_.OffloadObjectHeartbeat(client_id, enable_offloading);
+    return result;
+}
+
+tl::expected<void, ErrorCode>
+WrappedCentralizedMasterService::NotifyOffloadSuccess(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    const std::vector<StorageObjectMetadata>& metadatas) {
+    ScopedVLogTimer timer(1, "NotifyOffloadSuccess");
+    timer.LogRequest("action=notify_offload_success");
+
+    auto result =
+        master_service_.NotifyOffloadSuccess(client_id, keys, metadatas);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+void RegisterCentralizedRpcService(
+    coro_rpc::coro_rpc_server& server,
+    mooncake::WrappedCentralizedMasterService& wrapped_master_service) {
+    RegisterRpcService(server, wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedCentralizedMasterService::PutStart>(
+            &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedCentralizedMasterService::PutEnd>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedCentralizedMasterService::PutRevoke>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedCentralizedMasterService::BatchPutStart>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedCentralizedMasterService::BatchPutEnd>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedCentralizedMasterService::BatchPutRevoke>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedCentralizedMasterService::MountSegment>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedCentralizedMasterService::ReMountSegment>(
+        &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedCentralizedMasterService::GetFsdir>(
+            &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedCentralizedMasterService::GetStorageConfig>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedCentralizedMasterService::MountLocalDiskSegment>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedCentralizedMasterService::OffloadObjectHeartbeat>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedCentralizedMasterService::NotifyOffloadSuccess>(
+        &wrapped_master_service);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -1,6 +1,7 @@
 #include "ha_helper.h"
 #include "etcd_helper.h"
-#include "rpc_service.h"
+#include "centralized_rpc_service.h"
+#include "p2p_rpc_service.h"
 
 namespace mooncake {
 
@@ -152,9 +153,18 @@ int MasterServiceSupervisor::Start() {
         std::this_thread::sleep_for(std::chrono::seconds(waiting_time));
 
         LOG(INFO) << "Starting master service...";
-        mooncake::WrappedMasterService wrapped_master_service(
-            mooncake::WrappedMasterServiceConfig(config_, view_version));
-        mooncake::RegisterRpcService(server, wrapped_master_service);
+        if (config_.deployment_mode == DeploymentMode::CENTRALIZATION) {
+            WrappedCentralizedMasterService wrapped_master_service(
+                WrappedMasterServiceConfig(config_, view_version));
+            RegisterCentralizedRpcService(server, wrapped_master_service);
+        } else {
+            // TODO: wanyue-wy
+            // enable the following code
+            // WrappedP2PMasterService wrapped_master_service(
+            //     WrappedMasterServiceConfig(config_, view_version));
+
+            // RegisterP2PRpcService(server, wrapped_master_service);
+        }
         // Metric reporting is now handled by WrappedMasterService.
 
         async_simple::Future<coro_rpc::err_code> ec =

--- a/mooncake-store/src/p2p_rpc_service.cpp
+++ b/mooncake-store/src/p2p_rpc_service.cpp
@@ -1,0 +1,16 @@
+#include "p2p_rpc_service.h"
+#include "rpc_helper.h"
+
+namespace mooncake {
+
+WrappedP2PMasterService::WrappedP2PMasterService(
+    const WrappedMasterServiceConfig& config)
+    : WrappedMasterService(config) {}
+
+void RegisterP2PRpcService(
+    coro_rpc::coro_rpc_server& server,
+    mooncake::WrappedP2PMasterService& wrapped_master_service) {
+    RegisterRpcService(server, wrapped_master_service);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -4,7 +4,7 @@
 #include <thread>
 #include <vector>
 
-#include "rpc_service.h"
+#include "centralized_rpc_service.h"
 #include "types.h"
 #include "master_config.h"
 #include "master_metric_manager.h"
@@ -105,7 +105,7 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     WrappedMasterServiceConfig service_config;
     service_config.default_kv_lease_ttl = default_kv_lease_ttl;
     service_config.enable_metric_reporting = true;
-    WrappedMasterService service_(service_config);
+    WrappedCentralizedMasterService service_(service_config);
 
     constexpr size_t kBufferAddress = 0x300000000;
     constexpr size_t kSegmentSize = 1024 * 1024 * 16;
@@ -241,7 +241,7 @@ TEST_F(MasterMetricsTest, CalcCacheStatsTest) {
     WrappedMasterServiceConfig service_config;
     service_config.default_kv_lease_ttl = default_kv_lease_ttl;
     service_config.enable_metric_reporting = true;
-    WrappedMasterService service_(service_config);
+    WrappedCentralizedMasterService service_(service_config);
 
     constexpr size_t kBufferAddress = 0x300000000;
     constexpr size_t kSegmentSize = 1024 * 1024 * 16;
@@ -306,7 +306,7 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
     auto& metrics = MasterMetricManager::instance();
     WrappedMasterServiceConfig service_config;
     service_config.default_kv_lease_ttl = default_kv_lease_ttl;
-    WrappedMasterService service_(service_config);
+    WrappedCentralizedMasterService service_(service_config);
 
     constexpr size_t kBufferAddress = 0x300000000;
     constexpr size_t kSegmentSize = 1024 * 1024 * 64;

--- a/mooncake-store/tests/test_server_helpers.h
+++ b/mooncake-store/tests/test_server_helpers.h
@@ -10,7 +10,7 @@
 
 #include "http_metadata_server.h"
 #include "master_config.h"
-#include "rpc_service.h"
+#include "centralized_rpc_service.h"
 #include "types.h"
 #include "utils.h"
 #include <ylt/util/tl/expected.hpp>
@@ -85,8 +85,9 @@ class InProcMaster {
             wms_cfg.root_fs_dir = DEFAULT_ROOT_FS_DIR;
             wms_cfg.memory_allocator = BufferAllocatorType::OFFSET;
 
-            wrapped_ = std::make_unique<WrappedMasterService>(wms_cfg);
-            RegisterRpcService(*server_, *wrapped_);
+            wrapped_ =
+                std::make_unique<WrappedCentralizedMasterService>(wms_cfg);
+            RegisterCentralizedRpcService(*server_, *wrapped_);
 
             auto ec = server_->async_start();
             if (ec.hasResult()) {
@@ -131,7 +132,7 @@ class InProcMaster {
 
    private:
     std::unique_ptr<coro_rpc::coro_rpc_server> server_;
-    std::unique_ptr<WrappedMasterService> wrapped_;
+    std::unique_ptr<WrappedCentralizedMasterService> wrapped_;
     std::unique_ptr<HttpMetadataServer> meta_server_;
     int rpc_port_ = 0;
     int http_metrics_port_ = 0;


### PR DESCRIPTION
## Description
This is the second PR for Mooncake Store P2P architecture (https://github.com/kvcache-ai/Mooncake/issues/1209 ). As described in the RFC, during the first implementing phase of the new architecture, we will focus on extracting the common execution paths shared by both architectures to base class and specialize architecture-specific logic in subclasses. In this PR, we extract the common interfaces from rpc_service and master_client to the base class. Then, subclasses with the centralized prefix will inherit the logic of the old code, and the logic of subclasses with the p2p prefix will be implemented in the subsequent PR.

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [ ] Transfer Engine
    - [x] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
