### PR TITLE
[Store]: add ETCD snapshot object store backend in HA mode

### DIFF
--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -299,6 +299,7 @@ func EtcdStoreGetWrapper(key *C.char, keySize C.int, value **C.char,
 		return -1
 	}
 	if len(resp.Kvs) == 0 {
+		// The substring "key not found" is matched by C++ EtcdSnapshotObjectStore::kKeyNotFoundSubstring
 		*errMsg = C.CString("key not found in etcd")
 		return -2
 	} else {
@@ -1038,6 +1039,7 @@ func SnapshotStoreGetWrapper(key *C.char, keySize C.int, value **C.char,
 		return -1
 	}
 	if len(resp.Kvs) == 0 {
+		// The substring "key not found" is matched by C++ EtcdSnapshotObjectStore::kKeyNotFoundSubstring
 		*errMsg = C.CString("key not found in etcd")
 		return -2
 	} else {

--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -1072,4 +1072,40 @@ func SnapshotStoreDeleteWrapper(key *C.char, keySize C.int, usePrefix C.int, err
 	return 0
 }
 
+//export SnapshotStoreListKeysWrapper
+func SnapshotStoreListKeysWrapper(prefix *C.char, prefixSize C.int,
+	outKeys ***C.char, outKeySizes **C.int, outCount *C.int, errMsg **C.char) int {
+	if snapshotClient == nil {
+		*errMsg = C.CString("etcd snapshot client not initialized")
+		return -1
+	}
+	p := C.GoStringN(prefix, prefixSize)
+	ctx, cancel := context.WithTimeout(context.Background(), snapshotTimeout)
+	defer cancel()
+
+	resp, err := snapshotClient.Get(ctx, p, clientv3.WithPrefix(), clientv3.WithKeysOnly(),
+		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
+	if err != nil {
+		*errMsg = C.CString(err.Error())
+		return -1
+	}
+
+	n := len(resp.Kvs)
+	*outCount = C.int(n)
+	if n == 0 {
+		return 0
+	}
+
+	keysArr := (*[1 << 30]*C.char)(C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof((*C.char)(nil)))))
+	sizesArr := (*[1 << 30]C.int)(C.malloc(C.size_t(n) * C.size_t(unsafe.Sizeof(C.int(0)))))
+	for i, kv := range resp.Kvs {
+		keysArr[i] = C.CString(string(kv.Key))
+		sizesArr[i] = C.int(len(kv.Key))
+	}
+
+	*outKeys = (**C.char)(unsafe.Pointer(keysArr))
+	*outKeySizes = (*C.int)(unsafe.Pointer(sizesArr))
+	return 0
+}
+
 func main() {}

--- a/mooncake-store/include/ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.h
+++ b/mooncake-store/include/ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "ha/snapshot/object/snapshot_object_store.h"
+
+#ifdef STORE_USE_ETCD
+
+#include <string>
+#include <vector>
+
+namespace mooncake {
+
+/**
+ * @brief ETCD-based snapshot object store implementation.
+ *
+ * Stores snapshot data as key-value pairs in an etcd cluster via the
+ * cgo wrapper (libetcd_wrapper).  A dedicated snapshot etcd client is
+ * used with enlarged message size limits (2 GB) and extended timeouts
+ * to accommodate large snapshot payloads.
+ *
+ * IMPORTANT: All methods in this class call into cgo and therefore
+ * must only be invoked from a process that has a live Go runtime.
+ * In particular, they must NOT be called from a forked child process.
+ */
+class EtcdSnapshotObjectStore : public SnapshotObjectStore {
+   public:
+    explicit EtcdSnapshotObjectStore(const std::string& endpoints);
+    ~EtcdSnapshotObjectStore() override = default;
+
+    tl::expected<void, std::string> UploadBuffer(
+        const std::string& key, const std::vector<uint8_t>& buffer) override;
+
+    tl::expected<void, std::string> DownloadBuffer(
+        const std::string& key, std::vector<uint8_t>& buffer) override;
+
+    tl::expected<void, std::string> UploadString(
+        const std::string& key, const std::string& data) override;
+
+    tl::expected<void, std::string> DownloadString(
+        const std::string& key, std::string& data) override;
+
+    tl::expected<void, std::string> DeleteObjectsWithPrefix(
+        const std::string& prefix) override;
+
+    tl::expected<void, std::string> ListObjectsWithPrefix(
+        const std::string& prefix,
+        std::vector<std::string>& object_keys) override;
+
+    bool IsNotFoundError(const std::string& error) const override;
+
+    std::string GetConnectionInfo() const override;
+
+   private:
+    std::string endpoints_;
+};
+
+}  // namespace mooncake
+
+#endif  // STORE_USE_ETCD

--- a/mooncake-store/include/ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.h
+++ b/mooncake-store/include/ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.h
@@ -23,6 +23,10 @@ namespace mooncake {
  */
 class EtcdSnapshotObjectStore : public SnapshotObjectStore {
    public:
+    // Must match the Go-side error string in etcd_wrapper.go
+    // (SnapshotStoreGetWrapper returns "key not found in etcd")
+    static constexpr const char* kKeyNotFoundSubstring = "key not found";
+
     explicit EtcdSnapshotObjectStore(const std::string& endpoints);
     ~EtcdSnapshotObjectStore() override = default;
 

--- a/mooncake-store/include/ha/snapshot/object/snapshot_object_store.h
+++ b/mooncake-store/include/ha/snapshot/object/snapshot_object_store.h
@@ -12,12 +12,28 @@ namespace mooncake {
 // Snapshot object store type enumeration
 enum class SnapshotObjectStoreType {
     LOCAL_FILE = 0,  // Local file system
-    S3 = 1           // S3 storage
+    S3 = 1,          // S3 storage
+    ETCD = 2         // Etcd storage
 };
 
 // Convert string to SnapshotObjectStoreType
 inline SnapshotObjectStoreType ParseSnapshotObjectStoreType(
     const std::string& type_str) {
+    if (type_str.empty() || type_str == "local" || type_str == "LOCAL") {
+        return SnapshotObjectStoreType::LOCAL_FILE;
+    }
+#ifdef STORE_USE_ETCD
+    if (type_str == "etcd" || type_str == "ETCD") {
+        return SnapshotObjectStoreType::ETCD;
+    }
+#else
+    if (type_str == "etcd" || type_str == "ETCD") {
+        throw std::invalid_argument(
+            "ETCD snapshot object store requested but STORE_USE_ETCD is "
+            "not enabled. Please rebuild with STORE_USE_ETCD or use the "
+            "'local' object store.");
+    }
+#endif
 #ifdef HAVE_AWS_SDK
     if (type_str == "s3" || type_str == "S3") {
         return SnapshotObjectStoreType::S3;
@@ -30,9 +46,6 @@ inline SnapshotObjectStoreType ParseSnapshotObjectStoreType(
             "'local' object store.");
     }
 #endif
-    if (type_str == "local" || type_str == "LOCAL") {
-        return SnapshotObjectStoreType::LOCAL_FILE;
-    }
 
     // Unknown object store type - fail fast.
     throw std::invalid_argument("Unknown snapshot object store type: '" +
@@ -43,6 +56,8 @@ inline SnapshotObjectStoreType ParseSnapshotObjectStoreType(
 inline std::string SnapshotObjectStoreTypeToString(
     SnapshotObjectStoreType type) {
     switch (type) {
+        case SnapshotObjectStoreType::ETCD:
+            return "etcd";
         case SnapshotObjectStoreType::S3:
             return "s3";
         case SnapshotObjectStoreType::LOCAL_FILE:
@@ -137,7 +152,8 @@ class SnapshotObjectStore {
      * @return Smart pointer to object store instance
      */
     static std::unique_ptr<SnapshotObjectStore> Create(
-        SnapshotObjectStoreType type);
+        SnapshotObjectStoreType type,
+        const std::string& etcd_endpoints = "");
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha/snapshot/object/snapshot_object_store.h
+++ b/mooncake-store/include/ha/snapshot/object/snapshot_object_store.h
@@ -147,13 +147,20 @@ class SnapshotObjectStore {
     virtual std::string GetConnectionInfo() const = 0;
 
     /**
-     * @brief Factory method: create object store instance by type
-     * @param type Object store type
+     * @brief Configuration for creating a SnapshotObjectStore instance.
+     */
+    struct CreateConfig {
+        SnapshotObjectStoreType type = SnapshotObjectStoreType::LOCAL_FILE;
+        std::string etcd_endpoints;  // Only used when type == ETCD
+    };
+
+    /**
+     * @brief Factory method: create object store instance by config
+     * @param config Object store configuration
      * @return Smart pointer to object store instance
      */
     static std::unique_ptr<SnapshotObjectStore> Create(
-        SnapshotObjectStoreType type,
-        const std::string& etcd_endpoints = "");
+        const CreateConfig& config);
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha/snapshot/snapshot_socket_util.h
+++ b/mooncake-store/include/ha/snapshot/snapshot_socket_util.h
@@ -1,0 +1,48 @@
+#pragma once
+
+// Shared I/O helpers for the snapshot socketpair IPC protocol.
+// Used by MasterService::PersistStateViaChildSerialize() and
+// MasterService::PersistStateViaParentUpload().
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <unistd.h>
+
+namespace mooncake {
+namespace snapshot_socket {
+
+/// Read exactly @p len bytes from @p fd.  Returns false on EOF or error.
+inline bool ReadExact(int fd, void* buf, size_t len) {
+    size_t total = 0;
+    auto* ptr = static_cast<char*>(buf);
+    while (total < len) {
+        ssize_t n = ::read(fd, ptr + total, len - total);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (n == 0) return false;  // EOF
+        total += static_cast<size_t>(n);
+    }
+    return true;
+}
+
+/// Write exactly @p len bytes to @p fd.  Returns false on error.
+inline bool WriteExact(int fd, const void* buf, size_t len) {
+    size_t total = 0;
+    const auto* ptr = static_cast<const char*>(buf);
+    while (total < len) {
+        ssize_t n = ::write(fd, ptr + total, len - total);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (n == 0) return false;
+        total += static_cast<size_t>(n);
+    }
+    return true;
+}
+
+}  // namespace snapshot_socket
+}  // namespace mooncake

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -107,7 +107,7 @@ class MasterServiceSupervisorConfig {
     bool rpc_enable_tcp_no_delay = true;
     std::string ha_backend_type = "etcd";
     std::string ha_backend_connstring;
-    std::string etcd_endpoints = "0.0.0.0:2379";
+    std::string etcd_endpoints = "127.0.0.1:2379";
     std::string local_hostname = "0.0.0.0:50051";
     std::string cluster_id = DEFAULT_CLUSTER_ID;
     std::string root_fs_dir = DEFAULT_ROOT_FS_DIR;
@@ -290,7 +290,7 @@ class WrappedMasterServiceConfig {
     std::string snapshot_object_store_type;
     std::string snapshot_catalog_store_type;
     std::string snapshot_catalog_store_connstring;
-    std::string etcd_endpoints = "0.0.0.0:2379";
+    std::string etcd_endpoints = "127.0.0.1:2379";
     uint32_t max_total_finished_tasks = DEFAULT_MAX_TOTAL_FINISHED_TASKS;
     uint32_t max_total_pending_tasks = DEFAULT_MAX_TOTAL_PENDING_TASKS;
     uint32_t max_total_processing_tasks = DEFAULT_MAX_TOTAL_PROCESSING_TASKS;
@@ -769,7 +769,7 @@ class MasterServiceConfig {
     std::string snapshot_object_store_type;
     std::string snapshot_catalog_store_type;
     std::string snapshot_catalog_store_connstring;
-    std::string etcd_endpoints = "0.0.0.0:2379";
+    std::string etcd_endpoints = "127.0.0.1:2379";
     TaskManagerConfig task_manager_config = {
         .max_total_finished_tasks = DEFAULT_MAX_TOTAL_FINISHED_TASKS,
         .max_total_pending_tasks = DEFAULT_MAX_TOTAL_PENDING_TASKS,

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -290,6 +290,7 @@ class WrappedMasterServiceConfig {
     std::string snapshot_object_store_type;
     std::string snapshot_catalog_store_type;
     std::string snapshot_catalog_store_connstring;
+    std::string etcd_endpoints = "0.0.0.0:2379";
     uint32_t max_total_finished_tasks = DEFAULT_MAX_TOTAL_FINISHED_TASKS;
     uint32_t max_total_pending_tasks = DEFAULT_MAX_TOTAL_PENDING_TASKS;
     uint32_t max_total_processing_tasks = DEFAULT_MAX_TOTAL_PROCESSING_TASKS;
@@ -369,6 +370,7 @@ class WrappedMasterServiceConfig {
         snapshot_catalog_store_type = config.snapshot_catalog_store_type;
         snapshot_catalog_store_connstring =
             config.snapshot_catalog_store_connstring;
+        etcd_endpoints = config.etcd_endpoints;
         max_total_finished_tasks = config.max_total_finished_tasks;
         max_total_pending_tasks = config.max_total_pending_tasks;
         max_total_processing_tasks = config.max_total_processing_tasks;
@@ -424,6 +426,7 @@ class WrappedMasterServiceConfig {
         snapshot_catalog_store_type = config.snapshot_catalog_store_type;
         snapshot_catalog_store_connstring =
             config.snapshot_catalog_store_connstring;
+        etcd_endpoints = config.etcd_endpoints;
         max_total_finished_tasks = config.max_total_finished_tasks;
         max_total_pending_tasks = config.max_total_pending_tasks;
         max_total_processing_tasks = config.max_total_processing_tasks;
@@ -476,6 +479,7 @@ class MasterServiceConfigBuilder {
     std::string snapshot_object_store_type_;
     std::string snapshot_catalog_store_type_;
     std::string snapshot_catalog_store_connstring_;
+    std::string etcd_endpoints_ = "0.0.0.0:2379";
     uint32_t max_total_finished_tasks_ = DEFAULT_MAX_TOTAL_FINISHED_TASKS;
     uint32_t max_total_pending_tasks_ = DEFAULT_MAX_TOTAL_PENDING_TASKS;
     uint32_t max_total_processing_tasks_ = DEFAULT_MAX_TOTAL_PROCESSING_TASKS;
@@ -661,6 +665,12 @@ class MasterServiceConfigBuilder {
         return set_snapshot_catalog_store_connstring(connstring);
     }
 
+    MasterServiceConfigBuilder& set_etcd_endpoints(
+        const std::string& endpoints) {
+        etcd_endpoints_ = endpoints;
+        return *this;
+    }
+
     MasterServiceConfigBuilder& set_max_total_finished_tasks(
         uint32_t max_total_finished_tasks) {
         max_total_finished_tasks_ = max_total_finished_tasks;
@@ -759,6 +769,7 @@ class MasterServiceConfig {
     std::string snapshot_object_store_type;
     std::string snapshot_catalog_store_type;
     std::string snapshot_catalog_store_connstring;
+    std::string etcd_endpoints = "0.0.0.0:2379";
     TaskManagerConfig task_manager_config = {
         .max_total_finished_tasks = DEFAULT_MAX_TOTAL_FINISHED_TASKS,
         .max_total_pending_tasks = DEFAULT_MAX_TOTAL_PENDING_TASKS,
@@ -810,6 +821,7 @@ class MasterServiceConfig {
         snapshot_catalog_store_type = config.snapshot_catalog_store_type;
         snapshot_catalog_store_connstring =
             config.snapshot_catalog_store_connstring;
+        etcd_endpoints = config.etcd_endpoints;
 
         task_manager_config.max_total_finished_tasks =
             config.max_total_finished_tasks;
@@ -864,6 +876,7 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     config.snapshot_catalog_store_type = snapshot_catalog_store_type_;
     config.snapshot_catalog_store_connstring =
         snapshot_catalog_store_connstring_;
+    config.etcd_endpoints = etcd_endpoints_;
     config.task_manager_config.max_total_finished_tasks =
         max_total_finished_tasks_;
     config.task_manager_config.max_total_pending_tasks =

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -535,6 +535,14 @@ class MasterService {
         const std::vector<uint8_t>& data, const std::string& path,
         const std::string& local_filename, const std::string& snapshot_id);
 
+    // ETCD backend: child process serializes and writes to socketpair
+    tl::expected<void, SerializationError> PersistStateViaChildSerialize(
+        int socket_fd, const ha::SnapshotDescriptor& descriptor);
+
+    // ETCD backend: parent process reads from socketpair and uploads
+    tl::expected<void, SerializationError> PersistStateViaParentUpload(
+        int socket_fd, const ha::SnapshotDescriptor& descriptor);
+
     std::unique_ptr<ha::SnapshotCatalogStore> CreateSnapshotCatalogStore();
     void CleanupOldSnapshot(int keep_count, const std::string& snapshot_id);
     ha::SnapshotCatalogStore* GetSnapshotCatalogStore();
@@ -1179,6 +1187,9 @@ class MasterService {
     uint64_t snapshot_child_timeout_seconds_ =
         DEFAULT_SNAPSHOT_CHILD_TIMEOUT_SEC;
     uint32_t snapshot_retention_count_ = DEFAULT_SNAPSHOT_RETENTION_COUNT;
+    SnapshotObjectStoreType snapshot_object_store_type_ =
+        SnapshotObjectStoreType::LOCAL_FILE;
+    std::string etcd_endpoints_;
     std::string snapshot_catalog_store_type_{};
     std::string snapshot_catalog_store_connstring_;
     std::unique_ptr<SnapshotObjectStore> snapshot_object_store_;

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -36,6 +36,7 @@ set(MOONCAKE_STORE_SOURCES
     ha/snapshot/object/snapshot_object_store.cpp
     ha/snapshot/object/backends/local/local_file_snapshot_object_store.cpp
     ha/snapshot/object/backends/s3/s3_snapshot_object_store.cpp
+    ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.cpp
     ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store.cpp
     ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.cpp
     utils/type_util.cpp

--- a/mooncake-store/src/ha/snapshot/catalog_backed_snapshot_provider.cpp
+++ b/mooncake-store/src/ha/snapshot/catalog_backed_snapshot_provider.cpp
@@ -297,7 +297,7 @@ class CatalogBackedSnapshotProvider final : public SnapshotProvider {
         auto object_store_type =
             ParseSnapshotObjectStoreType(config.snapshot_object_store_type);
         object_store_ = SnapshotObjectStore::Create(
-            object_store_type, config.etcd_endpoints);
+            {object_store_type, config.etcd_endpoints});
 
         switch (catalog_kind.value()) {
             case SnapshotCatalogBackendKind::kEmbedded:

--- a/mooncake-store/src/ha/snapshot/catalog_backed_snapshot_provider.cpp
+++ b/mooncake-store/src/ha/snapshot/catalog_backed_snapshot_provider.cpp
@@ -296,7 +296,8 @@ class CatalogBackedSnapshotProvider final : public SnapshotProvider {
 
         auto object_store_type =
             ParseSnapshotObjectStoreType(config.snapshot_object_store_type);
-        object_store_ = SnapshotObjectStore::Create(object_store_type);
+        object_store_ = SnapshotObjectStore::Create(
+            object_store_type, config.etcd_endpoints);
 
         switch (catalog_kind.value()) {
             case SnapshotCatalogBackendKind::kEmbedded:

--- a/mooncake-store/src/ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.cpp
+++ b/mooncake-store/src/ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.cpp
@@ -29,6 +29,12 @@ EtcdSnapshotObjectStore::EtcdSnapshotObjectStore(
             "Failed to initialize snapshot etcd client: " + error);
     }
     if (err_msg) free(err_msg);
+
+    LOG(WARNING) << "EtcdSnapshotObjectStore: using etcd as snapshot object "
+                 << "store. Ensure the etcd server is configured with a "
+                 << "sufficiently large --max-request-bytes (recommended "
+                 << ">= 2GB for snapshot payloads). The default etcd limit "
+                 << "is 1.5MB which is too small for most snapshots.";
 }
 
 tl::expected<void, std::string> EtcdSnapshotObjectStore::UploadBuffer(
@@ -141,6 +147,11 @@ tl::expected<void, std::string> EtcdSnapshotObjectStore::ListObjectsWithPrefix(
                 object_keys.emplace_back(keys[i],
                                          static_cast<size_t>(key_sizes[i]));
                 free(keys[i]);
+            } else {
+                LOG(WARNING)
+                    << "EtcdSnapshotObjectStore::ListObjectsWithPrefix: "
+                    << "keys[" << i << "] is nullptr (possible Go-side "
+                    << "allocation failure), prefix=" << prefix;
             }
         }
         free(keys);
@@ -153,7 +164,7 @@ tl::expected<void, std::string> EtcdSnapshotObjectStore::ListObjectsWithPrefix(
 }
 
 bool EtcdSnapshotObjectStore::IsNotFoundError(const std::string& error) const {
-    return error.find("key not found") != std::string::npos;
+    return error.find(kKeyNotFoundSubstring) != std::string::npos;
 }
 
 std::string EtcdSnapshotObjectStore::GetConnectionInfo() const {

--- a/mooncake-store/src/ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.cpp
+++ b/mooncake-store/src/ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.cpp
@@ -1,0 +1,165 @@
+#include "ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.h"
+
+#ifdef STORE_USE_ETCD
+
+#include <cstdlib>
+#include <string>
+
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include "libetcd_wrapper.h"
+
+namespace mooncake {
+
+EtcdSnapshotObjectStore::EtcdSnapshotObjectStore(
+    const std::string& endpoints)
+    : endpoints_(endpoints) {
+    LOG(INFO) << "EtcdSnapshotObjectStore: initializing with endpoints="
+              << endpoints_;
+
+    char* err_msg = nullptr;
+    auto ret = NewSnapshotEtcdClient(
+        const_cast<char*>(endpoints_.c_str()), &err_msg);
+    if (ret != 0 && ret != -2) {  // -2 means already initialized
+        std::string error = err_msg ? err_msg : "unknown error";
+        if (err_msg) free(err_msg);
+        LOG(ERROR) << "Failed to initialize snapshot etcd client: " << error;
+        throw std::runtime_error(
+            "Failed to initialize snapshot etcd client: " + error);
+    }
+    if (err_msg) free(err_msg);
+}
+
+tl::expected<void, std::string> EtcdSnapshotObjectStore::UploadBuffer(
+    const std::string& key, const std::vector<uint8_t>& buffer) {
+    char* err_msg = nullptr;
+    auto ret = SnapshotStorePutWrapper(
+        const_cast<char*>(key.c_str()), static_cast<int>(key.size()),
+        const_cast<char*>(reinterpret_cast<const char*>(buffer.data())),
+        static_cast<int>(buffer.size()), &err_msg);
+
+    if (ret != 0) {
+        std::string error = err_msg ? err_msg : "unknown error";
+        if (err_msg) free(err_msg);
+        return tl::make_unexpected(
+            fmt::format("etcd put failed: key={}, error={}", key, error));
+    }
+
+    VLOG(1) << "EtcdSnapshotObjectStore: uploaded key=" << key
+            << ", size=" << buffer.size();
+    return {};
+}
+
+tl::expected<void, std::string> EtcdSnapshotObjectStore::DownloadBuffer(
+    const std::string& key, std::vector<uint8_t>& buffer) {
+    char* value = nullptr;
+    int value_size = 0;
+    GoInt64 revision_id = 0;
+    char* err_msg = nullptr;
+
+    auto ret = SnapshotStoreGetWrapper(
+        const_cast<char*>(key.c_str()), static_cast<int>(key.size()),
+        &value, &value_size, &revision_id, &err_msg);
+
+    if (ret != 0) {
+        std::string error = err_msg ? err_msg : "unknown error";
+        if (err_msg) free(err_msg);
+        return tl::make_unexpected(
+            fmt::format("etcd get failed: key={}, error={}", key, error));
+    }
+
+    buffer.assign(reinterpret_cast<uint8_t*>(value),
+                  reinterpret_cast<uint8_t*>(value) + value_size);
+    free(value);
+
+    VLOG(1) << "EtcdSnapshotObjectStore: downloaded key=" << key
+            << ", size=" << buffer.size();
+    return {};
+}
+
+tl::expected<void, std::string> EtcdSnapshotObjectStore::UploadString(
+    const std::string& key, const std::string& data) {
+    std::vector<uint8_t> buffer(data.begin(), data.end());
+    return UploadBuffer(key, buffer);
+}
+
+tl::expected<void, std::string> EtcdSnapshotObjectStore::DownloadString(
+    const std::string& key, std::string& data) {
+    std::vector<uint8_t> buffer;
+    auto result = DownloadBuffer(key, buffer);
+    if (!result) {
+        return result;
+    }
+    data.assign(reinterpret_cast<char*>(buffer.data()), buffer.size());
+    return {};
+}
+
+tl::expected<void, std::string> EtcdSnapshotObjectStore::DeleteObjectsWithPrefix(
+    const std::string& prefix) {
+    char* err_msg = nullptr;
+    auto ret = SnapshotStoreDeleteWrapper(
+        const_cast<char*>(prefix.c_str()), static_cast<int>(prefix.size()),
+        1,  // usePrefix = true
+        &err_msg);
+
+    if (ret != 0) {
+        std::string error = err_msg ? err_msg : "unknown error";
+        if (err_msg) free(err_msg);
+        return tl::make_unexpected(fmt::format(
+            "etcd delete prefix failed: prefix={}, error={}", prefix, error));
+    }
+
+    VLOG(1) << "EtcdSnapshotObjectStore: deleted prefix=" << prefix;
+    return {};
+}
+
+tl::expected<void, std::string> EtcdSnapshotObjectStore::ListObjectsWithPrefix(
+    const std::string& prefix, std::vector<std::string>& object_keys) {
+    object_keys.clear();
+
+    char** keys = nullptr;
+    int* key_sizes = nullptr;
+    int count = 0;
+    char* err_msg = nullptr;
+
+    auto ret = SnapshotStoreListKeysWrapper(
+        const_cast<char*>(prefix.c_str()), static_cast<int>(prefix.size()),
+        &keys, &key_sizes, &count, &err_msg);
+
+    if (ret != 0) {
+        std::string error = err_msg ? err_msg : "unknown error";
+        if (err_msg) free(err_msg);
+        return tl::make_unexpected(fmt::format(
+            "etcd list keys failed: prefix={}, error={}", prefix, error));
+    }
+
+    if (count > 0 && keys != nullptr && key_sizes != nullptr) {
+        object_keys.reserve(static_cast<size_t>(count));
+        for (int i = 0; i < count; i++) {
+            if (keys[i] != nullptr) {
+                object_keys.emplace_back(keys[i],
+                                         static_cast<size_t>(key_sizes[i]));
+                free(keys[i]);
+            }
+        }
+        free(keys);
+        free(key_sizes);
+    }
+
+    VLOG(1) << "EtcdSnapshotObjectStore: listed " << object_keys.size()
+            << " keys with prefix=" << prefix;
+    return {};
+}
+
+bool EtcdSnapshotObjectStore::IsNotFoundError(const std::string& error) const {
+    return error.find("key not found") != std::string::npos;
+}
+
+std::string EtcdSnapshotObjectStore::GetConnectionInfo() const {
+    return fmt::format("EtcdSnapshotObjectStore: endpoints={}", endpoints_);
+}
+
+}  // namespace mooncake
+
+#endif  // STORE_USE_ETCD

--- a/mooncake-store/src/ha/snapshot/object/snapshot_object_store.cpp
+++ b/mooncake-store/src/ha/snapshot/object/snapshot_object_store.cpp
@@ -4,12 +4,25 @@
 #ifdef HAVE_AWS_SDK
 #include "ha/snapshot/object/backends/s3/s3_snapshot_object_store.h"
 #endif
+#ifdef STORE_USE_ETCD
+#include "ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.h"
+#endif
 
 namespace mooncake {
 
 std::unique_ptr<SnapshotObjectStore> SnapshotObjectStore::Create(
-    SnapshotObjectStoreType type) {
+    SnapshotObjectStoreType type, const std::string& etcd_endpoints) {
     switch (type) {
+#ifdef STORE_USE_ETCD
+        case SnapshotObjectStoreType::ETCD:
+            return std::make_unique<EtcdSnapshotObjectStore>(etcd_endpoints);
+#else
+        case SnapshotObjectStoreType::ETCD:
+            throw std::runtime_error(
+                "ETCD snapshot object store requested but STORE_USE_ETCD "
+                "is not enabled. Please rebuild with STORE_USE_ETCD or "
+                "use the 'local' object store.");
+#endif
 #ifdef HAVE_AWS_SDK
         case SnapshotObjectStoreType::S3:
             return std::make_unique<S3SnapshotObjectStore>();

--- a/mooncake-store/src/ha/snapshot/object/snapshot_object_store.cpp
+++ b/mooncake-store/src/ha/snapshot/object/snapshot_object_store.cpp
@@ -11,11 +11,11 @@
 namespace mooncake {
 
 std::unique_ptr<SnapshotObjectStore> SnapshotObjectStore::Create(
-    SnapshotObjectStoreType type, const std::string& etcd_endpoints) {
-    switch (type) {
+    const CreateConfig& config) {
+    switch (config.type) {
 #ifdef STORE_USE_ETCD
         case SnapshotObjectStoreType::ETCD:
-            return std::make_unique<EtcdSnapshotObjectStore>(etcd_endpoints);
+            return std::make_unique<EtcdSnapshotObjectStore>(config.etcd_endpoints);
 #else
         case SnapshotObjectStoreType::ETCD:
             throw std::runtime_error(

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -173,7 +173,7 @@ DEFINE_uint32(snapshot_retention_count,
               "automatically deleted)");
 DEFINE_string(snapshot_object_store_type, "",
               "Snapshot object store type: 'local' for local filesystem, "
-              "'s3' for S3 storage");
+              "'s3' for S3 storage, 'etcd' for ETCD storage");
 DEFINE_string(snapshot_payload_store_type, "",
               "Deprecated alias of --snapshot_object_store_type");
 DEFINE_string(snapshot_payload_backend_type, "",

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -27,6 +27,8 @@
 #include "utils/zstd_util.h"
 #include "utils/file_util.h"
 #include "utils.h"
+#include "ha/snapshot/snapshot_socket_util.h"
+#include <sys/socket.h>
 
 namespace mooncake {
 
@@ -103,6 +105,9 @@ MasterService::MasterService(const MasterServiceConfig& config)
       snapshot_interval_seconds_(config.snapshot_interval_seconds),
       snapshot_child_timeout_seconds_(config.snapshot_child_timeout_seconds),
       snapshot_retention_count_(config.snapshot_retention_count),
+      snapshot_object_store_type_(
+          ParseSnapshotObjectStoreType(config.snapshot_object_store_type)),
+      etcd_endpoints_(config.etcd_endpoints),
       snapshot_catalog_store_type_(config.snapshot_catalog_store_type),
       snapshot_catalog_store_connstring_(
           config.snapshot_catalog_store_connstring),
@@ -114,10 +119,8 @@ MasterService::MasterService(const MasterServiceConfig& config)
       enable_cxl_(config.enable_cxl) {
     if (enable_snapshot_ || enable_snapshot_restore_) {
         try {
-            auto object_store_type =
-                ParseSnapshotObjectStoreType(config.snapshot_object_store_type);
-            snapshot_object_store_ =
-                SnapshotObjectStore::Create(object_store_type);
+            snapshot_object_store_ = SnapshotObjectStore::Create(
+                snapshot_object_store_type_, etcd_endpoints_);
             snapshot_catalog_store_ = CreateSnapshotCatalogStore();
         } catch (const std::exception& e) {
             LOG(ERROR) << "Failed to create snapshot stores: " << e.what();
@@ -2418,6 +2421,24 @@ void MasterService::SnapshotThreadFunc() {
             continue;
         }
 
+        auto snapshot_start_time = std::chrono::steady_clock::now();
+
+        // ETCD backend: create socketpair for child→parent data transfer
+        // (child cannot call cgo after fork, so parent uploads instead)
+        bool use_socketpair =
+            (snapshot_object_store_type_ == SnapshotObjectStoreType::ETCD);
+        int sv[2] = {-1, -1};
+        if (use_socketpair) {
+            if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1) {
+                LOG(ERROR)
+                    << "[Snapshot] Failed to create socketpair: "
+                    << strerror(errno) << ", snapshot_id=" << snapshot_id;
+                close(log_pipe[0]);
+                close(log_pipe[1]);
+                continue;
+            }
+        }
+
         pid_t pid;
         {
             std::unique_lock<std::shared_mutex> lock(snapshot_mutex_);
@@ -2432,37 +2453,105 @@ void MasterService::SnapshotThreadFunc() {
                        << strerror(errno) << ", snapshot_id=" << snapshot_id;
             close(log_pipe[0]);
             close(log_pipe[1]);
+            if (use_socketpair) {
+                close(sv[0]);
+                close(sv[1]);
+            }
         } else if (pid == 0) {
             // Child process
             // Close read end, set write end for logging
             close(log_pipe[0]);
             g_snapshot_log_pipe_fd = log_pipe[1];
+            if (use_socketpair) close(sv[0]);  // close parent end
 
-            // Save current state using the configured persistence mechanism
-            SNAP_LOG_INFO("[Snapshot] Child process started, snapshot_id={}",
-                          snapshot_id);
-            auto result = PersistState(descriptor.value());
-            if (!result) {
-                SNAP_LOG_ERROR(
-                    "[Snapshot] Child process failed to persist state, "
-                    "snapshot_id={},code={},msg={}",
-                    snapshot_id, toString(result.error().code),
-                    result.error().message);
+            if (use_socketpair) {
+                // ETCD: serialize and write to socketpair (no cgo calls)
+                SNAP_LOG_INFO(
+                    "[Snapshot] Child process started (ETCD mode), "
+                    "snapshot_id={}",
+                    snapshot_id);
+                auto result =
+                    PersistStateViaChildSerialize(sv[1], descriptor.value());
+                close(sv[1]);
+                if (!result) {
+                    SNAP_LOG_ERROR(
+                        "[Snapshot] Child serialize failed, "
+                        "snapshot_id={},code={},msg={}",
+                        snapshot_id, toString(result.error().code),
+                        result.error().message);
+                    close(log_pipe[1]);
+                    _exit(1);
+                }
+                SNAP_LOG_INFO(
+                    "[Snapshot] Child serialize completed, snapshot_id={}",
+                    snapshot_id);
                 close(log_pipe[1]);
-                _exit(1);  // Exit child process with error
+                _exit(0);
+            } else {
+                // LOCAL/S3: serialize + upload directly (unchanged)
+                SNAP_LOG_INFO(
+                    "[Snapshot] Child process started, snapshot_id={}",
+                    snapshot_id);
+                auto result = PersistState(descriptor.value());
+                if (!result) {
+                    SNAP_LOG_ERROR(
+                        "[Snapshot] Child process failed to persist state, "
+                        "snapshot_id={},code={},msg={}",
+                        snapshot_id, toString(result.error().code),
+                        result.error().message);
+                    close(log_pipe[1]);
+                    _exit(1);
+                }
+                SNAP_LOG_INFO(
+                    "[Snapshot] Child process successfully persisted state, "
+                    "snapshot_id={}",
+                    snapshot_id);
+                close(log_pipe[1]);
+                _exit(0);
             }
-            SNAP_LOG_INFO(
-                "[Snapshot] Child process successfully persisted state, "
-                "snapshot_id={}",
-                snapshot_id);
-
-            close(log_pipe[1]);
-            _exit(0);  // Exit child process successfully
         } else {
             // Parent process
-            // Close write end, pass read end to wait function
             close(log_pipe[1]);
-            WaitForSnapshotChild(pid, snapshot_id, log_pipe[0]);
+            if (use_socketpair) {
+                close(sv[1]);  // close child end
+                // ETCD: parent reads from socketpair and uploads
+                auto result =
+                    PersistStateViaParentUpload(sv[0], descriptor.value());
+                close(sv[0]);
+
+                // Reap child process
+                int status = 0;
+                waitpid(pid, &status, 0);
+
+                auto elapsed =
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - snapshot_start_time)
+                        .count();
+                MasterMetricManager::instance().set_snapshot_duration_ms(
+                    elapsed);
+
+                if (!result) {
+                    LOG(ERROR)
+                        << "[Snapshot] Parent upload failed, snapshot_id="
+                        << snapshot_id
+                        << ", code=" << toString(result.error().code)
+                        << ", msg=" << result.error().message;
+                    MasterMetricManager::instance().inc_snapshot_fail();
+                } else if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+                    LOG(INFO) << "[Snapshot] Snapshot completed successfully, "
+                                 "snapshot_id="
+                              << snapshot_id;
+                    MasterMetricManager::instance().inc_snapshot_success();
+                } else {
+                    LOG(ERROR)
+                        << "[Snapshot] Child process failed, snapshot_id="
+                        << snapshot_id << ", exit_status=" << WEXITSTATUS(status);
+                    MasterMetricManager::instance().inc_snapshot_fail();
+                }
+            } else {
+                // LOCAL/S3: wait for child to finish (unchanged)
+                WaitForSnapshotChild(pid, snapshot_id, log_pipe[0]);
+            }
             close(log_pipe[0]);
         }
     }
@@ -5002,6 +5091,237 @@ MasterService::MetadataSerializer::DeserializeDiscardedReplicas(
         service_->discarded_replicas_ = std::move(temp_list);
     }
 
+    return {};
+}
+
+// ============================================================================
+// ETCD snapshot: socketpair-based child serialize + parent upload
+// ============================================================================
+
+tl::expected<void, SerializationError>
+MasterService::PersistStateViaChildSerialize(
+    int socket_fd, const ha::SnapshotDescriptor& descriptor) {
+    using namespace snapshot_socket;
+
+    const std::string& snapshot_id = descriptor.snapshot_id;
+    const std::string& path_prefix = descriptor.object_prefix;
+
+    // Build manifest content
+    std::string manifest_content =
+        fmt::format("{}|{}|{}", SNAPSHOT_SERIALIZER_TYPE,
+                    SNAPSHOT_SERIALIZER_VERSION, snapshot_id);
+
+    // Define components to serialize one at a time
+    struct Component {
+        std::string key;
+        std::function<tl::expected<std::vector<uint8_t>, SerializationError>()>
+            serialize;
+    };
+
+    std::vector<Component> components = {
+        {path_prefix + SNAPSHOT_METADATA_FILE,
+         [this]() { return MetadataSerializer(this).Serialize(); }},
+        {path_prefix + SNAPSHOT_SEGMENTS_FILE,
+         [this]() { return SegmentSerializer(&segment_manager_).Serialize(); }},
+        {path_prefix + SNAPSHOT_TASK_MANAGER_FILE,
+         [this]() {
+             return TaskManagerSerializer(&task_manager_).Serialize();
+         }},
+        {path_prefix + SNAPSHOT_MANIFEST_FILE,
+         [&]() -> tl::expected<std::vector<uint8_t>, SerializationError> {
+             return std::vector<uint8_t>(manifest_content.begin(),
+                                         manifest_content.end());
+         }},
+    };
+
+    for (auto& comp : components) {
+        // Serialize
+        SNAP_LOG_INFO("[Snapshot] Serializing {}, snapshot_id={}", comp.key,
+                      snapshot_id);
+        auto data = comp.serialize();
+        if (!data) {
+            SNAP_LOG_ERROR(
+                "[Snapshot] Serialization failed for {}, snapshot_id={}, "
+                "code={}, msg={}",
+                comp.key, snapshot_id, toString(data.error().code),
+                data.error().message);
+            // Send end marker so parent knows we're done
+            uint32_t zero = 0;
+            WriteExact(socket_fd, &zero, sizeof(zero));
+            return tl::make_unexpected(data.error());
+        }
+
+        // Write: [key_len:4][key][data_len:8][data]
+        uint32_t key_len = static_cast<uint32_t>(comp.key.size());
+        uint64_t data_len = data->size();
+        if (!WriteExact(socket_fd, &key_len, sizeof(key_len)) ||
+            !WriteExact(socket_fd, comp.key.data(), key_len) ||
+            !WriteExact(socket_fd, &data_len, sizeof(data_len)) ||
+            (data_len > 0 &&
+             !WriteExact(socket_fd, data->data(), data_len))) {
+            SNAP_LOG_ERROR(
+                "[Snapshot] Failed to write to socketpair, key={}, "
+                "snapshot_id={}",
+                comp.key, snapshot_id);
+            return tl::make_unexpected(SerializationError(
+                ErrorCode::PERSISTENT_FAIL, "socketpair write failed"));
+        }
+
+        SNAP_LOG_INFO("[Snapshot] Sent to parent: key={}, size={}", comp.key,
+                      data_len);
+
+        // Free buffer before waiting for ack
+        data->clear();
+        data->shrink_to_fit();
+
+        // Wait for parent ack
+        uint8_t ack = 0;
+        if (!ReadExact(socket_fd, &ack, sizeof(ack))) {
+            SNAP_LOG_ERROR(
+                "[Snapshot] Failed to read ack from parent, key={}, "
+                "snapshot_id={}",
+                comp.key, snapshot_id);
+            return tl::make_unexpected(SerializationError(
+                ErrorCode::PERSISTENT_FAIL, "socketpair ack read failed"));
+        }
+        if (ack != 0) {
+            SNAP_LOG_ERROR(
+                "[Snapshot] Parent upload failed (ack={}), key={}, "
+                "snapshot_id={}",
+                ack, comp.key, snapshot_id);
+            return tl::make_unexpected(SerializationError(
+                ErrorCode::PERSISTENT_FAIL, "parent upload failed"));
+        }
+    }
+
+    // Send end marker: key_len = 0
+    uint32_t zero = 0;
+    WriteExact(socket_fd, &zero, sizeof(zero));
+
+    SNAP_LOG_INFO("[Snapshot] Child serialize completed, snapshot_id={}",
+                  snapshot_id);
+    return {};
+}
+
+tl::expected<void, SerializationError>
+MasterService::PersistStateViaParentUpload(
+    int socket_fd, const ha::SnapshotDescriptor& descriptor) {
+    using namespace snapshot_socket;
+
+    const std::string& snapshot_id = descriptor.snapshot_id;
+    bool all_success = true;
+    std::string error_msg;
+
+    LOG(INFO) << "[Snapshot] Parent upload started (ETCD mode), snapshot_id="
+              << snapshot_id << ", backend="
+              << snapshot_object_store_->GetConnectionInfo();
+
+    while (true) {
+        // Read key_len
+        uint32_t key_len = 0;
+        if (!ReadExact(socket_fd, &key_len, sizeof(key_len))) {
+            // Child closed connection or crashed
+            break;
+        }
+        if (key_len == 0) {
+            // End marker
+            break;
+        }
+
+        // Read key
+        std::string key(key_len, '\0');
+        if (!ReadExact(socket_fd, key.data(), key_len)) {
+            error_msg = "failed to read key from socketpair";
+            all_success = false;
+            break;
+        }
+
+        // Read data_len + data
+        uint64_t data_len = 0;
+        if (!ReadExact(socket_fd, &data_len, sizeof(data_len))) {
+            error_msg = "failed to read data_len from socketpair";
+            all_success = false;
+            break;
+        }
+        std::vector<uint8_t> data(data_len);
+        if (data_len > 0 && !ReadExact(socket_fd, data.data(), data_len)) {
+            error_msg = "failed to read data from socketpair";
+            all_success = false;
+            break;
+        }
+
+        // Upload to etcd via object store (cgo, safe in parent)
+        LOG(INFO) << "[Snapshot] Uploading key=" << key
+                  << ", size=" << data_len << ", snapshot_id=" << snapshot_id;
+        auto upload_result = snapshot_object_store_->UploadBuffer(key, data);
+
+        uint8_t ack = 0;
+        if (!upload_result) {
+            LOG(ERROR) << "[Snapshot] Upload failed: key=" << key
+                       << ", error=" << upload_result.error()
+                       << ", snapshot_id=" << snapshot_id;
+
+            // backup_dir fallback (same behavior as local/S3)
+            if (use_snapshot_backup_dir_) {
+                // Extract local filename from key (last path component)
+                auto slash_pos = key.rfind('/');
+                std::string local_filename =
+                    (slash_pos != std::string::npos)
+                        ? key.substr(slash_pos + 1)
+                        : key;
+                auto save_path = fs::path(snapshot_backup_dir_) /
+                                 SNAPSHOT_BACKUP_SAVE_DIR / local_filename;
+                auto save_result = FileUtil::SaveBinaryToFile(data, save_path);
+                if (!save_result) {
+                    LOG(ERROR) << "[Snapshot] Save to backup_dir failed: "
+                               << save_path;
+                }
+                error_msg.append(upload_result.error() + "\n");
+                all_success = false;
+                ack = 1;
+            } else {
+                // fail-fast: notify child and stop
+                ack = 1;
+                WriteExact(socket_fd, &ack, sizeof(ack));
+                return tl::make_unexpected(SerializationError(
+                    ErrorCode::PERSISTENT_FAIL, upload_result.error()));
+            }
+        }
+
+        // Send ack to child
+        if (!WriteExact(socket_fd, &ack, sizeof(ack))) {
+            error_msg = "failed to write ack to socketpair";
+            all_success = false;
+            break;
+        }
+
+        LOG(INFO) << "[Snapshot] Upload completed: key=" << key
+                  << ", snapshot_id=" << snapshot_id;
+    }
+
+    if (!all_success) {
+        return tl::make_unexpected(
+            SerializationError(ErrorCode::PERSISTENT_FAIL,
+                               error_msg.empty() ? "upload failed" : error_msg));
+    }
+
+    // Publish to catalog store and cleanup (parent process, cgo safe)
+    auto* snapshot_catalog_store = GetSnapshotCatalogStore();
+    if (snapshot_catalog_store) {
+        auto publish_result = snapshot_catalog_store->Publish(descriptor);
+        if (publish_result != ErrorCode::OK) {
+            LOG(ERROR) << "[Snapshot] Catalog publish failed, snapshot_id="
+                       << snapshot_id
+                       << ", code=" << toString(publish_result);
+            return tl::make_unexpected(SerializationError(
+                ErrorCode::PERSISTENT_FAIL, "catalog publish failed"));
+        }
+    }
+
+    CleanupOldSnapshot(snapshot_retention_count_, snapshot_id);
+
+    LOG(INFO) << "[Snapshot] Parent upload completed, snapshot_id="
+              << snapshot_id;
     return {};
 }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -29,6 +29,7 @@
 #include "utils.h"
 #include "ha/snapshot/snapshot_socket_util.h"
 #include <sys/socket.h>
+#include <thread>
 
 namespace mooncake {
 
@@ -120,7 +121,7 @@ MasterService::MasterService(const MasterServiceConfig& config)
     if (enable_snapshot_ || enable_snapshot_restore_) {
         try {
             snapshot_object_store_ = SnapshotObjectStore::Create(
-                snapshot_object_store_type_, etcd_endpoints_);
+                {snapshot_object_store_type_, etcd_endpoints_});
             snapshot_catalog_store_ = CreateSnapshotCatalogStore();
         } catch (const std::exception& e) {
             LOG(ERROR) << "Failed to create snapshot stores: " << e.what();
@@ -2514,6 +2515,20 @@ void MasterService::SnapshotThreadFunc() {
             close(log_pipe[1]);
             if (use_socketpair) {
                 close(sv[1]);  // close child end
+
+                // Drain child log pipe in a background thread to prevent
+                // the child from blocking when the pipe buffer fills up.
+                std::thread log_reader(
+                    [log_fd = log_pipe[0]]() {
+                        char buf[4096];
+                        while (true) {
+                            ssize_t n = ::read(log_fd, buf, sizeof(buf) - 1);
+                            if (n <= 0) break;
+                            buf[n] = '\0';
+                            LOG(INFO) << "[Snapshot-Child] " << buf;
+                        }
+                    });
+
                 // ETCD: parent reads from socketpair and uploads
                 auto result =
                     PersistStateViaParentUpload(sv[0], descriptor.value());
@@ -2522,6 +2537,9 @@ void MasterService::SnapshotThreadFunc() {
                 // Reap child process
                 int status = 0;
                 waitpid(pid, &status, 0);
+
+                // Child exited → pipe EOF → log_reader will finish
+                log_reader.join();
 
                 auto elapsed =
                     std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -5212,8 +5230,19 @@ MasterService::PersistStateViaParentUpload(
     bool all_success = true;
     std::string error_msg;
 
+    // Set socket receive timeout to match snapshot_child_timeout_seconds_,
+    // so ReadExact won't block indefinitely if the child hangs.
+    struct timeval tv;
+    tv.tv_sec = static_cast<time_t>(snapshot_child_timeout_seconds_);
+    tv.tv_usec = 0;
+    if (setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) != 0) {
+        LOG(WARNING) << "[Snapshot] Failed to set SO_RCVTIMEO on socketpair: "
+                     << strerror(errno);
+    }
+
     LOG(INFO) << "[Snapshot] Parent upload started (ETCD mode), snapshot_id="
-              << snapshot_id << ", backend="
+              << snapshot_id << ", timeout=" << snapshot_child_timeout_seconds_
+              << "s, backend="
               << snapshot_object_store_->GetConnectionInfo();
 
     while (true) {
@@ -5273,12 +5302,20 @@ MasterService::PersistStateViaParentUpload(
                                  SNAPSHOT_BACKUP_SAVE_DIR / local_filename;
                 auto save_result = FileUtil::SaveBinaryToFile(data, save_path);
                 if (!save_result) {
-                    LOG(ERROR) << "[Snapshot] Save to backup_dir failed: "
+                    LOG(ERROR) << "[Snapshot] Save to backup_dir also failed: "
                                << save_path;
+                    // Both upload and backup failed — abort
+                    ack = 1;
+                    WriteExact(socket_fd, &ack, sizeof(ack));
+                    return tl::make_unexpected(SerializationError(
+                        ErrorCode::PERSISTENT_FAIL,
+                        "upload and backup save both failed for key: " +
+                            key));
                 }
+                // Backup saved successfully — keep child alive to receive
+                // remaining components (ack stays 0).
                 error_msg.append(upload_result.error() + "\n");
                 all_success = false;
-                ack = 1;
             } else {
                 // fail-fast: notify child and stop
                 ack = 1;

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -63,6 +63,8 @@ add_store_test(embedded_snapshot_catalog_store_test
 add_store_test(zstd_util_test zstd_util_test.cpp)
 add_store_test(local_file_snapshot_object_store_test
                ha/snapshot/object/backends/local/local_file_snapshot_object_store_test.cpp)
+add_store_test(snapshot_socket_util_test
+               ha/snapshot/snapshot_socket_util_test.cpp)
 add_store_test(file_util_test file_util_test.cpp)
 add_store_test(snapshot_child_process_test
                ha/snapshot/snapshot_child_process_test.cpp)
@@ -147,4 +149,9 @@ if(STORE_USE_REDIS)
     target_link_libraries(${target}
                           PRIVATE ${MOONCAKE_STORE_HIREDIS_LIBRARY})
   endforeach()
+endif()
+
+if(STORE_USE_ETCD)
+  add_ha_test(etcd_snapshot_object_store_test
+              ha/snapshot/object/backends/etcd/etcd_snapshot_object_store_test.cpp)
 endif()

--- a/mooncake-store/tests/ha/snapshot/catalog_backed_snapshot_provider_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/catalog_backed_snapshot_provider_test.cpp
@@ -10,13 +10,14 @@
 
 #include "ha/snapshot/catalog/snapshot_catalog_store.h"
 #include "ha/snapshot/catalog_backed_snapshot_provider.h"
-#include "ha/snapshot/object/backends/local/local_file_snapshot_object_store.h"
 #include "ha/snapshot/snapshot_test_utils.h"
 
 namespace mooncake::test {
 
 DEFINE_string(redis_endpoint, "",
               "Redis endpoint for catalog-backed snapshot provider tests");
+DEFINE_string(etcd_endpoints, "",
+              "etcd endpoints for catalog-backed snapshot provider tests");
 
 namespace {
 
@@ -29,6 +30,9 @@ class CatalogBackedSnapshotProviderTest
         if (GetParam().requires_redis && FLAGS_redis_endpoint.empty()) {
             GTEST_SKIP() << "Redis endpoint is not configured";
         }
+        if (GetParam().requires_etcd && FLAGS_etcd_endpoints.empty()) {
+            GTEST_SKIP() << "etcd endpoint is not configured";
+        }
 
         cluster_id_ = "snapshot-provider-test-" + UuidToString(generate_uuid());
         temp_dir_ =
@@ -36,8 +40,17 @@ class CatalogBackedSnapshotProviderTest
         local_path_env_ =
             std::make_unique<ScopedEnvVar>(kSnapshotLocalPathEnv, temp_dir_);
 
-        object_store_ =
-            std::make_unique<LocalFileSnapshotObjectStore>(temp_dir_);
+        object_store_ = CreateObjectStoreForTest(
+            GetParam(), temp_dir_, FLAGS_etcd_endpoints);
+        ASSERT_NE(object_store_, nullptr);
+
+        // Etcd is shared state — clean up any leftover snapshot keys from
+        // previous runs so each test starts with an empty catalog.
+        if (GetParam().requires_etcd) {
+            (void)object_store_->DeleteObjectsWithPrefix(
+                "mooncake_master_snapshot/");
+        }
+
         catalog_store_ = CreateCatalogStoreForTest(
             GetParam(), object_store_.get(), cluster_id_, FLAGS_redis_endpoint);
         ASSERT_NE(catalog_store_, nullptr);
@@ -48,6 +61,10 @@ class CatalogBackedSnapshotProviderTest
     void TearDown() override {
         if (snapshot_published_ && catalog_store_ != nullptr) {
             (void)catalog_store_->Delete(descriptor_.snapshot_id);
+        }
+        if (GetParam().requires_etcd && object_store_) {
+            (void)object_store_->DeleteObjectsWithPrefix(
+                "mooncake_master_snapshot/");
         }
         catalog_store_.reset();
         object_store_.reset();
@@ -67,7 +84,8 @@ class CatalogBackedSnapshotProviderTest
     tl::expected<std::unique_ptr<SnapshotProvider>, ErrorCode> CreateProvider()
         const {
         return CreateCatalogBackedSnapshotProvider(MakeSnapshotProviderConfig(
-            GetParam(), cluster_id_, FLAGS_redis_endpoint));
+            GetParam(), cluster_id_, FLAGS_redis_endpoint,
+            FLAGS_etcd_endpoints));
     }
 
     std::string cluster_id_;
@@ -75,7 +93,7 @@ class CatalogBackedSnapshotProviderTest
     bool snapshot_published_{false};
     ha::SnapshotDescriptor descriptor_;
     std::unique_ptr<ScopedEnvVar> local_path_env_;
-    std::unique_ptr<LocalFileSnapshotObjectStore> object_store_;
+    std::unique_ptr<SnapshotObjectStore> object_store_;
     std::unique_ptr<ha::SnapshotCatalogStore> catalog_store_;
 };
 

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
@@ -794,7 +794,7 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
         // validation.
         if (!service_->snapshot_object_store_) {
             service_->snapshot_object_store_ = SnapshotObjectStore::Create(
-                SnapshotObjectStoreType::LOCAL_FILE);
+                {SnapshotObjectStoreType::LOCAL_FILE});
         }
         if (!service_->snapshot_catalog_store_ &&
             service_->snapshot_object_store_) {

--- a/mooncake-store/tests/ha/snapshot/object/backends/etcd/etcd_snapshot_object_store_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/object/backends/etcd/etcd_snapshot_object_store_test.cpp
@@ -1,0 +1,180 @@
+#ifdef STORE_USE_ETCD
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.h"
+
+DEFINE_string(etcd_endpoints, "127.0.0.1:2379",
+              "etcd endpoints for snapshot object store test");
+
+namespace mooncake::test {
+
+class EtcdSnapshotObjectStoreTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        // Build a unique key prefix per test to avoid collisions.
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        key_prefix_ = std::string("snapshot_obj_test/") +
+                       std::to_string(getpid()) + "_" +
+                       info->test_case_name() + "_" + info->name() + "/";
+
+        backend_ = std::make_unique<EtcdSnapshotObjectStore>(
+            FLAGS_etcd_endpoints);
+    }
+
+    void TearDown() override {
+        if (backend_) {
+            (void)backend_->DeleteObjectsWithPrefix(key_prefix_);
+        }
+        backend_.reset();
+    }
+
+    /// Return a full key by prepending the per-test prefix.
+    std::string key(const std::string& suffix) const {
+        return key_prefix_ + suffix;
+    }
+
+    std::unique_ptr<EtcdSnapshotObjectStore> backend_;
+    std::string key_prefix_;
+};
+
+// ========== Normal Functionality ==========
+
+TEST_F(EtcdSnapshotObjectStoreTest, UploadDownloadBuffer_Roundtrip) {
+    std::vector<uint8_t> data = {0, 1, 2, 128, 254, 255};
+    auto upload = backend_->UploadBuffer(key("buf"), data);
+    ASSERT_TRUE(upload.has_value()) << upload.error();
+
+    std::vector<uint8_t> downloaded;
+    auto download = backend_->DownloadBuffer(key("buf"), downloaded);
+    ASSERT_TRUE(download.has_value()) << download.error();
+    EXPECT_EQ(downloaded, data);
+}
+
+TEST_F(EtcdSnapshotObjectStoreTest, UploadDownloadString_Roundtrip) {
+    std::string data = "hello mooncake etcd snapshot";
+    auto upload = backend_->UploadString(key("str"), data);
+    ASSERT_TRUE(upload.has_value()) << upload.error();
+
+    std::string downloaded;
+    auto download = backend_->DownloadString(key("str"), downloaded);
+    ASSERT_TRUE(download.has_value()) << download.error();
+    EXPECT_EQ(downloaded, data);
+}
+
+TEST_F(EtcdSnapshotObjectStoreTest, ListObjectsWithPrefix) {
+    backend_->UploadString(key("snap/20240101/metadata"), "m");
+    backend_->UploadString(key("snap/20240101/segments"), "s");
+    backend_->UploadString(key("snap/20240102/metadata"), "m2");
+
+    std::vector<std::string> keys;
+    auto result = backend_->ListObjectsWithPrefix(key("snap/20240101/"), keys);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(keys.size(), 2u);
+
+    // Broader prefix should list all three.
+    keys.clear();
+    result = backend_->ListObjectsWithPrefix(key("snap/"), keys);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(keys.size(), 3u);
+}
+
+TEST_F(EtcdSnapshotObjectStoreTest, DeleteObjectsWithPrefix) {
+    backend_->UploadString(key("snap/20240101/metadata"), "m");
+    backend_->UploadString(key("snap/20240101/segments"), "s");
+
+    auto del = backend_->DeleteObjectsWithPrefix(key("snap/20240101/"));
+    ASSERT_TRUE(del.has_value()) << del.error();
+
+    // Verify keys are gone.
+    std::string data;
+    auto dl = backend_->DownloadString(key("snap/20240101/metadata"), data);
+    EXPECT_FALSE(dl.has_value());
+}
+
+TEST_F(EtcdSnapshotObjectStoreTest, GetConnectionInfo) {
+    auto info = backend_->GetConnectionInfo();
+    EXPECT_NE(info.find(FLAGS_etcd_endpoints), std::string::npos);
+}
+
+TEST_F(EtcdSnapshotObjectStoreTest, UploadBuffer_LargePayload) {
+    // 1 MB payload — exercises chunked transfer and memory management.
+    constexpr size_t kSize = 1024 * 1024;
+    std::vector<uint8_t> data(kSize);
+    std::iota(data.begin(), data.end(), uint8_t{0});
+
+    auto upload = backend_->UploadBuffer(key("large"), data);
+    ASSERT_TRUE(upload.has_value()) << upload.error();
+
+    std::vector<uint8_t> downloaded;
+    auto download = backend_->DownloadBuffer(key("large"), downloaded);
+    ASSERT_TRUE(download.has_value()) << download.error();
+    EXPECT_EQ(downloaded, data);
+}
+
+// ========== Error Handling ==========
+
+TEST_F(EtcdSnapshotObjectStoreTest, DownloadBuffer_NonExistentKey) {
+    std::vector<uint8_t> buf;
+    auto result = backend_->DownloadBuffer(key("no/such/key"), buf);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(EtcdSnapshotObjectStoreTest, DownloadString_NonExistentKey) {
+    std::string data;
+    auto result = backend_->DownloadString(key("no/such/key"), data);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(EtcdSnapshotObjectStoreTest, IsNotFoundError) {
+    // The implementation checks for "key not found" substring.
+    EXPECT_TRUE(backend_->IsNotFoundError("etcd: key not found"));
+    EXPECT_TRUE(backend_->IsNotFoundError("key not found"));
+    EXPECT_FALSE(backend_->IsNotFoundError("connection refused"));
+    EXPECT_FALSE(backend_->IsNotFoundError(""));
+}
+
+TEST_F(EtcdSnapshotObjectStoreTest, UploadBuffer_EmptyBuffer) {
+    std::vector<uint8_t> empty;
+    auto result = backend_->UploadBuffer(key("empty"), empty);
+    // etcd allows storing empty values — verify roundtrip.
+    ASSERT_TRUE(result.has_value()) << result.error();
+
+    std::vector<uint8_t> downloaded;
+    auto dl = backend_->DownloadBuffer(key("empty"), downloaded);
+    ASSERT_TRUE(dl.has_value()) << dl.error();
+    EXPECT_TRUE(downloaded.empty());
+}
+
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+    google::InitGoogleLogging(argv[0]);
+    FLAGS_logtostderr = true;
+    return RUN_ALL_TESTS();
+}
+
+#else  // !STORE_USE_ETCD
+
+#include <gtest/gtest.h>
+
+TEST(EtcdSnapshotObjectStoreTest, Skipped) {
+    GTEST_SKIP() << "STORE_USE_ETCD is not enabled";
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+#endif  // STORE_USE_ETCD

--- a/mooncake-store/tests/ha/snapshot/snapshot_socket_util_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_socket_util_test.cpp
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+
+#include <csignal>
+#include <cstdint>
+#include <cstring>
+#include <numeric>
+#include <thread>
+#include <vector>
+
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "ha/snapshot/snapshot_socket_util.h"
+
+namespace mooncake::test {
+
+class SnapshotSocketUtilTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        // Suppress SIGPIPE so that writing to a closed socket returns an error
+        // instead of killing the process.
+        signal(SIGPIPE, SIG_IGN);
+
+        ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv_), 0)
+            << "Failed to create socketpair: " << strerror(errno);
+    }
+
+    void TearDown() override {
+        if (sv_[0] >= 0) close(sv_[0]);
+        if (sv_[1] >= 0) close(sv_[1]);
+    }
+
+    // sv_[0] and sv_[1] are the two ends of the socketpair.
+    int sv_[2] = {-1, -1};
+};
+
+TEST_F(SnapshotSocketUtilTest, ReadWriteExact_Roundtrip) {
+    const std::vector<uint8_t> data = {0, 1, 2, 42, 128, 254, 255};
+
+    ASSERT_TRUE(snapshot_socket::WriteExact(sv_[0], data.data(), data.size()));
+
+    std::vector<uint8_t> buf(data.size());
+    ASSERT_TRUE(snapshot_socket::ReadExact(sv_[1], buf.data(), buf.size()));
+    EXPECT_EQ(buf, data);
+}
+
+TEST_F(SnapshotSocketUtilTest, ReadWriteExact_LargeBuffer) {
+    // 4 MB — much larger than the kernel socket buffer (~200 KB), which forces
+    // partial reads/writes internally.
+    constexpr size_t kSize = 4 * 1024 * 1024;
+    std::vector<uint8_t> data(kSize);
+    std::iota(data.begin(), data.end(), uint8_t{0});
+
+    // Writer must run in a separate thread because the socket buffer will fill
+    // up and block before all bytes are written.
+    std::thread writer([&] {
+        EXPECT_TRUE(snapshot_socket::WriteExact(sv_[0], data.data(), data.size()));
+    });
+
+    std::vector<uint8_t> buf(kSize);
+    ASSERT_TRUE(snapshot_socket::ReadExact(sv_[1], buf.data(), buf.size()));
+    EXPECT_EQ(buf, data);
+
+    writer.join();
+}
+
+TEST_F(SnapshotSocketUtilTest, ReadExact_PeerClose_ReturnsFalse) {
+    // Close the write end, then try to read — should return false (EOF).
+    close(sv_[0]);
+    sv_[0] = -1;
+
+    uint8_t buf[16];
+    EXPECT_FALSE(snapshot_socket::ReadExact(sv_[1], buf, sizeof(buf)));
+}
+
+TEST_F(SnapshotSocketUtilTest, WriteExact_ClosedFd_ReturnsFalse) {
+    // Close the read end, then try to write — should return false (EPIPE).
+    close(sv_[1]);
+    sv_[1] = -1;
+
+    const uint8_t data[16] = {};
+    EXPECT_FALSE(snapshot_socket::WriteExact(sv_[0], data, sizeof(data)));
+}
+
+TEST_F(SnapshotSocketUtilTest, ReadWriteExact_ZeroLength) {
+    // Zero-length operations should succeed immediately without touching the
+    // socket.
+    EXPECT_TRUE(snapshot_socket::ReadExact(sv_[0], nullptr, 0));
+    EXPECT_TRUE(snapshot_socket::WriteExact(sv_[1], nullptr, 0));
+}
+
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-store/tests/ha/snapshot/snapshot_test_utils.h
+++ b/mooncake-store/tests/ha/snapshot/snapshot_test_utils.h
@@ -16,6 +16,10 @@
 #include "ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.h"
 #include "ha/snapshot/catalog/snapshot_catalog_store.h"
 #include "ha/snapshot/object/snapshot_object_store.h"
+#include "ha/snapshot/object/backends/local/local_file_snapshot_object_store.h"
+#ifdef STORE_USE_ETCD
+#include "ha/snapshot/object/backends/etcd/etcd_snapshot_object_store.h"
+#endif
 #include "master_config.h"
 #include "replica.h"
 #include "segment.h"
@@ -41,7 +45,9 @@ constexpr int64_t kDefaultTestCreatedAtMs = 1700000000000LL;
 struct CatalogBackendParam {
     std::string name;
     std::string catalog_store_type;
+    std::string object_store_type{"local"};
     bool requires_redis{false};
+    bool requires_etcd{false};
 };
 
 class ScopedEnvVar {
@@ -83,6 +89,14 @@ inline std::vector<CatalogBackendParam> BuildCatalogBackendParams() {
         .name = "Redis",
         .catalog_store_type = "redis",
         .requires_redis = true,
+    });
+#endif
+#ifdef STORE_USE_ETCD
+    params.push_back(CatalogBackendParam{
+        .name = "EtcdEmbedded",
+        .catalog_store_type = "embedded",
+        .object_store_type = "etcd",
+        .requires_etcd = true,
     });
 #endif
     return params;
@@ -184,16 +198,37 @@ inline ha::SnapshotDescriptor MakeTestSnapshotDescriptor(
 
 inline MasterServiceSupervisorConfig MakeSnapshotProviderConfig(
     const CatalogBackendParam& param, const std::string& cluster_id,
-    const std::string& redis_endpoint) {
+    const std::string& redis_endpoint,
+    const std::string& etcd_endpoints = "") {
     MasterServiceSupervisorConfig config;
     config.cluster_id = cluster_id;
-    config.snapshot_object_store_type = "local";
+    config.snapshot_object_store_type = param.object_store_type;
     config.snapshot_catalog_store_type = param.catalog_store_type;
     if (param.requires_redis) {
         config.snapshot_catalog_store_connstring = redis_endpoint;
         config.ha_backend_connstring = redis_endpoint;
     }
+    if (param.requires_etcd && !etcd_endpoints.empty()) {
+        config.etcd_endpoints = etcd_endpoints;
+        config.ha_backend_connstring = etcd_endpoints;
+    }
     return config;
+}
+
+/// Create a SnapshotObjectStore matching the param's object_store_type.
+/// For "local", uses @p local_dir as root.  For "etcd", uses @p etcd_endpoints.
+inline std::unique_ptr<SnapshotObjectStore> CreateObjectStoreForTest(
+    const CatalogBackendParam& param, const std::string& local_dir,
+    const std::string& etcd_endpoints = "") {
+    if (param.object_store_type == "etcd") {
+#ifdef STORE_USE_ETCD
+        return std::make_unique<EtcdSnapshotObjectStore>(etcd_endpoints);
+#else
+        (void)etcd_endpoints;
+        return nullptr;
+#endif
+    }
+    return std::make_unique<LocalFileSnapshotObjectStore>(local_dir);
 }
 
 inline std::unique_ptr<ha::SnapshotCatalogStore> CreateCatalogStoreForTest(

--- a/mooncake-store/tests/ha/standby/hot_standby_snapshot_bootstrap_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_snapshot_bootstrap_test.cpp
@@ -12,13 +12,14 @@
 #include "ha/standby_controller.h"
 #include "ha/snapshot/catalog/snapshot_catalog_store.h"
 #include "ha/snapshot/catalog_backed_snapshot_provider.h"
-#include "ha/snapshot/object/backends/local/local_file_snapshot_object_store.h"
 #include "ha/snapshot/snapshot_test_utils.h"
 
 namespace mooncake::test {
 
 DEFINE_string(redis_endpoint, "",
               "Redis endpoint for HotStandby snapshot bootstrap tests");
+DEFINE_string(etcd_endpoints, "",
+              "etcd endpoints for HotStandby snapshot bootstrap tests");
 
 namespace {
 
@@ -34,6 +35,9 @@ class HotStandbySnapshotBootstrapTest
         if (GetParam().requires_redis && FLAGS_redis_endpoint.empty()) {
             GTEST_SKIP() << "Redis endpoint is not configured";
         }
+        if (GetParam().requires_etcd && FLAGS_etcd_endpoints.empty()) {
+            GTEST_SKIP() << "etcd endpoint is not configured";
+        }
 
         cluster_id_ =
             "hot-standby-bootstrap-test-" + UuidToString(generate_uuid());
@@ -41,8 +45,15 @@ class HotStandbySnapshotBootstrapTest
         local_path_env_ =
             std::make_unique<ScopedEnvVar>(kSnapshotLocalPathEnv, temp_dir_);
 
-        object_store_ =
-            std::make_unique<LocalFileSnapshotObjectStore>(temp_dir_);
+        object_store_ = CreateObjectStoreForTest(
+            GetParam(), temp_dir_, FLAGS_etcd_endpoints);
+        ASSERT_NE(object_store_, nullptr);
+
+        if (GetParam().requires_etcd) {
+            (void)object_store_->DeleteObjectsWithPrefix(
+                "mooncake_master_snapshot/");
+        }
+
         catalog_store_ = CreateCatalogStoreForTest(
             GetParam(), object_store_.get(), cluster_id_, FLAGS_redis_endpoint);
         ASSERT_NE(catalog_store_, nullptr);
@@ -53,6 +64,10 @@ class HotStandbySnapshotBootstrapTest
     void TearDown() override {
         if (snapshot_published_ && catalog_store_ != nullptr) {
             (void)catalog_store_->Delete(descriptor_.snapshot_id);
+        }
+        if (GetParam().requires_etcd && object_store_) {
+            (void)object_store_->DeleteObjectsWithPrefix(
+                "mooncake_master_snapshot/");
         }
         catalog_store_.reset();
         object_store_.reset();
@@ -74,7 +89,8 @@ class HotStandbySnapshotBootstrapTest
     tl::expected<std::unique_ptr<SnapshotProvider>, ErrorCode> CreateProvider()
         const {
         return CreateCatalogBackedSnapshotProvider(MakeSnapshotProviderConfig(
-            GetParam(), cluster_id_, FLAGS_redis_endpoint));
+            GetParam(), cluster_id_, FLAGS_redis_endpoint,
+            FLAGS_etcd_endpoints));
     }
 
     void PublishSnapshot() {
@@ -89,7 +105,7 @@ class HotStandbySnapshotBootstrapTest
     bool snapshot_published_{false};
     ha::SnapshotDescriptor descriptor_;
     std::unique_ptr<ScopedEnvVar> local_path_env_;
-    std::unique_ptr<LocalFileSnapshotObjectStore> object_store_;
+    std::unique_ptr<SnapshotObjectStore> object_store_;
     std::unique_ptr<ha::SnapshotCatalogStore> catalog_store_;
 };
 


### PR DESCRIPTION
## Description

Add ETCD as a snapshot object store backend, enabling master state snapshots to be persisted directly to the etcd cluster already used for HA coordination — no additional storage infrastructure required.

### Key design decisions
1. socketpair-based IPC: Using socketpair() between the forked child (serialization) and parent process (upload). This solves the core problem: the Go runtime (cgo) cannot be called from a fork()-ed child process.

2. Reuse EmbeddedSnapshotCatalogStore: Instead of creating a dedicated EtcdSnapshotCatalogStore, the embedded catalog stores its index data (latest.txt, descriptor.txt) as regular keys via the SnapshotObjectStore interface. With EtcdSnapshotObjectStore, these keys are automatically stored in etcd.

3. Per-component ack for memory control: The child serializes and sends one component at a time (metadata → segments → task_manager → manifest), waiting for the parent's ack before proceeding to the next. This keeps peak memory to max(single component size) in both processes.

Architecture: ETCD vs Local/S3

  | Local / S3 | ETCD
-- | -- | --
Child process | serialize + upload | serialize only → write to socketpair
Parent process | waitpid (passive) | read socketpair → upload via cgo → publish catalog
Why | Child can call object store directly | Child cannot call cgo after fork (Go runtime corrupted)
Restore | Same for all backends — main process calls SnapshotObjectStore::DownloadBuffer() |  


## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [ ] Transfer Engine
    - [x] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

1. Unit tests: etcd_snapshot_object_store_test (10 cases), snapshot_socket_util_test
2. E2E: persist → SIGKILL → restore → metadata intact → surviving client get() data byte-for-byte match

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
