### PR TITLE
[Misc][Dev] add indexer demo version & using example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,13 @@ jobs:
           echo "✅ Coverage collected successfully"
         fi
 
+    - name: Test mooncake conductor
+      run: |
+        cd mooncake-conductor/conductor-ctrl
+        go mod tidy
+        go test ./... -v -cover
+      shell: bash
+
     - name: Generate Python version tag
       id: generate_tag_build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(WITH_STORE "build mooncake store library and sample code" ON)
 option(WITH_P2P_STORE "build p2p store library and sample code" OFF)
 option(WITH_RUST_EXAMPLE "build the Rust interface and sample code for the transfer engine" OFF)
 option(WITH_EP "build mooncake with expert parallelism support" OFF)
+option(WITH_CONDUCTOR "build mooncake conductor and sample code" OFF)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extern/pybind11)
 set(PYTHON_EXECUTABLE "python3")
@@ -67,3 +68,9 @@ if (WITH_P2P_STORE)
   add_subdirectory(mooncake-p2p-store)
   message(STATUS "P2P Store will be built")
 endif()
+
+if (WITH_CONDUCTOR)
+  add_subdirectory(mooncake-conductor)
+  message(STATUS "Conductor will be built")
+endif()
+

--- a/mooncake-conductor/CMakeLists.txt
+++ b/mooncake-conductor/CMakeLists.txt
@@ -1,0 +1,17 @@
+find_program(GO_EXECUTABLE go)
+if(NOT GO_EXECUTABLE)
+    message(FATAL_ERROR "Go compiler not found. Please install Golang first.")
+endif()
+
+add_custom_target(mooncake_conductor ALL
+    COMMAND ./build.sh ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Building Go program: mooncake_conductor"
+    VERBATIM
+)
+
+set(GO_EXECUTABLE_PATH "${CMAKE_CURRENT_BINARY_DIR}/mooncake_conductor" 
+    CACHE INTERNAL "Path to Go executable")
+
+# Install target
+install(PROGRAMS ${GO_EXECUTABLE_PATH} DESTINATION bin)

--- a/mooncake-conductor/README.md
+++ b/mooncake-conductor/README.md
@@ -1,0 +1,167 @@
+
+# vLLM V1 Disaggregated Serving with MooncakeConductor
+
+## Overview
+This is the latest version of the Mooncake Conductor integration doc with the vLLM project to support KVCache-Aware scheduling algorithm.
+The conductor can be integrated as a plugin into any proxy to uniformly manage KV events from L1 to L3. We also provide a toy_proxy for those who want to try it out ([proxy](./cacheaware_disaggregated_proxy.py)). Benchmark results will be released soon.
+
+- only vLLM and vLLM-Ascend are supported.
+
+
+## Installation
+
+The mooncake conductor will be compiled and installed together with the mooncake store. Refer to [Build Guide](https://github.com/kvcache-ai/Mooncake/blob/main/docs/source/getting_started/build.md).
+
+- **WITH_CONDUCTOR must be set to ON in Mooncake/CMakeLists.txt.**
+
+### Install the latest version of vLLM and vLLM-Ascend
+
+#### 1. Clone vLLM from official repo
+
+```bash
+git clone git@github.com:vllm-project/vllm.git
+```
+
+#### 2. Build
+##### 2.1 Build from source
+```bash
+cd vllm
+pip3 install -e .
+```
+ - If you encounter any problems that you cannot solve, please refer to the [vLLM official compilation guide](https://docs.vllm.ai/en/latest/getting_started/installation/index.html).
+
+
+#### 3. Clone vLLM-Ascend from official repo
+
+```bash
+git clone git@github.com:vllm-project/vllm-ascend.git
+```
+
+#### 4. Build
+##### 4.1 Build from source
+```bash
+cd vllm-ascend
+pip install -e .
+```
+ - If you encounter any problems that you cannot solve, please refer to the [vLLM-Ascend official compilation guide](https://docs.vllm.ai/projects/ascend/en/latest/).
+
+
+## Configuration
+### Prepare configuration file to Run Example
+
+- Prepare a _**conductor_config.json**_ file for mooncake_conductor. Here is an example:
+
+```json
+{
+    "kvevent_instance":
+    {
+        "vllm-1": 
+        {
+            "ip": "127.0.0.1",
+            "port": 5557,
+            "type": "vLLM",
+            "modelname": "qwen2.5_7B",
+            "lora_id": -1
+        },
+        "mooncake":
+        {
+            "ip": "127.0.0.1",
+            "port": 19997,
+            "type": "Mooncake",
+            "modelname": "qwen2.5_7B",
+            "lora_id": -1
+        }
+    },
+    "http_server_port": 13333
+}
+```
+- `kvevent_instance`: Services capable of reporting KV events.
+- `vllm-1/mooncake`: rename of a VLLM instance or Mooncake-master instance.You can modify it according to your own preferences.
+  - `ip`: zmq publisher IP.
+  - `port`: zmq publisher port.
+  - `type`: Mark the type of kv-event publisher. Generally, there are currently only two types: `vLLM` and `Mooncake`.
+  - `modelname`: Model name used for match the model.
+  - `lora_id`: LoRA Adapter ID.
+
+- `http_server_port`: Conductor http server for querying cache hit rates, default use `13333`.
+
+
+
+## Run Example
+
+### 1. Start the mooncake_master server
+
+```sh
+# start mooncake_master without kv-event publish
+mooncake_master --rpc_port 50051
+# start moocake_master with kv-event
+mooncake_master -enable_kv_event_publish -kv_event_publisher_endpoint tcp://*:19997 -rpc_port 50051
+```
+### 2. Run multiple vllm instances
+```sh
+# kv_producer role
+ vllm serve /qwen2.5_7B_instruct/  \
+    --enforce-eager \
+    --max-model-len 10000 \
+    --port 8100 \
+    --gpu-memory-utilization 0.8 \
+    --served-model-name "qwen2.5_7B" \
+    --trust-remote-code \
+    --kv-events-config \
+    '{
+        "publisher": "zmq", 
+        "enable_kv_cache_events": true, 
+        "endpoint": "tcp://*:5557",
+        "topic": "kv-events",
+        "replay_endpoint": "tcp://*:5558"
+    }' \
+    --kv-transfer-config \
+    '{
+        "kv_connector": "MooncakeConnectorStoreV1",
+        "kv_role":"kv_producer",
+        "kv_connector_extra_config":{"use_layerwise": false}
+    }'
+```
+
+```sh
+# kv_consumer role
+ vllm serve /qwen2.5_7B_instruct/  \
+    --enforce-eager \
+    --max-model-len 10000 \
+    --port 8200 \
+    --gpu-memory-utilization 0.8 \
+    --served-model-name "qwen2.5_7B" \
+    --trust-remote-code \
+    --kv-transfer-config \
+    '{
+        "kv_connector": "MooncakeConnectorStoreV1",
+        "kv_role":"kv_consumer",
+        "kv_connector_extra_config":{"use_layerwise": false}
+    }'
+
+```
+
+
+### 3. Start the conductor server
+
+```sh
+export CONDUCTOR_CONFIG_PATH="./example/conductor_config.json"
+mooncake_conductor
+```
+
+### 4. Run the proxy in the example
+
+```sh
+python cacheaware_disaggregated_proxy.py --prefiller-hosts 127.0.0.1 --prefiller-ports 8100 --decoder-host 127.0.0.1 --decoder-ports 8200 --conductor-address 127.0.0.1:13333
+```
+
+## Test with openai compatible request
+
+```sh
+curl -s http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{
+  "model": "qwen2.5_7B",
+  "prompt": "What are the key architectural differences between vLLM and Mooncake when it comes to handling key-value (KV) cache events, and how can a centralized conductor component be designed in Go to normalize disparate event schemas from these systems, apply consistent metrics collection, and make dynamic scheduling decisions based on real-time KV cache hit rates without relying on Kubernetes-based autoscaling mechanisms?",
+  "max_tokens": 1000
+}'
+
+```

--- a/mooncake-conductor/build.sh
+++ b/mooncake-conductor/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 TARGET_PATH BUILD_DIR"
+    exit 1
+fi
+
+TARGET=$1
+BUILD_DIR=$2
+
+cd conductor-ctrl
+
+# Check if go.mod exists
+if [ ! -f "go.mod" ]; then
+    echo "Error: go.mod file not found"
+    exit 1
+fi
+
+echo "Cleaning previous build..."
+rm -f mooncake_conductor
+
+go mod tidy
+echo "Building Go program: mooncake_conductor"
+
+go build -o "$TARGET/mooncake_conductor" main.go
+
+
+if [ $? -eq 0 ] && [ -f "$TARGET/mooncake_conductor" ]; then
+    echo "mooncake_conductor built successfully"
+else
+    echo "mooncake_conductor build failed"
+    exit 1
+fi

--- a/mooncake-conductor/conductor-ctrl/common/sync_map.go
+++ b/mooncake-conductor/conductor-ctrl/common/sync_map.go
@@ -1,0 +1,82 @@
+package common
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type SyncMap[K any, V any] struct {
+	m   sync.Map
+	len atomic.Int32
+}
+
+func (sm *SyncMap[K, V]) Delete(key K) {
+	sm.LoadAndDelete(key)
+}
+
+func (sm *SyncMap[K, V]) Load(key K) (typedVal V, ok bool) {
+	value, ok := sm.m.Load(key)
+	if ok {
+		typedVal = value.(V)
+	}
+	return
+}
+
+func (sm *SyncMap[K, V]) LoadAndDelete(key K) (typedVal V, loaded bool) {
+	value, loaded := sm.m.LoadAndDelete(key)
+	if loaded {
+		typedVal = value.(V)
+		sm.len.Add(-1)
+	}
+	return
+}
+
+func (sm *SyncMap[K, V]) LoadOrStore(key K, value V) (V, bool) {
+	actual, loaded := sm.m.LoadOrStore(key, value)
+	if !loaded {
+		sm.len.Add(1)
+	}
+	return actual.(V), loaded
+}
+
+func (sm *SyncMap[K, V]) Range(f func(key K, value V) bool) {
+	sm.m.Range(func(key, value any) bool {
+		return f(key.(K), value.(V))
+	})
+}
+
+func (sm *SyncMap[K, V]) Keys() []K {
+	k := make([]K, 0, sm.Len())
+	sm.m.Range(func(key, value any) bool {
+		k = append(k, key.(K))
+		return true
+	})
+	return k
+}
+
+func (sm *SyncMap[K, V]) Values() []V {
+	v := make([]V, 0, sm.Len())
+	sm.m.Range(func(key, value any) bool {
+		v = append(v, value.(V))
+		return true
+	})
+	return v
+}
+
+func (sm *SyncMap[K, V]) Store(key K, value V) {
+	sm.Swap(key, value)
+}
+
+func (sm *SyncMap[K, V]) Swap(key K, value V) (V, bool) {
+	old, loaded := sm.m.Swap(key, value)
+	if !loaded {
+		var ret V
+		sm.len.Add(1)
+		return ret, loaded
+	}
+	return old.(V), loaded
+}
+
+func (sm *SyncMap[K, V]) Len() int {
+	return int(sm.len.Load())
+}

--- a/mooncake-conductor/conductor-ctrl/common/types.go
+++ b/mooncake-conductor/conductor-ctrl/common/types.go
@@ -1,0 +1,32 @@
+package common
+
+const (
+	ServiceTypeVLLM     string = "vLLM"
+	ServiceTypeMooncake string = "Mooncake"
+)
+
+type ServiceConfig struct {
+	Name      string // Unique identifier (e.g., "vllm-worker-0")
+	IP        string // Service IP address
+	Port      int    // ZMQ publisher port
+	Type      string // Service type (vLLM/Mooncake)
+	ModelName string // Model name hosted by the service
+	LoraID    int64  // LoRA ID (-1 if not applicable)
+}
+
+// TODO combine with /zmq/event_type
+type StoredEvent struct {
+	BlockHashes     []uint64
+	ModelName       string
+	LoraID          int64
+	EngineIp        string
+	ParentBlockHash uint64
+	TokenIds        []int32
+}
+
+type RemovedEvent struct {
+	BlockHashes []uint64
+	ModelName   string
+	LoraID      int64
+	SourcePod   string
+}

--- a/mooncake-conductor/conductor-ctrl/common/utils.go
+++ b/mooncake-conductor/conductor-ctrl/common/utils.go
@@ -1,0 +1,100 @@
+package common
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func LoadEnv(envName, defaultEnv string) string {
+	value := os.Getenv(envName)
+	if value == "" {
+		slog.Warn("environment variable is not set, using default value", "envName", envName, "defaultValue", defaultEnv)
+		return defaultEnv
+	}
+	return value
+}
+
+func LoadIntEnv(envName string, defaultEnv int) int {
+	value := os.Getenv(envName)
+	trimmedValue := strings.TrimSpace(value)
+	if value != "" {
+		intValue, err := strconv.Atoi(value)
+		if err != nil {
+			slog.Error("invalid value for environment variable", "envName", envName, "value", trimmedValue)
+		} else {
+			return intValue
+		}
+	}
+	slog.Warn("environment variable is not set, using default value", "envName", envName, "defaultValue", defaultEnv)
+	return defaultEnv
+}
+
+func ExtractTokenIdFromRequest(data map[string]interface{}, key string) ([]int32, error) {
+	raw, exists := data[key]
+	if !exists {
+		return nil, fmt.Errorf("missing key: %s", key)
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("the value of %s is not an array", key)
+	}
+	result := make([]int32, len(arr))
+	for i, v := range arr {
+		switch val := v.(type) {
+		case float64:
+			result[i] = int32(val)
+		case int:
+			result[i] = int32(val)
+		default:
+			return nil, fmt.Errorf("unsupported value type of token_id at [%d], the type is %s", i, val)
+		}
+	}
+	return result, nil
+}
+
+func ExtractCandidateEngineFromRequest(data map[string]interface{}, key string) (map[string]struct{}, error) {
+	raw, exists := data[key]
+	if !exists {
+		return nil, fmt.Errorf("missing key: %s", key)
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("the value of %s is not an array", key)
+	}
+	result := make(map[string]struct{}, len(arr))
+	for i, v := range arr {
+		str, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf(`"instances[%d]" is not a string`, i)
+		}
+		result[str] = struct{}{}
+	}
+	return result, nil
+}
+
+func ExtractStringValueFromRequest(data map[string]interface{}, key string) (string, error) {
+	raw, exists := data[key]
+	if !exists {
+		return "", fmt.Errorf("missing key: %s", key)
+	}
+	str, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf(`"the value of: %s" is not a string`, key)
+	}
+	return str, nil
+}
+
+func ExtractIntFromRequest(data map[string]interface{}, key string) (int64, error) {
+	raw, exists := data[key]
+	if !exists {
+		return -1, fmt.Errorf("missing key: %s", key)
+	}
+	result, ok := raw.(float64)
+	if !ok {
+		return -1, fmt.Errorf(`"the value of: %s" is not a number`, key)
+	}
+	return int64(result), nil
+}

--- a/mooncake-conductor/conductor-ctrl/go.mod
+++ b/mooncake-conductor/conductor-ctrl/go.mod
@@ -1,0 +1,9 @@
+module conductor
+
+go 1.23.8
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0
+	github.com/pebbe/zmq4 v1.4.0
+	github.com/shamaton/msgpack/v2 v2.4.0
+)

