### PR TITLE
[Bug fix]: async offload RPC to prevent client expiration and shm_not_mappedFix/issue 1711 async offload rpc

### DIFF
--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -19,6 +19,8 @@
 #include "rpc_types.h"
 #include <ylt/coro_http/coro_http_server.hpp>
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
+#include <ylt/coro_io/coro_io.hpp>
+#include <async_simple/coro/Lazy.h>
 
 namespace mooncake {
 
@@ -406,10 +408,11 @@ class RealClient : public PyClient {
         const std::string &key, std::vector<std::span<const char>> values,
         const ReplicateConfig &config, const UUID &client_id);
 
-    std::vector<tl::expected<int64_t, ErrorCode>> batch_get_into_dummy_helper(
-        const std::vector<std::string> &keys,
-        const std::vector<uint64_t> &buffers, const std::vector<size_t> &sizes,
-        int32_t device_id, const UUID &client_id);
+    async_simple::coro::Lazy<std::vector<tl::expected<int64_t, ErrorCode>>>
+    batch_get_into_dummy_helper(const std::vector<std::string> &keys,
+                                const std::vector<uint64_t> &buffers,
+                                const std::vector<size_t> &sizes,
+                                int32_t device_id, const UUID &client_id);
 
     std::vector<tl::expected<void, ErrorCode>> batch_put_from_dummy_helper(
         const std::vector<std::string> &keys,
@@ -645,7 +648,8 @@ class RealClient : public PyClient {
 
     tl::expected<PingResponse, ErrorCode> ping(const UUID &client_id);
 
-    tl::expected<BatchGetOffloadObjectResponse, ErrorCode>
+    async_simple::coro::Lazy<
+        tl::expected<BatchGetOffloadObjectResponse, ErrorCode>>
     batch_get_offload_object(const std::vector<std::string> &keys,
                              const std::vector<int64_t> &sizes);
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4204,8 +4204,8 @@ RealClient::batch_get_offload_object(const std::vector<std::string> &keys,
                                      const std::vector<int64_t> &sizes) {
     // Run SSD I/O on a dedicated thread pool
     // so the coro_rpc IO thread is free to handle ping and other RPCs.
-    auto try_result = co_await coro_io::post(
-        [file_storage = file_storage_, &keys, &sizes]() {
+    auto try_result =
+        co_await coro_io::post([file_storage = file_storage_, &keys, &sizes]() {
             return file_storage->BatchGet(keys, sizes);
         });
     auto result = try_result.value();

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3225,13 +3225,28 @@ RealClient::batch_get_into_dummy_helper(
 
     // Run batch_get_into_internal (which may block on offload RPC + SSD I/O)
     // on a dedicated thread pool so the coro_rpc IO thread stays free for ping.
-    // The shared_lock is captured to keep SHM pinned until the operation
-    // completes.
-    auto buffers = buffers_result.value();
-    auto try_result = co_await coro_io::post(
-        [this, &keys, buffers = std::move(buffers), &sizes, lock]() {
-            return batch_get_into_internal(keys, buffers, sizes);
-        });
+    //
+    // Pack everything the worker-thread call needs into a single heap-owned
+    // state object so the lambda captures only a raw pointer (trivially
+    // copyable, trivially destructible). Avoids GCC 11 coroutine + coro_io
+    // double-destruction interactions when non-trivial captures end up in
+    // both the OUTER coroutine frame and the post_helper chain.
+    struct CallState {
+        std::vector<std::string> keys;
+        std::vector<size_t> sizes;
+        std::vector<void *> buffers;
+        std::shared_ptr<std::shared_lock<std::shared_mutex>> lock;
+    };
+    auto state = std::make_unique<CallState>();
+    state->keys = keys;
+    state->sizes = sizes;
+    state->buffers = std::move(buffers_result.value());
+    state->lock = std::move(lock);
+
+    auto *s = state.get();
+    auto try_result = co_await coro_io::post([this, s]() {
+        return batch_get_into_internal(s->keys, s->buffers, s->sizes);
+    });
     co_return try_result.value();
 }
 
@@ -4202,12 +4217,22 @@ tl::expected<QueryTaskResponse, ErrorCode> RealClient::query_task(
 async_simple::coro::Lazy<tl::expected<BatchGetOffloadObjectResponse, ErrorCode>>
 RealClient::batch_get_offload_object(const std::vector<std::string> &keys,
                                      const std::vector<int64_t> &sizes) {
-    // Run SSD I/O on a dedicated thread pool
-    // so the coro_rpc IO thread is free to handle ping and other RPCs.
-    auto try_result =
-        co_await coro_io::post([file_storage = file_storage_, &keys, &sizes]() {
-            return file_storage->BatchGet(keys, sizes);
-        });
+    // Run SSD I/O on a dedicated thread pool so the coro_rpc IO thread is
+    // free to handle ping and other RPCs. Same heap-owned state pattern as
+    // batch_get_into_dummy_helper: the lambda captures only a raw pointer.
+    struct CallState {
+        std::vector<std::string> keys;
+        std::vector<int64_t> sizes;
+        std::shared_ptr<FileStorage> file_storage;
+    };
+    auto state = std::make_unique<CallState>();
+    state->keys = keys;
+    state->sizes = sizes;
+    state->file_storage = file_storage_;
+    auto *s = state.get();
+    auto try_result = co_await coro_io::post([s]() {
+        return s->file_storage->BatchGet(s->keys, s->sizes);
+    });
     auto result = try_result.value();
     if (!result) {
         LOG(ERROR) << "Batch get offload object failed,err_code = "

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3189,7 +3189,7 @@ std::vector<int64_t> RealClient::batch_get_into(
     return results;
 }
 
-std::vector<tl::expected<int64_t, ErrorCode>>
+async_simple::coro::Lazy<std::vector<tl::expected<int64_t, ErrorCode>>>
 RealClient::batch_get_into_dummy_helper(
     const std::vector<std::string> &keys,
     const std::vector<uint64_t> &dummy_buffers,
@@ -3199,16 +3199,18 @@ RealClient::batch_get_into_dummy_helper(
     if (!ContextManager::getInstance().setCurrentContextByPhysicalId(
             device_id)) {
         LOG(ERROR) << "Failed to set context for physical device " << device_id;
-        return std::vector<tl::expected<int64_t, ErrorCode>>(
+        co_return std::vector<tl::expected<int64_t, ErrorCode>>(
             keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
     }
 #endif
 
-    std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
+    // Hold shared_lock for the entire operation to prevent SHM from being
+    // unmapped while batch_get_into_internal is using the translated buffers.
+    auto lock = std::make_shared<std::shared_lock<std::shared_mutex>>(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
     if (it == shm_contexts_.end()) {
         LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
-        return std::vector<tl::expected<int64_t, ErrorCode>>(
+        co_return std::vector<tl::expected<int64_t, ErrorCode>>(
             keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
     }
     auto &context = it->second;
@@ -3216,10 +3218,18 @@ RealClient::batch_get_into_dummy_helper(
     auto buffers_result =
         map_dummy_addrs_to_real_ptrs(context, dummy_buffers, sizes, client_id);
     if (!buffers_result) {
-        return std::vector<tl::expected<int64_t, ErrorCode>>(
+        co_return std::vector<tl::expected<int64_t, ErrorCode>>(
             keys.size(), tl::unexpected(buffers_result.error()));
     }
-    return batch_get_into_internal(keys, buffers_result.value(), sizes);
+
+    // Run batch_get_into_internal (which may block on offload RPC + SSD I/O)
+    // on a dedicated thread pool so the coro_rpc IO thread stays free for ping.
+    // The shared_lock is captured to keep SHM pinned until the operation completes.
+    auto buffers = buffers_result.value();
+    auto try_result = co_await coro_io::post([this, &keys, &buffers, &sizes, lock]() {
+        return batch_get_into_internal(keys, buffers, sizes);
+    });
+    co_return try_result.value();
 }
 
 std::vector<tl::expected<void, ErrorCode>>
@@ -4186,16 +4196,22 @@ tl::expected<QueryTaskResponse, ErrorCode> RealClient::query_task(
     const UUID &task_id) {
     return client_->QueryTask(task_id);
 }
-tl::expected<BatchGetOffloadObjectResponse, ErrorCode>
+async_simple::coro::Lazy<tl::expected<BatchGetOffloadObjectResponse, ErrorCode>>
 RealClient::batch_get_offload_object(const std::vector<std::string> &keys,
                                      const std::vector<int64_t> &sizes) {
-    auto result = file_storage_->BatchGet(keys, sizes);
+    // Run SSD I/O on a dedicated thread pool
+    // so the coro_rpc IO thread is free to handle ping and other RPCs.
+    auto file_storage = file_storage_;
+    auto try_result = co_await coro_io::post([&file_storage, &keys, &sizes]() {
+        return file_storage->BatchGet(keys, sizes);
+    });
+    auto result = try_result.value();
     if (!result) {
         LOG(ERROR) << "Batch get offload object failed,err_code = "
                    << result.error();
-        return tl::make_unexpected(result.error());
+        co_return tl::make_unexpected(result.error());
     }
-    return BatchGetOffloadObjectResponse(
+    co_return BatchGetOffloadObjectResponse(
         result.value().batch_id, std::move(result.value().pointers),
         client_->GetTransportEndpoint(),
         file_storage_->config_.client_buffer_gc_ttl_ms);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3206,7 +3206,8 @@ RealClient::batch_get_into_dummy_helper(
 
     // Hold shared_lock for the entire operation to prevent SHM from being
     // unmapped while batch_get_into_internal is using the translated buffers.
-    auto lock = std::make_shared<std::shared_lock<std::shared_mutex>>(dummy_client_mutex_);
+    auto lock = std::make_shared<std::shared_lock<std::shared_mutex>>(
+        dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
     if (it == shm_contexts_.end()) {
         LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
@@ -3224,11 +3225,13 @@ RealClient::batch_get_into_dummy_helper(
 
     // Run batch_get_into_internal (which may block on offload RPC + SSD I/O)
     // on a dedicated thread pool so the coro_rpc IO thread stays free for ping.
-    // The shared_lock is captured to keep SHM pinned until the operation completes.
+    // The shared_lock is captured to keep SHM pinned until the operation
+    // completes.
     auto buffers = buffers_result.value();
-    auto try_result = co_await coro_io::post([this, &keys, &buffers, &sizes, lock]() {
-        return batch_get_into_internal(keys, buffers, sizes);
-    });
+    auto try_result = co_await coro_io::post(
+        [this, &keys, buffers = std::move(buffers), &sizes, lock]() {
+            return batch_get_into_internal(keys, buffers, sizes);
+        });
     co_return try_result.value();
 }
 
@@ -4201,10 +4204,10 @@ RealClient::batch_get_offload_object(const std::vector<std::string> &keys,
                                      const std::vector<int64_t> &sizes) {
     // Run SSD I/O on a dedicated thread pool
     // so the coro_rpc IO thread is free to handle ping and other RPCs.
-    auto file_storage = file_storage_;
-    auto try_result = co_await coro_io::post([&file_storage, &keys, &sizes]() {
-        return file_storage->BatchGet(keys, sizes);
-    });
+    auto try_result = co_await coro_io::post(
+        [file_storage = file_storage_, &keys, &sizes]() {
+            return file_storage->BatchGet(keys, sizes);
+        });
     auto result = try_result.value();
     if (!result) {
         LOG(ERROR) << "Batch get offload object failed,err_code = "

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4230,9 +4230,8 @@ RealClient::batch_get_offload_object(const std::vector<std::string> &keys,
     state->sizes = sizes;
     state->file_storage = file_storage_;
     auto *s = state.get();
-    auto try_result = co_await coro_io::post([s]() {
-        return s->file_storage->BatchGet(s->keys, s->sizes);
-    });
+    auto try_result = co_await coro_io::post(
+        [s]() { return s->file_storage->BatchGet(s->keys, s->sizes); });
     auto result = try_result.value();
     if (!result) {
         LOG(ERROR) << "Batch get offload object failed,err_code = "


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [✅ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [✅ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [✅ ] I have performed a self-review of my own code.
- [✅ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.

## Summary

Fixes #1711

When SSD offload is enabled with multiple mooncake_client instances, the coro_rpc IO thread gets blocked by:
1. **Caller side**: `syncAwait` in `invoke_rpc` waiting for remote offload RPC response (30-60s)
2. **Server side**: `file_storage_->BatchGet()` doing synchronous SSD I/O

While the IO thread is blocked, it cannot process `ping` RPCs from dummy clients. After 10s TTL (`DEFAULT_CLIENT_LIVE_TTL_SEC`), the monitor thread marks the client as expired and calls `unmap_shm_internal()`, which permanently erases the SHM context. All subsequent operations fail with `shm_not_mapped` indefinitely.

## Root Cause

`coro_rpc_server` dispatches all RPC handlers on its IO threads. Both `batch_get_into_dummy_helper` (caller) and `batch_get_offload_object` (server) contain blocking operations that prevent the IO thread from returning to the event loop, starving `ping` and other lightweight RPCs.

## Fix

Use `coro_io::post()` to run blocking operations on a dedicated thread pool, converting the RPC handlers to coroutines so the IO thread yields at `co_await` and stays free for `ping`:

- **`batch_get_into_dummy_helper`** → coroutine, posts `batch_get_into_internal` (which contains offload RPC `syncAwait`) to block executor
- **`batch_get_offload_object`** → coroutine, posts `file_storage_->BatchGet()` (SSD I/O) to block executor

The `shared_lock` on `dummy_client_mutex_` is now scoped to only the SHM address translation phase and released before any blocking I/O.
