### PR TITLE
[TENT] Fix RDMA task memory corruption

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -47,7 +47,8 @@ class LocalBuffers;
 using RdmaContextSet = std::vector<std::shared_ptr<RdmaContext>>;
 
 struct RdmaSubBatch : public Transport::SubBatch {
-    std::vector<RdmaTask*> task_list;  // Changed to pointer for independent lifecycle
+    std::vector<RdmaTask*>
+        task_list;  // Changed to pointer for independent lifecycle
     std::vector<RdmaSlice*> slice_chain;
     size_t max_size;
     virtual size_t size() const { return task_list.size(); }

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -47,7 +47,7 @@ class LocalBuffers;
 using RdmaContextSet = std::vector<std::shared_ptr<RdmaContext>>;
 
 struct RdmaSubBatch : public Transport::SubBatch {
-    std::vector<RdmaTask> task_list;
+    std::vector<RdmaTask*> task_list;  // Changed to pointer for independent lifecycle
     std::vector<RdmaSlice*> slice_chain;
     size_t max_size;
     virtual size_t size() const { return task_list.size(); }

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -38,15 +38,8 @@ struct RdmaSliceList {
     int num_slices = 0;
 };
 
-struct RdmaTask {
-    int num_slices;
-    Request request;
-    volatile TransferStatusEnum status_word;
-    volatile size_t transferred_bytes;
-    volatile int success_slices;
-    volatile int resolved_slices;
-    volatile TransferStatusEnum first_error = PENDING;
-};
+// Forward declaration
+struct RdmaTask;
 
 class RdmaEndPoint;
 
@@ -73,6 +66,28 @@ struct RdmaSlice {
 };
 
 using RdmaSliceStorage = Slab<RdmaSlice>;
+using RdmaTaskStorage = Slab<RdmaTask>;
+
+struct RdmaTask {
+    int num_slices;
+    Request request;
+    volatile TransferStatusEnum status_word;
+    volatile size_t transferred_bytes;
+    volatile int success_slices;
+    volatile int resolved_slices;
+    volatile TransferStatusEnum first_error = PENDING;
+
+    // Reference counting for independent lifecycle management
+    // When ref_count reaches 0, the task is deallocated from Slab
+    std::atomic<int> ref_count{0};
+
+    void ref() { ref_count.fetch_add(1, std::memory_order_relaxed); }
+    void deref() {
+        if (ref_count.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            RdmaTaskStorage::Get().deallocate(this);
+        }
+    }
+};
 
 static inline void updateSliceStatus(RdmaSlice* slice,
                                      TransferStatusEnum status) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -269,7 +269,8 @@ Status RdmaTransport::submitTransferTasks(
         size_t max_slice_count = 64;
         if (type == MTYPE_CUDA || opcode == Request::WRITE)
             max_slice_count = 32;
-        // Allocate task independently from Slab for separate lifecycle management
+        // Allocate task independently from Slab for separate lifecycle
+        // management
         auto* task = RdmaTaskStorage::Get().allocate();
         if (!task)
             return Status::InternalError("Failed to allocate task" LOC_MARK);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -228,6 +228,11 @@ Status RdmaTransport::freeSubBatch(SubBatchRef& batch) {
             slice = next;
         }
     }
+    rdma_batch->slice_chain.clear();
+    for (auto task : rdma_batch->task_list) {
+        task->deref();
+    }
+    rdma_batch->task_list.clear();
     Slab<RdmaSubBatch>::Get().deallocate(rdma_batch);
     batch = nullptr;
     return Status::OK();
@@ -264,12 +269,21 @@ Status RdmaTransport::submitTransferTasks(
         size_t max_slice_count = 64;
         if (type == MTYPE_CUDA || opcode == Request::WRITE)
             max_slice_count = 32;
-        rdma_batch->task_list.push_back(RdmaTask{});
-        auto& task = rdma_batch->task_list.back();
-        task.request = request;
-        task.num_slices = 0;
-        task.status_word = PENDING;
-        task.transferred_bytes = 0;
+        // Allocate task independently from Slab for separate lifecycle management
+        auto* task = RdmaTaskStorage::Get().allocate();
+        if (!task)
+            return Status::InternalError("Failed to allocate task" LOC_MARK);
+
+        task->request = request;
+        task->num_slices = 0;
+        task->status_word = PENDING;
+        task->transferred_bytes = 0;
+        task->success_slices = 0;
+        task->resolved_slices = 0;
+        task->first_error = PENDING;
+        task->ref_count = 0;
+
+        rdma_batch->task_list.push_back(task);
 
         const double merge_ratio = 0.25;
         uint64_t base_block = default_block_size;
@@ -299,13 +313,17 @@ Status RdmaTransport::submitTransferTasks(
             slice->source_addr = (char*)request.source + offset;
             slice->target_addr = request.target_offset + offset;
             slice->length = length;
-            slice->task = &task;
+            slice->task = task;
+            slice->priority = request.priority;
+            slice->device_mask = rdma_batch->device_mask;
             slice->retry_count = 0;
             slice->ep_weak_ptr = nullptr;
             slice->word = PENDING;
             slice->next = nullptr;
             slice->enqueue_ts = enqueue_ts;
-            task.num_slices++;
+            slice->source_dev_id = slice_dev_ids[slice_idx];
+            task->num_slices++;
+            task->ref();  // Each slice holds a reference to the task
             offset += length;
             int part_id =
                 ((enable_spray ? submit_slices : static_cast<int>(slice_idx)) /
@@ -339,8 +357,8 @@ Status RdmaTransport::getTransferStatus(SubBatchRef batch, int task_id,
     if (task_id < 0 || task_id >= (int)rdma_batch->task_list.size()) {
         return Status::InvalidArgument("Invalid task ID" LOC_MARK);
     }
-    auto& task = rdma_batch->task_list[task_id];
-    status = TransferStatus{task.status_word, task.transferred_bytes};
+    auto* task = rdma_batch->task_list[task_id];
+    status = TransferStatus{task->status_word, task->transferred_bytes};
     return Status::OK();
 }
 


### PR DESCRIPTION
## Description

When a large request is split into multiple slices, a race condition occurs between 
the worker thread's `acknowledge()` and the user thread's `lazyFreeBatch()`:

1. Worker thread processes the last slice and sets `task->status_word = COMPLETED`
2. User thread's `lazyFreeBatch()` sees COMPLETED and immediately frees `rdma_batch`
3. Worker thread's `acknowledge()` is still executing and accesses `slice->task`
4. Since `slice->task` points to memory inside `rdma_batch->task_list`, this becomes 
   a use-after-free, causing memory corruption

The issue is that `RdmaTask` has a dependent lifecycle on `RdmaSubBatch`, but slices 
may outlive the batch.

Solution:
---------
- Make `RdmaTask` independently allocated from Slab with reference counting
- Each slice holds a reference to its task
- `RdmaTask` is only deallocated when all its slices are released
- `slice->task` remains valid even after `rdma_batch` is freed

Changes:
--------
- Add `std::atomic<int> ref_count` and `ref()/deref()` methods to `RdmaTask`
- Change `RdmaSubBatch::task_list` from `vector<RdmaTask>` to `vector<RdmaTask*>`
- Allocate tasks from `RdmaTaskStorage::Get().allocate()` 
- Each slice calls `task->ref()` when created
- `freeSubBatch()` calls `task->deref()` when releasing

This ensures `slice->task` has an independent lifecycle and is always valid during 
`acknowledge()` execution, eliminating the race condition.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
