### PR TITLE
[TENT] Fix potential deadlock and UAF in `synchronizeLocal`  in #1826

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
@@ -147,8 +147,9 @@ class SegmentManager {
     std::string file_desc_basepath_;
     uint64_t ttl_ms_ = 10 * 1000;  // N.B. Frequent TTL harms p999
 
-    RWSpinlock subscribers_lock_;
-    std::unordered_set<std::string> subscribers_;
+    // shared_ptr to prevent UAF in async callbacks
+    std::shared_ptr<RWSpinlock> subscribers_lock_;
+    std::shared_ptr<std::unordered_set<std::string>> subscribers_;
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
@@ -173,10 +173,9 @@ Status SegmentManager::synchronizeLocal() {
     CHECK_STATUS(registry_->putSegmentDesc(local_desc_));
 
     std::vector<std::string> subscribers_snapshot;
-    subscribers_snapshot.reserve(subscribers_->size());
-
     {
         RWSpinlock::ReadGuard guard(*subscribers_lock_);
+        subscribers_snapshot.reserve(subscribers_->size());
         for (const auto &subscriber : *subscribers_) {
             subscribers_snapshot.emplace_back(subscriber);
         }

--- a/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
@@ -28,6 +28,8 @@ namespace tent {
 SegmentManager::SegmentManager(std::unique_ptr<SegmentRegistry> agent)
     : next_id_(1), version_(0), registry_(std::move(agent)) {
     local_desc_ = std::make_shared<SegmentDesc>();
+    subscribers_lock_ = std::make_shared<RWSpinlock>();
+    subscribers_ = std::make_shared<std::unordered_set<std::string>>();
 }
 
 SegmentManager::~SegmentManager() {}
@@ -135,8 +137,8 @@ Status SegmentManager::invalidateAllCacheForRemote(
 }
 
 void SegmentManager::addSubscriber(const std::string &subscriber_addr) {
-    RWSpinlock::WriteGuard guard(subscribers_lock_);
-    subscribers_.insert(subscriber_addr);
+    RWSpinlock::WriteGuard guard(*subscribers_lock_);
+    subscribers_->insert(subscriber_addr);
 }
 
 Status SegmentManager::makeFileRemote(SegmentDescRef &desc,
@@ -170,16 +172,29 @@ Status SegmentManager::makeFileRemote(SegmentDescRef &desc,
 Status SegmentManager::synchronizeLocal() {
     CHECK_STATUS(registry_->putSegmentDesc(local_desc_));
 
-    RWSpinlock::ReadGuard guard(subscribers_lock_);
-    if (subscribers_.empty()) return Status::OK();
+    std::vector<std::string> subscribers_snapshot;
+    subscribers_snapshot.reserve(subscribers_->size());
 
-    for (const auto &subscriber : subscribers_) {
+    {
+        RWSpinlock::ReadGuard guard(*subscribers_lock_);
+        for (const auto &subscriber : *subscribers_) {
+            subscribers_snapshot.emplace_back(subscriber);
+        }
+    }
+
+    // Avoid holding the lock while issuing RPCs. Since the async RPC is
+    // based on coroutine, the callback might be executed on the current thread
+    // (e.g., if an error occurs before the first suspension point).
+    // Holding the lock here could lead to a deadlock.
+    for (const auto &subscriber : subscribers_snapshot) {
         // Remove subscribers that have failed (e.g., peer might shutdown)
         // to avoid repeated RPC failures.
         ControlClient::notifySegmentUpdatedAsync(
-            subscriber, local_desc_->name, [this, subscriber] {
-                RWSpinlock::WriteGuard guard(subscribers_lock_);
-                subscribers_.erase(subscriber);
+            subscriber, local_desc_->name,
+            /* on_failure */
+            [subscribers = subscribers_, lock = subscribers_lock_, subscriber] {
+                RWSpinlock::WriteGuard guard(*lock);
+                subscribers->erase(subscriber);
             });
     }
     return Status::OK();


### PR DESCRIPTION
## Description

This fix addresses a potential deadlock and Use-After-Free in `synchronizeLocal` introduced by #1826.

Ref: https://github.com/kvcache-ai/Mooncake/pull/1826#discussion_r3055239872

#### Deadlock

Although `ControlClient::notifySegmentUpdatedAsync` is intended to be asynchronous via `CoroRpcAgent::callAsync`, the callback may still run on the calling thread.

In `callAsync`, the callback is passed to `Lazy::start`, which executes:

```c++
cb(co_await lazy.coAwaitTry());
```

Under normal conditions, `co_await` suspends and the callback is later resumed by a `coro_rpc` thread. However, if the coroutine completes synchronously, for example by hitting an early error before the first suspension point, `co_await` can return immediately.

In that case, the callback is invoked on the calling thread, which can lead to a deadlock. Though the risk is relatively low, notify failures are not uncommon during shutdown (e.g. when a subscriber shuts down before its subscribed peers). In such cases, once the peers shut down and unregister their buffers, subsequent notifications can fail.

#### UAF

`subscribers_lock_` and `subscribers_` were previously owned directly by `SegmentManager`. This creates a potential UAF risk if callback is invoked after `SegmentManager` is destroyed.

### Changes

This fix addresses both issues by:

- Releasing the lock before issuing RPC to avoid deadlock.
- Moving `subscribers_lock_` and `subscribers_` under `std::shared_ptr` to ensure they're alive in callbacks.

Thanks for @staryxchen for identifying this issue.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Tested with mooncake-pg.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
