### PR TITLE
[TE] Fixed an issue where start_timestamp is retrieved but batch_desc has already been freed

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -625,6 +625,7 @@ int TransferEnginePy::getBatchTransferStatus(
     while (!timeout_table.empty() && !failed_or_timeout) {
         for (auto &entry : timeout_table) {
             auto batch_desc = reinterpret_cast<BatchDesc *>(entry.first);
+            auto start_timestamp = batch_desc->start_timestamp;
             Status s = engine_->getBatchTransferStatus(entry.first, status);
             LOG_ASSERT(s.ok());
             if (status.s == TransferStatusEnum::COMPLETED) {
@@ -637,9 +638,9 @@ int TransferEnginePy::getBatchTransferStatus(
                 LOG(INFO) << "Sync data transfer timeout";
             }
             auto current_ts = getCurrentTimeInNano();
-            if (current_ts - batch_desc->start_timestamp > entry.second) {
+            if (current_ts - start_timestamp > entry.second) {
                 LOG(INFO) << "Sync batch data transfer timeout after "
-                          << current_ts - batch_desc->start_timestamp << "ns";
+                          << current_ts - start_timestamp << "ns";
                 failed_or_timeout = true;
             }
         }


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
