### PR TITLE
[Store] feat: wait Master ready when starting Store server

### DIFF
--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -127,14 +127,17 @@ class MooncakeStoreService:
                 elapsed_after_attempt = time.perf_counter() - start_time
                 remaining_time = max_wait_time - elapsed_after_attempt
 
+                # Calculate actual sleep duration
+                actual_sleep_time = min(retry_interval, remaining_time) if remaining_time > 0 else 0
+
                 logging.warning(
                     f"Store startup failed (attempt {retry_count}): {e}. "
-                    f"Retrying in {retry_interval}s... (remaining time: {remaining_time:.1f}s)"
+                    f"Retrying in {actual_sleep_time:.1f}s... (remaining time: {remaining_time:.1f}s)"
                 )
 
                 # Wait before retry, but don't exceed max_wait_time
-                if remaining_time > 0:
-                    await asyncio.sleep(min(retry_interval, remaining_time))
+                if actual_sleep_time > 0:
+                    await asyncio.sleep(actual_sleep_time)
 
 
     async def start_http_service(self, port: int = 8080):


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

In some deployment scenarios, because the starting order of each roles are orchestrated, the store server may start before the master, then the store server could not start normally, throw exception like this:
```
2026-01-25 01:54:10.015125 WARNING  [85] [client_pool.hpp:445] send request to s-20260123104030-rsjk0-sn31d-http-mc-master:50051 failed. connection refused.
E0125 01:54:10.015158    85 master_client.cpp:141] Client not available
I0125 01:54:10.015287     9 client_metric.cpp:126] Waiting for client metrics reporting thread to join...
2026-01-25 01:54:10.015763 WARNING  [86] [coro_rpc_client.hpp:579] client_id 1 async_resolve failed:Host not found (authoritative)
I0125 01:54:10.745271    81 client_metric.cpp:119] Client metrics reporting thread stopped
I0125 01:54:10.745324     9 client_metric.cpp:129] Client metrics reporting thread joined
E0125 01:54:10.745436     9 pybind_client.cpp:185] Failed to create client
2026-01-25 01:54:10,745 - root - ERROR - Store startup failed: Store initialization failed
2026-01-25 01:54:10,745 - root - ERROR - Service error: Failed to start store service
2026-01-25 01:54:10,745 - root - INFO - Mooncake service stopped
```

We can set a bearable waiting time for the store server to resolve this issue.


## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [x] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
