### PR TITLE
[TE] Remove false-positive slice leak detection in ThreadLocalSliceCache

### DIFF
--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -237,11 +237,6 @@ class Transport {
             for (uint64_t i = tail_; i != head_; i++) {
                 auto slice = lazy_delete_slices_[i % kLazyDeleteSliceCapacity];
                 delete slice;
-                freed_++;
-            }
-            if (allocated_ != freed_) {
-                LOG(WARNING) << "detected slice leak: allocated " << allocated_
-                             << " freed " << freed_;
             }
         }
 
@@ -249,7 +244,6 @@ class Transport {
             Slice *slice;
 
             if (head_ - tail_ == 0) {
-                allocated_++;
                 slice = new Slice();
                 slice->from_cache = false;
             } else {
@@ -264,7 +258,6 @@ class Transport {
         void deallocate(Slice *slice) {
             if (head_ - tail_ == kLazyDeleteSliceCapacity) {
                 delete slice;
-                freed_++;
                 return;
             }
             lazy_delete_slices_[head_ % kLazyDeleteSliceCapacity] = slice;
@@ -274,7 +267,6 @@ class Transport {
         const static size_t kLazyDeleteSliceCapacity = 4096;
         std::vector<Slice *> lazy_delete_slices_;
         uint64_t head_, tail_;
-        uint64_t allocated_ = 0, freed_ = 0;
     };
 
     struct TransferTask {


### PR DESCRIPTION
## Description

Fix #1654.

The leak detection logic assumes slices are always allocated and freed on the same thread. In practice, a slice allocated by thread A can be legitimately freed by thread B, causing the per-thread counters to mismatch and trigger a false-positive warning at shutdown. This is expected behavior — the cross-thread slice lifecycle is correct by design.

Remove the slice leak warning ("detected slice leak: allocated X freed Y") from ThreadLocalSliceCache, along with the now-unused allocated_ and freed_ counters.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
