### PR TITLE
[PG] Reduce CPU consumption of send/recv worker threads

### DIFF
--- a/mooncake-pg/src/p2p_proxy.cc
+++ b/mooncake-pg/src/p2p_proxy.cc
@@ -14,6 +14,8 @@ namespace {
 constexpr size_t kP2PBytesPerRank = kP2PBufferSize;
 constexpr size_t kP2PNumSlotsPerRank = kP2PNumSlots;
 
+constexpr int kP2PWorkerPollingSleepDuration = 50;
+
 static_assert(kP2PBufferSize % kP2PNumSlots == 0,
               "kP2PBufferSize must be divisible by kP2PNumSlots");
 static_assert(kP2PNumSlots > 1, "P2P ring requires at least 2 slots per rank");
@@ -768,7 +770,8 @@ void P2PProxy::SendWorkerThread() {
         }
 
         if (!did_work) {
-            std::this_thread::sleep_for(std::chrono::microseconds(50));
+            std::this_thread::sleep_for(
+                std::chrono::microseconds(kP2PWorkerPollingSleepDuration));
             PAUSE();
         }
     }
@@ -872,7 +875,8 @@ void P2PProxy::RecvWorkerThread() {
         }
 
         if (!did_work) {
-            std::this_thread::sleep_for(std::chrono::microseconds(50));
+            std::this_thread::sleep_for(
+                std::chrono::microseconds(kP2PWorkerPollingSleepDuration));
             PAUSE();
         }
     }


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues.

Reduce CPU consumption of send/recv worker threads by sleeping a while during polling.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
