### PR TITLE
[TE] Fix SIGSEGV in Session::writeBody/readBody logging.

### DIFF
--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -174,8 +174,8 @@ struct Session : public std::enable_shared_from_this<Session> {
                 if (ec) {
                     LOG(ERROR)
                         << "Session::writeBody failed. "
-                        << "Attempt to write data " << static_cast<void*>(addr)
-                        << " using buffer " << static_cast<void*>(dram_buffer)
+                        << "Attempt to write data " << static_cast<void *>(addr)
+                        << " using buffer " << static_cast<void *>(dram_buffer)
                         << ". Error: " << ec.message()
                         << " (value: " << ec.value() << ")"
                         << ", total_transferred_bytes_: "
@@ -222,8 +222,8 @@ struct Session : public std::enable_shared_from_this<Session> {
                 if (ec) {
                     LOG(ERROR)
                         << "Session::readBody failed. "
-                        << "Attempt to read data " << static_cast<void*>(addr)
-                        << " using buffer " << static_cast<void*>(dram_buffer)
+                        << "Attempt to read data " << static_cast<void *>(addr)
+                        << " using buffer " << static_cast<void *>(dram_buffer)
                         << ". Error: " << ec.message()
                         << " (value: " << ec.value() << ")"
                         << ", total_transferred_bytes_: "


### PR DESCRIPTION
## Description

This PR fixes a segmentation fault that occurs when an error happens during `Session::writeBody` or `Session::readBody`. The crash was masking the actual transport error, making debugging harder.

The pointers `addr` and `dram_buffer` are of type `char*`. When passed to `LOG(ERROR)`, `std::ostream::operator<<` attempts to treat them as null-terminated C-strings. This PR casts them to `void*` to ensure addresses are printed instead.

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
