### PR TITLE
[Store] Fix Ctrl-C hang in both Python and C++ client processes

### DIFF
--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -117,12 +117,12 @@ void ResourceTracker::startSignalThread() {
         sigaddset(&set, SIGUSR1);  // used to interrupt sigwait on stop
         pthread_sigmask(SIG_BLOCK, &set, nullptr);
 
-        signal_thread_ = std::jthread(
-            [set, ready = std::move(ready)](std::stop_token st) mutable {
+        signal_thread_ = std::jthread([set, ready = std::move(ready)](
+                                          std::stop_token st) mutable {
             // Register a stop callback to interrupt sigwait via SIGUSR1
             pthread_t self = pthread_self();
-                std::stop_callback cb(
-                    st, [self]() { pthread_kill(self, SIGUSR1); });
+            std::stop_callback cb(st,
+                                  [self]() { pthread_kill(self, SIGUSR1); });
             ready.set_value();
             for (;;) {
                 int sig = 0;


### PR DESCRIPTION
## Description

Fix two signal handling bugs in ResourceTracker that cause the mooncake client to hang or trigger a kernel soft lockup (CPU stuck for 22s) when terminated with Ctrl-C (issue #1603).

### Bug 1: Python process hangs on Ctrl-C

ResourceTracker::startSignalThread() calls pthread_sigmask(SIG_BLOCK, {SIGINT, SIGTERM, ...}) on the main thread to redirect signals to a dedicated signal thread via sigwait. However, in Python processes, this blocks SIGINT from reaching the main thread, which breaks Python's KeyboardInterrupt mechanism entirely — Ctrl-C has no effect.

Verified with /proc/<pid>/status:

SigBlk: 0000000000004203   →  SIGHUP, SIGINT, SIGUSR1, SIGTERM all blocked

**Fix: Detect Python at runtime using dlsym(RTLD_DEFAULT, "Py_IsInitialized") and skip startSignalThread() in embedded environments. The atexit handler is kept as a cleanup backstop. Python's own cleanup chain (KeyboardInterrupt → GC → C++ destructor → tearDownAll()) handles resource cleanup correctly.**

### Bug 2: C++ standalone process doesn't terminate after cleanup

In the C++ standalone process (mooncake_client), when the signal thread catches SIGINT:

1. It performs cleanup via cleanupAllResources()
2. Restores SIG_DFL via sigaction()
3. Calls raise(sig) to terminate the process

However, raise(sig) is equivalent to pthread_kill(self, sig), and SIGINT is still blocked in the signal thread (via pthread_sigmask). The signal becomes pending but is never delivered. When the signal thread exits, the pending signal is discarded, leaving the process alive indefinitely — which can trigger a kernel soft lockup warning:

```
kernel: watchdog: BUG: soft lockup - CPU#87 stuck for 22s! [mooncake_client:1112887]
```

**Fix: Call pthread_sigmask(SIG_UNBLOCK, {sig}) before raise(sig) so the signal is immediately delivered with the default terminate action.**


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

1. Start Python client (client.py), verify Ctrl-C raises KeyboardInterrupt immediately and process exits cleanly

2. Start C++ mooncake_client, verify Ctrl-C terminates the process immediately after cleanup (no 22s hang), and no kernel soft lockup warnings after Ctrl-C
```
sudo dmesg -w | grep -i "soft lockup\|stuck"
```

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
