### PR TITLE
Fix TENT Python binding initialization and build output

### DIFF
--- a/mooncake-transfer-engine/tent/src/python/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/python/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PYTHON_PACKAGE_NAME "tent-core")
 
 pybind11_add_module(tentpy ${SOURCES})
 set_target_properties(tentpy PROPERTIES
+    OUTPUT_NAME "tent"
     INSTALL_RPATH "$ORIGIN" 
 )
 

--- a/mooncake-transfer-engine/tent/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/tent/src/transfer_engine.cpp
@@ -25,7 +25,7 @@ TransferEngine::TransferEngine()
 
 TransferEngine::TransferEngine(const std::string config_path) {
     auto conf = std::make_shared<Config>();
-    auto status = conf->load(config_path);
+    auto status = conf->loadFile(config_path);
     if (!status.ok()) {
         LOG(WARNING) << "Failed to read config file " << config_path;
     }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -60,7 +60,7 @@ static Status configureLaneCount(std::shared_ptr<Config> conf,
         std::stringstream ss;
         ss << "Invalid RDMA " << name << ": " << value
            << ", expected a positive integer";
-        return Status::InvalidArgument(ss.str() LOC_MARK);
+        return Status::InvalidArgument(ss.str() + LOC_MARK);
     };
 
     auto status = validate_positive(num_lanes, "num_lanes");
@@ -89,7 +89,7 @@ static Status configureLaneCount(std::shared_ptr<Config> conf,
         ss << "Inconsistent RDMA lane configuration: " << name << "=" << value
            << " but expected lane count " << lane_count
            << " so worker/QP/CQ counts stay aligned";
-        return Status::InvalidArgument(ss.str() LOC_MARK);
+        return Status::InvalidArgument(ss.str() + LOC_MARK);
     };
 
     status = validate_match(num_cq_list, "device.num_cq_list");


### PR DESCRIPTION
This PR fixes three issues in the local TENT Python path that block stable integration:

  - make the built Python module importable as tent
  - load TransferEngine(<config_path>) as a config file via loadFile(...)
  - fix RDMA status string construction in rdma_transport.cpp

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
