### PR TITLE
[Store] Fix error log spam for non-memory replicas in DiscardedReplicas

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1054,7 +1054,9 @@ class MasterService {
                           std::chrono::system_clock::time_point ttl)
             : replicas_(std::move(replicas)), ttl_(ttl), mem_size_(0) {
             for (auto& replica : replicas_) {
-                mem_size_ += replica.get_memory_buffer_size();
+                if (replica.is_memory_replica()) {
+                    mem_size_ += replica.get_memory_buffer_size();
+                }
             }
             MasterMetricManager::instance().inc_put_start_discard_cnt(
                 1, mem_size_);

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -39,7 +39,8 @@ inline std::ostream& operator<<(std::ostream& os,
                                 const ReplicaType& replicaType) noexcept {
     static const std::unordered_map<ReplicaType, std::string_view>
         replica_type_strings{{ReplicaType::MEMORY, "MEMORY"},
-                             {ReplicaType::DISK, "DISK"}};
+                             {ReplicaType::DISK, "DISK"},
+                             {ReplicaType::LOCAL_DISK, "LOCAL_DISK"}};
 
     os << (replica_type_strings.count(replicaType)
                ? replica_type_strings.at(replicaType)


### PR DESCRIPTION
Fixes #1618

## Root Cause

`DiscardedReplicas` (master_service.h) iterates **all** discarded replicas and calls `get_memory_buffer_size()` on each. This method only handles `MEMORY` replicas — for `DISK` or `LOCAL_DISK`, it logs `"Invalid replica type: DISK"` and returns 0.

In L3/DFS scenarios where `DISK` replicas are routinely discarded, this produces continuous error log spam (as reported in #1618).

## Changes

1. **master_service.h**: Guard `get_memory_buffer_size()` call with `is_memory_replica()` in `DiscardedReplicas` constructor. Functionally equivalent (non-memory types already return 0) but eliminates the error log.

2. **replica.h**: Add `LOCAL_DISK` to the `operator<<` string map for `ReplicaType`. It was missing — printing a `LOCAL_DISK` type showed "UNKNOWN" instead of "LOCAL_DISK".