### PR TITLE
[Store] Make segment splitting transport-aware and use balanced partitioning

### DIFF
--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -734,4 +734,10 @@ class RealClient : public PyClient {
         size_t local_buffer_size);
 };
 
+// Compute GiB-aligned segment sizes that sum exactly to total_bytes.
+// Exposed for unit testing; see real_client.cpp for full documentation.
+std::vector<size_t> computeSegmentSizes(size_t total_bytes,
+                                        size_t max_mr_size,
+                                        bool is_rdma);
+
 }  // namespace mooncake

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -734,10 +734,16 @@ class RealClient : public PyClient {
         size_t local_buffer_size);
 };
 
-// Compute GiB-aligned segment sizes that sum exactly to total_bytes.
+enum class SegmentSplitMode {
+    kSingleSegment,
+    kBalanced,
+    kGiBAlignedBalanced,
+};
+
+// Compute segment sizes that sum exactly to total_bytes.
 // Exposed for unit testing; see real_client.cpp for full documentation.
 std::vector<size_t> computeSegmentSizes(size_t total_bytes,
-                                        size_t max_mr_size,
-                                        bool is_rdma);
+                                        size_t max_segment_size,
+                                        SegmentSplitMode split_mode);
 
 }  // namespace mooncake

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -203,8 +203,8 @@ tl::expected<std::optional<ha::HABackendSpec>, ErrorCode> ParseHABackendSpec(
     }};
 }
 
