### PR TITLE
[Wheel] Remove the default buffer pre-allocation in initialize()

### DIFF
--- a/docs/source/python-api-reference/transfer-engine.md
+++ b/docs/source/python-api-reference/transfer-engine.md
@@ -160,7 +160,7 @@ Gets the address of the first buffer in a specified segment.
 - `segment_name` (str): The name of the segment
 
 **Returns:**
-- `int`: The memory address of the first buffer in the segment
+- `int`: The memory address of the first buffer in the segment, or 0 if the segment is not found or has no registered buffers
 
 ### Data Transfer Operations
 
@@ -246,7 +246,7 @@ Checks the status of an asynchronous transfer operation.
 - `batch_id` (int): The batch ID returned from transfer_submit_write()
 
 **Returns:**
-- `int`: 
+- `int`:
   - 1: Transfer completed successfully
   - 0: Transfer still in progress
   - -1: Transfer failed
@@ -600,11 +600,11 @@ else:
     # Use the buffer
     test_data = b"Test data for managed buffer"
     engine.write_bytes_to_buffer(buffer_addr, test_data, len(test_data))
-    
+
     # Read back
     read_data = engine.read_bytes_from_buffer(buffer_addr, len(test_data))
     print(f"Read data: {read_data}")
-    
+
     # Free the buffer when done
     engine.free_managed_buffer(buffer_addr, buffer_size)
 ```

--- a/docs/source/zh_archive/transfer-engine-python.md
+++ b/docs/source/zh_archive/transfer-engine-python.md
@@ -115,7 +115,7 @@ get_first_buffer_address(segment_name)
 - `segment_name` (str): 段的名称
 
 **返回值：**
-- `int`: 段中第一个缓冲区的内存地址
+- `int`: 段中第一个缓冲区的内存地址，如果段不存在或没有已注册的缓冲区则返回 0
 
 ### 数据传输操作
 
@@ -200,7 +200,7 @@ transfer_check_status(batch_id)
 - `batch_id` (int): 从transfer_submit_write()返回的批次ID
 
 **返回值：**
-- `int`: 
+- `int`:
   - 1: 传输成功完成
   - 0: 传输仍在进行中
   - -1: 传输失败
@@ -388,11 +388,11 @@ else:
     # Use the buffer
     test_data = b"Test data for managed buffer"
     engine.write_bytes_to_buffer(buffer_addr, test_data, len(test_data))
-    
+
     # Read back
     read_data = engine.read_bytes_from_buffer(buffer_addr, len(test_data))
     print(f"Read data: {read_data}")
-    
+
     # Free the buffer when done
     engine.free_managed_buffer(buffer_addr, buffer_size)
 ```

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -657,6 +657,9 @@ uintptr_t TransferEnginePy::getFirstBufferAddress(
     Transport::SegmentHandle segment_id =
         engine_->openSegment(segment_name.c_str());
     auto segment_desc = engine_->getMetadata()->getSegmentDescByID(segment_id);
+    if (!segment_desc || segment_desc->buffers.empty()) {
+        return 0;
+    }
     return segment_desc->buffers[0].addr;
 }
 

--- a/mooncake-wheel/tests/transfer_engine_initiator_test.py
+++ b/mooncake-wheel/tests/transfer_engine_initiator_test.py
@@ -4,69 +4,97 @@ from mooncake.engine import TransferEngine
 
 
 class TestVLLMAdaptorTransfer(unittest.TestCase):
+    DEFAULT_BUFFER_CAPACITY = 64 * 1024 * 1024
+
     @classmethod
     def setUpClass(cls):
         cls.target_server_name = os.getenv("TARGET_SERVER_NAME", "127.0.0.1:12345")
-        cls.initiator_server_name = os.getenv("INITIATOR_SERVER_NAME", "127.0.0.1:12347")
+        cls.initiator_server_name = os.getenv(
+            "INITIATOR_SERVER_NAME", "127.0.0.1:12347"
+        )
         cls.metadata_server = os.getenv("MC_METADATA_SERVER", "127.0.0.1:2379")
-        cls.protocol = os.getenv("PROTOCOL", "tcp")        # "rdma" or "tcp"
+        cls.protocol = os.getenv("PROTOCOL", "tcp")  # "rdma" or "tcp"
         cls.circle = int(os.getenv("CIRCLE", 1000))
 
         cls.adaptor = TransferEngine()
         ret = cls.adaptor.initialize(
-            cls.initiator_server_name,
-            cls.metadata_server,
-            cls.protocol,
-            ""
+            cls.initiator_server_name, cls.metadata_server, cls.protocol, ""
         )
         if ret != 0:
             raise RuntimeError(f"Initialization failed with code {ret}")
 
         if cls.metadata_server == "P2PHANDSHAKE":
