### PR TITLE
fix: fix eviction notification unit test to ensure deterministic FIFO order

### DIFF
--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -1392,7 +1392,10 @@ class EvictionNotificationTest : public ::testing::Test {
 TEST_F(EvictionNotificationTest, DiskReplicaRemovedAfterEviction) {
     CreateClientAndMount();
 
-    // Put 3 keys — should all fit within quota
+    // Put 3 keys — should all fit within quota.
+    // Wait for each DISK replica before putting the next key so that the
+    // FIFO write-queue order is deterministic (write_thread_pool_ has >1
+    // thread, so concurrent writes can reorder).
     std::vector<std::string> keys;
     for (int i = 0; i < 3; ++i) {
         std::string key = "evict_test_key_" + std::to_string(i);
@@ -1411,10 +1414,9 @@ TEST_F(EvictionNotificationTest, DiskReplicaRemovedAfterEviction) {
             << "Put(" << key << ") failed: " << toString(put.error());
         alloc_->deallocate(buf, payload.size());
         keys.push_back(key);
-    }
 
-    // Wait for DISK replicas to appear (PutToLocalFile is async)
-    for (const auto& key : keys) {
+        // Wait for this key's DISK replica before proceeding to the next
+        // Put, ensuring deterministic FIFO order in the eviction queue.
         ASSERT_TRUE(WaitForDiskReplica(key, std::chrono::seconds(10)))
             << "DISK replica did not appear for key: " << key;
     }


### PR DESCRIPTION
## Description

When running the CI test suite, EvictionNotificationTest.DiskReplicaRemovedAfterEviction occasionally fails with the following errors:

```
[----------] 1 test from EvictionNotificationTest
[ RUN      ] EvictionNotificationTest.DiskReplicaRemovedAfterEviction
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0402 11:48:29.665012 41603 http_metadata_server.cpp:109] HTTP metadata server started on 127.0.0.1:41423
I0402 11:48:29.691743 42512 master_service.cpp:353] Task cleanup thread started
I0402 11:48:29.695127 41603 rpc_service.cpp:251] HTTP metrics server started on port 50185
I0402 11:48:29.898306 41603 client_metric.cpp:80] Client metrics enabled (default enabled)
I0402 11:48:29.901451 41603 client_service.cpp:62] client_id=3912542188742366792-2079619861641300380
I0402 11:48:29.901474 41603 client_service.cpp:70] Client metrics enabled but reporting disabled (interval=0)
I0402 11:48:29.903362 41603 client_service.cpp:591] Storage root directory is: /tmp/mc_evict_test_41603
I0402 11:48:29.903380 41603 client_service.cpp:592] Fs subdir is: mooncake_cluster
I0402 11:48:29.903386 41603 client_service.cpp:593] Disk eviction enabled: 1
I0402 11:48:29.903398 41603 client_service.cpp:595] Quota bytes: 3072
I0402 11:48:29.903712 41603 storage_backend.cpp:148] Reconstructing storage state from disk at: "/tmp/mc_evict_test_41603/mooncake_cluster"
I0402 11:48:29.903793 41603 storage_backend.cpp:237] Init: Quota: 3072, Used: 0, Available: 3072
I0402 11:48:29.903931 41603 transfer_engine_impl.cpp:597] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0402 11:48:29.903964 41603 transfer_engine_impl.cpp:105] Transfer Engine parseHostNameWithPort. server_name: localhost port: 17820
I0402 11:48:29.904000 41603 transfer_engine_impl.cpp:172] Transfer Engine RPC using P2P handshake, listening on localhost:15935
I0402 11:48:29.904263 41603 client_service.cpp:434] Transfer engine auto discovery is disabled for protocol: tcp
I0402 11:48:29.904346 41603 tcp_transport.cpp:530] TcpTransport: listen on port 15618
I0402 11:48:29.907128 42520 master_service.cpp:273] client_id=3912542188742366792-2079619861641300380, action=mount_segment, segment_name=localhost:17820
I0402 11:48:29.908931 41603 allocator.cpp:289] initializing_simple_allocator size=16777216
I0402 11:48:29.909096 41603 allocator.cpp:328] simple_allocator_initialized pool_id=0
W0402 11:48:29.909965 42520 segment.cpp:60] segment_name=localhost:17820, warn=segment_already_exists
W0402 11:48:29.909988 42520 segment.cpp:145] segment_name=localhost:17820, warn=segment_already_exists
/home/tzh/playgnd-mooncake/upsert-for-store/mooncake-store/tests/client_integration_test.cpp:1447: Failure
Value of: WaitForNoDiskReplica(keys[0], std::chrono::seconds(10))
  Actual: false
Expected: true
Evicted key's DISK replica was not removed from master
/home/tzh/playgnd-mooncake/upsert-for-store/mooncake-store/tests/client_integration_test.cpp:1452: Failure
Value of: HasDiskReplica(keys[i])
  Actual: false
Expected: true
Key evict_test_key_1 should still have a DISK replica
I0402 11:48:40.917323 41603 transfer_metadata.cpp:314] removeSegmentDesc localhost:15935 finish
2026-04-02 11:48:41.153592 ERROR    [42519] [coro_rpc_server.hpp:219] server quit with error: operation canceled
I0402 11:48:41.154786 42512 master_service.cpp:372] Task cleanup thread stopped
I0402 11:48:41.704370 41603 http_metadata_server.cpp:120] HTTP metadata server stopped
I0402 11:48:41.706028 41603 allocator.cpp:350] simple_allocator_destroyed status=success
[  FAILED  ] EvictionNotificationTest.DiskReplicaRemovedAfterEviction (12045 ms)
[----------] 1 test from EvictionNotificationTest (12045 ms total)
```

The test expects key_0 (the first Put) to be evicted by FIFO policy, but instead key_1 is evicted and key_0 remains.

The likely root cause is that write_thread_pool_ has 2 threads ([client_service.cpp:60](vscode-webview://13vhpemfvseba9in413l58pclopmtpougddgustr5ss0kcm37r83/mooncake-store/src/client_service.cpp#L60)). The test issues 3 Puts consecutively, each of which enqueues an async PutToLocalFile task. With 2 worker threads, the write completion order is non-deterministic — key_1 may finish its StoreObject before key_0 and get inserted into file_write_queue_ first. When the 4th Put triggers eviction, the FIFO policy picks the queue head (key_1) instead of the logically oldest key (key_0).

This fix waits for each key's DISK replica to appear before issuing the next Put, ensuring the FIFO queue order matches the logical Put order. The core test intent — verifying that evicted keys have their DISK replicas removed from master metadata — is unchanged.


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
