### PR TITLE
[Store] Remove duplicate code in allocate/free ascend fabric memory function of mooncake store

### DIFF
--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -512,17 +512,10 @@ class RealClient : public PyClient {
     };
 
     struct AscendSegmentDeleter {
+        std::string protocol = "ascend";
         void operator()(void *ptr) {
             if (ptr) {
-                free_memory("ascend", ptr);
-            }
-        }
-    };
-
-    struct UbshmemSegmentDeleter {
-        void operator()(void *ptr) {
-            if (ptr) {
-                free_memory("ubshmem", ptr);
+                free_memory(protocol.c_str(), ptr);
             }
         }
     };
@@ -532,8 +525,6 @@ class RealClient : public PyClient {
     std::vector<std::unique_ptr<void, SegmentDeleter>> segment_ptrs_;
     std::vector<std::unique_ptr<void, AscendSegmentDeleter>>
         ascend_segment_ptrs_;
-    std::vector<std::unique_ptr<void, UbshmemSegmentDeleter>>
-        ubshmem_segment_ptrs_;
     std::string protocol;
     std::string device_name;
     std::string local_hostname;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -372,22 +372,23 @@ ErrorCode Client::InitTransferEngine(
                 LOG(ERROR) << "Failed to install TCP transport";
                 return ErrorCode::INTERNAL_ERROR;
             }
-        } else if (protocol == "ascend") {
+        } else if (protocol == "ascend" || protocol == "ubshmem") {
             if (device_names.has_value()) {
-                LOG(WARNING) << "Ascend protocol does not use device "
-                                "names, ignoring";
+                LOG(WARNING) << protocol
+                             << " protocol does not use device names, ignoring";
             }
             try {
                 transport =
-                    transfer_engine_->installTransport("ascend", nullptr);
+                    transfer_engine_->installTransport(protocol, nullptr);
             } catch (std::exception& e) {
-                LOG(ERROR) << "ascend_transport_install_failed error_message=\""
+                LOG(ERROR) << protocol
+                           << "_transport_install_failed error_message=\""
                            << e.what() << "\"";
                 return ErrorCode::INTERNAL_ERROR;
             }
 
             if (!transport) {
-                LOG(ERROR) << "Failed to install Ascend transport";
+                LOG(ERROR) << "Failed to install " << protocol << " transport";
                 return ErrorCode::INTERNAL_ERROR;
             }
         } else if (protocol == "cxl") {
@@ -405,25 +406,6 @@ ErrorCode Client::InitTransferEngine(
 
             if (!transport) {
                 LOG(ERROR) << "Failed to install CXL transport";
-                return ErrorCode::INTERNAL_ERROR;
-            }
-        } else if (protocol == "ubshmem") {
-            if (device_names.has_value()) {
-                LOG(WARNING) << "Ubshmem protocol does not use device "
-                                "names, ignoring";
-            }
-            try {
-                transport =
-                    transfer_engine_->installTransport("ubshmem", nullptr);
-            } catch (std::exception& e) {
-                LOG(ERROR)
-                    << "ubshmem_transport_install_failed error_message=\""
-                    << e.what() << "\"";
-                return ErrorCode::INTERNAL_ERROR;
-            }
-
-            if (!transport) {
-                LOG(ERROR) << "Failed to install Ubshmem transport";
                 return ErrorCode::INTERNAL_ERROR;
             }
         } else {

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -325,10 +325,9 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 LOG(ERROR) << "Failed to allocate segment memory";
                 return tl::unexpected(ErrorCode::INVALID_PARAMS);
             }
-            if (this->protocol == "ascend") {
-                ascend_segment_ptrs_.emplace_back(ptr);
-            } else if (this->protocol == "ubshmem") {
-                ubshmem_segment_ptrs_.emplace_back(ptr);
+            if (this->protocol == "ascend" || this->protocol == "ubshmem") {
+                ascend_segment_ptrs_.emplace_back(
+                    ptr, AscendSegmentDeleter{this->protocol});
             } else if (should_use_hugepage) {
                 hugepage_segment_ptrs_.emplace_back(
                     ptr, HugepageSegmentDeleter{mapped_size});

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -163,13 +163,6 @@ void *allocate_buffer_allocator_memory(size_t total_size,
     }
 #endif
 
-#ifdef USE_UBSHMEM
-    if (protocol == "ubshmem" && total_size > 0) {
-        LOG(ERROR) << "Ascend runtime not support fabirc mem ";
-        return nullptr;
-    }
-#endif
-
     // Allocate aligned memory
     return aligned_alloc(alignment, total_size);
 }
@@ -239,13 +232,6 @@ void free_memory(const std::string &protocol, void *ptr) {
 #ifdef USE_ASCEND_DIRECT
     if (protocol == "ascend") {
         aclrtFreeHost(ptr);
-        return;
-    }
-#endif
-
-#ifdef USE_UBSHMEM
-    if (protocol == "ubshmem") {
-        LOG(ERROR) << "Ascend runtime not support fabirc mem ";
         return;
     }
 #endif


### PR DESCRIPTION


## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Mooncake store with 'ascend' and 'ubshmem' protocol have same steps to allocate and free ascend fabric memory. Remove duplicate code in allocate/free ascend fabric memory function of mooncake store to keep code clean.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

High-concurrency Mooncake Store scenario, testing using the batch_put_from_multi_buffers and batch_get_into_multi_buffers interfaces. Single-machine 16-NPU setup: rank 0 performs put operations, all ranks perform get operations.

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
