### PR TITLE
[Store] Unify batch replica mutation protocol

### DIFF
--- a/mooncake-store/include/p2p_client_service.h
+++ b/mooncake-store/include/p2p_client_service.h
@@ -176,10 +176,10 @@ class P2PClientService final : public ClientService {
     RemoveReplicaCallback BuildRemoveReplicaCallback();
 
     /**
-     * @brief build batch replica mutation callback.
-     *        used by SSD bucket eviction to batch-sync replica metadata.
+     * @brief build batch remove replica callback.
+     *        used by SSD bucket eviction to batch-sync replica deletions.
      */
-    BatchReplicaMutationCallback BuildBatchReplicaMutationCallback();
+    BatchRemoveReplicaCallback BuildBatchRemoveReplicaCallback();
 
     /**
      * @brief build segment sync callback.
@@ -192,21 +192,23 @@ class P2PClientService final : public ClientService {
      */
     tl::expected<void, ErrorCode> SyncAddReplica(const std::string& key,
                                                  const UUID& tier_id,
-                                                 size_t size);
+                                                 size_t size,
+                                                 uint64_t replica_generation);
 
     /**
      * @brief handle DELETE type callback: notify master to remove replica
      */
-    tl::expected<void, ErrorCode> SyncRemoveReplica(const std::string& key,
-                                                    const UUID& tier_id);
+    tl::expected<void, ErrorCode> SyncRemoveReplica(
+        const std::string& key, const UUID& tier_id,
+        uint64_t replica_generation = 0);
 
     /**
-     * @brief handle batch metadata mutations in one RPC call.
-     * @param mutations Mutation list; it will be moved into the request.
-     * @return Vector of ErrorCode results for each mutation.
+     * @brief handle batch replica removals in one RPC call.
+     * @param removals Removal list; it will be moved into the request.
+     * @return Vector of ErrorCode results for each removal.
      */
-    std::vector<tl::expected<void, ErrorCode>> SyncBatchMutateReplica(
-        std::vector<ReplicaMutation> mutations);
+    std::vector<tl::expected<void, ErrorCode>> SyncBatchRemoveReplica(
+        std::vector<BatchRemoveReplicaItem> removals);
 
     /**
      * @brief Collect tier info from DataManager and build P2P Segments.

--- a/mooncake-store/include/p2p_client_service.h
+++ b/mooncake-store/include/p2p_client_service.h
@@ -176,6 +176,12 @@ class P2PClientService final : public ClientService {
     RemoveReplicaCallback BuildRemoveReplicaCallback();
 
     /**
+     * @brief build batch replica mutation callback.
+     *        used by SSD bucket eviction to batch-sync replica metadata.
+     */
+    BatchReplicaMutationCallback BuildBatchReplicaMutationCallback();
+
+    /**
      * @brief build segment sync callback.
      *        when tier add/remove segment, call master to mount/unmount segment
      */
@@ -195,14 +201,12 @@ class P2PClientService final : public ClientService {
                                                     const UUID& tier_id);
 
     /**
-     * @brief handle batch DELETE: notify master to remove replicas from
-     *        multiple segments in one RPC call
-     * @param key Key to remove
-     * @param segment_ids Vector of segment IDs to remove (it will be moved)
-     * @return Vector of ErrorCode results for each segment
+     * @brief handle batch metadata mutations in one RPC call.
+     * @param mutations Mutation list; it will be moved into the request.
+     * @return Vector of ErrorCode results for each mutation.
      */
-    std::vector<tl::expected<void, ErrorCode>> SyncBatchRemoveReplica(
-        const std::string& key, std::vector<UUID> segment_ids);
+    std::vector<tl::expected<void, ErrorCode>> SyncBatchMutateReplica(
+        std::vector<ReplicaMutation> mutations);
 
     /**
      * @brief Collect tier info from DataManager and build P2P Segments.

--- a/mooncake-store/include/p2p_master_client.h
+++ b/mooncake-store/include/p2p_master_client.h
@@ -36,10 +36,10 @@ class P2PMasterClient final : public MasterClient {
         const RemoveReplicaRequest& req);
 
     /**
-     * @brief Removes replicas from multiple segments in one call
+     * @brief Applies a batch of replica metadata mutations.
      */
-    [[nodiscard]] std::vector<tl::expected<void, ErrorCode>> BatchRemoveReplica(
-        const BatchRemoveReplicaRequest& req);
+    [[nodiscard]] std::vector<tl::expected<void, ErrorCode>> BatchMutateReplica(
+        const BatchReplicaMutationRequest& req);
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/p2p_master_client.h
+++ b/mooncake-store/include/p2p_master_client.h
@@ -36,10 +36,10 @@ class P2PMasterClient final : public MasterClient {
         const RemoveReplicaRequest& req);
 
     /**
-     * @brief Applies a batch of replica metadata mutations.
+     * @brief Removes replicas from master in one batch RPC.
      */
