### PR TITLE
[TENT] feat: add tcp_hp transport for High-Concurrency Throughput

### DIFF
--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -101,7 +101,7 @@ int main(int argc, char* argv[]) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     XferBenchConfig::loadFromFlags();
     std::unique_ptr<BenchRunner> runner;
-    if (XferBenchConfig::backend == "classic")
+    if (XferBenchConfig::useClassicBackend())
         runner = std::make_unique<TEBenchRunner>();
     else
         runner = std::make_unique<TENTBenchRunner>();
@@ -110,7 +110,11 @@ int main(int argc, char* argv[]) {
                   << "  ./tebench --target_seg_name="
                   << runner->getSegmentName()
                   << " --seg_type=" << XferBenchConfig::seg_type
-                  << " --backend=" << XferBenchConfig::backend << std::endl
+                  << " --backend=" << XferBenchConfig::backend;
+        if (!XferBenchConfig::xport_type.empty()) {
+            std::cout << " --xport_type=" << XferBenchConfig::xport_type;
+        }
+        std::cout << std::endl
                   << "Press Ctrl-C to terminate\033[0m" << std::endl;
         return runner->runTarget();
     }

--- a/mooncake-transfer-engine/benchmark/te_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/te_backend.cpp
@@ -47,7 +47,8 @@ static inline int getCudaDeviceNumaID(int cuda_id) {
         LOG(WARNING) << "cudaDeviceGetPCIBusId: " << cudaGetErrorString(err);
         return 0;
     }
-    for (char* ch = pci_bus_id; (*ch = tolower(*ch)); ch++);
+    for (char* ch = pci_bus_id; (*ch = tolower(*ch)); ch++)
+        ;
     return getNumaNodeFromPciDevice(pci_bus_id);
 }
 #else
