### PR TITLE
[CI] update ascend ci workflow and docs

### DIFF
--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -51,6 +51,7 @@ jobs:
                 echo "Detected that extern/pybind11 already exists, continuing execution...."
             fi
         fi
+        bash scripts/ascend/dependencies_ascend_installation.sh
         echo "Configuring CMake..."
         rm -rf build
         mkdir -p build

--- a/docs/source/design/transfer-engine/ascend_transport.md
+++ b/docs/source/design/transfer-engine/ascend_transport.md
@@ -2,6 +2,8 @@
 
 The source code path for Ascend Transport is `Mooncake/mooncake-transfer-engine/src/transport/ascend_transport`, which also includes automated build scripts and the README file.
 
+**ASCEND TRANSPORT is scheduled for deprecation, please use [ASCEND DIRECT TRANSPORT](./ascend_direct_transport.md) on ASCEND platform. **
+
 ## Overview
 
 Ascend Transport is a high-performance zero-copy NPU data transfer library with one-sided semantics, directly compatible with Mooncake Transfer Engine. To compile and use the Ascend Transport library, please set the `USE_ASCEND` flag to `"ON"` in the `mooncake-common/common.cmake` file.
@@ -142,7 +144,7 @@ Therefore, in testing:
    Watch the log produced by `mooncake-transfer-engine/src/transfer_engine.cpp`; you should see a line similar to  
    ```
    Transfer Engine RPC using <protocol> listening on <IP>:<actual-port>
-   ```  
+   ```
    Note the **actual port** the target node is listening on.
 
 2. **Edit the initiator’s launch command**:  

--- a/docs/source/zh_archive/ascend_transport.md
+++ b/docs/source/zh_archive/ascend_transport.md
@@ -1,5 +1,8 @@
 # Ascend Transport
 Ascend Transport源代码路径为Mooncake/mooncake-transfer-engine/src/transport/ascend_transport，该路径下还包含自动化编译脚本、README文件。
+
+**Ascend Transport 已不再维护，昇腾平台推荐使用 [Ascend Direct Transport](./ascend_direct_transport.md). **
+
 ## 概述
 Ascend Transport是一个单边语义的高性能零拷贝NPU数据传输库，直接兼容Mooncake Transfer Engine。要编译使用Ascend Transport库，请在mooncake-common\common.cmake文件中将USE_ASCEND开关置于"ON"。
 

--- a/scripts/ascend/dependencies_ascend.sh
+++ b/scripts/ascend/dependencies_ascend.sh
@@ -15,6 +15,9 @@
 
 # If git clone fails, you can place dependencies and Mooncake source code in a directory for compilation and installation.
 
+# ASCEND TRANSPORT is scheduled for deprecation, please use ASCEND DIRECT TRANSPORT on ASCEND platform. 
+# Use dependencies_ascend_installation.sh to install dependencies instead.
+
 #!/bin/bash
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/ascend/dependencies_ascend_installation.sh
+++ b/scripts/ascend/dependencies_ascend_installation.sh
@@ -65,7 +65,10 @@ if command -v apt-get &> /dev/null; then
             pkg-config \
             patchelf \
             mpich \
-            libmpich-dev
+            libmpich-dev \
+            libzstd-dev \
+            libxxhash-dev \
+            libmsgpack-dev
     apt purge -y openmpi-bin libopenmpi-dev || true
 elif command -v yum &> /dev/null; then
     echo "Detected yum. Using Red Hat-based package manager."
@@ -83,7 +86,9 @@ elif command -v yum &> /dev/null; then
             libcurl-devel \
             jsoncpp-devel \
             mpich \
-            mpich-devel
+            mpich-devel \
+            zstd-devel \
+            xxhash-devel
     # Install yaml-cpp
     cd "$TARGET_DIR"
     clone_repo_if_not_exists "yaml-cpp" https://github.com/jbeder/yaml-cpp.git
@@ -92,6 +97,17 @@ elif command -v yum &> /dev/null; then
     mkdir -p build && cd build
     cmake ..
     make -j$(nproc)
+    make install
+    cd ../..
+
+    # Install msgpack-c
+    clone_repo_if_not_exists "msgpack" "https://github.com/msgpack/msgpack-c.git"
+    cd msgpack-c || exit
+    git checkout cpp-7.0.0
+    rm -rf build
+    mkdir -p build && cd build
+    cmake ..
+    make -j
     make install
     cd ../..
 else
@@ -116,9 +132,3 @@ make install
 cd ../..
 
 echo -e "yalantinglibs installed successfully."
-
-# Add the so package to the environment variables
-cp libascend_transport_mem.so /usr/local/Ascend/ascend-toolkit/latest/python/site-packages
-
-# Pip install whl
-pip install mooncake_transfer_engine*.whl --force


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
1. Update dependencies to fix ascend platform CI failure. 
2. Redirect ascend transport docs to ascend direct transport, for ascend transport is scheduled deprecated.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->
Workflow successfully finished.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
