### PR TITLE
[TENT] fix tebench RPATH to find libasio.so at runtime

### DIFF
--- a/mooncake-transfer-engine/benchmark/CMakeLists.txt
+++ b/mooncake-transfer-engine/benchmark/CMakeLists.txt
@@ -13,4 +13,4 @@ target_link_libraries(tebench PUBLIC transfer_engine tent)
 
 # Set RPATH for finding libasio.so at runtime
 set_target_properties(tebench PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                         INSTALL_RPATH "$ORIGIN/../lib")
+                                         INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/../../mooncake-asio")


### PR DESCRIPTION
## Description

Update tebench RPATH to include $ORIGIN/../../mooncake-asio so it can locate libasio.so during execution. This resolves the "libasio.so => not found" error when running tebench.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?


## Checklist

- [X] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
