### PR TITLE
[PG] Add GPU barrier support for mooncake-pg

### DIFF
--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -598,13 +598,21 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::alltoall(
 }
 c10::intrusive_ptr<c10d::Work> MooncakeBackend::barrier(
     const c10d::BarrierOptions& opts) {
-    TORCH_CHECK(isCpu_, "Barrier is available only for CPU.")
-    return worker_->putTaskCpu(
-        // a non-zero tensorSize is required to ensure the worker task for the
-        // barrier is created
-        c10d::OpType::BARRIER, kBarrierDummyTensorSize, 0, meta_,
-        connection_ctx_, [=](void*, size_t, size_t) {},
-        [=](void*, size_t, size_t) {});
+    if (isCpu_) {
+        return worker_->putTaskCpu(
+            // a non-zero tensorSize is required to ensure the worker task for
+            // the barrier is created
+            c10d::OpType::BARRIER, kBarrierDummyTensorSize, 0, meta_,
+            connection_ctx_, [=](void*, size_t, size_t) {},
+            [=](void*, size_t, size_t) {});
+    } else {
+        auto device_index = at::cuda::current_device();
+        auto stream = c10::cuda::getDefaultCUDAStream(device_index);
+        return worker_->putTaskCuda(
+            c10d::OpType::BARRIER, kBarrierDummyTensorSize, 0, meta_,
+            connection_ctx_, stream, [=](void*, size_t, size_t) {},
+            [=](void*, size_t, size_t) {});
+    }
 }
 
 c10::intrusive_ptr<c10d::Work> MooncakeBackend::reduce(

--- a/mooncake-wheel/tests/test_mooncake_backend.py
+++ b/mooncake-wheel/tests/test_mooncake_backend.py
@@ -42,6 +42,10 @@ def worker(rank, world_size, results, collective):
         dist.all_gather(gathered, tensor)
         results[rank] = [t.item() for t in gathered]
 
+    elif collective == "barrier":
+        dist.barrier()
+        results[rank] = "ok"
+
     elif collective == "gather":
         tensor = torch.tensor([rank], dtype=torch.int32, device="cuda")
         if rank == 0:
@@ -120,6 +124,9 @@ class TestMooncakeBackend(unittest.TestCase):
     def test_allgather(self):
         # Expected gather = [0, 1, 2, 3]
         self._spawn_and_check("all_gather", lambda size: list(range(size)))
+
+    def test_barrier(self):
+        self._spawn_and_check("barrier", lambda size: "ok")
 
     def test_gather(self):
         # Expected gather (Root) = [0, 1, 2, ..., size-1]


### PR DESCRIPTION
  ## Description

  Add GPU barrier support to `mooncake-pg` by routing `barrier()` through the CUDA
  task path instead of the CPU-only path.

  This PR also adds a PyTorch backend test for `dist.barrier()` in `mooncake-wheel/tests/test_mooncake_backend.py`.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [x] Python Wheel (`mooncake-wheel`)
  - [x] PyTorch Backend (`mooncake-pg`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Other

  ## How Has This Been Tested?

  - Added a barrier unit test in `mooncake-wheel/tests/test_mooncake_backend.py`
  - Manually reviewed the `mooncake-pg` barrier path to ensure the GPU backend
  routes through `putTaskCuda(...)`
  - Runtime validation on the GPU path is still being verified

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [ ] I have formatted my own code using `./scripts/code_format.sh` before
  submitting.
  - [ ] I have updated the documentation.
  - [x] I have added tests to prove my changes are effective.
