### PR TITLE
[TransferEngine] Fix RDMA GID auto-discovery for IPv6 and reduce spur…

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -442,7 +442,9 @@ GidNetworkState RdmaContext::findBestGidIndex(const std::string &device_name,
     gid_index = -1;
     int i;
     struct ibv_gid_entry gid_entry;
-    bool fallback_found = false;
+    int fallback_ipv4_gid_without_network = -1;
+    int fallback_ipv6_gid_with_network = -1;
+    int fallback_ipv6_gid_without_network = -1;
     GidNetworkState state = GidNetworkState::GID_NOT_FOUND;
 
     for (i = 0; i < port_attr.gid_tbl_len; i++) {
@@ -451,23 +453,53 @@ GidNetworkState RdmaContext::findBestGidIndex(const std::string &device_name,
             break;
         }
 
-        if (gid_entry.gid_type == IBV_GID_TYPE_ROCE_V2 ||
-            gid_entry.gid_type == IBV_GID_TYPE_IB) {
-            // Check if this GID has an associated network device
-            if (hasNetworkDevice(device_name, port, i)) {
-                // Found a GID with network device, this is the best choice
+        if (gid_entry.gid_type != IBV_GID_TYPE_ROCE_V2 &&
+            gid_entry.gid_type != IBV_GID_TYPE_IB) {
+            continue;
+        }
+
+        const bool is_ipv4_gid =
+            gid_entry.gid_type == IBV_GID_TYPE_ROCE_V2 &&
+            ipv6_addr_v4mapped((struct in6_addr *)gid_entry.gid.raw);
+        const bool has_network_device = hasNetworkDevice(device_name, port, i);
+
+        if (is_ipv4_gid) {
+            if (has_network_device) {
                 gid_index = i;
-                state = GidNetworkState::GID_WITH_NETWORK;
-                break;
+                return GidNetworkState::GID_WITH_NETWORK;
             }
-            // No network device, keep the first one as fallback candidate
-            if (!fallback_found) {
+            if (fallback_ipv4_gid_without_network < 0) {
                 gid_index = i;
-                fallback_found = true;
+                fallback_ipv4_gid_without_network = i;
                 state = GidNetworkState::GID_WITHOUT_NETWORK;
             }
+            continue;
+        }
+
+        if (has_network_device && fallback_ipv6_gid_with_network < 0) {
+            fallback_ipv6_gid_with_network = i;
+        }
+
+        if (!has_network_device && fallback_ipv6_gid_without_network < 0) {
+            fallback_ipv6_gid_without_network = i;
         }
     }
+
+    if (fallback_ipv4_gid_without_network >= 0) {
+        gid_index = fallback_ipv4_gid_without_network;
+        return GidNetworkState::GID_WITHOUT_NETWORK;
+    }
+
+    if (fallback_ipv6_gid_with_network >= 0) {
+        gid_index = fallback_ipv6_gid_with_network;
+        return GidNetworkState::GID_WITH_NETWORK;
+    }
+
+    if (fallback_ipv6_gid_without_network >= 0) {
+        gid_index = fallback_ipv6_gid_without_network;
+        return GidNetworkState::GID_WITHOUT_NETWORK;
+    }
+
     return state;
 }
 


### PR DESCRIPTION
…ious errors

Fixes #1593 and #1592

Changes:
1. Accept all RoCE v2 GIDs (both IPv4-mapped and pure IPv6) instead of only IPv4-mapped GIDs. This allows Transfer Engine to work in IPv6-only environments.

2. Stop querying GID indices on first failure instead of iterating through all 256 possible indices. This eliminates spurious 'Failed to query GID' error logs when devices have fewer GIDs.

3. Allow user-specified GIDs without network devices. When MC_GID_INDEX is explicitly set, log a warning but continue initialization instead of failing. Users setting this variable know their configuration.

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
