### PR TITLE
add efa protocol to  mooncake store client

### DIFF
--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -257,7 +257,8 @@ ErrorCode Client::InitTransferEngine(
             auto_discover = env_auto_discover.value();
         } else {
             // Enable auto-discover for RDMA if no devices are specified
-            if ((protocol == "rdma" || protocol == "efa") && !device_names.has_value()) {
+            if ((protocol == "rdma" || protocol == "efa") &&
+                !device_names.has_value()) {
                 LOG(INFO)
                     << "Set auto discovery ON by default for RDMA protocol, "
                        "since no "


### PR DESCRIPTION
## Description

add efa protocol to  mooncake store client. `efa` implements `rdma`, so, reuse the rdma protocol logic for mooncake transfer engine initialization.

## Type of Change

* Types
  - [x ] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ x] I have performed a self-review of my own code.
- [ x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
