### PR TITLE
[CI] Add hixl roce samples on ASCEND platforms.

### DIFF
--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-test:
-    # if: github.repository == 'kvcache-ai/Mooncake'
+    if: github.repository == 'kvcache-ai/Mooncake'
     runs-on: self-hosted
 
     container:


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
When using ascend direct transport, there are two intra-machine choices for transfer tasks.
* HCCS: default choice, due to some hardware restrictions, needs to be used together with environment variable `ACEND_BUFFER_POOL` (or use fabric mem).
* ROCE: set environment variable `HCCL_INTRA_ROCE_ENABLE`.

For these environment variables, refer to [ASCEND_DIRECT_TRANSPORT](https://github.com/kvcache-ai/Mooncake/blob/main/docs/source/design/transfer-engine/ascend_direct_transport.md)

Now the CI workflow covers both HCCS and ROCE options. 
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
