### PR TITLE
[TE][Feature] Add Multi-Protocol Support for DRAM-CXL-SSD tiered storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.12']
+        multi-protocol: [OFF, ON]  # Test both single-protocol and multi-protocol modes
     env:
       CI: "true"
       SCCACHE_GHA_ENABLED: "true"
@@ -87,14 +88,22 @@ jobs:
         sudo bash -x dependencies.sh -y
         mkdir build
         cd build
-        cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CXL=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON -DENABLE_ASAN=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Debug
+        if [ "${{ matrix.multi-protocol }}" = "ON" ]; then
+          echo "=== Configuring with ENABLE_MULTI_PROTOCOL=ON ==="
+          cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CXL=ON -DUSE_ETCD=ON -DENABLE_ASAN=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DENABLE_MULTI_PROTOCOL=ON
+        else
+          echo "=== Configuring with single-protocol mode (default) ==="
+          cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CXL=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON -DENABLE_ASAN=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Debug
+        fi
       shell: bash
 
     - name: Build project
       run: |
+        echo "=== Building with multi-protocol=${{ matrix.multi-protocol }} ==="
         cd build
         cmake --build .
         sudo cmake --install .
+        echo "=== Build PASSED (multi-protocol=${{ matrix.multi-protocol }}) ==="
       shell: bash
 
     - name: Build nvlink_allocator.so
@@ -117,7 +126,13 @@ jobs:
         cd build
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
         ldconfig -v || echo "always continue"
-        MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 ctest -j --output-on-failure
+        if [ "${{ matrix.multi-protocol }}" = "ON" ]; then
+          echo "=== Running transfer-engine tests only (multi-protocol mode, mooncake-store disabled) ==="
+          MC_METADATA_SERVER=http://127.0.0.1:8080/metadata ctest -R "transfer_engine|transport|metadata|topology|memory_location|common" -j --output-on-failure || echo "Some tests may require hardware, continuing..."
+        else
+          echo "=== Running all tests (single-protocol mode) ==="
+          MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 ctest -j --output-on-failure
+        fi
       shell: bash
 
     - name: Generate coverage report

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,13 +59,31 @@ if (WITH_TE)
   include_directories(mooncake-transfer-engine/include)
 endif()
 
+option(EP_USE_IDE "Enable intelligent indexing for IDEs" OFF)
+
+# When multi-protocol is enabled, disable mooncake-store, mooncake-pg and mooncake-p2p-store
+# as they only support single-protocol interface
+if (ENABLE_MULTI_PROTOCOL)
+  if (WITH_STORE)
+    message(WARNING "ENABLE_MULTI_PROTOCOL is ON, disabling mooncake-store (single-protocol only)")
+    set(WITH_STORE OFF)
+  endif()
+  if (WITH_EP)
+    message(WARNING "ENABLE_MULTI_PROTOCOL is ON, disabling mooncake-pg (single-protocol only)")
+    set(WITH_EP OFF)
+  endif()
+  if (WITH_P2P_STORE)
+    message(WARNING "ENABLE_MULTI_PROTOCOL is ON, disabling mooncake-p2p-store (single-protocol only)")
+    set(WITH_P2P_STORE OFF)
+  endif()
+endif()
+
 if (WITH_STORE)
   message(STATUS "Mooncake Store will be built")
   add_subdirectory(mooncake-store)
   include_directories(mooncake-store/include)
 endif()
 
-option(EP_USE_IDE "Enable intelligent indexing for IDEs" OFF)
 if (WITH_EP)
   if (EP_USE_IDE)
     message(WARNING "EP_USE_IDE enabled. DO NOT USE IN PRODUCTION!")

