### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /mooncake-integration/store @ykwd @stmatengss
 /mooncake-pg @UNIDY2002 @ympcMark @yuechen-sys
 /mooncake-store @ykwd @stmatengss @XucSh @YiXR
-/mooncake-store/include/ha/ @Libotry @YiXR @00fish0
+/mooncake-store/*/ha/ @Libotry @YiXR @00fish0
 /mooncake-transfer-engine @alogfans @doujiang24 @chestnut-Q
 /mooncake-transfer-engine/*/transport/hip_transport/ @alogfans @amd-arozanov
 /mooncake-transfer-engine/*/transport/ascend_transport/ @alogfans @ascend-direct-dev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,12 +9,14 @@
 .github @stmatengss @ykwd @Ann-1024 @luketong777
 /docs @ShangmingCai @stmatengss @ykwd
 /mooncake-ep @UNIDY2002 @ympcMark @yuechen-sys
-/mooncake-integration/transfer_engine @ShangmingCai @alogfans 
+/mooncake-integration/transfer_engine @ShangmingCai @alogfans
 /mooncake-integration/store @ykwd @stmatengss
 /mooncake-pg @UNIDY2002 @ympcMark @yuechen-sys
 /mooncake-store @ykwd @stmatengss @XucSh @YiXR
+/mooncake-store/include/ha/ @Libotry @YiXR @00fish0
 /mooncake-transfer-engine @alogfans @doujiang24 @chestnut-Q
 /mooncake-transfer-engine/*/transport/hip_transport/ @alogfans @amd-arozanov
 /mooncake-transfer-engine/*/transport/ascend_transport/ @alogfans @ascend-direct-dev
 /mooncake-wheel @ShangmingCai @stmatengss
 /scripts/tone_tests @luketong777
+/scripts/ascend/ @ascend-direct-dev @VNightMare @MingYang119


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

@Libotry, @YiXR, and @00fish0 have made significant contributions to the HA feature. Meanwhile, @ascend-direct-dev, @VNightMare, and @MingYang119 have consistently helped adapt Mooncake to Ascend. They also commit to continuing to maintain these areas going forward. Therefore, I would like to nominate them as code owners for the HA feature and the Ascend scripts, respectively.


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
