### PR TITLE
[Build] fix missing libcurl4 dependency in mooncake docker image

### DIFF
--- a/docker/mooncake.Dockerfile
+++ b/docker/mooncake.Dockerfile
@@ -86,7 +86,8 @@ RUN apt-get update && \
         librdmacm1 \
         libnuma1 \
         liburing2 \
-        libyaml-0-2 && \
+        libyaml-0-2 \
+        libcurl4 && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy wheels produced in builder stage and install them via pip

--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -76,7 +76,8 @@ RUN apt-get update && \
         librdmacm1 \
         libnuma1 \
         liburing2 \
-        libyaml-0-2 && \
+        libyaml-0-2 \
+        libcurl4 && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy wheels produced in builder stage and install them via pip


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

After building a image from `docker/mooncake.Dockerfile`, running `mooncake_client` gets the following error:
```
/usr/local/lib/python3.10/dist-packages/mooncake/mooncake_client: error while loading shared libraries: libcurl.so.4: cannot open shared object file: No such file or directory
```

The PR fixes it by adding `libcurl4` in mooncake's runtime docker images.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [x] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
