### PR TITLE
[EP] Clear sticky CUDA error on EP buffer re-init

### DIFF
--- a/mooncake-ep/src/mooncake_ep_buffer.cpp
+++ b/mooncake-ep/src/mooncake_ep_buffer.cpp
@@ -587,6 +587,12 @@ void MooncakeEpBuffer::sync_nvlink_ipc_handles(
             cudaError_t peer_err = cudaDeviceEnablePeerAccess(dst_device, 0);
             if (peer_err == cudaSuccess ||
                 peer_err == cudaErrorPeerAccessAlreadyEnabled) {
+                // Clear sticky error on re-init so CUDA graph capture /
+                // dispatch later does not see
+                // cudaErrorPeerAccessAlreadyEnabled.
+                if (peer_err == cudaErrorPeerAccessAlreadyEnabled) {
+                    cudaGetLastError();
+                }
                 nvlink_array[dst_rank] = 1;
 
                 // Open IPC handle for this peer


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Re-init calls cudaDeviceEnablePeerAccess again; when it returns cudaErrorPeerAccessAlreadyEnabled we treat it as success but the runtime keeps it as the last error, so later graph capture fails. Fix: call cudaGetLastError() when we accept that return and at the end of sync_nvlink_ipc_handles so no stale error is left.

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