--- a/mooncake-conductor/conductor-ctrl/kvevent/event_handler.go
+++ b/mooncake-conductor/conductor-ctrl/kvevent/event_handler.go
@@ -1,0 +1,105 @@
+package kvevent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"log/slog"
+
+	"conductor/common"
+	"conductor/zmq"
+)
+
+// KVEventHandler adapts the generic EventHandler interface for EventManager.
+// It is instantiated in event_manager.go but implemented here to keep files clean.
+type KVEventHandler struct {
+	manager   *EventManager
+	svcName   string
+	modelName string
+	loraID    int64
+}
+
+func (h *KVEventHandler) HandleEvent(event zmq.KVEvent) error {
+	h.manager.mu.RLock()
+	if h.manager.stopped {
+		h.manager.mu.RUnlock()
+		return fmt.Errorf("manager stopped")
+	}
+	h.manager.mu.RUnlock()
+
+	// Create context for processing
+	ctx, cancel := context.WithTimeout(h.manager.ctx, 10*time.Second)
+	defer cancel()
+
+	// Dispatch event
+	switch e := event.(type) {
+	case *zmq.BlockStoredEvent:
+		slog.Debug("BlockStored",
+			"service", h.svcName,
+			"blocks", len(e.BlockHashes),
+		)
+		return h.handleBlockStored(ctx, e)
+	case *zmq.BlockRemovedEvent:
+		slog.Debug("BlockRemoved",
+			"service", h.svcName,
+			"blocks", len(e.BlockHashes),
+		)
+		return h.handleBlockRemoved(ctx, e)
+
+	default:
+		slog.Warn("Unknown event type",
+			"type", fmt.Sprintf("%T", event),
+		)
+		return nil
+	}
+}
+
+func (h *KVEventHandler) handleBlockStored(ctx context.Context, event *zmq.BlockStoredEvent) error {
+
+	// Convert to conductor event
+	conductorEvent := common.StoredEvent{
+		BlockHashes:     event.BlockHashes,
+		ModelName:       h.modelName,
+		LoraID:          h.loraID,
+		EngineIp:        h.svcName,
+		ParentBlockHash: event.ParentBlockHash,
+		TokenIds:        event.TokenIDs,
+	}
+	indexer := h.manager.getIndexer()
+	er := indexer.ProcessStoreEvent(conductorEvent)
+	// TODO support mooncake_key map
+	if er != nil {
+		slog.Error("process store event failed.", "error", er)
+	}
+
+	slog.Debug("event generated",
+		"model", conductorEvent.ModelName,
+		"lora_id", conductorEvent.LoraID,
+	)
+
+	return nil
+}
+
+func (h *KVEventHandler) handleBlockRemoved(ctx context.Context, event *zmq.BlockRemovedEvent) error {
+	// Convert to conductor event
+	conductorEvent := common.RemovedEvent{
+		BlockHashes: event.BlockHashes,
+		ModelName:   h.modelName,
+		LoraID:      h.loraID,
+		SourcePod:   h.svcName,
+	}
+	indexer := h.manager.getIndexer()
+	er := indexer.ProcessRemoveEvent(conductorEvent)
+	if er != nil {
+		slog.Error("process store event failed.")
+	}
+	slog.Debug("event generated",
+		"model", conductorEvent.ModelName,
+		"lora_id", conductorEvent.LoraID,
+	)
+
+	return nil
+}
+
+// TODO support mooncake update kv event

--- a/mooncake-conductor/conductor-ctrl/kvevent/event_manager.go
+++ b/mooncake-conductor/conductor-ctrl/kvevent/event_manager.go
@@ -1,0 +1,243 @@
+package kvevent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"conductor/common"
+	"conductor/prefixindex"
+	"conductor/zmq"
+)
+
+type EventManager struct {
+	indexer        *prefixindex.PrefixCacheTable
+	services       []common.ServiceConfig
+	httpserverport int
+
+	subscribers common.SyncMap[string, *zmq.ZMQClient]
+
+	// Lifecycle management
+	ctx     context.Context
+	cancel  context.CancelFunc
+	mu      sync.RWMutex
+	stopped bool
+}
+
+func NewEventManager(
+	services []common.ServiceConfig,
+	httpserverport int,
+) *EventManager {
+	ctx, cancel := context.WithCancel(context.Background())
+	indexer := prefixindex.NewPrefixCacheTable()
+
+	return &EventManager{
+		services:       services,
+		indexer:        indexer,
+		httpserverport: httpserverport,
+		ctx:            ctx,
+		cancel:         cancel,
+	}
+}
+
+func (m *EventManager) Start() error {
+	slog.Info("Starting KV Event Manager...")
+
+	// Subscribe to all services concurrently
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(m.services))
+
+	for _, svc := range m.services {
+		wg.Add(1)
+		go func(service common.ServiceConfig) {
+			defer wg.Done()
+			if err := m.subscribeToService(service); err != nil {
+				slog.Error("Failed to initiate subscription",
+					"service_type", service.Type,
+					"service_name", service.Name,
+					"service_ip", service.IP,
+					"error", err,
+				)
+				errCh <- fmt.Errorf("failed to subscribe to %s: %w", service.Name, err)
+			}
+		}(svc)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	failureCount := len(errCh)
+	successCount := len(m.services) - failureCount
+	slog.Info("Static KV Event Manager started. Subscriptions",
+		"success", successCount,
+		"failed", failureCount,
+	)
+
+	return nil
+}
+
+func (m *EventManager) Stop() {
+	m.mu.Lock()
+	if m.stopped {
+		m.mu.Unlock()
+		return
+	}
+	m.stopped = true
+	m.mu.Unlock()
+
+	slog.Info("Stopping Conductor KV Event Manager.....")
+
+	// Cancel context
+	m.cancel()
+
+	// Stop all ZMQ clients
+	m.subscribers.Range(func(key string, client *zmq.ZMQClient) bool {
+		client.Stop()
+		slog.Info("Stopped all subscription",
+			"service_key", key,
+		)
+		return true
+	})
+}
+
+func (m *EventManager) subscribeToService(svc common.ServiceConfig) error {
+	if _, exists := m.subscribers.Load(svc.Name); exists {
+		return nil
+	}
+
+	handler := &KVEventHandler{
+		manager:   m,
+		svcName:   svc.IP,
+		modelName: svc.ModelName,
+		loraID:    svc.LoraID,
+	}
+
+	// Configure ZMQ Client
+	zmqConfig := &zmq.ZMQClientConfig{
+		CachePoolKey:   svc.Name,
+		ServiceIP:      svc.IP,
+		Port:           svc.Port,
+		ModelName:      svc.ModelName,
+		PollTimeout:    100 * time.Millisecond,
+		ReplayTimeout:  5 * time.Second,
+		ReconnectDelay: 1 * time.Second,
+		RouterPort:     svc.Port + 1,
+	}
+
+	// Validate ZMQ config
+	if err := zmq.ValidateConfig(zmqConfig); err != nil {
+		return fmt.Errorf("invalid ZMQ config: %w", err)
+	}
+
+	// Create and start client
+	client := zmq.NewZMQClient(zmqConfig, handler)
+	if err := client.Start(); err != nil {
+		return fmt.Errorf("failed to start ZMQ client: %w", err)
+	}
+
+	m.subscribers.Store(svc.Name, client)
+	slog.Info("Successfully subscribed to service",
+		"service_type", svc.Type,
+		"service_name", svc.Name,
+		"service_ip", svc.IP,
+		"service_port", svc.Port,
+	)
+
+	return nil
+}
+
+func (m *EventManager) getIndexer() *prefixindex.PrefixCacheTable {
+	return m.indexer
+}
+
+func (m *EventManager) StartHTTPServer() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cache", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var jsonBody map[string]interface{}
+		slog.Debug(
+			"receive req",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"remote", r.RemoteAddr,
+		)
+		if err := json.NewDecoder(r.Body).Decode(&jsonBody); err != nil {
+			slog.Error("Failed to decode JSON", "err", err)
+			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+			return
+		}
+		tokenIDs, err := common.ExtractTokenIdFromRequest(jsonBody, "token_ids")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		candidates, err := common.ExtractCandidateEngineFromRequest(jsonBody, "instances")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		modelName, err := common.ExtractStringValueFromRequest(jsonBody, "model_name")
+		if err != nil {
+			slog.Error("Failed to decode string", "err", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		loraID, err := common.ExtractIntFromRequest(jsonBody, "lora_id")
+		if err != nil {
+			slog.Error("Failed to decode int", "err", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		cacheHitResult := m.indexer.CacheHitCompute(modelName, loraID, tokenIDs, candidates)
+		slog.Debug("cache hit status", "hitresult", cacheHitResult)
+		response := map[string]interface{}{
+			"HitStatus": cacheHitResult,
+			"status":    "ok",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			slog.Error("Failed to encode response", "err", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+	})
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", m.httpserverport),
+		Handler: mux,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		slog.Info("HTTP server listening", "port", m.httpserverport)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("HTTP server failed", "err", err)
+		}
+	}()
+
+	// Start a goroutine to listen for context cancellation, used for graceful shutdown.
+	go func() {
+		<-m.ctx.Done()
+		slog.Info("Shutting down HTTP server")
+		// 5-second timeout for forced shutdown
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			slog.Error("HTTP server shutdown error", "err", err)
+			server.Close()
+		}
+	}()
+
+	return nil
+}

--- a/mooncake-conductor/conductor-ctrl/main.go
+++ b/mooncake-conductor/conductor-ctrl/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"conductor/common"
+	"conductor/kvevent"
+)
+
+var (
+	// TODO change default config path
+	conductorConfigPath = common.LoadEnv("CONDUCTOR_CONFIG_PATH", "/root/conductor_config.json")
+	httpServerPort      = 13333
+)
+
+type configStruct struct {
+	KVEventInstance map[string]serviceRaw `json:"kvevent_instance"`
+	HTTPPort        int                   `json:"http_server_port"`
+}
+
+type serviceRaw struct {
+	IP        string `json:"ip"`
+	Port      int    `json:"port"`
+	TypeStr   string `json:"type"`
+	ModelName string `json:"modelname"`
+	LoraID    int64  `json:"lora_id"`
+}
+
+func mapServiceType(s string) (string, bool) {
+	switch s {
+	case "vLLM":
+		return common.ServiceTypeVLLM, true
+	case "Mooncake":
+		return common.ServiceTypeMooncake, true
+	default:
+		return "None", false
+	}
+}
+
+func parseConfig() []common.ServiceConfig {
+	if _, err := os.Stat(conductorConfigPath); errors.Is(err, os.ErrNotExist) {
+		slog.Error("Config file does not exist, exiting.", "path", conductorConfigPath)
+		os.Exit(1)
+	} else if err != nil {
+		slog.Error("Error accessing config file", "path", conductorConfigPath, "error", err)
+		os.Exit(1)
+	}
+
+	data, err := os.ReadFile(conductorConfigPath)
+	if err != nil {
+		slog.Error("Failed to read config file", "path", conductorConfigPath, "error", err)
+		os.Exit(1)
+	}
+
+	var cfg configStruct
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		slog.Error("Failed to parse JSON config", "error", err)
+		os.Exit(1)
+	}
+	httpServerPort = cfg.HTTPPort
+
+	services := make([]common.ServiceConfig, 0, len(cfg.KVEventInstance))
+
+	for name, raw := range cfg.KVEventInstance {
+		serviceType, ok := mapServiceType(raw.TypeStr)
+		if !ok {
+			slog.Error("Unknown service type", "type", raw.TypeStr)
+			continue
+		}
+		services = append(services, common.ServiceConfig{
+			Name:      name,
+			IP:        raw.IP,
+			Port:      raw.Port,
+			Type:      serviceType,
+			ModelName: raw.ModelName,
+			LoraID:    raw.LoraID,
+		})
+	}
+
+	return services
+}
+
+func main() {
+	// TODO use environment to config log level
+	// TODO support print metrics for conductor
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+
+	slog.Info("Starting Conductor KV Event Manager...")
+
+	services := parseConfig()
+
+	manager := kvevent.NewEventManager(services, httpServerPort)
+
+	if err := manager.StartHTTPServer(); err != nil {
+		slog.Error("Failed to start HTTP server", "err", err)
+	}
+
+	if err := manager.Start(); err != nil {
+		slog.Error("Failed to start manager", "error", err)
+		os.Exit(1)
+	}
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	slog.Info("Manager is running. Press Ctrl+C to stop.")
+	<-sigChan
+
+	slog.Info("Shutting down...")
+	manager.Stop()
+}

