### PR TITLE
[Misc] fix wheel build script

### DIFF
--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -20,7 +20,7 @@ echo "Building wheel for Python ${PYTHON_VERSION} with output directory ${OUTPUT
 echo "Detected CUDA version ${CUDA_VERSION}"
 
 # Ensure LD_LIBRARY_PATH includes /usr/local/lib
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/$(pwd)/build/mooncake-asio:/usr/local/lib
 
 echo "Cleaning wheel-build directory"
 rm -rf mooncake-wheel/mooncake_transfer_engine*


### PR DESCRIPTION
## Description
auditwheel in build_wheel.sh will not work after 680ae5c8df6b6182030a281141e4093950b7e0d4
<img width="1666" height="520" alt="image" src="https://github.com/user-attachments/assets/3e3f32bb-4403-40e9-a5f3-24b4c3768df6" />

add LD_PATH to fix build_wheel scripts 

## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [x] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
