### PR TITLE
add required library when build

### DIFF
--- a/scripts/ascend/dependencies_ascend.sh
+++ b/scripts/ascend/dependencies_ascend.sh
@@ -59,6 +59,7 @@ if command -v apt-get &> /dev/null; then
             libpython3-dev \
             libboost-all-dev \
             libssl-dev \
+            libzstd-dev \
             libgrpc-dev \
             libgrpc++-dev \
             libprotobuf-dev \
@@ -86,6 +87,7 @@ elif command -v yum &> /dev/null; then
             hiredis-devel \
             libcurl-devel \
             jsoncpp-devel \
+            zstd-devel \
             mpich \
             mpich-devel
     # Install yaml-cpp


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

```
-- Http as metadata server support is enabled
-- metrics is enabled
YLT is imported by find_package
-- -------------YLT CONFIG SETTING-------------
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- YLT_ENABLE_DL: ON
-- YLT_ENABLE_SSL: OFF
-- YLT_ENABLE_PMR: OFF
-- YLT_ENABLE_IO_URING: OFF
-- YLT_ENABLE_STRUCT_PACK_UNPORTABLE_TYPE: OFF
-- YLT_ENABLE_STRUCT_PACK_OPTIMIZE: OFF
-- --------------------------------------------
-- pybind11 v2.13.6 
-- Found PythonInterp: /usr/local/python3.11.14/bin/python3 (found suitable version "3.11.14", minimum required is "3.7") 
-- Found PythonLibs: /usr/local/python3.11.14/lib/libpython3.11.so
-- Performing Test HAS_FLTO
-- Performing Test HAS_FLTO - Success
-- Found ASIO at: /usr/local/include
-- Found Python3: /usr/local/python3.11.14/bin/python3 (found version "3.11.14") found components: Interpreter Development Development.Module Development.Embed 
-- Found CURL: /usr/lib/aarch64-linux-gnu/libcurl.so (found version "7.81.0")  
-- Mooncake Store will be built
-- STORE_USE_ETCD=OFF, high availability of Store is disabled
-- AWS SDK not found, S3 functionality will be disabled
CMake Error at mooncake-store/src/CMakeLists.txt:56 (message):
  zstd library not found                                                                                                                                          
                                                                                                                                                                  
                                                                                                                                                                  
-- Configuring incomplete, errors occurred!
See also "/workspace/alg-product/mooncake/Mooncake/build/CMakeFiles/CMakeOutput.log".
make: *** No targets specified and no makefile found.  Stop.
make: *** No rule to make target 'install'.  Stop.
Mooncake installed successfully.
cp: cannot stat 'build/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/ascend_transport_c/libascend_transport_mem.so': No such file or directory
cp: cannot stat 'build/libascend_transport_mem.so': No such file or directory
cp: cannot stat '/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake/*.so': No such file or directory
cp: cannot stat '/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/libascend_transport_mem.so': No such file or directory
+ python -c import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')
+ PYTHON_VERSION=3.11
+ OUTPUT_DIR=dist

```

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
