### PR TITLE
[TE] filter the local network interface

### DIFF
--- a/mooncake-transfer-engine/include/transfer_metadata_plugin.h
+++ b/mooncake-transfer-engine/include/transfer_metadata_plugin.h
@@ -20,19 +20,19 @@
 namespace mooncake {
 struct MetadataStoragePlugin {
     static std::shared_ptr<MetadataStoragePlugin> Create(
-        const std::string &conn_string);
+        const std::string& conn_string);
 
     MetadataStoragePlugin() {}
     virtual ~MetadataStoragePlugin() {}
 
-    virtual bool get(const std::string &key, Json::Value &value) = 0;
-    virtual bool set(const std::string &key, const Json::Value &value) = 0;
-    virtual bool remove(const std::string &key) = 0;
+    virtual bool get(const std::string& key, Json::Value& value) = 0;
+    virtual bool set(const std::string& key, const Json::Value& value) = 0;
+    virtual bool remove(const std::string& key) = 0;
 };
 
 struct HandShakePlugin {
     static std::shared_ptr<HandShakePlugin> Create(
-        const std::string &conn_string);
+        const std::string& conn_string);
 
     HandShakePlugin() {}
     virtual ~HandShakePlugin() {}
@@ -41,21 +41,21 @@ struct HandShakePlugin {
     // called. The first param represents peer attributes, while the
     // second param represents local attributes.
     using OnReceiveCallBack =
-        std::function<int(const Json::Value &, Json::Value &)>;
+        std::function<int(const Json::Value&, Json::Value&)>;
 
     virtual int startDaemon(uint16_t listen_port, int sockfd) = 0;
 
     // Connect to peer endpoint, and wait for receiving
     // peer endpoint's attributes
     virtual int send(std::string ip_or_host_name, uint16_t rpc_port,
-                     const Json::Value &local, Json::Value &peer) = 0;
+                     const Json::Value& local, Json::Value& peer) = 0;
     virtual int sendNotify(std::string ip_or_host_name, uint16_t rpc_port,
-                           const Json::Value &local, Json::Value &peer) = 0;
+                           const Json::Value& local, Json::Value& peer) = 0;
 
     // Exchange metadata with remote peer.
     virtual int exchangeMetadata(std::string ip_or_host_name, uint16_t rpc_port,
-                                 const Json::Value &local_metadata,
-                                 Json::Value &peer_metadata) = 0;
+                                 const Json::Value& local_metadata,
+                                 Json::Value& peer_metadata) = 0;
 
     // Register callback function for receiving a new connection.
     virtual void registerOnConnectionCallBack(OnReceiveCallBack callback) = 0;
@@ -67,9 +67,10 @@ struct HandShakePlugin {
     virtual void registerOnNotifyCallBack(OnReceiveCallBack callback) = 0;
 };
 
-std::vector<std::string> findLocalIpAddresses();
+std::vector<std::string> findLocalIpAddresses(
+    const std::vector<std::string>& filterPrefix = {"lo"});
 
-uint16_t findAvailableTcpPort(int &sockfd, bool set_range = false);
+uint16_t findAvailableTcpPort(int& sockfd, bool set_range = false);
 
 }  // namespace mooncake
 

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -150,11 +150,17 @@ int TransferEngineImpl::init(const std::string& metadata_conn_string,
         if (ip_address)
             desc.ip_or_host_name = ip_address;
         else {
-            auto ip_list = findLocalIpAddresses();
+            auto ip_list =
+                findLocalIpAddresses({"lo", "docker", "veth", "br-"});
             if (ip_list.empty()) {
                 LOG(ERROR) << "not valid LAN address found";
                 return -1;
             } else {
+                // Warning:
+                // In multi-NIC, containerized, or virtualized environments, the
+                // first IP address maybe not the one we want to use. We cannot
+                // guarantee that it's reachable from peers.
+                // Whatever, If the code reach here, we just use the first one.
                 desc.ip_or_host_name = ip_list[0];
             }
         }


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Type of Change

* Types
  - [x] Bug fix
  - [x] New feature
    - [x] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## Summary
This PR(by iflytek) improves the reliability and correctness of RPC metadata population.
In multi-NIC, containerized, or virtualized environments, automatic interface selection can inadvertently choose non-routable or internal addresses—such as 127.0.0.1 (loopback) or 172.21.0.1 (Docker bridge)—leading to RPC endpoints that are unreachable from remote peers. By prioritizing user-specified addresses, we ensure the transport layer binds to the intended network interface.

## Rationale
1. User intent takes precedence: In TCP-based deployments, users typically specify the desired IP or hostname explicitly (e.g., via configuration or CLI flags). The system should respect this input rather than overriding it with auto-discovered interfaces.
2. Auto-detection risks incorrect bindings:
    Automatic IP/interface selection may pick:
    - 127.0.0.1 or ::1 — only reachable locally
    - Docker-managed addresses like 172.21.0.1 — isolated to container networks
    - Virtual NICs (e.g., veth, br-xxx) — not externally routable
        These choices can cause RPC servers to bind to interfaces that remote clients cannot access, resulting in silent connectivity failures.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
