### PR TITLE
[TE]fix: correct RDMA device path mapping

### DIFF
--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -44,8 +44,8 @@ static bool isIbDeviceAccessible(struct ibv_device *device) {
              device->dev_name);
 
     if (stat(device_path, &st) != 0) {
-        LOG(WARNING) << "Device " << ibv_get_device_name(device) 
-                     << " path " << device_path << " does not exist";
+        LOG(WARNING) << "Device " << ibv_get_device_name(device) << " path "
+                     << device_path << " does not exist";
         return false;
     }
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
Fix device path construction: Use `device->dev_name` instead of `ibv_get_device_name` to correctly locate character devices in `/dev/infiniband/`

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->
I have already tested it using ERDMA devices.
<img width="1654" height="128" alt="image" src="https://github.com/user-attachments/assets/cb35d0d3-7ffb-41c1-a182-a120e7e538fd" />


## Checklist

- [ ] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