--- a/mooncake-conductor/conductor-ctrl/prefixindex/prefix_indexer.go
+++ b/mooncake-conductor/conductor-ctrl/prefixindex/prefix_indexer.go
@@ -1,0 +1,356 @@
+package prefixindex
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"conductor/common"
+	"github.com/cespare/xxhash/v2"
+)
+
+var (
+	conductorBlockSize = common.LoadIntEnv("CONDUCTOR_BLOCK_SIZE", 128)
+)
+
+type ModelContext struct {
+	ModelName string
+	LoraID    int64 // -1 represents no LoRA adapter
+}
+
+type CacheStoreInfo struct {
+	// Currently, the KV cache at different levels is not distinguished.
+	// In the future, the caches of Mooncake and inference engines (vLLM, SGLang)
+	// should be handled separately. TODO
+	engineLastAccessTime map[string]*atomic.Int64
+	TotalReplicaNums     atomic.Int64
+}
+
+type HashMapStore struct {
+	// conductor prefixHash -> cachestore
+	prefixMap map[uint64]*CacheStoreInfo
+
+	createTime    time.Time
+	lastAccess    atomic.Int64
+	totalPrefixes int64
+}
+
+type ContextData struct {
+	prefixMu  sync.RWMutex
+	hashmapMu sync.RWMutex
+
+	prefixStore      *HashMapStore
+	proxyHashMapping map[uint64]uint64 // engine block hash -> conductor prefix hash
+}
+
+type PrefixCacheTable struct {
+	contextMap sync.Map // ModelContext → *ContextData
+
+	seed      uint64
+	blockSize int // TODO move it to contextData
+
+	contextCount atomic.Int32
+}
+
+func GenerateSeedFromEnv() uint64 {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	envSeed := common.LoadIntEnv("CONDUCTOR_SEED", -1)
+
+	var seed uint64
+	if envSeed != -1 {
+		seed = uint64(envSeed)
+	} else {
+		seed = r.Uint64()
+	}
+	return seed
+}
+
+func NewPrefixCacheTable() *PrefixCacheTable {
+	// init conductor first blockhash root
+	seed := GenerateSeedFromEnv()
+
+	slog.Info("mooncake-conductor prefix_hash_table_configurations",
+		"block_size", conductorBlockSize,
+		"seed", seed)
+
+	p := &PrefixCacheTable{
+		seed:      seed,
+		blockSize: conductorBlockSize,
+	}
+
+	return p
+}
+
+func (p *PrefixCacheTable) getContextData(modelName string, loraID int64) *ContextData {
+	ctx := ModelContext{
+		ModelName: modelName,
+		LoraID:    loraID,
+	}
+	value, exists := p.contextMap.Load(ctx)
+	if exists {
+		return value.(*ContextData)
+	}
+	newContextData := &ContextData{
+		prefixStore: &HashMapStore{
+			prefixMap:     make(map[uint64]*CacheStoreInfo),
+			createTime:    time.Now(),
+			totalPrefixes: 0,
+		},
+		proxyHashMapping: make(map[uint64]uint64),
+	}
+	newContextData.prefixStore.lastAccess.Store(time.Now().Unix())
+	p.contextMap.Store(ctx, newContextData)
+	slog.Debug("in func getContextData", "newContextData", newContextData)
+	p.contextCount.Add(1)
+	return newContextData
+}
+
+func (p *PrefixCacheTable) ComputePrefixHash(tokenIds []int32) []uint64 {
+	numBlocks := len(tokenIds) / p.blockSize
+	prefixHashes := make([]uint64, 0, numBlocks)
+	var parentHash uint64 = p.seed
+
+	for i := 0; i < numBlocks; i++ {
+		start := i * p.blockSize
+		end := start + p.blockSize
+		if end > len(tokenIds) {
+			break
+		}
+		hashValue := p.computeHash(parentHash, tokenIds[start:end])
+		prefixHashes = append(prefixHashes, hashValue)
+		parentHash = hashValue
+	}
+	return prefixHashes
+}
+
+func (p *PrefixCacheTable) CacheHitCompute(modelName string, loraID int64, tokenIds []int32, candidateEngine map[string]struct{}) map[string]int {
+	ctx := ModelContext{
+		ModelName: modelName,
+		LoraID:    loraID,
+	}
+	slog.Debug("In CacheHitCompute", "ModelName", modelName, "LoraID", loraID)
+	value, exists := p.contextMap.Load(ctx)
+	if !exists {
+		return map[string]int{}
+	}
+
+	prefixHashes := p.ComputePrefixHash(tokenIds)
+	slog.Debug("In CacheHitCompute", "prefixHashes", prefixHashes)
+
+	contextData := value.(*ContextData)
+	contextData.prefixMu.RLock()
+	defer contextData.prefixMu.RUnlock()
+	prefixStore := contextData.prefixStore
+	prefixMatchEngines := map[string]int{}
+
+	for i, prefixHash := range prefixHashes {
+		cacheStoreInfo, exists := prefixStore.prefixMap[prefixHash]
+		slog.Debug("In CacheHitCompute", "cacheStoreInfo", cacheStoreInfo)
+		if !exists || cacheStoreInfo.TotalReplicaNums.Load() == 0 {
+			break
+		}
+
+		prefixMatchPercent := (i + 1) * 100 / len(prefixHashes)
+
+		hasOneEngineMatch := false
+		for engineIp := range cacheStoreInfo.engineLastAccessTime {
+			if _, inCandidate := candidateEngine[engineIp]; inCandidate {
+				prefixMatchEngines[engineIp] = prefixMatchPercent
+				hasOneEngineMatch = true
+			}
+		}
+		if !hasOneEngineMatch {
+			break
+		}
+	}
+
+	prefixStore.lastAccess.Store(time.Now().Unix())
+
+	return prefixMatchEngines
+}
+
+func (p *PrefixCacheTable) ProcessStoreEvent(event common.StoredEvent) error {
+	if len(event.BlockHashes) == 0 {
+		return nil
+	}
+	slog.Debug("In ProcessStoreEvent", "event.ModelName", event.ModelName, "event.LoraID", event.LoraID)
+	contextData := p.getContextData(event.ModelName, event.LoraID)
+
+	contextData.hashmapMu.Lock()
+	defer contextData.hashmapMu.Unlock()
+	proxyHashMap := contextData.proxyHashMapping
+
+	if len(event.BlockHashes)*p.blockSize != len(event.TokenIds) {
+		if len(event.BlockHashes) != 1 {
+			return fmt.Errorf("block hashes and tokens length mismatch")
+		}
+		// mooncake event, only one block hash
+		prefixStore := contextData.prefixStore
+		for _, blockHash := range event.BlockHashes {
+			if existingHash, exists := proxyHashMap[blockHash]; exists {
+				p.addNewPrefixStore(prefixStore, existingHash, event.EngineIp)
+			}
+		}
+		return nil
+	}
+
+	newPrefixStore := make([]struct {
+		hashValue uint64
+		engineIp  string
+	}, 0)
+
+	var parentHash uint64 = p.seed
+	if event.ParentBlockHash != 0 {
+		slog.Debug("parent Block HASH is not None.")
+		if pbh, exists := proxyHashMap[event.ParentBlockHash]; exists {
+			parentHash = pbh
+		}
+	}
+
+	// TODO currently, mooncake kv-event does not contained token_ids,
+	// so you must enable vllm prefix_cache to get it.
+	for i, blockHash := range event.BlockHashes {
+		// cache already exists, add engine info and continue
+		if existingHash, exists := proxyHashMap[blockHash]; exists {
+			newPrefixStore = append(newPrefixStore, struct {
+				hashValue uint64
+				engineIp  string
+			}{existingHash, event.EngineIp})
+			continue
+		}
+		// if not exists, compute hash
+		hashValue := p.computeHash(parentHash, event.TokenIds[i*p.blockSize:(i+1)*p.blockSize])
+		parentHash = hashValue
+
+		proxyHashMap[blockHash] = hashValue
+
+		newPrefixStore = append(newPrefixStore, struct {
+			hashValue uint64
+			engineIp  string
+		}{
+			hashValue: hashValue,
+			engineIp:  event.EngineIp,
+		})
+
+	}
+	if len(newPrefixStore) > 0 {
+		contextData.prefixMu.Lock()
+		defer contextData.prefixMu.Unlock()
+
+		prefixStore := contextData.prefixStore
+		for _, newPrefix := range newPrefixStore {
+			slog.Debug("show new prefix data", "newPrefix", newPrefix)
+			p.addNewPrefixStore(prefixStore, newPrefix.hashValue, newPrefix.engineIp)
+		}
+	}
+	p.debugPrefixCacheTable()
+	p.debugStoreEvent(event)
+	return nil
+}
+
+func (p *PrefixCacheTable) ProcessRemoveEvent(event common.RemovedEvent) error {
+	if len(event.BlockHashes) == 0 {
+		return nil
+	}
+
+	ctx := ModelContext{
+		ModelName: event.ModelName,
+		LoraID:    event.LoraID,
+	}
+	value, exists := p.contextMap.Load(ctx)
+	if !exists {
+		return nil
+	}
+	contextData := value.(*ContextData)
+	contextData.hashmapMu.Lock()
+	defer contextData.hashmapMu.Unlock()
+	proxyHashMap := contextData.proxyHashMapping
+	removeConductorHash := make([]uint64, 0, len(event.BlockHashes))
+
+	// delete proxyHashMapping
+	for _, blockHash := range event.BlockHashes {
+		if conductorHash, exists := proxyHashMap[blockHash]; exists {
+			delete(proxyHashMap, blockHash)
+			removeConductorHash = append(removeConductorHash, conductorHash)
+		}
+	}
+
+	contextData.prefixMu.Lock()
+	defer contextData.prefixMu.Unlock()
+	prefixStore := contextData.prefixStore
+	for _, conductorHash := range removeConductorHash {
+		delete(prefixStore.prefixMap, conductorHash)
+		contextData.prefixStore.totalPrefixes--
+	}
+
+	p.debugPrefixCacheTable()
+	return nil
+}
+
+func (p *PrefixCacheTable) computeHash(parentHash uint64, blockTokenIDs []int32) uint64 {
+	digest := xxhash.NewWithSeed(p.seed)
+	var parentHashBytes [8]byte
+	binary.LittleEndian.PutUint64(parentHashBytes[:], parentHash)
+	_, _ = digest.Write(parentHashBytes[:])
+
+	var tokenIDsBytes [8]byte
+	for _, tokenID := range blockTokenIDs {
+		binary.LittleEndian.PutUint32(tokenIDsBytes[:], uint32(tokenID))
+		_, _ = digest.Write(tokenIDsBytes[:])
+	}
+	return digest.Sum64()
+}
+
+// only kv event can flush prefixMap
+func (p *PrefixCacheTable) addNewPrefixStore(prefixStore *HashMapStore, hashValue uint64, engineIp string) {
+	now := time.Now().Unix()
+	if prefixStore.prefixMap[hashValue] == nil {
+		prefixStore.prefixMap[hashValue] = &CacheStoreInfo{
+			engineLastAccessTime: make(map[string]*atomic.Int64),
+		}
+		prefixStore.totalPrefixes++
+	}
+	cacheStoreInfo := prefixStore.prefixMap[hashValue]
+
+	if _, exists := cacheStoreInfo.engineLastAccessTime[engineIp]; !exists {
+		var newTime atomic.Int64
+		newTime.Store(now)
+		cacheStoreInfo.engineLastAccessTime[engineIp] = &newTime
+	} else {
+		cacheStoreInfo.engineLastAccessTime[engineIp].Store(now)
+	}
+	cacheStoreInfo.TotalReplicaNums.Add(1)
+	slog.Debug("new prefixstore", "conductor_hash", hashValue, "AccessTime", cacheStoreInfo.engineLastAccessTime)
+}
+
+func (p *PrefixCacheTable) debugPrefixCacheTable() {
+	slog.Debug("global configuration", "seed: ", p.seed, "blockSize:", p.blockSize)
+	slog.Debug("show PrefixCacheTable", "contextCount: ", p.contextCount.Load())
+	p.contextMap.Range(func(key, value interface{}) bool {
+		ctx := key.(ModelContext)
+		ctxdata := p.getContextData(ctx.ModelName, ctx.LoraID)
+		slog.Debug("modelcontext", "ModelName: ", ctx.ModelName, "LoraID:", ctx.LoraID)
+		slog.Debug("show proxyHashMapping", "proxyHashMapping: ", ctxdata.proxyHashMapping)
+		prefixstore := ctxdata.prefixStore
+		slog.Debug("prfixstore", "totalPrefixes: ", prefixstore.totalPrefixes, "lastAccess:", prefixstore.lastAccess)
+		for engip := range prefixstore.prefixMap {
+			slog.Debug("prefixMap", "EngineIp", engip)
+		}
+		return true
+	})
+}
+
+func (p *PrefixCacheTable) debugStoreEvent(storeEvent common.StoredEvent) {
+	slog.Debug("StoredEvent debug information",
+		"model_name", storeEvent.ModelName,
+		"lora_id", storeEvent.LoraID,
+		"engine_ip", storeEvent.EngineIp,
+		"parent_block_hash", storeEvent.ParentBlockHash,
+		"block_hashes", storeEvent.BlockHashes,
+		"token_ids", storeEvent.TokenIds,
+	)
+}

--- a/mooncake-conductor/conductor-ctrl/zmq/event_type.go
+++ b/mooncake-conductor/conductor-ctrl/zmq/event_type.go
@@ -1,0 +1,101 @@
+package zmq
+
+import "time"
+
+type EventType string
+
+const (
+	EventTypeBlockStored  EventType = "BlockStored"
+	EventTypeBlockRemoved EventType = "BlockRemoved"
+
+	// EventTypeBlockUpdate indicates that blocks have been updated from the KV cache
+	EventTypeBlockUpdate EventType = "BlockUpdate"
+	EventTypeAllCleared  EventType = "AllBlocksCleared"
+)
+
+type KVEvent interface {
+	GetType() EventType
+	GetTimestamp() time.Time
+}
+
+type BlockStoredEvent struct {
+	Type            EventType
+	Timestamp       time.Time
+	BlockHashes     []uint64
+	TokenIDs        []int32
+	ParentBlockHash uint64
+	BlockSize       int64
+	MooncakeKey     string
+	ReplicaList     [][]string
+	ModelName       string
+	PodName         string
+}
+
+func (e *BlockStoredEvent) GetType() EventType {
+	return e.Type
+}
+
+func (e *BlockStoredEvent) GetTimestamp() time.Time {
+	return e.Timestamp
+}
+
+type BlockRemovedEvent struct {
+	Type        EventType
+	Timestamp   time.Time
+	BlockHashes []uint64
+	ModelName   string
+	PodName     string
+}
+
+func (e *BlockRemovedEvent) GetType() EventType {
+	return e.Type
+}
+
+func (e *BlockRemovedEvent) GetTimestamp() time.Time {
+	return e.Timestamp
+}
+
+type AllBlocksClearedEvent struct {
+	Type      EventType
+	Timestamp time.Time
+	ModelName string
+	PodName   string
+}
+
+func (e *AllBlocksClearedEvent) GetType() EventType {
+	return e.Type
+}
+
+func (e *AllBlocksClearedEvent) GetTimestamp() time.Time {
+	return e.Timestamp
+}
+
+type BlockUpdateEvent struct {
+	Type            EventType
+	Timestamp       time.Time
+	BlockHashes     []uint64
+	TokenIDs        []int32
+	ParentBlockHash uint64
+	ModelName       string
+	PodName         string
+	BlockSize       int64
+}
+
+// GetType returns the event type
+func (e *BlockUpdateEvent) GetType() EventType {
+	return e.Type
+}
+
+func (e *BlockUpdateEvent) GetTimestamp() time.Time {
+	return e.Timestamp
+}
+
+const (
+	SourceMooncake string = "mooncake"
+	SourceVLLM     string = "vllm"
+)
+
+type EventBatch struct {
+	Source string // indicates the origin of the event batch
+	Events []KVEvent
+}

