### PR TITLE
implement cpp methods for p2p connection

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -106,11 +106,11 @@ typedef struct tent_notifi_info tent_notifi_info;
 
 struct tent_memory_options {
     char location[64];
-    int permission;      /* PERM_LOCAL_READ_WRITE, etc. */
-    int transport_type;  /* TRANSPORT_RDMA, etc. */
+    int permission;     /* PERM_LOCAL_READ_WRITE, etc. */
+    int transport_type; /* TRANSPORT_RDMA, etc. */
     char shm_path[256];
     size_t shm_offset;
-    int internal;        /* 0 = false, nonzero = true */
+    int internal; /* 0 = false, nonzero = true */
 };
 
 typedef struct tent_memory_options tent_memory_options_t;

--- a/mooncake-transfer-engine/tent/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/tent/src/transfer_engine_c.cpp
@@ -338,12 +338,14 @@ int tent_overall_status(tent_engine_t engine, tent_batch_id_t batch_id,
 static mooncake::tent::MemoryOptions convert_options(
     const tent_memory_options_t* opts) {
     mooncake::tent::MemoryOptions options;
-    if (opts->location[0] != '\0')
+    if (opts->location[0] != '\0') {
         options.location = opts->location;
+    }
     options.perm = (mooncake::tent::Permission)opts->permission;
     options.type = (mooncake::tent::TransportType)opts->transport_type;
-    if (opts->shm_path[0] != '\0')
+    if (opts->shm_path[0] != '\0') {
         options.shm_path = opts->shm_path;
+    }
     options.shm_offset = opts->shm_offset;
     options.internal = opts->internal != 0;
     return options;
@@ -363,8 +365,7 @@ int tent_register_memory_with_perm(tent_engine_t engine, void* addr,
     CHECK_POINTER(engine);
     CHECK_POINTER(addr);
     auto perm = static_cast<mooncake::tent::Permission>(permission);
-    auto status =
-        CAST(engine)->registerLocalMemory({addr}, {size}, perm);
+    auto status = CAST(engine)->registerLocalMemory({addr}, {size}, perm);
     if (!status.ok()) {
         LOG(ERROR) << "tent_register_memory_with_perm: " << status.ToString();
         return -1;
@@ -394,8 +395,9 @@ int tent_unregister_memory_batch(tent_engine_t engine, void** addrs,
     CHECK_POINTER(addrs);
     std::vector<void*> addr_list(addrs, addrs + count);
     std::vector<size_t> size_list;
-    if (sizes)
+    if (sizes) {
         size_list.assign(sizes, sizes + count);
+    }
     auto status = CAST(engine)->unregisterLocalMemory(addr_list, size_list);
     if (!status.ok()) {
         LOG(ERROR) << "tent_unregister_memory_batch: " << status.ToString();
@@ -424,8 +426,7 @@ int tent_register_memory_ex(tent_engine_t engine, void* addr, size_t size,
     CHECK_POINTER(addr);
     CHECK_POINTER(opts);
     auto options = convert_options(opts);
-    auto status =
-        CAST(engine)->registerLocalMemory({addr}, {size}, options);
+    auto status = CAST(engine)->registerLocalMemory({addr}, {size}, options);
     if (!status.ok()) {
         LOG(ERROR) << "tent_register_memory_ex: " << status.ToString();
         return -1;


### PR DESCRIPTION
## Description

The TENT C API (`extern "C"` functions in `transfer_engine.h`) is missing several capabilities that the Python bindings (via PyBind11) expose. This creates a gap for FFI consumers such as Rust, Go, or plain C that cannot call the C++ `TransferEngine` class directly.

This PR adds 8 new C API functions and 1 new struct (`tent_memory_options_t`) to achieve feature parity with the Python API, plus a bugfix for C header compilation.

**New functions:**
- `tent_available` — check engine readiness
- `tent_register_memory_with_perm` — register memory with explicit permission (`kLocalReadWrite`, `kGlobalReadOnly`, `kGlobalReadWrite`)
- `tent_register_memory_batch` / `tent_unregister_memory_batch` — batch register/unregister multiple buffers in a single call
- `tent_allocate_memory_ex` — allocate memory with full `MemoryOptions` (transport type, shm path, etc.)
- `tent_register_memory_ex` / `tent_register_memory_batch_ex` — register with full `MemoryOptions`
- `tent_task_status_list` — retrieve all task statuses in a batch at once

**New types:**
- `tent_memory_options_t` struct — C equivalent of C++ `MemoryOptions`
- `PERM_*` and `TRANSPORT_*` constants for C consumers
- `tent_notifi_record_t` / `tent_notifi_info` typedefs (fixes pre-existing C compilation bug)

**Bugfix:** The header previously used bare `tent_notifi_info` without a typedef, causing compilation failure when included from C (`gcc -std=c11`). Added the missing typedef.

## Type of Change

* Types
  - [ ] Bug fix
  - [x] New feature
    - [x] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

- Syntax-verified with `g++ -std=c++20 -fsyntax-only` (C++ compilation of `transfer_engine_c.cpp`)
- Syntax-verified with `gcc -std=c11 -fsyntax-only` (C compilation of `transfer_engine.h`)
- All new functions follow the identical pattern of the existing 18 C API functions (cast opaque pointer → call `TransferEngineImpl` method → check status → return 0/-1)
- The backing C++ methods are already tested via the Python bindings

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
