### PR TITLE
[TE] Fix remaining race conditions in removeSegmentDesc and updateLocalSegmentDesc

### DIFF
--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -660,13 +660,16 @@ TransferMetadata::SegmentID TransferMetadata::getSegmentID(
 }
 
 int TransferMetadata::updateLocalSegmentDesc(uint64_t segment_id) {
-    RWSpinlock::ReadGuard guard(segment_lock_);
-    auto it = segment_id_to_desc_map_.find(segment_id);
-    if (it == segment_id_to_desc_map_.end() || !it->second) {
-        LOG(ERROR) << "Segment descriptor " << segment_id << " not found";
-        return ERR_METADATA;
+    std::shared_ptr<SegmentDesc> desc;
+    {
+        RWSpinlock::ReadGuard guard(segment_lock_);
+        auto it = segment_id_to_desc_map_.find(segment_id);
+        if (it == segment_id_to_desc_map_.end() || !it->second) {
+            LOG(ERROR) << "Segment descriptor " << segment_id << " not found";
+            return ERR_METADATA;
+        }
+        desc = it->second;
     }
-    auto desc = it->second;
     return this->updateSegmentDesc(desc->name, *desc);
 }
 


### PR DESCRIPTION
Follow-up to #1373 which fixed the main segfault in receivePeerMetadata
and getSegmentDesc. Two remaining thread-safety issues in the same file:

1. `removeSegmentDesc()` p2p path — accesses both segment maps without
   holding `segment_lock_`. Concurrent erase from this function + read
   from the daemon thread (which holds ReadGuard) causes iterator
   invalidation. Added `WriteGuard`.

2. `updateLocalSegmentDesc()` — uses `operator[]` under `ReadGuard`,
   which inserts a default element if the key is missing (UB under read
   lock). Also null-dereferences the result. Replaced with `find()` and
   a null check, matching the pattern from #1373.

Relates to #1369.

- [x] Do only one thing
- [x] Non breaking API changes

Made with [Cursor](https://cursor.com)