### PR TITLE
Fix client_ttl flag name check in master

### DIFF
--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -397,7 +397,7 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.etcd_endpoints = FLAGS_etcd_endpoints;
     }
-    if ((google::GetCommandLineFlagInfo("client_live_ttl_sec", &info) &&
+    if ((google::GetCommandLineFlagInfo("client_ttl", &info) &&
          !info.is_default) ||
         !conf_set) {
         master_config.client_live_ttl_sec = FLAGS_client_ttl;


### PR DESCRIPTION
## Description

Fix the command line flag name check for client TTL in `mooncake-store/src/master.cpp`.

`LoadConfigFromCmdline` was checking `client_live_ttl_sec` via `GetCommandLineFlagInfo`, but the actual registered gflag name is `client_ttl`. This could prevent `--client_ttl` from being recognized as an explicitly provided command line override when a config file is also present.

This PR updates the check to use `client_ttl`, matching the existing flag definition and `FLAGS_client_ttl` usage.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

No additional tests were run for this one-line flag name fix.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
