### PR TITLE
[bug fix]Inconsistent parameter of NVMeoFTransport::submitTransferTask

### DIFF
--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -106,7 +106,6 @@ Status NVMeoFTransport::getTransferStatus(BatchID batch_id, size_t task_id,
 
 // Dummy implement for solving build issues, WIP
 Status NVMeoFTransport::submitTransferTask(
-    const std::vector<TransferRequest *> &request_list,
     const std::vector<TransferTask *> &task_list) {
     /* TBD */
     return Status::OK();


### PR DESCRIPTION
## Description

[Fix this issue.](https://github.com/kvcache-ai/Mooncake/issues/1747)

## Module

- [ √ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ √ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Successful compilation.

## Checklist

- [ √ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
