### PR TITLE
[TE]feat(topology): add IB device availability filtering

### DIFF
--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -50,8 +50,8 @@ static bool isIbDeviceAccessible(const char *device_name) {
 
     if (!S_ISCHR(st.st_mode)) {
         LOG(WARNING) << "Device path " << device_path
-                     << " is not a character device (mode: "
-                     << std::oct << st.st_mode << std::dec << ")";
+                     << " is not a character device (mode: " << std::oct
+                     << st.st_mode << std::dec << ")";
         return false;
     }
 
@@ -65,8 +65,8 @@ static bool isIbDeviceAccessible(const char *device_name) {
 }
 
 static bool checkIbDevicePort(struct ibv_context *context,
-                               const std::string &device_name,
-                               uint8_t port_num) {
+                              const std::string &device_name,
+                              uint8_t port_num) {
     struct ibv_port_attr port_attr;
 
     if (ibv_query_port(context, port_num, &port_attr) != 0) {
@@ -158,7 +158,7 @@ static std::vector<InfinibandDevice> listInfiniBandDevices(
         if (!filter.empty() && std::find(filter.begin(), filter.end(),
                                          device_name) == filter.end())
             continue;
-        
+
         // Check device availability before adding to the list
         if (!isIbDeviceAvailable(device_list[i])) {
             LOG(WARNING) << "Skipping unavailable device: " << device_name;


### PR DESCRIPTION
## Description
feat(topology): add IB device availability check before topology discovery

- Add device accessibility check (path exists, char device, R/W permission)
- Add port status check (GID table non-empty, port state ACTIVE)
- Filter out unavailable devices in listInfiniBandDevices()

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [x] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?
I have created comprehensive unit test cases for the added functionality in the feat/nic-check-test branch of my personal repository.

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
