### PR TITLE
[Bugfix][HA] Disable client_pool alive_detect to stop stale reconnection logs after HA master failover

### DIFF
--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -30,9 +30,10 @@ class MasterClient {
         coro_io::client_pool<coro_rpc::coro_rpc_client>::pool_config
             pool_conf{};
 
-        // Disable alive_detect to prevent stale reconnection logs after HA failover.
-        // Old client_pool objects remain in client_pools_ map and would otherwise
-        // continue probing failed addresses indefinitely. See PR #1642.
+        // Disable alive_detect to prevent stale reconnection logs after HA
+        // failover. Old client_pool objects remain in client_pools_ map and
+        // would otherwise continue probing failed addresses indefinitely. See
+        // PR #1642.
         pool_conf.host_alive_detect_duration = std::chrono::seconds(0);
         const char* value = std::getenv("MC_RPC_PROTOCOL");
         if (value && std::string_view(value) == "rdma") {


### PR DESCRIPTION
## Description

After HA master failover, the client successfully reconnects to the new master, but the `client_pool` associated with the old master address continues to emit `Connection refused` WARNING logs at ~30-second intervals indefinitely.

### Observed Logs

```
# OLD master killed here
E0309 11:00:04.763258 91034 master_client.cpp:239] RPC call failed: End of file
E0309 11:00:04.763311 91098 client_service.cpp:2355] Failed to ping master
2026-03-09 11:00:05.763764 WARNING  [91038] [coro_rpc_client.hpp:989] client_id 1 failed:Connection refused
2026-03-09 11:00:06.764072 WARNING  [91038] [coro_rpc_client.hpp:989] client_id 1 failed:Connection refused
...
2026-03-09 11:00:15.301937 WARNING  [91042] [client_pool.hpp:445] send request to 127.0.0.1:50051 failed. connection refused.
E0309 11:00:15.301946 91042 master_client.cpp:234] Client not available
E0309 11:00:15.301988 91098 client_service.cpp:2363] Failed to ping master for 3 times; fetching latest master view and reconnecting
I0309 11:00:15.302630 91098 ha_helper.cpp:106] Get master address: 127.0.0.1:50052, version: 115
I0309 11:00:15.303279 91098 client_service.cpp:2388] Reconnected to master 127.0.0.1:50052

# After successful reconnection, stale logs persist every ~30s targeting the OLD master:
2026-03-09 11:00:40.033019 WARNING  [91040] [coro_rpc_client.hpp:989] client_id 1 failed:Connection refused
2026-03-09 11:01:10.822175 WARNING  [91040] [coro_rpc_client.hpp:989] client_id 1 failed:Connection refused
2026-03-09 11:01:45.355360 WARNING  [91040] [coro_rpc_client.hpp:989] client_id 1 failed:Connection refused
2026-03-09 11:02:18.106520 WARNING  [91040] [coro_rpc_client.hpp:989] client_id 1 failed:Connection refused
2026-03-09 11:02:51.302721 WARNING  [91040] [coro_rpc_client.hpp:989] client_id 1 failed:Connection refused
2026-03-09 11:03:22.615906 WARNING  [91040] [coro_rpc_client.hpp:989] client_id 1 failed:Connection refused
2026-03-09 11:03:52.898083 WARNING  [91040] [coro_rpc_client.hpp:989] client_id 1 failed:Connection refused
```

These ~30-second interval warnings are produced by the `alive_detect` coroutine in the old `client_pool` for `127.0.0.1:50051`, even though the client has already switched to `127.0.0.1:50052`.
### Root Cause

When all connections in a `coro_io::client_pool` fail to reconnect (exceeding `connect_retry_count`), yalantinglibs launches a background `alive_detect` coroutine that periodically probes the remote host to check if it comes back online. During `MasterClient::Connect`, when the address changes, a new pool is created via `client_pools_->at(new_address)` and swapped into `client_accessor_`, but the old pool remains in the `client_pools_` map. Since the map holds a `shared_ptr` to the old pool, the `alive_detect` coroutine's `weak_ptr` always locks successfully, causing it to loop forever.

### Fix

Set `pool_config.host_alive_detect_duration` to 0 in the `MasterClient` constructor. This disables the `alive_detect` mechanism entirely. When all connections in a pool fail, `alive_detect` checks `duration.count() != 0` at entry, fails the check, and returns immediately without starting the background reconnection loop.

### No Side Effects

`alive_detect` is a **background warm-up mechanism** that proactively probes whether a remote host has recovered and pre-establishes connections. Disabling it does not affect actual reconnection capability:

1. **Per-request reconnection is unaffected**: Each `send_request` -> `get_client` call creates a new connection and executes `reconnect` on the spot when `free_clients_` is empty. This path is completely independent of `alive_detect`.
2. **HA failover/failback is unaffected**: HA reconnection is driven by the application-layer ping thread (`client_service.cpp`: consecutive ping failures exceed threshold -> fetch latest master address from etcd -> call `MasterClient::Connect`). It does not rely on pool-level `alive_detect`.
3. **Normal operation is unaffected**: `alive_detect` only triggers after all connections have failed. When the master is online, this code path is never reached.

### Known Limitations

After failover, the old address's `client_pool` object remains in the `client_pools_` `unordered_map` and cannot be automatically cleaned up (yalantinglibs' `client_pools` does not provide an `erase` API or any GC mechanism). However:
- With `alive_detect` disabled, the old pool has no background coroutines, no connections, and no CPU overhead — it is effectively an empty shell.
- HA failover is an extremely low-frequency event, so abandoned pools will not accumulate into any meaningful memory leak.

If full cleanup is needed in the future, an `erase` method would need to be added to yalantinglibs' `client_pools`, and `MasterClient::Connect` would need to remove the old pool when switching addresses. （related yalantinglibs issue: https://github.com/alibaba/yalantinglibs/issues/1078)

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Simulated HA failover scenario: started dual masters, connected client to master A, killed master A, and verified the client automatically switches to master B with no further `Connection refused` logs targeting the old master address.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.


