### PR TITLE
feat: add get_engine_ptr method for easily send ptr to another c++ extensions from python

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -782,7 +782,8 @@ PYBIND11_MODULE(engine, m) {
             .def("get_first_buffer_address",
                  &TransferEnginePy::getFirstBufferAddress)
             .def("get_notifies", &TransferEnginePy::getNotifies)
-            .def("get_engine", &TransferEnginePy::getEngine);
+            .def("get_engine", &TransferEnginePy::getEngine)
+            .def("get_engine_ptr", &TransferEnginePy::getEnginePtr);
 
     adaptor_cls.attr("TransferOpcode") = transfer_opcode;
 

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -154,6 +154,8 @@ class TransferEnginePy {
 
     std::shared_ptr<TransferEngine> getEngine() const { return engine_; }
 
+    uintptr_t getEnginePtr() const { return (uintptr_t)engine_.get(); }
+
    private:
     char *allocateRawBuffer(size_t capacity);
 


### PR DESCRIPTION

## Description

Sometimes, we may gen a new `TransferEngine` instances in python codes. Also, we write a new pybind c++ extension by using mooncake. We want to send the TransferEngine init from python to the c++ extension for transfering data by RDMA. This PR can get the raw ptr to python and send it into another c++ extension

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [x] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
