### PR TITLE
p2p-store: expose GetLocalIpAndPort/GetLocalServerName in Go API

### DIFF
--- a/mooncake-p2p-store/src/p2pstore/core.go
+++ b/mooncake-p2p-store/src/p2pstore/core.go
@@ -98,6 +98,14 @@ func (store *P2PStore) Close() error {
 	return retErr
 }
 
+// GetLocalServerName returns the local server name (ip:port) that this
+// P2PStore instance is registered under. In P2P handshake mode the RPC
+// port is allocated dynamically, so callers must use this method to
+// discover the actual address after initialization.
+func (store *P2PStore) GetLocalServerName() (string, error) {
+	return store.transfer.GetLocalIpAndPort()
+}
+
 type Buffer struct {
 	addr uintptr
 	size uint64

--- a/mooncake-p2p-store/src/p2pstore/transfer_engine.go
+++ b/mooncake-p2p-store/src/p2pstore/transfer_engine.go
@@ -201,3 +201,22 @@ func (engine *TransferEngine) syncSegmentCache() error {
 	}
 	return nil
 }
+
+// GetLocalIpAndPort returns the local IP address and port that the
+// TransferEngine is listening on. This is particularly useful in P2P
+// handshake mode (metadata_conn_string == "P2PHANDSHAKE"), where the
+// RPC port is dynamically assigned at initialization time and callers
+// need to discover the actual listening address to share with peers.
+func (engine *TransferEngine) GetLocalIpAndPort() (string, error) {
+	const bufLen = 256
+	buf := make([]byte, bufLen)
+	ret := C.getLocalIpAndPort(engine.engine, (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(bufLen))
+	if ret != 0 {
+		return "", ErrTransferEngine
+	}
+	n := 0
+	for n < len(buf) && buf[n] != 0 {
+		n++
+	}
+	return string(buf[:n]), nil
+}

--- a/mooncake-transfer-engine/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_c.cpp
@@ -39,7 +39,7 @@ transfer_engine_t createTransferEngine(const char *metadata_conn_string,
 int getLocalIpAndPort(transfer_engine_t engine, char *buf_out, size_t buf_len) {
     TransferEngine *native = (TransferEngine *)engine;
     auto str = native->getLocalIpAndPort();
-    strncpy(buf_out, str.c_str(), buf_len);
+    snprintf(buf_out, buf_len, "%s", str.c_str());
     return 0;
 }
 


### PR DESCRIPTION
In P2P handshake mode (metadata_conn_string == "P2PHANDSHAKE"), the RPC port is dynamically allocated at initialization time by findAvailableTcpPort(). As a result, the local_server_name_ stored in TransferEngineImpl is rewritten to reflect the actual listening address (ip:dynamic_port), which differs from the value passed in by the caller.

Previously, the Go layer had no way to retrieve this resolved address. The C API already exposed getLocalIpAndPort() in transfer_engine_c.h, but neither TransferEngine nor P2PStore wrapped it.

This commit adds:
- TransferEngine.GetLocalIpAndPort() - cgo wrapper around the C API, returns the resolved "ip:port" string the engine is listening on.
- P2PStore.GetLocalServerName() - convenience method on P2PStore that delegates to TransferEngine.GetLocalIpAndPort(), returning the name under which this store is registered in the metadata (relevant for P2P handshake mode where the name is determined at runtime).

Fixes the inability to share the actual listen address with peers when operating in P2P handshake mode.

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
