### PR TITLE
[Bug fix]fix compile err without use uring

### DIFF
--- a/mooncake-store/benchmarks/file_interface_bench.cpp
+++ b/mooncake-store/benchmarks/file_interface_bench.cpp
@@ -803,8 +803,11 @@ int main(int argc, char* argv[]) {
 #ifdef USE_URING
             config.use_uring = true;
 #else
-            std::cerr << "Warning: io_uring support not compiled in"
+            std::cerr << "Error: --use-uring specified but io_uring support "
+                         "was not compiled in (USE_URING is not defined). "
+                         "Cannot benchmark UringFile performance."
                       << std::endl;
+            return 1;
 #endif
         } else if (arg == "--queue-depth" && i + 1 < argc) {
             config.uring_queue_depth = std::stoul(argv[++i]);
@@ -818,8 +821,11 @@ int main(int argc, char* argv[]) {
                 config.use_uring = true;
             }
 #else
-            std::cerr << "Warning: io_uring support not compiled in"
+            std::cerr << "Error: --uring-direct-io specified but io_uring "
+                         "support was not compiled in (USE_URING is not "
+                         "defined). Cannot benchmark UringFile performance."
                       << std::endl;
+            return 1;
 #endif
         } else if (arg == "--uring-direct-io-zerocopy") {
 #ifdef USE_URING
@@ -831,8 +837,11 @@ int main(int argc, char* argv[]) {
                 config.use_uring = true;
             }
 #else
-            std::cerr << "Warning: io_uring support not compiled in"
+            std::cerr << "Error: --uring-direct-io-zerocopy specified but "
+                         "io_uring support was not compiled in (USE_URING is "
+                         "not defined). Cannot benchmark UringFile performance."
                       << std::endl;
+            return 1;
 #endif
         } else if (arg == "--use-registered-buffers") {
 #ifdef USE_URING
@@ -849,8 +858,11 @@ int main(int argc, char* argv[]) {
                           << std::endl;
             }
 #else
-            std::cerr << "Warning: io_uring support not compiled in"
+            std::cerr << "Error: --use-registered-buffers specified but "
+                         "io_uring support was not compiled in (USE_URING is "
+                         "not defined). Cannot benchmark UringFile performance."
                       << std::endl;
+            return 1;
 #endif
         } else if (arg == "--direct-io") {
             config.use_direct_io = true;


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ✅] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ✅] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->


## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
file_interface_bench.cpp failed to compile when liburing was not available (i.e., USE_URING not defined). The BenchmarkAlignedIO method directly referenced UringFile — including dynamic_cast<UringFile*>, write_aligned(), read_aligned(), register_buffer(), and unregister_buffer() — without any compile-time guard, even though UringFile is only defined under #ifdef USE_URING.

Root Cause:

The benchmark target file_interface_bench is built unconditionally in CMakeLists.txt regardless of whether liburing is present. The BenchmarkAlignedIO function body, however, assumed UringFile was always available.

Fix:

Wrapped the body of BenchmarkAlignedIO with #ifdef USE_URING / #else / #endif. When USE_URING is not defined, the function falls back to returning std::nullopt with a diagnostic message. This is safe because the only call site (Run()) already guards the invocation behind config_.use_uring_direct_io_zero_copy, which can only be set to true when compiled with USE_URING.