### PR TITLE
[STORE] RPC server Listen on 0.0.0.0 to Prevent Bind Failures

### DIFF
--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -15,6 +15,7 @@ struct MasterConfig {
     uint32_t rpc_port;
     uint32_t rpc_thread_num;
     std::string rpc_address;
+    std::string bind_address;
     int32_t rpc_conn_timeout_seconds;
     bool rpc_enable_tcp_no_delay;
 
@@ -73,6 +74,7 @@ class MasterServiceSupervisorConfig {
 
     // Parameters with default values (optional parameters)
     std::string rpc_address = "0.0.0.0";
+    std::string bind_address = "0.0.0.0";
     std::chrono::steady_clock::duration rpc_conn_timeout = std::chrono::seconds(
         0);  // Client connection timeout. 0 = no timeout (infinite)
     bool rpc_enable_tcp_no_delay = true;
@@ -114,6 +116,7 @@ class MasterServiceSupervisorConfig {
 
         // Set optional parameters (these have default values)
         rpc_address = config.rpc_address;
+        bind_address = config.bind_address;
         rpc_conn_timeout =
             std::chrono::seconds(config.rpc_conn_timeout_seconds);
         rpc_enable_tcp_no_delay = config.rpc_enable_tcp_no_delay;

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -117,7 +117,7 @@ int MasterServiceSupervisor::Start() {
     while (true) {
         LOG(INFO) << "Init master service...";
         coro_rpc::coro_rpc_server server(
-            config_.rpc_thread_num, config_.rpc_port, std::string("0.0.0.0"),
+            config_.rpc_thread_num, config_.rpc_port, config_.bind_address,
             config_.rpc_conn_timeout, config_.rpc_enable_tcp_no_delay);
         const char* value = std::getenv("MC_RPC_PROTOCOL");
         if (value && std::string_view(value) == "rdma") {

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -117,7 +117,7 @@ int MasterServiceSupervisor::Start() {
     while (true) {
         LOG(INFO) << "Init master service...";
         coro_rpc::coro_rpc_server server(
-            config_.rpc_thread_num, config_.rpc_port, config_.rpc_address,
+            config_.rpc_thread_num, config_.rpc_port, std::string("0.0.0.0"),
             config_.rpc_conn_timeout, config_.rpc_enable_tcp_no_delay);
         const char* value = std::getenv("MC_RPC_PROTOCOL");
         if (value && std::string_view(value) == "rdma") {

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -559,7 +559,7 @@ int main(int argc, char* argv[]) {
         mooncake::ViewVersionId version = 0;
         coro_rpc::coro_rpc_server server(
             master_config.rpc_thread_num, master_config.rpc_port,
-            master_config.rpc_address,
+            std::string("0.0.0.0"),
             std::chrono::seconds(master_config.rpc_conn_timeout_seconds),
             master_config.rpc_enable_tcp_no_delay);
         const char* value = std::getenv("MC_RPC_PROTOCOL");


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [x] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## Summary
This PR changes the RPC server’s listening address from a specific IP (e.g., 127.0.0.1 or a detected local IP) to 0.0.0.0 (INADDR_ANY), allowing it to accept connections on all available network interfaces.
In cloud environments such as Alibaba Cloud, servers often use virtual or bonded network interfaces (e.g., bond0). When the server binds to a specified IP address, it may fail if that IP is not directly assigned to a physical interface.
By binding to 0.0.0.0, the service becomes reachable on any configured IP of the host, including those managed by virtual NICs, bond interfaces, or cloud networking layers—while still respecting firewall and security group policies.

## Changes
- Replace hardcoded or auto-detected IP address with "0.0.0.0" when starting the RPC server.

## Impact
- ✅ Improves compatibility in cloud and virtualized environments (Alibaba Cloud, AWS, etc.).
- ✅ Avoids bind failures on systems using bonded or virtual network interfaces.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
