### PR TITLE
[Store] - Optimize BucketStorageBackend for reduced lock contention and add delete safety

### DIFF
--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -99,7 +99,7 @@ class BucketReadGuard {
     explicit BucketReadGuard(std::shared_ptr<BucketMetadata> bucket)
         : bucket_(std::move(bucket)) {
         if (bucket_) {
-            bucket_->inflight_reads_.fetch_add(1, std::memory_order_acquire);
+            bucket_->inflight_reads_.fetch_add(1, std::memory_order_relaxed);
         }
     }
 


### PR DESCRIPTION
## Description


This commit addresses critical performance bottlenecks in BucketStorageBackend
by reducing mutex contention during read operations and adds future-proof
infrastructure for safe bucket deletion.

## Problem

The original BucketStorageBackend held a shared mutex (`mutex_`) for the entire
duration of BatchLoad operations, including all disk I/O (file open, preadv
syscalls). This caused severe lock contention:
- Lock hold time: 100ms-10s depending on I/O
- Concurrent readers were effectively serialized
- p99 latency suffered significantly under load

Additionally, BatchOffload had a correctness bug where duplicate keys would
silently overwrite existing entries via `emplace()`, leading to potential
data corruption.

## Solution

 **Fix Duplicate Key Detection in BatchOffload:**

- Add pre-check loop to detect duplicate keys before modifying any state
- Return OBJECT_ALREADY_EXISTS error if any key in the batch already exists
- Add CleanupOrphanedBucket() helper to remove bucket files when duplicate
  detection fails after files were written (since I/O happens before lock)
- Changed emplace() to insert() to be explicit about not overwriting

 **Release Lock Before I/O in BatchLoad**

Completely rewrote BatchLoad() to use a two-phase approach:

**Under lock (microseconds):**
- Lookup key metadata from object_bucket_map_
- Copy shared_ptr<BucketMetadata> for lifetime pinning
- Build ReadPlan structs with all info needed for I/O
- Create BucketReadGuard to track in-flight reads

**After lock release (milliseconds-seconds):**
- Open bucket files
- Perform all preadv() syscalls
- No locks held during any I/O operations

Removed old BatchLoadBucket() function that held lock during I/O.

**RAII-based Delete Safety (Future-proofing)**

Added infrastructure to safely delete buckets while reads may be in progress:

**BucketMetadata changes:**
- Added `mutable std::atomic<int32_t> inflight_reads_{0}` field
- Added copy/move constructors to handle non-copyable atomic
- Field is runtime-only, not serialized (excluded from YLT_REFL)

**New BucketReadGuard RAII class:**
- Increments inflight_reads_ on construction (acquire ordering)
- Decrements on destruction (release ordering)
- Non-copyable, movable
- Ensures bucket files are not deleted while reads are in progress

**New DeleteBucket() method:**
- Removes bucket from metadata maps under exclusive lock
- Waits for inflight_reads_ to reach 0 (spin + yield + sleep)
- Deletes bucket data and metadata files only after all readers complete
- Thread-safe with concurrent BatchLoad operations |



## Thread Safety Guarantees

| Operation                        | Safety                              |
|----------------------------------|-------------------------------------|
| Concurrent BatchLoad calls       | Safe - parallel I/O, no locks      |
| BatchLoad during DeleteBucket    | Safe - guard prevents file deletion |
| DeleteBucket during BatchLoad    | Safe - waits for readers to finish |
| Concurrent DeleteBucket calls    | Safe - second gets BUCKET_NOT_FOUND |

## Design Decisions

1. **Atomic batch semantics**: BatchOffload rejects entire batch if any key
   is duplicate (all-or-nothing) for consistency guarantees.

2. **Simple invariant-based safety**: Since bucket files are immutable and
   never deleted at runtime (except via explicit DeleteBucket), the
   shared_ptr + atomic counter approach is sufficient without full RCU.

3. **Spin-then-sleep waiting**: DeleteBucket uses adaptive waiting (spin
   1000 iterations, then sleep 100μs) to balance latency and CPU usage.

## Type of Change

* Types
  - [X] Bug fix
  - [X] New feature
    - [ ] Transfer Engine
    - [X] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [X] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

Have added new UTs and tested with it.

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [X] I have added tests to prove my changes are effective.
