### PR TITLE
[Build] Retrieve the actual glibc version during the build process

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -125,7 +125,9 @@ SYSTEM_PACKAGES="build-essential \
                   liburing-dev \
                   libjemalloc-dev \
                   pkg-config \
-                  patchelf"
+                  patchelf \
+                  libc6-dev \
+                  libc-bin"
 
 apt-get install -y $SYSTEM_PACKAGES
 check_success "Failed to install system packages"
@@ -215,6 +217,19 @@ else
     echo -e "${YELLOW}No .gitmodules file found. Skipping...${NC}"
     exit 1
 fi
+
+print_section "Verifying essential build tools"
+
+# Verify getconf and ldd (required for glibc version detection in build_wheel.sh)
+# Both are provided by libc-bin, which is included in SYSTEM_PACKAGES
+if ! command -v getconf >/dev/null 2>&1; then
+    print_error "getconf not found after installing system packages. This should not happen."
+fi
+if ! command -v ldd >/dev/null 2>&1; then
+    print_error "ldd not found after installing system packages. This should not happen."
+fi
+print_success "getconf found: $(getconf --version 2>&1 | head -1)"
+print_success "ldd found: $(ldd --version 2>&1 | head -1)"
 
 print_section "Installing Go $GOVER"
 


### PR DESCRIPTION
## Description

- Fix hardcoded glibc version and implement automatic detection
- Fix mooncake/wheel/setup.py ctypes return type issue 
- Simplify architecture detection logic
- Generate platform tag dynamically based on detected glibc version

## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
