### PR TITLE
[Store] batch remove

### DIFF
--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -721,6 +721,39 @@ print(f"Removed {count} objects")
 
 ---
 
+#### batch_remove()
+Remove multiple objects by their keys in a single batch operation.
+
+```python
+def batch_remove(self, keys: List[str], force: bool = False) -> List[int]
+```
+
+**Parameters:**
+- `keys` (List[str]): List of object identifiers to remove
+- `force` (bool): If True, skip lease and replication task checks (default: False)
+
+**Returns:**
+- `List[int]`: List of status codes for each key (0 = success, negative = error code)
+
+**Example:**
+```python
+# Remove multiple keys in one batch
+keys = ["key1", "key2", "key3", "key4", "key5"]
+results = store.batch_remove(keys)
+
+# Check results
+for key, result in zip(keys, results):
+    if result == 0:
+        print(f"✓ {key} removed successfully")
+    else:
+        print(f"✗ {key} failed with error code: {result}")
+
+# Force remove (bypass lease checks)
+results = store.batch_remove(keys, force=True)
+```
+
+---
+
 #### is_exist()
 Check if an object exists in the storage system.
 

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1381,6 +1381,16 @@ PYBIND11_MODULE(store, m) {
             py::arg("force") = false,
             "Remove all objects from the store. If force=True, skip lease "
             "and replication task checks.")
