### PR TITLE
refactor(rdma): replace C-style arrays with std::vector for work requests

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -275,10 +275,9 @@ int RdmaEndPoint::submitPostSend(
         std::min(int(globalConfig().max_cqe) - *cq_outstanding_, wr_count);
     if (wr_count <= 0) return 0;
 
-    std::vector<ibv_send_wr> wr_list(wr_count);
+    std::vector<ibv_send_wr> wr_list(wr_count, ibv_send_wr{});
     std::vector<ibv_sge> sge_list(wr_count);
     ibv_send_wr *bad_wr = nullptr;
-    memset(wr_list.data(), 0, sizeof(ibv_send_wr) * wr_count);
     for (int i = 0; i < wr_count; ++i) {
         auto slice = slice_list[i];
         auto &sge = sge_list[i];

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -494,10 +494,9 @@ int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
 
     if (wr_count <= 0 || !reserveQuota(qp_index, wr_count)) return 0;
 
-    std::vector<ibv_send_wr> wr_list(wr_count);
+    std::vector<ibv_send_wr> wr_list(wr_count, ibv_send_wr{});
     std::vector<ibv_sge> sge_list(sge_count);
     ibv_send_wr* bad_wr = nullptr;
-    memset(wr_list.data(), 0, sizeof(ibv_send_wr) * wr_count);
     int sge_idx = 0;
 
     for (int wr_idx = 0; wr_idx < wr_count; ++wr_idx) {


### PR DESCRIPTION
## Description

Replace C99-style Variable Length Arrays (VLAs) with `std::vector` in both RDMA endpoint implementations to prevent potential stack overflow.

Both `submitPostSend` (classic) and `submitSlices` (tent) allocate `ibv_send_wr` and `ibv_sge` arrays on the stack using VLAs, where the size is determined by runtime-configurable queue depth. With large `max_qp_wr` values (up to 65535 via `MC_MAX_WR` env var, or `max_cqe` defaulting to 4096), this can allocate hundreds of KB on the stack, risking stack overflow in threads with reduced stack sizes. VLAs are also a non-standard GCC extension in C++.

The change is a mechanical replacement of VLA with `std::vector`, preserving identical semantics. All pointer arithmetic (`bad_wr - wr_list`) is updated to use `.data()`. No behavioral change expected.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Run `tebench` and `transfer_engine_bench`

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
