### PR TITLE
[Store] Add HTTP metadata cleanup on client timeout

### DIFF
--- a/mooncake-store/include/http_metadata_server.h
+++ b/mooncake-store/include/http_metadata_server.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 #include <mutex>
+#include <vector>
 
 #include <ylt/coro_http/coro_http_server.hpp>
 
@@ -34,6 +35,14 @@ class HttpMetadataServer {
 
     // Check if the server is running
     bool is_running() const { return running_; }
+
+    // Remove a key from the metadata store (for internal use by MasterService)
+    // Returns true if key was found and removed, false if key did not exist
+    bool removeKey(const std::string& key);
+
+    // Remove multiple keys from the metadata store
+    // Returns the number of keys that were successfully removed
+    size_t removeKeys(const std::vector<std::string>& keys);
 
     // Non-copyable
     HttpMetadataServer(const HttpMetadataServer&) = delete;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -62,6 +62,10 @@ struct MasterConfig {
     bool enable_http_metadata_server;
     uint32_t http_metadata_server_port;
     std::string http_metadata_server_host;
+    // Enable cleanup of HTTP metadata (mooncake/ram/*, mooncake/rpc_meta/*)
+    // when client heartbeat times out. Only effective when
+    // enable_http_metadata_server is true.
+    bool enable_metadata_cleanup_on_timeout;
 
     // Pod identity for K8s label-based routing
     std::string pod_name;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -46,6 +46,7 @@ class EtcdOpLogStore;
 // Forward declarations
 class AllocationStrategy;
 class EvictionStrategy;
+class HttpMetadataServer;
 
 // Forward declarations for test classes
 namespace test {
@@ -742,6 +743,13 @@ class MasterService {
      */
     tl::expected<void, ErrorCode> MarkTaskToComplete(
         const UUID& client_id, const TaskCompleteRequest& request);
+
+    /**
+     * @brief Set the HttpMetadataServer pointer for cleanup on client timeout.
+     * @param server Pointer to HttpMetadataServer. If nullptr, cleanup is
+     * disabled.
+     */
+    void setHttpMetadataServer(HttpMetadataServer* server);
 
    private:
     void SnapshotThreadFunc();
@@ -1871,6 +1879,17 @@ class MasterService {
     std::atomic<uint64_t> default_tenant_quota_bytes_;
     const uint64_t tenant_quota_pool_capacity_bytes_;
     mutable std::mutex tenant_quota_recompute_mutex_;
+
+    // HTTP metadata server pointer for cleanup on client timeout
+    // nullptr means cleanup is disabled
+    HttpMetadataServer* http_metadata_server_{nullptr};
+
+    // Cached HTTP metadata key prefix (initialized once at startup)
+    std::string http_metadata_prefix_;
+
+    // Clean up HTTP metadata (mooncake/ram/*, mooncake/rpc_meta/*) for a
+    // segment
+    void cleanupHttpMetadata(const std::string& segment_name);
 
     bool use_disk_replica_{false};
 

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -16,9 +16,14 @@
 
 namespace mooncake {
 
+// Forward declaration
+class HttpMetadataServer;
 class WrappedMasterService {
    public:
-    WrappedMasterService(const WrappedMasterServiceConfig& config);
+    // Constructor with optional HttpMetadataServer pointer for cleanup on
+    // timeout If http_metadata_server is nullptr, cleanup is disabled
+    WrappedMasterService(const WrappedMasterServiceConfig& config,
+                         HttpMetadataServer* http_metadata_server = nullptr);
 
     ~WrappedMasterService();
 

--- a/mooncake-store/src/http_metadata_server.cpp
+++ b/mooncake-store/src/http_metadata_server.cpp
@@ -135,4 +135,25 @@ KVPoll HttpMetadataServer::poll() const {
     return KVPoll::Success;
 }
 
+bool HttpMetadataServer::removeKey(const std::string& key) {
+    std::lock_guard<std::mutex> lock(store_mutex_);
+    if (store_.erase(key) > 0) {
+        LOG(INFO) << "HttpMetadataServer: removed key=" << key;
+        return true;
+    }
+    return false;
+}
+
+size_t HttpMetadataServer::removeKeys(const std::vector<std::string>& keys) {
+    std::lock_guard<std::mutex> lock(store_mutex_);
+    size_t removed = 0;
+    for (const auto& key : keys) {
+        if (store_.erase(key) > 0) {
+            LOG(INFO) << "HttpMetadataServer: removed key=" << key;
+            ++removed;
+        }
+    }
+    return removed;
+}
+
 }  // namespace mooncake

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -189,6 +189,11 @@ DEFINE_int32(http_metadata_server_port, 8080,
              "Port for HTTP metadata server to listen on");
 DEFINE_string(http_metadata_server_host, "0.0.0.0",
               "Host for HTTP metadata server to bind to");
+DEFINE_bool(
+    enable_metadata_cleanup_on_timeout, false,
+    "Enable cleanup of HTTP metadata (mooncake/ram/*, mooncake/rpc_meta/*) "
+    "when client heartbeat times out. Only effective when "
+    "enable_http_metadata_server is true.");
 
 DEFINE_string(pod_name, "",
               "Pod name for K8s label-based routing (default: $POD_NAME)");
@@ -418,6 +423,9 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                              FLAGS_pod_name);
     default_config.GetString("pod_namespace", &master_config.pod_namespace,
                              FLAGS_pod_namespace);
+    default_config.GetBool("enable_metadata_cleanup_on_timeout",
+                           &master_config.enable_metadata_cleanup_on_timeout,
+                           FLAGS_enable_metadata_cleanup_on_timeout);
     default_config.GetUInt64("put_start_discard_timeout_sec",
                              &master_config.put_start_discard_timeout_sec,
                              FLAGS_put_start_discard_timeout_sec);
@@ -790,6 +798,13 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.pod_namespace = FLAGS_pod_namespace;
     }
+    if ((google::GetCommandLineFlagInfo("enable_metadata_cleanup_on_timeout",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.enable_metadata_cleanup_on_timeout =
+            FLAGS_enable_metadata_cleanup_on_timeout;
+    }
     if ((google::GetCommandLineFlagInfo("put_start_discard_timeout_sec",
                                         &info) &&
          !info.is_default) ||
@@ -1088,6 +1103,17 @@ int main(int argc, char* argv[]) {
     if (value && std::string_view(value) == "rdma") {
         protocol = "rdma";
     }
+
+    // Validate: enable_metadata_cleanup_on_timeout requires
+    // enable_http_metadata_server
+    if (master_config.enable_metadata_cleanup_on_timeout &&
+        !master_config.enable_http_metadata_server) {
+        LOG(WARNING) << "enable_metadata_cleanup_on_timeout is set to true but "
+                     << "enable_http_metadata_server is false. "
+                     << "Disabling metadata cleanup on timeout.";
+        master_config.enable_metadata_cleanup_on_timeout = false;
+    }
+
     LOG(INFO)
         << "Master service started on port " << master_config.rpc_port
         << ", max_threads=" << master_config.rpc_thread_num
@@ -1127,6 +1153,8 @@ int main(int argc, char* argv[]) {
         << master_config.http_metadata_server_port
         << ", http_metadata_server_host="
         << master_config.http_metadata_server_host
+        << ", enable_metadata_cleanup_on_timeout="
+        << master_config.enable_metadata_cleanup_on_timeout
         << ", put_start_discard_timeout_sec="
         << master_config.put_start_discard_timeout_sec
         << ", put_start_release_timeout_sec="
@@ -1188,9 +1216,18 @@ int main(int argc, char* argv[]) {
         if (value && std::string_view(value) == "rdma") {
             server.init_ibv();
         }
+        // Only pass HttpMetadataServer pointer if cleanup is enabled
+        // Note: enable_metadata_cleanup_on_timeout is automatically disabled
+        // if enable_http_metadata_server is false (validated earlier)
+        mooncake::HttpMetadataServer* metadata_server_ptr = nullptr;
+        if (master_config.enable_metadata_cleanup_on_timeout) {
+            metadata_server_ptr = http_metadata_server.get();
+        }
+
         auto wrapped_master_service =
             std::make_shared<mooncake::WrappedMasterService>(
-                mooncake::WrappedMasterServiceConfig(master_config, version));
+                mooncake::WrappedMasterServiceConfig(master_config, version),
+                metadata_server_ptr);
         mooncake::MasterAdminServer admin_server(
             static_cast<uint16_t>(master_config.metrics_port),
             master_config.enable_metric_reporting);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <random>
 #include <shared_mutex>
@@ -15,6 +16,7 @@
 #include <ylt/util/tl/expected.hpp>
 #include <boost/algorithm/string.hpp>
 
+#include "http_metadata_server.h"
 #include "master_metric_manager.h"
 #include "common.h"
 #include "segment.h"
@@ -212,6 +214,17 @@ MasterService::MasterService(const MasterServiceConfig& config)
       cxl_path_(config.cxl_path),
       cxl_size_(config.cxl_size),
       enable_cxl_(config.enable_cxl) {
+    // Initialize HTTP metadata key prefix (read env var once at startup)
+    const char* custom_prefix = std::getenv("MC_METADATA_CLUSTER_ID");
+    if (custom_prefix && std::strlen(custom_prefix) > 0) {
+        http_metadata_prefix_ = "mooncake/" + std::string(custom_prefix);
+        if (http_metadata_prefix_.back() != '/') {
+            http_metadata_prefix_ += '/';
+        }
+    } else {
+        http_metadata_prefix_ = "mooncake/";
+    }
+
     if (enable_snapshot_ || enable_snapshot_restore_) {
         try {
             auto object_store_type =
@@ -7032,6 +7045,8 @@ void MasterService::ClientMonitorFunc() {
                     LOG(INFO) << "client_id=" << client_ids[i]
                               << ", segment_name=" << segment_names[i]
                               << ", action=unmount_expired_mem_segment";
+                    // Clean up HTTP metadata if enabled
+                    cleanupHttpMetadata(segment_names[i]);
                 }
                 for (auto& client_id : expired_clients) {
                     segment_access.UnmountLocalDiskSegment(client_id);
@@ -8734,6 +8749,29 @@ MasterService::MetadataSerializer::DeserializeDiscardedReplicas(
     }
 
     return {};
+}
+
+void MasterService::setHttpMetadataServer(HttpMetadataServer* server) {
+    http_metadata_server_ = server;
+    if (server) {
+        LOG(INFO) << "HTTP metadata cleanup on client timeout: enabled";
+    }
+}
+
+void MasterService::cleanupHttpMetadata(const std::string& segment_name) {
+    if (!http_metadata_server_) {
+        return;
+    }
+
+    std::string ram_key = http_metadata_prefix_ + "ram/" + segment_name;
+    bool ram_removed = http_metadata_server_->removeKey(ram_key);
+
+    std::string rpc_key = http_metadata_prefix_ + "rpc_meta/" + segment_name;
+    bool rpc_removed = http_metadata_server_->removeKey(rpc_key);
+
+    LOG(INFO) << "Cleaned up HTTP metadata for segment: " << segment_name
+              << ", ram_key_removed=" << ram_removed
+              << ", rpc_key_removed=" << rpc_removed;
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -13,8 +13,12 @@
 namespace mooncake {
 
 WrappedMasterService::WrappedMasterService(
-    const WrappedMasterServiceConfig& config)
-    : master_service_(MasterServiceConfig(config)) {}
+    const WrappedMasterServiceConfig& config,
+    HttpMetadataServer* http_metadata_server)
+    : master_service_(MasterServiceConfig(config)) {
+    // Set HttpMetadataServer reference for cleanup on client timeout
+    master_service_.setHttpMetadataServer(http_metadata_server);
+}
 
 WrappedMasterService::~WrappedMasterService() = default;
 


### PR DESCRIPTION
## Description

This PR adds a new feature that allows the Master Service to automatically clean up HTTP Metadata Server entries when a client heartbeat times out. This cleanup functionality is controlled by a new configuration flag `--enable_metadata_cleanup_on_timeout` and only works when the HTTP Metadata Server is deployed alongside the Master Service (`--enable_http_metadata_server=true`).

## Problem

In Mooncake's distributed KV cache architecture, there are two services that store client metadata:

1. **Master Service** - Stores segment information, handles object storage coordination, and maintains client heartbeats via gRPC.
2. **HTTP Metadata Server** - Stores RDMA connection metadata (`mooncake/ram/{segment_name}`) and RPC routing information (`mooncake/rpc_meta/{segment_name}`).

When a client (e.g., SGLang inference server) terminates normally, it performs cleanup operations to both services:
- Calls `UnmountSegment()` to the Master Service
- Calls `removeSegmentDesc()` and `removeRpcMetaEntry()` to the HTTP Metadata Server

However, when a client **crashes or is forcefully terminated** (e.g., `kill -9`, OOM killed, node failure), the cleanup operations may fail or never execute. The Master Service can detect this through heartbeat timeout (`client_ttl`) and clean up its internal segment resources, but the HTTP Metadata Server has **no heartbeat mechanism** and cannot detect client failures.

This leads to **stale metadata residue** on the HTTP Metadata Server:
- `mooncake/ram/{segment_name}` - Contains outdated RDMA buffer information
- `mooncake/rpc_meta/{segment_name}` - Contains stale RPC connection details

These residual entries can cause issues when:
- New nodes attempt to connect using stale metadata
- The same node restarts and registers with different RDMA parameters
- Other nodes query and cache outdated peer information

## Solution

Leverage the Master Service's existing heartbeat mechanism to clean up HTTP Metadata Server entries when client timeout is detected:

```
Client (ping) ──────► Master Service ──────► HTTP Metadata Server
                            │                        │
                      Detect client timeout          │
                            │                        ▼
                            ▼                  Delete mooncake/ram/*
                      Unmount segment ────────► Delete mooncake/rpc_meta/*
```

### Design Decisions

1. **Opt-in Feature**: Disabled by default (`--enable_metadata_cleanup_on_timeout=false`) to ensure backward compatibility.

2. **Coupled Deployment Only**: This feature only works when the HTTP Metadata Server is co-located with the Master Service. If `enable_http_metadata_server=false` but `enable_metadata_cleanup_on_timeout=true`, a warning is logged and the cleanup feature is automatically disabled.

3. **Direct Memory Access**: Since both services run in the same process when co-deployed, the Master Service directly calls `HttpMetadataServer::removeKey()` without network overhead.

4. **Key Prefix Support**: Respects the `MC_METADATA_CLUSTER_ID` environment variable for custom key prefixes.

## Changes

### Configuration (`mooncake-store/include/master_config.h`)
- Added `enable_metadata_cleanup_on_timeout` boolean field to `MasterConfig` struct

### Main Entry (`mooncake-store/src/master.cpp`)
- Added `--enable_metadata_cleanup_on_timeout` command-line flag
- Added configuration parsing for the new flag
- Added validation logic: warns and disables cleanup if HTTP server is not enabled
- Pass `HttpMetadataServer` pointer to `WrappedMasterService` when cleanup is enabled

### HTTP Metadata Server (`mooncake-store/include/http_metadata_server.h`, `mooncake-store/src/http_metadata_server.cpp`)
- Added `removeKey(const std::string& key)` method for single key deletion
- Added `removeKeys(const std::vector<std::string>& keys)` method for batch deletion
- Both methods are thread-safe using `store_mutex_`

### Master Service (`mooncake-store/include/master_service.h`, `mooncake-store/src/master_service.cpp`)
- Added `HttpMetadataServer* http_metadata_server_` member
- Added `setHttpMetadataServer(HttpMetadataServer* server)` method
- Added `cleanupHttpMetadata(const std::string& segment_name)` method
- Integrated cleanup call in `ClientMonitorThreadMain()` when processing expired clients

### RPC Service (`mooncake-store/include/rpc_service.h`, `mooncake-store/src/rpc_service.cpp`)
- Modified `WrappedMasterService` constructor to accept optional `HttpMetadataServer*` parameter
- Pass the pointer to underlying `MasterService` when provided

## Usage

To enable this feature:

```bash
mooncake_master \
    --enable_http_metadata_server=true \
    --enable_metadata_cleanup_on_timeout=true \
    --client_ttl=20 \
    --v=1
```

