### PR TITLE
feat: enable jemalloc for Mooncake Store master by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,10 @@ if (STORE_USE_ETCD)
   add_compile_definitions(STORE_USE_ETCD)
 endif()
 
-option(STORE_USE_JEMALLOC "Use jemalloc in mooncake store master" OFF)
+option(STORE_USE_JEMALLOC "Use jemalloc in mooncake store master" ON)
+if (STORE_USE_JEMALLOC)
+  message(STATUS "jemalloc support is enabled for Mooncake Store master (improves memory management)")
+endif()
 
 add_subdirectory(mooncake-common)
 include_directories(mooncake-common/etcd)

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -162,6 +162,7 @@ The following options can be used during `cmake ..` to specify whether to compil
 - `-DUSE_HTTP=[ON|OFF]`: Enable Http-based metadata service
 - `-DUSE_ETCD=[ON|OFF]`: Enable etcd-based metadata service, require go 1.23+
 - `-DSTORE_USE_ETCD=[ON|OFF]`: Enable etcd-based failover for Mooncake Store, require go 1.23+. **Note:** `-DUSE_ETCD` and `-DSTORE_USE_ETCD` are two independent options. Enabling `-DSTORE_USE_ETCD` does **not** depend on `-DUSE_ETCD`
+- `-DSTORE_USE_JEMALLOC=[ON|OFF]`: Use jemalloc allocator in mooncake_master for better memory management, default is ON
 - `-DBUILD_SHARED_LIBS=[ON|OFF]`: Build Transfer Engine as shared library, default is OFF
 - `-DBUILD_UNIT_TESTS=[ON|OFF]`: Build unit tests, default is ON
 - `-DBUILD_EXAMPLES=[ON|OFF]`: Build examples, default is ON

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -74,6 +74,7 @@ pip install mooncake-transfer-engine-non-cuda
                        pybind11-dev \
                        libcurl4-openssl-dev \
                        libhiredis-dev \
+                       libjemalloc-dev \
                        pkg-config \
                        patchelf
 
@@ -88,7 +89,8 @@ pip install mooncake-transfer-engine-non-cuda
                 boost-devel \
                 openssl-devel \
                 hiredis-devel \
-                libcurl-devel
+                libcurl-devel \
+                jemalloc-devel
     ```
 
     NOTE: You may need to install gtest, glog, gflags from source code:

--- a/docs/source/zh_archive/build.md
+++ b/docs/source/zh_archive/build.md
@@ -146,6 +146,7 @@
 - `-DUSE_HTTP=[ON|OFF]`: 启用基于 Http 的元数据服务
 - `-DUSE_ETCD=[ON|OFF]`: 启用基于 etcd 的元数据服务，需要 go 1.23+
 - `-DSTORE_USE_ETCD=[ON|OFF]`: 启用基于 etcd 的 Mooncake Store 容错机制，需要 go 1.23+。**注意：** `-DUSE_ETCD` 和 `-DSTORE_USE_ETCD` 是两个相互独立的选项。启用 `-DSTORE_USE_ETCD` 并**不依赖**于 `-DUSE_ETCD`。
+- `-DSTORE_USE_JEMALLOC=[ON|OFF]`: 在 mooncake_master 中使用 jemalloc 内存分配器以获得更好的内存管理，默认为 ON
 - `-DBUILD_SHARED_LIBS=[ON|OFF]`: 将 Transfer Engine 编译为共享库，默认为 OFF
 - `-DBUILD_UNIT_TESTS=[ON|OFF]`: 编译单元测试，默认为 ON
 - `-DBUILD_EXAMPLES=[ON|OFF]`: 编译示例程序，默认为 ON

--- a/docs/source/zh_archive/build.md
+++ b/docs/source/zh_archive/build.md
@@ -70,7 +70,8 @@
                    libjsoncpp-dev \
                    libnuma-dev \
                    libcurl4-openssl-dev \
-                   libhiredis-dev
+                   libhiredis-dev \
+                   libjemalloc-dev
 
     # For centos/alibaba linux os
     yum install cmake \
@@ -83,7 +84,8 @@
                 boost-devel \
                 openssl-devel \
                 hiredis-devel \
-                libcurl-devel
+                libcurl-devel \
+                jemalloc-devel
     ```
 
     注意：如果源没有gtest, glog, gflags, 则需要通过源码安装

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -86,6 +86,11 @@ add_executable(mooncake_master master.cpp)
 set(MASTER_EXTRA_INCS)
 set(MASTER_EXTRA_LIBS)
 
+# Use jemalloc for better memory management in mooncake_master
+# jemalloc provides:
+# - More aggressive memory return to OS (reduces OOM issues)
+# - Better performance for multi-threaded allocation patterns
+# - Reduced memory fragmentation with std::unordered_map in MetadataShard
 if (STORE_USE_JEMALLOC)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(JEMALLOC REQUIRED jemalloc)


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Jemalloc is very important in high load senarios, it would encounter OOM frequently when insert in and remove keys from master unorderedmap.

We can provide Jemalloc version by default to prevent users encounter this issue.

before:
<img width="921" height="326" alt="image" src="https://github.com/user-attachments/assets/c25e8a8a-4ca0-4940-9cad-292e75daf51d" />


after:
<img width="939" height="321" alt="image" src="https://github.com/user-attachments/assets/069e0ef5-f30e-40c3-9954-99db4a0c2b92" />


## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [x] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [x] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
