### PR TITLE
[Transfer Engine] Round-robin slice batch across QPs in RdmaEndPoint::submitPostSend

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -272,32 +272,37 @@ int RdmaEndPoint::submitPostSend(
     const size_t num_qp = qp_list_.size();
     if (slice_list.empty()) return 0;
     const size_t requested = slice_list.size();
-
     int cq_remaining = int(globalConfig().max_cqe) - *cq_outstanding_;
-    std::vector<int> attempted_count(num_qp, 0);
+    std::vector<ibv_send_wr> wr_list(requested, ibv_send_wr{});
+    std::vector<ibv_sge> sge_list(requested);
+    size_t total_posted = 0;
+    size_t cursor = 0;
 
-    for (size_t qp_index = 0; qp_index < num_qp && cq_remaining > 0;
+    for (size_t qp_index = 0;
+         qp_index < num_qp && cq_remaining > 0 && cursor < requested;
          ++qp_index) {
-        int assigned_count =
-            qp_index < requested
-                ? (int)((requested - qp_index + num_qp - 1) / num_qp)
-                : 0;
-        int wr_count =
-            std::min(assigned_count, max_wr_depth_ - wr_depth_list_[qp_index]);
-        wr_count = std::min(wr_count, cq_remaining);
-        if (wr_count <= 0) continue;
-        attempted_count[qp_index] = wr_count;
+        int qp_avail = max_wr_depth_ - wr_depth_list_[qp_index];
+        if (qp_avail <= 0) continue;
 
-        std::vector<ibv_send_wr> wr_list(wr_count, ibv_send_wr{});
-        std::vector<ibv_sge> sge_list(wr_count);
+        size_t remaining_qps = num_qp - qp_index;
+        size_t remaining_slices = requested - cursor;
+        size_t chunk = (remaining_slices + remaining_qps - 1) / remaining_qps;
+        size_t start = cursor;
+        size_t end = std::min(start + chunk, requested);
+        int assigned_count = (int)(end - start);
+
+        int wr_count = std::min(assigned_count, qp_avail);
+        wr_count = std::min(wr_count, cq_remaining);
+
         for (int i = 0; i < wr_count; ++i) {
-            auto *slice = slice_list[qp_index + (size_t)i * num_qp];
+            auto *slice = slice_list[start + i];
             auto &sge = sge_list[i];
             sge.addr = (uint64_t)slice->source_addr;
             sge.length = slice->length;
             sge.lkey = slice->rdma.source_lkey;
 
             auto &wr = wr_list[i];
+            memset(&wr, 0, sizeof(ibv_send_wr));
             wr.wr_id = (uint64_t)slice;
             wr.opcode = slice->opcode == Transport::TransferRequest::READ
                             ? IBV_WR_RDMA_READ
@@ -306,7 +311,6 @@ int RdmaEndPoint::submitPostSend(
             wr.sg_list = &sge;
             wr.send_flags = IBV_SEND_SIGNALED;
             wr.next = (i + 1 == wr_count) ? nullptr : &wr_list[i + 1];
-            wr.imm_data = 0;
             wr.wr.rdma.remote_addr = slice->rdma.dest_addr;
             wr.wr.rdma.rkey = slice->rdma.dest_rkey;
             slice->ts = getCurrentTimeInNano();
@@ -318,31 +322,25 @@ int RdmaEndPoint::submitPostSend(
         __sync_fetch_and_add(&wr_depth_list_[qp_index], wr_count);
         __sync_fetch_and_add(cq_outstanding_, wr_count);
         int rc = ibv_post_send(qp_list_[qp_index], wr_list.data(), &bad_wr);
-        int actually_posted = wr_count;
         if (rc) {
             PLOG(ERROR) << "Failed to ibv_post_send";
-            int num_failed = 0;
             while (bad_wr) {
                 int i = bad_wr - wr_list.data();
-                failed_slice_list.push_back(
-                    slice_list[qp_index + (size_t)i * num_qp]);
+                failed_slice_list.push_back(slice_list[start + i]);
                 __sync_fetch_and_sub(&wr_depth_list_[qp_index], 1);
                 __sync_fetch_and_sub(cq_outstanding_, 1);
-                num_failed++;
                 bad_wr = bad_wr->next;
             }
-            actually_posted = wr_count - num_failed;
+            total_posted += wr_count;
+            cursor += wr_count;
+            break;
         }
-
-        cq_remaining -= actually_posted;
+        total_posted += wr_count;
+        cursor += wr_count;
+        cq_remaining -= wr_count;
     }
-
-    std::vector<Transport::Slice *> remaining_slices;
-    remaining_slices.reserve(slice_list.size());
-    for (size_t q = 0; q < num_qp; ++q)
-        for (size_t j = attempted_count[q]; q + j * num_qp < requested; ++j)
-            remaining_slices.push_back(slice_list[q + j * num_qp]);
-    slice_list.swap(remaining_slices);
+    slice_list.erase(slice_list.begin(),
+                     slice_list.begin() + (ptrdiff_t)total_posted);
     return 0;
 }
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
