### PR TITLE
[TENT] Fix resource cleanup order to prevent SubBatch/Slice leak

### DIFF
--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -249,19 +249,40 @@ Status TransferEngineImpl::construct() {
 Status TransferEngineImpl::deconstruct() {
     // Metrics cleanup is handled automatically by TentMetrics destructor
 
-    local_segment_tracker_->forEach([&](BufferDesc& desc) -> Status {
-        for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
-            if (transport_list_[type])
-                transport_list_[type]->removeMemoryBuffer(desc);
-        }
-        return Status::OK();
-    });
+    // Destroy staging_proxy_ first: its destructor calls back into
+    // unregisterLocalMemory/freeLocalMemory, which require
+    // local_segment_tracker_ and metadata_ to be alive.
+    staging_proxy_.reset();
+
+    if (local_segment_tracker_) {
+        local_segment_tracker_->forEach([&](BufferDesc& desc) -> Status {
+            for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
+                if (transport_list_[type])
+                    transport_list_[type]->removeMemoryBuffer(desc);
+            }
+            return Status::OK();
+        });
+    }
 
     // Free all batches BEFORE destroying transports, so that
     // freeSubBatch() can properly return SubBatch/Slice objects
-    // to each transport's Slab allocator.
+    // to the global Slab/allocator instances used by the transports.
+    //
+    // Safety note: freeSubBatch() only performs Slab deallocation and
+    // does not access transport-internal state (workers, connections).
+    // Callers must ensure no transfers are in-flight before calling
+    // deconstruct().
     batch_set_.forEach([&](BatchSet& entry) {
         for (auto& batch : entry.active) {
+            for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
+                auto& transport = transport_list_[type];
+                auto& sub_batch = batch->sub_batch[type];
+                if (!transport || !sub_batch) continue;
+                transport->freeSubBatch(sub_batch);
+            }
+            Slab<Batch>::Get().deallocate(batch);
+        }
+        for (auto& batch : entry.freelist) {
             for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
                 auto& transport = transport_list_[type];
                 auto& sub_batch = batch->sub_batch[type];
@@ -277,8 +298,10 @@ Status TransferEngineImpl::deconstruct() {
     // Now safe to destroy transports (workers join here)
     for (auto& transport : transport_list_) transport.reset();
     local_segment_tracker_.reset();
-    metadata_->segmentManager().deleteLocal();
-    metadata_.reset();
+    if (metadata_) {
+        metadata_->segmentManager().deleteLocal();
+        metadata_.reset();
+    }
     return Status::OK();
 }
 


### PR DESCRIPTION
## Description

In TransferEngineImpl::deconstruct(), the cleanup order was incorrect:

```
1. transport.reset()          ← transports destroyed, set to nullptr
2. batch_set_.forEach(...)    ← tries to call transport->freeSubBatch()
```


This means all RdmaSubBatch, RdmaSlice, TcpSubBatch, etc. allocated via Slab<T>::Get().allocate() during submitTransferTasks() were never returned to the Slab allocator during normal shutdown. The memory was only reclaimed implicitly when the global Slab<T> singleton was destroyed at process exit (atexit), which is not proper resource management.

### Fix

Move the batch cleanup (batch_set_.forEach(...)) before transport.reset(), so that freeSubBatch() is called while transports are still alive:

This is safe because freeSubBatch() only performs Slab deallocation — it does not depend on transport-internal state like RDMA workers or connections (which are already stopped during transport.reset() → uninstall() → Workers::stop()).
## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
