### PR TITLE
[PG] Increase kP2PBufferSize to unlock full performance potential

### DIFF
--- a/mooncake-pg/include/p2p_proxy.h
+++ b/mooncake-pg/include/p2p_proxy.h
@@ -17,7 +17,7 @@
 
 namespace mooncake {
 
-inline constexpr size_t kP2PBufferSize = 1u << 20;
+inline constexpr size_t kP2PBufferSize = 1u << 24;
 inline constexpr size_t kP2PNumSlots = 8;
 inline constexpr size_t kP2PSlotSize = kP2PBufferSize / kP2PNumSlots;
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