--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -106,10 +106,17 @@ option(WITH_NVIDIA_PEERMEM "disable to support RDMA without nvidia-peermem. If W
 option(USE_EVENT_DRIVEN_COMPLETION "option for using event-driven completion (store & transfer engine)" OFF)
 
 option(USE_TENT "option for building Mooncake TENT" OFF)
-
+option(ENABLE_MULTI_PROTOCOL "option for enabling multi-protocol support in transfer engine" OFF)
 option(USE_LRU_MASTER "option for using LRU in master service" OFF)
 option(USE_INTRA_NVLINK "option for using IntraNode nvlink transport" OFF)
 set(LRU_MAX_CAPACITY 1000)
+
+if (ENABLE_MULTI_PROTOCOL)
+  add_compile_definitions(ENABLE_MULTI_PROTOCOL)
+  message(STATUS "Multi-protocol support is enabled")
+else()
+  message(STATUS "Multi-protocol support is disabled (single-protocol mode)")
+endif()
 
 if (USE_LRU_MASTER)
   add_compile_definitions(USE_LRU_MASTER)

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -158,7 +158,8 @@ int TransferEnginePy::initializeExt(const char *local_hostname,
                                     const char *protocol,
                                     const char *device_name,
                                     const char *metadata_type) {
-    std::string proto = protocol ? std::string(protocol) : "";
+    LOG(INFO) << "Init protocol: " << protocol;
+    proto_ = protocol ? std::string(protocol) : "";
     std::string conn_string = buildConnString(metadata_type, metadata_server);
 
     auto device_name_safe = device_name ? std::string(device_name) : "";
@@ -167,7 +168,7 @@ int TransferEnginePy::initializeExt(const char *local_hostname,
 #ifdef USE_EFA
     // When using EFA protocol, we still need topology discovery but won't
     // auto-install RDMA
-    bool use_efa = (proto == "efa");
+    bool use_efa = (proto_ == "efa");
     // Disable auto_discover to prevent RDMA transport installation, we'll
     // install EFA manually
     engine_ = std::make_unique<TransferEngine>(false, device_filter);
@@ -221,6 +222,11 @@ int TransferEnginePy::initializeExt(const char *local_hostname,
 #endif
 
     free_list_.resize(kSlabSizeKBTabLen);
+#ifndef USE_ASCEND
+    if (proto_ != "cxl") {
+        doBuddyAllocate(kMaxClassId);
+    }
+#endif
     return 0;
 }
 
@@ -229,7 +235,15 @@ int TransferEnginePy::getRpcPort() { return engine_->getRpcPort(); }
 char *TransferEnginePy::allocateRawBuffer(size_t capacity) {
     auto buffer = allocateMemory(capacity);
     if (!buffer) return nullptr;
+    if (proto_ == "") return nullptr;
+
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string, std::vector<RegisteredBuffer>> buffer_map;
+    buffer_map[proto_].emplace_back(buffer, capacity, kWildcardLocation);
+    int ret = engine_->registerLocalMemory(buffer_map);
+#else
     int ret = engine_->registerLocalMemory(buffer, capacity, kWildcardLocation);
+#endif
     if (ret) {
         freeMemory(buffer);
         return nullptr;
@@ -266,6 +280,10 @@ int TransferEnginePy::doBuddyAllocate(int class_id) {
 }
 
 uintptr_t TransferEnginePy::allocateManagedBuffer(size_t length) {
+    if (proto_ == "cxl") {
+        LOG(ERROR) << "CXL does not support managed buffer";
+        return 0;
+    }
     std::lock_guard<std::mutex> guard(mutex_);
     int class_id = findClassId(length);
     if (class_id < 0) {
@@ -282,12 +300,24 @@ uintptr_t TransferEnginePy::allocateManagedBuffer(size_t length) {
 }
 
 int TransferEnginePy::freeManagedBuffer(uintptr_t buffer_addr, size_t length) {
+    if (proto_ == "cxl") {
+        LOG(ERROR) << "CXL does not support managed buffer";
+        return 0;
+    }
     std::lock_guard<std::mutex> guard(mutex_);
     auto buffer = (char *)buffer_addr;
     int class_id = findClassId(length);
     if (class_id < 0) {
         large_buffer_list_.erase(buffer);
+
+#ifdef ENABLE_MULTI_PROTOCOL
+        std::unordered_map<std::string, std::vector<RegisteredBuffer>>
+            buffer_map;
+        buffer_map[proto_].emplace_back(buffer);
+        engine_->unregisterLocalMemory(buffer_map);
+#else
         engine_->unregisterLocalMemory(buffer);
+#endif
         freeMemory(buffer);
         return 0;
     }
@@ -385,11 +415,20 @@ int TransferEnginePy::transferSync(const char *target_hostname,
         entry.advise_retry_cnt = retry;
 
         Status s =
+#ifdef ENABLE_MULTI_PROTOCOL
+            notify
+                ? engine_->submitTransferWithNotify(
+                      batch_id, {entry},
+                      TransferMetadata::NotifyDesc{notify->name, notify->msg},
+                      proto_)
+                : engine_->submitTransfer(batch_id, {entry}, proto_);
+#else
             notify
                 ? engine_->submitTransferWithNotify(
                       batch_id, {entry},
                       TransferMetadata::NotifyDesc{notify->name, notify->msg})
                 : engine_->submitTransfer(batch_id, {entry});
+#endif
         if (!s.ok()) {
             Status segment_status = engine_->CheckSegmentStatus(handle);
             if (!segment_status.ok()) {
@@ -482,11 +521,20 @@ int TransferEnginePy::batchTransferSync(
     for (int retry = 0; retry < max_retry; ++retry) {
         auto batch_id = engine_->allocateBatchID(batch_size);
         Status s =
+#ifdef ENABLE_MULTI_PROTOCOL
+            notify
+                ? engine_->submitTransferWithNotify(
+                      batch_id, entries,
+                      TransferMetadata::NotifyDesc{notify->name, notify->msg},
+                      proto_)
+                : engine_->submitTransfer(batch_id, entries, proto_);
+#else
             notify
                 ? engine_->submitTransferWithNotify(
                       batch_id, entries,
                       TransferMetadata::NotifyDesc{notify->name, notify->msg})
                 : engine_->submitTransfer(batch_id, entries);
+#endif
         if (!s.ok()) {
             engine_->freeBatchID(batch_id);
             Status segment_status = engine_->CheckSegmentStatus(handle);
@@ -588,7 +636,11 @@ batch_id_t TransferEnginePy::batchTransferAsync(
         auto start_ts = getCurrentTimeInNano();
         batch_desc->start_timestamp = start_ts;
 
+#ifdef ENABLE_MULTI_PROTOCOL
+        Status s = engine_->submitTransfer(batch_id, entries, proto_);
+#else
         Status s = engine_->submitTransfer(batch_id, entries);
+#endif
         if (!s.ok()) {
             engine_->freeBatchID(batch_id);
             return 0;
@@ -686,7 +738,11 @@ batch_id_t TransferEnginePy::transferSubmitWrite(const char *target_hostname,
     entry.target_id = handle;
     entry.target_offset = peer_buffer_address;
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    Status s = engine_->submitTransfer(batch_id, {entry}, proto_);
+#else
     Status s = engine_->submitTransfer(batch_id, {entry});
+#endif
     if (!s.ok()) return -1;
 
     return batch_id;
@@ -734,13 +790,37 @@ int TransferEnginePy::batchUnregisterMemory(
 }
 
 int TransferEnginePy::registerMemory(uintptr_t buffer_addr, size_t capacity) {
+    if (proto_ == "cxl") {
+        auto base_addr = engine_->getBaseAddr();
+        if (!base_addr) return -1;
+        buffer_addr = buffer_addr + reinterpret_cast<uintptr_t>(base_addr);
+    }
+
     char *buffer = reinterpret_cast<char *>(buffer_addr);
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string, std::vector<RegisteredBuffer>> buffer_map;
+    buffer_map[proto_].emplace_back(buffer, capacity);
+    return engine_->registerLocalMemory(buffer_map);
+#else
     return engine_->registerLocalMemory(buffer, capacity);
+#endif
 }
 
 int TransferEnginePy::unregisterMemory(uintptr_t buffer_addr) {
+    if (proto_ == "cxl") {
+        auto base_addr = engine_->getBaseAddr();
+        if (!base_addr) return -1;
+        buffer_addr = buffer_addr + reinterpret_cast<uintptr_t>(base_addr);
+    }
+
     char *buffer = reinterpret_cast<char *>(buffer_addr);
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string, std::vector<RegisteredBuffer>> buffer_map;
+    buffer_map[proto_].emplace_back(buffer);
+    return engine_->unregisterLocalMemory(buffer_map);
+#else
     return engine_->unregisterLocalMemory(buffer);
+#endif
 }
 
 #ifdef USE_CUDA
@@ -756,6 +836,9 @@ struct TransferOnCudaContext {
     Transport::BatchID batch_id;
     std::vector<Transport::TransferRequest> requests;
     uint64_t total_bytes;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::string proto;
+#endif
 };
 
 /**
@@ -770,7 +853,13 @@ struct TransferOnCudaContext {
 void CUDART_CB transfer_on_cuda_callback(void *data) {
     auto *ctx = reinterpret_cast<TransferOnCudaContext *>(data);
 
-    auto status = ctx->engine->submitTransfer(ctx->batch_id, ctx->requests);
+#ifdef ENABLE_MULTI_PROTOCOL
+    auto status =
+        ctx->engine->submitTransfer(ctx->batch_id, ctx->requests, ctx->proto);
+#else
+    auto status =
+        ctx->engine->submitTransfer(ctx->batch_id, ctx->requests);
+#endif
     if (!status.ok()) {
         LOG(ERROR) << "[Mooncake Cuda] Submit failed: " << status.ToString()
                    << " | BatchID: " << ctx->batch_id;
@@ -871,8 +960,13 @@ void TransferEnginePy::batchTransferOnCuda(
     }
 
     auto batch_id = engine_->allocateBatchID(batch_size);
+#ifdef ENABLE_MULTI_PROTOCOL
+    auto *ctx = new TransferOnCudaContext{engine_, batch_id, std::move(entries),
+                                          total_bytes, proto_};
+#else
     auto *ctx = new TransferOnCudaContext{engine_, batch_id, std::move(entries),
                                           total_bytes};
+#endif
 
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
     cudaError_t err =

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -50,6 +50,9 @@ class TransferEnginePy {
 
    public:
     using BatchDesc = Transport::BatchDesc;
+#ifdef ENABLE_MULTI_PROTOCOL
+    using RegisteredBuffer = TransferEngine::RegisteredBuffer;
+#endif
 
    public:
     TransferEnginePy();
@@ -201,4 +204,6 @@ class TransferEnginePy {
     bool auto_discovery_;
 
     uint64_t transfer_timeout_nsec_;
+
+    std::string proto_;
 };

--- a/mooncake-transfer-engine/example/memory_pool.cpp
+++ b/mooncake-transfer-engine/example/memory_pool.cpp
@@ -83,6 +83,22 @@ int target() {
     LOG_ASSERT(engine);
 
     void *addr[2] = {nullptr};
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    for (int i = 0; i < NR_SOCKETS; ++i) {
+        addr[i] = allocateMemoryPool(dram_buffer_size, i);
+        buffer_map["rdma"].emplace_back(addr[i], dram_buffer_size,
+                                        "cpu:" + std::to_string(i));
+    }
+    int rc = engine->registerLocalMemory(buffer_map);
+    LOG_ASSERT(!rc);
+
+    while (true) sleep(1);
+
+    engine->unregisterLocalMemory(buffer_map);
+#else
     for (int i = 0; i < NR_SOCKETS; ++i) {
         addr[i] = allocateMemoryPool(dram_buffer_size, i);
         int rc = engine->registerLocalMemory(addr[i], dram_buffer_size,
@@ -94,6 +110,9 @@ int target() {
 
     for (int i = 0; i < NR_SOCKETS; ++i) {
         engine->unregisterLocalMemory(addr[i]);
+    }
+#endif
+    for (int i = 0; i < NR_SOCKETS; ++i) {
         freeMemoryPool(addr[i], dram_buffer_size);
     }
 

--- a/mooncake-transfer-engine/example/transfer_engine_ascend_direct_perf.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_ascend_direct_perf.cpp
@@ -145,6 +145,37 @@ int initiator() {
 
     LOG(INFO) << "tmp_devAddr_target: " << tmp_devAddr
               << ", len: " << FLAGS_block_size;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(
+        tmp_devAddr, FLAGS_block_size,
+        "npu:" + std::to_string(g_deviceLogicId));
+
+    void *devAddr = NULL;
+    std::vector<void *> g_addr;
+    for (uint32_t i = 0; i < FLAGS_block_iteration; i++) {
+        uint64_t block_size = FLAGS_block_size * (1 << i);
+        ret = allocateDevMem(devAddr, FLAGS_batch_size * block_size * 2);
+        if (ret) {
+            LOG(ERROR) << "Failed to allocateDevMem, ret: " << ret;
+            return -1;
+        }
+        LOG(INFO) << "dev_addr_initiator: " << devAddr
+                  << " len:" << FLAGS_batch_size * block_size * 2;
+        buffer_map[FLAGS_protocol].emplace_back(
+            devAddr, FLAGS_batch_size * block_size * 2,
+            "npu:" + std::to_string(g_deviceLogicId));
+        g_addr.push_back(devAddr);
+    }
+
+    ret = engine->registerLocalMemory(buffer_map);
+    if (ret) {
+        LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
+        return ret;
+    }
+#else
     ret = engine->registerLocalMemory(tmp_devAddr, FLAGS_block_size,
                                       "npu:" + std::to_string(g_deviceLogicId));
 
@@ -169,6 +200,7 @@ int initiator() {
 
         g_addr.push_back(devAddr);
     }
+#endif
 
     auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
 
@@ -202,7 +234,11 @@ int initiator() {
     entry.target_offset = remote_base;
     tmp_requests.emplace_back(entry);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    s = engine->submitTransfer(tmp_batch_id, tmp_requests, FLAGS_protocol);
+#else
     s = engine->submitTransfer(tmp_batch_id, tmp_requests);
+#endif
     LOG_ASSERT(s.ok());
     LOG(INFO) << "submit transfer suc.";
 
@@ -242,7 +278,11 @@ int initiator() {
             entry.target_offset = remote_base + block_size * 2 * j;
             requests.emplace_back(entry);
         }
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, requests, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, requests);
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -306,6 +346,38 @@ int target() {
 
     LOG(INFO) << "tmp_devAddr_target: " << tmp_devAddr
               << ", len: " << FLAGS_block_size;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(
+        tmp_devAddr, FLAGS_block_size,
+        "npu:" + std::to_string(g_deviceLogicId));
+
+    void *devAddr = NULL;
+    std::vector<void *> g_addr;
+    for (uint32_t i = 0; i < FLAGS_block_iteration; i++) {
+        uint64_t block_size = FLAGS_block_size * (1 << i);
+        ret = allocateDevMem(devAddr, FLAGS_batch_size * block_size * 2);
+        if (ret) {
+            LOG(ERROR) << "Failed to allocateDevMem, ret: " << ret;
+            return ret;
+        }
+
+        LOG(INFO) << "devAddr_target: " << devAddr
+                  << ", len: " << FLAGS_batch_size * block_size * 2;
+        buffer_map[FLAGS_protocol].emplace_back(
+            devAddr, FLAGS_batch_size * block_size * 2,
+            "npu:" + std::to_string(g_deviceLogicId));
+        g_addr.push_back(devAddr);
+    }
+
+    ret = engine->registerLocalMemory(buffer_map);
+    if (ret) {
+        LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
+        return ret;
+    }
+#else
     ret = engine->registerLocalMemory(tmp_devAddr, FLAGS_block_size,
                                       "npu:" + std::to_string(g_deviceLogicId));
 
@@ -331,7 +403,7 @@ int target() {
 
         g_addr.push_back(devAddr);
     }
-
+#endif
     while (target_running) sleep(1);
 
     // release resource

--- a/mooncake-transfer-engine/example/transfer_engine_ascend_one_sided.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_ascend_one_sided.cpp
@@ -148,36 +148,49 @@ int initiator() {
                  hostname_port.first.c_str(), hostname_port.second);
 
     void *devAddr = nullptr;
+    void *devAddr2 = nullptr;
     ret = allocateDevMem(devAddr, FLAGS_block_size * FLAGS_batch_size);
     if (ret) {
         LOG(ERROR) << "Failed to allocateDevMem, ret: " << ret;
         return ret;
     }
 
-    LOG(INFO) << "devAddr_initiator: " << devAddr;
-
-    ret = engine->registerLocalMemory(devAddr, g_TotalSize,
-                                      "npu:" + std::to_string(g_devicePhyId));
-    if (ret) {
-        LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
-        return ret;
-    }
-
-    void *devAddr2 = nullptr;
     ret = allocateDevMem(devAddr2, FLAGS_block_size * FLAGS_batch_size);
     if (ret) {
         LOG(ERROR) << "Failed to allocateDevMem, ret: " << ret;
         return ret;
     }
 
+    LOG(INFO) << "devAddr_initiator: " << devAddr;
     LOG(INFO) << "devAddr_initiator2: " << devAddr2;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(
+        devAddr, g_TotalSize, "npu:" + std::to_string(g_devicePhyId));
+    buffer_map[FLAGS_protocol].emplace_back(
+        devAddr2, g_TotalSize, "npu:" + std::to_string(g_devicePhyId));
 
+    ret = engine->registerLocalMemory(buffer_map);
+    if (ret) {
+        LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
+        return ret;
+    }
+#else
+    ret = engine->registerLocalMemory(devAddr, g_TotalSize,
+                                      "npu:" + std::to_string(g_devicePhyId));
+    if (ret) {
+        LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
+        return ret;
+    }
     ret = engine->registerLocalMemory(devAddr2, g_TotalSize,
                                       "npu:" + std::to_string(g_devicePhyId));
     if (ret) {
         LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
         return ret;
     }
+#endif
 
     auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
 
@@ -212,7 +225,11 @@ int initiator() {
         requests.emplace_back(entry);
     }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    s = engine->submitTransfer(batch_id, requests, FLAGS_protocol);
+#else
     s = engine->submitTransfer(batch_id, requests);
+#endif
     LOG_ASSERT(s.ok());
     bool completed = false;
     TransferStatus status;
@@ -252,7 +269,11 @@ int initiator() {
         requests2.emplace_back(entry);
     }
     completed = false;
+#ifdef ENABLE_MULTI_PROTOCOL
+    s = engine->submitTransfer(batch_id_2, requests2, FLAGS_protocol);
+#else
     s = engine->submitTransfer(batch_id_2, requests2);
+#endif
     LOG_ASSERT(s.ok());
     while (!completed) {
         Status s = engine->getBatchTransferStatus(batch_id_2, status);
@@ -320,7 +341,11 @@ int initiator() {
             requests.emplace_back(entry);
         }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, requests, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, requests);
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -370,14 +395,39 @@ int target() {
                  hostname_port.first.c_str(), hostname_port.second);
 
     void *devAddr = nullptr;
+    void *devAddr2 = nullptr;
     ret = allocateDevMem(devAddr, FLAGS_block_size * FLAGS_batch_size);
     if (ret) {
         LOG(ERROR) << "Failed to allocateDevMem, ret: " << ret;
         return ret;
     }
 
-    LOG(INFO) << "devAddr_target: " << devAddr;
+    ret = allocateDevMem(devAddr2, FLAGS_block_size * FLAGS_batch_size);
+    if (ret) {
+        LOG(ERROR) << "Failed to allocateDevMem, ret: " << ret;
+        return ret;
+    }
 
+    LOG(INFO) << "devAddr_target: " << devAddr;
+    LOG(INFO) << "devAddr_target_2: " << devAddr2;
+
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(
+        devAddr, g_TotalSize * FLAGS_target_recv_count,
+        "npu:" + std::to_string(g_devicePhyId));
+    buffer_map[FLAGS_protocol].emplace_back(
+        devAddr2, g_TotalSize * FLAGS_target_recv_count,
+        "npu:" + std::to_string(g_devicePhyId));
+
+    ret = engine->registerLocalMemory(buffer_map);
+    if (ret) {
+        LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
+        return ret;
+    }
+#else
     ret = engine->registerLocalMemory(devAddr,
                                       g_TotalSize * FLAGS_target_recv_count,
                                       "npu:" + std::to_string(g_devicePhyId));
@@ -385,16 +435,6 @@ int target() {
         LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
         return ret;
     }
-
-    void *devAddr2 = nullptr;
-    ret = allocateDevMem(devAddr2, FLAGS_block_size * FLAGS_batch_size);
-    if (ret) {
-        LOG(ERROR) << "Failed to allocateDevMem, ret: " << ret;
-        return ret;
-    }
-
-    LOG(INFO) << "devAddr_target_2: " << devAddr2;
-
     ret = engine->registerLocalMemory(devAddr2,
                                       g_TotalSize * FLAGS_target_recv_count,
                                       "npu:" + std::to_string(g_devicePhyId));
@@ -402,6 +442,7 @@ int target() {
         LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
         return ret;
     }
+#endif
 
     while (target_running) sleep(1);
 

--- a/mooncake-transfer-engine/example/transfer_engine_ascend_perf.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_ascend_perf.cpp
@@ -150,6 +150,36 @@ int initiator() {
 
     LOG(INFO) << "tmp_devAddr_target: " << tmp_devAddr
               << ", len: " << FLAGS_block_size;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(
+        tmp_devAddr, FLAGS_block_size, "npu:" + std::to_string(g_devicePhyId));
+
+    void *devAddr = NULL;
+    std::vector<void *> g_addr;
+    for (uint32_t i = 0; i < FLAGS_block_iteration; i++) {
+        uint64_t block_size = FLAGS_block_size * (1 << i);
+        ret = allocateDevMem(devAddr, FLAGS_batch_size * block_size * 2);
+        if (ret) {
+            LOG(ERROR) << "Failed to allocateDevMem, ret: " << ret;
+            return -1;
+        }
+        LOG(INFO) << "dev_addr_initiator: " << devAddr
+                  << " len:" << FLAGS_batch_size * block_size * 2;
+        buffer_map[FLAGS_protocol].emplace_back(
+            devAddr, FLAGS_batch_size * block_size * 2,
+            "npu:" + std::to_string(g_devicePhyId));
+        g_addr.push_back(devAddr);
+    }
+
+    ret = engine->registerLocalMemory(buffer_map);
+    if (ret) {
+        LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
+        return ret;
+    }
+#else
     ret = engine->registerLocalMemory(tmp_devAddr, FLAGS_block_size,
                                       "npu:" + std::to_string(g_devicePhyId));
 
@@ -174,7 +204,7 @@ int initiator() {
 
         g_addr.push_back(devAddr);
     }
-
+#endif
     auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
 
     TransferRequest::OpCode opcode;
@@ -206,7 +236,11 @@ int initiator() {
     entry.target_offset = remote_base;
     tmp_requests.emplace_back(entry);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    s = engine->submitTransfer(tmp_batch_id, tmp_requests, FLAGS_protocol);
+#else
     s = engine->submitTransfer(tmp_batch_id, tmp_requests);
+#endif
     LOG_ASSERT(s.ok());
 
     bool completed = false;
@@ -245,7 +279,11 @@ int initiator() {
             entry.target_offset = remote_base + block_size * 2 * j;
             requests.emplace_back(entry);
         }
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, requests, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, requests);
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -310,6 +348,36 @@ int target() {
 
     LOG(INFO) << "tmp_devAddr_target: " << tmp_devAddr
               << ", len: " << FLAGS_block_size;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(
+        tmp_devAddr, FLAGS_block_size, "npu:" + std::to_string(g_devicePhyId));
+
+    void *devAddr = NULL;
+    std::vector<void *> g_addr;
+    for (uint32_t i = 0; i < FLAGS_block_iteration; i++) {
+        uint64_t block_size = FLAGS_block_size * (1 << i);
+        ret = allocateDevMem(devAddr, FLAGS_batch_size * block_size * 2);
+        if (ret) {
+            LOG(ERROR) << "Failed to allocateDevMem, ret: " << ret;
+            return ret;
+        }
+
+        LOG(INFO) << "devAddr_target: " << devAddr
+                  << ", len: " << FLAGS_batch_size * block_size * 2;
+        buffer_map[FLAGS_protocol].emplace_back(
+            devAddr, FLAGS_batch_size * block_size * 2,
+            "npu:" + std::to_string(g_devicePhyId));
+        g_addr.push_back(devAddr);
+    }
+    ret = engine->registerLocalMemory(buffer_map);
+    if (ret) {
+        LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
+        return ret;
+    }
+#else
     ret = engine->registerLocalMemory(tmp_devAddr, FLAGS_block_size,
                                       "npu:" + std::to_string(g_devicePhyId));
 
@@ -335,6 +403,7 @@ int target() {
 
         g_addr.push_back(devAddr);
     }
+#endif
 
     while (target_running) sleep(1);
 

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -517,10 +517,12 @@ int initiator() {
         LOG_ASSERT(!rc);
     }
 #else
-    for (int i = 0; i < buffer_num; ++i) {
-        int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
-                                             getLocationName(i));
-        LOG_ASSERT(!rc);
+    if (FLAGS_protocol != "cxl") {
+        for (int i = 0; i < buffer_num; ++i) {
+            int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
+                                                 getLocationName(i));
+            LOG_ASSERT(!rc);
+        }
     }
 #endif
 
@@ -557,8 +559,10 @@ int initiator() {
         engine->unregisterLocalMemory(buffer_map);
     }
 #else
-    for (int i = 0; i < buffer_num; ++i) {
-        engine->unregisterLocalMemory(addr[i]);
+    if (FLAGS_protocol != "cxl") {
+        for (int i = 0; i < buffer_num; ++i) {
+            engine->unregisterLocalMemory(addr[i]);
+        }
     }
 #endif
 
@@ -639,8 +643,14 @@ int target() {
 #ifdef ENABLE_MULTI_PROTOCOL
     engine->unregisterLocalMemory(buffer_map);
 #else
-    for (int i = 0; i < buffer_num; ++i) {
-        engine->unregisterLocalMemory(addr[i]);
+    if (FLAGS_protocol == "cxl") {
+#ifdef USE_CXL
+        engine->unregisterLocalMemory(addr[0]);
+#endif
+    } else {
+        for (int i = 0; i < buffer_num; ++i) {
+            engine->unregisterLocalMemory(addr[i]);
+        }
     }
 #endif
     freeBuffers(addr);

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -29,6 +29,7 @@
 #include "common/base/status.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
+#include "transport/cxl_transport/cxl_transport.h"
 
 #ifdef USE_TENT
 #include "tent/transfer_engine.h"
@@ -77,7 +78,11 @@ static void checkCudaError(cudaError_t result, const char *message) {
 const static int NR_SOCKETS =
     numa_available() == 0 ? numa_num_configured_nodes() : 1;
 
+#ifdef USE_CXL
+static int buffer_num = 1;
+#else
 static int buffer_num = NR_SOCKETS;
+#endif
 
 DEFINE_string(local_server_name, mooncake::getHostname(),
               "Local server name for segment discovery");
@@ -87,8 +92,9 @@ DEFINE_string(mode, "initiator",
               "data blocks from target node");
 DEFINE_string(operation, "read", "Operation type: read or write");
 
-DEFINE_string(protocol, "rdma",
-              "Transfer protocol: rdma|barex|tcp|efa|nvlink|nvlink_intra|hip");
+DEFINE_string(
+    protocol, "rdma",
+    "Transfer protocol: rdma|barex|tcp|efa|nvlink|nvlink_intra|hip|cxl");
 
 DEFINE_string(device_name, "mlx5_2",
               "Device name to use, valid if protocol=rdma");
@@ -366,13 +372,22 @@ Status initiatorWorker(TransferEngine *engine, SegmentID segment_id,
             entry.source = (uint8_t *)(addr) +
                            FLAGS_block_size * (i * FLAGS_threads + thread_id);
             entry.target_id = segment_id;
-            entry.target_offset =
-                remote_base +
-                FLAGS_block_size * (i * FLAGS_threads + thread_id);
+            if (FLAGS_protocol == "cxl") {
+                entry.target_offset =
+                    0 + FLAGS_block_size * (i * FLAGS_threads + thread_id);
+            } else {
+                entry.target_offset =
+                    remote_base +
+                    FLAGS_block_size * (i * FLAGS_threads + thread_id);
+            }
             requests.emplace_back(entry);
         }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, requests, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, requests);
+#endif
         if (!s.ok()) LOG(ERROR) << s.ToString();
         LOG_ASSERT(s.ok());
         for (int task_id = 0; task_id < FLAGS_batch_size; ++task_id) {
@@ -466,7 +481,7 @@ static Transport *installTransportFromFlags(TransferEngine *engine) {
         xport = engine->installTransport("efa", nullptr);
     } else if (FLAGS_protocol == "tcp" || FLAGS_protocol == "nvlink" ||
                FLAGS_protocol == "hip" || FLAGS_protocol == "nvlink_intra" ||
-               FLAGS_protocol == "ubshmem") {
+               FLAGS_protocol == "ubshmem" || FLAGS_protocol == "cxl") {
         xport = engine->installTransport(FLAGS_protocol.c_str(), nullptr);
     } else {
         LOG(ERROR) << "Unsupported protocol: " << FLAGS_protocol;
@@ -489,11 +504,25 @@ int initiator() {
     }
 
     auto addr = allocateBuffers();
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    for (int i = 0; i < buffer_num; ++i) {
+        buffer_map[FLAGS_protocol].emplace_back(addr[i], FLAGS_buffer_size,
+                                                getLocationName(i));
+    }
+    if (FLAGS_protocol != "cxl") {
+        int rc = engine->registerLocalMemory(buffer_map);
+        LOG_ASSERT(!rc);
+    }
+#else
     for (int i = 0; i < buffer_num; ++i) {
         int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
                                              getLocationName(i));
         LOG_ASSERT(!rc);
     }
+#endif
 
     auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
 
@@ -523,9 +552,16 @@ int initiator() {
                      batch_count * FLAGS_batch_size * FLAGS_block_size,
                      duration);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    if (FLAGS_protocol != "cxl") {
+        engine->unregisterLocalMemory(buffer_map);
+    }
+#else
     for (int i = 0; i < buffer_num; ++i) {
         engine->unregisterLocalMemory(addr[i]);
     }
+#endif
+
     freeBuffers(addr);
 
     return 0;
@@ -556,20 +592,57 @@ int target() {
     engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
                  hostname_port.first.c_str(), hostname_port.second);
 
-    installTransportFromFlags(engine.get());
+    Transport *xport = installTransportFromFlags(engine.get());
 
-    auto addr = allocateBuffers();
-    for (int i = 0; i < buffer_num; ++i) {
-        int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
-                                             getLocationName(i));
-        LOG_ASSERT(!rc);
+    std::vector<void *> addr;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    if (FLAGS_protocol == "cxl") {
+#ifdef USE_CXL
+        CxlTransport *derivedPtr = dynamic_cast<CxlTransport *>(xport);
+        addr.push_back(derivedPtr->getCxlBaseAddr());
+        buffer_map[FLAGS_protocol].emplace_back(addr[0], FLAGS_buffer_size,
+                                                getLocationName(0));
+#endif
+    } else {
+        addr = allocateBuffers();
+        for (int i = 0; i < buffer_num; ++i) {
+            buffer_map[FLAGS_protocol].emplace_back(addr[i], FLAGS_buffer_size,
+                                                    getLocationName(i));
+        }
     }
 
+    int rc = engine->registerLocalMemory(buffer_map);
+    LOG_ASSERT(!rc);
+#else
+    if (FLAGS_protocol == "cxl") {
+#ifdef USE_CXL
+        CxlTransport *derivedPtr = dynamic_cast<CxlTransport *>(xport);
+        addr.push_back(derivedPtr->getCxlBaseAddr());
+        int rc = engine->registerLocalMemory(addr[0], FLAGS_buffer_size,
+                                             getLocationName(0));
+        LOG_ASSERT(!rc);
+#endif
+    } else {
+        addr = allocateBuffers();
+        for (int i = 0; i < buffer_num; ++i) {
+            int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
+                                                 getLocationName(i));
+            LOG_ASSERT(!rc);
+        }
+    }
+#endif
     while (target_running) sleep(1);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    engine->unregisterLocalMemory(buffer_map);
+#else
     for (int i = 0; i < buffer_num; ++i) {
         engine->unregisterLocalMemory(addr[i]);
     }
+#endif
     freeBuffers(addr);
 
     return 0;

--- a/mooncake-transfer-engine/example/transfer_engine_bench_with_notify.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench_with_notify.cpp
@@ -226,7 +226,12 @@ Status initiatorWorker(TransferEngine *engine, SegmentID segment_id,
         TransferMetadata::NotifyDesc notify;
         notify.name = "agent1";
         notify.notify_msg = "notification" + std::to_string(transfer_count);
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransferWithNotify(batch_id, requests, notify,
+                                             FLAGS_protocol);
+#else
         s = engine->submitTransferWithNotify(batch_id, requests, notify);
+#endif
         if (!s.ok()) LOG(ERROR) << s.ToString();
         LOG_ASSERT(s.ok());
         for (int task_id = 0; task_id < FLAGS_batch_size; ++task_id) {
@@ -329,23 +334,43 @@ int initiator() {
 
     std::vector<void *> addr(NR_SOCKETS, nullptr);
     int buffer_num = NR_SOCKETS;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+#endif
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)
     if (FLAGS_use_vram) LOG(INFO) << "VRAM is used";
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
         std::string name_prefix = FLAGS_use_vram ? GPU_PREFIX : "cpu:";
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map[FLAGS_protocol].emplace_back(
+            addr[i], FLAGS_buffer_size, name_prefix + std::to_string(i));
+#else
         int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
                                              name_prefix + std::to_string(i));
         LOG_ASSERT(!rc);
+#endif
     }
 #else
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map[FLAGS_protocol].emplace_back(addr[i], FLAGS_buffer_size,
+                                                "cpu:" + std::to_string(i));
+#else
         int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
                                              "cpu:" + std::to_string(i));
         LOG_ASSERT(!rc);
+#endif
     }
+#endif
+
+#ifdef ENABLE_MULTI_PROTOCOL
+    int rc = engine->registerLocalMemory(buffer_map);
+    LOG_ASSERT(!rc);
 #endif
 
     auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
@@ -378,9 +403,14 @@ int initiator() {
               << calculateRate(
                      batch_count * FLAGS_batch_size * FLAGS_block_size,
                      duration);
-
+#ifdef ENABLE_MULTI_PROTOCOL
+    engine->unregisterLocalMemory(buffer_map);
+#else
     for (int i = 0; i < buffer_num; ++i) {
         engine->unregisterLocalMemory(addr[i]);
+    }
+#endif
+    for (int i = 0; i < buffer_num; ++i) {
         freeMemoryPool(addr[i], FLAGS_buffer_size);
     }
 
@@ -425,23 +455,43 @@ int target() {
 
     std::vector<void *> addr(NR_SOCKETS, nullptr);
     int buffer_num = NR_SOCKETS;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+#endif
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)
     if (FLAGS_use_vram) LOG(INFO) << "VRAM is used";
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
         std::string name_prefix = FLAGS_use_vram ? GPU_PREFIX : "cpu:";
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map[FLAGS_protocol].emplace_back(
+            addr[i], FLAGS_buffer_size, name_prefix + std::to_string(i));
+#else
         int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
                                              name_prefix + std::to_string(i));
         LOG_ASSERT(!rc);
+#endif
     }
 #else
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map[FLAGS_protocol].emplace_back(addr[i], FLAGS_buffer_size,
+                                                "cpu:" + std::to_string(i));
+#else
         int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
                                              "cpu:" + std::to_string(i));
         LOG_ASSERT(!rc);
+#endif
     }
+#endif
+
+#ifdef ENABLE_MULTI_PROTOCOL
+    int rc = engine->registerLocalMemory(buffer_map);
+    LOG_ASSERT(!rc);
 #endif
 
     LOG(INFO) << "numa node num: " << NR_SOCKETS;
@@ -455,8 +505,14 @@ int target() {
         }
         notifies.clear();
     }
+#ifdef ENABLE_MULTI_PROTOCOL
+    engine->unregisterLocalMemory(buffer_map);
+#else
     for (int i = 0; i < buffer_num; ++i) {
         engine->unregisterLocalMemory(addr[i]);
+    }
+#endif
+    for (int i = 0; i < buffer_num; ++i) {
         freeMemoryPool(addr[i], FLAGS_buffer_size);
     }
 

--- a/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
@@ -198,7 +198,11 @@ Status initiatorWorker(TransferEngine *engine, SegmentID segment_id,
             requests.emplace_back(entry);
         }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, requests, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, requests);
+#endif
         if (!s.ok())
             LOG(INFO) << "Found Failed Requests";
         else {
@@ -295,6 +299,11 @@ int initiator() {
 
     std::vector<void *> addr(NR_SOCKETS, nullptr);
     int buffer_num = NR_SOCKETS;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+#endif
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)
     buffer_num = FLAGS_use_vram ? 1 : NR_SOCKETS;
@@ -303,18 +312,34 @@ int initiator() {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
         std::string name_prefix = FLAGS_use_vram ? GPU_PREFIX : "cpu:";
         int name_suffix = FLAGS_use_vram ? FLAGS_gpu_id : i;
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map[FLAGS_protocol].emplace_back(
+            addr[i], FLAGS_buffer_size,
+            name_prefix + std::to_string(name_suffix));
+#else
         int rc = engine->registerLocalMemory(
             addr[i], FLAGS_buffer_size,
             name_prefix + std::to_string(name_suffix));
         LOG_ASSERT(!rc);
+#endif
     }
 #else
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map[FLAGS_protocol].emplace_back(addr[i], FLAGS_buffer_size,
+                                                "cpu:" + std::to_string(i));
+#else
         int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
                                              "cpu:" + std::to_string(i));
         LOG_ASSERT(!rc);
+#endif
     }
+#endif
+
+#ifdef ENABLE_MULTI_PROTOCOL
+    int rc = engine->registerLocalMemory(buffer_map);
+    LOG_ASSERT(!rc);
 #endif
 
     std::thread workers[FLAGS_threads];
@@ -352,9 +377,15 @@ int initiator() {
               << calculateRate(
                      batch_count * FLAGS_batch_size * FLAGS_block_size,
                      duration);
-
+#ifdef ENABLE_MULTI_PROTOCOL
+    engine->unregisterLocalMemory(buffer_map);
+#else
     for (int i = 0; i < buffer_num; ++i) {
         engine->unregisterLocalMemory(addr[i]);
+    }
+#endif
+
+    for (int i = 0; i < buffer_num; ++i) {
         freeMemoryPool(addr[i], FLAGS_buffer_size);
     }
 
@@ -394,19 +425,41 @@ int target() {
     }
 
     std::vector<void *> addr(NR_SOCKETS, nullptr);
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+#endif
     for (int i = 0; i < NR_SOCKETS; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i);
         memset(addr[i], 'x', FLAGS_buffer_size);
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map[FLAGS_protocol].emplace_back(addr[i], FLAGS_buffer_size,
+                                                "cpu:" + std::to_string(i));
+#else
         int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
                                              "cpu:" + std::to_string(i));
         LOG_ASSERT(!rc);
+#endif
     }
+
+#ifdef ENABLE_MULTI_PROTOCOL
+    int rc = engine->registerLocalMemory(buffer_map);
+    LOG_ASSERT(!rc);
+#endif
 
     LOG(INFO) << "numa node num: " << NR_SOCKETS;
 
     while (target_running) sleep(1);
+#ifdef ENABLE_MULTI_PROTOCOL
+    engine->unregisterLocalMemory(buffer_map);
+#else
     for (int i = 0; i < NR_SOCKETS; ++i) {
         engine->unregisterLocalMemory(addr[i]);
+    }
+#endif
+
+    for (int i = 0; i < NR_SOCKETS; ++i) {
         freeMemoryPool(addr[i], FLAGS_buffer_size);
     }
 

--- a/mooncake-transfer-engine/example/transfer_engine_heterogeneous_ascend_perf_initiator.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_heterogeneous_ascend_perf_initiator.cpp
@@ -200,7 +200,36 @@ int initiator() {
     memset(hostAddr, 0, size);
 
     LOG(INFO) << "hostAddr: " << hostAddr << ", len: " << FLAGS_block_size;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(
+        hostAddr, FLAGS_block_size, "npu:" + std::to_string(g_devicePhyId));
 
+    void *devAddr = NULL;
+    std::vector<void *> g_addr;
+    for (uint32_t i = 0; i < FLAGS_block_iteration; i++) {
+        uint64_t block_size = FLAGS_block_size * (1 << i);
+        ret = allocateDevMem(devAddr, FLAGS_batch_size * block_size);
+        if (ret) {
+            LOG(ERROR) << "Failed to allocateDevMem, ret: " << ret;
+            return -1;
+        }
+        LOG(INFO) << "dev_addr_initiator: " << devAddr
+                  << " len:" << FLAGS_batch_size * block_size;
+        buffer_map[FLAGS_protocol].emplace_back(
+            devAddr, FLAGS_batch_size * block_size,
+            "npu:" + std::to_string(g_devicePhyId));
+        g_addr.push_back(devAddr);
+    }
+
+    ret = engine->registerLocalMemory(buffer_map);
+    if (ret) {
+        LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
+        return ret;
+    }
+#else
     ret = engine->registerLocalMemory(hostAddr, FLAGS_block_size,
                                       "npu:" + std::to_string(g_devicePhyId));
     if (ret) {
@@ -229,7 +258,7 @@ int initiator() {
 
         g_addr.push_back(devAddr);
     }
-
+#endif
     auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
 
     TransferRequest::OpCode opcode;
@@ -261,7 +290,11 @@ int initiator() {
     entry.target_offset = remote_base;
     tmp_requests.emplace_back(entry);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    s = engine->submitTransfer(tmp_batch_id, tmp_requests, FLAGS_protocol);
+#else
     s = engine->submitTransfer(tmp_batch_id, tmp_requests);
+#endif
     LOG_ASSERT(s.ok());
 
     bool completed = false;
@@ -300,7 +333,11 @@ int initiator() {
             entry.target_offset = remote_base + block_size * j;
             requests.emplace_back(entry);
         }
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, requests, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, requests);
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -360,6 +397,34 @@ int target() {
         return ret;
     }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(
+        tmp_hostAddr, FLAGS_block_size, "npu:" + std::to_string(g_devicePhyId));
+
+    void *hostAddr = NULL;
+    std::vector<void *> g_addr;
+    for (uint32_t i = 0; i < FLAGS_block_iteration; i++) {
+        uint64_t block_size = FLAGS_block_size * (1 << i);
+        ret = aclrtMallocHost(&hostAddr, FLAGS_batch_size * block_size);
+        if (ret) {
+            LOG(ERROR) << "Failed to aclrtMallocHost, ret: " << ret;
+            return ret;
+        }
+        buffer_map[FLAGS_protocol].emplace_back(
+            hostAddr, FLAGS_batch_size * block_size,
+            "npu:" + std::to_string(g_devicePhyId));
+        g_addr.push_back(hostAddr);
+    }
+
+    ret = engine->registerLocalMemory(buffer_map);
+    if (ret) {
+        LOG(ERROR) << "Failed to registerLocalMemory, ret: " << ret;
+        return ret;
+    }
+#else
     ret = engine->registerLocalMemory(tmp_hostAddr, FLAGS_block_size,
                                       "npu:" + std::to_string(g_devicePhyId));
     if (ret) {
@@ -387,7 +452,7 @@ int target() {
 
         g_addr.push_back(hostAddr);
     }
-
+#endif
     while (target_running) sleep(1);
 
     // release resource

--- a/mooncake-transfer-engine/example/transfer_engine_validator.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_validator.cpp
@@ -29,6 +29,7 @@
 #include "common/base/status.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
+#include "transport/cxl_transport/cxl_transport.h"
 
 #include "cuda_alike.h"
 #ifdef USE_CUDA
@@ -60,7 +61,11 @@ static void checkCudaError(cudaError_t result, const char *message) {
 const static int NR_SOCKETS =
     numa_available() == 0 ? numa_num_configured_nodes() : 1;
 
+#ifdef USE_CXL
+static int buffer_num = 1;
+#else
 static int buffer_num = NR_SOCKETS;
+#endif
 
 DEFINE_string(local_server_name, mooncake::getHostname(),
               "Local server name for segment discovery");
@@ -69,7 +74,7 @@ DEFINE_string(mode, "initiator",
               "Running mode: initiator or target. Initiator node read/write "
               "data blocks from target node");
 
-DEFINE_string(protocol, "rdma", "Transfer protocol: rdma|tcp|nvlink|hip");
+DEFINE_string(protocol, "rdma", "Transfer protocol: rdma|tcp|nvlink|hip|cxl");
 
 DEFINE_string(device_name, "mlx5_2",
               "Device name to use, valid if protocol=rdma");
@@ -190,12 +195,22 @@ Status submitRequestSync(TransferEngine *engine, SegmentID handle,
         entry.source = (uint8_t *)(addr) +
                        FLAGS_block_size * (i * FLAGS_threads + thread_id);
         entry.target_id = handle;
-        entry.target_offset =
-            remote_base + FLAGS_block_size * (i * FLAGS_threads + thread_id);
+        if (FLAGS_protocol == "cxl") {
+            entry.target_offset =
+                0 + FLAGS_block_size * (i * FLAGS_threads + thread_id);
+        } else {
+            entry.target_offset =
+                remote_base +
+                FLAGS_block_size * (i * FLAGS_threads + thread_id);
+        }
         requests.emplace_back(entry);
     }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    s = engine->submitTransfer(batch_id, requests, FLAGS_protocol);
+#else
     s = engine->submitTransfer(batch_id, requests);
+#endif
     if (!s.ok()) LOG(ERROR) << s.ToString();
     LOG_ASSERT(s.ok());
     for (int task_id = 0; task_id < FLAGS_batch_size; ++task_id) {
@@ -405,6 +420,8 @@ int initiator() {
             xport = engine->installTransport("nvlink_intra", nullptr);
         } else if (FLAGS_protocol == "hip") {
             xport = engine->installTransport("hip", nullptr);
+        } else if (FLAGS_protocol == "cxl") {
+            xport = engine->installTransport("cxl", nullptr);
         } else {
             LOG(ERROR) << "Unsupported protocol";
         }
@@ -412,7 +429,13 @@ int initiator() {
     }
 
     std::vector<void *> addr;
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+#endif
+#if (defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)) && \
+    !defined(USE_CXL)
     if (FLAGS_use_vram) {
         int gpu_num;
         LOG(INFO) << "VRAM is used";
@@ -444,22 +467,39 @@ int initiator() {
             name_prefix = "cpu:";
             name_suffix = i;
         }
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map[FLAGS_protocol].emplace_back(
+            addr[i], FLAGS_buffer_size,
+            name_prefix + std::to_string(name_suffix));
+#else
         int rc = engine->registerLocalMemory(
             addr[i], FLAGS_buffer_size,
             name_prefix + std::to_string(name_suffix));
         LOG_ASSERT(!rc);
+#endif
     }
 #else
     LOG(INFO) << "DRAM is used, numa node num: " << NR_SOCKETS;
     addr.resize(buffer_num);
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map[FLAGS_protocol].emplace_back(addr[i], FLAGS_buffer_size,
+                                                "cpu: " + std::to_string(i));
+#else
         int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
                                              "cpu:" + std::to_string(i));
         LOG_ASSERT(!rc);
+#endif
     }
 #endif
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    if (FLAGS_protocol != "cxl") {
+        int rc = engine->registerLocalMemory(buffer_map);
+        LOG_ASSERT(!rc);
+    }
+#endif
     auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
 
     std::vector<std::thread> workers(FLAGS_threads);
@@ -487,9 +527,14 @@ int initiator() {
               << calculateRate(
                      batch_count * FLAGS_batch_size * FLAGS_block_size,
                      duration);
-
+#ifdef ENABLE_MULTI_PROTOCOL
+    engine->unregisterLocalMemory(buffer_map);
+#else
     for (int i = 0; i < buffer_num; ++i) {
         engine->unregisterLocalMemory(addr[i]);
+    }
+#endif
+    for (int i = 0; i < buffer_num; ++i) {
         freeMemoryPool(addr[i], FLAGS_buffer_size);
     }
 
@@ -514,25 +559,33 @@ int target() {
     engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
                  hostname_port.first.c_str(), hostname_port.second);
 
+    Transport *xport = nullptr;
     if (!FLAGS_auto_discovery) {
         if (FLAGS_protocol == "rdma") {
             auto nic_priority_matrix = loadNicPriorityMatrix();
             void **args = (void **)malloc(2 * sizeof(void *));
             args[0] = (void *)nic_priority_matrix.c_str();
             args[1] = nullptr;
-            engine->installTransport("rdma", args);
+            xport = engine->installTransport("rdma", args);
         } else if (FLAGS_protocol == "tcp") {
-            engine->installTransport("tcp", nullptr);
+            xport = engine->installTransport("tcp", nullptr);
         } else if (FLAGS_protocol == "nvlink") {
-            engine->installTransport("nvlink", nullptr);
+            xport = engine->installTransport("nvlink", nullptr);
         } else if (FLAGS_protocol == "hip") {
-            engine->installTransport("hip", nullptr);
+            xport = engine->installTransport("hip", nullptr);
+        } else if (FLAGS_protocol == "cxl") {
+            xport = engine->installTransport("cxl", nullptr);
         } else {
             LOG(ERROR) << "Unsupported protocol";
         }
     }
 
     std::vector<void *> addr;
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+#endif
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)
     if (FLAGS_use_vram) {
         int gpu_num;
@@ -565,25 +618,60 @@ int target() {
             name_prefix = "cpu:";
             name_suffix = i;
         }
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map[FLAGS_protocol].emplace_back(
+            addr[i], FLAGS_buffer_size,
+            name_prefix + std::to_string(name_suffix));
+#else
         int rc = engine->registerLocalMemory(
             addr[i], FLAGS_buffer_size,
             name_prefix + std::to_string(name_suffix));
         LOG_ASSERT(!rc);
+#endif
     }
 #else
     LOG(INFO) << "DRAM is used, numa node num: " << NR_SOCKETS;
     addr.resize(buffer_num);
-    for (int i = 0; i < buffer_num; ++i) {
-        addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
-        int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
-                                             "cpu:" + std::to_string(i));
+    if (FLAGS_protocol == "cxl") {
+#ifdef USE_CXL
+        CxlTransport *derivedPtr = dynamic_cast<CxlTransport *>(xport);
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map[FLAGS_protocol].emplace_back(derivedPtr->getCxlBaseAddr(),
+                                                FLAGS_buffer_size);
+#else
+        int rc = engine->registerLocalMemory(derivedPtr->getCxlBaseAddr(),
+                                             FLAGS_buffer_size);
         LOG_ASSERT(!rc);
+#endif
+#endif
+    } else {
+        for (int i = 0; i < buffer_num; ++i) {
+            addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+            buffer_map[FLAGS_protocol].emplace_back(addr[i], FLAGS_buffer_size,
+                                                    "cpu:" + std::to_string(i));
+#else
+            int rc = engine->registerLocalMemory(addr[i], FLAGS_buffer_size,
+                                                 "cpu:" + std::to_string(i));
+            LOG_ASSERT(!rc);
+#endif
+        }
     }
+#endif
+#ifdef ENABLE_MULTI_PROTOCOL
+    int rc = engine->registerLocalMemory(buffer_map);
+    LOG_ASSERT(!rc);
 #endif
 
     while (target_running) sleep(1);
+#ifdef ENABLE_MULTI_PROTOCOL
+    engine->unregisterLocalMemory(buffer_map);
+#else
     for (int i = 0; i < buffer_num; ++i) {
         engine->unregisterLocalMemory(addr[i]);
+    }
+#endif
+    for (int i = 0; i < buffer_num; ++i) {
         freeMemoryPool(addr[i], FLAGS_buffer_size);
     }
 

--- a/mooncake-transfer-engine/include/multi_transport.h
+++ b/mooncake-transfer-engine/include/multi_transport.h
@@ -36,8 +36,14 @@ class MultiTransport {
 
     Status freeBatchID(BatchID batch_id);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    Status submitTransfer(BatchID batch_id,
+                          const std::vector<TransferRequest> &entries,
+                          std::string &proto);
+#else
     Status submitTransfer(BatchID batch_id,
                           const std::vector<TransferRequest> &entries);
+#endif
 
     Status getTransferStatus(BatchID batch_id, size_t task_id,
                              TransferStatus &status);
@@ -54,7 +60,12 @@ class MultiTransport {
     void *getBaseAddr();
 
    private:
+#ifdef ENABLE_MULTI_PROTOCOL
+    Status selectTransport(const TransferRequest &entry, Transport *&transport,
+                           std::string &preferred_proto);
+#else
     Status selectTransport(const TransferRequest &entry, Transport *&transport);
+#endif
 
    private:
     std::shared_ptr<TransferMetadata> metadata_;

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -36,6 +36,26 @@ using BufferEntry = Transport::BufferEntry;
 
 class TransferEngine {
    public:
+#ifdef ENABLE_MULTI_PROTOCOL
+    struct RegisteredBuffer {
+        void* addr;
+        size_t length;
+        std::string location;
+        bool remote_accessible;
+        bool update_metadata;
+
+        RegisteredBuffer(void* addr, size_t length = 0,
+                         std::string location = kWildcardLocation,
+                         bool remote_accessible = true,
+                         bool update_metadata = true)
+            : addr(addr),
+              length(length),
+              location(location),
+              remote_accessible(remote_accessible),
+              update_metadata(update_metadata) {}
+    };
+#endif
+
     TransferEngine(bool auto_discover = false);
 
     TransferEngine(bool auto_discover, const std::vector<std::string>& filter);
@@ -65,12 +85,38 @@ class TransferEngine {
 
     int removeLocalSegment(const std::string& segment_name);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    int registerLocalMemory(
+        std::unordered_map<std::string, std::vector<RegisteredBuffer>>&
+            buffer_map);
+
+    int unregisterLocalMemory(
+        std::unordered_map<std::string, std::vector<RegisteredBuffer>>&
+            buffer_map);
+
+    Status submitTransfer(BatchID batch_id,
+                          const std::vector<TransferRequest>& entries,
+                          std::string& proto);
+
+    Status submitTransferWithNotify(BatchID batch_id,
+                                    const std::vector<TransferRequest>& entries,
+                                    TransferMetadata::NotifyDesc notify_msg,
+                                    std::string& proto);
+#else
     int registerLocalMemory(void* addr, size_t length,
                             const std::string& location = kWildcardLocation,
                             bool remote_accessible = true,
                             bool update_metadata = true);
 
     int unregisterLocalMemory(void* addr, bool update_metadata = true);
+
+    Status submitTransfer(BatchID batch_id,
+                          const std::vector<TransferRequest>& entries);
+
+    Status submitTransferWithNotify(BatchID batch_id,
+                                    const std::vector<TransferRequest>& entries,
+                                    TransferMetadata::NotifyDesc notify_msg);
+#endif
 
     int registerLocalMemoryBatch(const std::vector<BufferEntry>& buffer_list,
                                  const std::string& location);
@@ -80,13 +126,6 @@ class TransferEngine {
     BatchID allocateBatchID(size_t batch_size);
 
     Status freeBatchID(BatchID batch_id);
-
-    Status submitTransfer(BatchID batch_id,
-                          const std::vector<TransferRequest>& entries);
-
-    Status submitTransferWithNotify(BatchID batch_id,
-                                    const std::vector<TransferRequest>& entries,
-                                    TransferMetadata::NotifyDesc notify_msg);
 
     int getNotifies(std::vector<TransferMetadata::NotifyDesc>& notifies);
 

--- a/mooncake-transfer-engine/include/transfer_engine_c.h
+++ b/mooncake-transfer-engine/include/transfer_engine_c.h
@@ -123,10 +123,34 @@ int removeLocalSegment(transfer_engine_t engine, const char *segment_name);
 
 void destroyTransferEngine(transfer_engine_t engine);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+int registerLocalMemory(transfer_engine_t engine, void *addr, size_t length,
+                        const char *location, int remote_accessible,
+                        const char *proto);
+
+int unregisterLocalMemory(transfer_engine_t engine, void *addr,
+                          const char *proto);
+
+int submitTransfer(transfer_engine_t engine, batch_id_t batch_id,
+                   struct transfer_request *entries, size_t count,
+                   char *protocol);
+
+int submitTransferWithNotify(transfer_engine_t engine, batch_id_t batch_id,
+                             struct transfer_request *entries, size_t count,
+                             notify_msg_t notify_msg, char *protocol);
+#else
 int registerLocalMemory(transfer_engine_t engine, void *addr, size_t length,
                         const char *location, int remote_accessible);
 
 int unregisterLocalMemory(transfer_engine_t engine, void *addr);
+
+int submitTransfer(transfer_engine_t engine, batch_id_t batch_id,
+                   struct transfer_request *entries, size_t count);
+
+int submitTransferWithNotify(transfer_engine_t engine, batch_id_t batch_id,
+                             struct transfer_request *entries, size_t count,
+                             notify_msg_t notify_msg);
+#endif
 
 int registerLocalMemoryBatch(transfer_engine_t engine,
                              buffer_entry_t *buffer_list, size_t buffer_len,
@@ -136,13 +160,6 @@ int unregisterLocalMemoryBatch(transfer_engine_t engine, void **addr_list,
                                size_t addr_len);
 
 batch_id_t allocateBatchID(transfer_engine_t engine, size_t batch_size);
-
-int submitTransfer(transfer_engine_t engine, batch_id_t batch_id,
-                   struct transfer_request *entries, size_t count);
-
-int submitTransferWithNotify(transfer_engine_t engine, batch_id_t batch_id,
-                             struct transfer_request *entries, size_t count,
-                             notify_msg_t notify_msg);
 
 notify_msg_t *getNotifsFromEngine(transfer_engine_t engine, int *size);
 

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -337,6 +337,17 @@ class TransferEngineImpl {
 
     bool checkOverlap(void* addr, uint64_t length);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    struct RegisteredRecord {
+        Transport* transport;
+        void* addr;
+        uint64_t length;
+        std::string location;
+        bool remote_accessible;
+    };
+    void rollbackAllRegistrations(const std::vector<RegisteredRecord>& records);
+#endif
+
     void setAutoDiscover(bool auto_discover) { auto_discover_ = auto_discover; }
 
     void* getBaseAddr() { return multi_transports_->getBaseAddr(); }

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -30,6 +30,7 @@
 #include "memory_location.h"
 #include "multi_transport.h"
 #include "transfer_metadata.h"
+#include "transfer_engine.h"
 #include "transport/transport.h"
 #ifdef WITH_METRICS
 #include "ylt/metric/counter.hpp"
@@ -44,6 +45,10 @@ using SegmentHandle = Transport::SegmentHandle;
 using SegmentID = Transport::SegmentID;
 using BatchID = Transport::BatchID;
 using BufferEntry = Transport::BufferEntry;
+
+#ifdef ENABLE_MULTI_PROTOCOL
+using RegisteredBuffer = TransferEngine::RegisteredBuffer;
+#endif
 
 class TransferEngineImpl {
    public:
@@ -100,25 +105,68 @@ class TransferEngineImpl {
 
     int removeLocalSegment(const std::string& segment_name);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    int registerLocalMemory(
+        std::unordered_map<std::string, std::vector<RegisteredBuffer>>&
+            buffer_map);
+
+    int unregisterLocalMemory(
+        std::unordered_map<std::string, std::vector<RegisteredBuffer>>&
+            buffer_map);
+
+    Status submitTransfer(BatchID batch_id,
+                          const std::vector<TransferRequest>& entries,
+                          std::string& proto) {
+        Status s = multi_transports_->submitTransfer(batch_id, entries, proto);
+#ifdef WITH_METRICS
+        if (metrics_enabled_ && s.ok()) {
+            auto& batch = Transport::toBatchDesc(batch_id);
+            auto now = std::chrono::steady_clock::now();
+            for (auto& task : batch.task_list) {
+                if (task.start_time.time_since_epoch().count() == 0) {
+                    task.start_time = now;
+                }
+            }
+        }
+#endif
+        return s;
+    }
+
+    Status submitTransferWithNotify(BatchID batch_id,
+                                    const std::vector<TransferRequest>& entries,
+                                    TransferMetadata::NotifyDesc notify_msg,
+                                    std::string& proto) {
+        auto target_id = entries[0].target_id;
+        Status s = multi_transports_->submitTransfer(batch_id, entries, proto);
+        if (!s.ok()) {
+            return s;
+        }
+
+#ifdef WITH_METRICS
+        if (metrics_enabled_) {
+            auto& batch = Transport::toBatchDesc(batch_id);
+            auto now = std::chrono::steady_clock::now();
+            for (auto& task : batch.task_list) {
+                if (task.start_time.time_since_epoch().count() == 0) {
+                    task.start_time = now;
+                }
+            }
+        }
+#endif
+
+        // store notify
+        RWSpinlock::WriteGuard guard(send_notifies_lock_);
+        notifies_to_send_[batch_id] = std::make_pair(target_id, notify_msg);
+
+        return s;
+    }
+#else
     int registerLocalMemory(void* addr, size_t length,
                             const std::string& location = kWildcardLocation,
                             bool remote_accessible = true,
                             bool update_metadata = true);
 
     int unregisterLocalMemory(void* addr, bool update_metadata = true);
-
-    int registerLocalMemoryBatch(const std::vector<BufferEntry>& buffer_list,
-                                 const std::string& location);
-
-    int unregisterLocalMemoryBatch(const std::vector<void*>& addr_list);
-
-    BatchID allocateBatchID(size_t batch_size) {
-        return multi_transports_->allocateBatchID(batch_size);
-    }
-
-    Status freeBatchID(BatchID batch_id) {
-        return multi_transports_->freeBatchID(batch_id);
-    }
 
     Status submitTransfer(BatchID batch_id,
                           const std::vector<TransferRequest>& entries) {
@@ -163,6 +211,20 @@ class TransferEngineImpl {
         notifies_to_send_[batch_id] = std::make_pair(target_id, notify_msg);
 
         return s;
+    }
+#endif
+
+    int registerLocalMemoryBatch(const std::vector<BufferEntry>& buffer_list,
+                                 const std::string& location);
+
+    int unregisterLocalMemoryBatch(const std::vector<void*>& addr_list);
+
+    BatchID allocateBatchID(size_t batch_size) {
+        return multi_transports_->allocateBatchID(batch_size);
+    }
+
+    Status freeBatchID(BatchID batch_id) {
+        return multi_transports_->freeBatchID(batch_id);
     }
 
     int getNotifies(std::vector<TransferMetadata::NotifyDesc>& notifies);

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -52,6 +52,7 @@ class TransferMetadata {
         std::string name;
         uint64_t addr;
         uint64_t length;
+        std::string protocol;
         std::vector<uint32_t> lkey;  // for rdma
         std::vector<uint32_t> rkey;  // for rdma
         std::string shm_name;        // for nvlink and hip
@@ -81,7 +82,11 @@ class TransferMetadata {
 
     struct SegmentDesc {
         std::string name;
+#ifdef ENABLE_MULTI_PROTOCOL
+        std::vector<std::string> protocol;
+#else
         std::string protocol;
+#endif
         // this is for rdma/shm
         std::vector<DeviceDesc> devices;
         Topology topology;

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -405,11 +405,15 @@ Status MultiTransport::selectTransport(const TransferRequest &entry,
         preferred_proto = "ascend";
     }
 #endif
-    if (std::find(protos.begin(), protos.end(), preferred_proto) ==
-            protos.end() ||
-        !transport_map_.count(preferred_proto)) {
+    if (!transport_map_.count(preferred_proto)) {
         return Status::NotSupportedTransport("Transport " + preferred_proto +
                                              " not installed");
+    }
+    if (std::find(protos.begin(), protos.end(), preferred_proto) ==
+        protos.end()) {
+        return Status::NotSupportedTransport(
+            "Transport " + preferred_proto +
+            " not supported by target segment");
     }
     // if (!transport_map_.count(proto)) {
     //     return Status::NotSupportedTransport("Transport " + proto +

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -97,6 +97,48 @@ Status MultiTransport::freeBatchID(BatchID batch_id) {
     return Status::OK();
 }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+Status MultiTransport::submitTransfer(
+    BatchID batch_id, const std::vector<TransferRequest> &entries,
+    std::string &proto) {
+    auto &batch_desc = *((BatchDesc *)(batch_id));
+    if (batch_desc.task_list.size() + entries.size() > batch_desc.batch_size) {
+        return Status::TooManyRequests(
+            "Exceed the limitation of batch capacity");
+    }
+
+    size_t task_id = batch_desc.task_list.size();
+    batch_desc.task_list.resize(task_id + entries.size());
+
+    std::unordered_map<Transport *, std::vector<Transport::TransferTask *> >
+        submit_tasks;
+    for (auto &request : entries) {
+        Transport *transport = nullptr;
+        auto status = selectTransport(request, transport, proto);
+        if (!status.ok()) return status;
+        assert(transport);
+        auto &task = batch_desc.task_list[task_id];
+        task.batch_id = batch_id;
+#ifdef USE_ASCEND_HETEROGENEOUS
+        task.request = const_cast<Transport::TransferRequest *>(&request);
+#else
+        task.request = &request;
+#endif
+        ++task_id;
+        submit_tasks[transport].push_back(&task);
+    }
+    Status overall_status = Status::OK();
+    for (auto &entry : submit_tasks) {
+        auto status = entry.first->submitTransferTask(entry.second);
+        if (!status.ok()) {
+            // LOG(ERROR) << "Failed to submit transfer task to "
+            //            << entry.first->getName();
+            overall_status = status;
+        }
+    }
+    return overall_status;
+}
+#else
 Status MultiTransport::submitTransfer(
     BatchID batch_id, const std::vector<TransferRequest> &entries) {
     auto &batch_desc = *((BatchDesc *)(batch_id));
@@ -136,6 +178,7 @@ Status MultiTransport::submitTransfer(
     }
     return overall_status;
 }
+#endif
 
 Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
                                          TransferStatus &status) {
@@ -340,6 +383,42 @@ Transport *MultiTransport::installTransport(const std::string &proto,
     return transport;
 }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+Status MultiTransport::selectTransport(const TransferRequest &entry,
+                                       Transport *&transport,
+                                       std::string &preferred_proto) {
+    auto target_segment_desc = metadata_->getSegmentDescByID(entry.target_id);
+    if (!target_segment_desc) {
+        return Status::InvalidArgument("Invalid target segment ID " +
+                                       std::to_string(entry.target_id));
+    }
+    auto protos = target_segment_desc->protocol;
+#ifdef USE_ASCEND_HETEROGENEOUS
+    // When USE_ASCEND_HETEROGENEOUS is enabled:
+    // - Target side directly reuses RDMA Transport
+    // - Initiator side uses heterogeneous_rdma_transport
+    // if (target_segment_desc->protocol == "rdma") {
+    //     proto = "ascend";
+    // }
+    if (preferred_proto == "rdma" &&
+        std::find(protos.begin(), protos.end(), "rdma") != protos.end()) {
+        preferred_proto = "ascend";
+    }
+#endif
+    if (std::find(protos.begin(), protos.end(), preferred_proto) ==
+            protos.end() ||
+        !transport_map_.count(preferred_proto)) {
+        return Status::NotSupportedTransport("Transport " + preferred_proto +
+                                             " not installed");
+    }
+    // if (!transport_map_.count(proto)) {
+    //     return Status::NotSupportedTransport("Transport " + proto +
+    //                                          " not installed");
+    // }
+    transport = transport_map_[preferred_proto].get();
+    return Status::OK();
+}
+#else
 Status MultiTransport::selectTransport(const TransferRequest &entry,
                                        Transport *&transport) {
     auto target_segment_desc = metadata_->getSegmentDescByID(entry.target_id);
@@ -363,6 +442,7 @@ Status MultiTransport::selectTransport(const TransferRequest &entry,
     transport = transport_map_[proto].get();
     return Status::OK();
 }
+#endif
 
 Transport *MultiTransport::getTransport(const std::string &proto) {
     if (!transport_map_.count(proto)) return nullptr;

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -75,6 +75,32 @@ int TransferEngine::removeLocalSegment(const std::string& segment_name) {
     return impl_->removeLocalSegment(segment_name);
 }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+int TransferEngine::registerLocalMemory(
+    std::unordered_map<std::string, std::vector<RegisteredBuffer>>&
+        buffer_map) {
+    return impl_->registerLocalMemory(buffer_map);
+}
+
+int TransferEngine::unregisterLocalMemory(
+    std::unordered_map<std::string, std::vector<RegisteredBuffer>>&
+        buffer_map) {
+    return impl_->unregisterLocalMemory(buffer_map);
+}
+
+Status TransferEngine::submitTransfer(
+    BatchID batch_id, const std::vector<TransferRequest>& entries,
+    std::string& proto) {
+    return impl_->submitTransfer(batch_id, entries, proto);
+}
+
+Status TransferEngine::submitTransferWithNotify(
+    BatchID batch_id, const std::vector<TransferRequest>& entries,
+    TransferMetadata::NotifyDesc notify_msg, std::string& proto) {
+    return impl_->submitTransferWithNotify(batch_id, entries, notify_msg,
+                                           proto);
+}
+#else
 int TransferEngine::registerLocalMemory(void* addr, size_t length,
                                         const std::string& location,
                                         bool remote_accessible,
@@ -86,6 +112,18 @@ int TransferEngine::registerLocalMemory(void* addr, size_t length,
 int TransferEngine::unregisterLocalMemory(void* addr, bool update_metadata) {
     return impl_->unregisterLocalMemory(addr, update_metadata);
 }
+
+Status TransferEngine::submitTransfer(
+    BatchID batch_id, const std::vector<TransferRequest>& entries) {
+    return impl_->submitTransfer(batch_id, entries);
+}
+
+Status TransferEngine::submitTransferWithNotify(
+    BatchID batch_id, const std::vector<TransferRequest>& entries,
+    TransferMetadata::NotifyDesc notify_msg) {
+    return impl_->submitTransferWithNotify(batch_id, entries, notify_msg);
+}
+#endif
 
 int TransferEngine::registerLocalMemoryBatch(
     const std::vector<BufferEntry>& buffer_list, const std::string& location) {
@@ -103,17 +141,6 @@ BatchID TransferEngine::allocateBatchID(size_t batch_size) {
 
 Status TransferEngine::freeBatchID(BatchID batch_id) {
     return impl_->freeBatchID(batch_id);
-}
-
-Status TransferEngine::submitTransfer(
-    BatchID batch_id, const std::vector<TransferRequest>& entries) {
-    return impl_->submitTransfer(batch_id, entries);
-}
-
-Status TransferEngine::submitTransferWithNotify(
-    BatchID batch_id, const std::vector<TransferRequest>& entries,
-    TransferMetadata::NotifyDesc notify_msg) {
-    return impl_->submitTransferWithNotify(batch_id, entries, notify_msg);
 }
 
 int TransferEngine::getNotifies(

--- a/mooncake-transfer-engine/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_c.cpp
@@ -82,6 +82,73 @@ int removeLocalSegment(transfer_engine_t engine, const char *segment_name) {
     return native->removeLocalSegment(segment_name);
 }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+int registerLocalMemory(transfer_engine_t engine, void *addr, size_t length,
+                        const char *location, int remote_accessible,
+                        const char *proto) {
+    TransferEngine *native = (TransferEngine *)engine;
+    std::unordered_map<std::string,
+                       std::vector<TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[proto].emplace_back(addr, length, location, remote_accessible,
+                                   true);
+    return native->registerLocalMemory(buffer_map);
+}
+
+int unregisterLocalMemory(transfer_engine_t engine, void *addr,
+                          const char *proto) {
+    TransferEngine *native = (TransferEngine *)engine;
+    std::unordered_map<std::string,
+                       std::vector<TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[proto].emplace_back(addr);
+    return native->unregisterLocalMemory(buffer_map);
+}
+
+int submitTransfer(transfer_engine_t engine, batch_id_t batch_id,
+                   struct transfer_request *entries, size_t count,
+                   char *protocol) {
+    TransferEngine *native = (TransferEngine *)engine;
+    std::vector<Transport::TransferRequest> native_entries;
+    native_entries.resize(count);
+    for (size_t index = 0; index < count; index++) {
+        native_entries[index].opcode =
+            (Transport::TransferRequest::OpCode)entries[index].opcode;
+        native_entries[index].source = entries[index].source;
+        native_entries[index].target_id = entries[index].target_id;
+        native_entries[index].target_offset = entries[index].target_offset;
+        native_entries[index].length = entries[index].length;
+    }
+    std::string proto_str(protocol);
+    Status s = native->submitTransfer((Transport::BatchID)batch_id,
+                                      native_entries, proto_str);
+    return (int)s.code();
+}
+
+int submitTransferWithNotify(transfer_engine_t engine, batch_id_t batch_id,
+                             struct transfer_request *entries, size_t count,
+                             notify_msg_t notify_msg, char *protocol) {
+    TransferEngine *native = (TransferEngine *)engine;
+    std::vector<Transport::TransferRequest> native_entries;
+    native_entries.resize(count);
+    for (size_t index = 0; index < count; index++) {
+        native_entries[index].opcode =
+            (Transport::TransferRequest::OpCode)entries[index].opcode;
+        native_entries[index].source = entries[index].source;
+        native_entries[index].target_id = entries[index].target_id;
+        native_entries[index].target_offset = entries[index].target_offset;
+        native_entries[index].length = entries[index].length;
+    }
+    TransferMetadata::NotifyDesc native_notify_msg;
+    native_notify_msg.name = notify_msg.name;
+    native_notify_msg.notify_msg = notify_msg.msg;
+    std::string proto_str(protocol);
+    Status s = native->submitTransferWithNotify((Transport::BatchID)batch_id,
+                                                native_entries,
+                                                native_notify_msg, proto_str);
+    return (int)s.code();
+}
+#else
 int registerLocalMemory(transfer_engine_t engine, void *addr, size_t length,
                         const char *location, int remote_accessible) {
     TransferEngine *native = (TransferEngine *)engine;
@@ -92,34 +159,6 @@ int registerLocalMemory(transfer_engine_t engine, void *addr, size_t length,
 int unregisterLocalMemory(transfer_engine_t engine, void *addr) {
     TransferEngine *native = (TransferEngine *)engine;
     return native->unregisterLocalMemory(addr);
-}
-
-int registerLocalMemoryBatch(transfer_engine_t engine,
-                             buffer_entry_t *buffer_list, size_t buffer_len,
-                             const char *location) {
-    TransferEngine *native = (TransferEngine *)engine;
-    std::vector<BufferEntry> native_buffer_list;
-    for (size_t i = 0; i < buffer_len; ++i) {
-        BufferEntry entry;
-        entry.addr = buffer_list[i].addr;
-        entry.length = buffer_list[i].length;
-        native_buffer_list.push_back(entry);
-    }
-    return native->registerLocalMemoryBatch(native_buffer_list, location);
-}
-
-int unregisterLocalMemoryBatch(transfer_engine_t engine, void **addr_list,
-                               size_t addr_len) {
-    TransferEngine *native = (TransferEngine *)engine;
-    std::vector<void *> native_addr_list;
-    for (size_t i = 0; i < addr_len; ++i)
-        native_addr_list.push_back(addr_list[i]);
-    return native->unregisterLocalMemoryBatch(native_addr_list);
-}
-
-batch_id_t allocateBatchID(transfer_engine_t engine, size_t batch_size) {
-    TransferEngine *native = (TransferEngine *)engine;
-    return (batch_id_t)native->allocateBatchID(batch_size);
 }
 
 int submitTransfer(transfer_engine_t engine, batch_id_t batch_id,
@@ -160,6 +199,35 @@ int submitTransferWithNotify(transfer_engine_t engine, batch_id_t batch_id,
     Status s = native->submitTransferWithNotify(
         (Transport::BatchID)batch_id, native_entries, native_notify_msg);
     return (int)s.code();
+}
+#endif
+
+int registerLocalMemoryBatch(transfer_engine_t engine,
+                             buffer_entry_t *buffer_list, size_t buffer_len,
+                             const char *location) {
+    TransferEngine *native = (TransferEngine *)engine;
+    std::vector<BufferEntry> native_buffer_list;
+    for (size_t i = 0; i < buffer_len; ++i) {
+        BufferEntry entry;
+        entry.addr = buffer_list[i].addr;
+        entry.length = buffer_list[i].length;
+        native_buffer_list.push_back(entry);
+    }
+    return native->registerLocalMemoryBatch(native_buffer_list, location);
+}
+
+int unregisterLocalMemoryBatch(transfer_engine_t engine, void **addr_list,
+                               size_t addr_len) {
+    TransferEngine *native = (TransferEngine *)engine;
+    std::vector<void *> native_addr_list;
+    for (size_t i = 0; i < addr_len; ++i)
+        native_addr_list.push_back(addr_list[i]);
+    return native->unregisterLocalMemoryBatch(native_addr_list);
+}
+
+batch_id_t allocateBatchID(transfer_engine_t engine, size_t batch_size) {
+    TransferEngine *native = (TransferEngine *)engine;
+    return (batch_id_t)native->allocateBatchID(batch_size);
 }
 
 int getTransferStatus(transfer_engine_t engine, batch_id_t batch_id,

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -467,7 +467,7 @@ bool TransferEngineImpl::checkOverlap(void* addr, uint64_t length) {
 int TransferEngineImpl::registerLocalMemory(
     std::unordered_map<std::string, std::vector<RegisteredBuffer>>&
         buffer_map) {
-    // Check for overlaps first
+    // ========== Phase 1: Pre-check ==========
     for (const auto& entry : buffer_map) {
         for (const auto& buffer : entry.second) {
             if (checkOverlap(buffer.addr, buffer.length)) {
@@ -483,8 +483,24 @@ int TransferEngineImpl::registerLocalMemory(
         }
     }
 
-    // Register by protocol
-    std::vector<MemoryRegion> registered_buffers;
+    // ========== Phase 2: Prepare rollback records ==========
+    struct RegisteredRecord {
+        Transport* transport;  // Direct pointer to avoid lookup during rollback
+        void* addr;
+        uint64_t length;
+        std::string location;
+        bool remote_accessible;
+    };
+    std::vector<RegisteredRecord> success_records;
+    
+    // Reserve space to reduce reallocations
+    size_t total_buffers = 0;
+    for (const auto& entry : buffer_map) {
+        total_buffers += entry.second.size();
+    }
+    success_records.reserve(total_buffers);
+
+    // ========== Phase 3: Execute registration ==========
     for (const auto& entry : buffer_map) {
         const std::string& protocol = entry.first;
         const auto& buffer_list = entry.second;
@@ -492,36 +508,54 @@ int TransferEngineImpl::registerLocalMemory(
         auto transport = multi_transports_->getTransport(protocol);
         if (!transport) {
             LOG(ERROR) << "Transport " << protocol << " not found";
+            rollbackAllRegistrations(success_records);
             return -1;
         }
-
+        
         for (const auto& buffer : buffer_list) {
             int ret = transport->registerLocalMemory(
                 buffer.addr, buffer.length, buffer.location,
                 buffer.remote_accessible, buffer.update_metadata);
+            
             if (ret < 0) {
                 LOG(ERROR) << "Failed to register memory with transport "
                            << protocol << " addr=" << buffer.addr
                            << " length=" << buffer.length;
+                
+                // ========== Phase 4: Rollback on failure ==========
+                rollbackAllRegistrations(success_records);
                 return ret;
             }
-            registered_buffers.push_back({buffer.addr, buffer.length,
-                                          buffer.location,
-                                          buffer.remote_accessible});
+            
+            // Record successful registration for potential rollback
+            success_records.push_back({transport, buffer.addr, buffer.length,
+                                       buffer.location, buffer.remote_accessible});
         }
-        if (registered_buffers.size() != buffer_list.size()) {
-            for (auto& buffer : registered_buffers) {
-                transport->unregisterLocalMemory(buffer.addr, true);
-            }
-        } else {
-            std::unique_lock<std::shared_mutex> lock(mutex_);
-            local_memory_regions_.insert(local_memory_regions_.end(),
-                                         registered_buffers.begin(),
-                                         registered_buffers.end());
-        }
-        registered_buffers.clear();
     }
+    
+    // ========== Phase 5: Commit to system state ==========
+    {
+        std::unique_lock<std::shared_mutex> lock(mutex_);
+        for (const auto& record : success_records) {
+            local_memory_regions_.push_back({record.addr, record.length,
+                                             record.location,
+                                             record.remote_accessible});
+        }
+    }
+    
     return 0;
+}
+
+void TransferEngineImpl::rollbackAllRegistrations(
+    const std::vector<RegisteredRecord>& records) {
+    
+    LOG(INFO) << "Rolling back " << records.size() << " registered regions";
+    
+    for (const auto& record : records) {
+        if (record.transport) {
+            record.transport->unregisterLocalMemory(record.addr, true);
+        }
+    }
 }
 
 int TransferEngineImpl::unregisterLocalMemory(

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -463,6 +463,102 @@ bool TransferEngineImpl::checkOverlap(void* addr, uint64_t length) {
     return false;
 }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+int TransferEngineImpl::registerLocalMemory(
+    std::unordered_map<std::string, std::vector<RegisteredBuffer>>&
+        buffer_map) {
+    // Check for overlaps first
+    for (const auto& entry : buffer_map) {
+        for (const auto& buffer : entry.second) {
+            if (checkOverlap(buffer.addr, buffer.length)) {
+                LOG(ERROR) << "Transfer Engine does not support overlapped "
+                              "memory region";
+                return ERR_ADDRESS_OVERLAPPED;
+            }
+            if (buffer.length == 0) {
+                LOG(ERROR) << "Transfer Engine does not support zero length "
+                              "memory region";
+                return ERR_INVALID_ARGUMENT;
+            }
+        }
+    }
+
+    // Register by protocol
+    std::vector<MemoryRegion> registered_buffers;
+    for (const auto& entry : buffer_map) {
+        const std::string& protocol = entry.first;
+        const auto& buffer_list = entry.second;
+
+        auto transport = multi_transports_->getTransport(protocol);
+        if (!transport) {
+            LOG(ERROR) << "Transport " << protocol << " not found";
+            return -1;
+        }
+
+        for (const auto& buffer : buffer_list) {
+            int ret = transport->registerLocalMemory(
+                buffer.addr, buffer.length, buffer.location,
+                buffer.remote_accessible, buffer.update_metadata);
+            if (ret < 0) {
+                LOG(ERROR) << "Failed to register memory with transport "
+                           << protocol << " addr=" << buffer.addr
+                           << " length=" << buffer.length;
+                return ret;
+            }
+            registered_buffers.push_back({buffer.addr, buffer.length,
+                                          buffer.location,
+                                          buffer.remote_accessible});
+        }
+        if (registered_buffers.size() != buffer_list.size()) {
+            for (auto& buffer : registered_buffers) {
+                transport->unregisterLocalMemory(buffer.addr, true);
+            }
+        } else {
+            std::unique_lock<std::shared_mutex> lock(mutex_);
+            local_memory_regions_.insert(local_memory_regions_.end(),
+                                         registered_buffers.begin(),
+                                         registered_buffers.end());
+        }
+        registered_buffers.clear();
+    }
+    return 0;
+}
+
+int TransferEngineImpl::unregisterLocalMemory(
+    std::unordered_map<std::string, std::vector<RegisteredBuffer>>&
+        buffer_map) {
+    for (const auto& buffer_entry : buffer_map) {
+        const std::string& protocol = buffer_entry.first;
+        const std::vector<RegisteredBuffer>& buffer_list = buffer_entry.second;
+
+        auto transport = multi_transports_->getTransport(protocol);
+        if (!transport) {
+            LOG(ERROR) << "Transport " << protocol << " not found";
+            return -1;
+        }
+
+        for (const auto& buffer : buffer_list) {
+            int ret = transport->unregisterLocalMemory(buffer.addr,
+                                                       buffer.update_metadata);
+            if (ret) {
+                return ret;
+            }
+        }
+
+        std::unique_lock<std::shared_mutex> lock(mutex_);
+        for (const auto& buffer : buffer_list) {
+            for (auto it = local_memory_regions_.begin();
+                 it != local_memory_regions_.end(); ++it) {
+                if (it->addr == buffer.addr) {
+                    local_memory_regions_.erase(it);
+                    break;
+                }
+            }
+        }
+    }
+    return 0;
+}
+#else
 int TransferEngineImpl::registerLocalMemory(void* addr, size_t length,
                                             const std::string& location,
                                             bool remote_accessible,
@@ -506,6 +602,7 @@ int TransferEngineImpl::unregisterLocalMemory(void* addr,
     }
     return 0;
 }
+#endif
 
 int TransferEngineImpl::registerLocalMemoryBatch(
     const std::vector<BufferEntry>& buffer_list, const std::string& location) {

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <set>
+#include <algorithm>
 
 #include "common.h"
 #include "config.h"
@@ -25,6 +26,17 @@
 #include "transfer_metadata_plugin.h"
 
 namespace mooncake {
+#ifdef ENABLE_MULTI_PROTOCOL
+static std::string protocolsToString(
+    const std::vector<std::string> &protocols) {
+    std::string result;
+    for (size_t i = 0; i < protocols.size(); ++i) {
+        if (i > 0) result += ",";
+        result += protocols[i];
+    }
+    return result;
+}
+#endif
 
 static inline std::string extractProtocolFromConnString(
     const std::string &conn_string) {
@@ -162,6 +174,107 @@ int TransferMetadata::getNotifies(std::vector<NotifyDesc> &notifies) {
     return 0;
 }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
+                                        Json::Value &segmentJSON) {
+    segmentJSON["name"] = desc.name;
+    Json::Value protocolJSON(Json::arrayValue);
+    for (const auto &proto : desc.protocol) {
+        if (proto == "rdma" || proto == "barex" || proto == "efa") {
+            Json::Value devicesJSON(Json::arrayValue);
+            for (const auto &device : desc.devices) {
+                Json::Value deviceJSON;
+                deviceJSON["name"] = device.name;
+                deviceJSON["lid"] = device.lid;
+                deviceJSON["gid"] = device.gid;
+                devicesJSON.append(deviceJSON);
+            }
+            segmentJSON["devices"] = devicesJSON;
+            segmentJSON["priority_matrix"] = desc.topology.toJson();
+        } else if (proto == "ascend") {
+            Json::Value devicesJSON(Json::arrayValue);
+            for (const auto &device : desc.devices) {
+                Json::Value deviceJSON;
+                deviceJSON["name"] = device.name;
+                deviceJSON["lid"] = device.lid;
+                devicesJSON.append(deviceJSON);
+            }
+            segmentJSON["devices"] = devicesJSON;
+
+            Json::Value rankInfoJSON;
+            rankInfoJSON["rankId"] =
+                static_cast<Json::UInt64>(desc.rank_info.rankId);
+            rankInfoJSON["hostIp"] = desc.rank_info.hostIp;
+            rankInfoJSON["hostPort"] =
+                static_cast<Json::UInt64>(desc.rank_info.hostPort);
+            rankInfoJSON["deviceLogicId"] =
+                static_cast<Json::UInt64>(desc.rank_info.deviceLogicId);
+            rankInfoJSON["devicePhyId"] =
+                static_cast<Json::UInt64>(desc.rank_info.devicePhyId);
+            rankInfoJSON["deviceType"] =
+                static_cast<Json::UInt64>(desc.rank_info.deviceType);
+            rankInfoJSON["deviceIp"] = desc.rank_info.deviceIp;
+            rankInfoJSON["devicePort"] =
+                static_cast<Json::UInt64>(desc.rank_info.devicePort);
+            rankInfoJSON["pid"] = static_cast<Json::UInt64>(desc.rank_info.pid);
+            Json::Value endpointsJSON(Json::arrayValue);
+            for (const auto &endpoint : desc.rank_info.endpoints) {
+                endpointsJSON.append(endpoint);
+            }
+            rankInfoJSON["endpoints"] = endpointsJSON;
+
+            segmentJSON["rank_info"] = rankInfoJSON;
+        } else if (proto == "cxl") {
+            segmentJSON["cxl_name"] = desc.cxl_name;
+            segmentJSON["cxl_base_addr"] =
+                static_cast<Json::UInt64>(desc.cxl_base_addr);
+        }
+        protocolJSON.append(proto);
+    }
+
+    Json::Value buffersJSON(Json::arrayValue);
+    for (const auto &buffer : desc.buffers) {
+        Json::Value bufferJSON;
+        bufferJSON["name"] = buffer.name;
+        bufferJSON["length"] = static_cast<Json::UInt64>(buffer.length);
+        bufferJSON["protocol"] = buffer.protocol;
+
+        if (buffer.protocol == "cxl") {
+            // CXL uses offset instead of addr
+            bufferJSON["offset"] = static_cast<Json::UInt64>(buffer.offset);
+        } else if (buffer.protocol == "rdma" || buffer.protocol == "barex" ||
+                   buffer.protocol == "efa") {
+            bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
+            Json::Value rkeyJSON(Json::arrayValue);
+            for (auto &entry : buffer.rkey) rkeyJSON.append(entry);
+            bufferJSON["rkey"] = rkeyJSON;
+            Json::Value lkeyJSON(Json::arrayValue);
+            for (auto &entry : buffer.lkey) lkeyJSON.append(entry);
+            bufferJSON["lkey"] = lkeyJSON;
+        } else if (buffer.protocol == "tcp" || buffer.protocol == "ascend") {
+            bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
+        } else if (buffer.protocol == "nvlink" ||
+                   buffer.protocol == "nvlink_intra" ||
+                   buffer.protocol == "hip" || buffer.protocol == "ubshmem") {
+            bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
+            bufferJSON["shm_name"] = buffer.shm_name;
+        } else {
+            LOG(ERROR) << "Unsupported segment descriptor for register, name "
+                       << desc.name << " protocol "
+                       << Json::writeString(Json::StreamWriterBuilder(),
+                                            protocolJSON);
+            return ERR_METADATA;
+        }
+        buffersJSON.append(bufferJSON);
+    }
+    segmentJSON["buffers"] = buffersJSON;
+    segmentJSON["protocol"] = protocolJSON;
+    segmentJSON["tcp_data_port"] = desc.tcp_data_port;
+    segmentJSON["timestamp"] = getCurrentDateTime();
+
+    return 0;
+}
+#else
 int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
                                         Json::Value &segmentJSON) {
     segmentJSON["name"] = desc.name;
@@ -284,6 +397,7 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
     }
     return 0;
 }
+#endif
 
 int TransferMetadata::updateSegmentDesc(const std::string &segment_name,
                                         const SegmentDesc &desc) {
@@ -298,8 +412,14 @@ int TransferMetadata::updateSegmentDesc(const std::string &segment_name,
     }
 
     if (!storage_plugin_->set(getFullMetadataKey(segment_name), segmentJSON)) {
+#ifdef ENABLE_MULTI_PROTOCOL
+        LOG(ERROR) << "Failed to register segment descriptor, name "
+                   << desc.name << " protocol "
+                   << protocolsToString(desc.protocol);
+#else
         LOG(ERROR) << "Failed to register segment descriptor, name "
                    << desc.name << " protocol " << desc.protocol;
+#endif
         return ERR_METADATA;
     }
 
@@ -328,6 +448,174 @@ int TransferMetadata::removeSegmentDesc(const std::string &segment_name) {
     return 0;
 }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+std::shared_ptr<TransferMetadata::SegmentDesc>
+TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
+                                    const std::string &segment_name) {
+    auto desc = std::make_shared<SegmentDesc>();
+    desc->name = segmentJSON["name"].asString();
+    desc->tcp_data_port = segmentJSON["tcp_data_port"].asInt();
+    if (segmentJSON.isMember("timestamp"))
+        desc->timestamp = segmentJSON["timestamp"].asString();
+
+    for (const auto &protocolStr : segmentJSON["protocol"]) {
+        std::string proto = protocolStr.asString();
+        desc->protocol.push_back(proto);
+
+        if (proto == "rdma" || proto == "barex" || proto == "efa") {
+            if (desc->devices.empty()) {
+                for (const auto &deviceJSON : segmentJSON["devices"]) {
+                    DeviceDesc device;
+                    device.name = deviceJSON["name"].asString();
+                    device.lid = deviceJSON["lid"].asUInt();
+                    device.gid = deviceJSON["gid"].asString();
+                    if (device.name.empty() || device.gid.empty()) {
+                        LOG(WARNING) << "Corrupted segment descriptor, name "
+                                     << segment_name << " protocol " << proto;
+                        return nullptr;
+                    }
+                    desc->devices.push_back(device);
+                }
+
+                int ret = desc->topology.parse(
+                    segmentJSON["priority_matrix"].toStyledString());
+                if (ret) {
+                    LOG(WARNING) << "Corrupted segment descriptor, name "
+                                 << segment_name << " protocol " << proto;
+                }
+            }
+        } else if (proto == "ascend") {
+            if (desc->devices.empty()) {
+                for (const auto &deviceJSON : segmentJSON["devices"]) {
+                    DeviceDesc device;
+                    device.name = deviceJSON["name"].asString();
+                    device.lid = deviceJSON["lid"].asUInt();
+                    if (device.name.empty()) {
+                        LOG(WARNING) << "Corrupted segment descriptor, name "
+                                     << segment_name << " protocol " << proto;
+                        return nullptr;
+                    }
+                    desc->devices.push_back(device);
+                }
+            }
+
+            Json::Value rankInfoJSON = segmentJSON["rank_info"];
+            desc->rank_info.rankId = rankInfoJSON["rankId"].asUInt64();
+            desc->rank_info.hostIp = rankInfoJSON["hostIp"].asString();
+            desc->rank_info.hostPort = rankInfoJSON["hostPort"].asUInt64();
+            desc->rank_info.deviceLogicId =
+                rankInfoJSON["deviceLogicId"].asUInt64();
+            desc->rank_info.devicePhyId =
+                rankInfoJSON["devicePhyId"].asUInt64();
+            desc->rank_info.deviceType = rankInfoJSON["deviceType"].asUInt64();
+            desc->rank_info.deviceIp = rankInfoJSON["deviceIp"].asString();
+            desc->rank_info.devicePort = rankInfoJSON["devicePort"].asUInt64();
+            desc->rank_info.pid = rankInfoJSON["pid"].asUInt64();
+            if (rankInfoJSON.isMember("endpoints")) {
+                for (const auto &endpointJSON : rankInfoJSON["endpoints"]) {
+                    if (endpointJSON.isString()) {
+                        desc->rank_info.endpoints.push_back(
+                            endpointJSON.asString());
+                    }
+                }
+            }
+        } else if (proto == "cxl") {
+            desc->cxl_name = segmentJSON["cxl_name"].asString();
+            desc->cxl_base_addr = segmentJSON["cxl_base_addr"].asUInt64();
+        }
+    }
+
+    for (const auto &bufferJSON : segmentJSON["buffers"]) {
+        std::string buffer_protocol = bufferJSON["protocol"].asString();
+
+        if (buffer_protocol == "cxl") {
+            BufferDesc buffer;
+            buffer.name = bufferJSON["name"].asString();
+            buffer.offset = bufferJSON["offset"].asUInt64();
+            buffer.length = bufferJSON["length"].asUInt64();
+            buffer.protocol = buffer_protocol;
+            if (buffer.name.empty() || !buffer.length) {
+                LOG(WARNING)
+                    << "Corrupted segment descriptor, name " << segment_name
+                    << " buffer_protocol " << buffer_protocol;
+                return nullptr;
+            }
+            desc->buffers.push_back(buffer);
+        } else if (buffer_protocol == "rdma" || buffer_protocol == "barex" ||
+                   buffer_protocol == "efa") {
+            BufferDesc buffer;
+            buffer.name = bufferJSON["name"].asString();
+            buffer.addr = bufferJSON["addr"].asUInt64();
+            buffer.length = bufferJSON["length"].asUInt64();
+            buffer.protocol = buffer_protocol;
+            for (const auto &rkeyJSON : bufferJSON["rkey"])
+                buffer.rkey.push_back(rkeyJSON.asUInt());
+            for (const auto &lkeyJSON : bufferJSON["lkey"])
+                buffer.lkey.push_back(lkeyJSON.asUInt());
+            if (buffer.name.empty() || !buffer.addr || !buffer.length ||
+                buffer.rkey.empty() ||
+                buffer.rkey.size() != buffer.lkey.size()) {
+                LOG(WARNING)
+                    << "Corrupted segment descriptor, name " << segment_name
+                    << " buffer_protocol " << buffer_protocol << ", "
+                    << buffer.name << ", " << buffer.addr << ", "
+                    << buffer.length << ", " << buffer.rkey.size() << ", "
+                    << buffer.lkey.size();
+                return nullptr;
+            }
+            desc->buffers.push_back(buffer);
+        } else if (buffer_protocol == "tcp" || buffer_protocol == "ascend") {
+            BufferDesc buffer;
+            buffer.name = bufferJSON["name"].asString();
+            buffer.addr = bufferJSON["addr"].asUInt64();
+            buffer.length = bufferJSON["length"].asUInt64();
+            buffer.protocol = buffer_protocol;
+            if (buffer.name.empty() || !buffer.addr || !buffer.length) {
+                LOG(WARNING)
+                    << "Corrupted segment descriptor, name " << segment_name
+                    << " buffer_protocol " << buffer_protocol;
+                return nullptr;
+            }
+            desc->buffers.push_back(buffer);
+        } else if (buffer_protocol == "nvlink" ||
+                   buffer_protocol == "nvlink_intra" ||
+                   buffer_protocol == "hip" || buffer_protocol == "ubshmem") {
+            BufferDesc buffer;
+            buffer.name = bufferJSON["name"].asString();
+            buffer.addr = bufferJSON["addr"].asUInt64();
+            buffer.length = bufferJSON["length"].asUInt64();
+            buffer.shm_name = bufferJSON["shm_name"].asString();
+            buffer.protocol = buffer_protocol;
+            if (buffer.name.empty() || !buffer.addr || !buffer.length ||
+                buffer.shm_name.empty()) {
+                LOG(WARNING)
+                    << "Corrupted segment descriptor, name " << segment_name
+                    << " buffer_protocol " << buffer_protocol << "buffer name "
+                    << buffer.name << "buffer addr " << buffer.addr
+                    << "buffer length " << buffer.length << "buffer shm_name "
+                    << buffer.shm_name;
+                return nullptr;
+            }
+            desc->buffers.push_back(buffer);
+        } else if (buffer_protocol == "nvmeof") {
+            NVMeoFBufferDesc buffer;
+            buffer.file_path = bufferJSON["file_path"].asString();
+            buffer.length = bufferJSON["length"].asUInt64();
+            const Json::Value &local_path_map = bufferJSON["local_path_map"];
+            for (const auto &key : local_path_map.getMemberNames()) {
+                buffer.local_path_map[key] = local_path_map[key].asString();
+            }
+            desc->nvmeof_buffers.push_back(buffer);
+        } else {
+            LOG(ERROR) << "Unsupported buffer protocol, name " << segment_name
+                       << " buffer_protocol " << buffer_protocol;
+            return nullptr;
+        }
+    }
+
+    return desc;
+}
+#else
 std::shared_ptr<TransferMetadata::SegmentDesc>
 TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
                                     const std::string &segment_name) {
@@ -491,6 +779,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
     }
     return desc;
 }
+#endif
 
 int TransferMetadata::receivePeerMetadata(const Json::Value &peer_json,
                                           Json::Value &local_json) {

--- a/mooncake-transfer-engine/src/transfer_metadata_dump.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_dump.cpp
@@ -18,7 +18,14 @@
 namespace mooncake {
 void TransferMetadata::SegmentDesc::dump() const {
     LOG(INFO) << "  segment name: " << name;
+#ifdef ENABLE_MULTI_PROTOCOL
+    LOG(INFO) << "  protocols: ";
+    for (std::string proto : protocol) {
+        LOG(INFO) << "    protocol: " << proto;
+    }
+#else
     LOG(INFO) << "  protocol: " << protocol;
+#endif
     LOG(INFO) << "  topology: " << topology.toString();
     LOG(INFO) << "  devices: ";
     for (auto &device : devices) {

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
@@ -146,7 +146,11 @@ int AscendDirectTransport::allocateLocalSegmentID() {
     auto desc = std::make_shared<SegmentDesc>();
     if (!desc) return ERR_MEMORY;
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc->protocol.push_back("ascend");
+#else
     desc->protocol = "ascend";
+#endif
 
     dummy_real_mode_ = globalConfig().ascend_agent_mode;
     char *roce_enable_str = std::getenv("HCCL_INTRA_ROCE_ENABLE");
@@ -325,6 +329,7 @@ int AscendDirectTransport::registerLocalMemory(void *addr, size_t length,
     buffer_desc.name = location;
     buffer_desc.addr = (uint64_t)addr;
     buffer_desc.length = (uint64_t)length;
+    buffer_desc.protocol = "ascend";
 
     adxl::MemType mem_type;
     if (location.starts_with("cpu")) {

--- a/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/hccl_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/hccl_transport/hccl_transport.cpp
@@ -563,6 +563,7 @@ int HcclTransport::registerLocalMemory(void *addr, size_t length,
     buffer_desc.name = location;
     buffer_desc.addr = (uint64_t)addr;
     buffer_desc.length = (uint64_t)length;
+    buffer_desc.protocol = "ascend";
 
     int ret;
     ret = regLocalRmaMem(addr, (uint64_t)length);
@@ -589,7 +590,11 @@ int HcclTransport::allocateLocalSegmentID() {
     auto desc = std::make_shared<SegmentDesc>();
     if (!desc) return ERR_MEMORY;
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc->protocol.push_back("ascend");
+#else
     desc->protocol = "ascend";
+#endif
     desc->rank_info.rankId = local_rank_info_.rankId;
     desc->rank_info.hostIp = inet_ntoa(local_rank_info_.hostIp);
     desc->rank_info.hostPort = local_rank_info_.hostPort;

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ubshmem_transport/ubshmem_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ubshmem_transport/ubshmem_transport.cpp
@@ -322,7 +322,11 @@ int UBShmemTransport::install(std::string &local_server_name,
     if (!desc) return ERR_MEMORY;
 
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc->protocol.push_back("ubshmem");
+#else
     desc->protocol = "ubshmem";
+#endif
 
     metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
                                std::move(desc));
@@ -600,6 +604,7 @@ int UBShmemTransport::registerLocalMemory(void *addr, size_t length,
         desc.addr = (uint64_t)addr;
         desc.length = length;
         desc.name = location;
+        desc.protocol = "ubshmem";
         desc.shm_name =
             serializeBinaryData((const void *)ipc_key, kIPCHandleKeyLength);
         return metadata_->addLocalMemoryBuffer(desc, true);
@@ -632,6 +637,7 @@ int UBShmemTransport::registerLocalMemory(void *addr, size_t length,
         desc.addr = (uint64_t)addr;
         desc.length = length;
         desc.name = location;
+        desc.protocol = "ubshmem";
         desc.shm_name = serializeBinaryData((const void *)&export_handle_raw,
                                             sizeof(aclrtMemFabricHandle));
         return metadata_->addLocalMemoryBuffer(desc, true);

--- a/mooncake-transfer-engine/src/transport/barex_transport/barex_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/barex_transport/barex_transport.cpp
@@ -218,6 +218,7 @@ int BarexTransport::registerLocalMemoryBase(void *addr, size_t length,
             buffer_desc.name = entry.location;
             buffer_desc.addr = entry.start;
             buffer_desc.length = entry.len;
+            buffer_desc.protocol = "barex";
             int rc =
                 metadata_->addLocalMemoryBuffer(buffer_desc, update_metadata);
             if (rc) return rc;
@@ -226,6 +227,7 @@ int BarexTransport::registerLocalMemoryBase(void *addr, size_t length,
         buffer_desc.name = name;
         buffer_desc.addr = (uint64_t)addr;
         buffer_desc.length = length;
+        buffer_desc.protocol = "barex";
         int rc = metadata_->addLocalMemoryBuffer(buffer_desc, update_metadata);
         if (rc) return rc;
     }
@@ -282,7 +284,11 @@ int BarexTransport::allocateLocalSegmentID() {
     auto desc = std::make_shared<SegmentDesc>();
     if (!desc) return ERR_MEMORY;
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc->protocol.push_back("barex");
+#else
     desc->protocol = "barex";
+#endif
     for (auto &entry : server_context_list_) {
         TransferMetadata::DeviceDesc device_desc;
         device_desc.name = entry->getCtx()->GetXDevice()->GetName();

--- a/mooncake-transfer-engine/src/transport/cxl_transport/cxl_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/cxl_transport/cxl_transport.cpp
@@ -218,10 +218,14 @@ int CxlTransport::install(std::string &local_server_name,
 }
 
 int CxlTransport::allocateLocalSegmentID() {
-    auto desc = std::make_shared<SegmentDesc>();
-    if (!desc) return ERR_MEMORY;
+    auto desc = metadata_->getSegmentDesc(local_server_name_);
+    if (!desc) desc = std::make_shared<SegmentDesc>();
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc->protocol.push_back("cxl");
+#else
     desc->protocol = "cxl";
+#endif
     desc->cxl_base_addr = (uint64_t)cxl_base_addr;
     desc->cxl_name = cxl_dev_path;
     metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
@@ -254,6 +258,7 @@ int CxlTransport::registerLocalMemory(void *addr, size_t length,
 
     cxl_buffer_desc.offset = (uint64_t)addr - (uint64_t)cxl_base_addr;
     cxl_buffer_desc.length = length;
+    cxl_buffer_desc.protocol = "cxl";
     return metadata_->addLocalMemoryBuffer(cxl_buffer_desc, update_metadata);
 }
 

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -295,6 +295,7 @@ int EfaTransport::registerLocalMemoryInternal(void *addr, size_t length,
 
     buffer_desc.addr = (uint64_t)addr;
     buffer_desc.length = length;
+    buffer_desc.protocol = "efa";
     int rc = metadata_->addLocalMemoryBuffer(buffer_desc, update_metadata);
     if (rc) return rc;
     return 0;
@@ -360,7 +361,11 @@ int EfaTransport::allocateLocalSegmentID() {
     auto desc = std::make_shared<SegmentDesc>();
     if (!desc) return ERR_MEMORY;
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc->protocol.push_back("efa");
+#else
     desc->protocol = "efa";
+#endif
     for (auto &entry : context_list_) {
         TransferMetadata::DeviceDesc device_desc;
         device_desc.name = entry->deviceName();

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -410,7 +410,11 @@ int HipTransport::install(std::string &local_server_name,
     if (!desc) return ERR_MEMORY;
 
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc->protocol.push_back("hip");
+#else
     desc->protocol = "hip";
+#endif
 
     metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
                                std::move(desc));
@@ -652,6 +656,7 @@ int HipTransport::registerLocalMemory(void *addr, size_t length,
         desc.addr = (uint64_t)addr;
         desc.length = length;
         desc.name = location;
+        desc.protocol = "hip";
         desc.shm_name = serializeBinaryData(&handle, sizeof(hipIpcMemHandle_t));
         return metadata_->addLocalMemoryBuffer(desc, true);
     }
@@ -696,6 +701,7 @@ int HipTransport::registerLocalMemory(void *addr, size_t length,
         desc.addr = (uint64_t)real_addr;
         desc.length = real_size;
         desc.name = location;
+        desc.protocol = "hip";
         desc.shm_name = serializeBinaryData((const void *)&export_handle_raw,
                                             sizeof(hipxFabricHandle));
         return metadata_->addLocalMemoryBuffer(desc, true);

--- a/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
@@ -154,7 +154,11 @@ int IntraNodeNvlinkTransport::install(
     auto desc = std::make_shared<SegmentDesc>();
     if (!desc) return ERR_MEMORY;
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc->protocol.push_back("nvlink_intra");
+#else
     desc->protocol = "nvlink_intra";
+#endif
     metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
                                std::move(desc));
     return 0;
@@ -330,6 +334,7 @@ int IntraNodeNvlinkTransport::registerLocalMemory(void *addr, size_t length,
     desc.addr = (uint64_t)base_ptr;
     desc.length = alloc_size;
     desc.name = location;
+    desc.protocol = "nvlink_intra";
     desc.shm_name = serializeBinaryData(&handle, sizeof(cudaIpcMemHandle_t));
     int rc = metadata_->addLocalMemoryBuffer(desc, true);
     if (rc == 0) {

--- a/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
@@ -182,7 +182,11 @@ int NvlinkTransport::install(std::string &local_server_name,
     auto desc = std::make_shared<SegmentDesc>();
     if (!desc) return ERR_MEMORY;
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc->protocol.push_back("nvlink");
+#else
     desc->protocol = "nvlink";
+#endif
     metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
                                std::move(desc));
     return 0;
@@ -337,6 +341,7 @@ int NvlinkTransport::registerLocalMemory(void *addr, size_t length,
         desc.addr = (uint64_t)addr;
         desc.length = length;
         desc.name = location;
+        desc.protocol = "nvlink";
         desc.shm_name =
             serializeBinaryData(&handle, sizeof(cudaIpcMemHandle_t));
         return metadata_->addLocalMemoryBuffer(desc, true);
@@ -378,6 +383,7 @@ int NvlinkTransport::registerLocalMemory(void *addr, size_t length,
         desc.addr = (uint64_t)real_addr;  // (uint64_t)addr;
         desc.length = real_size;          // length;
         desc.name = location;
+        desc.protocol = "nvlink";
         desc.shm_name =
             serializeBinaryData(&export_handle, sizeof(CUmemFabricHandle));
         return metadata_->addLocalMemoryBuffer(desc, true);

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -144,7 +144,12 @@ Status NVMeoFTransport::submitTransfer(
 
         auto &desc = segment_desc_map.at(target_id);
         // LOG(INFO) << "desc " << desc->name << " " << desc->protocol;
+#ifdef ENABLE_MULTI_PROTOCOL
+        assert(std::find(desc->protocol.begin(), desc->protocol.end(),
+                         "nvmeof") != desc->protocol.end());
+#else
         assert(desc->protocol == "nvmeof");
+#endif
         // TODO: solving iterator invalidation due to vector resize
         // Handle File Offset
         uint32_t buffer_id = 0;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -294,6 +294,7 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
 
     buffer_desc.addr = (uint64_t)addr;
     buffer_desc.length = length;
+    buffer_desc.protocol = "rdma";
     int rc = metadata_->addLocalMemoryBuffer(buffer_desc, update_metadata);
     if (rc) return rc;
     return 0;
@@ -355,10 +356,14 @@ int RdmaTransport::unregisterLocalMemoryInternal(void *addr,
 }
 
 int RdmaTransport::allocateLocalSegmentID() {
-    auto desc = std::make_shared<SegmentDesc>();
-    if (!desc) return ERR_MEMORY;
+    auto desc = metadata_->getSegmentDesc(local_server_name_);
+    if (!desc) desc = std::make_shared<SegmentDesc>();
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc->protocol.push_back("rdma");
+#else
     desc->protocol = "rdma";
+#endif
     for (auto &entry : context_list_) {
         TransferMetadata::DeviceDesc device_desc;
         device_desc.name = entry->deviceName();

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -535,10 +535,14 @@ int TcpTransport::install(std::string& local_server_name,
 }
 
 int TcpTransport::allocateLocalSegmentID(int tcp_data_port) {
-    auto desc = std::make_shared<SegmentDesc>();
-    if (!desc) return ERR_MEMORY;
+    auto desc = metadata_->getSegmentDesc(local_server_name_);
+    if (!desc) desc = std::make_shared<SegmentDesc>();
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc->protocol.push_back("tcp");
+#else
     desc->protocol = "tcp";
+#endif
     desc->tcp_data_port = tcp_data_port;
     metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
                                std::move(desc));
@@ -554,6 +558,7 @@ int TcpTransport::registerLocalMemory(void* addr, size_t length,
     buffer_desc.name = local_server_name_;
     buffer_desc.addr = (uint64_t)addr;
     buffer_desc.length = length;
+    buffer_desc.protocol = "tcp";
     return metadata_->addLocalMemoryBuffer(buffer_desc, update_metadata);
 }
 

--- a/mooncake-transfer-engine/tests/cxl_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/cxl_transport_test.cpp
@@ -104,8 +104,20 @@ class CXLTransportTest : public ::testing::Test {
         cxl_xport = dynamic_cast<CxlTransport *>(xport);
         base_addr = (uint8_t *)cxl_xport->getCxlBaseAddr();
         addr = (uint8_t *)allocateMemoryPool(kDataLength, 0, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+
+        std::unordered_map<
+            std::string,
+            std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+            buffer_map;
+        buffer_map[FLAGS_protocol].emplace_back(base_addr + offset_1, len);
+        int rc = engine->registerLocalMemory(buffer_map);
+        ASSERT_EQ(rc, 0);
+
+#else
         int rc = engine->registerLocalMemory(base_addr + offset_1, len);
         ASSERT_EQ(rc, 0);
+#endif
 
         segment_id = engine->openSegment(FLAGS_local_server_name.c_str());
         // bindToSocket(0);
@@ -136,8 +148,12 @@ TEST_F(CXLTransportTest, MultiWrite) {
         entry.source = (uint8_t *)(addr);
         entry.target_id = segment_id;
         entry.target_offset = offset_1;
-        // s = xport->submitTransfer(batch_id, {entry});
+// s = xport->submitTransfer(batch_id, {entry});
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
 
         bool completed = false;
@@ -171,8 +187,12 @@ TEST_F(CXLTransportTest, MultipleRead) {
         entry.source = (uint8_t *)(addr);
         entry.target_id = segment_id;
         entry.target_offset = offset_2;
-        // s = xport->submitTransfer(batch_id, {entry});
+// s = xport->submitTransfer(batch_id, {entry});
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
 
         bool completed = false;
@@ -207,8 +227,12 @@ TEST_F(CXLTransportTest, MultipleRead) {
         entry.target_id = segment_id;
         entry.target_offset = offset_2;
         Status s;
-        // s = xport->submitTransfer(batch_id, {entry});
+// s = xport->submitTransfer(batch_id, {entry});
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         ASSERT_EQ(s, Status::OK());
 
         bool completed = false;
@@ -230,7 +254,17 @@ TEST_F(CXLTransportTest, MultipleRead) {
 
         freeMemoryPool(src, kDataLength);
     }
+#ifdef ENABLE_MULTI_PROTOCOL
+
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(addr);
+    engine->unregisterLocalMemory(buffer_map);
+
+#else
     engine->unregisterLocalMemory(addr);
+#endif
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/efa_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/efa_transport_test.cpp
@@ -27,6 +27,7 @@ using namespace mooncake;
 
 namespace mooncake {
 
+DEFINE_string(protocol, "efa", "Transfer protocol");
 static void *allocateMemoryPool(size_t size, int socket_id) {
     return numa_alloc_onnode(size, socket_id);
 }
@@ -89,8 +90,19 @@ class EFATransportTest : public ::testing::Test {
         s.addr = allocateMemoryPool(buffer_size, 0);
         EXPECT_NE(s.addr, nullptr) << "allocateMemoryPool failed";
 
+#ifdef ENABLE_MULTI_PROTOCOL
+        std::unordered_map<
+            std::string,
+            std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+            buffer_map;
+        buffer_map[FLAGS_protocol].emplace_back(s.addr, buffer_size, "cpu:0");
+        rc = s.engine->registerLocalMemory(buffer_map);
+        EXPECT_EQ(rc, 0) << "registerLocalMemory failed";
+
+#else
         rc = s.engine->registerLocalMemory(s.addr, buffer_size, "cpu:0");
         EXPECT_EQ(rc, 0) << "registerLocalMemory failed";
+#endif
 
         // Use actual RPC address (P2PHANDSHAKE picks a random port)
         auto actual_addr = s.engine->getLocalIpAndPort();
@@ -100,7 +112,16 @@ class EFATransportTest : public ::testing::Test {
 
     void destroyEngine(EngineSetup &s) {
         if (s.engine && s.addr) {
+#ifdef ENABLE_MULTI_PROTOCOL
+            std::unordered_map<
+                std::string,
+                std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+                buffer_map;
+            buffer_map[FLAGS_protocol].emplace_back(s.addr);
+            s.engine->unregisterLocalMemory(buffer_map);
+#else
             s.engine->unregisterLocalMemory(s.addr);
+#endif
         }
         if (s.addr) {
             freeMemoryPool(s.addr, s.buffer_size);
@@ -121,7 +142,11 @@ class EFATransportTest : public ::testing::Test {
         entry.target_id = segment_id;
         entry.target_offset = target_offset;
 
+#ifdef ENABLE_MULTI_PROTOCOL
+        Status s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         Status s = engine->submitTransfer(batch_id, {entry});
+#endif
         if (!s.ok()) {
             LOG(ERROR) << "submitTransfer failed: " << s.ToString();
             engine->freeBatchID(batch_id);
@@ -248,8 +273,11 @@ TEST_F(EFATransportTest, MultiWrite) {
         entry.target_offset = remote_base + i * kDataLength;
         requests.push_back(entry);
     }
-
+#ifdef ENABLE_MULTI_PROTOCOL
+    Status s = setup.engine->submitTransfer(batch_id, requests, FLAGS_protocol);
+#else
     Status s = setup.engine->submitTransfer(batch_id, requests);
+#endif
     ASSERT_TRUE(s.ok()) << "submitTransfer failed: " << s.ToString();
 
     // Poll all tasks until completion
@@ -301,8 +329,12 @@ TEST_F(EFATransportTest, StressMultipleBatches) {
                 remote_base + (i + batch * kBatchSize) * kDataLength;
             requests.push_back(entry);
         }
-
+#ifdef ENABLE_MULTI_PROTOCOL
+        Status s =
+            setup.engine->submitTransfer(batch_id, requests, FLAGS_protocol);
+#else
         Status s = setup.engine->submitTransfer(batch_id, requests);
+#endif
         ASSERT_TRUE(s.ok())
             << "Batch " << batch << " submitTransfer failed: " << s.ToString();
 

--- a/mooncake-transfer-engine/tests/nvlink_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/nvlink_transport_test.cpp
@@ -22,6 +22,7 @@ DEFINE_string(metadata_server, "127.0.0.1:2379", "etcd server host address");
 DEFINE_string(local_server_name, "cuda_server:12345", "Local server name");
 DEFINE_string(segment_id, "cuda_server:12345", "Segment ID to access data");
 DEFINE_int32(gpu_id, 0, "GPU ID to use");
+DEFINE_string(protocol, "nvlink", "Transfer protocol");
 
 static void checkCudaError(cudaError_t result, const char* message) {
     if (result != cudaSuccess) {
@@ -57,9 +58,20 @@ TEST(NvlinkTransportTest, WriteAndRead) {
     ASSERT_NE(server_transport, nullptr);
 
     void* server_buffer = allocateCudaBuffer(kDataLength * 2, gpu_id);
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(server_buffer, kDataLength * 2,
+                                            "cuda:0");
+    int rc = server_engine->registerLocalMemory(buffer_map);
+    ASSERT_EQ(rc, 0);
+    buffer_map.clear();
+#else
     int rc = server_engine->registerLocalMemory(server_buffer, kDataLength * 2,
                                                 "cuda:0");
     ASSERT_EQ(rc, 0);
+#endif
 
     auto segment_id = server_engine->openSegment(FLAGS_segment_id);
 
@@ -73,9 +85,17 @@ TEST(NvlinkTransportTest, WriteAndRead) {
     ASSERT_NE(client_transport, nullptr);
 
     void* client_buffer = allocateCudaBuffer(kDataLength * 2, gpu_id);
+#ifdef ENABLE_MULTI_PROTOCOL
+    buffer_map[FLAGS_protocol].emplace_back(client_buffer, kDataLength * 2,
+                                            "cuda:" + std::to_string(gpu_id));
+    rc = client_engine->registerLocalMemory(buffer_map);
+    ASSERT_EQ(rc, 0);
+    buffer_map.clear();
+#else
     rc = client_engine->registerLocalMemory(client_buffer, kDataLength * 2,
                                             "cuda:" + std::to_string(gpu_id));
     ASSERT_EQ(rc, 0);
+#endif
 
     // Write: client -> server
     {
@@ -92,7 +112,12 @@ TEST(NvlinkTransportTest, WriteAndRead) {
         entry.source = client_buffer;
         entry.target_id = segment_id;
         entry.target_offset = (uint64_t)server_buffer;
-        Status s = client_engine->submitTransfer(batch_id, {entry});
+        Status s =
+#ifdef ENABLE_MULTI_PROTOCOL
+            client_engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
+            client_engine->submitTransfer(batch_id, {entry});
+#endif
         ASSERT_TRUE(s.ok());
 
         // Wait for completion
@@ -116,7 +141,12 @@ TEST(NvlinkTransportTest, WriteAndRead) {
         entry.source = (char*)client_buffer + kDataLength;
         entry.target_id = segment_id;
         entry.target_offset = (uint64_t)server_buffer;
-        Status s = client_engine->submitTransfer(batch_id, {entry});
+        Status s =
+#ifdef ENABLE_MULTI_PROTOCOL
+            client_engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
+            client_engine->submitTransfer(batch_id, {entry});
+#endif
         ASSERT_TRUE(s.ok());
 
         // Wait for completion
@@ -142,10 +172,21 @@ TEST(NvlinkTransportTest, WriteAndRead) {
     }
 
     // Cleanup
+#ifdef ENABLE_MULTI_PROTOCOL
+    buffer_map[FLAGS_protocol].emplace_back(client_buffer);
+    client_engine->unregisterLocalMemory(buffer_map);
+    freeCudaBuffer(client_buffer);
+    buffer_map.clear();
+    buffer_map[FLAGS_protocol].emplace_back(server_buffer);
+    server_engine->unregisterLocalMemory(buffer_map);
+    freeCudaBuffer(server_buffer);
+    buffer_map.clear();
+#else
     client_engine->unregisterLocalMemory(client_buffer);
     freeCudaBuffer(client_buffer);
     server_engine->unregisterLocalMemory(server_buffer);
     freeCudaBuffer(server_buffer);
+#endif
 }
 
 int main(int argc, char** argv) {

--- a/mooncake-transfer-engine/tests/nvmeof_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/nvmeof_transport_test.cpp
@@ -87,7 +87,18 @@ class NVMeofTransportTest : public ::testing::Test {
         xport = engine->installTransport("nvmeof", args);
         ASSERT_NE(xport, nullptr);
         addr = allocateMemoryPool(ram_buffer_size, 0, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+
+        std::unordered_map<
+            std::string,
+            std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+            buffer_map;
+        buffer_map[FLAGS_protocol].emplace_back(addr, ram_buffer_size, "cpu:0");
+        int rc = engine->registerLocalMemory(buffer_map);
+
+#else
         int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+#endif
         ASSERT_EQ(rc, 0);
         segment_id = engine->openSegment(FLAGS_segment_id.c_str());
         bindToSocket(0);
@@ -97,7 +108,18 @@ class NVMeofTransportTest : public ::testing::Test {
 
     void TearDown() override {
         google::ShutdownGoogleLogging();
+#ifdef ENABLE_MULTI_PROTOCOL
+
+        std::unordered_map<
+            std::string,
+            std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+            buffer_map;
+        buffer_map[FLAGS_protocol].emplace_back(addr);
+        engine->unregisterLocalMemory(buffer_map);
+
+#else
         engine->unregisterLocalMemory(addr);
+#endif
         freeMemoryPool(addr, ram_buffer_size);
     }
 };
@@ -197,7 +219,16 @@ TEST_F(NVMeofTransportTest, MultipleRead) {
                      kDataLength);
         ASSERT_EQ(ret, 0);
     }
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(addr);
+    engine->unregisterLocalMemory(buffer_map);
+
+#else
     engine->unregisterLocalMemory(addr);
+#endif
     freeMemoryPool(addr, ram_buffer_size);
 }
 

--- a/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
@@ -107,6 +107,11 @@ struct TEContext {
     bool segment_opened_{false};
     SegmentHandle segment_handle_{};
     uint64_t remote_base_{};
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map_;
+#endif
 
     TEContext(const std::string &local_server_name,
               const std::string &metadata_server, const std::string &segment_id,
@@ -126,8 +131,13 @@ struct TEContext {
         local_addr_ = static_cast<uint8_t *>(numa_alloc_onnode(kRAMBufSize, 0));
         memset(local_addr_, 0, kDataLength);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+        buffer_map_["rdma"].emplace_back(local_addr_, kRAMBufSize, "cpu:0");
+        int rc = engine_->registerLocalMemory(buffer_map_);
+#else
         int rc =
             engine_->registerLocalMemory(local_addr_, kRAMBufSize, "cpu:0");
+#endif
         LOG_ASSERT(!rc);
 
         if (!segment_id.empty()) {
@@ -141,7 +151,11 @@ struct TEContext {
     }
 
     ~TEContext() {
+#ifdef ENABLE_MULTI_PROTOCOL
+        engine_->unregisterLocalMemory(buffer_map_);
+#else
         engine_->unregisterLocalMemory(local_addr_);
+#endif
         numa_free(local_addr_, kRAMBufSize);
         if (segment_opened_) engine_->closeSegment(segment_handle_);
     }
@@ -210,7 +224,12 @@ TEST_F(RDMAEndpointReestablishTest, EndpointReestablish) {
         entry.target_id = init_ctx.segment_handle_;
         entry.target_offset = init_ctx.remote_base_;
 
+#ifdef ENABLE_MULTI_PROTOCOL
+        std::string protocol = "rdma";
+        Status s = init_ctx.engine_->submitTransfer(batch_id, {entry}, protocol);
+#else
         Status s = init_ctx.engine_->submitTransfer(batch_id, {entry});
+#endif
         ASSERT_EQ(s, Status::OK());
 
         wait_for_transfer(init_ctx.engine_.get(), batch_id, "WRITE");
@@ -237,7 +256,12 @@ TEST_F(RDMAEndpointReestablishTest, EndpointReestablish) {
         entry.target_id = init_ctx.segment_handle_;
         entry.target_offset = init_ctx.remote_base_;
 
+#ifdef ENABLE_MULTI_PROTOCOL
+        std::string protocol = "rdma";
+        Status s = init_ctx.engine_->submitTransfer(batch_id, {entry}, protocol);
+#else
         Status s = init_ctx.engine_->submitTransfer(batch_id, {entry});
+#endif
         ASSERT_EQ(s, Status::OK());
 
         wait_for_transfer(init_ctx.engine_.get(), batch_id, "READ");

--- a/mooncake-transfer-engine/tests/rdma_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_loopback_test.cpp
@@ -31,7 +31,7 @@ namespace mooncake {
 
 DEFINE_string(metadata_server, "127.0.0.1:2379",
               "central metadata server for transfer engine");
-
+DEFINE_string(protocol, "nvlink", "Transfer protocol");
 class RDMALoopbackTest : public ::testing::Test {
    public:
     void *addr = nullptr;
@@ -46,13 +46,35 @@ class RDMALoopbackTest : public ::testing::Test {
         engine = std::make_unique<TransferEngine>(true);
         engine->init(FLAGS_metadata_server, "test_node");
         addr = numa_alloc_onnode(ram_buffer_size, 0);
+#ifdef ENABLE_MULTI_PROTOCOL
+
+        std::unordered_map<
+            std::string,
+            std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+            buffer_map;
+        buffer_map[FLAGS_protocol].emplace_back(addr, ram_buffer_size, "cpu:0");
+        int rc = engine->registerLocalMemory(buffer_map);
+
+#else
         int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+#endif
         ASSERT_EQ(rc, 0);
     }
 
     void TearDown() override {
         google::ShutdownGoogleLogging();
+#ifdef ENABLE_MULTI_PROTOCOL
+
+        std::unordered_map<
+            std::string,
+            std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+            buffer_map;
+        buffer_map[FLAGS_protocol].emplace_back(addr);
+        engine->unregisterLocalMemory(buffer_map);
+
+#else
         engine->unregisterLocalMemory(addr);
+#endif
         numa_free(addr, ram_buffer_size);
     }
 };
@@ -71,7 +93,11 @@ TEST_F(RDMALoopbackTest, MultiWrite) {
         entry.source = (uint8_t *)(addr);
         entry.target_id = LOCAL_SEGMENT_ID;
         entry.target_offset = (uint64_t)addr + kDataLength;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;

--- a/mooncake-transfer-engine/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test.cpp
@@ -134,7 +134,11 @@ int initiatorWorker(TransferEngine *engine, SegmentID segment_id, int thread_id,
         entry.source = (uint8_t *)(addr);
         entry.target_id = segment_id;
         entry.target_offset = remote_base;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -163,7 +167,11 @@ int initiatorWorker(TransferEngine *engine, SegmentID segment_id, int thread_id,
         entry.source = (uint8_t *)(addr) + kDataLength;
         entry.target_id = segment_id;
         entry.target_offset = remote_base;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -258,25 +266,49 @@ int initiator() {
 
     LOG_ASSERT(xport);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+#endif
+
     void *addr = nullptr;
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)
     addr = allocateMemoryPool(ram_buffer_size, 0, FLAGS_use_vram);
     std::string name_prefix = FLAGS_use_vram ? GPU_PREFIX : "cpu:";
     int name_suffix = FLAGS_use_vram ? FLAGS_gpu_id : 0;
+#ifdef ENABLE_MULTI_PROTOCOL
+    buffer_map[FLAGS_protocol].emplace_back(
+        addr, ram_buffer_size, name_prefix + std::to_string(name_suffix));
+    int rc = engine->registerLocalMemory(buffer_map);
+    LOG_ASSERT(!rc);
+#else
     int rc = engine->registerLocalMemory(
         addr, ram_buffer_size, name_prefix + std::to_string(name_suffix));
     LOG_ASSERT(!rc);
+#endif
 #else
     addr = allocateMemoryPool(ram_buffer_size, 0, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+    buffer_map[FLAGS_protocol].emplace_back(addr, ram_buffer_size,
+                                            kWildcardLocation);
+    int rc = engine->registerLocalMemory(buffer_map);
+    LOG_ASSERT(!rc);
+#else
     int rc =
         engine->registerLocalMemory(addr, ram_buffer_size, kWildcardLocation);
     LOG_ASSERT(!rc);
+#endif
 #endif
 
     auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
     std::thread workers(initiatorWorker, engine.get(), segment_id, 0, addr);
     workers.join();
+#ifdef ENABLE_MULTI_PROTOCOL
+    engine->unregisterLocalMemory(buffer_map);
+#else
     engine->unregisterLocalMemory(addr);
+#endif
     freeMemoryPool(addr, ram_buffer_size);
     return 0;
 }
@@ -304,14 +336,30 @@ int target() {
         LOG(ERROR) << "Unsupported protocol";
     }
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+#endif
+
     void *addr = nullptr;
     addr = allocateMemoryPool(ram_buffer_size, 0);
+#ifdef ENABLE_MULTI_PROTOCOL
+    buffer_map[FLAGS_protocol].emplace_back(addr, ram_buffer_size, "cpu:0");
+    int rc = engine->registerLocalMemory(buffer_map);
+    LOG_ASSERT(!rc);
+#else
     int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
     LOG_ASSERT(!rc);
+#endif
 
     while (true) sleep(1);
 
+#ifdef ENABLE_MULTI_PROTOCOL
+    engine->unregisterLocalMemory(buffer_map);
+#else
     engine->unregisterLocalMemory(addr);
+#endif
     freeMemoryPool(addr, ram_buffer_size);
     return 0;
 }

--- a/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
@@ -130,8 +130,20 @@ class RDMATransportTest : public ::testing::Test {
         xport = engine->installTransport("rdma", args);
         ASSERT_NE(xport, nullptr);
         addr = allocateMemoryPool(ram_buffer_size, 0, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+
+        std::unordered_map<
+            std::string,
+            std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+            buffer_map;
+        buffer_map[FLAGS_protocol].emplace_back(addr, ram_buffer_size, "cpu:0");
+        int rc = engine->registerLocalMemory(buffer_map);
+        ASSERT_EQ(rc, 0);
+
+#else
         int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
         ASSERT_EQ(rc, 0);
+#endif
         segment_id = engine->openSegment(FLAGS_segment_id.c_str());
         bindToSocket(0);
         segment_desc = engine->getMetadata()->getSegmentDescByID(segment_id);
@@ -140,7 +152,18 @@ class RDMATransportTest : public ::testing::Test {
 
     void TearDown() override {
         google::ShutdownGoogleLogging();
+#ifdef ENABLE_MULTI_PROTOCOL
+
+        std::unordered_map<
+            std::string,
+            std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+            buffer_map;
+        buffer_map[FLAGS_protocol].emplace_back(addr);
+        engine->unregisterLocalMemory(buffer_map);
+
+#else
         engine->unregisterLocalMemory(addr);
+#endif
         freeMemoryPool(addr, ram_buffer_size);
     }
 };
@@ -159,7 +182,11 @@ TEST_F(RDMATransportTest, MultiWrite) {
         entry.source = (uint8_t *)(addr);
         entry.target_id = segment_id;
         entry.target_offset = remote_base;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -193,7 +220,11 @@ TEST_F(RDMATransportTest, MultipleRead) {
         entry.source = (uint8_t *)(addr);
         entry.target_id = segment_id;
         entry.target_offset = remote_base;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -221,7 +252,11 @@ TEST_F(RDMATransportTest, MultipleRead) {
         entry.target_id = segment_id;
         entry.target_offset = remote_base;
         Status s;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         ASSERT_EQ(s, Status::OK());
         bool completed = false;
         TransferStatus status;
@@ -240,7 +275,17 @@ TEST_F(RDMATransportTest, MultipleRead) {
                      kDataLength);
         ASSERT_EQ(ret, 0);
     }
+#ifdef ENABLE_MULTI_PROTOCOL
+
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(addr);
+    engine->unregisterLocalMemory(buffer_map);
+
+#else
     engine->unregisterLocalMemory(addr);
+#endif
     freeMemoryPool(addr, ram_buffer_size);
 }
 

--- a/mooncake-transfer-engine/tests/tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_transport_test.cpp
@@ -50,7 +50,7 @@ DEFINE_int32(gpu_id, 0, "GPU ID to use");
 using namespace mooncake;
 
 namespace mooncake {
-
+DEFINE_string(protocol, "tcp", "Transfer protocol");
 class TCPTransportTest : public ::testing::Test {
    public:
    protected:
@@ -114,7 +114,17 @@ TEST_F(TCPTransportTest, Writetest) {
     LOG_ASSERT(xport != nullptr);
 
     addr = allocateMemoryPool(ram_buffer_size, 0, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(addr, ram_buffer_size, "cpu:0");
+    rc = engine->registerLocalMemory(buffer_map);
+
+#else
     rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+#endif
     LOG_ASSERT(!rc);
 
     for (size_t offset = 0; offset < kDataLength; ++offset)
@@ -130,7 +140,11 @@ TEST_F(TCPTransportTest, Writetest) {
     entry.source = (uint8_t *)(addr);
     entry.target_id = segment_id;
     entry.target_offset = remote_base;
+#ifdef ENABLE_MULTI_PROTOCOL
+    s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
     s = engine->submitTransfer(batch_id, {entry});
+#endif
     LOG_ASSERT(s.ok());
     bool completed = false;
     TransferStatus status;
@@ -158,7 +172,17 @@ TEST_F(TCPTransportTest, WriteAndReadtest) {
     LOG_ASSERT(xport != nullptr);
 
     addr = allocateMemoryPool(ram_buffer_size, 0, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(addr, ram_buffer_size, "cpu:0");
+    int rc = engine->registerLocalMemory(buffer_map);
+
+#else
     int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+#endif
     LOG_ASSERT(!rc);
     for (size_t offset = 0; offset < kDataLength; ++offset)
         *((char *)(addr) + offset) = 'a' + lrand48() % 26;
@@ -175,7 +199,11 @@ TEST_F(TCPTransportTest, WriteAndReadtest) {
         entry.source = (uint8_t *)(addr);
         entry.target_id = segment_id;
         entry.target_offset = remote_base;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -199,7 +227,11 @@ TEST_F(TCPTransportTest, WriteAndReadtest) {
         entry.source = (uint8_t *)(addr) + kDataLength;
         entry.target_id = segment_id;
         entry.target_offset = remote_base;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -230,7 +262,17 @@ TEST_F(TCPTransportTest, WriteAndRead2test) {
     LOG_ASSERT(xport != nullptr);
 
     addr = allocateMemoryPool(ram_buffer_size, 0, false);
+#ifdef ENABLE_MULTI_PROTOCOL
+
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[FLAGS_protocol].emplace_back(addr, ram_buffer_size, "cpu:0");
+    int rc = engine->registerLocalMemory(buffer_map);
+
+#else
     int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+#endif
     LOG_ASSERT(!rc);
     for (size_t offset = 0; offset < kDataLength; ++offset)
         *((char *)(addr) + offset) = 'a' + lrand48() % 26;
@@ -248,7 +290,11 @@ TEST_F(TCPTransportTest, WriteAndRead2test) {
         entry.source = (uint8_t *)(addr);
         entry.target_id = segment_id;
         entry.target_offset = remote_base;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -271,7 +317,11 @@ TEST_F(TCPTransportTest, WriteAndRead2test) {
         entry.source = (uint8_t *)(addr) + kDataLength;
         entry.target_id = segment_id;
         entry.target_offset = remote_base;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -298,7 +348,11 @@ TEST_F(TCPTransportTest, WriteAndRead2test) {
         entry.source = (uint8_t *)(addr);
         entry.target_id = segment_id;
         entry.target_offset = remote_base;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;
@@ -321,7 +375,11 @@ TEST_F(TCPTransportTest, WriteAndRead2test) {
         entry.source = (uint8_t *)(addr) + kDataLength;
         entry.target_id = segment_id;
         entry.target_offset = remote_base;
+#ifdef ENABLE_MULTI_PROTOCOL
+        s = engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
         s = engine->submitTransfer(batch_id, {entry});
+#endif
         LOG_ASSERT(s.ok());
         bool completed = false;
         TransferStatus status;

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -63,7 +63,11 @@ class TransferMetadataTest : public ::testing::Test {
 TEST_F(TransferMetadataTest, LocalSegmentTest) {
     auto segment_des = std::make_shared<TransferMetadata::SegmentDesc>();
     segment_des->name = "test_server";
+#ifdef ENABLE_MULTI_PROTOCOL
+    segment_des->protocol.push_back("rdma");
+#else
     segment_des->protocol = "rdma";
+#endif
     TransferMetadata::SegmentID segment_id = 1111111;
     std::string segment_name = "test_segment";
     int re = metadata_client->addLocalSegment(segment_id, segment_name,
@@ -83,7 +87,11 @@ TEST_F(TransferMetadataTest, LocalSegmentTest) {
 TEST_F(TransferMetadataTest, LocalMemoryBufferTest) {
     auto segment_des = std::make_shared<TransferMetadata::SegmentDesc>();
     segment_des->name = "test_localMemory";
+#ifdef ENABLE_MULTI_PROTOCOL
+    segment_des->protocol.push_back("rdma");
+#else
     segment_des->protocol = "rdma";
+#endif
     int re = metadata_client->addLocalSegment(
         LOCAL_SEGMENT_ID, "test_local_segment", std::move(segment_des));
     ASSERT_EQ(re, 0);

--- a/mooncake-transfer-engine/tests/ubshmem_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/ubshmem_transport_test.cpp
@@ -20,6 +20,7 @@ DEFINE_string(local_server_name, "127.0.0.1:12345", "Local server name");
 DEFINE_string(local_client_name, "127.0.0.1:12346", "Local client name");
 DEFINE_int32(server_npu_id, 0, "Server NPU ID to use");
 DEFINE_int32(client_npu_id, 2, "Client NPU ID to use");
+DEFINE_string(protocol, PROTOCOL, "Transfer protocol");
 
 enum class MemoryType { FABRIC_MEM_HOST, FABRIC_MEM_DEVICE, IPC_MEM_DEVICE };
 
@@ -167,15 +168,29 @@ static void serverThread(int npu_id, const std::string& metadataServer,
 
     const size_t kDataLength = 4194304;
     void* server_buffer = allocateAclBuffer(kDataLength * 2, npu_id, mem_type);
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
     if (mem_type == MemoryType::FABRIC_MEM_HOST) {
-        int rc = server_engine->registerLocalMemory(
-            server_buffer, kDataLength * 2, "cpu: " + std::to_string(npu_id));
-        ASSERT_EQ(rc, 0);
+        buffer_map[PROTOCOL].emplace_back(server_buffer, kDataLength * 2,
+                                          "cpu: " + std::to_string(npu_id));
     } else {
-        int rc = server_engine->registerLocalMemory(
-            server_buffer, kDataLength * 2, "npu: " + std::to_string(npu_id));
-        ASSERT_EQ(rc, 0);
+        buffer_map[PROTOCOL].emplace_back(server_buffer, kDataLength * 2,
+                                          "npu: " + std::to_string(npu_id));
     }
+    int rc = server_engine->registerLocalMemory(buffer_map);
+#else
+    std::string location;
+    if (mem_type == MemoryType::FABRIC_MEM_HOST) {
+        location = "cpu: " + std::to_string(npu_id);
+    } else {
+        location = "npu: " + std::to_string(npu_id);
+    }
+    int rc = server_engine->registerLocalMemory(server_buffer, kDataLength * 2,
+                                                location);
+#endif
+    ASSERT_EQ(rc, 0);
 
     // Notify main thread that server is ready
     serverReady.set_value();
@@ -184,7 +199,11 @@ static void serverThread(int npu_id, const std::string& metadataServer,
     testComplete.wait();
 
     // Cleanup
+#ifdef ENABLE_MULTI_PROTOCOL
+    server_engine->unregisterLocalMemory(buffer_map);
+#else
     server_engine->unregisterLocalMemory(server_buffer);
+#endif
     freeAclBuffer(server_buffer, mem_type);
 
     LOG(INFO) << "Server thread completed";
@@ -213,8 +232,17 @@ static void clientThread(int npu_id, const std::string& metadataServer,
     ASSERT_NE(client_transport, nullptr);
 
     void* client_buffer = allocateAclBuffer(kDataLength * 2, npu_id, mem_type);
-    int rc = client_engine->registerLocalMemory(
-        client_buffer, kDataLength * 2, "npu:" + std::to_string(npu_id));
+#ifdef ENABLE_MULTI_PROTOCOL
+    std::unordered_map<std::string,
+                       std::vector<mooncake::TransferEngine::RegisteredBuffer>>
+        buffer_map;
+    buffer_map[PROTOCOL].emplace_back(client_buffer, kDataLength * 2,
+                                      "npu:" + std::to_string(npu_id));
+    rc = client_engine->registerLocalMemory(buffer_map);
+#else
+    rc = client_engine->registerLocalMemory(client_buffer, kDataLength * 2,
+                                            "npu:" + std::to_string(npu_id));
+#endif
     ASSERT_EQ(rc, 0);
 
     auto server_segment_id = client_engine->openSegment(segmentId);
@@ -237,7 +265,12 @@ static void clientThread(int npu_id, const std::string& metadataServer,
         entry.source = client_buffer;
         entry.target_id = server_segment_id;
         entry.target_offset = (uint64_t)segment_desc->buffers[0].addr;
-        Status s = client_engine->submitTransfer(batch_id, {entry});
+        Status s =
+#ifdef ENABLE_MULTI_PROTOCOL
+            client_engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
+            client_engine->submitTransfer(batch_id, {entry});
+#endif
         ASSERT_TRUE(s.ok());
 
         // Wait for completion
@@ -265,7 +298,12 @@ static void clientThread(int npu_id, const std::string& metadataServer,
         entry.source = (char*)client_buffer + kDataLength;
         entry.target_id = server_segment_id;
         entry.target_offset = (uint64_t)segment_desc->buffers[0].addr;
-        Status s = client_engine->submitTransfer(batch_id, {entry});
+        Status s =
+#ifdef ENABLE_MULTI_PROTOCOL
+            client_engine->submitTransfer(batch_id, {entry}, FLAGS_protocol);
+#else
+            client_engine->submitTransfer(batch_id, {entry});
+#endif
         ASSERT_TRUE(s.ok());
 
         // Wait for completion
@@ -293,7 +331,11 @@ static void clientThread(int npu_id, const std::string& metadataServer,
     }
 
     // Cleanup
+#ifdef ENABLE_MULTI_PROTOCOL
+    client_engine->unregisterLocalMemory(buffer_map);
+#else
     client_engine->unregisterLocalMemory(client_buffer);
+#endif
     freeAclBuffer(client_buffer, mem_type);
 
     // Notify server to cleanup


### PR DESCRIPTION
## Description

This is the third PR in the CXL series (following PR #1365, PR #1531), implementing the DRAM-CXL-SSD tiered storage architecture for Mooncake Store.The design retains hot data in ultra-low-latency DRAM, places warm data in a shareable CXL memory pool, and writes cold data to high-capacity SSD.

**Note on PR Structure:** This PR is part of a staged submission approach for the tiered storage feature. We are splitting the implementation into two separate PRs:

1. This PR: Focuses exclusively on the `mooncake-transfer-engine` module, introducing multi-protocol infrastructure
2. Follow-up PR: Will contain `mooncake-store` module changes, including:
   - Supports multi-protocol client initialization
   - Enables tier-aware allocation, which, in a tiered storage scenario, selects the specific allocation method based on the preferred storage level.

The main changes introduced by this PR:

1. Added `ENABLE_MULTI_PROTOCOL` compile-time flag to enable multi-protocol functionality

- When enabled, the transfer engine can simultaneously manage multiple transport protocols (RDMA, CXL, TCP, etc.)

2. Protocol-Aware Memory Registration

- Modified `registerLocalMemory()` interface to support protocol-specific buffer registration
- Added buffer_map based registration for multi-protocol scenarios, allowing memory to be registered with specific transport protocols
- Maintained backward compatibility with single-protocol interface when ENABLE_MULTI_PROTOCOL is disabled

3. Protocol-Aware Transfer Submission

- Extended `submitTransfer()` interface with protocol parameter for multi-protocol routing
- Transfer requests are now routed to appropriate transport layer based on specified protocol
- Single-protocol behavior preserved when multi-protocol support is not enabled

4. Segment Descriptor

- Updated `SegmentDesc` structure to support multiple protocols in multi-protocol mode

#### Notes

> - This PR only includes changes to the `mooncake-transfer-engine` module.
> - `mooncake-store` module changes for tiered storage will be submitted in a follow-up PR.
> - Hot/cold data promotion/demotion feature will be open-sourced in subsequent PRs.
> - All changes maintain backward compatibility when `ENABLE_MULTI_PROTOCOL` is disabled.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
