### PR TITLE
[TE] fix wakeup race condition in RDMA WorkerPool

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -395,7 +395,8 @@ void WorkerPool::transferWorker(int thread_id) {
             if (curr_wait_ts - last_wait_ts > kWaitPeriodInNano) {
                 std::unique_lock<std::mutex> lock(cond_mutex_);
                 suspended_flag_.fetch_add(1);
-                // Double-check condition after acquiring lock to avoid lost wakeup
+                // Double-check condition after acquiring lock to avoid lost
+                // wakeup
                 if (processed_slice_count_.load(std::memory_order_relaxed) ==
                     submitted_slice_count_.load(std::memory_order_relaxed)) {
                     cond_var_.wait_for(lock, std::chrono::seconds(1));


### PR DESCRIPTION
## Description

During large-scale testing, we observed intermittent latency spikes where `transfer_sync` would hang for exactly 1 second.

Root cause analysis revealed a race condition in the wakeup logic of the RDMA worker thread, resulting in lost wakeup. The detail can be explained by the fix code. Any feedback on this issue is welcome!

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

After applying this PR, the intermittent 1-second transfer stall is no longer observed in our test environment.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
