### PR TITLE
[tent] Set Auto_Connect as default

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/ascend/ascend_direct_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/ascend/ascend_direct_transport.h
@@ -17,7 +17,6 @@
 
 #include <functional>
 #include <iostream>
-#include <queue>
 #include <string>
 
 #include <acl/acl.h>
@@ -38,7 +37,6 @@ struct HixlTask {
     uint64_t batch_size = 0;
     std::string remote_hixl;
     uint64_t start_time = 0;
-    bool sync = false;
 };
 
 struct HixlSubBatch : public Transport::SubBatch {
@@ -78,8 +76,6 @@ class AscendDirectTransport : public Transport {
     virtual const char *getName() const { return "ascend_direct"; }
 
    private:
-    void workerThread();
-
     Status initHixl(const std::shared_ptr<Config> &conf);
 
     Status checkAndConnect(const std::string &remote_hixl);
@@ -87,7 +83,7 @@ class AscendDirectTransport : public Transport {
     void disconnect(const std::string &remote_hixl, int32_t timeout_in_millis);
 
     void startTransfer(SegmentID target_id, Request::OpCode opcode,
-                       const std::vector<HixlTask *> &tasks, bool sync = false);
+                       const std::vector<HixlTask *> &tasks);
 
     void localCopy(Request::OpCode opcode,
                    const std::vector<HixlTask *> &tasks);
@@ -114,8 +110,7 @@ class AscendDirectTransport : public Transport {
     int32_t device_logic_id_{};
     aclrtContext rt_context_{nullptr};
     std::unique_ptr<hixl::Hixl> hixl_;
-    bool use_buffer_pool_{false};
-    bool auto_connect_{false};
+    bool auto_connect_{true};
     uint64_t connect_timeout_;
     uint64_t transfer_timeout_;
     std::string local_hixl_name_{};
@@ -132,12 +127,6 @@ class AscendDirectTransport : public Transport {
 
     std::map<uint64_t, hixl::MemHandle> addr_to_mem_handle_;
     std::mutex mem_handle_mutex_;
-
-    std::atomic_bool running_ = false;
-    std::mutex queue_mutex_;
-    std::condition_variable queue_cv_;
-    std::queue<std::vector<HixlTask *>> task_queue_;
-    std::thread worker_thread_;
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/ascend/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/ascend/ascend_direct_transport.cpp
@@ -20,6 +20,7 @@
 #include <iomanip>
 #include <memory>
 #include <random>
+#include <string>
 
 #include <bits/stdint-uintn.h>
 #include <glog/logging.h>
@@ -33,6 +34,20 @@ namespace tent {
 namespace {
 constexpr size_t MEM_CPY_LIMIT = 4096;
 constexpr int BASE_PORT = 20000;
+std::string hixlTransferStatusToString(hixl::TransferStatus status) {
+    switch (status) {
+        case hixl::TransferStatus::WAITING:
+            return "WAITING";
+        case hixl::TransferStatus::COMPLETED:
+            return "COMPLETED";
+        case hixl::TransferStatus::TIMEOUT:
+            return "TIMEOUT";
+        case hixl::TransferStatus::FAILED:
+            return "FAILED";
+        default:
+            return "UNKNOWN(" + std::to_string(static_cast<int>(status)) + ")";
+    }
+}
 uint16_t findListenPort(int32_t dev_id) {
     char *rt_visible_devices = std::getenv("ASCEND_RT_VISIBLE_DEVICES");
     if (rt_visible_devices) {
@@ -95,41 +110,7 @@ uint16_t findListenPort(int32_t dev_id) {
 }  // namespace
 AscendDirectTransport::AscendDirectTransport() : installed_(false) {}
 
-void AscendDirectTransport::workerThread() {
-    LOG(INFO) << "AscendDirectTransport worker thread started";
-    auto ret = aclrtSetCurrentContext(rt_context_);
-    if (ret) {
-        LOG(ERROR) << "Call aclrtSetCurrentContext failed, ret: " << ret;
-        return;
-    }
-    while (running_) {
-        std::vector<HixlTask *> task_list;
-        {
-            std::unique_lock<std::mutex> lock(queue_mutex_);
-            queue_cv_.wait(
-                lock, [this] { return !running_ || !task_queue_.empty(); });
-            if (!running_) {
-                break;
-            }
-            task_list = std::move(task_queue_.front());
-            task_queue_.pop();
-        }
-        if (task_list.empty()) {
-            LOG(ERROR) << "Empty transfer request batch";
-            continue;
-        }
-        startTransfer(task_list[0]->request.target_id,
-                      task_list[0]->request.opcode, task_list, true);
-    }
-    LOG(INFO) << "AscendDirectTransport worker thread stopped";
-}
-
 AscendDirectTransport::~AscendDirectTransport() {
-    running_ = false;
-    queue_cv_.notify_one();
-    if (worker_thread_.joinable()) {
-        worker_thread_.join();
-    }
     hixl_->Finalize();
     uninstall();
 }
@@ -210,18 +191,14 @@ Status AscendDirectTransport::initHixl(const std::shared_ptr<Config> &conf) {
     }
     std::string auto_connect =
         conf->get("transports/ascend_direct/auto_connect", "");
-    auto auto_connect_opt = parseFromString<int32_t>(auto_connect);
-    if (auto_connect_opt.has_value()) {
-        auto_connect_ = (*auto_connect_opt == 1);
+    if (!auto_connect.empty()) {
+        auto_connect_ = (auto_connect == "1");
         options["AutoConnect"] = auto_connect_ ? "1" : "0";
         LOG(INFO) << "Set AutoConnect to: " << auto_connect;
-    }
-    std::string buffer_pool =
-        conf->get("transports/ascend_direct/buffer_pool", "");
-    if (!buffer_pool.empty()) {
-        options["BufferPool"] = buffer_pool.c_str();
-        use_buffer_pool_ = true;
-        LOG(INFO) << "Set BufferPool to:" << buffer_pool;
+    } else {
+        options["AutoConnect"] = "1";
+        auto_connect_ = true;
+        LOG(INFO) << "Set AutoConnect to default: 1";
     }
     auto status =
         hixl_->Initialize(hixl::AscendString(hixl_name.c_str()), options);
@@ -239,8 +216,6 @@ Status AscendDirectTransport::initHixl(const std::shared_ptr<Config> &conf) {
     }
     LOG(INFO) << "Success to initialize hixl engine:" << hixl_name
               << " with device_id:" << device_logic_id_;
-    running_ = true;
-    worker_thread_ = std::thread(&AscendDirectTransport::workerThread, this);
     return Status::OK();
 }
 
@@ -289,22 +264,13 @@ Status AscendDirectTransport::submitTransferTasks(
         task.target_addr = target_addr;
         task.request = request;
         task.status_word = TransferStatusEnum::PENDING;
-        task.sync = use_buffer_pool_;
         task.transferred_bytes = 0;
         seg_to_tasks[task.request.target_id][task.request.opcode].push_back(
             &task);
     }
     for (auto &[seg_id, op_to_tasks] : seg_to_tasks) {
         for (auto &[opcode, tasks] : op_to_tasks) {
-            if (use_buffer_pool_) {
-                {
-                    std::lock_guard<std::mutex> lock(queue_mutex_);
-                    task_queue_.push(tasks);
-                }
-                queue_cv_.notify_one();
-            } else {
-                startTransfer(seg_id, opcode, tasks);
-            }
+            startTransfer(seg_id, opcode, tasks);
         }
     }
     return Status::OK();
@@ -337,10 +303,9 @@ Status AscendDirectTransport::checkAndConnect(const std::string &remote_hixl) {
     return Status::OK();
 }
 
-void AscendDirectTransport::startTransfer(SegmentID target_id,
-                                          Request::OpCode opcode,
-                                          const std::vector<HixlTask *> &tasks,
-                                          bool sync) {
+void AscendDirectTransport::startTransfer(
+    SegmentID target_id, Request::OpCode opcode,
+    const std::vector<HixlTask *> &tasks) {
     std::string rpc_server_addr;
     SegmentDesc *desc = nullptr;
     auto status = metadata_->segmentManager().getRemoteCached(desc, target_id);
@@ -354,9 +319,6 @@ void AscendDirectTransport::startTransfer(SegmentID target_id,
     auto remote_hixl = detail.device_attrs["hixl_name"];
     if (remote_hixl == local_hixl_name_) {
         VLOG(1) << "Target is local.";
-        for (auto &task : tasks) {
-            task->sync = true;
-        }
         auto start = std::chrono::steady_clock::now();
         localCopy(opcode, tasks);
         LOG(INFO) << "Local copy cost: "
@@ -386,15 +348,8 @@ void AscendDirectTransport::startTransfer(SegmentID target_id,
     }
     hixl::Status hixl_ret;
     hixl::TransferReq req_handle;
-    if (sync) {
-        hixl_ret = hixl_->TransferSync(
-            hixl::AscendString(remote_hixl.c_str()), op, op_descs,
-            static_cast<int32_t>(transfer_timeout_ / 1000));
-    } else {
-        hixl_ret =
-            hixl_->TransferAsync(hixl::AscendString(remote_hixl.c_str()), op,
-                                 op_descs, hixl::TransferArgs(), req_handle);
-    }
+    hixl_ret = hixl_->TransferAsync(hixl::AscendString(remote_hixl.c_str()), op,
+                                    op_descs, hixl::TransferArgs(), req_handle);
     if (hixl_ret != hixl::SUCCESS) {
         LOG(ERROR) << "Failed to transfer to: " << remote_hixl
                    << ", status: " << hixl_ret
@@ -411,8 +366,7 @@ void AscendDirectTransport::startTransfer(SegmentID target_id,
         task->req_handle = req_handle;
         task->batch_size = tasks.size();
         task->remote_hixl = remote_hixl;
-        task->status_word =
-            sync ? TransferStatusEnum::COMPLETED : TransferStatusEnum::PENDING;
+        task->status_word = TransferStatusEnum::PENDING;
     }
 }
 
@@ -424,10 +378,10 @@ Status AscendDirectTransport::getTransferStatus(SubBatchRef batch, int task_id,
     }
     auto &task = hixl_batch->task_list[task_id];
     status = TransferStatus{task.status_word, task.transferred_bytes};
-    if (task.sync) {
-        return Status::OK();
-    }
     if (task.status_word == TransferStatusEnum::PENDING) {
+        if (task.req_handle == nullptr) {
+            return Status::OK();
+        }
         std::lock_guard<std::mutex> lock(req_mutex_);
         auto it = req_map_.find(task.req_handle);
         if (it != req_map_.end()) {
@@ -464,7 +418,8 @@ Status AscendDirectTransport::getTransferStatus(SubBatchRef batch, int task_id,
             task.transferred_bytes = task.request.length;
             task.status_word = TransferStatusEnum::COMPLETED;
         } else if (xfer_status == hixl::TransferStatus::FAILED) {
-            LOG(ERROR) << "Get transfer status failed, ret: " << xfer_status
+            LOG(ERROR) << "Get transfer status failed, ret: "
+                       << hixlTransferStatusToString(xfer_status)
                        << ", errmsg: " << aclGetRecentErrMsg();
             disconnect(task.remote_hixl, 10);
             task.status_word = TransferStatusEnum::FAILED;


### PR DESCRIPTION
…ferAsync in AscendDirectTransport

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
Auto_Connect is enabled by default, remove sync parameter and buffer pool config, unify into TransferAsync in AscendDirectTransport

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->
tested in Ascend A3 platfrom

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
