### PR TITLE
[TENT] fix: avoid resetting RDMA endpoint on duplicate concurrent bootstrap

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -177,6 +177,7 @@ class RdmaEndPoint {
 
     std::string peer_server_name_;
     std::string peer_nic_name_;
+    std::vector<uint32_t> peer_qp_num_list_;
     std::atomic<int>* endpoints_count_;
 
     // Notification QP (one per endpoint for control plane operations)

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -170,6 +170,7 @@ int RdmaEndPoint::deconstruct() {
     if (status_ == EP_UNINIT) return 0;
     status_ = EP_RESET;
     resetInflightSlices();
+    peer_qp_num_list_.clear();
 
     // Destroy notification QP
     if (notify_qp_) {
@@ -208,6 +209,8 @@ int RdmaEndPoint::deconstruct() {
     slice_queue_.clear();
     delete[] wr_depth_list_;
     wr_depth_list_ = nullptr;
+    peer_server_name_.clear();
+    peer_nic_name_.clear();
     status_ = EP_UNINIT;
     return 0;
 }
@@ -316,6 +319,7 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
             return Status::InternalError(
                 "Failed to configure RDMA endpoint" LOC_MARK);
         }
+        peer_qp_num_list_ = qp_num;
 
         // Setup notification QP connection if peer supports it
         if (peer_desc.notify_qp_num != 0 && notify_qp_) {
@@ -341,9 +345,9 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     RWSpinlock::WriteGuard guard(lock_);
     if (status_ == EP_READY) {
         // Idempotency check: if the incoming bootstrap is from the same peer
-        // and has the same number of QPs as we already have connected, this is
-        // a duplicate request (e.g. from a concurrent connect() on the
-        // initiator that released its lock during Phase 2).  Re-using the
+        // and carries the same peer QP list as the established connection,
+        // this is a duplicate request (e.g. from a concurrent connect() on
+        // the initiator that released its lock during Phase 2). Re-using the
         // existing connection is safe and avoids resetting QPs that may
         // already have in-flight RDMA operations.
         auto incoming_peer_server =
@@ -352,7 +356,7 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
             getNicNameFromNicPath(peer_desc.local_nic_path);
         if (incoming_peer_server == peer_server_name_ &&
             incoming_peer_nic == peer_nic_name_ &&
-            peer_desc.qp_num.size() == qp_list_.size()) {
+            peer_desc.qp_num == peer_qp_num_list_) {
             LOG(INFO) << "Endpoint already established with " << peer_nic_name_
                       << " of " << peer_server_name_
                       << " (duplicate bootstrap, reusing connection)";
@@ -404,6 +408,7 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
         return Status::InternalError(
             "Failed to configure RDMA endpoint" LOC_MARK);
     }
+    peer_qp_num_list_ = peer_desc.qp_num;
 
     // Setup notification QP connection if peer supports it
     if (peer_desc.notify_qp_num != 0 && notify_qp_) {
@@ -430,6 +435,7 @@ int RdmaEndPoint::reset() {
 int RdmaEndPoint::resetUnlocked() {
     if (status_ != EP_READY) return 0;
     status_ = EP_RESET;
+    peer_qp_num_list_.clear();
     resetInflightSlices();
 
     if (notify_qp_) {


### PR DESCRIPTION
## Description

Special thanks to @Primary33 for finding the bug!

Fix a race condition in RdmaEndPoint::accept() where concurrent connect() calls from the same peer could reset an already-established endpoint, disrupting in-flight RDMA operations.

When the initiator side releases its endpoint lock during the bootstrap handshake, a second concurrent connect() call can race and send a duplicate bootstrap request. Previously, the acceptor would blindly reset the endpoint (destroying existing QPs) and re-establish the connection. This could cause failures or data corruption for any RDMA operations already in flight on the original connection.

## Changes

Add an idempotency check: if the endpoint is already EP_READY and the incoming bootstrap request comes from the same peer (matching server name, NIC name, and QP count), directly return the existing connection info instead of resetting and re-handshaking.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