+        .def(
+            "batch_remove",
+            [](MooncakeStorePyWrapper &self,
+               const std::vector<std::string> &keys, bool force) {
+                py::gil_scoped_release release;
+                return self.store_->batchRemove(keys, force);
+            },
+            py::arg("keys"), py::arg("force") = false,
+            "Batch remove objects by keys. Returns a list of status codes "
+            "(0=success, negative=error code) for each key.")
         .def("is_exist",
              [](MooncakeStorePyWrapper &self, const std::string &key) {
                  py::gil_scoped_release release;

--- a/mooncake-store/benchmarks/batch_remove_benchmark.py
+++ b/mooncake-store/benchmarks/batch_remove_benchmark.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+Batch Remove API Benchmark, Examples and Comprehensive Tests
+
+Usage:
+    # Run examples
+    python3 batch_remove_benchmark.py --mode example
+    
+    # Run performance benchmark
+    python3 batch_remove_benchmark.py --mode benchmark --key-counts 10 100 1000
+    
+    # Run comprehensive tests
+    python3 batch_remove_benchmark.py --mode test --test-mode all
+    
+    # Run specific test
+    python3 batch_remove_benchmark.py --mode test --test-mode basic
+"""
+
+import argparse
+import sys
+import time
+import statistics
+
+try:
+    from mooncake.store import MooncakeDistributedStore
+except ImportError:
+    print("Error: mooncake-transfer-engine not installed")
+    sys.exit(1)
+
+
+class BenchmarkDemo:
+    """Demonstrates batch_remove() API and performance benchmarking."""
+    
+    def __init__(self, master_addr, metadata_server):
+        self.store = MooncakeDistributedStore()
+        result = self.store.setup(
+            "localhost", metadata_server, 512*1024*1024, 128*1024*1024,
+            "tcp", "", master_addr
+        )
+        if result != 0:
+            raise RuntimeError(f"Setup failed: {result}")
+    
+    def close(self):
+        self.store.close()
+    
+    def example_basic_batch_remove(self):
+        """Basic batch_remove() example."""
+        print("\n=== Example: Basic Batch Remove ===")
+        keys = [f"user_data_{i}" for i in range(5)]
+        for key in keys:
+            self.store.put(key, b"user data")
+        
+        results = self.store.batch_remove(keys)
+        for key, result in zip(keys, results):
+            status = "✓ removed" if result == 0 else f"✗ error {result}"
+            print(f"  {key}: {status}")
+    
+    def benchmark(self, key_counts, iterations):
+        """Compare sequential vs batch remove performance."""
+        print("\n" + "="*60)
+        print("Batch Remove Performance Benchmark")
+        print("="*60)
+        
+        results = []
+        for count in key_counts:
+            print(f"\n--- Testing {count} keys ({iterations} iterations) ---")
+            seq_times, batch_times = [], []
+            
+            for i in range(iterations):
+                keys = [f"key_{count}_{i}_{j}" for j in range(count)]
+                
+                # Prepare data
+                for key in keys:
+                    self.store.put(key, b"x" * 1024)
+                
+                # Sequential
+                start = time.time()
+                for key in keys:
+                    self.store.remove(key)
+                seq_times.append(time.time() - start)
+                
+                # Prepare again
+                for key in keys:
+                    self.store.put(key, b"x" * 1024)
+                
+                # Batch
+                start = time.time()
+                self.store.batch_remove(keys)
+                batch_times.append(time.time() - start)
+            
+            seq_mean = statistics.mean(seq_times)
+            batch_mean = statistics.mean(batch_times)
+            speedup = seq_mean / batch_mean if batch_mean > 0 else 0
+            
+            results.append({
+                'count': count, 'seq': seq_mean, 
+                'batch': batch_mean, 'speedup': speedup
+            })
+            print(f"  Sequential: {seq_mean:.3f}s, Batch: {batch_mean:.3f}s, Speedup: {speedup:.2f}x")
+        
+        # Summary
+        print("\n" + "="*60)
+        print("SUMMARY")
+        print("="*60)
+        print(f"{'Keys':>8} | {'Sequential':>12} | {'Batch':>12} | {'Speedup':>8}")
+        print("-"*60)
+        for r in results:
+            print(f"{r['count']:>8} | {r['seq']:>12.3f} | {r['batch']:>12.3f} | {r['speedup']:>8.2f}x")
+
+
+class ComprehensiveTest:
+    """Comprehensive tests for batch_remove() API."""
+    
+    def __init__(self, master_addr, metadata_server):
+        self.store = MooncakeDistributedStore()
+        result = self.store.setup(
+            "localhost", metadata_server, 512*1024*1024, 128*1024*1024,
+            "tcp", "", master_addr
+        )
+        if result != 0:
+            raise RuntimeError(f"Setup failed: {result}")
+        self.passed = 0
+        self.failed = 0
+    
+    def close(self):
+        self.store.close()
+    
+    def assert_eq(self, actual, expected, msg=""):
+        """Helper: assert equal."""
+        if actual == expected:
+            self.passed += 1
+            print(f"  ✓ {msg}")
+            return True
+        else:
+            self.failed += 1
+            print(f"  ✗ {msg}")
+            print(f"    Expected: {expected}, Actual: {actual}")
+            return False
+    
+    def assert_true(self, condition, msg=""):
+        """Helper: assert true."""
+        if condition:
+            self.passed += 1
+            print(f"  ✓ {msg}")
+            return True
+        else:
+            self.failed += 1
+            print(f"  ✗ {msg}")
+            return False
+    
+    def test_basic_functionality(self):
+        """Test #1: Basic batch remove after put."""
+        print("\n=== Test #1: Basic Functionality ===")
+        
+        keys = [f"test_basic_{i}" for i in range(10)]
+        
+        # Put data
+        for key in keys:
+            self.store.put(key, b"test data")
+        
+        # Batch remove
+        results = self.store.batch_remove(keys)
+        
+        # Verify all succeeded
+        success = all(r == 0 for r in results)
+        self.assert_true(success, f"All {len(keys)} keys removed successfully")
+        self.assert_eq(len(results), len(keys), "Result count matches key count")
+    
+    def test_mixed_existence(self):
+        """Test #2: Mixed existing and non-existing keys."""
+        print("\n=== Test #2: Mixed Existence ===")
+        
+        # Create some keys
+        existing_keys = [f"test_mixed_exist_{i}" for i in range(3)]
+        for key in existing_keys:
+            self.store.put(key, b"data")
+        
+        non_existing_keys = [f"test_mixed_not_exist_{i}" for i in range(3)]
+        
+        # Mix them
+        keys = existing_keys + non_existing_keys
+        
+        results = self.store.batch_remove(keys)
+        
+        # Verify existing keys removed (return 0)
+        for i, key in enumerate(existing_keys):
+            self.assert_eq(results[i], 0, f"Existing key {key} removed (code 0)")
+        
+        # Verify non-existing keys return OBJECT_NOT_FOUND (negative)
+        for i, key in enumerate(non_existing_keys, start=3):
+            self.assert_true(results[i] < 0, 
+                           f"Non-existing key {key} returns negative error code")
+    
+    def test_empty_and_duplicate(self):
+        """Test #3: Empty key list and duplicate keys."""
+        print("\n=== Test #3: Edge Cases ===")
+        
+        # Empty list
+        results = self.store.batch_remove([])
+        self.assert_eq(len(results), 0, "Empty list returns empty results")
+        
+        # Duplicate keys
+        key = "test_duplicate_key"
+        self.store.put(key, b"data")
+        
+        keys = [key, key, key]  # Same key 3 times
+        results = self.store.batch_remove(keys)
+        
+        self.assert_eq(len(results), 3, "Duplicate keys return 3 results")
+        self.assert_eq(results[0], 0, "First remove succeeds")
+        # Second and third should fail (key already removed)
+        self.assert_true(results[1] < 0, "Second remove fails (not found)")
+        self.assert_true(results[2] < 0, "Third remove fails (not found)")
+    
+    def test_consistency_with_single_remove(self):
+        """Test #4: Error code consistency with single remove."""
+        print("\n=== Test #4: Consistency with Single Remove ===")
+        
+        # Test 1: Non-existing key
+        key = "test_consistency_nonexist"
+        
+        single_result = self.store.remove(key)
+        batch_results = self.store.batch_remove([key])
+        
+        self.assert_eq(single_result, batch_results[0],
+                      "Non-existing: Single and Batch return same error code")
+        
+        # Test 2: Existing key
+        key = "test_consistency_exist"
+        self.store.put(key, b"data")
+        
+        single_result = self.store.remove(key)
+        
+        key2 = "test_consistency_exist2"
+        self.store.put(key2, b"data")
+        batch_results = self.store.batch_remove([key2])
+        
+        self.assert_eq(single_result, batch_results[0],
+                      "Existing: Single and Batch return same code (0)")
+    
+    def test_error_code_format(self):
+        """Test #5: Error code format (should be ErrorCode enum values)."""
+        print("\n=== Test #5: Error Code Format ===")
+        
+        key = "test_error_format"
+        # Don't put, so it doesn't exist
+        
+        results = self.store.batch_remove([key])
+        error_code = results[0]
+        
+        # Should be negative (error)
+        self.assert_true(error_code < 0, 
+                        f"Error code is negative: {error_code}")
+        
+        # Should match known error codes (from types.h)
+        # OBJECT_NOT_FOUND = -704 typically
+        known_error_codes = [-704, -706, -707]  # Common error codes
+        self.assert_true(error_code in known_error_codes or error_code < 0,
+                        f"Error code {error_code} is a valid negative value")
+    
+    def test_large_batch(self):
+        """Test #6: Large batch performance."""
+        print("\n=== Test #6: Large Batch ===")
+        
+        count = 1000
+        keys = [f"test_large_{i}" for i in range(count)]
+        
+        # Prepare data
+        for key in keys:
+            self.store.put(key, b"x" * 1024)
+        
+        # Measure time
+        start = time.time()
+        results = self.store.batch_remove(keys)
+        elapsed = time.time() - start
+        
+        success_count = sum(1 for r in results if r == 0)
+        
+        self.assert_eq(success_count, count, 
+                      f"All {count} keys removed successfully")
+        self.assert_true(elapsed < 5.0, 
+                        f"Large batch completes in reasonable time ({elapsed:.2f}s)")
+        print(f"  Info: Removed {count} keys in {elapsed:.3f}s "
+              f"({count/elapsed:.0f} ops/sec)")
+    
+    def test_special_characters(self):
+        """Test #7: Keys with special characters."""
+        print("\n=== Test #7: Special Characters ===")
+        
+        special_keys = [
+            "key with spaces",
+            "key/with/slashes",
+            "key:with:colons",
+            "key#hash",
+            "key@at",
+            "unicode_中文",
+        ]
+        
+        for key in special_keys:
+            self.store.put(key, b"data")
+        
+        results = self.store.batch_remove(special_keys)
+        
+        success = all(r == 0 for r in results)
+        self.assert_true(success, "All special character keys handled correctly")
+    
+    def run_all_tests(self):
+        """Run all test cases."""
+        print("="*60)
+        print("Batch Remove Comprehensive Test Suite")
+        print("="*60)
+        
+        self.test_basic_functionality()
+        self.test_mixed_existence()
+        self.test_empty_and_duplicate()
+        self.test_consistency_with_single_remove()
+        self.test_error_code_format()
+        self.test_large_batch()
+        self.test_special_characters()
+        
+        # Summary
+        print("\n" + "="*60)
+        print("SUMMARY")
+        print("="*60)
+        total = self.passed + self.failed
+        print(f"Passed: {self.passed}/{total}")
+        print(f"Failed: {self.failed}/{total}")
+        
+        if self.failed == 0:
+            print("\n✓ All tests passed!")
+            return 0
+        else:
+            print(f"\n✗ {self.failed} test(s) failed")
+            return 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Batch Remove Benchmark, Examples & Comprehensive Tests'
+    )
+    parser.add_argument('--mode', 
+                       choices=['example', 'benchmark', 'test', 'all'], 
+                       default='all',
+                       help='Run mode: example=demo, benchmark=performance, test=functional, all=everything')
+    parser.add_argument('--test-mode',
+                       choices=['all', 'basic', 'consistency', 'edge', 'large', 'format'],
+                       default='all',
+                       help='Test mode (only used when --mode is test or all)')
+    parser.add_argument('--master', default='localhost:30051',
+                       help='Master server address (default: localhost:30051)')
+    parser.add_argument('--metadata', default='http://localhost:30080/metadata',
+                       help='Metadata server URL (default: http://localhost:30080/metadata)')
+    parser.add_argument('--key-counts', type=int, nargs='+', 
+                       default=[10, 50, 100, 500, 1000],
+                       help='Key counts for benchmark (default: 10 50 100 500 1000)')
+    parser.add_argument('--iterations', type=int, default=2,
+                       help='Iterations for benchmark (default: 2)')
+    args = parser.parse_args()
+    
+    exit_code = 0
+    
+    # Run examples
+    if args.mode in ['example', 'all']:
+        demo = BenchmarkDemo(args.master, args.metadata)
+        try:
+            demo.example_basic_batch_remove()
+        finally:
+            demo.close()
+    
+    # Run benchmark
+    if args.mode in ['benchmark', 'all']:
+        demo = BenchmarkDemo(args.master, args.metadata)
+        try:
+            demo.benchmark(args.key_counts, args.iterations)
+        finally:
+            demo.close()
+    
+    # Run tests
+    if args.mode in ['test', 'all']:
+        test = ComprehensiveTest(args.master, args.metadata)
+        try:
+            if args.test_mode == 'all':
+                exit_code = test.run_all_tests()
+            elif args.test_mode == 'basic':
+                test.test_basic_functionality()
+            elif args.test_mode == 'consistency':
+                test.test_consistency_with_single_remove()
+                test.test_error_code_format()
+            elif args.test_mode == 'edge':
+                test.test_mixed_existence()
+                test.test_empty_and_duplicate()
+                test.test_special_characters()
+            elif args.test_mode == 'large':
+                test.test_large_batch()
+            else:
+                print(f"Test mode {args.test_mode} not implemented")
+                exit_code = 1
+        finally:
+            test.close()
+    
+    sys.exit(exit_code)
+
+
+if __name__ == '__main__':
+    main()

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -228,6 +228,15 @@ class Client {
     tl::expected<long, ErrorCode> RemoveAll(bool force = false);
 
     /**
+     * @brief Batch remove objects and all their replicas
+     * @param keys List of keys to remove
+     * @param force If true, skip lease and replication task checks
+     * @return Vector of expected results for each key
+     */
+    std::vector<tl::expected<void, ErrorCode>> BatchRemove(
+        const std::vector<ObjectKey>& keys, bool force = false);
+
+    /**
      * @brief Notify master that a disk replica was evicted locally
      * @param key The evicted object key
      * @param replica_type DISK or LOCAL_DISK

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -108,6 +108,9 @@ class DummyClient : public PyClient {
 
     long removeAll(bool force = false);
 
+    std::vector<int> batchRemove(const std::vector<std::string> &keys,
+                                 bool force = false);
+
     int isExist(const std::string &key);
 
     std::vector<int> batchIsExist(const std::vector<std::string> &keys);

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -224,6 +224,15 @@ class MasterClient {
     [[nodiscard]] tl::expected<long, ErrorCode> RemoveAll(bool force = false);
 
     /**
+     * @brief Batch remove objects and all their replicas
+     * @param keys List of keys to remove
+     * @param force If true, skip lease and replication task checks
+     * @return Vector of expected results for each key
+     */
+    [[nodiscard]] std::vector<tl::expected<void, ErrorCode>> BatchRemove(
+        const std::vector<std::string>& keys, bool force = false);
+
+    /**
      * @brief Registers a segment to master for allocation
      * @param segment Segment to register
      * @return tl::expected<void, ErrorCode> indicating success/failure

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -336,6 +336,15 @@ class MasterService {
     long RemoveAll(bool force = false);
 
     /**
+     * @brief Batch remove objects and their replicas
+     * @param keys The list of keys to remove.
+     * @param force If true, skip lease and replication task checks.
+     * @return Vector of expected results for each key.
+     */
+    auto BatchRemove(const std::vector<std::string>& keys, bool force = false)
+        -> std::vector<tl::expected<void, ErrorCode>>;
+
+    /**
      * @brief Get the count of keys
      * @return The count of keys
      */

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -212,6 +212,9 @@ class PyClient {
 
     virtual long removeAll(bool force = false) = 0;
 
+    virtual std::vector<int> batchRemove(const std::vector<std::string> &keys,
+                                         bool force = false) = 0;
+
     virtual int isExist(const std::string &key) = 0;
 
     virtual std::vector<int> batchIsExist(

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -244,6 +244,9 @@ class RealClient : public PyClient {
 
     long removeAll(bool force = false);
 
+    std::vector<int> batchRemove(const std::vector<std::string> &keys,
+                                 bool force = false);
+
     int tearDownAll();
 
     int health_check() override;
@@ -485,6 +488,9 @@ class RealClient : public PyClient {
                                                          bool force = false);
 
     tl::expected<int64_t, ErrorCode> removeAll_internal(bool force = false);
+
+    std::vector<tl::expected<void, ErrorCode>> batchRemove_internal(
+        const std::vector<std::string> &keys, bool force = false);
 
     tl::expected<void, ErrorCode> tearDownAll_internal();
 

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -85,6 +85,9 @@ class WrappedMasterService {
 
     long RemoveAll(bool force = false);
 
+    std::vector<tl::expected<void, ErrorCode>> BatchRemove(
+        const std::vector<std::string>& keys, bool force = false);
+
     tl::expected<void, ErrorCode> MountSegment(const Segment& segment,
                                                const UUID& client_id);
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1755,6 +1755,11 @@ tl::expected<long, ErrorCode> Client::RemoveAll(bool force) {
     return master_client_.RemoveAll(force);
 }
 
+std::vector<tl::expected<void, ErrorCode>> Client::BatchRemove(
+    const std::vector<ObjectKey>& keys, bool force) {
+    return master_client_.BatchRemove(keys, force);
+}
+
 tl::expected<void, ErrorCode> Client::EvictDiskReplica(
     const std::string& key, ReplicaType replica_type) {
     return master_client_.EvictDiskReplica(key, replica_type);

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -557,6 +557,19 @@ long DummyClient::removeAll(bool force) {
         invoke_rpc<&RealClient::removeAll_internal, int64_t>(force));
 }
 
+std::vector<int> DummyClient::batchRemove(const std::vector<std::string>& keys,
+                                          bool force) {
+    auto internal_results =
+        invoke_batch_rpc<&RealClient::batchRemove_internal, void>(keys.size(),
+                                                                  keys, force);
+    std::vector<int> results;
+    results.reserve(internal_results.size());
+    for (const auto& result : internal_results) {
+        results.push_back(to_py_ret(result));
+    }
+    return results;
+}
+
 int DummyClient::isExist(const std::string& key) {
     auto result = invoke_rpc<&RealClient::isExist_internal, bool>(key);
 

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -108,6 +108,11 @@ struct RpcNameTraits<&WrappedMasterService::RemoveAll> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::BatchRemove> {
+    static constexpr const char* value = "BatchRemove";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::MountSegment> {
     static constexpr const char* value = "MountSegment";
 };
@@ -555,6 +560,17 @@ tl::expected<long, ErrorCode> MasterClient::RemoveAll(bool force) {
 
     auto result = invoke_rpc<&WrappedMasterService::RemoveAll, long>(force);
     timer.LogResponseExpected(result);
+    return result;
+}
+
+std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchRemove(
+    const std::vector<std::string>& keys, bool force) {
+    ScopedVLogTimer timer(1, "MasterClient::BatchRemove");
+    timer.LogRequest("keys_count=", keys.size(), ", force=", force);
+
+    auto result = invoke_batch_rpc<&WrappedMasterService::BatchRemove, void>(
+        keys.size(), keys, force);
+    timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1614,6 +1614,90 @@ long MasterService::RemoveAll(bool force) {
     return removed_count;
 }
 
+auto MasterService::BatchRemove(const std::vector<std::string>& keys,
+                                bool force)
+    -> std::vector<tl::expected<void, ErrorCode>> {
+    std::vector<tl::expected<void, ErrorCode>> results(keys.size());
+
+    // Group keys by shard to reduce lock contention
+    std::unordered_map<size_t,
+                       std::vector<std::pair<size_t, const std::string*>>>
+        keys_by_shard;
+    keys_by_shard.reserve(
+        std::min(keys.size(), static_cast<size_t>(kNumShards)));
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        size_t shard_idx = getShardIndex(keys[i]);
+        keys_by_shard[shard_idx].emplace_back(i, &keys[i]);
+    }
+
+    std::shared_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
+
+    // Process each shard once, acquiring lock per shard
+    for (auto& [shard_idx, key_group] : keys_by_shard) {
+        MetadataShardAccessorRW shard(this, shard_idx);
+        auto now = std::chrono::system_clock::now();
+
+        for (const auto& [original_idx, key_ptr] : key_group) {
+            const std::string& key = *key_ptr;
+            auto it = shard->metadata.find(key);
+
+            if (it == shard->metadata.end()) {
+                VLOG(1) << "key=" << key << ", error=object_not_found";
+                results[original_idx] =
+                    tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+                continue;
+            }
+
+            // Clean up stale replica handles (consistent with single Remove)
+            if (CleanupStaleHandles(it->second)) {
+                shard->processing_keys.erase(key);
+                shard->replication_tasks.erase(key);
+                shard->offloading_tasks.erase(key);
+                shard->metadata.erase(it);
+                results[original_idx] =
+                    tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+                continue;
+            }
+            if (!it->second.IsValid()) {
+                results[original_idx] =
+                    tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+                continue;
+            }
+
+            auto& metadata = it->second;
+
+            if (!force && !metadata.IsLeaseExpired(now)) {
+                VLOG(1) << "key=" << key << ", error=object_has_lease";
+                results[original_idx] =
+                    tl::make_unexpected(ErrorCode::OBJECT_HAS_LEASE);
+                continue;
+            }
+
+            if (!metadata.AllReplicas(&Replica::fn_is_completed)) {
+                LOG(ERROR) << "key=" << key << ", error=replica_not_ready";
+                results[original_idx] =
+                    tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+                continue;
+            }
+
+            if (shard->replication_tasks.contains(key)) {
+                LOG(ERROR) << "key=" << key
+                           << ", error=object_has_replication_task";
+                results[original_idx] =
+                    tl::make_unexpected(ErrorCode::OBJECT_HAS_REPLICATION_TASK);
+                continue;
+            }
+
+            // Remove object metadata
+            shard->metadata.erase(it);
+            results[original_idx] = {};  // Success
+        }
+    }
+
+    return results;
+}
+
 bool MasterService::CleanupStaleHandles(ObjectMetadata& metadata) {
     // Remove those with invalid allocators
     metadata.EraseReplicas([](const Replica& replica) {

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1122,6 +1122,32 @@ long RealClient::removeAll(bool force) {
     return to_py_ret(removeAll_internal(force));
 }
 
+std::vector<tl::expected<void, ErrorCode>> RealClient::batchRemove_internal(
+    const std::vector<std::string> &keys, bool force) {
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+    return client_->BatchRemove(keys, force);
+}
+
+std::vector<int> RealClient::batchRemove(const std::vector<std::string> &keys,
+                                         bool force) {
+    auto results = batchRemove_internal(keys, force);
+    std::vector<int> ret;
+    ret.reserve(results.size());
+
+    for (const auto &item : results) {
+        if (item.has_value()) {
+            ret.push_back(0);
+        } else {
+            ret.push_back(toInt(item.error()));
+        }
+    }
+    return ret;
+}
+
 tl::expected<bool, ErrorCode> RealClient::isExist_internal(
     const std::string &key) {
     if (!client_) {

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -31,6 +31,7 @@ void RegisterClientRpcService(coro_rpc::coro_rpc_server &server,
     server.register_handler<&RealClient::remove_internal>(&real_client);
     server.register_handler<&RealClient::removeByRegex_internal>(&real_client);
     server.register_handler<&RealClient::removeAll_internal>(&real_client);
+    server.register_handler<&RealClient::batchRemove_internal>(&real_client);
     server.register_handler<&RealClient::isExist_internal>(&real_client);
     server.register_handler<&RealClient::batchIsExist_internal>(&real_client);
     server.register_handler<&RealClient::getSize_internal>(&real_client);

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -683,6 +683,29 @@ long WrappedMasterService::RemoveAll(bool force) {
     return result;
 }
 
+std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchRemove(
+    const std::vector<std::string>& keys, bool force) {
+    ScopedVLogTimer timer(1, "BatchRemove");
+    const size_t total_keys = keys.size();
+    timer.LogRequest("keys_count=", total_keys, ", force=", force);
+    MasterMetricManager::instance().inc_remove_requests(total_keys);
+
+    auto results = master_service_.BatchRemove(keys, force);
+
+    size_t failure_count = 0;
+    for (const auto& result : results) {
+        if (!result.has_value()) {
+            failure_count++;
+        }
+    }
+    if (failure_count > 0) {
+        MasterMetricManager::instance().inc_remove_failures(failure_count);
+    }
+
+    timer.LogResponse("total=", total_keys, ", failures=", failure_count);
+    return results;
+}
+
 tl::expected<void, ErrorCode> WrappedMasterService::MountSegment(
     const Segment& segment, const UUID& client_id) {
     return execute_rpc(
@@ -1030,6 +1053,8 @@ void RegisterRpcService(
     server.register_handler<&mooncake::WrappedMasterService::RemoveByRegex>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::RemoveAll>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::BatchRemove>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::MountSegment>(
         &wrapped_master_service);

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_store_test(buffer_allocator_test buffer_allocator_test.cpp)
 add_store_test(allocation_strategy_test allocation_strategy_test.cpp)
 add_store_test(eviction_strategy_test eviction_strategy_test.cpp)
 add_store_test(master_service_test master_service_test.cpp)
+add_store_test(batch_remove_test batch_remove_test.cpp)
 add_store_test(master_service_ssd_test master_service_ssd_test.cpp)
 add_store_test(master_service_ssd_test_for_snapshot
                master_service_ssd_test_for_snapshot.cpp)
@@ -55,8 +56,8 @@ add_store_test(pybind_client_test pybind_client_test.cpp)
 add_store_test(ipv6_client_test ipv6_client_test.cpp)
 add_store_test(client_metrics_test client_metrics_test.cpp)
 add_store_test(serializer_test serializer_test.cpp)
-add_store_test(serializer_snapshot_store_test
-               serializer_snapshot_store_test.cpp)
+add_store_test(embedded_snapshot_catalog_store_test
+               ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store_test.cpp)
 add_store_test(zstd_util_test zstd_util_test.cpp)
 add_store_test(local_file_backend_test local_file_backend_test.cpp)
 add_store_test(file_util_test file_util_test.cpp)
@@ -83,14 +84,17 @@ if(STORE_USE_REDIS)
     target_link_libraries(high_availability_test PRIVATE
         ${MOONCAKE_STORE_HIREDIS_LIBRARY})
 
-    add_executable(redis_snapshot_store_test redis_snapshot_store_test.cpp)
-    target_include_directories(redis_snapshot_store_test PRIVATE
+    add_executable(redis_snapshot_catalog_store_test
+                   ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store_test.cpp)
+    target_include_directories(redis_snapshot_catalog_store_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
         ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
-    target_link_libraries(redis_snapshot_store_test
+    target_link_libraries(redis_snapshot_catalog_store_test
         PUBLIC mooncake_store transfer_engine cachelib_memory_allocator
                ${ETCD_WRAPPER_LIB} glog gflags ibverbs gtest pthread
         PRIVATE ${MOONCAKE_STORE_HIREDIS_LIBRARY})
-    add_test(NAME redis_snapshot_store_test COMMAND redis_snapshot_store_test)
+    add_test(NAME redis_snapshot_catalog_store_test
+             COMMAND redis_snapshot_catalog_store_test)
 endif()
 target_link_libraries(high_availability_test PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gtest gtest_main pthread)
 if (STORE_USE_ETCD OR STORE_USE_REDIS)

--- a/mooncake-store/tests/batch_remove_test.cpp
+++ b/mooncake-store/tests/batch_remove_test.cpp
@@ -1,0 +1,362 @@
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "allocator.h"
+#include "client_service.h"
+#include "test_server_helpers.h"
+#include "default_config.h"
+
+DEFINE_string(protocol, "tcp", "Transfer protocol: rdma|tcp");
+DEFINE_string(device_name, "", "Device name to use, valid if protocol=rdma");
+DEFINE_uint64(default_kv_lease_ttl, mooncake::DEFAULT_DEFAULT_KV_LEASE_TTL,
+              "Default lease time for kv objects, must be set to the "
+              "same as the master's default_kv_lease_ttl");
+
+namespace mooncake {
+namespace testing {
+
+class BatchRemoveTest : public ::testing::Test {
+   protected:
+    static std::shared_ptr<Client> CreateClient(const std::string& host_name) {
+        auto client_opt =
+            Client::Create(host_name,       // Local hostname
+                           "P2PHANDSHAKE",  // Metadata connection string
+                           FLAGS_protocol,  // Transfer protocol
+                           std::nullopt,  // RDMA device names (auto-discovery)
+                           master_address_  // Master server address (non-HA)
+            );
+
+        EXPECT_TRUE(client_opt.has_value())
+            << "Failed to create client with host_name: " << host_name;
+        if (!client_opt.has_value()) {
+            return nullptr;
+        }
+        return client_opt.value();
+    }
+
+    static void SetUpTestSuite() {
+        google::InitGoogleLogging("BatchRemoveTest");
+        FLAGS_logtostderr = 1;
+
+        if (getenv("PROTOCOL")) FLAGS_protocol = getenv("PROTOCOL");
+        if (getenv("DEVICE_NAME")) FLAGS_device_name = getenv("DEVICE_NAME");
+
+        LOG(INFO) << "Protocol: " << FLAGS_protocol
+                  << ", Device name: " << FLAGS_device_name;
+
+        if (getenv("DEFAULT_KV_LEASE_TTL")) {
+            default_kv_lease_ttl_ = std::stoul(getenv("DEFAULT_KV_LEASE_TTL"));
+        } else {
+            default_kv_lease_ttl_ = FLAGS_default_kv_lease_ttl;
+        }
+        LOG(INFO) << "Default KV lease TTL: " << default_kv_lease_ttl_;
+
+        ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder().build()));
+        master_address_ = master_.master_address();
+        LOG(INFO) << "Started in-proc master at " << master_address_
+                  << ", metadata=P2PHANDSHAKE";
+
+        InitializeClients();
+        InitializeSegment();
+    }
+
+    static void TearDownTestSuite() {
+        CleanupSegment();
+        CleanupClients();
+        master_.Stop();
+        google::ShutdownGoogleLogging();
+    }
+
+    static void InitializeSegment() {
+        ram_buffer_size_ = 512 * 1024 * 1024;
+        segment_ptr_ = allocate_buffer_allocator_memory(ram_buffer_size_);
+        LOG_ASSERT(segment_ptr_);
+        auto mount_result = segment_provider_client_->MountSegment(
+            segment_ptr_, ram_buffer_size_, FLAGS_protocol);
+        if (!mount_result.has_value()) {
+            LOG(ERROR) << "Failed to mount segment: "
+                       << toString(mount_result.error());
+        }
+        LOG(INFO) << "Segment mounted successfully";
+    }
+
+    static void InitializeClients() {
+        test_client_ = CreateClient("localhost:17813");
+        ASSERT_TRUE(test_client_ != nullptr);
+
+        segment_provider_client_ = CreateClient("localhost:17812");
+        ASSERT_TRUE(segment_provider_client_ != nullptr);
+
+        client_buffer_allocator_ =
+            std::make_unique<SimpleAllocator>(128 * 1024 * 1024);
+        auto register_result = test_client_->RegisterLocalMemory(
+            client_buffer_allocator_->getBase(), 128 * 1024 * 1024, "cpu:0",
+            false, false);
+        if (!register_result.has_value()) {
+            LOG(ERROR) << "Failed to register local memory: "
+                       << toString(register_result.error());
+        }
+
+        test_client_ram_buffer_size_ = 512 * 1024 * 1024;
+        test_client_segment_ptr_ =
+            allocate_buffer_allocator_memory(test_client_ram_buffer_size_);
+        LOG_ASSERT(test_client_segment_ptr_);
+        auto test_client_mount_result = test_client_->MountSegment(
+            test_client_segment_ptr_, test_client_ram_buffer_size_,
+            FLAGS_protocol);
+        if (!test_client_mount_result.has_value()) {
+            LOG(ERROR) << "Failed to mount segment for test_client_: "
+                       << toString(test_client_mount_result.error());
+        }
+        LOG(INFO) << "Test client segment mounted successfully";
+    }
+
+    static void CleanupClients() {
+        if (test_client_ && test_client_segment_ptr_) {
+            test_client_->UnmountSegment(test_client_segment_ptr_,
+                                         test_client_ram_buffer_size_);
+        }
+        test_client_.reset();
+        segment_provider_client_.reset();
+
+        if (test_client_segment_ptr_) free(test_client_segment_ptr_);
+        if (segment_ptr_) free(segment_ptr_);
+    }
+
+    static void CleanupSegment() {
+        segment_provider_client_->UnmountSegment(segment_ptr_,
+                                                 ram_buffer_size_);
+    }
+
+    void PutKey(const std::string& key, const std::string& data) {
+        void* buffer = client_buffer_allocator_->allocate(data.size());
+        memcpy(buffer, data.data(), data.size());
+        std::vector<Slice> slices;
+        slices.emplace_back(Slice{buffer, data.size()});
+        ReplicateConfig config;
+        config.replica_num = 1;
+        auto put_result = test_client_->Put(key, slices, config);
+        EXPECT_TRUE(put_result.has_value())
+            << "Put operation failed: " << toString(put_result.error());
+        client_buffer_allocator_->deallocate(buffer, data.size());
+    }
+
+    static std::shared_ptr<Client> test_client_;
+    static std::shared_ptr<Client> segment_provider_client_;
+    static std::unique_ptr<SimpleAllocator> client_buffer_allocator_;
+    static void* segment_ptr_;
+    static size_t ram_buffer_size_;
+    static void* test_client_segment_ptr_;
+    static size_t test_client_ram_buffer_size_;
+    static uint64_t default_kv_lease_ttl_;
+    static InProcMaster master_;
+    static std::string master_address_;
+};
+
+// Static members initialization
+std::shared_ptr<Client> BatchRemoveTest::test_client_ = nullptr;
+std::shared_ptr<Client> BatchRemoveTest::segment_provider_client_ = nullptr;
+void* BatchRemoveTest::segment_ptr_ = nullptr;
+void* BatchRemoveTest::test_client_segment_ptr_ = nullptr;
+std::unique_ptr<SimpleAllocator> BatchRemoveTest::client_buffer_allocator_ =
+    nullptr;
+size_t BatchRemoveTest::ram_buffer_size_ = 0;
+size_t BatchRemoveTest::test_client_ram_buffer_size_ = 0;
+uint64_t BatchRemoveTest::default_kv_lease_ttl_ = 0;
+InProcMaster BatchRemoveTest::master_;
+std::string BatchRemoveTest::master_address_;
+
+// Test #1: Basic batch remove after put
+TEST_F(BatchRemoveTest, BasicFunctionality) {
+    std::vector<std::string> keys;
+    for (int i = 0; i < 10; ++i) {
+        keys.push_back("test_basic_" + std::to_string(i));
+        PutKey(keys.back(), "test data");
+    }
+
+    auto results = test_client_->BatchRemove(keys);
+
+    ASSERT_EQ(results.size(), keys.size());
+    for (size_t i = 0; i < results.size(); ++i) {
+        EXPECT_TRUE(results[i].has_value())
+            << "Failed to remove key " << keys[i] << ": "
+            << toString(results[i].error());
+    }
+}
+
+// Test #2: Mixed existing and non-existing keys
+TEST_F(BatchRemoveTest, MixedExistence) {
+    std::vector<std::string> existing_keys;
+    for (int i = 0; i < 3; ++i) {
+        existing_keys.push_back("test_mixed_exist_" + std::to_string(i));
+        PutKey(existing_keys.back(), "data");
+    }
+
+    std::vector<std::string> non_existing_keys;
+    for (int i = 0; i < 3; ++i) {
+        non_existing_keys.push_back("test_mixed_not_exist_" +
+                                    std::to_string(i));
+    }
+
+    std::vector<std::string> keys = existing_keys;
+    keys.insert(keys.end(), non_existing_keys.begin(), non_existing_keys.end());
+
+    auto results = test_client_->BatchRemove(keys);
+
+    ASSERT_EQ(results.size(), keys.size());
+    // Verify existing keys removed (have value)
+    for (size_t i = 0; i < existing_keys.size(); ++i) {
+        EXPECT_TRUE(results[i].has_value())
+            << "Existing key " << existing_keys[i] << " should be removed";
+    }
+    // Verify non-existing keys return error
+    for (size_t i = existing_keys.size(); i < results.size(); ++i) {
+        EXPECT_FALSE(results[i].has_value())
+            << "Non-existing key " << keys[i] << " should return error";
+    }
+}
+
+// Test #3: Empty key list and duplicate keys
+TEST_F(BatchRemoveTest, EmptyAndDuplicate) {
+    // Empty list
+    std::vector<std::string> empty_keys;
+    auto results = test_client_->BatchRemove(empty_keys);
+    EXPECT_EQ(results.size(), 0);
+
+    // Duplicate keys
+    std::string key = "test_duplicate_key";
+    PutKey(key, "data");
+
+    std::vector<std::string> dup_keys = {key, key, key};
+    results = test_client_->BatchRemove(dup_keys);
+
+    ASSERT_EQ(results.size(), 3);
+    EXPECT_TRUE(results[0].has_value()) << "First remove should succeed";
+    // Second and third should fail (key already removed)
+    EXPECT_FALSE(results[1].has_value())
+        << "Second remove should fail (not found)";
+    EXPECT_FALSE(results[2].has_value())
+        << "Third remove should fail (not found)";
+}
+
+// Test #4: Error code consistency with single remove
+TEST_F(BatchRemoveTest, ConsistencyWithSingleRemove) {
+    // Test non-existing key
+    std::string key1 = "test_consistency_nonexist";
+
+    auto single_result = test_client_->Remove(key1);
+    auto batch_results = test_client_->BatchRemove({key1});
+
+    ASSERT_EQ(batch_results.size(), 1);
+    // Both should fail
+    EXPECT_FALSE(single_result.has_value());
+    EXPECT_FALSE(batch_results[0].has_value());
+    // Error codes should match
+    EXPECT_EQ(single_result.error(), batch_results[0].error());
+
+    // Test existing key
+    std::string key2 = "test_consistency_exist";
+    PutKey(key2, "data");
+
+    single_result = test_client_->Remove(key2);
+
+    std::string key3 = "test_consistency_exist2";
+    PutKey(key3, "data");
+    batch_results = test_client_->BatchRemove({key3});
+
+    ASSERT_EQ(batch_results.size(), 1);
+    EXPECT_TRUE(single_result.has_value())
+        << "Single remove should succeed for existing key";
+    EXPECT_TRUE(batch_results[0].has_value())
+        << "Batch remove should succeed for existing key";
+}
+
+// Test #5: Error code format (should be ErrorCode enum values)
+TEST_F(BatchRemoveTest, ErrorCodeFormat) {
+    std::string key = "test_error_format";
+    // Don't put, so it doesn't exist
+
+    auto results = test_client_->BatchRemove({key});
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_FALSE(results[0].has_value());
+    // Error code should be a valid ErrorCode value
+    ErrorCode error_code = results[0].error();
+    EXPECT_TRUE(error_code == ErrorCode::OBJECT_NOT_FOUND ||
+                error_code == ErrorCode::RPC_FAIL)
+        << "Error code should be a valid ErrorCode value, got: "
+        << static_cast<int>(error_code);
+}
+
+// Test #6: Large batch performance
+TEST_F(BatchRemoveTest, LargeBatch) {
+    const int count = 1000;
+    const std::string data(1024, 'x');
+    std::vector<std::string> keys;
+    keys.reserve(count);
+
+    // Prepare data
+    for (int i = 0; i < count; ++i) {
+        keys.push_back("test_large_" + std::to_string(i));
+        PutKey(keys.back(), data);
+    }
+
+    // Measure time
+    auto start = std::chrono::high_resolution_clock::now();
+    auto results = test_client_->BatchRemove(keys);
+    auto end = std::chrono::high_resolution_clock::now();
+
+    std::chrono::duration<double> elapsed = end - start;
+
+    ASSERT_EQ(results.size(), count);
+    int success_count = 0;
+    for (const auto& result : results) {
+        if (result.has_value()) success_count++;
+    }
+    EXPECT_EQ(success_count, count)
+        << "All " << count << " keys should be removed";
+    EXPECT_LT(elapsed.count(), 5.0)
+        << "Large batch should complete in reasonable time (" << elapsed.count()
+        << "s)";
+    LOG(INFO) << "Removed " << count << " keys in " << elapsed.count() << "s ("
+              << count / elapsed.count() << " ops/sec)";
+}
+
+// Test #7: Keys with special characters
+TEST_F(BatchRemoveTest, SpecialCharacters) {
+    std::vector<std::string> special_keys = {
+        "key with spaces",
+        "key/with/slashes",
+        "key:with:colons",
+        "key#hash",
+        "key@at",
+        "unicode_\xE4\xB8\xAD\xE6\x96\x87",  // UTF-8 encoded "中文"
+    };
+
+    for (const auto& key : special_keys) {
+        PutKey(key, "data");
+    }
+
+    auto results = test_client_->BatchRemove(special_keys);
+
+    ASSERT_EQ(results.size(), special_keys.size());
+    for (size_t i = 0; i < results.size(); ++i) {
+        EXPECT_TRUE(results[i].has_value())
+            << "Failed to remove key: " << special_keys[i];
+    }
+}
+
+}  // namespace testing
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

This PR introduces a new batch remove API to Mooncake Store for efficient bulk deletion of objects:

- `batch_remove(keys, force)` - Remove multiple objects by their keys in a single RPC call

These APIs significantly improve performance for bulk deletion scenarios by reducing RPC round trips, especially beneficial in distributed deployments with network latency.

**Motivation:**
Previously, users needed to call `remove()` in a loop to delete multiple objects, causing:
1. Multiple RPC round trips and network overhead
2. Complex error handling (tracking which keys failed)
3. Reduced overall throughput

The batch APIs solve these issues with per-key/per-pattern error reporting and optimized RPC handling.

**API Return Values:**
- `batch_remove`: Returns `List[int]` where `0=success`, negative values are error codes


## Module
- [x] Mooncake Store (`mooncake-store`)
- [x] Integration (`mooncake-integration`)
- [x] Python Wheel (`mooncake-wheel`)
- [x] Docs

## Type of Change
- [x] New feature


## How Has This Been Tested?

### Performance Benchmark

Added `mooncake-store/tests/batch_remove_benchmark.py` for comprehensive performance testing.

**Complete Testing Workflow:**

```bash
# 1. Build the project
mkdir build && cd build
cmake .. 
make -j32
sudo make install

# 2. Clean up ports if needed
for port in 30051 30080 30013; do
    pid=$(netstat -tlnp 2>/dev/null | grep ":$port " | awk '{print $7}' | cut -d'/' -f1)
    [ -n "$pid" ] && kill -9 $pid 2>/dev/null
done

# 3. Start mooncake_master
./build/mooncake-store/src/mooncake_master \
    --rpc_port=30051 \
    --enable_http_metadata_server=true \
    --http_metadata_server_port=30080 \
    --metrics_port=30013

# 4. Run performance benchmark (in another terminal)
cd mooncake-store/tests
python3 batch_remove_benchmark.py \
    --master localhost:30051 \
    --metadata http://localhost:30080/metadata \
    --key-counts 10 100 1000 \
    --iterations 10
```

**Results:**
```
============================================================
Batch Remove Performance Benchmark
============================================================

--- Testing 10 keys (10 iterations) ---
  Sequential: 0.001s, Batch: 0.000s, Speedup: 7.33x

--- Testing 100 keys (10 iterations) ---
  Sequential: 0.010s, Batch: 0.000s, Speedup: 35.76x

--- Testing 1000 keys (10 iterations) ---
  Sequential: 0.093s, Batch: 0.002s, Speedup: 57.65x

============================================================
SUMMARY
============================================================
    Keys |   Sequential |        Batch |  Speedup
------------------------------------------------------------
      10 |        0.001 |        0.000 |     7.33x
     100 |        0.010 |        0.000 |    35.76x
    1000 |        0.093 |        0.002 |    57.65x
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.