### PR TITLE
[Store] Add Go language bindings for Mooncake Store via C API

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,11 +23,20 @@ RUN apt-get install -y libibverbs-dev \
     libhiredis-dev \
     libyaml-cpp-dev \
     libjemalloc-dev \
+    libzstd-dev \
+    libmsgpack-dev \
+    libgflags-dev \
     pkg-config \
     patchelf
 
-RUN wget https://go.dev/dl/go1.22.12.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go1.22.12.linux-amd64.tar.gz
+RUN GO_VERSION="1.23.8" && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "aarch64" ]; then GOARCH="arm64"; \
+    elif [ "$ARCH" = "x86_64" ]; then GOARCH="amd64"; \
+    else echo "Unsupported architecture: $ARCH" && exit 1; fi && \
+    wget https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz \
+    && tar -C /usr/local -xzf go${GO_VERSION}.linux-${GOARCH}.tar.gz \
+    && rm go${GO_VERSION}.linux-${GOARCH}.tar.gz
 
 RUN git clone https://github.com/alibaba/yalantinglibs.git \
     && cd yalantinglibs \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,16 @@ jobs:
         sudo cmake --install .
       shell: bash
 
+    - name: Run Go store binding unit tests
+      run: |
+        cd mooncake-store/go
+        export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/mooncake-asio:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd
+        export CGO_ENABLED=1
+        export CGO_CFLAGS="-I$GITHUB_WORKSPACE/mooncake-store/include -I$GITHUB_WORKSPACE/mooncake-transfer-engine/include"
+        export CGO_LDFLAGS="-L$GITHUB_WORKSPACE/build/mooncake-store/src -L$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator -L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src -L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base -L$GITHUB_WORKSPACE/build/mooncake-asio -L$GITHUB_WORKSPACE/build/mooncake-common/etcd -lmooncake_store -lcachelib_memory_allocator -ltransfer_engine -lbase -lasio -letcd_wrapper -lstdc++ -lnuma -lglog -lgflags -libverbs -ljsoncpp -lzstd -lcurl -luring -lasan -lm -lgcov"
+        ASAN_OPTIONS=detect_leaks=0:verify_asan_link_order=0 go test -short -v ./mooncakestore/...
+      shell: bash
+
     - name: Build nvlink_allocator.so
       run: |
         mkdir -p build/mooncake-transfer-engine/nvlink-allocator
@@ -110,6 +120,23 @@ jobs:
         cd mooncake-transfer-engine/example/http-metadata-server-python
         pip install aiohttp
         python ./bootstrap_server.py &
+      shell: bash
+
+    - name: Run Go store binding integration tests
+      run: |
+        $GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master \
+          --eviction_high_watermark_ratio=0.95 \
+          --cluster_id=ci_go_test_cluster \
+          --port 50051 &
+        MASTER_PID=$!
+        sleep 3
+        cd mooncake-store/go
+        export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/mooncake-asio:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd
+        export CGO_ENABLED=1
+        export CGO_CFLAGS="-I$GITHUB_WORKSPACE/mooncake-store/include -I$GITHUB_WORKSPACE/mooncake-transfer-engine/include"
+        export CGO_LDFLAGS="-L$GITHUB_WORKSPACE/build/mooncake-store/src -L$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator -L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src -L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base -L$GITHUB_WORKSPACE/build/mooncake-asio -L$GITHUB_WORKSPACE/build/mooncake-common/etcd -lmooncake_store -lcachelib_memory_allocator -ltransfer_engine -lbase -lasio -letcd_wrapper -lstdc++ -lnuma -lglog -lgflags -libverbs -ljsoncpp -lzstd -lcurl -luring -lasan -lm -lgcov"
+        ASAN_OPTIONS=detect_leaks=0:verify_asan_link_order=0 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata go test -v ./mooncakestore/...
+        kill $MASTER_PID 2>/dev/null || true
       shell: bash
 
     - name: Test (in build env) with coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 option(WITH_TE "build mooncake transfer engine and sample code" ON)
 option(WITH_STORE "build mooncake store library and sample code" ON)
+option(WITH_STORE_GO "build Go bindings for mooncake store" OFF)
 option(WITH_P2P_STORE "build p2p store library and sample code" OFF)
 option(WITH_RUST_EXAMPLE "build the Rust interface and sample code for the transfer engine" OFF)
 option(WITH_EP "build mooncake with expert parallelism support" OFF)
@@ -140,6 +141,17 @@ if (WITH_EP)
 endif()
 
 add_subdirectory(mooncake-integration)
+
+if (WITH_STORE_GO AND WITH_STORE)
+  add_custom_target(build_store_go DEPENDS mooncake_store transfer_engine)
+  add_custom_command(
+      TARGET build_store_go
+      COMMAND bash build.sh ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${USE_ETCD} ${USE_REDIS} ${USE_HTTP} ${USE_ETCD_LEGACY}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mooncake-store/go
+  )
+  set_property(TARGET build_store_go PROPERTY EXCLUDE_FROM_ALL FALSE)
+  message(STATUS "Mooncake Store Go bindings will be built")
+endif()
 
 if (WITH_P2P_STORE)
   add_subdirectory(mooncake-p2p-store)

