### PR TITLE
[TENT] Disconnect before registering memory

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/ascend/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/ascend/ascend_direct_transport.cpp
@@ -333,6 +333,9 @@ void AscendDirectTransport::startTransfer(
             if (!ret.ok()) {
                 return;
             }
+        } else {
+            std::lock_guard<std::mutex> lock(connection_mutex_);
+            connected_segments_.emplace(remote_hixl);
         }
     }
     auto op = (opcode == Request::WRITE) ? hixl::WRITE : hixl::READ;
@@ -438,6 +441,9 @@ void AscendDirectTransport::disconnect(const std::string &remote_hixl,
             LOG(ERROR) << "Failed to disconnect to: " << remote_hixl
                        << ", status: " << status
                        << ", errmsg: " << aclGetRecentErrMsg();
+        } else {
+            std::lock_guard<std::mutex> lock(connection_mutex_);
+            connected_segments_.erase(remote_hixl);
         }
         return;
     }
@@ -506,6 +512,15 @@ Status AscendDirectTransport::addMemoryBuffer(BufferDesc &desc,
 }
 
 Status AscendDirectTransport::removeMemoryBuffer(BufferDesc &desc) {
+    std::vector<std::string> remote_hixls;
+    {
+        std::lock_guard<std::mutex> lock(connection_mutex_);
+        remote_hixls.assign(connected_segments_.begin(),
+                            connected_segments_.end());
+    }
+    for (const auto &remote_hixl : remote_hixls) {
+        disconnect(remote_hixl, 10);
+    }
     std::lock_guard<std::mutex> lock(mem_handle_mutex_);
     auto addr = desc.addr;
     if (addr_to_mem_handle_.find(addr) != addr_to_mem_handle_.end()) {


### PR DESCRIPTION
## Description
Disconnect before registering memory
<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?
tested in ascend env
<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
