### PR TITLE
[P2P] fix: cannot disable NV_PEERMEM and enable CUDA at the same time

### DIFF
--- a/mooncake-p2p-store/build.sh
+++ b/mooncake-p2p-store/build.sh
@@ -36,8 +36,12 @@ EXT_LDFLAGS+=" -L$BUILD_DIR/mooncake-transfer-engine/src/common/base"
 EXT_LDFLAGS+=" -L$BUILD_DIR/mooncake-asio"
 EXT_LDFLAGS+=" -ltransfer_engine -lbase -lasio -lstdc++ -lnuma -lglog -libverbs -ljsoncpp"
 
+if [ -d "/usr/local/cuda/lib64/stubs" ]; then
+    EXT_LDFLAGS+=" -L/usr/local/cuda/lib64/stubs"
+fi
+
 if [ -d "/usr/local/cuda/lib64" ]; then
-    EXT_LDFLAGS+=" -L/usr/local/cuda/lib64 -lcudart"
+    EXT_LDFLAGS+=" -L/usr/local/cuda/lib64 -lcuda -lcudart"
 fi
 
 if [ -d "/opt/rocm/lib" ]; then


### PR DESCRIPTION
fix:  cannot disable NV_PEERMEM and enable CUDA at the same time

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
