### PR TITLE
[CI](feat) CI: testcases can run in a docker

### DIFF
--- a/scripts/tone_tests/README_en.md
+++ b/scripts/tone_tests/README_en.md
@@ -15,41 +15,22 @@ This directory contains end-to-end (E2E) test cases for the Mooncake project. Th
 
 **Description**: Distributed inference test with Prefill-Decode disaggregation architecture
 
-- **Test Scenario**: Deploy Prefill and Decode servers on two separate machines communicating via ERDMA (Elastic RDMA) network
-- **Test Coverage**:
-  - Local machine runs SGLang server in Prefill mode
-  - Remote machine runs SGLang server in Decode mode
-  - Proxy requests through a load balancer
-  - Send test requests to verify distributed inference functionality
-- **Supported Models**: Qwen/Qwen3-8B, deepseek-ai/DeepSeek-V2-Lite
-- **Test Environment**: Dual-machine setup with 2 GPUs per machine (TP=2)
-
 ### 2. test_hicache_storage_mooncake_backend.sh
 
 **Description**: Integration test for HiCache storage system with Mooncake backend
 
-- **Test Scenario**: Verify the functionality of HiCache storage system using Mooncake as backend
-- **Test Coverage**:
-  - Start Mooncake metadata and master services
-  - Run pytest tests in Docker container
-  - Test different memory layouts (page_first, page_first_direct, etc.)
-  - Test different models (standard models, MLA models)
-  - Verify cache accuracy
-- **Test Environment**: Single machine with 2 GPUs (TP=2)
+### 3. test_disaggregation_different_tp.sh
+
+**Description**: Prefill-Decode disaggregation test with different TP configurations
 
 ## T-One/tone-cli Support
 
 [tone-cli](https://gitee.com/anolis/tone-cli/tree/master/tests/mooncake-ci-test) provides the following automation features:
 
 1. **Code Fetching**: Automatically pulls E2E test code from GitHub
-2. **Variable Replacement**: Scans scripts starting with `test_` in the `scripts/` directory and replaces the following variables:
-   - `LOCAL_IP` - Local machine IP
-   - `REMOTE_IP` - Remote machine IP
-   - `ARTIFACT_ID` - GitHub Actions artifact ID
-   - `GIT_REPO` - Git repository address for downloading wheel packages
-3. **Test Execution**: Automatically executes compliant test scripts
-4. **Result Parsing**: Reads `test_results.json` file to parse test results
-5. **Log Collection**: Copies test logs to T-One platform accessible paths
+2. **Test Execution**: Automatically executes test case sets
+3. **Result Parsing**: Reads `test_results.json` file to parse test results
+4. **Log Collection**: Copies test logs to T-One platform accessible paths
 
 ## E2E Test Case Development Guidelines
 
@@ -64,15 +45,18 @@ This directory contains end-to-end (E2E) test cases for the Mooncake project. Th
 Declare the following variables at the beginning of the script:
 
 ```bash
-# For dual-machine tests
-LOCAL_IP=
-REMOTE_IP=
+# Test case name (required)
+test_case_name="test_demo"
 
-# Required for both single and multi-machine tests
-ARTIFACT_ID=
-GIT_REPO=
-test_case_name=
+# Test type (required): single (single machine) or double (dual machine)
+TEST_TYPE="single"  # or "double"
 ```
+
+**Important Notes**:
+- `test_case_name`: Must match the script file name (without `.sh`)
+- `TEST_TYPE`: Used by `run_test.sh` to determine environment preparation type
+  - `single`: Single machine test, runs only on local machine
+  - `double`: Dual machine test, requires coordination between local and remote machines
 
 ### 3. Path Usage Guidelines
 
@@ -86,24 +70,56 @@ test_case_name=
 
 ### 4. Directory Structure Requirements
 
-All test-generated files must be saved in `tone_tests/run/${test_case_name}/` directory:
+All test-generated files must be saved in the `tone_tests/run/` directory:
 
 ```
-tone_tests/run/test_1p1d_erdma/
-├── logs/                    # Test logs
-├── whls/                    # Wheel packages
+tone_tests/run/
+├── logs/                           # Test logs root directory
+│   ├── test_1p1d_erdma/           # Log directory for each test case
+│   │   ├── test_results.json      # Test results (required)
+│   │   ├── Qwen__Qwen3-8B/        # Model-related logs (if applicable)
+│   │   │   ├── sglang_server_local.log
+│   │   │   ├── sglang_server_remote.log
+│   │   │   ├── load_balancer.log
+│   │   │   └── curl_response.log
+│   │   └── ...
+│   └── test_disaggregation_different_tp/
+│       ├── test_results.json
+│       └── test_disaggregation_different_tp.log
+├── whls/                           # Wheel packages
 │   └── mooncake-*.whl
-├── .shrc                    # Environment variable configuration
-└── test_results.json        # Test results (required)
+├── pids/                           # Process PID records (for cleanup)
+│   └── test_case_name/
+│       ├── server_prefill.pid
+│       └── proxy.pid
+└── .shrc                           # Environment variable configuration file
 ```
+
+**Path Specifications**:
+- Use variables for log paths: `${BASE_DIR}/run/logs/${test_case_name}/`
+- Reference via `TEST_CASE_RESULT_PATH` variable: `run/logs/${test_case_name}`
+- Avoid hardcoded paths, use environment variables to ensure portability
 
 ### 5. Self-Contained Test Principle
 
-- **Container Management**: Scripts must manage Docker containers independently (pull images, configure parameters, start/stop)
-- **Environment Isolation**: Single and multi-machine tests must be completed independently by scripts
-- **Reuse Common Functions**: Can use common functions from `common.sh`:
-  - `setup_test_result_directory` - Create test result directory
-  - `setup_log_directory` - Create log directory
+Test case scripts should follow the self-contained principle, but environment preparation is managed uniformly by `run_test.sh`:
+
+**Managed by `run_test.sh`**:
+- Environment initialization (create directories, generate `.shrc` configuration file)
+- Docker container management (pull images, start/stop containers)
+- Wheel package download and installation
+- Single/dual machine environment determination and preparation
+- ERDMA driver installation
+- Remote machine synchronization and configuration (dual machine tests)
+
+**Test scripts need to implement**:
+- `run_test()` function: Execute specific test logic
+- `parse()` function: Parse test results and generate `test_results.json`
+- Optional other functions (e.g., `start_server`, `run_proxy`, etc.)
+
+**Reuse Common Functions** (from `common.sh`):
+  - `setup_directory` - Create directory
+  - `setup_log_directory` - Create/clean log directory
   - `get_whl` - Download wheel package
   - `get_image` - Pull Docker image
   - `docker_launch` - Launch Docker container
@@ -111,10 +127,13 @@ tone_tests/run/test_1p1d_erdma/
   - `stop_container` - Stop container
   - `check_server_ready` - Check server readiness
   - `check_proxy_ready` - Check proxy readiness
+  - `save_test_result` - Save test result to JSON file
+  - `launch_and_track_process` - Launch process and record PID
+  - `kill_process` - Stop process based on PID file
 
 ### 6. Test Result Format Requirements
 
-**Required File**: `tone_tests/run/${test_case_name}/test_results.json`
+**Required File**: `tone_tests/run/logs/${test_case_name}/test_results.json`
 
 **JSON Format**:
 
@@ -143,66 +162,118 @@ Or when failed:
 
 ### 7. Script Structure Example
 
-Recommended script structure:
+#### Test Script Example
 
 ```bash
 #!/bin/bash
 
+# Test case basic information
 test_case_name="test_demo"
-TONE_TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)
+TEST_TYPE="single"  # Single machine test
 
-# Variable declarations
-LOCAL_IP=
-REMOTE_IP=
-ARTIFACT_ID=
-GIT_REPO=
+# Initialize paths and load common functions
+BASE_DIR=${BASE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)}
+. ${BASE_DIR}/scripts/common.sh
 
-. ${TONE_TESTS_DIR}/scripts/common.sh
+run_test()
+{
+    echo "===== Running pytest tests ====="
+    local log_file="${BASE_DIR}/${TEST_CASE_RESULT_PATH}/${test_case_name}.log"
 
-setup() {
-    # Container launch and environment configuration
+    echo "Running tests in container and saving output to: $log_file"
+    ${docker_exec} "\
+        cd /test_workspace && \
+        python3 -m pytest test_demo.py -v -s --tb=long" | tee "$log_file"
+    
+    return ${PIPESTATUS[0]}
 }
 
-run_test() {
-    # Execute tests
+parse()
+{
+    local test_exit_code=$1
+
+    echo "===== Parsing test results ====="
+    if [ $test_exit_code -eq 0 ]; then
+        save_test_result "$test_case_name" "Pass" "${BASE_DIR}/${TEST_CASE_RESULT_PATH}"
+        echo "✓ Test PASSED"
+        return 0
+    else
+        save_test_result "$test_case_name" "Fail" "${BASE_DIR}/${TEST_CASE_RESULT_PATH}"
+        echo "✗ Test FAILED"
+        return 1
+    fi
 }
 
-parse() {
-    # Parse results and generate test_results.json
-}
-
-cleanup() {
-    # Clean up resources
-}
-
-main() {
-    setup
-    run_test
-    parse
-    cleanup
-}
-
-main
+# Script entry point
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    exit_code=0
+    if ! run_test; then
+        exit_code=1
+    fi
+    
+    parse $exit_code
+    exit $?
+fi
 ```
 
 ## Usage
 
-### Execute Full Test
+### Via run_test.sh (Recommended)
+
+`run_test.sh` is the unified entry point for test cases, responsible for the complete lifecycle management of environment preparation, test execution, and resource cleanup.
+
+#### Run a Single Test Case
 
 ```bash
-cd scripts && ./test_demo.sh
+cd scripts/tone_tests/scripts
+./run_test.sh run-single test_hicache_storage_mooncake_backend.sh
 ```
 
-### Execute on T-One Platform
+Execution flow:
+1. Prepare environment based on test type (`TEST_TYPE`) (single or dual machine)
+2. Create and configure Docker containers
+3. Download and install Mooncake wheel package
+4. Execute the test script's `run_test()` function
+5. Call the `parse()` function to parse results
+6. Clean up environment and containers
 
-Test cases will be automatically scanned and executed by tone-cli without manual intervention.
+#### Run All SGLANG Test Cases
+
+```bash
+cd scripts/tone_tests/scripts
+./run_test.sh run-all SGLANG
+```
+
+Will execute all tests in the `All_TEST_SCRIPTS_SGLANG` array in order:
+- `test_hicache_storage_mooncake_backend.sh`
+- `test_disaggregation_different_tp.sh`
+- `test_1p1d_erdma.sh`
+
+#### View Help Information
+
+```bash
+./run_test.sh
+```
+
+Output:
+```
+Mooncake CI Controller
+Usage: ./run_test.sh <command> [args]
+
+Commands:
+  run-single <test_name>             - Full lifecycle: setup -> run -> parse -> cleanup
+  run-all [SGLANG|VLLM]              - Run all tests for specific framework
+  run-all SGLANG                     - Run all SGLANG tests (using SGLANG image)
+  run-all VLLM                       - Run all VLLM tests (using VLLM image)
+```
 
 ## Important Notes
 
-1. **Environment Variable Priority**: tone-cli will replace variables in scripts
-2. **Log Completeness**: Ensure all important logs are saved to the specified directory for troubleshooting
-3. **Resource Cleanup**: Execute cleanup even if tests fail to clean up resources
-4. **JSON Format**: Strictly follow JSON format specifications to avoid syntax errors
+1. **Environment Variable Usage**: Use environment variables like `$BASE_DIR`, `$TEST_CASE_RESULT_PATH`, avoid hardcoded paths
+2. **Log Completeness**: Ensure all important logs are saved to the `${BASE_DIR}/run/logs/${test_case_name}/` directory
+3. **Resource Cleanup**: Test scripts should manage processes via PID files to ensure proper resource cleanup
+4. **JSON Format**: Strictly follow JSON format specifications, must include `test_case` and `status` fields
+5. **Test Type Declaration**: Must declare `TEST_TYPE` variable at the beginning of the script for `run_test.sh` to determine environment preparation type
 
 ## Related Links
 

--- a/scripts/tone_tests/README_zh.md
+++ b/scripts/tone_tests/README_zh.md
@@ -15,41 +15,23 @@
 
 **用例说明**：Prefill-Decode 分离架构的分布式推理测试
 
-- **测试场景**：在两台机器上分别部署 Prefill 和 Decode 服务器，通过 ERDMA（弹性 RDMA）网络进行通信
-- **测试内容**：
-  - 本地机器运行 Prefill 模式的 SGLang 服务器
-  - 远程机器运行 Decode 模式的 SGLang 服务器  
-  - 通过负载均衡器（Load Balancer）代理请求
-  - 发送测试请求验证分布式推理功能
-- **支持的模型**：Qwen/Qwen3-8B，deepseek-ai/DeepSeek-V2-Lite
-- **测试环境**：双机运行，每机 2 个 GPU（TP=2）
-
 ### 2. test_hicache_storage_mooncake_backend.sh
 
 **用例说明**：HiCache 存储系统与 Mooncake 后端集成测试
 
-- **测试场景**：验证 HiCache 存储系统使用 Mooncake 作为后端的功能正确性
-- **测试内容**：
-  - 启动 Mooncake metadata 和 master 服务
-  - 在 Docker 容器中运行 pytest 测试
-  - 测试不同的内存布局（page_first、page_first_direct 等）
-  - 测试不同模型（标准模型、MLA 模型）
-  - 验证缓存准确性
-- **测试环境**：单机运行，使用 2 个 GPU（TP=2）
+### 3. test_disaggregation_different_tp.sh
+
+**用例说明**：不同 TP 配置的 Prefill-Decode 分离架构测试
+
 
 ## T-One/tone-cli 支持
 
 [tone-cli](https://gitee.com/anolis/tone-cli/tree/master/tests/mooncake-ci-test) 提供以下自动化功能：
 
 1. **代码拉取**：自动从 GitHub 拉取 E2E 测试代码
-2. **变量替换**：扫描 `scripts/` 目录下以 `test_` 开头的脚本，自动替换以下变量：
-   - `LOCAL_IP` - 本地机器 IP
-   - `REMOTE_IP` - 远程机器 IP
-   - `ARTIFACT_ID` - GitHub Actions artifact ID
-   - `GIT_REPO` - 下载whl包的 Git 仓库地址
-3. **用例执行**：自动执行符合规范的测试脚本
-4. **结果解析**：读取 `test_results.json` 文件解析测试结果
-5. **日志收集**：将测试日志复制到 T-One 平台可访问的路径
+2. **用例执行**：自动执行指定用例集
+3. **结果解析**：读取 `test_results.json` 文件解析测试结果
+4. **日志收集**：将测试日志复制到 T-One 平台可访问的路径
 
 ## E2E 测试用例编写规范
 
@@ -64,15 +46,18 @@
 必须在脚本开头声明以下变量：
 
 ```bash
-# 双机测试
-LOCAL_IP=
-REMOTE_IP=
+# 测试用例名称（必需）
+test_case_name="test_demo"
 
-# 单机/多机测试都需要
-ARTIFACT_ID=
-GIT_REPO=
-test_case_name=
+# 测试类型（必需）：single（单机）或 double（双机）
+TEST_TYPE="single"  # 或 "double"
 ```
+
+**重要说明**：
+- `test_case_name`：必须与脚本文件名（不含 `.sh`）一致
+- `TEST_TYPE`：用于 `run_test.sh` 判断环境准备类型
+  - `single`：单机测试，仅在本地机器运行
+  - `double`：双机测试，需要本地和远程两台机器协同
 
 ### 3. 路径使用规范
 
@@ -86,35 +71,70 @@ test_case_name=
 
 ### 4. 目录结构要求
 
-测试产生的所有文件必须保存在 `tone_tests/run/${test_case_name}/` 目录下：
+测试产生的所有文件必须保存在 `tone_tests/run/` 目录下：
 
 ```
-tone_tests/run/test_1p1d_erdma/
-├── logs/                    # 测试日志
-├── whls/                    # wheel 包
+tone_tests/run/
+├── logs/                           # 测试日志根目录
+│   ├── test_1p1d_erdma/           # 每个测试用例的日志目录
+│   │   ├── test_results.json      # 测试结果（必需）
+│   │   ├── Qwen__Qwen3-8B/        # 模型相关日志（如适用）
+│   │   │   ├── sglang_server_local.log
+│   │   │   ├── sglang_server_remote.log
+│   │   │   ├── load_balancer.log
+│   │   │   └── curl_response.log
+│   │   └── ...
+│   └── test_disaggregation_different_tp/
+│       ├── test_results.json
+│       └── test_disaggregation_different_tp.log
+├── whls/                           # wheel 包
 │   └── mooncake-*.whl
-├── .shrc                    # 环境变量配置
-└── test_results.json        # 测试结果（必需）
+├── pids/                           # 进程 PID 记录（用于清理）
+│   └── test_case_name/
+│       ├── server_prefill.pid
+│       └── proxy.pid
+└── .shrc                           # 环境变量配置文件
 ```
+
+**路径规范**：
+- 日志路径使用变量：`${BASE_DIR}/run/logs/${test_case_name}/`
+- 通过 `TEST_CASE_RESULT_PATH` 变量引用：`run/logs/${test_case_name}`
+- 避免硬编码路径，使用环境变量确保可移植性
 
 ### 5. 测试自包含原则
 
-- **容器管理**：脚本需自行管理 Docker 容器（拉取镜像、配置参数、启动/停止）
-- **环境隔离**：单机和多机测试均由脚本独立完成
-- **公共函数复用**：可使用 `common.sh` 中的公共函数：
-  - `setup_test_result_directory` - 创建测试结果目录
-  - `setup_log_directory` - 创建日志目录
+测试用例脚本应遵循自包含原则，但环境准备由 `run_test.sh` 统一管理：
+
+**由 `run_test.sh` 负责**：
+- 环境初始化（创建目录、生成 `.shrc` 配置文件）
+- Docker 容器管理（拉取镜像、启动/停止容器）
+- Wheel 包下载和安装
+- 单机/双机环境判断和准备
+- ERDMA 驱动安装
+- 远程机器同步和配置（双机测试）
+
+**测试脚本需要实现**：
+- `run_test()` 函数：执行具体的测试逻辑
+- `parse()` 函数：解析测试结果并生成 `test_results.json`
+- 可选的其他函数（如 `start_server`、`run_proxy` 等）
+
+**公共函数复用**（来自 `common.sh`）：
+  - `setup_directory` - 创建目录
+  - `setup_log_directory` - 创建/清理日志目录
   - `get_whl` - 下载 wheel 包
-  - `get_image` - 拉取 Docker 镜像
+  - `get_image` - 下载镜像
   - `docker_launch` - 启动 Docker 容器
   - `clean_container` - 清理容器
   - `stop_container` - 停止容器
   - `check_server_ready` - 检查服务器就绪状态
   - `check_proxy_ready` - 检查代理就绪状态
+  - `save_test_result` - 保存测试结果到 JSON 文件
+  - `launch_and_track_process` - 启动进程并记录 PID
+  - `kill_process` - 根据 PID 文件停止进程
 
 ### 6. 测试结果格式要求
 
-**必需文件**：`tone_tests/run/${test_case_name}/test_results.json`
+**必需文件**：`tone_tests/run/logs/${test_case_name}/test_results.json`
 
 **JSON 格式**：
 
@@ -143,66 +163,118 @@ tone_tests/run/test_1p1d_erdma/
 
 ### 7. 脚本结构示例
 
-推荐的脚本结构：
+#### 测试脚本示例
 
 ```bash
 #!/bin/bash
 
+# 测试用例基本信息
 test_case_name="test_demo"
-TONE_TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)
+TEST_TYPE="single"  # 单机测试
 
-# 变量声明
-LOCAL_IP=
-REMOTE_IP=
-ARTIFACT_ID=
-GIT_REPO=
+# 初始化路径和加载公共函数
+BASE_DIR=${BASE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)}
+. ${BASE_DIR}/scripts/common.sh
 
-. ${TONE_TESTS_DIR}/scripts/common.sh
+run_test()
+{
+    echo "===== Running pytest tests ====="
+    local log_file="${BASE_DIR}/${TEST_CASE_RESULT_PATH}/${test_case_name}.log"
 
-setup() {
-    # 容器启动等环境配置
+    echo "Running tests in container and saving output to: $log_file"
+    ${docker_exec} "\
+        cd /test_workspace && \
+        python3 -m pytest test_demo.py -v -s --tb=long" | tee "$log_file"
+    
+    return ${PIPESTATUS[0]}
 }
 
-run_test() {
-    # 执行测试
+parse()
+{
+    local test_exit_code=$1
+
+    echo "===== Parsing test results ====="
+    if [ $test_exit_code -eq 0 ]; then
+        save_test_result "$test_case_name" "Pass" "${BASE_DIR}/${TEST_CASE_RESULT_PATH}"
+        echo "✓ Test PASSED"
+        return 0
+    else
+        save_test_result "$test_case_name" "Fail" "${BASE_DIR}/${TEST_CASE_RESULT_PATH}"
+        echo "✗ Test FAILED"
+        return 1
+    fi
 }
 
-parse() {
-    # 解析结果并生成 test_results.json
-}
-
-cleanup() {
-    # 清理资源
-}
-
-main() {
-    setup
-    run_test
-    parse
-    cleanup
-}
-
-main
+# 脚本入口点
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    exit_code=0
+    if ! run_test; then
+        exit_code=1
+    fi
+    
+    parse $exit_code
+    exit $?
+fi
 ```
 
 ## 使用方法
 
-### 执行完整测试
+### 通过 run_test.sh 控制（推荐）
+
+`run_test.sh` 是测试用例的统一入口，负责环境准备、测试执行和资源清理的完整生命周期管理。
+
+#### 运行单个测试用例
 
 ```bash
-cd scripts && ./test_demo.sh
+cd scripts/tone_tests/scripts
+./run_test.sh run-single test_hicache_storage_mooncake_backend.sh
 ```
 
-### 在 T-One 平台执行
+执行流程：
+1. 根据测试类型（`TEST_TYPE`）准备环境（单机或双机）
+2. 创建和配置 Docker 容器
+3. 下载和安装 Mooncake wheel 包
+4. 执行测试脚本的 `run_test()` 函数
+5. 调用 `parse()` 函数解析结果
+6. 清理环境和容器
 
-测试用例会由 tone-cli 自动扫描和执行，无需手动干预。
+#### 运行所有 SGLANG 测试用例
+
+```bash
+cd scripts/tone_tests/scripts
+./run_test.sh run-all SGLANG
+```
+
+将按顺序执行 `All_TEST_SCRIPTS_SGLANG` 数组中的所有测试：
+- `test_hicache_storage_mooncake_backend.sh`
+- `test_disaggregation_different_tp.sh`
+- `test_1p1d_erdma.sh`
+
+#### 查看帮助信息
+
+```bash
+./run_test.sh
+```
+
+输出：
+```
+Mooncake CI Controller
+Usage: ./run_test.sh <command> [args]
+
+Commands:
+  run-single <test_name>             - Full lifecycle: setup -> run -> parse -> cleanup
+  run-all [SGLANG|VLLM]              - Run all tests for specific framework
+  run-all SGLANG                     - Run all SGLANG tests (using SGLANG image)
+  run-all VLLM                       - Run all VLLM tests (using VLLM image)
+```
 
 ## 注意事项
 
-1. **环境变量优先级**：tone-cli 会替换脚本中的变量
-2. **日志完整性**：确保所有重要日志都保存到指定目录，方便排查问题
-3. **资源清理**：即使测试失败也要执行 cleanup 清理资源
-4. **JSON 格式**：严格遵守 JSON 格式规范，避免语法错误
+1. **环境变量使用**：使用 `$BASE_DIR`、`$TEST_CASE_RESULT_PATH` 等环境变量，避免硬编码路径
+2. **日志完整性**：确保所有重要日志都保存到 `${BASE_DIR}/run/logs/${test_case_name}/` 目录
+3. **资源清理**：测试脚本应通过 PID 文件管理进程，确保资源正确清理
+4. **JSON 格式**：严格遵守 JSON 格式规范，必须包含 `test_case` 和 `status` 字段
+5. **测试类型声明**：必须在脚本开头声明 `TEST_TYPE` 变量，供 `run_test.sh` 判断环境准备类型
 
 ## 相关链接
 

--- a/scripts/tone_tests/scripts/common.sh
+++ b/scripts/tone_tests/scripts/common.sh
@@ -1,30 +1,53 @@
 #!/bin/bash
 
+TEST_CASE_RESULT_PATH="run/logs/$test_case_name"
 docker_exec="docker exec ${CONTAINER_NAME} bash -c"
-TEST_CASE_RESULT_PATH="run/$test_case_name"
+
+setup_directory(){
+    local dir_path=$1
+    
+    if [ -z "$dir_path" ]; then
+        echo "ERROR: Directory path not provided" >&2
+        return 1
+    fi
+    
+    if [ -d "$dir_path" ]; then
+        echo "Directory already exists: $dir_path"
+        return 0
+    fi
+
+    if mkdir -p "$dir_path"; then
+        echo "Directory created successfully: $dir_path"
+        return 0
+    else
+        echo "ERROR: Failed to create directory: $dir_path" >&2
+        return 1
+    fi
+}
 
 setup_log_directory(){
-    local test_name=$1
-    local model_name=$2
-
-    log_path="$BASE_DIR/$test_name/logs/$model_name"
-    [ -d $log_path ] && rm -rf $log_path
-    mkdir -p $log_path
-
-    echo "Log directory set up at: $log_path"
+    local log_dir="$1"
+    
+    if [ -d "$log_dir" ]; then
+        echo "Removing existing log directory: $log_dir"
+        rm -rf "$log_dir"
+    fi
+    mkdir -p "$log_dir"
+    echo "Log directory set up at: $log_dir"
 }
 
 docker_launch(){
-    local extra_args=$1
+    local registry_addr=$1
+    local extra_args=$2
 
-    docker_run_cmd="docker run --name ${CONTAINER_NAME} \
+    docker_run_cmd="docker run  --init --name ${CONTAINER_NAME} \
     -d --ipc=host --cap-add=SYS_PTRACE --network=host --gpus all \
     --ulimit memlock=-1 --ulimit stack=67108864 --shm-size=128g \
     -v ${MODEL_CACHE}:/root/.cache $extra_args --privileged \
     -v $BASE_DIR:/test_run \
     -v /root/test.jsonl:/tmp/test.jsonl \
     --entrypoint bash \
-    ${REGISTRY_ADDR} -c \"hostname;sleep 360000\""
+    ${registry_addr} -c \"hostname;sleep 360000\""
 
     echo "Executing Docker run command:"
     echo "$docker_run_cmd"
@@ -56,12 +79,12 @@ docker_launch(){
     echo "deb [ ] http://mirrors.cloud.aliyuncs.com/erdma/apt/ubuntu '"${erdma_repo_codename}"'/erdma main" | tee /etc/apt/sources.list.d/erdma.list && \
     apt update && \
     apt install libibverbs1 ibverbs-providers ibverbs-utils librdmacm1 -y'
-    mooncake_whl_file=$(ls $TEST_CASE_RESULT_DIR/whls/*.whl 2>/dev/null | xargs -n 1 basename | head -n 1)
+    mooncake_whl_file=$(ls $TEST_RUN_DIR/whls/*.whl 2>/dev/null | xargs -n 1 basename | head -n 1)
     if [ -z "$mooncake_whl_file" ]; then
-        echo "No wheel file found in $TEST_CASE_RESULT_DIR/whls/"
+        echo "No wheel file found in $TEST_RUN_DIR/whls/"
         return 1
     fi
-    local relative_path=${TEST_CASE_RESULT_DIR#$BASE_DIR}
+    local relative_path=${TEST_RUN_DIR#$BASE_DIR}
     local cleaned_path=${relative_path#/}
     pip_cmd=$(append_str "${pip_cmd}" "pip install /test_run/$cleaned_path/whls/$mooncake_whl_file")
 
@@ -138,7 +161,7 @@ append_str() {
 
 check_server_ready() { 
     local server_log_path=$1
-    local max_attempts=${2:-60}
+    local max_attempts=${2:-120}
 
     if [ -z "$server_log_path" ]; then
         echo "ERROR: Server log path not provided" >&2
@@ -217,12 +240,13 @@ get_whl(){
 
 get_image(){
     # only support run in container
-    echo "Get image $REGISTRY_ADDR"
+    local registry_addr=$1
+    echo "Get image $registry_addr"
 
-    echo "Pulling latest image ${REGISTRY_ADDR}..."
-    docker pull $REGISTRY_ADDR
+    echo "Pulling image ${registry_addr}..."
+    docker pull $registry_addr
     if [ $? -ne 0 ]; then
-        echo "Failed to pull image ${REGISTRY_ADDR}"
+        echo "Failed to pull image ${registry_addr}"
         return 1
     fi
 
@@ -276,26 +300,8 @@ check_proxy_ready() {
     return 1
 }
 
-setup_test_result_directory() {
-    local test_case_result_path=$1
-    
-    if [ -d "$test_case_result_path" ]; then
-        echo "Removing existing test result directory: $test_case_result_path"
-        rm -rf "$test_case_result_path"
-    fi
-    
-    echo "Creating test result directory: $test_case_result_path"
-    if ! mkdir -p "$test_case_result_path"; then
-        echo "ERROR: Failed to create test result directory: $test_case_result_path"
-        return 1
-    fi
-    
-    echo "Test result directory set up successfully"
-    return 0
-}
 
-stop_container()
-{
+stop_container(){
     local container_name=${1:-$CONTAINER_NAME}
     local remote_host=$2
     local location="local"
@@ -324,4 +330,128 @@ stop_container()
         echo "Failed to stop ${location} container: ${container_name} (may not exist)"
         return 1
     fi
+}
+
+save_test_result() {
+    local test_case_name=$1
+    local status=$2
+    local result_dir=$3
+    
+    local result_json="${result_dir}/test_results.json"
+    
+    echo "{\"test_case\": \"$test_case_name\", \"status\": \"$status\", \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$result_json"
+    echo "Test results saved to: $result_json"
+    echo "$test_case_name: $status"
+}
+
+cleanup_test_env() {
+    local test_type=$1
+    
+    echo "===== Cleaning up $test_type machine environment ====="
+    
+    stop_container "${CONTAINER_NAME}"
+    
+    if [ "$test_type" = "double" ] && [ -n "$REMOTE_IP" ]; then
+        stop_container "${CONTAINER_NAME}" "$REMOTE_IP"
+    fi
+    
+    echo "Cleanup completed"
+}
+
+setup_node_env() {
+    local registry_addr=$1
+    echo "===== Setting up docker environment ====="
+    
+    if ! get_image "$registry_addr"; then
+        echo "ERROR: Failed to get the required image"
+        return 1
+    fi
+
+    if ! clean_container ${CONTAINER_NAME}; then
+        echo "ERROR: Failed to clean up container"
+        return 1
+    fi
+
+    local extra_args=""
+    extra_args="$extra_args --device=/dev/infiniband/uverbs0 --device=/dev/infiniband/uverbs1 --device=/dev/infiniband/rdma_cm "
+    if [ "${USE_HUGGINGFACE_MIRROR}" = "true" ]; then
+        extra_args="$extra_args -e HF_ENDPOINT=${HUGGINGFACE_MIRROR} -e HF_HUB_ENABLE_HF_TRANSFER=1"
+    fi
+    if [ "${USE_MODELSCOPE}" = "true" ]; then
+        extra_args="$extra_args -e SGLANG_USE_MODELSCOPE=true"
+    fi
+
+    if ! docker_launch "$registry_addr" "$extra_args"; then
+        echo "ERROR: Failed to launch docker container"
+        return 1
+    fi
+
+    echo "Node environment setup completed"
+    return 0
+}
+
+launch_and_track_process() {
+    local full_cmd="$1"
+    local grep_pattern="$2"
+    local pid_file="$3"
+
+    echo "Executing command..."
+    echo "$full_cmd"
+    eval "$full_cmd"
+
+    echo "Waiting for process to initialize..."
+    for i in {1..15}; do
+        local container_main_pid=$(docker inspect --format '{{.State.Pid}}' "${CONTAINER_NAME}" 2>/dev/null)
+        if [ -n "$container_main_pid" ] && [ "$container_main_pid" != "0" ]; then
+            pid=$(ps -eo pid,ppid,cmd | awk -v root="$container_main_pid" -v pattern="$grep_pattern" '
+                BEGIN { pids[root] = 1 }
+                {
+                    if ($2 in pids && $0 ~ pattern) {
+                        print $1
+                        exit
+                    }
+                }
+            ')
+        fi
+
+        if [ -n "$pid" ]; then
+            echo "$pid" > "$pid_file"
+            echo "PID $pid (on host) saved to $pid_file"
+            return 0
+        fi
+        
+        echo "  Attempt $i/15..."
+        sleep 2
+    done
+
+    echo "Process not found after 30 seconds"
+    return 1
+}
+
+kill_process() {
+    local pid_file=$1
+    local service_name=$2
+
+    if [ ! -f "$pid_file" ]; then
+        echo "No PID file for $service_name."
+        return 0
+    fi
+
+    local pid=$(cat "$pid_file")
+    if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+        rm -f "$pid_file"
+        return 0
+    fi
+
+    echo "Stopping $service_name (PID: $pid)..."
+    
+    kill -TERM "$pid" 2>/dev/null
+    sleep 2
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -KILL "$pid" 2>/dev/null
+    fi
+    
+    rm -f "$pid_file"
+    echo "✓ $service_name stopped"
+    return 0
 }

--- a/scripts/tone_tests/scripts/run_test.sh
+++ b/scripts/tone_tests/scripts/run_test.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+
+CONTAINER_NAME=${CONTAINER_NAME:-"mooncake-ci-test"}
+MODEL_CACHE=${MODEL_CACHE:-"/root/.cache"}
+REGISTRY_ADDR_SGLANG=${REGISTRY_ADDR_SGLANG:-"lmsysorg/sglang:latest"}
+REGISTRY_ADDR_VLLM=${REGISTRY_ADDR_VLLM:-"vllm/vllm-openai:latest"}
+USE_HUGGINGFACE_MIRROR=${USE_HUGGINGFACE_MIRROR:-true}
+HUGGINGFACE_MIRROR=${HUGGINGFACE_MIRROR:-"https://hf-mirror.com"}
+USE_MODELSCOPE=${USE_MODELSCOPE:-false}
+REMOTE_TEST_DIR=${REMOTE_TEST_DIR:-"/tmp/Mooncake_tone/mooncake_ci_test"}
+LOCAL_IP=${LOCAL_IP}
+REMOTE_IP=${REMOTE_IP}
+ARTIFACT_ID=${ARTIFACT_ID}
+GIT_REPO=${GIT_REPO}
+
+All_TEST_SCRIPTS_SGLANG=(
+    "test_hicache_storage_mooncake_backend.sh"
+    "test_disaggregation_different_tp.sh"
+    "test_1p1d_erdma.sh"
+)
+
+# All_TEST_SCRIPTS_VLLM=()
+
+readonly SSH_CMD="ssh -o StrictHostKeyChecking=no"
+
+TONE_TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)
+RUN_DIR="$TONE_TESTS_DIR/run"
+
+. $TONE_TESTS_DIR/scripts/common.sh
+
+get_test_type() {
+    local test_name=$1
+    
+    if [ ! -f "$TONE_TESTS_DIR/scripts/$test_name" ]; then
+        echo "unknown"
+        return 1
+    fi
+    
+    local test_type=$(grep "^TEST_TYPE=" "$TONE_TESTS_DIR/scripts/$test_name" | head -n 1 | cut -d'"' -f2)
+    
+    if [ -z "$test_type" ]; then
+        echo "unknown"
+        return 1
+    fi
+    
+    echo "$test_type"
+    return 0
+}
+
+get_framework_from_test_array() {
+    local test_array_name=$1
+    
+    case $test_array_name in
+        "All_TEST_SCRIPTS_SGLANG")
+            echo "SGLANG"
+            ;;
+        "All_TEST_SCRIPTS_VLLM")
+            echo "VLLM"
+            ;;
+        *)
+            echo "SGLANG"
+            ;;
+    esac
+}
+
+get_framework_from_test_name() {
+    local test_name=$1
+    
+    for vllm_test in "${All_TEST_SCRIPTS_VLLM[@]}"; do
+        if [ "$test_name" = "$vllm_test" ]; then
+            echo "VLLM"
+            return 0
+        fi
+    done
+    
+    # default SGLANG
+    echo "SGLANG"
+}
+
+get_registry_addr_for_framework() {
+    local framework_type=$1
+    case $framework_type in
+        "SGLANG")
+            echo "$REGISTRY_ADDR_SGLANG"
+            ;;
+        "VLLM")
+            echo "$REGISTRY_ADDR_VLLM"
+            ;;
+        *)
+            echo "$REGISTRY_ADDR_SGLANG"  # default
+            ;;
+    esac
+}
+
+is_base_env_prepared() {
+    if [ ! -f "$RUN_DIR/.shrc" ]; then
+        return 1  # config file doesn't exist
+    fi
+
+    # Check if ARTIFACT_ID matches current environment
+    local current_artifact_id=$(grep "^export ARTIFACT_ID=" "$RUN_DIR/.shrc" | cut -d'=' -f2-)
+    if [ "$current_artifact_id" != "$ARTIFACT_ID" ]; then
+        return 1  # ARTIFACT_ID mismatch
+    fi
+
+    # Check if whl package exists
+    local whl_count=$(find "$RUN_DIR/whls/" -name "*.whl" -type f 2>/dev/null | wc -l)
+    [ $whl_count -gt 0 ]
+}
+
+prepare_single_env(){
+    local registry_addr=$1 
+    local framework_type=$2
+
+    if is_base_env_prepared; then
+        echo "Environment already prepared for current ARTIFACT_ID, skipping setup"
+        return 0
+    fi
+
+    echo "===== Preparing environment for $framework_type (registry: $registry_addr) ====="
+    
+    setup_directory $RUN_DIR
+    setup_directory $RUN_DIR/logs
+
+    cat > $RUN_DIR/.shrc << EOF
+# Mooncake CI Test Environment Variables - Main Controller
+export CONTAINER_NAME=${CONTAINER_NAME}
+export MODEL_CACHE=${MODEL_CACHE}
+export REGISTRY_ADDR_SGLANG=${REGISTRY_ADDR_SGLANG}
+export REGISTRY_ADDR_VLLM=${REGISTRY_ADDR_VLLM}
+export USE_HUGGINGFACE_MIRROR=${USE_HUGGINGFACE_MIRROR}
+export HUGGINGFACE_MIRROR=${HUGGINGFACE_MIRROR}
+export USE_MODELSCOPE=${USE_MODELSCOPE}
+export ARTIFACT_ID=${ARTIFACT_ID}
+export GIT_REPO=${GIT_REPO}
+export LOCAL_IP=${LOCAL_IP}
+export REMOTE_IP=${REMOTE_IP}
+export BASE_DIR=${TONE_TESTS_DIR}
+export TEST_RUN_DIR=${RUN_DIR}
+export TEST_RESULT_DIR=${RUN_DIR}/logs
+export REMOTE_TEST_DIR=${REMOTE_TEST_DIR}
+EOF
+
+    echo "===== Preparing local machine ====="
+    echo "Get mooncake whl on local machine..."
+    source $RUN_DIR/.shrc && get_whl $RUN_DIR
+    if [ $? -ne 0 ]; then
+        echo "Failed to get mooncake whl on local machine"
+        return 1
+    fi
+    echo "Local preparation completed successfully"
+
+    return 0
+}
+
+prepare_double_env(){
+    local registry_addr=$1
+    local framework_type=$2
+
+    echo "===== Preparing Double-Machine Environment (local + remote) ====="
+
+    if ! prepare_single_env "$registry_addr" "$framework_type"; then
+        echo "ERROR: prepare_single_env failed"
+        return 1
+    fi
+
+    if [ -z "$REMOTE_IP" ]; then
+        echo "ERROR: REMOTE_IP must be set for double-machine prepare"
+        return 1
+    fi
+
+    echo "Preparing remote machine $REMOTE_IP..."
+    ${SSH_CMD} $REMOTE_IP "rm -rf ${REMOTE_TEST_DIR} && mkdir -p ${REMOTE_TEST_DIR}"
+    
+    rsync -av ${TONE_TESTS_DIR}/ $REMOTE_IP:${REMOTE_TEST_DIR}/
+    if [ $? -ne 0 ]; then
+        echo "Failed to sync files to remote server"
+        return 1
+    fi
+    
+    ${SSH_CMD} $REMOTE_IP "sed -i 's|^export BASE_DIR=.*$|export BASE_DIR=${REMOTE_TEST_DIR}|' ${REMOTE_TEST_DIR}/run/.shrc && \
+                            sed -i 's|^export TEST_RUN_DIR=.*$|export TEST_RUN_DIR=${REMOTE_TEST_DIR}/run|' ${REMOTE_TEST_DIR}/run/.shrc && \
+                            sed -i 's|^export TEST_RESULT_DIR=.*$|export TEST_RESULT_DIR=${REMOTE_TEST_DIR}/logs|' ${REMOTE_TEST_DIR}/run/.shrc"
+    
+    echo "Remote preparation completed successfully"
+
+    return 0
+}
+
+setup_env_for_test() {
+    local target=$1
+    local framework_type=$2
+    local type=$(get_test_type "$target")
+    [ "$target" = "all" ] && type="double"
+
+    local registry_addr=$(get_registry_addr_for_framework "$framework_type")
+
+    if [ "$type" = "double" ]; then
+        prepare_double_env "$registry_addr" "$framework_type" || return 1
+    else
+        prepare_single_env "$registry_addr" "$framework_type" || return 1
+    fi
+
+    source "$RUN_DIR/.shrc" && setup_node_env "$registry_addr" || return 1
+
+    if [ "$type" = "double" ]; then
+        echo "Initializing remote node $REMOTE_IP..."
+        ${SSH_CMD} "$REMOTE_IP" "
+            source ${REMOTE_TEST_DIR}/run/.shrc && \
+            source ${REMOTE_TEST_DIR}/scripts/common.sh && \
+            setup_node_env '${registry_addr}'
+        " || { echo "ERROR: Remote setup failed"; return 1; }
+    fi
+    
+    echo "All environments are ready."
+}
+
+run_single_test(){
+    local test_name=$1
+    shift
+    echo "===== Running Single Test: $test_name ====="
+
+    local framework_type=$(get_framework_from_test_name "$test_name")
+    echo "Test $test_name will use framework: $framework_type"
+    
+    setup_env_for_test "$test_name" "$framework_type" || return 1
+    
+    source "$RUN_DIR/.shrc"
+    cd "$TONE_TESTS_DIR/scripts"
+    source "./$test_name"
+    
+    local exit_code=0
+    run_test "$@" || exit_code=1
+    
+    if declare -f parse >/dev/null 2>&1; then
+        parse "$exit_code" || exit_code=1
+    fi
+
+    local type=$(get_test_type "$test_name")
+    cleanup_test_env "$type"
+    return $exit_code
+}
+
+run_all_tests(){
+    local input_tests=${1:-"All_TEST_SCRIPTS_SGLANG"}
+    if ! [[ -v "$input_tests" ]]; then
+        echo "ERROR: Variable '$input_tests' does not exist"
+        return 1
+    fi
+    local tests_array_ref="${input_tests}[@]"
+    local tests=("${!tests_array_ref}")
+
+    local framework_type=$(get_framework_from_test_array "$input_tests")
+    echo "===== Running All Tests for $framework_type Framework (Double Machine Mode) ====="
+    
+    setup_env_for_test "all" "$framework_type" || return 1
+    
+    source "$RUN_DIR/.shrc"
+    cd "$TONE_TESTS_DIR/scripts"
+    
+    local all_passed=true
+    for test_name in "${tests[@]}"; do
+        if [[ ! -f "./$test_name" ]]; then
+            echo "WARNING: test case $test_name is not found, skipping"
+            continue
+        fi
+        echo "Executing: $test_name"
+
+        local log_dir="${BASE_DIR}/run/logs/$(basename "$test_name" .sh)"
+        setup_log_directory "$log_dir"
+
+        source "./$test_name"
+        local exit_code=0
+        run_test || exit_code=1
+        
+        if declare -f parse >/dev/null 2>&1; then
+            parse "$exit_code" || exit_code=1
+        fi
+        
+        [ $exit_code -ne 0 ] && all_passed=false
+    done
+    
+    cleanup_test_env "double"
+    $all_passed && return 0 || return 1
+}
+
+show_help(){
+    echo "Mooncake CI Controller"
+    echo "Usage: $0 <command> [args]"
+    echo ""
+    echo "Commands:"
+    echo "  run-single <test_name>             - Full lifecycle: setup -> run -> parse -> cleanup"
+    echo "  run-all [SGLANG|VLLM]              - Run all tests for specific framework"
+    echo "  run-all SGLANG                     - Run all SGLANG tests (using SGLANG image)"
+    echo "  run-all VLLM                       - Run all VLLM tests (using VLLM image)"
+}
+
+case "$1" in
+    "run-single")
+        shift
+        run_single_test "$@"
+        ;;
+    "run-all")
+        shift
+        local framework=${1:-"SGLANG"}  # 默认为 SGLANG
+        if [ "$framework" = "VLLM" ]; then
+            run_all_tests "All_TEST_SCRIPTS_VLLM"
+        else
+            run_all_tests "All_TEST_SCRIPTS_SGLANG"
+        fi
+        ;;
+    *)
+        show_help
+        ;;
+esac

--- a/scripts/tone_tests/scripts/test_1p1d_erdma.sh
+++ b/scripts/tone_tests/scripts/test_1p1d_erdma.sh
@@ -1,127 +1,24 @@
 #!/bin/bash
 
 test_case_name="test_1p1d_erdma"
-
-LOCAL_IP=
-REMOTE_IP=
-
-readonly SSH_CMD="ssh -o StrictHostKeyChecking=no"
+TEST_TYPE="double"
 SUPPORT_MODELS=("Qwen/Qwen3-8B" "deepseek-ai/DeepSeek-V2-Lite")
-CONTAINER_NAME=${CONTAINER_NAME:-"mooncake-ci-test"}
-MODEL_CACHE=${MODEL_CACHE:-"/root/.cache"}
-REGISTRY_ADDR=${REGISTRY_ADDR:-"lmsysorg/sglang:latest"}
-USE_HUGGINGFACE_MIRROR=${USE_HUGGINGFACE_MIRROR:-true}
-HUGGINGFACE_MIRROR=${HUGGINGFACE_MIRROR:-"https://hf-mirror.com"}
-USE_MODELSCOPE=${USE_MODELSCOPE:-false}
-REMOTE_TEST_DIR=${REMOTE_TEST_DIR:-"/tmp/Mooncake_tone/mooncake_ci_test"}
-ARTIFACT_ID=
-GIT_REPO=
 
-TONE_TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)
+PID_DIR=${BASE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)}/run/pids/${test_case_name}
 
-. $TONE_TESTS_DIR/scripts/common.sh
-
-prepare(){
-    # get client server ip
-    echo "===== Getting Local and Remote IP ====="
-    echo "LOCAL: $LOCAL_IP, REMOTE: $REMOTE_IP" 
-
-    setup_test_result_directory $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH
-
-    cat > $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH/.shrc << EOF
-# Mooncake CI Test Environment Variables - ${test_case_name}
-export CONTAINER_NAME=${CONTAINER_NAME}
-export MODEL_CACHE=${MODEL_CACHE}
-export ARTIFACT_ID=${ARTIFACT_ID}
-export REGISTRY_ADDR=${REGISTRY_ADDR} 
-export ISREMOTE=0
-export LOCAL_IP=${LOCAL_IP}
-export REMOTE_IP=${REMOTE_IP}
-export USE_HUGGINGFACE_MIRROR=${USE_HUGGINGFACE_MIRROR}
-export HUGGINGFACE_MIRROR=${HUGGINGFACE_MIRROR}
-export USE_MODELSCOPE=${USE_MODELSCOPE}
-export BASE_DIR=${TONE_TESTS_DIR}
-export GIT_REPO=${GIT_REPO}
-export TEST_CASE_RESULT_DIR=${TONE_TESTS_DIR}/${TEST_CASE_RESULT_PATH}
-EOF
-
-    echo "===== Starting Local Installation ====="
-    echo "Get mooncake whl on local machine..."
-    echo "Verifying local environment variables:"
-    cat $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH/.shrc
-    source $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH/.shrc && get_whl $TEST_CASE_RESULT_DIR
-    if [ $? -ne 0 ]; then
-        echo "Failed to get mooncake whl on local machine"
-        return 1
-    fi
-    echo "Local installation completed successfully"
-
-    echo "===== Starting Remote Installation ====="
-    echo "Local: $LOCAL_IP, Remote: $REMOTE_IP"
-    if [ -n "$REMOTE_IP" ]; then
-        echo "Copying test script to remote server $REMOTE_IP..."
-        ${SSH_CMD} $REMOTE_IP "rm -rf ${REMOTE_TEST_DIR} && mkdir -p ${REMOTE_TEST_DIR}"
-
-        rsync -av ${TONE_TESTS_DIR}/ $REMOTE_IP:${REMOTE_TEST_DIR}/
-        if [ $? -ne 0 ]; then
-            echo "Failed to copy files to remote server"
-            return 1
-        fi
-        
-        ${SSH_CMD} $REMOTE_IP "sed -i 's|^export ISREMOTE=0|export ISREMOTE=1|' ${REMOTE_TEST_DIR}/${TEST_CASE_RESULT_PATH}/.shrc && \
-                              sed -i 's|^export BASE_DIR=.*$|export BASE_DIR=${REMOTE_TEST_DIR}|' ${REMOTE_TEST_DIR}/${TEST_CASE_RESULT_PATH}/.shrc && \
-                              sed -i 's|^export TEST_CASE_RESULT_DIR=.*$|export TEST_CASE_RESULT_DIR=${REMOTE_TEST_DIR}/${TEST_CASE_RESULT_PATH}|' ${REMOTE_TEST_DIR}/${TEST_CASE_RESULT_PATH}/.shrc"
-        echo "Verifying remote environment variables:"
-        ${SSH_CMD} $REMOTE_IP "cat ${REMOTE_TEST_DIR}/${TEST_CASE_RESULT_PATH}/.shrc"
-
-        echo "Remote installation completed successfully"
+if [ -z "${ISREMOTE}" ]; then
+    if [ -n "${REMOTE_IP}" ] && [ -n "${REMOTE_TEST_DIR}" ] && [[ "$PWD" == "${REMOTE_TEST_DIR}"* ]]; then
+        ISREMOTE=1
     else
-        echo "No client specified, skipping remote installation"
+        ISREMOTE=0
     fi
+    export ISREMOTE
+fi
 
-    echo "===== Installation Completed ====="
-    return 0
-}
+BASE_DIR=${BASE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)}
+. ${BASE_DIR}/scripts/common.sh
 
-setup()
-{   
-    local model_name=$1
-    echo "===== Setting up Mooncake CI test ====="
-    echo "mkdir log path..."
-    setup_log_directory $TEST_CASE_RESULT_PATH $model_name
-
-    echo "Get the latest sglang image..."
-    if ! get_image; then
-        echo "ERROR: Failed to get the required image"
-        exit 1
-    fi
-
-    # qit old container
-    echo "Quit old container..."
-    if ! clean_container ${CONTAINER_NAME}; then
-        echo "ERROR: Failed to clean up container"
-        exit 1
-    fi
-
-    extra_args=""
-    extra_args="$extra_args --device=/dev/infiniband/uverbs0 --device=/dev/infiniband/uverbs1 --device=/dev/infiniband/rdma_cm "
-    if ${USE_HUGGINGFACE_MIRROR}; then
-       extra_args="$extra_args -e HF_ENDPOINT=${HUGGINGFACE_MIRROR}"
-       extra_args="$extra_args -e HF_HUB_ENABLE_HF_TRANSFER=1"
-    fi
-    if ${USE_MODELSCOPE}; then
-       extra_args="$extra_args -e SGLANG_USE_MODELSCOPE=true"
-    fi
-    echo "extra_args: $extra_args"
-
-    echo "Launching docker container..."
-    if ! docker_launch "$extra_args"; then
-        echo "ERROR: Failed to launch docker container"
-        exit 1
-    fi
-
-    return 0
-}
+mkdir -p "$PID_DIR"
 
 start_server()
 {   
@@ -131,21 +28,26 @@ start_server()
     local sglang_server_log_path
     if [ "$ISREMOTE" == "0" ]; then 
         host=$LOCAL_IP
-        sglang_server_log_path=/test_run/run/$test_case_name/logs/$model_name_clean/sglang_server_local.log
+        sglang_server_log_path=/test_run/run/logs/$test_case_name/$model_name_clean/sglang_server_local.log
         mode_name=prefill
     else
         host=$REMOTE_IP
-        sglang_server_log_path=/test_run/run/$test_case_name/logs/$model_name_clean/sglang_server_remote.log
+        sglang_server_log_path=/test_run/run/logs/$test_case_name/$model_name_clean/sglang_server_remote.log
         mode_name=decode
     fi
 
-    sglang_start_server_cmd_remote="
+    sglang_start_server_cmd="
     ${docker_exec} \
     \"python -m sglang.launch_server --model-path ${model_name} \
-    --disaggregation-mode $mode_name --port 30001 --host ${host} --tp-size 2 --base-gpu-id=6 > ${sglang_server_log_path} 2>&1 &\""
-    echo "Start sglang server command:"
-    echo "$sglang_start_server_cmd_remote"
-    eval "$sglang_start_server_cmd_remote"
+    --disaggregation-mode $mode_name --port 30001 --host ${host} --tp-size 2 --base-gpu-id=0 > ${sglang_server_log_path} 2>&1 &\""
+
+    local pid_file="${PID_DIR}/server_${mode_name}.pid"
+    local grep_pattern="python -m sglang.launch_server.*${model_name}"
+
+    echo "Starting SGLang Server..."
+    if ! launch_and_track_process "$sglang_start_server_cmd" "$grep_pattern" "$pid_file"; then
+        return 1
+    fi
 
     exactly_sglang_server_log_path=$(echo "$sglang_server_log_path" | sed "s|/test_run/|$BASE_DIR/|")
     if ! check_server_ready "$exactly_sglang_server_log_path"; then
@@ -157,15 +59,19 @@ start_server()
 
 run_proxy(){
     local model_name=$1
-    local proxy_log_path="/test_run/run/$test_case_name/logs/$model_name/load_balancer.log"
+    local proxy_log_path="/test_run/run/logs/$test_case_name/$model_name/load_balancer.log"
 
     echo "===== Proxy Run ====="
     lb_cmd="${docker_exec} \"python3 -m sglang_router.launch_router --pd-disaggregation \
     --prefill http://${LOCAL_IP}:30001 --decode http://${REMOTE_IP}:30001 --host 0.0.0.0 \
     --port 8000 > $proxy_log_path 2>&1 &\""
-    echo "Load balancer command:"
-    echo "$lb_cmd"
-    eval "$lb_cmd"
+
+    local pid_file="${PID_DIR}/proxy.pid"
+    local grep_pattern="sglang::router"
+    echo "Load balancer starting..."
+    if ! launch_and_track_process "$lb_cmd" "$grep_pattern" "$pid_file"; then
+        return 1
+    fi
 
     exactly_proxy_log_path=$(echo "$proxy_log_path" | sed "s|/test_run/|$BASE_DIR/|")
     if ! check_proxy_ready "$exactly_proxy_log_path"; then
@@ -190,7 +96,7 @@ run_request(){
     echo "$response_body"
     echo "Status Code: $status_code"
 
-    echo "$response_body" > $BASE_DIR/run/$test_case_name/logs/$model_name/curl_response.log
+    echo "$response_body" > $BASE_DIR/run/logs/$test_case_name/$model_name/curl_response.log
 
     if [ $status_code -eq 200 ]; then
         echo "Test request successful!"
@@ -201,47 +107,71 @@ run_request(){
     fi
 }
 
+kill_model_processes() {
+    echo "===== Killing model processes ====="
+    
+    if [ -d "$PID_DIR" ]; then
+        echo "Cleaning up by PID files in $PID_DIR..."
+        for pid_file in "${PID_DIR}"/*.pid; do
+            if [ -f "$pid_file" ]; then
+                local service_name=$(basename "$pid_file" .pid)
+                kill_process "$pid_file" "$service_name"
+            fi
+        done
+    fi
+    
+    if [ "$ISREMOTE" == "0" ] && [ -n "$REMOTE_IP" ]; then
+        echo "===== Killing model processes (remote: $REMOTE_IP) ====="
+        ${SSH_CMD} "$REMOTE_IP" "source $REMOTE_TEST_DIR/run/.shrc; cd \$BASE_DIR/scripts && ./$test_case_name.sh stop_server" 2>/dev/null || true
+    fi
+    
+    echo "Process cleanup completed."
+}
+
 run_single_model()
 {
     local model_name=$1
     local model_name_clean=$(echo "$model_name" | sed 's/\//__/g')
+    local status=0
+
+    setup_log_directory "$TEST_RUN_DIR/logs/$test_case_name/$model_name_clean"
+    ${SSH_CMD} $REMOTE_IP "source $REMOTE_TEST_DIR/run/.shrc; cd \$BASE_DIR/scripts && source ./common.sh && setup_log_directory \"\$TEST_RUN_DIR/logs/$test_case_name/$model_name_clean\""
     
-    echo "===== Run MODEL NAME: $model_name ====="
-    # launch docker
-    echo "Launching docker container on local machine..."
-    setup $model_name_clean
-    echo -e "\n\nLaunching docker container on remote machine..."
-    ${SSH_CMD} $REMOTE_IP "source $REMOTE_TEST_DIR/$TEST_CASE_RESULT_PATH/.shrc; cd \$BASE_DIR/scripts && bash ./$test_case_name.sh setup $model_name_clean"
-    
+    echo "===== Run MODEL NAME: $model_name ====="    
     # Local start server
     if ! start_server $model_name $model_name_clean; then
         echo "ERROR: Failed to start local server for model $model_name"
-        return 1
-    fi
-    # Remote start server
-    if ! ${SSH_CMD} $REMOTE_IP "source $REMOTE_TEST_DIR/$TEST_CASE_RESULT_PATH/.shrc; cd \$BASE_DIR/scripts && ./$test_case_name.sh start_server $model_name $model_name_clean"; then
-        echo "ERROR: Failed to start remote server for model $model_name"
-        return 1
+        status=1
+    else
+        # Remote start server
+        if ! ${SSH_CMD} $REMOTE_IP "source $REMOTE_TEST_DIR/run/.shrc; cd \$BASE_DIR/scripts && ./$test_case_name.sh start_server $model_name $model_name_clean"; then
+            echo "ERROR: Failed to start remote server for model $model_name"
+            status=1
+        else
+            # Local run proxy
+            if ! run_proxy $model_name_clean; then
+                echo "ERROR: Failed to start local proxy for model $model_name"
+                status=1
+            else
+                sleep 5
+                # Local Sending Test Request
+                if ! run_request $model_name_clean; then
+                    echo "ERROR: Failed to send test request for model $model_name"
+                    status=1
+                fi
+            fi
+        fi
     fi
 
-    # Local run proxy
-    if ! run_proxy $model_name_clean; then
-        echo "ERROR: Failed to start local proxy for model $model_name"
-        return 1
-    fi
-    sleep 5
-    # Local Sending Test Request
-    if ! run_request $model_name_clean; then
-        echo "ERROR: Failed to send test request for model $model_name"
-        return 1
-    fi
+    echo "===== Cleaning up model processes for $model_name ====="
+    kill_model_processes
+    sleep 2
 
-    return 0
+    return $status
 }
 
 run_test()
 {
-    source $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH/.shrc
     if [ -z "$REMOTE_IP" ] || [ -z "$LOCAL_IP" ]; then
         echo "Please specify client and server IPs"
         return 1
@@ -263,32 +193,18 @@ run_test()
     return 0
 }
 
-cleanup()
-{
-    echo "===== Cleaning up ====="
-    # Stop the Docker container
-    stop_container "${CONTAINER_NAME}"
-    
-    if [ -n "$REMOTE_IP" ]; then
-        stop_container "${CONTAINER_NAME}" "$REMOTE_IP"
-    fi
-}
-
 parse()
 {
     echo "===== Parsing test results ====="
-    source $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH/.shrc
-
     local all_passed=true
-    local result_json="${BASE_DIR}/${TEST_CASE_RESULT_PATH}/test_results.json"
 
     if [ -n "$REMOTE_IP" ]; then
         echo "Getting remote results from remote server..."
         for model in "${SUPPORT_MODELS[@]}"; do
             local model_name_clean=$(echo "$model" | sed 's/\//__/g')
             
-            local remote_log_dir="${REMOTE_TEST_DIR}/${TEST_CASE_RESULT_PATH}/logs/${model_name_clean}"
-            local local_log_dir="${BASE_DIR}/${TEST_CASE_RESULT_PATH}/logs/${model_name_clean}"
+            local remote_log_dir="${REMOTE_TEST_DIR}/${TEST_CASE_RESULT_PATH}/${model_name_clean}"
+            local local_log_dir="${BASE_DIR}/${TEST_CASE_RESULT_PATH}/${model_name_clean}"
             
             echo "Processing model: $model_name_clean"
             echo "  Remote log dir: $remote_log_dir"
@@ -335,103 +251,29 @@ parse()
     fi
 
     if [ "$all_passed" = true ]; then
-        echo "{\"test_case\": \"$test_case_name\", \"status\": \"Pass\", \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$result_json"
-        echo "$test_case_name: Pass"
+        save_test_result "$test_case_name" "Pass" "${BASE_DIR}/${TEST_CASE_RESULT_PATH}"
+        echo "✓ Test PASSED"
+        return 0
     else
-        echo "{\"test_case\": \"$test_case_name\", \"status\": \"Fail\", \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$result_json"
-        echo "$test_case_name: Fail"
-    fi
-    echo "Test results saved to: $result_json"
-}
-
-
-main()
-{
-    local exit_code=0
-    
-    echo "===== Step 1: Prepare ====="
-    if ! prepare; then
-        echo "ERROR: Prepare failed"
-        exit_code=1
-    fi
-    
-    if [ $exit_code -eq 0 ]; then
-        echo "===== Step 2: Run Test ====="
-        if ! run_test; then
-            echo "ERROR: Run test failed"
-            exit_code=1
-        fi
-    fi
-
-    echo "===== Step 3: Parse Results ====="
-    parse
-    
-    echo "===== Step 4: Cleanup ====="
-    cleanup
-    
-    if [ $exit_code -ne 0 ]; then
-        echo "===== Test completed with errors ====="
-        exit 1
-    else
-        echo "===== Test completed successfully ====="
+        save_test_result "$test_case_name" "Fail" "${BASE_DIR}/${TEST_CASE_RESULT_PATH}"
+        echo "✗ Test FAILED"
+        return 1
     fi
 }
 
 case "$1" in
-    "prepare")
-        shift
-        prepare "$@"
-        exit 0
-        ;;
-    "setup")
-        shift
-        setup "$@"
-        exit 0
-        ;;
     "start_server")
         shift
         start_server "$@"
-        exit 0
+        exit $?
         ;;
-    "run_proxy")
-        shift
-        run_proxy "$@"
-        exit 0
-        ;;
-    "run_request")
-        shift
-        run_request "$@"
-        exit 0
-        ;;
-    "parse")
-        shift
-        parse "$@"
-        exit 0
-        ;;
-    "cleanup")
-        shift
-        cleanup "$@"
-        exit 0
-        ;;
-    "main")
-        shift
-        main "$@"
-        exit 0
-        ;;
-    "")
-        main
+    "stop_server")
+        kill_model_processes
         exit 0
         ;;
     *)
-        echo "Usage: $0 {prepare|setup|start_server|run_proxy|run_request|parse|cleanup|main}"
-        echo "  prepare      - Prepare test environment and sync code to remote"
-        echo "  setup        - Setup docker container and install dependencies"
-        echo "  start_server - Start the SGLang server (prefill/decode mode)"
-        echo "  run_proxy    - Start the load balancer/proxy"
-        echo "  run_request  - Send test request to the server"
-        echo "  parse        - Collect remote logs to local machine"
-        echo "  cleanup      - Stop and cleanup docker containers (local and remote)"
-        echo "  main         - Run complete test workflow (prepare -> run_test -> parse -> cleanup)"
-        exit 1
+        if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+            run_test && parse || parse
+        fi
         ;;
 esac

--- a/scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
+++ b/scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
@@ -4,88 +4,15 @@
 # The original MLA model has been replaced with deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
 
 test_case_name="test_disaggregation_different_tp"
-CONTAINER_NAME=${CONTAINER_NAME:-"mooncake-ci-test"}
-MODEL_CACHE=${MODEL_CACHE:-"/root/.cache"}
-REGISTRY_ADDR=${REGISTRY_ADDR:-"lmsysorg/sglang:latest"}
-USE_HUGGINGFACE_MIRROR=${USE_HUGGINGFACE_MIRROR:-true}
-HUGGINGFACE_MIRROR=${HUGGINGFACE_MIRROR:-"https://hf-mirror.com"}
-USE_MODELSCOPE=${USE_MODELSCOPE:-false}
-ARTIFACT_ID=
-GIT_REPO=
+TEST_TYPE="single"
 
-TONE_TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)
-echo "TONE_TESTS_DIR: $TONE_TESTS_DIR"
-. $TONE_TESTS_DIR/scripts/common.sh
-
-setup()
-{
-    echo "===== Setting up test environment ====="
-    echo "Setup test result directory..."
-    setup_test_result_directory $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH
-
-    cat > $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH/.shrc << EOF
-# Mooncake CI Test Environment Variables - ${test_case_name}
-export CONTAINER_NAME=${CONTAINER_NAME}
-export MODEL_CACHE=${MODEL_CACHE}
-export REGISTRY_ADDR=${REGISTRY_ADDR}
-export USE_HUGGINGFACE_MIRROR=${USE_HUGGINGFACE_MIRROR}
-export HUGGINGFACE_MIRROR=${HUGGINGFACE_MIRROR}
-export USE_MODELSCOPE=${USE_MODELSCOPE}
-export ARTIFACT_ID=${ARTIFACT_ID}
-export GIT_REPO=${GIT_REPO}
-export BASE_DIR=${TONE_TESTS_DIR}
-export TEST_CASE_RESULT_DIR=${TONE_TESTS_DIR}/${TEST_CASE_RESULT_PATH}
-EOF
-
-    echo "Get mooncake whl..."
-    source $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH/.shrc && get_whl $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH
-    if [ $? -ne 0 ]; then
-        echo "Failed to get mooncake whl"
-        return 1
-    fi
-
-    echo "Get the latest sglang image..."
-    if ! get_image; then
-        echo "ERROR: Failed to get the required image"
-        return 1
-    fi
-
-    echo "Quit old container..."
-    if ! clean_container ${CONTAINER_NAME}; then
-        echo "ERROR: Failed to clean up container"
-        return 1
-    fi
-
-    extra_args=""
-    extra_args="$extra_args --device=/dev/infiniband/uverbs0 --device=/dev/infiniband/uverbs1 --device=/dev/infiniband/rdma_cm "
-    if ${USE_HUGGINGFACE_MIRROR}; then
-        extra_args="$extra_args -e HF_ENDPOINT=${HUGGINGFACE_MIRROR}"
-        extra_args="$extra_args -e HF_HUB_ENABLE_HF_TRANSFER=1"
-    fi
-    if ${USE_MODELSCOPE}; then
-        extra_args="$extra_args -e SGLANG_USE_MODELSCOPE=true"
-    fi
-    echo "extra_args: $extra_args"
-
-    echo "Launching docker container..."
-    if ! docker_launch "$extra_args"; then
-        echo "ERROR: Failed to launch docker container"
-        return 1
-    fi
-
-    return 0
-}
+BASE_DIR=${BASE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)}
+. ${BASE_DIR}/scripts/common.sh
 
 run_test()
 { 
     echo "===== Running pytest tests ====="
-    local log_dir="${TONE_TESTS_DIR}/${TEST_CASE_RESULT_PATH}/logs"
-    if [ -d "$log_dir" ]; then
-        echo "Removing existing log directory: $log_dir"
-        rm -rf "$log_dir"
-    fi
-    mkdir -p "$log_dir"
-    local log_file="${log_dir}/${test_case_name}.log"
+    local log_file="${BASE_DIR}/${TEST_CASE_RESULT_PATH}/${test_case_name}.log"
 
     echo "Running tests in container and saving output to: $log_file"
     ${docker_exec} "\
@@ -102,57 +29,23 @@ parse()
     local test_exit_code=$1
 
     echo "===== Parsing test results ====="
-    local result_json="${TONE_TESTS_DIR}/${TEST_CASE_RESULT_PATH}/test_results.json"
-
     if [ $test_exit_code -eq 0 ]; then
-        echo "All tests passed"
-        echo "{\"test_case\": \"$test_case_name\", \"status\": \"Pass\", \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$result_json"
-        echo "$test_case_name: Pass"
+        save_test_result "$test_case_name" "Pass" "${BASE_DIR}/${TEST_CASE_RESULT_PATH}"
+        echo "✓ Test PASSED"
+        return 0
     else
-        echo "Tests failed - check log file for details"
-        echo "{\"test_case\": \"$test_case_name\", \"status\": \"Fail\", \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$result_json"
-        echo "$test_case_name: Fail"
+        save_test_result "$test_case_name" "Fail" "${BASE_DIR}/${TEST_CASE_RESULT_PATH}"
+        echo "✗ Test FAILED"
+        return 1
     fi
-    
-    echo "Test results saved to: $result_json"
 }
 
-cleanup()
-{
-    echo "===== Cleaning up ====="
-    stop_container "${CONTAINER_NAME}"
-}
-
-main()
-{
-    local exit_code=0
-    
-    echo "===== Step 1: Setup ====="
-    if ! setup; then
-        echo "ERROR: Setup failed"
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    exit_code=0
+    if ! run_test; then
         exit_code=1
     fi
     
-    if [ $exit_code -eq 0 ]; then
-        echo "===== Step 2: Run Test ====="
-        if ! run_test; then
-            echo "ERROR: Run test failed"
-            exit_code=1
-        fi
-    fi
-    
-    echo "===== Step 3: Parse Results ====="
     parse $exit_code
-    
-    echo "===== Step 4: Cleanup ====="
-    cleanup
-    
-    if [ $exit_code -ne 0 ]; then
-        echo "===== Test completed with errors ====="
-        exit 1
-    else
-        echo "===== Test completed successfully ====="
-    fi
-}
-
-main
+    exit $?
+fi

--- a/scripts/tone_tests/scripts/test_hicache_storage_mooncake_backend.sh
+++ b/scripts/tone_tests/scripts/test_hicache_storage_mooncake_backend.sh
@@ -1,90 +1,15 @@
 #!/bin/bash
 
 test_case_name="test_hicache_storage_mooncake_backend"
-CONTAINER_NAME=${CONTAINER_NAME:-"mooncake-ci-test"}
-MODEL_CACHE=${MODEL_CACHE:-"/root/.cache"}
-REGISTRY_ADDR=${REGISTRY_ADDR:-"lmsysorg/sglang:latest"}
-USE_HUGGINGFACE_MIRROR=${USE_HUGGINGFACE_MIRROR:-true}
-HUGGINGFACE_MIRROR=${HUGGINGFACE_MIRROR:-"https://hf-mirror.com"}
-USE_MODELSCOPE=${USE_MODELSCOPE:-false}
-ARTIFACT_ID=
-GIT_REPO=
+TEST_TYPE="single"
 
-TONE_TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)
-echo "TONE_TESTS_DIR: $TONE_TESTS_DIR"
-. $TONE_TESTS_DIR/scripts/common.sh
-
-setup()
-{   
-    echo "===== Setting up test environment ====="
-    echo "Setup test result directory..."
-    setup_test_result_directory $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH
-
-    cat > $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH/.shrc << EOF
-# Mooncake CI Test Environment Variables - ${test_case_name}
-export CONTAINER_NAME=${CONTAINER_NAME}
-export MODEL_CACHE=${MODEL_CACHE}
-export REGISTRY_ADDR=${REGISTRY_ADDR}
-export USE_HUGGINGFACE_MIRROR=${USE_HUGGINGFACE_MIRROR}
-export HUGGINGFACE_MIRROR=${HUGGINGFACE_MIRROR}
-export USE_MODELSCOPE=${USE_MODELSCOPE}
-export ARTIFACT_ID=${ARTIFACT_ID}
-export GIT_REPO=${GIT_REPO}
-export BASE_DIR=${TONE_TESTS_DIR}
-export TEST_CASE_RESULT_DIR=${TONE_TESTS_DIR}/${TEST_CASE_RESULT_PATH}
-EOF
-
-    echo "Get mooncake whl..."
-    source $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH/.shrc && get_whl $TONE_TESTS_DIR/$TEST_CASE_RESULT_PATH
-    if [ $? -ne 0 ]; then
-        echo "Failed to get mooncake whl"
-        return 1
-    fi
-
-    # get sglang image
-    echo "Get the latest sglang image..."
-    if ! get_image; then
-        echo "ERROR: Failed to get the required image"
-        return 1
-    fi
-
-    # qit old container
-    echo "Quit old container..."
-    if ! clean_container ${CONTAINER_NAME}; then
-        echo "ERROR: Failed to clean up container"
-        return 1
-    fi
-
-    extra_args=""
-    extra_args="$extra_args --device=/dev/infiniband/uverbs0 --device=/dev/infiniband/uverbs1 --device=/dev/infiniband/rdma_cm "
-    if ${USE_HUGGINGFACE_MIRROR}; then
-        extra_args="$extra_args -e HF_ENDPOINT=${HUGGINGFACE_MIRROR}"
-        extra_args="$extra_args -e HF_HUB_ENABLE_HF_TRANSFER=1"
-    fi
-    if ${USE_MODELSCOPE}; then
-        extra_args="$extra_args -e SGLANG_USE_MODELSCOPE=true"
-    fi
-    echo "extra_args: $extra_args"
-
-    echo "Launching docker container..."
-    if ! docker_launch "$extra_args"; then
-        echo "ERROR: Failed to launch docker container"
-        return 1
-    fi
-
-    return 0
-}
+BASE_DIR=${BASE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)}
+. ${BASE_DIR}/scripts/common.sh
 
 run_test()
 {
     echo "===== Running pytest tests ====="
-    local log_dir="${TONE_TESTS_DIR}/${TEST_CASE_RESULT_PATH}/logs"
-    if [ -d "$log_dir" ]; then
-        echo "Removing existing log directory: $log_dir"
-        rm -rf "$log_dir"
-    fi
-    mkdir -p "$log_dir"
-    local log_file="${log_dir}/${test_case_name}.log"
+    local log_file="${BASE_DIR}/${TEST_CASE_RESULT_PATH}/${test_case_name}.log"
 
     echo "Running tests in container and saving output to: $log_file"
     ${docker_exec} "\
@@ -100,57 +25,23 @@ parse()
     local test_exit_code=$1
 
     echo "===== Parsing test results ====="
-    local result_json="${TONE_TESTS_DIR}/${TEST_CASE_RESULT_PATH}/test_results.json"
-
     if [ $test_exit_code -eq 0 ]; then
-        echo "All tests passed"
-        echo "{\"test_case\": \"$test_case_name\", \"status\": \"Pass\", \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$result_json"
-        echo "$test_case_name: Pass"
+        save_test_result "$test_case_name" "Pass" "${BASE_DIR}/${TEST_CASE_RESULT_PATH}"
+        echo "✓ Test PASSED"
+        return 0
     else
-        echo "Tests failed - check log file for details"
-        echo "{\"test_case\": \"$test_case_name\", \"status\": \"Fail\", \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$result_json"
-        echo "$test_case_name: Fail"
+        save_test_result "$test_case_name" "Fail" "${BASE_DIR}/${TEST_CASE_RESULT_PATH}"
+        echo "✗ Test FAILED"
+        return 1
     fi
-    
-    echo "Test results saved to: $result_json"
 }
 
-cleanup()
-{
-    echo "===== Cleaning up ====="
-    stop_container "${CONTAINER_NAME}"
-}
-
-main()
-{
-    local exit_code=0
-    
-    echo "===== Step 1: Setup ====="
-    if ! setup; then
-        echo "ERROR: Setup failed"
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    exit_code=0
+    if ! run_test; then
         exit_code=1
     fi
     
-    if [ $exit_code -eq 0 ]; then
-        echo "===== Step 2: Run Test ====="
-        if ! run_test; then
-            echo "ERROR: Run test failed"
-            exit_code=1
-        fi
-    fi
-    
-    echo "===== Step 3: Parse Results ====="
     parse $exit_code
-    
-    echo "===== Step 4: Cleanup ====="
-    cleanup
-    
-    if [ $exit_code -ne 0 ]; then
-        echo "===== Test completed with errors ====="
-        exit 1
-    else
-        echo "===== Test completed successfully ====="
-    fi
-}
-
-main
+    exit $?
+fi


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

- Add run_test.sh controller for automated testing with environment setup, Docker management, package installation, single/dual-machine support, ERDMA driver setup, and remote machine configuration.

- Add test set configuration, currently including SGLANG and reserved VLLM, preparing for future VLLM test case integration

## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [x] CI/CD
  - [x] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->
I have verified this on the T-One platform:https://tone.openanolis.cn/ws/gclfnh19/test_result/194949".
The task duration has been reduced to 12 minutes.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
