### PR TITLE
fix: check MC_INTRANODE_NVLINK before HCA auto-detection fallback

### DIFF
--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -253,16 +253,8 @@ int TransferEngineImpl::init(const std::string& metadata_conn_string,
 
         const char* force_mnnvl = getenv("MC_FORCE_MNNVL");
         const char* intra_env = getenv("MC_INTRANODE_NVLINK");
-        if (force_mnnvl || local_topology_->getHcaList().empty()) {
-            Transport* t =
-                multi_transports_->installTransport("nvlink", nullptr);
-            if (!t) {
-                LOG(ERROR) << "Failed to install NVLink transport";
-                return -1;
-            }
-            LOG(INFO) << "Using cross-node NVLink transport "
-                      << "(MC_FORCE_MNNVL or no HCA detected)";
-        } else if (intra_env) {
+        // Explicit env var overrides take priority over HCA auto-detection
+        if (intra_env) {
             Transport* t =
                 multi_transports_->installTransport("nvlink_intra", nullptr);
             if (!t) {
@@ -271,6 +263,15 @@ int TransferEngineImpl::init(const std::string& metadata_conn_string,
             }
             LOG(INFO) << "Using Intra-Node NVLink transport "
                          "(MC_INTRANODE_NVLINK set)";
+        } else if (force_mnnvl || local_topology_->getHcaList().empty()) {
+            Transport* t =
+                multi_transports_->installTransport("nvlink", nullptr);
+            if (!t) {
+                LOG(ERROR) << "Failed to install NVLink transport";
+                return -1;
+            }
+            LOG(INFO) << "Using cross-node NVLink transport "
+                      << "(MC_FORCE_MNNVL or no HCA detected)";
         } else {
             Transport* t =
                 multi_transports_->installTransport("rdma", local_topology_);


### PR DESCRIPTION
## Summary

- `MC_INTRANODE_NVLINK` env var is unreachable on machines with no RDMA HCAs (e.g., cloud VMs with NVSwitch but no InfiniBand)
- The `getHcaList().empty()` condition at line 256 matches first and tries to install cross-node NVLink (`"nvlink"` transport), which requires `USE_MNNVL` — failing with `"Unsupported transport nvlink, please rebuild Mooncake"`
- Fix: check `MC_INTRANODE_NVLINK` before the HCA auto-detection fallback, so explicit user overrides take priority

## Repro

1. Build Mooncake with `-DUSE_INTRA_NVLINK=ON -DUSE_CUDA=ON` (no `-DUSE_MNNVL`)
2. Run on a machine with NVSwitch but no RDMA HCAs (e.g., Brev cloud VM with 8x H100)
3. Set `MC_INTRANODE_NVLINK=1`
4. Observe: `"Unsupported transport nvlink, please rebuild Mooncake"` — the intra-node NVLink branch is never reached

## Before (buggy)

```cpp
if (force_mnnvl || local_topology_->getHcaList().empty()) {  // <-- matches when no HCAs
    installTransport("nvlink", ...);  // requires USE_MNNVL, fails
} else if (intra_env) {  // <-- unreachable when no HCAs
    installTransport("nvlink_intra", ...);
}
```

## After (fixed)

```cpp
if (intra_env) {  // <-- explicit env var checked first
    installTransport("nvlink_intra", ...);
} else if (force_mnnvl || local_topology_->getHcaList().empty()) {
    installTransport("nvlink", ...);
}
```

## Test plan

- [x] Verified on Brev cloud VM (8x H100, NVSwitch, no RDMA HCAs) — SGLang ModelExpress weight transfer over Mooncake IntraNodeNvlinkTransport works after this fix