-            cls.initiator_server_name = cls.initiator_server_name.rpartition(':')[0] + ":" + str(cls.adaptor.get_rpc_port())
+            cls.initiator_server_name = (
+                cls.initiator_server_name.rpartition(":")[0]
+                + ":"
+                + str(cls.adaptor.get_rpc_port())
+            )
 
+        cls._fallback_buffer_addr = None
+
+    @classmethod
+    def _ensure_buffer_available(cls):
+        src_addr = cls.adaptor.get_first_buffer_address(cls.initiator_server_name)
+        if src_addr == 0:
+            cls._fallback_buffer_addr = cls.adaptor.allocate_managed_buffer(
+                cls.DEFAULT_BUFFER_CAPACITY
+            )
+            if cls._fallback_buffer_addr == 0:
+                raise RuntimeError("Failed to allocate fallback buffer")
+            src_addr = cls._fallback_buffer_addr
+        return src_addr
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._fallback_buffer_addr is not None:
+            cls.adaptor.free_managed_buffer(
+                cls._fallback_buffer_addr, cls.DEFAULT_BUFFER_CAPACITY
+            )
+            cls._fallback_buffer_addr = None
 
     def test_random_write_circle_times(self):
         """Test circle times of random string write/read via buffer transfer."""
-        import random, string
+        import random
+        import string
 
         def generate_random_string(length):
             chars = string.ascii_letters + string.digits + string.punctuation
-            return ''.join(random.choices(chars, k=length))
+            return "".join(random.choices(chars, k=length))
 
         adaptor = self.adaptor
         circles = self.circle
 
-        src_addr = adaptor.get_first_buffer_address(self.initiator_server_name)
+        src_addr = self._ensure_buffer_available()
         dst_addr = adaptor.get_first_buffer_address(self.target_server_name)
+        self.assertNotEqual(dst_addr, 0, "Target server has no registered buffers")
 
         for i in range(circles):
             str_len = random.randint(16, 256)
-            src_data = generate_random_string(str_len).encode('utf-8')
+            src_data = generate_random_string(str_len).encode("utf-8")
             data_len = len(src_data)
 
-            #Write to local buffer
+            # Write to local buffer
             result = adaptor.write_bytes_to_buffer(src_addr, src_data, data_len)
             self.assertEqual(result, 0, f"[{i}] writeBytesToBuffer failed")
 
-            #Write to the remote end
+            # Write to the remote end
             result = adaptor.transfer_sync_write(
                 self.target_server_name, src_addr, dst_addr, data_len
             )
             self.assertEqual(result, 0, f"[{i}] WRITE transferSyncExt failed")
 
-            #Clear the local buffer
+            # Clear the local buffer
             clear_data = bytes([0] * data_len)
             result = adaptor.write_bytes_to_buffer(src_addr, clear_data, data_len)
             self.assertEqual(result, 0, f"[{i}] Clear buffer failed")
 
-            #Read it back from the remote end
+            # Read it back from the remote end
             result = adaptor.transfer_sync_read(
                 self.target_server_name, src_addr, dst_addr, data_len
             )
             self.assertEqual(result, 0, f"[{i}] READ transferSyncExt failed")
 
-            #Verify data consistency
+            # Verify data consistency
             read_back = adaptor.read_bytes_from_buffer(src_addr, data_len)
             self.assertEqual(read_back, src_data, f"[{i}] Data mismatch")
 
@@ -74,23 +102,25 @@ class TestVLLMAdaptorTransfer(unittest.TestCase):
 
     def test_batch_write_read(self):
         """Test batch_transfer_sync_write and batch_transfer_sync_read for batch write/read consistency."""
-        import random, string
+        import random
+        import string
 
         def generate_random_string(length):
             chars = string.ascii_letters + string.digits + string.punctuation