--- a/mooncake-conductor/conductor-ctrl/zmq/msg_decoder.go
+++ b/mooncake-conductor/conductor-ctrl/zmq/msg_decoder.go
@@ -1,0 +1,638 @@
+package zmq
+
+import (
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	msgpack "github.com/shamaton/msgpack/v2"
+)
+
+type EventParser interface {
+	ParseEvent(raw []interface{}, timestamp interface{}) (KVEvent, error)
+	EventMappings() map[string]EventType
+	Source() string
+}
+
+type mooncakeParser struct{}
+
+func (p *mooncakeParser) Source() string { return SourceMooncake }
+
+func (p *mooncakeParser) EventMappings() map[string]EventType {
+	return map[string]EventType{
+		"BlockStoreEvent":  EventTypeBlockStored,
+		"BlockUpdateEvent": EventTypeBlockUpdate,
+		"RemoveAllEvent":   EventTypeAllCleared,
+	}
+}
+
+func (p *mooncakeParser) ParseEvent(raw []interface{}, timestamp interface{}) (KVEvent, error) {
+	eventTypeStr, ok := raw[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid event type format: %T", raw[0])
+	}
+
+	eventType, exists := p.EventMappings()[eventTypeStr]
+	if !exists {
+		return nil, fmt.Errorf("unknown mooncake event type: %s", eventTypeStr)
+	}
+
+	switch eventType {
+	case EventTypeBlockStored:
+		return parseMooncakeBlockStored(raw, timestamp)
+	default:
+		return nil, fmt.Errorf("unhandled event: %s", eventType)
+	}
+}
+
+func decodeCommonEventBatch(
+	data []byte,
+	expectedLength int,
+	extractEvents func([]interface{}) ([]interface{}, interface{}, error),
+	parser EventParser,
+) (*EventBatch, error) {
+
+	if len(data) > 0 {
+		slog.Debug("First byte of payload", "hex", fmt.Sprintf("%02x", data[0]))
+	}
+
+	var arr []interface{}
+	if err := msgpack.Unmarshal(data, &arr); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal event batch: %w", err)
+	}
+
+	if len(arr) != expectedLength {
+		return nil, fmt.Errorf("expected %d-element array, got %d", expectedLength, len(arr))
+	}
+
+	events, timestamp, err := extractEvents(arr)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(events) == 0 {
+		slog.Warn("Received empty event list")
+	}
+
+	batch := &EventBatch{
+		Source: parser.Source(),
+		Events: make([]KVEvent, 0, len(events)),
+	}
+
+	for i, rawEvent := range events {
+		eventSlice, ok := rawEvent.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("event at index %d is not a slice: %T", i, rawEvent)
+		}
+		event, err := parser.ParseEvent(eventSlice, timestamp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse event at index %d: %w", i, err)
+		}
+		batch.Events = append(batch.Events, event)
+	}
+
+	return batch, nil
+}
+
+func newMooncakeParser() EventParser {
+	return &mooncakeParser{}
+}
+
+func DecodeMooncakeEventBatch(data []byte) (*EventBatch, error) {
+	return decodeCommonEventBatch(
+		data,
+		2,
+		func(arr []interface{}) ([]interface{}, interface{}, error) {
+			events, ok := arr[1].([]interface{})
+			if !ok {
+				return nil, nil, fmt.Errorf("invalid events type: %T", arr[1])
+			}
+			return events, arr[0], nil
+		},
+		newMooncakeParser(),
+	)
+}
+
+type vllmParser struct{}
+
+func (p *vllmParser) Source() string { return SourceVLLM }
+
+func (p *vllmParser) EventMappings() map[string]EventType {
+	return map[string]EventType{
+		"BlockStored":      EventTypeBlockStored,
+		"BlockRemoved":     EventTypeBlockRemoved,
+		"AllBlocksCleared": EventTypeAllCleared,
+	}
+}
+
+func (p *vllmParser) ParseEvent(raw []interface{}, timestamp interface{}) (KVEvent, error) {
+	eventTypeStr, ok := raw[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid event type format: %T", raw[0])
+	}
+
+	eventType, exists := p.EventMappings()[eventTypeStr]
+	if !exists {
+		return nil, fmt.Errorf("unknown vllm event type: %s", eventTypeStr)
+	}
+
+	switch eventType {
+	case EventTypeBlockStored:
+		return parseVllmBlockStored(raw, timestamp)
+	default:
+		return nil, fmt.Errorf("unhandled event: %s", eventType)
+	}
+}
+
+func newVLLMParser() EventParser {
+	return &vllmParser{}
+}
+
+func DecodeVllmEventBatch(data []byte) (*EventBatch, error) {
+	return decodeCommonEventBatch(
+		data,
+		3,
+		func(arr []interface{}) ([]interface{}, interface{}, error) {
+			events, ok := arr[1].([]interface{})
+			if !ok {
+				return nil, nil, fmt.Errorf("invalid events type: %T", arr[1])
+			}
+			return events, arr[0], nil
+		},
+		newVLLMParser(),
+	)
+}
+
+func parseMooncakeBlockStored(data []interface{}, timestamp interface{}) (*BlockStoredEvent, error) {
+	event := &BlockStoredEvent{
+		Type: EventTypeBlockStored,
+	}
+
+	if mooncakekey, err := safeGetString(data[1]); err == nil {
+		event.MooncakeKey = mooncakekey
+	} else {
+		return nil, fmt.Errorf("failed to parse MooncakeKey from field at index 1: %w", err)
+	}
+
+	if replicalist, err := convertToReplicaList(data[2]); err == nil {
+		event.ReplicaList = replicalist
+		slog.Debug("ReplicaList:", "ReplicaList", event.ReplicaList)
+	} else {
+		return nil, fmt.Errorf("failed to parse ReplicaList from field at index 2: %w", err)
+	}
+
+	if blocksize, err := parseInt64(data[4]); err == nil {
+		event.BlockSize = blocksize
+		slog.Debug("BlockSize:", "BlockSize", event.BlockSize)
+	} else {
+		return nil, fmt.Errorf("failed to parse BlockSize from field at index 4: %w", err)
+	}
+
+	if blockhash, err := parseMooncakeParentUint64(data[5]); err == nil {
+		event.BlockHashes = blockhash
+		slog.Debug("BlockHashes:", "BlockHashes", event.BlockHashes)
+	} else {
+		return nil, fmt.Errorf("failed to parse BlockHashes from field at index 5: %w", err)
+	}
+
+	if parentblockhash, err := parseMooncakeUint64(data[6]); err == nil {
+		event.ParentBlockHash = parentblockhash
+		slog.Debug("ParentBlockHash:", "ParentBlockHash", event.ParentBlockHash)
+	} else {
+		return nil, fmt.Errorf("failed to parse ParentBlockHash from field at index 6: %w", err)
+	}
+
+	if tokenIDsRaw, ok := data[7].([]interface{}); ok {
+		tokens, err := parseInt32Array(tokenIDsRaw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse TokenIDs from field at index 7: %w", err)
+		}
+		event.TokenIDs = tokens
+		slog.Debug("TokenIDs:", "TokenIDs", event.TokenIDs)
+	} else {
+		return nil, fmt.Errorf("missing or invalid token_ids")
+	}
+
+	return event, nil
+}
+
+// parseBlockStoredEvent parses a BlockStoredEvent from raw data
+func parseVllmBlockStored(data []interface{}, timestamp interface{}) (*BlockStoredEvent, error) {
+	event := &BlockStoredEvent{
+		Type: EventTypeBlockStored,
+	}
+
+	slog.Debug("success parseBlockStoredEvent")
+	for i, elem := range data {
+		slog.Debug("Array element", "index", i, "type", fmt.Sprintf("%T", elem), "value", elem)
+	}
+
+	slog.Debug("Raw eventType bytes:", "timestamp", timestamp)
+	// Parse timestamp
+	if ts, err := parseTimestamp(timestamp); err == nil {
+		slog.Debug("timestamp:", "timestamp", ts)
+		event.Timestamp = ts
+	} else {
+		return nil, fmt.Errorf("failed to parse timestamp: %w", err)
+	}
+
+	// // Parse block hashes
+	if hashes, err := parseUint64Array(data[1]); err == nil {
+		slog.Debug("BlockHashes:", "BlockHashes", hashes)
+		event.BlockHashes = hashes
+	} else {
+		return nil, fmt.Errorf("failed to parse block_hashes: %w", err)
+	}
+
+	// // Parse token IDs (array of arrays)
+	if tokenIDsRaw, ok := data[3].([]interface{}); ok {
+		tokens, err := parseInt32Array(tokenIDsRaw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse token_ids at index %w", err)
+		}
+		event.TokenIDs = tokens
+		slog.Debug("TokenIDs:", "TokenIDs", event.TokenIDs)
+	} else {
+		return nil, fmt.Errorf("missing or invalid token_ids")
+	}
+
+	var parentHash uint64
+	if data[2] == nil {
+		parentHash = uint64(0)
+	} else {
+		hash := data[2]
+		// fmt.Printf("Type of hash>>>>: %T\n", hash)
+		if h, ok := hash.(uint64); ok {
+			parentHash = h
+		} else {
+			return nil, fmt.Errorf("expected uint64, got %T", hash)
+		}
+	}
+	event.ParentBlockHash = parentHash
+
+	if blocksize, err := parseInt64(data[4]); err == nil {
+		event.BlockSize = blocksize
+	} else {
+		return nil, fmt.Errorf("failed to parse field at index 4 as integer: %w", err)
+	}
+
+	return event, nil
+}
+
+func convertToReplicaList(raw interface{}) ([][]string, error) {
+	list, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected []interface{}, got %T", raw)
+	}
+
+	result := make([][]string, len(list))
+	for i, item := range list {
+		subList, ok := item.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("item %d is not []interface{}, got %T", i, item)
+		}
+		result[i] = make([]string, len(subList))
+		for j, v := range subList {
+			str, ok := v.(string)
+			if !ok {
+				return nil, fmt.Errorf("element [%d][%d] is not string, got %T", i, j, v)
+			}
+			result[i][j] = str
+		}
+	}
+	return result, nil
+}
+
+func safeGetString(val interface{}) (string, error) {
+	switch v := val.(type) {
+	case string:
+		return v, nil
+	case []byte:
+		return string(v), nil
+	case fmt.Stringer:
+		return v.String(), nil
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return fmt.Sprintf("%v", v), nil
+	case nil:
+		return "", nil
+	default:
+		slog.Warn("Unexpected type in string field",
+			"type", fmt.Sprintf("%T", v),
+			"value", v)
+		return fmt.Sprintf("%v", v), nil
+	}
+}
+
+// Helper functions for parsing common types
+func parseTimestamp(v interface{}) (time.Time, error) {
+	switch t := v.(type) {
+	case time.Time:
+		return t, nil
+	case int64:
+		return time.Unix(t, 0).UTC(), nil
+	case int:
+		return time.Unix(int64(t), 0).UTC(), nil
+	case int32:
+		return time.Unix(int64(t), 0).UTC(), nil
+	case uint32:
+		return time.Unix(int64(t), 0).UTC(), nil
+	case uint64:
+		return time.Unix(int64(t), 0).UTC(), nil
+	case float64:
+		sec := int64(t)
+		nsec := int64((t - float64(sec)) * 1e9)
+		return time.Unix(sec, nsec).UTC().Truncate(time.Microsecond), nil
+	case float32:
+		f64 := float64(t)
+		sec := int64(f64)
+		nsec := int64((f64 - float64(sec)) * 1e9)
+		return time.Unix(sec, nsec).UTC().Truncate(time.Microsecond), nil
+	case string:
+		// Try to parse RFC3339 format
+		return time.Parse(time.RFC3339, t)
+	default:
+		return time.Time{}, fmt.Errorf("unsupported timestamp type: %T", v)
+	}
+}
+
+func parseInt64(v interface{}) (int64, error) {
+	switch n := v.(type) {
+	case int64:
+		return n, nil
+	case int:
+		return int64(n), nil
+	case int32:
+		return int64(n), nil
+	case int16:
+		return int64(n), nil
+	case int8:
+		return int64(n), nil
+	case uint:
+		return int64(n), nil
+	case uint64:
+		return int64(n), nil
+	case uint32:
+		return int64(n), nil
+	case uint16:
+		return int64(n), nil
+	case uint8:
+		return int64(n), nil
+	case float64:
+		return int64(n), nil
+	case float32:
+		return int64(n), nil
+	default:
+		return 0, fmt.Errorf("unsupported int64 type: %T", v)
+	}
+}
+
+func parseUint64(v interface{}) (uint64, error) {
+	switch n := v.(type) {
+	case uint64:
+		return n, nil
+	case int:
+		return uint64(n), nil
+	case int32:
+		return uint64(n), nil
+	case int16:
+		return uint64(n), nil
+	case int8:
+		return uint64(n), nil
+	case uint:
+		return uint64(n), nil
+	case int64:
+		return uint64(n), nil
+	case uint32:
+		return uint64(n), nil
+	case uint16:
+		return uint64(n), nil
+	case uint8:
+		return uint64(n), nil
+	case float64:
+		return uint64(n), nil
+	case float32:
+		return uint64(n), nil
+	default:
+		return 0, fmt.Errorf("unsupported int64 type: %T", v)
+	}
+}
+
+func parseUint64Array(v interface{}) ([]uint64, error) {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected array, got %T", v)
+	}
+
+	result := make([]uint64, 0, len(arr))
+	for i, item := range arr {
+		val, err := parseUint64(item)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse element at index %d: %w", i, err)
+		}
+		result = append(result, val)
+	}
+	return result, nil
+}
+
+func parseInt32Array(v interface{}) ([]int32, error) {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected array, got %T", v)
+	}
+
+	result := make([]int32, 0, len(arr))
+	for i, item := range arr {
+		switch n := item.(type) {
+		case int32:
+			result = append(result, n)
+		case int:
+			result = append(result, int32(n))
+		case int64:
+			result = append(result, int32(n))
+		case int16:
+			result = append(result, int32(n))
+		case int8:
+			result = append(result, int32(n))
+		case uint:
+			result = append(result, int32(n))
+		case uint64:
+			result = append(result, int32(n))
+		case uint32:
+			result = append(result, int32(n))
+		case uint16:
+			result = append(result, int32(n))
+		case uint8:
+			result = append(result, int32(n))
+		case float64:
+			result = append(result, int32(n))
+		case float32:
+			result = append(result, int32(n))
+		default:
+			return nil, fmt.Errorf("unsupported int32 type at index %d: %T", i, item)
+		}
+	}
+	return result, nil
+}
+
+func parseMooncakeUint64(v interface{}) (uint64, error) {
+	var s string
+	switch val := v.(type) {
+	case string:
+		s = val
+	case nil:
+		s = ""
+	case uint64:
+		return val, nil
+	case int:
+		if val < 0 {
+			return 0, fmt.Errorf("negative value %d", val)
+		}
+		return uint64(val), nil
+	case int8:
+		if val < 0 {
+			return 0, fmt.Errorf("negative value %d", val)
+		}
+		return uint64(val), nil
+	case int16:
+		if val < 0 {
+			return 0, fmt.Errorf("negative value %d", val)
+		}
+		return uint64(val), nil
+	case int32:
+		if val < 0 {
+			return 0, fmt.Errorf("negative value %d", val)
+		}
+		return uint64(val), nil
+	case int64:
+		if val < 0 {
+			return 0, fmt.Errorf("negative value %d", val)
+		}
+		return uint64(val), nil
+	case uint:
+		return uint64(val), nil
+	case uint8:
+		return uint64(val), nil
+	case uint16:
+		return uint64(val), nil
+	case uint32:
+		return uint64(val), nil
+	default:
+		s = fmt.Sprint(v)
+	}
+	if s == "" {
+		return 0, nil
+	}
+	return strconv.ParseUint(s, 10, 64)
+}
+
+func parseMooncakeParentUint64(v interface{}) ([]uint64, error) {
+	switch val := v.(type) {
+	case nil:
+		return []uint64{}, nil
+
+	case string:
+		if val == "" {
+			return []uint64{}, nil
+		}
+		parts := strings.FieldsFunc(val, func(r rune) bool {
+			return r == ',' || r == ' ' || r == '\t' || r == '\n'
+		})
+		result := make([]uint64, 0, len(parts))
+		for _, part := range parts {
+			if part == "" {
+				continue
+			}
+			u, err := strconv.ParseUint(part, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse uint64 from string %q: %w", part, err)
+			}
+			result = append(result, u)
+		}
+		return result, nil
+
+	case []interface{}:
+		result := make([]uint64, 0, len(val))
+		for _, item := range val {
+			u, err := parseSingleUint64(item)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse element %v: %w", item, err)
+			}
+			result = append(result, u)
+		}
+		return result, nil
+
+	case []uint64:
+		// already correct type
+		return val, nil
+
+	default:
+		// try parse as single uint64
+		u, err := parseSingleUint64(val)
+		if err != nil {
+			return nil, err
+		}
+		return []uint64{u}, nil
+	}
+}
+
+func parseSingleUint64(v interface{}) (uint64, error) {
+	switch val := v.(type) {
+	case uint64:
+		return val, nil
+	case int:
+		if val < 0 {
+			return 0, fmt.Errorf("negative int %d cannot convert to uint64", val)
+		}
+		return uint64(val), nil
+	case int8:
+		if val < 0 {
+			return 0, fmt.Errorf("negative int8 %d cannot convert to uint64", val)
+		}
+		return uint64(val), nil
+	case int16:
+		if val < 0 {
+			return 0, fmt.Errorf("negative int16 %d cannot convert to uint64", val)
+		}
+		return uint64(val), nil
+	case int32:
+		if val < 0 {
+			return 0, fmt.Errorf("negative int32 %d cannot convert to uint64", val)
+		}
+		return uint64(val), nil
+	case int64:
+		if val < 0 {
+			return 0, fmt.Errorf("negative int64 %d cannot convert to uint64", val)
+		}
+		return uint64(val), nil
+	case uint:
+		return uint64(val), nil
+	case uint8:
+		return uint64(val), nil
+	case uint16:
+		return uint64(val), nil
+	case uint32:
+		return uint64(val), nil
+	case float32:
+		f := float64(val)
+		if f < 0 || f != float64(uint64(f)) {
+			return 0, fmt.Errorf("float32 %v invalid for uint64", val)
+		}
+		return uint64(f), nil
+	case float64:
+		if val < 0 || val != float64(uint64(val)) {
+			return 0, fmt.Errorf("float64 %v invalid for uint64", val)
+		}
+		return uint64(val), nil
+	case string:
+		if val == "" {
+			return 0, fmt.Errorf("empty string cannot be parsed as uint64")
+		}
+		return strconv.ParseUint(val, 10, 64)
+	case nil:
+		return 0, fmt.Errorf("nil cannot be parsed as uint64")
+	default:
+		return 0, fmt.Errorf("unsupported type %T for uint64 conversion", v)
+	}
+}

