### PR TITLE
[CI] add CU13_BUILD environment variable to CI workflow

### DIFF
--- a/.github/workflows/ci_cu13.yml
+++ b/.github/workflows/ci_cu13.yml
@@ -75,18 +75,19 @@ jobs:
         mkdir build
         cd build
         cmake .. \
-          -DUSE_ETCD=OFF \
-          -DUSE_REDIS=OFF \
+          -DUSE_ETCD=ON \
+          -DUSE_REDIS=ON \
           -DUSE_HTTP=ON \
           -DWITH_STORE=ON \
-          -DWITH_P2P_STORE=OFF \
+          -DWITH_P2P_STORE=ON \
           -DWITH_EP=ON \
           -DWITH_METRICS=ON \
           -DBUILD_UNIT_TESTS=OFF \
-          -DBUILD_EXAMPLES=OFF \
+          -DBUILD_EXAMPLES=ON \
           -DENABLE_SCCACHE=ON \
-          -DBUILD_BENCHMARK=OFF \
+          -DBUILD_BENCHMARK=ON \
           -DUSE_CUDA=ON \
+          -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs"
       shell: bash
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
