### PR TITLE
[Store] Introduce cached batch query result

### DIFF
--- a/mooncake-integration/integration_utils.h
+++ b/mooncake-integration/integration_utils.h
@@ -75,6 +75,32 @@ static const std::array<ArrayCreatorFunc, 15> array_creators = {{
     create_typed_array<uint8_t>,  // FLOAT8_E5M2 = 14 (using uint8_t as storage)
 }};
 
+inline std::optional<size_t> TensorDtypeElementSize(int32_t dtype) {
+    switch (static_cast<TensorDtype>(dtype)) {
+        case TensorDtype::FLOAT64:
+        case TensorDtype::INT64:
+        case TensorDtype::UINT64:
+            return size_t{8};
+        case TensorDtype::FLOAT32:
+        case TensorDtype::INT32:
+        case TensorDtype::UINT32:
+            return size_t{4};
+        case TensorDtype::INT16:
+        case TensorDtype::UINT16:
+        case TensorDtype::FLOAT16:
+        case TensorDtype::BFLOAT16:
+            return size_t{2};
+        case TensorDtype::INT8:
+        case TensorDtype::UINT8:
+        case TensorDtype::BOOL:
+        case TensorDtype::FLOAT8_E4M3:
+        case TensorDtype::FLOAT8_E5M2:
+            return size_t{1};
+        default:
+            return std::nullopt;
+    }
+}
+
 inline TensorDtype get_tensor_dtype(py::object dtype_obj) {
     if (dtype_obj.is_none()) {
         return TensorDtype::UNKNOWN;

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -290,60 +290,11 @@ class MooncakeStorePyWrapper {
    public:
     std::shared_ptr<PyClient> store_{nullptr};
     bool use_dummy_client_{false};
-    std::unique_ptr<char[]> metadata_prefix_scratch_;
-    size_t metadata_prefix_scratch_size_{0};
-    std::mutex metadata_prefix_scratch_mutex_;
 
     MooncakeStorePyWrapper() = default;
 
-    ~MooncakeStorePyWrapper() { release_metadata_prefix_scratch(); }
-
-    void release_metadata_prefix_scratch_locked() {
-        if (metadata_prefix_scratch_) {
-            if (store_ && is_client_initialized()) {
-                store_->unregister_buffer(metadata_prefix_scratch_.get());
-            }
-            metadata_prefix_scratch_.reset();
-            metadata_prefix_scratch_size_ = 0;
-        }
-    }
-
-    void release_metadata_prefix_scratch() {
-        std::lock_guard<std::mutex> lock(metadata_prefix_scratch_mutex_);
-        release_metadata_prefix_scratch_locked();
-    }
-
-    bool ensure_metadata_prefix_scratch_locked(size_t slot_count,
-                                               const std::string &context) {
-        const size_t required_size =
-            std::max<size_t>(slot_count, 1) * sizeof(TensorMetadata);
-        if (metadata_prefix_scratch_size_ >= required_size &&
-            metadata_prefix_scratch_) {
-            return true;
-        }
-
-        release_metadata_prefix_scratch_locked();
-        auto buffer = std::make_unique<char[]>(required_size);
-        if (store_->register_buffer(buffer.get(), required_size) != 0) {
-            LOG(ERROR) << context
-                       << ": failed to register metadata scratch buffer";
-            return false;
-        }
-
-        metadata_prefix_scratch_ = std::move(buffer);
-        metadata_prefix_scratch_size_ = required_size;
-        return true;
-    }
-
-    bool ensure_metadata_prefix_scratch(size_t slot_count,
-                                        const std::string &context) {
-        std::lock_guard<std::mutex> lock(metadata_prefix_scratch_mutex_);
-        return ensure_metadata_prefix_scratch_locked(slot_count, context);
-    }
-
     // Helper to initialize real client and register it
     std::shared_ptr<RealClient> init_real_client() {
-        release_metadata_prefix_scratch();
         auto &resource_tracker = ResourceTracker::getInstance();
         auto real_client = RealClient::create();
         use_dummy_client_ = false;
@@ -2071,7 +2022,6 @@ PYBIND11_MODULE(store, m) {
             "setup_dummy",
             [](MooncakeStorePyWrapper &self, size_t mem_pool_size,
                size_t local_buffer_size, const std::string &server_address) {
-                self.release_metadata_prefix_scratch();
                 auto &resource_tracker = ResourceTracker::getInstance();
                 self.use_dummy_client_ = true;
                 self.store_ = std::make_shared<DummyClient>();
@@ -2190,7 +2140,6 @@ PYBIND11_MODULE(store, m) {
         .def("close",
              [](MooncakeStorePyWrapper &self) {
                  if (!self.store_) return 0;
-                 self.release_metadata_prefix_scratch();
                  int rc = self.store_->tearDownAll();
                  self.store_.reset();
                  return rc;

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -290,11 +290,60 @@ class MooncakeStorePyWrapper {
    public:
     std::shared_ptr<PyClient> store_{nullptr};
     bool use_dummy_client_{false};
+    std::unique_ptr<char[]> metadata_prefix_scratch_;
+    size_t metadata_prefix_scratch_size_{0};
+    std::mutex metadata_prefix_scratch_mutex_;
 
     MooncakeStorePyWrapper() = default;
 
+    ~MooncakeStorePyWrapper() { release_metadata_prefix_scratch(); }
+
+    void release_metadata_prefix_scratch_locked() {
+        if (metadata_prefix_scratch_) {
+            if (store_ && is_client_initialized()) {
+                store_->unregister_buffer(metadata_prefix_scratch_.get());
+            }
+            metadata_prefix_scratch_.reset();
+            metadata_prefix_scratch_size_ = 0;
+        }
+    }
+
+    void release_metadata_prefix_scratch() {
+        std::lock_guard<std::mutex> lock(metadata_prefix_scratch_mutex_);
+        release_metadata_prefix_scratch_locked();
+    }
+
+    bool ensure_metadata_prefix_scratch_locked(size_t slot_count,
+                                               const std::string &context) {
+        const size_t required_size =
+            std::max<size_t>(slot_count, 1) * sizeof(TensorMetadata);
+        if (metadata_prefix_scratch_size_ >= required_size &&
+            metadata_prefix_scratch_) {
+            return true;
+        }
+
+        release_metadata_prefix_scratch_locked();
+        auto buffer = std::make_unique<char[]>(required_size);
+        if (store_->register_buffer(buffer.get(), required_size) != 0) {
+            LOG(ERROR) << context
+                       << ": failed to register metadata scratch buffer";
+            return false;
+        }
+
+        metadata_prefix_scratch_ = std::move(buffer);
+        metadata_prefix_scratch_size_ = required_size;
+        return true;
+    }
+
+    bool ensure_metadata_prefix_scratch(size_t slot_count,
+                                        const std::string &context) {
+        std::lock_guard<std::mutex> lock(metadata_prefix_scratch_mutex_);
+        return ensure_metadata_prefix_scratch_locked(slot_count, context);
+    }
+
     // Helper to initialize real client and register it
     std::shared_ptr<RealClient> init_real_client() {
+        release_metadata_prefix_scratch();
         auto &resource_tracker = ResourceTracker::getInstance();
         auto real_client = RealClient::create();
         use_dummy_client_ = false;
@@ -2022,6 +2071,7 @@ PYBIND11_MODULE(store, m) {
             "setup_dummy",
             [](MooncakeStorePyWrapper &self, size_t mem_pool_size,
                size_t local_buffer_size, const std::string &server_address) {
+                self.release_metadata_prefix_scratch();
                 auto &resource_tracker = ResourceTracker::getInstance();
                 self.use_dummy_client_ = true;
                 self.store_ = std::make_shared<DummyClient>();
@@ -2140,6 +2190,7 @@ PYBIND11_MODULE(store, m) {
         .def("close",
              [](MooncakeStorePyWrapper &self) {
                  if (!self.store_) return 0;
+                 self.release_metadata_prefix_scratch();
                  int rc = self.store_->tearDownAll();
                  self.store_.reset();
                  return rc;

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -289,6 +289,7 @@ inline int to_py_ret(ErrorCode error_code) {
 class MooncakeStorePyWrapper {
    public:
     std::shared_ptr<PyClient> store_{nullptr};
+    std::shared_ptr<RealClient> real_client_{nullptr};
     bool use_dummy_client_{false};
 
     MooncakeStorePyWrapper() = default;
@@ -299,6 +300,7 @@ class MooncakeStorePyWrapper {
         auto real_client = RealClient::create();
         use_dummy_client_ = false;
         store_ = real_client;
+        real_client_ = real_client;
         resource_tracker.registerInstance(
             std::static_pointer_cast<PyClient>(store_));
         return real_client;
@@ -1137,7 +1139,7 @@ class MooncakeStorePyWrapper {
         if (use_dummy_client_) {
             return nullptr;
         }
-        return std::dynamic_pointer_cast<RealClient>(store_);
+        return real_client_;
     }
 
     std::optional<RealClient::WritableBufferRegion>
@@ -2046,6 +2048,7 @@ PYBIND11_MODULE(store, m) {
                 auto &resource_tracker = ResourceTracker::getInstance();
                 self.use_dummy_client_ = true;
                 self.store_ = std::make_shared<DummyClient>();
+                self.real_client_.reset();
                 resource_tracker.registerInstance(
                     std::static_pointer_cast<PyClient>(self.store_));
                 auto [ip, port] = parseHostNameWithPort(server_address);

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1165,6 +1165,27 @@ class MooncakeStorePyWrapper {
         return region;
     }
 
+    std::optional<ParsedParallelismManifest> load_parallelism_manifest(
+        const std::string &key, const std::string &context) const {
+        std::shared_ptr<BufferHandle> manifest_handle;
+        {
+            py::gil_scoped_release release_gil;
+            manifest_handle =
+                store_->get_buffer(get_parallelism_manifest_key_name(key));
+        }
+        auto parsed_manifest =
+            parse_writer_shard_manifest(manifest_handle.get());
+        if (!parsed_manifest.has_value()) {
+            return std::nullopt;
+        }
+        if (parsed_manifest->manifest.header.ndim !=
+            static_cast<int32_t>(parsed_manifest->global_shape.size())) {
+            LOG(ERROR) << context << ": invalid parallelism manifest shape";
+            return std::nullopt;
+        }
+        return parsed_manifest;
+    }
+
 #include "store_py_parallel_read.h"
 
     // --- Upsert tensor methods ---

--- a/mooncake-integration/store/store_py_internal.h
+++ b/mooncake-integration/store/store_py_internal.h
@@ -90,12 +90,21 @@ struct PlannedQueryResult {
     std::optional<CachedQueryResultResponse> cached_query_result;
 };
 
+struct TensorIntoRegularFullFormulaPlan {
+    std::vector<std::string> read_keys;
+    std::vector<int64_t> global_shape;
+    int split_dim{0};
+    size_t element_size{0};
+    size_t data_offset{sizeof(TensorMetadata)};
+};
+
 struct TensorIntoPlan {
     uintptr_t user_buffer_ptr{0};
     uintptr_t registered_buffer_ptr{0};
     size_t registered_buffer_size{0};
     size_t total_length{0};
     std::vector<TensorIntoFragment> fragments;
+    std::optional<TensorIntoRegularFullFormulaPlan> regular_full_formula;
     std::vector<PlannedQueryResult> query_results;
     std::optional<TensorMetadata> materialized_metadata;
 };

--- a/mooncake-integration/store/store_py_internal.h
+++ b/mooncake-integration/store/store_py_internal.h
@@ -85,12 +85,15 @@ struct TensorIntoFragment {
     size_t size{0};
 };
 
+using QueryResultCache = mooncake::PyClient::QueryResultCache;
+
 struct TensorIntoPlan {
     uintptr_t user_buffer_ptr{0};
     uintptr_t registered_buffer_ptr{0};
     size_t registered_buffer_size{0};
     size_t total_length{0};
     std::vector<TensorIntoFragment> fragments;
+    QueryResultCache query_result_cache;
     std::optional<TensorMetadata> materialized_metadata;
 };
 
@@ -108,6 +111,7 @@ enum class ParallelismShardReadStorageRoute {
 struct ReconstructedShardSource {
     std::string read_key;
     ParsedTensorMetadata metadata;
+    tl::expected<QueryResult, ErrorCode> query_result;
 };
 
 struct FullTensorReconstructionSources {

--- a/mooncake-integration/store/store_py_internal.h
+++ b/mooncake-integration/store/store_py_internal.h
@@ -111,7 +111,8 @@ enum class ParallelismShardReadStorageRoute {
 struct ReconstructedShardSource {
     std::string read_key;
     ParsedTensorMetadata metadata;
-    tl::expected<QueryResult, ErrorCode> query_result;
+    tl::expected<QueryResult, ErrorCode> query_result =
+        tl::make_unexpected(ErrorCode::INVALID_PARAMS);
 };
 
 struct FullTensorReconstructionSources {

--- a/mooncake-integration/store/store_py_internal.h
+++ b/mooncake-integration/store/store_py_internal.h
@@ -87,7 +87,7 @@ struct TensorIntoFragment {
 
 struct PlannedQueryResult {
     std::string read_key;
-    CachedQueryResultResponse cached_query_result;
+    std::optional<CachedQueryResultResponse> cached_query_result;
 };
 
 struct TensorIntoPlan {
@@ -114,7 +114,7 @@ enum class ParallelismShardReadStorageRoute {
 struct ReconstructedShardSource {
     std::string read_key;
     ParsedTensorMetadata metadata;
-    CachedQueryResultResponse cached_query_result;
+    std::optional<CachedQueryResultResponse> cached_query_result;
 };
 
 struct FullTensorReconstructionSources {

--- a/mooncake-integration/store/store_py_internal.h
+++ b/mooncake-integration/store/store_py_internal.h
@@ -85,7 +85,11 @@ struct TensorIntoFragment {
     size_t size{0};
 };
 
-using QueryResultCache = mooncake::PyClient::QueryResultCache;
+struct PlannedQueryResult {
+    std::string read_key;
+    tl::expected<QueryResult, ErrorCode> query_result =
+        tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+};
 
 struct TensorIntoPlan {
     uintptr_t user_buffer_ptr{0};
@@ -93,7 +97,7 @@ struct TensorIntoPlan {
     size_t registered_buffer_size{0};
     size_t total_length{0};
     std::vector<TensorIntoFragment> fragments;
-    QueryResultCache query_result_cache;
+    std::vector<PlannedQueryResult> query_results;
     std::optional<TensorMetadata> materialized_metadata;
 };
 

--- a/mooncake-integration/store/store_py_internal.h
+++ b/mooncake-integration/store/store_py_internal.h
@@ -87,8 +87,7 @@ struct TensorIntoFragment {
 
 struct PlannedQueryResult {
     std::string read_key;
-    tl::expected<QueryResult, ErrorCode> query_result =
-        tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    CachedQueryResultResponse cached_query_result;
 };
 
 struct TensorIntoPlan {
@@ -115,8 +114,7 @@ enum class ParallelismShardReadStorageRoute {
 struct ReconstructedShardSource {
     std::string read_key;
     ParsedTensorMetadata metadata;
-    tl::expected<QueryResult, ErrorCode> query_result =
-        tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    CachedQueryResultResponse cached_query_result;
 };
 
 struct FullTensorReconstructionSources {

--- a/mooncake-integration/store/store_py_parallel_read.h
+++ b/mooncake-integration/store/store_py_parallel_read.h
@@ -42,7 +42,24 @@ std::optional<ParsedTensorMetadata> parse_tensor_metadata_from_prefix(
     return parsed;
 }
 
-std::optional<std::unordered_map<std::string, ReconstructedShardSource>>
+std::vector<CachedQueryResultResponse> batch_query_for_reuse(
+    const std::vector<std::string> &keys) {
+    if (auto real_client = std::dynamic_pointer_cast<RealClient>(store_)) {
+        return real_client->batch_get_query_results(keys);
+    }
+
+    auto query_results = store_->batch_query(keys);
+    std::vector<CachedQueryResultResponse> cached_results;
+    cached_results.reserve(query_results.size());
+    auto now = std::chrono::steady_clock::now();
+    for (const auto &query_result : query_results) {
+        cached_results.push_back(
+            to_cached_query_result_response(query_result, now));
+    }
+    return cached_results;
+}
+
+std::optional<std::vector<ReconstructedShardSource>>
 load_reconstructed_shard_sources_batch(const std::vector<std::string> &keys,
                                        const std::string &context) {
     if (!is_client_initialized()) {
@@ -50,62 +67,67 @@ load_reconstructed_shard_sources_batch(const std::vector<std::string> &keys,
         return std::nullopt;
     }
     if (keys.empty()) {
-        return std::unordered_map<std::string, ReconstructedShardSource>{};
+        return std::vector<ReconstructedShardSource>{};
     }
 
-    std::vector<tl::expected<QueryResult, ErrorCode>> query_results;
+    std::vector<CachedQueryResultResponse> cached_query_results;
     {
         py::gil_scoped_release release_gil;
-        query_results = store_->batch_query(keys);
+        cached_query_results = batch_query_for_reuse(keys);
     }
-    if (query_results.size() != keys.size()) {
+    if (cached_query_results.size() != keys.size()) {
         LOG(ERROR) << context << ": BatchQuery result size mismatch";
         return std::nullopt;
     }
 
     mooncake::PyClient::QueryResultCache query_result_cache;
-    std::vector<std::shared_ptr<BufferHandle>> metadata_handles;
+    auto now = std::chrono::steady_clock::now();
     std::vector<void *> metadata_buffers;
     std::vector<size_t> metadata_key_indices;
-    metadata_handles.reserve(keys.size());
     metadata_buffers.reserve(keys.size());
     metadata_key_indices.reserve(keys.size());
 
     for (size_t i = 0; i < keys.size(); ++i) {
-        if (!query_results[i]) {
-            continue;
+        auto query_result =
+            from_cached_query_result_response(cached_query_results[i], now);
+        if (!query_result) {
+            LOG(ERROR) << context << ": missing query result for key "
+                       << keys[i] << ": " << toString(query_result.error());
+            return std::nullopt;
         }
-
-        query_result_cache.emplace(keys[i], query_results[i]);
-
-        auto alloc_result =
-            store_->client_buffer_allocator_->allocate(sizeof(TensorMetadata));
-        if (!alloc_result) {
-            LOG(ERROR) << context
-                       << ": failed to allocate metadata buffer for key "
+        if (query_result->IsLeaseExpired(now)) {
+            LOG(ERROR) << context << ": expired query result for key "
                        << keys[i];
             return std::nullopt;
         }
-        auto metadata_handle =
-            std::make_shared<BufferHandle>(std::move(*alloc_result));
-        metadata_buffers.push_back(metadata_handle->ptr());
+
+        query_result_cache.emplace(keys[i], std::move(query_result));
         metadata_key_indices.push_back(i);
-        metadata_handles.push_back(std::move(metadata_handle));
     }
 
     std::vector<std::optional<ParsedTensorMetadata>> prefix_metadata(
         keys.size());
     if (!metadata_key_indices.empty()) {
+        std::unique_lock<std::mutex> scratch_lock(
+            metadata_prefix_scratch_mutex_);
+        if (!ensure_metadata_prefix_scratch_locked(metadata_key_indices.size(),
+                                                   context)) {
+            return std::nullopt;
+        }
+
+        char *scratch_base = metadata_prefix_scratch_.get();
         std::vector<std::vector<std::string>> metadata_all_keys(
             metadata_key_indices.size());
         std::vector<std::vector<std::vector<size_t>>> metadata_all_dst_offsets(
-            metadata_key_indices.size(), {{0}});
+            metadata_key_indices.size());
         std::vector<std::vector<std::vector<size_t>>> metadata_all_src_offsets(
             metadata_key_indices.size(), {{0}});
         std::vector<std::vector<std::vector<size_t>>> metadata_all_sizes(
             metadata_key_indices.size(), {{sizeof(TensorMetadata)}});
         for (size_t i = 0; i < metadata_key_indices.size(); ++i) {
+            metadata_buffers.push_back(scratch_base);
             metadata_all_keys[i] = {keys[metadata_key_indices[i]]};
+            metadata_all_dst_offsets[i] = {{i * sizeof(TensorMetadata)}};
         }
 
         py::gil_scoped_release release_gil;
@@ -115,39 +137,37 @@ load_reconstructed_shard_sources_batch(const std::vector<std::string> &keys,
         for (size_t i = 0;
              i < metadata_results.size() && i < metadata_key_indices.size();
              ++i) {
+            const size_t key_index = metadata_key_indices[i];
             if (metadata_results[i].size() == 1 &&
                 metadata_results[i][0].size() == 1 &&
                 metadata_results[i][0][0] ==
                     static_cast<int64_t>(sizeof(TensorMetadata))) {
-                prefix_metadata[metadata_key_indices[i]] =
-                    parse_tensor_metadata_from_prefix(
-                        metadata_buffers[i], context,
-                        keys[metadata_key_indices[i]]);
+                prefix_metadata[key_index] = parse_tensor_metadata_from_prefix(
+                    scratch_base + i * sizeof(TensorMetadata), context,
+                    keys[key_index]);
             }
         }
     }
 
-    std::unordered_map<std::string, ReconstructedShardSource> sources;
-    sources.reserve(metadata_key_indices.size());
+    std::vector<ReconstructedShardSource> sources;
+    sources.reserve(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
-        if (!query_results[i]) {
-            continue;
-        }
-
         auto parsed = std::move(prefix_metadata[i]);
         if (!parsed.has_value()) {
             parsed = get_tensor_metadata(keys[i]);
         }
         if (!parsed.has_value()) {
-            continue;
+            LOG(ERROR) << context
+                       << ": missing reconstructed shard source for key "
+                       << keys[i];
+            return std::nullopt;
         }
-
-        sources.emplace(keys[i],
-                        ReconstructedShardSource{keys[i], *parsed,
-                                                 std::move(query_results[i])});
+        sources.push_back(ReconstructedShardSource{keys[i], *parsed,
+                                                   cached_query_results[i]});
     }
     return sources;
 }
+
 std::optional<TensorIntoPlan> build_tensor_into_plan(
     const std::string &read_key, uintptr_t buffer_ptr, size_t size,
     const std::string &context,
@@ -367,8 +387,8 @@ std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
             covered[static_cast<size_t>(idx)] = true;
         }
 
-        plan.query_results.push_back(PlannedQueryResult{
-            source.read_key, std::move(source.query_result)});
+        plan.query_results.push_back(
+            PlannedQueryResult{source.read_key, source.cached_query_result});
         for (int64_t slice_idx = 0; slice_idx < elements_before; ++slice_idx) {
             const size_t dst_offset =
                 region->offset + sizeof(TensorMetadata) +
@@ -626,10 +646,9 @@ load_tp_full_reconstruction_sources(
         return std::nullopt;
     }
 
-    FullTensorReconstructionSources reconstruction;
-    reconstruction.sources.reserve(axis.size);
+    std::vector<std::string> read_keys;
+    read_keys.reserve(axis.size);
     for (int shard_rank = 0; shard_rank < axis.size; ++shard_rank) {
-        std::string read_key;
         if (parallelism.has_value()) {
             auto shard_parallelism = *parallelism;
             auto tp_axis_index = find_tp_axis_index(shard_parallelism.axes);
@@ -639,33 +658,43 @@ load_tp_full_reconstruction_sources(
                 return std::nullopt;
             }
             shard_parallelism.axes[*tp_axis_index].rank = shard_rank;
-            read_key = get_parallelism_key_name(key, shard_parallelism);
+            read_keys.push_back(
+                get_parallelism_key_name(key, shard_parallelism));
         } else {
-            read_key = resolve_tp_read_key(key, shard_rank, axis.size);
+            read_keys.push_back(
+                resolve_tp_read_key(key, shard_rank, axis.size));
         }
-        auto metadata = get_tensor_metadata(read_key);
-        if (!metadata.has_value()) {
-            return std::nullopt;
-        }
+    }
+
+    auto ordered_sources =
+        load_reconstructed_shard_sources_batch(read_keys, context);
+    if (!ordered_sources.has_value()) {
+        return std::nullopt;
+    }
+
+    FullTensorReconstructionSources reconstruction;
+    reconstruction.sources.reserve(axis.size);
+    for (int shard_rank = 0; shard_rank < axis.size; ++shard_rank) {
+        auto &source = (*ordered_sources)[shard_rank];
+        const auto &metadata = source.metadata;
         const LayoutAxis *tp_axis =
-            find_layout_axis(metadata->metadata, LayoutAxisKind::TP);
-        if (!is_shard_tensor_metadata(metadata->metadata) || !tp_axis ||
+            find_layout_axis(metadata.metadata, LayoutAxisKind::TP);
+        if (!is_shard_tensor_metadata(metadata.metadata) || !tp_axis ||
             tp_axis->shard_rank != shard_rank ||
             tp_axis->shard_count != axis.size) {
             LOG(ERROR) << context << ": TP metadata mismatch for key "
-                       << read_key;
+                       << source.read_key;
             return std::nullopt;
         }
         if (parallelism.has_value()) {
             auto stored_parallelism =
                 resolve_tp_compatible_parallelism_from_metadata(
-                    *parallelism, metadata->metadata, context);
+                    *parallelism, metadata.metadata, context);
             if (!stored_parallelism.has_value()) {
                 return std::nullopt;
             }
         }
-        reconstruction.sources.push_back(
-            ReconstructedShardSource{read_key, *metadata});
+        reconstruction.sources.push_back(std::move(source));
     }
 
     reconstruction.global_shape = TensorShapeToVector(
@@ -720,32 +749,38 @@ std::optional<FullTensorReconstructionSources> load_writer_shard_reconstruction(
         return std::nullopt;
     }
 
-    FullTensorReconstructionSources reconstruction;
-    reconstruction.sources.reserve(shard_count);
+    std::vector<std::string> shard_keys;
+    shard_keys.reserve(shard_count);
     for (int shard_rank = 0; shard_rank < shard_count; ++shard_rank) {
         WriterPartitionSpec writer{
             .rank = shard_rank,
             .size = shard_count,
             .split_dim = split_dim,
         };
-        const std::string shard_key = get_writer_shard_key_name(key, writer);
-        auto metadata = get_tensor_metadata(shard_key);
-        if (!metadata.has_value()) {
-            LOG(ERROR) << context << ": missing writer shard key " << shard_key;
-            return std::nullopt;
-        }
-        auto writer_parallelism =
-            writer_partition_parallelism_from_metadata(metadata->metadata);
+        shard_keys.push_back(get_writer_shard_key_name(key, writer));
+    }
+
+    auto ordered_sources =
+        load_reconstructed_shard_sources_batch(shard_keys, context);
+    if (!ordered_sources.has_value()) {
+        return std::nullopt;
+    }
+
+    FullTensorReconstructionSources reconstruction;
+    reconstruction.sources.reserve(shard_count);
+    for (int shard_rank = 0; shard_rank < shard_count; ++shard_rank) {
+        auto &source = (*ordered_sources)[shard_rank];
+        auto writer_parallelism = writer_partition_parallelism_from_metadata(
+            source.metadata.metadata);
         if (!writer_parallelism.has_value() ||
             writer_parallelism->axes[0].rank != shard_rank ||
             writer_parallelism->axes[0].size != shard_count ||
             writer_parallelism->axes[0].split_dim != split_dim) {
             LOG(ERROR) << context << ": writer shard metadata mismatch for key "
-                       << shard_key;
+                       << source.read_key;
             return std::nullopt;
         }
-        reconstruction.sources.push_back(
-            ReconstructedShardSource{shard_key, *metadata});
+        reconstruction.sources.push_back(std::move(source));
     }
     reconstruction.global_shape = manifest.global_shape;
     reconstruction.split_dim = manifest.manifest.header.split_dim;
@@ -820,6 +855,21 @@ load_parallelism_manifest_reconstruction(
         return std::nullopt;
     }
 
+    std::vector<std::string> shard_keys;
+    shard_keys.reserve(shard_count);
+    for (int shard_rank = 0; shard_rank < shard_count; ++shard_rank) {
+        auto shard_parallelism = *canonical_parallelism;
+        shard_parallelism.axes[*tp_axis_index].rank = shard_rank;
+        shard_parallelism.axes[*tp_axis_index].size = shard_count;
+        shard_keys.push_back(get_parallelism_key_name(key, shard_parallelism));
+    }
+
+    auto ordered_sources =
+        load_reconstructed_shard_sources_batch(shard_keys, context);
+    if (!ordered_sources.has_value()) {
+        return std::nullopt;
+    }
+
     FullTensorReconstructionSources reconstruction;
     reconstruction.global_shape = global_shape;
     reconstruction.split_dim = split_dim;
@@ -829,18 +879,10 @@ load_parallelism_manifest_reconstruction(
         auto shard_parallelism = *canonical_parallelism;
         shard_parallelism.axes[*tp_axis_index].rank = shard_rank;
         shard_parallelism.axes[*tp_axis_index].size = shard_count;
-        const std::string shard_key =
-            get_parallelism_key_name(key, shard_parallelism);
-        auto metadata = get_tensor_metadata(shard_key);
-        if (!metadata.has_value()) {
-            LOG(ERROR) << context
-                       << ": no shard matched stored layout for TP rank "
-                       << shard_rank;
-            return std::nullopt;
-        }
+        auto &source = (*ordered_sources)[shard_rank];
         auto stored_parallelism =
             resolve_tp_compatible_parallelism_from_metadata(
-                shard_parallelism, metadata->metadata, context);
+                shard_parallelism, source.metadata.metadata, context);
         if (!stored_parallelism.has_value() ||
             !parallelism_specs_equal_by_kind(
                 shard_parallelism, *stored_parallelism,
@@ -849,8 +891,7 @@ load_parallelism_manifest_reconstruction(
                        << shard_rank;
             return std::nullopt;
         }
-        reconstruction.sources.push_back(
-            ReconstructedShardSource{shard_key, *metadata});
+        reconstruction.sources.push_back(std::move(source));
     }
     return reconstruction;
 }
@@ -920,21 +961,25 @@ load_parallelism_full_reconstruction_sources(
             return std::nullopt;
         }
         reconstruction.dtype = first_metadata->metadata.header.dtype;
+        std::vector<std::string> shard_keys;
+        shard_keys.reserve(stored_tp_axis->shard_count);
+        for (int shard_rank = 0; shard_rank < stored_tp_axis->shard_count;
+             ++shard_rank) {
+            shard_keys.push_back(resolve_tp_read_key(
+                key, shard_rank, stored_tp_axis->shard_count));
+        }
+        auto ordered_sources =
+            load_reconstructed_shard_sources_batch(shard_keys, context);
+        if (!ordered_sources.has_value()) {
+            return std::nullopt;
+        }
         reconstruction.sources.reserve(stored_tp_axis->shard_count);
         for (int shard_rank = 0; shard_rank < stored_tp_axis->shard_count;
              ++shard_rank) {
-            const std::string shard_key = resolve_tp_read_key(
-                key, shard_rank, stored_tp_axis->shard_count);
-            auto metadata = get_tensor_metadata(shard_key);
-            if (!metadata.has_value()) {
-                LOG(ERROR) << context
-                           << ": no shard matched stored layout for TP rank "
-                           << shard_rank;
-                return std::nullopt;
-            }
+            auto &source = (*ordered_sources)[shard_rank];
             const LayoutAxis *source_tp_axis =
-                find_layout_axis(metadata->metadata, LayoutAxisKind::TP);
-            if (!is_shard_tensor_metadata(metadata->metadata) ||
+                find_layout_axis(source.metadata.metadata, LayoutAxisKind::TP);
+            if (!is_shard_tensor_metadata(source.metadata.metadata) ||
                 !source_tp_axis || source_tp_axis->shard_rank != shard_rank ||
                 source_tp_axis->shard_count != stored_tp_axis->shard_count ||
                 source_tp_axis->split_dim != reconstruction.split_dim) {
@@ -943,29 +988,33 @@ load_parallelism_full_reconstruction_sources(
                            << shard_rank;
                 return std::nullopt;
             }
-            reconstruction.sources.push_back(
-                ReconstructedShardSource{shard_key, *metadata});
+            reconstruction.sources.push_back(std::move(source));
         }
         return reconstruction;
+    }
+
+    std::vector<std::string> shard_keys;
+    shard_keys.reserve(request_tp_axis->size);
+    for (int shard_rank = 0; shard_rank < request_tp_axis->size; ++shard_rank) {
+        auto shard_parallelism = *canonical_parallelism;
+        shard_parallelism.axes[*tp_axis_index].rank = shard_rank;
+        shard_keys.push_back(get_parallelism_key_name(key, shard_parallelism));
+    }
+    auto ordered_sources =
+        load_reconstructed_shard_sources_batch(shard_keys, context);
+    if (!ordered_sources.has_value()) {
+        return std::nullopt;
     }
 
     reconstruction.sources.reserve(request_tp_axis->size);
     for (int shard_rank = 0; shard_rank < request_tp_axis->size; ++shard_rank) {
         auto shard_parallelism = *canonical_parallelism;
         shard_parallelism.axes[*tp_axis_index].rank = shard_rank;
-        const std::string shard_key =
-            get_parallelism_key_name(key, shard_parallelism);
-        auto metadata = get_tensor_metadata(shard_key);
-        if (!metadata.has_value()) {
-            LOG(ERROR) << context
-                       << ": no shard matched requested layout for TP rank "
-                       << shard_rank;
-            return std::nullopt;
-        }
+        auto &source = (*ordered_sources)[shard_rank];
 
         auto stored_parallelism =
             resolve_tp_compatible_parallelism_from_metadata(
-                shard_parallelism, metadata->metadata, context);
+                shard_parallelism, source.metadata.metadata, context);
         if (!stored_parallelism.has_value() ||
             !parallelism_specs_equal_by_kind(
                 *canonical_parallelism, *stored_parallelism,
@@ -974,8 +1023,7 @@ load_parallelism_full_reconstruction_sources(
                        << shard_rank;
             return std::nullopt;
         }
-        reconstruction.sources.push_back(
-            ReconstructedShardSource{shard_key, *metadata});
+        reconstruction.sources.push_back(std::move(source));
     }
 
     const LayoutAxis *stored_tp_axis = find_layout_axis(
@@ -1183,11 +1231,16 @@ std::vector<bool> execute_tensor_into_plan_transfers(
     {
         py::gil_scoped_release release_gil;
         mooncake::PyClient::QueryResultCache merged_query_result_cache;
+        auto now = std::chrono::steady_clock::now();
         for (auto &plan : plans) {
             for (auto &planned_query_result : plan.query_results) {
-                merged_query_result_cache.emplace(
-                    std::move(planned_query_result.read_key),
-                    std::move(planned_query_result.query_result));
+                auto query_result = from_cached_query_result_response(
+                    planned_query_result.cached_query_result, now);
+                if (!query_result || query_result->IsLeaseExpired(now)) {
+                    continue;
+                }
+                merged_query_result_cache.emplace(planned_query_result.read_key,
+                                                  std::move(query_result));
             }
         }
         range_results = store_->get_into_ranges(

--- a/mooncake-integration/store/store_py_parallel_read.h
+++ b/mooncake-integration/store/store_py_parallel_read.h
@@ -23,33 +23,28 @@ std::optional<ParsedTensorMetadata> get_tensor_metadata(
 }
 
 std::optional<ParsedTensorMetadata> parse_tensor_metadata_from_prefix(
-    const void *buffer_ptr, size_t prefix_size, const std::string &context,
+    const void *buffer_ptr, const std::string &context,
     const std::string &key) {
-    if (buffer_ptr == nullptr || prefix_size < sizeof(TensorMetadata)) {
+    if (buffer_ptr == nullptr) {
         LOG(ERROR) << context << ": invalid metadata prefix for key " << key;
         return std::nullopt;
     }
 
     TensorMetadata metadata{};
     std::memcpy(&metadata, buffer_ptr, sizeof(TensorMetadata));
-    const size_t total_length =
+    auto parsed = ParseTensorMetadata(
+        static_cast<const char *>(buffer_ptr),
         static_cast<size_t>(metadata.header.data_offset) +
-        static_cast<size_t>(metadata.header.data_bytes);
-    if (!ValidateTensorMetadata(metadata, total_length)) {
+            static_cast<size_t>(metadata.header.data_bytes));
+    if (!parsed.has_value()) {
         LOG(ERROR) << context << ": invalid tensor metadata for key " << key;
-        return std::nullopt;
     }
-
-    return ParsedTensorMetadata{.metadata = metadata,
-                                .data_offset = static_cast<size_t>(
-                                    metadata.header.data_offset),
-                                .data_bytes = static_cast<size_t>(
-                                    metadata.header.data_bytes)};
+    return parsed;
 }
 
 std::optional<std::unordered_map<std::string, ReconstructedShardSource>>
-load_reconstructed_shard_sources_batch(
-    const std::vector<std::string> &keys, const std::string &context) {
+load_reconstructed_shard_sources_batch(const std::vector<std::string> &keys,
+                                       const std::string &context) {
     if (!is_client_initialized()) {
         LOG(ERROR) << context << ": client is not initialized";
         return std::nullopt;
@@ -69,21 +64,19 @@ load_reconstructed_shard_sources_batch(
     }
 
     mooncake::PyClient::QueryResultCache query_result_cache;
-    query_result_cache.reserve(keys.size());
-    std::vector<std::shared_ptr<BufferHandle>> metadata_handles(keys.size(),
-                                                                nullptr);
-    std::vector<std::string> metadata_keys;
+    std::vector<std::shared_ptr<BufferHandle>> metadata_handles;
     std::vector<void *> metadata_buffers;
     std::vector<size_t> metadata_key_indices;
-    metadata_keys.reserve(keys.size());
+    metadata_handles.reserve(keys.size());
     metadata_buffers.reserve(keys.size());
     metadata_key_indices.reserve(keys.size());
 
     for (size_t i = 0; i < keys.size(); ++i) {
-        query_result_cache.emplace(keys[i], query_results[i]);
         if (!query_results[i]) {
             continue;
         }
+
+        query_result_cache.emplace(keys[i], query_results[i]);
 
         auto alloc_result =
             store_->client_buffer_allocator_->allocate(sizeof(TensorMetadata));
@@ -93,43 +86,55 @@ load_reconstructed_shard_sources_batch(
                        << keys[i];
             return std::nullopt;
         }
-        metadata_handles[i] =
+        auto metadata_handle =
             std::make_shared<BufferHandle>(std::move(*alloc_result));
-        metadata_keys.push_back(keys[i]);
-        metadata_buffers.push_back(metadata_handles[i]->ptr());
+        metadata_buffers.push_back(metadata_handle->ptr());
         metadata_key_indices.push_back(i);
+        metadata_handles.push_back(std::move(metadata_handle));
     }
 
-    std::vector<int64_t> metadata_results_by_key(
-        keys.size(), static_cast<int64_t>(toInt(ErrorCode::INVALID_PARAMS)));
-    if (!metadata_keys.empty()) {
+    std::vector<std::optional<ParsedTensorMetadata>> prefix_metadata(
+        keys.size());
+    if (!metadata_key_indices.empty()) {
+        std::vector<std::vector<std::string>> metadata_all_keys(
+            metadata_key_indices.size());
+        std::vector<std::vector<std::vector<size_t>>> metadata_all_dst_offsets(
+            metadata_key_indices.size(), {{0}});
+        std::vector<std::vector<std::vector<size_t>>> metadata_all_src_offsets(
+            metadata_key_indices.size(), {{0}});
+        std::vector<std::vector<std::vector<size_t>>> metadata_all_sizes(
+            metadata_key_indices.size(), {{sizeof(TensorMetadata)}});
+        for (size_t i = 0; i < metadata_key_indices.size(); ++i) {
+            metadata_all_keys[i] = {keys[metadata_key_indices[i]]};
+        }
+
         py::gil_scoped_release release_gil;
-        auto metadata_results = store_->batch_get_metadata_prefixes(
-            metadata_keys, metadata_buffers, sizeof(TensorMetadata),
-            &query_result_cache);
-        for (size_t i = 0; i < metadata_results.size() &&
-                           i < metadata_key_indices.size();
+        auto metadata_results = store_->get_into_ranges(
+            metadata_buffers, metadata_all_keys, metadata_all_dst_offsets,
+            metadata_all_src_offsets, metadata_all_sizes, &query_result_cache);
+        for (size_t i = 0;
+             i < metadata_results.size() && i < metadata_key_indices.size();
              ++i) {
-            metadata_results_by_key[metadata_key_indices[i]] = metadata_results[i];
+            if (metadata_results[i].size() == 1 &&
+                metadata_results[i][0].size() == 1 &&
+                metadata_results[i][0][0] ==
+                    static_cast<int64_t>(sizeof(TensorMetadata))) {
+                prefix_metadata[metadata_key_indices[i]] =
+                    parse_tensor_metadata_from_prefix(
+                        metadata_buffers[i], context,
+                        keys[metadata_key_indices[i]]);
+            }
         }
     }
 
     std::unordered_map<std::string, ReconstructedShardSource> sources;
-    sources.reserve(keys.size());
+    sources.reserve(metadata_key_indices.size());
     for (size_t i = 0; i < keys.size(); ++i) {
-        auto cache_it = query_result_cache.find(keys[i]);
-        if (cache_it == query_result_cache.end() || !cache_it->second) {
+        if (!query_results[i]) {
             continue;
         }
 
-        std::optional<ParsedTensorMetadata> parsed;
-        if (metadata_handles[i] &&
-            metadata_results_by_key[i] ==
-                static_cast<int64_t>(sizeof(TensorMetadata))) {
-            parsed = parse_tensor_metadata_from_prefix(
-                metadata_handles[i]->ptr(), sizeof(TensorMetadata), context,
-                keys[i]);
-        }
+        auto parsed = std::move(prefix_metadata[i]);
         if (!parsed.has_value()) {
             parsed = get_tensor_metadata(keys[i]);
         }
@@ -139,7 +144,7 @@ load_reconstructed_shard_sources_batch(
 
         sources.emplace(keys[i],
                         ReconstructedShardSource{keys[i], *parsed,
-                                                 std::move(cache_it->second)});
+                                                 std::move(query_results[i])});
     }
     return sources;
 }
@@ -324,6 +329,7 @@ std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
     plan.registered_buffer_ptr = reinterpret_cast<uintptr_t>(region->base);
     plan.registered_buffer_size = region->size;
     plan.total_length = total_length;
+    plan.query_results.reserve(sources.size());
     plan.materialized_metadata = materialized_metadata;
 
     int64_t elements_before = 1;
@@ -361,8 +367,8 @@ std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
             covered[static_cast<size_t>(idx)] = true;
         }
 
-        plan.query_result_cache.emplace(source.read_key,
-                                        std::move(source.query_result));
+        plan.query_results.push_back(PlannedQueryResult{
+            source.read_key, std::move(source.query_result)});
         for (int64_t slice_idx = 0; slice_idx < elements_before; ++slice_idx) {
             const size_t dst_offset =
                 region->offset + sizeof(TensorMetadata) +
@@ -1143,6 +1149,11 @@ std::vector<bool> execute_tensor_into_plan_transfers(
         std::vector<std::vector<size_t>> dst_offsets;
         std::vector<std::vector<size_t>> src_offsets;
         std::vector<std::vector<size_t>> sizes;
+        key_to_index.reserve(plan.fragments.size());
+        keys.reserve(plan.fragments.size());
+        dst_offsets.reserve(plan.fragments.size());
+        src_offsets.reserve(plan.fragments.size());
+        sizes.reserve(plan.fragments.size());
 
         for (const auto &fragment : plan.fragments) {
             if (fragment.read_key.empty() || fragment.size == 0) {
@@ -1152,9 +1163,9 @@ std::vector<bool> execute_tensor_into_plan_transfers(
                 key_to_index.emplace(fragment.read_key, keys.size());
             if (inserted) {
                 keys.push_back(fragment.read_key);
-                dst_offsets.push_back({});
-                src_offsets.push_back({});
-                sizes.push_back({});
+                dst_offsets.emplace_back();
+                src_offsets.emplace_back();
+                sizes.emplace_back();
             }
             const size_t key_index = it->second;
             dst_offsets[key_index].push_back(fragment.dst_offset);
@@ -1172,15 +1183,12 @@ std::vector<bool> execute_tensor_into_plan_transfers(
     {
         py::gil_scoped_release release_gil;
         mooncake::PyClient::QueryResultCache merged_query_result_cache;
-        size_t merged_cache_size = 0;
-        for (const auto &plan : plans) {
-            merged_cache_size += plan.query_result_cache.size();
-        }
-        merged_query_result_cache.reserve(merged_cache_size);
         for (auto &plan : plans) {
-            merged_query_result_cache.insert(
-                std::make_move_iterator(plan.query_result_cache.begin()),
-                std::make_move_iterator(plan.query_result_cache.end()));
+            for (auto &planned_query_result : plan.query_results) {
+                merged_query_result_cache.emplace(
+                    std::move(planned_query_result.read_key),
+                    std::move(planned_query_result.query_result));
+            }
         }
         range_results = store_->get_into_ranges(
             buffers, all_keys, all_dst_offsets, all_src_offsets, all_sizes,

--- a/mooncake-integration/store/store_py_parallel_read.h
+++ b/mooncake-integration/store/store_py_parallel_read.h
@@ -82,40 +82,39 @@ load_reconstructed_shard_sources_batch(const std::vector<std::string> &keys,
 
     mooncake::PyClient::QueryResultCache query_result_cache;
     auto now = std::chrono::steady_clock::now();
-    std::vector<void *> metadata_buffers;
     std::vector<size_t> metadata_key_indices;
-    metadata_buffers.reserve(keys.size());
     metadata_key_indices.reserve(keys.size());
+    std::vector<std::optional<CachedQueryResultResponse>>
+        reusable_query_results(keys.size());
 
     for (size_t i = 0; i < keys.size(); ++i) {
         auto query_result =
             from_cached_query_result_response(cached_query_results[i], now);
-        if (!query_result) {
-            LOG(ERROR) << context << ": missing query result for key "
-                       << keys[i] << ": " << toString(query_result.error());
-            return std::nullopt;
-        }
-        if (query_result->IsLeaseExpired(now)) {
-            LOG(ERROR) << context << ": expired query result for key "
-                       << keys[i];
-            return std::nullopt;
+        if (!query_result || query_result->IsLeaseExpired(now)) {
+            continue;
         }
 
         query_result_cache.emplace(keys[i], std::move(query_result));
+        reusable_query_results[i] = cached_query_results[i];
         metadata_key_indices.push_back(i);
     }
 
     std::vector<std::optional<ParsedTensorMetadata>> prefix_metadata(
         keys.size());
     if (!metadata_key_indices.empty()) {
-        std::unique_lock<std::mutex> scratch_lock(
-            metadata_prefix_scratch_mutex_);
-        if (!ensure_metadata_prefix_scratch_locked(metadata_key_indices.size(),
-                                                   context)) {
+        const size_t scratch_size =
+            std::max<size_t>(metadata_key_indices.size(), 1) *
+            sizeof(TensorMetadata);
+        auto scratch_buffer = std::make_unique<char[]>(scratch_size);
+        if (store_->register_buffer(scratch_buffer.get(), scratch_size) != 0) {
+            LOG(ERROR) << context
+                       << ": failed to register metadata scratch buffer";
             return std::nullopt;
         }
 
-        char *scratch_base = metadata_prefix_scratch_.get();
+        char *scratch_base = scratch_buffer.get();
+        std::vector<void *> metadata_buffers;
+        metadata_buffers.reserve(metadata_key_indices.size());
         std::vector<std::vector<std::string>> metadata_all_keys(
             metadata_key_indices.size());
         std::vector<std::vector<std::vector<size_t>>> metadata_all_dst_offsets(
@@ -130,10 +129,14 @@ load_reconstructed_shard_sources_batch(const std::vector<std::string> &keys,
             metadata_all_dst_offsets[i] = {{i * sizeof(TensorMetadata)}};
         }
 
-        py::gil_scoped_release release_gil;
-        auto metadata_results = store_->get_into_ranges(
-            metadata_buffers, metadata_all_keys, metadata_all_dst_offsets,
-            metadata_all_src_offsets, metadata_all_sizes, &query_result_cache);
+        std::vector<std::vector<std::vector<int64_t>>> metadata_results;
+        {
+            py::gil_scoped_release release_gil;
+            metadata_results = store_->get_into_ranges(
+                metadata_buffers, metadata_all_keys, metadata_all_dst_offsets,
+                metadata_all_src_offsets, metadata_all_sizes,
+                &query_result_cache);
+        }
         for (size_t i = 0;
              i < metadata_results.size() && i < metadata_key_indices.size();
              ++i) {
@@ -147,14 +150,17 @@ load_reconstructed_shard_sources_batch(const std::vector<std::string> &keys,
                     keys[key_index]);
             }
         }
+        store_->unregister_buffer(scratch_buffer.get());
     }
 
     std::vector<ReconstructedShardSource> sources;
     sources.reserve(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
         auto parsed = std::move(prefix_metadata[i]);
+        auto reusable_query_result = reusable_query_results[i];
         if (!parsed.has_value()) {
             parsed = get_tensor_metadata(keys[i]);
+            reusable_query_result.reset();
         }
         if (!parsed.has_value()) {
             LOG(ERROR) << context
@@ -162,8 +168,8 @@ load_reconstructed_shard_sources_batch(const std::vector<std::string> &keys,
                        << keys[i];
             return std::nullopt;
         }
-        sources.push_back(ReconstructedShardSource{keys[i], *parsed,
-                                                   cached_query_results[i]});
+        sources.push_back(
+            ReconstructedShardSource{keys[i], *parsed, reusable_query_result});
     }
     return sources;
 }
@@ -387,8 +393,10 @@ std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
             covered[static_cast<size_t>(idx)] = true;
         }
 
-        plan.query_results.push_back(
-            PlannedQueryResult{source.read_key, source.cached_query_result});
+        if (source.cached_query_result.has_value()) {
+            plan.query_results.push_back(PlannedQueryResult{
+                source.read_key, std::move(source.cached_query_result)});
+        }
         for (int64_t slice_idx = 0; slice_idx < elements_before; ++slice_idx) {
             const size_t dst_offset =
                 region->offset + sizeof(TensorMetadata) +
@@ -1234,8 +1242,11 @@ std::vector<bool> execute_tensor_into_plan_transfers(
         auto now = std::chrono::steady_clock::now();
         for (auto &plan : plans) {
             for (auto &planned_query_result : plan.query_results) {
+                if (!planned_query_result.cached_query_result.has_value()) {
+                    continue;
+                }
                 auto query_result = from_cached_query_result_response(
-                    planned_query_result.cached_query_result, now);
+                    *planned_query_result.cached_query_result, now);
                 if (!query_result || query_result->IsLeaseExpired(now)) {
                     continue;
                 }

--- a/mooncake-integration/store/store_py_parallel_read.h
+++ b/mooncake-integration/store/store_py_parallel_read.h
@@ -342,21 +342,23 @@ std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
     }
     const size_t target_tensor_bytes = target_tensor_numel * *element_size;
     const size_t total_length = sizeof(TensorMetadata) + target_tensor_bytes;
+
+    auto region = resolve_writable_buffer_region(buffer_ptr, size, context);
+    if (!region.has_value()) {
+        return std::nullopt;
+    }
     if (total_length > size || region->offset + total_length > region->size) {
         LOG(ERROR) << context << ": buffer too small for reconstructed tensor";
         return std::nullopt;
     }
-
-    TensorMetadata materialized_metadata = target_metadata;
-    materialized_metadata.header.data_bytes = target_tensor_bytes;
 
     TensorIntoPlan plan;
     plan.user_buffer_ptr = buffer_ptr;
     plan.registered_buffer_ptr = reinterpret_cast<uintptr_t>(region->base);
     plan.registered_buffer_size = region->size;
     plan.total_length = total_length;
-    plan.query_results.reserve(sources.size());
-    plan.materialized_metadata = materialized_metadata;
+    plan.materialized_metadata = target_metadata;
+    plan.materialized_metadata->header.data_bytes = target_tensor_bytes;
 
     int64_t elements_before = 1;
     for (int i = 0; i < split_dim; ++i) {
@@ -393,10 +395,6 @@ std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
             covered[static_cast<size_t>(idx)] = true;
         }
 
-        if (source.cached_query_result.has_value()) {
-            plan.query_results.push_back(PlannedQueryResult{
-                source.read_key, std::move(source.cached_query_result)});
-        }
         for (int64_t slice_idx = 0; slice_idx < elements_before; ++slice_idx) {
             const size_t dst_offset =
                 region->offset + sizeof(TensorMetadata) +
@@ -429,6 +427,14 @@ std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
         !(allow_empty_fragments && target_tensor_bytes == 0)) {
         LOG(ERROR) << context << ": no fragments planned for reconstruction";
         return std::nullopt;
+    }
+
+    plan.query_results.reserve(sources.size());
+    for (auto &source : sources) {
+        if (source.cached_query_result.has_value()) {
+            plan.query_results.push_back(PlannedQueryResult{
+                source.read_key, std::move(source.cached_query_result)});
+        }
     }
     return plan;
 }
@@ -811,6 +817,24 @@ std::optional<TensorIntoPlan> build_writer_shard_full_tensor_into_plan(
         reconstruction->allow_empty_fragments);
 }
 
+std::vector<std::string> build_parallelism_shard_read_keys(
+    const std::string &key, const TensorParallelismSpec &canonical_parallelism,
+    size_t tp_axis_index, int shard_count,
+    std::optional<int> split_dim = std::nullopt) {
+    std::vector<std::string> shard_keys;
+    shard_keys.reserve(shard_count);
+    for (int shard_rank = 0; shard_rank < shard_count; ++shard_rank) {
+        auto shard_parallelism = canonical_parallelism;
+        shard_parallelism.axes[tp_axis_index].rank = shard_rank;
+        shard_parallelism.axes[tp_axis_index].size = shard_count;
+        if (split_dim.has_value()) {
+            shard_parallelism.axes[tp_axis_index].split_dim = *split_dim;
+        }
+        shard_keys.push_back(get_parallelism_key_name(key, shard_parallelism));
+    }
+    return shard_keys;
+}
+
 std::optional<FullTensorReconstructionSources>
 load_parallelism_manifest_reconstruction(
     const std::string &key, const TensorParallelismSpec &parallelism,
@@ -822,13 +846,7 @@ load_parallelism_manifest_reconstruction(
         return std::nullopt;
     }
 
-    std::shared_ptr<BufferHandle> manifest_handle;
-    {
-        py::gil_scoped_release release_gil;
-        manifest_handle =
-            store_->get_buffer(get_parallelism_manifest_key_name(key));
-    }
-    auto parsed_manifest = parse_writer_shard_manifest(manifest_handle.get());
+    auto parsed_manifest = load_parallelism_manifest(key, context);
     if (!parsed_manifest.has_value()) {
         return std::nullopt;
     }
@@ -863,14 +881,8 @@ load_parallelism_manifest_reconstruction(
         return std::nullopt;
     }
 
-    std::vector<std::string> shard_keys;
-    shard_keys.reserve(shard_count);
-    for (int shard_rank = 0; shard_rank < shard_count; ++shard_rank) {
-        auto shard_parallelism = *canonical_parallelism;
-        shard_parallelism.axes[*tp_axis_index].rank = shard_rank;
-        shard_parallelism.axes[*tp_axis_index].size = shard_count;
-        shard_keys.push_back(get_parallelism_key_name(key, shard_parallelism));
-    }
+    auto shard_keys = build_parallelism_shard_read_keys(
+        key, *canonical_parallelism, *tp_axis_index, shard_count);
 
     auto ordered_sources =
         load_reconstructed_shard_sources_batch(shard_keys, context);
@@ -1001,13 +1013,8 @@ load_parallelism_full_reconstruction_sources(
         return reconstruction;
     }
 
-    std::vector<std::string> shard_keys;
-    shard_keys.reserve(request_tp_axis->size);
-    for (int shard_rank = 0; shard_rank < request_tp_axis->size; ++shard_rank) {
-        auto shard_parallelism = *canonical_parallelism;
-        shard_parallelism.axes[*tp_axis_index].rank = shard_rank;
-        shard_keys.push_back(get_parallelism_key_name(key, shard_parallelism));
-    }
+    auto shard_keys = build_parallelism_shard_read_keys(
+        key, *canonical_parallelism, *tp_axis_index, request_tp_axis->size);
     auto ordered_sources =
         load_reconstructed_shard_sources_batch(shard_keys, context);
     if (!ordered_sources.has_value()) {
@@ -1061,9 +1068,120 @@ load_parallelism_full_reconstruction_sources(
     return reconstruction;
 }
 
-std::optional<TensorIntoPlan> build_parallelism_full_tensor_into_plan(
+std::optional<TensorIntoPlan> build_parallelism_full_tensor_into_formula_plan(
     const std::string &key, uintptr_t buffer_ptr, size_t size,
     const TensorParallelismSpec &parallelism, const std::string &context) {
+    if (std::getenv("MOONCAKE_DISABLE_REGULAR_FULL_FORMULA")) {
+        return std::nullopt;
+    }
+
+    const ParallelAxisSpec *request_tp_axis =
+        find_axis_spec_by_kind(parallelism, LayoutAxisKind::TP);
+    if (!request_tp_axis) {
+        return std::nullopt;
+    }
+
+    auto manifest = load_parallelism_manifest(key, context);
+    if (!manifest.has_value()) {
+        return std::nullopt;
+    }
+    const auto &global_shape = manifest->global_shape;
+    const int split_dim = manifest->manifest.header.split_dim;
+    const int shard_count = manifest->manifest.header.shard_count;
+    if (split_dim < 0 || split_dim >= static_cast<int>(global_shape.size()) ||
+        shard_count <= 0) {
+        return std::nullopt;
+    }
+    if (request_tp_axis->split_dim.has_value() &&
+        request_tp_axis->split_dim.value() != split_dim) {
+        return std::nullopt;
+    }
+    if (!is_uniform_shardable_dim(global_shape[split_dim],
+                                  request_tp_axis->size) ||
+        !is_uniform_shardable_dim(global_shape[split_dim], shard_count)) {
+        return std::nullopt;
+    }
+    auto element_size = TensorDtypeElementSize(manifest->manifest.header.dtype);
+    if (!element_size.has_value()) {
+        return std::nullopt;
+    }
+
+    auto canonical_parallelism = canonicalize_parallelism_spec(parallelism);
+    if (!canonical_parallelism.has_value()) {
+        return std::nullopt;
+    }
+    auto tp_axis_index = find_tp_axis_index(canonical_parallelism->axes);
+    if (!tp_axis_index.has_value()) {
+        return std::nullopt;
+    }
+
+    size_t tensor_numel = 1;
+    for (auto dim : global_shape) {
+        if (dim <= 0) {
+            return std::nullopt;
+        }
+        tensor_numel *= static_cast<size_t>(dim);
+    }
+    const size_t tensor_bytes = tensor_numel * *element_size;
+    const size_t total_length = sizeof(TensorMetadata) + tensor_bytes;
+
+    auto region = resolve_writable_buffer_region(buffer_ptr, size, context);
+    if (!region.has_value()) {
+        return std::nullopt;
+    }
+    if (total_length > size || region->offset + total_length > region->size) {
+        LOG(ERROR) << context << ": buffer too small for reconstructed tensor";
+        return std::nullopt;
+    }
+
+    TensorIntoPlan plan;
+    plan.user_buffer_ptr = buffer_ptr;
+    plan.registered_buffer_ptr = reinterpret_cast<uintptr_t>(region->base);
+    plan.registered_buffer_size = region->size;
+    plan.total_length = total_length;
+    plan.materialized_metadata =
+        BuildTensorMetadata(manifest->manifest.header.dtype, global_shape,
+                            global_shape, TensorLayoutKind::FULL);
+    plan.materialized_metadata->header.data_bytes = tensor_bytes;
+
+    TensorIntoRegularFullFormulaPlan formula;
+    formula.global_shape = global_shape;
+    formula.split_dim = split_dim;
+    formula.element_size = *element_size;
+    formula.data_offset = sizeof(TensorMetadata);
+    formula.read_keys = build_parallelism_shard_read_keys(
+        key, *canonical_parallelism, *tp_axis_index, shard_count, split_dim);
+
+    std::vector<CachedQueryResultResponse> cached_query_results;
+    {
+        py::gil_scoped_release release_gil;
+        cached_query_results = batch_query_for_reuse(formula.read_keys);
+    }
+    if (cached_query_results.size() != formula.read_keys.size()) {
+        return std::nullopt;
+    }
+    plan.query_results.reserve(formula.read_keys.size());
+    for (size_t i = 0; i < formula.read_keys.size(); ++i) {
+        plan.query_results.push_back(
+            PlannedQueryResult{formula.read_keys[i], cached_query_results[i]});
+    }
+
+    plan.regular_full_formula = std::move(formula);
+    return plan;
+}
+
+std::optional<TensorIntoPlan> build_parallelism_full_tensor_into_plan(
+    const std::string &key, uintptr_t buffer_ptr, size_t size,
+    const TensorParallelismSpec &parallelism, const std::string &context,
+    bool allow_formula_plan = true) {
+    if (allow_formula_plan) {
+        if (auto formula_plan = build_parallelism_full_tensor_into_formula_plan(
+                key, buffer_ptr, size, parallelism, context);
+            formula_plan.has_value()) {
+            return formula_plan;
+        }
+    }
+
     auto reconstruction =
         load_parallelism_full_reconstruction_sources(key, parallelism, context);
     if (!reconstruction.has_value()) {
@@ -1205,28 +1323,83 @@ std::vector<bool> execute_tensor_into_plan_transfers(
         std::vector<std::vector<size_t>> dst_offsets;
         std::vector<std::vector<size_t>> src_offsets;
         std::vector<std::vector<size_t>> sizes;
-        key_to_index.reserve(plan.fragments.size());
-        keys.reserve(plan.fragments.size());
-        dst_offsets.reserve(plan.fragments.size());
-        src_offsets.reserve(plan.fragments.size());
-        sizes.reserve(plan.fragments.size());
 
-        for (const auto &fragment : plan.fragments) {
-            if (fragment.read_key.empty() || fragment.size == 0) {
-                continue;
+        if (plan.regular_full_formula.has_value()) {
+            const auto &formula = *plan.regular_full_formula;
+            keys = formula.read_keys;
+            dst_offsets.resize(keys.size());
+            src_offsets.resize(keys.size());
+            sizes.resize(keys.size());
+
+            int64_t elements_before = 1;
+            for (int i = 0; i < formula.split_dim; ++i) {
+                elements_before *= formula.global_shape[i];
             }
-            auto [it, inserted] =
-                key_to_index.emplace(fragment.read_key, keys.size());
-            if (inserted) {
-                keys.push_back(fragment.read_key);
-                dst_offsets.emplace_back();
-                src_offsets.emplace_back();
-                sizes.emplace_back();
+            int64_t elements_after = 1;
+            for (size_t i = formula.split_dim + 1;
+                 i < formula.global_shape.size(); ++i) {
+                elements_after *= formula.global_shape[i];
             }
-            const size_t key_index = it->second;
-            dst_offsets[key_index].push_back(fragment.dst_offset);
-            src_offsets[key_index].push_back(fragment.src_offset);
-            sizes[key_index].push_back(fragment.size);
+            const size_t base_dst_offset =
+                plan.user_buffer_ptr - plan.registered_buffer_ptr;
+            const int64_t split_extent =
+                formula.global_shape[formula.split_dim];
+            for (size_t shard_rank = 0; shard_rank < formula.read_keys.size();
+                 ++shard_rank) {
+                const auto [shard_start, shard_extent] = calculate_shard_range(
+                    split_extent, static_cast<int>(shard_rank),
+                    static_cast<int>(formula.read_keys.size()));
+                if (shard_extent <= 0) {
+                    continue;
+                }
+                const size_t row_bytes = static_cast<size_t>(shard_extent) *
+                                         static_cast<size_t>(elements_after) *
+                                         formula.element_size;
+                dst_offsets[shard_rank].reserve(
+                    static_cast<size_t>(elements_before));
+                src_offsets[shard_rank].reserve(
+                    static_cast<size_t>(elements_before));
+                sizes[shard_rank].reserve(static_cast<size_t>(elements_before));
+                for (int64_t slice_idx = 0; slice_idx < elements_before;
+                     ++slice_idx) {
+                    dst_offsets[shard_rank].push_back(
+                        base_dst_offset + sizeof(TensorMetadata) +
+                        static_cast<size_t>(slice_idx * split_extent +
+                                            shard_start) *
+                            static_cast<size_t>(elements_after) *
+                            formula.element_size);
+                    src_offsets[shard_rank].push_back(
+                        formula.data_offset +
+                        static_cast<size_t>(slice_idx * shard_extent) *
+                            static_cast<size_t>(elements_after) *
+                            formula.element_size);
+                    sizes[shard_rank].push_back(row_bytes);
+                }
+            }
+        } else {
+            key_to_index.reserve(plan.fragments.size());
+            keys.reserve(plan.fragments.size());
+            dst_offsets.reserve(plan.fragments.size());
+            src_offsets.reserve(plan.fragments.size());
+            sizes.reserve(plan.fragments.size());
+
+            for (const auto &fragment : plan.fragments) {
+                if (fragment.read_key.empty() || fragment.size == 0) {
+                    continue;
+                }
+                auto [it, inserted] =
+                    key_to_index.emplace(fragment.read_key, keys.size());
+                if (inserted) {
+                    keys.push_back(fragment.read_key);
+                    dst_offsets.emplace_back();
+                    src_offsets.emplace_back();
+                    sizes.emplace_back();
+                }
+                const size_t key_index = it->second;
+                dst_offsets[key_index].push_back(fragment.dst_offset);
+                src_offsets[key_index].push_back(fragment.src_offset);
+                sizes[key_index].push_back(fragment.size);
+            }
         }
 
         all_keys.push_back(std::move(keys));
@@ -1314,7 +1487,8 @@ py::list execute_tensor_into_plans(std::vector<TensorIntoPlan> plans) {
 
 std::optional<TensorIntoPlan> build_tensor_into_plan_for_target(
     const std::string &key, uintptr_t buffer_ptr, size_t size,
-    const py::object &target, const std::string &context) {
+    const py::object &target, const std::string &context,
+    bool allow_formula_plan = true) {
     auto parsed_target = parse_read_target_spec(target);
     if (!parsed_target.has_value()) {
         return std::nullopt;
@@ -1357,8 +1531,8 @@ std::optional<TensorIntoPlan> build_tensor_into_plan_for_target(
     }
 
     if (parsed_target->mode == ReadTargetMode::FULL) {
-        return build_parallelism_full_tensor_into_plan(key, buffer_ptr, size,
-                                                       *parallelism, context);
+        return build_parallelism_full_tensor_into_plan(
+            key, buffer_ptr, size, *parallelism, context, allow_formula_plan);
     }
 
     LOG(ERROR) << context << ": unsupported ReadTarget mode";
@@ -1469,11 +1643,25 @@ pybind11::object get_tensor_with_parallelism_into(
     if (!plan.has_value()) {
         return py::none();
     }
+    const bool used_formula_plan = plan->regular_full_formula.has_value();
     auto results = execute_tensor_into_plans({*plan});
-    if (results.empty()) {
-        return py::none();
+    if (!results.empty() && !results[0].is_none()) {
+        return py::reinterpret_borrow<py::object>(results[0]);
     }
-    return py::reinterpret_borrow<py::object>(results[0]);
+
+    if (used_formula_plan) {
+        auto fallback_plan = build_tensor_into_plan_for_target(
+            key, buffer_ptr, size, target, "get_tensor_with_parallelism_into",
+            false /* allow_formula_plan */);
+        if (!fallback_plan.has_value()) {
+            return py::none();
+        }
+        auto fallback_results = execute_tensor_into_plans({*fallback_plan});
+        if (!fallback_results.empty()) {
+            return py::reinterpret_borrow<py::object>(fallback_results[0]);
+        }
+    }
+    return py::none();
 }
 
 pybind11::list batch_get_tensor_with_parallelism_into(
@@ -1505,6 +1693,8 @@ pybind11::list batch_get_tensor_with_parallelism_into(
     plans.reserve(keys.size());
     std::vector<size_t> plan_indices;
     plan_indices.reserve(keys.size());
+    std::vector<bool> plan_used_formula;
+    plan_used_formula.reserve(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
         py::object target =
             target_list.has_value()
@@ -1517,12 +1707,43 @@ pybind11::list batch_get_tensor_with_parallelism_into(
             continue;
         }
         plan_indices.push_back(i);
+        plan_used_formula.push_back(plan->regular_full_formula.has_value());
         plans.push_back(std::move(*plan));
     }
 
     auto results = execute_tensor_into_plans(std::move(plans));
+    std::vector<TensorIntoPlan> fallback_plans;
+    std::vector<size_t> fallback_indices;
+    fallback_plans.reserve(plan_indices.size());
+    fallback_indices.reserve(plan_indices.size());
     for (size_t i = 0; i < plan_indices.size() && i < results.size(); ++i) {
-        empty[plan_indices[i]] = results[i];
+        if (!results[i].is_none() || !plan_used_formula[i]) {
+            empty[plan_indices[i]] = results[i];
+            continue;
+        }
+
+        const size_t original_index = plan_indices[i];
+        py::object target = target_list.has_value()
+                                ? py::reinterpret_borrow<py::object>(
+                                      (*target_list)[original_index])
+                                : py::none();
+        auto fallback_plan = build_tensor_into_plan_for_target(
+            keys[original_index], buffer_ptrs[original_index],
+            sizes[original_index], target,
+            "batch_get_tensor_with_parallelism_into",
+            false /* allow_formula_plan */);
+        if (!fallback_plan.has_value()) {
+            continue;
+        }
+        fallback_indices.push_back(original_index);
+        fallback_plans.push_back(std::move(*fallback_plan));
+    }
+
+    auto fallback_results =
+        execute_tensor_into_plans(std::move(fallback_plans));
+    for (size_t i = 0;
+         i < fallback_indices.size() && i < fallback_results.size(); ++i) {
+        empty[fallback_indices[i]] = fallback_results[i];
     }
     return empty;
 }

--- a/mooncake-integration/store/store_py_parallel_read.h
+++ b/mooncake-integration/store/store_py_parallel_read.h
@@ -22,6 +22,127 @@ std::optional<ParsedTensorMetadata> get_tensor_metadata(
                                buffer_handle->size());
 }
 
+std::optional<ParsedTensorMetadata> parse_tensor_metadata_from_prefix(
+    const void *buffer_ptr, size_t prefix_size, const std::string &context,
+    const std::string &key) {
+    if (buffer_ptr == nullptr || prefix_size < sizeof(TensorMetadata)) {
+        LOG(ERROR) << context << ": invalid metadata prefix for key " << key;
+        return std::nullopt;
+    }
+
+    TensorMetadata metadata{};
+    std::memcpy(&metadata, buffer_ptr, sizeof(TensorMetadata));
+    const size_t total_length =
+        static_cast<size_t>(metadata.header.data_offset) +
+        static_cast<size_t>(metadata.header.data_bytes);
+    if (!ValidateTensorMetadata(metadata, total_length)) {
+        LOG(ERROR) << context << ": invalid tensor metadata for key " << key;
+        return std::nullopt;
+    }
+
+    return ParsedTensorMetadata{.metadata = metadata,
+                                .data_offset = static_cast<size_t>(
+                                    metadata.header.data_offset),
+                                .data_bytes = static_cast<size_t>(
+                                    metadata.header.data_bytes)};
+}
+
+std::optional<std::unordered_map<std::string, ReconstructedShardSource>>
+load_reconstructed_shard_sources_batch(
+    const std::vector<std::string> &keys, const std::string &context) {
+    if (!is_client_initialized()) {
+        LOG(ERROR) << context << ": client is not initialized";
+        return std::nullopt;
+    }
+    if (keys.empty()) {
+        return std::unordered_map<std::string, ReconstructedShardSource>{};
+    }
+
+    std::vector<tl::expected<QueryResult, ErrorCode>> query_results;
+    {
+        py::gil_scoped_release release_gil;
+        query_results = store_->batch_query(keys);
+    }
+    if (query_results.size() != keys.size()) {
+        LOG(ERROR) << context << ": BatchQuery result size mismatch";
+        return std::nullopt;
+    }
+
+    mooncake::PyClient::QueryResultCache query_result_cache;
+    query_result_cache.reserve(keys.size());
+    std::vector<std::shared_ptr<BufferHandle>> metadata_handles(keys.size(),
+                                                                nullptr);
+    std::vector<std::string> metadata_keys;
+    std::vector<void *> metadata_buffers;
+    std::vector<size_t> metadata_key_indices;
+    metadata_keys.reserve(keys.size());
+    metadata_buffers.reserve(keys.size());
+    metadata_key_indices.reserve(keys.size());
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        query_result_cache.emplace(keys[i], query_results[i]);
+        if (!query_results[i]) {
+            continue;
+        }
+
+        auto alloc_result =
+            store_->client_buffer_allocator_->allocate(sizeof(TensorMetadata));
+        if (!alloc_result) {
+            LOG(ERROR) << context
+                       << ": failed to allocate metadata buffer for key "
+                       << keys[i];
+            return std::nullopt;
+        }
+        metadata_handles[i] =
+            std::make_shared<BufferHandle>(std::move(*alloc_result));
+        metadata_keys.push_back(keys[i]);
+        metadata_buffers.push_back(metadata_handles[i]->ptr());
+        metadata_key_indices.push_back(i);
+    }
+
+    std::vector<int64_t> metadata_results_by_key(
+        keys.size(), static_cast<int64_t>(toInt(ErrorCode::INVALID_PARAMS)));
+    if (!metadata_keys.empty()) {
+        py::gil_scoped_release release_gil;
+        auto metadata_results = store_->batch_get_metadata_prefixes(
+            metadata_keys, metadata_buffers, sizeof(TensorMetadata),
+            &query_result_cache);
+        for (size_t i = 0; i < metadata_results.size() &&
+                           i < metadata_key_indices.size();
+             ++i) {
+            metadata_results_by_key[metadata_key_indices[i]] = metadata_results[i];
+        }
+    }
+
+    std::unordered_map<std::string, ReconstructedShardSource> sources;
+    sources.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        auto cache_it = query_result_cache.find(keys[i]);
+        if (cache_it == query_result_cache.end() || !cache_it->second) {
+            continue;
+        }
+
+        std::optional<ParsedTensorMetadata> parsed;
+        if (metadata_handles[i] &&
+            metadata_results_by_key[i] ==
+                static_cast<int64_t>(sizeof(TensorMetadata))) {
+            parsed = parse_tensor_metadata_from_prefix(
+                metadata_handles[i]->ptr(), sizeof(TensorMetadata), context,
+                keys[i]);
+        }
+        if (!parsed.has_value()) {
+            parsed = get_tensor_metadata(keys[i]);
+        }
+        if (!parsed.has_value()) {
+            continue;
+        }
+
+        sources.emplace(keys[i],
+                        ReconstructedShardSource{keys[i], *parsed,
+                                                 std::move(cache_it->second)});
+    }
+    return sources;
+}
 std::optional<TensorIntoPlan> build_tensor_into_plan(
     const std::string &read_key, uintptr_t buffer_ptr, size_t size,
     const std::string &context,
@@ -152,7 +273,7 @@ std::optional<std::pair<int64_t, int64_t>> get_source_shard_range(
 
 std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
     uintptr_t buffer_ptr, size_t size,
-    const std::vector<ReconstructedShardSource> &sources,
+    std::vector<ReconstructedShardSource> sources,
     const std::vector<int64_t> &global_shape, int split_dim,
     const TensorMetadata &target_metadata, int64_t target_start,
     int64_t target_extent, const std::string &context,
@@ -216,7 +337,7 @@ std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
 
     std::vector<bool> covered(
         static_cast<size_t>(target_extent > 0 ? target_extent : 0), false);
-    for (const auto &source : sources) {
+    for (auto &source : sources) {
         auto source_range =
             get_source_shard_range(source, global_shape, split_dim, context);
         if (!source_range.has_value()) {
@@ -240,6 +361,8 @@ std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
             covered[static_cast<size_t>(idx)] = true;
         }
 
+        plan.query_result_cache.emplace(source.read_key,
+                                        std::move(source.query_result));
         for (int64_t slice_idx = 0; slice_idx < elements_before; ++slice_idx) {
             const size_t dst_offset =
                 region->offset + sizeof(TensorMetadata) +
@@ -278,14 +401,15 @@ std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
 
 std::optional<TensorIntoPlan> build_full_tensor_into_plan_from_sources(
     uintptr_t buffer_ptr, size_t size,
-    const std::vector<ReconstructedShardSource> &sources,
+    std::vector<ReconstructedShardSource> sources,
     const std::vector<int64_t> &global_shape, int split_dim, int32_t dtype,
     const std::string &context, bool allow_empty_fragments = false) {
     TensorMetadata full_metadata = BuildTensorMetadata(
         dtype, global_shape, global_shape, TensorLayoutKind::FULL);
     return build_reconstructed_tensor_into_plan_from_sources(
-        buffer_ptr, size, sources, global_shape, split_dim, full_metadata, 0,
-        global_shape[split_dim], context, allow_empty_fragments);
+        buffer_ptr, size, std::move(sources), global_shape, split_dim,
+        full_metadata, 0, global_shape[split_dim], context,
+        allow_empty_fragments);
 }
 
 std::string resolve_tp_read_key(const std::string &key, int tp_rank,
@@ -358,7 +482,9 @@ pybind11::object get_tensor_with_writer_shard_full(const std::string &key,
         return py::none();
     }
 
-    auto success = execute_tensor_into_plan_transfers({*plan});
+    std::vector<TensorIntoPlan> plans;
+    plans.push_back(std::move(*plan));
+    auto success = execute_tensor_into_plan_transfers(plans);
     if (success.empty() || !success[0]) {
         store_->unregister_buffer(owned_buffer);
         delete[] owned_buffer;
@@ -451,7 +577,9 @@ pybind11::object get_tensor_with_tp_full(
         return pybind11::none();
     }
 
-    auto success = execute_tensor_into_plan_transfers({*plan});
+    std::vector<TensorIntoPlan> plans;
+    plans.push_back(std::move(*plan));
+    auto success = execute_tensor_into_plan_transfers(plans);
     if (success.empty() || !success[0]) {
         store_->unregister_buffer(owned_buffer);
         delete[] owned_buffer;
@@ -913,9 +1041,10 @@ std::optional<TensorIntoPlan> build_parallelism_shard_tensor_into_plan(
         return std::nullopt;
     }
     return build_reconstructed_tensor_into_plan_from_sources(
-        buffer_ptr, size, reconstruction->sources, reconstruction->global_shape,
-        reconstruction->split_dim, *target_metadata, target_start,
-        target_extent, context, reconstruction->allow_empty_fragments);
+        buffer_ptr, size, std::move(reconstruction->sources),
+        reconstruction->global_shape, reconstruction->split_dim,
+        *target_metadata, target_start, target_extent, context,
+        reconstruction->allow_empty_fragments);
 }
 
 pybind11::object get_tensor_with_parallelism_shard_full_materialized(
@@ -970,7 +1099,9 @@ pybind11::object get_tensor_with_parallelism_shard_full_materialized(
         return py::none();
     }
 
-    auto success = execute_tensor_into_plan_transfers({*plan});
+    std::vector<TensorIntoPlan> plans;
+    plans.push_back(std::move(*plan));
+    auto success = execute_tensor_into_plan_transfers(plans);
     if (success.empty() || !success[0]) {
         store_->unregister_buffer(owned_buffer);
         delete[] owned_buffer;
@@ -987,7 +1118,7 @@ pybind11::object get_tensor_with_parallelism_shard_full_materialized(
 }
 
 std::vector<bool> execute_tensor_into_plan_transfers(
-    const std::vector<TensorIntoPlan> &plans) {
+    std::vector<TensorIntoPlan> &plans) {
     std::vector<bool> success(plans.size(), false);
     if (plans.empty()) {
         return success;
@@ -1040,8 +1171,21 @@ std::vector<bool> execute_tensor_into_plan_transfers(
     std::vector<std::vector<std::vector<int64_t>>> range_results;
     {
         py::gil_scoped_release release_gil;
+        mooncake::PyClient::QueryResultCache merged_query_result_cache;
+        size_t merged_cache_size = 0;
+        for (const auto &plan : plans) {
+            merged_cache_size += plan.query_result_cache.size();
+        }
+        merged_query_result_cache.reserve(merged_cache_size);
+        for (auto &plan : plans) {
+            merged_query_result_cache.insert(
+                std::make_move_iterator(plan.query_result_cache.begin()),
+                std::make_move_iterator(plan.query_result_cache.end()));
+        }
         range_results = store_->get_into_ranges(
-            buffers, all_keys, all_dst_offsets, all_src_offsets, all_sizes);
+            buffers, all_keys, all_dst_offsets, all_src_offsets, all_sizes,
+            merged_query_result_cache.empty() ? nullptr
+                                              : &merged_query_result_cache);
     }
 
     for (size_t i = 0; i < plans.size(); ++i) {
@@ -1079,7 +1223,7 @@ std::vector<bool> execute_tensor_into_plan_transfers(
     return success;
 }
 
-py::list execute_tensor_into_plans(const std::vector<TensorIntoPlan> &plans) {
+py::list execute_tensor_into_plans(std::vector<TensorIntoPlan> plans) {
     py::list results;
     for (size_t i = 0; i < plans.size(); ++i) {
         results.append(py::none());
@@ -1301,10 +1445,10 @@ pybind11::list batch_get_tensor_with_parallelism_into(
             continue;
         }
         plan_indices.push_back(i);
-        plans.push_back(*plan);
+        plans.push_back(std::move(*plan));
     }
 
-    auto results = execute_tensor_into_plans(plans);
+    auto results = execute_tensor_into_plans(std::move(plans));
     for (size_t i = 0; i < plan_indices.size() && i < results.size(); ++i) {
         empty[plan_indices[i]] = results[i];
     }

--- a/mooncake-integration/store/store_py_parallel_read.h
+++ b/mooncake-integration/store/store_py_parallel_read.h
@@ -44,7 +44,7 @@ std::optional<ParsedTensorMetadata> parse_tensor_metadata_from_prefix(
 
 std::vector<CachedQueryResultResponse> batch_query_for_reuse(
     const std::vector<std::string> &keys) {
-    if (auto real_client = std::dynamic_pointer_cast<RealClient>(store_)) {
+    if (auto real_client = get_real_client()) {
         return real_client->batch_get_query_results(keys);
     }
 
@@ -124,6 +124,9 @@ load_reconstructed_shard_sources_batch(const std::vector<std::string> &keys,
         std::vector<std::vector<std::vector<size_t>>> metadata_all_sizes(
             metadata_key_indices.size(), {{sizeof(TensorMetadata)}});
         for (size_t i = 0; i < metadata_key_indices.size(); ++i) {
+            // Each metadata read is modeled as a separate request, but they all
+            // write into non-overlapping offsets in the same registered scratch
+            // buffer.
             metadata_buffers.push_back(scratch_base);
             metadata_all_keys[i] = {keys[metadata_key_indices[i]]};
             metadata_all_dst_offsets[i] = {{i * sizeof(TensorMetadata)}};
@@ -1068,13 +1071,40 @@ load_parallelism_full_reconstruction_sources(
     return reconstruction;
 }
 
+bool validate_regular_full_formula_sources(
+    const std::vector<ReconstructedShardSource> &sources,
+    const std::vector<int64_t> &global_shape, int split_dim, int32_t dtype,
+    int shard_count, const std::string &context) {
+    if (sources.size() != static_cast<size_t>(shard_count)) {
+        return false;
+    }
+    for (int shard_rank = 0; shard_rank < shard_count; ++shard_rank) {
+        const auto &source = sources[shard_rank];
+        if (source.metadata.metadata.header.dtype != dtype) {
+            LOG(ERROR) << context << ": shard dtype mismatch for key "
+                       << source.read_key;
+            return false;
+        }
+        const LayoutAxis *tp_axis =
+            find_layout_axis(source.metadata.metadata, LayoutAxisKind::TP);
+        if (!tp_axis || tp_axis->shard_rank != shard_rank ||
+            tp_axis->shard_count != shard_count ||
+            tp_axis->split_dim != split_dim) {
+            LOG(ERROR) << context << ": shard TP metadata mismatch for key "
+                       << source.read_key;
+            return false;
+        }
+        if (!get_source_shard_range(source, global_shape, split_dim, context)
+                 .has_value()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 std::optional<TensorIntoPlan> build_parallelism_full_tensor_into_formula_plan(
     const std::string &key, uintptr_t buffer_ptr, size_t size,
     const TensorParallelismSpec &parallelism, const std::string &context) {
-    if (std::getenv("MOONCAKE_DISABLE_REGULAR_FULL_FORMULA")) {
-        return std::nullopt;
-    }
-
     const ParallelAxisSpec *request_tp_axis =
         find_axis_spec_by_kind(parallelism, LayoutAxisKind::TP);
     if (!request_tp_axis) {
@@ -1152,18 +1182,21 @@ std::optional<TensorIntoPlan> build_parallelism_full_tensor_into_formula_plan(
     formula.read_keys = build_parallelism_shard_read_keys(
         key, *canonical_parallelism, *tp_axis_index, shard_count, split_dim);
 
-    std::vector<CachedQueryResultResponse> cached_query_results;
-    {
-        py::gil_scoped_release release_gil;
-        cached_query_results = batch_query_for_reuse(formula.read_keys);
-    }
-    if (cached_query_results.size() != formula.read_keys.size()) {
+    auto sources =
+        load_reconstructed_shard_sources_batch(formula.read_keys, context);
+    if (!sources.has_value() ||
+        !validate_regular_full_formula_sources(
+            *sources, global_shape, split_dim, manifest->manifest.header.dtype,
+            shard_count, context)) {
         return std::nullopt;
     }
-    plan.query_results.reserve(formula.read_keys.size());
-    for (size_t i = 0; i < formula.read_keys.size(); ++i) {
-        plan.query_results.push_back(
-            PlannedQueryResult{formula.read_keys[i], cached_query_results[i]});
+    plan.query_results.reserve(sources->size());
+    for (auto &source : *sources) {
+        if (!source.cached_query_result.has_value()) {
+            return std::nullopt;
+        }
+        plan.query_results.push_back(PlannedQueryResult{
+            source.read_key, std::move(*source.cached_query_result)});
     }
 
     plan.regular_full_formula = std::move(formula);
@@ -1650,6 +1683,9 @@ pybind11::object get_tensor_with_parallelism_into(
     }
 
     if (used_formula_plan) {
+        LOG(WARNING)
+            << "get_tensor_with_parallelism_into"
+            << ": formula plan execution failed, falling back to generic path";
         auto fallback_plan = build_tensor_into_plan_for_target(
             key, buffer_ptr, size, target, "get_tensor_with_parallelism_into",
             false /* allow_formula_plan */);
@@ -1723,6 +1759,10 @@ pybind11::list batch_get_tensor_with_parallelism_into(
         }
 
         const size_t original_index = plan_indices[i];
+        LOG(WARNING) << "batch_get_tensor_with_parallelism_into"
+                     << ": formula plan execution failed for key "
+                     << keys[original_index]
+                     << ", falling back to generic path";
         py::object target = target_list.has_value()
                                 ? py::reinterpret_borrow<py::object>(
                                       (*target_list)[original_index])

--- a/mooncake-integration/store/store_py_parallel_read.h
+++ b/mooncake-integration/store/store_py_parallel_read.h
@@ -346,10 +346,6 @@ std::optional<TensorIntoPlan> build_reconstructed_tensor_into_plan_from_sources(
     const size_t target_tensor_bytes = target_tensor_numel * *element_size;
     const size_t total_length = sizeof(TensorMetadata) + target_tensor_bytes;
 
-    auto region = resolve_writable_buffer_region(buffer_ptr, size, context);
-    if (!region.has_value()) {
-        return std::nullopt;
-    }
     if (total_length > size || region->offset + total_length > region->size) {
         LOG(ERROR) << context << ": buffer too small for reconstructed tensor";
         return std::nullopt;

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -3,13 +3,13 @@
 #include <atomic>
 #include <csignal>
 #include <mutex>
+#include <shared_mutex>
 #include <unordered_map>
 #include <ylt/coro_rpc/coro_rpc_client.hpp>
 
-#include "pyclient.h"
-#include "real_client.h"
-#include "shm_helper.h"
 #include "client_metric.h"
+#include "pyclient.h"
+#include "shm_helper.h"
 #include <memory>
 
 namespace mooncake {
@@ -61,8 +61,11 @@ class DummyClient : public PyClient {
         const std::vector<std::vector<std::string>> &all_keys,
         const std::vector<std::vector<std::vector<size_t>>> &all_dst_offsets,
         const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
-        const std::vector<std::vector<std::vector<size_t>>> &all_sizes)
-        override;
+        const std::vector<std::vector<std::vector<size_t>>> &all_sizes,
+        const QueryResultCache *query_result_cache = nullptr) override;
+
+    std::vector<tl::expected<QueryResult, ErrorCode>> batch_query(
+        const std::vector<std::string> &keys) override;
 
     std::vector<int64_t> batch_get_into(const std::vector<std::string> &keys,
                                         const std::vector<void *> &buffers,

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -207,6 +207,13 @@ class ClientRequester {
 // Python-specific wrapper class for client interface
 class PyClient {
    public:
+    // Request-scoped cache of fresh batch_query() results that can be reused by
+    // subsequent ranged reads in the same operation. Callers should not retain
+    // entries across independent requests.
+    using QueryResultCache =
+        std::unordered_map<std::string,
+                           tl::expected<QueryResult, ErrorCode>>;
+
     virtual ~PyClient() = 0;
     virtual int setup_real(
         const std::string &local_hostname, const std::string &metadata_server,
@@ -238,12 +245,53 @@ class PyClient {
     virtual int64_t get_into(const std::string &key, void *buffer,
                              size_t size) = 0;
 
+    // query_result_cache is optional and is only used to reuse fresh
+    // batch_query() results for this read; callers still do not provide any
+    // replica-selection or ranged-read metadata directly.
     virtual std::vector<std::vector<std::vector<int64_t>>> get_into_ranges(
         const std::vector<void *> &buffers,
         const std::vector<std::vector<std::string>> &all_keys,
         const std::vector<std::vector<std::vector<size_t>>> &all_dst_offsets,
         const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
-        const std::vector<std::vector<std::vector<size_t>>> &all_sizes) = 0;
+        const std::vector<std::vector<std::vector<size_t>>> &all_sizes,
+        const QueryResultCache *query_result_cache = nullptr) = 0;
+
+    std::vector<int64_t> batch_get_metadata_prefixes(
+        const std::vector<std::string> &keys, const std::vector<void *> &buffers,
+        size_t prefix_size, const QueryResultCache *query_result_cache = nullptr) {
+        std::vector<std::vector<std::string>> all_keys;
+        std::vector<std::vector<std::vector<size_t>>> all_dst_offsets;
+        std::vector<std::vector<std::vector<size_t>>> all_src_offsets;
+        std::vector<std::vector<std::vector<size_t>>> all_sizes;
+        all_keys.reserve(keys.size());
+        all_dst_offsets.reserve(keys.size());
+        all_src_offsets.reserve(keys.size());
+        all_sizes.reserve(keys.size());
+        for (const auto &key : keys) {
+            all_keys.push_back({key});
+            all_dst_offsets.push_back({{0}});
+            all_src_offsets.push_back({{0}});
+            all_sizes.push_back({{prefix_size}});
+        }
+        auto results = get_into_ranges(buffers, all_keys, all_dst_offsets,
+                                       all_src_offsets, all_sizes,
+                                       query_result_cache);
+        std::vector<int64_t> flattened;
+        flattened.reserve(keys.size());
+        for (size_t i = 0; i < keys.size(); ++i) {
+            if (i >= results.size() || results[i].size() != 1 ||
+                results[i][0].size() != 1) {
+                flattened.push_back(static_cast<int64_t>(
+                    toInt(ErrorCode::INVALID_PARAMS)));
+                continue;
+            }
+            flattened.push_back(results[i][0][0]);
+        }
+        return flattened;
+    }
+
+    virtual std::vector<tl::expected<QueryResult, ErrorCode>> batch_query(
+        const std::vector<std::string> &keys) = 0;
 
     virtual std::vector<int64_t> batch_get_into(
         const std::vector<std::string> &keys,

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -422,7 +422,7 @@ inline PyClient::QueryResultCache build_query_result_cache_from_cached_results(
     for (const auto &[key, cached_result] : cached_query_results) {
         auto query_result =
             from_cached_query_result_response(cached_result, now);
-        if (query_result && query_result->IsLeaseExpired(now)) {
+        if (!query_result || query_result->IsLeaseExpired(now)) {
             continue;
         }
         query_result_cache.emplace(key, std::move(query_result));

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -1,10 +1,13 @@
 #pragma once
 
-#include <csignal>
 #include <atomic>
-#include <thread>
-#include <string>
+#include <chrono>
+#include <csignal>
+#include <map>
 #include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "client_service.h"
@@ -370,5 +373,80 @@ class PyClient {
     std::shared_ptr<mooncake::FileStorage> file_storage_ = nullptr;
     std::shared_ptr<ClientBufferAllocator> client_buffer_allocator_ = nullptr;
 };
+
+inline uint64_t remaining_lease_ttl_ms(
+    const QueryResult &query_result,
+    std::chrono::steady_clock::time_point now) {
+    if (query_result.IsLeaseExpired(now)) {
+        return 0;
+    }
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            query_result.lease_timeout - now)
+            .count());
+}
+
+inline CachedQueryResultResponse to_cached_query_result_response(
+    const tl::expected<QueryResult, ErrorCode> &query_result,
+    std::chrono::steady_clock::time_point now) {
+    if (!query_result) {
+        return CachedQueryResultResponse(query_result.error());
+    }
+    if (query_result->IsLeaseExpired(now)) {
+        return CachedQueryResultResponse(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    return CachedQueryResultResponse(GetReplicaListResponse(
+        std::vector<Replica::Descriptor>(query_result->replicas.begin(),
+                                         query_result->replicas.end()),
+        remaining_lease_ttl_ms(*query_result, now)));
+}
+
+inline tl::expected<QueryResult, ErrorCode> from_cached_query_result_response(
+    const CachedQueryResultResponse &cached_result,
+    std::chrono::steady_clock::time_point now) {
+    if (!cached_result.success) {
+        return tl::make_unexpected(cached_result.error);
+    }
+    return QueryResult(
+        std::vector<Replica::Descriptor>(cached_result.value.replicas.begin(),
+                                         cached_result.value.replicas.end()),
+        now + std::chrono::milliseconds(cached_result.value.lease_ttl_ms));
+}
+
+inline PyClient::QueryResultCache build_query_result_cache_from_cached_results(
+    const std::map<std::string, CachedQueryResultResponse>
+        &cached_query_results) {
+    PyClient::QueryResultCache query_result_cache;
+    query_result_cache.reserve(cached_query_results.size());
+    auto now = std::chrono::steady_clock::now();
+    for (const auto &[key, cached_result] : cached_query_results) {
+        auto query_result =
+            from_cached_query_result_response(cached_result, now);
+        if (query_result && query_result->IsLeaseExpired(now)) {
+            continue;
+        }
+        query_result_cache.emplace(key, std::move(query_result));
+    }
+    return query_result_cache;
+}
+
+inline std::map<std::string, CachedQueryResultResponse>
+build_cached_query_results_from_query_result_cache(
+    const PyClient::QueryResultCache *query_result_cache) {
+    std::map<std::string, CachedQueryResultResponse> cached_query_results;
+    if (query_result_cache == nullptr) {
+        return cached_query_results;
+    }
+
+    auto now = std::chrono::steady_clock::now();
+    for (const auto &[key, query_result] : *query_result_cache) {
+        if (query_result && query_result->IsLeaseExpired(now)) {
+            continue;
+        }
+        cached_query_results.emplace(
+            key, to_cached_query_result_response(query_result, now));
+    }
+    return cached_query_results;
+}
 
 }  // namespace mooncake

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -211,8 +211,7 @@ class PyClient {
     // subsequent ranged reads in the same operation. Callers should not retain
     // entries across independent requests.
     using QueryResultCache =
-        std::unordered_map<std::string,
-                           tl::expected<QueryResult, ErrorCode>>;
+        std::unordered_map<std::string, tl::expected<QueryResult, ErrorCode>>;
 
     virtual ~PyClient() = 0;
     virtual int setup_real(
@@ -255,40 +254,6 @@ class PyClient {
         const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
         const std::vector<std::vector<std::vector<size_t>>> &all_sizes,
         const QueryResultCache *query_result_cache = nullptr) = 0;
-
-    std::vector<int64_t> batch_get_metadata_prefixes(
-        const std::vector<std::string> &keys, const std::vector<void *> &buffers,
-        size_t prefix_size, const QueryResultCache *query_result_cache = nullptr) {
-        std::vector<std::vector<std::string>> all_keys;
-        std::vector<std::vector<std::vector<size_t>>> all_dst_offsets;
-        std::vector<std::vector<std::vector<size_t>>> all_src_offsets;
-        std::vector<std::vector<std::vector<size_t>>> all_sizes;
-        all_keys.reserve(keys.size());
-        all_dst_offsets.reserve(keys.size());
-        all_src_offsets.reserve(keys.size());
-        all_sizes.reserve(keys.size());
-        for (const auto &key : keys) {
-            all_keys.push_back({key});
-            all_dst_offsets.push_back({{0}});
-            all_src_offsets.push_back({{0}});
-            all_sizes.push_back({{prefix_size}});
-        }
-        auto results = get_into_ranges(buffers, all_keys, all_dst_offsets,
-                                       all_src_offsets, all_sizes,
-                                       query_result_cache);
-        std::vector<int64_t> flattened;
-        flattened.reserve(keys.size());
-        for (size_t i = 0; i < keys.size(); ++i) {
-            if (i >= results.size() || results[i].size() != 1 ||
-                results[i][0].size() != 1) {
-                flattened.push_back(static_cast<int64_t>(
-                    toInt(ErrorCode::INVALID_PARAMS)));
-                continue;
-            }
-            flattened.push_back(results[i][0][0]);
-        }
-        return flattened;
-    }
 
     virtual std::vector<tl::expected<QueryResult, ErrorCode>> batch_query(
         const std::vector<std::string> &keys) = 0;

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -535,7 +535,7 @@ class RealClient : public PyClient {
     tl::expected<RangedReadMetadata, ErrorCode>
     build_ranged_read_metadata_from_query_result(
         const std::string &key,
-        const tl::expected<QueryResult, ErrorCode> &query_result);
+        tl::expected<QueryResult, ErrorCode> query_result);
 
     tl::expected<RangedReadMetadata, ErrorCode> resolve_ranged_read_metadata(
         const std::string &key);
@@ -902,6 +902,7 @@ class RealClient : public PyClient {
     tl::expected<void, ErrorCode> setup_ascend_internal(
         size_t local_buffer_size);
 
+   private:
     std::unordered_map<std::string, MountedSegmentRecord>
         mounted_segment_records_;
     std::mutex mounted_segment_records_mutex_;

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -526,6 +526,20 @@ class RealClient : public PyClient {
     tl::expected<void, ErrorCode> register_buffer_internal(void *buffer,
                                                            size_t size);
 
+    struct RangedReadMetadata {
+        QueryResult query_result;
+        Replica::Descriptor replica;
+        uint64_t total_size;
+    };
+
+    tl::expected<RangedReadMetadata, ErrorCode>
+    build_ranged_read_metadata_from_query_result(
+        const std::string &key,
+        const tl::expected<QueryResult, ErrorCode> &query_result);
+
+    tl::expected<RangedReadMetadata, ErrorCode> resolve_ranged_read_metadata(
+        const std::string &key);
+
     tl::expected<int64_t, ErrorCode> get_into_range_internal(
         const std::string &key, void *buffer, size_t dst_offset,
         size_t src_offset, size_t size, bool size_is_buffer_capacity = false);
@@ -871,9 +885,8 @@ class RealClient : public PyClient {
 
    private:
     tl::expected<int64_t, ErrorCode> execute_ranged_read(
-        const std::string &key,
-        const tl::expected<QueryResult, ErrorCode> &query_result, void *buffer,
-        size_t dst_offset, size_t src_offset, size_t size,
+        const std::string &key, void *buffer, size_t dst_offset,
+        size_t src_offset, size_t size, const RangedReadMetadata &metadata,
         bool size_is_buffer_capacity = false);
 
     std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -870,34 +870,10 @@ class RealClient : public PyClient {
         size_t local_buffer_size);
 
    private:
-    struct RangedReadMetadata {
-        QueryResult query_result;
-        Replica::Descriptor replica;
-        uint64_t total_size;
-    };
-
-    using RangedReadMetadataCache =
-        std::unordered_map<std::string,
-                           tl::expected<RangedReadMetadata, ErrorCode>>;
-
-    tl::expected<RangedReadMetadata, ErrorCode> resolve_ranged_read_metadata(
-        const std::string &key);
-
-    tl::expected<RangedReadMetadata, ErrorCode>
-    build_ranged_read_metadata_from_query_result(
-        const std::string &key,
-        const tl::expected<QueryResult, ErrorCode> &query_result);
-
-    RangedReadMetadataCache batch_resolve_ranged_read_metadata(
-        const std::vector<std::vector<std::string>> &all_keys,
-        const std::vector<std::vector<std::vector<bool>>> &valid_fragments,
-        const std::vector<size_t> &buffer_capacities,
-        bool skip_zero_capacity_buffers,
-        const QueryResultCache *initial_query_result_cache = nullptr);
-
     tl::expected<int64_t, ErrorCode> execute_ranged_read(
-        const std::string &key, void *buffer, size_t dst_offset,
-        size_t src_offset, size_t size, const RangedReadMetadata &metadata,
+        const std::string &key,
+        const tl::expected<QueryResult, ErrorCode> &query_result, void *buffer,
+        size_t dst_offset, size_t src_offset, size_t size,
         bool size_is_buffer_capacity = false);
 
     std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <boost/lockfree/queue.hpp>
 #include <csignal>
+#include <map>
 #include <memory>
 #include <shared_mutex>
 #include <string>
@@ -130,21 +131,17 @@ class RealClient : public PyClient {
         const std::vector<std::vector<std::string>> &all_keys,
         const std::vector<std::vector<std::vector<size_t>>> &all_dst_offsets,
         const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
-        const std::vector<std::vector<std::vector<size_t>>> &all_sizes)
-        override;
+        const std::vector<std::vector<std::vector<size_t>>> &all_sizes,
+        const QueryResultCache *query_result_cache = nullptr) override;
 
     /**
-     * @brief Get object data directly into pre-allocated buffers for multiple
-     * keys (batch version)
-     * @param keys Vector of keys of the objects to get
-     * @param buffers Vector of pointers to the pre-allocated buffers
-     * @param sizes Vector of sizes of the buffers
-     * @return Vector of 64-bit integers, where each element is the number of
-     * bytes read on success, or a negative value on error
-     * @note The buffer addresses must resolve to Store-managed registered
-     * memory, either explicit register_buffer() regions or the setup-time local
-     * buffer
+     * @brief Batch query object placement/lease metadata for later read reuse
+     * @param keys Vector of keys to query
+     * @return Vector of query results in the same order as keys
      */
+    std::vector<tl::expected<QueryResult, ErrorCode>> batch_query(
+        const std::vector<std::string> &keys) override;
+
     std::vector<int64_t> batch_get_into(const std::vector<std::string> &keys,
                                         const std::vector<void *> &buffers,
                                         const std::vector<size_t> &sizes);
@@ -184,20 +181,15 @@ class RealClient : public PyClient {
                  const ReplicateConfig &config = ReplicateConfig{});
 
     /**
-     * @brief Put object data directly from pre-allocated buffers for multiple
-     * keys(metadata version, better not be directly used in Python)
-     * @param keys Vector of keys of the objects to put
-     * @param buffers Vector of pointers to the pre-allocated buffers
-     * @param metadata_buffers Vector of pointers to the pre-allocated metadata
-     * buffers
-     * @param size Number of sizes of the buffers
-     * @param metadata_size Number of sizes of the metadata buffers
+     * @brief Put one object directly from a registered data buffer plus a
+     * registered metadata buffer
+     * @param key Key of the object to put
+     * @param buffer Pointer to the registered data buffer
+     * @param metadata_buffer Pointer to the registered metadata buffer
+     * @param size Size of the data buffer in bytes
+     * @param metadata_size Size of the metadata buffer in bytes
      * @param config Replication configuration
-     * @return Vector of integers, where each element is 0 on success, or a
-     * negative value on error
-     * @note The buffer addresses must resolve to Store-managed registered
-     * memory, either explicit register_buffer() regions or the setup-time local
-     * buffer
+     * @return 0 on success, negative value on error
      */
     int put_from_with_metadata(
         const std::string &key, void *buffer, void *metadata_buffer,
@@ -464,6 +456,8 @@ class RealClient : public PyClient {
         const std::vector<std::vector<std::vector<size_t>>> &all_dst_offsets,
         const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
         const std::vector<std::vector<std::vector<size_t>>> &all_sizes,
+        const std::map<std::string, CachedQueryResultResponse>
+            &cached_query_results,
         int32_t device_id, const UUID &client_id);
 
     // Share mem management for dummy client
@@ -532,36 +526,9 @@ class RealClient : public PyClient {
     tl::expected<void, ErrorCode> register_buffer_internal(void *buffer,
                                                            size_t size);
 
-    struct RangedReadMetadata {
-        QueryResult query_result;
-        Replica::Descriptor replica;
-        uint64_t total_size;
-    };
-
-    tl::expected<RangedReadMetadata, ErrorCode> resolve_ranged_read_metadata(
-        const std::string &key);
-
-    tl::expected<int64_t, ErrorCode> execute_ranged_read(
-        const std::string &key, void *buffer, size_t dst_offset,
-        size_t src_offset, size_t size, const RangedReadMetadata &metadata,
-        bool size_is_buffer_capacity = false);
-
     tl::expected<int64_t, ErrorCode> get_into_range_internal(
         const std::string &key, void *buffer, size_t dst_offset,
         size_t src_offset, size_t size, bool size_is_buffer_capacity = false);
-
-    std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
-    get_into_ranges_internal(
-        const std::vector<void *> &buffers,
-        const std::vector<std::vector<std::string>> &all_keys,
-        const std::vector<std::vector<std::vector<size_t>>> &all_dst_offsets,
-        const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
-        const std::vector<std::vector<std::vector<size_t>>> &all_sizes,
-        const std::vector<size_t> *buffer_capacities = nullptr,
-        std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
-            *prepared_results = nullptr,
-        const std::vector<std::vector<std::vector<bool>>> *valid_fragments =
-            nullptr);
 
     std::vector<tl::expected<int64_t, ErrorCode>> batch_get_into_internal(
         const std::vector<std::string> &keys,
@@ -664,6 +631,8 @@ class RealClient : public PyClient {
 
     std::map<std::string, std::vector<Replica::Descriptor>>
     batch_get_replica_desc(const std::vector<std::string> &keys);
+    std::vector<CachedQueryResultResponse> batch_get_query_results(
+        const std::vector<std::string> &keys);
     std::vector<Replica::Descriptor> get_replica_desc(const std::string &key);
 
     std::vector<std::string> batch_replica_clear(
@@ -901,6 +870,50 @@ class RealClient : public PyClient {
         size_t local_buffer_size);
 
    private:
+    struct RangedReadMetadata {
+        QueryResult query_result;
+        Replica::Descriptor replica;
+        uint64_t total_size;
+    };
+
+    using RangedReadMetadataCache =
+        std::unordered_map<std::string,
+                           tl::expected<RangedReadMetadata, ErrorCode>>;
+
+    tl::expected<RangedReadMetadata, ErrorCode> resolve_ranged_read_metadata(
+        const std::string &key);
+
+    tl::expected<RangedReadMetadata, ErrorCode>
+    build_ranged_read_metadata_from_query_result(
+        const std::string &key,
+        const tl::expected<QueryResult, ErrorCode> &query_result);
+
+    RangedReadMetadataCache batch_resolve_ranged_read_metadata(
+        const std::vector<std::vector<std::string>> &all_keys,
+        const std::vector<std::vector<std::vector<bool>>> &valid_fragments,
+        const std::vector<size_t> &buffer_capacities,
+        bool skip_zero_capacity_buffers,
+        const QueryResultCache *initial_query_result_cache = nullptr);
+
+    tl::expected<int64_t, ErrorCode> execute_ranged_read(
+        const std::string &key, void *buffer, size_t dst_offset,
+        size_t src_offset, size_t size, const RangedReadMetadata &metadata,
+        bool size_is_buffer_capacity = false);
+
+    std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
+    get_into_ranges_internal(
+        const std::vector<void *> &buffers,
+        const std::vector<std::vector<std::string>> &all_keys,
+        const std::vector<std::vector<std::vector<size_t>>> &all_dst_offsets,
+        const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
+        const std::vector<std::vector<std::vector<size_t>>> &all_sizes,
+        const std::vector<size_t> *buffer_capacities = nullptr,
+        std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
+            *prepared_results = nullptr,
+        const std::vector<std::vector<std::vector<bool>>> *valid_fragments =
+            nullptr,
+        const QueryResultCache *query_result_cache = nullptr);
+
     std::unordered_map<std::string, MountedSegmentRecord>
         mounted_segment_records_;
     std::mutex mounted_segment_records_mutex_;

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -540,9 +540,28 @@ class RealClient : public PyClient {
     tl::expected<RangedReadMetadata, ErrorCode> resolve_ranged_read_metadata(
         const std::string &key);
 
+    tl::expected<int64_t, ErrorCode> execute_ranged_read(
+        const std::string &key, void *buffer, size_t dst_offset,
+        size_t src_offset, size_t size, const RangedReadMetadata &metadata,
+        bool size_is_buffer_capacity = false);
+
     tl::expected<int64_t, ErrorCode> get_into_range_internal(
         const std::string &key, void *buffer, size_t dst_offset,
         size_t src_offset, size_t size, bool size_is_buffer_capacity = false);
+
+    std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
+    get_into_ranges_internal(
+        const std::vector<void *> &buffers,
+        const std::vector<std::vector<std::string>> &all_keys,
+        const std::vector<std::vector<std::vector<size_t>>> &all_dst_offsets,
+        const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
+        const std::vector<std::vector<std::vector<size_t>>> &all_sizes,
+        const std::vector<size_t> *buffer_capacities = nullptr,
+        std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
+            *prepared_results = nullptr,
+        const std::vector<std::vector<std::vector<bool>>> *valid_fragments =
+            nullptr,
+        const QueryResultCache *query_result_cache = nullptr);
 
     std::vector<tl::expected<int64_t, ErrorCode>> batch_get_into_internal(
         const std::vector<std::string> &keys,
@@ -882,26 +901,6 @@ class RealClient : public PyClient {
     void teardown_ascend_shm_buffer(MappedShm &shm);
     tl::expected<void, ErrorCode> setup_ascend_internal(
         size_t local_buffer_size);
-
-   private:
-    tl::expected<int64_t, ErrorCode> execute_ranged_read(
-        const std::string &key, void *buffer, size_t dst_offset,
-        size_t src_offset, size_t size, const RangedReadMetadata &metadata,
-        bool size_is_buffer_capacity = false);
-
-    std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
-    get_into_ranges_internal(
-        const std::vector<void *> &buffers,
-        const std::vector<std::vector<std::string>> &all_keys,
-        const std::vector<std::vector<std::vector<size_t>>> &all_dst_offsets,
-        const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
-        const std::vector<std::vector<std::vector<size_t>>> &all_sizes,
-        const std::vector<size_t> *buffer_capacities = nullptr,
-        std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
-            *prepared_results = nullptr,
-        const std::vector<std::vector<std::vector<bool>>> *valid_fragments =
-            nullptr,
-        const QueryResultCache *query_result_cache = nullptr);
 
     std::unordered_map<std::string, MountedSegmentRecord>
         mounted_segment_records_;

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -41,6 +41,21 @@ struct GetReplicaListResponse {
 };
 YLT_REFL(GetReplicaListResponse, replicas, lease_ttl_ms);
 
+struct CachedQueryResultResponse {
+    bool success;
+    GetReplicaListResponse value;
+    ErrorCode error;
+
+    CachedQueryResultResponse()
+        : success(false), value(), error(ErrorCode::INVALID_PARAMS) {}
+    CachedQueryResultResponse(GetReplicaListResponse&& value_param)
+        : success(true), value(std::move(value_param)),
+          error(ErrorCode::INVALID_PARAMS) {}
+    CachedQueryResultResponse(ErrorCode error_param)
+        : success(false), value(), error(error_param) {}
+};
+YLT_REFL(CachedQueryResultResponse, success, value, error);
+
 /**
  * @brief Response structure for GetStorageConfig operation
  */

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -49,7 +49,8 @@ struct CachedQueryResultResponse {
     CachedQueryResultResponse()
         : success(false), value(), error(ErrorCode::INVALID_PARAMS) {}
     CachedQueryResultResponse(GetReplicaListResponse&& value_param)
-        : success(true), value(std::move(value_param)),
+        : success(true),
+          value(std::move(value_param)),
           error(ErrorCode::INVALID_PARAMS) {}
     CachedQueryResultResponse(ErrorCode error_param)
         : success(false), value(), error(error_param) {}

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -49,9 +49,7 @@ struct CachedQueryResultResponse {
     CachedQueryResultResponse()
         : success(false), value(), error(ErrorCode::INVALID_PARAMS) {}
     CachedQueryResultResponse(GetReplicaListResponse&& value_param)
-        : success(true),
-          value(std::move(value_param)),
-          error(ErrorCode::INVALID_PARAMS) {}
+        : success(true), value(std::move(value_param)), error(ErrorCode::OK) {}
     CachedQueryResultResponse(ErrorCode error_param)
         : success(false), value(), error(error_param) {}
 };

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -37,14 +37,15 @@ uint64_t remaining_lease_ttl_ms(const mooncake::QueryResult& query_result,
     if (query_result.IsLeaseExpired(now)) {
         return 0;
     }
-    return static_cast<uint64_t>(std::chrono::duration_cast<
-                                      std::chrono::milliseconds>(
-                                      query_result.lease_timeout - now)
-                                      .count());
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            query_result.lease_timeout - now)
+            .count());
 }
 
 mooncake::CachedQueryResultResponse to_cached_query_result_response(
-    const tl::expected<mooncake::QueryResult, mooncake::ErrorCode>& query_result,
+    const tl::expected<mooncake::QueryResult, mooncake::ErrorCode>&
+        query_result,
     std::chrono::steady_clock::time_point now) {
     if (!query_result) {
         return mooncake::CachedQueryResultResponse(query_result.error());
@@ -54,8 +55,8 @@ mooncake::CachedQueryResultResponse to_cached_query_result_response(
             mooncake::ErrorCode::OBJECT_NOT_FOUND);
     }
     return mooncake::CachedQueryResultResponse(mooncake::GetReplicaListResponse(
-        std::vector<mooncake::Replica::Descriptor>(query_result->replicas.begin(),
-                                                   query_result->replicas.end()),
+        std::vector<mooncake::Replica::Descriptor>(
+            query_result->replicas.begin(), query_result->replicas.end()),
         remaining_lease_ttl_ms(*query_result, now)));
 }
 
@@ -70,7 +71,7 @@ build_cached_query_results(
 
     auto now = std::chrono::steady_clock::now();
     for (const auto& [key, query_result] : *query_result_cache) {
-        if (!query_result || query_result->IsLeaseExpired(now)) {
+        if (query_result && query_result->IsLeaseExpired(now)) {
             continue;
         }
         cached_query_results.emplace(
@@ -1116,9 +1117,9 @@ std::vector<std::vector<std::vector<int64_t>>> DummyClient::get_into_ranges(
 
 std::vector<tl::expected<QueryResult, ErrorCode>> DummyClient::batch_query(
     const std::vector<std::string>& keys) {
-    auto cached_results = invoke_rpc<&RealClient::batch_get_query_results,
-                                     std::vector<CachedQueryResultResponse>>(
-        keys);
+    auto cached_results =
+        invoke_rpc<&RealClient::batch_get_query_results,
+                   std::vector<CachedQueryResultResponse>>(keys);
     if (!cached_results) {
         return std::vector<tl::expected<QueryResult, ErrorCode>>(
             keys.size(), tl::unexpected(cached_results.error()));
@@ -1139,8 +1140,9 @@ std::vector<tl::expected<QueryResult, ErrorCode>> DummyClient::batch_query(
             continue;
         }
         results.emplace_back(QueryResult(
-            std::vector<Replica::Descriptor>(cached_result.value.replicas.begin(),
-                                             cached_result.value.replicas.end()),
+            std::vector<Replica::Descriptor>(
+                cached_result.value.replicas.begin(),
+                cached_result.value.replicas.end()),
             now + std::chrono::milliseconds(cached_result.value.lease_ttl_ms)));
     }
     return results;

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -32,54 +32,6 @@ size_t sum_value_sizes(const std::vector<std::span<const char>>& values) {
     return total;
 }
 
-uint64_t remaining_lease_ttl_ms(const mooncake::QueryResult& query_result,
-                                std::chrono::steady_clock::time_point now) {
-    if (query_result.IsLeaseExpired(now)) {
-        return 0;
-    }
-    return static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            query_result.lease_timeout - now)
-            .count());
-}
-
-mooncake::CachedQueryResultResponse to_cached_query_result_response(
-    const tl::expected<mooncake::QueryResult, mooncake::ErrorCode>&
-        query_result,
-    std::chrono::steady_clock::time_point now) {
-    if (!query_result) {
-        return mooncake::CachedQueryResultResponse(query_result.error());
-    }
-    if (query_result->IsLeaseExpired(now)) {
-        return mooncake::CachedQueryResultResponse(
-            mooncake::ErrorCode::OBJECT_NOT_FOUND);
-    }
-    return mooncake::CachedQueryResultResponse(mooncake::GetReplicaListResponse(
-        std::vector<mooncake::Replica::Descriptor>(
-            query_result->replicas.begin(), query_result->replicas.end()),
-        remaining_lease_ttl_ms(*query_result, now)));
-}
-
-std::map<std::string, mooncake::CachedQueryResultResponse>
-build_cached_query_results(
-    const mooncake::PyClient::QueryResultCache* query_result_cache) {
-    std::map<std::string, mooncake::CachedQueryResultResponse>
-        cached_query_results;
-    if (query_result_cache == nullptr) {
-        return cached_query_results;
-    }
-
-    auto now = std::chrono::steady_clock::now();
-    for (const auto& [key, query_result] : *query_result_cache) {
-        if (query_result && query_result->IsLeaseExpired(now)) {
-            continue;
-        }
-        cached_query_results.emplace(
-            key, to_cached_query_result_response(query_result, now));
-    }
-    return cached_query_results;
-}
-
 size_t sum_sizes(const std::vector<size_t>& sizes) {
     size_t total = 0;
     for (size_t size : sizes) {
@@ -1091,7 +1043,8 @@ std::vector<std::vector<std::vector<int64_t>>> DummyClient::get_into_ranges(
     const std::vector<std::vector<std::vector<size_t>>>& all_sizes,
     const QueryResultCache* query_result_cache) {
     std::vector<uint64_t> dummy_buffers = void_ptrs_to_u64(buffers);
-    auto cached_query_results = build_cached_query_results(query_result_cache);
+    auto cached_query_results =
+        build_cached_query_results_from_query_result_cache(query_result_cache);
     const auto start_time = std::chrono::steady_clock::now();
     auto internal_results =
         invoke_rpc<&RealClient::get_into_ranges_shm_helper,

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -32,6 +32,53 @@ size_t sum_value_sizes(const std::vector<std::span<const char>>& values) {
     return total;
 }
 
+uint64_t remaining_lease_ttl_ms(const mooncake::QueryResult& query_result,
+                                std::chrono::steady_clock::time_point now) {
+    if (query_result.IsLeaseExpired(now)) {
+        return 0;
+    }
+    return static_cast<uint64_t>(std::chrono::duration_cast<
+                                      std::chrono::milliseconds>(
+                                      query_result.lease_timeout - now)
+                                      .count());
+}
+
+mooncake::CachedQueryResultResponse to_cached_query_result_response(
+    const tl::expected<mooncake::QueryResult, mooncake::ErrorCode>& query_result,
+    std::chrono::steady_clock::time_point now) {
+    if (!query_result) {
+        return mooncake::CachedQueryResultResponse(query_result.error());
+    }
+    if (query_result->IsLeaseExpired(now)) {
+        return mooncake::CachedQueryResultResponse(
+            mooncake::ErrorCode::OBJECT_NOT_FOUND);
+    }
+    return mooncake::CachedQueryResultResponse(mooncake::GetReplicaListResponse(
+        std::vector<mooncake::Replica::Descriptor>(query_result->replicas.begin(),
+                                                   query_result->replicas.end()),
+        remaining_lease_ttl_ms(*query_result, now)));
+}
+
+std::map<std::string, mooncake::CachedQueryResultResponse>
+build_cached_query_results(
+    const mooncake::PyClient::QueryResultCache* query_result_cache) {
+    std::map<std::string, mooncake::CachedQueryResultResponse>
+        cached_query_results;
+    if (query_result_cache == nullptr) {
+        return cached_query_results;
+    }
+
+    auto now = std::chrono::steady_clock::now();
+    for (const auto& [key, query_result] : *query_result_cache) {
+        if (!query_result || query_result->IsLeaseExpired(now)) {
+            continue;
+        }
+        cached_query_results.emplace(
+            key, to_cached_query_result_response(query_result, now));
+    }
+    return cached_query_results;
+}
+
 size_t sum_sizes(const std::vector<size_t>& sizes) {
     size_t total = 0;
     for (size_t size : sizes) {
@@ -1040,15 +1087,17 @@ std::vector<std::vector<std::vector<int64_t>>> DummyClient::get_into_ranges(
     const std::vector<std::vector<std::string>>& all_keys,
     const std::vector<std::vector<std::vector<size_t>>>& all_dst_offsets,
     const std::vector<std::vector<std::vector<size_t>>>& all_src_offsets,
-    const std::vector<std::vector<std::vector<size_t>>>& all_sizes) {
+    const std::vector<std::vector<std::vector<size_t>>>& all_sizes,
+    const QueryResultCache* query_result_cache) {
     std::vector<uint64_t> dummy_buffers = void_ptrs_to_u64(buffers);
+    auto cached_query_results = build_cached_query_results(query_result_cache);
     const auto start_time = std::chrono::steady_clock::now();
     auto internal_results =
         invoke_rpc<&RealClient::get_into_ranges_shm_helper,
                    std::vector<std::vector<
                        std::vector<tl::expected<int64_t, ErrorCode>>>>>(
             dummy_buffers, all_keys, all_dst_offsets, all_src_offsets,
-            all_sizes, device_id_, client_id_);
+            all_sizes, cached_query_results, device_id_, client_id_);
 
     if (!internal_results) {
         LOG(ERROR) << "get_into_ranges RPC failed";
@@ -1061,6 +1110,38 @@ std::vector<std::vector<std::vector<int64_t>>> DummyClient::get_into_ranges(
     if (total_bytes > 0) {
         ObserveTransferMetric(TransferOperationKind::kRead, "get_into_ranges",
                               total_bytes, elapsed_us_since(start_time), true);
+    }
+    return results;
+}
+
+std::vector<tl::expected<QueryResult, ErrorCode>> DummyClient::batch_query(
+    const std::vector<std::string>& keys) {
+    auto cached_results = invoke_rpc<&RealClient::batch_get_query_results,
+                                     std::vector<CachedQueryResultResponse>>(
+        keys);
+    if (!cached_results) {
+        return std::vector<tl::expected<QueryResult, ErrorCode>>(
+            keys.size(), tl::unexpected(cached_results.error()));
+    }
+    if (cached_results->size() != keys.size()) {
+        LOG(ERROR) << "BatchQuery response size mismatch: expected "
+                   << keys.size() << ", got " << cached_results->size();
+        return std::vector<tl::expected<QueryResult, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::RPC_FAIL));
+    }
+
+    std::vector<tl::expected<QueryResult, ErrorCode>> results;
+    results.reserve(keys.size());
+    const auto now = std::chrono::steady_clock::now();
+    for (const auto& cached_result : *cached_results) {
+        if (!cached_result.success) {
+            results.emplace_back(tl::unexpected(cached_result.error));
+            continue;
+        }
+        results.emplace_back(QueryResult(
+            std::vector<Replica::Descriptor>(cached_result.value.replicas.begin(),
+                                             cached_result.value.replicas.end()),
+            now + std::chrono::milliseconds(cached_result.value.lease_ttl_ms)));
     }
     return results;
 }

--- a/mooncake-store/src/engram/engram_store.cpp
+++ b/mooncake-store/src/engram/engram_store.cpp
@@ -112,20 +112,21 @@ int EngramStore::lookup_rows_flat(const int64_t* row_ids, int B, int L,
         }
     }
 
+    const int register_ret =
+        store_->register_buffer(output_buffer, expected_size);
+    if (register_ret != 0) {
+        return fail_lookup();
+    }
+
     mooncake::PyClient::QueryResultCache query_result_cache;
     auto query_results = store_->batch_query(embed_keys_);
     if (query_results.size() != embed_keys_.size()) {
+        store_->unregister_buffer(output_buffer);
         return fail_lookup();
     }
     query_result_cache.reserve(embed_keys_.size());
     for (size_t i = 0; i < embed_keys_.size(); ++i) {
         query_result_cache.emplace(embed_keys_[i], query_results[i]);
-    }
-
-    const int register_ret =
-        store_->register_buffer(output_buffer, expected_size);
-    if (register_ret != 0) {
-        return fail_lookup();
     }
 
     auto results = store_->get_into_ranges(buffers, all_keys, all_dst_offsets,

--- a/mooncake-store/src/engram/engram_store.cpp
+++ b/mooncake-store/src/engram/engram_store.cpp
@@ -112,6 +112,16 @@ int EngramStore::lookup_rows_flat(const int64_t* row_ids, int B, int L,
         }
     }
 
+    mooncake::PyClient::QueryResultCache query_result_cache;
+    auto query_results = store_->batch_query(embed_keys_);
+    if (query_results.size() != embed_keys_.size()) {
+        return fail_lookup();
+    }
+    query_result_cache.reserve(embed_keys_.size());
+    for (size_t i = 0; i < embed_keys_.size(); ++i) {
+        query_result_cache.emplace(embed_keys_[i], query_results[i]);
+    }
+
     const int register_ret =
         store_->register_buffer(output_buffer, expected_size);
     if (register_ret != 0) {
@@ -119,7 +129,8 @@ int EngramStore::lookup_rows_flat(const int64_t* row_ids, int B, int L,
     }
 
     auto results = store_->get_into_ranges(buffers, all_keys, all_dst_offsets,
-                                           all_src_offsets, all_sizes);
+                                           all_src_offsets, all_sizes,
+                                           &query_result_cache);
     const int unregister_ret = store_->unregister_buffer(output_buffer);
     if (unregister_ret != 0) {
         return fail_lookup();

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3382,7 +3382,12 @@ RealClient::get_into_ranges_internal(
     auto now = std::chrono::steady_clock::now();
     if (query_result_cache != nullptr) {
         for (const auto &[key, query_result] : *query_result_cache) {
-            if (!query_result || query_result->IsLeaseExpired(now)) {
+            if (!query_result) {
+                metadata_cache.emplace(key,
+                                       tl::unexpected(query_result.error()));
+                continue;
+            }
+            if (query_result->IsLeaseExpired(now)) {
                 continue;
             }
             metadata_cache.emplace(key,
@@ -3490,8 +3495,7 @@ std::vector<tl::expected<QueryResult, ErrorCode>> RealClient::batch_query(
 
 tl::expected<RealClient::RangedReadMetadata, ErrorCode>
 RealClient::build_ranged_read_metadata_from_query_result(
-    const std::string &key,
-    const tl::expected<QueryResult, ErrorCode> &query_result) {
+    const std::string &key, tl::expected<QueryResult, ErrorCode> query_result) {
     if (!query_result) {
         if (query_result.error() == ErrorCode::OBJECT_NOT_FOUND ||
             query_result.error() == ErrorCode::REPLICA_IS_NOT_READY) {
@@ -3515,7 +3519,7 @@ RealClient::build_ranged_read_metadata_from_query_result(
         return tl::unexpected(ErrorCode::INVALID_REPLICA);
     }
 
-    auto query_value = query_result.value();
+    auto query_value = std::move(query_result.value());
     auto replica = *best_replica;
     return RangedReadMetadata{.query_result = std::move(query_value),
                               .replica = std::move(replica),

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -80,6 +80,50 @@ tl::expected<void, ErrorCode> set_context_if_needed(const std::string &protocol,
 }
 #endif
 
+CachedQueryResultResponse to_cached_query_result_response(
+    const tl::expected<QueryResult, ErrorCode> &query_result,
+    std::chrono::steady_clock::time_point now) {
+    if (!query_result) {
+        return CachedQueryResultResponse(query_result.error());
+    }
+    const auto remaining_ttl_ms = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            query_result->lease_timeout - now)
+            .count());
+    return CachedQueryResultResponse(GetReplicaListResponse(
+        std::vector<Replica::Descriptor>(query_result->replicas.begin(),
+                                         query_result->replicas.end()),
+        remaining_ttl_ms));
+}
+
+tl::expected<QueryResult, ErrorCode> from_cached_query_result_response(
+    const CachedQueryResultResponse &cached_result,
+    std::chrono::steady_clock::time_point now) {
+    if (!cached_result.success) {
+        return tl::make_unexpected(cached_result.error);
+    }
+    return QueryResult(
+        std::vector<Replica::Descriptor>(cached_result.value.replicas.begin(),
+                                         cached_result.value.replicas.end()),
+        now + std::chrono::milliseconds(cached_result.value.lease_ttl_ms));
+}
+
+PyClient::QueryResultCache build_query_result_cache_from_cached_results(
+    const std::map<std::string, CachedQueryResultResponse>
+        &cached_query_results) {
+    PyClient::QueryResultCache query_result_cache;
+    query_result_cache.reserve(cached_query_results.size());
+    auto now = std::chrono::steady_clock::now();
+    for (const auto &[key, cached_result] : cached_query_results) {
+        auto query_result = from_cached_query_result_response(cached_result, now);
+        if (!query_result || query_result->IsLeaseExpired(now)) {
+            continue;
+        }
+        query_result_cache.emplace(key, std::move(query_result));
+    }
+    return query_result_cache;
+}
+
 struct PreparedRangedReadRequest {
     std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
         results;
@@ -3107,13 +3151,9 @@ RealClient::resolve_writable_buffer_region(void *buffer) const {
 }
 
 tl::expected<RealClient::RangedReadMetadata, ErrorCode>
-RealClient::resolve_ranged_read_metadata(const std::string &key) {
-    if (!client_) {
-        LOG(ERROR) << "Client is not initialized";
-        return tl::unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    auto query_result = client_->Query(key);
+RealClient::build_ranged_read_metadata_from_query_result(
+    const std::string &key,
+    const tl::expected<QueryResult, ErrorCode> &query_result) {
     if (!query_result) {
         if (query_result.error() == ErrorCode::OBJECT_NOT_FOUND ||
             query_result.error() == ErrorCode::REPLICA_IS_NOT_READY) {
@@ -3124,7 +3164,7 @@ RealClient::resolve_ranged_read_metadata(const std::string &key) {
         return tl::unexpected(query_result.error());
     }
 
-    const auto &replica_list = query_result.value().replicas;
+    const auto &replica_list = query_result->replicas;
     if (replica_list.empty()) {
         LOG(ERROR) << "Internal error: replica_list is empty";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -3139,13 +3179,119 @@ RealClient::resolve_ranged_read_metadata(const std::string &key) {
         return tl::unexpected(ErrorCode::INVALID_REPLICA);
     }
 
-    auto query_value = std::move(query_result.value());
+    QueryResult query_value(
+        std::vector<Replica::Descriptor>(query_result->replicas.begin(),
+                                         query_result->replicas.end()),
+        query_result->lease_timeout);
     auto replica = *best_replica;
     return RangedReadMetadata{.query_result = std::move(query_value),
                               .replica = std::move(replica),
                               .total_size = calculate_total_size(replica)};
 }
 
+tl::expected<RealClient::RangedReadMetadata, ErrorCode>
+RealClient::resolve_ranged_read_metadata(const std::string &key) {
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    return build_ranged_read_metadata_from_query_result(key,
+                                                        client_->Query(key));
+}
+
+RealClient::RangedReadMetadataCache RealClient::batch_resolve_ranged_read_metadata(
+    const std::vector<std::vector<std::string>> &all_keys,
+    const std::vector<std::vector<std::vector<bool>>> &valid_fragments,
+    const std::vector<size_t> &buffer_capacities,
+    bool skip_zero_capacity_buffers,
+    const QueryResultCache *initial_query_result_cache) {
+    RangedReadMetadataCache metadata_cache;
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return metadata_cache;
+    }
+
+    if (all_keys.size() != valid_fragments.size() ||
+        all_keys.size() != buffer_capacities.size()) {
+        LOG(ERROR) << "get_into_ranges: metadata input size mismatch";
+        return metadata_cache;
+    }
+
+    size_t key_count_hint = 0;
+    for (const auto &keys : all_keys) {
+        key_count_hint += keys.size();
+    }
+    metadata_cache.reserve(key_count_hint);
+    if (initial_query_result_cache != nullptr) {
+        auto now = std::chrono::steady_clock::now();
+        for (const auto &[key, query_result] : *initial_query_result_cache) {
+            if (!query_result || query_result->IsLeaseExpired(now)) {
+                continue;
+            }
+            auto metadata =
+                build_ranged_read_metadata_from_query_result(key, query_result);
+            if (!metadata) {
+                continue;
+            }
+            metadata_cache.emplace(key, std::move(metadata));
+        }
+    }
+
+    std::vector<std::string> unique_keys;
+    unique_keys.reserve(key_count_hint);
+    for (size_t i = 0; i < valid_fragments.size(); ++i) {
+        if (skip_zero_capacity_buffers && buffer_capacities[i] == 0 &&
+            !all_keys[i].empty()) {
+            continue;
+        }
+        if (all_keys[i].size() != valid_fragments[i].size()) {
+            LOG(ERROR) << "get_into_ranges: metadata key-group size mismatch";
+            continue;
+        }
+        for (size_t j = 0; j < valid_fragments[i].size(); ++j) {
+            bool has_valid_fragment = false;
+            for (bool valid_fragment : valid_fragments[i][j]) {
+                if (valid_fragment) {
+                    has_valid_fragment = true;
+                    break;
+                }
+            }
+            if (!has_valid_fragment) {
+                continue;
+            }
+            if (metadata_cache.find(all_keys[i][j]) != metadata_cache.end()) {
+                continue;
+            }
+            auto [_, inserted] = metadata_cache.emplace(
+                all_keys[i][j], tl::unexpected(ErrorCode::INVALID_PARAMS));
+            if (inserted) {
+                unique_keys.push_back(all_keys[i][j]);
+            }
+        }
+    }
+    if (unique_keys.empty()) {
+        return metadata_cache;
+    }
+
+    auto query_results = client_->BatchQuery(unique_keys);
+    if (query_results.size() != unique_keys.size()) {
+        LOG(ERROR) << "BatchQuery result size mismatch in get_into_ranges";
+        for (const auto &key : unique_keys) {
+            metadata_cache.erase(key);
+            metadata_cache.emplace(key, tl::unexpected(ErrorCode::RPC_FAIL));
+        }
+        return metadata_cache;
+    }
+
+    for (size_t i = 0; i < unique_keys.size(); ++i) {
+        metadata_cache.erase(unique_keys[i]);
+        metadata_cache.emplace(
+            unique_keys[i], build_ranged_read_metadata_from_query_result(
+                                unique_keys[i], std::move(query_results[i])));
+    }
+    return metadata_cache;
+}
 tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     const std::string &key, void *buffer, size_t dst_offset, size_t src_offset,
     size_t size, const RangedReadMetadata &metadata,
@@ -3342,6 +3488,16 @@ int64_t RealClient::get_into(const std::string &key, void *buffer,
     return to_py_ret(result);
 }
 
+std::vector<tl::expected<QueryResult, ErrorCode>> RealClient::batch_query(
+    const std::vector<std::string> &keys) {
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return std::vector<tl::expected<QueryResult, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+    return client_->BatchQuery(keys);
+}
+
 std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
 RealClient::get_into_ranges_internal(
     const std::vector<void *> &buffers,
@@ -3352,7 +3508,8 @@ RealClient::get_into_ranges_internal(
     const std::vector<size_t> *buffer_capacities,
     std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
         *prepared_results,
-    const std::vector<std::vector<std::vector<bool>>> *valid_fragments) {
+    const std::vector<std::vector<std::vector<bool>>> *valid_fragments,
+    const QueryResultCache *query_result_cache) {
     const size_t buffer_count = buffers.size();
     PreparedRangedReadRequest prepared;
     if (prepared_results != nullptr && valid_fragments != nullptr) {
@@ -3393,8 +3550,9 @@ RealClient::get_into_ranges_internal(
         }
     }
 
-    std::unordered_map<std::string, tl::expected<RangedReadMetadata, ErrorCode>>
-        metadata_cache;
+    auto resolved_metadata_cache = batch_resolve_ranged_read_metadata(
+        all_keys, prepared.valid_fragments, resolved_buffer_capacities,
+        buffer_capacities == nullptr, query_result_cache);
 
     for (size_t i = 0; i < buffer_count; ++i) {
         const size_t key_count = prepared.results[i].size();
@@ -3404,9 +3562,13 @@ RealClient::get_into_ranges_internal(
         }
 
         for (size_t j = 0; j < key_count; ++j) {
-            auto [metadata_it, inserted] = metadata_cache.try_emplace(
-                all_keys[i][j], resolve_ranged_read_metadata(all_keys[i][j]));
-            (void)inserted;
+            auto metadata_it = resolved_metadata_cache.find(all_keys[i][j]);
+            if (metadata_it == resolved_metadata_cache.end()) {
+                prepared.results[i][j].assign(
+                    prepared.results[i][j].size(),
+                    tl::unexpected(ErrorCode::INVALID_PARAMS));
+                continue;
+            }
             auto &metadata_result = metadata_it->second;
 
             for (size_t k = 0; k < prepared.results[i][j].size(); ++k) {
@@ -3458,13 +3620,16 @@ std::vector<std::vector<std::vector<int64_t>>> RealClient::get_into_ranges(
     const std::vector<std::vector<std::string>> &all_keys,
     const std::vector<std::vector<std::vector<size_t>>> &all_dst_offsets,
     const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
-    const std::vector<std::vector<std::vector<size_t>>> &all_sizes) {
+    const std::vector<std::vector<std::vector<size_t>>> &all_sizes,
+    const QueryResultCache *query_result_cache) {
     auto results =
         execute_timed_operation<std::vector<std::vector<std::vector<int64_t>>>>(
             [&]() {
                 return convert_ranged_read_results(
                     get_into_ranges_internal(buffers, all_keys, all_dst_offsets,
-                                             all_src_offsets, all_sizes));
+                                             all_src_offsets, all_sizes,
+                                             nullptr, nullptr, nullptr,
+                                             query_result_cache));
             },
             [](const auto &) { return true; },
             [&](uint64_t latency_us, const auto &ret) {
@@ -4258,6 +4423,8 @@ RealClient::get_into_ranges_shm_helper(
     const std::vector<std::vector<std::vector<size_t>>> &all_dst_offsets,
     const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
     const std::vector<std::vector<std::vector<size_t>>> &all_sizes,
+    const std::map<std::string, CachedQueryResultResponse>
+        &cached_query_results,
     int32_t device_id, const UUID &client_id) {
 #ifdef USE_ASCEND_DIRECT
     if (!ContextManager::getInstance().setCurrentContextByPhysicalId(
@@ -4301,10 +4468,13 @@ RealClient::get_into_ranges_shm_helper(
         return prepared.results;
     }
 
+    auto query_result_cache =
+        build_query_result_cache_from_cached_results(cached_query_results);
     return get_into_ranges_internal(
         real_buffers_result.value(), all_keys, all_dst_offsets, all_src_offsets,
         all_sizes, &prepared.required_buffer_sizes, &prepared.results,
-        &prepared.valid_fragments);
+        &prepared.valid_fragments,
+        query_result_cache.empty() ? nullptr : &query_result_cache);
 }
 
 std::vector<tl::expected<int64_t, ErrorCode>>
@@ -5427,6 +5597,31 @@ RealClient::batch_get_replica_desc(const std::vector<std::string> &keys) {
         }
     }
     return replica_map;
+}
+
+std::vector<CachedQueryResultResponse> RealClient::batch_get_query_results(
+    const std::vector<std::string> &keys) {
+    if (!client_) {
+        LOG(ERROR) << "batch_get_query_results: client not initialized";
+        return std::vector<CachedQueryResultResponse>(
+            keys.size(), CachedQueryResultResponse(ErrorCode::INVALID_PARAMS));
+    }
+    auto query_results = client_->BatchQuery(keys);
+    std::vector<CachedQueryResultResponse> cached_results;
+    cached_results.reserve(keys.size());
+    if (query_results.size() != keys.size()) {
+        LOG(ERROR) << "Batch query response size mismatch in batch_get_query_results: expected "
+                   << keys.size() << ", got " << query_results.size() << ".";
+        return std::vector<CachedQueryResultResponse>(
+            keys.size(), CachedQueryResultResponse(ErrorCode::RPC_FAIL));
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    for (const auto &query_result : query_results) {
+        cached_results.push_back(
+            to_cached_query_result_response(query_result, now));
+    }
+    return cached_results;
 }
 
 std::vector<std::string> RealClient::batch_replica_clear(

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -133,6 +133,218 @@ struct PreparedRangedReadRequest {
     bool has_any_valid_fragment = false;
 };
 
+struct PreparedBatchReadOp {
+    std::string key;
+    size_t original_index;
+    QueryResult query_result;
+    std::vector<Slice> slices;
+};
+
+template <typename Results>
+void apply_batch_get_failures(
+    const std::vector<tl::expected<void, ErrorCode>> &batch_get_results,
+    const std::vector<PreparedBatchReadOp> &valid_operations,
+    Results &results) {
+    for (size_t i = 0; i < batch_get_results.size(); ++i) {
+        if (batch_get_results[i]) {
+            continue;
+        }
+        const auto error = batch_get_results[i].error();
+        LOG(ERROR) << "BatchGet failed for key '" << valid_operations[i].key
+                   << "': " << toString(error);
+        results[valid_operations[i].original_index] = tl::unexpected(error);
+    }
+}
+
+template <typename Results>
+void apply_offload_failures(
+    const std::unordered_map<std::string, PreparedBatchReadOp>
+        &valid_local_disk_operations,
+    const std::unordered_map<std::string, std::vector<Slice>> &objects,
+    ErrorCode error, Results &results) {
+    for (const auto &[key, _] : objects) {
+        results[valid_local_disk_operations.at(key).original_index] =
+            tl::unexpected(error);
+    }
+}
+
+struct PreparedBatchReadSet {
+    std::vector<PreparedBatchReadOp> memory_operations;
+    std::unordered_map<std::string, PreparedBatchReadOp> local_disk_operations;
+};
+
+inline const Replica::Descriptor *SelectBestReplica(
+    const std::vector<Replica::Descriptor> &replicas,
+    const std::unordered_set<std::string> &local_endpoints);
+inline QueryResult FilterQueryResult(const QueryResult &qr,
+                                     const Replica::Descriptor &replica);
+
+template <typename Results, typename LocalEndpoints, typename AvailableSizeFn,
+          typename SliceBuilderFn, typename ShouldLogQueryErrorFn>
+PreparedBatchReadSet prepare_batch_read_operations(
+    const std::vector<std::string> &keys,
+    const std::vector<tl::expected<QueryResult, ErrorCode>> &query_results,
+    Results &results, const LocalEndpoints &local_endpoints,
+    AvailableSizeFn &&available_size_for_index,
+    SliceBuilderFn &&build_slices_for_index,
+    ShouldLogQueryErrorFn &&should_log_query_error) {
+    PreparedBatchReadSet prepared;
+    prepared.memory_operations.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const auto &key = keys[i];
+        if (!query_results[i]) {
+            const auto error = query_results[i].error();
+            results[i] = tl::unexpected(error);
+            if (should_log_query_error(error)) {
+                LOG(ERROR) << "Query failed for key '" << key
+                           << "': " << toString(error);
+            }
+            continue;
+        }
+
+        auto query_result_values = query_results[i].value();
+        const auto *best_replica =
+            SelectBestReplica(query_result_values.replicas, local_endpoints);
+        if (!best_replica) {
+            LOG(ERROR) << "No usable replica for key: " << key;
+            results[i] = tl::unexpected(ErrorCode::INVALID_REPLICA);
+            continue;
+        }
+
+        const auto &replica = *best_replica;
+        const uint64_t total_size = calculate_total_size(replica);
+        const uint64_t available_size = available_size_for_index(i);
+        if (available_size < total_size) {
+            LOG(ERROR) << "Buffer too small for key '" << key
+                       << "': required=" << total_size
+                       << ", available=" << available_size;
+            results[i] = tl::unexpected(ErrorCode::INVALID_PARAMS);
+            continue;
+        }
+
+        auto filtered_query_result =
+            FilterQueryResult(query_result_values, replica);
+        auto key_slices = build_slices_for_index(i, replica);
+        if (replica.is_local_disk_replica()) {
+            prepared.local_disk_operations.emplace(
+                key, PreparedBatchReadOp{.key = key,
+                                         .original_index = i,
+                                         .query_result =
+                                             std::move(filtered_query_result),
+                                         .slices = std::move(key_slices)});
+        } else {
+            prepared.memory_operations.push_back(
+                {.key = key,
+                 .original_index = i,
+                 .query_result = std::move(filtered_query_result),
+                 .slices = std::move(key_slices)});
+        }
+        results[i] = static_cast<int64_t>(total_size);
+    }
+    return prepared;
+}
+
+template <typename Results, typename ExecuteBatchFn>
+size_t execute_local_disk_batch_reads(
+    const std::unordered_map<std::string, PreparedBatchReadOp>
+        &valid_local_disk_operations,
+    Results &results, ExecuteBatchFn &&execute_batch) {
+    std::unordered_map<std::string,
+                       std::unordered_map<std::string, std::vector<Slice>>>
+        offload_objects;
+    for (const auto &[key, op] : valid_local_disk_operations) {
+        const auto &replica = op.query_result.replicas.at(0);
+        auto [store_segment_it, _] = offload_objects.try_emplace(
+            replica.get_local_disk_descriptor().transport_endpoint);
+        store_segment_it->second.emplace(key, op.slices);
+    }
+
+    size_t offload_object_count = 0;
+    for (auto &[transport_endpoint, objects] : offload_objects) {
+        offload_object_count += objects.size();
+        auto batch_get_offload_result = execute_batch(transport_endpoint, objects);
+        if (!batch_get_offload_result) {
+            LOG(ERROR) << "Batch get store object failed with error: "
+                       << batch_get_offload_result.error();
+            apply_offload_failures(valid_local_disk_operations, objects,
+                                   batch_get_offload_result.error(), results);
+        }
+    }
+    return offload_object_count;
+}
+
+struct BatchReadExecutionStats {
+    size_t memory_operation_count{0};
+    size_t offload_object_count{0};
+};
+
+std::optional<std::vector<tl::expected<int64_t, ErrorCode>>>
+validate_batch_get_inputs(bool client_ready, size_t key_count,
+                          size_t buffer_count, size_t size_count,
+                          const char *buffer_label) {
+    if (!client_ready) {
+        LOG(ERROR) << "Client is not initialized";
+        return std::vector<tl::expected<int64_t, ErrorCode>>(
+            key_count, tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+    if (key_count != buffer_count || key_count != size_count) {
+        LOG(ERROR) << "Input vector sizes mismatch: keys=" << key_count
+                   << ", " << buffer_label << "=" << buffer_count
+                   << ", sizes=" << size_count;
+        return std::vector<tl::expected<int64_t, ErrorCode>>(
+            key_count, tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+    return std::nullopt;
+}
+
+template <typename Results, typename LocalEndpoints, typename AvailableSizeFn,
+          typename SliceBuilderFn, typename ShouldLogQueryErrorFn,
+          typename ExecuteMemoryBatchFn, typename ExecuteOffloadBatchFn>
+BatchReadExecutionStats execute_batch_read_operations(
+    const std::vector<std::string> &keys,
+    const std::vector<tl::expected<QueryResult, ErrorCode>> &query_results,
+    Results &results, const LocalEndpoints &local_endpoints,
+    AvailableSizeFn &&available_size_for_index,
+    SliceBuilderFn &&build_slices_for_index,
+    ShouldLogQueryErrorFn &&should_log_query_error,
+    ExecuteMemoryBatchFn &&execute_memory_batch,
+    ExecuteOffloadBatchFn &&execute_offload_batch) {
+    auto prepared = prepare_batch_read_operations(
+        keys, query_results, results, local_endpoints,
+        std::forward<AvailableSizeFn>(available_size_for_index),
+        std::forward<SliceBuilderFn>(build_slices_for_index),
+        std::forward<ShouldLogQueryErrorFn>(should_log_query_error));
+    if (prepared.memory_operations.empty() &&
+        prepared.local_disk_operations.empty()) {
+        return {};
+    }
+
+    BatchReadExecutionStats stats{.memory_operation_count =
+                                      prepared.memory_operations.size()};
+    std::vector<std::string> batch_keys;
+    std::vector<QueryResult> batch_query_results;
+    std::unordered_map<std::string, std::vector<Slice>> batch_slices;
+    batch_keys.reserve(prepared.memory_operations.size());
+    batch_query_results.reserve(prepared.memory_operations.size());
+    for (const auto &op : prepared.memory_operations) {
+        batch_keys.push_back(op.key);
+        batch_query_results.push_back(op.query_result);
+        batch_slices[op.key] = op.slices;
+    }
+    if (!prepared.memory_operations.empty()) {
+        auto batch_get_results = execute_memory_batch(batch_keys,
+                                                      batch_query_results,
+                                                      batch_slices);
+        apply_batch_get_failures(batch_get_results, prepared.memory_operations,
+                                 results);
+    }
+
+    stats.offload_object_count = execute_local_disk_batch_reads(
+        prepared.local_disk_operations, results,
+        std::forward<ExecuteOffloadBatchFn>(execute_offload_batch));
+    return stats;
+}
+
 size_t sum_value_sizes(const std::vector<std::span<const char>> &values) {
     size_t total = 0;
     for (const auto &value : values) {
@@ -3150,10 +3362,11 @@ RealClient::resolve_writable_buffer_region(void *buffer) const {
     return std::nullopt;
 }
 
-tl::expected<RealClient::RangedReadMetadata, ErrorCode>
-RealClient::build_ranged_read_metadata_from_query_result(
+tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     const std::string &key,
-    const tl::expected<QueryResult, ErrorCode> &query_result) {
+    const tl::expected<QueryResult, ErrorCode> &query_result, void *buffer,
+    size_t dst_offset, size_t src_offset, size_t size,
+    bool size_is_buffer_capacity) {
     if (!query_result) {
         if (query_result.error() == ErrorCode::OBJECT_NOT_FOUND ||
             query_result.error() == ErrorCode::REPLICA_IS_NOT_READY) {
@@ -3170,8 +3383,6 @@ RealClient::build_ranged_read_metadata_from_query_result(
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    // Select best replica: prefer local MEMORY, then any MEMORY,
-    // then LOCAL_DISK, then DISK.
     auto local_endpoints = client_->GetLocalEndpoints();
     const auto *best_replica = SelectBestReplica(replica_list, local_endpoints);
     if (!best_replica) {
@@ -3179,126 +3390,30 @@ RealClient::build_ranged_read_metadata_from_query_result(
         return tl::unexpected(ErrorCode::INVALID_REPLICA);
     }
 
-    QueryResult query_value(
-        std::vector<Replica::Descriptor>(query_result->replicas.begin(),
-                                         query_result->replicas.end()),
-        query_result->lease_timeout);
-    auto replica = *best_replica;
-    return RangedReadMetadata{.query_result = std::move(query_value),
-                              .replica = std::move(replica),
-                              .total_size = calculate_total_size(replica)};
-}
-
-tl::expected<RealClient::RangedReadMetadata, ErrorCode>
-RealClient::resolve_ranged_read_metadata(const std::string &key) {
-    if (!client_) {
-        LOG(ERROR) << "Client is not initialized";
-        return tl::unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    return build_ranged_read_metadata_from_query_result(key,
-                                                        client_->Query(key));
-}
-
-RealClient::RangedReadMetadataCache RealClient::batch_resolve_ranged_read_metadata(
-    const std::vector<std::vector<std::string>> &all_keys,
-    const std::vector<std::vector<std::vector<bool>>> &valid_fragments,
-    const std::vector<size_t> &buffer_capacities,
-    bool skip_zero_capacity_buffers,
-    const QueryResultCache *initial_query_result_cache) {
-    RangedReadMetadataCache metadata_cache;
-    if (!client_) {
-        LOG(ERROR) << "Client is not initialized";
-        return metadata_cache;
-    }
-
-    if (all_keys.size() != valid_fragments.size() ||
-        all_keys.size() != buffer_capacities.size()) {
-        LOG(ERROR) << "get_into_ranges: metadata input size mismatch";
-        return metadata_cache;
-    }
-
-    size_t key_count_hint = 0;
-    for (const auto &keys : all_keys) {
-        key_count_hint += keys.size();
-    }
-    metadata_cache.reserve(key_count_hint);
-    if (initial_query_result_cache != nullptr) {
-        auto now = std::chrono::steady_clock::now();
-        for (const auto &[key, query_result] : *initial_query_result_cache) {
-            if (!query_result || query_result->IsLeaseExpired(now)) {
-                continue;
+    const auto &replica = *best_replica;
+    const uint64_t total_size = calculate_total_size(replica);
+    const auto filtered_qr = FilterQueryResult(query_result.value(), replica);
+    auto get_via_client =
+        [&](void *dst, uint64_t read_offset,
+            bool read_full_object) -> tl::expected<void, ErrorCode> {
+        std::vector<Slice> slices;
+        if (read_full_object) {
+            allocateSlices(slices, replica, dst);
+            auto get_result = client_->Get(key, filtered_qr, slices);
+            if (!get_result) {
+                LOG(ERROR) << "Get failed for key: " << key
+                           << " with error: " << toString(get_result.error());
+                return tl::unexpected(get_result.error());
             }
-            auto metadata =
-                build_ranged_read_metadata_from_query_result(key, query_result);
-            if (!metadata) {
-                continue;
-            }
-            metadata_cache.emplace(key, std::move(metadata));
+            return {};
         }
-    }
-
-    std::vector<std::string> unique_keys;
-    unique_keys.reserve(key_count_hint);
-    for (size_t i = 0; i < valid_fragments.size(); ++i) {
-        if (skip_zero_capacity_buffers && buffer_capacities[i] == 0 &&
-            !all_keys[i].empty()) {
-            continue;
+        slices.emplace_back(Slice{static_cast<char *>(dst), size});
+        auto get_result = client_->Get(key, filtered_qr, slices, read_offset);
+        if (!get_result) {
+            return tl::unexpected(get_result.error());
         }
-        if (all_keys[i].size() != valid_fragments[i].size()) {
-            LOG(ERROR) << "get_into_ranges: metadata key-group size mismatch";
-            continue;
-        }
-        for (size_t j = 0; j < valid_fragments[i].size(); ++j) {
-            bool has_valid_fragment = false;
-            for (bool valid_fragment : valid_fragments[i][j]) {
-                if (valid_fragment) {
-                    has_valid_fragment = true;
-                    break;
-                }
-            }
-            if (!has_valid_fragment) {
-                continue;
-            }
-            if (metadata_cache.find(all_keys[i][j]) != metadata_cache.end()) {
-                continue;
-            }
-            auto [_, inserted] = metadata_cache.emplace(
-                all_keys[i][j], tl::unexpected(ErrorCode::INVALID_PARAMS));
-            if (inserted) {
-                unique_keys.push_back(all_keys[i][j]);
-            }
-        }
-    }
-    if (unique_keys.empty()) {
-        return metadata_cache;
-    }
-
-    auto query_results = client_->BatchQuery(unique_keys);
-    if (query_results.size() != unique_keys.size()) {
-        LOG(ERROR) << "BatchQuery result size mismatch in get_into_ranges";
-        for (const auto &key : unique_keys) {
-            metadata_cache.erase(key);
-            metadata_cache.emplace(key, tl::unexpected(ErrorCode::RPC_FAIL));
-        }
-        return metadata_cache;
-    }
-
-    for (size_t i = 0; i < unique_keys.size(); ++i) {
-        metadata_cache.erase(unique_keys[i]);
-        metadata_cache.emplace(
-            unique_keys[i], build_ranged_read_metadata_from_query_result(
-                                unique_keys[i], std::move(query_results[i])));
-    }
-    return metadata_cache;
-}
-tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
-    const std::string &key, void *buffer, size_t dst_offset, size_t src_offset,
-    size_t size, const RangedReadMetadata &metadata,
-    bool size_is_buffer_capacity) {
-    const auto &query_result = metadata.query_result;
-    const auto &replica = metadata.replica;
-    const uint64_t total_size = metadata.total_size;
+        return {};
+    };
 
     if (size_is_buffer_capacity) {
         if (size < total_size) {
@@ -3313,74 +3428,27 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    if (src_offset == 0 && size == total_size) {
-        // LOCAL_DISK full-object read: destination buffer is passed
-        // directly to SSD RPC (same pattern as single-buffer batch_get_into;
-        // GPU buffers are pre-registered by vLLM via register_buffer).
-        if (replica.is_local_disk_replica()) {
-            const auto &endpoint =
-                replica.get_local_disk_descriptor().transport_endpoint;
-            std::unordered_map<std::string, std::vector<Slice>> objects;
-            objects.emplace(
-                key, std::vector<Slice>{
-                         {static_cast<char *>(buffer) + dst_offset, size}});
-            auto result =
-                batch_get_into_offload_object_internal(endpoint, objects);
-            if (!result) return tl::unexpected(result.error());
-            return static_cast<int64_t>(total_size);
-        }
+    auto read_via_offload = [&](void *dst, size_t read_size)
+        -> tl::expected<void, ErrorCode> {
+        const auto &endpoint =
+            replica.get_local_disk_descriptor().transport_endpoint;
+        std::unordered_map<std::string, std::vector<Slice>> objects;
+        objects.emplace(key,
+                        std::vector<Slice>{{static_cast<char *>(dst), read_size}});
+        return batch_get_into_offload_object_internal(endpoint, objects);
+    };
 
-        if (replica.is_disk_replica()) {
-            // DISK full read: local file I/O (vector_read) cannot write to
-            // GPU memory. Use temp CPU buffer, then scatter to dst.
-            auto alloc_result = client_buffer_allocator_->allocate(total_size);
-            if (!alloc_result) {
-                LOG(ERROR) << "Failed to allocate temp buffer for DISK full "
-                           << "read, key: " << key << ", size: " << total_size;
-                return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
-            }
-            BufferHandle tmp_handle(std::move(*alloc_result));
-            std::vector<mooncake::Slice> tmp_slices;
-            allocateSlices(tmp_slices, replica, tmp_handle.ptr());
-            auto filtered_qr = FilterQueryResult(query_result, replica);
-            auto get_result = client_->Get(key, filtered_qr, tmp_slices);
-            if (!get_result) {
-                LOG(ERROR) << "DISK Get failed for key: " << key
-                           << " with error: " << toString(get_result.error());
-                return tl::unexpected(get_result.error());
-            }
-            void *dst = static_cast<char *>(buffer) + dst_offset;
-            const void *src = tmp_handle.ptr();
-            if (auto r = scatter_host_to_maybe_device(
-                    dst, src, total_size, "DISK full read, key: " + key);
-                !r) {
-                return tl::unexpected(r.error());
-            }
-            return static_cast<int64_t>(total_size);
-        }
-
-        std::vector<mooncake::Slice> slices;
-        allocateSlices(slices, replica,
-                       static_cast<char *>(buffer) + dst_offset);
-
-        auto filtered_qr = FilterQueryResult(query_result, replica);
-        auto get_result = client_->Get(key, filtered_qr, slices);
-        if (!get_result) {
-            LOG(ERROR) << "Get failed for key: " << key
-                       << " with error: " << toString(get_result.error());
-            return tl::unexpected(get_result.error());
+    if (src_offset == 0 && size == total_size &&
+        replica.is_local_disk_replica()) {
+        auto read_result =
+            read_via_offload(static_cast<char *>(buffer) + dst_offset, size);
+        if (!read_result) {
+            return tl::unexpected(read_result.error());
         }
         return static_cast<int64_t>(total_size);
     }
 
-    // Partial disk read: allocate temp CPU buffer, invoke read_op to
-    // fill it, then scatter [src_offset, src_offset+size) to dst.
-    //
-    // buf_size controls how much to allocate / read.  DISK must use
-    // total_size (allocateSlices requires full-object slices).
-    // LOCAL_DISK can use src_offset + size (offload RPC transfers
-    // sequentially from remote offset 0).
-    auto partial_disk_read =
+    auto read_via_temp_host_buffer =
         [&](auto &&read_op,
             size_t buf_size) -> tl::expected<int64_t, ErrorCode> {
         auto alloc_result = client_buffer_allocator_->allocate(buf_size);
@@ -3391,7 +3459,9 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         }
         BufferHandle tmp_handle(std::move(*alloc_result));
         auto read_result = read_op(tmp_handle.ptr());
-        if (!read_result) return tl::unexpected(read_result.error());
+        if (!read_result) {
+            return tl::unexpected(read_result.error());
+        }
         void *dst = static_cast<char *>(buffer) + dst_offset;
         const void *src =
             static_cast<const char *>(tmp_handle.ptr()) + src_offset;
@@ -3404,38 +3474,17 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     };
 
     if (replica.is_local_disk_replica()) {
-        // LOCAL_DISK: offload RPC transfers sequentially from remote offset
-        // 0, so we only need src_offset + size bytes (not total_size).
-        return partial_disk_read(
+        return read_via_temp_host_buffer(
             [&](void *tmp_buf) -> tl::expected<void, ErrorCode> {
-                const auto &endpoint =
-                    replica.get_local_disk_descriptor().transport_endpoint;
-                std::unordered_map<std::string, std::vector<Slice>> objects;
-                objects.emplace(
-                    key, std::vector<Slice>{{static_cast<char *>(tmp_buf),
-                                             src_offset + size}});
-                return batch_get_into_offload_object_internal(endpoint,
-                                                              objects);
+                return read_via_offload(tmp_buf, src_offset + size);
             },
             src_offset + size);
     }
 
     if (replica.is_disk_replica()) {
-        // DISK: client_->Get + allocateSlices requires full-object slices,
-        // so we must allocate total_size.
-        return partial_disk_read(
+        return read_via_temp_host_buffer(
             [&](void *tmp_buf) -> tl::expected<void, ErrorCode> {
-                std::vector<mooncake::Slice> tmp_slices;
-                allocateSlices(tmp_slices, replica, tmp_buf);
-                auto filtered_qr = FilterQueryResult(query_result, replica);
-                auto get_result = client_->Get(key, filtered_qr, tmp_slices);
-                if (!get_result) {
-                    LOG(ERROR)
-                        << "DISK Get failed for key: " << key
-                        << " with error: " << toString(get_result.error());
-                    return tl::unexpected(get_result.error());
-                }
-                return {};
+                return get_via_client(tmp_buf, 0, true);
             },
             total_size);
     }
@@ -3445,12 +3494,11 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return tl::unexpected(ErrorCode::INVALID_REPLICA);
     }
 
-    std::vector<Slice> slices;
-    slices.emplace_back(Slice{static_cast<char *>(buffer) + dst_offset, size});
-
-    auto get_result = client_->Get(key, query_result, slices, src_offset);
-    if (!get_result) {
-        return tl::unexpected(get_result.error());
+    auto read_result = get_via_client(static_cast<char *>(buffer) + dst_offset,
+                                      src_offset, src_offset == 0 &&
+                                                      size == total_size);
+    if (!read_result) {
+        return tl::unexpected(read_result.error());
     }
     return static_cast<int64_t>(size);
 }
@@ -3458,19 +3506,21 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
 tl::expected<int64_t, ErrorCode> RealClient::get_into_range_internal(
     const std::string &key, void *buffer, size_t dst_offset, size_t src_offset,
     size_t size, bool size_is_buffer_capacity) {
-    auto metadata_result = resolve_ranged_read_metadata(key);
-    if (!metadata_result) {
-        if ((metadata_result.error() == ErrorCode::OBJECT_NOT_FOUND ||
-             metadata_result.error() == ErrorCode::REPLICA_IS_NOT_READY) &&
-            src_offset == 0) {
-            VLOG(1) << "Object not found for key: " << key;
-        }
-        return tl::unexpected(metadata_result.error());
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    return execute_ranged_read(key, buffer, dst_offset, src_offset, size,
-                               metadata_result.value(),
-                               size_is_buffer_capacity);
+    auto query_result = client_->Query(key);
+    if (!query_result &&
+        (query_result.error() == ErrorCode::OBJECT_NOT_FOUND ||
+         query_result.error() == ErrorCode::REPLICA_IS_NOT_READY) &&
+        src_offset == 0) {
+        VLOG(1) << "Object not found for key: " << key;
+    }
+
+    return execute_ranged_read(key, query_result, buffer, dst_offset,
+                               src_offset, size, size_is_buffer_capacity);
 }
 
 int64_t RealClient::get_into(const std::string &key, void *buffer,
@@ -3510,6 +3560,12 @@ RealClient::get_into_ranges_internal(
         *prepared_results,
     const std::vector<std::vector<std::vector<bool>>> *valid_fragments,
     const QueryResultCache *query_result_cache) {
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return build_ranged_read_internal_error_results(
+            buffers.size(), all_keys, all_dst_offsets, ErrorCode::INVALID_PARAMS);
+    }
+
     const size_t buffer_count = buffers.size();
     PreparedRangedReadRequest prepared;
     if (prepared_results != nullptr && valid_fragments != nullptr) {
@@ -3550,9 +3606,69 @@ RealClient::get_into_ranges_internal(
         }
     }
 
-    auto resolved_metadata_cache = batch_resolve_ranged_read_metadata(
-        all_keys, prepared.valid_fragments, resolved_buffer_capacities,
-        buffer_capacities == nullptr, query_result_cache);
+    size_t key_count_hint = 0;
+    for (const auto &keys : all_keys) {
+        key_count_hint += keys.size();
+    }
+
+    QueryResultCache resolved_query_results;
+    resolved_query_results.reserve(key_count_hint);
+    auto now = std::chrono::steady_clock::now();
+    if (query_result_cache != nullptr) {
+        for (const auto &[key, query_result] : *query_result_cache) {
+            if (!query_result || query_result->IsLeaseExpired(now)) {
+                continue;
+            }
+            resolved_query_results.emplace(key, query_result);
+        }
+    }
+
+    std::vector<std::string> missing_keys;
+    missing_keys.reserve(key_count_hint);
+    std::unordered_set<std::string> seen_missing_keys;
+    seen_missing_keys.reserve(key_count_hint);
+    for (size_t i = 0; i < buffer_count; ++i) {
+        if (buffer_capacities == nullptr && resolved_buffer_capacities[i] == 0 &&
+            !all_keys[i].empty()) {
+            continue;
+        }
+        if (all_keys[i].size() != prepared.valid_fragments[i].size()) {
+            LOG(ERROR) << "get_into_ranges: metadata key-group size mismatch";
+            continue;
+        }
+        for (size_t j = 0; j < all_keys[i].size(); ++j) {
+            if (resolved_query_results.find(all_keys[i][j]) !=
+                resolved_query_results.end()) {
+                continue;
+            }
+            const bool has_valid_fragment = std::any_of(
+                prepared.valid_fragments[i][j].begin(),
+                prepared.valid_fragments[i][j].end(),
+                [](bool valid_fragment) { return valid_fragment; });
+            if (!has_valid_fragment) {
+                continue;
+            }
+            if (seen_missing_keys.insert(all_keys[i][j]).second) {
+                missing_keys.push_back(all_keys[i][j]);
+            }
+        }
+    }
+
+    if (!missing_keys.empty()) {
+        auto query_results = client_->BatchQuery(missing_keys);
+        if (query_results.size() != missing_keys.size()) {
+            LOG(ERROR) << "BatchQuery result size mismatch in get_into_ranges";
+            for (const auto &key : missing_keys) {
+                resolved_query_results.emplace(
+                    key, tl::unexpected(ErrorCode::RPC_FAIL));
+            }
+        } else {
+            for (size_t i = 0; i < missing_keys.size(); ++i) {
+                resolved_query_results.emplace(missing_keys[i],
+                                               std::move(query_results[i]));
+            }
+        }
+    }
 
     for (size_t i = 0; i < buffer_count; ++i) {
         const size_t key_count = prepared.results[i].size();
@@ -3562,15 +3678,13 @@ RealClient::get_into_ranges_internal(
         }
 
         for (size_t j = 0; j < key_count; ++j) {
-            auto metadata_it = resolved_metadata_cache.find(all_keys[i][j]);
-            if (metadata_it == resolved_metadata_cache.end()) {
+            auto query_result_it = resolved_query_results.find(all_keys[i][j]);
+            if (query_result_it == resolved_query_results.end()) {
                 prepared.results[i][j].assign(
                     prepared.results[i][j].size(),
                     tl::unexpected(ErrorCode::INVALID_PARAMS));
                 continue;
             }
-            auto &metadata_result = metadata_it->second;
-
             for (size_t k = 0; k < prepared.results[i][j].size(); ++k) {
                 if (!prepared.valid_fragments[i][j][k]) {
                     continue;
@@ -3590,24 +3704,24 @@ RealClient::get_into_ranges_internal(
                     continue;
                 }
 
-                if (!metadata_result) {
-                    if ((metadata_result.error() ==
+                if (!query_result_it->second) {
+                    if ((query_result_it->second.error() ==
                              ErrorCode::OBJECT_NOT_FOUND ||
-                         metadata_result.error() ==
+                         query_result_it->second.error() ==
                              ErrorCode::REPLICA_IS_NOT_READY) &&
                         all_src_offsets[i][j][k] == 0) {
                         VLOG(1)
                             << "Object not found for key: " << all_keys[i][j];
                     }
                     prepared.results[i][j][k] =
-                        tl::unexpected(metadata_result.error());
+                        tl::unexpected(query_result_it->second.error());
                     continue;
                 }
 
                 prepared.results[i][j][k] = execute_ranged_read(
-                    all_keys[i][j], buffers[i], all_dst_offsets[i][j][k],
-                    all_src_offsets[i][j][k], all_sizes[i][j][k],
-                    metadata_result.value());
+                    all_keys[i][j], query_result_it->second, buffers[i],
+                    all_dst_offsets[i][j][k], all_src_offsets[i][j][k],
+                    all_sizes[i][j][k]);
             }
         }
     }
@@ -4482,19 +4596,10 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
                                     const std::vector<void *> &buffers,
                                     const std::vector<size_t> &sizes) {
     auto start_time = std::chrono::steady_clock::now();
-    // Validate preconditions
-    if (!client_) {
-        LOG(ERROR) << "Client is not initialized";
-        return std::vector<tl::expected<int64_t, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-
-    if (keys.size() != buffers.size() || keys.size() != sizes.size()) {
-        LOG(ERROR) << "Input vector sizes mismatch: keys=" << keys.size()
-                   << ", buffers=" << buffers.size()
-                   << ", sizes=" << sizes.size();
-        return std::vector<tl::expected<int64_t, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    if (auto invalid_results = validate_batch_get_inputs(
+            client_ != nullptr, keys.size(), buffers.size(), sizes.size(),
+            "buffers")) {
+        return std::move(*invalid_results);
     }
 
     const size_t num_keys = keys.size();
@@ -4504,268 +4609,30 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
         return results;
     }
 
-    // Query metadata for all keys
     const auto query_results = client_->BatchQuery(keys);
-
-    // Process each key individually and prepare for batch transfer
-    struct ValidKeyInfo {
-        std::string key;
-        size_t original_index;
-        QueryResult query_result;
-        std::vector<Slice> slices;
-        uint64_t total_size;
-    };
-    struct DiskKeyInfo {
-        std::string key;
-        size_t original_index;
-        QueryResult query_result;
-        void *dst_buffer;
-        uint64_t total_size;
-    };
-
-    std::vector<ValidKeyInfo> valid_operations;
-    std::unordered_map<std::string, ValidKeyInfo> valid_local_disk_operations;
-    std::vector<DiskKeyInfo> disk_operations;
-    valid_operations.reserve(num_keys);
-
-    auto local_endpoints = client_->GetLocalEndpoints();
-    for (size_t i = 0; i < num_keys; ++i) {
-        const auto &key = keys[i];
-
-        // Handle query failures
-        if (!query_results[i]) {
-            const auto error = query_results[i].error();
-            results[i] = tl::unexpected(error);
-            if (error != ErrorCode::OBJECT_NOT_FOUND &&
-                error != ErrorCode::REPLICA_IS_NOT_READY) {
-                LOG(ERROR) << "Query failed for key '" << key
-                           << "': " << toString(error);
-            }
-            continue;
-        }
-
-        // Validate replica list
-        auto query_result_values = query_results[i].value();
-        if (query_result_values.replicas.empty()) {
-            LOG(ERROR) << "Empty replica list for key: " << key;
-            results[i] = tl::unexpected(ErrorCode::INVALID_REPLICA);
-            continue;
-        }
-
-        // Select best replica: prefer local MEMORY, then any MEMORY,
-        // then LOCAL_DISK, then DISK.
-        const auto *best_replica =
-            SelectBestReplica(query_result_values.replicas, local_endpoints);
-        if (!best_replica) {
-            LOG(ERROR) << "No usable replica for key: " << key;
-            results[i] = tl::unexpected(ErrorCode::INVALID_REPLICA);
-            continue;
-        }
-
-        // Calculate required buffer size
-        const auto replica = *best_replica;
-        uint64_t total_size = calculate_total_size(replica);
-
-        // Validate buffer capacity
-        if (sizes[i] < total_size) {
-            LOG(ERROR) << "Buffer too small for key '" << key
-                       << "': required=" << total_size
-                       << ", available=" << sizes[i];
-            results[i] = tl::unexpected(ErrorCode::INVALID_PARAMS);
-            continue;
-        }
-
-        if (replica.is_local_disk_replica()) {
+    auto start_read_store_time = std::chrono::steady_clock::now();
+    const auto stats = execute_batch_read_operations(
+        keys, query_results, results, client_->GetLocalEndpoints(),
+        [&](size_t i) { return sizes[i]; },
+        [&](size_t i, const Replica::Descriptor &replica) {
             std::vector<Slice> key_slices;
             allocateSlices(key_slices, replica, buffers[i]);
-            valid_local_disk_operations.emplace(
-                key,
-                ValidKeyInfo{.key = key,
-                             .original_index = i,
-                             .query_result = std::move(query_result_values),
-                             .slices = std::move(key_slices),
-                             .total_size = total_size});
-            results[i] = static_cast<int64_t>(total_size);
-            continue;
-        }
-        if (replica.is_disk_replica()) {
-            // DISK: file I/O (vector_read) cannot write to user GPU buffer.
-            // Defer — allocate CPU temp buffer, BatchGet, then scatter.
-            disk_operations.emplace_back(
-                DiskKeyInfo{.key = key,
-                            .original_index = i,
-                            .query_result = std::move(query_result_values),
-                            .dst_buffer = buffers[i],
-                            .total_size = total_size});
-            results[i] = static_cast<int64_t>(total_size);
-            continue;
-        }
-        // MEMORY: RDMA directly to user buffer.
-        std::vector<Slice> key_slices;
-        allocateSlices(key_slices, replica, buffers[i]);
-        valid_operations.push_back(
-            {.key = key,
-             .original_index = i,
-             .query_result = FilterQueryResult(query_result_values, replica),
-             .slices = std::move(key_slices),
-             .total_size = total_size});
-
-        // Set success result (actual bytes transferred)
-        results[i] = static_cast<int64_t>(total_size);
-    }
-
-    // Early return if no valid operations
-    if (valid_operations.empty() && valid_local_disk_operations.empty() &&
-        disk_operations.empty()) {
-        return results;
-    }
-
-    // Prepare batch transfer data structures
-    std::vector<std::string> batch_keys;
-    std::vector<QueryResult> batch_query_results;
-    std::unordered_map<std::string, std::vector<Slice>> batch_slices;
-
-    batch_keys.reserve(valid_operations.size());
-    batch_query_results.reserve(valid_operations.size());
-
-    for (const auto &op : valid_operations) {
-        batch_keys.push_back(op.key);
-        batch_query_results.push_back(op.query_result);
-        batch_slices[op.key] = op.slices;
-    }
-    if (!valid_operations.empty()) {
-        // Execute batch transfer
-        const auto batch_get_results =
-            client_->BatchGet(batch_keys, batch_query_results, batch_slices);
-
-        // Process transfer results
-        for (size_t j = 0; j < batch_get_results.size(); ++j) {
-            const auto &op = valid_operations[j];
-
-            if (!batch_get_results[j]) {
-                const auto error = batch_get_results[j].error();
-                LOG(ERROR) << "BatchGet failed for key '" << op.key
-                           << "': " << toString(error);
-                results[op.original_index] = tl::unexpected(error);
-            }
-        }
-    }
-
-    // ---- DISK replicas: BatchGet into CPU temp buffers, then scatter ----
-    if (!disk_operations.empty()) {
-        std::vector<std::string> disk_batch_keys;
-        std::vector<QueryResult> disk_batch_qrs;
-        std::unordered_map<std::string, std::vector<Slice>> disk_batch_slices;
-        std::vector<size_t> disk_batch_indices;
-        std::unordered_map<std::string, std::unique_ptr<BufferHandle>>
-            disk_temp_handles;
-
-        for (size_t di = 0; di < disk_operations.size(); ++di) {
-            auto &op = disk_operations[di];
-            // Find the DISK replica.
-            const Replica::Descriptor *replica_ptr = nullptr;
-            for (const auto &r : op.query_result.replicas) {
-                if (r.is_disk_replica()) {
-                    replica_ptr = &r;
-                    break;
-                }
-            }
-            if (!replica_ptr) {
-                LOG(ERROR) << "No DISK replica found for key: " << op.key;
-                results[op.original_index] =
-                    tl::unexpected(ErrorCode::INVALID_REPLICA);
-                continue;
-            }
-            auto alloc_result =
-                client_buffer_allocator_->allocate(op.total_size);
-            if (!alloc_result) {
-                LOG(ERROR) << "Failed to allocate temp buffer for DISK "
-                           << "read, key: " << op.key
-                           << ", size: " << op.total_size;
-                results[op.original_index] =
-                    tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
-                continue;
-            }
-            auto handle =
-                std::make_unique<BufferHandle>(std::move(*alloc_result));
-            std::vector<Slice> disk_slices;
-            allocateSlices(disk_slices, *replica_ptr, handle->ptr());
-            disk_batch_keys.push_back(op.key);
-            disk_batch_qrs.push_back(
-                FilterQueryResult(op.query_result, *replica_ptr));
-            disk_batch_slices[op.key] = std::move(disk_slices);
-            disk_batch_indices.push_back(di);
-            disk_temp_handles.emplace(op.key, std::move(handle));
-        }
-
-        if (!disk_batch_keys.empty()) {
-            auto disk_results = client_->BatchGet(
-                disk_batch_keys, disk_batch_qrs, disk_batch_slices);
-
-            for (size_t di = 0; di < disk_batch_indices.size(); ++di) {
-                const auto &key = disk_batch_keys[di];
-                auto &op = disk_operations[disk_batch_indices[di]];
-                auto handle_it = disk_temp_handles.find(key);
-                if (!disk_results[di]) {
-                    LOG(ERROR) << "DISK BatchGet failed for key '" << key
-                               << "': " << toString(disk_results[di].error());
-                    results[op.original_index] =
-                        tl::unexpected(disk_results[di].error());
-                    continue;
-                }
-                if (auto r = scatter_host_to_maybe_device(
-                        op.dst_buffer,
-                        static_cast<char *>(handle_it->second->ptr()),
-                        op.total_size, "DISK read, key: " + key);
-                    !r) {
-                    results[op.original_index] = tl::make_unexpected(r.error());
-                }
-            }
-        }
-    }
-
-    // Prepare batch transfer data structures
-    std::unordered_map<std::string,
-                       std::unordered_map<std::string, std::vector<Slice>>>
-        offload_objects;
-
-    for (const auto &op_it : valid_local_disk_operations) {
-        // Find the LOCAL_DISK replica from the list — replicas may be in
-        // any order from Master.
-        const Replica::Descriptor *replica_ptr = nullptr;
-        for (const auto &r : op_it.second.query_result.replicas) {
-            if (r.is_local_disk_replica()) {
-                replica_ptr = &r;
-                break;
-            }
-        }
-        if (!replica_ptr) {
-            LOG(ERROR) << "No LOCAL_DISK replica found for key: "
-                       << op_it.first;
-            continue;
-        }
-        const auto &replica = *replica_ptr;
-        auto [store_segment_it, _] = offload_objects.try_emplace(
-            replica.get_local_disk_descriptor().transport_endpoint);
-        store_segment_it->second.emplace(op_it.first, op_it.second.slices);
-    }
-
-    size_t offload_object_count = 0;
-    auto start_read_store_time = std::chrono::steady_clock::now();
-    for (auto &offload_objects_it : offload_objects) {
-        offload_object_count += offload_objects_it.second.size();
-        auto batch_get_offload_result = batch_get_into_offload_object_internal(
-            offload_objects_it.first, offload_objects_it.second);
-        if (!batch_get_offload_result) {
-            LOG(ERROR) << "Batch get store object failed with error: "
-                       << batch_get_offload_result.error();
-            for (const auto &offload_object_it : offload_objects_it.second) {
-                results[valid_local_disk_operations.at(offload_object_it.first)
-                            .original_index] =
-                    tl::make_unexpected(batch_get_offload_result.error());
-            }
-        }
-    }
+            return key_slices;
+        },
+        [](ErrorCode error) {
+            return error != ErrorCode::OBJECT_NOT_FOUND &&
+                   error != ErrorCode::REPLICA_IS_NOT_READY;
+        },
+        [&](const auto &batch_keys, const auto &batch_query_results,
+            auto &batch_slices) {
+            return client_->BatchGet(batch_keys, batch_query_results,
+                                     batch_slices);
+        },
+        [&](const std::string &transport_endpoint,
+            std::unordered_map<std::string, std::vector<Slice>> &objects) {
+            return batch_get_into_offload_object_internal(transport_endpoint,
+                                                          objects);
+        });
 
     auto end_time = std::chrono::steady_clock::now();
     auto elapsed_time = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -4775,10 +4642,10 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
         std::chrono::duration_cast<std::chrono::microseconds>(
             end_time - start_read_store_time)
             .count();
-    // LOG(INFO) << "Time taken for batch_get_into: " << elapsed_time
-    //           << "us, read store: " << read_store_time
-    //           << "us, with memory key count: " << valid_operations.size()
-    //           << ", offload key count: " << offload_object_count;
+    VLOG(1) << "Time taken for batch_get_into: " << elapsed_time
+            << "us, read store: " << read_store_time
+            << "us, with memory key count: " << stats.memory_operation_count
+            << ", offload key count: " << stats.offload_object_count;
 
     return results;
 }
@@ -4962,342 +4829,42 @@ RealClient::batch_get_into_multi_buffers_internal(
     const std::vector<std::vector<void *>> &all_buffers,
     const std::vector<std::vector<size_t>> &all_sizes,
     bool prefer_alloc_in_same_node) {
-    // Validate preconditions
-    if (!client_) {
-        LOG(ERROR) << "Client is not initialized";
-        return std::vector<tl::expected<int64_t, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-
-    if (keys.size() != all_buffers.size() || keys.size() != all_sizes.size()) {
-        LOG(ERROR) << "Input vector sizes mismatch: keys=" << keys.size()
-                   << ", buffers=" << all_buffers.size()
-                   << ", sizes=" << all_sizes.size();
-        return std::vector<tl::expected<int64_t, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    if (auto invalid_results = validate_batch_get_inputs(
+            client_ != nullptr, keys.size(), all_buffers.size(),
+            all_sizes.size(), "buffers")) {
+        return std::move(*invalid_results);
     }
 
     const size_t num_keys = keys.size();
-    std::vector<tl::expected<int64_t, ErrorCode>> results;
-    results.reserve(num_keys);
+    std::vector<tl::expected<int64_t, ErrorCode>> results(num_keys);
     if (num_keys == 0) {
         return results;
     }
-    // Query metadata for all keys
     const auto query_results = client_->BatchQuery(keys);
-    // Process each key individually and prepare for batch transfer
-    struct ValidKeyInfo {
-        std::string key;
-        size_t original_index;
-        QueryResult query_result;
-        std::vector<Slice> slices;
-        uint64_t total_size;
-    };
-
-    struct DiskKeyInfo {
-        std::string key;
-        size_t original_index;
-        QueryResult query_result;
-        std::vector<void *> buffers;
-        std::vector<size_t> sizes;
-        uint64_t total_size;
-        bool is_local_disk;  // true=LOCAL_DISK (offload RPC), false=DISK
-                             // (BatchGet)
-    };
-
-    std::vector<ValidKeyInfo> valid_operations;
-    std::unordered_map<std::string, DiskKeyInfo> valid_local_disk_ops;
-    valid_operations.reserve(num_keys);
-    auto local_endpoints = client_->GetLocalEndpoints();
-    for (size_t i = 0; i < num_keys; ++i) {
-        const auto &key = keys[i];
-        // Handle query failures
-        if (!query_results[i]) {
-            const auto error = query_results[i].error();
-            results.emplace_back(tl::unexpected(error));
-            if (error != ErrorCode::OBJECT_NOT_FOUND) {
-                LOG(ERROR) << "Query failed for key '" << key
-                           << "': " << toString(error);
-            }
-            continue;
-        }
-        // Validate replica list
-        auto query_result_values = query_results[i].value();
-        if (query_result_values.replicas.empty()) {
-            LOG(ERROR) << "Empty replica list for key: " << key;
-            results.emplace_back(tl::unexpected(ErrorCode::INVALID_REPLICA));
-            continue;
-        }
-        // Select best replica: prefer MEMORY (direct RDMA to GPU), then
-        // LOCAL_DISK, then DISK. Master may return multiple replicas in any
-        // order, so always scan rather than blindly taking replicas[0].
-        const auto *best_replica =
-            SelectBestReplica(query_result_values.replicas, local_endpoints);
-        if (!best_replica) {
-            LOG(ERROR) << "No usable replica for key: " << key;
-            results.emplace_back(tl::unexpected(ErrorCode::INVALID_REPLICA));
-            continue;
-        }
-        const auto replica = *best_replica;
-        uint64_t total_size = calculate_total_size(replica);
-        const auto &sizes = all_sizes[i];
-        uint64_t dst_total_size = 0;
-        for (auto &size : sizes) {
-            dst_total_size += size;
-        }
-        if (dst_total_size < total_size) {
-            LOG(ERROR) << "Buffer too small for key '" << key
-                       << "': required=" << total_size
-                       << ", available=" << dst_total_size;
-            results.emplace_back(tl::unexpected(ErrorCode::INVALID_PARAMS));
-            continue;
-        }
-        // Create slices for this key's buffer
-        const auto &buffers = all_buffers[i];
-        std::vector<Slice> key_slices;
-        key_slices.reserve(buffers.size());
-        if (replica.is_memory_replica()) {
-            // MEMORY: RDMA from remote memory directly to GPU (GPUDirect).
+    execute_batch_read_operations(
+        keys, query_results, results, client_->GetLocalEndpoints(),
+        [&](size_t i) { return static_cast<uint64_t>(sum_sizes(all_sizes[i])); },
+        [&](size_t i, const Replica::Descriptor &) {
+            const auto &buffers = all_buffers[i];
+            const auto &sizes = all_sizes[i];
+            std::vector<Slice> key_slices;
+            key_slices.reserve(buffers.size());
             for (size_t j = 0; j < buffers.size(); ++j) {
                 key_slices.emplace_back(Slice{buffers[j], sizes[j]});
             }
-        } else if (replica.is_local_disk_replica() ||
-                   replica.is_disk_replica()) {
-            // LOCAL_DISK: GPU buffers passed directly as scatter-gather slices
-            // (zero-copy). DISK: file I/O cannot write to GPU memory; temp CPU
-            // buffer used at read time.
-            valid_local_disk_ops.emplace(
-                key,
-                DiskKeyInfo{.key = key,
-                            .original_index = i,
-                            .query_result = std::move(query_result_values),
-                            .buffers = all_buffers[i],
-                            .sizes = all_sizes[i],
-                            .total_size = total_size,
-                            .is_local_disk = replica.is_local_disk_replica()});
-            results.emplace_back(static_cast<int64_t>(total_size));
-            continue;
-        } else {
-            LOG(ERROR) << "Unsupported replica type for key: " << key;
-            results.emplace_back(tl::unexpected(ErrorCode::INVALID_PARAMS));
-            continue;
-        }
-
-        valid_operations.push_back(
-            {.key = key,
-             .original_index = i,
-             .query_result = FilterQueryResult(query_result_values, replica),
-             .slices = std::move(key_slices),
-             .total_size = total_size});
-        // Set success result (actual bytes transferred)
-        results.emplace_back(static_cast<int64_t>(total_size));
-    }
-    // Early return if no valid operations
-    if (valid_operations.empty() && valid_local_disk_ops.empty()) {
-        return results;
-    }
-
-    // ---- Memory/Disk replica: existing BatchGet path ----
-    if (!valid_operations.empty()) {
-        std::vector<std::string> batch_keys;
-        std::vector<QueryResult> batch_query_results;
-        std::unordered_map<std::string, std::vector<Slice>> batch_slices;
-        batch_keys.reserve(valid_operations.size());
-        batch_query_results.reserve(valid_operations.size());
-        for (auto &op : valid_operations) {
-            batch_keys.push_back(op.key);
-            batch_query_results.push_back(op.query_result);
-            batch_slices[op.key] = op.slices;
-        }
-
-        auto batch_get_results =
-            client_->BatchGet(batch_keys, batch_query_results, batch_slices,
-                              prefer_alloc_in_same_node);
-
-        for (size_t j = 0; j < batch_get_results.size(); ++j) {
-            const auto &op = valid_operations[j];
-            if (!batch_get_results[j]) {
-                const auto error = batch_get_results[j].error();
-                LOG(ERROR) << "BatchGet failed for key '" << op.key
-                           << "': " << toString(error);
-                results[op.original_index] = tl::unexpected(error);
-            }
-        }
-    }
-
-    // ---- LOCAL_DISK / DISK replica: disk read paths ----
-    if (!valid_local_disk_ops.empty()) {
-        // LOCAL_DISK: pass user GPU buffers directly as scatter-gather slices.
-        // vLLM pre-registers all GPU KV-cache memory with TransferEngine via
-        // register_buffer(), so the offload RDMA can scatter the on-disk blob
-        // into non-contiguous per-layer GPU destinations natively — no temp
-        // CPU buffer or H2D copy needed.
-        {
-            std::unordered_map<
-                std::string,
-                std::unordered_map<std::string, std::vector<Slice>>>
-                offload_objects;
-
-            for (auto &[key, op] : valid_local_disk_ops) {
-                if (!op.is_local_disk) continue;
-                // Find the correct LOCAL_DISK replica — Master may return
-                // replicas in any order (e.g. [DISK, LOCAL_DISK]).
-                const Replica::Descriptor *replica_ptr = nullptr;
-                for (const auto &r : op.query_result.replicas) {
-                    if (r.is_local_disk_replica()) {
-                        replica_ptr = &r;
-                        break;
-                    }
-                }
-                if (!replica_ptr) {
-                    LOG(ERROR)
-                        << "No LOCAL_DISK replica found for key: " << key;
-                    results[op.original_index] =
-                        tl::make_unexpected(ErrorCode::INVALID_REPLICA);
-                    continue;
-                }
-                const auto &replica = *replica_ptr;
-                std::vector<Slice> user_slices;
-                user_slices.reserve(op.buffers.size());
-                size_t slice_total = 0;
-                for (size_t j = 0; j < op.buffers.size(); ++j) {
-                    user_slices.push_back(Slice{op.buffers[j], op.sizes[j]});
-                    slice_total += op.sizes[j];
-                }
-                if (slice_total < op.total_size) {
-                    LOG(ERROR) << "Slice size too small for key " << key
-                               << ": slices=" << slice_total
-                               << ", total=" << op.total_size;
-                    results[op.original_index] =
-                        tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-                    continue;
-                }
-                offload_objects[replica.get_local_disk_descriptor()
-                                    .transport_endpoint]
-                    .emplace(key, std::move(user_slices));
-            }
-
-            for (auto &[endpoint, objects] : offload_objects) {
-                if (objects.empty()) continue;
-                auto read_result =
-                    batch_get_into_offload_object_internal(endpoint, objects);
-                // On success: results[original_index] was already pre-filled
-                // with total_size when valid_local_disk_ops was built; nothing
-                // to update. Only overwrite on failure.
-                if (!read_result) {
-                    for (auto &[key, slices] : objects) {
-                        auto disk_it = valid_local_disk_ops.find(key);
-                        if (disk_it == valid_local_disk_ops.end()) continue;
-                        LOG(ERROR) << "SSD read failed for key '" << key
-                                   << "': " << toString(read_result.error());
-                        results[disk_it->second.original_index] =
-                            tl::make_unexpected(read_result.error());
-                    }
-                }
-            }
-        }
-
-        // DISK: one batched BatchGet into CPU temp buffers, then scatter.
-        // (storage_backend::vector_read cannot write directly to GPU memory)
-        {
-            // Scatter temp CPU buffer -> user multi_buffers (GPU or host).
-            // Returns false and sets results[original_index] on error.
-            auto scatter_to_buffers = [&](const std::string &key, char *src,
-                                          const DiskKeyInfo &op) -> bool {
-                size_t offset = 0;
-                for (size_t j = 0; j < op.buffers.size(); ++j) {
-                    if (offset >= op.total_size) break;
-                    size_t sz =
-                        std::min(op.sizes[j],
-                                 static_cast<size_t>(op.total_size - offset));
-                    void *dst = op.buffers[j];
-                    if (auto r = scatter_host_to_maybe_device(
-                            dst, src + offset, sz, "DISK scatter, key: " + key);
-                        !r) {
-                        results[op.original_index] =
-                            tl::make_unexpected(r.error());
-                        return false;
-                    }
-                    offset += sz;
-                }
-                return true;
-            };
-
-            std::vector<std::string> disk_batch_keys;
-            std::vector<QueryResult> disk_batch_qrs;
-            std::unordered_map<std::string, std::vector<Slice>>
-                disk_batch_slices;
-            std::vector<std::string> disk_key_order;
-            std::unordered_map<std::string, std::unique_ptr<BufferHandle>>
-                temp_handles;
-
-            for (auto &[key, op] : valid_local_disk_ops) {
-                if (op.is_local_disk) continue;
-                auto alloc_result =
-                    client_buffer_allocator_->allocate(op.total_size);
-                if (!alloc_result) {
-                    LOG(ERROR)
-                        << "Failed to allocate temp buffer for DISK "
-                        << "read, key: " << key << ", size: " << op.total_size;
-                    results[op.original_index] =
-                        tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
-                    continue;
-                }
-                auto handle =
-                    std::make_unique<BufferHandle>(std::move(*alloc_result));
-                // Find the correct DISK replica — Master may return
-                // replicas in any order (e.g. [LOCAL_DISK, DISK]).
-                const Replica::Descriptor *replica_ptr = nullptr;
-                for (const auto &r : op.query_result.replicas) {
-                    if (r.is_disk_replica()) {
-                        replica_ptr = &r;
-                        break;
-                    }
-                }
-                if (!replica_ptr) {
-                    LOG(ERROR) << "No DISK replica found for key: " << key;
-                    results[op.original_index] =
-                        tl::make_unexpected(ErrorCode::INVALID_REPLICA);
-                    continue;
-                }
-                const auto &replica = *replica_ptr;
-                std::vector<Slice> disk_slices;
-                allocateSlices(disk_slices, replica, handle->ptr());
-                disk_batch_keys.push_back(key);
-                disk_batch_qrs.push_back(
-                    FilterQueryResult(op.query_result, *replica_ptr));
-                disk_batch_slices[key] = std::move(disk_slices);
-                disk_key_order.push_back(key);
-                temp_handles.emplace(key, std::move(handle));
-            }
-
-            if (!disk_batch_keys.empty()) {
-                auto disk_results = client_->BatchGet(
-                    disk_batch_keys, disk_batch_qrs, disk_batch_slices,
-                    prefer_alloc_in_same_node);
-
-                for (size_t di = 0; di < disk_key_order.size(); ++di) {
-                    const auto &key = disk_key_order[di];
-                    auto &op = valid_local_disk_ops.at(key);
-                    auto handle_it = temp_handles.find(key);
-                    if (!disk_results[di]) {
-                        LOG(ERROR)
-                            << "DISK BatchGet failed for key '" << key
-                            << "': " << toString(disk_results[di].error());
-                        results[op.original_index] =
-                            tl::make_unexpected(disk_results[di].error());
-                        continue;
-                    }
-                    if (!scatter_to_buffers(
-                            key, static_cast<char *>(handle_it->second->ptr()),
-                            op))
-                        continue;
-                }
-            }
-            // temp_handles: BufferHandle RAII releases allocator memory
-        }
-    }
-
+            return key_slices;
+        },
+        [](ErrorCode error) { return error != ErrorCode::OBJECT_NOT_FOUND; },
+        [&](const auto &batch_keys, const auto &batch_query_results,
+            auto &batch_slices) {
+            return client_->BatchGet(batch_keys, batch_query_results,
+                                     batch_slices, prefer_alloc_in_same_node);
+        },
+        [&](const std::string &transport_endpoint,
+            std::unordered_map<std::string, std::vector<Slice>> &objects) {
+            return batch_get_into_offload_object_internal(transport_endpoint,
+                                                          objects);
+        });
     return results;
 }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3152,40 +3152,6 @@ RealClient::resolve_writable_buffer_region(void *buffer) const {
 }
 
 tl::expected<RealClient::RangedReadMetadata, ErrorCode>
-RealClient::build_ranged_read_metadata_from_query_result(
-    const std::string &key,
-    const tl::expected<QueryResult, ErrorCode> &query_result) {
-    if (!query_result) {
-        if (query_result.error() == ErrorCode::OBJECT_NOT_FOUND ||
-            query_result.error() == ErrorCode::REPLICA_IS_NOT_READY) {
-            return tl::unexpected(query_result.error());
-        }
-        LOG(ERROR) << "Query failed for key: " << key
-                   << " with error: " << toString(query_result.error());
-        return tl::unexpected(query_result.error());
-    }
-
-    const auto &replica_list = query_result->replicas;
-    if (replica_list.empty()) {
-        LOG(ERROR) << "Internal error: replica_list is empty";
-        return tl::unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    auto local_endpoints = client_->GetLocalEndpoints();
-    const auto *best_replica = SelectBestReplica(replica_list, local_endpoints);
-    if (!best_replica) {
-        LOG(ERROR) << "No usable replica for key: " << key;
-        return tl::unexpected(ErrorCode::INVALID_REPLICA);
-    }
-
-    auto query_value = query_result.value();
-    auto replica = *best_replica;
-    return RangedReadMetadata{.query_result = std::move(query_value),
-                              .replica = std::move(replica),
-                              .total_size = calculate_total_size(replica)};
-}
-
-tl::expected<RealClient::RangedReadMetadata, ErrorCode>
 RealClient::resolve_ranged_read_metadata(const std::string &key) {
     if (!client_) {
         LOG(ERROR) << "Client is not initialized";
@@ -3218,6 +3184,9 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     }
 
     if (src_offset == 0 && size == total_size) {
+        // LOCAL_DISK full-object read: destination buffer is passed
+        // directly to SSD RPC (same pattern as single-buffer batch_get_into;
+        // GPU buffers are pre-registered by vLLM via register_buffer).
         if (replica.is_local_disk_replica()) {
             const auto &endpoint =
                 replica.get_local_disk_descriptor().transport_endpoint;
@@ -3232,6 +3201,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         }
 
         if (replica.is_disk_replica()) {
+            // DISK full read: local file I/O (vector_read) cannot write to
+            // GPU memory. Use temp CPU buffer, then scatter to dst.
             auto alloc_result = client_buffer_allocator_->allocate(total_size);
             if (!alloc_result) {
                 LOG(ERROR) << "Failed to allocate temp buffer for DISK full "
@@ -3272,6 +3243,13 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return static_cast<int64_t>(total_size);
     }
 
+    // Partial disk read: allocate temp CPU buffer, invoke read_op to
+    // fill it, then scatter [src_offset, src_offset+size) to dst.
+    //
+    // buf_size controls how much to allocate / read.  DISK must use
+    // total_size (allocateSlices requires full-object slices).
+    // LOCAL_DISK can use src_offset + size (offload RPC transfers
+    // sequentially from remote offset 0).
     auto partial_disk_read =
         [&](auto &&read_op,
             size_t buf_size) -> tl::expected<int64_t, ErrorCode> {
@@ -3296,6 +3274,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     };
 
     if (replica.is_local_disk_replica()) {
+        // LOCAL_DISK: offload RPC transfers sequentially from remote offset
+        // 0, so we only need src_offset + size bytes (not total_size).
         return partial_disk_read(
             [&](void *tmp_buf) -> tl::expected<void, ErrorCode> {
                 const auto &endpoint =
@@ -3311,6 +3291,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     }
 
     if (replica.is_disk_replica()) {
+        // DISK: client_->Get + allocateSlices requires full-object slices,
+        // so we must allocate total_size.
         return partial_disk_read(
             [&](void *tmp_buf) -> tl::expected<void, ErrorCode> {
                 std::vector<mooncake::Slice> tmp_slices;
@@ -3374,16 +3356,6 @@ int64_t RealClient::get_into(const std::string &key, void *buffer,
                 static_cast<uint64_t>(ret.value()), latency_us);
         });
     return to_py_ret(result);
-}
-
-std::vector<tl::expected<QueryResult, ErrorCode>> RealClient::batch_query(
-    const std::vector<std::string> &keys) {
-    if (!client_) {
-        LOG(ERROR) << "Client is not initialized";
-        return std::vector<tl::expected<QueryResult, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-    return client_->BatchQuery(keys);
 }
 
 std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
@@ -3549,6 +3521,50 @@ std::vector<std::vector<std::vector<int64_t>>> RealClient::get_into_ranges(
                     sum_positive_ranges(ret), latency_us);
             });
     return results;
+}
+
+std::vector<tl::expected<QueryResult, ErrorCode>> RealClient::batch_query(
+    const std::vector<std::string> &keys) {
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return std::vector<tl::expected<QueryResult, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+    return client_->BatchQuery(keys);
+}
+
+tl::expected<RealClient::RangedReadMetadata, ErrorCode>
+RealClient::build_ranged_read_metadata_from_query_result(
+    const std::string &key,
+    const tl::expected<QueryResult, ErrorCode> &query_result) {
+    if (!query_result) {
+        if (query_result.error() == ErrorCode::OBJECT_NOT_FOUND ||
+            query_result.error() == ErrorCode::REPLICA_IS_NOT_READY) {
+            return tl::unexpected(query_result.error());
+        }
+        LOG(ERROR) << "Query failed for key: " << key
+                   << " with error: " << toString(query_result.error());
+        return tl::unexpected(query_result.error());
+    }
+
+    const auto &replica_list = query_result->replicas;
+    if (replica_list.empty()) {
+        LOG(ERROR) << "Internal error: replica_list is empty";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    auto local_endpoints = client_->GetLocalEndpoints();
+    const auto *best_replica = SelectBestReplica(replica_list, local_endpoints);
+    if (!best_replica) {
+        LOG(ERROR) << "No usable replica for key: " << key;
+        return tl::unexpected(ErrorCode::INVALID_REPLICA);
+    }
+
+    auto query_value = query_result.value();
+    auto replica = *best_replica;
+    return RangedReadMetadata{.query_result = std::move(query_value),
+                              .replica = std::move(replica),
+                              .total_size = calculate_total_size(replica)};
 }
 
 std::string RealClient::get_hostname() const { return local_hostname; }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -134,218 +134,6 @@ struct PreparedRangedReadRequest {
     bool has_any_valid_fragment = false;
 };
 
-struct PreparedBatchReadOp {
-    std::string key;
-    size_t original_index;
-    QueryResult query_result;
-    std::vector<Slice> slices;
-};
-
-template <typename Results>
-void apply_batch_get_failures(
-    const std::vector<tl::expected<void, ErrorCode>> &batch_get_results,
-    const std::vector<PreparedBatchReadOp> &valid_operations,
-    Results &results) {
-    for (size_t i = 0; i < batch_get_results.size(); ++i) {
-        if (batch_get_results[i]) {
-            continue;
-        }
-        const auto error = batch_get_results[i].error();
-        LOG(ERROR) << "BatchGet failed for key '" << valid_operations[i].key
-                   << "': " << toString(error);
-        results[valid_operations[i].original_index] = tl::unexpected(error);
-    }
-}
-
-template <typename Results>
-void apply_offload_failures(
-    const std::unordered_map<std::string, PreparedBatchReadOp>
-        &valid_local_disk_operations,
-    const std::unordered_map<std::string, std::vector<Slice>> &objects,
-    ErrorCode error, Results &results) {
-    for (const auto &[key, _] : objects) {
-        results[valid_local_disk_operations.at(key).original_index] =
-            tl::unexpected(error);
-    }
-}
-
-struct PreparedBatchReadSet {
-    std::vector<PreparedBatchReadOp> memory_operations;
-    std::unordered_map<std::string, PreparedBatchReadOp> local_disk_operations;
-};
-
-inline const Replica::Descriptor *SelectBestReplica(
-    const std::vector<Replica::Descriptor> &replicas,
-    const std::unordered_set<std::string> &local_endpoints);
-inline QueryResult FilterQueryResult(const QueryResult &qr,
-                                     const Replica::Descriptor &replica);
-
-template <typename Results, typename LocalEndpoints, typename AvailableSizeFn,
-          typename SliceBuilderFn, typename ShouldLogQueryErrorFn>
-PreparedBatchReadSet prepare_batch_read_operations(
-    const std::vector<std::string> &keys,
-    const std::vector<tl::expected<QueryResult, ErrorCode>> &query_results,
-    Results &results, const LocalEndpoints &local_endpoints,
-    AvailableSizeFn &&available_size_for_index,
-    SliceBuilderFn &&build_slices_for_index,
-    ShouldLogQueryErrorFn &&should_log_query_error) {
-    PreparedBatchReadSet prepared;
-    prepared.memory_operations.reserve(keys.size());
-    for (size_t i = 0; i < keys.size(); ++i) {
-        const auto &key = keys[i];
-        if (!query_results[i]) {
-            const auto error = query_results[i].error();
-            results[i] = tl::unexpected(error);
-            if (should_log_query_error(error)) {
-                LOG(ERROR) << "Query failed for key '" << key
-                           << "': " << toString(error);
-            }
-            continue;
-        }
-
-        auto query_result_values = query_results[i].value();
-        const auto *best_replica =
-            SelectBestReplica(query_result_values.replicas, local_endpoints);
-        if (!best_replica) {
-            LOG(ERROR) << "No usable replica for key: " << key;
-            results[i] = tl::unexpected(ErrorCode::INVALID_REPLICA);
-            continue;
-        }
-
-        const auto &replica = *best_replica;
-        const uint64_t total_size = calculate_total_size(replica);
-        const uint64_t available_size = available_size_for_index(i);
-        if (available_size < total_size) {
-            LOG(ERROR) << "Buffer too small for key '" << key
-                       << "': required=" << total_size
-                       << ", available=" << available_size;
-            results[i] = tl::unexpected(ErrorCode::INVALID_PARAMS);
-            continue;
-        }
-
-        auto filtered_query_result =
-            FilterQueryResult(query_result_values, replica);
-        auto key_slices = build_slices_for_index(i, replica);
-        if (replica.is_local_disk_replica()) {
-            prepared.local_disk_operations.emplace(
-                key, PreparedBatchReadOp{
-                         .key = key,
-                         .original_index = i,
-                         .query_result = std::move(filtered_query_result),
-                         .slices = std::move(key_slices)});
-        } else {
-            prepared.memory_operations.push_back(
-                {.key = key,
-                 .original_index = i,
-                 .query_result = std::move(filtered_query_result),
-                 .slices = std::move(key_slices)});
-        }
-        results[i] = static_cast<int64_t>(total_size);
-    }
-    return prepared;
-}
-
-template <typename Results, typename ExecuteBatchFn>
-size_t execute_local_disk_batch_reads(
-    const std::unordered_map<std::string, PreparedBatchReadOp>
-        &valid_local_disk_operations,
-    Results &results, ExecuteBatchFn &&execute_batch) {
-    std::unordered_map<std::string,
-                       std::unordered_map<std::string, std::vector<Slice>>>
-        offload_objects;
-    for (const auto &[key, op] : valid_local_disk_operations) {
-        const auto &replica = op.query_result.replicas.at(0);
-        auto [store_segment_it, _] = offload_objects.try_emplace(
-            replica.get_local_disk_descriptor().transport_endpoint);
-        store_segment_it->second.emplace(key, op.slices);
-    }
-
-    size_t offload_object_count = 0;
-    for (auto &[transport_endpoint, objects] : offload_objects) {
-        offload_object_count += objects.size();
-        auto batch_get_offload_result =
-            execute_batch(transport_endpoint, objects);
-        if (!batch_get_offload_result) {
-            LOG(ERROR) << "Batch get store object failed with error: "
-                       << batch_get_offload_result.error();
-            apply_offload_failures(valid_local_disk_operations, objects,
-                                   batch_get_offload_result.error(), results);
-        }
-    }
-    return offload_object_count;
-}
-
-struct BatchReadExecutionStats {
-    size_t memory_operation_count{0};
-    size_t offload_object_count{0};
-};
-
-std::optional<std::vector<tl::expected<int64_t, ErrorCode>>>
-validate_batch_get_inputs(bool client_ready, size_t key_count,
-                          size_t buffer_count, size_t size_count,
-                          const char *buffer_label) {
-    if (!client_ready) {
-        LOG(ERROR) << "Client is not initialized";
-        return std::vector<tl::expected<int64_t, ErrorCode>>(
-            key_count, tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-    if (key_count != buffer_count || key_count != size_count) {
-        LOG(ERROR) << "Input vector sizes mismatch: keys=" << key_count << ", "
-                   << buffer_label << "=" << buffer_count
-                   << ", sizes=" << size_count;
-        return std::vector<tl::expected<int64_t, ErrorCode>>(
-            key_count, tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-    return std::nullopt;
-}
-
-template <typename Results, typename LocalEndpoints, typename AvailableSizeFn,
-          typename SliceBuilderFn, typename ShouldLogQueryErrorFn,
-          typename ExecuteMemoryBatchFn, typename ExecuteOffloadBatchFn>
-BatchReadExecutionStats execute_batch_read_operations(
-    const std::vector<std::string> &keys,
-    const std::vector<tl::expected<QueryResult, ErrorCode>> &query_results,
-    Results &results, const LocalEndpoints &local_endpoints,
-    AvailableSizeFn &&available_size_for_index,
-    SliceBuilderFn &&build_slices_for_index,
-    ShouldLogQueryErrorFn &&should_log_query_error,
-    ExecuteMemoryBatchFn &&execute_memory_batch,
-    ExecuteOffloadBatchFn &&execute_offload_batch) {
-    auto prepared = prepare_batch_read_operations(
-        keys, query_results, results, local_endpoints,
-        std::forward<AvailableSizeFn>(available_size_for_index),
-        std::forward<SliceBuilderFn>(build_slices_for_index),
-        std::forward<ShouldLogQueryErrorFn>(should_log_query_error));
-    if (prepared.memory_operations.empty() &&
-        prepared.local_disk_operations.empty()) {
-        return {};
-    }
-
-    BatchReadExecutionStats stats{.memory_operation_count =
-                                      prepared.memory_operations.size()};
-    std::vector<std::string> batch_keys;
-    std::vector<QueryResult> batch_query_results;
-    std::unordered_map<std::string, std::vector<Slice>> batch_slices;
-    batch_keys.reserve(prepared.memory_operations.size());
-    batch_query_results.reserve(prepared.memory_operations.size());
-    for (const auto &op : prepared.memory_operations) {
-        batch_keys.push_back(op.key);
-        batch_query_results.push_back(op.query_result);
-        batch_slices[op.key] = op.slices;
-    }
-    if (!prepared.memory_operations.empty()) {
-        auto batch_get_results =
-            execute_memory_batch(batch_keys, batch_query_results, batch_slices);
-        apply_batch_get_failures(batch_get_results, prepared.memory_operations,
-                                 results);
-    }
-
-    stats.offload_object_count = execute_local_disk_batch_reads(
-        prepared.local_disk_operations, results,
-        std::forward<ExecuteOffloadBatchFn>(execute_offload_batch));
-    return stats;
-}
-
 size_t sum_value_sizes(const std::vector<std::span<const char>> &values) {
     size_t total = 0;
     for (const auto &value : values) {
@@ -3363,11 +3151,10 @@ RealClient::resolve_writable_buffer_region(void *buffer) const {
     return std::nullopt;
 }
 
-tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
+tl::expected<RealClient::RangedReadMetadata, ErrorCode>
+RealClient::build_ranged_read_metadata_from_query_result(
     const std::string &key,
-    const tl::expected<QueryResult, ErrorCode> &query_result, void *buffer,
-    size_t dst_offset, size_t src_offset, size_t size,
-    bool size_is_buffer_capacity) {
+    const tl::expected<QueryResult, ErrorCode> &query_result) {
     if (!query_result) {
         if (query_result.error() == ErrorCode::OBJECT_NOT_FOUND ||
             query_result.error() == ErrorCode::REPLICA_IS_NOT_READY) {
@@ -3391,30 +3178,31 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return tl::unexpected(ErrorCode::INVALID_REPLICA);
     }
 
-    const auto &replica = *best_replica;
-    const uint64_t total_size = calculate_total_size(replica);
-    const auto filtered_qr = FilterQueryResult(query_result.value(), replica);
-    auto get_via_client =
-        [&](void *dst, uint64_t read_offset,
-            bool read_full_object) -> tl::expected<void, ErrorCode> {
-        std::vector<Slice> slices;
-        if (read_full_object) {
-            allocateSlices(slices, replica, dst);
-            auto get_result = client_->Get(key, filtered_qr, slices);
-            if (!get_result) {
-                LOG(ERROR) << "Get failed for key: " << key
-                           << " with error: " << toString(get_result.error());
-                return tl::unexpected(get_result.error());
-            }
-            return {};
-        }
-        slices.emplace_back(Slice{static_cast<char *>(dst), size});
-        auto get_result = client_->Get(key, filtered_qr, slices, read_offset);
-        if (!get_result) {
-            return tl::unexpected(get_result.error());
-        }
-        return {};
-    };
+    auto query_value = query_result.value();
+    auto replica = *best_replica;
+    return RangedReadMetadata{.query_result = std::move(query_value),
+                              .replica = std::move(replica),
+                              .total_size = calculate_total_size(replica)};
+}
+
+tl::expected<RealClient::RangedReadMetadata, ErrorCode>
+RealClient::resolve_ranged_read_metadata(const std::string &key) {
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    return build_ranged_read_metadata_from_query_result(key,
+                                                        client_->Query(key));
+}
+
+tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
+    const std::string &key, void *buffer, size_t dst_offset, size_t src_offset,
+    size_t size, const RangedReadMetadata &metadata,
+    bool size_is_buffer_capacity) {
+    const auto &query_result = metadata.query_result;
+    const auto &replica = metadata.replica;
+    const uint64_t total_size = metadata.total_size;
 
     if (size_is_buffer_capacity) {
         if (size < total_size) {
@@ -3429,27 +3217,62 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    auto read_via_offload =
-        [&](void *dst, size_t read_size) -> tl::expected<void, ErrorCode> {
-        const auto &endpoint =
-            replica.get_local_disk_descriptor().transport_endpoint;
-        std::unordered_map<std::string, std::vector<Slice>> objects;
-        objects.emplace(
-            key, std::vector<Slice>{{static_cast<char *>(dst), read_size}});
-        return batch_get_into_offload_object_internal(endpoint, objects);
-    };
+    if (src_offset == 0 && size == total_size) {
+        if (replica.is_local_disk_replica()) {
+            const auto &endpoint =
+                replica.get_local_disk_descriptor().transport_endpoint;
+            std::unordered_map<std::string, std::vector<Slice>> objects;
+            objects.emplace(
+                key, std::vector<Slice>{
+                         {static_cast<char *>(buffer) + dst_offset, size}});
+            auto result =
+                batch_get_into_offload_object_internal(endpoint, objects);
+            if (!result) return tl::unexpected(result.error());
+            return static_cast<int64_t>(total_size);
+        }
 
-    if (src_offset == 0 && size == total_size &&
-        replica.is_local_disk_replica()) {
-        auto read_result =
-            read_via_offload(static_cast<char *>(buffer) + dst_offset, size);
-        if (!read_result) {
-            return tl::unexpected(read_result.error());
+        if (replica.is_disk_replica()) {
+            auto alloc_result = client_buffer_allocator_->allocate(total_size);
+            if (!alloc_result) {
+                LOG(ERROR) << "Failed to allocate temp buffer for DISK full "
+                           << "read, key: " << key << ", size: " << total_size;
+                return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+            }
+            BufferHandle tmp_handle(std::move(*alloc_result));
+            std::vector<mooncake::Slice> tmp_slices;
+            allocateSlices(tmp_slices, replica, tmp_handle.ptr());
+            auto filtered_qr = FilterQueryResult(query_result, replica);
+            auto get_result = client_->Get(key, filtered_qr, tmp_slices);
+            if (!get_result) {
+                LOG(ERROR) << "DISK Get failed for key: " << key
+                           << " with error: " << toString(get_result.error());
+                return tl::unexpected(get_result.error());
+            }
+            void *dst = static_cast<char *>(buffer) + dst_offset;
+            const void *src = tmp_handle.ptr();
+            if (auto r = scatter_host_to_maybe_device(
+                    dst, src, total_size, "DISK full read, key: " + key);
+                !r) {
+                return tl::unexpected(r.error());
+            }
+            return static_cast<int64_t>(total_size);
+        }
+
+        std::vector<mooncake::Slice> slices;
+        allocateSlices(slices, replica,
+                       static_cast<char *>(buffer) + dst_offset);
+
+        auto filtered_qr = FilterQueryResult(query_result, replica);
+        auto get_result = client_->Get(key, filtered_qr, slices);
+        if (!get_result) {
+            LOG(ERROR) << "Get failed for key: " << key
+                       << " with error: " << toString(get_result.error());
+            return tl::unexpected(get_result.error());
         }
         return static_cast<int64_t>(total_size);
     }
 
-    auto read_via_temp_host_buffer =
+    auto partial_disk_read =
         [&](auto &&read_op,
             size_t buf_size) -> tl::expected<int64_t, ErrorCode> {
         auto alloc_result = client_buffer_allocator_->allocate(buf_size);
@@ -3460,9 +3283,7 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         }
         BufferHandle tmp_handle(std::move(*alloc_result));
         auto read_result = read_op(tmp_handle.ptr());
-        if (!read_result) {
-            return tl::unexpected(read_result.error());
-        }
+        if (!read_result) return tl::unexpected(read_result.error());
         void *dst = static_cast<char *>(buffer) + dst_offset;
         const void *src =
             static_cast<const char *>(tmp_handle.ptr()) + src_offset;
@@ -3475,17 +3296,34 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     };
 
     if (replica.is_local_disk_replica()) {
-        return read_via_temp_host_buffer(
+        return partial_disk_read(
             [&](void *tmp_buf) -> tl::expected<void, ErrorCode> {
-                return read_via_offload(tmp_buf, src_offset + size);
+                const auto &endpoint =
+                    replica.get_local_disk_descriptor().transport_endpoint;
+                std::unordered_map<std::string, std::vector<Slice>> objects;
+                objects.emplace(
+                    key, std::vector<Slice>{{static_cast<char *>(tmp_buf),
+                                             src_offset + size}});
+                return batch_get_into_offload_object_internal(endpoint,
+                                                              objects);
             },
             src_offset + size);
     }
 
     if (replica.is_disk_replica()) {
-        return read_via_temp_host_buffer(
+        return partial_disk_read(
             [&](void *tmp_buf) -> tl::expected<void, ErrorCode> {
-                return get_via_client(tmp_buf, 0, true);
+                std::vector<mooncake::Slice> tmp_slices;
+                allocateSlices(tmp_slices, replica, tmp_buf);
+                auto filtered_qr = FilterQueryResult(query_result, replica);
+                auto get_result = client_->Get(key, filtered_qr, tmp_slices);
+                if (!get_result) {
+                    LOG(ERROR)
+                        << "DISK Get failed for key: " << key
+                        << " with error: " << toString(get_result.error());
+                    return tl::unexpected(get_result.error());
+                }
+                return {};
             },
             total_size);
     }
@@ -3495,11 +3333,12 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return tl::unexpected(ErrorCode::INVALID_REPLICA);
     }
 
-    auto read_result =
-        get_via_client(static_cast<char *>(buffer) + dst_offset, src_offset,
-                       src_offset == 0 && size == total_size);
-    if (!read_result) {
-        return tl::unexpected(read_result.error());
+    std::vector<Slice> slices;
+    slices.emplace_back(Slice{static_cast<char *>(buffer) + dst_offset, size});
+
+    auto get_result = client_->Get(key, query_result, slices, src_offset);
+    if (!get_result) {
+        return tl::unexpected(get_result.error());
     }
     return static_cast<int64_t>(size);
 }
@@ -3507,21 +3346,19 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
 tl::expected<int64_t, ErrorCode> RealClient::get_into_range_internal(
     const std::string &key, void *buffer, size_t dst_offset, size_t src_offset,
     size_t size, bool size_is_buffer_capacity) {
-    if (!client_) {
-        LOG(ERROR) << "Client is not initialized";
-        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    auto metadata_result = resolve_ranged_read_metadata(key);
+    if (!metadata_result) {
+        if ((metadata_result.error() == ErrorCode::OBJECT_NOT_FOUND ||
+             metadata_result.error() == ErrorCode::REPLICA_IS_NOT_READY) &&
+            src_offset == 0) {
+            VLOG(1) << "Object not found for key: " << key;
+        }
+        return tl::unexpected(metadata_result.error());
     }
 
-    auto query_result = client_->Query(key);
-    if (!query_result &&
-        (query_result.error() == ErrorCode::OBJECT_NOT_FOUND ||
-         query_result.error() == ErrorCode::REPLICA_IS_NOT_READY) &&
-        src_offset == 0) {
-        VLOG(1) << "Object not found for key: " << key;
-    }
-
-    return execute_ranged_read(key, query_result, buffer, dst_offset,
-                               src_offset, size, size_is_buffer_capacity);
+    return execute_ranged_read(key, buffer, dst_offset, src_offset, size,
+                               metadata_result.value(),
+                               size_is_buffer_capacity);
 }
 
 int64_t RealClient::get_into(const std::string &key, void *buffer,
@@ -3608,67 +3445,22 @@ RealClient::get_into_ranges_internal(
         }
     }
 
+    std::unordered_map<std::string, tl::expected<RangedReadMetadata, ErrorCode>>
+        metadata_cache;
     size_t key_count_hint = 0;
     for (const auto &keys : all_keys) {
         key_count_hint += keys.size();
     }
-
-    QueryResultCache resolved_query_results;
-    resolved_query_results.reserve(key_count_hint);
+    metadata_cache.reserve(key_count_hint);
     auto now = std::chrono::steady_clock::now();
     if (query_result_cache != nullptr) {
         for (const auto &[key, query_result] : *query_result_cache) {
             if (query_result && query_result->IsLeaseExpired(now)) {
                 continue;
             }
-            resolved_query_results.emplace(key, query_result);
-        }
-    }
-
-    std::vector<std::string> missing_keys;
-    missing_keys.reserve(key_count_hint);
-    std::unordered_set<std::string> seen_missing_keys;
-    seen_missing_keys.reserve(key_count_hint);
-    for (size_t i = 0; i < buffer_count; ++i) {
-        if (buffer_capacities == nullptr &&
-            resolved_buffer_capacities[i] == 0 && !all_keys[i].empty()) {
-            continue;
-        }
-        if (all_keys[i].size() != prepared.valid_fragments[i].size()) {
-            LOG(ERROR) << "get_into_ranges: metadata key-group size mismatch";
-            continue;
-        }
-        for (size_t j = 0; j < all_keys[i].size(); ++j) {
-            if (resolved_query_results.find(all_keys[i][j]) !=
-                resolved_query_results.end()) {
-                continue;
-            }
-            const bool has_valid_fragment =
-                std::any_of(prepared.valid_fragments[i][j].begin(),
-                            prepared.valid_fragments[i][j].end(),
-                            [](bool valid_fragment) { return valid_fragment; });
-            if (!has_valid_fragment) {
-                continue;
-            }
-            if (seen_missing_keys.insert(all_keys[i][j]).second) {
-                missing_keys.push_back(all_keys[i][j]);
-            }
-        }
-    }
-
-    if (!missing_keys.empty()) {
-        auto query_results = client_->BatchQuery(missing_keys);
-        if (query_results.size() != missing_keys.size()) {
-            LOG(ERROR) << "BatchQuery result size mismatch in get_into_ranges";
-            for (const auto &key : missing_keys) {
-                resolved_query_results.emplace(
-                    key, tl::unexpected(ErrorCode::RPC_FAIL));
-            }
-        } else {
-            for (size_t i = 0; i < missing_keys.size(); ++i) {
-                resolved_query_results.emplace(missing_keys[i],
-                                               std::move(query_results[i]));
-            }
+            metadata_cache.emplace(key,
+                                   build_ranged_read_metadata_from_query_result(
+                                       key, query_result));
         }
     }
 
@@ -3680,13 +3472,18 @@ RealClient::get_into_ranges_internal(
         }
 
         for (size_t j = 0; j < key_count; ++j) {
-            auto query_result_it = resolved_query_results.find(all_keys[i][j]);
-            if (query_result_it == resolved_query_results.end()) {
-                prepared.results[i][j].assign(
-                    prepared.results[i][j].size(),
-                    tl::unexpected(ErrorCode::INVALID_PARAMS));
-                continue;
+            auto metadata_it = metadata_cache.find(all_keys[i][j]);
+            if (metadata_it == metadata_cache.end()) {
+                metadata_it =
+                    metadata_cache
+                        .emplace(
+                            all_keys[i][j],
+                            build_ranged_read_metadata_from_query_result(
+                                all_keys[i][j], client_->Query(all_keys[i][j])))
+                        .first;
             }
+            auto &metadata_result = metadata_it->second;
+
             for (size_t k = 0; k < prepared.results[i][j].size(); ++k) {
                 if (!prepared.valid_fragments[i][j][k]) {
                     continue;
@@ -3706,24 +3503,24 @@ RealClient::get_into_ranges_internal(
                     continue;
                 }
 
-                if (!query_result_it->second) {
-                    if ((query_result_it->second.error() ==
+                if (!metadata_result) {
+                    if ((metadata_result.error() ==
                              ErrorCode::OBJECT_NOT_FOUND ||
-                         query_result_it->second.error() ==
+                         metadata_result.error() ==
                              ErrorCode::REPLICA_IS_NOT_READY) &&
                         all_src_offsets[i][j][k] == 0) {
                         VLOG(1)
                             << "Object not found for key: " << all_keys[i][j];
                     }
                     prepared.results[i][j][k] =
-                        tl::unexpected(query_result_it->second.error());
+                        tl::unexpected(metadata_result.error());
                     continue;
                 }
 
                 prepared.results[i][j][k] = execute_ranged_read(
-                    all_keys[i][j], query_result_it->second, buffers[i],
-                    all_dst_offsets[i][j][k], all_src_offsets[i][j][k],
-                    all_sizes[i][j][k]);
+                    all_keys[i][j], buffers[i], all_dst_offsets[i][j][k],
+                    all_src_offsets[i][j][k], all_sizes[i][j][k],
+                    metadata_result.value());
             }
         }
     }
@@ -4596,10 +4393,19 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
                                     const std::vector<void *> &buffers,
                                     const std::vector<size_t> &sizes) {
     auto start_time = std::chrono::steady_clock::now();
-    if (auto invalid_results = validate_batch_get_inputs(
-            client_ != nullptr, keys.size(), buffers.size(), sizes.size(),
-            "buffers")) {
-        return std::move(*invalid_results);
+    // Validate preconditions
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return std::vector<tl::expected<int64_t, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+
+    if (keys.size() != buffers.size() || keys.size() != sizes.size()) {
+        LOG(ERROR) << "Input vector sizes mismatch: keys=" << keys.size()
+                   << ", buffers=" << buffers.size()
+                   << ", sizes=" << sizes.size();
+        return std::vector<tl::expected<int64_t, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
     }
 
     const size_t num_keys = keys.size();
@@ -4609,30 +4415,268 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
         return results;
     }
 
+    // Query metadata for all keys
     const auto query_results = client_->BatchQuery(keys);
-    auto start_read_store_time = std::chrono::steady_clock::now();
-    const auto stats = execute_batch_read_operations(
-        keys, query_results, results, client_->GetLocalEndpoints(),
-        [&](size_t i) { return sizes[i]; },
-        [&](size_t i, const Replica::Descriptor &replica) {
+
+    // Process each key individually and prepare for batch transfer
+    struct ValidKeyInfo {
+        std::string key;
+        size_t original_index;
+        QueryResult query_result;
+        std::vector<Slice> slices;
+        uint64_t total_size;
+    };
+    struct DiskKeyInfo {
+        std::string key;
+        size_t original_index;
+        QueryResult query_result;
+        void *dst_buffer;
+        uint64_t total_size;
+    };
+
+    std::vector<ValidKeyInfo> valid_operations;
+    std::unordered_map<std::string, ValidKeyInfo> valid_local_disk_operations;
+    std::vector<DiskKeyInfo> disk_operations;
+    valid_operations.reserve(num_keys);
+
+    auto local_endpoints = client_->GetLocalEndpoints();
+    for (size_t i = 0; i < num_keys; ++i) {
+        const auto &key = keys[i];
+
+        // Handle query failures
+        if (!query_results[i]) {
+            const auto error = query_results[i].error();
+            results[i] = tl::unexpected(error);
+            if (error != ErrorCode::OBJECT_NOT_FOUND &&
+                error != ErrorCode::REPLICA_IS_NOT_READY) {
+                LOG(ERROR) << "Query failed for key '" << key
+                           << "': " << toString(error);
+            }
+            continue;
+        }
+
+        // Validate replica list
+        auto query_result_values = query_results[i].value();
+        if (query_result_values.replicas.empty()) {
+            LOG(ERROR) << "Empty replica list for key: " << key;
+            results[i] = tl::unexpected(ErrorCode::INVALID_REPLICA);
+            continue;
+        }
+
+        // Select best replica: prefer local MEMORY, then any MEMORY,
+        // then LOCAL_DISK, then DISK.
+        const auto *best_replica =
+            SelectBestReplica(query_result_values.replicas, local_endpoints);
+        if (!best_replica) {
+            LOG(ERROR) << "No usable replica for key: " << key;
+            results[i] = tl::unexpected(ErrorCode::INVALID_REPLICA);
+            continue;
+        }
+
+        // Calculate required buffer size
+        const auto replica = *best_replica;
+        uint64_t total_size = calculate_total_size(replica);
+
+        // Validate buffer capacity
+        if (sizes[i] < total_size) {
+            LOG(ERROR) << "Buffer too small for key '" << key
+                       << "': required=" << total_size
+                       << ", available=" << sizes[i];
+            results[i] = tl::unexpected(ErrorCode::INVALID_PARAMS);
+            continue;
+        }
+
+        if (replica.is_local_disk_replica()) {
             std::vector<Slice> key_slices;
             allocateSlices(key_slices, replica, buffers[i]);
-            return key_slices;
-        },
-        [](ErrorCode error) {
-            return error != ErrorCode::OBJECT_NOT_FOUND &&
-                   error != ErrorCode::REPLICA_IS_NOT_READY;
-        },
-        [&](const auto &batch_keys, const auto &batch_query_results,
-            auto &batch_slices) {
-            return client_->BatchGet(batch_keys, batch_query_results,
-                                     batch_slices);
-        },
-        [&](const std::string &transport_endpoint,
-            std::unordered_map<std::string, std::vector<Slice>> &objects) {
-            return batch_get_into_offload_object_internal(transport_endpoint,
-                                                          objects);
-        });
+            valid_local_disk_operations.emplace(
+                key,
+                ValidKeyInfo{.key = key,
+                             .original_index = i,
+                             .query_result = std::move(query_result_values),
+                             .slices = std::move(key_slices),
+                             .total_size = total_size});
+            results[i] = static_cast<int64_t>(total_size);
+            continue;
+        }
+        if (replica.is_disk_replica()) {
+            // DISK: file I/O (vector_read) cannot write to user GPU buffer.
+            // Defer — allocate CPU temp buffer, BatchGet, then scatter.
+            disk_operations.emplace_back(
+                DiskKeyInfo{.key = key,
+                            .original_index = i,
+                            .query_result = std::move(query_result_values),
+                            .dst_buffer = buffers[i],
+                            .total_size = total_size});
+            results[i] = static_cast<int64_t>(total_size);
+            continue;
+        }
+        // MEMORY: RDMA directly to user buffer.
+        std::vector<Slice> key_slices;
+        allocateSlices(key_slices, replica, buffers[i]);
+        valid_operations.push_back(
+            {.key = key,
+             .original_index = i,
+             .query_result = FilterQueryResult(query_result_values, replica),
+             .slices = std::move(key_slices),
+             .total_size = total_size});
+
+        // Set success result (actual bytes transferred)
+        results[i] = static_cast<int64_t>(total_size);
+    }
+
+    // Early return if no valid operations
+    if (valid_operations.empty() && valid_local_disk_operations.empty() &&
+        disk_operations.empty()) {
+        return results;
+    }
+
+    // Prepare batch transfer data structures
+    std::vector<std::string> batch_keys;
+    std::vector<QueryResult> batch_query_results;
+    std::unordered_map<std::string, std::vector<Slice>> batch_slices;
+
+    batch_keys.reserve(valid_operations.size());
+    batch_query_results.reserve(valid_operations.size());
+
+    for (const auto &op : valid_operations) {
+        batch_keys.push_back(op.key);
+        batch_query_results.push_back(op.query_result);
+        batch_slices[op.key] = op.slices;
+    }
+    if (!valid_operations.empty()) {
+        // Execute batch transfer
+        const auto batch_get_results =
+            client_->BatchGet(batch_keys, batch_query_results, batch_slices);
+
+        // Process transfer results
+        for (size_t j = 0; j < batch_get_results.size(); ++j) {
+            const auto &op = valid_operations[j];
+
+            if (!batch_get_results[j]) {
+                const auto error = batch_get_results[j].error();
+                LOG(ERROR) << "BatchGet failed for key '" << op.key
+                           << "': " << toString(error);
+                results[op.original_index] = tl::unexpected(error);
+            }
+        }
+    }
+
+    // ---- DISK replicas: BatchGet into CPU temp buffers, then scatter ----
+    if (!disk_operations.empty()) {
+        std::vector<std::string> disk_batch_keys;
+        std::vector<QueryResult> disk_batch_qrs;
+        std::unordered_map<std::string, std::vector<Slice>> disk_batch_slices;
+        std::vector<size_t> disk_batch_indices;
+        std::unordered_map<std::string, std::unique_ptr<BufferHandle>>
+            disk_temp_handles;
+
+        for (size_t di = 0; di < disk_operations.size(); ++di) {
+            auto &op = disk_operations[di];
+            // Find the DISK replica.
+            const Replica::Descriptor *replica_ptr = nullptr;
+            for (const auto &r : op.query_result.replicas) {
+                if (r.is_disk_replica()) {
+                    replica_ptr = &r;
+                    break;
+                }
+            }
+            if (!replica_ptr) {
+                LOG(ERROR) << "No DISK replica found for key: " << op.key;
+                results[op.original_index] =
+                    tl::unexpected(ErrorCode::INVALID_REPLICA);
+                continue;
+            }
+            auto alloc_result =
+                client_buffer_allocator_->allocate(op.total_size);
+            if (!alloc_result) {
+                LOG(ERROR) << "Failed to allocate temp buffer for DISK "
+                           << "read, key: " << op.key
+                           << ", size: " << op.total_size;
+                results[op.original_index] =
+                    tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+                continue;
+            }
+            auto handle =
+                std::make_unique<BufferHandle>(std::move(*alloc_result));
+            std::vector<Slice> disk_slices;
+            allocateSlices(disk_slices, *replica_ptr, handle->ptr());
+            disk_batch_keys.push_back(op.key);
+            disk_batch_qrs.push_back(
+                FilterQueryResult(op.query_result, *replica_ptr));
+            disk_batch_slices[op.key] = std::move(disk_slices);
+            disk_batch_indices.push_back(di);
+            disk_temp_handles.emplace(op.key, std::move(handle));
+        }
+
+        if (!disk_batch_keys.empty()) {
+            auto disk_results = client_->BatchGet(
+                disk_batch_keys, disk_batch_qrs, disk_batch_slices);
+
+            for (size_t di = 0; di < disk_batch_indices.size(); ++di) {
+                const auto &key = disk_batch_keys[di];
+                auto &op = disk_operations[disk_batch_indices[di]];
+                auto handle_it = disk_temp_handles.find(key);
+                if (!disk_results[di]) {
+                    LOG(ERROR) << "DISK BatchGet failed for key '" << key
+                               << "': " << toString(disk_results[di].error());
+                    results[op.original_index] =
+                        tl::unexpected(disk_results[di].error());
+                    continue;
+                }
+                if (auto r = scatter_host_to_maybe_device(
+                        op.dst_buffer,
+                        static_cast<char *>(handle_it->second->ptr()),
+                        op.total_size, "DISK read, key: " + key);
+                    !r) {
+                    results[op.original_index] = tl::make_unexpected(r.error());
+                }
+            }
+        }
+    }
+
+    // Prepare batch transfer data structures
+    std::unordered_map<std::string,
+                       std::unordered_map<std::string, std::vector<Slice>>>
+        offload_objects;
+
+    for (const auto &op_it : valid_local_disk_operations) {
+        // Find the LOCAL_DISK replica from the list — replicas may be in
+        // any order from Master.
+        const Replica::Descriptor *replica_ptr = nullptr;
+        for (const auto &r : op_it.second.query_result.replicas) {
+            if (r.is_local_disk_replica()) {
+                replica_ptr = &r;
+                break;
+            }
+        }
+        if (!replica_ptr) {
+            LOG(ERROR) << "No LOCAL_DISK replica found for key: "
+                       << op_it.first;
+            continue;
+        }
+        const auto &replica = *replica_ptr;
+        auto [store_segment_it, _] = offload_objects.try_emplace(
+            replica.get_local_disk_descriptor().transport_endpoint);
+        store_segment_it->second.emplace(op_it.first, op_it.second.slices);
+    }
+
+    size_t offload_object_count = 0;
+    auto start_read_store_time = std::chrono::steady_clock::now();
+    for (auto &offload_objects_it : offload_objects) {
+        offload_object_count += offload_objects_it.second.size();
+        auto batch_get_offload_result = batch_get_into_offload_object_internal(
+            offload_objects_it.first, offload_objects_it.second);
+        if (!batch_get_offload_result) {
+            LOG(ERROR) << "Batch get store object failed with error: "
+                       << batch_get_offload_result.error();
+            for (const auto &offload_object_it : offload_objects_it.second) {
+                results[valid_local_disk_operations.at(offload_object_it.first)
+                            .original_index] =
+                    tl::make_unexpected(batch_get_offload_result.error());
+            }
+        }
+    }
 
     auto end_time = std::chrono::steady_clock::now();
     auto elapsed_time = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -4642,10 +4686,10 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
         std::chrono::duration_cast<std::chrono::microseconds>(
             end_time - start_read_store_time)
             .count();
-    VLOG(1) << "Time taken for batch_get_into: " << elapsed_time
-            << "us, read store: " << read_store_time
-            << "us, with memory key count: " << stats.memory_operation_count
-            << ", offload key count: " << stats.offload_object_count;
+    // LOG(INFO) << "Time taken for batch_get_into: " << elapsed_time
+    //           << "us, read store: " << read_store_time
+    //           << "us, with memory key count: " << valid_operations.size()
+    //           << ", offload key count: " << offload_object_count;
 
     return results;
 }
@@ -4829,44 +4873,342 @@ RealClient::batch_get_into_multi_buffers_internal(
     const std::vector<std::vector<void *>> &all_buffers,
     const std::vector<std::vector<size_t>> &all_sizes,
     bool prefer_alloc_in_same_node) {
-    if (auto invalid_results = validate_batch_get_inputs(
-            client_ != nullptr, keys.size(), all_buffers.size(),
-            all_sizes.size(), "buffers")) {
-        return std::move(*invalid_results);
+    // Validate preconditions
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return std::vector<tl::expected<int64_t, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+
+    if (keys.size() != all_buffers.size() || keys.size() != all_sizes.size()) {
+        LOG(ERROR) << "Input vector sizes mismatch: keys=" << keys.size()
+                   << ", buffers=" << all_buffers.size()
+                   << ", sizes=" << all_sizes.size();
+        return std::vector<tl::expected<int64_t, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
     }
 
     const size_t num_keys = keys.size();
-    std::vector<tl::expected<int64_t, ErrorCode>> results(num_keys);
+    std::vector<tl::expected<int64_t, ErrorCode>> results;
+    results.reserve(num_keys);
     if (num_keys == 0) {
         return results;
     }
+    // Query metadata for all keys
     const auto query_results = client_->BatchQuery(keys);
-    execute_batch_read_operations(
-        keys, query_results, results, client_->GetLocalEndpoints(),
-        [&](size_t i) {
-            return static_cast<uint64_t>(sum_sizes(all_sizes[i]));
-        },
-        [&](size_t i, const Replica::Descriptor &) {
-            const auto &buffers = all_buffers[i];
-            const auto &sizes = all_sizes[i];
-            std::vector<Slice> key_slices;
-            key_slices.reserve(buffers.size());
+    // Process each key individually and prepare for batch transfer
+    struct ValidKeyInfo {
+        std::string key;
+        size_t original_index;
+        QueryResult query_result;
+        std::vector<Slice> slices;
+        uint64_t total_size;
+    };
+
+    struct DiskKeyInfo {
+        std::string key;
+        size_t original_index;
+        QueryResult query_result;
+        std::vector<void *> buffers;
+        std::vector<size_t> sizes;
+        uint64_t total_size;
+        bool is_local_disk;  // true=LOCAL_DISK (offload RPC), false=DISK
+                             // (BatchGet)
+    };
+
+    std::vector<ValidKeyInfo> valid_operations;
+    std::unordered_map<std::string, DiskKeyInfo> valid_local_disk_ops;
+    valid_operations.reserve(num_keys);
+    auto local_endpoints = client_->GetLocalEndpoints();
+    for (size_t i = 0; i < num_keys; ++i) {
+        const auto &key = keys[i];
+        // Handle query failures
+        if (!query_results[i]) {
+            const auto error = query_results[i].error();
+            results.emplace_back(tl::unexpected(error));
+            if (error != ErrorCode::OBJECT_NOT_FOUND) {
+                LOG(ERROR) << "Query failed for key '" << key
+                           << "': " << toString(error);
+            }
+            continue;
+        }
+        // Validate replica list
+        auto query_result_values = query_results[i].value();
+        if (query_result_values.replicas.empty()) {
+            LOG(ERROR) << "Empty replica list for key: " << key;
+            results.emplace_back(tl::unexpected(ErrorCode::INVALID_REPLICA));
+            continue;
+        }
+        // Select best replica: prefer MEMORY (direct RDMA to GPU), then
+        // LOCAL_DISK, then DISK. Master may return multiple replicas in any
+        // order, so always scan rather than blindly taking replicas[0].
+        const auto *best_replica =
+            SelectBestReplica(query_result_values.replicas, local_endpoints);
+        if (!best_replica) {
+            LOG(ERROR) << "No usable replica for key: " << key;
+            results.emplace_back(tl::unexpected(ErrorCode::INVALID_REPLICA));
+            continue;
+        }
+        const auto replica = *best_replica;
+        uint64_t total_size = calculate_total_size(replica);
+        const auto &sizes = all_sizes[i];
+        uint64_t dst_total_size = 0;
+        for (auto &size : sizes) {
+            dst_total_size += size;
+        }
+        if (dst_total_size < total_size) {
+            LOG(ERROR) << "Buffer too small for key '" << key
+                       << "': required=" << total_size
+                       << ", available=" << dst_total_size;
+            results.emplace_back(tl::unexpected(ErrorCode::INVALID_PARAMS));
+            continue;
+        }
+        // Create slices for this key's buffer
+        const auto &buffers = all_buffers[i];
+        std::vector<Slice> key_slices;
+        key_slices.reserve(buffers.size());
+        if (replica.is_memory_replica()) {
+            // MEMORY: RDMA from remote memory directly to GPU (GPUDirect).
             for (size_t j = 0; j < buffers.size(); ++j) {
                 key_slices.emplace_back(Slice{buffers[j], sizes[j]});
             }
-            return key_slices;
-        },
-        [](ErrorCode error) { return error != ErrorCode::OBJECT_NOT_FOUND; },
-        [&](const auto &batch_keys, const auto &batch_query_results,
-            auto &batch_slices) {
-            return client_->BatchGet(batch_keys, batch_query_results,
-                                     batch_slices, prefer_alloc_in_same_node);
-        },
-        [&](const std::string &transport_endpoint,
-            std::unordered_map<std::string, std::vector<Slice>> &objects) {
-            return batch_get_into_offload_object_internal(transport_endpoint,
-                                                          objects);
-        });
+        } else if (replica.is_local_disk_replica() ||
+                   replica.is_disk_replica()) {
+            // LOCAL_DISK: GPU buffers passed directly as scatter-gather slices
+            // (zero-copy). DISK: file I/O cannot write to GPU memory; temp CPU
+            // buffer used at read time.
+            valid_local_disk_ops.emplace(
+                key,
+                DiskKeyInfo{.key = key,
+                            .original_index = i,
+                            .query_result = std::move(query_result_values),
+                            .buffers = all_buffers[i],
+                            .sizes = all_sizes[i],
+                            .total_size = total_size,
+                            .is_local_disk = replica.is_local_disk_replica()});
+            results.emplace_back(static_cast<int64_t>(total_size));
+            continue;
+        } else {
+            LOG(ERROR) << "Unsupported replica type for key: " << key;
+            results.emplace_back(tl::unexpected(ErrorCode::INVALID_PARAMS));
+            continue;
+        }
+
+        valid_operations.push_back(
+            {.key = key,
+             .original_index = i,
+             .query_result = FilterQueryResult(query_result_values, replica),
+             .slices = std::move(key_slices),
+             .total_size = total_size});
+        // Set success result (actual bytes transferred)
+        results.emplace_back(static_cast<int64_t>(total_size));
+    }
+    // Early return if no valid operations
+    if (valid_operations.empty() && valid_local_disk_ops.empty()) {
+        return results;
+    }
+
+    // ---- Memory/Disk replica: existing BatchGet path ----
+    if (!valid_operations.empty()) {
+        std::vector<std::string> batch_keys;
+        std::vector<QueryResult> batch_query_results;
+        std::unordered_map<std::string, std::vector<Slice>> batch_slices;
+        batch_keys.reserve(valid_operations.size());
+        batch_query_results.reserve(valid_operations.size());
+        for (auto &op : valid_operations) {
+            batch_keys.push_back(op.key);
+            batch_query_results.push_back(op.query_result);
+            batch_slices[op.key] = op.slices;
+        }
+
+        auto batch_get_results =
+            client_->BatchGet(batch_keys, batch_query_results, batch_slices,
+                              prefer_alloc_in_same_node);
+
+        for (size_t j = 0; j < batch_get_results.size(); ++j) {
+            const auto &op = valid_operations[j];
+            if (!batch_get_results[j]) {
+                const auto error = batch_get_results[j].error();
+                LOG(ERROR) << "BatchGet failed for key '" << op.key
+                           << "': " << toString(error);
+                results[op.original_index] = tl::unexpected(error);
+            }
+        }
+    }
+
+    // ---- LOCAL_DISK / DISK replica: disk read paths ----
+    if (!valid_local_disk_ops.empty()) {
+        // LOCAL_DISK: pass user GPU buffers directly as scatter-gather slices.
+        // vLLM pre-registers all GPU KV-cache memory with TransferEngine via
+        // register_buffer(), so the offload RDMA can scatter the on-disk blob
+        // into non-contiguous per-layer GPU destinations natively — no temp
+        // CPU buffer or H2D copy needed.
+        {
+            std::unordered_map<
+                std::string,
+                std::unordered_map<std::string, std::vector<Slice>>>
+                offload_objects;
+
+            for (auto &[key, op] : valid_local_disk_ops) {
+                if (!op.is_local_disk) continue;
+                // Find the correct LOCAL_DISK replica — Master may return
+                // replicas in any order (e.g. [DISK, LOCAL_DISK]).
+                const Replica::Descriptor *replica_ptr = nullptr;
+                for (const auto &r : op.query_result.replicas) {
+                    if (r.is_local_disk_replica()) {
+                        replica_ptr = &r;
+                        break;
+                    }
+                }
+                if (!replica_ptr) {
+                    LOG(ERROR)
+                        << "No LOCAL_DISK replica found for key: " << key;
+                    results[op.original_index] =
+                        tl::make_unexpected(ErrorCode::INVALID_REPLICA);
+                    continue;
+                }
+                const auto &replica = *replica_ptr;
+                std::vector<Slice> user_slices;
+                user_slices.reserve(op.buffers.size());
+                size_t slice_total = 0;
+                for (size_t j = 0; j < op.buffers.size(); ++j) {
+                    user_slices.push_back(Slice{op.buffers[j], op.sizes[j]});
+                    slice_total += op.sizes[j];
+                }
+                if (slice_total < op.total_size) {
+                    LOG(ERROR) << "Slice size too small for key " << key
+                               << ": slices=" << slice_total
+                               << ", total=" << op.total_size;
+                    results[op.original_index] =
+                        tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                    continue;
+                }
+                offload_objects[replica.get_local_disk_descriptor()
+                                    .transport_endpoint]
+                    .emplace(key, std::move(user_slices));
+            }
+
+            for (auto &[endpoint, objects] : offload_objects) {
+                if (objects.empty()) continue;
+                auto read_result =
+                    batch_get_into_offload_object_internal(endpoint, objects);
+                // On success: results[original_index] was already pre-filled
+                // with total_size when valid_local_disk_ops was built; nothing
+                // to update. Only overwrite on failure.
+                if (!read_result) {
+                    for (auto &[key, slices] : objects) {
+                        auto disk_it = valid_local_disk_ops.find(key);
+                        if (disk_it == valid_local_disk_ops.end()) continue;
+                        LOG(ERROR) << "SSD read failed for key '" << key
+                                   << "': " << toString(read_result.error());
+                        results[disk_it->second.original_index] =
+                            tl::make_unexpected(read_result.error());
+                    }
+                }
+            }
+        }
+
+        // DISK: one batched BatchGet into CPU temp buffers, then scatter.
+        // (storage_backend::vector_read cannot write directly to GPU memory)
+        {
+            // Scatter temp CPU buffer -> user multi_buffers (GPU or host).
+            // Returns false and sets results[original_index] on error.
+            auto scatter_to_buffers = [&](const std::string &key, char *src,
+                                          const DiskKeyInfo &op) -> bool {
+                size_t offset = 0;
+                for (size_t j = 0; j < op.buffers.size(); ++j) {
+                    if (offset >= op.total_size) break;
+                    size_t sz =
+                        std::min(op.sizes[j],
+                                 static_cast<size_t>(op.total_size - offset));
+                    void *dst = op.buffers[j];
+                    if (auto r = scatter_host_to_maybe_device(
+                            dst, src + offset, sz, "DISK scatter, key: " + key);
+                        !r) {
+                        results[op.original_index] =
+                            tl::make_unexpected(r.error());
+                        return false;
+                    }
+                    offset += sz;
+                }
+                return true;
+            };
+
+            std::vector<std::string> disk_batch_keys;
+            std::vector<QueryResult> disk_batch_qrs;
+            std::unordered_map<std::string, std::vector<Slice>>
+                disk_batch_slices;
+            std::vector<std::string> disk_key_order;
+            std::unordered_map<std::string, std::unique_ptr<BufferHandle>>
+                temp_handles;
+
+            for (auto &[key, op] : valid_local_disk_ops) {
+                if (op.is_local_disk) continue;
+                auto alloc_result =
+                    client_buffer_allocator_->allocate(op.total_size);
+                if (!alloc_result) {
+                    LOG(ERROR)
+                        << "Failed to allocate temp buffer for DISK "
+                        << "read, key: " << key << ", size: " << op.total_size;
+                    results[op.original_index] =
+                        tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+                    continue;
+                }
+                auto handle =
+                    std::make_unique<BufferHandle>(std::move(*alloc_result));
+                // Find the correct DISK replica — Master may return
+                // replicas in any order (e.g. [LOCAL_DISK, DISK]).
+                const Replica::Descriptor *replica_ptr = nullptr;
+                for (const auto &r : op.query_result.replicas) {
+                    if (r.is_disk_replica()) {
+                        replica_ptr = &r;
+                        break;
+                    }
+                }
+                if (!replica_ptr) {
+                    LOG(ERROR) << "No DISK replica found for key: " << key;
+                    results[op.original_index] =
+                        tl::make_unexpected(ErrorCode::INVALID_REPLICA);
+                    continue;
+                }
+                const auto &replica = *replica_ptr;
+                std::vector<Slice> disk_slices;
+                allocateSlices(disk_slices, replica, handle->ptr());
+                disk_batch_keys.push_back(key);
+                disk_batch_qrs.push_back(
+                    FilterQueryResult(op.query_result, *replica_ptr));
+                disk_batch_slices[key] = std::move(disk_slices);
+                disk_key_order.push_back(key);
+                temp_handles.emplace(key, std::move(handle));
+            }
+
+            if (!disk_batch_keys.empty()) {
+                auto disk_results = client_->BatchGet(
+                    disk_batch_keys, disk_batch_qrs, disk_batch_slices,
+                    prefer_alloc_in_same_node);
+
+                for (size_t di = 0; di < disk_key_order.size(); ++di) {
+                    const auto &key = disk_key_order[di];
+                    auto &op = valid_local_disk_ops.at(key);
+                    auto handle_it = temp_handles.find(key);
+                    if (!disk_results[di]) {
+                        LOG(ERROR)
+                            << "DISK BatchGet failed for key '" << key
+                            << "': " << toString(disk_results[di].error());
+                        results[op.original_index] =
+                            tl::make_unexpected(disk_results[di].error());
+                        continue;
+                    }
+                    if (!scatter_to_buffers(
+                            key, static_cast<char *>(handle_it->second->ptr()),
+                            op))
+                        continue;
+                }
+            }
+            // temp_handles: BufferHandle RAII releases allocator memory
+        }
+    }
+
     return results;
 }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -80,51 +80,6 @@ tl::expected<void, ErrorCode> set_context_if_needed(const std::string &protocol,
 }
 #endif
 
-CachedQueryResultResponse to_cached_query_result_response(
-    const tl::expected<QueryResult, ErrorCode> &query_result,
-    std::chrono::steady_clock::time_point now) {
-    if (!query_result) {
-        return CachedQueryResultResponse(query_result.error());
-    }
-    const auto remaining_ttl_ms = static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            query_result->lease_timeout - now)
-            .count());
-    return CachedQueryResultResponse(GetReplicaListResponse(
-        std::vector<Replica::Descriptor>(query_result->replicas.begin(),
-                                         query_result->replicas.end()),
-        remaining_ttl_ms));
-}
-
-tl::expected<QueryResult, ErrorCode> from_cached_query_result_response(
-    const CachedQueryResultResponse &cached_result,
-    std::chrono::steady_clock::time_point now) {
-    if (!cached_result.success) {
-        return tl::make_unexpected(cached_result.error);
-    }
-    return QueryResult(
-        std::vector<Replica::Descriptor>(cached_result.value.replicas.begin(),
-                                         cached_result.value.replicas.end()),
-        now + std::chrono::milliseconds(cached_result.value.lease_ttl_ms));
-}
-
-PyClient::QueryResultCache build_query_result_cache_from_cached_results(
-    const std::map<std::string, CachedQueryResultResponse>
-        &cached_query_results) {
-    PyClient::QueryResultCache query_result_cache;
-    query_result_cache.reserve(cached_query_results.size());
-    auto now = std::chrono::steady_clock::now();
-    for (const auto &[key, cached_result] : cached_query_results) {
-        auto query_result =
-            from_cached_query_result_response(cached_result, now);
-        if (query_result && query_result->IsLeaseExpired(now)) {
-            continue;
-        }
-        query_result_cache.emplace(key, std::move(query_result));
-    }
-    return query_result_cache;
-}
-
 struct PreparedRangedReadRequest {
     std::vector<std::vector<std::vector<tl::expected<int64_t, ErrorCode>>>>
         results;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3382,7 +3382,7 @@ RealClient::get_into_ranges_internal(
     auto now = std::chrono::steady_clock::now();
     if (query_result_cache != nullptr) {
         for (const auto &[key, query_result] : *query_result_cache) {
-            if (query_result && query_result->IsLeaseExpired(now)) {
+            if (!query_result || query_result->IsLeaseExpired(now)) {
                 continue;
             }
             metadata_cache.emplace(key,

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -115,8 +115,9 @@ PyClient::QueryResultCache build_query_result_cache_from_cached_results(
     query_result_cache.reserve(cached_query_results.size());
     auto now = std::chrono::steady_clock::now();
     for (const auto &[key, cached_result] : cached_query_results) {
-        auto query_result = from_cached_query_result_response(cached_result, now);
-        if (!query_result || query_result->IsLeaseExpired(now)) {
+        auto query_result =
+            from_cached_query_result_response(cached_result, now);
+        if (query_result && query_result->IsLeaseExpired(now)) {
             continue;
         }
         query_result_cache.emplace(key, std::move(query_result));
@@ -227,11 +228,11 @@ PreparedBatchReadSet prepare_batch_read_operations(
         auto key_slices = build_slices_for_index(i, replica);
         if (replica.is_local_disk_replica()) {
             prepared.local_disk_operations.emplace(
-                key, PreparedBatchReadOp{.key = key,
-                                         .original_index = i,
-                                         .query_result =
-                                             std::move(filtered_query_result),
-                                         .slices = std::move(key_slices)});
+                key, PreparedBatchReadOp{
+                         .key = key,
+                         .original_index = i,
+                         .query_result = std::move(filtered_query_result),
+                         .slices = std::move(key_slices)});
         } else {
             prepared.memory_operations.push_back(
                 {.key = key,
@@ -262,7 +263,8 @@ size_t execute_local_disk_batch_reads(
     size_t offload_object_count = 0;
     for (auto &[transport_endpoint, objects] : offload_objects) {
         offload_object_count += objects.size();
-        auto batch_get_offload_result = execute_batch(transport_endpoint, objects);
+        auto batch_get_offload_result =
+            execute_batch(transport_endpoint, objects);
         if (!batch_get_offload_result) {
             LOG(ERROR) << "Batch get store object failed with error: "
                        << batch_get_offload_result.error();
@@ -288,8 +290,8 @@ validate_batch_get_inputs(bool client_ready, size_t key_count,
             key_count, tl::unexpected(ErrorCode::INVALID_PARAMS));
     }
     if (key_count != buffer_count || key_count != size_count) {
-        LOG(ERROR) << "Input vector sizes mismatch: keys=" << key_count
-                   << ", " << buffer_label << "=" << buffer_count
+        LOG(ERROR) << "Input vector sizes mismatch: keys=" << key_count << ", "
+                   << buffer_label << "=" << buffer_count
                    << ", sizes=" << size_count;
         return std::vector<tl::expected<int64_t, ErrorCode>>(
             key_count, tl::unexpected(ErrorCode::INVALID_PARAMS));
@@ -332,9 +334,8 @@ BatchReadExecutionStats execute_batch_read_operations(
         batch_slices[op.key] = op.slices;
     }
     if (!prepared.memory_operations.empty()) {
-        auto batch_get_results = execute_memory_batch(batch_keys,
-                                                      batch_query_results,
-                                                      batch_slices);
+        auto batch_get_results =
+            execute_memory_batch(batch_keys, batch_query_results, batch_slices);
         apply_batch_get_failures(batch_get_results, prepared.memory_operations,
                                  results);
     }
@@ -3428,13 +3429,13 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    auto read_via_offload = [&](void *dst, size_t read_size)
-        -> tl::expected<void, ErrorCode> {
+    auto read_via_offload =
+        [&](void *dst, size_t read_size) -> tl::expected<void, ErrorCode> {
         const auto &endpoint =
             replica.get_local_disk_descriptor().transport_endpoint;
         std::unordered_map<std::string, std::vector<Slice>> objects;
-        objects.emplace(key,
-                        std::vector<Slice>{{static_cast<char *>(dst), read_size}});
+        objects.emplace(
+            key, std::vector<Slice>{{static_cast<char *>(dst), read_size}});
         return batch_get_into_offload_object_internal(endpoint, objects);
     };
 
@@ -3494,9 +3495,9 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return tl::unexpected(ErrorCode::INVALID_REPLICA);
     }
 
-    auto read_result = get_via_client(static_cast<char *>(buffer) + dst_offset,
-                                      src_offset, src_offset == 0 &&
-                                                      size == total_size);
+    auto read_result =
+        get_via_client(static_cast<char *>(buffer) + dst_offset, src_offset,
+                       src_offset == 0 && size == total_size);
     if (!read_result) {
         return tl::unexpected(read_result.error());
     }
@@ -3563,7 +3564,8 @@ RealClient::get_into_ranges_internal(
     if (!client_) {
         LOG(ERROR) << "Client is not initialized";
         return build_ranged_read_internal_error_results(
-            buffers.size(), all_keys, all_dst_offsets, ErrorCode::INVALID_PARAMS);
+            buffers.size(), all_keys, all_dst_offsets,
+            ErrorCode::INVALID_PARAMS);
     }
 
     const size_t buffer_count = buffers.size();
@@ -3616,7 +3618,7 @@ RealClient::get_into_ranges_internal(
     auto now = std::chrono::steady_clock::now();
     if (query_result_cache != nullptr) {
         for (const auto &[key, query_result] : *query_result_cache) {
-            if (!query_result || query_result->IsLeaseExpired(now)) {
+            if (query_result && query_result->IsLeaseExpired(now)) {
                 continue;
             }
             resolved_query_results.emplace(key, query_result);
@@ -3628,8 +3630,8 @@ RealClient::get_into_ranges_internal(
     std::unordered_set<std::string> seen_missing_keys;
     seen_missing_keys.reserve(key_count_hint);
     for (size_t i = 0; i < buffer_count; ++i) {
-        if (buffer_capacities == nullptr && resolved_buffer_capacities[i] == 0 &&
-            !all_keys[i].empty()) {
+        if (buffer_capacities == nullptr &&
+            resolved_buffer_capacities[i] == 0 && !all_keys[i].empty()) {
             continue;
         }
         if (all_keys[i].size() != prepared.valid_fragments[i].size()) {
@@ -3641,10 +3643,10 @@ RealClient::get_into_ranges_internal(
                 resolved_query_results.end()) {
                 continue;
             }
-            const bool has_valid_fragment = std::any_of(
-                prepared.valid_fragments[i][j].begin(),
-                prepared.valid_fragments[i][j].end(),
-                [](bool valid_fragment) { return valid_fragment; });
+            const bool has_valid_fragment =
+                std::any_of(prepared.valid_fragments[i][j].begin(),
+                            prepared.valid_fragments[i][j].end(),
+                            [](bool valid_fragment) { return valid_fragment; });
             if (!has_valid_fragment) {
                 continue;
             }
@@ -3739,11 +3741,9 @@ std::vector<std::vector<std::vector<int64_t>>> RealClient::get_into_ranges(
     auto results =
         execute_timed_operation<std::vector<std::vector<std::vector<int64_t>>>>(
             [&]() {
-                return convert_ranged_read_results(
-                    get_into_ranges_internal(buffers, all_keys, all_dst_offsets,
-                                             all_src_offsets, all_sizes,
-                                             nullptr, nullptr, nullptr,
-                                             query_result_cache));
+                return convert_ranged_read_results(get_into_ranges_internal(
+                    buffers, all_keys, all_dst_offsets, all_src_offsets,
+                    all_sizes, nullptr, nullptr, nullptr, query_result_cache));
             },
             [](const auto &) { return true; },
             [&](uint64_t latency_us, const auto &ret) {
@@ -4843,7 +4843,9 @@ RealClient::batch_get_into_multi_buffers_internal(
     const auto query_results = client_->BatchQuery(keys);
     execute_batch_read_operations(
         keys, query_results, results, client_->GetLocalEndpoints(),
-        [&](size_t i) { return static_cast<uint64_t>(sum_sizes(all_sizes[i])); },
+        [&](size_t i) {
+            return static_cast<uint64_t>(sum_sizes(all_sizes[i]));
+        },
         [&](size_t i, const Replica::Descriptor &) {
             const auto &buffers = all_buffers[i];
             const auto &sizes = all_sizes[i];
@@ -5177,7 +5179,8 @@ std::vector<CachedQueryResultResponse> RealClient::batch_get_query_results(
     std::vector<CachedQueryResultResponse> cached_results;
     cached_results.reserve(keys.size());
     if (query_results.size() != keys.size()) {
-        LOG(ERROR) << "Batch query response size mismatch in batch_get_query_results: expected "
+        LOG(ERROR) << "Batch query response size mismatch in "
+                      "batch_get_query_results: expected "
                    << keys.size() << ", got " << query_results.size() << ".";
         return std::vector<CachedQueryResultResponse>(
             keys.size(), CachedQueryResultResponse(ErrorCode::RPC_FAIL));

--- a/scripts/test_tensor_api.py
+++ b/scripts/test_tensor_api.py
@@ -1381,6 +1381,59 @@ class TestMooncakeFunctional(MooncakeTestBase):
                     )
                     self.assertNotEqual(rc, 0)
 
+    def test_27b_unified_parallelism_full_into_formula_all_split_dims_and_hetero_tp(self):
+        require_unified_parallelism_api(self)
+        previous_disable = os.environ.pop("MOONCAKE_DISABLE_REGULAR_FULL_FORMULA", None)
+        cases = [
+            ((8, 12, 16), 0, 4, [2, 4, 8]),
+            ((8, 12, 16), 1, 4, [2, 3, 4, 6]),
+            ((8, 12, 16), 2, 4, [2, 4, 8, 16]),
+        ]
+        try:
+            for case_index, (shape, split_dim, write_tp_size, read_tp_sizes) in enumerate(cases):
+                tensor = make_deterministic_tensor(shape)
+                for read_tp_size in read_tp_sizes:
+                    with self.subTest(
+                        case=f"split_dim={split_dim},write_tp={write_tp_size},read_tp={read_tp_size}"
+                    ):
+                        key = f"func_unified_formula_split_{case_index}_{read_tp_size}"
+                        self.assertEqual(shape[split_dim] % read_tp_size, 0)
+                        rc = put_uniform_full_tensor_with_unified_tp(
+                            self.store, key, tensor, write_tp_size, split_dim
+                        )
+                        self.assertEqual(rc, 0)
+                        target = make_read_target(
+                            "full",
+                            build_tp_parallelism(
+                                read_tp_size, split_dim, rank=read_tp_size - 1
+                            ),
+                        )
+                        full_result = self.store.get_tensor_with_parallelism(
+                            key, target
+                        )
+                        self.assertIsNotNone(full_result)
+                        self.assertTrue(torch.equal(full_result, tensor))
+
+                        buffer_spacing = max(
+                            serialized_tensor_size(tensor) + 4096, 1 * 1024 * 1024
+                        )
+                        buffer = (ctypes.c_ubyte * buffer_spacing)()
+                        buffer_ptr = ctypes.addressof(buffer)
+                        self.assertEqual(
+                            self.store.register_buffer(buffer_ptr, buffer_spacing), 0
+                        )
+                        try:
+                            into_result = self.store.get_tensor_with_parallelism_into(
+                                key, buffer_ptr, buffer_spacing, target=target
+                            )
+                            self.assertIsNotNone(into_result)
+                            self.assertTrue(torch.equal(into_result, tensor))
+                        finally:
+                            self.assertEqual(self.store.unregister_buffer(buffer_ptr), 0)
+        finally:
+            if previous_disable is not None:
+                os.environ["MOONCAKE_DISABLE_REGULAR_FULL_FORMULA"] = previous_disable
+
     def test_28_writer_shard_full_reconstruction(self):
         require_unified_parallelism_api(self)
         key = "func_writer_shard_full"
@@ -2362,6 +2415,51 @@ class TestMooncakeBenchmark(MooncakeTestBase):
 
         self.total_bits = tensor.numel() * tensor.element_size() * 8
         self._print_perf("Unified Full Into", into_times)
+
+    def test_benchmark_09_unified_full_into_formula_vs_generic_cold(self):
+        require_unified_parallelism_api(self)
+        key = "bench_unified_full_into_formula"
+        tensor = self.tensors[0]
+        tp_size = 4
+        split_dim = 0
+        full_target = make_read_target("full", build_tp_parallelism(tp_size, split_dim, rank=2))
+        buffer_spacing = serialized_tensor_size(tensor) + 1 * 1024 * 1024
+        buffer = (ctypes.c_ubyte * buffer_spacing)()
+        buffer_ptr = ctypes.addressof(buffer)
+        self.assertEqual(self.store.register_buffer(buffer_ptr, buffer_spacing), 0)
+        generic_times = []
+        formula_times = []
+        try:
+            print(f"--- Running Unified Full Into Formula vs Generic Cold Benchmark (TP={tp_size}) ---")
+            for _ in range(self.BENCH_ITERATIONS):
+                self.store.remove_all()
+                rc = put_uniform_full_tensor_with_unified_tp(
+                    self.store, key, tensor, tp_size, split_dim
+                )
+                self.assertEqual(rc, 0)
+
+                os.environ["MOONCAKE_DISABLE_REGULAR_FULL_FORMULA"] = "1"
+                t0 = time.perf_counter()
+                self._run_unified_full_into(key, full_target, buffer_ptr, buffer_spacing, tensor)
+                generic_times.append(time.perf_counter() - t0)
+
+                self.store.remove_all()
+                rc = put_uniform_full_tensor_with_unified_tp(
+                    self.store, key, tensor, tp_size, split_dim
+                )
+                self.assertEqual(rc, 0)
+
+                os.environ.pop("MOONCAKE_DISABLE_REGULAR_FULL_FORMULA", None)
+                t0 = time.perf_counter()
+                self._run_unified_full_into(key, full_target, buffer_ptr, buffer_spacing, tensor)
+                formula_times.append(time.perf_counter() - t0)
+        finally:
+            os.environ.pop("MOONCAKE_DISABLE_REGULAR_FULL_FORMULA", None)
+            self.assertEqual(self.store.unregister_buffer(buffer_ptr), 0)
+
+        self.total_bits = tensor.numel() * tensor.element_size() * 8
+        self._print_perf("Unified Full Into Generic Cold", generic_times)
+        self._print_perf("Unified Full Into Formula Cold", formula_times)
 
 # ==========================================
 #  Stress/Concurrency Tests

--- a/scripts/test_tensor_api.py
+++ b/scripts/test_tensor_api.py
@@ -1383,56 +1383,51 @@ class TestMooncakeFunctional(MooncakeTestBase):
 
     def test_27b_unified_parallelism_full_into_formula_all_split_dims_and_hetero_tp(self):
         require_unified_parallelism_api(self)
-        previous_disable = os.environ.pop("MOONCAKE_DISABLE_REGULAR_FULL_FORMULA", None)
         cases = [
             ((8, 12, 16), 0, 4, [2, 4, 8]),
             ((8, 12, 16), 1, 4, [2, 3, 4, 6]),
             ((8, 12, 16), 2, 4, [2, 4, 8, 16]),
         ]
-        try:
-            for case_index, (shape, split_dim, write_tp_size, read_tp_sizes) in enumerate(cases):
-                tensor = make_deterministic_tensor(shape)
-                for read_tp_size in read_tp_sizes:
-                    with self.subTest(
-                        case=f"split_dim={split_dim},write_tp={write_tp_size},read_tp={read_tp_size}"
-                    ):
-                        key = f"func_unified_formula_split_{case_index}_{read_tp_size}"
-                        self.assertEqual(shape[split_dim] % read_tp_size, 0)
-                        rc = put_uniform_full_tensor_with_unified_tp(
-                            self.store, key, tensor, write_tp_size, split_dim
-                        )
-                        self.assertEqual(rc, 0)
-                        target = make_read_target(
-                            "full",
-                            build_tp_parallelism(
-                                read_tp_size, split_dim, rank=read_tp_size - 1
-                            ),
-                        )
-                        full_result = self.store.get_tensor_with_parallelism(
-                            key, target
-                        )
-                        self.assertIsNotNone(full_result)
-                        self.assertTrue(torch.equal(full_result, tensor))
+        for case_index, (shape, split_dim, write_tp_size, read_tp_sizes) in enumerate(cases):
+            tensor = make_deterministic_tensor(shape)
+            for read_tp_size in read_tp_sizes:
+                with self.subTest(
+                    case=f"split_dim={split_dim},write_tp={write_tp_size},read_tp={read_tp_size}"
+                ):
+                    key = f"func_unified_formula_split_{case_index}_{read_tp_size}"
+                    self.assertEqual(shape[split_dim] % read_tp_size, 0)
+                    rc = put_uniform_full_tensor_with_unified_tp(
+                        self.store, key, tensor, write_tp_size, split_dim
+                    )
+                    self.assertEqual(rc, 0)
+                    target = make_read_target(
+                        "full",
+                        build_tp_parallelism(
+                            read_tp_size, split_dim, rank=read_tp_size - 1
+                        ),
+                    )
+                    full_result = self.store.get_tensor_with_parallelism(
+                        key, target
+                    )
+                    self.assertIsNotNone(full_result)
+                    self.assertTrue(torch.equal(full_result, tensor))
 
-                        buffer_spacing = max(
-                            serialized_tensor_size(tensor) + 4096, 1 * 1024 * 1024
+                    buffer_spacing = max(
+                        serialized_tensor_size(tensor) + 4096, 1 * 1024 * 1024
+                    )
+                    buffer = (ctypes.c_ubyte * buffer_spacing)()
+                    buffer_ptr = ctypes.addressof(buffer)
+                    self.assertEqual(
+                        self.store.register_buffer(buffer_ptr, buffer_spacing), 0
+                    )
+                    try:
+                        into_result = self.store.get_tensor_with_parallelism_into(
+                            key, buffer_ptr, buffer_spacing, target=target
                         )
-                        buffer = (ctypes.c_ubyte * buffer_spacing)()
-                        buffer_ptr = ctypes.addressof(buffer)
-                        self.assertEqual(
-                            self.store.register_buffer(buffer_ptr, buffer_spacing), 0
-                        )
-                        try:
-                            into_result = self.store.get_tensor_with_parallelism_into(
-                                key, buffer_ptr, buffer_spacing, target=target
-                            )
-                            self.assertIsNotNone(into_result)
-                            self.assertTrue(torch.equal(into_result, tensor))
-                        finally:
-                            self.assertEqual(self.store.unregister_buffer(buffer_ptr), 0)
-        finally:
-            if previous_disable is not None:
-                os.environ["MOONCAKE_DISABLE_REGULAR_FULL_FORMULA"] = previous_disable
+                        self.assertIsNotNone(into_result)
+                        self.assertTrue(torch.equal(into_result, tensor))
+                    finally:
+                        self.assertEqual(self.store.unregister_buffer(buffer_ptr), 0)
 
     def test_28_writer_shard_full_reconstruction(self):
         require_unified_parallelism_api(self)
@@ -2415,51 +2410,6 @@ class TestMooncakeBenchmark(MooncakeTestBase):
 
         self.total_bits = tensor.numel() * tensor.element_size() * 8
         self._print_perf("Unified Full Into", into_times)
-
-    def test_benchmark_09_unified_full_into_formula_vs_generic_cold(self):
-        require_unified_parallelism_api(self)
-        key = "bench_unified_full_into_formula"
-        tensor = self.tensors[0]
-        tp_size = 4
-        split_dim = 0
-        full_target = make_read_target("full", build_tp_parallelism(tp_size, split_dim, rank=2))
-        buffer_spacing = serialized_tensor_size(tensor) + 1 * 1024 * 1024
-        buffer = (ctypes.c_ubyte * buffer_spacing)()
-        buffer_ptr = ctypes.addressof(buffer)
-        self.assertEqual(self.store.register_buffer(buffer_ptr, buffer_spacing), 0)
-        generic_times = []
-        formula_times = []
-        try:
-            print(f"--- Running Unified Full Into Formula vs Generic Cold Benchmark (TP={tp_size}) ---")
-            for _ in range(self.BENCH_ITERATIONS):
-                self.store.remove_all()
-                rc = put_uniform_full_tensor_with_unified_tp(
-                    self.store, key, tensor, tp_size, split_dim
-                )
-                self.assertEqual(rc, 0)
-
-                os.environ["MOONCAKE_DISABLE_REGULAR_FULL_FORMULA"] = "1"
-                t0 = time.perf_counter()
-                self._run_unified_full_into(key, full_target, buffer_ptr, buffer_spacing, tensor)
-                generic_times.append(time.perf_counter() - t0)
-
-                self.store.remove_all()
-                rc = put_uniform_full_tensor_with_unified_tp(
-                    self.store, key, tensor, tp_size, split_dim
-                )
-                self.assertEqual(rc, 0)
-
-                os.environ.pop("MOONCAKE_DISABLE_REGULAR_FULL_FORMULA", None)
-                t0 = time.perf_counter()
-                self._run_unified_full_into(key, full_target, buffer_ptr, buffer_spacing, tensor)
-                formula_times.append(time.perf_counter() - t0)
-        finally:
-            os.environ.pop("MOONCAKE_DISABLE_REGULAR_FULL_FORMULA", None)
-            self.assertEqual(self.store.unregister_buffer(buffer_ptr), 0)
-
-        self.total_bits = tensor.numel() * tensor.element_size() * 8
-        self._print_perf("Unified Full Into Generic Cold", generic_times)
-        self._print_perf("Unified Full Into Formula Cold", formula_times)
 
 # ==========================================
 #  Stress/Concurrency Tests

--- a/scripts/test_tensor_api.py
+++ b/scripts/test_tensor_api.py
@@ -1941,6 +1941,16 @@ class TestMooncakeFunctional(MooncakeTestBase):
             (6, 3, [(0, 4, 2, "tp"), (1, 4, 2, "pp_tp"), (2, 4, 2, "ep_tp")]),
         ]
 
+        def expand_jobs(cases, worker_count):
+            jobs = list(enumerate(cases))
+            if worker_count <= len(cases):
+                return jobs
+            extra_jobs = worker_count - len(cases)
+            for extra_index in range(extra_jobs):
+                case_index = extra_index % len(cases)
+                jobs.append((case_index, cases[case_index]))
+            return jobs
+
         def put_worker(key, split_dim, put_tp_size, mode):
             return put_full_tensor_with_parallelism_mode(
                 self.store, key, original, split_dim, put_tp_size, mode
@@ -1965,23 +1975,46 @@ class TestMooncakeFunctional(MooncakeTestBase):
 
         for scenario_index, (put_workers, get_workers, cases) in enumerate(scenarios):
             with self.subTest(put_workers=put_workers, get_workers=get_workers):
-                keys = [
-                    f"func_unified_concurrency_{scenario_index}_{case_index}"
-                    for case_index in range(len(cases))
+                put_jobs = [
+                    (
+                        case_index,
+                        f"func_unified_concurrency_{scenario_index}_put_{job_index}_case_{case_index}",
+                        split_dim,
+                        put_tp_size,
+                        get_tp_size,
+                        mode,
+                    )
+                    for job_index, (case_index, (split_dim, put_tp_size, get_tp_size, mode)) in enumerate(
+                        expand_jobs(cases, put_workers)
+                    )
                 ]
+                case_keys = {}
+                for case_index, key, split_dim, put_tp_size, get_tp_size, mode in put_jobs:
+                    case_keys.setdefault(case_index, []).append(
+                        (key, split_dim, put_tp_size, get_tp_size, mode)
+                    )
+
+                get_jobs = []
+                case_read_counts = {}
+                for case_index, (split_dim, put_tp_size, get_tp_size, mode) in expand_jobs(cases, get_workers):
+                    read_index = case_read_counts.get(case_index, 0)
+                    key, _split_dim, _put_tp_size, _get_tp_size, _mode = case_keys[case_index][
+                        read_index % len(case_keys[case_index])
+                    ]
+                    get_jobs.append((key, split_dim, put_tp_size, get_tp_size, mode))
+                    case_read_counts[case_index] = read_index + 1
+
                 with concurrent.futures.ThreadPoolExecutor(max_workers=max(put_workers, get_workers)) as executor:
                     put_futures = [
                         executor.submit(put_worker, key, split_dim, put_tp_size, mode)
-                        for key, (split_dim, put_tp_size, _get_tp_size, mode) in zip(keys, cases)
-                        for _ in range(max(1, put_workers // len(cases)))
+                        for _case_index, key, split_dim, put_tp_size, _get_tp_size, mode in put_jobs
                     ]
                     for future in concurrent.futures.as_completed(put_futures):
                         self.assertEqual(future.result(), 0)
 
                     get_futures = [
                         executor.submit(get_worker, key, split_dim, get_tp_size, mode)
-                        for key, (split_dim, _put_tp_size, get_tp_size, mode) in zip(keys, cases)
-                        for _ in range(max(1, get_workers // len(cases)))
+                        for key, split_dim, _put_tp_size, get_tp_size, mode in get_jobs
                     ]
                     for future in concurrent.futures.as_completed(get_futures):
                         error = future.result()


### PR DESCRIPTION
## Motivation                                                                                                           
                                                                                                                          
  Unified `with_parallelism` reconstruction and Engram ranged reads already know the target object keys before executing the final data transfer, but the old path still paid for redundant query work inside `get_into_ranges(...)`.                                                            
                                                                                                                          
  This showed up in two places:                                                                                           
                                                                                                                          
  1. reconstruction planning queried source shards, then execution queried the same keys again;                                                                                                          
  2. Engram resolved keys up front, but the final ranged read still repeated the lookup.                                                                                                              
                                                                                                                          
  The goal of this PR is to reuse those existing query results end-to-end, keep the public cache surface small, and avoid introducing a second low-level read path.                                         
                                                                                                                          
  ## Scenario                                                                                                             
                                                                                                                          
  This PR targets the two read paths that already have key-resolution information available before transfer:                                                                                              
                                                                                                                          
  1. Unified `with_parallelism` reconstruction resolves source shard keys for one logical tensor read.                                                                                                 
  2. Reconstruction metadata loading only needs the tensor metadata prefix, not a full-object metadata fetch.                                                                                          
  3. Final `get_into_ranges(...)` execution should reuse the same resolved query results instead of issuing another `BatchQuery`.                                                                     
  4. Engram lookup follows the same pattern: resolve the embedding object keys once, then pass the cache into the final ranged read.                                                                      
                                                                                                                          
  The same cached-query representation is reused across planning, metadata fetch, and final execution.                                                                                                    
                                                                                                                          
  ## Description                                                                                                          
                                                                                                                          
  This PR reuses cached query results across reconstruction reads and removes duplicated cached-query conversion logic.                                                                               
                                                                                                                          
  ### Shared cached-query helpers                                                                                         
                                                                                                                          
  - Move cached-query conversion helpers into the shared client layer in `mooncake-store/include/pyclient.h`.                                                                                  
  - Centralize:                                                                                                           
    - `to_cached_query_result_response(...)`                                                                              
    - `from_cached_query_result_response(...)`                                                                            
    - cache build helpers in both directions                                                                              
  - Keep lease handling consistent by converting relative TTLs back into absolute lease timeouts at the call site.                                                                             
                                                                                                                          
  ### Unified `with_parallelism` reconstruction                                                                           
                                                                                                                          
  - Reconstruction planning now batch-queries source keys once and keeps the query results for later execution.                                                                                          
  - Metadata loading reuses those same query results and reads only the `TensorMetadata` prefix through `get_into_ranges(...)`.                                                               
  - Final reconstruction execution rebuilds the `QueryResultCache` from the planned cached results and passes it into `store_->get_into_ranges(...)`, so execution no longer re-queries the same keys.                                                                                   
  - Missing or expired cached query results now fail fast instead of silently falling back through partially invalid state.                                                                         
                                                                                                                          
  ### Reusable metadata prefix scratch buffer                                                                             
                                                                                                                          
  - Add a reusable registered scratch buffer in the Python store wrapper for metadata-prefix reads.                                                                                                
  - Reconstruction metadata fetches can now reuse that registered buffer across calls instead of re-registering a temporary buffer each time on the hot path.                                         
                                                                                                                          
  ### RealClient / DummyClient cleanup                                                                                    
                                                                                                                          
  - Remove duplicate cached-query conversion helpers from `real_client.cpp`.                                              
  - Make `DummyClient` use the same shared cached-query helper path as `RealClient`.                                      
  - Keep the existing ranged-read execution path intact; only the metadata source                                         
    and cache plumbing change.                                                                                            
                                                                                                                          
  ## Performance                                                                                                          
                                                                                                                          
  This PR is meant to reduce duplicated query/planning overhead while keeping the underlying transfer path unchanged.                                                                                     
                                                                                                                          
  ### with_parallelism                                                                                                    
                                                                                                                          
  Focused reconstruction benchmark (`get_tensor_with_parallelism_into`, 16MB, TP=4, split_dim=0, 5 iterations):                                                                                       
                                                                                                                          
  | Variant | Mean (ms) | P50 (ms) | P99 (ms) |                                                                           
  | --- | ---: | ---: | ---: |                                                                                            
  | Baseline | 4.290 | 4.169 | 5.106 |                                                                                    
  | Current | 2.453 | 2.367 | 2.865 |                                                                                     
  | Delta | **-42.8%** | **-43.2%** | **-43.9%** |                                                                        
                                                                                                                          
  ### Engram                                                                                                              
                                                                                                                          
  Full localhost sweep (30 iterations, matching rebuilt master / `.so`):                                                  
                                                                                                                          
| Batch size | Baseline (ms) | Current (ms) | Delta |                                                                   
  |---|---:|---:|---:|                                                                                                    
  | 1 | 0.462 | 0.320 | -30.7% |                                                                                          
  | 4 | 0.670 | 0.664 | -0.9% |                                                                                           
  | 16 | 1.699 | 1.611 | -5.2% |                                                                                          
  | 64 | 4.657 | 4.489 | -3.6% |                                                                                          
  | 128 | 8.965 | 8.732 | -2.6% |                                                                                         
  | 256 | 17.559 | 17.239 | -1.8% |                                                                                                
                                                                                                                          
  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [x] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] PyTorch Backend (`mooncake-pg`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [x] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [x] Refactor
  - [ ] Breaking change
  - [x] Documentation update
  - [ ] Other

  ## How Has This Been Tested?

  Ran the following tests:

  - `ctest --output-on-failure -R '^(dummy_client_get_buffer_test|batch_query_buffer_fetch_test)$'`

  Both tests passed.

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
  - [x] I have updated the documentation.
  - [x] I have added tests to prove my changes are effective.