--- a/mooncake-store/go/build.sh
+++ b/mooncake-store/go/build.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Copyright 2024 KVCache.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 BUILD_DIR TARGET_PATH [USE_ETCD=OFF] [USE_REDIS=OFF] [USE_HTTP=OFF] [USE_ETCD_LEGACY=OFF]"
+    exit 1
+fi
+
+BUILD_DIR=$(cd "$1" && pwd)
+TARGET=$(cd "$2" && pwd)
+USE_ETCD=${3:-OFF}
+USE_REDIS=${4:-OFF}
+USE_HTTP=${5:-OFF}
+USE_ETCD_LEGACY=${6:-OFF}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# CGo compiler flags — point at the store_c.h header
+CGO_CFLAGS="-I${REPO_ROOT}/mooncake-store/include"
+CGO_CFLAGS+=" -I${REPO_ROOT}/mooncake-transfer-engine/include"
+
+# CGo linker flags — link against mooncake_store, transfer_engine, and deps
+CGO_LDFLAGS="-L${BUILD_DIR}/mooncake-store/src"
+CGO_LDFLAGS+=" -L${BUILD_DIR}/mooncake-store/src/cachelib_memory_allocator"
+CGO_LDFLAGS+=" -L${BUILD_DIR}/mooncake-transfer-engine/src"
+CGO_LDFLAGS+=" -L${BUILD_DIR}/mooncake-transfer-engine/src/common/base"
+CGO_LDFLAGS+=" -L${BUILD_DIR}/mooncake-asio"
+CGO_LDFLAGS+=" -lmooncake_store -lcachelib_memory_allocator -ltransfer_engine -lbase -lasio"
+CGO_LDFLAGS+=" -lstdc++ -lnuma -lglog -lgflags -libverbs -ljsoncpp -lzstd -lcurl"
+
+if [ -d "/usr/local/cuda/lib64" ]; then
+    CGO_LDFLAGS+=" -L/usr/local/cuda/lib64 -lcudart"
+fi
+
+CGO_LDFLAGS+=" -luring"
+
+if [ "$USE_ETCD" = "ON" ]; then
+    if [ "$USE_ETCD_LEGACY" = "ON" ]; then
+        CGO_LDFLAGS+=" -letcd-cpp-api -lprotobuf -lgrpc++ -lgrpc"
+    else
+        CGO_LDFLAGS+=" -L${BUILD_DIR}/mooncake-common/etcd -letcd_wrapper"
+    fi
+fi
+
+if [ "$USE_REDIS" = "ON" ]; then
+    CGO_LDFLAGS+=" -lhiredis"
+fi
+
+
+export CGO_CFLAGS
+export CGO_LDFLAGS
+export CGO_ENABLED=1
+
+cd "$SCRIPT_DIR"
+
+echo "Building Mooncake Store Go example..."
+echo "  CGO_CFLAGS=$CGO_CFLAGS"
+echo "  CGO_LDFLAGS=$CGO_LDFLAGS"
+
+go build -o "${TARGET}/mooncake-store-go-example" ./examples/basic/
+
+echo "Mooncake Store Go bindings: build successful"

