### PR TITLE
[Store] bugfix: fix signal missing

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -256,11 +256,12 @@ class MooncakeStorePyWrapper {
 
     // Helper to initialize real client and register it
     std::shared_ptr<RealClient> init_real_client() {
+        auto &resource_tracker = ResourceTracker::getInstance();
         auto real_client = RealClient::create();
         use_dummy_client_ = false;
         store_ = real_client;
-        ResourceTracker::getInstance().registerInstance(
-            std::dynamic_pointer_cast<PyClient>(store_));
+        resource_tracker.registerInstance(
+            std::static_pointer_cast<PyClient>(store_));
         return real_client;
     }
 
@@ -1188,10 +1189,11 @@ PYBIND11_MODULE(store, m) {
             "setup_dummy",
             [](MooncakeStorePyWrapper &self, size_t mem_pool_size,
                size_t local_buffer_size, const std::string &server_address) {
+                auto &resource_tracker = ResourceTracker::getInstance();
                 self.use_dummy_client_ = true;
                 self.store_ = std::make_shared<DummyClient>();
-                ResourceTracker::getInstance().registerInstance(
-                    std::dynamic_pointer_cast<PyClient>(self.store_));
+                resource_tracker.registerInstance(
+                    std::static_pointer_cast<PyClient>(self.store_));
                 auto [ip, port] = parseHostNameWithPort(server_address);
                 return self.store_->setup_dummy(
                     mem_pool_size, local_buffer_size, server_address,

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -134,6 +134,14 @@ void ResourceTracker::startSignalThread() {
                     sigemptyset(&sa.sa_mask);
                     sa.sa_flags = 0;
                     sigaction(sig, &sa, nullptr);
+
+                    // Unblock the signal before raising it so it can be
+                    // delivered immediately
+                    sigset_t unblock_set;
+                    sigemptyset(&unblock_set);
+                    sigaddset(&unblock_set, sig);
+                    pthread_sigmask(SIG_UNBLOCK, &unblock_set, nullptr);
+
                     raise(sig);
 
                     break;  // Should not reach due to process termination

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -58,6 +58,12 @@ void RegisterClientRpcService(coro_rpc::coro_rpc_server &server,
 }  // namespace mooncake
 
 int main(int argc, char *argv[]) {
+    // Attention !!!
+    // Initialization of ResourceTracker must be the most earliest.
+    // Otherwise, the main thread will not apply signal mask before other
+    // spawning threads, leading to missing signal processing.
+    mooncake::ResourceTracker::getInstance();
+
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     size_t global_segment_size = string_to_byte_size(FLAGS_global_segment_size);
 


### PR DESCRIPTION
## Description
Based on global capturing signals, ResourceTracker is used to handle cleanup on abnormal termination. However, if the ResourceTracker object is not created immediately when the client process starts, then as long as another thread is created before it is created, the ResourceTracker may not be the globally unique entry point for handling exit signals, which can lead to errors in the resource cleanup logic during exit.

Therefore, I place the access to the static ResourceTracker object at the beginning of the program entry. Ensure that the ResourceTracker has blocked the main thread from obtaining the signal before the Client object is created

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