@@ -167,6 +168,13 @@ int TEBenchRunner::freeBuffers() {
 TEBenchRunner::TEBenchRunner() {
     signal(SIGINT, signalHandlerV0);
     signal(SIGTERM, signalHandlerV0);
+
+    if (XferBenchConfig::xport_type == "tcp") {
+        setenv("MC_FORCE_TCP", "1", 1);
+        LOG(INFO) << "Force classic/TE benchmark to use TCP transport "
+                  << "because --xport_type=tcp";
+    }
+
     engine_ = std::make_unique<mooncake::TransferEngine>(true);
     auto conn_str = XferBenchConfig::metadata_type == "p2p"
                         ? "P2PHANDSHAKE"

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -50,9 +50,10 @@ std::shared_ptr<Config> loadConfig() {
     if (!XferBenchConfig::xport_type.empty()) {
         // Map of transport names to their config keys (handle name mismatches)
         std::unordered_map<std::string, std::string> transport_map = {
-            {"rdma", "rdma"},        {"tcp", "tcp"},    {"shm", "shm"},
-            {"iouring", "io_uring"},  // Note: iouring -> io_uring
-            {"gds", "gds"},          {"mnnvl", "mnnvl"}};
+            {"rdma", "rdma"}, {"tcp", "tcp"},          {"tcp_hp", "tcp_hp"},
+            {"shm", "shm"},   {"iouring", "io_uring"},  // Note: iouring ->
+                                                        // io_uring
+            {"gds", "gds"},   {"mnnvl", "mnnvl"}};
 
         // Disable all transports by default
         for (const auto& entry : transport_map) {
@@ -75,6 +76,7 @@ static TransportType getTransportType(const std::string& xport_type) {
     if (xport_type == "gds") return GDS;
     if (xport_type == "mnnvl") return MNNVL;
     if (xport_type == "tcp") return TCP;
+    if (xport_type == "tcp_hp") return TCP_HP;
     if (xport_type == "iouring") return IOURING;
     return UNSPEC;
 }
@@ -212,7 +214,8 @@ static inline int getCudaDeviceNumaID(int cuda_id) {
         LOG(WARNING) << "cudaDeviceGetPCIBusId: " << cudaGetErrorString(err);
         return 0;
     }
-    for (char* ch = pci_bus_id; (*ch = tolower(*ch)); ch++);
+    for (char* ch = pci_bus_id; (*ch = tolower(*ch)); ch++)
+        ;
     return getNumaNodeFromPciDevice(pci_bus_id);
 }
 #else

--- a/mooncake-transfer-engine/benchmark/utils.cpp
+++ b/mooncake-transfer-engine/benchmark/utils.cpp
@@ -15,7 +15,10 @@
 #include "utils.h"
 
 #include <gflags/gflags.h>
+#include <algorithm>
+#include <cctype>
 #include <iostream>
+#include <sstream>
 
 DEFINE_string(seg_name, "", "Memory segment name for the local side");
 DEFINE_string(seg_type, "DRAM",
@@ -44,8 +47,9 @@ DEFINE_string(metadata_url_list, "",
 DEFINE_int32(
     rpc_server_port, 0,
     "RPC server port used for p2p metadata service (0 = auto-select).");
-DEFINE_string(xport_type, "", "Transport type: rdma|shm|mnnvl|gds|iouring");
-DEFINE_string(backend, "tent", "Transport backend: classic|tent");
+DEFINE_string(xport_type, "",
+              "Transport type: tcp|tcp_hp|rdma|shm|mnnvl|gds|iouring|io_uring");
+DEFINE_string(backend, "tent", "Transport backend: te|classic|tent");
 DEFINE_bool(notifi, false,
             "Enable RDMA notification for performance measurement.");
 
@@ -76,6 +80,12 @@ bool XferBenchConfig::notifi = false;
 int XferBenchConfig::local_gpu_id = 0;
 int XferBenchConfig::target_gpu_id = 0;
 
+static std::string normalizeFlagValue(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return std::tolower(ch); });
+    return value;
+}
+
 void XferBenchConfig::loadFromFlags() {
     seg_type = FLAGS_seg_type;
     seg_name = FLAGS_seg_name;
@@ -96,13 +106,49 @@ void XferBenchConfig::loadFromFlags() {
     metadata_url_list = FLAGS_metadata_url_list;
     rpc_server_port = FLAGS_rpc_server_port;
 
-    xport_type = FLAGS_xport_type;
-    backend = FLAGS_backend;
+    xport_type = normalizeFlagValue(FLAGS_xport_type);
+    if (xport_type == "io_uring") xport_type = "iouring";
+
+    backend = normalizeFlagValue(FLAGS_backend);
+    if (backend == "te") backend = "classic";
+    if (backend.empty()) backend = "tent";
+
+    if (backend != "classic" && backend != "tent") {
+        LOG(ERROR) << "Invalid --backend=" << FLAGS_backend
+                   << ", only support te|classic|tent";
+        exit(EXIT_FAILURE);
+    }
+
+    static const std::vector<std::string> kSupportedXports = {
+        "", "tcp", "tcp_hp", "rdma", "shm", "mnnvl", "gds", "iouring"};
+    if (std::find(kSupportedXports.begin(), kSupportedXports.end(),
+                  xport_type) == kSupportedXports.end()) {
+        std::ostringstream oss;
+        for (size_t i = 1; i < kSupportedXports.size(); ++i) {
+            if (i > 1) oss << "|";
+            oss << kSupportedXports[i];
+        }
+        LOG(ERROR) << "Invalid --xport_type=" << FLAGS_xport_type
+                   << ", only support " << oss.str();
+        exit(EXIT_FAILURE);
+    }
+
+    if (backend == "classic" && xport_type == "tcp_hp") {
+        LOG(ERROR)
+            << "classic/TE backend does not support --xport_type=tcp_hp; "
+            << "please use --backend=tent for tcp_hp benchmark";
+        exit(EXIT_FAILURE);
+    }
+
     notifi = FLAGS_notifi;
 
     local_gpu_id = FLAGS_local_gpu_id;
     target_gpu_id = FLAGS_target_gpu_id;
 }
+
+bool XferBenchConfig::useClassicBackend() { return backend == "classic"; }
+
+bool XferBenchConfig::useTentBackend() { return backend == "tent"; }
 
 double XferMetricStats::percentile(double p) {
     if (samples.empty()) return 0.0;

--- a/mooncake-transfer-engine/benchmark/utils.h
+++ b/mooncake-transfer-engine/benchmark/utils.h
@@ -47,6 +47,8 @@ namespace mooncake {
 namespace tent {
 struct XferBenchConfig {
     static void loadFromFlags();
+    static bool useClassicBackend();
+    static bool useTentBackend();
 
     static std::string seg_name;
     static std::string seg_type;

--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -79,9 +79,10 @@ enum TransportType {
     IOURING,
     TCP,
     AscendDirect,
+    TCP_HP,
     UNSPEC
 };
-const static int kSupportedTransportTypes = 8;
+const static int kSupportedTransportTypes = 9;
 
 struct MemoryOptions {
     Location location = kWildcardLocation;

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
@@ -15,17 +15,10 @@
 #ifndef TCP_TRANSPORT_H_
 #define TCP_TRANSPORT_H_
 
-#include <atomic>
 #include <functional>
-#include <memory>
-#include <mutex>
+#include <iostream>
+#include <queue>
 #include <string>
-#include <thread>
-#include <unordered_map>
-#include <vector>
-
-#include <asio/io_context.hpp>
-#include <asio/ip/tcp.hpp>
 
 #include "tent/runtime/control_plane.h"
 #include "tent/runtime/transport.h"
@@ -84,45 +77,16 @@ class TcpTransport : public Transport {
     virtual Status receiveNotification(std::vector<Notification> &notify_list);
 
    private:
-    // Initiate an async transfer for one task via raw TCP socket.
     void startTransfer(TcpTask *task);
 
-    // Resolve the remote segment to get the TCP data endpoint (host:dataport).
-    Status findRemoteDataEndpoint(uint64_t dest_addr, uint64_t length,
-                                  uint64_t target_id, std::string &host,
-                                  uint16_t &data_port);
-
-    // Server-side: start accepting incoming data connections.
-    void doAccept();
-
-    // Find an available TCP port and bind the acceptor.
-    Status startDataServer();
-
-    // Connection pool: acquire/release reusable TCP connections.
-    asio::ip::tcp::socket acquireConnection(const std::string &host,
-                                            uint16_t port);
-    void releaseConnection(const std::string &key,
-                           asio::ip::tcp::socket socket);
+    Status findRemoteSegment(uint64_t dest_addr, uint64_t length,
+                             uint64_t target_id, std::string &rpc_server_addr);
 
    private:
-    bool installed_ = false;
+    bool installed_;
     std::string local_segment_name_;
     std::shared_ptr<Topology> local_topology_;
     std::shared_ptr<ControlService> metadata_;
-
-    // ASIO data plane
-    std::unique_ptr<asio::io_context> io_context_;
-    std::unique_ptr<asio::executor_work_guard<asio::io_context::executor_type>>
-        work_guard_;
-    std::unique_ptr<asio::ip::tcp::acceptor> acceptor_;
-    std::thread worker_thread_;
-    std::atomic<bool> running_{false};
-    uint16_t data_port_ = 0;
-
-    // Connection pool for reusing TCP connections to remote endpoints.
-    std::mutex pool_mutex_;
-    std::unordered_map<std::string, std::vector<asio::ip::tcp::socket>>
-        conn_pool_;
 
     RWSpinlock notify_lock_;
     std::vector<Notification> notify_list_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
@@ -15,10 +15,17 @@
 #ifndef TCP_TRANSPORT_H_
 #define TCP_TRANSPORT_H_
 
+#include <atomic>
 #include <functional>
-#include <iostream>
-#include <queue>
+#include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
 
 #include "tent/runtime/control_plane.h"
 #include "tent/runtime/transport.h"
@@ -77,16 +84,45 @@ class TcpTransport : public Transport {
     virtual Status receiveNotification(std::vector<Notification> &notify_list);
 
    private:
+    // Initiate an async transfer for one task via raw TCP socket.
     void startTransfer(TcpTask *task);
 
-    Status findRemoteSegment(uint64_t dest_addr, uint64_t length,
-                             uint64_t target_id, std::string &rpc_server_addr);
+    // Resolve the remote segment to get the TCP data endpoint (host:dataport).
+    Status findRemoteDataEndpoint(uint64_t dest_addr, uint64_t length,
+                                  uint64_t target_id, std::string &host,
+                                  uint16_t &data_port);
+
+    // Server-side: start accepting incoming data connections.
+    void doAccept();
+
+    // Find an available TCP port and bind the acceptor.
+    Status startDataServer();
+
+    // Connection pool: acquire/release reusable TCP connections.
+    asio::ip::tcp::socket acquireConnection(const std::string &host,
+                                            uint16_t port);
+    void releaseConnection(const std::string &key,
+                           asio::ip::tcp::socket socket);
 
    private:
-    bool installed_;
+    bool installed_ = false;
     std::string local_segment_name_;
     std::shared_ptr<Topology> local_topology_;
     std::shared_ptr<ControlService> metadata_;
+
+    // ASIO data plane
+    std::unique_ptr<asio::io_context> io_context_;
+    std::unique_ptr<asio::executor_work_guard<asio::io_context::executor_type>>
+        work_guard_;
+    std::unique_ptr<asio::ip::tcp::acceptor> acceptor_;
+    std::thread worker_thread_;
+    std::atomic<bool> running_{false};
+    uint16_t data_port_ = 0;
+
+    // Connection pool for reusing TCP connections to remote endpoints.
+    std::mutex pool_mutex_;
+    std::unordered_map<std::string, std::vector<asio::ip::tcp::socket>>
+        conn_pool_;
 
     RWSpinlock notify_lock_;
     std::vector<Notification> notify_list_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/bounce_buffer_pool.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/bounce_buffer_pool.h
@@ -1,0 +1,65 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TCP_HP_BOUNCE_BUFFER_POOL_H_
+#define TCP_HP_BOUNCE_BUFFER_POOL_H_
+
+#include <cstddef>
+#include <mutex>
+#include <vector>
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+// Pre-allocated pool of fixed-size DRAM buffers used as bounce buffers
+// for GPU<->TCP transfers. Eliminates per-chunk malloc/free overhead.
+//
+// Thread-safe: acquire/release can be called from any thread.
+class BounceBufferPool {
+   public:
+    // buffer_size:    size of each buffer (typically = chunk_size)
+    // initial_count:  number of buffers to pre-allocate
+    // max_count:      hard cap on total buffers (0 = unlimited)
+    BounceBufferPool(size_t buffer_size, size_t initial_count,
+                     size_t max_count);
+    ~BounceBufferPool();
+
+    // Non-copyable, non-movable
+    BounceBufferPool(const BounceBufferPool&) = delete;
+    BounceBufferPool& operator=(const BounceBufferPool&) = delete;
+
+    // Acquire a buffer. Returns nullptr if max_count reached.
+    char* acquire();
+
+    // Return a buffer to the pool.
+    void release(char* buf);
+
+    size_t buffer_size() const { return buffer_size_; }
+    size_t total_allocated() const;
+    size_t free_count() const;
+
+   private:
+    size_t buffer_size_;
+    size_t max_count_;
+    mutable std::mutex mutex_;
+    std::vector<char*> free_list_;
+    size_t total_allocated_ = 0;
+};
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TCP_HP_BOUNCE_BUFFER_POOL_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/conn_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/conn_manager.h
@@ -1,0 +1,91 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TCP_HP_CONN_MANAGER_H_
+#define TCP_HP_CONN_MANAGER_H_
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <asio/ip/tcp.hpp>
+
+#include "tent/common/status.h"
+#include "tent/transport/tcp_hp/io_context_pool.h"
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+struct ConnOptions {
+    size_t max_pool_size = 64;
+    int connect_timeout_ms = 3000;
+    int connect_retries = 5;
+    int keepalive_idle_s = 10;
+    int keepalive_interval_s = 2;
+    int keepalive_count = 5;
+    int sndbuf = 0;   // 0 = OS default
+    int rcvbuf = 0;   // 0 = OS default
+};
+
+class ConnManager {
+   public:
+    ConnManager(IoContextPool& pool, ConnOptions opts);
+    ~ConnManager();
+
+    // Acquire a handshaked connection. Creates a new one if pool is empty.
+    Status acquire(const std::string& host, uint16_t port,
+                   asio::ip::tcp::socket& out_socket);
+
+    // Return a connection to the pool. Closes if pool is full.
+    void release(const std::string& host, uint16_t port,
+                 asio::ip::tcp::socket socket);
+
+    // Server-side: validate incoming handshake (synchronous). Returns OK if valid.
+    Status serverHandshake(asio::ip::tcp::socket& socket);
+
+    // Server-side: validate incoming handshake (async, non-blocking).
+    // Calls handler(Status, socket) when done; socket is moved on success.
+    using HandshakeHandler =
+        std::function<void(Status, asio::ip::tcp::socket)>;
+    void asyncServerHandshake(asio::ip::tcp::socket socket,
+                              HandshakeHandler handler);
+
+    // Configure socket options (TCP_NODELAY, keepalive, buffer sizes).
+    void configureSocket(asio::ip::tcp::socket& socket);
+
+    // Close all pooled connections.
+    void shutdown();
+
+   private:
+    static std::string makeKey(const std::string& host, uint16_t port);
+    Status connectWithRetry(const std::string& host, uint16_t port,
+                            asio::ip::tcp::socket& socket);
+    Status clientHandshake(asio::ip::tcp::socket& socket);
+    bool isSocketAlive(asio::ip::tcp::socket& socket);
+
+    IoContextPool& pool_;
+    ConnOptions opts_;
+    std::mutex pool_mutex_;
+    std::unordered_map<std::string, std::vector<asio::ip::tcp::socket>> pool_map_;
+};
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TCP_HP_CONN_MANAGER_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/conn_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/conn_manager.h
@@ -78,10 +78,19 @@ class ConnManager {
     Status clientHandshake(asio::ip::tcp::socket& socket);
     bool isSocketAlive(asio::ip::tcp::socket& socket);
 
+    // Per-endpoint connection pool to avoid global lock contention.
+    struct EndpointPool {
+        std::mutex mutex;
+        std::vector<asio::ip::tcp::socket> sockets;
+    };
+
+    // Get or create per-endpoint pool (thread-safe).
+    std::shared_ptr<EndpointPool> getEndpointPool(const std::string& key);
+
     IoContextPool& pool_;
     ConnOptions opts_;
-    std::mutex pool_mutex_;
-    std::unordered_map<std::string, std::vector<asio::ip::tcp::socket>> pool_map_;
+    std::mutex map_mutex_;  // protects pool_map_ structural changes only
+    std::unordered_map<std::string, std::shared_ptr<EndpointPool>> pool_map_;
 };
 
 }  // namespace tcp_hp

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/hp_session.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/hp_session.h
@@ -1,0 +1,105 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TCP_HP_SESSION_H_
+#define TCP_HP_SESSION_H_
+
+#include <chrono>
+#include <functional>
+#include <memory>
+
+#include <asio/ip/tcp.hpp>
+#include <asio/steady_timer.hpp>
+
+#include "tent/common/types.h"
+#include "tent/runtime/control_plane.h"
+#include "tent/transport/tcp_hp/bounce_buffer_pool.h"
+#include "tent/transport/tcp_hp/protocol.h"
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+// Handles one data transfer over a TCP connection.
+//
+// Client side: sends DataHeader, then WRITE sends body / READ receives body.
+// Server side: reads DataHeader, validates buffer, then mirrors the operation.
+//
+// Phase 2 enhancements:
+// - BounceBufferPool: reuses pre-allocated DRAM buffers for GPU transfers
+// - Scatter-gather: zero-copy send for CPU memory (header+body in one writev)
+class HpSession : public std::enable_shared_from_this<HpSession> {
+   public:
+    // timeout_s: per-transfer timeout in seconds (0 = no timeout)
+    explicit HpSession(asio::ip::tcp::socket socket, size_t chunk_size,
+                       BounceBufferPool* bounce_pool = nullptr,
+                       unsigned timeout_s = 0);
+
+    // --- Client-side initiation ---
+    void initiateClient(void* buffer, uint64_t dest_addr, size_t size,
+                        uint8_t opcode);
+
+    // --- Server-side: start reading next transfer header ---
+    void onAccept(SegmentManager* seg_mgr);
+
+    // Completion callback: called with final status.
+    std::function<void(TransferStatusEnum)> on_complete;
+    // Socket return callback: called on success to return socket to pool.
+    std::function<void(asio::ip::tcp::socket)> return_socket;
+
+   private:
+    void writeHeader();
+    void readHeader();
+
+    // Chunked send/recv (used for GPU memory or server-side).
+    void sendBodyChunked();
+    void recvBodyChunked();
+
+    // Scatter-gather zero-copy: header + full body in one async_write.
+    // Used for client-side WRITE with CPU memory.
+    void sendBodyZeroCopy();
+
+    // Full-buffer zero-copy: header then one large async_read.
+    // Used for client-side READ with CPU memory.
+    void recvBodyZeroCopy();
+
+    // Zero-copy send without header prefix (server-side READ response).
+    void sendBodyZeroCopyNoHeader();
+
+    void finish(TransferStatusEnum status);
+
+    // Check if local_buffer_ is GPU memory and needs bounce buffer.
+    bool needBounceBuffer() const;
+
+    // Start / cancel deadline timer for the current transfer.
+    void startDeadline();
+    void cancelDeadline();
+
+    asio::ip::tcp::socket socket_;
+    DataHeader header_{};
+    char* local_buffer_ = nullptr;
+    uint64_t total_transferred_ = 0;
+    SegmentManager* seg_mgr_ = nullptr;
+    size_t chunk_size_;
+    BounceBufferPool* bounce_pool_;  // nullable; owned by TcpHpTransport
+    unsigned timeout_s_ = 0;
+    asio::steady_timer deadline_;
+    bool finished_ = false;  // guard against double-finish from timeout + I/O
+};
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TCP_HP_SESSION_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/hp_session.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/hp_session.h
@@ -57,6 +57,12 @@ class HpSession : public std::enable_shared_from_this<HpSession> {
     std::function<void(TransferStatusEnum)> on_complete;
     // Socket return callback: called on success to return socket to pool.
     std::function<void(asio::ip::tcp::socket)> return_socket;
+    // Server session close callback: notifies transport when a server-side
+    // session ends (error/EOF), so it can be removed from active tracking.
+    std::function<void()> on_close;
+
+    // Close socket externally (used during shutdown to cancel pending I/O).
+    void closeSocket();
 
    private:
     void writeHeader();

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/inflight_controller.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/inflight_controller.h
@@ -1,0 +1,65 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TCP_HP_INFLIGHT_CONTROLLER_H_
+#define TCP_HP_INFLIGHT_CONTROLLER_H_
+
+#include <atomic>
+#include <functional>
+#include <mutex>
+#include <queue>
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+// Limits the number of concurrent inflight transfers.
+// When the limit is reached, new transfers are queued and dispatched
+// as earlier transfers complete.
+//
+// Thread-safe: tryAcquire/release/enqueue can be called from any thread.
+class InflightController {
+   public:
+    // max_inflight: maximum concurrent transfers (0 = unlimited)
+    explicit InflightController(size_t max_inflight);
+
+    // Try to acquire a slot. Returns true if under limit.
+    bool tryAcquire();
+
+    // Release a slot and dispatch the next pending task (if any).
+    void release();
+
+    // Enqueue a task to run when a slot becomes available.
+    void enqueue(std::function<void()> task);
+
+    size_t current() const {
+        return current_.load(std::memory_order_relaxed);
+    }
+
+    size_t pending() const;
+
+   private:
+    void dispatchPending();
+
+    size_t max_inflight_;
+    std::atomic<size_t> current_{0};
+    std::mutex queue_mutex_;
+    std::queue<std::function<void()>> pending_;
+};
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TCP_HP_INFLIGHT_CONTROLLER_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/io_context_pool.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/io_context_pool.h
@@ -1,0 +1,70 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TCP_HP_IO_CONTEXT_POOL_H_
+#define TCP_HP_IO_CONTEXT_POOL_H_
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <asio/io_context.hpp>
+#include <asio/executor_work_guard.hpp>
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+// A pool of io_context instances, each running on its own thread.
+// Phase 1: pool_size=1 (single-threaded, same as existing).
+// Phase 2: pool_size=N for multi-threaded I/O.
+class IoContextPool {
+   public:
+    explicit IoContextPool(size_t pool_size);
+    ~IoContextPool();
+
+    // Start all worker threads. Must be called once after construction.
+    void start();
+
+    // Stop all io_contexts and join threads. Safe to call multiple times.
+    void stop();
+
+    // Round-robin: get the next io_context for distributing work.
+    asio::io_context& getNextContext();
+
+    // Get a specific io_context by index (e.g., index 0 for acceptor).
+    asio::io_context& getContext(size_t index);
+
+    size_t size() const { return entries_.size(); }
+
+   private:
+    struct Entry {
+        std::unique_ptr<asio::io_context> context;
+        std::unique_ptr<
+            asio::executor_work_guard<asio::io_context::executor_type>>
+            work_guard;
+        std::thread thread;
+    };
+
+    std::vector<Entry> entries_;
+    std::atomic<size_t> next_index_{0};
+    bool running_ = false;
+};
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TCP_HP_IO_CONTEXT_POOL_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/protocol.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/protocol.h
@@ -27,16 +27,34 @@ static constexpr uint64_t kMagic = 0x4D4F4F4E54435048ULL;
 static constexpr uint32_t kProtocolVersion = 1;
 
 // Sent by client immediately after TCP connect.
+// All fields are stored in little-endian wire format.
 struct __attribute__((packed)) HandshakeReq {
-    uint64_t magic;     // kMagic
-    uint32_t version;   // kProtocolVersion
+    uint64_t magic;     // kMagic (little-endian)
+    uint32_t version;   // kProtocolVersion (little-endian)
     uint32_t flags;     // reserved, set to 0
+
+    void encode() {
+        magic = htole64(kMagic);
+        version = htole32(kProtocolVersion);
+        flags = 0;
+    }
+
+    uint64_t decodedMagic() const { return le64toh(magic); }
+    uint32_t decodedVersion() const { return le32toh(version); }
 };
 
 // Sent by server in response to HandshakeReq.
+// All fields are stored in little-endian wire format.
 struct __attribute__((packed)) HandshakeAck {
-    uint16_t status;    // 0 = OK, non-zero = error
+    uint16_t status;    // 0 = OK, non-zero = error (little-endian)
     uint16_t flags;     // reserved
+
+    void encode(uint16_t s) {
+        status = htole16(s);
+        flags = 0;
+    }
+
+    uint16_t decodedStatus() const { return le16toh(status); }
 };
 
 // Status codes for HandshakeAck.

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/protocol.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/protocol.h
@@ -1,0 +1,75 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TCP_HP_PROTOCOL_H_
+#define TCP_HP_PROTOCOL_H_
+
+#include <cstdint>
+#include <endian.h>
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+// "MOONTCPH" in ASCII = 0x4D4F4F4E'54435048
+static constexpr uint64_t kMagic = 0x4D4F4F4E54435048ULL;
+static constexpr uint32_t kProtocolVersion = 1;
+
+// Sent by client immediately after TCP connect.
+struct __attribute__((packed)) HandshakeReq {
+    uint64_t magic;     // kMagic
+    uint32_t version;   // kProtocolVersion
+    uint32_t flags;     // reserved, set to 0
+};
+
+// Sent by server in response to HandshakeReq.
+struct __attribute__((packed)) HandshakeAck {
+    uint16_t status;    // 0 = OK, non-zero = error
+    uint16_t flags;     // reserved
+};
+
+// Status codes for HandshakeAck.
+static constexpr uint16_t kHandshakeOK = 0;
+static constexpr uint16_t kHandshakeBadMagic = 1;
+static constexpr uint16_t kHandshakeBadVersion = 2;
+
+// Data transfer header, sent before each transfer payload.
+struct __attribute__((packed)) DataHeader {
+    uint8_t  opcode;    // Request::WRITE=1 or Request::READ=0
+    uint8_t  flags;     // reserved
+    uint16_t reserved;  // alignment padding
+    uint64_t addr;      // destination address (little-endian)
+    uint64_t length;    // transfer length (little-endian)
+
+    void encode(uint8_t op, uint64_t a, uint64_t len) {
+        opcode = op;
+        flags = 0;
+        reserved = 0;
+        addr = htole64(a);
+        length = htole64(len);
+    }
+
+    uint64_t decodedAddr() const { return le64toh(addr); }
+    uint64_t decodedLength() const { return le64toh(length); }
+};
+
+static_assert(sizeof(HandshakeReq) == 16, "HandshakeReq must be 16 bytes");
+static_assert(sizeof(HandshakeAck) == 4, "HandshakeAck must be 4 bytes");
+static_assert(sizeof(DataHeader) == 20, "DataHeader must be 20 bytes (packed)");
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TCP_HP_PROTOCOL_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/striped_transfer.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/striped_transfer.h
@@ -1,0 +1,67 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TCP_HP_STRIPED_TRANSFER_H_
+#define TCP_HP_STRIPED_TRANSFER_H_
+
+#include <atomic>
+#include <cstddef>
+#include <functional>
+
+#include "tent/common/types.h"
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+// Coordinates multiple parallel TCP connections (stripes) that together
+// complete a single logical transfer. Each stripe transfers a contiguous
+// sub-range of the buffer independently.
+//
+// The transfer is considered COMPLETED only when all stripes succeed.
+// If any stripe fails, the overall transfer is marked FAILED immediately.
+class StripedTransfer : public std::enable_shared_from_this<StripedTransfer> {
+   public:
+    StripedTransfer(size_t num_stripes,
+                    std::function<void(TransferStatusEnum)> on_complete)
+        : num_stripes_(num_stripes), on_complete_(std::move(on_complete)) {}
+
+    // Called by each stripe's HpSession when it finishes.
+    void onStripeComplete(TransferStatusEnum status) {
+        if (status != TransferStatusEnum::COMPLETED) {
+            failed_.fetch_add(1, std::memory_order_relaxed);
+        }
+        size_t done = completed_.fetch_add(1, std::memory_order_acq_rel) + 1;
+        if (done == num_stripes_) {
+            bool any_failed =
+                failed_.load(std::memory_order_relaxed) > 0;
+            if (on_complete_) {
+                on_complete_(any_failed ? TransferStatusEnum::FAILED
+                                        : TransferStatusEnum::COMPLETED);
+            }
+        }
+    }
+
+   private:
+    size_t num_stripes_;
+    std::atomic<size_t> completed_{0};
+    std::atomic<size_t> failed_{0};
+    std::function<void(TransferStatusEnum)> on_complete_;
+};
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TCP_HP_STRIPED_TRANSFER_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/tcp_hp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/tcp_hp_transport.h
@@ -40,6 +40,22 @@ struct TcpHpTask {
     std::atomic<TransferStatusEnum> status_word{TransferStatusEnum::INITIAL};
     std::atomic<size_t> transferred_bytes{0};
     uint64_t target_addr = 0;
+
+    TcpHpTask() = default;
+    TcpHpTask(TcpHpTask&& other) noexcept
+        : request(std::move(other.request)),
+          status_word(other.status_word.load(std::memory_order_relaxed)),
+          transferred_bytes(other.transferred_bytes.load(std::memory_order_relaxed)),
+          target_addr(other.target_addr) {}
+    TcpHpTask& operator=(TcpHpTask&& other) noexcept {
+        request = std::move(other.request);
+        status_word.store(other.status_word.load(std::memory_order_relaxed), std::memory_order_relaxed);
+        transferred_bytes.store(other.transferred_bytes.load(std::memory_order_relaxed), std::memory_order_relaxed);
+        target_addr = other.target_addr;
+        return *this;
+    }
+    TcpHpTask(const TcpHpTask&) = delete;
+    TcpHpTask& operator=(const TcpHpTask&) = delete;
 };
 
 struct TcpHpSubBatch : public Transport::SubBatch {

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/tcp_hp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/tcp_hp_transport.h
@@ -18,7 +18,9 @@
 #include <atomic>
 #include <cstddef>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <asio/ip/tcp.hpp>
@@ -29,8 +31,10 @@
 #include "tent/runtime/transport.h"
 #include "tent/transport/tcp_hp/bounce_buffer_pool.h"
 #include "tent/transport/tcp_hp/conn_manager.h"
+#include "tent/transport/tcp_hp/hp_session.h"
 #include "tent/transport/tcp_hp/inflight_controller.h"
 #include "tent/transport/tcp_hp/io_context_pool.h"
+#include "tent/transport/tcp_hp/striped_transfer.h"
 
 namespace mooncake {
 namespace tent {
@@ -98,6 +102,17 @@ class TcpHpTransport : public Transport {
 
    private:
     void startTransfer(TcpHpSubBatch* batch, TcpHpTask* task);
+
+    // Single-connection transfer (small buffers, GPU memory).
+    void doSingleTransfer(TcpHpSubBatch* batch, TcpHpTask* task,
+                          const std::string& host, uint16_t port);
+
+    // Multi-connection striped transfer (large CPU buffers).
+    // Splits the buffer into num_stripes_ contiguous sub-ranges, each sent
+    // over an independent TCP connection in parallel.
+    void doStripedTransfer(TcpHpSubBatch* batch, TcpHpTask* task,
+                           const std::string& host, uint16_t port);
+
     Status findRemoteDataEndpoint(uint64_t dest_addr, uint64_t length,
                                   uint64_t target_id, std::string& host,
                                   uint16_t& data_port);
@@ -118,6 +133,11 @@ class TcpHpTransport : public Transport {
     size_t chunk_size_ = 65536;
     unsigned transfer_timeout_s_ = 30;  // 0 = no timeout
 
+    // Multi-rail striping: split large CPU transfers across parallel connections.
+    // Disabled for GPU memory (bounce-buffer path already limits parallelism).
+    size_t stripe_threshold_ = 1 * 1024 * 1024;  // 0 = always stripe
+    size_t num_stripes_ = 1;                       // 1 = disabled
+
     // Phase 2: bounce buffer pool for GPU transfers
     std::unique_ptr<tcp_hp::BounceBufferPool> bounce_pool_;
 
@@ -127,6 +147,11 @@ class TcpHpTransport : public Transport {
     // Thread pool for blocking connection work (connect + handshake),
     // so io_context threads are never blocked by synchronous operations.
     std::unique_ptr<asio::thread_pool> connect_pool_;
+
+    // Active server-side sessions: tracked so we can close their sockets
+    // during shutdown before destroying metadata_ / SegmentManager.
+    std::mutex server_sessions_mutex_;
+    std::unordered_set<std::shared_ptr<tcp_hp::HpSession>> server_sessions_;
 
     // Notification (same as TcpTransport)
     RWSpinlock notify_lock_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/tcp_hp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp_hp/tcp_hp_transport.h
@@ -1,0 +1,123 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TCP_HP_TRANSPORT_H_
+#define TCP_HP_TRANSPORT_H_
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <asio/ip/tcp.hpp>
+#include <asio/thread_pool.hpp>
+
+#include "tent/common/concurrent/rw_spinlock.h"
+#include "tent/runtime/control_plane.h"
+#include "tent/runtime/transport.h"
+#include "tent/transport/tcp_hp/bounce_buffer_pool.h"
+#include "tent/transport/tcp_hp/conn_manager.h"
+#include "tent/transport/tcp_hp/inflight_controller.h"
+#include "tent/transport/tcp_hp/io_context_pool.h"
+
+namespace mooncake {
+namespace tent {
+
+struct TcpHpTask {
+    Request request;
+    std::atomic<TransferStatusEnum> status_word{TransferStatusEnum::INITIAL};
+    std::atomic<size_t> transferred_bytes{0};
+    uint64_t target_addr = 0;
+};
+
+struct TcpHpSubBatch : public Transport::SubBatch {
+    std::vector<TcpHpTask> task_list;
+    size_t max_size;
+    std::atomic<size_t> outstanding{0};  // inflight transfers referencing tasks
+    size_t size() const override { return task_list.size(); }
+};
+
+class TcpHpTransport : public Transport {
+   public:
+    TcpHpTransport();
+    ~TcpHpTransport();
+
+    Status install(std::string& local_segment_name,
+                   std::shared_ptr<ControlService> metadata,
+                   std::shared_ptr<Topology> local_topology,
+                   std::shared_ptr<Config> conf = nullptr) override;
+    Status uninstall() override;
+
+    Status allocateSubBatch(SubBatchRef& batch, size_t max_size) override;
+    Status freeSubBatch(SubBatchRef& batch) override;
+    Status submitTransferTasks(
+        SubBatchRef batch,
+        const std::vector<Request>& request_list) override;
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override;
+
+    Status addMemoryBuffer(BufferDesc& desc,
+                           const MemoryOptions& options) override;
+    Status removeMemoryBuffer(BufferDesc& desc) override;
+
+    bool supportNotification() const override { return true; }
+    Status sendNotification(SegmentID target_id,
+                            const Notification& notify) override;
+    Status receiveNotification(
+        std::vector<Notification>& notify_list) override;
+
+    const char* getName() const override { return "tcp_hp"; }
+
+   private:
+    void startTransfer(TcpHpSubBatch* batch, TcpHpTask* task);
+    Status findRemoteDataEndpoint(uint64_t dest_addr, uint64_t length,
+                                  uint64_t target_id, std::string& host,
+                                  uint16_t& data_port);
+    void doAccept();
+    Status startDataServer();
+
+    bool installed_ = false;
+    std::string local_segment_name_;
+    std::shared_ptr<Topology> local_topology_;
+    std::shared_ptr<ControlService> metadata_;
+
+    // I/O pool (Phase 1: size=1, Phase 2: configurable)
+    std::unique_ptr<tcp_hp::IoContextPool> io_pool_;
+    std::unique_ptr<tcp_hp::ConnManager> conn_mgr_;
+    std::unique_ptr<asio::ip::tcp::acceptor> acceptor_;
+    std::atomic<bool> running_{false};
+    uint16_t data_port_ = 0;
+    size_t chunk_size_ = 65536;
+    unsigned transfer_timeout_s_ = 30;  // 0 = no timeout
+
+    // Phase 2: bounce buffer pool for GPU transfers
+    std::unique_ptr<tcp_hp::BounceBufferPool> bounce_pool_;
+
+    // Phase 2: inflight transfer limiter
+    std::unique_ptr<tcp_hp::InflightController> inflight_ctrl_;
+
+    // Thread pool for blocking connection work (connect + handshake),
+    // so io_context threads are never blocked by synchronous operations.
+    std::unique_ptr<asio::thread_pool> connect_pool_;
+
+    // Notification (same as TcpTransport)
+    RWSpinlock notify_lock_;
+    std::vector<Notification> notify_list_;
+};
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TCP_HP_TRANSPORT_H_

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -463,6 +463,7 @@ std::vector<TransportType> TransferEngineImpl::getSupportedTransports(
     if (transport_list_[AscendDirect]) result.push_back(AscendDirect);
     if (transport_list_[SHM]) result.push_back(SHM);
     if (transport_list_[TCP]) result.push_back(TCP);
+    if (transport_list_[TCP_HP]) result.push_back(TCP_HP);
     if (transport_list_[GDS]) result.push_back(GDS);
     return result;
 }

--- a/mooncake-transfer-engine/tent/src/runtime/transport_loader.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transport_loader.cpp
@@ -15,6 +15,7 @@
 #include "tent/runtime/transfer_engine_impl.h"
 #include "tent/transport/shm/shm_transport.h"
 #include "tent/transport/tcp/tcp_transport.h"
+#include "tent/transport/tcp_hp/tcp_hp_transport.h"
 
 #ifdef USE_RDMA
 #include "tent/transport/rdma/rdma_transport.h"
@@ -43,6 +44,9 @@ namespace tent {
 Status TransferEngineImpl::loadTransports() {
     if (conf_->get("transports/tcp/enable", true))
         transport_list_[TCP] = std::make_shared<TcpTransport>();
+
+    if (conf_->get("transports/tcp_hp/enable", false))
+        transport_list_[TCP_HP] = std::make_shared<TcpHpTransport>();
 
     // TODO affect the end-to-end performance because it is not numa aware
     if (conf_->get("transports/shm/enable", false))

--- a/mooncake-transfer-engine/tent/src/transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/transport/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(tcp)
+add_subdirectory(tcp_hp)
 add_subdirectory(rdma)
 add_subdirectory(shm)
 add_subdirectory(nvlink)
@@ -17,6 +18,7 @@ foreach(tgt tent_xport_gds
             tent_xport_rdma
             tent_xport_shm
             tent_xport_tcp
+            tent_xport_tcp_hp
             tent_xport_ascend_direct)
     if (TARGET ${tgt})
         target_link_libraries(tent_transport_all INTERFACE ${tgt})

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -14,6 +14,7 @@
 
 #include "tent/transport/tcp/tcp_transport.h"
 
+#include <bits/stdint-uintn.h>
 #include <glog/logging.h>
 
 #include <algorithm>
@@ -22,35 +23,13 @@
 #include <cstdint>
 #include <iomanip>
 #include <memory>
-#include <random>
-
-#include <asio.hpp>
-#include <asio/ip/v6_only.hpp>
 
 #include "tent/common/status.h"
-#include "tent/common/utils/ip.h"
-#include "tent/runtime/platform.h"
 #include "tent/runtime/slab.h"
 #include "tent/runtime/control_plane.h"
 
 namespace mooncake {
 namespace tent {
-
-using tcpsocket = asio::ip::tcp::socket;
-
-// Wire protocol header for the data plane.
-// Kept minimal: opcode + dest addr + length (17 bytes).
-struct DataHeader {
-    uint8_t opcode;   // Request::WRITE or Request::READ
-    uint64_t addr;    // destination address (little-endian)
-    uint64_t length;  // transfer length    (little-endian)
-};
-
-static const size_t kChunkSize = 65536;
-
-// ---------------------------------------------------------------------------
-// Helper: extract host part from "host:port" or "[host]:port"
-// ---------------------------------------------------------------------------
 static std::string ExtractHost(const std::string &endpoint) {
     if (!endpoint.empty() && endpoint.front() == '[') {
         auto end = endpoint.find(']');
@@ -76,283 +55,9 @@ static bool IsLoopbackEndpoint(const std::string &endpoint) {
            host == "localhost" || host == "::1";
 }
 
-// ===========================================================================
-// Session: handles one data transfer over a TCP connection.
-//
-// Client side (initiator): creates socket, connects, sends header, then
-//   WRITE: sends body data  ->  done
-//   READ:  receives body data -> done
-//
-// Server side (acceptor): accepts socket, reads header, then
-//   WRITE (from client's perspective): reads body and copies to local memory
-//   READ  (from client's perspective): sends body from local memory
-// ===========================================================================
-struct Session : public std::enable_shared_from_this<Session> {
-    explicit Session(tcpsocket socket) : socket_(std::move(socket)) {}
-
-    tcpsocket socket_;
-    DataHeader header_{};
-    uint64_t total_transferred_ = 0;
-    char *local_buffer_ = nullptr;
-    std::function<void(TransferStatusEnum)> on_complete_;
-    // Callback to return socket to pool on successful client transfer.
-    std::function<void(asio::ip::tcp::socket)> return_socket_;
-
-    // ---------- Client-side initiation ----------
-    void initiateClient(void *buffer, uint64_t dest_addr, size_t size,
-                        uint8_t opcode) {
-        local_buffer_ = static_cast<char *>(buffer);
-        header_.opcode = opcode;
-        header_.addr = htole64(dest_addr);
-        header_.length = htole64(size);
-        total_transferred_ = 0;
-        writeHeader();
-    }
-
-    // ---------- Server-side acceptance ----------
-    void onAccept(SegmentManager *seg_mgr) {
-        total_transferred_ = 0;
-        seg_mgr_ = seg_mgr;
-        readHeader();
-    }
-
-   private:
-    SegmentManager *seg_mgr_ = nullptr;
-
-    void writeHeader() {
-        auto self(shared_from_this());
-        asio::async_write(
-            socket_, asio::buffer(&header_, sizeof(DataHeader)),
-            [this, self](const asio::error_code &ec, std::size_t len) {
-                if (ec || len != sizeof(DataHeader)) {
-                    LOG(ERROR)
-                        << "Session::writeHeader failed: " << ec.message();
-                    finish(TransferStatusEnum::FAILED);
-                    return;
-                }
-                uint8_t op = header_.opcode;
-                if (op == static_cast<uint8_t>(Request::WRITE))
-                    sendBody();
-                else
-                    recvBody();
-            });
-    }
-
-    void readHeader() {
-        auto self(shared_from_this());
-        asio::async_read(
-            socket_, asio::buffer(&header_, sizeof(DataHeader)),
-            [this, self](const asio::error_code &ec, std::size_t len) {
-                if (ec || len != sizeof(DataHeader)) {
-                    if (ec != asio::error::eof)
-                        LOG(ERROR)
-                            << "Session::readHeader failed: " << ec.message();
-                    finish(TransferStatusEnum::FAILED);
-                    return;
-                }
-                uint64_t addr = le64toh(header_.addr);
-                uint64_t length = le64toh(header_.length);
-
-                // Validate buffer ownership on the server side.
-                auto *local_desc = seg_mgr_->getLocal().get();
-                if (!local_desc->findBuffer(addr, length)) {
-                    LOG(ERROR) << "Session: target address 0x" << std::hex
-                               << addr << " length " << std::dec << length
-                               << " not in registered buffer";
-                    finish(TransferStatusEnum::FAILED);
-                    return;
-                }
-                local_buffer_ = reinterpret_cast<char *>(addr);
-
-                // From the client's perspective WRITE means client sends data
-                // to us (server reads body). READ means client wants data from
-                // us (server sends data).
-                if (header_.opcode == static_cast<uint8_t>(Request::WRITE))
-                    recvBody();  // server reads data from client
-                else
-                    sendBody();  // server sends data to client
-            });
-    }
-
-    static bool needBounceBuffer() {
-        auto &loader = Platform::getLoader();
-        return loader.type() == "cuda" || loader.type() == "cann";
-    }
-
-    // Send body in kChunkSize chunks.
-    void sendBody() {
-        auto self(shared_from_this());
-        uint64_t size = le64toh(header_.length);
-        size_t remaining = size - total_transferred_;
-        if (remaining == 0) {
-            finish(TransferStatusEnum::COMPLETED);
-            return;
-        }
-
-        size_t chunk = std::min(kChunkSize, remaining);
-        char *src = local_buffer_ + total_transferred_;
-
-        // For GPU memory we stage through a DRAM bounce buffer.
-        // Must allocate per-chunk because async_write holds the buffer
-        // reference until the callback fires, while other sessions may
-        // interleave on the same event loop thread.
-        char *send_buf = src;
-        std::shared_ptr<char[]> bounce;
-        if (needBounceBuffer()) {
-            bounce.reset(new char[chunk]);
-            Platform::getLoader().copy(bounce.get(), src, chunk);
-            send_buf = bounce.get();
-        }
-
-        asio::async_write(socket_, asio::buffer(send_buf, chunk),
-                          [this, self, bounce](const asio::error_code &ec,
-                                               std::size_t transferred) {
-                              // bounce kept alive by shared_ptr capture until
-                              // callback.
-                              if (ec) {
-                                  LOG(ERROR) << "Session::sendBody failed: "
-                                             << ec.message();
-                                  finish(TransferStatusEnum::FAILED);
-                                  return;
-                              }
-                              total_transferred_ += transferred;
-                              sendBody();
-                          });
-    }
-
-    // Receive body in kChunkSize chunks.
-    void recvBody() {
-        auto self(shared_from_this());
-        uint64_t size = le64toh(header_.length);
-        size_t remaining = size - total_transferred_;
-        if (remaining == 0) {
-            finish(TransferStatusEnum::COMPLETED);
-            return;
-        }
-
-        size_t chunk = std::min(kChunkSize, remaining);
-        char *dst = local_buffer_ + total_transferred_;
-
-        char *recv_buf = dst;
-        std::shared_ptr<char[]> bounce;
-        if (needBounceBuffer()) {
-            bounce.reset(new char[chunk]);
-            recv_buf = bounce.get();
-        }
-
-        asio::async_read(
-            socket_, asio::buffer(recv_buf, chunk),
-            [this, self, dst, bounce](const asio::error_code &ec,
-                                      std::size_t transferred) {
-                if (ec) {
-                    LOG(ERROR) << "Session::recvBody failed: " << ec.message();
-                    finish(TransferStatusEnum::FAILED);
-                    return;
-                }
-                if (bounce) {
-                    Platform::getLoader().copy(dst, bounce.get(), transferred);
-                }
-                total_transferred_ += transferred;
-                recvBody();
-            });
-    }
-
-    void finish(TransferStatusEnum status) {
-        if (status == TransferStatusEnum::COMPLETED && seg_mgr_) {
-            // Server side: keep connection alive, wait for next transfer.
-            total_transferred_ = 0;
-            local_buffer_ = nullptr;
-            readHeader();
-            return;
-        }
-
-        if (status == TransferStatusEnum::COMPLETED && return_socket_) {
-            // Client side success: return socket to connection pool.
-            auto cb = std::move(return_socket_);
-            cb(std::move(socket_));
-        } else {
-            // Failure: close socket.
-            asio::error_code ec;
-            socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
-            socket_.close(ec);
-        }
-        if (on_complete_) on_complete_(status);
-    }
-};
-
-// ===========================================================================
-// TcpTransport implementation
-// ===========================================================================
-
-TcpTransport::TcpTransport() {}
+TcpTransport::TcpTransport() : installed_(false) {}
 
 TcpTransport::~TcpTransport() { uninstall(); }
-
-Status TcpTransport::startDataServer() {
-    io_context_ = std::make_unique<asio::io_context>();
-
-    // Try a few random ports, similar to CoroRpcAgent::start().
-    const int kStartPort = 10000;
-    const int kPortRange = 50000;
-    const int kMaxRetries = 32;
-    std::mt19937 rng(std::random_device{}());
-
-    for (int i = 0; i < kMaxRetries; ++i) {
-        uint16_t port = kStartPort + static_cast<uint16_t>(rng() % kPortRange);
-        try {
-            // Try IPv6 dual-stack first, fall back to IPv4.
-            asio::ip::tcp::endpoint ep(asio::ip::tcp::v6(), port);
-            auto acc = std::make_unique<asio::ip::tcp::acceptor>(*io_context_);
-            std::error_code ec;
-            acc->open(ep.protocol(), ec);
-            if (!ec) {
-                acc->set_option(asio::ip::v6_only(false), ec);
-                if (!ec) {
-                    acc->set_option(
-                        asio::ip::tcp::acceptor::reuse_address(true));
-                    acc->bind(ep, ec);
-                    if (!ec) {
-                        acc->listen(asio::socket_base::max_listen_connections);
-                        acceptor_ = std::move(acc);
-                        data_port_ = port;
-                        return Status::OK();
-                    }
-                }
-                acc->close();
-            }
-            // Fallback: IPv4
-            asio::ip::tcp::endpoint ep4(asio::ip::tcp::v4(), port);
-            acc = std::make_unique<asio::ip::tcp::acceptor>(*io_context_);
-            acc->open(ep4.protocol(), ec);
-            if (ec) continue;
-            acc->set_option(asio::ip::tcp::acceptor::reuse_address(true));
-            acc->bind(ep4, ec);
-            if (ec) continue;
-            acc->listen(asio::socket_base::max_listen_connections);
-            acceptor_ = std::move(acc);
-            data_port_ = port;
-            return Status::OK();
-        } catch (const std::exception &e) {
-            LOG(WARNING) << "TCP data server: port " << port
-                         << " failed: " << e.what();
-        }
-    }
-    return Status::InternalError(
-        "TCP data server: unable to find available port");
-}
-
-void TcpTransport::doAccept() {
-    acceptor_->async_accept([this](asio::error_code ec, tcpsocket socket) {
-        if (!ec) {
-            socket.set_option(asio::ip::tcp::no_delay(true), ec);
-            auto session = std::make_shared<Session>(std::move(socket));
-            session->onAccept(&metadata_->segmentManager());
-        }
-        if (running_.load(std::memory_order_relaxed)) {
-            doAccept();
-        }
-    });
-}
 
 Status TcpTransport::install(std::string &local_segment_name,
                              std::shared_ptr<ControlService> metadata,
@@ -372,37 +77,6 @@ Status TcpTransport::install(std::string &local_segment_name,
         notify_list_.push_back(message);
         return 0;
     });
-
-    // Start the ASIO-based TCP data server.
-    CHECK_STATUS(startDataServer());
-    running_.store(true, std::memory_order_release);
-
-    // Keep io_context alive even when there's no pending work, so worker
-    // threads don't exit prematurely.
-    work_guard_ = std::make_unique<
-        asio::executor_work_guard<asio::io_context::executor_type>>(
-        io_context_->get_executor());
-
-    doAccept();
-
-    worker_thread_ = std::thread([this]() {
-        try {
-            io_context_->run();
-        } catch (const std::exception &e) {
-            LOG(ERROR) << "TCP data server worker exception: " << e.what();
-        }
-    });
-
-    LOG(INFO) << "TCP data server listening on port " << data_port_;
-
-    // Publish the TCP data port in the segment's transport_attrs so that
-    // remote peers can discover it.
-    auto &manager = metadata_->segmentManager();
-    auto segment = manager.getLocal();
-    auto &detail = std::get<MemorySegmentDesc>(segment->detail);
-    detail.transport_attrs[static_cast<int>(TransportType::TCP)] =
-        std::to_string(data_port_);
-
     caps.dram_to_dram = true;
     if (Platform::getLoader().type() == "cuda" ||
         Platform::getLoader().type() == "cann") {
@@ -415,19 +89,6 @@ Status TcpTransport::install(std::string &local_segment_name,
 
 Status TcpTransport::uninstall() {
     if (installed_) {
-        running_.store(false, std::memory_order_release);
-        work_guard_.reset();  // Allow io_context::run() to return.
-        if (io_context_) {
-            io_context_->stop();
-        }
-        if (worker_thread_.joinable()) worker_thread_.join();
-        // Drain connection pool before destroying io_context.
-        {
-            std::lock_guard<std::mutex> lock(pool_mutex_);
-            conn_pool_.clear();
-        }
-        acceptor_.reset();
-        io_context_.reset();
         metadata_.reset();
         installed_ = false;
     }
@@ -460,25 +121,14 @@ Status TcpTransport::submitTransferTasks(
         return Status::InvalidArgument("Invalid TCP sub-batch" LOC_MARK);
     if (request_list.size() + tcp_batch->task_list.size() > tcp_batch->max_size)
         return Status::TooManyRequests("Exceed batch capacity" LOC_MARK);
-
-    // First, add all tasks to the vector. This must be done before
-    // dispatching any transfers, because push_back could reallocate the
-    // vector and invalidate pointers to earlier elements.
-    size_t base = tcp_batch->task_list.size();
     for (auto &request : request_list) {
         tcp_batch->task_list.push_back(TcpTask{});
-        auto &task = tcp_batch->task_list.back();
-        task.target_addr = request.target_offset;
+        auto &task = tcp_batch->task_list[tcp_batch->task_list.size() - 1];
+        uint64_t target_addr = request.target_offset;
+        task.target_addr = target_addr;
         task.request = request;
         task.status_word = TransferStatusEnum::PENDING;
-        task.transferred_bytes = 0;
-    }
-
-    // Now dispatch all transfers. The vector won't reallocate since all
-    // elements are already added, so task pointers are stable.
-    size_t end = tcp_batch->task_list.size();
-    for (size_t i = base; i < end; ++i) {
-        startTransfer(&tcp_batch->task_list[i]);
+        startTransfer(&task);
     }
     return Status::OK();
 }
@@ -504,39 +154,6 @@ Status TcpTransport::removeMemoryBuffer(BufferDesc &desc) {
     return Status::OK();
 }
 
-// ---------------------------------------------------------------------------
-// Connection pool: reuse TCP connections to avoid per-transfer connect cost.
-// ---------------------------------------------------------------------------
-asio::ip::tcp::socket TcpTransport::acquireConnection(const std::string &host,
-                                                      uint16_t port) {
-    std::string key = host + ":" + std::to_string(port);
-    {
-        std::lock_guard<std::mutex> lock(pool_mutex_);
-        auto it = conn_pool_.find(key);
-        if (it != conn_pool_.end() && !it->second.empty()) {
-            auto socket = std::move(it->second.back());
-            it->second.pop_back();
-            return socket;
-        }
-    }
-    // No pooled connection — create a new one.
-    asio::ip::tcp::resolver resolver(*io_context_);
-    auto endpoints = resolver.resolve(host, std::to_string(port));
-    asio::ip::tcp::socket socket(*io_context_);
-    asio::connect(socket, endpoints);
-    socket.set_option(asio::ip::tcp::no_delay(true));
-    return socket;
-}
-
-void TcpTransport::releaseConnection(const std::string &key,
-                                     asio::ip::tcp::socket socket) {
-    std::lock_guard<std::mutex> lock(pool_mutex_);
-    conn_pool_[key].push_back(std::move(socket));
-}
-
-// ---------------------------------------------------------------------------
-// startTransfer: resolve remote endpoint, connect, and dispatch async I/O.
-// ---------------------------------------------------------------------------
 void TcpTransport::startTransfer(TcpTask *task) {
     if (task->request.target_id == LOCAL_SEGMENT_ID &&
         IsLoopbackEndpoint(local_segment_name_)) {
@@ -547,74 +164,42 @@ void TcpTransport::startTransfer(TcpTask *task) {
                "MC_STORE_MEMCPY=0, TCP local transfers will fail. Enable "
                "MC_STORE_MEMCPY or SHM, or use a non-loopback address.";
     }
-
-    std::string host;
-    uint16_t remote_data_port = 0;
-    auto status = findRemoteDataEndpoint(
-        task->request.target_offset, task->request.length,
-        task->request.target_id, host, remote_data_port);
+    std::string rpc_server_addr;
+    auto status =
+        findRemoteSegment(task->request.target_offset, task->request.length,
+                          task->request.target_id, rpc_server_addr);
     if (!status.ok()) {
         task->status_word = TransferStatusEnum::FAILED;
         return;
     }
-
-    try {
-        auto socket = acquireConnection(host, remote_data_port);
-        std::string pool_key = host + ":" + std::to_string(remote_data_port);
-
-        auto session = std::make_shared<Session>(std::move(socket));
-        session->on_complete_ = [task](TransferStatusEnum s) {
-            if (s == TransferStatusEnum::COMPLETED) {
-                task->transferred_bytes = task->request.length;
-            }
-            task->status_word = s;
-        };
-        session->return_socket_ = [this, pool_key](asio::ip::tcp::socket s) {
-            releaseConnection(pool_key, std::move(s));
-        };
-        session->initiateClient(
-            task->request.source, task->request.target_offset,
-            task->request.length, static_cast<uint8_t>(task->request.opcode));
-    } catch (const std::exception &e) {
-        LOG(ERROR) << "TCP startTransfer connect failed to " << host << ":"
-                   << remote_data_port << " : " << e.what();
-        task->status_word = TransferStatusEnum::FAILED;
+    if (task->request.opcode == Request::WRITE) {
+        status = ControlClient::sendData(
+            rpc_server_addr, task->request.target_offset, task->request.source,
+            task->request.length);
+    } else {
+        status = ControlClient::recvData(
+            rpc_server_addr, task->request.target_offset, task->request.source,
+            task->request.length);
     }
+    if (!status.ok()) {
+        task->status_word = TransferStatusEnum::FAILED;
+        return;
+    }
+    task->transferred_bytes = task->request.length;
+    task->status_word = TransferStatusEnum::COMPLETED;
 }
 
-// ---------------------------------------------------------------------------
-// findRemoteDataEndpoint: look up the remote segment, extract host from
-// rpc_server_addr, and get TCP data port from transport_attrs[TCP].
-// ---------------------------------------------------------------------------
-Status TcpTransport::findRemoteDataEndpoint(uint64_t dest_addr, uint64_t length,
-                                            uint64_t target_id,
-                                            std::string &host,
-                                            uint16_t &data_port) {
+Status TcpTransport::findRemoteSegment(uint64_t dest_addr, uint64_t length,
+                                       uint64_t target_id,
+                                       std::string &rpc_server_addr) {
     SegmentDesc *desc = nullptr;
     auto status = metadata_->segmentManager().getRemoteCached(desc, target_id);
     if (!status.ok()) return status;
     auto buffer = desc->findBuffer(dest_addr, length);
-    const auto &mem = desc->getMemory();
-    if (!buffer || mem.rpc_server_addr.empty())
+    rpc_server_addr = desc->getMemory().rpc_server_addr;
+    if (!buffer || rpc_server_addr.empty())
         return Status::InvalidArgument(
             "Requested address is not in registered buffer" LOC_MARK);
-
-    // Extract host from the rpc_server_addr (e.g. "192.168.1.1:12345").
-    auto parsed = parseHostNameWithPort(mem.rpc_server_addr, 0);
-    host = parsed.first;
-
-    // Get TCP data port from transport_attrs.
-    auto *port_str =
-        mem.getTransportAttrs(static_cast<int>(TransportType::TCP));
-    if (!port_str || port_str->empty())
-        return Status::InvalidArgument(
-            "Remote segment has no TCP data port published" LOC_MARK);
-
-    int port_val = std::atoi(port_str->c_str());
-    if (port_val <= 0 || port_val > 65535)
-        return Status::InvalidArgument(
-            "Remote segment has invalid TCP data port" LOC_MARK);
-    data_port = static_cast<uint16_t>(port_val);
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -14,7 +14,6 @@
 
 #include "tent/transport/tcp/tcp_transport.h"
 
-#include <bits/stdint-uintn.h>
 #include <glog/logging.h>
 
 #include <algorithm>
@@ -23,13 +22,35 @@
 #include <cstdint>
 #include <iomanip>
 #include <memory>
+#include <random>
+
+#include <asio.hpp>
+#include <asio/ip/v6_only.hpp>
 
 #include "tent/common/status.h"
+#include "tent/common/utils/ip.h"
+#include "tent/runtime/platform.h"
 #include "tent/runtime/slab.h"
 #include "tent/runtime/control_plane.h"
 
 namespace mooncake {
 namespace tent {
+
+using tcpsocket = asio::ip::tcp::socket;
+
+// Wire protocol header for the data plane.
+// Kept minimal: opcode + dest addr + length (17 bytes).
+struct DataHeader {
+    uint8_t opcode;   // Request::WRITE or Request::READ
+    uint64_t addr;    // destination address (little-endian)
+    uint64_t length;  // transfer length    (little-endian)
+};
+
+static const size_t kChunkSize = 65536;
+
+// ---------------------------------------------------------------------------
+// Helper: extract host part from "host:port" or "[host]:port"
+// ---------------------------------------------------------------------------
 static std::string ExtractHost(const std::string &endpoint) {
     if (!endpoint.empty() && endpoint.front() == '[') {
         auto end = endpoint.find(']');
@@ -55,9 +76,283 @@ static bool IsLoopbackEndpoint(const std::string &endpoint) {
            host == "localhost" || host == "::1";
 }
 
-TcpTransport::TcpTransport() : installed_(false) {}
+// ===========================================================================
+// Session: handles one data transfer over a TCP connection.
+//
+// Client side (initiator): creates socket, connects, sends header, then
+//   WRITE: sends body data  ->  done
+//   READ:  receives body data -> done
+//
+// Server side (acceptor): accepts socket, reads header, then
+//   WRITE (from client's perspective): reads body and copies to local memory
+//   READ  (from client's perspective): sends body from local memory
+// ===========================================================================
+struct Session : public std::enable_shared_from_this<Session> {
+    explicit Session(tcpsocket socket) : socket_(std::move(socket)) {}
+
+    tcpsocket socket_;
+    DataHeader header_{};
+    uint64_t total_transferred_ = 0;
+    char *local_buffer_ = nullptr;
+    std::function<void(TransferStatusEnum)> on_complete_;
+    // Callback to return socket to pool on successful client transfer.
+    std::function<void(asio::ip::tcp::socket)> return_socket_;
+
+    // ---------- Client-side initiation ----------
+    void initiateClient(void *buffer, uint64_t dest_addr, size_t size,
+                        uint8_t opcode) {
+        local_buffer_ = static_cast<char *>(buffer);
+        header_.opcode = opcode;
+        header_.addr = htole64(dest_addr);
+        header_.length = htole64(size);
+        total_transferred_ = 0;
+        writeHeader();
+    }
+
+    // ---------- Server-side acceptance ----------
+    void onAccept(SegmentManager *seg_mgr) {
+        total_transferred_ = 0;
+        seg_mgr_ = seg_mgr;
+        readHeader();
+    }
+
+   private:
+    SegmentManager *seg_mgr_ = nullptr;
+
+    void writeHeader() {
+        auto self(shared_from_this());
+        asio::async_write(
+            socket_, asio::buffer(&header_, sizeof(DataHeader)),
+            [this, self](const asio::error_code &ec, std::size_t len) {
+                if (ec || len != sizeof(DataHeader)) {
+                    LOG(ERROR)
+                        << "Session::writeHeader failed: " << ec.message();
+                    finish(TransferStatusEnum::FAILED);
+                    return;
+                }
+                uint8_t op = header_.opcode;
+                if (op == static_cast<uint8_t>(Request::WRITE))
+                    sendBody();
+                else
+                    recvBody();
+            });
+    }
+
+    void readHeader() {
+        auto self(shared_from_this());
+        asio::async_read(
+            socket_, asio::buffer(&header_, sizeof(DataHeader)),
+            [this, self](const asio::error_code &ec, std::size_t len) {
+                if (ec || len != sizeof(DataHeader)) {
+                    if (ec != asio::error::eof)
+                        LOG(ERROR)
+                            << "Session::readHeader failed: " << ec.message();
+                    finish(TransferStatusEnum::FAILED);
+                    return;
+                }
+                uint64_t addr = le64toh(header_.addr);
+                uint64_t length = le64toh(header_.length);
+
+                // Validate buffer ownership on the server side.
+                auto *local_desc = seg_mgr_->getLocal().get();
+                if (!local_desc->findBuffer(addr, length)) {
+                    LOG(ERROR) << "Session: target address 0x" << std::hex
+                               << addr << " length " << std::dec << length
+                               << " not in registered buffer";
+                    finish(TransferStatusEnum::FAILED);
+                    return;
+                }
+                local_buffer_ = reinterpret_cast<char *>(addr);
+
+                // From the client's perspective WRITE means client sends data
+                // to us (server reads body). READ means client wants data from
+                // us (server sends data).
+                if (header_.opcode == static_cast<uint8_t>(Request::WRITE))
+                    recvBody();  // server reads data from client
+                else
+                    sendBody();  // server sends data to client
+            });
+    }
+
+    static bool needBounceBuffer() {
+        auto &loader = Platform::getLoader();
+        return loader.type() == "cuda" || loader.type() == "cann";
+    }
+
+    // Send body in kChunkSize chunks.
+    void sendBody() {
+        auto self(shared_from_this());
+        uint64_t size = le64toh(header_.length);
+        size_t remaining = size - total_transferred_;
+        if (remaining == 0) {
+            finish(TransferStatusEnum::COMPLETED);
+            return;
+        }
+
+        size_t chunk = std::min(kChunkSize, remaining);
+        char *src = local_buffer_ + total_transferred_;
+
+        // For GPU memory we stage through a DRAM bounce buffer.
+        // Must allocate per-chunk because async_write holds the buffer
+        // reference until the callback fires, while other sessions may
+        // interleave on the same event loop thread.
+        char *send_buf = src;
+        std::shared_ptr<char[]> bounce;
+        if (needBounceBuffer()) {
+            bounce.reset(new char[chunk]);
+            Platform::getLoader().copy(bounce.get(), src, chunk);
+            send_buf = bounce.get();
+        }
+
+        asio::async_write(socket_, asio::buffer(send_buf, chunk),
+                          [this, self, bounce](const asio::error_code &ec,
+                                               std::size_t transferred) {
+                              // bounce kept alive by shared_ptr capture until
+                              // callback.
+                              if (ec) {
+                                  LOG(ERROR) << "Session::sendBody failed: "
+                                             << ec.message();
+                                  finish(TransferStatusEnum::FAILED);
+                                  return;
+                              }
+                              total_transferred_ += transferred;
+                              sendBody();
+                          });
+    }
+
+    // Receive body in kChunkSize chunks.
+    void recvBody() {
+        auto self(shared_from_this());
+        uint64_t size = le64toh(header_.length);
+        size_t remaining = size - total_transferred_;
+        if (remaining == 0) {
+            finish(TransferStatusEnum::COMPLETED);
+            return;
+        }
+
+        size_t chunk = std::min(kChunkSize, remaining);
+        char *dst = local_buffer_ + total_transferred_;
+
+        char *recv_buf = dst;
+        std::shared_ptr<char[]> bounce;
+        if (needBounceBuffer()) {
+            bounce.reset(new char[chunk]);
+            recv_buf = bounce.get();
+        }
+
+        asio::async_read(
+            socket_, asio::buffer(recv_buf, chunk),
+            [this, self, dst, bounce](const asio::error_code &ec,
+                                      std::size_t transferred) {
+                if (ec) {
+                    LOG(ERROR) << "Session::recvBody failed: " << ec.message();
+                    finish(TransferStatusEnum::FAILED);
+                    return;
+                }
+                if (bounce) {
+                    Platform::getLoader().copy(dst, bounce.get(), transferred);
+                }
+                total_transferred_ += transferred;
+                recvBody();
+            });
+    }
+
+    void finish(TransferStatusEnum status) {
+        if (status == TransferStatusEnum::COMPLETED && seg_mgr_) {
+            // Server side: keep connection alive, wait for next transfer.
+            total_transferred_ = 0;
+            local_buffer_ = nullptr;
+            readHeader();
+            return;
+        }
+
+        if (status == TransferStatusEnum::COMPLETED && return_socket_) {
+            // Client side success: return socket to connection pool.
+            auto cb = std::move(return_socket_);
+            cb(std::move(socket_));
+        } else {
+            // Failure: close socket.
+            asio::error_code ec;
+            socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+            socket_.close(ec);
+        }
+        if (on_complete_) on_complete_(status);
+    }
+};
+
+// ===========================================================================
+// TcpTransport implementation
+// ===========================================================================
+
+TcpTransport::TcpTransport() {}
 
 TcpTransport::~TcpTransport() { uninstall(); }
+
+Status TcpTransport::startDataServer() {
+    io_context_ = std::make_unique<asio::io_context>();
+
+    // Try a few random ports, similar to CoroRpcAgent::start().
+    const int kStartPort = 10000;
+    const int kPortRange = 50000;
+    const int kMaxRetries = 32;
+    std::mt19937 rng(std::random_device{}());
+
+    for (int i = 0; i < kMaxRetries; ++i) {
+        uint16_t port = kStartPort + static_cast<uint16_t>(rng() % kPortRange);
+        try {
+            // Try IPv6 dual-stack first, fall back to IPv4.
+            asio::ip::tcp::endpoint ep(asio::ip::tcp::v6(), port);
+            auto acc = std::make_unique<asio::ip::tcp::acceptor>(*io_context_);
+            std::error_code ec;
+            acc->open(ep.protocol(), ec);
+            if (!ec) {
+                acc->set_option(asio::ip::v6_only(false), ec);
+                if (!ec) {
+                    acc->set_option(
+                        asio::ip::tcp::acceptor::reuse_address(true));
+                    acc->bind(ep, ec);
+                    if (!ec) {
+                        acc->listen(asio::socket_base::max_listen_connections);
+                        acceptor_ = std::move(acc);
+                        data_port_ = port;
+                        return Status::OK();
+                    }
+                }
+                acc->close();
+            }
+            // Fallback: IPv4
+            asio::ip::tcp::endpoint ep4(asio::ip::tcp::v4(), port);
+            acc = std::make_unique<asio::ip::tcp::acceptor>(*io_context_);
+            acc->open(ep4.protocol(), ec);
+            if (ec) continue;
+            acc->set_option(asio::ip::tcp::acceptor::reuse_address(true));
+            acc->bind(ep4, ec);
+            if (ec) continue;
+            acc->listen(asio::socket_base::max_listen_connections);
+            acceptor_ = std::move(acc);
+            data_port_ = port;
+            return Status::OK();
+        } catch (const std::exception &e) {
+            LOG(WARNING) << "TCP data server: port " << port
+                         << " failed: " << e.what();
+        }
+    }
+    return Status::InternalError(
+        "TCP data server: unable to find available port");
+}
+
+void TcpTransport::doAccept() {
+    acceptor_->async_accept([this](asio::error_code ec, tcpsocket socket) {
+        if (!ec) {
+            socket.set_option(asio::ip::tcp::no_delay(true), ec);
+            auto session = std::make_shared<Session>(std::move(socket));
+            session->onAccept(&metadata_->segmentManager());
+        }
+        if (running_.load(std::memory_order_relaxed)) {
+            doAccept();
+        }
+    });
+}
 
 Status TcpTransport::install(std::string &local_segment_name,
                              std::shared_ptr<ControlService> metadata,
@@ -77,6 +372,37 @@ Status TcpTransport::install(std::string &local_segment_name,
         notify_list_.push_back(message);
         return 0;
     });
+
+    // Start the ASIO-based TCP data server.
+    CHECK_STATUS(startDataServer());
+    running_.store(true, std::memory_order_release);
+
+    // Keep io_context alive even when there's no pending work, so worker
+    // threads don't exit prematurely.
+    work_guard_ = std::make_unique<
+        asio::executor_work_guard<asio::io_context::executor_type>>(
+        io_context_->get_executor());
+
+    doAccept();
+
+    worker_thread_ = std::thread([this]() {
+        try {
+            io_context_->run();
+        } catch (const std::exception &e) {
+            LOG(ERROR) << "TCP data server worker exception: " << e.what();
+        }
+    });
+
+    LOG(INFO) << "TCP data server listening on port " << data_port_;
+
+    // Publish the TCP data port in the segment's transport_attrs so that
+    // remote peers can discover it.
+    auto &manager = metadata_->segmentManager();
+    auto segment = manager.getLocal();
+    auto &detail = std::get<MemorySegmentDesc>(segment->detail);
+    detail.transport_attrs[static_cast<int>(TransportType::TCP)] =
+        std::to_string(data_port_);
+
     caps.dram_to_dram = true;
     if (Platform::getLoader().type() == "cuda" ||
         Platform::getLoader().type() == "cann") {
@@ -89,6 +415,19 @@ Status TcpTransport::install(std::string &local_segment_name,
 
 Status TcpTransport::uninstall() {
     if (installed_) {
+        running_.store(false, std::memory_order_release);
+        work_guard_.reset();  // Allow io_context::run() to return.
+        if (io_context_) {
+            io_context_->stop();
+        }
+        if (worker_thread_.joinable()) worker_thread_.join();
+        // Drain connection pool before destroying io_context.
+        {
+            std::lock_guard<std::mutex> lock(pool_mutex_);
+            conn_pool_.clear();
+        }
+        acceptor_.reset();
+        io_context_.reset();
         metadata_.reset();
         installed_ = false;
     }
@@ -121,14 +460,25 @@ Status TcpTransport::submitTransferTasks(
         return Status::InvalidArgument("Invalid TCP sub-batch" LOC_MARK);
     if (request_list.size() + tcp_batch->task_list.size() > tcp_batch->max_size)
         return Status::TooManyRequests("Exceed batch capacity" LOC_MARK);
+
+    // First, add all tasks to the vector. This must be done before
+    // dispatching any transfers, because push_back could reallocate the
+    // vector and invalidate pointers to earlier elements.
+    size_t base = tcp_batch->task_list.size();
     for (auto &request : request_list) {
         tcp_batch->task_list.push_back(TcpTask{});
-        auto &task = tcp_batch->task_list[tcp_batch->task_list.size() - 1];
-        uint64_t target_addr = request.target_offset;
-        task.target_addr = target_addr;
+        auto &task = tcp_batch->task_list.back();
+        task.target_addr = request.target_offset;
         task.request = request;
         task.status_word = TransferStatusEnum::PENDING;
-        startTransfer(&task);
+        task.transferred_bytes = 0;
+    }
+
+    // Now dispatch all transfers. The vector won't reallocate since all
+    // elements are already added, so task pointers are stable.
+    size_t end = tcp_batch->task_list.size();
+    for (size_t i = base; i < end; ++i) {
+        startTransfer(&tcp_batch->task_list[i]);
     }
     return Status::OK();
 }
@@ -154,6 +504,39 @@ Status TcpTransport::removeMemoryBuffer(BufferDesc &desc) {
     return Status::OK();
 }
 
+// ---------------------------------------------------------------------------
+// Connection pool: reuse TCP connections to avoid per-transfer connect cost.
+// ---------------------------------------------------------------------------
+asio::ip::tcp::socket TcpTransport::acquireConnection(const std::string &host,
+                                                      uint16_t port) {
+    std::string key = host + ":" + std::to_string(port);
+    {
+        std::lock_guard<std::mutex> lock(pool_mutex_);
+        auto it = conn_pool_.find(key);
+        if (it != conn_pool_.end() && !it->second.empty()) {
+            auto socket = std::move(it->second.back());
+            it->second.pop_back();
+            return socket;
+        }
+    }
+    // No pooled connection — create a new one.
+    asio::ip::tcp::resolver resolver(*io_context_);
+    auto endpoints = resolver.resolve(host, std::to_string(port));
+    asio::ip::tcp::socket socket(*io_context_);
+    asio::connect(socket, endpoints);
+    socket.set_option(asio::ip::tcp::no_delay(true));
+    return socket;
+}
+
+void TcpTransport::releaseConnection(const std::string &key,
+                                     asio::ip::tcp::socket socket) {
+    std::lock_guard<std::mutex> lock(pool_mutex_);
+    conn_pool_[key].push_back(std::move(socket));
+}
+
+// ---------------------------------------------------------------------------
+// startTransfer: resolve remote endpoint, connect, and dispatch async I/O.
+// ---------------------------------------------------------------------------
 void TcpTransport::startTransfer(TcpTask *task) {
     if (task->request.target_id == LOCAL_SEGMENT_ID &&
         IsLoopbackEndpoint(local_segment_name_)) {
@@ -164,42 +547,74 @@ void TcpTransport::startTransfer(TcpTask *task) {
                "MC_STORE_MEMCPY=0, TCP local transfers will fail. Enable "
                "MC_STORE_MEMCPY or SHM, or use a non-loopback address.";
     }
-    std::string rpc_server_addr;
-    auto status =
-        findRemoteSegment(task->request.target_offset, task->request.length,
-                          task->request.target_id, rpc_server_addr);
+
+    std::string host;
+    uint16_t remote_data_port = 0;
+    auto status = findRemoteDataEndpoint(
+        task->request.target_offset, task->request.length,
+        task->request.target_id, host, remote_data_port);
     if (!status.ok()) {
         task->status_word = TransferStatusEnum::FAILED;
         return;
     }
-    if (task->request.opcode == Request::WRITE) {
-        status = ControlClient::sendData(
-            rpc_server_addr, task->request.target_offset, task->request.source,
-            task->request.length);
-    } else {
-        status = ControlClient::recvData(
-            rpc_server_addr, task->request.target_offset, task->request.source,
-            task->request.length);
-    }
-    if (!status.ok()) {
+
+    try {
+        auto socket = acquireConnection(host, remote_data_port);
+        std::string pool_key = host + ":" + std::to_string(remote_data_port);
+
+        auto session = std::make_shared<Session>(std::move(socket));
+        session->on_complete_ = [task](TransferStatusEnum s) {
+            if (s == TransferStatusEnum::COMPLETED) {
+                task->transferred_bytes = task->request.length;
+            }
+            task->status_word = s;
+        };
+        session->return_socket_ = [this, pool_key](asio::ip::tcp::socket s) {
+            releaseConnection(pool_key, std::move(s));
+        };
+        session->initiateClient(
+            task->request.source, task->request.target_offset,
+            task->request.length, static_cast<uint8_t>(task->request.opcode));
+    } catch (const std::exception &e) {
+        LOG(ERROR) << "TCP startTransfer connect failed to " << host << ":"
+                   << remote_data_port << " : " << e.what();
         task->status_word = TransferStatusEnum::FAILED;
-        return;
     }
-    task->transferred_bytes = task->request.length;
-    task->status_word = TransferStatusEnum::COMPLETED;
 }
 
-Status TcpTransport::findRemoteSegment(uint64_t dest_addr, uint64_t length,
-                                       uint64_t target_id,
-                                       std::string &rpc_server_addr) {
+// ---------------------------------------------------------------------------
+// findRemoteDataEndpoint: look up the remote segment, extract host from
+// rpc_server_addr, and get TCP data port from transport_attrs[TCP].
+// ---------------------------------------------------------------------------
+Status TcpTransport::findRemoteDataEndpoint(uint64_t dest_addr, uint64_t length,
+                                            uint64_t target_id,
+                                            std::string &host,
+                                            uint16_t &data_port) {
     SegmentDesc *desc = nullptr;
     auto status = metadata_->segmentManager().getRemoteCached(desc, target_id);
     if (!status.ok()) return status;
     auto buffer = desc->findBuffer(dest_addr, length);
-    rpc_server_addr = desc->getMemory().rpc_server_addr;
-    if (!buffer || rpc_server_addr.empty())
+    const auto &mem = desc->getMemory();
+    if (!buffer || mem.rpc_server_addr.empty())
         return Status::InvalidArgument(
             "Requested address is not in registered buffer" LOC_MARK);
+
+    // Extract host from the rpc_server_addr (e.g. "192.168.1.1:12345").
+    auto parsed = parseHostNameWithPort(mem.rpc_server_addr, 0);
+    host = parsed.first;
+
+    // Get TCP data port from transport_attrs.
+    auto *port_str =
+        mem.getTransportAttrs(static_cast<int>(TransportType::TCP));
+    if (!port_str || port_str->empty())
+        return Status::InvalidArgument(
+            "Remote segment has no TCP data port published" LOC_MARK);
+
+    int port_val = std::atoi(port_str->c_str());
+    if (port_val <= 0 || port_val > 65535)
+        return Status::InvalidArgument(
+            "Remote segment has invalid TCP data port" LOC_MARK);
+    data_port = static_cast<uint16_t>(port_val);
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/tcp_hp/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/transport/tcp_hp/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB XPORT_SOURCES "*.cpp")
+add_library(tent_xport_tcp_hp STATIC ${XPORT_SOURCES})
+target_link_libraries(tent_xport_tcp_hp PUBLIC tent_rpc tent_common)

--- a/mooncake-transfer-engine/tent/src/transport/tcp_hp/bounce_buffer_pool.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp_hp/bounce_buffer_pool.cpp
@@ -1,0 +1,83 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/transport/tcp_hp/bounce_buffer_pool.h"
+
+#include <glog/logging.h>
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+BounceBufferPool::BounceBufferPool(size_t buffer_size, size_t initial_count,
+                                   size_t max_count)
+    : buffer_size_(buffer_size), max_count_(max_count) {
+    CHECK_GT(buffer_size, 0u);
+    free_list_.reserve(initial_count);
+    for (size_t i = 0; i < initial_count; ++i) {
+        free_list_.push_back(new char[buffer_size]);
+    }
+    total_allocated_ = initial_count;
+    LOG(INFO) << "BounceBufferPool: pre-allocated " << initial_count
+              << " x " << buffer_size << " byte buffers";
+}
+
+BounceBufferPool::~BounceBufferPool() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto* buf : free_list_) {
+        delete[] buf;
+    }
+    if (free_list_.size() != total_allocated_) {
+        LOG(WARNING) << "BounceBufferPool: destroyed with "
+                     << (total_allocated_ - free_list_.size())
+                     << " buffers still in use";
+    }
+    free_list_.clear();
+    total_allocated_ = 0;
+}
+
+char* BounceBufferPool::acquire() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!free_list_.empty()) {
+        char* buf = free_list_.back();
+        free_list_.pop_back();
+        return buf;
+    }
+    // Pool empty — try to allocate a new buffer.
+    if (max_count_ > 0 && total_allocated_ >= max_count_) {
+        return nullptr;  // Hard limit reached.
+    }
+    ++total_allocated_;
+    return new char[buffer_size_];
+}
+
+void BounceBufferPool::release(char* buf) {
+    if (!buf) return;
+    std::lock_guard<std::mutex> lock(mutex_);
+    free_list_.push_back(buf);
+}
+
+size_t BounceBufferPool::total_allocated() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return total_allocated_;
+}
+
+size_t BounceBufferPool::free_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return free_list_.size();
+}
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/tcp_hp/conn_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp_hp/conn_manager.cpp
@@ -107,9 +107,7 @@ bool ConnManager::isSocketAlive(asio::ip::tcp::socket& socket) {
 
 Status ConnManager::clientHandshake(asio::ip::tcp::socket& socket) {
     HandshakeReq req;
-    req.magic = kMagic;
-    req.version = kProtocolVersion;
-    req.flags = 0;
+    req.encode();
 
     asio::error_code ec;
     asio::write(socket, asio::buffer(&req, sizeof(req)), ec);
@@ -125,9 +123,10 @@ Status ConnManager::clientHandshake(asio::ip::tcp::socket& socket) {
                                      ec.message());
     }
 
-    if (ack.status != kHandshakeOK) {
+    if (ack.decodedStatus() != kHandshakeOK) {
         return Status::InternalError(
-            "TCP_HP handshake rejected, status=" + std::to_string(ack.status));
+            "TCP_HP handshake rejected, status=" +
+            std::to_string(ack.decodedStatus()));
     }
     return Status::OK();
 }
@@ -142,22 +141,22 @@ Status ConnManager::serverHandshake(asio::ip::tcp::socket& socket) {
     }
 
     HandshakeAck ack;
-    ack.flags = 0;
 
-    if (req.magic != kMagic) {
-        ack.status = kHandshakeBadMagic;
+    if (req.decodedMagic() != kMagic) {
+        ack.encode(kHandshakeBadMagic);
         asio::write(socket, asio::buffer(&ack, sizeof(ack)), ec);
         return Status::InternalError("TCP_HP bad magic number");
     }
-    if (req.version != kProtocolVersion) {
-        ack.status = kHandshakeBadVersion;
+    if (req.decodedVersion() != kProtocolVersion) {
+        ack.encode(kHandshakeBadVersion);
         asio::write(socket, asio::buffer(&ack, sizeof(ack)), ec);
         return Status::InternalError(
-            "TCP_HP version mismatch: got " + std::to_string(req.version) +
-            ", expected " + std::to_string(kProtocolVersion));
+            "TCP_HP version mismatch: got " +
+            std::to_string(req.decodedVersion()) + ", expected " +
+            std::to_string(kProtocolVersion));
     }
 
-    ack.status = kHandshakeOK;
+    ack.encode(kHandshakeOK);
     asio::write(socket, asio::buffer(&ack, sizeof(ack)), ec);
     if (ec) {
         return Status::InternalError("TCP_HP server handshake write failed: " +
@@ -199,49 +198,54 @@ Status ConnManager::connectWithRetry(const std::string& host, uint16_t port,
                                  std::to_string(port));
 }
 
+std::shared_ptr<ConnManager::EndpointPool> ConnManager::getEndpointPool(
+    const std::string& key) {
+    std::lock_guard<std::mutex> lock(map_mutex_);
+    auto& ptr = pool_map_[key];
+    if (!ptr) ptr = std::make_shared<EndpointPool>();
+    return ptr;
+}
+
 Status ConnManager::acquire(const std::string& host, uint16_t port,
                             asio::ip::tcp::socket& out_socket) {
     std::string key = makeKey(host, port);
+    auto ep = getEndpointPool(key);
     {
-        std::lock_guard<std::mutex> lock(pool_mutex_);
-        auto it = pool_map_.find(key);
-        if (it != pool_map_.end()) {
-            while (!it->second.empty()) {
-                auto socket = std::move(it->second.back());
-                it->second.pop_back();
-                if (isSocketAlive(socket)) {
-                    out_socket = std::move(socket);
-                    return Status::OK();
-                }
-                // Stale connection, discard and try next
+        std::lock_guard<std::mutex> lock(ep->mutex);
+        while (!ep->sockets.empty()) {
+            auto socket = std::move(ep->sockets.back());
+            ep->sockets.pop_back();
+            if (isSocketAlive(socket)) {
+                out_socket = std::move(socket);
+                return Status::OK();
             }
+            // Stale connection, discard and try next
         }
     }
     // No pooled connection — create new, configure, and handshake.
-    asio::ip::tcp::socket socket(pool_.getNextContext());
-    auto status = connectWithRetry(host, port, socket);
+    // connectWithRetry selects an io_context and creates the socket internally.
+    auto status = connectWithRetry(host, port, out_socket);
     if (!status.ok()) return status;
 
-    configureSocket(socket);
+    configureSocket(out_socket);
 
-    status = clientHandshake(socket);
+    status = clientHandshake(out_socket);
     if (!status.ok()) {
         asio::error_code ec;
-        socket.close(ec);
+        out_socket.close(ec);
         return status;
     }
 
-    out_socket = std::move(socket);
     return Status::OK();
 }
 
 void ConnManager::release(const std::string& host, uint16_t port,
                           asio::ip::tcp::socket socket) {
     std::string key = makeKey(host, port);
-    std::lock_guard<std::mutex> lock(pool_mutex_);
-    auto& vec = pool_map_[key];
-    if (vec.size() < opts_.max_pool_size) {
-        vec.push_back(std::move(socket));
+    auto ep = getEndpointPool(key);
+    std::lock_guard<std::mutex> lock(ep->mutex);
+    if (ep->sockets.size() < opts_.max_pool_size) {
+        ep->sockets.push_back(std::move(socket));
     } else {
         asio::error_code ec;
         socket.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
@@ -273,20 +277,21 @@ struct AsyncHandshakeState
                             std::move(socket));
                     return;
                 }
-                ack.flags = 0;
-                if (req.magic != kMagic) {
-                    ack.status = kHandshakeBadMagic;
+                if (req.decodedMagic() != kMagic) {
+                    ack.encode(kHandshakeBadMagic);
                     sendAckAndFail("TCP_HP bad magic number");
                     return;
                 }
-                if (req.version != kProtocolVersion) {
-                    ack.status = kHandshakeBadVersion;
-                    sendAckAndFail("TCP_HP version mismatch: got " +
-                                  std::to_string(req.version) + ", expected " +
-                                  std::to_string(kProtocolVersion));
+                if (req.decodedVersion() != kProtocolVersion) {
+                    ack.encode(kHandshakeBadVersion);
+                    sendAckAndFail(
+                        "TCP_HP version mismatch: got " +
+                        std::to_string(req.decodedVersion()) +
+                        ", expected " +
+                        std::to_string(kProtocolVersion));
                     return;
                 }
-                ack.status = kHandshakeOK;
+                ack.encode(kHandshakeOK);
                 sendAckAndSucceed();
             });
     }
@@ -326,7 +331,7 @@ void ConnManager::asyncServerHandshake(asio::ip::tcp::socket socket,
 }
 
 void ConnManager::shutdown() {
-    std::lock_guard<std::mutex> lock(pool_mutex_);
+    std::lock_guard<std::mutex> lock(map_mutex_);
     pool_map_.clear();
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/tcp_hp/conn_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp_hp/conn_manager.cpp
@@ -1,0 +1,335 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/transport/tcp_hp/conn_manager.h"
+
+#include <glog/logging.h>
+#include <poll.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+
+#include <chrono>
+#include <thread>
+
+#include <asio.hpp>
+
+#include "tent/transport/tcp_hp/protocol.h"
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+ConnManager::ConnManager(IoContextPool& pool, ConnOptions opts)
+    : pool_(pool), opts_(std::move(opts)) {}
+
+ConnManager::~ConnManager() { shutdown(); }
+
+std::string ConnManager::makeKey(const std::string& host, uint16_t port) {
+    return host + ":" + std::to_string(port);
+}
+
+void ConnManager::configureSocket(asio::ip::tcp::socket& socket) {
+    asio::error_code ec;
+
+    // TCP_NODELAY: disable Nagle for low latency
+    socket.set_option(asio::ip::tcp::no_delay(true), ec);
+    if (ec) LOG(WARNING) << "set TCP_NODELAY failed: " << ec.message();
+
+    // SO_KEEPALIVE
+    socket.set_option(asio::socket_base::keep_alive(true), ec);
+    if (ec) LOG(WARNING) << "set SO_KEEPALIVE failed: " << ec.message();
+
+    int fd = socket.native_handle();
+
+    // TCP keepalive parameters (Linux-specific)
+#ifdef TCP_KEEPIDLE
+    if (opts_.keepalive_idle_s > 0) {
+        setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &opts_.keepalive_idle_s,
+                   sizeof(opts_.keepalive_idle_s));
+    }
+#endif
+#ifdef TCP_KEEPINTVL
+    if (opts_.keepalive_interval_s > 0) {
+        setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &opts_.keepalive_interval_s,
+                   sizeof(opts_.keepalive_interval_s));
+    }
+#endif
+#ifdef TCP_KEEPCNT
+    if (opts_.keepalive_count > 0) {
+        setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &opts_.keepalive_count,
+                   sizeof(opts_.keepalive_count));
+    }
+#endif
+
+    // Socket buffer sizes
+    if (opts_.sndbuf > 0) {
+        socket.set_option(asio::socket_base::send_buffer_size(opts_.sndbuf), ec);
+        if (ec) LOG(WARNING) << "set SO_SNDBUF failed: " << ec.message();
+    }
+    if (opts_.rcvbuf > 0) {
+        socket.set_option(
+            asio::socket_base::receive_buffer_size(opts_.rcvbuf), ec);
+        if (ec) LOG(WARNING) << "set SO_RCVBUF failed: " << ec.message();
+    }
+}
+
+bool ConnManager::isSocketAlive(asio::ip::tcp::socket& socket) {
+    if (!socket.is_open()) return false;
+    struct pollfd pfd;
+    pfd.fd = socket.native_handle();
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    int ret = ::poll(&pfd, 1, 0);
+    if (ret > 0 && (pfd.revents & (POLLERR | POLLHUP | POLLNVAL))) {
+        return false;
+    }
+    // If POLLIN is set, the peer might have sent data or closed.
+    // A recv with MSG_PEEK can check for EOF.
+    if (ret > 0 && (pfd.revents & POLLIN)) {
+        char buf;
+        ssize_t n = ::recv(pfd.fd, &buf, 1, MSG_PEEK | MSG_DONTWAIT);
+        if (n == 0) return false;   // peer closed
+        if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) return false;
+    }
+    return true;
+}
+
+Status ConnManager::clientHandshake(asio::ip::tcp::socket& socket) {
+    HandshakeReq req;
+    req.magic = kMagic;
+    req.version = kProtocolVersion;
+    req.flags = 0;
+
+    asio::error_code ec;
+    asio::write(socket, asio::buffer(&req, sizeof(req)), ec);
+    if (ec) {
+        return Status::InternalError("TCP_HP handshake send failed: " +
+                                     ec.message());
+    }
+
+    HandshakeAck ack;
+    asio::read(socket, asio::buffer(&ack, sizeof(ack)), ec);
+    if (ec) {
+        return Status::InternalError("TCP_HP handshake recv failed: " +
+                                     ec.message());
+    }
+
+    if (ack.status != kHandshakeOK) {
+        return Status::InternalError(
+            "TCP_HP handshake rejected, status=" + std::to_string(ack.status));
+    }
+    return Status::OK();
+}
+
+Status ConnManager::serverHandshake(asio::ip::tcp::socket& socket) {
+    HandshakeReq req;
+    asio::error_code ec;
+    asio::read(socket, asio::buffer(&req, sizeof(req)), ec);
+    if (ec) {
+        return Status::InternalError("TCP_HP server handshake read failed: " +
+                                     ec.message());
+    }
+
+    HandshakeAck ack;
+    ack.flags = 0;
+
+    if (req.magic != kMagic) {
+        ack.status = kHandshakeBadMagic;
+        asio::write(socket, asio::buffer(&ack, sizeof(ack)), ec);
+        return Status::InternalError("TCP_HP bad magic number");
+    }
+    if (req.version != kProtocolVersion) {
+        ack.status = kHandshakeBadVersion;
+        asio::write(socket, asio::buffer(&ack, sizeof(ack)), ec);
+        return Status::InternalError(
+            "TCP_HP version mismatch: got " + std::to_string(req.version) +
+            ", expected " + std::to_string(kProtocolVersion));
+    }
+
+    ack.status = kHandshakeOK;
+    asio::write(socket, asio::buffer(&ack, sizeof(ack)), ec);
+    if (ec) {
+        return Status::InternalError("TCP_HP server handshake write failed: " +
+                                     ec.message());
+    }
+    return Status::OK();
+}
+
+Status ConnManager::connectWithRetry(const std::string& host, uint16_t port,
+                                     asio::ip::tcp::socket& socket) {
+    auto& ctx = pool_.getNextContext();
+    asio::ip::tcp::resolver resolver(ctx);
+    asio::error_code ec;
+    auto endpoints = resolver.resolve(host, std::to_string(port), ec);
+    if (ec) {
+        return Status::InternalError("TCP_HP resolve failed for " + host +
+                                     ":" + std::to_string(port) + ": " +
+                                     ec.message());
+    }
+
+    int backoff_ms = 100;
+    for (int attempt = 0; attempt <= opts_.connect_retries; ++attempt) {
+        socket = asio::ip::tcp::socket(ctx);
+        asio::connect(socket, endpoints, ec);
+        if (!ec) {
+            return Status::OK();
+        }
+        LOG(WARNING) << "TCP_HP connect attempt " << (attempt + 1) << "/"
+                     << (opts_.connect_retries + 1) << " to " << host << ":"
+                     << port << " failed: " << ec.message();
+        if (attempt < opts_.connect_retries) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
+            backoff_ms = std::min(backoff_ms * 2, 5000);
+        }
+    }
+    return Status::InternalError("TCP_HP connect failed after " +
+                                 std::to_string(opts_.connect_retries + 1) +
+                                 " attempts to " + host + ":" +
+                                 std::to_string(port));
+}
+
+Status ConnManager::acquire(const std::string& host, uint16_t port,
+                            asio::ip::tcp::socket& out_socket) {
+    std::string key = makeKey(host, port);
+    {
+        std::lock_guard<std::mutex> lock(pool_mutex_);
+        auto it = pool_map_.find(key);
+        if (it != pool_map_.end()) {
+            while (!it->second.empty()) {
+                auto socket = std::move(it->second.back());
+                it->second.pop_back();
+                if (isSocketAlive(socket)) {
+                    out_socket = std::move(socket);
+                    return Status::OK();
+                }
+                // Stale connection, discard and try next
+            }
+        }
+    }
+    // No pooled connection — create new, configure, and handshake.
+    asio::ip::tcp::socket socket(pool_.getNextContext());
+    auto status = connectWithRetry(host, port, socket);
+    if (!status.ok()) return status;
+
+    configureSocket(socket);
+
+    status = clientHandshake(socket);
+    if (!status.ok()) {
+        asio::error_code ec;
+        socket.close(ec);
+        return status;
+    }
+
+    out_socket = std::move(socket);
+    return Status::OK();
+}
+
+void ConnManager::release(const std::string& host, uint16_t port,
+                          asio::ip::tcp::socket socket) {
+    std::string key = makeKey(host, port);
+    std::lock_guard<std::mutex> lock(pool_mutex_);
+    auto& vec = pool_map_[key];
+    if (vec.size() < opts_.max_pool_size) {
+        vec.push_back(std::move(socket));
+    } else {
+        asio::error_code ec;
+        socket.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+        socket.close(ec);
+    }
+}
+
+// Helper that holds state for an async server handshake.
+struct AsyncHandshakeState
+    : public std::enable_shared_from_this<AsyncHandshakeState> {
+    asio::ip::tcp::socket socket;
+    ConnManager::HandshakeHandler handler;
+    HandshakeReq req{};
+    HandshakeAck ack{};
+
+    AsyncHandshakeState(asio::ip::tcp::socket s,
+                        ConnManager::HandshakeHandler h)
+        : socket(std::move(s)), handler(std::move(h)) {}
+
+    void start() {
+        auto self = shared_from_this();
+        asio::async_read(
+            socket, asio::buffer(&req, sizeof(req)),
+            [this, self](const asio::error_code& ec, std::size_t) {
+                if (ec) {
+                    handler(Status::InternalError(
+                                "TCP_HP async handshake read failed: " +
+                                ec.message()),
+                            std::move(socket));
+                    return;
+                }
+                ack.flags = 0;
+                if (req.magic != kMagic) {
+                    ack.status = kHandshakeBadMagic;
+                    sendAckAndFail("TCP_HP bad magic number");
+                    return;
+                }
+                if (req.version != kProtocolVersion) {
+                    ack.status = kHandshakeBadVersion;
+                    sendAckAndFail("TCP_HP version mismatch: got " +
+                                  std::to_string(req.version) + ", expected " +
+                                  std::to_string(kProtocolVersion));
+                    return;
+                }
+                ack.status = kHandshakeOK;
+                sendAckAndSucceed();
+            });
+    }
+
+   private:
+    void sendAckAndFail(const std::string& reason) {
+        auto self = shared_from_this();
+        asio::async_write(
+            socket, asio::buffer(&ack, sizeof(ack)),
+            [this, self, reason](const asio::error_code&, std::size_t) {
+                handler(Status::InternalError(reason), std::move(socket));
+            });
+    }
+
+    void sendAckAndSucceed() {
+        auto self = shared_from_this();
+        asio::async_write(
+            socket, asio::buffer(&ack, sizeof(ack)),
+            [this, self](const asio::error_code& ec, std::size_t) {
+                if (ec) {
+                    handler(Status::InternalError(
+                                "TCP_HP async handshake write failed: " +
+                                ec.message()),
+                            std::move(socket));
+                    return;
+                }
+                handler(Status::OK(), std::move(socket));
+            });
+    }
+};
+
+void ConnManager::asyncServerHandshake(asio::ip::tcp::socket socket,
+                                       HandshakeHandler handler) {
+    auto state = std::make_shared<AsyncHandshakeState>(std::move(socket),
+                                                       std::move(handler));
+    state->start();
+}
+
+void ConnManager::shutdown() {
+    std::lock_guard<std::mutex> lock(pool_mutex_);
+    pool_map_.clear();
+}
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/tcp_hp/hp_session.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp_hp/hp_session.cpp
@@ -261,7 +261,15 @@ void HpSession::sendBodyChunked() {
         } else {
             bounce = new char[chunk];
         }
-        Platform::getLoader().copy(bounce, src, chunk);
+        auto copy_status = Platform::getLoader().copy(bounce, src, chunk);
+        if (!copy_status.ok()) {
+            LOG(ERROR) << "HpSession::sendBodyChunked: GPU->DRAM copy failed: "
+                       << copy_status.message();
+            if (bounce_from_pool) bounce_pool_->release(bounce);
+            else delete[] bounce;
+            finish(TransferStatusEnum::FAILED);
+            return;
+        }
         send_buf = bounce;
     }
 
@@ -326,16 +334,29 @@ void HpSession::recvBodyChunked() {
                 return;
             }
             if (bounce) {
-                Platform::getLoader().copy(dst, bounce, transferred);
+                auto copy_status =
+                    Platform::getLoader().copy(dst, bounce, transferred);
                 if (bounce_from_pool) pool->release(bounce);
                 else delete[] bounce;
+                if (!copy_status.ok()) {
+                    LOG(ERROR)
+                        << "HpSession::recvBodyChunked: DRAM->GPU copy failed: "
+                        << copy_status.message();
+                    finish(TransferStatusEnum::FAILED);
+                    return;
+                }
             }
             total_transferred_ += transferred;
             recvBodyChunked();
         });
 }
 
-// ========== Finish ==========
+// ========== Close / Finish ==========
+
+void HpSession::closeSocket() {
+    asio::error_code ec;
+    socket_.close(ec);  // cancels all pending async ops on this socket
+}
 
 void HpSession::finish(TransferStatusEnum status) {
     // Guard against double-finish (e.g. timeout fires after I/O error).
@@ -350,6 +371,11 @@ void HpSession::finish(TransferStatusEnum status) {
         local_buffer_ = nullptr;
         readHeader();
         return;
+    }
+
+    // Server session ending (error/EOF): notify transport for cleanup.
+    if (seg_mgr_ && on_close) {
+        on_close();
     }
 
     if (status == TransferStatusEnum::COMPLETED && return_socket) {

--- a/mooncake-transfer-engine/tent/src/transport/tcp_hp/hp_session.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp_hp/hp_session.cpp
@@ -1,0 +1,368 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/transport/tcp_hp/hp_session.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <array>
+#include <memory>
+
+#include <asio.hpp>
+
+#include "tent/runtime/platform.h"
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+HpSession::HpSession(asio::ip::tcp::socket socket, size_t chunk_size,
+                     BounceBufferPool* bounce_pool, unsigned timeout_s)
+    : socket_(std::move(socket)),
+      chunk_size_(chunk_size),
+      bounce_pool_(bounce_pool),
+      timeout_s_(timeout_s),
+      deadline_(socket_.get_executor()) {}
+
+// Check actual memory type of local_buffer_, not the platform type.
+// This avoids the CUDA-build pitfall where DRAM<->DRAM transfers
+// would incorrectly go through cudaMemcpy bounce path.
+bool HpSession::needBounceBuffer() const {
+    if (!local_buffer_) return false;
+    auto mtype = Platform::getLoader().getMemoryType(local_buffer_);
+    return mtype == MTYPE_CUDA;
+}
+
+// ========== Deadline timer ==========
+
+void HpSession::startDeadline() {
+    if (timeout_s_ == 0) return;
+    auto self(shared_from_this());
+    deadline_.expires_after(std::chrono::seconds(timeout_s_));
+    deadline_.async_wait([this, self](const asio::error_code& ec) {
+        if (!ec && !finished_) {
+            LOG(ERROR) << "HpSession: transfer timed out after "
+                       << timeout_s_ << "s";
+            asio::error_code close_ec;
+            socket_.close(close_ec);  // cancels all pending async ops
+        }
+    });
+}
+
+void HpSession::cancelDeadline() {
+    if (timeout_s_ == 0) return;
+    asio::error_code ec;
+    deadline_.cancel(ec);
+}
+
+// ========== Client-side ==========
+
+void HpSession::initiateClient(void* buffer, uint64_t dest_addr, size_t size,
+                                uint8_t opcode) {
+    local_buffer_ = static_cast<char*>(buffer);
+    header_.encode(opcode, dest_addr, size);
+    total_transferred_ = 0;
+    startDeadline();
+
+    bool is_gpu = needBounceBuffer();
+
+    if (opcode == static_cast<uint8_t>(Request::WRITE) && !is_gpu) {
+        // CPU WRITE: scatter-gather header+body in one writev.
+        sendBodyZeroCopy();
+        return;
+    }
+
+    if (opcode == static_cast<uint8_t>(Request::READ) && !is_gpu) {
+        // CPU READ: send header, then receive full body in one async_read.
+        // writeHeader will dispatch to recvBodyZeroCopy via the opcode check.
+    }
+
+    writeHeader();
+}
+
+void HpSession::writeHeader() {
+    auto self(shared_from_this());
+    asio::async_write(
+        socket_, asio::buffer(&header_, sizeof(DataHeader)),
+        [this, self](const asio::error_code& ec, std::size_t len) {
+            if (ec || len != sizeof(DataHeader)) {
+                LOG(ERROR) << "HpSession::writeHeader failed: "
+                           << ec.message();
+                finish(TransferStatusEnum::FAILED);
+                return;
+            }
+            bool is_gpu = needBounceBuffer();
+            if (header_.opcode == static_cast<uint8_t>(Request::WRITE)) {
+                sendBodyChunked();
+            } else {
+                // READ path
+                if (!is_gpu) {
+                    recvBodyZeroCopy();
+                } else {
+                    recvBodyChunked();
+                }
+            }
+        });
+}
+
+// ========== Server-side ==========
+
+void HpSession::onAccept(SegmentManager* seg_mgr) {
+    total_transferred_ = 0;
+    seg_mgr_ = seg_mgr;
+    readHeader();
+}
+
+void HpSession::readHeader() {
+    auto self(shared_from_this());
+    asio::async_read(
+        socket_, asio::buffer(&header_, sizeof(DataHeader)),
+        [this, self](const asio::error_code& ec, std::size_t len) {
+            if (ec || len != sizeof(DataHeader)) {
+                if (ec != asio::error::eof)
+                    LOG(ERROR) << "HpSession::readHeader failed: "
+                               << ec.message();
+                finish(TransferStatusEnum::FAILED);
+                return;
+            }
+            uint64_t addr = header_.decodedAddr();
+            uint64_t length = header_.decodedLength();
+
+            auto* local_desc = seg_mgr_->getLocal().get();
+            if (!local_desc->findBuffer(addr, length)) {
+                LOG(ERROR) << "HpSession: target address 0x" << std::hex
+                           << addr << " length " << std::dec << length
+                           << " not in registered buffer";
+                finish(TransferStatusEnum::FAILED);
+                return;
+            }
+            local_buffer_ = reinterpret_cast<char*>(addr);
+
+            bool is_gpu = needBounceBuffer();
+            if (header_.opcode == static_cast<uint8_t>(Request::WRITE)) {
+                // Client sends data -> server receives.
+                if (!is_gpu) {
+                    // CPU: receive full body directly into local_buffer_.
+                    recvBodyZeroCopy();
+                } else {
+                    recvBodyChunked();
+                }
+            } else {
+                // Client reads data -> server sends.
+                if (!is_gpu) {
+                    // CPU: send full body directly from local_buffer_.
+                    // Note: server-side send can't do scatter-gather with
+                    // header (header already sent by client), so we just
+                    // do a single large async_write.
+                    sendBodyZeroCopyNoHeader();
+                } else {
+                    sendBodyChunked();
+                }
+            }
+        });
+}
+
+// ========== Zero-copy paths (CPU memory only) ==========
+
+void HpSession::sendBodyZeroCopy() {
+    auto self(shared_from_this());
+    uint64_t size = header_.decodedLength();
+
+    // Client-side WRITE: gather [DataHeader] [entire body] in one writev.
+    std::array<asio::const_buffer, 2> bufs = {
+        asio::buffer(&header_, sizeof(DataHeader)),
+        asio::buffer(local_buffer_, size)};
+
+    asio::async_write(
+        socket_, bufs,
+        [this, self, size](const asio::error_code& ec, std::size_t /*n*/) {
+            if (ec) {
+                LOG(ERROR) << "HpSession::sendBodyZeroCopy failed: "
+                           << ec.message();
+                finish(TransferStatusEnum::FAILED);
+                return;
+            }
+            total_transferred_ = size;
+            finish(TransferStatusEnum::COMPLETED);
+        });
+}
+
+void HpSession::recvBodyZeroCopy() {
+    auto self(shared_from_this());
+    uint64_t size = header_.decodedLength();
+
+    // Receive entire body in one async_read directly into local_buffer_.
+    asio::async_read(
+        socket_, asio::buffer(local_buffer_, size),
+        [this, self, size](const asio::error_code& ec, std::size_t /*n*/) {
+            if (ec) {
+                LOG(ERROR) << "HpSession::recvBodyZeroCopy failed: "
+                           << ec.message();
+                finish(TransferStatusEnum::FAILED);
+                return;
+            }
+            total_transferred_ = size;
+            finish(TransferStatusEnum::COMPLETED);
+        });
+}
+
+void HpSession::sendBodyZeroCopyNoHeader() {
+    auto self(shared_from_this());
+    uint64_t size = header_.decodedLength();
+
+    // Server-side READ response: send full body without DataHeader prefix.
+    asio::async_write(
+        socket_, asio::buffer(local_buffer_, size),
+        [this, self, size](const asio::error_code& ec, std::size_t /*n*/) {
+            if (ec) {
+                LOG(ERROR) << "HpSession::sendBodyZeroCopyNoHeader failed: "
+                           << ec.message();
+                finish(TransferStatusEnum::FAILED);
+                return;
+            }
+            total_transferred_ = size;
+            finish(TransferStatusEnum::COMPLETED);
+        });
+}
+
+// ========== Chunked data transfer (GPU memory) ==========
+
+void HpSession::sendBodyChunked() {
+    auto self(shared_from_this());
+    uint64_t size = header_.decodedLength();
+    size_t remaining = size - total_transferred_;
+    if (remaining == 0) {
+        finish(TransferStatusEnum::COMPLETED);
+        return;
+    }
+
+    size_t chunk = std::min(chunk_size_, remaining);
+    char* src = local_buffer_ + total_transferred_;
+
+    char* send_buf = src;
+    char* bounce = nullptr;
+    bool bounce_from_pool = false;
+    if (needBounceBuffer()) {
+        if (bounce_pool_) bounce = bounce_pool_->acquire();
+        if (bounce) {
+            bounce_from_pool = true;
+        } else {
+            bounce = new char[chunk];
+        }
+        Platform::getLoader().copy(bounce, src, chunk);
+        send_buf = bounce;
+    }
+
+    auto* pool = bounce_pool_;
+    asio::async_write(
+        socket_, asio::buffer(send_buf, chunk),
+        [this, self, bounce, bounce_from_pool, pool](
+            const asio::error_code& ec, std::size_t transferred) {
+            if (bounce) {
+                if (bounce_from_pool) pool->release(bounce);
+                else delete[] bounce;
+            }
+            if (ec) {
+                LOG(ERROR) << "HpSession::sendBodyChunked failed: "
+                           << ec.message();
+                finish(TransferStatusEnum::FAILED);
+                return;
+            }
+            total_transferred_ += transferred;
+            sendBodyChunked();
+        });
+}
+
+void HpSession::recvBodyChunked() {
+    auto self(shared_from_this());
+    uint64_t size = header_.decodedLength();
+    size_t remaining = size - total_transferred_;
+    if (remaining == 0) {
+        finish(TransferStatusEnum::COMPLETED);
+        return;
+    }
+
+    size_t chunk = std::min(chunk_size_, remaining);
+    char* dst = local_buffer_ + total_transferred_;
+
+    char* recv_buf = dst;
+    char* bounce = nullptr;
+    bool bounce_from_pool = false;
+    if (needBounceBuffer()) {
+        if (bounce_pool_) bounce = bounce_pool_->acquire();
+        if (bounce) {
+            bounce_from_pool = true;
+        } else {
+            bounce = new char[chunk];
+        }
+        recv_buf = bounce;
+    }
+
+    auto* pool = bounce_pool_;
+    asio::async_read(
+        socket_, asio::buffer(recv_buf, chunk),
+        [this, self, dst, bounce, bounce_from_pool, pool](
+            const asio::error_code& ec, std::size_t transferred) {
+            if (ec) {
+                if (bounce) {
+                    if (bounce_from_pool) pool->release(bounce);
+                    else delete[] bounce;
+                }
+                LOG(ERROR) << "HpSession::recvBodyChunked failed: "
+                           << ec.message();
+                finish(TransferStatusEnum::FAILED);
+                return;
+            }
+            if (bounce) {
+                Platform::getLoader().copy(dst, bounce, transferred);
+                if (bounce_from_pool) pool->release(bounce);
+                else delete[] bounce;
+            }
+            total_transferred_ += transferred;
+            recvBodyChunked();
+        });
+}
+
+// ========== Finish ==========
+
+void HpSession::finish(TransferStatusEnum status) {
+    // Guard against double-finish (e.g. timeout fires after I/O error).
+    if (finished_) return;
+    finished_ = true;
+    cancelDeadline();
+
+    if (status == TransferStatusEnum::COMPLETED && seg_mgr_) {
+        // Server side: keep connection alive, wait for next transfer.
+        finished_ = false;  // reset for next transfer on this connection
+        total_transferred_ = 0;
+        local_buffer_ = nullptr;
+        readHeader();
+        return;
+    }
+
+    if (status == TransferStatusEnum::COMPLETED && return_socket) {
+        auto cb = std::move(return_socket);
+        cb(std::move(socket_));
+    } else {
+        asio::error_code ec;
+        socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+        socket_.close(ec);
+    }
+    if (on_complete) on_complete(status);
+}
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/tcp_hp/inflight_controller.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp_hp/inflight_controller.cpp
@@ -1,0 +1,82 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/transport/tcp_hp/inflight_controller.h"
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+InflightController::InflightController(size_t max_inflight)
+    : max_inflight_(max_inflight) {}
+
+bool InflightController::tryAcquire() {
+    if (max_inflight_ == 0) return true;  // Unlimited.
+    size_t cur = current_.load(std::memory_order_relaxed);
+    while (cur < max_inflight_) {
+        if (current_.compare_exchange_weak(cur, cur + 1,
+                                           std::memory_order_acq_rel)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void InflightController::release() {
+    if (max_inflight_ == 0) return;
+    current_.fetch_sub(1, std::memory_order_acq_rel);
+    dispatchPending();
+}
+
+void InflightController::enqueue(std::function<void()> task) {
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        pending_.push(std::move(task));
+    }
+    // Try to dispatch immediately in case a slot freed up.
+    dispatchPending();
+}
+
+void InflightController::dispatchPending() {
+    while (true) {
+        std::function<void()> task;
+        {
+            std::lock_guard<std::mutex> lock(queue_mutex_);
+            if (pending_.empty()) return;
+            // Try to acquire a slot for this pending task.
+            size_t cur = current_.load(std::memory_order_relaxed);
+            while (cur < max_inflight_) {
+                if (current_.compare_exchange_weak(cur, cur + 1,
+                                                   std::memory_order_acq_rel)) {
+                    goto acquired;
+                }
+            }
+            return;  // No slot available.
+        acquired:
+            task = std::move(pending_.front());
+            pending_.pop();
+        }
+        task();
+    }
+}
+
+size_t InflightController::pending() const {
+    std::lock_guard<std::mutex> lock(
+        const_cast<std::mutex&>(queue_mutex_));
+    return pending_.size();
+}
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/tcp_hp/io_context_pool.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp_hp/io_context_pool.cpp
@@ -1,0 +1,78 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/transport/tcp_hp/io_context_pool.h"
+
+#include <glog/logging.h>
+
+namespace mooncake {
+namespace tent {
+namespace tcp_hp {
+
+IoContextPool::IoContextPool(size_t pool_size) {
+    CHECK_GT(pool_size, 0u) << "IoContextPool size must be > 0";
+    entries_.resize(pool_size);
+    for (auto& entry : entries_) {
+        entry.context = std::make_unique<asio::io_context>();
+        entry.work_guard = std::make_unique<
+            asio::executor_work_guard<asio::io_context::executor_type>>(
+            entry.context->get_executor());
+    }
+}
+
+IoContextPool::~IoContextPool() { stop(); }
+
+void IoContextPool::start() {
+    if (running_) return;
+    running_ = true;
+    for (auto& entry : entries_) {
+        entry.thread = std::thread([&ctx = *entry.context]() {
+            try {
+                ctx.run();
+            } catch (const std::exception& e) {
+                LOG(ERROR) << "IoContextPool worker exception: " << e.what();
+            }
+        });
+    }
+    LOG(INFO) << "IoContextPool started with " << entries_.size() << " thread(s)";
+}
+
+void IoContextPool::stop() {
+    if (!running_) return;
+    running_ = false;
+    for (auto& entry : entries_) {
+        entry.work_guard.reset();
+    }
+    for (auto& entry : entries_) {
+        entry.context->stop();
+    }
+    for (auto& entry : entries_) {
+        if (entry.thread.joinable()) entry.thread.join();
+    }
+}
+
+asio::io_context& IoContextPool::getNextContext() {
+    size_t idx =
+        next_index_.fetch_add(1, std::memory_order_relaxed) % entries_.size();
+    return *entries_[idx].context;
+}
+
+asio::io_context& IoContextPool::getContext(size_t index) {
+    CHECK_LT(index, entries_.size());
+    return *entries_[index].context;
+}
+
+}  // namespace tcp_hp
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/tcp_hp/tcp_hp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp_hp/tcp_hp_transport.cpp
@@ -17,7 +17,6 @@
 #include <glog/logging.h>
 
 #include <chrono>
-#include <random>
 #include <thread>
 
 #include <asio.hpp>
@@ -27,7 +26,6 @@
 #include "tent/common/utils/ip.h"
 #include "tent/runtime/platform.h"
 #include "tent/runtime/slab.h"
-#include "tent/transport/tcp_hp/hp_session.h"
 #include "tent/transport/tcp_hp/protocol.h"
 
 namespace mooncake {
@@ -69,53 +67,36 @@ TcpHpTransport::~TcpHpTransport() { uninstall(); }
 Status TcpHpTransport::startDataServer() {
     auto& ctx = io_pool_->getContext(0);
 
-    const int kStartPort = 10000;
-    const int kPortRange = 50000;
-    const int kMaxRetries = 32;
-    std::mt19937 rng(std::random_device{}());
+    // Use port 0 to let the OS assign an available ephemeral port.
+    // Try IPv6 dual-stack first, then fall back to IPv4.
+    auto try_bind = [&](asio::ip::tcp protocol) -> bool {
+        auto acc = std::make_unique<asio::ip::tcp::acceptor>(ctx);
+        asio::error_code ec;
+        acc->open(protocol, ec);
+        if (ec) return false;
 
-    for (int i = 0; i < kMaxRetries; ++i) {
-        uint16_t port = kStartPort + static_cast<uint16_t>(rng() % kPortRange);
-        try {
-            // Try IPv6 dual-stack first.
-            asio::ip::tcp::endpoint ep(asio::ip::tcp::v6(), port);
-            auto acc = std::make_unique<asio::ip::tcp::acceptor>(ctx);
-            std::error_code ec;
-            acc->open(ep.protocol(), ec);
-            if (!ec) {
-                acc->set_option(asio::ip::v6_only(false), ec);
-                if (!ec) {
-                    acc->set_option(
-                        asio::ip::tcp::acceptor::reuse_address(true));
-                    acc->bind(ep, ec);
-                    if (!ec) {
-                        acc->listen(asio::socket_base::max_listen_connections);
-                        acceptor_ = std::move(acc);
-                        data_port_ = port;
-                        return Status::OK();
-                    }
-                }
-                acc->close();
-            }
-            // Fallback: IPv4.
-            asio::ip::tcp::endpoint ep4(asio::ip::tcp::v4(), port);
-            acc = std::make_unique<asio::ip::tcp::acceptor>(ctx);
-            acc->open(ep4.protocol(), ec);
-            if (ec) continue;
-            acc->set_option(asio::ip::tcp::acceptor::reuse_address(true));
-            acc->bind(ep4, ec);
-            if (ec) continue;
-            acc->listen(asio::socket_base::max_listen_connections);
-            acceptor_ = std::move(acc);
-            data_port_ = port;
-            return Status::OK();
-        } catch (const std::exception& e) {
-            LOG(WARNING) << "TCP_HP data server: port " << port
-                         << " failed: " << e.what();
+        if (protocol == asio::ip::tcp::v6()) {
+            acc->set_option(asio::ip::v6_only(false), ec);
+            if (ec) { acc->close(); return false; }
         }
+
+        acc->set_option(asio::ip::tcp::acceptor::reuse_address(true), ec);
+        acc->bind(asio::ip::tcp::endpoint(protocol, 0), ec);
+        if (ec) { acc->close(); return false; }
+
+        acc->listen(asio::socket_base::max_listen_connections, ec);
+        if (ec) { acc->close(); return false; }
+
+        data_port_ = acc->local_endpoint().port();
+        acceptor_ = std::move(acc);
+        return true;
+    };
+
+    if (try_bind(asio::ip::tcp::v6()) || try_bind(asio::ip::tcp::v4())) {
+        return Status::OK();
     }
     return Status::InternalError(
-        "TCP_HP data server: unable to find available port");
+        "TCP_HP data server: unable to bind on any protocol");
 }
 
 void TcpHpTransport::doAccept() {
@@ -134,6 +115,23 @@ void TcpHpTransport::doAccept() {
                         auto session = std::make_shared<tcp_hp::HpSession>(
                             std::move(hs_socket), chunk_size_,
                             bounce_pool_.get(), transfer_timeout_s_);
+
+                        // Track server session so we can close it on shutdown
+                        // before metadata_/SegmentManager is destroyed.
+                        {
+                            std::lock_guard<std::mutex> lock(
+                                server_sessions_mutex_);
+                            server_sessions_.insert(session);
+                        }
+                        std::weak_ptr<tcp_hp::HpSession> weak = session;
+                        session->on_close = [this, weak]() {
+                            if (auto s = weak.lock()) {
+                                std::lock_guard<std::mutex> lock(
+                                    server_sessions_mutex_);
+                                server_sessions_.erase(s);
+                            }
+                        };
+
                         session->onAccept(&metadata_->segmentManager());
                     } else {
                         LOG(WARNING) << "TCP_HP handshake rejected: "
@@ -207,6 +205,11 @@ Status TcpHpTransport::install(std::string& local_segment_name,
         conn_opts.keepalive_count =
             conf->get("transports/tcp_hp/socket/keepalive_count",
                       conn_opts.keepalive_count);
+        stripe_threshold_ =
+            conf->get("transports/tcp_hp/stripe_threshold",
+                      static_cast<int>(stripe_threshold_));
+        num_stripes_ = conf->get("transports/tcp_hp/num_stripes",
+                                 static_cast<int>(num_stripes_));
     }
 
     // Create I/O pool and connection manager.
@@ -240,7 +243,9 @@ Status TcpHpTransport::install(std::string& local_segment_name,
               << " (io_threads=" << io_threads << ", chunk_size=" << chunk_size_
               << ", max_inflight=" << max_inflight
               << ", bounce_pool=" << (bounce_pool_ ? "yes" : "no")
-              << ", timeout=" << transfer_timeout_s_ << "s)";
+              << ", timeout=" << transfer_timeout_s_ << "s"
+              << ", stripes=" << num_stripes_
+              << ", stripe_threshold=" << stripe_threshold_ << ")";
 
     // Publish TCP_HP data port in segment's transport_attrs.
     auto& manager = metadata_->segmentManager();
@@ -285,6 +290,16 @@ Status TcpHpTransport::uninstall() {
                              << " transfers still inflight after "
                              << kDrainTimeoutMs << "ms, forcing shutdown";
             }
+        }
+
+        // Close all active server sessions to cancel their pending I/O,
+        // ensuring seg_mgr_ pointers are not accessed after metadata_ reset.
+        {
+            std::lock_guard<std::mutex> lock(server_sessions_mutex_);
+            for (auto& session : server_sessions_) {
+                session->closeSocket();
+            }
+            server_sessions_.clear();
         }
 
         if (connect_pool_) connect_pool_->join();
@@ -336,7 +351,10 @@ Status TcpHpTransport::submitTransferTasks(
 
     size_t base = tcp_batch->task_list.size();
     for (auto& request : request_list) {
-        tcp_batch->task_list.push_back(TcpHpTask{});
+        // emplace_back: TcpHpTask contains std::atomic members (non-movable),
+        // so push_back(TcpHpTask{}) is ill-formed. The vector is pre-reserved
+        // to max_size (checked above), so no reallocation will occur.
+        tcp_batch->task_list.emplace_back();
         auto& task = tcp_batch->task_list.back();
         task.target_addr = request.target_offset;
         task.request = request;
@@ -375,7 +393,7 @@ Status TcpHpTransport::removeMemoryBuffer(BufferDesc& desc) {
 }
 
 // ---------------------------------------------------------------------------
-// startTransfer
+// startTransfer / doSingleTransfer / doStripedTransfer
 // ---------------------------------------------------------------------------
 void TcpHpTransport::startTransfer(TcpHpSubBatch* batch, TcpHpTask* task) {
     if (task->request.target_id == LOCAL_SEGMENT_ID &&
@@ -385,7 +403,15 @@ void TcpHpTransport::startTransfer(TcpHpSubBatch* batch, TcpHpTask* task) {
             << local_segment_name_;
     }
 
-    auto do_transfer = [this, batch, task]() {
+    // Decide routing before posting: GPU memory always uses the single-conn
+    // path (bounce-buffer chunking already limits parallelism), while large
+    // CPU buffers use the striped path when num_stripes_ > 1.
+    bool is_gpu = (Platform::getLoader().getMemoryType(task->request.source) ==
+                   MTYPE_CUDA);
+    bool use_stripe = num_stripes_ > 1 &&
+                      task->request.length >= stripe_threshold_ && !is_gpu;
+
+    auto do_transfer = [this, batch, task, use_stripe]() {
         std::string host;
         uint16_t remote_data_port = 0;
         auto status = findRemoteDataEndpoint(
@@ -399,43 +425,10 @@ void TcpHpTransport::startTransfer(TcpHpSubBatch* batch, TcpHpTask* task) {
             return;
         }
 
-        asio::ip::tcp::socket socket(io_pool_->getNextContext());
-        status = conn_mgr_->acquire(host, remote_data_port, socket);
-        if (!status.ok()) {
-            LOG(ERROR) << "TCP_HP connect failed to " << host << ":"
-                       << remote_data_port << ": " << status.message();
-            task->status_word.store(TransferStatusEnum::FAILED,
-                                   std::memory_order_release);
-            batch->outstanding.fetch_sub(1, std::memory_order_release);
-            if (inflight_ctrl_) inflight_ctrl_->release();
-            return;
-        }
-
-        auto session = std::make_shared<tcp_hp::HpSession>(
-            std::move(socket), chunk_size_, bounce_pool_.get(),
-            transfer_timeout_s_);
-
-        // Release inflight slot when transfer completes.
-        auto* ctrl = inflight_ctrl_.get();
-        session->on_complete = [batch, task, ctrl](TransferStatusEnum s) {
-            if (s == TransferStatusEnum::COMPLETED)
-                task->transferred_bytes.store(task->request.length,
-                                             std::memory_order_release);
-            task->status_word.store(s, std::memory_order_release);
-            batch->outstanding.fetch_sub(1, std::memory_order_release);
-            if (ctrl) ctrl->release();
-        };
-
-        auto* mgr = conn_mgr_.get();
-        session->return_socket =
-            [mgr, host, remote_data_port](asio::ip::tcp::socket s) {
-                mgr->release(host, remote_data_port, std::move(s));
-            };
-
-        session->initiateClient(
-            task->request.source, task->request.target_offset,
-            task->request.length,
-            static_cast<uint8_t>(task->request.opcode));
+        if (use_stripe)
+            doStripedTransfer(batch, task, host, remote_data_port);
+        else
+            doSingleTransfer(batch, task, host, remote_data_port);
     };
 
     // Wrap do_transfer to always run on connect_pool_ so that blocking
@@ -449,6 +442,98 @@ void TcpHpTransport::startTransfer(TcpHpSubBatch* batch, TcpHpTask* task) {
         inflight_ctrl_->enqueue(std::move(posted_transfer));
     } else {
         posted_transfer();
+    }
+}
+
+void TcpHpTransport::doSingleTransfer(TcpHpSubBatch* batch, TcpHpTask* task,
+                                       const std::string& host, uint16_t port) {
+    asio::ip::tcp::socket socket(io_pool_->getNextContext());
+    auto status = conn_mgr_->acquire(host, port, socket);
+    if (!status.ok()) {
+        LOG(ERROR) << "TCP_HP connect failed to " << host << ":" << port
+                   << ": " << status.message();
+        task->status_word.store(TransferStatusEnum::FAILED,
+                               std::memory_order_release);
+        batch->outstanding.fetch_sub(1, std::memory_order_release);
+        if (inflight_ctrl_) inflight_ctrl_->release();
+        return;
+    }
+
+    auto session = std::make_shared<tcp_hp::HpSession>(
+        std::move(socket), chunk_size_, bounce_pool_.get(), transfer_timeout_s_);
+
+    auto* ctrl = inflight_ctrl_.get();
+    session->on_complete = [batch, task, ctrl](TransferStatusEnum s) {
+        if (s == TransferStatusEnum::COMPLETED)
+            task->transferred_bytes.store(task->request.length,
+                                         std::memory_order_release);
+        task->status_word.store(s, std::memory_order_release);
+        batch->outstanding.fetch_sub(1, std::memory_order_release);
+        if (ctrl) ctrl->release();
+    };
+
+    auto* mgr = conn_mgr_.get();
+    session->return_socket = [mgr, host, port](asio::ip::tcp::socket s) {
+        mgr->release(host, port, std::move(s));
+    };
+
+    session->initiateClient(task->request.source, task->request.target_offset,
+                            task->request.length,
+                            static_cast<uint8_t>(task->request.opcode));
+}
+
+void TcpHpTransport::doStripedTransfer(TcpHpSubBatch* batch, TcpHpTask* task,
+                                        const std::string& host, uint16_t port) {
+    const size_t total = task->request.length;
+    const size_t n = num_stripes_;
+    const size_t base_len = total / n;
+
+    // The coordinator fires on_complete exactly once — when all n stripes
+    // report back — consuming the single inflight slot acquired by the caller.
+    auto* ctrl = inflight_ctrl_.get();
+    auto coord = std::make_shared<tcp_hp::StripedTransfer>(
+        n, [batch, task, ctrl](TransferStatusEnum s) {
+            if (s == TransferStatusEnum::COMPLETED)
+                task->transferred_bytes.store(task->request.length,
+                                             std::memory_order_release);
+            task->status_word.store(s, std::memory_order_release);
+            batch->outstanding.fetch_sub(1, std::memory_order_release);
+            if (ctrl) ctrl->release();
+        });
+
+    auto* mgr = conn_mgr_.get();
+    for (size_t i = 0; i < n; ++i) {
+        const size_t offset = i * base_len;
+        const size_t len = (i + 1 == n) ? (total - offset) : base_len;
+        char* src = static_cast<char*>(task->request.source) + offset;
+        uint64_t dest = task->request.target_offset + offset;
+
+        asio::ip::tcp::socket socket(io_pool_->getNextContext());
+        auto status = conn_mgr_->acquire(host, port, socket);
+        if (!status.ok()) {
+            LOG(ERROR) << "TCP_HP stripe " << i << "/" << n
+                       << " connect failed to " << host << ":" << port
+                       << ": " << status.message();
+            // Report FAILED for this stripe and all remaining ones so the
+            // coordinator fires exactly once with n total completions.
+            for (size_t j = i; j < n; ++j)
+                coord->onStripeComplete(TransferStatusEnum::FAILED);
+            return;
+        }
+
+        auto session = std::make_shared<tcp_hp::HpSession>(
+            std::move(socket), chunk_size_, bounce_pool_.get(),
+            transfer_timeout_s_);
+
+        session->on_complete = [coord](TransferStatusEnum s) {
+            coord->onStripeComplete(s);
+        };
+        session->return_socket = [mgr, host, port](asio::ip::tcp::socket s) {
+            mgr->release(host, port, std::move(s));
+        };
+
+        session->initiateClient(src, dest, len,
+                                static_cast<uint8_t>(task->request.opcode));
     }
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/tcp_hp/tcp_hp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp_hp/tcp_hp_transport.cpp
@@ -1,0 +1,506 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/transport/tcp_hp/tcp_hp_transport.h"
+
+#include <glog/logging.h>
+
+#include <chrono>
+#include <random>
+#include <thread>
+
+#include <asio.hpp>
+#include <asio/ip/v6_only.hpp>
+
+#include "tent/common/status.h"
+#include "tent/common/utils/ip.h"
+#include "tent/runtime/platform.h"
+#include "tent/runtime/slab.h"
+#include "tent/transport/tcp_hp/hp_session.h"
+#include "tent/transport/tcp_hp/protocol.h"
+
+namespace mooncake {
+namespace tent {
+
+using tcpsocket = asio::ip::tcp::socket;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+static std::string ExtractHost(const std::string& endpoint) {
+    if (!endpoint.empty() && endpoint.front() == '[') {
+        auto end = endpoint.find(']');
+        if (end != std::string::npos) return endpoint.substr(1, end - 1);
+    }
+    auto first_colon = endpoint.find(':');
+    if (first_colon != std::string::npos) {
+        if (endpoint.find(':', first_colon + 1) != std::string::npos)
+            return endpoint;  // IPv6 literal without port
+        return endpoint.substr(0, first_colon);
+    }
+    return endpoint;
+}
+
+static bool IsLoopbackEndpoint(const std::string& endpoint) {
+    const std::string host = ExtractHost(endpoint);
+    return host.compare(0, 4, "127.") == 0 || host == "localhost" ||
+           host == "::1";
+}
+
+// ===========================================================================
+// TcpHpTransport
+// ===========================================================================
+
+TcpHpTransport::TcpHpTransport() {}
+
+TcpHpTransport::~TcpHpTransport() { uninstall(); }
+
+Status TcpHpTransport::startDataServer() {
+    auto& ctx = io_pool_->getContext(0);
+
+    const int kStartPort = 10000;
+    const int kPortRange = 50000;
+    const int kMaxRetries = 32;
+    std::mt19937 rng(std::random_device{}());
+
+    for (int i = 0; i < kMaxRetries; ++i) {
+        uint16_t port = kStartPort + static_cast<uint16_t>(rng() % kPortRange);
+        try {
+            // Try IPv6 dual-stack first.
+            asio::ip::tcp::endpoint ep(asio::ip::tcp::v6(), port);
+            auto acc = std::make_unique<asio::ip::tcp::acceptor>(ctx);
+            std::error_code ec;
+            acc->open(ep.protocol(), ec);
+            if (!ec) {
+                acc->set_option(asio::ip::v6_only(false), ec);
+                if (!ec) {
+                    acc->set_option(
+                        asio::ip::tcp::acceptor::reuse_address(true));
+                    acc->bind(ep, ec);
+                    if (!ec) {
+                        acc->listen(asio::socket_base::max_listen_connections);
+                        acceptor_ = std::move(acc);
+                        data_port_ = port;
+                        return Status::OK();
+                    }
+                }
+                acc->close();
+            }
+            // Fallback: IPv4.
+            asio::ip::tcp::endpoint ep4(asio::ip::tcp::v4(), port);
+            acc = std::make_unique<asio::ip::tcp::acceptor>(ctx);
+            acc->open(ep4.protocol(), ec);
+            if (ec) continue;
+            acc->set_option(asio::ip::tcp::acceptor::reuse_address(true));
+            acc->bind(ep4, ec);
+            if (ec) continue;
+            acc->listen(asio::socket_base::max_listen_connections);
+            acceptor_ = std::move(acc);
+            data_port_ = port;
+            return Status::OK();
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "TCP_HP data server: port " << port
+                         << " failed: " << e.what();
+        }
+    }
+    return Status::InternalError(
+        "TCP_HP data server: unable to find available port");
+}
+
+void TcpHpTransport::doAccept() {
+    acceptor_->async_accept([this](asio::error_code ec, tcpsocket socket) {
+        // Immediately re-arm acceptor so we don't block on handshake.
+        if (running_.load(std::memory_order_relaxed)) {
+            doAccept();
+        }
+        if (!ec) {
+            conn_mgr_->configureSocket(socket);
+            // Async server-side handshake — does not block the io_context.
+            conn_mgr_->asyncServerHandshake(
+                std::move(socket),
+                [this](Status hs_status, tcpsocket hs_socket) {
+                    if (hs_status.ok()) {
+                        auto session = std::make_shared<tcp_hp::HpSession>(
+                            std::move(hs_socket), chunk_size_,
+                            bounce_pool_.get(), transfer_timeout_s_);
+                        session->onAccept(&metadata_->segmentManager());
+                    } else {
+                        LOG(WARNING) << "TCP_HP handshake rejected: "
+                                     << hs_status.message();
+                        asio::error_code close_ec;
+                        hs_socket.close(close_ec);
+                    }
+                });
+        }
+    });
+}
+
+Status TcpHpTransport::install(std::string& local_segment_name,
+                               std::shared_ptr<ControlService> metadata,
+                               std::shared_ptr<Topology> local_topology,
+                               std::shared_ptr<Config> conf) {
+    if (installed_) {
+        return Status::InvalidArgument(
+            "TCP_HP transport has been installed" LOC_MARK);
+    }
+
+    metadata_ = metadata;
+    local_segment_name_ = local_segment_name;
+    local_topology_ = local_topology;
+    installed_ = true;
+
+    metadata_->setNotifyCallback([&](const Notification& message) -> int {
+        RWSpinlock::WriteGuard guard(notify_lock_);
+        notify_list_.push_back(message);
+        return 0;
+    });
+
+    // Read configuration.
+    size_t io_threads = 8;
+    size_t max_inflight = 128;
+    size_t bounce_initial = 32;
+    size_t bounce_max = 256;
+    tcp_hp::ConnOptions conn_opts;
+    if (conf) {
+        chunk_size_ = conf->get("transports/tcp_hp/chunk_size",
+                                static_cast<int>(chunk_size_));
+        io_threads = conf->get("transports/tcp_hp/io_threads",
+                               static_cast<int>(io_threads));
+        max_inflight = conf->get("transports/tcp_hp/max_inflight",
+                                 static_cast<int>(max_inflight));
+        transfer_timeout_s_ = conf->get("transports/tcp_hp/transfer_timeout_s",
+                                        static_cast<int>(transfer_timeout_s_));
+        bounce_initial =
+            conf->get("transports/tcp_hp/bounce_buffer/initial_count",
+                      static_cast<int>(bounce_initial));
+        bounce_max = conf->get("transports/tcp_hp/bounce_buffer/max_count",
+                               static_cast<int>(bounce_max));
+        conn_opts.max_pool_size =
+            conf->get("transports/tcp_hp/max_pool_size",
+                      static_cast<int>(conn_opts.max_pool_size));
+        conn_opts.connect_timeout_ms =
+            conf->get("transports/tcp_hp/connect_timeout_ms",
+                      conn_opts.connect_timeout_ms);
+        conn_opts.connect_retries = conf->get(
+            "transports/tcp_hp/connect_retries", conn_opts.connect_retries);
+        conn_opts.sndbuf =
+            conf->get("transports/tcp_hp/socket/sndbuf", conn_opts.sndbuf);
+        conn_opts.rcvbuf =
+            conf->get("transports/tcp_hp/socket/rcvbuf", conn_opts.rcvbuf);
+        conn_opts.keepalive_idle_s =
+            conf->get("transports/tcp_hp/socket/keepalive_idle_s",
+                      conn_opts.keepalive_idle_s);
+        conn_opts.keepalive_interval_s =
+            conf->get("transports/tcp_hp/socket/keepalive_interval_s",
+                      conn_opts.keepalive_interval_s);
+        conn_opts.keepalive_count =
+            conf->get("transports/tcp_hp/socket/keepalive_count",
+                      conn_opts.keepalive_count);
+    }
+
+    // Create I/O pool and connection manager.
+    io_pool_ = std::make_unique<tcp_hp::IoContextPool>(io_threads);
+    conn_mgr_ =
+        std::make_unique<tcp_hp::ConnManager>(*io_pool_, std::move(conn_opts));
+
+    // Phase 2: bounce buffer pool (only for GPU platforms).
+    if (Platform::getLoader().type() == "cuda" ||
+        Platform::getLoader().type() == "cann") {
+        bounce_pool_ = std::make_unique<tcp_hp::BounceBufferPool>(
+            chunk_size_, bounce_initial, bounce_max);
+    }
+
+    // Phase 2: inflight controller.
+    inflight_ctrl_ = std::make_unique<tcp_hp::InflightController>(max_inflight);
+
+    // Thread pool for blocking connect operations (so io_context threads
+    // are never blocked by synchronous connect + retry + sleep).
+    connect_pool_ = std::make_unique<asio::thread_pool>(
+        std::max<size_t>(2, io_threads / 2));
+
+    // Start the TCP data server.
+    CHECK_STATUS(startDataServer());
+    running_.store(true, std::memory_order_release);
+
+    io_pool_->start();
+    doAccept();
+
+    LOG(INFO) << "TCP_HP data server listening on port " << data_port_
+              << " (io_threads=" << io_threads << ", chunk_size=" << chunk_size_
+              << ", max_inflight=" << max_inflight
+              << ", bounce_pool=" << (bounce_pool_ ? "yes" : "no")
+              << ", timeout=" << transfer_timeout_s_ << "s)";
+
+    // Publish TCP_HP data port in segment's transport_attrs.
+    auto& manager = metadata_->segmentManager();
+    auto segment = manager.getLocal();
+    auto& detail = std::get<MemorySegmentDesc>(segment->detail);
+    detail.transport_attrs[static_cast<int>(TransportType::TCP_HP)] =
+        std::to_string(data_port_);
+
+    caps.dram_to_dram = true;
+    if (Platform::getLoader().type() == "cuda" ||
+        Platform::getLoader().type() == "cann") {
+        caps.dram_to_gpu = true;
+        caps.gpu_to_dram = true;
+        caps.gpu_to_gpu = true;
+    }
+    return Status::OK();
+}
+
+Status TcpHpTransport::uninstall() {
+    if (installed_) {
+        running_.store(false, std::memory_order_release);
+
+        // Close acceptor first to stop new incoming connections.
+        if (acceptor_) {
+            asio::error_code ec;
+            acceptor_->close(ec);
+        }
+
+        // Wait for inflight transfers to drain (best-effort with timeout).
+        if (inflight_ctrl_ && inflight_ctrl_->current() > 0) {
+            constexpr int kDrainTimeoutMs = 5000;
+            constexpr int kPollIntervalMs = 10;
+            int waited = 0;
+            while (inflight_ctrl_->current() > 0 &&
+                   waited < kDrainTimeoutMs) {
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(kPollIntervalMs));
+                waited += kPollIntervalMs;
+            }
+            if (inflight_ctrl_->current() > 0) {
+                LOG(WARNING) << "TCP_HP uninstall: " << inflight_ctrl_->current()
+                             << " transfers still inflight after "
+                             << kDrainTimeoutMs << "ms, forcing shutdown";
+            }
+        }
+
+        if (connect_pool_) connect_pool_->join();
+        if (io_pool_) io_pool_->stop();
+        inflight_ctrl_.reset();
+        connect_pool_.reset();
+        conn_mgr_.reset();
+        acceptor_.reset();
+        bounce_pool_.reset();
+        io_pool_.reset();
+        metadata_.reset();
+        installed_ = false;
+    }
+    return Status::OK();
+}
+
+Status TcpHpTransport::allocateSubBatch(SubBatchRef& batch, size_t max_size) {
+    auto tcp_batch = Slab<TcpHpSubBatch>::Get().allocate();
+    if (!tcp_batch)
+        return Status::InternalError("Unable to allocate TCP_HP sub-batch");
+    batch = tcp_batch;
+    tcp_batch->task_list.reserve(max_size);
+    tcp_batch->max_size = max_size;
+    return Status::OK();
+}
+
+Status TcpHpTransport::freeSubBatch(SubBatchRef& batch) {
+    auto tcp_batch = dynamic_cast<TcpHpSubBatch*>(batch);
+    if (!tcp_batch)
+        return Status::InvalidArgument("Invalid TCP_HP sub-batch" LOC_MARK);
+    size_t inflight = tcp_batch->outstanding.load(std::memory_order_acquire);
+    if (inflight > 0) {
+        return Status::InternalError(
+            "Cannot free TCP_HP sub-batch with " + std::to_string(inflight) +
+            " inflight transfers" LOC_MARK);
+    }
+    Slab<TcpHpSubBatch>::Get().deallocate(tcp_batch);
+    batch = nullptr;
+    return Status::OK();
+}
+
+Status TcpHpTransport::submitTransferTasks(
+    SubBatchRef batch, const std::vector<Request>& request_list) {
+    auto tcp_batch = dynamic_cast<TcpHpSubBatch*>(batch);
+    if (!tcp_batch)
+        return Status::InvalidArgument("Invalid TCP_HP sub-batch" LOC_MARK);
+    if (request_list.size() + tcp_batch->task_list.size() > tcp_batch->max_size)
+        return Status::TooManyRequests("Exceed batch capacity" LOC_MARK);
+
+    size_t base = tcp_batch->task_list.size();
+    for (auto& request : request_list) {
+        tcp_batch->task_list.push_back(TcpHpTask{});
+        auto& task = tcp_batch->task_list.back();
+        task.target_addr = request.target_offset;
+        task.request = request;
+        task.status_word.store(TransferStatusEnum::PENDING,
+                              std::memory_order_release);
+        task.transferred_bytes.store(0, std::memory_order_release);
+    }
+
+    size_t end = tcp_batch->task_list.size();
+    for (size_t i = base; i < end; ++i) {
+        tcp_batch->outstanding.fetch_add(1, std::memory_order_relaxed);
+        startTransfer(tcp_batch, &tcp_batch->task_list[i]);
+    }
+    return Status::OK();
+}
+
+Status TcpHpTransport::getTransferStatus(SubBatchRef batch, int task_id,
+                                         TransferStatus& status) {
+    auto tcp_batch = dynamic_cast<TcpHpSubBatch*>(batch);
+    if (task_id < 0 || task_id >= static_cast<int>(tcp_batch->task_list.size()))
+        return Status::InvalidArgument("Invalid task id" LOC_MARK);
+    auto& task = tcp_batch->task_list[task_id];
+    status = TransferStatus{task.status_word.load(std::memory_order_acquire),
+                            task.transferred_bytes.load(std::memory_order_acquire)};
+    return Status::OK();
+}
+
+Status TcpHpTransport::addMemoryBuffer(BufferDesc& desc,
+                                       const MemoryOptions& options) {
+    desc.transports.push_back(TransportType::TCP_HP);
+    return Status::OK();
+}
+
+Status TcpHpTransport::removeMemoryBuffer(BufferDesc& desc) {
+    return Status::OK();
+}
+
+// ---------------------------------------------------------------------------
+// startTransfer
+// ---------------------------------------------------------------------------
+void TcpHpTransport::startTransfer(TcpHpSubBatch* batch, TcpHpTask* task) {
+    if (task->request.target_id == LOCAL_SEGMENT_ID &&
+        IsLoopbackEndpoint(local_segment_name_)) {
+        LOG_FIRST_N(WARNING, 1)
+            << "TCP_HP transfer targets LOCAL_SEGMENT_ID on loopback "
+            << local_segment_name_;
+    }
+
+    auto do_transfer = [this, batch, task]() {
+        std::string host;
+        uint16_t remote_data_port = 0;
+        auto status = findRemoteDataEndpoint(
+            task->request.target_offset, task->request.length,
+            task->request.target_id, host, remote_data_port);
+        if (!status.ok()) {
+            task->status_word.store(TransferStatusEnum::FAILED,
+                                   std::memory_order_release);
+            batch->outstanding.fetch_sub(1, std::memory_order_release);
+            if (inflight_ctrl_) inflight_ctrl_->release();
+            return;
+        }
+
+        asio::ip::tcp::socket socket(io_pool_->getNextContext());
+        status = conn_mgr_->acquire(host, remote_data_port, socket);
+        if (!status.ok()) {
+            LOG(ERROR) << "TCP_HP connect failed to " << host << ":"
+                       << remote_data_port << ": " << status.message();
+            task->status_word.store(TransferStatusEnum::FAILED,
+                                   std::memory_order_release);
+            batch->outstanding.fetch_sub(1, std::memory_order_release);
+            if (inflight_ctrl_) inflight_ctrl_->release();
+            return;
+        }
+
+        auto session = std::make_shared<tcp_hp::HpSession>(
+            std::move(socket), chunk_size_, bounce_pool_.get(),
+            transfer_timeout_s_);
+
+        // Release inflight slot when transfer completes.
+        auto* ctrl = inflight_ctrl_.get();
+        session->on_complete = [batch, task, ctrl](TransferStatusEnum s) {
+            if (s == TransferStatusEnum::COMPLETED)
+                task->transferred_bytes.store(task->request.length,
+                                             std::memory_order_release);
+            task->status_word.store(s, std::memory_order_release);
+            batch->outstanding.fetch_sub(1, std::memory_order_release);
+            if (ctrl) ctrl->release();
+        };
+
+        auto* mgr = conn_mgr_.get();
+        session->return_socket =
+            [mgr, host, remote_data_port](asio::ip::tcp::socket s) {
+                mgr->release(host, remote_data_port, std::move(s));
+            };
+
+        session->initiateClient(
+            task->request.source, task->request.target_offset,
+            task->request.length,
+            static_cast<uint8_t>(task->request.opcode));
+    };
+
+    // Wrap do_transfer to always run on connect_pool_ so that blocking
+    // connect + retry never stalls an io_context thread.
+    auto posted_transfer = [this, xfer = std::move(do_transfer)]() {
+        asio::post(*connect_pool_, xfer);
+    };
+
+    // Inflight flow control: queue if at limit.
+    if (inflight_ctrl_ && !inflight_ctrl_->tryAcquire()) {
+        inflight_ctrl_->enqueue(std::move(posted_transfer));
+    } else {
+        posted_transfer();
+    }
+}
+
+Status TcpHpTransport::findRemoteDataEndpoint(uint64_t dest_addr,
+                                              uint64_t length,
+                                              uint64_t target_id,
+                                              std::string& host,
+                                              uint16_t& data_port) {
+    SegmentDesc* desc = nullptr;
+    auto status = metadata_->segmentManager().getRemoteCached(desc, target_id);
+    if (!status.ok()) return status;
+    auto buffer = desc->findBuffer(dest_addr, length);
+    const auto& mem = desc->getMemory();
+    if (!buffer || mem.rpc_server_addr.empty())
+        return Status::InvalidArgument(
+            "Requested address is not in registered buffer" LOC_MARK);
+
+    auto parsed = parseHostNameWithPort(mem.rpc_server_addr, 0);
+    host = parsed.first;
+
+    auto* port_str =
+        mem.getTransportAttrs(static_cast<int>(TransportType::TCP_HP));
+    if (!port_str || port_str->empty())
+        return Status::InvalidArgument(
+            "Remote segment has no TCP_HP data port published" LOC_MARK);
+
+    int port_val = std::atoi(port_str->c_str());
+    if (port_val <= 0 || port_val > 65535)
+        return Status::InvalidArgument(
+            "Remote segment has invalid TCP_HP data port" LOC_MARK);
+    data_port = static_cast<uint16_t>(port_val);
+    return Status::OK();
+}
+
+Status TcpHpTransport::sendNotification(SegmentID target_id,
+                                        const Notification& message) {
+    SegmentDesc* desc = nullptr;
+    auto status = metadata_->segmentManager().getRemoteCached(desc, target_id);
+    if (!status.ok()) return status;
+    std::string rpc_server_addr = desc->getMemory().rpc_server_addr;
+    if (rpc_server_addr.empty())
+        return Status::InvalidArgument("Requested segment type error" LOC_MARK);
+    return ControlClient::notify(rpc_server_addr, message);
+}
+
+Status TcpHpTransport::receiveNotification(
+    std::vector<Notification>& notify_list) {
+    RWSpinlock::WriteGuard guard(notify_lock_);
+    notify_list.clear();
+    notify_list.swap(notify_list_);
+    return Status::OK();
+}
+
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

This PR reworks the TCP transport in TENT to use a dedicated ASIO-based data plane instead of sending payloads through the control-plane RPC path.

The existing TENT TCP transport routes payload through control-plane RPC helpers (`ControlClient::sendData/recvData`), which adds overhead in the hot path: extra RPC framing, per-transfer connection setup, and tight coupling between control and data planes.

`tcp_hp` is a standalone transport that performs direct socket I/O, bypassing the control plane entirely.



**Changes:**

- **Dedicated data server**: `TcpHpTransport` starts its own TCP acceptor and publishes the data port via `transport_attrs[TCP_HP]`
  - **Lightweight session protocol**: fixed header (`opcode + addr + length`) for async read/write — no RPC framing overhead
  - **Connection pooling**: client-side pool keyed by `host:port`, connections are reused across transfers
  - **Bounce-buffer staging**: pre-allocated bounce buffers for chunked transfers, supporting both CUDA and CANN memory
  - **Inflight control**: configurable max in-flight transfers to avoid overwhelming the receiver
  - **IoContextPool**: dedicated ASIO thread pool for data-plane I/O, decoupled from the control plane

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

```
 ./mooncake-transfer-engine/benchmark/tebench  --xport_type=tcp --seg_type=DRAM --metadata_type=p2p
```

 ## Benchmark

  Tested on 2x H20 nodes connected via 25GbE (eth0), using `tebench --seg_type=DRAM --metadata_type=p2p`:


  | Block Size | Classic TE TCP (GB/s) | TENT tcp_hp (GB/s) | Speedup |
  |---|---|---|---|
  | 4 KB | 0.020 | 0.059 | 2.9x |
  | 8 KB | 0.038 | 0.140 | 3.7x |
  | 16 KB | 0.059 | 0.268 | 4.5x |
  | 32 KB | 0.107 | 0.500 | 4.7x |
  | 64 KB | 0.169 | 0.683 | 4.0x |
  | 128 KB | 0.241 | 1.152 | 4.8x |
  | 256 KB | 0.397 | 1.867 | 4.7x |
  | 512 KB | 0.628 | 2.464 | 3.9x |
  | 1 MB | 0.849 | 3.239 | 3.8x |
  | 2 MB | 1.071 | 3.617 | 3.4x |
  | 4 MB | 1.345 | 4.368 | 3.2x |
  | 8 MB | 1.720 | 4.788 | 2.8x |
  | 16 MB | 2.170 | 5.020 | 2.3x |
  | 32 MB | 2.882 | 5.280 | 1.8x |
  | 64 MB | 3.451 | 5.386 | 1.6x |

### Multi-rail TCP

```
BlkSize (B)   Batch   BW (GB/S)     Avg Lat (us)  Avg Tx (us)   P99 Tx (us)   P999 Tx (us)
     --------------------------------------------------------------------------------------------------------------------------------------------------------------
     --
     I0320 17:27:29.354880 376535 segment_manager.cpp:44] Opened segment #1: 172.31.0.2:16225
     4096          1       0.075039      54.6          53.7          79.0          112.4
     8192          1       0.144342      56.8          55.9          81.0          132.0
     16384         1       0.302256      54.2          53.4          79.0          108.0
     32768         1       0.535509      61.2          60.4          87.0          135.3
     65536         1       0.760989      86.1          85.3          154.0         245.9
     131072        1       1.268964      103.3         102.4         189.0         390.8
     262144        1       2.076751      126.2         125.4         198.0         385.0
     524288        1       2.816657      186.1         185.3         275.4         447.1
     1048576       1       3.665964      286.0         285.2         373.0         688.2
     2097152       1       4.447156      471.6         470.7         803.0         1233.2
     4194304       1       5.325520      787.6         786.8         966.6         1694.2
     8388608       1       5.558700      1509.1        1508.2        2021.0        14370.1
     16777216      1       6.321644      2653.9        2653.0        3091.3        4688.1
     33554432      1       6.490177      5170.0        5169.0        5640.6        6902.4
     67108864      1       6.678029      10049.2       10048.2       10875.8       12933.9
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
