### PR TITLE
[Store] fix malloc physical for ascend fabric mem

### DIFF
--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -15,6 +15,7 @@
 #ifdef USE_ASCEND_DIRECT
 #include "acl/acl.h"
 #include "config.h"
+#include "common.h"
 #endif
 
 #include <ylt/coro_http/coro_http_client.hpp>
@@ -73,6 +74,47 @@ AutoPortBinder::~AutoPortBinder() {
     }
 }
 
+#if defined(USE_ASCEND_DIRECT) && defined(ASCEND_SUPPORT_FABRIC_MEM)
+int allocate_physical_memory(size_t total_size, aclrtDrvMemHandle &handle) {
+    int32_t user_dev_id;
+    auto ret = aclrtGetDevice(&user_dev_id);
+    if (ret != ACL_ERROR_NONE) {
+        LOG(ERROR) << "Failed to get device: " << ret;
+        return -1;
+    }
+    int32_t physical_dev_id;
+    ret = aclrtGetPhyDevIdByLogicDevId(user_dev_id, &physical_dev_id);
+    if (ret != ACL_ERROR_NONE) {
+        LOG(ERROR) << "Failed to get physical dev id: " << ret;
+        return -1;
+    }
+    aclrtPhysicalMemProp prop = {};
+    prop.handleType = ACL_MEM_HANDLE_TYPE_NONE;
+    prop.allocationType = ACL_MEM_ALLOCATION_TYPE_PINNED;
+    prop.memAttr = ACL_MEM_P2P_HUGE1G;
+    prop.location.type = ACL_MEM_LOCATION_TYPE_HOST_NUMA;
+    // Only 0 2 4 6 is available for fabric mem, map 4 device to one numa.
+    const int32_t kDevicesPerChip = 4;
+    const int32_t kNumaNodeStep = 2;
+    prop.location.id = (physical_dev_id / kDevicesPerChip) * kNumaNodeStep;
+    prop.reserve = 0;
+    LOG(INFO) << "Malloc host memory for numa:" << prop.location.id;
+    ret = aclrtMallocPhysical(&handle, total_size, &prop, 0);
+    if (ret != ACL_ERROR_NONE) {
+        LOG(INFO) << "Malloc host memory for numa:" << prop.location.id
+                  << " failed, try common allocate instead.";
+        prop.location.type = ACL_MEM_LOCATION_TYPE_HOST;
+        prop.location.id = 0;
+        ret = aclrtMallocPhysical(&handle, total_size, &prop, 0);
+        if (ret != ACL_ERROR_NONE) {
+            LOG(ERROR) << "Failed to allocate memory: " << ret;
+            return -1;
+        }
+    }
+    return 0;
+}
+#endif
+
 void *allocate_buffer_allocator_memory(size_t total_size,
                                        const std::string &protocol,
                                        size_t alignment) {
@@ -86,35 +128,12 @@ void *allocate_buffer_allocator_memory(size_t total_size,
     if (protocol == "ascend" && total_size > 0) {
 #ifdef ASCEND_SUPPORT_FABRIC_MEM
         if (globalConfig().ascend_use_fabric_mem) {
-            int32_t device_logic_id;
-            auto ret = aclrtGetDevice(&device_logic_id);
-            if (ret != ACL_ERROR_NONE) {
-                LOG(ERROR) << "Failed to get device: " << ret;
-                return nullptr;
-            }
             aclrtDrvMemHandle handle = nullptr;
-            aclrtPhysicalMemProp prop = {};
-            prop.handleType = ACL_MEM_HANDLE_TYPE_NONE;
-            prop.allocationType = ACL_MEM_ALLOCATION_TYPE_PINNED;
-            prop.memAttr = ACL_MEM_P2P_HUGE1G;
-            prop.location.type = ACL_MEM_LOCATION_TYPE_HOST_NUMA;
-            prop.location.id = static_cast<int32_t>(device_logic_id / 4) * 2;
-            prop.reserve = 0;
-            LOG(INFO) << "Malloc host memory for numa:" << prop.location.id;
-            ret = aclrtMallocPhysical(&handle, total_size, &prop, 0);
-            if (ret != ACL_ERROR_NONE) {
-                LOG(ERROR) << "Failed to allocate specific numa memory: "
-                           << ret;
-                prop.location.type = ACL_MEM_LOCATION_TYPE_HOST;
-                prop.location.id = 0;
-                ret = aclrtMallocPhysical(&handle, total_size, &prop, 0);
-                if (ret != ACL_ERROR_NONE) {
-                    LOG(ERROR) << "Failed to allocate memory: " << ret;
-                }
+            if (allocate_physical_memory(total_size, handle) != 0) {
                 return nullptr;
             }
             void *va;
-            ret = aclrtReserveMemAddress(&va, total_size, 0, nullptr, 1);
+            auto ret = aclrtReserveMemAddress(&va, total_size, 0, nullptr, 1);
             if (ret != ACL_ERROR_NONE) {
                 LOG(ERROR) << "Failed to reserve memory: " << ret;
                 return nullptr;


### PR DESCRIPTION
## Description

In ascend platform, ASCEND_RT_VISIBLE_DEVICES may be set, in such scenario, malloc host numa memory may be not correct, we need to get physical dev id firstly, then malloc specific numa memory according to the physical dev id.

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

construct mooncake store example: set ASCEND_RT_VISIBLE_DEVICES=1 environment and set user device to 0.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
