### PR TITLE
[Bugfix] Fix RDMA notification send buffer DMA race and reconnect hang

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -187,9 +187,8 @@ class RdmaEndPoint {
     static constexpr size_t kNotifyMaxPendingSends = 256;
     std::vector<std::vector<char>> notify_recv_buffers_;
     std::vector<ibv_mr*> notify_recv_mrs_;  // Memory regions for recv buffers
-    std::vector<std::vector<char>>
-        notify_send_buffers_;               // Ring of send buffers
-    std::vector<ibv_mr*> notify_send_mrs_;  // MRs for send buffers
+    std::vector<char> notify_send_buffer_;  // Single contiguous send buffer
+    ibv_mr* notify_send_mr_ = nullptr;      // Single MR for all send slots
     std::mutex notify_send_mutex_;
     std::condition_variable notify_send_cv_;
     int notify_pending_count_ = 0;    // Number of pending sends


### PR DESCRIPTION
## Description

Fix three issues in the RDMA notification subsystem (the latter two introduced by #1560):
### 1. DMA-vs-overwrite data corruption in `sendNotification()`

`sendNotification()` used a single shared `notify_send_buffer_` for all RDMA sends. The flow control only checked send-queue depth (`notify_pending_count_ < kNotifyMaxPendingSends`), but did NOT wait for the DMA of previously posted send WRs to complete. After one thread posted a send and released the mutex, another thread could immediately overwrite the buffer while the HCA was still performing DMA from it.

**Fix**: Replace the single buffer/MR with a ring of `kNotifyMaxPendingSends` buffers (`notify_send_buffers_` / `notify_send_mrs_`). Each send uses slot `notify_send_wr_id_ % kNotifyMaxPendingSends`. Flow control guarantees the slot's previous DMA has completed.

### 2. Hang after reconnection — missing recv buffer repost

`setupNotifyQpConnection()` transitions the notify QP through RESET→INIT→RTR→RTS. The RESET state flushes all posted recv WRs. However, recv buffers were never re-posted after reconnection, leaving the recv queue empty. The peer's sends would receive RNR NAKs indefinitely, causing a hang.

**Fix**: Add `repostAllNotifyRecvs()` and call it in both `connect()` and `accept()` after `setupNotifyQpConnection()` succeeds.

### 3. "unknown QP" warning during reconnection

`resetUnlocked()` called `unregisterNotifyQp()`, removing the QP from the transport lookup map. But between unregister and re-register (after reconnection), the notify worker thread could poll completions (including flush errors) from the CQ and fail to route them, producing `"Received notification from unknown QP"` warnings.

**Fix**: Keep the notify QP registered in the transport map during reset — `qp_num` and endpoint pointer don't change across resets. Only `deconstruct()` (actual QP destruction) performs unregister.


## Type of Change

* Types
  - [x] Bug fix
  - [ ] New feature
    - [ ] Transfer Engine
    - [ ] Mooncake Store
    - [ ] Mooncake EP
    - [ ] Integration
    - [ ] P2P Store
    - [ ] Python Wheel
  - [ ] Breaking change
  - [ ] CI/CD
  - [ ] Documentation update
  - [ ] Other

## How Has This Been Tested?

Run `tebench` with --notifi.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
