### PR TITLE
fix qp_leak bug after PR#384

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -71,6 +71,7 @@ int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     // in case it is setting up connection or submitting slice
     if (iter != endpoint_map_.end()) {
         waiting_list_.insert(iter->second);
+        iter->second->set_active(false);
         endpoint_map_.erase(iter);
         auto fifo_iter = fifo_map_[peer_nic_path];
         fifo_list_.erase(fifo_iter);
@@ -174,6 +175,7 @@ int SIEVEEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     if (iter != endpoint_map_.end()) {
         waiting_list_len_++;
         waiting_list_.insert(iter->second.first);
+        iter->second.first->set_active(false);
         endpoint_map_.erase(iter);
         auto fifo_iter = fifo_map_[peer_nic_path];
         if (hand_.has_value() && hand_.value() == fifo_iter) {


### PR DESCRIPTION
PR#384 leaves the endpoint status unchanged to fix the concurrency bug in the following scenarios: "1 NIC for the prefill server, and config another NIC for the decode server. Or try setting up a greater MC_TRANSFER_TIMEOUT when your servers are under heavy load. Or try intra-node nvlink." However, this commit causes a QP leak during network fluctuations, accompanied by the log "Worker: Process failed for slice ......: transport retry counter exceeded". Therefore, we would like to revert this change, or find alternative approaches to avoid the QP leak issue.