### PR TITLE
[EP] Add differential test with DeepEP

### DIFF
--- a/mooncake-ep/tests/compare_with_deepep.py
+++ b/mooncake-ep/tests/compare_with_deepep.py
@@ -6,6 +6,7 @@ import faulthandler
 
 from deep_ep.buffer import Buffer as DeepEPBuffer
 from mooncake.mooncake_ep_buffer import Buffer as MooncakeBuffer
+import mooncake.pg as pg
 
 
 def check_close(
@@ -291,10 +292,12 @@ def worker(rank: int, num_ranks: int):
     total_configs = len(combinations)
 
     # Device filter
-    device_filter = ["mlx5_1", "mlx5_2", "mlx5_3", "mlx5_4"]
+    device_filter = [
+        f
+        for f in os.getenv("DEVICE_FILTER", "mlx5_1,mlx5_2,mlx5_3,mlx5_4").split(",")
+        if f
+    ]
     if device_filter:
-        import mooncake.pg as pg
-
         pg.set_device_filter(device_filter)
 
     # Print message


### PR DESCRIPTION
## Description

This PR adds a differential test between MooncakeEP and DeepEP.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [x] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other

## How Has This Been Tested?

Ran the newly added test. All configurations successfully passed the test.
```
==============================================================================================================
 Summary: MooncakeEP vs DeepEP
==============================================================================================================
| use_fp | zero_c | async_ | use_fa | M-Disp(ms) | D-Disp(ms) | M-Comb(ms) | D-Comb(ms) | Match? |
--------------------------------------------------------------------------------------------------
| False  | False  | False  | False  |       1.78 |       3.78 |       0.14 |       1.93 | ✅ PASS |
| False  | False  | False  | True   |      45.34 |       0.30 |     120.78 |       1.17 | ✅ PASS |
| False  | False  | True   | False  |       0.20 |       0.31 |       0.10 |       0.05 | ✅ PASS |
| False  | False  | True   | True   |      34.24 |       0.29 |     156.59 |      23.11 | ✅ PASS |
| False  | True   | False  | False  |       0.26 |       0.29 |       0.10 |       0.05 | ✅ PASS |
| False  | True   | False  | True   |      39.69 |       1.17 |     145.73 |      13.39 | ✅ PASS |
| False  | True   | True   | False  |       0.31 |       0.26 |       0.09 |       0.05 | ✅ PASS |
| False  | True   | True   | True   |      32.52 |       0.28 |     144.08 |      18.50 | ✅ PASS |
| True   | False  | False  | False  |       0.45 |       1.12 |       0.12 |       0.28 | ✅ PASS |
| True   | False  | False  | True   |      65.60 |       0.35 |     145.18 |      29.73 | ✅ PASS |
| True   | False  | True   | False  |       0.49 |       0.40 |       0.12 |       0.51 | ✅ PASS |
| True   | False  | True   | True   |      38.24 |       0.31 |      99.07 |       6.22 | ✅ PASS |
| True   | True   | False  | False  |       0.29 |       0.65 |       0.15 |       0.05 | ✅ PASS |
| True   | True   | False  | True   |      39.08 |       0.52 |     143.79 |      22.82 | ✅ PASS |
| True   | True   | True   | False  |       1.28 |       1.07 |       0.18 |       0.05 | ✅ PASS |
| True   | True   | True   | True   |      39.10 |       0.34 |     142.93 |      27.43 | ✅ PASS |
--------------------------------------------------------------------------------------------------
==============================================================================================================
🎉 All tests passed.

```

(The recorded time may be inaccurate because no warm-up was performed and only a single round was run.)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
