### PR TITLE
[PG] optimize p2p-proxy buffer size

### DIFF
--- a/mooncake-pg/include/p2p_proxy.h
+++ b/mooncake-pg/include/p2p_proxy.h
@@ -20,7 +20,6 @@ namespace mooncake {
 inline constexpr size_t kP2PBufferSize = 1u << 20;
 inline constexpr size_t kP2PNumSlots = 8;
 inline constexpr size_t kP2PSlotSize = kP2PBufferSize / kP2PNumSlots;
-inline constexpr size_t kP2PTotalBufferSize = kP2PBufferSize * kMaxNumRanks;
 
 struct alignas(64) AtomicHeadTail {
     uint32_t load(

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -68,37 +68,49 @@ void P2PProxy::AllocateResources() {
         return;
     }
 
+    TORCH_CHECK(size_ >= 0, "P2PProxy invalid size_: ", size_);
+    TORCH_CHECK(static_cast<size_t>(size_) <= kMaxNumRanks,
+                "P2PProxy size_ exceeds kMaxNumRanks: ", size_);
+
+    const size_t p2p_total_buffer_size =
+        kP2PBufferSize * static_cast<size_t>(size_);
+
+    if (p2p_total_buffer_size == 0) {
+        TORCH_CHECK(false, "P2PProxy total buffer size is invalid: ",
+                    p2p_total_buffer_size);
+    }
+
     if (is_cpu_) {
-        resources_.send_buffer_ = std::malloc(kP2PTotalBufferSize);
+        resources_.send_buffer_ = std::malloc(p2p_total_buffer_size);
         TORCH_CHECK(resources_.send_buffer_ != nullptr,
                     "Failed to allocate CPU P2P send buffer");
         int rc = engine_->registerLocalMemory(resources_.send_buffer_,
-                                              kP2PTotalBufferSize, location_);
+                                              p2p_total_buffer_size, location_);
         TORCH_CHECK(rc == 0, "Failed to register CPU P2P send buffer");
 
-        resources_.recv_buffer_ = std::malloc(kP2PTotalBufferSize);
+        resources_.recv_buffer_ = std::malloc(p2p_total_buffer_size);
         TORCH_CHECK(resources_.recv_buffer_ != nullptr,
                     "Failed to allocate CPU P2P recv buffer");
         rc = engine_->registerLocalMemory(resources_.recv_buffer_,
-                                          kP2PTotalBufferSize, location_);
+                                          p2p_total_buffer_size, location_);
         TORCH_CHECK(rc == 0, "Failed to register CPU P2P recv buffer");
     } else {
         SetCudaDeviceIfNeeded(
             is_cpu_, cuda_device_index_,
             "P2PProxy AllocateResources cudaSetDevice failed");
         cudaError_t err =
-            cudaMalloc(&resources_.send_buffer_, kP2PTotalBufferSize);
+            cudaMalloc(&resources_.send_buffer_, p2p_total_buffer_size);
         TORCH_CHECK(err == cudaSuccess,
                     "Failed to allocate CUDA P2P send buffer");
         int rc = engine_->registerLocalMemory(resources_.send_buffer_,
-                                              kP2PTotalBufferSize, location_);
+                                              p2p_total_buffer_size, location_);
         TORCH_CHECK(rc == 0, "Failed to register CUDA P2P send buffer");
 
-        err = cudaMalloc(&resources_.recv_buffer_, kP2PTotalBufferSize);
+        err = cudaMalloc(&resources_.recv_buffer_, p2p_total_buffer_size);
         TORCH_CHECK(err == cudaSuccess,
                     "Failed to allocate CUDA P2P recv buffer");
         rc = engine_->registerLocalMemory(resources_.recv_buffer_,
-                                          kP2PTotalBufferSize, location_);
+                                          p2p_total_buffer_size, location_);
         TORCH_CHECK(rc == 0, "Failed to register CUDA P2P recv buffer");
     }
 

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -72,13 +72,12 @@ void P2PProxy::AllocateResources() {
     TORCH_CHECK(static_cast<size_t>(size_) <= kMaxNumRanks,
                 "P2PProxy size_ exceeds kMaxNumRanks: ", size_);
 
+    if (size_ == 0) {
+        return;
+    }
+
     const size_t p2p_total_buffer_size =
         kP2PBufferSize * static_cast<size_t>(size_);
-
-    if (p2p_total_buffer_size == 0) {
-        TORCH_CHECK(false, "P2PProxy total buffer size is invalid: ",
-                    p2p_total_buffer_size);
-    }
 
     if (is_cpu_) {
         resources_.send_buffer_ = std::malloc(p2p_total_buffer_size);


### PR DESCRIPTION
## Description

This PR optimizes the buffer size used in `mooncake-pg`'s `p2p-proxy`.

## Motivation
Previously, p2p-proxy used a fixed send/receive buffer size (`kP2PTotalBufferSize`), resulting in unnecessary memory usage. This has been optimized so that the buffer size is now allocated according to actual demand.

## Changes
- Adjust the buffer size in `mooncake-pg/p2p-proxy`
- Keep the existing logic unchanged except for the buffer size tuning

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Validated with `test_mooncake_backend.py` and verified memory usage afterward.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