-    [[nodiscard]] std::vector<tl::expected<void, ErrorCode>> BatchMutateReplica(
-        const BatchReplicaMutationRequest& req);
+    [[nodiscard]] std::vector<tl::expected<void, ErrorCode>> BatchRemoveReplica(
+        const BatchRemoveReplicaRequest& req);
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -35,9 +35,9 @@ class P2PMasterService : public MasterService {
         -> tl::expected<void, ErrorCode>;
 
     /**
-     * @brief Remove replicas from multiple segments in one call
+     * @brief Apply a batch of replica metadata mutations.
      */
-    auto BatchRemoveReplica(const BatchRemoveReplicaRequest& req)
+    auto BatchMutateReplica(const BatchReplicaMutationRequest& req)
         -> std::vector<tl::expected<void, ErrorCode>>;
 
     std::vector<Replica::Descriptor> FilterReplicas(

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -35,9 +35,9 @@ class P2PMasterService : public MasterService {
         -> tl::expected<void, ErrorCode>;
 
     /**
-     * @brief Apply a batch of replica metadata mutations.
+     * @brief Remove replicas from master in one batch request.
      */
-    auto BatchMutateReplica(const BatchReplicaMutationRequest& req)
+    auto BatchRemoveReplica(const BatchRemoveReplicaRequest& req)
         -> std::vector<tl::expected<void, ErrorCode>>;
 
     std::vector<Replica::Descriptor> FilterReplicas(

--- a/mooncake-store/include/p2p_rpc_service.h
+++ b/mooncake-store/include/p2p_rpc_service.h
@@ -23,8 +23,8 @@ class WrappedP2PMasterService final : public WrappedMasterService {
     tl::expected<void, ErrorCode> RemoveReplica(
         const RemoveReplicaRequest& req);
 
-    std::vector<tl::expected<void, ErrorCode>> BatchMutateReplica(
-        const BatchReplicaMutationRequest& req);
+    std::vector<tl::expected<void, ErrorCode>> BatchRemoveReplica(
+        const BatchRemoveReplicaRequest& req);
 
    private:
     P2PMasterService master_service_;

--- a/mooncake-store/include/p2p_rpc_service.h
+++ b/mooncake-store/include/p2p_rpc_service.h
@@ -23,8 +23,8 @@ class WrappedP2PMasterService final : public WrappedMasterService {
     tl::expected<void, ErrorCode> RemoveReplica(
         const RemoveReplicaRequest& req);
 
-    std::vector<tl::expected<void, ErrorCode>> BatchRemoveReplica(
-        const BatchRemoveReplicaRequest& req);
+    std::vector<tl::expected<void, ErrorCode>> BatchMutateReplica(
+        const BatchReplicaMutationRequest& req);
 
    private:
     P2PMasterService master_service_;

--- a/mooncake-store/include/p2p_rpc_types.h
+++ b/mooncake-store/include/p2p_rpc_types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -92,13 +93,29 @@ struct RemoveReplicaRequest {
 YLT_REFL(RemoveReplicaRequest, key, client_id, segment_id);
 
 /**
- * @brief Request to remove replicas from multiple segments in one call
+ * @brief Mutation type for batched replica metadata updates.
  */
-struct BatchRemoveReplicaRequest {
-    std::string key;
-    UUID client_id;
-    std::vector<UUID> segment_ids;
+enum class ReplicaMutationType : uint8_t {
+    REMOVE = 0,
 };
-YLT_REFL(BatchRemoveReplicaRequest, key, client_id, segment_ids);
+
+/**
+ * @brief One replica mutation entry in a batch request.
+ */
+struct ReplicaMutation {
+    ReplicaMutationType type = ReplicaMutationType::REMOVE;
+    std::string key;
+    UUID segment_id;
+};
+YLT_REFL(ReplicaMutation, type, key, segment_id);
+
+/**
+ * @brief Request to mutate multiple replicas in one call.
+ */
+struct BatchReplicaMutationRequest {
+    UUID client_id;
+    std::vector<ReplicaMutation> mutations;
+};
+YLT_REFL(BatchReplicaMutationRequest, client_id, mutations);
 
 }  // namespace mooncake

--- a/mooncake-store/include/p2p_rpc_types.h
+++ b/mooncake-store/include/p2p_rpc_types.h
@@ -89,33 +89,27 @@ struct RemoveReplicaRequest {
     std::string key;
     UUID client_id;
     UUID segment_id;
+    uint64_t replica_generation = 0;
 };
-YLT_REFL(RemoveReplicaRequest, key, client_id, segment_id);
+YLT_REFL(RemoveReplicaRequest, key, client_id, segment_id, replica_generation);
 
 /**
- * @brief Mutation type for batched replica metadata updates.
+ * @brief One replica removal entry in a batch request.
  */
-enum class ReplicaMutationType : uint8_t {
-    REMOVE = 0,
-};
-
-/**
- * @brief One replica mutation entry in a batch request.
- */
-struct ReplicaMutation {
-    ReplicaMutationType type = ReplicaMutationType::REMOVE;
+struct BatchRemoveReplicaItem {
     std::string key;
     UUID segment_id;
+    uint64_t replica_generation = 0;
 };
-YLT_REFL(ReplicaMutation, type, key, segment_id);
+YLT_REFL(BatchRemoveReplicaItem, key, segment_id, replica_generation);
 
 /**
- * @brief Request to mutate multiple replicas in one call.
+ * @brief Request to remove multiple replicas in one call.
  */
-struct BatchReplicaMutationRequest {
+struct BatchRemoveReplicaRequest {
     UUID client_id;
-    std::vector<ReplicaMutation> mutations;
+    std::vector<BatchRemoveReplicaItem> removals;
 };
-YLT_REFL(BatchReplicaMutationRequest, client_id, mutations);
+YLT_REFL(BatchRemoveReplicaRequest, client_id, removals);
 
 }  // namespace mooncake

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -127,14 +127,17 @@ struct LocalDiskReplicaData {
 struct P2PProxyReplicaData {
     P2PProxyReplicaData() = default;
     P2PProxyReplicaData(std::shared_ptr<P2PClientMeta> client,
-                        std::shared_ptr<Segment> segment, uint64_t object_size)
+                        std::shared_ptr<Segment> segment, uint64_t object_size,
+                        uint64_t replica_generation = 0)
         : client(std::move(client)),
           segment(std::move(segment)),
-          object_size(object_size) {}
+          object_size(object_size),
+          replica_generation(replica_generation) {}
 
     std::shared_ptr<const P2PClientMeta> client;
     std::shared_ptr<const Segment> segment;
     uint64_t object_size = 0;
+    uint64_t replica_generation = 0;
 };
 
 struct MemoryDescriptor {
@@ -161,8 +164,9 @@ struct P2PProxyDescriptor {
     std::string ip_address;
     uint16_t rpc_port = 0;
     uint64_t object_size = 0;
+    uint64_t replica_generation = 0;
     YLT_REFL(P2PProxyDescriptor, client_id, segment_id, ip_address, rpc_port,
-             object_size);
+             object_size, replica_generation);
 };
 
 class Replica {
@@ -315,6 +319,7 @@ class Replica {
     }
 
     std::optional<UUID> get_p2p_client_id() const;
+    std::optional<uint64_t> get_p2p_replica_generation() const;
 
     std::shared_ptr<const Segment> get_p2p_segment() const {
         if (!is_p2p_proxy_replica()) return nullptr;

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -725,12 +725,12 @@ class BucketStorageBackend : public StorageBackendInterface {
     tl::expected<int64_t, ErrorCode> SelectBucketForEviction() const;
 
     /**
-     * @brief List live keys currently reachable from a bucket.
+     * @brief List live storage replicas currently reachable from a bucket.
      * @param bucket_id The bucket to inspect.
-     * @return On success: live keys still visible to the cache namespace.
+     * @return On success: bucket-scoped eviction tokens for live replicas.
      */
-    tl::expected<std::vector<std::string>, ErrorCode> GetBucketLiveKeys(
-        int64_t bucket_id) const;
+    tl::expected<std::vector<StorageReplicaEvictionToken>, ErrorCode>
+    GetBucketLiveReplicaTokens(int64_t bucket_id) const;
 
     /**
      * @brief Evict an entire bucket by removing its data and metadata files.

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -725,6 +725,14 @@ class BucketStorageBackend : public StorageBackendInterface {
     tl::expected<int64_t, ErrorCode> SelectBucketForEviction() const;
 
     /**
+     * @brief List live keys currently reachable from a bucket.
+     * @param bucket_id The bucket to inspect.
+     * @return On success: live keys still visible to the cache namespace.
+     */
+    tl::expected<std::vector<std::string>, ErrorCode> GetBucketLiveKeys(
+        int64_t bucket_id) const;
+
+    /**
      * @brief Evict an entire bucket by removing its data and metadata files.
      * @param bucket_id The ID of the bucket to evict
      * @return tl::expected<size_t, ErrorCode>

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -93,6 +93,14 @@ using RemoveReplicaCallback = std::function<tl::expected<void, ErrorCode>(
     enum REMOVE_CALLBACK_TYPE type)>;
 
 /**
+ * @brief Callback for removing replicas for multiple keys in one tier.
+ * Used by SSD bucket eviction to batch-sync logical deletions to Master.
+ */
+using BatchReplicaMutationCallback =
+    std::function<std::vector<tl::expected<void, ErrorCode>>(
+        const UUID& tier_id, const std::vector<std::string>& keys)>;
+
+/**
  * @brief Callback for segment lifecycle synchronization.
  * Invoked when a tier is created (mount=true) or destroyed (mount=false).
  * The callback should register/unregister the segment with Master.
@@ -125,6 +133,7 @@ class TieredBackend {
         Json::Value root, TransferEngine* engine,
         AddReplicaCallback add_replica_callback,
         RemoveReplicaCallback remove_replica_callback,
+        BatchReplicaMutationCallback batch_replica_mutation_callback,
         SegmentSyncCallback segment_sync_callback);
 
     // --- Client-Centric Operations ---
@@ -194,6 +203,14 @@ class TieredBackend {
     tl::expected<void, ErrorCode> Delete(
         const std::string& key, std::optional<UUID> tier_id = std::nullopt);
 
+    /**
+     * @brief Remove replicas from one tier without invoking tier Free().
+     * Used by bucket eviction, where the storage tier reclaims the bucket as a
+     * whole after metadata has been detached from the cache namespace.
+     */
+    tl::expected<void, ErrorCode> DeleteBatchFromEviction(
+        const std::vector<std::string>& keys, const UUID& tier_id);
+
     // --- Composite Operations ---
 
     tl::expected<void, ErrorCode> CopyData(
@@ -261,6 +278,7 @@ class TieredBackend {
     // Callbacks for metadata synchronization with Master
     AddReplicaCallback add_replica_callback_;
     RemoveReplicaCallback remove_replica_callback_;
+    BatchReplicaMutationCallback batch_replica_mutation_callback_;
     // Callback for segment lifecycle synchronization with Master
     SegmentSyncCallback segment_sync_callback_;
 

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -45,12 +45,6 @@ struct TierView {
 };
 
 /**
- * @enum REMOVE_CALLBACK_TYPE
- * @brief The type of metadata synchronization callback.
- */
-enum REMOVE_CALLBACK_TYPE { DELETE = 0, DELETE_ALL = 1 };
-
-/**
  * @struct AllocationEntry
  * @brief The internal state of an allocation.
  * acts as the "Control Block" for the resource.
@@ -60,6 +54,7 @@ enum REMOVE_CALLBACK_TYPE { DELETE = 0, DELETE_ALL = 1 };
 struct AllocationEntry {
     TieredBackend* backend;
     TieredLocation loc;
+    uint64_t replica_generation = 0;
 
     AllocationEntry(TieredBackend* b, TieredLocation&& l)
         : backend(b), loc(std::move(l)) {}
@@ -82,23 +77,24 @@ using AllocationHandle = std::shared_ptr<AllocationEntry>;
  * Returns true if sync succeeds, false otherwise.
  */
 using AddReplicaCallback = std::function<tl::expected<void, ErrorCode>(
-    const std::string& key, const UUID& tier_id, size_t size)>;
+    const std::string& key, const UUID& tier_id, size_t size,
+    uint64_t replica_generation)>;
 
 /**
  * @brief Callback for metadata synchronization when a replica is removed.
  * Returns true if sync succeeds, false otherwise.
  */
 using RemoveReplicaCallback = std::function<tl::expected<void, ErrorCode>(
-    const std::string& key, const UUID& tier_id,
-    enum REMOVE_CALLBACK_TYPE type)>;
+    const std::string& key, const UUID& tier_id, uint64_t replica_generation)>;
 
 /**
  * @brief Callback for removing replicas for multiple keys in one tier.
  * Used by SSD bucket eviction to batch-sync logical deletions to Master.
  */
-using BatchReplicaMutationCallback =
+using BatchRemoveReplicaCallback =
     std::function<std::vector<tl::expected<void, ErrorCode>>(
-        const UUID& tier_id, const std::vector<std::string>& keys)>;
+        const UUID& tier_id,
+        const std::vector<ReplicaRemoveRequest>& requests)>;
 
 /**
  * @brief Callback for segment lifecycle synchronization.
@@ -133,7 +129,7 @@ class TieredBackend {
         Json::Value root, TransferEngine* engine,
         AddReplicaCallback add_replica_callback,
         RemoveReplicaCallback remove_replica_callback,
-        BatchReplicaMutationCallback batch_replica_mutation_callback,
+        BatchRemoveReplicaCallback batch_remove_replica_callback,
         SegmentSyncCallback segment_sync_callback);
 
     // --- Client-Centric Operations ---
@@ -209,6 +205,15 @@ class TieredBackend {
      * whole after metadata has been detached from the cache namespace.
      */
     tl::expected<void, ErrorCode> DeleteBatchFromEviction(
+        const std::vector<StorageReplicaEvictionToken>& tokens,
+        const UUID& tier_id);
+
+    /**
+     * @brief Compatibility wrapper for callers that only have key strings.
+     * This keeps non-storage tests simple while storage bucket eviction uses
+     * explicit replica tokens.
+     */
+    tl::expected<void, ErrorCode> DeleteBatchFromEviction(
         const std::vector<std::string>& keys, const UUID& tier_id);
 
     // --- Composite Operations ---
@@ -248,9 +253,16 @@ class TieredBackend {
     struct MetadataEntry {
         mutable std::shared_mutex mutex;  // Entry-level lock
         std::vector<std::pair<UUID, AllocationHandle>>
-            replicas;          // tier_id -> handle
-        uint64_t version = 0;  // Monotonically increasing version
+            replicas;             // tier_id -> handle
+        uint64_t version = 0;     // Monotonically increasing version
+        uint64_t generation = 0;  // Monotonically increasing incarnation id
+        bool tombstone = false;   // Marks an entry detached from namespace
     };
+
+    std::shared_ptr<MetadataEntry> CreateMetadataEntry();
+    void CleanupTombstonedEntry(const std::string& key,
+                                const std::shared_ptr<MetadataEntry>& entry,
+                                uint64_t generation);
 
     // Get list of Tier IDs sorted by priority (descending)
     std::vector<UUID> GetSortedTiers() const;
@@ -273,12 +285,14 @@ class TieredBackend {
     std::unordered_map<std::string, std::shared_ptr<MetadataEntry>>
         metadata_index_;
     mutable std::shared_mutex map_mutex_;
+    std::atomic<uint64_t> next_entry_generation_{1};
+    std::atomic<uint64_t> next_replica_generation_{1};
 
     std::unique_ptr<DataCopier> data_copier_;
     // Callbacks for metadata synchronization with Master
     AddReplicaCallback add_replica_callback_;
     RemoveReplicaCallback remove_replica_callback_;
-    BatchReplicaMutationCallback batch_replica_mutation_callback_;
+    BatchRemoveReplicaCallback batch_remove_replica_callback_;
     // Callback for segment lifecycle synchronization with Master
     SegmentSyncCallback segment_sync_callback_;
 
@@ -290,6 +304,8 @@ class TieredBackend {
 
     // Destroy flag
     std::atomic<bool> is_destroyed_{false};
+
+    friend class TieredBackendTest;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/tiered_cache/tiers/storage_tier.h
+++ b/mooncake-store/include/tiered_cache/tiers/storage_tier.h
@@ -65,6 +65,12 @@ class StorageBuffer : public BufferBase {
 
     void SetKey(const std::string& key) { key_ = key; }
     const std::string& GetKey() const { return key_; }
+    void SetBucketId(int64_t bucket_id) {
+        bucket_id_.store(bucket_id, std::memory_order_release);
+    }
+    int64_t GetBucketId() const {
+        return bucket_id_.load(std::memory_order_acquire);
+    }
 
     // Transition from staging pool -> on disk.
     void Persist() {
@@ -132,6 +138,7 @@ class StorageBuffer : public BufferBase {
     std::atomic<bool> is_on_disk_{false};
     std::atomic<bool> is_flushing_{false};
     std::atomic<bool> is_evicted_{false};
+    std::atomic<int64_t> bucket_id_{kInvalidBucketId};
     size_t size_ = 0;
 };
 

--- a/mooncake-store/include/tiered_cache/tiers/storage_tier.h
+++ b/mooncake-store/include/tiered_cache/tiers/storage_tier.h
@@ -81,6 +81,12 @@ class StorageBuffer : public BufferBase {
         return is_on_disk_.load(std::memory_order_acquire);
     }
 
+    void MarkEvicted() { is_evicted_.store(true, std::memory_order_release); }
+
+    bool IsEvicted() const {
+        return is_evicted_.load(std::memory_order_acquire);
+    }
+
     void SetFlushing(bool flushing) {
         is_flushing_.store(flushing, std::memory_order_release);
     }
@@ -91,6 +97,9 @@ class StorageBuffer : public BufferBase {
 
     // Read data to destination buffer (handles staging vs disk transparently).
     tl::expected<void, ErrorCode> ReadTo(void* dst, size_t length) {
+        if (is_evicted_.load(std::memory_order_acquire)) {
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
         {
             std::lock_guard<std::mutex> lock(data_mutex_);
             if (!is_on_disk_.load(std::memory_order_acquire)) {
@@ -122,6 +131,7 @@ class StorageBuffer : public BufferBase {
     std::string key_;
     std::atomic<bool> is_on_disk_{false};
     std::atomic<bool> is_flushing_{false};
+    std::atomic<bool> is_evicted_{false};
     size_t size_ = 0;
 };
 

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -368,6 +368,19 @@ struct StorageObjectMetadata {
              transport_endpoint);
 };
 
+static constexpr int64_t kInvalidBucketId = -1;
+
+struct StorageReplicaEvictionToken {
+    std::string key;
+    int64_t bucket_id = kInvalidBucketId;
+};
+
+struct ReplicaRemoveRequest {
+    std::string key;
+    uint64_t replica_generation = 0;
+    YLT_REFL(ReplicaRemoveRequest, key, replica_generation);
+};
+
 /**
  * @brief object iteration strategy in for-each interface
  */

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -143,13 +143,13 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
 
     auto add_replica_callback = BuildAddReplicaCallback();
     auto remove_replica_callback = BuildRemoveReplicaCallback();
-    auto batch_replica_mutation_callback = BuildBatchReplicaMutationCallback();
+    auto batch_remove_replica_callback = BuildBatchRemoveReplicaCallback();
     auto segment_sync_callback = BuildSegmentSyncCallback();
 
     auto init_result = tiered_backend->Init(
         config.tiered_backend_config, transfer_engine_.get(),
         add_replica_callback, remove_replica_callback,
-        batch_replica_mutation_callback, segment_sync_callback);
+        batch_remove_replica_callback, segment_sync_callback);
     if (!init_result) {
         LOG(ERROR) << "Failed to init TieredBackend: " << init_result.error();
         return init_result.error();
@@ -161,13 +161,12 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
         [this](const std::string& key, std::optional<UUID> tier_id) {
             if (!tier_id) {
                 auto tier_views = data_manager_->GetTierViews();
-                std::vector<ReplicaMutation> mutations;
-                mutations.reserve(tier_views.size());
+                std::vector<BatchRemoveReplicaItem> removals;
+                removals.reserve(tier_views.size());
                 for (const auto& tv : tier_views) {
-                    mutations.push_back(ReplicaMutation{
-                        ReplicaMutationType::REMOVE, key, tv.id});
+                    removals.push_back(BatchRemoveReplicaItem{key, tv.id});
                 }
-                SyncBatchMutateReplica(std::move(mutations));
+                SyncBatchRemoveReplica(std::move(removals));
             } else {
                 SyncRemoveReplica(key, *tier_id);
             }
@@ -176,50 +175,38 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
 }
 
 AddReplicaCallback P2PClientService::BuildAddReplicaCallback() {
-    return [this](const std::string& key, const UUID& tier_id,
-                  size_t size) -> tl::expected<void, ErrorCode> {
-        return SyncAddReplica(key, tier_id, size);
-    };
+    return
+        [this](const std::string& key, const UUID& tier_id, size_t size,
+               uint64_t replica_generation) -> tl::expected<void, ErrorCode> {
+            return SyncAddReplica(key, tier_id, size, replica_generation);
+        };
 }
 
 RemoveReplicaCallback P2PClientService::BuildRemoveReplicaCallback() {
     return
-        [this](
-            const std::string& key, const UUID& tier_id,
-            enum REMOVE_CALLBACK_TYPE type) -> tl::expected<void, ErrorCode> {
-            if (type == REMOVE_CALLBACK_TYPE::DELETE) {
-                return SyncRemoveReplica(key, tier_id);
-            } else if (type == REMOVE_CALLBACK_TYPE::DELETE_ALL) {
-                // TODO:
-                // Currently Master does not support deleting all replicas of a
-                // key within a client. The future will be implemented in
-                // future.
-                LOG(ERROR) << "DELETE_ALL callback is not supported"
-                           << ", key: " << key;
-                return tl::unexpected(ErrorCode::NOT_IMPLEMENTED);
-            }
-
-            LOG(ERROR) << "Unknown callback type: " << static_cast<int>(type);
-            return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+        [this](const std::string& key, const UUID& tier_id,
+               uint64_t replica_generation) -> tl::expected<void, ErrorCode> {
+            return SyncRemoveReplica(key, tier_id, replica_generation);
         };
 }
 
-BatchReplicaMutationCallback
-P2PClientService::BuildBatchReplicaMutationCallback() {
-    return [this](const UUID& tier_id, const std::vector<std::string>& keys)
+BatchRemoveReplicaCallback P2PClientService::BuildBatchRemoveReplicaCallback() {
+    return [this](const UUID& tier_id,
+                  const std::vector<ReplicaRemoveRequest>& requests)
                -> std::vector<tl::expected<void, ErrorCode>> {
-        std::vector<ReplicaMutation> mutations;
-        mutations.reserve(keys.size());
-        for (const auto& key : keys) {
-            mutations.push_back(
-                ReplicaMutation{ReplicaMutationType::REMOVE, key, tier_id});
+        std::vector<BatchRemoveReplicaItem> removals;
+        removals.reserve(requests.size());
+        for (const auto& request : requests) {
+            removals.push_back(BatchRemoveReplicaItem{
+                request.key, tier_id, request.replica_generation});
         }
-        return SyncBatchMutateReplica(std::move(mutations));
+        return SyncBatchRemoveReplica(std::move(removals));
     };
 }
 
 tl::expected<void, ErrorCode> P2PClientService::SyncAddReplica(
-    const std::string& key, const UUID& tier_id, size_t size) {
+    const std::string& key, const UUID& tier_id, size_t size,
+    uint64_t replica_generation) {
     AddReplicaRequest req;
     req.key = key;
     req.size = size;
@@ -227,6 +214,7 @@ tl::expected<void, ErrorCode> P2PClientService::SyncAddReplica(
     req.replica.segment_id = tier_id;
     req.replica.rpc_port = client_rpc_port_;
     req.replica.ip_address = local_ip_;
+    req.replica.replica_generation = replica_generation;
     auto result = master_client_.AddReplica(req);
     if (!result) {
         LOG(ERROR) << "Failed to add replica for key: " << key
@@ -237,11 +225,12 @@ tl::expected<void, ErrorCode> P2PClientService::SyncAddReplica(
 }
 
 tl::expected<void, ErrorCode> P2PClientService::SyncRemoveReplica(
-    const std::string& key, const UUID& tier_id) {
+    const std::string& key, const UUID& tier_id, uint64_t replica_generation) {
     RemoveReplicaRequest req;
     req.key = key;
     req.client_id = client_id_;
     req.segment_id = tier_id;
+    req.replica_generation = replica_generation;
     auto result = master_client_.RemoveReplica(req);
     if (!result) {
         LOG(ERROR) << "Failed to remove replica for key: " << key
@@ -252,19 +241,18 @@ tl::expected<void, ErrorCode> P2PClientService::SyncRemoveReplica(
 }
 
 std::vector<tl::expected<void, ErrorCode>>
-P2PClientService::SyncBatchMutateReplica(
-    std::vector<ReplicaMutation> mutations) {
-    BatchReplicaMutationRequest req;
+P2PClientService::SyncBatchRemoveReplica(
+    std::vector<BatchRemoveReplicaItem> removals) {
+    BatchRemoveReplicaRequest req;
     req.client_id = client_id_;
-    req.mutations = std::move(mutations);
+    req.removals = std::move(removals);
 
-    auto results = master_client_.BatchMutateReplica(req);
+    auto results = master_client_.BatchRemoveReplica(req);
     for (size_t i = 0; i < results.size(); i++) {
         if (!results[i]) {
-            LOG(ERROR) << "Failed to mutate replica for key: "
-                       << req.mutations[i].key
-                       << ", segment_id: " << req.mutations[i].segment_id
-                       << ", type: " << static_cast<int>(req.mutations[i].type)
+            LOG(ERROR) << "Failed to remove replica for key: "
+                       << req.removals[i].key
+                       << ", segment_id: " << req.removals[i].segment_id
                        << ", error: " << results[i].error();
         }
     }
@@ -597,8 +585,8 @@ tl::expected<void, ErrorCode> P2PClientService::GetRemoteViaRoute(
             auto local_result = GetLocal(key, slices);
             if (!local_result) {
                 LOG(WARNING)
-                    << "fail to get local via route"
-                    << ", key: " << key << ", error: " << local_result.error();
+                    << "fail to get local via route" << ", key: " << key
+                    << ", error: " << local_result.error();
                 // Rectify stale local route
                 if (data_manager_.has_value()) {
                     data_manager_->RectifyReadRoute(key, proxy.segment_id);
@@ -657,8 +645,7 @@ tl::expected<void, ErrorCode> P2PClientService::Get(
     auto local_result = GetLocal(object_key, slices);
     if (!local_result) {
         if (local_result.error() != ErrorCode::OBJECT_NOT_FOUND) {
-            LOG(ERROR) << "Failed to get local data"
-                       << ", key: " << object_key
+            LOG(ERROR) << "Failed to get local data" << ", key: " << object_key
                        << ", error: " << local_result.error();
         }
     } else {
@@ -669,8 +656,7 @@ tl::expected<void, ErrorCode> P2PClientService::Get(
     auto remote_result = GetRemoteViaRoute(object_key, slices);
     if (!remote_result) {
         if (remote_result.error() != ErrorCode::OBJECT_NOT_FOUND) {
-            LOG(ERROR) << "Failed to get remote data"
-                       << ", key: " << object_key
+            LOG(ERROR) << "Failed to get remote data" << ", key: " << object_key
                        << ", error: " << remote_result.error();
         }
         return remote_result;

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -143,11 +143,13 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
 
     auto add_replica_callback = BuildAddReplicaCallback();
     auto remove_replica_callback = BuildRemoveReplicaCallback();
+    auto batch_replica_mutation_callback = BuildBatchReplicaMutationCallback();
     auto segment_sync_callback = BuildSegmentSyncCallback();
 
     auto init_result = tiered_backend->Init(
         config.tiered_backend_config, transfer_engine_.get(),
-        add_replica_callback, remove_replica_callback, segment_sync_callback);
+        add_replica_callback, remove_replica_callback,
+        batch_replica_mutation_callback, segment_sync_callback);
     if (!init_result) {
         LOG(ERROR) << "Failed to init TieredBackend: " << init_result.error();
         return init_result.error();
@@ -159,12 +161,13 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
         [this](const std::string& key, std::optional<UUID> tier_id) {
             if (!tier_id) {
                 auto tier_views = data_manager_->GetTierViews();
-                std::vector<UUID> segment_ids;
-                segment_ids.reserve(tier_views.size());
+                std::vector<ReplicaMutation> mutations;
+                mutations.reserve(tier_views.size());
                 for (const auto& tv : tier_views) {
-                    segment_ids.push_back(tv.id);
+                    mutations.push_back(ReplicaMutation{
+                        ReplicaMutationType::REMOVE, key, tv.id});
                 }
-                SyncBatchRemoveReplica(key, std::move(segment_ids));
+                SyncBatchMutateReplica(std::move(mutations));
             } else {
                 SyncRemoveReplica(key, *tier_id);
             }
@@ -201,6 +204,20 @@ RemoveReplicaCallback P2PClientService::BuildRemoveReplicaCallback() {
         };
 }
 
+BatchReplicaMutationCallback
+P2PClientService::BuildBatchReplicaMutationCallback() {
+    return [this](const UUID& tier_id, const std::vector<std::string>& keys)
+               -> std::vector<tl::expected<void, ErrorCode>> {
+        std::vector<ReplicaMutation> mutations;
+        mutations.reserve(keys.size());
+        for (const auto& key : keys) {
+            mutations.push_back(
+                ReplicaMutation{ReplicaMutationType::REMOVE, key, tier_id});
+        }
+        return SyncBatchMutateReplica(std::move(mutations));
+    };
+}
+
 tl::expected<void, ErrorCode> P2PClientService::SyncAddReplica(
     const std::string& key, const UUID& tier_id, size_t size) {
     AddReplicaRequest req;
@@ -235,17 +252,19 @@ tl::expected<void, ErrorCode> P2PClientService::SyncRemoveReplica(
 }
 
 std::vector<tl::expected<void, ErrorCode>>
-P2PClientService::SyncBatchRemoveReplica(const std::string& key,
-                                         std::vector<UUID> segment_ids) {
-    BatchRemoveReplicaRequest req;
-    req.key = key;
+P2PClientService::SyncBatchMutateReplica(
+    std::vector<ReplicaMutation> mutations) {
+    BatchReplicaMutationRequest req;
     req.client_id = client_id_;
-    req.segment_ids = std::move(segment_ids);
-    auto results = master_client_.BatchRemoveReplica(req);
+    req.mutations = std::move(mutations);
+
+    auto results = master_client_.BatchMutateReplica(req);
     for (size_t i = 0; i < results.size(); i++) {
         if (!results[i]) {
-            LOG(ERROR) << "Failed to remove replica for key: " << key
-                       << ", segment_id: " << req.segment_ids[i]
+            LOG(ERROR) << "Failed to mutate replica for key: "
+                       << req.mutations[i].key
+                       << ", segment_id: " << req.mutations[i].segment_id
+                       << ", type: " << static_cast<int>(req.mutations[i].type)
                        << ", error: " << results[i].error();
         }
     }

--- a/mooncake-store/src/p2p_master_client.cpp
+++ b/mooncake-store/src/p2p_master_client.cpp
@@ -21,8 +21,8 @@ struct RpcNameTraits<&WrappedP2PMasterService::RemoveReplica> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedP2PMasterService::BatchMutateReplica> {
-    static constexpr const char* value = "BatchMutateReplica";
+struct RpcNameTraits<&WrappedP2PMasterService::BatchRemoveReplica> {
+    static constexpr const char* value = "BatchRemoveReplica";
 };
 
 tl::expected<WriteRouteResponse, ErrorCode> P2PMasterClient::GetWriteRoute(
@@ -58,19 +58,19 @@ tl::expected<void, ErrorCode> P2PMasterClient::RemoveReplica(
     return result;
 }
 
-std::vector<tl::expected<void, ErrorCode>> P2PMasterClient::BatchMutateReplica(
-    const BatchReplicaMutationRequest& req) {
-    ScopedVLogTimer timer(1, "P2PMasterClient::BatchMutateReplica");
-    timer.LogRequest("mutation_count=", req.mutations.size());
+std::vector<tl::expected<void, ErrorCode>> P2PMasterClient::BatchRemoveReplica(
+    const BatchRemoveReplicaRequest& req) {
+    ScopedVLogTimer timer(1, "P2PMasterClient::BatchRemoveReplica");
+    timer.LogRequest("removal_count=", req.removals.size());
 
-    auto result = invoke_rpc<&WrappedP2PMasterService::BatchMutateReplica,
+    auto result = invoke_rpc<&WrappedP2PMasterService::BatchRemoveReplica,
                              std::vector<tl::expected<void, ErrorCode>>>(req);
     if (!result) {
-        LOG(ERROR) << "BatchMutateReplica RPC failed: "
+        LOG(ERROR) << "BatchRemoveReplica RPC failed: "
                    << toString(result.error());
         std::vector<tl::expected<void, ErrorCode>> fallback;
-        fallback.reserve(req.mutations.size());
-        for (size_t i = 0; i < req.mutations.size(); ++i) {
+        fallback.reserve(req.removals.size());
+        for (size_t i = 0; i < req.removals.size(); ++i) {
             fallback.push_back(tl::make_unexpected(result.error()));
         }
         return fallback;

--- a/mooncake-store/src/p2p_master_client.cpp
+++ b/mooncake-store/src/p2p_master_client.cpp
@@ -21,8 +21,8 @@ struct RpcNameTraits<&WrappedP2PMasterService::RemoveReplica> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedP2PMasterService::BatchRemoveReplica> {
-    static constexpr const char* value = "BatchRemoveReplica";
+struct RpcNameTraits<&WrappedP2PMasterService::BatchMutateReplica> {
+    static constexpr const char* value = "BatchMutateReplica";
 };
 
 tl::expected<WriteRouteResponse, ErrorCode> P2PMasterClient::GetWriteRoute(
@@ -58,19 +58,19 @@ tl::expected<void, ErrorCode> P2PMasterClient::RemoveReplica(
     return result;
 }
 
-std::vector<tl::expected<void, ErrorCode>> P2PMasterClient::BatchRemoveReplica(
-    const BatchRemoveReplicaRequest& req) {
-    ScopedVLogTimer timer(1, "P2PMasterClient::BatchRemoveReplica");
-    timer.LogRequest("key=", req.key, "segment_count=", req.segment_ids.size());
+std::vector<tl::expected<void, ErrorCode>> P2PMasterClient::BatchMutateReplica(
+    const BatchReplicaMutationRequest& req) {
+    ScopedVLogTimer timer(1, "P2PMasterClient::BatchMutateReplica");
+    timer.LogRequest("mutation_count=", req.mutations.size());
 
-    auto result = invoke_rpc<&WrappedP2PMasterService::BatchRemoveReplica,
+    auto result = invoke_rpc<&WrappedP2PMasterService::BatchMutateReplica,
                              std::vector<tl::expected<void, ErrorCode>>>(req);
-
     if (!result) {
-        LOG(ERROR) << "BatchRemoveReplica RPC failed: "
+        LOG(ERROR) << "BatchMutateReplica RPC failed: "
                    << toString(result.error());
         std::vector<tl::expected<void, ErrorCode>> fallback;
-        for (size_t i = 0; i < req.segment_ids.size(); i++) {
+        fallback.reserve(req.mutations.size());
+        for (size_t i = 0; i < req.mutations.size(); ++i) {
             fallback.push_back(tl::make_unexpected(result.error()));
         }
         return fallback;

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -271,36 +271,45 @@ auto P2PMasterService::RemoveReplica(const RemoveReplicaRequest& req)
     return {};
 }
 
-auto P2PMasterService::BatchRemoveReplica(const BatchRemoveReplicaRequest& req)
+auto P2PMasterService::BatchMutateReplica(
+    const BatchReplicaMutationRequest& req)
     -> std::vector<tl::expected<void, ErrorCode>> {
     std::vector<tl::expected<void, ErrorCode>> results;
-    results.reserve(req.segment_ids.size());
+    results.reserve(req.mutations.size());
 
     RemoveReplicaRequest single_req;
-    single_req.key = req.key;
     single_req.client_id = req.client_id;
-    for (const auto& segment_id : req.segment_ids) {
-        single_req.segment_id = segment_id;
+    for (const auto& mutation : req.mutations) {
+        if (mutation.type != ReplicaMutationType::REMOVE) {
+            LOG(ERROR) << "unsupported replica mutation type"
+                       << ", key: " << mutation.key
+                       << ", segment_id: " << mutation.segment_id
+                       << ", type: " << static_cast<int>(mutation.type);
+            results.push_back(tl::make_unexpected(ErrorCode::NOT_IMPLEMENTED));
+            continue;
+        }
+
+        single_req.key = mutation.key;
+        single_req.segment_id = mutation.segment_id;
         auto result = RemoveReplica(single_req);
         if (!result.has_value()) {
             if (result.error() == ErrorCode::OBJECT_NOT_FOUND) {
-                // This may happen if the object is removed by another thread
-                LOG(INFO) << "object not found when batch remove replica"
-                          << ", key: " << req.key
+                LOG(INFO) << "object not found when batch mutate replica"
+                          << ", key: " << mutation.key
                           << ", client_id: " << req.client_id
-                          << ", segment_id: " << segment_id;
+                          << ", segment_id: " << mutation.segment_id;
                 results.push_back({});
             } else if (result.error() == ErrorCode::REPLICA_NOT_FOUND) {
-                // This may happen if the replica is removed by another thread
-                LOG(INFO) << "replica not found when batch remove replica"
-                          << ", key: " << req.key
+                LOG(INFO) << "replica not found when batch mutate replica"
+                          << ", key: " << mutation.key
                           << ", client_id: " << req.client_id
-                          << ", segment_id: " << segment_id;
+                          << ", segment_id: " << mutation.segment_id;
                 results.push_back({});
             } else {
-                LOG(ERROR) << "failed to remove replica" << ", key: " << req.key
+                LOG(ERROR) << "failed to mutate replica"
+                           << ", key: " << mutation.key
                            << ", client_id: " << req.client_id
-                           << ", segment_id: " << segment_id
+                           << ", segment_id: " << mutation.segment_id
                            << ", error: " << toString(result.error());
                 results.push_back(tl::make_unexpected(result.error()));
             }

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -6,6 +6,68 @@
 
 namespace mooncake {
 
+namespace {
+
+enum class ReplicaIdentityMatch {
+    kNone,
+    kExact,
+    kStaleGeneration,
+};
+
+struct ReplicaIdentityProbe {
+    std::optional<size_t> exact_index;
+    std::optional<size_t> stale_index;
+};
+
+auto MatchReplicaIdentity(const Replica& replica, const UUID& client_id,
+                          const UUID& segment_id, uint64_t replica_generation)
+    -> tl::expected<ReplicaIdentityMatch, ErrorCode> {
+    if (!replica.is_p2p_proxy_replica()) {
+        return tl::make_unexpected(ErrorCode::INVALID_REPLICA);
+    }
+
+    auto replica_segment_id = replica.get_segment_id();
+    auto replica_client_id = replica.get_p2p_client_id();
+    if (!(replica_client_id && replica_segment_id &&
+          *replica_client_id == client_id &&
+          *replica_segment_id == segment_id)) {
+        return ReplicaIdentityMatch::kNone;
+    }
+
+    const uint64_t existing_generation =
+        replica.get_p2p_replica_generation().value_or(0);
+    if (replica_generation != 0 && existing_generation != replica_generation) {
+        return ReplicaIdentityMatch::kStaleGeneration;
+    }
+
+    return ReplicaIdentityMatch::kExact;
+}
+
+auto ProbeReplicaIdentity(const std::vector<Replica>& replicas,
+                          const UUID& client_id, const UUID& segment_id,
+                          uint64_t replica_generation)
+    -> tl::expected<ReplicaIdentityProbe, ErrorCode> {
+    ReplicaIdentityProbe probe;
+    for (size_t index = 0; index < replicas.size(); ++index) {
+        auto match = MatchReplicaIdentity(replicas[index], client_id,
+                                          segment_id, replica_generation);
+        if (!match.has_value()) {
+            return tl::make_unexpected(match.error());
+        }
+
+        if (*match == ReplicaIdentityMatch::kExact && !probe.exact_index) {
+            probe.exact_index = index;
+        } else if (*match == ReplicaIdentityMatch::kStaleGeneration &&
+                   !probe.stale_index) {
+            probe.stale_index = index;
+        }
+    }
+
+    return probe;
+}
+
+}  // namespace
+
 P2PMasterService::P2PMasterService(const MasterServiceConfig& config)
     : MasterService(config),
       max_replicas_per_key_(config.max_replicas_per_key) {
@@ -24,8 +86,7 @@ std::vector<Replica::Descriptor> P2PMasterService::FilterReplicas(
     // 1. filter qualified replicas
     for (const auto& replica : metadata.replicas_) {
         if (!replica.is_p2p_proxy_replica()) {
-            LOG(ERROR) << "invalid replica type"
-                       << ", replica: " << replica;
+            LOG(ERROR) << "invalid replica type" << ", replica: " << replica;
             continue;
         } else if (!replica.get_p2p_client()->is_health()) {
             // The client of the replica might be disconnected, just skip it.
@@ -164,42 +225,45 @@ auto P2PMasterService::AddReplica(const AddReplicaRequest& req)
 
     // Construct Replica from resolved pointers
     Replica new_replica(
-        P2PProxyReplicaData(client, segment_res.value(), req.size),
+        P2PProxyReplicaData(client, segment_res.value(), req.size,
+                            req.replica.replica_generation),
         ReplicaStatus::COMPLETE);
 
     if (accessor->Exists()) {
         auto& metadata = accessor->Get();
-        if (max_replicas_per_key_ > 0 &&
-            metadata.replicas_.size() >= max_replicas_per_key_) {
+        auto probe = ProbeReplicaIdentity(
+            metadata.replicas_, req.replica.client_id, req.replica.segment_id,
+            req.replica.replica_generation);
+        if (!probe.has_value()) {
+            LOG(ERROR) << "unexpected replica type" << ", key: " << req.key
+                       << ", request client_id: " << req.replica.client_id
+                       << ", request segment_id: " << req.replica.segment_id;
+            return tl::make_unexpected(probe.error());
+        }
+
+        if (probe->exact_index.has_value()) {
+            LOG(WARNING) << "replica has existed" << ", key: " << req.key
+                         << ", client_id: " << req.replica.client_id
+                         << ", segment_id: " << req.replica.segment_id;
+            return tl::make_unexpected(ErrorCode::REPLICA_ALREADY_EXISTS);
+        }
+
+        if (probe->stale_index.has_value()) {
+            auto& replica = metadata.replicas_[*probe->stale_index];
+            RemoveReplicaFromSegmentIndex(accessor->GetShard(), req.key,
+                                          replica);
+            OnReplicaRemoved(replica);
+            replica = std::move(new_replica);
+            AddReplicaToSegmentIndex(accessor->GetShard(), req.key, replica);
+            OnReplicaAdded(replica);
+            metadata.size_ = req.size;
+        } else if (max_replicas_per_key_ > 0 &&
+                   metadata.replicas_.size() >= max_replicas_per_key_) {
             LOG(WARNING) << "replica num exceeded" << ", key: " << req.key
                          << ", client_id: " << req.replica.client_id
                          << ", segment_id: " << req.replica.segment_id
                          << ", current replica num:" << max_replicas_per_key_;
             return tl::make_unexpected(ErrorCode::REPLICA_NUM_EXCEEDED);
-        }
-        // Skip duplicate
-        bool exist = false;
-        for (const auto& replica : metadata.replicas_) {
-            if (!replica.is_p2p_proxy_replica()) {
-                LOG(ERROR) << "unexpected replica type" << ", key: " << req.key
-                           << ", request client_id: " << req.replica.client_id
-                           << ", request segment_id: " << req.replica.segment_id
-                           << ", replica:" << replica;
-                return tl::make_unexpected(ErrorCode::INVALID_REPLICA);
-            }
-            auto seg_id = replica.get_segment_id();
-            auto cli_id = replica.get_p2p_client_id();
-            if (cli_id && seg_id && cli_id == req.replica.client_id &&
-                *seg_id == req.replica.segment_id) {
-                exist = true;
-                break;
-            }
-        }
-        if (exist) {
-            LOG(WARNING) << "replica has existed" << ", key: " << req.key
-                         << ", client_id: " << req.replica.client_id
-                         << ", segment_id: " << req.replica.segment_id;
-            return tl::make_unexpected(ErrorCode::REPLICA_ALREADY_EXISTS);
         } else {
             AddReplicaToSegmentIndex(accessor->GetShard(), req.key,
                                      new_replica);
@@ -233,37 +297,35 @@ auto P2PMasterService::RemoveReplica(const RemoveReplicaRequest& req)
     }
 
     auto& metadata = accessor->Get();
-
-    bool removed = false;
-    for (auto it = metadata.replicas_.begin(); it != metadata.replicas_.end();
-         ++it) {
-        if (!it->is_p2p_proxy_replica()) {
-            LOG(ERROR) << "unexpected replica type" << ", key: " << req.key
-                       << ", client_id: " << req.client_id
-                       << ", segment_id: " << req.segment_id
-                       << ", replica: " << *it;
-            return tl::make_unexpected(ErrorCode::INVALID_REPLICA);
-        } else {
-            auto seg_id = it->get_segment_id();
-            auto cli_id = it->get_p2p_client_id();
-            if (cli_id && seg_id && cli_id == req.client_id &&
-                *seg_id == req.segment_id) {
-                RemoveReplicaFromSegmentIndex(accessor->GetShard(), req.key,
-                                              *it);
-                OnReplicaRemoved(*it);
-                metadata.replicas_.erase(it);
-                removed = true;
-                break;
-            }
-        }
+    auto probe = ProbeReplicaIdentity(metadata.replicas_, req.client_id,
+                                      req.segment_id, req.replica_generation);
+    if (!probe.has_value()) {
+        LOG(ERROR) << "unexpected replica type" << ", key: " << req.key
+                   << ", client_id: " << req.client_id
+                   << ", segment_id: " << req.segment_id;
+        return tl::make_unexpected(probe.error());
     }
 
-    if (!removed) {
+    if (!probe->exact_index.has_value()) {
+        if (probe->stale_index.has_value()) {
+            LOG(INFO) << "skip stale replica removal" << ", key: " << req.key
+                      << ", client_id: " << req.client_id
+                      << ", segment_id: " << req.segment_id
+                      << ", replica_generation: " << req.replica_generation;
+            return {};
+        }
         LOG(WARNING) << "replica not found" << ", key: " << req.key
                      << ", client_id: " << req.client_id
                      << ", segment_id: " << req.segment_id;
         return tl::make_unexpected(ErrorCode::REPLICA_NOT_FOUND);
-    } else if (metadata.replicas_.empty()) {
+    }
+
+    auto replica_it = metadata.replicas_.begin() + *probe->exact_index;
+    RemoveReplicaFromSegmentIndex(accessor->GetShard(), req.key, *replica_it);
+    OnReplicaRemoved(*replica_it);
+    metadata.replicas_.erase(replica_it);
+
+    if (metadata.replicas_.empty()) {
         OnObjectRemoved(metadata);
         accessor->Erase();
     }
@@ -271,45 +333,36 @@ auto P2PMasterService::RemoveReplica(const RemoveReplicaRequest& req)
     return {};
 }
 
-auto P2PMasterService::BatchMutateReplica(
-    const BatchReplicaMutationRequest& req)
+auto P2PMasterService::BatchRemoveReplica(const BatchRemoveReplicaRequest& req)
     -> std::vector<tl::expected<void, ErrorCode>> {
     std::vector<tl::expected<void, ErrorCode>> results;
-    results.reserve(req.mutations.size());
+    results.reserve(req.removals.size());
 
     RemoveReplicaRequest single_req;
     single_req.client_id = req.client_id;
-    for (const auto& mutation : req.mutations) {
-        if (mutation.type != ReplicaMutationType::REMOVE) {
-            LOG(ERROR) << "unsupported replica mutation type"
-                       << ", key: " << mutation.key
-                       << ", segment_id: " << mutation.segment_id
-                       << ", type: " << static_cast<int>(mutation.type);
-            results.push_back(tl::make_unexpected(ErrorCode::NOT_IMPLEMENTED));
-            continue;
-        }
-
-        single_req.key = mutation.key;
-        single_req.segment_id = mutation.segment_id;
+    for (const auto& removal : req.removals) {
+        single_req.key = removal.key;
+        single_req.segment_id = removal.segment_id;
+        single_req.replica_generation = removal.replica_generation;
         auto result = RemoveReplica(single_req);
         if (!result.has_value()) {
             if (result.error() == ErrorCode::OBJECT_NOT_FOUND) {
-                LOG(INFO) << "object not found when batch mutate replica"
-                          << ", key: " << mutation.key
+                LOG(INFO) << "object not found when batch remove replica"
+                          << ", key: " << removal.key
                           << ", client_id: " << req.client_id
-                          << ", segment_id: " << mutation.segment_id;
+                          << ", segment_id: " << removal.segment_id;
                 results.push_back({});
             } else if (result.error() == ErrorCode::REPLICA_NOT_FOUND) {
-                LOG(INFO) << "replica not found when batch mutate replica"
-                          << ", key: " << mutation.key
+                LOG(INFO) << "replica not found when batch remove replica"
+                          << ", key: " << removal.key
                           << ", client_id: " << req.client_id
-                          << ", segment_id: " << mutation.segment_id;
+                          << ", segment_id: " << removal.segment_id;
                 results.push_back({});
             } else {
-                LOG(ERROR) << "failed to mutate replica"
-                           << ", key: " << mutation.key
+                LOG(ERROR) << "failed to remove replica"
+                           << ", key: " << removal.key
                            << ", client_id: " << req.client_id
-                           << ", segment_id: " << mutation.segment_id
+                           << ", segment_id: " << removal.segment_id
                            << ", error: " << toString(result.error());
                 results.push_back(tl::make_unexpected(result.error()));
             }
@@ -337,8 +390,7 @@ void P2PMasterService::OnReplicaRemoved(const Replica& replica) {
     if (replica.is_p2p_proxy_replica()) {
         auto type = replica.get_p2p_memory_type();
         if (!type) {
-            LOG(ERROR) << "invalid memory type"
-                       << ", replica: " << replica;
+            LOG(ERROR) << "invalid memory type" << ", replica: " << replica;
         } else if (*type == MemoryType::DRAM) {
             MasterMetricManager::instance().dec_mem_cache_nums();
         } else if (*type == MemoryType::NVME) {
@@ -351,8 +403,7 @@ void P2PMasterService::OnReplicaAdded(const Replica& replica) {
     if (replica.is_p2p_proxy_replica()) {
         auto type = replica.get_p2p_memory_type();
         if (!type) {
-            LOG(ERROR) << "invalid memory type"
-                       << ", replica: " << replica;
+            LOG(ERROR) << "invalid memory type" << ", replica: " << replica;
         } else if (*type == MemoryType::DRAM) {
             MasterMetricManager::instance().inc_mem_cache_nums();
         } else if (*type == MemoryType::NVME) {

--- a/mooncake-store/src/p2p_rpc_service.cpp
+++ b/mooncake-store/src/p2p_rpc_service.cpp
@@ -18,7 +18,7 @@ void RegisterP2PRpcService(
     server.register_handler<&mooncake::WrappedP2PMasterService::RemoveReplica>(
         &wrapped_master_service);
     server.register_handler<
-        &mooncake::WrappedP2PMasterService::BatchRemoveReplica>(
+        &mooncake::WrappedP2PMasterService::BatchMutateReplica>(
         &wrapped_master_service);
 }
 
@@ -50,24 +50,25 @@ tl::expected<void, ErrorCode> WrappedP2PMasterService::RemoveReplica(
 }
 
 std::vector<tl::expected<void, ErrorCode>>
-WrappedP2PMasterService::BatchRemoveReplica(
-    const BatchRemoveReplicaRequest& req) {
-    ScopedVLogTimer timer(1, "BatchRemoveReplica");
-    const size_t total_requests = req.segment_ids.size();
-    timer.LogRequest("key=", req.key, "segment_count=", total_requests);
+WrappedP2PMasterService::BatchMutateReplica(
+    const BatchReplicaMutationRequest& req) {
+    ScopedVLogTimer timer(1, "BatchMutateReplica");
+    const size_t total_requests = req.mutations.size();
+    timer.LogRequest("mutation_count=", total_requests);
     MasterMetricManager::instance().inc_batch_remove_replica_requests(
         total_requests);
 
-    auto results = master_service_.BatchRemoveReplica(req);
+    auto results = master_service_.BatchMutateReplica(req);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
         if (!results[i].has_value()) {
             failure_count++;
             auto error = results[i].error();
-            LOG(ERROR) << "BatchRemoveReplica failed for key '" << req.key
-                       << "', segment_id: " << req.segment_ids[i] << ": "
-                       << toString(error);
+            LOG(ERROR) << "BatchMutateReplica failed for key '"
+                       << req.mutations[i].key
+                       << "', segment_id: " << req.mutations[i].segment_id
+                       << ": " << toString(error);
         }
     }
 

--- a/mooncake-store/src/p2p_rpc_service.cpp
+++ b/mooncake-store/src/p2p_rpc_service.cpp
@@ -18,7 +18,7 @@ void RegisterP2PRpcService(
     server.register_handler<&mooncake::WrappedP2PMasterService::RemoveReplica>(
         &wrapped_master_service);
     server.register_handler<
-        &mooncake::WrappedP2PMasterService::BatchMutateReplica>(
+        &mooncake::WrappedP2PMasterService::BatchRemoveReplica>(
         &wrapped_master_service);
 }
 
@@ -50,24 +50,24 @@ tl::expected<void, ErrorCode> WrappedP2PMasterService::RemoveReplica(
 }
 
 std::vector<tl::expected<void, ErrorCode>>
-WrappedP2PMasterService::BatchMutateReplica(
-    const BatchReplicaMutationRequest& req) {
-    ScopedVLogTimer timer(1, "BatchMutateReplica");
-    const size_t total_requests = req.mutations.size();
-    timer.LogRequest("mutation_count=", total_requests);
+WrappedP2PMasterService::BatchRemoveReplica(
+    const BatchRemoveReplicaRequest& req) {
+    ScopedVLogTimer timer(1, "BatchRemoveReplica");
+    const size_t total_requests = req.removals.size();
+    timer.LogRequest("removal_count=", total_requests);
     MasterMetricManager::instance().inc_batch_remove_replica_requests(
         total_requests);
 
-    auto results = master_service_.BatchMutateReplica(req);
+    auto results = master_service_.BatchRemoveReplica(req);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
         if (!results[i].has_value()) {
             failure_count++;
             auto error = results[i].error();
-            LOG(ERROR) << "BatchMutateReplica failed for key '"
-                       << req.mutations[i].key
-                       << "', segment_id: " << req.mutations[i].segment_id
+            LOG(ERROR) << "BatchRemoveReplica failed for key '"
+                       << req.removals[i].key
+                       << "', segment_id: " << req.removals[i].segment_id
                        << ": " << toString(error);
         }
     }

--- a/mooncake-store/src/replica.cpp
+++ b/mooncake-store/src/replica.cpp
@@ -12,6 +12,13 @@ std::optional<UUID> Replica::get_p2p_client_id() const {
     return std::nullopt;
 }
 
+std::optional<uint64_t> Replica::get_p2p_replica_generation() const {
+    if (!is_p2p_proxy_replica()) {
+        return std::nullopt;
+    }
+    return std::get<P2PProxyReplicaData>(data_).replica_generation;
+}
+
 Replica::Descriptor Replica::get_descriptor() const {
     Replica::Descriptor desc;
     desc.status = status_;
@@ -57,6 +64,7 @@ Replica::Descriptor Replica::get_descriptor() const {
             proxy_desc.segment_id = proxy_data.segment->id;
         }
         proxy_desc.object_size = proxy_data.object_size;
+        proxy_desc.replica_generation = proxy_data.replica_generation;
         desc.descriptor_variant = std::move(proxy_desc);
     }
 
@@ -84,7 +92,8 @@ std::ostream& operator<<(std::ostream& os, const Replica::Descriptor& desc) {
                 os << "type: P2P_PROXY, client: " << d.client_id
                    << ", segment: " << d.segment_id
                    << ", endpoint: " << d.ip_address << ":" << d.rpc_port
-                   << ", size: " << d.object_size;
+                   << ", size: " << d.object_size
+                   << ", generation: " << d.replica_generation;
             }
         },
         desc.descriptor_variant);
@@ -126,7 +135,8 @@ std::ostream& operator<<(std::ostream& os, const Replica& replica) {
                           proxy_data.segment->GetP2PExtra().memory_type);
             }
         }
-        os << ", object_size: " << proxy_data.object_size;
+        os << ", object_size: " << proxy_data.object_size
+           << ", replica_generation: " << proxy_data.replica_generation;
     }
 
     os << " }";

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1896,8 +1896,8 @@ tl::expected<int64_t, ErrorCode> BucketStorageBackend::SelectBucketForEviction()
     return oldest_bucket;
 }
 
-tl::expected<std::vector<std::string>, ErrorCode>
-BucketStorageBackend::GetBucketLiveKeys(int64_t bucket_id) const {
+tl::expected<std::vector<StorageReplicaEvictionToken>, ErrorCode>
+BucketStorageBackend::GetBucketLiveReplicaTokens(int64_t bucket_id) const {
     SharedMutexLocker lock(&mutex_, shared_lock);
 
     auto bucket_it = buckets_.find(bucket_id);
@@ -1906,14 +1906,19 @@ BucketStorageBackend::GetBucketLiveKeys(int64_t bucket_id) const {
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
 
-    std::vector<std::string> live_keys;
-    live_keys.reserve(bucket_it->second->keys.size());
+    std::vector<StorageReplicaEvictionToken> live_tokens;
+    live_tokens.reserve(bucket_it->second->keys.size());
     for (const auto& key : bucket_it->second->keys) {
-        if (object_bucket_map_.find(key) != object_bucket_map_.end()) {
-            live_keys.push_back(key);
+        auto obj_it = object_bucket_map_.find(key);
+        if (obj_it == object_bucket_map_.end()) {
+            continue;
         }
+        if (obj_it->second.bucket_id != bucket_id) {
+            continue;
+        }
+        live_tokens.push_back(StorageReplicaEvictionToken{key, bucket_id});
     }
-    return live_keys;
+    return live_tokens;
 }
 
 tl::expected<size_t, ErrorCode> BucketStorageBackend::EvictBucket(
@@ -1941,6 +1946,9 @@ tl::expected<size_t, ErrorCode> BucketStorageBackend::EvictBucket(
         for (const auto& key : bucket_meta->keys) {
             auto obj_it = object_bucket_map_.find(key);
             if (obj_it == object_bucket_map_.end()) {
+                continue;
+            }
+            if (obj_it->second.bucket_id != bucket_id) {
                 continue;
             }
             freed_size += obj_it->second.data_size;

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1896,6 +1896,26 @@ tl::expected<int64_t, ErrorCode> BucketStorageBackend::SelectBucketForEviction()
     return oldest_bucket;
 }
 
+tl::expected<std::vector<std::string>, ErrorCode>
+BucketStorageBackend::GetBucketLiveKeys(int64_t bucket_id) const {
+    SharedMutexLocker lock(&mutex_, shared_lock);
+
+    auto bucket_it = buckets_.find(bucket_id);
+    if (bucket_it == buckets_.end()) {
+        LOG(ERROR) << "Bucket " << bucket_id << " not found";
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+
+    std::vector<std::string> live_keys;
+    live_keys.reserve(bucket_it->second->keys.size());
+    for (const auto& key : bucket_it->second->keys) {
+        if (object_bucket_map_.find(key) != object_bucket_map_.end()) {
+            live_keys.push_back(key);
+        }
+    }
+    return live_keys;
+}
+
 tl::expected<size_t, ErrorCode> BucketStorageBackend::EvictBucket(
     int64_t bucket_id) {
     size_t freed_size = 0;

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -87,6 +87,7 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     Json::Value root, TransferEngine* engine,
     AddReplicaCallback add_replica_callback,
     RemoveReplicaCallback remove_replica_callback,
+    BatchReplicaMutationCallback batch_replica_mutation_callback,
     SegmentSyncCallback segment_sync_callback) {
     // Initialize DataCopier
     try {
@@ -100,6 +101,7 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     // Register callback for syncing metadata to Master
     add_replica_callback_ = add_replica_callback;
     remove_replica_callback_ = remove_replica_callback;
+    batch_replica_mutation_callback_ = batch_replica_mutation_callback;
     // Register callback for segment lifecycle synchronization with Master
     segment_sync_callback_ = segment_sync_callback;
 
@@ -771,6 +773,113 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
         scheduler_->OnDelete(key, std::nullopt);
     }
     return tl::expected<void, ErrorCode>{};
+}
+
+tl::expected<void, ErrorCode> TieredBackend::DeleteBatchFromEviction(
+    const std::vector<std::string>& keys, const UUID& tier_id) {
+    if (is_shutting_down_.load(std::memory_order_acquire)) {
+        LOG(ERROR) << "TieredBackend is shutting down";
+        return tl::make_unexpected(ErrorCode::SHUTTING_DOWN);
+    }
+    if (keys.empty()) {
+        return {};
+    }
+
+    if (batch_replica_mutation_callback_) {
+        auto results = batch_replica_mutation_callback_(tier_id, keys);
+        if (results.size() != keys.size()) {
+            LOG(ERROR) << "Batch replica mutation callback returned "
+                          "unexpected result count: expected="
+                       << keys.size() << ", actual=" << results.size();
+            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+
+        for (size_t i = 0; i < results.size(); ++i) {
+            if (!results[i].has_value()) {
+                LOG(ERROR) << "Failed to batch delete key " << keys[i]
+                           << " in tier " << tier_id
+                           << " for Master, error_code=" << results[i].error();
+                return tl::make_unexpected(results[i].error());
+            }
+        }
+    }
+
+    std::vector<AllocationHandle> detached_handles;
+    std::vector<std::string> deleted_keys;
+    detached_handles.reserve(keys.size());
+    deleted_keys.reserve(keys.size());
+
+    for (const auto& key : keys) {
+        bool found_tier = false;
+        bool need_cleanup = false;
+
+        {
+            std::shared_lock<std::shared_mutex> read_lock(map_mutex_);
+            auto it = metadata_index_.find(key);
+            if (it == metadata_index_.end()) {
+                VLOG(1) << "Skip missing key during bucket eviction: " << key;
+                continue;
+            }
+
+            auto entry = it->second;
+            std::unique_lock<std::shared_mutex> entry_write_lock(entry->mutex);
+            auto tier_it = entry->replicas.end();
+            for (auto it = entry->replicas.begin(); it != entry->replicas.end();
+                 ++it) {
+                if (it->first == tier_id) {
+                    tier_it = it;
+                    break;
+                }
+            }
+
+            if (tier_it == entry->replicas.end()) {
+                VLOG(1) << "Skip missing tier during bucket eviction: key="
+                        << key << ", tier_id=" << tier_id;
+                continue;
+            }
+
+            detached_handles.push_back(tier_it->second);
+            entry->replicas.erase(tier_it);
+            entry->version++;
+            found_tier = true;
+            need_cleanup = entry->replicas.empty();
+        }
+
+        if (need_cleanup) {
+            std::unique_lock<std::shared_mutex> write_lock(map_mutex_);
+            auto it = metadata_index_.find(key);
+            if (it != metadata_index_.end()) {
+                auto entry = it->second;
+                std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
+                if (entry->replicas.empty()) {
+                    metadata_index_.erase(it);
+                }
+            }
+        }
+
+        if (found_tier) {
+            deleted_keys.push_back(key);
+        }
+    }
+
+    for (const auto& handle : detached_handles) {
+        if (!handle || !handle->loc.data.buffer) {
+            continue;
+        }
+        auto* storage_buffer =
+            dynamic_cast<StorageBuffer*>(handle->loc.data.buffer.get());
+        if (storage_buffer) {
+            storage_buffer->MarkEvicted();
+        }
+    }
+
+    if (scheduler_) {
+        for (const auto& key : deleted_keys) {
+            scheduler_->OnDelete(key, tier_id);
+        }
+    }
+
+    return {};
 }
 
 tl::expected<void, ErrorCode> TieredBackend::CopyData(

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -14,6 +14,27 @@
 
 namespace mooncake {
 
+namespace {
+
+bool MatchesEvictionToken(const AllocationHandle& handle,
+                          const StorageReplicaEvictionToken& token) {
+    if (token.bucket_id == kInvalidBucketId) {
+        return true;
+    }
+    if (!handle || !handle->loc.data.buffer) {
+        return false;
+    }
+
+    auto* storage_buffer =
+        dynamic_cast<StorageBuffer*>(handle->loc.data.buffer.get());
+    if (!storage_buffer) {
+        return false;
+    }
+    return storage_buffer->GetBucketId() == token.bucket_id;
+}
+
+}  // namespace
+
 AllocationEntry::~AllocationEntry() {
     if (loc.tier) {
         // Keep the tier alive until the final handle has released the buffer.
@@ -22,6 +43,36 @@ AllocationEntry::~AllocationEntry() {
 }
 
 TieredBackend::TieredBackend() = default;
+
+std::shared_ptr<TieredBackend::MetadataEntry>
+TieredBackend::CreateMetadataEntry() {
+    auto entry = std::make_shared<MetadataEntry>();
+    entry->generation =
+        next_entry_generation_.fetch_add(1, std::memory_order_relaxed);
+    return entry;
+}
+
+void TieredBackend::CleanupTombstonedEntry(
+    const std::string& key, const std::shared_ptr<MetadataEntry>& entry,
+    uint64_t generation) {
+    if (!entry) {
+        return;
+    }
+
+    std::unique_lock<std::shared_mutex> map_lock(map_mutex_);
+    auto it = metadata_index_.find(key);
+    if (it == metadata_index_.end() || it->second != entry) {
+        return;
+    }
+
+    std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
+    if (!entry->tombstone || !entry->replicas.empty() ||
+        entry->generation != generation) {
+        return;
+    }
+
+    metadata_index_.erase(it);
+}
 
 TieredBackend::~TieredBackend() {
     Stop();
@@ -87,7 +138,7 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     Json::Value root, TransferEngine* engine,
     AddReplicaCallback add_replica_callback,
     RemoveReplicaCallback remove_replica_callback,
-    BatchReplicaMutationCallback batch_replica_mutation_callback,
+    BatchRemoveReplicaCallback batch_remove_replica_callback,
     SegmentSyncCallback segment_sync_callback) {
     // Initialize DataCopier
     try {
@@ -101,7 +152,7 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     // Register callback for syncing metadata to Master
     add_replica_callback_ = add_replica_callback;
     remove_replica_callback_ = remove_replica_callback;
-    batch_replica_mutation_callback_ = batch_replica_mutation_callback;
+    batch_remove_replica_callback_ = batch_remove_replica_callback;
     // Register callback for segment lifecycle synchronization with Master
     segment_sync_callback_ = segment_sync_callback;
 
@@ -457,40 +508,23 @@ tl::expected<void, ErrorCode> TieredBackend::Commit(
     }
     if (!handle) return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
 
-    std::shared_ptr<MetadataEntry> entry = nullptr;
-
-    // Try to find existing entry (Global Read Lock)
-    {
-        std::shared_lock<std::shared_mutex> read_lock(map_mutex_);
+    // CAS check BEFORE any side effects
+    if (expected_version.has_value()) {
+        std::shared_lock<std::shared_mutex> map_lock(map_mutex_);
         auto it = metadata_index_.find(key);
-        if (it != metadata_index_.end()) {
-            entry = it->second;
-        }
-    }
-
-    // Create if not exists (Global Write Lock)
-    if (!entry) {
-        if (expected_version.has_value()) {
+        if (it == metadata_index_.end()) {
+            VLOG(1) << "CAS Failed for key " << key
+                    << ": key missing before commit";
             return tl::make_unexpected(ErrorCode::CAS_FAILED);
         }
 
-        std::unique_lock<std::shared_mutex> write_lock(map_mutex_);
-        auto it = metadata_index_.find(key);
-        if (it != metadata_index_.end()) {
-            entry = it->second;
-        } else {
-            entry = std::make_shared<MetadataEntry>();
-            metadata_index_[key] = entry;
-        }
-    }
-
-    // CAS check BEFORE any side effects
-    if (expected_version.has_value()) {
+        auto entry = it->second;
         std::shared_lock<std::shared_mutex> entry_read_lock(entry->mutex);
-        if (entry->version != expected_version.value()) {
+        if (entry->tombstone || entry->version != expected_version.value()) {
             VLOG(1) << "CAS Failed for key " << key
                     << ": valid_version=" << entry->version
-                    << ", expected=" << expected_version.value();
+                    << ", expected=" << expected_version.value()
+                    << ", tombstone=" << entry->tombstone;
             return tl::make_unexpected(ErrorCode::CAS_FAILED);
         }
     }
@@ -506,21 +540,12 @@ tl::expected<void, ErrorCode> TieredBackend::Commit(
     UUID current_tier_id = handle->loc.tier->GetTierId();
     size_t handle_size =
         handle->loc.data.buffer ? handle->loc.data.buffer->size() : 0;
+    handle->replica_generation =
+        next_replica_generation_.fetch_add(1, std::memory_order_relaxed);
 
-    // Update Entry (Entry Write Lock)
-    {
-        std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
-
-        // Re-check version under write lock (another commit may have raced)
-        if (expected_version.has_value() &&
-            entry->version != expected_version.value()) {
-            VLOG(1) << "CAS Failed (re-check) for key " << key;
-            return tl::make_unexpected(ErrorCode::CAS_FAILED);
-        }
-
-        // Insert or replace the handle for this tier
+    auto install_handle = [&](MetadataEntry& entry) {
         bool found = false;
-        for (auto& replica : entry->replicas) {
+        for (auto& replica : entry.replicas) {
             if (replica.first == current_tier_id) {
                 replica.second = handle;
                 found = true;
@@ -529,8 +554,8 @@ tl::expected<void, ErrorCode> TieredBackend::Commit(
         }
 
         if (!found) {
-            entry->replicas.emplace_back(current_tier_id, handle);
-            std::sort(entry->replicas.begin(), entry->replicas.end(),
+            entry.replicas.emplace_back(current_tier_id, handle);
+            std::sort(entry.replicas.begin(), entry.replicas.end(),
                       [this](const std::pair<UUID, AllocationHandle>& a,
                              const std::pair<UUID, AllocationHandle>& b) {
                           return tier_info_.at(a.first).priority >
@@ -538,9 +563,80 @@ tl::expected<void, ErrorCode> TieredBackend::Commit(
                       });
         }
 
-        // Increment Version on modification
-        entry->version++;
+        entry.tombstone = false;
+        entry.version++;
+    };
+
+    bool committed = false;
+
+    // Fast path: update an existing live entry under the shared map lock.
+    {
+        std::shared_lock<std::shared_mutex> map_lock(map_mutex_);
+        auto it = metadata_index_.find(key);
+        if (it != metadata_index_.end()) {
+            auto entry = it->second;
+            std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
+            if (!entry->tombstone) {
+                if (expected_version.has_value() &&
+                    entry->version != expected_version.value()) {
+                    VLOG(1) << "CAS Failed (re-check) for key " << key;
+                    return tl::make_unexpected(ErrorCode::CAS_FAILED);
+                }
+
+                install_handle(*entry);
+                committed = true;
+            }
+        }
     }
+
+    if (!committed) {
+        std::unique_lock<std::shared_mutex> map_lock(map_mutex_);
+        auto it = metadata_index_.find(key);
+        std::shared_ptr<MetadataEntry> entry;
+
+        if (it != metadata_index_.end()) {
+            entry = it->second;
+            std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
+            if (!entry->tombstone) {
+                if (expected_version.has_value() &&
+                    entry->version != expected_version.value()) {
+                    VLOG(1) << "CAS Failed (re-check) for key " << key;
+                    return tl::make_unexpected(ErrorCode::CAS_FAILED);
+                }
+
+                install_handle(*entry);
+                committed = true;
+            } else {
+                if (expected_version.has_value()) {
+                    return tl::make_unexpected(ErrorCode::CAS_FAILED);
+                }
+
+                auto new_entry = CreateMetadataEntry();
+                {
+                    std::unique_lock<std::shared_mutex> new_entry_lock(
+                        new_entry->mutex);
+                    install_handle(*new_entry);
+                }
+                metadata_index_[key] = new_entry;
+                committed = true;
+            }
+        } else {
+            if (expected_version.has_value()) {
+                return tl::make_unexpected(ErrorCode::CAS_FAILED);
+            }
+
+            auto new_entry = CreateMetadataEntry();
+            {
+                std::unique_lock<std::shared_mutex> entry_lock(
+                    new_entry->mutex);
+                install_handle(*new_entry);
+            }
+            metadata_index_[key] = new_entry;
+            committed = true;
+        }
+    }
+
+    CHECK(committed) << "Commit should have installed the handle";
 
     if (scheduler_) {
         scheduler_->OnCommit(key, current_tier_id, handle_size);
@@ -552,8 +648,9 @@ tl::expected<void, ErrorCode> TieredBackend::Commit(
     if (add_replica_callback_) {
         size_t data_size =
             handle->loc.data.buffer ? handle->loc.data.buffer->size() : 0;
-        auto result = add_replica_callback_(key, handle->loc.tier->GetTierId(),
-                                            data_size);
+        auto result =
+            add_replica_callback_(key, handle->loc.tier->GetTierId(), data_size,
+                                  handle->replica_generation);
 
         if (!result.has_value()) {
             LOG(ERROR) << "Failed to Commit key " << key
@@ -572,69 +669,80 @@ tl::expected<AllocationHandle, ErrorCode> TieredBackend::Get(
         LOG(ERROR) << "TieredBackend is shutting down";
         return tl::make_unexpected(ErrorCode::SHUTTING_DOWN);
     }
-    std::shared_ptr<MetadataEntry> entry = nullptr;
+    AllocationHandle result;
 
-    // Find Entry (Global Read Lock)
     {
-        std::shared_lock<std::shared_mutex> read_lock(map_mutex_);
+        std::shared_lock<std::shared_mutex> map_lock(map_mutex_);
         auto it = metadata_index_.find(key);
         if (it == metadata_index_.end()) {
             LOG(ERROR) << "Key not found: " << key;
             return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
         }
-        entry = it->second;
+
+        auto entry = it->second;
+        std::shared_lock<std::shared_mutex> entry_read_lock(entry->mutex);
+
+        if (entry->tombstone) {
+            LOG(ERROR) << "Key not found (tombstoned): " << key;
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+
+        if (out_version) {
+            *out_version = entry->version;
+        }
+
+        if (entry->replicas.empty()) {
+            LOG(ERROR) << "Empty replicas for key: " << key;
+            return tl::make_unexpected(ErrorCode::EMPTY_REPLICAS);
+        }
+
+        if (tier_id.has_value()) {
+            for (const auto& replica : entry->replicas) {
+                if (replica.first == *tier_id) {
+                    result = replica.second;
+                    break;
+                }
+            }
+            if (!result) {
+                LOG(ERROR) << "Tier not found: " << *tier_id;
+                return tl::make_unexpected(ErrorCode::TIER_NOT_FOUND);
+            }
+        } else {
+            result = entry->replicas.begin()->second;
+        }
     }
 
     if (record_access && scheduler_) {
         scheduler_->OnAccess(key);
     }
 
-    // Read Entry (Entry Read Lock)
-    std::shared_lock<std::shared_mutex> entry_read_lock(entry->mutex);
-
-    // Return current version if requested
-    if (out_version) {
-        *out_version = entry->version;
-    }
-
-    if (entry->replicas.empty()) {
-        LOG(ERROR) << "Empty replicas for key: " << key;
-        return tl::make_unexpected(ErrorCode::EMPTY_REPLICAS);
-    }
-
-    if (tier_id.has_value()) {
-        for (const auto& replica : entry->replicas) {
-            if (replica.first == *tier_id) {
-                return replica.second;
-            }
-        }
-        LOG(ERROR) << "Tier not found: " << *tier_id;
-        return tl::make_unexpected(ErrorCode::TIER_NOT_FOUND);
-    }
-
-    // Fallback: Return highest priority replica
-    return entry->replicas.begin()->second;
+    return result;
 }
 
 bool TieredBackend::Exist(const std::string& key,
                           std::optional<UUID> tier_id) const {
-    std::shared_lock<std::shared_mutex> read_lock(map_mutex_);
+    std::shared_lock<std::shared_mutex> map_lock(map_mutex_);
     auto it = metadata_index_.find(key);
     if (it == metadata_index_.end()) {
-        return false;  // Key not found
+        return false;
     }
-    if (!tier_id.has_value()) {
-        return true;  // Key exists in backend
-    }
-    // Check specific tier
+
     auto entry = it->second;
     std::shared_lock<std::shared_mutex> entry_lock(entry->mutex);
+    if (entry->tombstone) {
+        return false;
+    }
+
+    if (!tier_id.has_value()) {
+        return true;
+    }
+
     for (const auto& replica : entry->replicas) {
         if (replica.first == *tier_id) {
-            return true;  // Key exists in target tier
+            return true;
         }
     }
-    return false;  // Key does not exist in target tier
+    return false;
 }
 
 tl::expected<void, ErrorCode> TieredBackend::Delete(
@@ -653,6 +761,8 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
 
         bool need_cleanup = false;
         bool found_tier = false;
+        std::shared_ptr<MetadataEntry> cleanup_entry;
+        uint64_t cleanup_generation = 0;
 
         // Optimistic Delete (Global Read Lock + Entry Write Lock)
         // This is fast and allows high concurrency.
@@ -666,6 +776,10 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
             auto entry = it->second;
 
             std::unique_lock<std::shared_mutex> entry_write_lock(entry->mutex);
+            if (entry->tombstone) {
+                LOG(ERROR) << "Key not found: " << key;
+                return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+            }
             auto tier_it = entry->replicas.end();
             for (auto it = entry->replicas.begin(); it != entry->replicas.end();
                  ++it) {
@@ -678,7 +792,8 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
             if (tier_it != entry->replicas.end()) {
                 if (remove_replica_callback_) {
                     auto result = remove_replica_callback_(
-                        key, tier_it->second->loc.tier->GetTierId(), DELETE);
+                        key, tier_it->second->loc.tier->GetTierId(),
+                        tier_it->second->replica_generation);
                     if (!result.has_value()) {
                         LOG(ERROR)
                             << "Failed to Delete key " << key << " in Tier "
@@ -696,30 +811,15 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
 
             // Mark for cleanup if entry becomes empty
             if (entry->replicas.empty()) {
+                entry->tombstone = true;
                 need_cleanup = true;
+                cleanup_entry = entry;
+                cleanup_generation = entry->generation;
             }
         }  // Read lock released here
 
-        // Retry with Write Lock
-        // If the entry is empty, we upgrade to a global write lock to
-        // remove it. This prevents memory leaks from empty "zombie"
-        // entries.
         if (need_cleanup) {
-            std::unique_lock<std::shared_mutex> write_lock(map_mutex_);
-
-            auto it = metadata_index_.find(key);
-            if (it != metadata_index_.end()) {
-                auto entry = it->second;
-
-                // Double-Check Locking:
-                // Another thread might have added a replica now
-                std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
-
-                if (entry->replicas.empty()) {
-                    // Confirmed empty, safe to remove from global index
-                    metadata_index_.erase(it);
-                }
-            }
+            CleanupTombstonedEntry(key, cleanup_entry, cleanup_generation);
         }
 
         if (found_tier) {
@@ -741,25 +841,56 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
             LOG(ERROR) << "Key not found: " << key;
             return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
         }
-        UUID invalid_id{0, 0};
-        if (remove_replica_callback_) {
-            auto result = remove_replica_callback_(key, invalid_id, DELETE_ALL);
-            if (!result.has_value()) {
-                LOG(ERROR) << "Failed to Delete key " << key
-                           << " for Master, error_code=" << result.error();
-                return tl::make_unexpected(result.error());
-            }
-        }
-
         auto entry = it->second;
 
         {
             std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
+            if (entry->tombstone) {
+                LOG(ERROR) << "Key not found: " << key;
+                return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+            }
+
+            if (batch_remove_replica_callback_) {
+                for (const auto& replica : entry->replicas) {
+                    auto results = batch_remove_replica_callback_(
+                        replica.first,
+                        {ReplicaRemoveRequest{
+                            key, replica.second->replica_generation}});
+                    if (results.size() != 1) {
+                        LOG(ERROR) << "Batch remove callback returned "
+                                      "unexpected result count for key "
+                                   << key << ": actual=" << results.size();
+                        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+                    }
+                    if (!results[0].has_value()) {
+                        LOG(ERROR)
+                            << "Failed to delete key " << key << " in tier "
+                            << replica.first
+                            << " for Master, error_code=" << results[0].error();
+                        return tl::make_unexpected(results[0].error());
+                    }
+                }
+            } else if (remove_replica_callback_) {
+                for (const auto& replica : entry->replicas) {
+                    auto result = remove_replica_callback_(
+                        key, replica.first, replica.second->replica_generation);
+                    if (!result.has_value()) {
+                        LOG(ERROR)
+                            << "Failed to delete key " << key << " in tier "
+                            << replica.first
+                            << " for Master, error_code=" << result.error();
+                        return tl::make_unexpected(result.error());
+                    }
+                }
+            }
+
             handles_to_free.reserve(entry->replicas.size());
             for (auto& replica : entry->replicas) {
                 handles_to_free.push_back(replica.second);
             }
             entry->replicas.clear();
+            entry->tombstone = true;
+            entry->version++;
         }
 
         // Remove the entry from the global index
@@ -777,99 +908,200 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
 
 tl::expected<void, ErrorCode> TieredBackend::DeleteBatchFromEviction(
     const std::vector<std::string>& keys, const UUID& tier_id) {
+    std::vector<StorageReplicaEvictionToken> tokens;
+    tokens.reserve(keys.size());
+    for (const auto& key : keys) {
+        tokens.push_back(StorageReplicaEvictionToken{key, kInvalidBucketId});
+    }
+    return DeleteBatchFromEviction(tokens, tier_id);
+}
+
+tl::expected<void, ErrorCode> TieredBackend::DeleteBatchFromEviction(
+    const std::vector<StorageReplicaEvictionToken>& tokens,
+    const UUID& tier_id) {
     if (is_shutting_down_.load(std::memory_order_acquire)) {
         LOG(ERROR) << "TieredBackend is shutting down";
         return tl::make_unexpected(ErrorCode::SHUTTING_DOWN);
     }
-    if (keys.empty()) {
+    if (tokens.empty()) {
         return {};
     }
 
-    if (batch_replica_mutation_callback_) {
-        auto results = batch_replica_mutation_callback_(tier_id, keys);
-        if (results.size() != keys.size()) {
+    std::vector<ReplicaRemoveRequest> callback_requests;
+    callback_requests.reserve(tokens.size());
+    {
+        std::shared_lock<std::shared_mutex> map_lock(map_mutex_);
+        for (const auto& token : tokens) {
+            auto it = metadata_index_.find(token.key);
+            if (it == metadata_index_.end()) {
+                continue;
+            }
+
+            auto entry = it->second;
+            std::shared_lock<std::shared_mutex> entry_lock(entry->mutex);
+            if (entry->tombstone) {
+                continue;
+            }
+
+            for (const auto& replica : entry->replicas) {
+                if (replica.first == tier_id &&
+                    MatchesEvictionToken(replica.second, token)) {
+                    callback_requests.push_back(ReplicaRemoveRequest{
+                        token.key, replica.second->replica_generation});
+                    break;
+                }
+            }
+        }
+    }
+
+    if (batch_remove_replica_callback_ && !callback_requests.empty()) {
+        auto results =
+            batch_remove_replica_callback_(tier_id, callback_requests);
+        if (results.size() != callback_requests.size()) {
             LOG(ERROR) << "Batch replica mutation callback returned "
                           "unexpected result count: expected="
-                       << keys.size() << ", actual=" << results.size();
+                       << callback_requests.size()
+                       << ", actual=" << results.size();
             return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
         }
 
         for (size_t i = 0; i < results.size(); ++i) {
             if (!results[i].has_value()) {
-                LOG(ERROR) << "Failed to batch delete key " << keys[i]
-                           << " in tier " << tier_id
+                LOG(ERROR) << "Failed to batch delete key "
+                           << callback_requests[i].key << " in tier " << tier_id
                            << " for Master, error_code=" << results[i].error();
                 return tl::make_unexpected(results[i].error());
             }
         }
     }
 
+    struct BatchDeleteTarget {
+        std::string key;
+        std::shared_ptr<MetadataEntry> entry;
+        StorageReplicaEvictionToken token;
+    };
+
+    struct CleanupCandidate {
+        std::string key;
+        std::shared_ptr<MetadataEntry> entry;
+        uint64_t generation;
+    };
+
     std::vector<AllocationHandle> detached_handles;
     std::vector<std::string> deleted_keys;
-    detached_handles.reserve(keys.size());
-    deleted_keys.reserve(keys.size());
+    std::vector<CleanupCandidate> cleanup_candidates;
+    detached_handles.reserve(tokens.size());
+    deleted_keys.reserve(tokens.size());
+    cleanup_candidates.reserve(tokens.size());
 
-    for (const auto& key : keys) {
-        bool found_tier = false;
-        bool need_cleanup = false;
-
-        {
-            std::shared_lock<std::shared_mutex> read_lock(map_mutex_);
-            auto it = metadata_index_.find(key);
+    {
+        std::shared_lock<std::shared_mutex> map_lock(map_mutex_);
+        std::vector<BatchDeleteTarget> targets;
+        targets.reserve(tokens.size());
+        for (const auto& token : tokens) {
+            auto it = metadata_index_.find(token.key);
             if (it == metadata_index_.end()) {
-                VLOG(1) << "Skip missing key during bucket eviction: " << key;
+                VLOG(1) << "Skip missing key during bucket eviction: "
+                        << token.key;
                 continue;
             }
-
-            auto entry = it->second;
-            std::unique_lock<std::shared_mutex> entry_write_lock(entry->mutex);
-            auto tier_it = entry->replicas.end();
-            for (auto it = entry->replicas.begin(); it != entry->replicas.end();
-                 ++it) {
-                if (it->first == tier_id) {
-                    tier_it = it;
-                    break;
-                }
-            }
-
-            if (tier_it == entry->replicas.end()) {
-                VLOG(1) << "Skip missing tier during bucket eviction: key="
-                        << key << ", tier_id=" << tier_id;
-                continue;
-            }
-
-            detached_handles.push_back(tier_it->second);
-            entry->replicas.erase(tier_it);
-            entry->version++;
-            found_tier = true;
-            need_cleanup = entry->replicas.empty();
+            targets.push_back({token.key, it->second, token});
         }
 
-        if (need_cleanup) {
-            std::unique_lock<std::shared_mutex> write_lock(map_mutex_);
-            auto it = metadata_index_.find(key);
-            if (it != metadata_index_.end()) {
-                auto entry = it->second;
-                std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
-                if (entry->replicas.empty()) {
-                    metadata_index_.erase(it);
+        if (!targets.empty()) {
+            std::vector<std::shared_ptr<MetadataEntry>> entries_to_lock;
+            entries_to_lock.reserve(targets.size());
+            for (const auto& target : targets) {
+                entries_to_lock.push_back(target.entry);
+            }
+
+            std::sort(entries_to_lock.begin(), entries_to_lock.end(),
+                      [](const auto& lhs, const auto& rhs) {
+                          return lhs.get() < rhs.get();
+                      });
+            entries_to_lock.erase(
+                std::unique(entries_to_lock.begin(), entries_to_lock.end()),
+                entries_to_lock.end());
+
+            std::vector<std::unique_lock<std::shared_mutex>> entry_locks;
+            entry_locks.reserve(entries_to_lock.size());
+            for (const auto& entry : entries_to_lock) {
+                entry_locks.emplace_back(entry->mutex);
+            }
+
+            for (const auto& target : targets) {
+                const auto& token = target.token;
+                auto& entry = *target.entry;
+                if (entry.tombstone) {
+                    VLOG(1) << "Skip tombstoned key during bucket eviction: "
+                            << target.key;
+                    continue;
+                }
+
+                auto tier_it = entry.replicas.end();
+                for (auto it = entry.replicas.begin();
+                     it != entry.replicas.end(); ++it) {
+                    if (it->first == tier_id) {
+                        tier_it = it;
+                        break;
+                    }
+                }
+
+                if (tier_it == entry.replicas.end()) {
+                    VLOG(1) << "Skip missing tier during bucket eviction: key="
+                            << target.key << ", tier_id=" << tier_id;
+                    continue;
+                }
+
+                if (!MatchesEvictionToken(tier_it->second, token)) {
+                    VLOG(1) << "Skip mismatched storage replica during bucket "
+                               "eviction: key="
+                            << target.key
+                            << ", expected_bucket_id=" << token.bucket_id;
+                    continue;
+                }
+
+                AllocationHandle detached_handle = tier_it->second;
+                entry.replicas.erase(tier_it);
+                entry.version++;
+
+                if (detached_handle && detached_handle->loc.data.buffer) {
+                    auto* storage_buffer = dynamic_cast<StorageBuffer*>(
+                        detached_handle->loc.data.buffer.get());
+                    if (storage_buffer) {
+                        storage_buffer->MarkEvicted();
+                    }
+                }
+
+                detached_handles.push_back(detached_handle);
+                deleted_keys.push_back(target.key);
+
+                if (entry.replicas.empty()) {
+                    entry.tombstone = true;
+                    cleanup_candidates.push_back(
+                        {target.key, target.entry, entry.generation});
                 }
             }
-        }
-
-        if (found_tier) {
-            deleted_keys.push_back(key);
         }
     }
 
-    for (const auto& handle : detached_handles) {
-        if (!handle || !handle->loc.data.buffer) {
-            continue;
-        }
-        auto* storage_buffer =
-            dynamic_cast<StorageBuffer*>(handle->loc.data.buffer.get());
-        if (storage_buffer) {
-            storage_buffer->MarkEvicted();
+    if (!cleanup_candidates.empty()) {
+        std::unique_lock<std::shared_mutex> map_lock(map_mutex_);
+        for (const auto& candidate : cleanup_candidates) {
+            auto it = metadata_index_.find(candidate.key);
+            if (it == metadata_index_.end() || it->second != candidate.entry) {
+                continue;
+            }
+
+            std::unique_lock<std::shared_mutex> entry_lock(
+                candidate.entry->mutex);
+            if (!candidate.entry->tombstone ||
+                !candidate.entry->replicas.empty() ||
+                candidate.entry->generation != candidate.generation) {
+                continue;
+            }
+
+            metadata_index_.erase(it);
         }
     }
 
@@ -983,6 +1215,10 @@ std::vector<UUID> TieredBackend::GetReplicaTierIds(
     }
 
     std::shared_lock entry_lock(it->second->mutex);
+    if (it->second->tombstone) {
+        return {};
+    }
+
     std::vector<UUID> tiers;
     tiers.reserve(it->second->replicas.size());
     for (const auto& replica : it->second->replicas) {

--- a/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
@@ -5,6 +5,7 @@
 
 #include "tiered_cache/tiers/storage_tier.h"
 #include "tiered_cache/copier_registry.h"
+#include "tiered_cache/tiered_backend.h"
 #include "utils.h"
 
 namespace mooncake {
@@ -197,6 +198,12 @@ tl::expected<void, ErrorCode> StorageTier::Free(DataSource data) {
     auto* staging = static_cast<StorageBuffer*>(data.buffer.get());
     if (!staging) return {};
 
+    if (staging->IsEvicted()) {
+        VLOG(1) << "Skip free for evicted storage buffer, key="
+                << staging->GetKey();
+        return {};
+    }
+
     size_t size = staging->size();
     std::string key = staging->GetKey();
 
@@ -380,6 +387,44 @@ tl::expected<size_t, ErrorCode> StorageTier::TriggerBucketEviction(
     constexpr int MAX_EVICTION_ATTEMPTS = 10;  // Prevent infinite loop
     int attempts = 0;
 
+    auto evict_bucket =
+        [&](int64_t bucket_id) -> tl::expected<size_t, ErrorCode> {
+        auto live_keys_res = bucket_backend->GetBucketLiveKeys(bucket_id);
+        if (!live_keys_res) {
+            LOG(ERROR) << "Failed to collect live keys for bucket " << bucket_id
+                       << ": " << live_keys_res.error();
+            return tl::make_unexpected(live_keys_res.error());
+        }
+
+        const auto& live_keys = live_keys_res.value();
+        if (!live_keys.empty()) {
+            if (!backend_) {
+                LOG(ERROR) << "StorageTier backend is not initialized";
+                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+            }
+
+            auto delete_res =
+                backend_->DeleteBatchFromEviction(live_keys, tier_id_);
+            if (!delete_res) {
+                LOG(ERROR) << "Failed to remove bucket replicas from tiered "
+                              "metadata before eviction: bucket_id="
+                           << bucket_id << ", error=" << delete_res.error();
+                return tl::make_unexpected(delete_res.error());
+            }
+        }
+
+        auto evict_res = bucket_backend->EvictBucket(bucket_id);
+        if (!evict_res) {
+            LOG(ERROR) << "Failed to evict bucket " << bucket_id << ": "
+                       << evict_res.error();
+            return tl::make_unexpected(evict_res.error());
+        }
+
+        persisted_live_data_bytes_.fetch_sub(evict_res.value(),
+                                             std::memory_order_acq_rel);
+        return evict_res;
+    };
+
     // If target_free_size is 0, evict just one bucket
     if (target_free_size == 0) {
         auto select_res = bucket_backend->SelectBucketForEviction();
@@ -390,20 +435,12 @@ tl::expected<size_t, ErrorCode> StorageTier::TriggerBucketEviction(
         }
 
         int64_t bucket_id = select_res.value();
-        auto evict_res = bucket_backend->EvictBucket(bucket_id);
+        auto evict_res = evict_bucket(bucket_id);
         if (!evict_res) {
-            LOG(ERROR) << "Failed to evict bucket " << bucket_id << ": "
-                       << evict_res.error();
             return tl::make_unexpected(evict_res.error());
         }
 
         total_freed = evict_res.value();
-
-        // Update live persisted bytes to reflect cache-visible space freed by
-        // eviction.
-        persisted_live_data_bytes_.fetch_sub(total_freed,
-                                             std::memory_order_acq_rel);
-
         LOG(INFO) << "Evicted 1 bucket, freed " << total_freed << " bytes";
         return total_freed;
     }
@@ -425,22 +462,14 @@ tl::expected<size_t, ErrorCode> StorageTier::TriggerBucketEviction(
         }
 
         int64_t bucket_id = select_res.value();
-        auto evict_res = bucket_backend->EvictBucket(bucket_id);
+        auto evict_res = evict_bucket(bucket_id);
         if (!evict_res) {
-            LOG(ERROR) << "Failed to evict bucket " << bucket_id << ": "
-                       << evict_res.error();
-            // Continue trying other buckets
-            attempts++;
-            continue;
+            return tl::make_unexpected(evict_res.error());
         }
 
         size_t freed = evict_res.value();
         total_freed += freed;
         attempts++;
-
-        // Update live persisted bytes to reflect cache-visible space freed by
-        // eviction.
-        persisted_live_data_bytes_.fetch_sub(freed, std::memory_order_acq_rel);
 
         LOG(INFO) << "Evicted bucket " << bucket_id << ", freed " << freed
                   << " bytes (total: " << total_freed << "/" << target_free_size

--- a/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
@@ -316,8 +316,32 @@ tl::expected<void, ErrorCode> StorageTier::FlushInternal() {
         }
     }
 
+    auto complete_handler =
+        [&snapshot](
+            const std::vector<std::string>& keys,
+            std::vector<StorageObjectMetadata>& metadatas) -> ErrorCode {
+        if (keys.size() != metadatas.size()) {
+            LOG(ERROR) << "Flush complete handler got mismatched metadata: "
+                       << "keys=" << keys.size()
+                       << ", metadatas=" << metadatas.size();
+            return ErrorCode::INTERNAL_ERROR;
+        }
+
+        for (size_t i = 0; i < keys.size(); ++i) {
+            auto it = snapshot.find(keys[i]);
+            if (it == snapshot.end() || !it->second) {
+                LOG(ERROR)
+                    << "Flush complete handler cannot find snapshot key: "
+                    << keys[i];
+                return ErrorCode::INTERNAL_ERROR;
+            }
+            it->second->SetBucketId(metadatas[i].bucket_id);
+        }
+        return ErrorCode::OK;
+    };
+
     // 2. IO without lock
-    auto res = storage_backend_->BatchOffload(batch_to_write, nullptr);
+    auto res = storage_backend_->BatchOffload(batch_to_write, complete_handler);
 
     // 3. Finalize under lock: update state and notify waiters
     {
@@ -389,22 +413,23 @@ tl::expected<size_t, ErrorCode> StorageTier::TriggerBucketEviction(
 
     auto evict_bucket =
         [&](int64_t bucket_id) -> tl::expected<size_t, ErrorCode> {
-        auto live_keys_res = bucket_backend->GetBucketLiveKeys(bucket_id);
-        if (!live_keys_res) {
-            LOG(ERROR) << "Failed to collect live keys for bucket " << bucket_id
-                       << ": " << live_keys_res.error();
-            return tl::make_unexpected(live_keys_res.error());
+        auto live_tokens_res =
+            bucket_backend->GetBucketLiveReplicaTokens(bucket_id);
+        if (!live_tokens_res) {
+            LOG(ERROR) << "Failed to collect live replicas for bucket "
+                       << bucket_id << ": " << live_tokens_res.error();
+            return tl::make_unexpected(live_tokens_res.error());
         }
 
-        const auto& live_keys = live_keys_res.value();
-        if (!live_keys.empty()) {
+        const auto& live_tokens = live_tokens_res.value();
+        if (!live_tokens.empty()) {
             if (!backend_) {
                 LOG(ERROR) << "StorageTier backend is not initialized";
                 return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
             }
 
             auto delete_res =
-                backend_->DeleteBatchFromEviction(live_keys, tier_id_);
+                backend_->DeleteBatchFromEviction(live_tokens, tier_id_);
             if (!delete_res) {
                 LOG(ERROR) << "Failed to remove bucket replicas from tiered "
                               "metadata before eviction: bucket_id="

--- a/mooncake-store/tests/data_manager_test.cpp
+++ b/mooncake-store/tests/data_manager_test.cpp
@@ -1390,7 +1390,7 @@ TEST_F(DataManagerTest, RealRDMALoopbackTransfer) {
     // Pass TransferEngine to TieredBackend so DRAM memory gets registered for
     // RDMA
     auto init_backend_result = rdma_tiered_backend->Init(
-        config, rdma_transfer_engine.get(), nullptr, nullptr, nullptr);
+        config, rdma_transfer_engine.get(), nullptr, nullptr, nullptr, nullptr);
     ASSERT_TRUE(init_backend_result.has_value())
         << "Failed to initialize TieredBackend";
 
@@ -1552,7 +1552,7 @@ TEST_F(DataManagerTest, RealRDMAMultiBatchTransfer) {
     // Pass TransferEngine to TieredBackend so DRAM memory gets registered for
     // RDMA
     auto init_backend_result = rdma_tiered_backend->Init(
-        config, rdma_transfer_engine.get(), nullptr, nullptr, nullptr);
+        config, rdma_transfer_engine.get(), nullptr, nullptr, nullptr, nullptr);
     ASSERT_TRUE(init_backend_result.has_value())
         << "Failed to initialize TieredBackend";
 
@@ -1743,7 +1743,7 @@ TEST_F(DataManagerTest, RealRDMAMultiBatchPartialFailure) {
 
     auto rdma_tiered_backend = std::make_unique<TieredBackend>();
     auto init_backend_result = rdma_tiered_backend->Init(
-        config, rdma_transfer_engine.get(), nullptr, nullptr, nullptr);
+        config, rdma_transfer_engine.get(), nullptr, nullptr, nullptr, nullptr);
     ASSERT_TRUE(init_backend_result.has_value())
         << "Failed to initialize TieredBackend";
 
@@ -1889,7 +1889,7 @@ TEST_F(DataManagerTest, RealRDMAMultiBatchWriteRemoteData) {
 
     auto rdma_tiered_backend = std::make_unique<TieredBackend>();
     auto init_backend_result = rdma_tiered_backend->Init(
-        config, rdma_transfer_engine.get(), nullptr, nullptr, nullptr);
+        config, rdma_transfer_engine.get(), nullptr, nullptr, nullptr, nullptr);
     ASSERT_TRUE(init_backend_result.has_value())
         << "Failed to initialize TieredBackend";
 
@@ -2052,7 +2052,7 @@ TEST_F(DataManagerTest, RealRDMAMultiBatchWriteRemoteDataPartialFailure) {
 
     auto rdma_tiered_backend = std::make_unique<TieredBackend>();
     auto init_backend_result = rdma_tiered_backend->Init(
-        config, rdma_transfer_engine.get(), nullptr, nullptr, nullptr);
+        config, rdma_transfer_engine.get(), nullptr, nullptr, nullptr, nullptr);
     ASSERT_TRUE(init_backend_result.has_value())
         << "Failed to initialize TieredBackend";
 

--- a/mooncake-store/tests/p2p_master_service_test.cpp
+++ b/mooncake-store/tests/p2p_master_service_test.cpp
@@ -443,6 +443,40 @@ TEST_F(P2PMasterServiceTest, RemoveReplicaPartial) {
     EXPECT_EQ(1, get_res.value().replicas.size());
 }
 
+TEST_F(P2PMasterServiceTest, BatchMutateReplicaMixedPatterns) {
+    auto service = CreateService();
+    auto seg1 = MakeP2PSegment("seg1");
+    auto seg2 = MakeP2PSegment("seg2");
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg1, seg2}, "127.0.0.1", 50051);
+
+    AddReplicaHelper(*service, "key1", 1024, client_id, seg1.id);
+    AddReplicaHelper(*service, "key1", 1024, client_id, seg2.id);
+    AddReplicaHelper(*service, "key2", 1024, client_id, seg1.id);
+    AddReplicaHelper(*service, "key3", 1024, client_id, seg2.id);
+
+    BatchReplicaMutationRequest req;
+    req.client_id = client_id;
+    req.mutations = {
+        ReplicaMutation{ReplicaMutationType::REMOVE, "key1", seg1.id},
+        ReplicaMutation{ReplicaMutationType::REMOVE, "key1", seg2.id},
+        ReplicaMutation{ReplicaMutationType::REMOVE, "key2", seg1.id},
+        ReplicaMutation{ReplicaMutationType::REMOVE, "key3", seg2.id},
+    };
+
+    auto results = service->BatchMutateReplica(req);
+    ASSERT_EQ(results.size(), req.mutations.size());
+    for (const auto& result : results) {
+        ASSERT_TRUE(result.has_value());
+    }
+
+    for (const auto& key : {"key1", "key2", "key3"}) {
+        auto get_res = service->GetReplicaList(key);
+        EXPECT_FALSE(get_res.has_value());
+        EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_res.error());
+    }
+}
+
 TEST_F(P2PMasterServiceTest, RemoveReplicaNotFound) {
     auto service = CreateService();
     auto seg = MakeP2PSegment();

--- a/mooncake-store/tests/p2p_master_service_test.cpp
+++ b/mooncake-store/tests/p2p_master_service_test.cpp
@@ -71,12 +71,14 @@ class P2PMasterServiceTest : public ::testing::Test {
     /// Helper to add a replica via AddReplica
     void AddReplicaHelper(P2PMasterService& service, const std::string& key,
                           size_t size, const UUID& client_id,
-                          const UUID& segment_id) {
+                          const UUID& segment_id,
+                          uint64_t replica_generation = 0) {
         AddReplicaRequest req;
         req.key = key;
         req.size = size;
         req.replica.client_id = client_id;
         req.replica.segment_id = segment_id;
+        req.replica.replica_generation = replica_generation;
         auto res = service.AddReplica(req);
         EXPECT_TRUE(res.has_value())
             << "Failed to add replica: " << res.error();
@@ -334,6 +336,103 @@ TEST_F(P2PMasterServiceTest, AddReplicaDuplicate) {
     EXPECT_EQ(ErrorCode::REPLICA_ALREADY_EXISTS, res2.error());
 }
 
+TEST_F(P2PMasterServiceTest,
+       AddReplicaNewGenerationReplacesSameSegmentReplica) {
+    auto service = CreateService();
+    auto seg = MakeP2PSegment();
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
+
+    AddReplicaRequest req1;
+    req1.key = "key1";
+    req1.size = 1024;
+    req1.replica.client_id = client_id;
+    req1.replica.segment_id = seg.id;
+    req1.replica.replica_generation = 1;
+    ASSERT_TRUE(service->AddReplica(req1).has_value());
+
+    AddReplicaRequest req2 = req1;
+    req2.size = 2048;
+    req2.replica.replica_generation = 2;
+    auto res2 = service->AddReplica(req2);
+    ASSERT_TRUE(res2.has_value());
+
+    auto get_res = service->GetReplicaList("key1");
+    ASSERT_TRUE(get_res.has_value());
+    ASSERT_EQ(1, get_res->replicas.size());
+    const auto& desc = get_res->replicas[0].get_p2p_proxy_descriptor();
+    EXPECT_EQ(2048, desc.object_size);
+    EXPECT_EQ(2, desc.replica_generation);
+}
+
+TEST_F(P2PMasterServiceTest, AddReplicaReplacementBypassesReplicaLimit) {
+    auto service = CreateService(/* max_replicas_per_key= */ 1);
+    auto seg = MakeP2PSegment();
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
+
+    AddReplicaHelper(*service, "key1", 1024, client_id, seg.id, 1);
+    AddReplicaHelper(*service, "key1", 2048, client_id, seg.id, 2);
+
+    auto get_res = service->GetReplicaList("key1");
+    ASSERT_TRUE(get_res.has_value());
+    ASSERT_EQ(1, get_res->replicas.size());
+    const auto& desc = get_res->replicas[0].get_p2p_proxy_descriptor();
+    EXPECT_EQ(2048, desc.object_size);
+    EXPECT_EQ(2, desc.replica_generation);
+}
+
+TEST_F(P2PMasterServiceTest, BatchRemoveReplicaSkipsStaleGeneration) {
+    auto service = CreateService();
+    auto seg = MakeP2PSegment();
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
+
+    AddReplicaHelper(*service, "key1", 1024, client_id, seg.id, 1);
+    AddReplicaHelper(*service, "key1", 2048, client_id, seg.id, 2);
+
+    BatchRemoveReplicaRequest req;
+    req.client_id = client_id;
+    req.removals = {BatchRemoveReplicaItem{"key1", seg.id, 1}};
+
+    auto results = service->BatchRemoveReplica(req);
+    ASSERT_EQ(1, results.size());
+    ASSERT_TRUE(results[0].has_value());
+
+    auto get_res = service->GetReplicaList("key1");
+    ASSERT_TRUE(get_res.has_value());
+    ASSERT_EQ(1, get_res->replicas.size());
+    const auto& desc = get_res->replicas[0].get_p2p_proxy_descriptor();
+    EXPECT_EQ(2, desc.replica_generation);
+    EXPECT_EQ(2048, desc.object_size);
+}
+
+TEST_F(P2PMasterServiceTest, RemoveReplicaSkipsStaleGeneration) {
+    auto service = CreateService();
+    auto seg = MakeP2PSegment();
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
+
+    AddReplicaHelper(*service, "key1", 1024, client_id, seg.id, 1);
+    AddReplicaHelper(*service, "key1", 2048, client_id, seg.id, 2);
+
+    RemoveReplicaRequest req;
+    req.key = "key1";
+    req.client_id = client_id;
+    req.segment_id = seg.id;
+    req.replica_generation = 1;
+
+    auto res = service->RemoveReplica(req);
+    ASSERT_TRUE(res.has_value());
+
+    auto get_res = service->GetReplicaList("key1");
+    ASSERT_TRUE(get_res.has_value());
+    ASSERT_EQ(1, get_res->replicas.size());
+    const auto& desc = get_res->replicas[0].get_p2p_proxy_descriptor();
+    EXPECT_EQ(2, desc.replica_generation);
+    EXPECT_EQ(2048, desc.object_size);
+}
+
 TEST_F(P2PMasterServiceTest, AddReplicaMaxLimit) {
     auto service = CreateService(/* max_replicas_per_key= */ 2);
     auto seg1 = MakeP2PSegment("seg1");
@@ -443,7 +542,7 @@ TEST_F(P2PMasterServiceTest, RemoveReplicaPartial) {
     EXPECT_EQ(1, get_res.value().replicas.size());
 }
 
-TEST_F(P2PMasterServiceTest, BatchMutateReplicaMixedPatterns) {
+TEST_F(P2PMasterServiceTest, BatchRemoveReplicaMixedPatterns) {
     auto service = CreateService();
     auto seg1 = MakeP2PSegment("seg1");
     auto seg2 = MakeP2PSegment("seg2");
@@ -455,17 +554,17 @@ TEST_F(P2PMasterServiceTest, BatchMutateReplicaMixedPatterns) {
     AddReplicaHelper(*service, "key2", 1024, client_id, seg1.id);
     AddReplicaHelper(*service, "key3", 1024, client_id, seg2.id);
 
-    BatchReplicaMutationRequest req;
+    BatchRemoveReplicaRequest req;
     req.client_id = client_id;
-    req.mutations = {
-        ReplicaMutation{ReplicaMutationType::REMOVE, "key1", seg1.id},
-        ReplicaMutation{ReplicaMutationType::REMOVE, "key1", seg2.id},
-        ReplicaMutation{ReplicaMutationType::REMOVE, "key2", seg1.id},
-        ReplicaMutation{ReplicaMutationType::REMOVE, "key3", seg2.id},
+    req.removals = {
+        BatchRemoveReplicaItem{"key1", seg1.id},
+        BatchRemoveReplicaItem{"key1", seg2.id},
+        BatchRemoveReplicaItem{"key2", seg1.id},
+        BatchRemoveReplicaItem{"key3", seg2.id},
     };
 
-    auto results = service->BatchMutateReplica(req);
-    ASSERT_EQ(results.size(), req.mutations.size());
+    auto results = service->BatchRemoveReplica(req);
+    ASSERT_EQ(results.size(), req.removals.size());
     for (const auto& result : results) {
         ASSERT_TRUE(result.has_value());
     }

--- a/mooncake-store/tests/scheduler_integration_test.cpp
+++ b/mooncake-store/tests/scheduler_integration_test.cpp
@@ -889,8 +889,8 @@ TEST_F(ConcurrencyTest, CASFailureNoCallbackInvoked) {
     // Re-init backend with a counting callback
     std::atomic<int> commit_count{0};
     AddReplicaCallback counting_cb =
-        [&commit_count](const std::string&, const UUID&,
-                        size_t) -> tl::expected<void, ErrorCode> {
+        [&commit_count](const std::string&, const UUID&, size_t,
+                        uint64_t) -> tl::expected<void, ErrorCode> {
         commit_count.fetch_add(1);
         return {};
     };

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -777,6 +777,64 @@ TEST_F(StorageBackendTest, BucketStoreMetadataTracksPhysicalBytes) {
     EXPECT_EQ(metadata_after_delete->total_size, 0);
 }
 
+TEST_F(StorageBackendTest, EvictOldBucketKeepsRecreatedKeyMapping) {
+    FileStorageConfig config;
+    config.storage_filepath = data_path;
+    BucketBackendConfig bucket_config;
+    BucketStorageBackend backend(config, bucket_config);
+    ASSERT_TRUE(backend.Init());
+
+    std::string old_value(1024, 'a');
+    std::unordered_map<std::string, std::vector<Slice>> old_batch = {
+        {"shared-key", {Slice{old_value.data(), old_value.size()}}},
+    };
+
+    auto old_offload_res = backend.BatchOffload(old_batch, nullptr);
+    ASSERT_TRUE(old_offload_res);
+    const int64_t old_bucket_id = old_offload_res.value();
+
+    ASSERT_TRUE(backend.MarkKeyDeleted("shared-key"));
+
+    std::string new_value(2048, 'b');
+    std::unordered_map<std::string, std::vector<Slice>> new_batch = {
+        {"shared-key", {Slice{new_value.data(), new_value.size()}}},
+    };
+
+    auto new_offload_res = backend.BatchOffload(new_batch, nullptr);
+    ASSERT_TRUE(new_offload_res);
+    const int64_t new_bucket_id = new_offload_res.value();
+    ASSERT_NE(new_bucket_id, old_bucket_id);
+
+    auto old_tokens = backend.GetBucketLiveReplicaTokens(old_bucket_id);
+    ASSERT_TRUE(old_tokens);
+    EXPECT_TRUE(old_tokens->empty());
+
+    auto new_tokens = backend.GetBucketLiveReplicaTokens(new_bucket_id);
+    ASSERT_TRUE(new_tokens);
+    ASSERT_EQ(new_tokens->size(), 1);
+    EXPECT_EQ(new_tokens->front().key, "shared-key");
+    EXPECT_EQ(new_tokens->front().bucket_id, new_bucket_id);
+
+    auto evict_res = backend.EvictBucket(old_bucket_id);
+    ASSERT_TRUE(evict_res);
+    EXPECT_EQ(evict_res.value(), 0);
+
+    EXPECT_TRUE(WaitForPathRemoved(
+        fs::path(data_path) / (std::to_string(old_bucket_id) + ".bucket")));
+    EXPECT_TRUE(WaitForPathRemoved(fs::path(data_path) /
+                                   (std::to_string(old_bucket_id) + ".meta")));
+
+    auto exist_res = backend.IsExist("shared-key");
+    ASSERT_TRUE(exist_res);
+    EXPECT_TRUE(exist_res.value());
+
+    std::unordered_map<std::string, StorageObjectMetadata> metadatas;
+    ASSERT_TRUE(backend.BatchQuery({"shared-key"}, metadatas));
+    ASSERT_EQ(metadatas.size(), 1);
+    EXPECT_EQ(metadatas.at("shared-key").bucket_id, new_bucket_id);
+    EXPECT_EQ(metadatas.at("shared-key").data_size, new_value.size());
+}
+
 TEST_F(StorageBackendTest, AdaptorMarkKeyDeletedReclaimsPhysicalBytes) {
     FileStorageConfig cfg;
     cfg.storage_filepath = data_path;

--- a/mooncake-store/tests/storage_tier_test.cpp
+++ b/mooncake-store/tests/storage_tier_test.cpp
@@ -28,10 +28,14 @@ class StorageTierTest : public ::testing::Test {
 
     void SetUp() override {
         unsetenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES");
+        unsetenv("MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT");
+        unsetenv("MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES");
     }
 
     void TearDown() override {
         unsetenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES");
+        unsetenv("MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT");
+        unsetenv("MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES");
     }
 
     std::unique_ptr<char[]> CreateTestBuffer(size_t size) {
@@ -585,6 +589,8 @@ TEST_F(StorageTierTest, AutoEvictionOnCapacityExceeded) {
            "bucket_storage_backend", 1);
     setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH",
            "/tmp/mooncake_test_auto_eviction", 1);
+    setenv("MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT", "5", 1);
+    setenv("MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES", "8192", 1);
 
     // Create a TieredBackend with small capacity (20KB)
     std::string json_config_str = R"({
@@ -602,7 +608,19 @@ TEST_F(StorageTierTest, AutoEvictionOnCapacityExceeded) {
 
     {
         TieredBackend backend;
-        auto init_res = InitTieredBackendForTest(backend, config);
+        std::vector<std::vector<std::string>> deleted_batches;
+        BatchReplicaMutationCallback batch_replica_mutation_callback =
+            [&deleted_batches](const UUID& tier_id,
+                               const std::vector<std::string>& keys) {
+                static_cast<void>(tier_id);
+                deleted_batches.push_back(keys);
+                return std::vector<tl::expected<void, ErrorCode>>(
+                    keys.size(), tl::expected<void, ErrorCode>{});
+            };
+
+        auto init_res =
+            InitTieredBackendForTest(backend, config, nullptr, nullptr, nullptr,
+                                     batch_replica_mutation_callback);
         ASSERT_TRUE(init_res.has_value());
 
         // Fill up the tier with data (~20KB)
@@ -645,6 +663,22 @@ TEST_F(StorageTierTest, AutoEvictionOnCapacityExceeded) {
             << "Should succeed after automatic eviction";
 
         LOG(INFO) << "Successfully allocated after auto-eviction";
+        ASSERT_FALSE(deleted_batches.empty())
+            << "bucket eviction should batch-sync keys before reclaim";
+
+        bool saw_multi_key_batch = false;
+        for (const auto& batch : deleted_batches) {
+            if (batch.size() > 1) {
+                saw_multi_key_batch = true;
+            }
+            for (const auto& key : batch) {
+                EXPECT_FALSE(backend.Exist(key))
+                    << "evicted key should be removed from tiered metadata: "
+                    << key;
+            }
+        }
+        EXPECT_TRUE(saw_multi_key_batch)
+            << "bucket eviction should notify master with batched keys";
 
         // The evicted keys should no longer be in the storage backend
         // (they were removed from the bucket that was evicted)

--- a/mooncake-store/tests/storage_tier_test.cpp
+++ b/mooncake-store/tests/storage_tier_test.cpp
@@ -609,18 +609,24 @@ TEST_F(StorageTierTest, AutoEvictionOnCapacityExceeded) {
     {
         TieredBackend backend;
         std::vector<std::vector<std::string>> deleted_batches;
-        BatchReplicaMutationCallback batch_replica_mutation_callback =
-            [&deleted_batches](const UUID& tier_id,
-                               const std::vector<std::string>& keys) {
+        BatchRemoveReplicaCallback batch_remove_replica_callback =
+            [&deleted_batches](
+                const UUID& tier_id,
+                const std::vector<ReplicaRemoveRequest>& requests) {
                 static_cast<void>(tier_id);
+                std::vector<std::string> keys;
+                keys.reserve(requests.size());
+                for (const auto& request : requests) {
+                    keys.push_back(request.key);
+                }
                 deleted_batches.push_back(keys);
                 return std::vector<tl::expected<void, ErrorCode>>(
-                    keys.size(), tl::expected<void, ErrorCode>{});
+                    requests.size(), tl::expected<void, ErrorCode>{});
             };
 
         auto init_res =
             InitTieredBackendForTest(backend, config, nullptr, nullptr, nullptr,
-                                     batch_replica_mutation_callback);
+                                     batch_remove_replica_callback);
         ASSERT_TRUE(init_res.has_value());
 
         // Fill up the tier with data (~20KB)
@@ -699,6 +705,97 @@ TEST_F(StorageTierTest, AutoEvictionOnCapacityExceeded) {
     fs::remove_all("/tmp/mooncake_test_auto_eviction");
 }
 
+TEST_F(StorageTierTest, BucketEvictionTokenSkipsRecreatedStorageReplica) {
+    fs::remove_all("/tmp/mooncake_test_bucket_token");
+    fs::create_directories("/tmp/mooncake_test_bucket_token");
+
+    setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
+           "bucket_storage_backend", 1);
+    setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH",
+           "/tmp/mooncake_test_bucket_token", 1);
+    setenv("MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT", "1", 1);
+    setenv("MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES", "4096", 1);
+
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "STORAGE",
+                "capacity": 1073741824,
+                "priority": 5,
+                "tags": ["ssd"]
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    {
+        TieredBackend backend;
+        auto init_res = InitTieredBackendForTest(backend, config);
+        ASSERT_TRUE(init_res.has_value())
+            << "Init failed: " << init_res.error();
+
+        auto storage_tier_id = backend.GetTierViews().front().id;
+        auto tier = backend.GetTier(storage_tier_id);
+        ASSERT_NE(tier, nullptr);
+
+        auto alloc_old = backend.Allocate(1024, storage_tier_id);
+        ASSERT_TRUE(alloc_old.has_value());
+        AllocationHandle old_handle = alloc_old.value();
+        auto raw_old = std::make_unique<char[]>(1024);
+        std::memset(raw_old.get(), 0x11, 1024);
+        DataSource old_source;
+        old_source.buffer =
+            std::make_unique<TempDRAMBuffer>(std::move(raw_old), 1024);
+        old_source.type = MemoryType::DRAM;
+        ASSERT_TRUE(backend.Write(old_source, old_handle).has_value());
+        ASSERT_TRUE(backend.Commit("race_key", old_handle).has_value());
+        ASSERT_TRUE(const_cast<CacheTier*>(tier)->Flush().has_value());
+
+        auto* old_storage_buffer =
+            dynamic_cast<StorageBuffer*>(old_handle->loc.data.buffer.get());
+        ASSERT_NE(old_storage_buffer, nullptr);
+        ASSERT_NE(old_storage_buffer->GetBucketId(), kInvalidBucketId);
+        int64_t old_bucket_id = old_storage_buffer->GetBucketId();
+
+        auto alloc_new = backend.Allocate(1024, storage_tier_id);
+        ASSERT_TRUE(alloc_new.has_value());
+        AllocationHandle new_handle = alloc_new.value();
+        auto raw_new = std::make_unique<char[]>(1024);
+        std::memset(raw_new.get(), 0x22, 1024);
+        DataSource new_source;
+        new_source.buffer =
+            std::make_unique<TempDRAMBuffer>(std::move(raw_new), 1024);
+        new_source.type = MemoryType::DRAM;
+        ASSERT_TRUE(backend.Write(new_source, new_handle).has_value());
+        ASSERT_TRUE(backend.Commit("race_key", new_handle).has_value());
+        ASSERT_TRUE(const_cast<CacheTier*>(tier)->Flush().has_value());
+
+        auto* new_storage_buffer =
+            dynamic_cast<StorageBuffer*>(new_handle->loc.data.buffer.get());
+        ASSERT_NE(new_storage_buffer, nullptr);
+        ASSERT_NE(new_storage_buffer->GetBucketId(), kInvalidBucketId);
+        ASSERT_NE(new_storage_buffer->GetBucketId(), old_bucket_id);
+
+        auto delete_res = backend.DeleteBatchFromEviction(
+            {StorageReplicaEvictionToken{"race_key", old_bucket_id}},
+            storage_tier_id);
+        ASSERT_TRUE(delete_res.has_value());
+
+        auto get_res = backend.Get("race_key", storage_tier_id);
+        ASSERT_TRUE(get_res.has_value())
+            << "old bucket token must not delete recreated storage replica";
+        EXPECT_EQ(get_res.value(), new_handle);
+        auto* visible_storage_buffer = dynamic_cast<StorageBuffer*>(
+            get_res.value()->loc.data.buffer.get());
+        ASSERT_NE(visible_storage_buffer, nullptr);
+        EXPECT_EQ(visible_storage_buffer->GetBucketId(),
+                  new_storage_buffer->GetBucketId());
+    }
+
+    fs::remove_all("/tmp/mooncake_test_bucket_token");
+}
+
 // ============================================================
 // Concurrency Tests
 // ============================================================
@@ -727,7 +824,8 @@ TEST_F(StorageTierTest, ConcurrentReadWrite) {
     ASSERT_TRUE(parseJsonString(json_config_str, config));
 
     TieredBackend backend;
-    auto init_res = backend.Init(config, nullptr, nullptr, nullptr, nullptr);
+    auto init_res =
+        backend.Init(config, nullptr, nullptr, nullptr, nullptr, nullptr);
     ASSERT_TRUE(init_res.has_value());
 
     // Phase 1: Concurrent writes

--- a/mooncake-store/tests/tiered_backend_test.cpp
+++ b/mooncake-store/tests/tiered_backend_test.cpp
@@ -111,6 +111,49 @@ class TieredBackendTest : public ::testing::Test {
 
         return handle;
     }
+
+    std::shared_ptr<TieredBackend::MetadataEntry> FindEntry(
+        TieredBackend& backend, const std::string& key) {
+        std::shared_lock<std::shared_mutex> map_lock(backend.map_mutex_);
+        auto it = backend.metadata_index_.find(key);
+        if (it == backend.metadata_index_.end()) {
+            return nullptr;
+        }
+        return it->second;
+    }
+
+    uint64_t GetEntryGeneration(
+        const std::shared_ptr<TieredBackend::MetadataEntry>& entry) {
+        std::shared_lock<std::shared_mutex> entry_lock(entry->mutex);
+        return entry->generation;
+    }
+
+    void ForceTombstoneEntry(TieredBackend& backend, const std::string& key) {
+        std::shared_ptr<TieredBackend::MetadataEntry> entry;
+        {
+            std::shared_lock<std::shared_mutex> map_lock(backend.map_mutex_);
+            auto it = backend.metadata_index_.find(key);
+            ASSERT_NE(it, backend.metadata_index_.end());
+            entry = it->second;
+        }
+
+        std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
+        entry->replicas.clear();
+        entry->version++;
+        entry->tombstone = true;
+    }
+
+    bool IsTombstoned(
+        const std::shared_ptr<TieredBackend::MetadataEntry>& entry) {
+        std::shared_lock<std::shared_mutex> entry_lock(entry->mutex);
+        return entry->tombstone;
+    }
+
+    void RunCleanup(TieredBackend& backend, const std::string& key,
+                    const std::shared_ptr<TieredBackend::MetadataEntry>& entry,
+                    uint64_t generation) {
+        backend.CleanupTombstonedEntry(key, entry, generation);
+    }
 };
 
 // Test basic DRAM tier initialization
@@ -713,6 +756,38 @@ TEST_F(TieredBackendTest, GetNonExistentKey) {
     EXPECT_EQ(get_result.error(), ErrorCode::OBJECT_NOT_FOUND);
 }
 
+TEST_F(TieredBackendTest, GetTreatsTombstonedEntryAsNotFound) {
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": 1073741824,
+                "priority": 10,
+                "allocator_type": "OFFSET"
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    TieredBackend backend;
+    ASSERT_TRUE(InitTieredBackendForTest(backend, config).has_value());
+
+    auto test_buffer = CreateTestBuffer(SMALL_DATA_SIZE);
+    auto handle_result =
+        AllocateAndWrite(backend, SMALL_DATA_SIZE, test_buffer.get());
+    ASSERT_TRUE(handle_result.has_value());
+    ASSERT_TRUE(
+        backend.Commit("tombstoned_key", handle_result.value()).has_value());
+
+    ForceTombstoneEntry(backend, "tombstoned_key");
+
+    auto get_result = backend.Get("tombstoned_key");
+    ASSERT_FALSE(get_result.has_value());
+    EXPECT_EQ(get_result.error(), ErrorCode::OBJECT_NOT_FOUND);
+    EXPECT_FALSE(backend.Exist("tombstoned_key"));
+}
+
 // Test get from specified tier
 TEST_F(TieredBackendTest, GetFromSpecifiedTier) {
     std::string json_config_str = R"({
@@ -963,6 +1038,175 @@ TEST_F(TieredBackendTest, DeleteAllReplicas) {
     auto get_result = backend.Get("delete_all_key");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(get_result.error(), ErrorCode::OBJECT_NOT_FOUND);
+}
+
+TEST_F(TieredBackendTest, DeleteBatchFromEvictionRemovesTierReplicasInBatch) {
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": 536870912,
+                "priority": 100,
+                "allocator_type": "OFFSET"
+            },
+            {
+                "type": "DRAM",
+                "capacity": 1073741824,
+                "priority": 50,
+                "allocator_type": "OFFSET"
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    TieredBackend backend;
+    ASSERT_TRUE(InitTieredBackendForTest(backend, config).has_value());
+
+    auto high_tier_id = GetTierIdByPriority(backend, 100);
+    auto low_tier_id = GetTierIdByPriority(backend, 50);
+    ASSERT_TRUE(high_tier_id.has_value());
+    ASSERT_TRUE(low_tier_id.has_value());
+
+    auto commit_to_tier = [&](const std::string& key, UUID tier_id) {
+        auto test_buffer = CreateTestBuffer(SMALL_DATA_SIZE);
+        auto handle = AllocateAndWrite(backend, SMALL_DATA_SIZE,
+                                       test_buffer.get(), tier_id);
+        ASSERT_TRUE(handle.has_value());
+        ASSERT_TRUE(backend.Commit(key, handle.value()).has_value());
+    };
+
+    commit_to_tier("evict_only_1", low_tier_id.value());
+    commit_to_tier("evict_only_2", low_tier_id.value());
+    commit_to_tier("survivor_key", high_tier_id.value());
+    commit_to_tier("survivor_key", low_tier_id.value());
+    commit_to_tier("high_only_key", high_tier_id.value());
+
+    auto delete_result = backend.DeleteBatchFromEviction(
+        std::vector<std::string>{"evict_only_1", "evict_only_2", "survivor_key",
+                                 "high_only_key", "missing_key"},
+        low_tier_id.value());
+    ASSERT_TRUE(delete_result.has_value());
+
+    EXPECT_FALSE(backend.Get("evict_only_1").has_value());
+    EXPECT_FALSE(backend.Get("evict_only_2").has_value());
+    EXPECT_EQ(FindEntry(backend, "evict_only_1"), nullptr);
+    EXPECT_EQ(FindEntry(backend, "evict_only_2"), nullptr);
+
+    auto survivor_high = backend.Get("survivor_key", high_tier_id.value());
+    ASSERT_TRUE(survivor_high.has_value());
+    auto survivor_low = backend.Get("survivor_key", low_tier_id.value());
+    ASSERT_FALSE(survivor_low.has_value());
+    EXPECT_EQ(survivor_low.error(), ErrorCode::TIER_NOT_FOUND);
+
+    auto survivor_default = backend.Get("survivor_key");
+    ASSERT_TRUE(survivor_default.has_value());
+    EXPECT_EQ(survivor_default.value()->loc.tier->GetTierId(),
+              high_tier_id.value());
+
+    auto high_only = backend.Get("high_only_key", high_tier_id.value());
+    ASSERT_TRUE(high_only.has_value());
+    EXPECT_TRUE(backend.Exist("high_only_key"));
+}
+
+TEST_F(TieredBackendTest, CommitReplacesTombstonedEntryWithNewGeneration) {
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": 1073741824,
+                "priority": 10,
+                "allocator_type": "OFFSET"
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    TieredBackend backend;
+    ASSERT_TRUE(InitTieredBackendForTest(backend, config).has_value());
+
+    auto first_buffer = CreateTestBuffer(SMALL_DATA_SIZE);
+    auto first_handle =
+        AllocateAndWrite(backend, SMALL_DATA_SIZE, first_buffer.get());
+    ASSERT_TRUE(first_handle.has_value());
+    ASSERT_TRUE(
+        backend.Commit("recreate_key", first_handle.value()).has_value());
+
+    auto old_entry = FindEntry(backend, "recreate_key");
+    ASSERT_TRUE(old_entry);
+    uint64_t old_generation = GetEntryGeneration(old_entry);
+
+    ForceTombstoneEntry(backend, "recreate_key");
+    ASSERT_TRUE(IsTombstoned(old_entry));
+
+    auto second_buffer = CreateTestBuffer(SMALL_DATA_SIZE);
+    auto second_handle =
+        AllocateAndWrite(backend, SMALL_DATA_SIZE, second_buffer.get());
+    ASSERT_TRUE(second_handle.has_value());
+    ASSERT_TRUE(
+        backend.Commit("recreate_key", second_handle.value()).has_value());
+
+    auto new_entry = FindEntry(backend, "recreate_key");
+    ASSERT_TRUE(new_entry);
+    EXPECT_NE(new_entry.get(), old_entry.get());
+    EXPECT_GT(GetEntryGeneration(new_entry), old_generation);
+
+    auto get_result = backend.Get("recreate_key");
+    ASSERT_TRUE(get_result.has_value());
+    EXPECT_EQ(get_result.value(), second_handle.value());
+}
+
+TEST_F(TieredBackendTest, StaleCleanupDoesNotEraseRecreatedEntry) {
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": 1073741824,
+                "priority": 10,
+                "allocator_type": "OFFSET"
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    TieredBackend backend;
+    ASSERT_TRUE(InitTieredBackendForTest(backend, config).has_value());
+
+    auto first_buffer = CreateTestBuffer(SMALL_DATA_SIZE);
+    auto first_handle =
+        AllocateAndWrite(backend, SMALL_DATA_SIZE, first_buffer.get());
+    ASSERT_TRUE(first_handle.has_value());
+    ASSERT_TRUE(
+        backend.Commit("cleanup_key", first_handle.value()).has_value());
+
+    auto old_entry = FindEntry(backend, "cleanup_key");
+    ASSERT_TRUE(old_entry);
+    uint64_t old_generation = GetEntryGeneration(old_entry);
+
+    ForceTombstoneEntry(backend, "cleanup_key");
+
+    auto second_buffer = CreateTestBuffer(SMALL_DATA_SIZE);
+    auto second_handle =
+        AllocateAndWrite(backend, SMALL_DATA_SIZE, second_buffer.get());
+    ASSERT_TRUE(second_handle.has_value());
+    ASSERT_TRUE(
+        backend.Commit("cleanup_key", second_handle.value()).has_value());
+
+    auto recreated_entry = FindEntry(backend, "cleanup_key");
+    ASSERT_TRUE(recreated_entry);
+    ASSERT_NE(recreated_entry.get(), old_entry.get());
+
+    RunCleanup(backend, "cleanup_key", old_entry, old_generation);
+
+    auto final_entry = FindEntry(backend, "cleanup_key");
+    ASSERT_TRUE(final_entry);
+    EXPECT_EQ(final_entry.get(), recreated_entry.get());
+
+    auto get_result = backend.Get("cleanup_key");
+    ASSERT_TRUE(get_result.has_value());
+    EXPECT_EQ(get_result.value(), second_handle.value());
 }
 
 // Test delete non-existent key

--- a/mooncake-store/tests/utils/common.h
+++ b/mooncake-store/tests/utils/common.h
@@ -68,12 +68,12 @@ inline tl::expected<void, ErrorCode> InitTieredBackendForTest(
     TransferEngine* engine = nullptr,
     AddReplicaCallback add_replica_callback = nullptr,
     RemoveReplicaCallback remove_replica_callback = nullptr,
-    BatchReplicaMutationCallback batch_replica_mutation_callback = nullptr,
+    BatchRemoveReplicaCallback batch_remove_replica_callback = nullptr,
     SegmentSyncCallback segment_sync_callback = nullptr) {
     return backend.Init(std::move(config), engine,
                         std::move(add_replica_callback),
                         std::move(remove_replica_callback),
-                        std::move(batch_replica_mutation_callback),
+                        std::move(batch_remove_replica_callback),
                         std::move(segment_sync_callback));
 }
 }  // namespace mooncake

--- a/mooncake-store/tests/utils/common.h
+++ b/mooncake-store/tests/utils/common.h
@@ -68,9 +68,12 @@ inline tl::expected<void, ErrorCode> InitTieredBackendForTest(
     TransferEngine* engine = nullptr,
     AddReplicaCallback add_replica_callback = nullptr,
     RemoveReplicaCallback remove_replica_callback = nullptr,
+    BatchReplicaMutationCallback batch_replica_mutation_callback = nullptr,
     SegmentSyncCallback segment_sync_callback = nullptr) {
-    return backend.Init(
-        std::move(config), engine, std::move(add_replica_callback),
-        std::move(remove_replica_callback), std::move(segment_sync_callback));
+    return backend.Init(std::move(config), engine,
+                        std::move(add_replica_callback),
+                        std::move(remove_replica_callback),
+                        std::move(batch_replica_mutation_callback),
+                        std::move(segment_sync_callback));
 }
 }  // namespace mooncake


### PR DESCRIPTION
## Description

  - Background
      - We had two separate batch delete paths in the P2P control plane:
      - one for key + segment_ids[]
      - one for segment_id + keys[]
      - They solved different calling patterns, but they encoded the same intent: batch replica metadata mutation.
      - This split leaked protocol details into higher layers and made the internal callback naming inconsistent with the actual
        semantics.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## What changed
    - Introduce a unified batch mutation protocol:
    - ReplicaMutationType
    - ReplicaMutation
    - BatchReplicaMutationRequest
    - Replace the two specialized batch RPCs with a single BatchMutateReplica(...) path across:
    - P2P master service
    - P2P master client
    - wrapped RPC service
    - P2P client service
    - Unify the internal tiered-backend callback naming to BatchReplicaMutationCallback.
    - Keep SSD bucket eviction on the same logical-delete flow:
    - collect live keys from the bucket
    - batch detach replicas from tiered metadata
    - batch notify master
    - physically evict the bucket asynchronously
    - Preserve idempotent behavior for replica deletion:
    - OBJECT_NOT_FOUND and REPLICA_NOT_FOUND are still treated as success in batch mutation handling.
## How Has This Been Tested?

      - Built:
      - cmake --build build --target mooncake_store p2p_master_service_test storage_tier_test -j8
      - Passed:
      - ctest --test-dir build --output-on-failure -R '^(p2p_master_service_test|storage_tier_test)$'
     
## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
