### PR TITLE
fix compile error when use -DUSE_ASCEND_HETEROGENEOUS=ON

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -82,8 +82,8 @@ class RdmaTransport : public Transport {
     int unregisterLocalMemoryInternal(void *addr, bool update_metadata,
                                       bool force_sequential);
 
+   public:
     // TRANSFER
-
     Status submitTransfer(BatchID batch_id,
                           const std::vector<TransferRequest> &entries) override;
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Met exception when turn on ` -DUSE_ASCEND_HETEROGENEOUS=ON` option.

```
/usr/include/c++/12/bits/basic_string.h:294:21: warning: ‘((std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*)((char*)&<unnamed> + offsetof(std::async_rpc_raw_result, std::variant<coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Variant_base<coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Move_assign_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Copy_assign_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Move_ctor_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Copy_ctor_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Variant_storage<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::_M_u)))[1].std::__cxx11::basic_string<char>::<anonymous>.std::__cxx11::basic_string<char>::<unnamed union>::_M_allocated_capacity’ may be used uninitialized [-Wmaybe-uninitialized]
  294 |           _M_destroy(_M_allocated_capacity);
      |           ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/ylt/coro_rpc/impl/coro_rpc_client.hpp: In static member function ‘static void coro_rpc::coro_rpc_client::send_err_response(control_t*, std::error_code&)’:
/usr/local/include/ylt/coro_rpc/impl/coro_rpc_client.hpp:834:48: note: ‘<anonymous>’ declared here
  834 |       promise_.setValue(async_rpc_raw_result{ec});
      |                                                ^
In member function ‘constexpr void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_dispose() [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’,
    inlined from ‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::~basic_string() [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12/bits/basic_string.h:803:19,
    inlined from ‘constexpr coro_rpc::resp_body::~resp_body()’ at /usr/local/include/ylt/coro_rpc/impl/coro_rpc_client.hpp:102:8,
    inlined from ‘constexpr coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type::~async_rpc_raw_result_value_type()’ at /usr/local/include/ylt/coro_rpc/impl/coro_rpc_client.hpp:802:10,
    inlined from ‘constexpr void std::destroy_at(_Tp*) [with _Tp = coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type]’ at /usr/include/c++/12/bits/stl_construct.h:88:18,
    inlined from ‘constexpr void std::_Destroy(_Tp*) [with _Tp = coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type]’ at /usr/include/c++/12/bits/stl_construct.h:149:22,
    inlined from ‘std::__detail::__variant::_Variant_storage<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::_M_reset()::<lambda(auto:20&&)> mutable [with auto:20 = coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type&]’ at /usr/include/c++/12/variant:472:19,
    inlined from ‘constexpr _Res std::__invoke_impl(__invoke_other, _Fn&&, _Args&& ...) [with _Res = void; _Fn = __detail::__variant::_Variant_storage<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, error_code>::_M_reset()::<lambda(auto:20&&)>; _Args = {coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type&}]’ at /usr/include/c++/12/bits/invoke.h:61:36,
    inlined from ‘constexpr std::enable_if_t<is_invocable_r_v<_Res, _Callable, _Args ...>, _Res> std::__invoke_r(_Callable&&, _Args&& ...) [with _Res = void; _Callable = __detail::__variant::_Variant_storage<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, error_code>::_M_reset()::<lambda(auto:20&&)>; _Args = {coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type&}]’ at /usr/include/c++/12/bits/invoke.h:111:28,
    inlined from ‘static constexpr decltype(auto) std::__detail::__variant::__gen_vtable_impl<std::__detail::__variant::_Multi_array<_Result_type (*)(_Visitor, _Variants ...)>, std::integer_sequence<long unsigned int, __indices ...> >::__visit_invoke(_Visitor&&, _Variants ...) [with _Result_type = void; _Visitor = std::__detail::__variant::_Variant_storage<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::_M_reset()::<lambda(auto:20&&)>&&; _Variants = {std::variant<coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>&}; long unsigned int ...__indices = {0}]’ at /usr/include/c++/12/variant:1035:40,
    inlined from ‘constexpr decltype(auto) std::__do_visit(_Visitor&&, _Variants&& ...) [with _Result_type = void; _Visitor = __detail::__variant::_Variant_storage<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, error_code>::_M_reset()::<lambda(auto:20&&)>; _Variants = {variant<coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, error_code>&}]’ at /usr/include/c++/12/variant:1790:5,
    inlined from ‘constexpr decltype(auto) std::__do_visit(_Visitor&&, _Variants&& ...) [with _Result_type = void; _Visitor = __detail::__variant::_Variant_storage<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, error_code>::_M_reset()::<lambda(auto:20&&)>; _Variants = {variant<coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, error_code>&}]’ at /usr/include/c++/12/variant:1731:5,
    inlined from ‘constexpr void std::__detail::__variant::_Variant_storage<false, _Types ...>::_M_reset() [with _Types = {coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code}]’ at /usr/include/c++/12/variant:470:23,
    inlined from ‘constexpr std::__detail::__variant::_Variant_storage<false, _Types ...>::~_Variant_storage() [with _Types = {coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code}]’ at /usr/include/c++/12/variant:480:17,
    inlined from ‘constexpr std::__detail::__variant::_Copy_ctor_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::~_Copy_ctor_base()’ at /usr/include/c++/12/variant:554:12,
    inlined from ‘constexpr std::__detail::__variant::_Move_ctor_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::~_Move_ctor_base()’ at /usr/include/c++/12/variant:591:12,
    inlined from ‘constexpr std::__detail::__variant::_Copy_assign_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::~_Copy_assign_base()’ at /usr/include/c++/12/variant:629:12,
    inlined from ‘constexpr std::__detail::__variant::_Move_assign_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::~_Move_assign_base()’ at /usr/include/c++/12/variant:681:12,
    inlined from ‘constexpr std::__detail::__variant::_Variant_base<coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::~_Variant_base()’ at /usr/include/c++/12/variant:735:12,
    inlined from ‘constexpr std::variant<_Types>::~variant() [with _Types = {coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code}]’ at /usr/include/c++/12/variant:1407:28,
    inlined from ‘void coro_rpc::coro_rpc_client::handler_t::local_error(std::error_code&)’ at /usr/local/include/ylt/coro_rpc/impl/coro_rpc_client.hpp:834:25,
    inlined from ‘static void coro_rpc::coro_rpc_client::send_err_response(control_t*, std::error_code&)’ at /usr/local/include/ylt/coro_rpc/impl/coro_rpc_client.hpp:936:27:
/usr/include/c++/12/bits/basic_string.h:294:21: warning: ‘*(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*)((char*)&<unnamed> + offsetof(std::async_rpc_raw_result, std::variant<coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Variant_base<coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Move_assign_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Copy_assign_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Move_ctor_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Copy_ctor_base<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::<unnamed>.std::__detail::__variant::_Variant_storage<false, coro_rpc::coro_rpc_client::async_rpc_raw_result_value_type, std::error_code>::_M_u)).std::__cxx11::basic_string<char>::<anonymous>.std::__cxx11::basic_string<char>::<unnamed union>::_M_allocated_capacity’ may be used uninitialized [-Wmaybe-uninitialized]
  294 |           _M_destroy(_M_allocated_capacity);
      |           ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/ylt/coro_rpc/impl/coro_rpc_client.hpp: In static member function ‘static void coro_rpc::coro_rpc_client::send_err_response(control_t*, std::error_code&)’:
/usr/local/include/ylt/coro_rpc/impl/coro_rpc_client.hpp:834:48: note: ‘<anonymous>’ declared here
  834 |       promise_.setValue(async_rpc_raw_result{ec});
      |                                                ^
[ 12%] Built target rpc_communicator
make: *** [Makefile:146: all] Error 2
[  1%] Built target base
[  2%] Building CXX object mooncake-transfer-engine/src/transport/ascend_transport/CMakeFiles/ascend_transport.dir/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp.o
[  3%] Built target mooncake_common
[  4%] Built target asio_shared
[  7%] Built target cachelib_memory_allocator
[  8%] Built target tcp_transport
[ 11%] Built target rdma_transport
[ 12%] Built target rpc_communicator
[ 13%] Building CXX object mooncake-common/tests/CMakeFiles/default_config_test.dir/default_config_test.cpp.o
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp: In member function ‘void mooncake::HeterogeneousRdmaTransport::transferLoop()’:
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp:87:43: error: ‘virtual mooncake::Status mooncake::RdmaTransport::submitTransferTask(const std::vector<mooncake::Transport::TransferTask*>&)’ is private within this context
   87 |         s = transport_->submitTransferTask(task_list);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
In file included from /vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/include/transport/ascend_transport/heterogeneous_rdma_transport.h:19,
                 from /vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp:1:
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h:90:12: note: declared private here
   90 |     Status submitTransferTask(
      |            ^~~~~~~~~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp: In member function ‘virtual mooncake::Status mooncake::HeterogeneousRdmaTransport::submitTransfer(mooncake::Transport::BatchID, const std::vector<mooncake::Transport::TransferRequest>&)’:
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp:247:42: error: ‘virtual mooncake::Status mooncake::RdmaTransport::submitTransfer(mooncake::Transport::BatchID, const std::vector<mooncake::Transport::TransferRequest>&)’ is private within this context
  247 |         return transport_->submitTransfer(batch_id, entries);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h:87:12: note: declared private here
   87 |     Status submitTransfer(BatchID batch_id,
      |            ^~~~~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp:295:38: error: ‘virtual mooncake::Status mooncake::RdmaTransport::submitTransfer(mooncake::Transport::BatchID, const std::vector<mooncake::Transport::TransferRequest>&)’ is private within this context
  295 |     return transport_->submitTransfer(batch_id, new_entries);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h:87:12: note: declared private here
   87 |     Status submitTransfer(BatchID batch_id,
      |            ^~~~~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp: In member function ‘mooncake::Status mooncake::HeterogeneousRdmaTransport::noAggTransport(const std::vector<mooncake::Transport::TransferTask*>&)’:
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp:339:42: error: ‘virtual mooncake::Status mooncake::RdmaTransport::submitTransferTask(const std::vector<mooncake::Transport::TransferTask*>&)’ is private within this context
  339 |     return transport_->submitTransferTask(task_list);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h:90:12: note: declared private here
   90 |     Status submitTransferTask(
      |            ^~~~~~~~~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp: In member function ‘virtual mooncake::Status mooncake::HeterogeneousRdmaTransport::submitTransferTask(const std::vector<mooncake::Transport::TransferTask*>&)’:
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp:420:46: error: ‘virtual mooncake::Status mooncake::RdmaTransport::submitTransferTask(const std::vector<mooncake::Transport::TransferTask*>&)’ is private within this context
  420 |         return transport_->submitTransferTask(task_list);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h:90:12: note: declared private here
   90 |     Status submitTransferTask(
      |            ^~~~~~~~~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp: In member function ‘mooncake::Status mooncake::HeterogeneousRdmaTransport::getTransferStatus(mooncake::Transport::BatchID, std::vector<mooncake::Transport::TransferStatus>&)’:
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp:445:41: error: ‘mooncake::Status mooncake::RdmaTransport::getTransferStatus(mooncake::Transport::BatchID, std::vector<mooncake::Transport::TransferStatus>&)’ is private within this context
  445 |     return transport_->getTransferStatus(batch_id, status);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h:93:12: note: declared private here
   93 |     Status getTransferStatus(BatchID batch_id,
      |            ^~~~~~~~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp: In member function ‘virtual mooncake::Status mooncake::HeterogeneousRdmaTransport::getTransferStatus(mooncake::Transport::BatchID, size_t, mooncake::Transport::TransferStatus&)’:
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/src/transport/ascend_transport/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp:451:41: error: ‘virtual mooncake::Status mooncake::RdmaTransport::getTransferStatus(mooncake::Transport::BatchID, size_t, mooncake::Transport::TransferStatus&)’ is private within this context
  451 |     return transport_->getTransferStatus(batch_id, task_id, status);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
/vector-engine-workspace/alg-product/mooncake/Mooncake/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h:96:12: note: declared private here
   96 |     Status getTransferStatus(BatchID batch_id, size_t task_id,
      |            ^~~~~~~~~~~~~~~~~
make[2]: *** [mooncake-transfer-engine/src/transport/ascend_transport/CMakeFiles/ascend_transport.dir/build.make:79: mooncake-transfer-engine/src/transport/ascend_transport/CMakeFiles/ascend_transport.dir/heterogeneous_rdma_transport/heterogeneous_rdma_transport.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1091: mooncake-transfer-engine/src/transport/ascend_transport/CMakeFiles/ascend_transport.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 13%] Linking CXX executable default_config_test
[ 13%] Built target default_config_test
make: *** [Makefile:146: all] Error 2
Mooncake installed successfully.
cp: cannot stat 'build/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/ascend_transport_c/libascend_transport_mem.so': No such file or directory
cp: cannot stat 'build/libascend_transport_mem.so': No such file or directory
cp: cannot stat '/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake/*.so': No such file or directory
cp: cannot stat '/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/libascend_transport_mem.so': No such file or directory
+ PYTHON_VERSION=3.11.6
+ OUTPUT_DIR=dist
+ BUILD_DIR=build
+ echo 'Building wheel for Python 3.11.6 with output directory dist'
Building wheel for Python 3.11.6 with output directory dist
```


## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