--- a/mooncake-store/go/examples/basic/main.go
+++ b/mooncake-store/go/examples/basic/main.go
@@ -1,0 +1,99 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// basic demonstrates using Mooncake Store from Go.
+//
+// Prerequisites:
+//
+//	mooncake_master --enable_http_metadata_server=true \
+//	  --http_metadata_server_port=8080
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	store "github.com/kvcache-ai/Mooncake/mooncake-store/go/mooncakestore"
+)
+
+func main() {
+	metadataServer := envOrDefault("MC_METADATA_SERVER", "http://localhost:8080/metadata")
+	masterAddr := envOrDefault("MC_MASTER_ADDR", "localhost:50051")
+
+	s, err := store.New()
+	if err != nil {
+		log.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+
+	err = s.Setup(
+		"localhost",
+		metadataServer,
+		512*1024*1024, // 512 MB global segment
+		128*1024*1024, // 128 MB local buffer
+		"tcp",
+		"",
+		masterAddr,
+	)
+	if err != nil {
+		log.Fatalf("Setup: %v", err)
+	}
+	fmt.Println("Connected to Mooncake Store")
+
+	// Put
+	key := "hello_from_go"
+	value := []byte("Hello, Mooncake!")
+	if err := s.Put(key, value, nil); err != nil {
+		log.Fatalf("Put: %v", err)
+	}
+	fmt.Printf("Put: %s => %s\n", key, value)
+
+	// Exists
+	exists, err := s.Exists(key)
+	if err != nil {
+		log.Fatalf("Exists: %v", err)
+	}
+	fmt.Printf("Exists(%s) = %v\n", key, exists)
+
+	// GetSize
+	size, err := s.GetSize(key)
+	if err != nil {
+		log.Fatalf("GetSize: %v", err)
+	}
+	fmt.Printf("GetSize(%s) = %d bytes\n", key, size)
+
+	// Get
+	buf := make([]byte, size)
+	n, err := s.Get(key, buf)
+	if err != nil {
+		log.Fatalf("Get: %v", err)
+	}
+	fmt.Printf("Get: %s => %s\n", key, buf[:n])
+
+	// Remove
+	if err := s.Remove(key, false); err != nil {
+		log.Fatalf("Remove: %v", err)
+	}
+	fmt.Printf("Removed: %s\n", key)
+
+	fmt.Println("Done!")
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/mooncake-store/go/go.mod
+++ b/mooncake-store/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/kvcache-ai/Mooncake/mooncake-store/go
+
+go 1.23

--- a/mooncake-store/go/mooncakestore/config.go
+++ b/mooncake-store/go/mooncakestore/config.go
@@ -1,0 +1,30 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mooncakestore
+
+// ReplicateConfig controls replica placement for put operations.
+type ReplicateConfig struct {
+	ReplicaNum        int
+	WithSoftPin       bool
+	PreferredSegments []string
+}
+
+// DefaultReplicateConfig returns the default configuration (1 replica, no pinning).
+func DefaultReplicateConfig() ReplicateConfig {
+	return ReplicateConfig{
+		ReplicaNum:  1,
+		WithSoftPin: false,
+	}
+}

--- a/mooncake-store/go/mooncakestore/errors.go
+++ b/mooncake-store/go/mooncakestore/errors.go
@@ -1,0 +1,33 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mooncakestore
+
+import "errors"
+
+var (
+	ErrStoreNil        = errors.New("mooncakestore: store handle is nil")
+	ErrSetupFailed     = errors.New("mooncakestore: setup failed")
+	ErrInitAllFailed   = errors.New("mooncakestore: init_all failed")
+	ErrHealthCheck     = errors.New("mooncakestore: health check failed")
+	ErrPut             = errors.New("mooncakestore: put failed")
+	ErrGet             = errors.New("mooncakestore: get failed")
+	ErrRemove          = errors.New("mooncakestore: remove failed")
+	ErrExist           = errors.New("mooncakestore: existence check failed")
+	ErrGetSize         = errors.New("mooncakestore: get size failed")
+	ErrRegisterBuffer  = errors.New("mooncakestore: register buffer failed")
+	ErrBatchOp         = errors.New("mooncakestore: batch operation failed")
+	ErrHostname        = errors.New("mooncakestore: get hostname failed")
+	ErrInvalidArgument = errors.New("mooncakestore: invalid argument")
+)

--- a/mooncake-store/go/mooncakestore/store.go
+++ b/mooncake-store/go/mooncakestore/store.go
@@ -1,0 +1,541 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mooncakestore provides Go bindings for the Mooncake distributed
+// KVCache store. It wraps the C API (store_c.h) via CGo, giving Go programs
+// access to high-performance, RDMA-capable put/get operations.
+package mooncakestore
+
+/*
+#include "store_c.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"unsafe"
+)
+
+// Store wraps a Mooncake Store client handle.
+type Store struct {
+	handle C.mooncake_store_t
+}
+
+// New creates a new Store instance. Call Setup before performing operations,
+// and Close when done.
+func New() (*Store, error) {
+	h := C.mooncake_store_create()
+	if h == nil {
+		return nil, ErrStoreNil
+	}
+	return &Store{handle: h}, nil
+}
+
+// Setup initialises the store client and connects to the cluster.
+//
+// Parameters:
+//   - localHostname: hostname/IP of this node
+//   - metadataServer: metadata server URL (e.g. "http://host:8080/metadata")
+//   - globalSegmentSize: size of the global memory segment in bytes
+//   - localBufferSize: size of the local transfer buffer in bytes
+//   - protocol: transport protocol ("tcp" or "rdma")
+//   - deviceName: RDMA device name (empty for TCP or auto-discovery)
+//   - masterServerAddr: master service address (e.g. "host:50051")
+func (s *Store) Setup(localHostname, metadataServer string,
+	globalSegmentSize, localBufferSize uint64,
+	protocol, deviceName, masterServerAddr string) error {
+	if s.handle == nil {
+		return ErrStoreNil
+	}
+
+	cLocalHostname := C.CString(localHostname)
+	cMetadataServer := C.CString(metadataServer)
+	cProtocol := C.CString(protocol)
+	cDeviceName := C.CString(deviceName)
+	cMasterAddr := C.CString(masterServerAddr)
+	defer C.free(unsafe.Pointer(cLocalHostname))
+	defer C.free(unsafe.Pointer(cMetadataServer))
+	defer C.free(unsafe.Pointer(cProtocol))
+	defer C.free(unsafe.Pointer(cDeviceName))
+	defer C.free(unsafe.Pointer(cMasterAddr))
+
+	ret := C.mooncake_store_setup(s.handle,
+		cLocalHostname, cMetadataServer,
+		C.uint64_t(globalSegmentSize), C.uint64_t(localBufferSize),
+		cProtocol, cDeviceName, cMasterAddr)
+	if ret != 0 {
+		return ErrSetupFailed
+	}
+	return nil
+}
+
+// InitAll mounts additional memory segments after setup.
+func (s *Store) InitAll(protocol, deviceName string, mountSegmentSize uint64) error {
+	if s.handle == nil {
+		return ErrStoreNil
+	}
+
+	cProtocol := C.CString(protocol)
+	cDeviceName := C.CString(deviceName)
+	defer C.free(unsafe.Pointer(cProtocol))
+	defer C.free(unsafe.Pointer(cDeviceName))
+
+	ret := C.mooncake_store_init_all(s.handle, cProtocol, cDeviceName,
+		C.uint64_t(mountSegmentSize))
+	if ret != 0 {
+		return ErrInitAllFailed
+	}
+	return nil
+}
+
+// HealthCheck verifies connectivity to the master and cluster.
+// Returns nil if healthy.
+func (s *Store) HealthCheck() error {
+	if s.handle == nil {
+		return ErrStoreNil
+	}
+	ret := C.mooncake_store_health_check(s.handle)
+	if ret != 0 {
+		return ErrHealthCheck
+	}
+	return nil
+}
+
+// Close tears down the store client and frees resources.
+func (s *Store) Close() {
+	if s.handle != nil {
+		C.mooncake_store_destroy(s.handle)
+		s.handle = nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Put operations
+// ---------------------------------------------------------------------------
+
+func (s *Store) toCConfig(cfg *ReplicateConfig) (C.mooncake_replicate_config_t, []*C.char, error) {
+	var cc C.mooncake_replicate_config_t
+	var cSegs []*C.char
+
+	if cfg == nil {
+		cc.replica_num = 1
+		return cc, nil, nil
+	}
+
+	if cfg.ReplicaNum <= 0 {
+		return cc, nil, ErrInvalidArgument
+	}
+
+	cc.replica_num = C.size_t(cfg.ReplicaNum)
+	if cfg.WithSoftPin {
+		cc.with_soft_pin = 1
+	}
+
+	if len(cfg.PreferredSegments) > 0 {
+		cSegs = make([]*C.char, len(cfg.PreferredSegments))
+		for i, seg := range cfg.PreferredSegments {
+			cSegs[i] = C.CString(seg)
+		}
+		cc.preferred_segments = &cSegs[0]
+		cc.preferred_segments_count = C.size_t(len(cSegs))
+	}
+
+	return cc, cSegs, nil
+}
+
+func freeCStrings(strs []*C.char) {
+	for _, s := range strs {
+		C.free(unsafe.Pointer(s))
+	}
+}
+
+// Put stores a byte slice under the given key.
+func (s *Store) Put(key string, value []byte, config *ReplicateConfig) error {
+	if s.handle == nil {
+		return ErrStoreNil
+	}
+
+	cc, cSegs, err := s.toCConfig(config)
+	if err != nil {
+		return err
+	}
+	defer freeCStrings(cSegs)
+
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	var ptr unsafe.Pointer
+	if len(value) > 0 {
+		ptr = unsafe.Pointer(&value[0])
+	}
+
+	ret := C.mooncake_store_put(s.handle, cKey, ptr, C.size_t(len(value)), &cc)
+	if ret != 0 {
+		return ErrPut
+	}
+	return nil
+}
+
+// PutFrom stores data directly from a pre-registered memory buffer.
+// The buffer at ptr must have been registered via RegisterBuffer.
+func (s *Store) PutFrom(key string, ptr uintptr, size uint64, config *ReplicateConfig) error {
+	if s.handle == nil {
+		return ErrStoreNil
+	}
+	if ptr == 0 || size == 0 {
+		return ErrInvalidArgument
+	}
+
+	cc, cSegs, err := s.toCConfig(config)
+	if err != nil {
+		return err
+	}
+	defer freeCStrings(cSegs)
+
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	ret := C.mooncake_store_put_from(s.handle, cKey,
+		unsafe.Pointer(ptr), C.size_t(size), &cc)
+	if ret != 0 {
+		return ErrPut
+	}
+	return nil
+}
+
+// BatchPutFrom stores multiple objects from pre-registered memory buffers.
+// Returns per-key result codes (0 = success).
+func (s *Store) BatchPutFrom(keys []string, ptrs []uintptr, sizes []uint64,
+	config *ReplicateConfig) ([]int, error) {
+	if s.handle == nil {
+		return nil, ErrStoreNil
+	}
+	count := len(keys)
+	if count == 0 {
+		return nil, nil
+	}
+	if len(ptrs) != count || len(sizes) != count {
+		return nil, ErrInvalidArgument
+	}
+
+	cKeys := make([]*C.char, count)
+	for i, k := range keys {
+		cKeys[i] = C.CString(k)
+	}
+	defer func() {
+		for _, ck := range cKeys {
+			C.free(unsafe.Pointer(ck))
+		}
+	}()
+
+	cBufs := make([]unsafe.Pointer, count)
+	cSizes := make([]C.size_t, count)
+	for i := range ptrs {
+		cBufs[i] = unsafe.Pointer(ptrs[i])
+		cSizes[i] = C.size_t(sizes[i])
+	}
+
+	cc, cSegs, err := s.toCConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	defer freeCStrings(cSegs)
+
+	results := make([]C.int, count)
+	ret := C.mooncake_store_batch_put_from(s.handle,
+		&cKeys[0], &cBufs[0], &cSizes[0], C.size_t(count),
+		&cc, &results[0])
+	if ret != 0 {
+		return nil, ErrBatchOp
+	}
+
+	goResults := make([]int, count)
+	for i := range results {
+		goResults[i] = int(results[i])
+	}
+	return goResults, nil
+}
+
+// ---------------------------------------------------------------------------
+// Get operations
+// ---------------------------------------------------------------------------
+
+// GetInto reads an object directly into a pre-registered buffer.
+// Returns the number of bytes read.
+func (s *Store) GetInto(key string, ptr uintptr, size uint64) (int64, error) {
+	if s.handle == nil {
+		return 0, ErrStoreNil
+	}
+
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	ret := C.mooncake_store_get_into(s.handle, cKey,
+		unsafe.Pointer(ptr), C.size_t(size))
+	if ret < 0 {
+		return 0, ErrGet
+	}
+	return int64(ret), nil
+}
+
+// Get is a convenience method that copies value bytes into a Go slice.
+// For high-performance use cases, prefer GetInto with registered buffers.
+func (s *Store) Get(key string, buf []byte) (int64, error) {
+	if s.handle == nil {
+		return 0, ErrStoreNil
+	}
+	if len(buf) == 0 {
+		return 0, ErrInvalidArgument
+	}
+
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	ret := C.mooncake_store_get_into(s.handle, cKey,
+		unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
+	if ret < 0 {
+		return 0, ErrGet
+	}
+	return int64(ret), nil
+}
+
+// BatchGetInto reads multiple objects into pre-registered buffers.
+// Returns per-key byte counts (negative = error).
+func (s *Store) BatchGetInto(keys []string, ptrs []uintptr, sizes []uint64) ([]int64, error) {
+	if s.handle == nil {
+		return nil, ErrStoreNil
+	}
+	count := len(keys)
+	if count == 0 {
+		return nil, nil
+	}
+	if len(ptrs) != count || len(sizes) != count {
+		return nil, ErrInvalidArgument
+	}
+
+	cKeys := make([]*C.char, count)
+	for i, k := range keys {
+		cKeys[i] = C.CString(k)
+	}
+	defer func() {
+		for _, ck := range cKeys {
+			C.free(unsafe.Pointer(ck))
+		}
+	}()
+
+	cBufs := make([]unsafe.Pointer, count)
+	cSizes := make([]C.size_t, count)
+	for i := range ptrs {
+		cBufs[i] = unsafe.Pointer(ptrs[i])
+		cSizes[i] = C.size_t(sizes[i])
+	}
+
+	results := make([]C.int64_t, count)
+	ret := C.mooncake_store_batch_get_into(s.handle,
+		&cKeys[0], &cBufs[0], &cSizes[0], C.size_t(count), &results[0])
+	if ret != 0 {
+		return nil, ErrBatchOp
+	}
+
+	goResults := make([]int64, count)
+	for i := range results {
+		goResults[i] = int64(results[i])
+	}
+	return goResults, nil
+}
+
+// ---------------------------------------------------------------------------
+// Existence / size / hostname
+// ---------------------------------------------------------------------------
+
+// Exists checks whether a key exists in the store.
+func (s *Store) Exists(key string) (bool, error) {
+	if s.handle == nil {
+		return false, ErrStoreNil
+	}
+
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	ret := C.mooncake_store_is_exist(s.handle, cKey)
+	if ret < 0 {
+		return false, ErrExist
+	}
+	return ret == 1, nil
+}
+
+// BatchExists checks existence for multiple keys.
+func (s *Store) BatchExists(keys []string) ([]bool, error) {
+	if s.handle == nil {
+		return nil, ErrStoreNil
+	}
+	count := len(keys)
+	if count == 0 {
+		return nil, nil
+	}
+
+	cKeys := make([]*C.char, count)
+	for i, k := range keys {
+		cKeys[i] = C.CString(k)
+	}
+	defer func() {
+		for _, ck := range cKeys {
+			C.free(unsafe.Pointer(ck))
+		}
+	}()
+
+	results := make([]C.int, count)
+	ret := C.mooncake_store_batch_is_exist(s.handle, &cKeys[0],
+		C.size_t(count), &results[0])
+	if ret != 0 {
+		return nil, ErrBatchOp
+	}
+
+	goResults := make([]bool, count)
+	for i := range results {
+		goResults[i] = results[i] == 1
+	}
+	return goResults, nil
+}
+
+// GetSize returns the size in bytes of the object stored under key.
+func (s *Store) GetSize(key string) (int64, error) {
+	if s.handle == nil {
+		return 0, ErrStoreNil
+	}
+
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	ret := C.mooncake_store_get_size(s.handle, cKey)
+	if ret < 0 {
+		return 0, ErrGetSize
+	}
+	return int64(ret), nil
+}
+
+// Hostname returns the hostname of this store client node.
+func (s *Store) Hostname() (string, error) {
+	if s.handle == nil {
+		return "", ErrStoreNil
+	}
+	const bufLen = 256
+	buf := make([]byte, bufLen)
+	ret := C.mooncake_store_get_hostname(s.handle,
+		(*C.char)(unsafe.Pointer(&buf[0])), C.size_t(bufLen))
+	if ret != 0 {
+		return "", ErrHostname
+	}
+	n := 0
+	for n < len(buf) && buf[n] != 0 {
+		n++
+	}
+	return string(buf[:n]), nil
+}
+
+// ---------------------------------------------------------------------------
+// Remove operations
+// ---------------------------------------------------------------------------
+
+// Remove deletes an object by key. If force is true, the object is removed
+// even if it has active leases.
+func (s *Store) Remove(key string, force bool) error {
+	if s.handle == nil {
+		return ErrStoreNil
+	}
+
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	cForce := C.int(0)
+	if force {
+		cForce = 1
+	}
+	ret := C.mooncake_store_remove(s.handle, cKey, cForce)
+	if ret != 0 {
+		return ErrRemove
+	}
+	return nil
+}
+
+// RemoveByRegex removes all objects whose keys match the given regex pattern.
+// Returns the number of objects removed.
+func (s *Store) RemoveByRegex(pattern string, force bool) (int64, error) {
+	if s.handle == nil {
+		return 0, ErrStoreNil
+	}
+
+	cPattern := C.CString(pattern)
+	defer C.free(unsafe.Pointer(cPattern))
+
+	cForce := C.int(0)
+	if force {
+		cForce = 1
+	}
+	ret := C.mooncake_store_remove_by_regex(s.handle, cPattern, cForce)
+	if ret < 0 {
+		return 0, ErrRemove
+	}
+	return int64(ret), nil
+}
+
+// RemoveAll removes every object in the store.
+// Returns the number of objects removed.
+func (s *Store) RemoveAll(force bool) (int64, error) {
+	if s.handle == nil {
+		return 0, ErrStoreNil
+	}
+
+	cForce := C.int(0)
+	if force {
+		cForce = 1
+	}
+	ret := C.mooncake_store_remove_all(s.handle, cForce)
+	if ret < 0 {
+		return 0, ErrRemove
+	}
+	return int64(ret), nil
+}
+
+// ---------------------------------------------------------------------------
+// Buffer registration
+// ---------------------------------------------------------------------------
+
+// RegisterBuffer registers a memory region for zero-copy operations.
+// The memory at ptr must remain valid until UnregisterBuffer is called.
+func (s *Store) RegisterBuffer(ptr uintptr, size uint64) error {
+	if s.handle == nil {
+		return ErrStoreNil
+	}
+	if ptr == 0 || size == 0 {
+		return ErrInvalidArgument
+	}
+	ret := C.mooncake_store_register_buffer(s.handle,
+		unsafe.Pointer(ptr), C.size_t(size))
+	if ret != 0 {
+		return ErrRegisterBuffer
+	}
+	return nil
+}
+
+// UnregisterBuffer unregisters a previously registered memory region.
+func (s *Store) UnregisterBuffer(ptr uintptr) error {
+	if s.handle == nil {
+		return ErrStoreNil
+	}
+	ret := C.mooncake_store_unregister_buffer(s.handle, unsafe.Pointer(ptr))
+	if ret != 0 {
+		return ErrRegisterBuffer
+	}
+	return nil
+}

--- a/mooncake-store/go/mooncakestore/store_test.go
+++ b/mooncake-store/go/mooncakestore/store_test.go
@@ -1,0 +1,309 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mooncakestore
+
+import (
+	"testing"
+)
+
+// Unit tests run with `go test -short`. Integration tests additionally
+// require a running mooncake_master (mooncake_master --enable_http_metadata_server=true)
+// and are invoked via `go test -v ./...` (without -short).
+
+func setupStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := New()
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	err = store.Setup(
+		"localhost",
+		"http://localhost:8080/metadata",
+		512*1024*1024, // 512 MB global segment
+		128*1024*1024, // 128 MB local buffer
+		"tcp",
+		"",
+		"localhost:50051",
+	)
+	if err != nil {
+		store.Close()
+		t.Fatalf("Setup() failed: %v", err)
+	}
+	return store
+}
+
+func TestNewAndClose(t *testing.T) {
+	store, err := New()
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	// Close without setup should not panic
+	store.Close()
+
+	// Double close should be safe
+	store.Close()
+}
+
+func TestNilStoreOperations(t *testing.T) {
+	s := &Store{handle: nil}
+
+	if err := s.Setup("", "", 0, 0, "", "", ""); err != ErrStoreNil {
+		t.Errorf("expected ErrStoreNil, got %v", err)
+	}
+	if err := s.Put("k", []byte("v"), nil); err != ErrStoreNil {
+		t.Errorf("expected ErrStoreNil, got %v", err)
+	}
+	if _, err := s.Get("k", make([]byte, 10)); err != ErrStoreNil {
+		t.Errorf("expected ErrStoreNil, got %v", err)
+	}
+	if _, err := s.Exists("k"); err != ErrStoreNil {
+		t.Errorf("expected ErrStoreNil, got %v", err)
+	}
+	if err := s.Remove("k", false); err != ErrStoreNil {
+		t.Errorf("expected ErrStoreNil, got %v", err)
+	}
+}
+
+func TestDefaultReplicateConfig(t *testing.T) {
+	cfg := DefaultReplicateConfig()
+	if cfg.ReplicaNum != 1 {
+		t.Errorf("expected ReplicaNum=1, got %d", cfg.ReplicaNum)
+	}
+	if cfg.WithSoftPin {
+		t.Error("expected WithSoftPin=false")
+	}
+	if len(cfg.PreferredSegments) != 0 {
+		t.Error("expected empty PreferredSegments")
+	}
+}
+
+func TestInvalidReplicaNum(t *testing.T) {
+	store, err := New()
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	defer store.Close()
+
+	cfg := &ReplicateConfig{ReplicaNum: 0}
+	if err := store.Put("k", []byte("v"), cfg); err != ErrInvalidArgument {
+		t.Errorf("expected ErrInvalidArgument for ReplicaNum=0, got %v", err)
+	}
+
+	cfg.ReplicaNum = -1
+	if err := store.Put("k", []byte("v"), cfg); err != ErrInvalidArgument {
+		t.Errorf("expected ErrInvalidArgument for ReplicaNum=-1, got %v", err)
+	}
+}
+
+func TestPutFromValidation(t *testing.T) {
+	store, err := New()
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.PutFrom("k", 0, 100, nil); err != ErrInvalidArgument {
+		t.Errorf("expected ErrInvalidArgument for nil ptr, got %v", err)
+	}
+	if err := store.PutFrom("k", 0xDEAD, 0, nil); err != ErrInvalidArgument {
+		t.Errorf("expected ErrInvalidArgument for zero size, got %v", err)
+	}
+}
+
+func TestRegisterBufferValidation(t *testing.T) {
+	store, err := New()
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.RegisterBuffer(0, 100); err != ErrInvalidArgument {
+		t.Errorf("expected ErrInvalidArgument for nil ptr, got %v", err)
+	}
+	if err := store.RegisterBuffer(0xDEAD, 0); err != ErrInvalidArgument {
+		t.Errorf("expected ErrInvalidArgument for zero size, got %v", err)
+	}
+}
+
+// Integration tests below require a running cluster.
+// They are skipped when `go test -short` is used.
+// Run with:  go test -v ./...
+
+func TestPutGetRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	store := setupStore(t)
+	defer store.Close()
+
+	key := "test_go_roundtrip"
+	value := []byte("hello from Go")
+
+	// Put
+	if err := store.Put(key, value, nil); err != nil {
+		t.Fatalf("Put() failed: %v", err)
+	}
+
+	// Exists
+	exists, err := store.Exists(key)
+	if err != nil {
+		t.Fatalf("Exists() failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected key to exist after Put")
+	}
+
+	// GetSize
+	size, err := store.GetSize(key)
+	if err != nil {
+		t.Fatalf("GetSize() failed: %v", err)
+	}
+	if size != int64(len(value)) {
+		t.Fatalf("expected size=%d, got %d", len(value), size)
+	}
+
+	// Get
+	buf := make([]byte, 1024)
+	n, err := store.Get(key, buf)
+	if err != nil {
+		t.Fatalf("Get() failed: %v", err)
+	}
+	if string(buf[:n]) != string(value) {
+		t.Fatalf("expected %q, got %q", value, buf[:n])
+	}
+
+	// Remove (force=true because the object may still have an active lease)
+	if err := store.Remove(key, true); err != nil {
+		t.Fatalf("Remove() failed: %v", err)
+	}
+
+	// Verify removed
+	exists, err = store.Exists(key)
+	if err != nil {
+		t.Fatalf("Exists() after remove failed: %v", err)
+	}
+	if exists {
+		t.Fatal("expected key to not exist after Remove")
+	}
+}
+
+func TestBatchExists(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	store := setupStore(t)
+	defer store.Close()
+
+	keys := []string{"batch_go_1", "batch_go_2", "batch_go_3"}
+
+	// Put first two
+	for _, k := range keys[:2] {
+		if err := store.Put(k, []byte("data"), nil); err != nil {
+			t.Fatalf("Put(%s) failed: %v", k, err)
+		}
+	}
+
+	results, err := store.BatchExists(keys)
+	if err != nil {
+		t.Fatalf("BatchExists() failed: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	if !results[0] || !results[1] {
+		t.Error("expected first two keys to exist")
+	}
+	if results[2] {
+		t.Error("expected third key to not exist")
+	}
+
+	// Cleanup
+	for _, k := range keys[:2] {
+		_ = store.Remove(k, true)
+	}
+}
+
+func TestRemoveAll(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	store := setupStore(t)
+	defer store.Close()
+
+	for i := 0; i < 5; i++ {
+		key := "removeall_go_" + string(rune('a'+i))
+		if err := store.Put(key, []byte("data"), nil); err != nil {
+			t.Fatalf("Put(%s) failed: %v", key, err)
+		}
+	}
+
+	removed, err := store.RemoveAll(false)
+	if err != nil {
+		t.Fatalf("RemoveAll() failed: %v", err)
+	}
+	if removed < 5 {
+		t.Logf("RemoveAll returned %d (may include pre-existing keys)", removed)
+	}
+}
+
+func TestHostname(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	store := setupStore(t)
+	defer store.Close()
+
+	hostname, err := store.Hostname()
+	if err != nil {
+		t.Fatalf("Hostname() failed: %v", err)
+	}
+	if hostname == "" {
+		t.Fatal("expected non-empty hostname")
+	}
+	t.Logf("Store hostname: %s", hostname)
+}
+
+func TestReplicateConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	store := setupStore(t)
+	defer store.Close()
+
+	cfg := &ReplicateConfig{
+		ReplicaNum:  2,
+		WithSoftPin: true,
+	}
+
+	key := "test_go_replicated"
+	if err := store.Put(key, []byte("replicated data"), cfg); err != nil {
+		t.Fatalf("Put with ReplicateConfig failed: %v", err)
+	}
+
+	exists, err := store.Exists(key)
+	if err != nil {
+		t.Fatalf("Exists() failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected replicated key to exist")
+	}
+
+	_ = store.Remove(key, true)
+}

--- a/mooncake-store/include/store_c.h
+++ b/mooncake-store/include/store_c.h
@@ -1,0 +1,131 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOONCAKE_STORE_C_H
+#define MOONCAKE_STORE_C_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void *mooncake_store_t;
+
+struct mooncake_replicate_config {
+    size_t replica_num;
+    int with_soft_pin;
+    const char **preferred_segments;
+    size_t preferred_segments_count;
+};
+typedef struct mooncake_replicate_config mooncake_replicate_config_t;
+
+/*
+ * All memory pointed to by the "char *" parameters will not be used
+ * after the C function returns.
+ * This means that the caller can free the memory pointed to by "char *"
+ * parameters, after the call is completed.
+ * All the C functions here follow this convention.
+ */
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+mooncake_store_t mooncake_store_create();
+
+void mooncake_store_destroy(mooncake_store_t store);
+
+int mooncake_store_setup(mooncake_store_t store, const char *local_hostname,
+                         const char *metadata_server,
+                         uint64_t global_segment_size,
+                         uint64_t local_buffer_size, const char *protocol,
+                         const char *device_name,
+                         const char *master_server_addr);
+
+int mooncake_store_init_all(mooncake_store_t store, const char *protocol,
+                            const char *device_name,
+                            uint64_t mount_segment_size);
+
+int mooncake_store_health_check(mooncake_store_t store);
+
+// ---------------------------------------------------------------------------
+// Put operations
+// ---------------------------------------------------------------------------
+
+int mooncake_store_put(mooncake_store_t store, const char *key,
+                       const void *value, size_t size,
+                       const mooncake_replicate_config_t *config);
+
+int mooncake_store_put_from(mooncake_store_t store, const char *key,
+                            void *buffer, size_t size,
+                            const mooncake_replicate_config_t *config);
+
+int mooncake_store_batch_put_from(mooncake_store_t store, const char **keys,
+                                  void **buffers, const size_t *sizes,
+                                  size_t count,
+                                  const mooncake_replicate_config_t *config,
+                                  int *results_out);
+
+// ---------------------------------------------------------------------------
+// Get operations
+// ---------------------------------------------------------------------------
+
+int64_t mooncake_store_get_into(mooncake_store_t store, const char *key,
+                                void *buffer, size_t size);
+
+int mooncake_store_batch_get_into(mooncake_store_t store, const char **keys,
+                                  void **buffers, const size_t *sizes,
+                                  size_t count, int64_t *results_out);
+
+// ---------------------------------------------------------------------------
+// Existence / size / hostname
+// ---------------------------------------------------------------------------
+
+int mooncake_store_is_exist(mooncake_store_t store, const char *key);
+
+int mooncake_store_batch_is_exist(mooncake_store_t store, const char **keys,
+                                  size_t count, int *results_out);
+
+int64_t mooncake_store_get_size(mooncake_store_t store, const char *key);
+
+int mooncake_store_get_hostname(mooncake_store_t store, char *buf_out,
+                                size_t buf_len);
+
+// ---------------------------------------------------------------------------
+// Remove operations
+// ---------------------------------------------------------------------------
+
+int mooncake_store_remove(mooncake_store_t store, const char *key, int force);
+
+int64_t mooncake_store_remove_by_regex(mooncake_store_t store,
+                                       const char *pattern, int force);
+
+int64_t mooncake_store_remove_all(mooncake_store_t store, int force);
+
+// ---------------------------------------------------------------------------
+// Buffer registration (for zero-copy operations)
+// ---------------------------------------------------------------------------
+
+int mooncake_store_register_buffer(mooncake_store_t store, void *buffer,
+                                   size_t size);
+
+int mooncake_store_unregister_buffer(mooncake_store_t store, void *buffer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // MOONCAKE_STORE_C_H

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -46,7 +46,8 @@ set(MOONCAKE_STORE_SOURCES
     oplog_applier.cpp
     hot_standby_service.cpp
     standby_state_machine.cpp
-    ha_metric_manager.cpp)
+    ha_metric_manager.cpp
+    store_c.cpp)
 
 set(EXTRA_LIBS "")
 

--- a/mooncake-store/src/store_c.cpp
+++ b/mooncake-store/src/store_c.cpp
@@ -1,0 +1,274 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "store_c.h"
+
+#include <cstring>
+#include <memory>
+#include <new>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "real_client.h"
+#include "replica.h"
+#include "types.h"
+
+namespace {
+
+// Thin wrapper to keep the shared_ptr alive across the C API boundary.
+// RealClient::create() returns shared_ptr and registers a weak_ptr in
+// ResourceTracker, so we must not let the shared_ptr die prematurely.
+struct StoreHandle {
+    std::shared_ptr<mooncake::RealClient> client;
+};
+
+mooncake::ReplicateConfig to_replicate_config(
+    const mooncake_replicate_config_t *c_config) {
+    mooncake::ReplicateConfig config;
+    if (!c_config) return config;
+
+    config.replica_num = c_config->replica_num;
+    config.with_soft_pin = c_config->with_soft_pin != 0;
+    if (c_config->preferred_segments &&
+        c_config->preferred_segments_count > 0) {
+        for (size_t i = 0; i < c_config->preferred_segments_count; ++i) {
+            if (c_config->preferred_segments[i]) {
+                config.preferred_segments.emplace_back(
+                    c_config->preferred_segments[i]);
+            }
+        }
+    }
+    return config;
+}
+
+StoreHandle *as_handle(mooncake_store_t store) {
+    return static_cast<StoreHandle *>(store);
+}
+
+mooncake::RealClient *as_client(mooncake_store_t store) {
+    return as_handle(store)->client.get();
+}
+
+}  // namespace
+
+extern "C" {
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+mooncake_store_t mooncake_store_create() {
+    auto client = mooncake::RealClient::create();
+    if (!client) return nullptr;
+    auto *handle = new (std::nothrow) StoreHandle{std::move(client)};
+    if (!handle) return nullptr;
+    return static_cast<mooncake_store_t>(handle);
+}
+
+void mooncake_store_destroy(mooncake_store_t store) {
+    if (!store) return;
+    auto *handle = as_handle(store);
+    if (handle->client) {
+        handle->client->tearDownAll();
+    }
+    delete handle;
+}
+
+int mooncake_store_setup(mooncake_store_t store, const char *local_hostname,
+                         const char *metadata_server,
+                         uint64_t global_segment_size,
+                         uint64_t local_buffer_size, const char *protocol,
+                         const char *device_name,
+                         const char *master_server_addr) {
+    if (!store) return -1;
+    return as_client(store)->setup_real(
+        local_hostname ? local_hostname : "",
+        metadata_server ? metadata_server : "", global_segment_size,
+        local_buffer_size, protocol ? protocol : "tcp",
+        device_name ? device_name : "",
+        master_server_addr ? master_server_addr : "127.0.0.1:50051");
+}
+
+int mooncake_store_init_all(mooncake_store_t store, const char *protocol,
+                            const char *device_name,
+                            uint64_t mount_segment_size) {
+    if (!store) return -1;
+    return as_client(store)->initAll(protocol ? protocol : "",
+                                     device_name ? device_name : "",
+                                     mount_segment_size);
+}
+
+int mooncake_store_health_check(mooncake_store_t store) {
+    if (!store) return -1;
+    return as_client(store)->health_check();
+}
+
+// ---------------------------------------------------------------------------
+// Put operations
+// ---------------------------------------------------------------------------
+
+int mooncake_store_put(mooncake_store_t store, const char *key,
+                       const void *value, size_t size,
+                       const mooncake_replicate_config_t *config) {
+    if (!store || !key) return -1;
+    if (!value && size > 0) return -1;
+    auto rc = to_replicate_config(config);
+    std::span<const char> data(static_cast<const char *>(value), size);
+    return as_client(store)->put(key, data, rc);
+}
+
+int mooncake_store_put_from(mooncake_store_t store, const char *key,
+                            void *buffer, size_t size,
+                            const mooncake_replicate_config_t *config) {
+    if (!store || !key) return -1;
+    auto rc = to_replicate_config(config);
+    return as_client(store)->put_from(key, buffer, size, rc);
+}
+
+int mooncake_store_batch_put_from(mooncake_store_t store, const char **keys,
+                                  void **buffers, const size_t *sizes,
+                                  size_t count,
+                                  const mooncake_replicate_config_t *config,
+                                  int *results_out) {
+    if (!store || !keys || !buffers || !sizes || !results_out) return -1;
+
+    std::vector<std::string> key_vec(count);
+    std::vector<void *> buf_vec(count);
+    std::vector<size_t> size_vec(count);
+    for (size_t i = 0; i < count; ++i) {
+        key_vec[i] = keys[i] ? keys[i] : "";
+        buf_vec[i] = buffers[i];
+        size_vec[i] = sizes[i];
+    }
+
+    auto rc = to_replicate_config(config);
+    auto results =
+        as_client(store)->batch_put_from(key_vec, buf_vec, size_vec, rc);
+
+    for (size_t i = 0; i < count; ++i) {
+        results_out[i] = (i < results.size()) ? results[i] : -1;
+    }
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Get operations
+// ---------------------------------------------------------------------------
+
+int64_t mooncake_store_get_into(mooncake_store_t store, const char *key,
+                                void *buffer, size_t size) {
+    if (!store || !key) return -1;
+    return as_client(store)->get_into(key, buffer, size);
+}
+
+int mooncake_store_batch_get_into(mooncake_store_t store, const char **keys,
+                                  void **buffers, const size_t *sizes,
+                                  size_t count, int64_t *results_out) {
+    if (!store || !keys || !buffers || !sizes || !results_out) return -1;
+
+    std::vector<std::string> key_vec(count);
+    std::vector<void *> buf_vec(count);
+    std::vector<size_t> size_vec(count);
+    for (size_t i = 0; i < count; ++i) {
+        key_vec[i] = keys[i] ? keys[i] : "";
+        buf_vec[i] = buffers[i];
+        size_vec[i] = sizes[i];
+    }
+
+    auto results = as_client(store)->batch_get_into(key_vec, buf_vec, size_vec);
+
+    for (size_t i = 0; i < count; ++i) {
+        results_out[i] = (i < results.size()) ? results[i] : -1;
+    }
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Existence / size / hostname
+// ---------------------------------------------------------------------------
+
+int mooncake_store_is_exist(mooncake_store_t store, const char *key) {
+    if (!store || !key) return -1;
+    return as_client(store)->isExist(key);
+}
+
+int mooncake_store_batch_is_exist(mooncake_store_t store, const char **keys,
+                                  size_t count, int *results_out) {
+    if (!store || !keys || !results_out) return -1;
+
+    std::vector<std::string> key_vec(count);
+    for (size_t i = 0; i < count; ++i) {
+        key_vec[i] = keys[i] ? keys[i] : "";
+    }
+
+    auto results = as_client(store)->batchIsExist(key_vec);
+
+    for (size_t i = 0; i < count; ++i) {
+        results_out[i] = (i < results.size()) ? results[i] : -1;
+    }
+    return 0;
+}
+
+int64_t mooncake_store_get_size(mooncake_store_t store, const char *key) {
+    if (!store || !key) return -1;
+    return as_client(store)->getSize(key);
+}
+
+int mooncake_store_get_hostname(mooncake_store_t store, char *buf_out,
+                                size_t buf_len) {
+    if (!store || !buf_out || buf_len == 0) return -1;
+    std::string hostname = as_client(store)->get_hostname();
+    if (hostname.size() >= buf_len) return -1;
+    std::memcpy(buf_out, hostname.c_str(), hostname.size() + 1);
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Remove operations
+// ---------------------------------------------------------------------------
+
+int mooncake_store_remove(mooncake_store_t store, const char *key, int force) {
+    if (!store || !key) return -1;
+    return as_client(store)->remove(key, force != 0);
+}
+
+int64_t mooncake_store_remove_by_regex(mooncake_store_t store,
+                                       const char *pattern, int force) {
+    if (!store || !pattern) return -1;
+    return static_cast<int64_t>(
+        as_client(store)->removeByRegex(pattern, force != 0));
+}
+
+int64_t mooncake_store_remove_all(mooncake_store_t store, int force) {
+    if (!store) return -1;
+    return static_cast<int64_t>(as_client(store)->removeAll(force != 0));
+}
+
+// ---------------------------------------------------------------------------
+// Buffer registration
+// ---------------------------------------------------------------------------
+
+int mooncake_store_register_buffer(mooncake_store_t store, void *buffer,
+                                   size_t size) {
+    if (!store || !buffer || size == 0) return -1;
+    return as_client(store)->register_buffer(buffer, size);
+}
+
+int mooncake_store_unregister_buffer(mooncake_store_t store, void *buffer) {
+    if (!store) return -1;
+    return as_client(store)->unregister_buffer(buffer);
+}
+
+}  // extern "C"


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
Add Go language bindings for Mooncake Store, enabling Go programs to use Store operations (put, get, batch, zero-copy, buffer registration) 

The structure of changes from top to bottom:
```
main.go            Example program / user application 
store_test.go      Tests 

store.go           Go API layer (calls C via CGo)
config.go          Go data types 
errors.go          Go error definitions 
           (CGo boundary)
store_c.h          C header (the "contract") 
store_c.cpp        C implementation (translates C → C++)

build.sh           Wires it all together
```
Also added `WITH_STORE_GO` build option to provide flexibilities.
Also updated the outdated `.devcontainer/Dockerfile` to have arm64 support.
Also added unit tests and integration tests.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->
Build verification: store_c.cpp compiles as part of libmooncake_store via CMake with WITH_STORE_GO=ON.
Nil-safety tests (TestNilStoreOperations, TestNewAndClose): verify safe behavior on nil handles and double-close. These run without a cluster.
Integration tests (TestPutGetRoundTrip, TestBatchExists, TestRemoveAll, TestHostname, TestReplicateConfig): 
from CI test:
```
PASS
ok  	github.com/kvcache-ai/Mooncake/mooncake-store/go/mooncakestore	6.045s
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
