### PR TITLE
[TENT] Fix duplicate notify recv WR posting and PLOG misuse in RDMA endpoint

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -564,7 +564,8 @@ int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
 
     int rc = ibv_post_send(qp_list_[qp_index], wr_list.data(), &bad_wr);
     if (rc) {
-        LOG(ERROR) << "ibv_post_send: " << strerror(-rc) << " [" << rc << "]";
+        LOG(ERROR) << "ibv_post_send: " << strerror(abs(rc)) << " [" << rc
+                   << "]";
         while (bad_wr) {
             slice_list[bad_wr - wr_list.data()]->failed = true;
             cancelQuota(qp_index, 1);
@@ -593,7 +594,8 @@ int RdmaEndPoint::submitRecvImmDataRequest(int qp_index, uint64_t id) {
     int rc = ibv_post_recv(qp_list_[qp_index], &wr, &bad_wr);
     if (rc) {
         cancelQuota(qp_index, 1);
-        LOG(ERROR) << "ibv_post_recv: " << strerror(-rc) << " [" << rc << "]";
+        LOG(ERROR) << "ibv_post_recv: " << strerror(abs(rc)) << " [" << rc
+                   << "]";
         return -1;
     }
     return 1;
@@ -772,7 +774,7 @@ void RdmaEndPoint::postNotifyRecv(size_t idx) {
     ibv_recv_wr* bad_wr = nullptr;
     int ret = ibv_post_recv(notify_qp_, &wr, &bad_wr);
     if (ret) {
-        LOG(ERROR) << "Failed to post notification recv: " << strerror(-ret)
+        LOG(ERROR) << "Failed to post notification recv: " << strerror(abs(ret))
                    << " [" << ret << "]";
     }
 }
@@ -924,7 +926,7 @@ bool RdmaEndPoint::sendNotification(const std::string& name,
     ibv_send_wr* bad_wr = nullptr;
     int ret = ibv_post_send(notify_qp_, &wr, &bad_wr);
     if (ret) {
-        LOG(ERROR) << "Failed to post notification send: " << strerror(-ret)
+        LOG(ERROR) << "Failed to post notification send: " << strerror(abs(ret))
                    << " [" << ret << "], "
                    << "bad_wr id: " << (bad_wr ? bad_wr->wr_id : -1)
                    << ", endpoint: " << peer_nic_name_ << " of "


### PR DESCRIPTION
## Description

### Fix duplicate notify recv WR posting and PLOG misuse in RDMA endpoint

#### Problem

When testing with `tebench` using ERDMA devices, every new connection produces 256 `-ENOMEM` errors from `ibv_post_recv` on the notification QP:

```
Failed to post notification recv: Success [0]
```

The error message itself is also misleading — it reports "Success [0]" despite the operation actually failing.

#### Root Cause

**1. Duplicate recv WR posting**

`construct()` posts 256 recv WRs to the notification QP after moving it to INIT state. Later, `connect()`/`accept()` calls `setupNotifyQpConnection()` which transitions the QP through RESET -> INIT -> RTR -> RTS, then calls `repostAllNotifyRecvs()` to post another 256 recv WRs.

Per the IB spec, the RESET transition should flush all previously posted WRs. However, the ERDMA driver does not properly drain the receive queue on QP RESET, so the 256 WRs from `construct()` remain. When `repostAllNotifyRecvs()` attempts to post 256 more, all fail with `-ENOMEM` (queue full, capacity = 256).

This was confirmed by instrumented logging: both initiator and target show exactly 256 `ret=0` followed by 256 `ret=-12`, with the transition aligned to the `setupNotifyQpConnection()` call.

**2. PLOG misuse on libibverbs functions**

`ibv_post_send` and `ibv_post_recv` return error codes directly as negative errno values — they do **not** set `errno`. Using `PLOG` (which reads `errno`) produces misleading output like "Success [0]" when the actual error is `-ENOMEM`.

#### Fix

- Remove the premature `postNotifyRecv()` calls from `construct()`. Recv WRs are only needed after the QP is fully connected, and `repostAllNotifyRecvs()` in `connect()`/`accept()` already handles this.
- Replace `PLOG(ERROR)` with `LOG(ERROR)` + `strerror(-ret)` for all 4 `ibv_post_send`/`ibv_post_recv` call sites so that the actual error code is correctly reported.

#### Testing

Verified with `tebench` on ERDMA devices. The 256 spurious `-ENOMEM` errors on both initiator and target are eliminated. Transfer throughput and latency are unaffected.

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