-            return ''.join(random.choices(chars, k=length))
+            return "".join(random.choices(chars, k=length))
 
         adaptor = self.adaptor
         batch_size = 100  # Adjust batch size if needed
         circles = max(2, self.circle // 100)  # Number of batch test rounds
 
-        base_src_addr = adaptor.get_first_buffer_address(self.initiator_server_name)
+        base_src_addr = self._ensure_buffer_available()
         base_dst_addr = adaptor.get_first_buffer_address(self.target_server_name)
-        
+        self.assertNotEqual(base_dst_addr, 0, "Target server has no registered buffers")
+
         src_addr_list = []
         dst_addr_list = []
         offset_size = 1024  # 1KB offset between each buffer
-        
+
         for i in range(batch_size):
             src_addr_list.append(base_src_addr + i * offset_size)
             dst_addr_list.append(base_dst_addr + i * offset_size)
@@ -101,13 +131,15 @@ class TestVLLMAdaptorTransfer(unittest.TestCase):
             data_len_list = []
             for _ in range(batch_size):
                 str_len = random.randint(32, min(128, offset_size))
-                src_data = generate_random_string(str_len).encode('utf-8')
+                src_data = generate_random_string(str_len).encode("utf-8")
                 data_list.append(src_data)
                 data_len_list.append(len(src_data))
 
             # Write to local buffers in batch
             for j in range(batch_size):
-                result = adaptor.write_bytes_to_buffer(src_addr_list[j], data_list[j], data_len_list[j])
+                result = adaptor.write_bytes_to_buffer(
+                    src_addr_list[j], data_list[j], data_len_list[j]
+                )
                 self.assertEqual(result, 0, f"[{i}-{j}] writeBytesToBuffer failed")
 
             # Batch write to remote
@@ -119,7 +151,9 @@ class TestVLLMAdaptorTransfer(unittest.TestCase):
             # Clear local buffers
             for j in range(batch_size):
                 clear_data = bytes([0] * data_len_list[j])
-                result = adaptor.write_bytes_to_buffer(src_addr_list[j], clear_data, data_len_list[j])
+                result = adaptor.write_bytes_to_buffer(
+                    src_addr_list[j], clear_data, data_len_list[j]
+                )
                 self.assertEqual(result, 0, f"[{i}-{j}] Clear buffer failed")
 
             # Batch read back from remote
@@ -130,30 +164,38 @@ class TestVLLMAdaptorTransfer(unittest.TestCase):
 
             # Verify data consistency
             for j in range(batch_size):
-                read_back = adaptor.read_bytes_from_buffer(src_addr_list[j], data_len_list[j])
-                self.assertEqual(read_back, data_list[j], f"[{i}-{j}] Data mismatch in batch read")
+                read_back = adaptor.read_bytes_from_buffer(
+                    src_addr_list[j], data_len_list[j]
+                )
+                self.assertEqual(
+                    read_back, data_list[j], f"[{i}-{j}] Data mismatch in batch read"
+                )
 
-        print(f"[✓] {circles} rounds of batch_write_read passed, batch size {batch_size}.")
+        print(
+            f"[✓] {circles} rounds of batch_write_read passed, batch size {batch_size}."
+        )
 
     def test_async_batch_write_read(self):
         """Test batch_transfer_async_write and batch_transfer_async_read for batch write/read consistency."""
-        import random, string
+        import random
+        import string
 
         def generate_random_string(length):
             chars = string.ascii_letters + string.digits + string.punctuation
-            return ''.join(random.choices(chars, k=length))
+            return "".join(random.choices(chars, k=length))
 
         adaptor = self.adaptor
         batch_size = 100  # Adjust batch size if needed
         circles = max(2, self.circle // 100)  # Number of batch test rounds
 
-        base_src_addr = adaptor.get_first_buffer_address(self.initiator_server_name)
+        base_src_addr = self._ensure_buffer_available()
         base_dst_addr = adaptor.get_first_buffer_address(self.target_server_name)
-        
+        self.assertNotEqual(base_dst_addr, 0, "Target server has no registered buffers")
+
         src_addr_list = []
         dst_addr_list = []
         offset_size = 1024  # 1KB offset between each buffer
-        
+
         for i in range(batch_size):
             src_addr_list.append(base_src_addr + i * offset_size)
             dst_addr_list.append(base_dst_addr + i * offset_size)
@@ -164,45 +206,68 @@ class TestVLLMAdaptorTransfer(unittest.TestCase):
             data_len_list = []
             for _ in range(batch_size):
                 str_len = random.randint(32, min(128, offset_size))
-                src_data = generate_random_string(str_len).encode('utf-8')
+                src_data = generate_random_string(str_len).encode("utf-8")
                 data_list.append(src_data)
                 data_len_list.append(len(src_data))
 
             # Write to local buffers in batch
             for j in range(batch_size):
-                result = adaptor.write_bytes_to_buffer(src_addr_list[j], data_list[j], data_len_list[j])
+                result = adaptor.write_bytes_to_buffer(
+                    src_addr_list[j], data_list[j], data_len_list[j]
+                )
                 self.assertEqual(result, 0, f"[{i}-{j}] writeBytesToBuffer failed")
 
             # Batch write to remote
             batch_id = adaptor.batch_transfer_async_write(
                 self.target_server_name, src_addr_list, dst_addr_list, data_len_list
             )
-            self.assertNotEqual(batch_id, 0, f"[{i}] batch_transfer_async_write {batch_id} failed in submitting task(s)")
+            self.assertNotEqual(
+                batch_id,
+                0,
+                f"[{i}] batch_transfer_async_write {batch_id} failed in submitting task(s)",
+            )
 
             result = adaptor.get_batch_transfer_status([batch_id])
-            self.assertEqual(result, 0, f"[{i}] batch {batch_id} failed during transferring")
+            self.assertEqual(
+                result, 0, f"[{i}] batch {batch_id} failed during transferring"
+            )
 
             # Clear local buffers
             for j in range(batch_size):
                 clear_data = bytes([0] * data_len_list[j])
-                result = adaptor.write_bytes_to_buffer(src_addr_list[j], clear_data, data_len_list[j])
+                result = adaptor.write_bytes_to_buffer(
+                    src_addr_list[j], clear_data, data_len_list[j]
+                )
                 self.assertEqual(result, 0, f"[{i}-{j}] Clear buffer failed")
 
             # Batch read back from remote
             batch_id = adaptor.batch_transfer_async_read(
                 self.target_server_name, src_addr_list, dst_addr_list, data_len_list
             )
-            self.assertNotEqual(batch_id, 0, f"[{i}] batch_transfer_async_read {batch_id} failed in submitting task(s)")
+            self.assertNotEqual(
+                batch_id,
+                0,
+                f"[{i}] batch_transfer_async_read {batch_id} failed in submitting task(s)",
+            )
 
             result = adaptor.get_batch_transfer_status([batch_id])
-            self.assertEqual(result, 0, f"[{i}] batch {batch_id} failed during transferring")
+            self.assertEqual(
+                result, 0, f"[{i}] batch {batch_id} failed during transferring"
+            )
 
             # Verify data consistency
             for j in range(batch_size):
-                read_back = adaptor.read_bytes_from_buffer(src_addr_list[j], data_len_list[j])
-                self.assertEqual(read_back, data_list[j], f"[{i}-{j}] Data mismatch in batch read")
+                read_back = adaptor.read_bytes_from_buffer(
+                    src_addr_list[j], data_len_list[j]
+                )
+                self.assertEqual(
+                    read_back, data_list[j], f"[{i}-{j}] Data mismatch in batch read"
+                )
 
-        print(f"[✓] {circles} rounds of batch_write_async_read passed, batch size {batch_size}.")
+        print(
+            f"[✓] {circles} rounds of batch_write_async_read passed, batch size {batch_size}."
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/mooncake-wheel/tests/transfer_engine_target.py
+++ b/mooncake-wheel/tests/transfer_engine_target.py
@@ -4,11 +4,24 @@ from mooncake.engine import TransferEngine
 target_server_name = os.getenv("TARGET_SERVER_NAME", "127.0.0.1:12345")
 initiator_server_name = os.getenv("INITIATOR_SERVER_NAME", "127.0.0.1:12347")
 metadata_server = os.getenv("MC_METADATA_SERVER", "127.0.0.1:2379")
-protocol = os.getenv("PROTOCOL", "tcp")       # Protocol type: "rdma" or "tcp"
+protocol = os.getenv("PROTOCOL", "tcp")  # Protocol type: "rdma" or "tcp"
+
+DEFAULT_BUFFER_CAPACITY = 64 * 1024 * 1024
 
 target = TransferEngine()
-target.initialize(target_server_name,metadata_server, protocol, "")
+ret = target.initialize(target_server_name, metadata_server, protocol, "")
+if ret != 0:
+    raise RuntimeError(f"Target initialization failed with code {ret}")
 
-while( True ):
+buffer_addr = target.get_first_buffer_address(target_server_name)
+if buffer_addr == 0:
+    # No buffer registered, allocate a managed buffer as fallback
+    buffer_addr = target.allocate_managed_buffer(DEFAULT_BUFFER_CAPACITY)
+    if buffer_addr == 0:
+        raise RuntimeError("Failed to allocate fallback buffer for target")
+    print(f"Target allocated fallback buffer at {buffer_addr}")
+
+print(f"Target server ready at {target_server_name}")
+
+while True:
     pass
-

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,7 +7,6 @@ set -e  # Exit immediately if a command exits with a non-zero status
 # Ensure LD_LIBRARY_PATH includes /usr/local/lib
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
-
 echo "Running transfer_engine tests..."
 cd mooncake-wheel/tests
 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata MC_FORCE_TCP=true python transfer_engine_target.py &


### PR DESCRIPTION
## Description

When calling `TransferEngine`'s `initialize()`, it invokes `doBuddyAllocate(kMaxClassId)` to pre-allocate a 2GB buffer. However, this pre-allocation is unnecessary as users can allocate memory themselves via `allocateManagedBuffer`. Instead, this causes an unexpected 2GB memory overhead for users unaware of this internal behavior.

## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [x] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

After removing the pre-allocation code, memory usage decreased by 2GB when calling `initialize()`.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