-tl::expected<void, ErrorCode> CheckRegisterMemoryParams(const void* addr,
-                                                        size_t length) {
+tl::expected<void, ErrorCode> CheckRegisterMemoryParams(
+    const void* addr, size_t length, const std::string& protocol) {
     if (addr == nullptr) {
         LOG(ERROR) << "addr is nullptr";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -213,12 +213,14 @@ tl::expected<void, ErrorCode> CheckRegisterMemoryParams(const void* addr,
         LOG(ERROR) << "length is 0";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
-    // Tcp is not limited by max_mr_size, but we ignore it for now.
-    auto max_mr_size = globalConfig().max_mr_size;  // Max segment size
-    if (length > max_mr_size) {
-        LOG(ERROR) << "length " << length
-                   << " is larger than max_mr_size: " << max_mr_size;
-        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    // Only RDMA is limited by max_mr_size due to ibv_reg_mr() hardware limits.
+    if (protocol == "rdma") {
+        auto max_mr_size = globalConfig().max_mr_size;
+        if (length > max_mr_size) {
+            LOG(ERROR) << "length " << length
+                       << " is larger than max_mr_size: " << max_mr_size;
+            return tl::unexpected(ErrorCode::INVALID_PARAMS);
+        }
     }
     return {};
 }
@@ -2039,7 +2041,7 @@ std::vector<int> Client::GetNicNumaNodes() const {
 tl::expected<void, ErrorCode> Client::MountSegment(
     const void* buffer, size_t size, const std::string& protocol,
     const std::string& location) {
-    auto check_result = CheckRegisterMemoryParams(buffer, size);
+    auto check_result = CheckRegisterMemoryParams(buffer, size, protocol_);
     if (!check_result) {
         return tl::unexpected(check_result.error());
     }
@@ -2148,7 +2150,7 @@ tl::expected<void, ErrorCode> Client::UnmountSegment(const void* buffer,
 tl::expected<void, ErrorCode> Client::RegisterLocalMemory(
     void* addr, size_t length, const std::string& location,
     bool remote_accessible, bool update_metadata) {
-    auto check_result = CheckRegisterMemoryParams(addr, length);
+    auto check_result = CheckRegisterMemoryParams(addr, length, protocol_);
     if (!check_result) {
         return tl::unexpected(check_result.error());
     }

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -213,8 +213,8 @@ tl::expected<void, ErrorCode> CheckRegisterMemoryParams(
         LOG(ERROR) << "length is 0";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
-    // Only RDMA is limited by max_mr_size due to ibv_reg_mr() hardware limits.
-    if (protocol == "rdma") {
+    // Only RDMA/EFA is limited by max_mr_size due to ibv_reg_mr() hardware limits.
+    if (protocol == "rdma" || protocol == "efa") {
         auto max_mr_size = globalConfig().max_mr_size;
         if (length > max_mr_size) {
             LOG(ERROR) << "length " << length
@@ -2041,7 +2041,7 @@ std::vector<int> Client::GetNicNumaNodes() const {
 tl::expected<void, ErrorCode> Client::MountSegment(
     const void* buffer, size_t size, const std::string& protocol,
     const std::string& location) {
-    auto check_result = CheckRegisterMemoryParams(buffer, size, protocol_);
+    auto check_result = CheckRegisterMemoryParams(buffer, size, protocol);
     if (!check_result) {
         return tl::unexpected(check_result.error());
     }

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -213,7 +213,8 @@ tl::expected<void, ErrorCode> CheckRegisterMemoryParams(
         LOG(ERROR) << "length is 0";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
-    // Only RDMA/EFA is limited by max_mr_size due to ibv_reg_mr() hardware limits.
+    // Only RDMA/EFA is limited by max_mr_size due to ibv_reg_mr() hardware
+    // limits.
     if (protocol == "rdma" || protocol == "efa") {
         auto max_mr_size = globalConfig().max_mr_size;
         if (length > max_mr_size) {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -29,6 +29,20 @@
 #include "local_hot_cache.h"
 
 namespace mooncake {
+namespace {
+
+std::optional<size_t> GetTransportRegistrationLimit(
+    const std::string& protocol) {
+    if (protocol == "rdma" || protocol == "efa") {
+        return globalConfig().max_mr_size;
+    }
+    if (protocol == "ub") {
+        return globalConfig().max_seg_size;
+    }
+    return std::nullopt;
+}
+
+}  // namespace
 
 [[nodiscard]] size_t CalculateSliceSize(const std::vector<Slice>& slices) {
     size_t slice_size = 0;
@@ -213,13 +227,13 @@ tl::expected<void, ErrorCode> CheckRegisterMemoryParams(
         LOG(ERROR) << "length is 0";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
-    // Only RDMA/EFA is limited by max_mr_size due to ibv_reg_mr() hardware
-    // limits.
-    if (protocol == "rdma" || protocol == "efa") {
-        auto max_mr_size = globalConfig().max_mr_size;
-        if (length > max_mr_size) {
+    if (auto max_registration_size = GetTransportRegistrationLimit(protocol);
+        max_registration_size.has_value()) {
+        if (length > *max_registration_size) {
             LOG(ERROR) << "length " << length
-                       << " is larger than max_mr_size: " << max_mr_size;
+                       << " is larger than the transport registration limit "
+                       << *max_registration_size << " for protocol "
+                       << protocol;
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
     }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -434,9 +434,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         LOG(INFO) << "Local buffer size is 0, skip registering local memory";
     }
 
-    if (global_segment_size == 0) {
-        LOG(INFO) << "Global segment size is 0, skip mounting segment";
-    } else if (protocol == "cxl") {
+    if (protocol == "cxl") {
         size_t cxl_dev_size = 0;
         const char *env = std::getenv("MC_CXL_DEV_SIZE");
         if (env) {
@@ -458,6 +456,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                        << toString(mount_result.error());
             return tl::unexpected(mount_result.error());
         }
+    } else if (global_segment_size == 0) {
+        LOG(INFO) << "Global segment size is 0, skip mounting segment";
     } else {
         // Only RDMA/EFA needs splitting due to ibv_reg_mr() hardware limits.
         // Other transports mount as a single segment to avoid unnecessary

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -459,11 +459,11 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             return tl::unexpected(mount_result.error());
         }
     } else {
-        // Only RDMA needs splitting due to ibv_reg_mr() hardware limits.
+        // Only RDMA/EFA needs splitting due to ibv_reg_mr() hardware limits.
         // Other transports mount as a single segment to avoid unnecessary
-        // allocator fragmentation. RDMA splits into equal-sized segments
+        // allocator fragmentation. RDMA/EFA splits into equal-sized segments
         // for balanced allocation (e.g. 1.4TB → 2×0.7TB).
-        size_t max_segment_size = (protocol == "rdma")
+        size_t max_segment_size = (protocol == "rdma" || protocol == "efa")
                                       ? globalConfig().max_mr_size
                                       : global_segment_size;
         size_t num_segments =

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -434,10 +434,9 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         LOG(INFO) << "Local buffer size is 0, skip registering local memory";
     }
 
-    // If global_segment_size is 0, skip mount segment;
-    // If global_segment_size is larger than max_mr_size, split to multiple
-    // mapped_shms.
-    if (protocol == "cxl") {
+    if (global_segment_size == 0) {
+        LOG(INFO) << "Global segment size is 0, skip mounting segment";
+    } else if (protocol == "cxl") {
         size_t cxl_dev_size = 0;
         const char *env = std::getenv("MC_CXL_DEV_SIZE");
         if (env) {
@@ -459,11 +458,16 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                        << toString(mount_result.error());
             return tl::unexpected(mount_result.error());
         }
-
     } else {
-        auto max_mr_size = globalConfig().max_mr_size;     // Max segment size
-        uint64_t total_glbseg_size = global_segment_size;  // For logging
-        uint64_t current_glbseg_size = 0;                  // For logging
+        // Only RDMA needs splitting due to ibv_reg_mr() hardware limits.
+        // Other transports mount as a single segment to avoid unnecessary
+        // allocator fragmentation. RDMA splits into equal-sized segments
+        // for balanced allocation (e.g. 1.4TB → 2×0.7TB).
+        size_t max_segment_size = (protocol == "rdma")
+                                      ? globalConfig().max_mr_size
+                                      : global_segment_size;
+        size_t num_segments =
+            (global_segment_size + max_segment_size - 1) / max_segment_size;
 
         // In standalone mode with RDMA, auto-discover NUMA nodes with NICs
         // and distribute global_segment across them for full NIC utilization.
@@ -483,12 +487,13 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             }
         }
 
-        while (global_segment_size > 0) {
-            size_t segment_size = std::min(global_segment_size, max_mr_size);
-            global_segment_size -= segment_size;
-            current_glbseg_size += segment_size;
+        size_t remaining = global_segment_size;
+        for (size_t i = 0; i < num_segments; i++) {
+            size_t segment_size = remaining / (num_segments - i);
+            remaining -= segment_size;
             LOG(INFO) << "Mounting segment: " << segment_size << " bytes, "
-                      << current_glbseg_size << " of " << total_glbseg_size;
+                      << (global_segment_size - remaining) << " of "
+                      << global_segment_size;
 
             size_t mapped_size = segment_size;
             void *ptr = nullptr;
@@ -536,9 +541,6 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                            << toString(mount_result.error());
                 return tl::unexpected(mount_result.error());
             }
-        }
-        if (total_glbseg_size == 0) {
-            LOG(INFO) << "Global segment size is 0, skip mounting segment";
         }
     }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -474,10 +474,11 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                                       ? globalConfig().max_mr_size
                                       : global_segment_size;
         size_t max_seg_gib = max_segment_size / kGiB;
-        if (max_seg_gib == 0) max_seg_gib = 1;  // max_mr_size < 1 GiB: 1 GiB cap
+        if (max_seg_gib == 0)
+            max_seg_gib = 1;  // max_mr_size < 1 GiB: 1 GiB cap
         size_t total_gib_ceil = (global_segment_size + kGiB - 1) / kGiB;
-        size_t num_segments =
-            std::max<size_t>(1, (total_gib_ceil + max_seg_gib - 1) / max_seg_gib);
+        size_t num_segments = std::max<size_t>(
+            1, (total_gib_ceil + max_seg_gib - 1) / max_seg_gib);
 
         // In standalone mode with RDMA, auto-discover NUMA nodes with NICs
         // and distribute global_segment across them for full NIC utilization.
@@ -498,8 +499,9 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         }
 
         // Two parallel trackers:
-        //   remaining_gib_ceil — GiB quota (ceil-rounded), drives even splitting
-        //   remaining_bytes    — actual bytes left, determines real segment size
+        //   remaining_gib_ceil — GiB quota (ceil-rounded), drives even
+        //   splitting remaining_bytes    — actual bytes left, determines real
+        //   segment size
         size_t remaining_gib_ceil = total_gib_ceil;
         size_t remaining_bytes = global_segment_size;
         size_t mounted_bytes = 0;
@@ -517,7 +519,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             LOG(INFO) << "Mounting segment [" << i + 1 << "/" << num_segments
                       << "]: " << segment_size / kGiB << " GiB"
                       << (segment_size % kGiB
-                              ? " + " + std::to_string(segment_size % kGiB) + " B"
+                              ? " + " + std::to_string(segment_size % kGiB) +
+                                    " B"
                               : std::string{})
                       << " (" << segment_size << " bytes)"
                       << ", " << mounted_bytes << " of " << global_segment_size

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -461,13 +461,23 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     } else {
         // Only RDMA/EFA needs splitting due to ibv_reg_mr() hardware limits.
         // Other transports mount as a single segment to avoid unnecessary
-        // allocator fragmentation. RDMA/EFA splits into equal-sized segments
-        // for balanced allocation (e.g. 1.4TB → 2×0.7TB).
+        // allocator fragmentation. RDMA/EFA splits into equal-sized GiB-aligned
+        // segments (e.g. 1401 GiB → 701 GiB + 700 GiB).
+        //
+        // Strategy: round total UP to the next GiB boundary as the scheduling
+        // quota, then allocate min(quota_bytes, remaining_bytes) per segment.
+        // This keeps non-last segments strictly GiB-aligned while letting the
+        // last segment naturally absorb the sub-GiB tail — without exceeding
+        // max_segment_size regardless of whether max_mr_size is GiB-aligned.
+        static constexpr size_t kGiB = 1ULL << 30;
         size_t max_segment_size = (protocol == "rdma" || protocol == "efa")
                                       ? globalConfig().max_mr_size
                                       : global_segment_size;
+        size_t max_seg_gib = max_segment_size / kGiB;
+        if (max_seg_gib == 0) max_seg_gib = 1;  // max_mr_size < 1 GiB: 1 GiB cap
+        size_t total_gib_ceil = (global_segment_size + kGiB - 1) / kGiB;
         size_t num_segments =
-            (global_segment_size + max_segment_size - 1) / max_segment_size;
+            std::max<size_t>(1, (total_gib_ceil + max_seg_gib - 1) / max_seg_gib);
 
         // In standalone mode with RDMA, auto-discover NUMA nodes with NICs
         // and distribute global_segment across them for full NIC utilization.
@@ -487,13 +497,31 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             }
         }
 
-        size_t remaining = global_segment_size;
+        // Two parallel trackers:
+        //   remaining_gib_ceil — GiB quota (ceil-rounded), drives even splitting
+        //   remaining_bytes    — actual bytes left, determines real segment size
+        size_t remaining_gib_ceil = total_gib_ceil;
+        size_t remaining_bytes = global_segment_size;
+        size_t mounted_bytes = 0;
         for (size_t i = 0; i < num_segments; i++) {
-            size_t segment_size = remaining / (num_segments - i);
-            remaining -= segment_size;
-            LOG(INFO) << "Mounting segment: " << segment_size << " bytes, "
-                      << (global_segment_size - remaining) << " of "
-                      << global_segment_size;
+            // Distribute remaining quota evenly across remaining segments.
+            // Floor division ensures sizes differ by at most 1 GiB.
+            size_t seg_gib = remaining_gib_ceil / (num_segments - i);
+            remaining_gib_ceil -= seg_gib;
+            // Non-last segments: exactly seg_gib * kGiB (GiB-aligned).
+            // Last segment: min() absorbs the sub-GiB tail, staying within
+            // max_segment_size since seg_gib <= max_seg_gib and tail < kGiB.
+            size_t segment_size = std::min(seg_gib * kGiB, remaining_bytes);
+            remaining_bytes -= segment_size;
+            mounted_bytes += segment_size;
+            LOG(INFO) << "Mounting segment [" << i + 1 << "/" << num_segments
+                      << "]: " << segment_size / kGiB << " GiB"
+                      << (segment_size % kGiB
+                              ? " + " + std::to_string(segment_size % kGiB) + " B"
+                              : std::string{})
+                      << " (" << segment_size << " bytes)"
+                      << ", " << mounted_bytes << " of " << global_segment_size
+                      << " total";
 
             size_t mapped_size = segment_size;
             void *ptr = nullptr;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -328,6 +328,11 @@ tl::expected<void, ErrorCode> RealClient::setup_ascend_internal(
 //   (a) every segment <= max_mr_size
 //   (b) adjacent segments differ by at most 1 GiB
 //   (c) sum of all segments == total_bytes  (no memory wasted)
+//
+// Precondition (RDMA/EFA only): max_mr_size >= 1 GiB. GiB-aligned splitting
+// cannot honor a sub-GiB cap; callers configuring a smaller cap get an empty
+// result and an error log. In practice RDMA hardware always reports
+// max_mr_size well above 1 GiB.
 std::vector<size_t> computeSegmentSizes(size_t total_bytes,
                                         size_t max_mr_size,
                                         bool is_rdma) {
@@ -336,14 +341,21 @@ std::vector<size_t> computeSegmentSizes(size_t total_bytes,
     // Non-RDMA: single segment, no splitting needed.
     if (!is_rdma) return {total_bytes};
 
+    // RDMA/EFA precondition: GiB-aligned splitting requires at least 1 GiB
+    // of headroom. Sub-GiB caps would force segments that exceed the cap.
+    if (max_mr_size < kGiB) {
+        LOG(ERROR) << "computeSegmentSizes: max_mr_size (" << max_mr_size
+                   << " B) < 1 GiB is not supported for RDMA/EFA";
+        return {};
+    }
+
     // Round total UP so the sub-GiB tail occupies a full GiB quota slot,
     // preventing the last segment from exceeding max_mr_size.
     const size_t total_gib_ceil = (total_bytes + kGiB - 1) / kGiB;
 
     // Floor division keeps each GiB-aligned segment within max_mr_size
     // even when max_mr_size itself is not GiB-aligned.
-    size_t max_seg_gib = max_mr_size / kGiB;
-    if (max_seg_gib == 0) max_seg_gib = 1;  // max_mr_size < 1 GiB
+    const size_t max_seg_gib = max_mr_size / kGiB;
 
     const size_t num_segments = std::max<size_t>(
         1, (total_gib_ceil + max_seg_gib - 1) / max_seg_gib);
@@ -511,6 +523,9 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         const bool is_rdma = (protocol == "rdma" || protocol == "efa");
         const std::vector<size_t> seg_sizes = computeSegmentSizes(
             global_segment_size, globalConfig().max_mr_size, is_rdma);
+        if (seg_sizes.empty()) {
+            return tl::unexpected(ErrorCode::INVALID_PARAMS);
+        }
         const size_t num_segments = seg_sizes.size();
 
         // In standalone mode with RDMA, auto-discover NUMA nodes with NICs

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -313,6 +313,55 @@ tl::expected<void, ErrorCode> RealClient::setup_ascend_internal(
     return {};
 }
 
+// Compute GiB-aligned segment sizes that sum exactly to total_bytes.
+//
+// For non-RDMA protocols there is no hardware MR size limit, so a single
+// segment of total_bytes is returned.
+//
+// For RDMA/EFA, segments are split to respect the ibv_reg_mr() hardware
+// limit (max_mr_size).  The algorithm uses two parallel trackers:
+//   remaining_gib_ceil  — ceil-rounded GiB quota, drives even splitting
+//   remaining_bytes     — actual bytes remaining, determines real sizes
+//
+// This keeps all non-last segments strictly GiB-aligned while letting the
+// last segment naturally absorb the sub-GiB tail via min(), guaranteeing:
+//   (a) every segment <= max_mr_size
+//   (b) adjacent segments differ by at most 1 GiB
+//   (c) sum of all segments == total_bytes  (no memory wasted)
+std::vector<size_t> computeSegmentSizes(size_t total_bytes,
+                                        size_t max_mr_size,
+                                        bool is_rdma) {
+    static constexpr size_t kGiB = 1ULL << 30;
+
+    // Non-RDMA: single segment, no splitting needed.
+    if (!is_rdma) return {total_bytes};
+
+    // Round total UP so the sub-GiB tail occupies a full GiB quota slot,
+    // preventing the last segment from exceeding max_mr_size.
+    const size_t total_gib_ceil = (total_bytes + kGiB - 1) / kGiB;
+
+    // Floor division keeps each GiB-aligned segment within max_mr_size
+    // even when max_mr_size itself is not GiB-aligned.
+    size_t max_seg_gib = max_mr_size / kGiB;
+    if (max_seg_gib == 0) max_seg_gib = 1;  // max_mr_size < 1 GiB
+
+    const size_t num_segments = std::max<size_t>(
+        1, (total_gib_ceil + max_seg_gib - 1) / max_seg_gib);
+
+    std::vector<size_t> sizes;
+    sizes.reserve(num_segments);
+    size_t remaining_gib_ceil = total_gib_ceil;
+    size_t remaining_bytes = total_bytes;
+    for (size_t i = 0; i < num_segments; i++) {
+        size_t seg_gib = remaining_gib_ceil / (num_segments - i);
+        remaining_gib_ceil -= seg_gib;
+        size_t seg_bytes = std::min(seg_gib * kGiB, remaining_bytes);
+        remaining_bytes -= seg_bytes;
+        sizes.push_back(seg_bytes);
+    }
+    return sizes;
+}
+
 tl::expected<void, ErrorCode> RealClient::setup_internal(
     const std::string &local_hostname, const std::string &metadata_server,
     size_t global_segment_size, size_t local_buffer_size,
@@ -459,26 +508,10 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     } else if (global_segment_size == 0) {
         LOG(INFO) << "Global segment size is 0, skip mounting segment";
     } else {
-        // Only RDMA/EFA needs splitting due to ibv_reg_mr() hardware limits.
-        // Other transports mount as a single segment to avoid unnecessary
-        // allocator fragmentation. RDMA/EFA splits into equal-sized GiB-aligned
-        // segments (e.g. 1401 GiB → 701 GiB + 700 GiB).
-        //
-        // Strategy: round total UP to the next GiB boundary as the scheduling
-        // quota, then allocate min(quota_bytes, remaining_bytes) per segment.
-        // This keeps non-last segments strictly GiB-aligned while letting the
-        // last segment naturally absorb the sub-GiB tail — without exceeding
-        // max_segment_size regardless of whether max_mr_size is GiB-aligned.
-        static constexpr size_t kGiB = 1ULL << 30;
-        size_t max_segment_size = (protocol == "rdma" || protocol == "efa")
-                                      ? globalConfig().max_mr_size
-                                      : global_segment_size;
-        size_t max_seg_gib = max_segment_size / kGiB;
-        if (max_seg_gib == 0)
-            max_seg_gib = 1;  // max_mr_size < 1 GiB: 1 GiB cap
-        size_t total_gib_ceil = (global_segment_size + kGiB - 1) / kGiB;
-        size_t num_segments = std::max<size_t>(
-            1, (total_gib_ceil + max_seg_gib - 1) / max_seg_gib);
+        const bool is_rdma = (protocol == "rdma" || protocol == "efa");
+        const std::vector<size_t> seg_sizes = computeSegmentSizes(
+            global_segment_size, globalConfig().max_mr_size, is_rdma);
+        const size_t num_segments = seg_sizes.size();
 
         // In standalone mode with RDMA, auto-discover NUMA nodes with NICs
         // and distribute global_segment across them for full NIC utilization.
@@ -498,23 +531,10 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             }
         }
 
-        // Two parallel trackers:
-        //   remaining_gib_ceil — GiB quota (ceil-rounded), drives even
-        //   splitting remaining_bytes    — actual bytes left, determines real
-        //   segment size
-        size_t remaining_gib_ceil = total_gib_ceil;
-        size_t remaining_bytes = global_segment_size;
+        static constexpr size_t kGiB = 1ULL << 30;
         size_t mounted_bytes = 0;
         for (size_t i = 0; i < num_segments; i++) {
-            // Distribute remaining quota evenly across remaining segments.
-            // Floor division ensures sizes differ by at most 1 GiB.
-            size_t seg_gib = remaining_gib_ceil / (num_segments - i);
-            remaining_gib_ceil -= seg_gib;
-            // Non-last segments: exactly seg_gib * kGiB (GiB-aligned).
-            // Last segment: min() absorbs the sub-GiB tail, staying within
-            // max_segment_size since seg_gib <= max_seg_gib and tail < kGiB.
-            size_t segment_size = std::min(seg_gib * kGiB, remaining_bytes);
-            remaining_bytes -= segment_size;
+            size_t segment_size = seg_sizes[i];
             mounted_bytes += segment_size;
             LOG(INFO) << "Mounting segment [" << i + 1 << "/" << num_segments
                       << "]: " << segment_size / kGiB << " GiB"

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>  // for atexit
 #include <algorithm>
 #include <cctype>
+#include <limits>
 #include <optional>
 #include <vector>
 
@@ -40,6 +41,32 @@ DEFINE_int32(http_port, 9300,
 
 namespace mooncake {
 namespace {
+std::optional<size_t> GetTransportRegistrationLimit(
+    const std::string& protocol) {
+    if (protocol == "rdma" || protocol == "efa") {
+        return globalConfig().max_mr_size;
+    }
+    if (protocol == "ub") {
+        return globalConfig().max_seg_size;
+    }
+    return std::nullopt;
+}
+
+SegmentSplitMode GetSegmentSplitMode(const std::string& protocol) {
+    if (protocol == "rdma" || protocol == "efa") {
+        return SegmentSplitMode::kGiBAlignedBalanced;
+    }
+    if (protocol == "ub") {
+        return SegmentSplitMode::kBalanced;
+    }
+    return SegmentSplitMode::kSingleSegment;
+}
+
+size_t ceilDiv(size_t value, size_t divisor) {
+    DCHECK_NE(divisor, 0u);
+    return value == 0 ? 0 : 1 + (value - 1) / divisor;
+}
+
 #ifdef USE_ASCEND_DIRECT
 bool checkAcl(aclError result, const char *message) {
     if (result != ACL_ERROR_NONE) {
@@ -313,13 +340,15 @@ tl::expected<void, ErrorCode> RealClient::setup_ascend_internal(
     return {};
 }
 
-// Compute GiB-aligned segment sizes that sum exactly to total_bytes.
+// Compute segment sizes that sum exactly to total_bytes.
 //
-// For non-RDMA protocols there is no hardware MR size limit, so a single
-// segment of total_bytes is returned.
+// SegmentSplitMode::kSingleSegment returns {total_bytes}.
 //
-// For RDMA/EFA, segments are split to respect the ibv_reg_mr() hardware
-// limit (max_mr_size).  The algorithm uses two parallel trackers:
+// SegmentSplitMode::kBalanced splits the range into near-equal byte-sized
+// chunks, each <= max_segment_size. This is used for protocols like UB that
+// have a transport registration cap but do not require GiB alignment.
+//
+// SegmentSplitMode::kGiBAlignedBalanced uses two parallel trackers:
 //   remaining_gib_ceil  — ceil-rounded GiB quota, drives even splitting
 //   remaining_bytes     — actual bytes remaining, determines real sizes
 //
@@ -329,36 +358,59 @@ tl::expected<void, ErrorCode> RealClient::setup_ascend_internal(
 //   (b) adjacent segments differ by at most 1 GiB
 //   (c) sum of all segments == total_bytes  (no memory wasted)
 //
-// Precondition (RDMA/EFA only): max_mr_size >= 1 GiB. GiB-aligned splitting
-// cannot honor a sub-GiB cap; callers configuring a smaller cap get an empty
-// result and an error log. In practice RDMA hardware always reports
-// max_mr_size well above 1 GiB.
+// Precondition for SegmentSplitMode::kGiBAlignedBalanced: max_segment_size
+// >= 1 GiB. GiB-aligned splitting cannot honor a sub-GiB cap; callers
+// configuring a smaller cap get an empty result and an error log.
 std::vector<size_t> computeSegmentSizes(size_t total_bytes,
-                                        size_t max_mr_size,
-                                        bool is_rdma) {
+                                        size_t max_segment_size,
+                                        SegmentSplitMode split_mode) {
     static constexpr size_t kGiB = 1ULL << 30;
 
-    // Non-RDMA: single segment, no splitting needed.
-    if (!is_rdma) return {total_bytes};
+    if (split_mode == SegmentSplitMode::kSingleSegment) {
+        return {total_bytes};
+    }
+
+    if (max_segment_size == 0) {
+        LOG(ERROR) << "computeSegmentSizes: max_segment_size must be > 0";
+        return {};
+    }
+
+    if (total_bytes == 0) {
+        return {0};
+    }
+
+    if (split_mode == SegmentSplitMode::kBalanced) {
+        const size_t num_segments =
+            1 + (total_bytes - 1) / max_segment_size;
+        const size_t base_size = total_bytes / num_segments;
+        const size_t remainder = total_bytes % num_segments;
+
+        std::vector<size_t> sizes;
+        sizes.reserve(num_segments);
+        for (size_t i = 0; i < num_segments; ++i) {
+            sizes.push_back(base_size + (i < remainder ? 1 : 0));
+        }
+        return sizes;
+    }
 
     // RDMA/EFA precondition: GiB-aligned splitting requires at least 1 GiB
     // of headroom. Sub-GiB caps would force segments that exceed the cap.
-    if (max_mr_size < kGiB) {
-        LOG(ERROR) << "computeSegmentSizes: max_mr_size (" << max_mr_size
-                   << " B) < 1 GiB is not supported for RDMA/EFA";
+    if (max_segment_size < kGiB) {
+        LOG(ERROR) << "computeSegmentSizes: max_segment_size ("
+                   << max_segment_size
+                   << " B) < 1 GiB is not supported for GiB-aligned splitting";
         return {};
     }
 
     // Round total UP so the sub-GiB tail occupies a full GiB quota slot,
     // preventing the last segment from exceeding max_mr_size.
-    const size_t total_gib_ceil = (total_bytes + kGiB - 1) / kGiB;
+    const size_t total_gib_ceil = ceilDiv(total_bytes, kGiB);
 
-    // Floor division keeps each GiB-aligned segment within max_mr_size
+    // Floor division keeps each GiB-aligned segment within max_segment_size
     // even when max_mr_size itself is not GiB-aligned.
-    const size_t max_seg_gib = max_mr_size / kGiB;
+    const size_t max_seg_gib = max_segment_size / kGiB;
 
-    const size_t num_segments = std::max<size_t>(
-        1, (total_gib_ceil + max_seg_gib - 1) / max_seg_gib);
+    const size_t num_segments = std::max<size_t>(1, ceilDiv(total_gib_ceil, max_seg_gib));
 
     std::vector<size_t> sizes;
     sizes.reserve(num_segments);
@@ -367,7 +419,11 @@ std::vector<size_t> computeSegmentSizes(size_t total_bytes,
     for (size_t i = 0; i < num_segments; i++) {
         size_t seg_gib = remaining_gib_ceil / (num_segments - i);
         remaining_gib_ceil -= seg_gib;
-        size_t seg_bytes = std::min(seg_gib * kGiB, remaining_bytes);
+        size_t seg_bytes_cap =
+            seg_gib > std::numeric_limits<size_t>::max() / kGiB
+                ? std::numeric_limits<size_t>::max()
+                : seg_gib * kGiB;
+        size_t seg_bytes = std::min(seg_bytes_cap, remaining_bytes);
         remaining_bytes -= seg_bytes;
         sizes.push_back(seg_bytes);
     }
@@ -520,9 +576,11 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     } else if (global_segment_size == 0) {
         LOG(INFO) << "Global segment size is 0, skip mounting segment";
     } else {
-        const bool is_rdma = (protocol == "rdma" || protocol == "efa");
+        const SegmentSplitMode split_mode = GetSegmentSplitMode(protocol);
+        const size_t max_segment_size =
+            GetTransportRegistrationLimit(protocol).value_or(0);
         const std::vector<size_t> seg_sizes = computeSegmentSizes(
-            global_segment_size, globalConfig().max_mr_size, is_rdma);
+            global_segment_size, max_segment_size, split_mode);
         if (seg_sizes.empty()) {
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
@@ -601,7 +659,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 segment_ptrs_.emplace_back(ptr);
             }
             auto mount_result =
-                client_->MountSegment(ptr, mapped_size, protocol, seg_location);
+                client_->MountSegment(ptr, segment_size, protocol, seg_location);
             if (!mount_result.has_value()) {
                 LOG(ERROR) << "Failed to mount segment: "
                            << toString(mount_result.error());

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ function(add_ha_test name)
   add_test(NAME ${name} COMMAND ${name})
 endfunction()
 
+add_store_test(compute_segment_sizes_test compute_segment_sizes_test.cpp)
 add_store_test(buffer_allocator_test buffer_allocator_test.cpp)
 add_store_test(allocation_strategy_test allocation_strategy_test.cpp)
 add_store_test(eviction_strategy_test eviction_strategy_test.cpp)

--- a/mooncake-store/tests/compute_segment_sizes_test.cpp
+++ b/mooncake-store/tests/compute_segment_sizes_test.cpp
@@ -115,14 +115,4 @@ TEST(ComputeSegmentSizesTest, RdmaMaxMrSizeBelowOneGiBClampsToOneGiB) {
     EXPECT_EQ(sum, total);
 }
 
-// RDMA, total_bytes == 0: pure-function contract says "return {0}". Callers
-// are expected to short-circuit before calling in production, but pin the
-// behavior here so any future change is a deliberate one.
-TEST(ComputeSegmentSizesTest, RdmaZeroTotalReturnsSingleZeroSegment) {
-    const size_t max_mr = 2 * kGiB;
-    auto sizes = computeSegmentSizes(0, max_mr, /*is_rdma=*/true);
-    ASSERT_EQ(sizes.size(), 1u);
-    EXPECT_EQ(sizes[0], 0u);
-}
-
 }  // namespace mooncake

--- a/mooncake-store/tests/compute_segment_sizes_test.cpp
+++ b/mooncake-store/tests/compute_segment_sizes_test.cpp
@@ -1,0 +1,128 @@
+#include <gtest/gtest.h>
+
+#include <numeric>
+
+#include "real_client.h"
+
+namespace mooncake {
+
+static constexpr size_t kGiB = 1ULL << 30;
+
+// Helper: verify invariants that must hold for every valid result.
+static void checkInvariants(const std::vector<size_t>& sizes,
+                            size_t total_bytes, size_t max_mr_size) {
+    ASSERT_FALSE(sizes.empty());
+    // (c) sum == total_bytes
+    size_t sum = std::accumulate(sizes.begin(), sizes.end(), size_t{0});
+    EXPECT_EQ(sum, total_bytes) << "segments do not sum to total_bytes";
+    // (a) every segment <= max_mr_size
+    for (size_t i = 0; i < sizes.size(); i++) {
+        EXPECT_LE(sizes[i], max_mr_size)
+            << "segment " << i << " (" << sizes[i]
+            << " B) exceeds max_mr_size (" << max_mr_size << " B)";
+    }
+    // (b) adjacent segments differ by at most 1 GiB
+    for (size_t i = 1; i < sizes.size(); i++) {
+        size_t lo = std::min(sizes[i - 1], sizes[i]);
+        size_t hi = std::max(sizes[i - 1], sizes[i]);
+        EXPECT_LE(hi - lo, kGiB) << "segments " << i - 1 << " and " << i
+                                 << " differ by more than 1 GiB";
+    }
+}
+
+// Non-RDMA: always a single segment regardless of size.
+TEST(ComputeSegmentSizesTest, NonRdmaAlwaysSingleSegment) {
+    const size_t total = 1401 * kGiB;
+    const size_t max_mr = 1024 * kGiB;  // would split under RDMA
+    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/false);
+    ASSERT_EQ(sizes.size(), 1u);
+    EXPECT_EQ(sizes[0], total);
+}
+
+// RDMA, GiB-aligned total: balanced split, all segments are exact GiB.
+// 1401 GiB / 1 TiB limit -> 2 segments: 700 GiB + 701 GiB.
+TEST(ComputeSegmentSizesTest, RdmaGiBAlignedBalancedSplit) {
+    const size_t total = 1401 * kGiB;
+    const size_t max_mr = 1024 * kGiB;  // 1 TiB
+    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    checkInvariants(sizes, total, max_mr);
+    ASSERT_EQ(sizes.size(), 2u);
+    EXPECT_EQ(sizes[0], 700 * kGiB);
+    EXPECT_EQ(sizes[1], 701 * kGiB);
+}
+
+// RDMA, sub-GiB tail: last segment absorbs the tail, must not exceed
+// max_mr_size even when max_mr_size is not GiB-aligned.
+// 7 GiB + 500 MB, max = 3 GiB -> 3 segments: [2 GiB, 3 GiB, 2 GiB+500 MB].
+TEST(ComputeSegmentSizesTest, RdmaSubGiBTailAbsorbedInLastSegment) {
+    const size_t tail = 500 * 1024 * 1024;  // 500 MiB
+    const size_t total = 7 * kGiB + tail;
+    const size_t max_mr = 3 * kGiB;
+    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    checkInvariants(sizes, total, max_mr);
+    ASSERT_EQ(sizes.size(), 3u);
+    EXPECT_EQ(sizes[0], 2 * kGiB);
+    EXPECT_EQ(sizes[1], 3 * kGiB);
+    EXPECT_EQ(sizes[2], 2 * kGiB + tail);
+}
+
+// RDMA, total slightly over one max_mr_size: must produce 2 segments, not 1.
+// floor(total_gib/max_seg_gib) == 1 but the 1-byte tail would push the single
+// segment over max_mr_size.
+TEST(ComputeSegmentSizesTest, RdmaTotalJustOverMaxMrSizeRequiresTwoSegments) {
+    const size_t max_mr = 2 * kGiB;
+    const size_t total = max_mr + 1;  // 2 GiB + 1 byte
+    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    checkInvariants(sizes, total, max_mr);
+    ASSERT_EQ(sizes.size(), 2u);
+}
+
+// RDMA, total exactly equals max_mr_size: exactly 1 segment, no split.
+TEST(ComputeSegmentSizesTest, RdmaTotalEqualsMaxMrSizeSingleSegment) {
+    const size_t max_mr = 4 * kGiB;
+    const size_t total = max_mr;
+    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    checkInvariants(sizes, total, max_mr);
+    ASSERT_EQ(sizes.size(), 1u);
+    EXPECT_EQ(sizes[0], total);
+}
+
+// RDMA, total below max_mr_size with sub-GiB tail: 1 segment containing tail.
+TEST(ComputeSegmentSizesTest, RdmaTotalBelowMaxMrSizeWithTailSingleSegment) {
+    const size_t tail = 123 * 1024 * 1024;  // 123 MiB
+    const size_t total = 3 * kGiB + tail;
+    const size_t max_mr = 8 * kGiB;
+    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    checkInvariants(sizes, total, max_mr);
+    ASSERT_EQ(sizes.size(), 1u);
+    EXPECT_EQ(sizes[0], total);
+}
+
+// RDMA, max_mr_size < 1 GiB: floor(max_mr_size/GiB) == 0, implementation
+// clamps max_seg_gib to 1, so every non-last segment ends up exactly 1 GiB.
+// This violates invariant (a) (seg > max_mr_size) — we test only the cap-to-1
+// behavior rather than calling checkInvariants, to pin down the current
+// contract: the function prefers GiB alignment over honoring a sub-GiB cap.
+TEST(ComputeSegmentSizesTest, RdmaMaxMrSizeBelowOneGiBClampsToOneGiB) {
+    const size_t max_mr = 512 * 1024 * 1024;  // 512 MiB, < 1 GiB
+    const size_t total = 3 * kGiB;
+    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    // max_seg_gib clamped to 1 → 3 segments of 1 GiB each.
+    ASSERT_EQ(sizes.size(), 3u);
+    for (size_t s : sizes) EXPECT_EQ(s, kGiB);
+    // Sum still matches (invariant (c)).
+    size_t sum = std::accumulate(sizes.begin(), sizes.end(), size_t{0});
+    EXPECT_EQ(sum, total);
+}
+
+// RDMA, total_bytes == 0: pure-function contract says "return {0}". Callers
+// are expected to short-circuit before calling in production, but pin the
+// behavior here so any future change is a deliberate one.
+TEST(ComputeSegmentSizesTest, RdmaZeroTotalReturnsSingleZeroSegment) {
+    const size_t max_mr = 2 * kGiB;
+    auto sizes = computeSegmentSizes(0, max_mr, /*is_rdma=*/true);
+    ASSERT_EQ(sizes.size(), 1u);
+    EXPECT_EQ(sizes[0], 0u);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/tests/compute_segment_sizes_test.cpp
+++ b/mooncake-store/tests/compute_segment_sizes_test.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <numeric>
+#include <vector>
 
 #include "real_client.h"
 
@@ -53,7 +55,7 @@ TEST(ComputeSegmentSizesTest, RdmaGiBAlignedBalancedSplit) {
 
 // RDMA, sub-GiB tail: last segment absorbs the tail, must not exceed
 // max_mr_size even when max_mr_size is not GiB-aligned.
-// 7 GiB + 500 MB, max = 3 GiB -> 3 segments: [2 GiB, 3 GiB, 2 GiB+500 MB].
+// 7 GiB + 500 MiB, max = 3 GiB -> 3 segments: [2 GiB, 3 GiB, 2 GiB+500 MiB].
 TEST(ComputeSegmentSizesTest, RdmaSubGiBTailAbsorbedInLastSegment) {
     const size_t tail = 500 * 1024 * 1024;  // 500 MiB
     const size_t total = 7 * kGiB + tail;
@@ -98,21 +100,25 @@ TEST(ComputeSegmentSizesTest, RdmaTotalBelowMaxMrSizeWithTailSingleSegment) {
     EXPECT_EQ(sizes[0], total);
 }
 
-// RDMA, max_mr_size < 1 GiB: floor(max_mr_size/GiB) == 0, implementation
-// clamps max_seg_gib to 1, so every non-last segment ends up exactly 1 GiB.
-// This violates invariant (a) (seg > max_mr_size) — we test only the cap-to-1
-// behavior rather than calling checkInvariants, to pin down the current
-// contract: the function prefers GiB alignment over honoring a sub-GiB cap.
-TEST(ComputeSegmentSizesTest, RdmaMaxMrSizeBelowOneGiBClampsToOneGiB) {
+// RDMA, max_mr_size exactly 1 GiB: the boundary of the supported range.
+// Every segment must be exactly 1 GiB; invariant (a) must hold strictly.
+TEST(ComputeSegmentSizesTest, RdmaMaxMrSizeExactlyOneGiBHonorsCap) {
+    const size_t max_mr = kGiB;
+    const size_t total = 3 * kGiB;
+    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    checkInvariants(sizes, total, max_mr);
+    ASSERT_EQ(sizes.size(), 3u);
+    for (size_t s : sizes) EXPECT_EQ(s, kGiB);
+}
+
+// RDMA, max_mr_size < 1 GiB: unsupported precondition. The function logs
+// an error and returns an empty vector so callers fail loudly rather than
+// mounting segments that violate the cap.
+TEST(ComputeSegmentSizesTest, RdmaMaxMrSizeBelowOneGiBReturnsEmpty) {
     const size_t max_mr = 512 * 1024 * 1024;  // 512 MiB, < 1 GiB
     const size_t total = 3 * kGiB;
     auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
-    // max_seg_gib clamped to 1 → 3 segments of 1 GiB each.
-    ASSERT_EQ(sizes.size(), 3u);
-    for (size_t s : sizes) EXPECT_EQ(s, kGiB);
-    // Sum still matches (invariant (c)).
-    size_t sum = std::accumulate(sizes.begin(), sizes.end(), size_t{0});
-    EXPECT_EQ(sum, total);
+    EXPECT_TRUE(sizes.empty());
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/compute_segment_sizes_test.cpp
+++ b/mooncake-store/tests/compute_segment_sizes_test.cpp
@@ -32,11 +32,12 @@ static void checkInvariants(const std::vector<size_t>& sizes,
     }
 }
 
-// Non-RDMA: always a single segment regardless of size.
-TEST(ComputeSegmentSizesTest, NonRdmaAlwaysSingleSegment) {
+// Single-segment mode: always returns one segment regardless of size.
+TEST(ComputeSegmentSizesTest, SingleSegmentModeAlwaysSingleSegment) {
     const size_t total = 1401 * kGiB;
     const size_t max_mr = 1024 * kGiB;  // would split under RDMA
-    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/false);
+    auto sizes =
+        computeSegmentSizes(total, max_mr, SegmentSplitMode::kSingleSegment);
     ASSERT_EQ(sizes.size(), 1u);
     EXPECT_EQ(sizes[0], total);
 }
@@ -46,7 +47,8 @@ TEST(ComputeSegmentSizesTest, NonRdmaAlwaysSingleSegment) {
 TEST(ComputeSegmentSizesTest, RdmaGiBAlignedBalancedSplit) {
     const size_t total = 1401 * kGiB;
     const size_t max_mr = 1024 * kGiB;  // 1 TiB
-    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    auto sizes = computeSegmentSizes(total, max_mr,
+                                     SegmentSplitMode::kGiBAlignedBalanced);
     checkInvariants(sizes, total, max_mr);
     ASSERT_EQ(sizes.size(), 2u);
     EXPECT_EQ(sizes[0], 700 * kGiB);
@@ -60,7 +62,8 @@ TEST(ComputeSegmentSizesTest, RdmaSubGiBTailAbsorbedInLastSegment) {
     const size_t tail = 500 * 1024 * 1024;  // 500 MiB
     const size_t total = 7 * kGiB + tail;
     const size_t max_mr = 3 * kGiB;
-    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    auto sizes = computeSegmentSizes(total, max_mr,
+                                     SegmentSplitMode::kGiBAlignedBalanced);
     checkInvariants(sizes, total, max_mr);
     ASSERT_EQ(sizes.size(), 3u);
     EXPECT_EQ(sizes[0], 2 * kGiB);
@@ -74,7 +77,8 @@ TEST(ComputeSegmentSizesTest, RdmaSubGiBTailAbsorbedInLastSegment) {
 TEST(ComputeSegmentSizesTest, RdmaTotalJustOverMaxMrSizeRequiresTwoSegments) {
     const size_t max_mr = 2 * kGiB;
     const size_t total = max_mr + 1;  // 2 GiB + 1 byte
-    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    auto sizes = computeSegmentSizes(total, max_mr,
+                                     SegmentSplitMode::kGiBAlignedBalanced);
     checkInvariants(sizes, total, max_mr);
     ASSERT_EQ(sizes.size(), 2u);
 }
@@ -83,7 +87,8 @@ TEST(ComputeSegmentSizesTest, RdmaTotalJustOverMaxMrSizeRequiresTwoSegments) {
 TEST(ComputeSegmentSizesTest, RdmaTotalEqualsMaxMrSizeSingleSegment) {
     const size_t max_mr = 4 * kGiB;
     const size_t total = max_mr;
-    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    auto sizes = computeSegmentSizes(total, max_mr,
+                                     SegmentSplitMode::kGiBAlignedBalanced);
     checkInvariants(sizes, total, max_mr);
     ASSERT_EQ(sizes.size(), 1u);
     EXPECT_EQ(sizes[0], total);
@@ -94,10 +99,36 @@ TEST(ComputeSegmentSizesTest, RdmaTotalBelowMaxMrSizeWithTailSingleSegment) {
     const size_t tail = 123 * 1024 * 1024;  // 123 MiB
     const size_t total = 3 * kGiB + tail;
     const size_t max_mr = 8 * kGiB;
-    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    auto sizes = computeSegmentSizes(total, max_mr,
+                                     SegmentSplitMode::kGiBAlignedBalanced);
     checkInvariants(sizes, total, max_mr);
     ASSERT_EQ(sizes.size(), 1u);
     EXPECT_EQ(sizes[0], total);
+}
+
+// UB: split on byte granularity to respect URMA's max_seg_size cap exactly.
+TEST(ComputeSegmentSizesTest, UbBalancedSplitHonorsMaxSegSize) {
+    const size_t total = 7 * kGiB + 1;  // forces a non-even byte tail
+    const size_t max_seg = 3 * kGiB;
+    auto sizes =
+        computeSegmentSizes(total, max_seg, SegmentSplitMode::kBalanced);
+    checkInvariants(sizes, total, max_seg);
+    ASSERT_EQ(sizes.size(), 3u);
+    EXPECT_LE(*std::max_element(sizes.begin(), sizes.end()) -
+                  *std::min_element(sizes.begin(), sizes.end()),
+              size_t{1});
+}
+
+// UB: sub-GiB caps are supported because splitting is byte-balanced rather
+// than GiB-aligned.
+TEST(ComputeSegmentSizesTest, UbSubGiBCapIsSupported) {
+    const size_t max_seg = 512 * 1024 * 1024;  // 512 MiB
+    const size_t total = 3 * kGiB;
+    auto sizes =
+        computeSegmentSizes(total, max_seg, SegmentSplitMode::kBalanced);
+    checkInvariants(sizes, total, max_seg);
+    ASSERT_EQ(sizes.size(), 6u);
+    for (size_t s : sizes) EXPECT_EQ(s, max_seg);
 }
 
 // RDMA, max_mr_size exactly 1 GiB: the boundary of the supported range.
@@ -105,7 +136,8 @@ TEST(ComputeSegmentSizesTest, RdmaTotalBelowMaxMrSizeWithTailSingleSegment) {
 TEST(ComputeSegmentSizesTest, RdmaMaxMrSizeExactlyOneGiBHonorsCap) {
     const size_t max_mr = kGiB;
     const size_t total = 3 * kGiB;
-    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    auto sizes = computeSegmentSizes(total, max_mr,
+                                     SegmentSplitMode::kGiBAlignedBalanced);
     checkInvariants(sizes, total, max_mr);
     ASSERT_EQ(sizes.size(), 3u);
     for (size_t s : sizes) EXPECT_EQ(s, kGiB);
@@ -117,7 +149,8 @@ TEST(ComputeSegmentSizesTest, RdmaMaxMrSizeExactlyOneGiBHonorsCap) {
 TEST(ComputeSegmentSizesTest, RdmaMaxMrSizeBelowOneGiBReturnsEmpty) {
     const size_t max_mr = 512 * 1024 * 1024;  // 512 MiB, < 1 GiB
     const size_t total = 3 * kGiB;
-    auto sizes = computeSegmentSizes(total, max_mr, /*is_rdma=*/true);
+    auto sizes = computeSegmentSizes(total, max_mr,
+                                     SegmentSplitMode::kGiBAlignedBalanced);
     EXPECT_TRUE(sizes.empty());
 }
 


### PR DESCRIPTION

## Description

Previously, segment splitting was unconditionally applied using `globalConfig().max_mr_size` regardless of transport protocol. This caused two issues:

  1. **Unnecessary splitting for non-RDMA**: TCP and other transports have no hardware MR size limit, but segments were still split at 1TB boundaries, creating multiple allocators under the same segment name. This adds overhead in `allocateSingle()` (random selection + fallback loop instead of direct call) and increases memory allocator fragmentation.

  2. **Unbalanced segment sizes cause skewed load under `RandomAllocationStrategy`**: The greedy approach (`min(remaining, max_mr_size)`) created unevenly sized segments (e.g., 1TB + 0.4TB for a 1.4TB region). Since `RandomAllocationStrategy` picks segments with equal probability regardless of capacity, the smaller segment receives the same request rate but fills up much faster — once full, all allocation pressure falls onto the remaining segment, effectively wasting the parallelism that splitting was meant to provide.

  While `FreeRatioFirstAllocationStrategy` can compensate by sorting on free ratio, `RandomAllocationStrategy` is the default and fastest path, so fixing segment sizes at the source benefits all strategies.

  The existing code already acknowledged part of this with the comment:

```
// Tcp is not limited by max_mr_size, but we ignore it for now.
```

## Changes

- Skip segment splitting for non-RDMA transports (tcp, ascend, etc.) to avoid unnecessary allocator fragmentation. The max_mr_size limit is an RDMA hardware constraint (ibv_reg_mr()), not applicable to other transports.
- For RDMA, use balanced equal-sized partitioning instead of greedy splitting. For example, 1.4TB is now split into 2×0.7TB instead of 1TB + 0.4TB, ensuring more even allocation across allocators.
- Make CheckRegisterMemoryParams protocol-aware so it only enforces max_mr_size validation for RDMA.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