--- a/mooncake-conductor/conductor-ctrl/zmq/msg_decoder_test.go
+++ b/mooncake-conductor/conductor-ctrl/zmq/msg_decoder_test.go
@@ -1,0 +1,178 @@
+package zmq_test
+
+import (
+	"testing"
+	"time"
+
+	"conductor/zmq"
+
+	msgpack "github.com/shamaton/msgpack/v2"
+)
+
+func TestDecodeMooncakeEventBatch(t *testing.T) {
+	timestamp := int64(1700000000)
+	event := []interface{}{
+		"BlockStoreEvent",
+		"mooncake-key-123",
+		[][]interface{}{
+			[]interface{}{"replica1", "replica2"},
+			[]interface{}{"replica3"},
+		},
+		nil,                                     // index 3 is not used
+		int64(1024),                             // BlockSize at index 4
+		[]interface{}{uint64(100), uint64(200)}, // BlockHashes at index 5
+		uint64(50),                              // ParentBlockHash at index 6
+		[]interface{}{int32(1), int32(2), int32(3)}, // TokenIDs at index 7
+	}
+	events := []interface{}{event}
+	batch := []interface{}{timestamp, events}
+
+	data, err := msgpack.Marshal(batch)
+	if err != nil {
+		t.Fatalf("Failed to marshal test data: %v", err)
+	}
+
+	result, err := zmq.DecodeMooncakeEventBatch(data)
+	if err != nil {
+		t.Fatalf("DecodeMooncakeEventBatch failed: %v", err)
+	}
+
+	if result.Source != zmq.SourceMooncake {
+		t.Errorf("Expected source %v, got %v", zmq.SourceMooncake, result.Source)
+	}
+
+	if len(result.Events) != 1 {
+		t.Fatalf("Expected 1 event, got %d", len(result.Events))
+	}
+
+	blockEvent, ok := result.Events[0].(*zmq.BlockStoredEvent)
+	if !ok {
+		t.Fatalf("Expected BlockStoredEvent, got %T", result.Events[0])
+	}
+
+	if blockEvent.Type != zmq.EventTypeBlockStored {
+		t.Errorf("Expected type %v, got %v", zmq.EventTypeBlockStored, blockEvent.Type)
+	}
+
+	if blockEvent.MooncakeKey != "mooncake-key-123" {
+		t.Errorf("Expected MooncakeKey 'mooncake-key-123', got '%s'", blockEvent.MooncakeKey)
+	}
+
+	if blockEvent.BlockSize != 1024 {
+		t.Errorf("Expected BlockSize 1024, got %d", blockEvent.BlockSize)
+	}
+
+	if len(blockEvent.BlockHashes) != 2 {
+		t.Fatalf("Expected 2 block hashes, got %d", len(blockEvent.BlockHashes))
+	}
+
+	if blockEvent.BlockHashes[0] != 100 || blockEvent.BlockHashes[1] != 200 {
+		t.Errorf("Expected block hashes [100, 200], got %v", blockEvent.BlockHashes)
+	}
+
+	if blockEvent.ParentBlockHash != 50 {
+		t.Errorf("Expected ParentBlockHash 50, got %d", blockEvent.ParentBlockHash)
+	}
+
+	if len(blockEvent.TokenIDs) != 3 {
+		t.Fatalf("Expected 3 token IDs, got %d", len(blockEvent.TokenIDs))
+	}
+
+	if len(blockEvent.ReplicaList) != 2 {
+		t.Fatalf("Expected 2 replica lists, got %d", len(blockEvent.ReplicaList))
+	}
+}
+
+func TestDecodeVllmEventBatch(t *testing.T) {
+	timestamp := int64(1700000000)
+	event := []interface{}{
+		"BlockStored",
+		[]interface{}{uint64(100), uint64(200)},            // BlockHashes
+		uint64(5000000000),                                 // ParentBlockHash
+		[]interface{}{int32(10000000), int32(2), int32(3)}, // TokenIDs
+		int64(1024),                                        // BlockSize
+	}
+	events := []interface{}{event}
+	status := "ok"
+	batch := []interface{}{timestamp, events, status}
+
+	data, err := msgpack.Marshal(batch)
+	if err != nil {
+		t.Fatalf("Failed to marshal test data: %v", err)
+	}
+
+	result, err := zmq.DecodeVllmEventBatch(data)
+	if err != nil {
+		t.Fatalf("DecodeVllmEventBatch failed: %v", err)
+	}
+
+	if result.Source != zmq.SourceVLLM {
+		t.Errorf("Expected source %v, got %v", zmq.SourceVLLM, result.Source)
+	}
+
+	if len(result.Events) != 1 {
+		t.Fatalf("Expected 1 event, got %d", len(result.Events))
+	}
+
+	blockEvent, ok := result.Events[0].(*zmq.BlockStoredEvent)
+	if !ok {
+		t.Fatalf("Expected BlockStoredEvent, got %T", result.Events[0])
+	}
+
+	if blockEvent.Type != zmq.EventTypeBlockStored {
+		t.Errorf("Expected type %v, got %v", zmq.EventTypeBlockStored, blockEvent.Type)
+	}
+
+	expectedTime := time.Unix(1700000000, 0).UTC()
+	if !blockEvent.Timestamp.Equal(expectedTime) {
+		t.Errorf("Expected timestamp %v, got %v", expectedTime, blockEvent.Timestamp)
+	}
+
+	if len(blockEvent.BlockHashes) != 2 {
+		t.Fatalf("Expected 2 block hashes, got %d", len(blockEvent.BlockHashes))
+	}
+
+	if blockEvent.BlockHashes[0] != 100 || blockEvent.BlockHashes[1] != 200 {
+		t.Errorf("Expected block hashes [100, 200], got %v", blockEvent.BlockHashes)
+	}
+
+	if blockEvent.ParentBlockHash != 5000000000 {
+		t.Errorf("Expected ParentBlockHash 50, got %d", blockEvent.ParentBlockHash)
+	}
+
+	if blockEvent.BlockSize != 1024 {
+		t.Errorf("Expected BlockSize 1024, got %d", blockEvent.BlockSize)
+	}
+
+	if len(blockEvent.TokenIDs) != 3 {
+		t.Fatalf("Expected 3 token IDs, got %d", len(blockEvent.TokenIDs))
+	}
+}
+
+func TestDecodeMooncakeEventBatch_InvalidData(t *testing.T) {
+	// Test with invalid array length
+	invalidBatch := []interface{}{int64(1700000000)} // Missing events
+	data, err := msgpack.Marshal(invalidBatch)
+	if err != nil {
+		t.Fatalf("Failed to marshal test data: %v", err)
+	}
+
+	_, err = zmq.DecodeMooncakeEventBatch(data)
+	if err == nil {
+		t.Error("Expected error for invalid array length, got nil")
+	}
+}
+
+func TestDecodeVllmEventBatch_InvalidData(t *testing.T) {
+	// Test with invalid array length
+	invalidBatch := []interface{}{int64(1700000000)} // Missing events and status
+	data, err := msgpack.Marshal(invalidBatch)
+	if err != nil {
+		t.Fatalf("Failed to marshal test data: %v", err)
+	}
+
+	_, err = zmq.DecodeVllmEventBatch(data)
+	if err == nil {
+		t.Error("Expected error for invalid array length, got nil")
+	}
+}

--- a/mooncake-conductor/conductor-ctrl/zmq/types.go
+++ b/mooncake-conductor/conductor-ctrl/zmq/types.go
@@ -1,0 +1,58 @@
+package zmq
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+// EventHandler processes received KV events
+type EventHandler interface {
+	HandleEvent(event KVEvent) error
+}
+
+// ZMQClientConfig contains configuration for the ZMQ client
+type ZMQClientConfig struct {
+	CachePoolKey   string
+	ServiceIP      string
+	ModelName      string
+	Port           int
+	RouterPort     int
+	PollTimeout    time.Duration
+	ReplayTimeout  time.Duration
+	ReconnectDelay time.Duration
+}
+
+const (
+	DefaultPubPort    = 5557
+	DefaultRouterPort = 5558
+
+	// Timeouts and intervals
+	DefaultPollTimeout       = 100 * time.Millisecond
+	DefaultReplayTimeout     = 5 * time.Second
+	DefaultReconnectInterval = 1 * time.Second
+	MaxReconnectInterval     = 30 * time.Second
+	ReconnectBackoffFactor   = 2.0
+
+	EventChannelBufferSize = 1000
+)
+
+func ValidateConfig(config *ZMQClientConfig) error {
+	if config.ServiceIP == "" {
+		return fmt.Errorf("publisher IP is required")
+	}
+
+	if ip := net.ParseIP(config.ServiceIP); ip == nil {
+		return fmt.Errorf("invalid IP address: %s", config.ServiceIP)
+	}
+
+	if config.Port <= 0 || config.Port > 65535 {
+		return fmt.Errorf("invalid publisher port: %d", config.Port)
+	}
+
+	if config.RouterPort <= 0 || config.RouterPort > 65535 {
+		return fmt.Errorf("invalid router port: %d", config.RouterPort)
+	}
+
+	return nil
+}

