### PR TITLE
[TE] fix use short connect bug: disconnect happen before mark success

### DIFF
--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
@@ -829,9 +829,6 @@ void AscendDirectTransport::connectAndTransfer(
     auto status = adxl_->TransferSync(target_adxl_engine_name.c_str(),
                                       operation, op_descs, transfer_timeout_);
     if (status == adxl::SUCCESS) {
-        for (auto &slice : slice_list) {
-            slice->markSuccess();
-        }
         VLOG(1) << "Transfer to:" << target_adxl_engine_name << ", cost: "
                 << std::chrono::duration_cast<std::chrono::microseconds>(
                        std::chrono::steady_clock::now() - start)
@@ -839,6 +836,9 @@ void AscendDirectTransport::connectAndTransfer(
                 << " us";
         if (use_short_connection_) {
             disconnect(target_adxl_engine_name, connect_timeout_);
+        }
+        for (auto &slice : slice_list) {
+            slice->markSuccess();
         }
     } else {
         if (status == adxl::TIMEOUT) {


### PR DESCRIPTION
## Description

fix use short connect bug: disconnect happen before mark success

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

use short connection, and unregister mem after transfer success, which do not report error.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
