### PR TITLE
[Doc] Document missing USE_MNNVL compile option

### DIFF
--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -151,7 +151,7 @@ cd /Mooncake-main/build/mooncake-transfer-engine/example
 ## Advanced Compile Options
 The following options can be used during `cmake ..` to specify whether to compile certain components of Mooncake.
 - `-DUSE_CUDA=[ON|OFF]`: Enable GPU Direct RDMA and NVMe-of support
-- `-DUSE_MNNVL=[ON|OFF]`: Enable Multi-Node NVLink transport support, default is OFF, **Note:** `-DUSE_CUDA` is required when `-DUSE_MNNVL` is on.
+- `-DUSE_MNNVL=[ON|OFF]`: Enable Multi-Node NVLink transport support, default is OFF. **Note:** `-DUSE_CUDA` is required when `-DUSE_MNNVL` is on.
 - `-DUSE_MUSA=[ON|OFF]`: Enable Moore Threads GPU support via MUSA
 - `-DUSE_HIP=[ON|OFF]`: Enable AMD GPU support via HIP/ROCm
 - `-DUSE_INTRA_NVLINK=[ON|OFF]`: Enable intranode nvlink transport


### PR DESCRIPTION
Add documentation for Multi-Node NVLink transport option.

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Type of Change

* Types
  - [ ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [x] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