--- a/mooncake-conductor/conductor-ctrl/zmq/zmq_client.go
+++ b/mooncake-conductor/conductor-ctrl/zmq/zmq_client.go
@@ -1,0 +1,359 @@
+package zmq
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	zmq "github.com/pebbe/zmq4"
+)
+
+type ZMQClient struct {
+	config *ZMQClientConfig
+
+	subSocket    *zmq.Socket
+	replaySocket *zmq.Socket
+
+	eventHandler EventHandler
+
+	// State management
+	mu             sync.RWMutex
+	connected      bool
+	lastSeq        int64
+	reconnectDelay time.Duration
+
+	// Lifecycle
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func NewZMQClient(config *ZMQClientConfig, handler EventHandler) *ZMQClient {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &ZMQClient{
+		config:         config,
+		eventHandler:   handler,
+		lastSeq:        -1,
+		reconnectDelay: config.ReconnectDelay,
+		ctx:            ctx,
+		cancel:         cancel,
+	}
+}
+
+// Start initiates the connection and background event consumption loop.
+func (c *ZMQClient) Start() error {
+	// Attempt initial connection
+	if err := c.Connect(); err != nil {
+		return fmt.Errorf("initial connection failed: %w", err)
+	}
+
+	c.wg.Add(1)
+	go c.loop()
+
+	slog.Info("ZMQ client started", "service", c.config.CachePoolKey)
+	return nil
+}
+
+func (c *ZMQClient) Stop() {
+	c.cancel()
+	c.wg.Wait()
+
+	c.mu.Lock()
+	c.cleanupSockets()
+	c.mu.Unlock()
+
+	slog.Info("ZMQ client stopped", "service", c.config.CachePoolKey)
+}
+
+// loop is the main background loop handling events and reconnections.
+// Simplified: Fixed reconnect interval, single loop structure.
+func (c *ZMQClient) loop() {
+	defer c.wg.Done()
+
+	for {
+		// Check if we should stop
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+
+		// 1. If disconnected, wait for ticker then try to reconnect
+		if !c.isConnected() {
+			c.handleReconnect()
+			continue
+		}
+
+		// 2. If connected, consume events
+		if err := c.consume(); err != nil {
+			slog.Error("Consumption error", "service", c.config.CachePoolKey, "error", err)
+			c.markDisconnected()
+		}
+	}
+}
+
+func (c *ZMQClient) handleReconnect() {
+	slog.Info("Attempting to reconnect to the service.", "service", c.config.CachePoolKey, "reconnectDelay", c.reconnectDelay)
+
+	ticker := time.NewTicker(c.config.ReconnectDelay)
+	defer ticker.Stop()
+
+	select {
+	case <-c.ctx.Done():
+		return
+	case <-ticker.C:
+	}
+
+	if err := c.Connect(); err != nil {
+		slog.Error("Reconnect failed", "service", c.config.CachePoolKey, "error", err)
+	}
+
+	// Reconnected! Request replay from last known sequence
+	lastSeq := c.getLastSequence()
+	if lastSeq >= 0 {
+		slog.Info("Reconnected", "service", c.config.CachePoolKey, "resuming_from", lastSeq+1)
+		if err := c.requestReplay(lastSeq + 1); err != nil {
+			slog.Warn("Failed to request replay after reconnect", "service", c.config.CachePoolKey, "error", err)
+		}
+	}
+
+}
+
+// Connect establishes the ZMQ SUB and DEALER sockets.
+func (c *ZMQClient) Connect() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.connected {
+		return nil
+	}
+
+	// Ensure clean state
+	c.cleanupSockets()
+
+	sock, err := zmq.NewSocket(zmq.SUB)
+	if err != nil {
+		return fmt.Errorf("create socket failed: %w", err)
+	}
+
+	if err := sock.SetIpv6(true); err != nil {
+		_ = sock.Close()
+		return fmt.Errorf("failed to enable IPv6 on socket: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("tcp://%s", net.JoinHostPort(c.config.ServiceIP, strconv.Itoa(c.config.Port)))
+	if err := sock.Connect(endpoint); err != nil {
+		_ = sock.Close()
+		return fmt.Errorf("failed to connect to %s: %w", endpoint, err)
+	}
+
+	// Important: Subscribe to all topics
+	if err := sock.SetSubscribe(""); err != nil {
+		_ = sock.Close()
+		return fmt.Errorf("failed to subscribe: %w", err)
+	}
+
+	replaySocket, err := zmq.NewSocket(zmq.DEALER)
+	if err != nil {
+		sock.Close()
+		return fmt.Errorf("failed to create DEALER socket: %w", err)
+	}
+
+	// Enable IPv6 for dual-stack support
+	if err := replaySocket.SetIpv6(true); err != nil {
+		_ = sock.Close()
+		_ = replaySocket.Close()
+		return fmt.Errorf("failed to enable IPv6 on DEALER socket: %w", err)
+	}
+
+	replayEndpoint := fmt.Sprintf("tcp://%s", net.JoinHostPort(c.config.ServiceIP, strconv.Itoa(c.config.RouterPort)))
+	if err := replaySocket.Connect(replayEndpoint); err != nil {
+		_ = sock.Close()
+		_ = replaySocket.Close()
+		return fmt.Errorf("failed to connect to replay endpoint: %w", err)
+	}
+
+	c.subSocket = sock
+	c.replaySocket = replaySocket
+	c.connected = true
+
+	c.reconnectDelay = c.config.ReconnectDelay
+
+	slog.Info("Successfully connected to vLLM publisher", "service", c.config.CachePoolKey, "ip", c.config.ServiceIP)
+
+	return nil
+}
+
+// consume reads and processes messages from the SUB socket.
+func (c *ZMQClient) consume() error {
+	c.mu.RLock()
+	socket := c.subSocket
+	c.mu.RUnlock()
+
+	if socket == nil {
+		return fmt.Errorf("socket is nil")
+	}
+
+	poller := zmq.NewPoller()
+	poller.Add(socket, zmq.POLLIN)
+
+	// Poll for data
+	polled, err := poller.Poll(c.config.PollTimeout)
+	if err != nil {
+		return fmt.Errorf("poll error: %w", err)
+	}
+	if len(polled) == 0 {
+		return nil // No data, continue loop
+	}
+
+	if err := c.processMessage(socket); err != nil {
+		return fmt.Errorf("failed to process message: %w", err)
+	}
+
+	return nil
+
+}
+
+func (c *ZMQClient) processMessage(socket *zmq.Socket) error {
+
+	if socket == nil {
+		return fmt.Errorf("socket is nil")
+	}
+
+	// Read Frames: [Topic, Seq, Payload]
+	topic, err := socket.RecvBytes(0)
+	if err != nil {
+		return err
+	}
+	seqBytes, err := socket.RecvBytes(0)
+	if err != nil {
+		return err
+	}
+	payload, err := socket.RecvBytes(0)
+	if err != nil {
+		return err
+	}
+
+	if len(seqBytes) != 8 {
+		return fmt.Errorf("invalid sequence length")
+	}
+	seq := int64(binary.BigEndian.Uint64(seqBytes))
+
+	c.mu.RLock()
+	lastSeq := c.lastSeq
+	c.mu.RUnlock()
+
+	if lastSeq != -1 && seq > lastSeq+1 {
+		slog.Warn("Event gap detected",
+			"service", c.config.CachePoolKey,
+			"missed", seq-lastSeq-1,
+			"last", lastSeq,
+			"current", seq,
+		)
+		// Trigger replay for missed events?
+		// Usually we just log warning here, or could auto-trigger requestReplay
+	}
+
+	// Update Sequence immediately to keep state fresh
+	c.mu.Lock()
+	c.lastSeq = seq
+	c.mu.Unlock()
+
+	slog.Debug("enter deal topic", "topic", topic)
+
+	var batch *EventBatch
+	switch string(topic) {
+	case "mooncake":
+		batch, err = DecodeMooncakeEventBatch(payload)
+	default:
+		batch, err = DecodeVllmEventBatch(payload)
+	}
+	if err != nil {
+		return fmt.Errorf("decode failed: %w", err)
+	}
+
+	for _, event := range batch.Events {
+		// Inject Source Name
+		switch e := event.(type) {
+		case *BlockStoredEvent:
+			e.PodName = c.config.CachePoolKey
+		case *BlockRemovedEvent:
+			e.PodName = c.config.CachePoolKey
+		}
+
+		if err := c.eventHandler.HandleEvent(event); err != nil {
+			slog.Error("Handler error", "service", c.config.CachePoolKey, "error", err)
+		}
+	}
+
+	slog.Debug("Processed batch", "service", c.config.CachePoolKey, "seq", seq, "topic", string(topic))
+	return nil
+
+}
+
+func (c *ZMQClient) requestReplay(fromSeq int64) error {
+	c.mu.RLock()
+	socket := c.replaySocket
+	c.mu.RUnlock()
+
+	if socket == nil {
+		return fmt.Errorf("replay socket is nil")
+	}
+
+	req := make([]byte, 8)
+	binary.BigEndian.PutUint64(req, uint64(fromSeq))
+
+	if _, err := socket.SendBytes(req, 0); err != nil {
+		return fmt.Errorf("failed to send replay request: %w", err)
+	}
+
+	// Ideally, we should wait for an ACK here if the protocol supports it
+	// For simplicity in static client, we fire and forget the request,
+	// assuming the server will send the replayed events via the SUB channel (or DEALER response)
+	// Original code read response from DEALER, let's keep that.
+
+	_ = socket.SetRcvtimeo(c.config.ReplayTimeout)
+
+	resp, err := socket.RecvBytes(0)
+	if err != nil {
+		return fmt.Errorf("failed to receive replay response: %w", err)
+	}
+
+	slog.Info("Replay requested", "service", c.config.CachePoolKey, "from", fromSeq, "resp_len", len(resp))
+	return nil
+}
+
+func (c *ZMQClient) cleanupSockets() {
+	if c.subSocket != nil {
+		c.subSocket.Close()
+		c.subSocket = nil
+	}
+	if c.replaySocket != nil {
+		c.replaySocket.Close()
+		c.replaySocket = nil
+	}
+	c.connected = false
+}
+
+func (c *ZMQClient) markDisconnected() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.connected = false
+}
+
+func (c *ZMQClient) isConnected() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.connected
+}
+
+func (c *ZMQClient) getLastSequence() int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.lastSeq
+}

