### PR TITLE
[CI]Set DEFAULT_MODEL_NAME_FOR_TEST to meta-llama/Llama-3.2-3B-Instruct for test_disaggregation_different_tp

### DIFF
--- a/scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
+++ b/scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
@@ -90,7 +90,7 @@ run_test()
     echo "Running tests in container and saving output to: $log_file"
     ${docker_exec} "\
         cd /sgl-workspace/sglang/test/srt && \
-        sed -i '0,/^class /s|^class |DEFAULT_MODEL_NAME_FOR_TEST_MLA = \"deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct\"\n&|' test_disaggregation_different_tp.py && \
+        sed -i '0,/^class /s|^class |DEFAULT_MODEL_NAME_FOR_TEST_MLA = \"deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct\"\nDEFAULT_MODEL_NAME_FOR_TEST = \"meta-llama/Llama-3.2-3B-Instruct\"\n&|' test_disaggregation_different_tp.py && \
         echo 'Model override applied successfully' && \
         python3 -m pytest test_disaggregation_different_tp.py -v -s --tb=long" | tee "$log_file"
     


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
Set `DEFAULT_MODEL_NAME_FOR_TEST` to `meta-llama/Llama-3.2-3B-Instruct` for `test_disaggregation_different_tp`, switching to a smaller model from `meta-llama/Llama-3.1-8B-Instruct`.

## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [x] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
