### PR TITLE
[Bug fix] Fix get tcp port collision

### DIFF
--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -401,7 +401,8 @@ int getFreeTcpPort();
 
 // Obtain multiple unique available TCP ports atomically.
 // All ports are bound simultaneously before any are released, preventing
-// duplicate port assignments that can occur with repeated getFreeTcpPort() calls.
+// duplicate port assignments that can occur with repeated getFreeTcpPort()
+// calls.
 std::vector<int> getFreeTcpPorts(int count);
 
 int64_t time_gen();

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -322,7 +322,6 @@ int getFreeTcpPort() {
     return port;
 }
 
-
 std::vector<int> getFreeTcpPorts(int count) {
     std::vector<int> ports;
     std::vector<int> sockets;
@@ -336,14 +335,14 @@ std::vector<int> getFreeTcpPorts(int count) {
         addr.sin_family = AF_INET;
         addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
         addr.sin_port = htons(0);
-        if (::bind(sock, reinterpret_cast<sockaddr *>(&addr),
-                   sizeof(addr)) != 0) {
+        if (::bind(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) !=
+            0) {
             ::close(sock);
             break;
         }
         socklen_t len = sizeof(addr);
-        if (::getsockname(sock, reinterpret_cast<sockaddr *>(&addr),
-                          &len) != 0) {
+        if (::getsockname(sock, reinterpret_cast<sockaddr *>(&addr), &len) !=
+            0) {
             ::close(sock);
             break;
         }

--- a/mooncake-store/tests/test_server_helpers.h
+++ b/mooncake-store/tests/test_server_helpers.h
@@ -38,9 +38,8 @@ class InProcMaster {
             auto free_ports = getFreeTcpPorts(needed);
             if (static_cast<int>(free_ports.size()) < needed) return false;
             int idx = 0;
-            rpc_port_ = config.rpc_port.has_value()
-                            ? config.rpc_port.value()
-                            : free_ports[idx++];
+            rpc_port_ = config.rpc_port.has_value() ? config.rpc_port.value()
+                                                    : free_ports[idx++];
             http_metrics_port_ = config.http_metrics_port.has_value()
                                      ? config.http_metrics_port.value()
                                      : free_ports[idx++];


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [✅ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [✅ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [✅ ] I have performed a self-review of my own code.
- [ ✅] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.

Summary                                                                                                                                                                                                           
                                                                                                                                                                                                                    
  InProcMaster::Start() calls getFreeTcpPort() three times in succession to obtain ports for the RPC server, HTTP metrics server, and HTTP metadata server. Because getFreeTcpPort() closes the socket before       
  returning, the OS can reassign the same port number on the very next call, leading to bind collisions such as:                                                                                                    
                                                                                                                                                                                                                    
  HTTP metadata server started on 127.0.0.1:42423
  bind port: 42423 error: Address already in use                                                                                                                                                                    
  Failed to start master admin server on port 42423                                                                                                                                                                 
                                                                                                                                                                                                                    
  This caused StorageBackendE2ETest.CrossClientReadback to fail intermittently in CI (observed in https://github.com/kvcache-ai/Mooncake/actions/runs/23904544820/job/69709793859).                                 
                  
  Root Cause                                                                                                                                                                                                        
                  
  getFreeTcpPort() has a classic TOCTOU (Time of Check, Time of Use) race:                                                                                                                                          
  
  1. Bind a socket to port 0 → OS assigns a free port (e.g. 42423)                                                                                                                                                  
  2. Read the assigned port via getsockname()
  3. Close the socket → port is immediately returned to the OS free pool                                                                                                                                            
  4. Return the port number
                                                                                                                                                                                                                    
  When called back-to-back, the OS may hand out the same port again because it was freed in step 3.                                                                                                                 
  
  Fix                                                                                                                                                                                                               
                  
  Add getFreeTcpPorts(int count) which allocates multiple ports atomically — all sockets are kept open simultaneously so the OS cannot reassign any of them, and only closed after all ports have been collected.   
  InProcMaster::Start() now uses this function instead of three separate getFreeTcpPort() calls.
                                                                                                                                                                                                                    
  Changes         

  - mooncake-store/include/utils.h — declare getFreeTcpPorts()                                                                                                                                                      
  - mooncake-store/src/utils.cpp — implement getFreeTcpPorts()
  - mooncake-store/tests/test_server_helpers.h — InProcMaster::Start() uses getFreeTcpPorts() for atomic port allocation 