--- a/mooncake-conductor/conductor-ctrl/zmq/zmq_client_test.go
+++ b/mooncake-conductor/conductor-ctrl/zmq/zmq_client_test.go
@@ -1,0 +1,663 @@
+package zmq_test
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"conductor/zmq"
+
+	zmq4 "github.com/pebbe/zmq4"
+	msgpack "github.com/shamaton/msgpack/v2"
+)
+
+// MockEventHandler implements EventHandler for testing
+type MockEventHandler struct {
+	mu          sync.Mutex
+	events      []zmq.KVEvent
+	handleError error
+	callCount   int64
+}
+
+func NewMockEventHandler() *MockEventHandler {
+	return &MockEventHandler{
+		events: make([]zmq.KVEvent, 0),
+	}
+}
+
+func (m *MockEventHandler) HandleEvent(event zmq.KVEvent) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	atomic.AddInt64(&m.callCount, 1)
+	if m.handleError != nil {
+		return m.handleError
+	}
+	m.events = append(m.events, event)
+	return nil
+}
+
+func (m *MockEventHandler) GetEvents() []zmq.KVEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	events := make([]zmq.KVEvent, len(m.events))
+	copy(events, m.events)
+	return events
+}
+
+func (m *MockEventHandler) GetCallCount() int64 {
+	return atomic.LoadInt64(&m.callCount)
+}
+
+func (m *MockEventHandler) SetHandleError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.handleError = err
+}
+
+func (m *MockEventHandler) Clear() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = m.events[:0]
+	m.handleError = nil
+	atomic.StoreInt64(&m.callCount, 0)
+}
+
+// MockPublisher simulates a ZMQ publisher for testing
+type MockPublisher struct {
+	pubSocket    *zmq4.Socket
+	routerSocket *zmq4.Socket
+	sequence     int64
+	mu           sync.Mutex
+	ctx          context.Context
+	cancel       context.CancelFunc
+	wg           sync.WaitGroup
+}
+
+func createMockPublisher(t *testing.T, pubPort, routerPort int) *MockPublisher {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Create PUB socket
+	pubSocket, err := zmq4.NewSocket(zmq4.PUB)
+	if err != nil {
+		t.Fatalf("Failed to create PUB socket: %v", err)
+	}
+
+	err = pubSocket.SetIpv6(true)
+	if err != nil {
+		pubSocket.Close()
+		t.Fatalf("Failed to enable IPv6 on PUB socket: %v", err)
+	}
+
+	err = pubSocket.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		pubSocket.Close()
+		t.Fatalf("Failed to bind PUB socket: %v", err)
+	}
+
+	// Create ROUTER socket for replay
+	routerSocket, err := zmq4.NewSocket(zmq4.ROUTER)
+	if err != nil {
+		pubSocket.Close()
+		t.Fatalf("Failed to create ROUTER socket: %v", err)
+	}
+
+	err = routerSocket.SetIpv6(true)
+	if err != nil {
+		pubSocket.Close()
+		routerSocket.Close()
+		t.Fatalf("Failed to enable IPv6 on ROUTER socket: %v", err)
+	}
+
+	err = routerSocket.Bind("tcp://127.0.0.1:*")
+	if err != nil {
+		pubSocket.Close()
+		routerSocket.Close()
+		t.Fatalf("Failed to bind ROUTER socket: %v", err)
+	}
+
+	mp := &MockPublisher{
+		pubSocket:    pubSocket,
+		routerSocket: routerSocket,
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+
+	// Start replay handler
+	mp.wg.Add(1)
+	go mp.handleReplay()
+
+	// Wait for sockets to bind
+	time.Sleep(100 * time.Millisecond)
+
+	return mp
+}
+
+func (mp *MockPublisher) PublishEvent(topic string, event zmq.KVEvent) error {
+	// Encode event based on topic
+	var payload []byte
+	var err error
+
+	if topic == "mooncake" {
+		payload, err = encodeMooncakeEvent(event)
+	} else {
+		payload, err = encodeVllmEvent(event)
+	}
+	if err != nil {
+		return err
+	}
+
+	mp.mu.Lock()
+	mp.sequence++
+	seq := mp.sequence
+	mp.mu.Unlock()
+
+	seqBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(seqBytes, uint64(seq))
+
+	_, err = mp.pubSocket.SendMessage(topic, seqBytes, payload)
+	return err
+}
+
+func (mp *MockPublisher) handleReplay() {
+	defer mp.wg.Done()
+	for {
+		select {
+		case <-mp.ctx.Done():
+			return
+		default:
+		}
+
+		// Set receive timeout
+		_ = mp.routerSocket.SetRcvtimeo(100 * time.Millisecond)
+
+		msg, err := mp.routerSocket.RecvBytes(0)
+		if err != nil {
+			continue
+		}
+
+		if len(msg) == 8 {
+			// Send ACK
+			_, _ = mp.routerSocket.SendBytes([]byte("OK"), 0)
+		}
+	}
+}
+
+func (mp *MockPublisher) Close() {
+	mp.cancel()
+	mp.wg.Wait()
+	_ = mp.pubSocket.Close()
+	_ = mp.routerSocket.Close()
+}
+
+func encodeMooncakeEvent(event zmq.KVEvent) ([]byte, error) {
+	switch e := event.(type) {
+	case *zmq.BlockStoredEvent:
+		timestamp := e.Timestamp.Unix()
+		eventData := []interface{}{
+			"BlockStoreEvent",
+			e.MooncakeKey,
+			e.ReplicaList,
+			nil, // index 3 not used
+			e.BlockSize,
+			convertUint64Slice(e.BlockHashes),
+			e.ParentBlockHash,
+			convertInt32Slice(e.TokenIDs),
+		}
+		batch := []interface{}{timestamp, []interface{}{eventData}}
+		return msgpack.Marshal(batch)
+	default:
+		return nil, errors.New("unsupported event type for mooncake")
+	}
+}
+
+func encodeVllmEvent(event zmq.KVEvent) ([]byte, error) {
+	switch e := event.(type) {
+	case *zmq.BlockStoredEvent:
+		timestamp := e.Timestamp.Unix()
+		eventData := []interface{}{
+			"BlockStored",
+			convertUint64Slice(e.BlockHashes),
+			e.ParentBlockHash,
+			convertInt32Slice(e.TokenIDs),
+			e.BlockSize,
+		}
+		batch := []interface{}{timestamp, []interface{}{eventData}, "ok"}
+		return msgpack.Marshal(batch)
+	case *zmq.BlockRemovedEvent:
+		timestamp := e.Timestamp.Unix()
+		eventData := []interface{}{
+			"BlockRemoved",
+			convertUint64Slice(e.BlockHashes),
+		}
+		batch := []interface{}{timestamp, []interface{}{eventData}, "ok"}
+		return msgpack.Marshal(batch)
+	default:
+		return nil, errors.New("unsupported event type for vllm")
+	}
+}
+
+func convertUint64Slice(slice []uint64) []interface{} {
+	result := make([]interface{}, len(slice))
+	for i, v := range slice {
+		result[i] = uint64(v)
+	}
+	return result
+}
+
+func convertInt32Slice(slice []int32) []interface{} {
+	result := make([]interface{}, len(slice))
+	for i, v := range slice {
+		result[i] = int32(v)
+	}
+	return result
+}
+
+func skipIfZMQUnavailable(t *testing.T) {
+	ctx, err := zmq4.NewContext()
+	if err != nil {
+		t.Skip("ZMQ not available:", err)
+	}
+	_ = ctx.Term()
+}
+
+func TestZMQClient_Connect_Success(t *testing.T) {
+	skipIfZMQUnavailable(t)
+
+	publisher := createMockPublisher(t, 5547, 5548)
+	defer publisher.Close()
+
+	// Get actual bound ports
+	pubEndpoint, err := publisher.pubSocket.GetLastEndpoint()
+	if err != nil {
+		t.Fatalf("Failed to get PUB endpoint: %v", err)
+	}
+	routerEndpoint, err := publisher.routerSocket.GetLastEndpoint()
+	if err != nil {
+		t.Fatalf("Failed to get ROUTER endpoint: %v", err)
+	}
+
+	pubPort := extractPortFromEndpoint(pubEndpoint)
+	routerPort := extractPortFromEndpoint(routerEndpoint)
+
+	config := &zmq.ZMQClientConfig{
+		CachePoolKey:   "test-pod",
+		ServiceIP:      "127.0.0.1",
+		ModelName:      "test-model",
+		Port:           pubPort,
+		RouterPort:     routerPort,
+		PollTimeout:    100 * time.Millisecond,
+		ReplayTimeout:  1 * time.Second,
+		ReconnectDelay: 100 * time.Millisecond,
+	}
+
+	handler := NewMockEventHandler()
+	client := zmq.NewZMQClient(config, handler)
+
+	err = client.Connect()
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	client.Stop()
+}
+
+func TestZMQClient_Connect_AlreadyConnected(t *testing.T) {
+	skipIfZMQUnavailable(t)
+
+	publisher := createMockPublisher(t, 5557, 5558)
+	defer publisher.Close()
+
+	pubEndpoint, _ := publisher.pubSocket.GetLastEndpoint()
+	routerEndpoint, _ := publisher.routerSocket.GetLastEndpoint()
+
+	pubPort := extractPortFromEndpoint(pubEndpoint)
+	routerPort := extractPortFromEndpoint(routerEndpoint)
+
+	config := &zmq.ZMQClientConfig{
+		CachePoolKey:   "test-pod",
+		ServiceIP:      "127.0.0.1",
+		ModelName:      "test-model",
+		Port:           pubPort,
+		RouterPort:     routerPort,
+		PollTimeout:    100 * time.Millisecond,
+		ReplayTimeout:  1 * time.Second,
+		ReconnectDelay: 100 * time.Millisecond,
+	}
+
+	handler := NewMockEventHandler()
+	client := zmq.NewZMQClient(config, handler)
+
+	err := client.Connect()
+	if err != nil {
+		t.Fatalf("First Connect failed: %v", err)
+	}
+
+	// Connect again should not error
+	err = client.Connect()
+	if err != nil {
+		t.Fatalf("Second Connect failed: %v", err)
+	}
+
+	client.Stop()
+}
+
+func TestZMQClient_Start_Stop(t *testing.T) {
+	skipIfZMQUnavailable(t)
+
+	publisher := createMockPublisher(t, 5557, 5558)
+	defer publisher.Close()
+
+	pubEndpoint, _ := publisher.pubSocket.GetLastEndpoint()
+	routerEndpoint, _ := publisher.routerSocket.GetLastEndpoint()
+
+	pubPort := extractPortFromEndpoint(pubEndpoint)
+	routerPort := extractPortFromEndpoint(routerEndpoint)
+
+	config := &zmq.ZMQClientConfig{
+		CachePoolKey:   "test-pod",
+		ServiceIP:      "127.0.0.1",
+		ModelName:      "test-model",
+		Port:           pubPort,
+		RouterPort:     routerPort,
+		PollTimeout:    100 * time.Millisecond,
+		ReplayTimeout:  1 * time.Second,
+		ReconnectDelay: 100 * time.Millisecond,
+	}
+
+	handler := NewMockEventHandler()
+	client := zmq.NewZMQClient(config, handler)
+
+	err := client.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	// Wait a bit for loop to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Stop should work gracefully
+	client.Stop()
+}
+
+func TestZMQClient_ProcessMessage_MooncakeTopic(t *testing.T) {
+	skipIfZMQUnavailable(t)
+
+	publisher := createMockPublisher(t, 5557, 5558)
+	defer publisher.Close()
+
+	pubEndpoint, _ := publisher.pubSocket.GetLastEndpoint()
+	routerEndpoint, _ := publisher.routerSocket.GetLastEndpoint()
+
+	pubPort := extractPortFromEndpoint(pubEndpoint)
+	routerPort := extractPortFromEndpoint(routerEndpoint)
+
+	config := &zmq.ZMQClientConfig{
+		CachePoolKey:   "test-pod",
+		ServiceIP:      "127.0.0.1",
+		ModelName:      "test-model",
+		Port:           pubPort,
+		RouterPort:     routerPort,
+		PollTimeout:    100 * time.Millisecond,
+		ReplayTimeout:  1 * time.Second,
+		ReconnectDelay: 100 * time.Millisecond,
+	}
+
+	handler := NewMockEventHandler()
+	client := zmq.NewZMQClient(config, handler)
+
+	err := client.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer client.Stop()
+
+	// Wait for connection
+	time.Sleep(100 * time.Millisecond)
+
+	// Create and publish mooncake event
+	event := &zmq.BlockStoredEvent{
+		Type:            zmq.EventTypeBlockStored,
+		Timestamp:       time.Now().UTC(),
+		BlockHashes:     []uint64{100, 200},
+		TokenIDs:        []int32{1, 2, 3},
+		ParentBlockHash: 50,
+		BlockSize:       1024,
+		MooncakeKey:     "mooncake-key-123",
+		ReplicaList:     [][]string{{"replica1", "replica2"}},
+		ModelName:       "test-model",
+	}
+
+	err = publisher.PublishEvent("mooncake", event)
+	if err != nil {
+		t.Fatalf("PublishEvent failed: %v", err)
+	}
+
+	// Wait for processing
+	time.Sleep(200 * time.Millisecond)
+
+	events := handler.GetEvents()
+	if len(events) < 1 {
+		t.Fatalf("Expected at least 1 event, got %d", len(events))
+	}
+
+	blockEvent, ok := events[0].(*zmq.BlockStoredEvent)
+	if !ok {
+		t.Fatalf("Expected BlockStoredEvent, got %T", events[0])
+	}
+	if blockEvent.PodName != "test-pod" {
+		t.Errorf("Expected PodName 'test-pod', got '%s'", blockEvent.PodName)
+	}
+	if blockEvent.MooncakeKey != "mooncake-key-123" {
+		t.Errorf("Expected MooncakeKey 'mooncake-key-123', got '%s'", blockEvent.MooncakeKey)
+	}
+	if len(blockEvent.BlockHashes) == 0 || blockEvent.BlockHashes[0] != 100 {
+		t.Errorf("Expected first BlockHash 100, got %v", blockEvent.BlockHashes)
+	}
+}
+
+func TestZMQClient_ProcessMessage_VllmTopic(t *testing.T) {
+	skipIfZMQUnavailable(t)
+
+	publisher := createMockPublisher(t, 5557, 5558)
+	defer publisher.Close()
+
+	pubEndpoint, _ := publisher.pubSocket.GetLastEndpoint()
+	routerEndpoint, _ := publisher.routerSocket.GetLastEndpoint()
+
+	pubPort := extractPortFromEndpoint(pubEndpoint)
+	routerPort := extractPortFromEndpoint(routerEndpoint)
+
+	config := &zmq.ZMQClientConfig{
+		CachePoolKey:   "test-pod",
+		ServiceIP:      "127.0.0.1",
+		ModelName:      "test-model",
+		Port:           pubPort,
+		RouterPort:     routerPort,
+		PollTimeout:    100 * time.Millisecond,
+		ReplayTimeout:  1 * time.Second,
+		ReconnectDelay: 100 * time.Millisecond,
+	}
+
+	handler := NewMockEventHandler()
+	client := zmq.NewZMQClient(config, handler)
+
+	err := client.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer client.Stop()
+
+	// Wait for connection
+	time.Sleep(100 * time.Millisecond)
+
+	// Create and publish vllm event
+	event := &zmq.BlockStoredEvent{
+		Type:            zmq.EventTypeBlockStored,
+		Timestamp:       time.Now().UTC(),
+		BlockHashes:     []uint64{300, 400},
+		TokenIDs:        []int32{4, 5, 6},
+		ParentBlockHash: 1500000000000000,
+		BlockSize:       2048,
+		ModelName:       "test-model",
+	}
+
+	err = publisher.PublishEvent("vllm", event)
+	if err != nil {
+		t.Fatalf("PublishEvent failed: %v", err)
+	}
+
+	// Wait for processing
+	time.Sleep(200 * time.Millisecond)
+
+	events := handler.GetEvents()
+	if len(events) < 1 {
+		t.Fatalf("Expected at least 1 event, got %d", len(events))
+	}
+	blockEvent, ok := events[0].(*zmq.BlockStoredEvent)
+	if !ok {
+		t.Fatalf("Expected BlockStoredEvent, got %T", events[0])
+	}
+	if blockEvent.PodName != "test-pod" {
+		t.Errorf("Expected PodName 'test-pod', got '%s'", blockEvent.PodName)
+	}
+	if len(blockEvent.BlockHashes) == 0 || blockEvent.BlockHashes[0] != 300 {
+		t.Errorf("Expected first BlockHash 300, got %v", blockEvent.BlockHashes)
+	}
+}
+
+func TestZMQClient_SequenceTracking(t *testing.T) {
+	skipIfZMQUnavailable(t)
+
+	publisher := createMockPublisher(t, 5557, 5558)
+	defer publisher.Close()
+
+	pubEndpoint, _ := publisher.pubSocket.GetLastEndpoint()
+	routerEndpoint, _ := publisher.routerSocket.GetLastEndpoint()
+
+	pubPort := extractPortFromEndpoint(pubEndpoint)
+	routerPort := extractPortFromEndpoint(routerEndpoint)
+
+	config := &zmq.ZMQClientConfig{
+		CachePoolKey:   "test-pod",
+		ServiceIP:      "127.0.0.1",
+		ModelName:      "test-model",
+		Port:           pubPort,
+		RouterPort:     routerPort,
+		PollTimeout:    100 * time.Millisecond,
+		ReplayTimeout:  1 * time.Second,
+		ReconnectDelay: 100 * time.Millisecond,
+	}
+
+	handler := NewMockEventHandler()
+	client := zmq.NewZMQClient(config, handler)
+
+	err := client.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer client.Stop()
+
+	// Wait for connection
+	time.Sleep(100 * time.Millisecond)
+
+	// Publish multiple events
+	for i := 0; i < 5; i++ {
+		event := &zmq.BlockStoredEvent{
+			Type:            zmq.EventTypeBlockStored,
+			Timestamp:       time.Now().UTC(),
+			BlockHashes:     []uint64{uint64(i)},
+			TokenIDs:        []int32{int32(i)},
+			ParentBlockHash: 1000000000000000000,
+			BlockSize:       128,
+			ModelName:       "test-model",
+		}
+		_ = publisher.PublishEvent("vllm", event)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Wait for processing
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify events were processed
+	events := handler.GetEvents()
+	if len(events) < 5 {
+		t.Errorf("Expected at least 5 events, got %d", len(events))
+	}
+}
+
+func TestZMQClient_ProcessMessage_EventGap(t *testing.T) {
+	skipIfZMQUnavailable(t)
+
+	publisher := createMockPublisher(t, 5557, 5558)
+	defer publisher.Close()
+
+	pubEndpoint, _ := publisher.pubSocket.GetLastEndpoint()
+	routerEndpoint, _ := publisher.routerSocket.GetLastEndpoint()
+
+	pubPort := extractPortFromEndpoint(pubEndpoint)
+	routerPort := extractPortFromEndpoint(routerEndpoint)
+
+	config := &zmq.ZMQClientConfig{
+		CachePoolKey:   "test-pod",
+		ServiceIP:      "127.0.0.1",
+		ModelName:      "test-model",
+		Port:           pubPort,
+		RouterPort:     routerPort,
+		PollTimeout:    100 * time.Millisecond,
+		ReplayTimeout:  1 * time.Second,
+		ReconnectDelay: 100 * time.Millisecond,
+	}
+
+	handler := NewMockEventHandler()
+	client := zmq.NewZMQClient(config, handler)
+
+	err := client.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer client.Stop()
+
+	// Wait for connection
+	time.Sleep(100 * time.Millisecond)
+
+	// Manually set last sequence to simulate gap
+	// This is a bit tricky since we need to access internal state
+	// For now, we publish events and verify gap detection works
+	// The actual gap detection is logged, so we verify the code path exists
+	event := &zmq.BlockStoredEvent{
+		Type:        zmq.EventTypeBlockStored,
+		Timestamp:   time.Now().UTC(),
+		BlockHashes: []uint64{100},
+		TokenIDs:    []int32{1},
+		ModelName:   "test-model",
+	}
+
+	_ = publisher.PublishEvent("vllm", event)
+	time.Sleep(100 * time.Millisecond)
+
+	// Publish another event - gap detection should work for subsequent events
+	_ = publisher.PublishEvent("vllm", event)
+	time.Sleep(100 * time.Millisecond)
+}
+
+// Helper function to extract port from endpoint string like "tcp://127.0.0.1:5557"
+func extractPortFromEndpoint(endpoint string) int {
+	// Parse "tcp://127.0.0.1:5557" to get 5557
+	parts := strings.Split(endpoint, ":")
+	if len(parts) < 3 {
+		return 5557 // Default fallback
+	}
+	portStr := parts[len(parts)-1]
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 5557 // Default fallback
+	}
+	return port
+}

--- a/mooncake-conductor/example/cache_aware_disagg_proxy.py
+++ b/mooncake-conductor/example/cache_aware_disagg_proxy.py
@@ -1,0 +1,355 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from the vLLM repository's toy_proxy_server.py in tests/v1/kv_connector/nixl_integration/.
+
+import argparse
+import itertools
+import logging
+import os
+import uuid
+from contextlib import asynccontextmanager
+
+import httpx
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class CacheAwareRouter():
+    def __init__(self, address, endpoint):
+        self.address = address
+        self.endpoint = endpoint
+        self.client = httpx.AsyncClient(timeout=None, base_url=f'http://{address}')
+
+    async def get_best_prefiller(self, token_ids: list, ready_instances, req_data):
+        # call conductor restful api to get cache hit situation
+        model_name = req_data.get("model", "ds")
+        lora_id = req_data.get("lora_id", -1)
+        request_data = {
+            "instances": ready_instances,
+            "token_ids": token_ids,
+            "model_name": model_name,
+            "lora_id": lora_id
+
+        }
+        headers = {
+            "Content-Type": "application/json",
+        }
+        logger.debug(f"conductor request_data: {request_data}")
+        response = await self.client.post(self.endpoint, json=request_data, headers=headers)
+        response.raise_for_status()
+        return response.json()["HitStatus"]
+
+    async def close(self) -> None:
+        if self.client:
+            await self.client.aclose()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """
+    Lifespan context manager to handle startup and shutdown events.
+    """
+    # Startup: Initialize client pools for prefiller and decoder services
+    app.state.prefill_clients = []
+    app.state.decode_clients = []
+
+    # Create prefill clients
+    for i, (host, port) in enumerate(global_args.prefiller_instances):
+        prefiller_base_url = f'http://{host}:{port}'
+        app.state.prefill_clients.append({
+            'client':
+            httpx.AsyncClient(timeout=None, base_url=prefiller_base_url),
+            'host':
+            host,
+            'port':
+            port,
+            'id':
+            i
+        })
+
+    # Create decode clients
+    for i, (host, port) in enumerate(global_args.decoder_instances):
+        decoder_base_url = f'http://{host}:{port}'
+        app.state.decode_clients.append({
+            'client':
+            httpx.AsyncClient(timeout=None, base_url=decoder_base_url),
+            'host':
+            host,
+            'port':
+            port,
+            'id':
+            i
+        })
+
+    # Create conductor client
+    app.state.conductor_client = CacheAwareRouter(global_args.conductor_address, "/cache")
+
+    # Initialize round-robin iterators
+    app.state.prefill_iterator = itertools.cycle(
+        range(len(app.state.prefill_clients)))
+    app.state.decode_iterator = itertools.cycle(
+        range(len(app.state.decode_clients)))
+
+    logger.info(f"Initialized {len(app.state.prefill_clients)} prefill clients "
+          f"and {len(app.state.decode_clients)} decode clients.")
+
+    yield
+
+    # Shutdown: Close all clients
+    for client_info in app.state.prefill_clients:
+        await client_info['client'].aclose()
+
+    for client_info in app.state.decode_clients:
+        await client_info['client'].aclose()
+
+    # Close conductor client
+    await app.state.conductor_client.close()
+
+
+# Update FastAPI app initialization to use lifespan
+app = FastAPI(lifespan=lifespan)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--host", type=str, default="localhost")
+
+    # For prefiller instances
+    parser.add_argument("--prefiller-hosts",
+                        "--prefiller-host",
+                        type=str,
+                        nargs="+",
+                        default=["localhost"])
+    parser.add_argument("--prefiller-ports",
+                        "--prefiller-port",
+                        type=int,
+                        nargs="+",
+                        default=[8100])
+
+    # For decoder instances
+    parser.add_argument("--decoder-hosts",
+                        "--decoder-host",
+                        type=str,
+                        nargs="+",
+                        default=["localhost"])
+    parser.add_argument("--decoder-ports",
+                        "--decoder-port",
+                        type=int,
+                        nargs="+",
+                        default=[8200])
+    
+    parser.add_argument("--conductor-address", type=str, default="127.0.0.1:13333")
+
+    args = parser.parse_args()
+
+    # Validate and pair hosts with ports
+    if len(args.prefiller_hosts) != len(args.prefiller_ports):
+        raise ValueError(
+            "Number of prefiller hosts must match number of prefiller ports")
+
+    if len(args.decoder_hosts) != len(args.decoder_ports):
+        raise ValueError(
+            "Number of decoder hosts must match number of decoder ports")
+
+    # Create tuples of (host, port) for each service type
+    args.prefiller_instances = list(
+        zip(args.prefiller_hosts, args.prefiller_ports))
+    args.decoder_instances = list(zip(args.decoder_hosts, args.decoder_ports))
+
+    return args
+
+
+def get_next_client(app, service_type: str):
+    """
+    Get the next client in round-robin fashion.
+
+    Args:
+        app: The FastAPI app instance
+        service_type: Either 'prefill' or 'decode'
+
+    Returns:
+        The next client to use
+    """
+    if service_type == 'prefill':
+        client_idx = next(app.state.prefill_iterator)
+        return app.state.prefill_clients[client_idx]
+    elif service_type == 'decode':
+        client_idx = next(app.state.decode_iterator)
+        return app.state.decode_clients[client_idx]
+    else:
+        raise ValueError(f"Unknown service type: {service_type}")
+
+
+async def get_best_prefiller(app, token_ids: list, round_robin_prefill, req_data):
+    # Get all prefill instances
+    ready_instances = []
+    index_map = {}
+    for index, client_info in enumerate(app.state.prefill_clients):
+        if client_info['client'].is_closed:
+            continue
+        ready_instances.append(client_info['host'])
+        index_map[client_info['host']] = index
+    
+    cache_hit_status = await app.state.conductor_client.get_best_prefiller(token_ids, ready_instances, req_data)
+
+    if not cache_hit_status:
+        return round_robin_prefill
+    best_prefiller_index = None
+    max_hit_value = -1
+    for k, v in cache_hit_status.items():
+        if v > max_hit_value:
+            best_prefiller_index = index_map[k]
+            max_hit_value = v
+    return app.state.prefill_clients[best_prefiller_index]
+
+
+async def get_tokenid(client_info: dict, req_data: dict, request_id: str):
+    req_data = req_data.copy()
+    req_data["stream"] = False
+    req_data["max_tokens"] = 1
+    if "stream_options" in req_data:
+        del req_data["stream_options"]
+    headers = {
+        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
+        "X-Request-Id": request_id
+    }
+
+    response = await client_info['client'].post("/tokenize",
+                                                json=req_data,
+                                                headers=headers)
+    response.raise_for_status()
+    token_id = response.json()["tokens"]
+    return token_id
+
+
+async def send_request_to_service(client_info: dict, endpoint: str,
+                                  req_data: dict, request_id: str):
+    """
+    Send a request to a service using a client from the pool.
+    """
+    req_data = req_data.copy()
+    req_data['kv_transfer_params'] = {
+        "do_remote_decode": True,
+        "do_remote_prefill": False,
+        "remote_engine_id": None,
+        "remote_block_ids": None,
+        "remote_host": None,
+        "remote_port": None
+    }
+    req_data["stream"] = False
+    req_data["max_tokens"] = 1
+    if "max_completion_tokens" in req_data:
+        req_data["max_completion_tokens"] = 1
+    if "stream_options" in req_data:
+        del req_data["stream_options"]
+    headers = {
+        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
+        "X-Request-Id": request_id
+    }
+    logger.debug(f"req_data: {req_data}")
+
+    response = await client_info['client'].post(endpoint,
+                                                json=req_data,
+                                                headers=headers)
+    response.raise_for_status()
+
+    return response
+
+
+async def stream_service_response(client_info: dict, endpoint: str,
+                                  req_data: dict, request_id: str):
+    """
+    Asynchronously stream response from a service using a client from the pool.
+    """
+    headers = {
+        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
+        "X-Request-Id": request_id
+    }
+
+    async with client_info['client'].stream("POST",
+                                            endpoint,
+                                            json=req_data,
+                                            headers=headers) as response:
+        response.raise_for_status()
+        async for chunk in response.aiter_bytes():
+            yield chunk
+
+
+async def _handle_completions(api: str, request: Request):
+    try:
+        req_data = await request.json()
+        request_id = str(uuid.uuid4())
+        
+        # select tokenizer client in round-robin fashion
+        remote_tokenizer_client_info = get_next_client(request.app, 'prefill')
+        token_ids = await get_tokenid(remote_tokenizer_client_info, req_data, request_id)
+
+        # choice best cache hit prefill instance
+        prefill_client_info = await get_best_prefiller(request.app, token_ids, remote_tokenizer_client_info, req_data)
+        response = await send_request_to_service(prefill_client_info, api,
+                                                 req_data, request_id)
+
+        # Extract the needed fields
+        response_json = response.json()
+        kv_transfer_params = response_json.get('kv_transfer_params', {})
+        if kv_transfer_params:
+            req_data["kv_transfer_params"] = kv_transfer_params
+
+        # Get the next decode client in round-robin fashion
+        decode_client_info = get_next_client(request.app, 'decode')
+
+        logger.debug("Using %s %s", prefill_client_info, decode_client_info)
+
+        # Stream response from decode service
+        async def generate_stream():
+            async for chunk in stream_service_response(decode_client_info,
+                                                       api,
+                                                       req_data,
+                                                       request_id=request_id):
+                yield chunk
+
+        return StreamingResponse(generate_stream(),
+                                 media_type="application/json")
+
+    except Exception as e:
+        import sys
+        import traceback
+        exc_info = sys.exc_info()
+        logger.error("Error occurred in disagg prefill proxy server"
+              f" - {api} endpoint")
+        logger.error(e)
+        logger.error("".join(traceback.format_exception(*exc_info)))
+        raise
+
+
+@app.post("/v1/completions")
+async def handle_completions(request: Request):
+    return await _handle_completions("/v1/completions", request)
+
+
+@app.post("/v1/chat/completions")
+async def handle_chat_completions(request: Request):
+    return await _handle_completions("/v1/chat/completions", request)
+
+
+@app.get("/healthcheck")
+async def healthcheck():
+    """Simple endpoint to check if the server is running."""
+    return {
+        "status": "ok",
+        "prefill_instances": len(app.state.prefill_clients),
+        "decode_instances": len(app.state.decode_clients)
+    }
+
+
+if __name__ == '__main__':
+    global global_args
+    global_args = parse_args()
+
+    import uvicorn
+    uvicorn.run(app, host=global_args.host, port=global_args.port)

--- a/mooncake-conductor/example/conductor_config.json
+++ b/mooncake-conductor/example/conductor_config.json
@@ -1,0 +1,22 @@
+{
+    "kvevent_instance":
+    {
+        "vllm-1": 
+        {
+            "ip": "127.0.0.1",
+            "port": 5557,
+            "type": "vLLM",
+            "modelname": "qwen2.5",
+            "lora_id": -1
+        },
+        "mooncake":
+        {
+            "ip": "127.0.0.1",
+            "port": 19997,
+            "type": "Mooncake",
+            "modelname": "qwen2.5",
+            "lora_id": -1
+        }
+    },
+    "http_server_port": 13333
+}


### PR DESCRIPTION
## Description
add kv-indexer demo version, it's a cache aware indexer based on kv-event. **`mooncake_conductor`** is mainly divided into four components, which are:
* **EventManager**
    Manages the subscription and lifecycle of all services  
   - Starts/stops all ZMQ clients  
   - Handles service connections and reconnections  
   - Provides HTTP API interfaces  

* **ZMQClient**
   Establishes ZMQ connections with AI inference services & mooncake_mastaer

* **KVEventHandler**
   Handles specific KV events
   - `BlockStoredEvent`: Block storage events
   - `BlockRemovedEvent`: Block removal events

*  **PrefixCacheTable**
   Provides prefix block_hash-based cache indexing  
   - Calculates prefix hashes for token sequences  
   - Tracks cache block distribution across different engines  
   - Provides cache hit ratio calculation

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
