### PR TITLE
[Tracing] Introduce end-to-end tracing pipeline for Mooncake transfers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ add_compile_definitions(ASIO_SEPARATE_COMPILATION ASIO_DYN_LINK)
 add_subdirectory(mooncake-asio)
 
 add_subdirectory(mooncake-common)
+add_subdirectory(mooncake-tracing)
+include_directories(mooncake-tracing/include)
 include_directories(mooncake-common/etcd)
 include_directories(mooncake-common/include)
 

--- a/mooncake-store/CMakeLists.txt
+++ b/mooncake-store/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include/
     ${CMAKE_CURRENT_BINARY_DIR}/include/
     ${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-transfer-engine/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-tracing/include
     ${ETCD_WRAPPER_INCLUDE}
 )
 

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -24,6 +24,7 @@
 #include "master_metric_manager.h"
 #include "count_min_sketch.h"
 #include "local_hot_cache.h"
+#include "trace_context.h"
 
 namespace mooncake {
 
@@ -530,11 +531,17 @@ class Client {
     void InitTransferSubmitter();
     ErrorCode TransferData(const Replica::Descriptor& replica_descriptor,
                            std::vector<Slice>& slices,
-                           TransferRequest::OpCode op_code);
+                           TransferRequest::OpCode op_code,
+                           const tracing::TraceContext* trace_context =
+                               nullptr);
     ErrorCode TransferWrite(const Replica::Descriptor& replica_descriptor,
-                            std::vector<Slice>& slices);
+                            std::vector<Slice>& slices,
+                            const tracing::TraceContext* trace_context =
+                                nullptr);
     ErrorCode TransferRead(const Replica::Descriptor& replica_descriptor,
-                           std::vector<Slice>& slices);
+                           std::vector<Slice>& slices,
+                           const tracing::TraceContext* trace_context =
+                               nullptr);
 
     /**
      * @brief Prepare and use the storage backend for persisting data
@@ -685,7 +692,8 @@ class Client {
         std::function<tl::expected<void, ErrorCode>()> end_fn,
         std::function<tl::expected<void, ErrorCode>()> revoke_fn,
         const Replica::Descriptor& source,
-        const std::vector<Replica::Descriptor>& targets);
+        const std::vector<Replica::Descriptor>& targets,
+        const tracing::TraceContext* trace_context = nullptr);
 
     /**
      * @brief Copy an object's replica to target segments
@@ -696,7 +704,9 @@ class Client {
      */
     tl::expected<void, ErrorCode> Copy(const std::string& key,
                                        const std::string& source,
-                                       const std::vector<std::string>& targets);
+                                       const std::vector<std::string>& targets,
+                                       const tracing::TraceContext* trace_context =
+                                           nullptr);
 
     /**
      * @brief Move an object's replica from source segment to target segment
@@ -707,7 +717,9 @@ class Client {
      */
     tl::expected<void, ErrorCode> Move(const std::string& key,
                                        const std::string& source,
-                                       const std::string& target);
+                                       const std::string& target,
+                                       const tracing::TraceContext* trace_context =
+                                           nullptr);
 
     // Task thread pool for async task execution
     ThreadPool task_thread_pool_;

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -529,19 +529,18 @@ class Client {
         const std::string& metadata_connstring, const std::string& protocol,
         const std::optional<std::string>& device_names);
     void InitTransferSubmitter();
-    ErrorCode TransferData(const Replica::Descriptor& replica_descriptor,
-                           std::vector<Slice>& slices,
-                           TransferRequest::OpCode op_code,
-                           const tracing::TraceContext* trace_context =
-                               nullptr);
-    ErrorCode TransferWrite(const Replica::Descriptor& replica_descriptor,
-                            std::vector<Slice>& slices,
-                            const tracing::TraceContext* trace_context =
-                                nullptr);
-    ErrorCode TransferRead(const Replica::Descriptor& replica_descriptor,
-                           std::vector<Slice>& slices,
-                           const tracing::TraceContext* trace_context =
-                               nullptr);
+    ErrorCode TransferData(
+        const Replica::Descriptor& replica_descriptor,
+        std::vector<Slice>& slices, TransferRequest::OpCode op_code,
+        const tracing::TraceContext* trace_context = nullptr);
+    ErrorCode TransferWrite(
+        const Replica::Descriptor& replica_descriptor,
+        std::vector<Slice>& slices,
+        const tracing::TraceContext* trace_context = nullptr);
+    ErrorCode TransferRead(
+        const Replica::Descriptor& replica_descriptor,
+        std::vector<Slice>& slices,
+        const tracing::TraceContext* trace_context = nullptr);
 
     /**
      * @brief Prepare and use the storage backend for persisting data
@@ -702,11 +701,10 @@ class Client {
      * @param targets Target segments
      * @return tl::expected<void, ErrorCode> indicating success/failure
      */
-    tl::expected<void, ErrorCode> Copy(const std::string& key,
-                                       const std::string& source,
-                                       const std::vector<std::string>& targets,
-                                       const tracing::TraceContext* trace_context =
-                                           nullptr);
+    tl::expected<void, ErrorCode> Copy(
+        const std::string& key, const std::string& source,
+        const std::vector<std::string>& targets,
+        const tracing::TraceContext* trace_context = nullptr);
 
     /**
      * @brief Move an object's replica from source segment to target segment
@@ -715,11 +713,10 @@ class Client {
      * @param target Target segment
      * @return tl::expected<void, ErrorCode> indicating success/failure
      */
-    tl::expected<void, ErrorCode> Move(const std::string& key,
-                                       const std::string& source,
-                                       const std::string& target,
-                                       const tracing::TraceContext* trace_context =
-                                           nullptr);
+    tl::expected<void, ErrorCode> Move(
+        const std::string& key, const std::string& source,
+        const std::string& target,
+        const tracing::TraceContext* trace_context = nullptr);
 
     // Task thread pool for async task execution
     ThreadPool task_thread_pool_;

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -116,6 +116,7 @@ struct TaskAssignment {
     std::string payload;
     int64_t created_at_ms_epoch;
     uint32_t max_retry_attempts;
+    std::string trace_carrier;
 
     TaskAssignment() = default;
     TaskAssignment(const Task& task)
@@ -126,10 +127,11 @@ struct TaskAssignment {
               std::chrono::duration_cast<std::chrono::milliseconds>(
                   task.created_at.time_since_epoch())
                   .count())),
-          max_retry_attempts(task.max_retry_attempts) {}
+          max_retry_attempts(task.max_retry_attempts),
+          trace_carrier(task.trace_carrier) {}
 };
 YLT_REFL(TaskAssignment, id, type, payload, created_at_ms_epoch,
-         max_retry_attempts);
+         max_retry_attempts, trace_carrier);
 
 /**
  * @brief Task update structure

--- a/mooncake-store/include/task_manager.h
+++ b/mooncake-store/include/task_manager.h
@@ -261,7 +261,7 @@ class ClientTaskManager {
 };
 
 class TaskManagerSerializer {
-    static constexpr size_t kTaskSerializedFields = 8;
+    static constexpr size_t kTaskSerializedFields = 10;
     static constexpr size_t kMaxDecompressedSize = 1024 * 1024 * 1024;  // 1 GB
 
    public:

--- a/mooncake-store/include/task_manager.h
+++ b/mooncake-store/include/task_manager.h
@@ -76,6 +76,7 @@ struct Task {
     std::string message;
     UUID assigned_client;
     uint32_t max_retry_attempts;
+    std::string trace_carrier;
 
     bool is_finished() const { return is_finished_status(status); }
 
@@ -166,7 +167,16 @@ class ScopedTaskWriteAccess {
         const UUID& client_id,
         const typename TaskPayloadTraits<Type>::type& payload) {
         std::string json = serialize_payload(payload);
-        return submit_task(client_id, Type, json);
+        return submit_task(client_id, Type, json, "");
+    }
+
+    template <TaskType Type>
+    tl::expected<UUID, ErrorCode> submit_task_typed_with_trace(
+        const UUID& client_id,
+        const typename TaskPayloadTraits<Type>::type& payload,
+        const std::string& trace_carrier) {
+        std::string json = serialize_payload(payload);
+        return submit_task(client_id, Type, json, trace_carrier);
     }
 
     std::vector<Task> pop_tasks(const UUID& client_id, size_t batch_size);
@@ -185,7 +195,8 @@ class ScopedTaskWriteAccess {
    private:
     tl::expected<UUID, ErrorCode> submit_task(const UUID& client_id,
                                               TaskType type,
-                                              const std::string& payload);
+                                              const std::string& payload,
+                                              const std::string& trace_carrier);
 
     ClientTaskManager* manager_;
     SharedMutexLocker lock_;

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -18,6 +18,7 @@
 #include "replica.h"
 #include "storage_backend.h"
 #include "client_metric.h"
+#include "trace_context.h"
 
 namespace mooncake {
 
@@ -173,8 +174,10 @@ class FilereadOperationState : public OperationState {
 class TransferEngineOperationState : public OperationState {
    public:
     TransferEngineOperationState(TransferEngine& engine, BatchID batch_id,
-                                 size_t batch_size)
-        : engine_(engine), batch_id_(batch_id), batch_size_(batch_size) {}
+                                 size_t batch_size,
+                                 mooncake::tracing::TraceContext trace_context = {})
+        : engine_(engine), batch_id_(batch_id), batch_size_(batch_size),
+          trace_context_(std::move(trace_context)) {}
 
     ~TransferEngineOperationState() { engine_.freeBatchID(batch_id_); }
 
@@ -199,6 +202,7 @@ class TransferEngineOperationState : public OperationState {
     TransferEngine& engine_;
     BatchID batch_id_;
     size_t batch_size_;
+    mooncake::tracing::TraceContext trace_context_;
 };
 
 /**

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -184,6 +184,8 @@ class TransferTraceSession {
 
     bool owns_operation_span() const { return operation_span_.valid(); }
 
+    void StartQueueWait(mooncake::tracing::TracingFacade& tracing,
+                        BatchID batch_id, size_t batch_size);
     mooncake::tracing::Span* EnsureWaitSpan(
         mooncake::tracing::TracingFacade& tracing, BatchID batch_id,
         size_t batch_size);
@@ -194,11 +196,16 @@ class TransferTraceSession {
     void RecordBatch(BatchID batch_id);
     void MarkSubmitError();
     void FinishWait(ErrorCode error_code);
-    void Finish(ErrorCode error_code);
+    void Finish(mooncake::tracing::TracingFacade& tracing,
+                ErrorCode error_code);
 
    private:
+    void FinishQueueWait(ErrorCode error_code);
+
     mooncake::tracing::TraceContext parent_context_;
     mooncake::tracing::Span operation_span_;
+    mooncake::tracing::Span queue_wait_span_;
+    mooncake::tracing::TraceContext queue_wait_context_;
     mooncake::tracing::Span wait_span_;
     mooncake::tracing::TraceContext wait_context_;
     BatchID batch_id_{INVALID_BATCH_ID};

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -19,6 +19,7 @@
 #include "storage_backend.h"
 #include "client_metric.h"
 #include "trace_context.h"
+#include "tracing_facade.h"
 
 namespace mooncake {
 
@@ -168,6 +169,42 @@ class FilereadOperationState : public OperationState {
     }
 };
 
+class TransferTraceSession {
+   public:
+    TransferTraceSession() = default;
+
+    static TransferTraceSession Start(
+        mooncake::tracing::TracingFacade& tracing,
+        const mooncake::tracing::TraceContext* trace_context,
+        size_t batch_size, size_t total_bytes);
+
+    const mooncake::tracing::TraceContext* parent_context() const {
+        return parent_context_.valid() ? &parent_context_ : nullptr;
+    }
+
+    bool owns_operation_span() const { return operation_span_.valid(); }
+
+    mooncake::tracing::Span* EnsureWaitSpan(
+        mooncake::tracing::TracingFacade& tracing, BatchID batch_id,
+        size_t batch_size);
+    const mooncake::tracing::TraceContext* wait_context() const {
+        return wait_context_.valid() ? &wait_context_ : nullptr;
+    }
+
+    void RecordBatch(BatchID batch_id);
+    void MarkSubmitError();
+    void FinishWait(ErrorCode error_code);
+    void Finish(ErrorCode error_code);
+
+   private:
+    mooncake::tracing::TraceContext parent_context_;
+    mooncake::tracing::Span operation_span_;
+    mooncake::tracing::Span wait_span_;
+    mooncake::tracing::TraceContext wait_context_;
+    BatchID batch_id_{INVALID_BATCH_ID};
+    size_t batch_size_{0};
+};
+
 /**
  * @brief Operation state for transfer engine operations
  */
@@ -175,9 +212,9 @@ class TransferEngineOperationState : public OperationState {
    public:
     TransferEngineOperationState(TransferEngine& engine, BatchID batch_id,
                                  size_t batch_size,
-                                 mooncake::tracing::TraceContext trace_context = {})
+                                 TransferTraceSession trace_session = {})
         : engine_(engine), batch_id_(batch_id), batch_size_(batch_size),
-          trace_context_(std::move(trace_context)) {}
+          trace_session_(std::move(trace_session)) {}
 
     ~TransferEngineOperationState() { engine_.freeBatchID(batch_id_); }
 
@@ -202,7 +239,7 @@ class TransferEngineOperationState : public OperationState {
     TransferEngine& engine_;
     BatchID batch_id_;
     size_t batch_size_;
-    mooncake::tracing::TraceContext trace_context_;
+    TransferTraceSession trace_session_;
 };
 
 /**

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -387,12 +387,15 @@ class TransferSubmitter {
      */
     std::optional<TransferFuture> submit(const Replica::Descriptor& replica,
                                          std::vector<Slice>& slices,
-                                         TransferRequest::OpCode op_code);
+                                         TransferRequest::OpCode op_code,
+                                         const tracing::TraceContext* trace_context =
+                                             nullptr);
 
     std::optional<TransferFuture> submit_batch(
         const std::vector<Replica::Descriptor>& replicas,
         std::vector<std::vector<Slice>>& all_slices,
-        TransferRequest::OpCode op_code);
+        TransferRequest::OpCode op_code,
+        const tracing::TraceContext* trace_context = nullptr);
 
     std::optional<TransferFuture> submit_batch_get_offload_object(
         const std::string& transfer_engine_addr,
@@ -430,7 +433,8 @@ class TransferSubmitter {
     std::optional<TransferFuture> submitMemcpyOperation(
         const AllocatedBuffer::Descriptor& handle,
         const std::vector<Slice>& slices,
-        const TransferRequest::OpCode op_code);
+        const TransferRequest::OpCode op_code,
+        const tracing::TraceContext* trace_context);
 
     /**
      * @brief Submit transfer engine operation asynchronously
@@ -438,11 +442,13 @@ class TransferSubmitter {
     std::optional<TransferFuture> submitTransferEngineOperation(
         const AllocatedBuffer::Descriptor& handle,
         const std::vector<Slice>& slices,
-        const TransferRequest::OpCode op_code);
+        const TransferRequest::OpCode op_code,
+        const tracing::TraceContext* trace_context);
 
     std::optional<TransferFuture> submitFileReadOperation(
         const Replica::Descriptor& replica, std::vector<Slice>& slices,
-        TransferRequest::OpCode op_code);
+        TransferRequest::OpCode op_code,
+        const tracing::TraceContext* trace_context);
 
     /**
      * @brief Calculate total bytes for transfer operation and update metrics
@@ -451,7 +457,8 @@ class TransferSubmitter {
                                TransferRequest::OpCode op);
 
     std::optional<TransferFuture> submitTransfer(
-        std::vector<TransferRequest>& requests);
+        std::vector<TransferRequest>& requests,
+        const tracing::TraceContext* trace_context);
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -175,8 +175,8 @@ class TransferTraceSession {
 
     static TransferTraceSession Start(
         mooncake::tracing::TracingFacade& tracing,
-        const mooncake::tracing::TraceContext* trace_context,
-        size_t batch_size, size_t total_bytes);
+        const mooncake::tracing::TraceContext* trace_context, size_t batch_size,
+        size_t total_bytes);
 
     const mooncake::tracing::TraceContext* parent_context() const {
         return parent_context_.valid() ? &parent_context_ : nullptr;
@@ -220,7 +220,9 @@ class TransferEngineOperationState : public OperationState {
     TransferEngineOperationState(TransferEngine& engine, BatchID batch_id,
                                  size_t batch_size,
                                  TransferTraceSession trace_session = {})
-        : engine_(engine), batch_id_(batch_id), batch_size_(batch_size),
+        : engine_(engine),
+          batch_id_(batch_id),
+          batch_size_(batch_size),
           trace_session_(std::move(trace_session)) {}
 
     ~TransferEngineOperationState() { engine_.freeBatchID(batch_id_); }
@@ -429,11 +431,10 @@ class TransferSubmitter {
      * @return TransferFuture representing the async operation, or nullopt on
      * failure
      */
-    std::optional<TransferFuture> submit(const Replica::Descriptor& replica,
-                                         std::vector<Slice>& slices,
-                                         TransferRequest::OpCode op_code,
-                                         const tracing::TraceContext* trace_context =
-                                             nullptr);
+    std::optional<TransferFuture> submit(
+        const Replica::Descriptor& replica, std::vector<Slice>& slices,
+        TransferRequest::OpCode op_code,
+        const tracing::TraceContext* trace_context = nullptr);
 
     std::optional<TransferFuture> submit_batch(
         const std::vector<Replica::Descriptor>& replicas,
@@ -476,8 +477,7 @@ class TransferSubmitter {
      */
     std::optional<TransferFuture> submitMemcpyOperation(
         const AllocatedBuffer::Descriptor& handle,
-        const std::vector<Slice>& slices,
-        const TransferRequest::OpCode op_code,
+        const std::vector<Slice>& slices, const TransferRequest::OpCode op_code,
         const tracing::TraceContext* trace_context);
 
     /**
@@ -485,8 +485,7 @@ class TransferSubmitter {
      */
     std::optional<TransferFuture> submitTransferEngineOperation(
         const AllocatedBuffer::Descriptor& handle,
-        const std::vector<Slice>& slices,
-        const TransferRequest::OpCode op_code,
+        const std::vector<Slice>& slices, const TransferRequest::OpCode op_code,
         const tracing::TraceContext* trace_context);
 
     std::optional<TransferFuture> submitFileReadOperation(

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -184,7 +184,7 @@ class TransferTraceSession {
 
     bool owns_operation_span() const { return operation_span_.valid(); }
 
-    void StartQueueWait(mooncake::tracing::TracingFacade& tracing,
+    void StartSubmitGap(mooncake::tracing::TracingFacade& tracing,
                         BatchID batch_id, size_t batch_size);
     mooncake::tracing::Span* EnsureWaitSpan(
         mooncake::tracing::TracingFacade& tracing, BatchID batch_id,
@@ -200,12 +200,12 @@ class TransferTraceSession {
                 ErrorCode error_code);
 
    private:
-    void FinishQueueWait(ErrorCode error_code);
+    void FinishSubmitGap(ErrorCode error_code);
 
     mooncake::tracing::TraceContext parent_context_;
     mooncake::tracing::Span operation_span_;
-    mooncake::tracing::Span queue_wait_span_;
-    mooncake::tracing::TraceContext queue_wait_context_;
+    mooncake::tracing::Span submit_gap_span_;
+    mooncake::tracing::TraceContext submit_gap_context_;
     mooncake::tracing::Span wait_span_;
     mooncake::tracing::TraceContext wait_context_;
     BatchID batch_id_{INVALID_BATCH_ID};

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -157,6 +157,7 @@ target_link_libraries(mooncake_store
         gflags::gflags
         ${EXTRA_LIBS}
         asio_shared
+        mooncake-tracing
     PRIVATE
         transfer_engine
 )

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2369,10 +2369,9 @@ tl::expected<void, ErrorCode> Client::Copy(
     return result;
 }
 
-tl::expected<void, ErrorCode> Client::Move(const std::string& key,
-                                           const std::string& source,
-                                           const std::string& target,
-                                           const tracing::TraceContext* trace_context) {
+tl::expected<void, ErrorCode> Client::Move(
+    const std::string& key, const std::string& source,
+    const std::string& target, const tracing::TraceContext* trace_context) {
     LOG(INFO) << "action=replica_move_start" << ", key=" << key
               << ", source_segment=" << source << ", target_segment=" << target;
 
@@ -2525,18 +2524,17 @@ ErrorCode Client::TransferData(const Replica::Descriptor& replica_descriptor,
     for (const auto& slice : slices) {
         total_bytes += slice.size;
     }
-    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
-                                                     "client-service");
+    auto& tracing =
+        tracing::TracingFacade::Instance("mooncake-store", "client-service");
     auto operation_span = tracing.StartSpan(
         "mooncake.transfer.operation", trace_context,
-        {{"transfer.op",
-          op_code == TransferRequest::READ ? "READ" : "WRITE"},
+        {{"transfer.op", op_code == TransferRequest::READ ? "READ" : "WRITE"},
          {"slice.count", std::to_string(slices.size())},
          {"bytes.total", std::to_string(total_bytes)}});
 
     auto operation_context = operation_span.context();
-    auto future = transfer_submitter_->submit(replica_descriptor, slices, op_code,
-                                              &operation_context);
+    auto future = transfer_submitter_->submit(replica_descriptor, slices,
+                                              op_code, &operation_context);
     if (!future) {
         LOG(ERROR) << "Failed to submit transfer operation";
         operation_span.SetStatus("ERROR");
@@ -2623,15 +2621,15 @@ void Client::TaskPollThreadMain() {
 
 void Client::SubmitTask(const TaskAssignment& assignment) {
     auto carrier = tracing::DecodeTraceCarrier(assignment.trace_carrier);
-    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
-                                                     "client-task");
-    auto span = carrier.empty()
-                    ? tracing.StartSpan(
-                          "SubmitTask", nullptr,
-                          {{"task.id", UuidToString(assignment.id)}})
-                    : tracing.StartSpanFromCarrier(
-                          "SubmitTask", carrier,
-                          {{"task.id", UuidToString(assignment.id)}});
+    auto& tracing =
+        tracing::TracingFacade::Instance("mooncake-store", "client-task");
+    auto span =
+        carrier.empty()
+            ? tracing.StartSpan("SubmitTask", nullptr,
+                                {{"task.id", UuidToString(assignment.id)}})
+            : tracing.StartSpanFromCarrier(
+                  "SubmitTask", carrier,
+                  {{"task.id", UuidToString(assignment.id)}});
     if (!task_running_.load()) {
         LOG(WARNING) << "action=task_rejected" << ", task_id=" << assignment.id
                      << ", reason=executor_stopped";
@@ -2653,16 +2651,17 @@ void Client::ExecuteTask(const ClientTask& client_task) {
     const auto& assignment = client_task.assignment;
     ErrorCode result = ErrorCode::OK;
     auto carrier = tracing::DecodeTraceCarrier(assignment.trace_carrier);
-    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
-                                                     "client-task");
-    auto span = carrier.empty()
-                    ? tracing.StartSpan(
-                          "ExecuteTask", nullptr,
-                          {{"task.id", UuidToString(assignment.id)}})
-                    : tracing.StartSpanFromCarrier(
-                          "ExecuteTask", carrier,
-                          {{"task.id", UuidToString(assignment.id)}});
-    span.SetAttribute("task.retry_count", std::to_string(client_task.retry_count));
+    auto& tracing =
+        tracing::TracingFacade::Instance("mooncake-store", "client-task");
+    auto span =
+        carrier.empty()
+            ? tracing.StartSpan("ExecuteTask", nullptr,
+                                {{"task.id", UuidToString(assignment.id)}})
+            : tracing.StartSpanFromCarrier(
+                  "ExecuteTask", carrier,
+                  {{"task.id", UuidToString(assignment.id)}});
+    span.SetAttribute("task.retry_count",
+                      std::to_string(client_task.retry_count));
 
     try {
         switch (assignment.type) {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -27,6 +27,7 @@
 #include "utils.h"
 #include "rpc_types.h"
 #include "local_hot_cache.h"
+#include "tracing_facade.h"
 
 namespace mooncake {
 
@@ -2270,7 +2271,8 @@ tl::expected<void, ErrorCode> Client::ExecuteReplicaTransfer(
     std::function<tl::expected<void, ErrorCode>()> end_fn,
     std::function<tl::expected<void, ErrorCode>()> revoke_fn,
     const Replica::Descriptor& source,
-    const std::vector<Replica::Descriptor>& targets) {
+    const std::vector<Replica::Descriptor>& targets,
+    const tracing::TraceContext* trace_context) {
     auto revoke_lambda = [&]() {
         auto revoke_result = revoke_fn();
         if (!revoke_result.has_value()) {
@@ -2306,7 +2308,7 @@ tl::expected<void, ErrorCode> Client::ExecuteReplicaTransfer(
 
     // Transfer to each target
     for (const auto& target : targets) {
-        if (TransferWrite(target, slices) != ErrorCode::OK) {
+        if (TransferWrite(target, slices, trace_context) != ErrorCode::OK) {
             revoke_lambda();
             return tl::unexpected(ErrorCode::TRANSFER_FAIL);
         }
@@ -2324,7 +2326,8 @@ tl::expected<void, ErrorCode> Client::ExecuteReplicaTransfer(
 
 tl::expected<void, ErrorCode> Client::Copy(
     const std::string& key, const std::string& source,
-    const std::vector<std::string>& targets) {
+    const std::vector<std::string>& targets,
+    const tracing::TraceContext* trace_context) {
     LOG(INFO) << "action=replica_copy_start" << ", key=" << key
               << ", targets_count=" << targets.size();
 
@@ -2356,7 +2359,7 @@ tl::expected<void, ErrorCode> Client::Copy(
     auto result = ExecuteReplicaTransfer(
         key, "copy", [&]() { return master_client_.CopyEnd(key); },
         [&]() { return master_client_.CopyRevoke(key); }, response.source,
-        response.targets);
+        response.targets, trace_context);
 
     if (result.has_value()) {
         LOG(INFO) << "action=replica_copy_success" << ", key=" << key
@@ -2368,7 +2371,8 @@ tl::expected<void, ErrorCode> Client::Copy(
 
 tl::expected<void, ErrorCode> Client::Move(const std::string& key,
                                            const std::string& source,
-                                           const std::string& target) {
+                                           const std::string& target,
+                                           const tracing::TraceContext* trace_context) {
     LOG(INFO) << "action=replica_move_start" << ", key=" << key
               << ", source_segment=" << source << ", target_segment=" << target;
 
@@ -2403,7 +2407,7 @@ tl::expected<void, ErrorCode> Client::Move(const std::string& key,
     auto result = ExecuteReplicaTransfer(
         key, "move", [&]() { return master_client_.MoveEnd(key); },
         [&]() { return master_client_.MoveRevoke(key); }, response.source,
-        targets);
+        targets, trace_context);
 
     if (result.has_value()) {
         LOG(INFO) << "action=replica_move_success" << ", key=" << key
@@ -2510,31 +2514,60 @@ void Client::PutToLocalFile(const std::string& key,
 
 ErrorCode Client::TransferData(const Replica::Descriptor& replica_descriptor,
                                std::vector<Slice>& slices,
-                               TransferRequest::OpCode op_code) {
+                               TransferRequest::OpCode op_code,
+                               const tracing::TraceContext* trace_context) {
     if (!transfer_submitter_) {
         LOG(ERROR) << "TransferSubmitter not initialized";
         return ErrorCode::INVALID_PARAMS;
     }
 
-    auto future =
-        transfer_submitter_->submit(replica_descriptor, slices, op_code);
+    size_t total_bytes = 0;
+    for (const auto& slice : slices) {
+        total_bytes += slice.size;
+    }
+    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
+                                                     "client-service");
+    auto operation_span = tracing.StartSpan(
+        "mooncake.transfer.operation", trace_context,
+        {{"transfer.op",
+          op_code == TransferRequest::READ ? "READ" : "WRITE"},
+         {"slice.count", std::to_string(slices.size())},
+         {"bytes.total", std::to_string(total_bytes)}});
+
+    auto operation_context = operation_span.context();
+    auto future = transfer_submitter_->submit(replica_descriptor, slices, op_code,
+                                              &operation_context);
     if (!future) {
         LOG(ERROR) << "Failed to submit transfer operation";
+        operation_span.SetStatus("ERROR");
         return ErrorCode::TRANSFER_FAIL;
     }
 
-    VLOG(1) << "Using transfer strategy: " << future->strategy();
+    operation_span.SetAttribute(
+        "transfer.strategy",
+        future->strategy() == TransferStrategy::LOCAL_MEMCPY
+            ? "LOCAL_MEMCPY"
+            : (future->strategy() == TransferStrategy::TRANSFER_ENGINE
+                   ? "TRANSFER_ENGINE"
+                   : "FILE_READ"));
 
-    return future->get();
+    auto result = future->get();
+    if (result != ErrorCode::OK) {
+        operation_span.SetStatus("ERROR");
+    }
+    return result;
 }
 
 ErrorCode Client::TransferWrite(const Replica::Descriptor& replica_descriptor,
-                                std::vector<Slice>& slices) {
-    return TransferData(replica_descriptor, slices, TransferRequest::WRITE);
+                                std::vector<Slice>& slices,
+                                const tracing::TraceContext* trace_context) {
+    return TransferData(replica_descriptor, slices, TransferRequest::WRITE,
+                        trace_context);
 }
 
 ErrorCode Client::TransferRead(const Replica::Descriptor& replica_descriptor,
-                               std::vector<Slice>& slices) {
+                               std::vector<Slice>& slices,
+                               const tracing::TraceContext* trace_context) {
     size_t total_size = 0;
     if (replica_descriptor.is_memory_replica()) {
         auto& mem_desc = replica_descriptor.get_memory_descriptor();
@@ -2551,7 +2584,8 @@ ErrorCode Client::TransferRead(const Replica::Descriptor& replica_descriptor,
         return ErrorCode::INVALID_PARAMS;
     }
 
-    return TransferData(replica_descriptor, slices, TransferRequest::READ);
+    return TransferData(replica_descriptor, slices, TransferRequest::READ,
+                        trace_context);
 }
 
 void Client::PollAndDispatchTasks() {
@@ -2588,9 +2622,20 @@ void Client::TaskPollThreadMain() {
 }
 
 void Client::SubmitTask(const TaskAssignment& assignment) {
+    auto carrier = tracing::DecodeTraceCarrier(assignment.trace_carrier);
+    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
+                                                     "client-task");
+    auto span = carrier.empty()
+                    ? tracing.StartSpan(
+                          "SubmitTask", nullptr,
+                          {{"task.id", UuidToString(assignment.id)}})
+                    : tracing.StartSpanFromCarrier(
+                          "SubmitTask", carrier,
+                          {{"task.id", UuidToString(assignment.id)}});
     if (!task_running_.load()) {
         LOG(WARNING) << "action=task_rejected" << ", task_id=" << assignment.id
                      << ", reason=executor_stopped";
+        span.SetStatus("ERROR");
         return;
     }
 
@@ -2598,6 +2643,7 @@ void Client::SubmitTask(const TaskAssignment& assignment) {
     ClientTask client_task;
     client_task.assignment = assignment;
     client_task.retry_count = 0;
+    span.AddEvent("task enqueued");
 
     task_thread_pool_.enqueue(
         [this, client_task]() { ExecuteTask(client_task); });
@@ -2606,14 +2652,26 @@ void Client::SubmitTask(const TaskAssignment& assignment) {
 void Client::ExecuteTask(const ClientTask& client_task) {
     const auto& assignment = client_task.assignment;
     ErrorCode result = ErrorCode::OK;
+    auto carrier = tracing::DecodeTraceCarrier(assignment.trace_carrier);
+    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
+                                                     "client-task");
+    auto span = carrier.empty()
+                    ? tracing.StartSpan(
+                          "ExecuteTask", nullptr,
+                          {{"task.id", UuidToString(assignment.id)}})
+                    : tracing.StartSpanFromCarrier(
+                          "ExecuteTask", carrier,
+                          {{"task.id", UuidToString(assignment.id)}});
+    span.SetAttribute("task.retry_count", std::to_string(client_task.retry_count));
 
     try {
         switch (assignment.type) {
             case TaskType::REPLICA_COPY: {
                 ReplicaCopyPayload payload;
                 struct_json::from_json(payload, assignment.payload);
-                auto copy_result =
-                    Copy(payload.key, payload.source, payload.targets);
+                auto task_context = span.context();
+                auto copy_result = Copy(payload.key, payload.source,
+                                        payload.targets, &task_context);
                 if (copy_result.has_value()) {
                     result = ErrorCode::OK;
                 } else {
@@ -2624,8 +2682,9 @@ void Client::ExecuteTask(const ClientTask& client_task) {
             case TaskType::REPLICA_MOVE: {
                 ReplicaMovePayload payload;
                 struct_json::from_json(payload, assignment.payload);
-                auto move_result =
-                    Move(payload.key, payload.source, payload.target);
+                auto task_context = span.context();
+                auto move_result = Move(payload.key, payload.source,
+                                        payload.target, &task_context);
                 if (move_result.has_value()) {
                     result = ErrorCode::OK;
                 } else {
@@ -2638,6 +2697,7 @@ void Client::ExecuteTask(const ClientTask& client_task) {
                            << ", task_id=" << assignment.id
                            << ", error=unknown_task_type"
                            << ", task_type=" << assignment.type;
+                span.SetStatus("ERROR");
                 result = ErrorCode::INVALID_PARAMS;
                 break;
         }
@@ -2645,7 +2705,13 @@ void Client::ExecuteTask(const ClientTask& client_task) {
         LOG(ERROR) << "action=task_execution_failed"
                    << ", task_id=" << assignment.id << ", error=exception"
                    << ", exception=" << e.what();
+        span.SetStatus("ERROR");
         result = ErrorCode::INTERNAL_ERROR;
+    }
+
+    span.SetAttribute("task.result", toString(result));
+    if (result != ErrorCode::OK) {
+        span.SetStatus("ERROR");
     }
 
     if (result == ErrorCode::OK) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -4232,11 +4232,12 @@ std::string MasterService::FormatTimestamp(
 
 tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
     const std::string& key, const std::vector<std::string>& targets) {
-    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
-                                                     "master-service");
-    auto span = tracing.StartSpan(
-        "CreateCopyTask", nullptr,
-        {{"object.key", key}, {"target.count", std::to_string(targets.size())}});
+    auto& tracing =
+        tracing::TracingFacade::Instance("mooncake-store", "master-service");
+    auto span =
+        tracing.StartSpan("CreateCopyTask", nullptr,
+                          {{"object.key", key},
+                           {"target.count", std::to_string(targets.size())}});
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     if (targets.empty()) {
         LOG(ERROR) << "key=" << key << ", error=empty_targets";
@@ -4284,9 +4285,10 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
     }
     auto task_id = task_manager_.get_write_access()
                        .submit_task_typed_with_trace<TaskType::REPLICA_COPY>(
-                           select_client, {.key = key,
-                                           .source = selected_source_segment,
-                                           .targets = targets},
+                           select_client,
+                           {.key = key,
+                            .source = selected_source_segment,
+                            .targets = targets},
                            tracing::EncodeTraceCarrier(
                                tracing::ToCarrier(span.context())));
     if (task_id.has_value()) {
@@ -4300,8 +4302,8 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
 tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
     const std::string& key, const std::string& source,
     const std::string& target) {
-    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
-                                                     "master-service");
+    auto& tracing =
+        tracing::TracingFacade::Instance("mooncake-store", "master-service");
     auto span = tracing.StartSpan("CreateMoveTask", nullptr,
                                   {{"object.key", key},
                                    {"source.segment", source},
@@ -4351,12 +4353,12 @@ tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
 
-    auto task_id = task_manager_.get_write_access()
-                       .submit_task_typed_with_trace<TaskType::REPLICA_MOVE>(
-                           select_client,
-                           {.key = key, .source = source, .target = target},
-                           tracing::EncodeTraceCarrier(
-                               tracing::ToCarrier(span.context())));
+    auto task_id =
+        task_manager_.get_write_access()
+            .submit_task_typed_with_trace<TaskType::REPLICA_MOVE>(
+                select_client, {.key = key, .source = source, .target = target},
+                tracing::EncodeTraceCarrier(
+                    tracing::ToCarrier(span.context())));
     if (task_id.has_value()) {
         span.SetAttribute("task.id", UuidToString(task_id.value()));
     } else {
@@ -4380,8 +4382,8 @@ tl::expected<QueryTaskResponse, ErrorCode> MasterService::QueryTask(
         }
         return "UNKNOWN";
     };
-    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
-                                                     "master-service");
+    auto& tracing =
+        tracing::TracingFacade::Instance("mooncake-store", "master-service");
     auto span = tracing.StartSpan("QueryTask", nullptr,
                                   {{"task.id", UuidToString(task_id)}});
     const auto& task_option =
@@ -4391,14 +4393,15 @@ tl::expected<QueryTaskResponse, ErrorCode> MasterService::QueryTask(
         span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::TASK_NOT_FOUND);
     }
-    span.SetAttribute("task.status", task_status_to_string(task_option->status));
+    span.SetAttribute("task.status",
+                      task_status_to_string(task_option->status));
     return QueryTaskResponse(task_option.value());
 }
 
 tl::expected<std::vector<TaskAssignment>, ErrorCode> MasterService::FetchTasks(
     const UUID& client_id, size_t batch_size) {
-    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
-                                                     "master-service");
+    auto& tracing =
+        tracing::TracingFacade::Instance("mooncake-store", "master-service");
     auto span = tracing.StartSpan(
         "FetchTasks", nullptr,
         {{"client.id", UuidToString(client_id)},
@@ -4410,7 +4413,8 @@ tl::expected<std::vector<TaskAssignment>, ErrorCode> MasterService::FetchTasks(
     for (const auto& task : tasks) {
         assignments.emplace_back(task);
     }
-    span.SetAttribute("batch.size.returned", std::to_string(assignments.size()));
+    span.SetAttribute("batch.size.returned",
+                      std::to_string(assignments.size()));
     return assignments;
 }
 
@@ -4429,8 +4433,8 @@ tl::expected<void, ErrorCode> MasterService::MarkTaskToComplete(
         }
         return "UNKNOWN";
     };
-    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
-                                                     "master-service");
+    auto& tracing =
+        tracing::TracingFacade::Instance("mooncake-store", "master-service");
     auto span = tracing.StartSpan(
         "MarkTaskToComplete", nullptr,
         {{"client.id", UuidToString(client_id)},

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -23,6 +23,7 @@
 #include "types.h"
 #include "serialize/serializer.hpp"
 #include "ha/snapshot/snapshot_logger.h"
+#include "tracing_facade.h"
 #include "utils/zstd_util.h"
 #include "utils/file_util.h"
 #include "utils.h"
@@ -4231,14 +4232,21 @@ std::string MasterService::FormatTimestamp(
 
 tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
     const std::string& key, const std::vector<std::string>& targets) {
+    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
+                                                     "master-service");
+    auto span = tracing.StartSpan(
+        "CreateCopyTask", nullptr,
+        {{"object.key", key}, {"target.count", std::to_string(targets.size())}});
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     if (targets.empty()) {
         LOG(ERROR) << "key=" << key << ", error=empty_targets";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
     MetadataAccessorRO accessor(this, key);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
 
@@ -4247,6 +4255,7 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
         if (!segment_accessor.ExistsSegmentName(target)) {
             LOG(ERROR) << "key=" << key << ", target_segment=" << target
                        << ", error=target_segment_not_mounted";
+            span.SetStatus("ERROR");
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
     }
@@ -4255,6 +4264,7 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
     const auto& segment_names = metadata.GetReplicaSegmentNames();
     if (segment_names.empty()) {
         LOG(ERROR) << "key=" << key << ", error=no_valid_source_replicas";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
 
@@ -4269,22 +4279,38 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
         LOG(ERROR) << "key=" << key
                    << ", segment_name=" << selected_source_segment
                    << ", error=client_id_not_found";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
-    return task_manager_.get_write_access()
-        .submit_task_typed<TaskType::REPLICA_COPY>(
-            select_client, {.key = key,
-                            .source = selected_source_segment,
-                            .targets = targets});
+    auto task_id = task_manager_.get_write_access()
+                       .submit_task_typed_with_trace<TaskType::REPLICA_COPY>(
+                           select_client, {.key = key,
+                                           .source = selected_source_segment,
+                                           .targets = targets},
+                           tracing::EncodeTraceCarrier(
+                               tracing::ToCarrier(span.context())));
+    if (task_id.has_value()) {
+        span.SetAttribute("task.id", UuidToString(task_id.value()));
+    } else {
+        span.SetStatus("ERROR");
+    }
+    return task_id;
 }
 
 tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
     const std::string& key, const std::string& source,
     const std::string& target) {
+    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
+                                                     "master-service");
+    auto span = tracing.StartSpan("CreateMoveTask", nullptr,
+                                  {{"object.key", key},
+                                   {"source.segment", source},
+                                   {"target.segment", target}});
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataAccessorRO accessor(this, key);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
 
@@ -4292,6 +4318,7 @@ tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
         LOG(ERROR) << "key=" << key << ", source_segment=" << source
                    << ", target_segment=" << target
                    << ", error=source_target_segments_are_same";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
@@ -4299,6 +4326,7 @@ tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
     if (!segment_accessor.ExistsSegmentName(target)) {
         LOG(ERROR) << "key=" << key << ", target_segment=" << target
                    << ", error=target_segment_not_mounted";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
@@ -4308,6 +4336,7 @@ tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
         segment_names.end()) {
         LOG(ERROR) << "key=" << key << ", source_segment=" << source
                    << ", error=source_segment_not_found";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
@@ -4318,27 +4347,62 @@ tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
     if (error != ErrorCode::OK) {
         LOG(ERROR) << "key=" << key << ", segment_name=" << source
                    << ", error=client_id_not_found";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
 
-    return task_manager_.get_write_access()
-        .submit_task_typed<TaskType::REPLICA_MOVE>(
-            select_client, {.key = key, .source = source, .target = target});
+    auto task_id = task_manager_.get_write_access()
+                       .submit_task_typed_with_trace<TaskType::REPLICA_MOVE>(
+                           select_client,
+                           {.key = key, .source = source, .target = target},
+                           tracing::EncodeTraceCarrier(
+                               tracing::ToCarrier(span.context())));
+    if (task_id.has_value()) {
+        span.SetAttribute("task.id", UuidToString(task_id.value()));
+    } else {
+        span.SetStatus("ERROR");
+    }
+    return task_id;
 }
 
 tl::expected<QueryTaskResponse, ErrorCode> MasterService::QueryTask(
     const UUID& task_id) {
+    const auto task_status_to_string = [](TaskStatus status) -> std::string {
+        switch (status) {
+            case TaskStatus::PENDING:
+                return "PENDING";
+            case TaskStatus::PROCESSING:
+                return "PROCESSING";
+            case TaskStatus::FAILED:
+                return "FAILED";
+            case TaskStatus::SUCCESS:
+                return "SUCCESS";
+        }
+        return "UNKNOWN";
+    };
+    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
+                                                     "master-service");
+    auto span = tracing.StartSpan("QueryTask", nullptr,
+                                  {{"task.id", UuidToString(task_id)}});
     const auto& task_option =
         task_manager_.get_read_access().find_task_by_id(task_id);
     if (!task_option.has_value()) {
         LOG(ERROR) << "task_id=" << task_id << ", error=task_not_found";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::TASK_NOT_FOUND);
     }
+    span.SetAttribute("task.status", task_status_to_string(task_option->status));
     return QueryTaskResponse(task_option.value());
 }
 
 tl::expected<std::vector<TaskAssignment>, ErrorCode> MasterService::FetchTasks(
     const UUID& client_id, size_t batch_size) {
+    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
+                                                     "master-service");
+    auto span = tracing.StartSpan(
+        "FetchTasks", nullptr,
+        {{"client.id", UuidToString(client_id)},
+         {"batch.size.requested", std::to_string(batch_size)}});
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     const auto& tasks =
         task_manager_.get_write_access().pop_tasks(client_id, batch_size);
@@ -4346,11 +4410,32 @@ tl::expected<std::vector<TaskAssignment>, ErrorCode> MasterService::FetchTasks(
     for (const auto& task : tasks) {
         assignments.emplace_back(task);
     }
+    span.SetAttribute("batch.size.returned", std::to_string(assignments.size()));
     return assignments;
 }
 
 tl::expected<void, ErrorCode> MasterService::MarkTaskToComplete(
     const UUID& client_id, const TaskCompleteRequest& request) {
+    const auto task_status_to_string = [](TaskStatus status) -> std::string {
+        switch (status) {
+            case TaskStatus::PENDING:
+                return "PENDING";
+            case TaskStatus::PROCESSING:
+                return "PROCESSING";
+            case TaskStatus::FAILED:
+                return "FAILED";
+            case TaskStatus::SUCCESS:
+                return "SUCCESS";
+        }
+        return "UNKNOWN";
+    };
+    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
+                                                     "master-service");
+    auto span = tracing.StartSpan(
+        "MarkTaskToComplete", nullptr,
+        {{"client.id", UuidToString(client_id)},
+         {"task.id", UuidToString(request.id)},
+         {"task.status", task_status_to_string(request.status)}});
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     auto write_access = task_manager_.get_write_access();
     ErrorCode err = write_access.complete_task(client_id, request.id,
@@ -4358,6 +4443,7 @@ tl::expected<void, ErrorCode> MasterService::MarkTaskToComplete(
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "task_id=" << request.id
                    << ", error=complete_task_failed";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(err);
     }
     return {};

--- a/mooncake-store/src/task_manager.cpp
+++ b/mooncake-store/src/task_manager.cpp
@@ -31,8 +31,8 @@ tl::expected<UUID, ErrorCode> ScopedTaskWriteAccess::submit_task(
     const UUID& client_id, TaskType type, const std::string& payload,
     const std::string& trace_carrier) {
     auto carrier = tracing::DecodeTraceCarrier(trace_carrier);
-    auto& tracing_facade = tracing::TracingFacade::Instance(
-        "mooncake-store", "task-manager");
+    auto& tracing_facade =
+        tracing::TracingFacade::Instance("mooncake-store", "task-manager");
     auto span = carrier.empty()
                     ? tracing_facade.StartSpan(
                           "task_manager.submit_task", nullptr,
@@ -104,15 +104,14 @@ std::vector<Task> ScopedTaskWriteAccess::pop_tasks(const UUID& client_id,
 
         Task& task = it->second;
         auto carrier = tracing::DecodeTraceCarrier(task.trace_carrier);
-        auto& tracing_facade = tracing::TracingFacade::Instance(
-            "mooncake-store", "task-manager");
-        auto span = carrier.empty()
-                        ? tracing_facade.StartSpan(
-                              "task_manager.pop_tasks", nullptr,
-                              {{"task.id", UuidToString(task.id)}})
-                        : tracing_facade.StartSpanFromCarrier(
-                              "task_manager.pop_tasks", carrier,
-                              {{"task.id", UuidToString(task.id)}});
+        auto& tracing_facade =
+            tracing::TracingFacade::Instance("mooncake-store", "task-manager");
+        auto span = carrier.empty() ? tracing_facade.StartSpan(
+                                          "task_manager.pop_tasks", nullptr,
+                                          {{"task.id", UuidToString(task.id)}})
+                                    : tracing_facade.StartSpanFromCarrier(
+                                          "task_manager.pop_tasks", carrier,
+                                          {{"task.id", UuidToString(task.id)}});
         task.mark_processing();
         span.AddEvent("task marked processing",
                       {{"assigned_client", UuidToString(client_id)}});
@@ -136,8 +135,8 @@ ErrorCode ScopedTaskWriteAccess::complete_task(const UUID& client_id,
                                                const UUID& task_id,
                                                TaskStatus status,
                                                const std::string& message) {
-    auto& tracing_facade = tracing::TracingFacade::Instance(
-        "mooncake-store", "task-manager");
+    auto& tracing_facade =
+        tracing::TracingFacade::Instance("mooncake-store", "task-manager");
     if (!is_finished_status(status)) {
         LOG(ERROR) << "complete_task: invalid completion status=" << status
                    << ", task_id=" << task_id;
@@ -152,13 +151,12 @@ ErrorCode ScopedTaskWriteAccess::complete_task(const UUID& client_id,
 
     Task& task = it->second;
     auto carrier = tracing::DecodeTraceCarrier(task.trace_carrier);
-    auto span = carrier.empty()
-                    ? tracing_facade.StartSpan(
-                          "task_manager.complete_task", nullptr,
-                          {{"task.id", UuidToString(task_id)}})
-                    : tracing_facade.StartSpanFromCarrier(
-                          "task_manager.complete_task", carrier,
-                          {{"task.id", UuidToString(task_id)}});
+    auto span = carrier.empty() ? tracing_facade.StartSpan(
+                                      "task_manager.complete_task", nullptr,
+                                      {{"task.id", UuidToString(task_id)}})
+                                : tracing_facade.StartSpanFromCarrier(
+                                      "task_manager.complete_task", carrier,
+                                      {{"task.id", UuidToString(task_id)}});
 
     if (task.assigned_client != client_id) {
         LOG(ERROR) << "Client " << client_id << " is not assigned to task "
@@ -174,8 +172,8 @@ ErrorCode ScopedTaskWriteAccess::complete_task(const UUID& client_id,
     }
 
     task.mark_complete(status, message);
-    span.SetAttribute("task.status", status == TaskStatus::SUCCESS ? "SUCCESS"
-                                                                   : "FAILED");
+    span.SetAttribute("task.status",
+                      status == TaskStatus::SUCCESS ? "SUCCESS" : "FAILED");
     if (status == TaskStatus::FAILED) {
         span.SetStatus("ERROR");
     }
@@ -195,8 +193,8 @@ ErrorCode ScopedTaskWriteAccess::complete_task(const UUID& client_id,
 }
 
 void ScopedTaskWriteAccess::prune_finished_tasks() {
-    auto& tracing_facade = tracing::TracingFacade::Instance(
-        "mooncake-store", "task-manager");
+    auto& tracing_facade =
+        tracing::TracingFacade::Instance("mooncake-store", "task-manager");
     const auto before = manager_->finished_task_history_.size();
     while (manager_->finished_task_history_.size() >
            manager_->max_total_finished_tasks_) {
@@ -213,8 +211,8 @@ void ScopedTaskWriteAccess::prune_finished_tasks() {
 }
 
 void ScopedTaskWriteAccess::prune_expired_tasks() {
-    auto& tracing_facade = tracing::TracingFacade::Instance(
-        "mooncake-store", "task-manager");
+    auto& tracing_facade =
+        tracing::TracingFacade::Instance("mooncake-store", "task-manager");
     const auto pending_before = manager_->total_pending_tasks_;
     const auto processing_before = manager_->total_processing_tasks_;
     const auto now = std::chrono::system_clock::now();

--- a/mooncake-store/src/task_manager.cpp
+++ b/mooncake-store/src/task_manager.cpp
@@ -27,7 +27,8 @@ size_t ScopedTaskReadAccess::size() const {
 }
 
 tl::expected<UUID, ErrorCode> ScopedTaskWriteAccess::submit_task(
-    const UUID& client_id, TaskType type, const std::string& payload) {
+    const UUID& client_id, TaskType type, const std::string& payload,
+    const std::string& trace_carrier) {
     if (manager_->total_pending_tasks_ >= manager_->max_total_pending_tasks_) {
         LOG(ERROR) << "Cannot submit new task: pending task limit reached ("
                    << manager_->total_pending_tasks_ << "/"
@@ -47,7 +48,8 @@ tl::expected<UUID, ErrorCode> ScopedTaskWriteAccess::submit_task(
                  .last_updated_at = now,
                  .message = "",
                  .assigned_client = client_id,
-                 .max_retry_attempts = manager_->max_retry_attempts_};
+                 .max_retry_attempts = manager_->max_retry_attempts_,
+                 .trace_carrier = trace_carrier};
     manager_->total_pending_tasks_++;
     manager_->all_tasks_[task.id] = task;
     manager_->pending_tasks_[client_id].push(task.id);

--- a/mooncake-store/src/task_manager.cpp
+++ b/mooncake-store/src/task_manager.cpp
@@ -1,6 +1,7 @@
 #include "task_manager.h"
 #include <glog/logging.h>
 #include <msgpack.hpp>
+#include "tracing_facade.h"
 #include "utils/zstd_util.h"
 
 namespace mooncake {
@@ -29,10 +30,21 @@ size_t ScopedTaskReadAccess::size() const {
 tl::expected<UUID, ErrorCode> ScopedTaskWriteAccess::submit_task(
     const UUID& client_id, TaskType type, const std::string& payload,
     const std::string& trace_carrier) {
+    auto carrier = tracing::DecodeTraceCarrier(trace_carrier);
+    auto& tracing_facade = tracing::TracingFacade::Instance(
+        "mooncake-store", "task-manager");
+    auto span = carrier.empty()
+                    ? tracing_facade.StartSpan(
+                          "task_manager.submit_task", nullptr,
+                          {{"assigned_client", UuidToString(client_id)}})
+                    : tracing_facade.StartSpanFromCarrier(
+                          "task_manager.submit_task", carrier,
+                          {{"assigned_client", UuidToString(client_id)}});
     if (manager_->total_pending_tasks_ >= manager_->max_total_pending_tasks_) {
         LOG(ERROR) << "Cannot submit new task: pending task limit reached ("
                    << manager_->total_pending_tasks_ << "/"
                    << manager_->max_total_pending_tasks_ << ")";
+        span.SetStatus("ERROR");
         return tl::make_unexpected(ErrorCode::TASK_PENDING_LIMIT_EXCEEDED);
     }
     UUID id = generate_uuid();
@@ -53,6 +65,7 @@ tl::expected<UUID, ErrorCode> ScopedTaskWriteAccess::submit_task(
     manager_->total_pending_tasks_++;
     manager_->all_tasks_[task.id] = task;
     manager_->pending_tasks_[client_id].push(task.id);
+    span.SetAttribute("task.id", UuidToString(task.id));
 
     return task.id;
 }
@@ -90,7 +103,19 @@ std::vector<Task> ScopedTaskWriteAccess::pop_tasks(const UUID& client_id,
         }
 
         Task& task = it->second;
+        auto carrier = tracing::DecodeTraceCarrier(task.trace_carrier);
+        auto& tracing_facade = tracing::TracingFacade::Instance(
+            "mooncake-store", "task-manager");
+        auto span = carrier.empty()
+                        ? tracing_facade.StartSpan(
+                              "task_manager.pop_tasks", nullptr,
+                              {{"task.id", UuidToString(task.id)}})
+                        : tracing_facade.StartSpanFromCarrier(
+                              "task_manager.pop_tasks", carrier,
+                              {{"task.id", UuidToString(task.id)}});
         task.mark_processing();
+        span.AddEvent("task marked processing",
+                      {{"assigned_client", UuidToString(client_id)}});
 
         const auto [_, inserted] = processing_set.insert(task_id);
         if (!inserted) {
@@ -111,6 +136,8 @@ ErrorCode ScopedTaskWriteAccess::complete_task(const UUID& client_id,
                                                const UUID& task_id,
                                                TaskStatus status,
                                                const std::string& message) {
+    auto& tracing_facade = tracing::TracingFacade::Instance(
+        "mooncake-store", "task-manager");
     if (!is_finished_status(status)) {
         LOG(ERROR) << "complete_task: invalid completion status=" << status
                    << ", task_id=" << task_id;
@@ -124,10 +151,19 @@ ErrorCode ScopedTaskWriteAccess::complete_task(const UUID& client_id,
     }
 
     Task& task = it->second;
+    auto carrier = tracing::DecodeTraceCarrier(task.trace_carrier);
+    auto span = carrier.empty()
+                    ? tracing_facade.StartSpan(
+                          "task_manager.complete_task", nullptr,
+                          {{"task.id", UuidToString(task_id)}})
+                    : tracing_facade.StartSpanFromCarrier(
+                          "task_manager.complete_task", carrier,
+                          {{"task.id", UuidToString(task_id)}});
 
     if (task.assigned_client != client_id) {
         LOG(ERROR) << "Client " << client_id << " is not assigned to task "
                    << task_id;
+        span.SetStatus("ERROR");
         return ErrorCode::ILLEGAL_CLIENT;
     }
 
@@ -138,6 +174,11 @@ ErrorCode ScopedTaskWriteAccess::complete_task(const UUID& client_id,
     }
 
     task.mark_complete(status, message);
+    span.SetAttribute("task.status", status == TaskStatus::SUCCESS ? "SUCCESS"
+                                                                   : "FAILED");
+    if (status == TaskStatus::FAILED) {
+        span.SetStatus("ERROR");
+    }
 
     auto ps_it = manager_->processing_tasks_.find(client_id);
     if (ps_it != manager_->processing_tasks_.end()) {
@@ -154,15 +195,28 @@ ErrorCode ScopedTaskWriteAccess::complete_task(const UUID& client_id,
 }
 
 void ScopedTaskWriteAccess::prune_finished_tasks() {
+    auto& tracing_facade = tracing::TracingFacade::Instance(
+        "mooncake-store", "task-manager");
+    const auto before = manager_->finished_task_history_.size();
     while (manager_->finished_task_history_.size() >
            manager_->max_total_finished_tasks_) {
         UUID oldest_task_id = manager_->finished_task_history_.front();
         manager_->finished_task_history_.pop_front();
         manager_->all_tasks_.erase(oldest_task_id);
     }
+    const auto after = manager_->finished_task_history_.size();
+    auto span = tracing_facade.StartSpan(
+        "task_manager.prune_finished_tasks", nullptr,
+        {{"finished.count.before", std::to_string(before)},
+         {"finished.count.after", std::to_string(after)},
+         {"tasks.pruned", std::to_string(before - after)}});
 }
 
 void ScopedTaskWriteAccess::prune_expired_tasks() {
+    auto& tracing_facade = tracing::TracingFacade::Instance(
+        "mooncake-store", "task-manager");
+    const auto pending_before = manager_->total_pending_tasks_;
+    const auto processing_before = manager_->total_processing_tasks_;
     const auto now = std::chrono::system_clock::now();
     // Pending timeout: based on created_at
     if (manager_->pending_task_timeout_sec_ > 0) {
@@ -252,6 +306,14 @@ void ScopedTaskWriteAccess::prune_expired_tasks() {
             }
         }
     }
+
+    auto span = tracing_facade.StartSpan(
+        "task_manager.prune_expired_tasks", nullptr,
+        {{"pending.before", std::to_string(pending_before)},
+         {"pending.after", std::to_string(manager_->total_pending_tasks_)},
+         {"processing.before", std::to_string(processing_before)},
+         {"processing.after",
+          std::to_string(manager_->total_processing_tasks_)}});
 }
 
 void ScopedTaskWriteAccess::restore_task(Task&& task) {
@@ -334,6 +396,8 @@ TaskManagerSerializer::Serialize() {
                 .count()));
         packer.pack(task.message);
         packer.pack(UuidToString(task.assigned_client));
+        packer.pack(task.max_retry_attempts);
+        packer.pack(task.trace_carrier);
     }
 
     // Compress entire data
@@ -417,6 +481,8 @@ tl::expected<void, SerializationError> TaskManagerSerializer::Deserialize(
             task.last_updated_at = std::chrono::system_clock::time_point(
                 std::chrono::milliseconds(arr[5].as<int64_t>()));
             task.message = arr[6].as<std::string>();
+            task.max_retry_attempts = arr[8].as<uint32_t>();
+            task.trace_carrier = arr[9].as<std::string>();
         } catch (const std::exception& e) {
             LOG(WARNING) << "Invalid task field types for task index " << i
                          << ": " << e.what() << ", skipping deserialization";

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -446,7 +446,8 @@ TransferSubmitter::TransferSubmitter(TransferEngine& engine,
 
 std::optional<TransferFuture> TransferSubmitter::submit(
     const Replica::Descriptor& replica, std::vector<Slice>& slices,
-    TransferRequest::OpCode op_code) {
+    TransferRequest::OpCode op_code,
+    const tracing::TraceContext* trace_context) {
     std::optional<TransferFuture> future;
 
     if (replica.is_memory_replica()) {
@@ -461,17 +462,20 @@ std::optional<TransferFuture> TransferSubmitter::submit(
 
         switch (strategy) {
             case TransferStrategy::LOCAL_MEMCPY:
-                future = submitMemcpyOperation(handle, slices, op_code);
+                future = submitMemcpyOperation(handle, slices, op_code,
+                                               trace_context);
                 break;
             case TransferStrategy::TRANSFER_ENGINE:
-                future = submitTransferEngineOperation(handle, slices, op_code);
+                future = submitTransferEngineOperation(handle, slices, op_code,
+                                                       trace_context);
                 break;
             default:
                 LOG(ERROR) << "Unknown transfer strategy: " << strategy;
                 return std::nullopt;
         }
     } else {
-        future = submitFileReadOperation(replica, slices, op_code);
+        future = submitFileReadOperation(replica, slices, op_code,
+                                         trace_context);
     }
 
     // Update metrics on successful submission
@@ -485,7 +489,8 @@ std::optional<TransferFuture> TransferSubmitter::submit(
 std::optional<TransferFuture> TransferSubmitter::submit_batch(
     const std::vector<Replica::Descriptor>& replicas,
     std::vector<std::vector<Slice>>& all_slices,
-    TransferRequest::OpCode op_code) {
+    TransferRequest::OpCode op_code,
+    const tracing::TraceContext* trace_context) {
     std::optional<TransferFuture> future;
     std::vector<TransferRequest> requests;
     for (size_t i = 0; i < replicas.size(); ++i) {
@@ -514,7 +519,7 @@ std::optional<TransferFuture> TransferSubmitter::submit_batch(
             offset += slice.size;
         }
     }
-    future = submitTransfer(requests);
+    future = submitTransfer(requests, trace_context);
     // Update metrics on successful submission
     if (future.has_value()) {
         for (auto& slices : all_slices) {
@@ -548,12 +553,14 @@ TransferSubmitter::submit_batch_get_offload_object(
         request.length = slice.size;
         requests.emplace_back(request);
     }
-    return submitTransfer(requests);
+    return submitTransfer(requests, nullptr);
 }
 
 std::optional<TransferFuture> TransferSubmitter::submitMemcpyOperation(
     const AllocatedBuffer::Descriptor& handle, const std::vector<Slice>& slices,
-    const TransferRequest::OpCode op_code) {
+    const TransferRequest::OpCode op_code,
+    const tracing::TraceContext* trace_context) {
+    (void)trace_context;
     auto state = std::make_shared<MemcpyOperationState>();
 
     // Create memcpy operations
@@ -597,20 +604,29 @@ std::optional<TransferFuture> TransferSubmitter::submitMemcpyOperation(
 }
 
 std::optional<TransferFuture> TransferSubmitter::submitTransfer(
-    std::vector<TransferRequest>& requests) {
+    std::vector<TransferRequest>& requests,
+    const tracing::TraceContext* trace_context) {
+    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
+                                                     "transfer-task");
+    auto span = tracing.StartSpan(
+        "mooncake.transfer.prepare", trace_context,
+        {{"batch.size", std::to_string(requests.size())}});
     // Allocate batch ID
     const size_t batch_size = requests.size();
     BatchID batch_id = engine_.allocateBatchID(batch_size);
     if (batch_id == INVALID_BATCH_ID) {
         LOG(ERROR) << "Failed to allocate batch ID";
+        span.SetStatus("ERROR");
         return std::nullopt;
     }
+    span.SetAttribute("te.batch_id", std::to_string(batch_id));
 
     // Submit transfer
     Status s = engine_.submitTransfer(batch_id, requests);
     if (!s.ok()) {
         LOG(ERROR) << "Failed to submit all transfers, error code is "
                    << s.code();
+        span.SetStatus("ERROR");
         // Note: batch_id will be freed by TransferEngineOperationState
         // destructor if we create the state object, otherwise we need to free
         // it here
@@ -626,14 +642,15 @@ std::optional<TransferFuture> TransferSubmitter::submitTransfer(
     // Create state with transfer engine context - no polling thread
     // needed
     auto state = std::make_shared<TransferEngineOperationState>(
-        engine_, batch_id, batch_size);
+        engine_, batch_id, batch_size, span.context());
 
     return TransferFuture(state);
 }
 
 std::optional<TransferFuture> TransferSubmitter::submitTransferEngineOperation(
     const AllocatedBuffer::Descriptor& handle, const std::vector<Slice>& slices,
-    const TransferRequest::OpCode op_code) {
+    const TransferRequest::OpCode op_code,
+    const tracing::TraceContext* trace_context) {
     if (handle.transport_endpoint_.empty()) {
         LOG(ERROR) << "Transport endpoint is empty for handle with address "
                    << handle.buffer_address_;
@@ -667,12 +684,14 @@ std::optional<TransferFuture> TransferSubmitter::submitTransferEngineOperation(
         offset += slice.size;
         requests.emplace_back(request);
     }
-    return submitTransfer(requests);
+    return submitTransfer(requests, trace_context);
 }
 
 std::optional<TransferFuture> TransferSubmitter::submitFileReadOperation(
     const Replica::Descriptor& replica, std::vector<Slice>& slices,
-    TransferRequest::OpCode op_code) {
+    TransferRequest::OpCode op_code,
+    const tracing::TraceContext* trace_context) {
+    (void)trace_context;
     auto state = std::make_shared<FilereadOperationState>();
     auto disk_replica = replica.get_disk_descriptor();
     std::string file_path = disk_replica.file_path;

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -181,22 +181,22 @@ void TransferTraceSession::RecordBatch(BatchID batch_id) {
     operation_span_.SetAttribute("te.batch_id", std::to_string(batch_id_));
 }
 
-void TransferTraceSession::StartQueueWait(
+void TransferTraceSession::StartSubmitGap(
     mooncake::tracing::TracingFacade& tracing, BatchID batch_id,
     size_t batch_size) {
-    if (queue_wait_context_.valid() || wait_context_.valid()) {
+    if (submit_gap_context_.valid() || wait_context_.valid()) {
         return;
     }
 
     auto span = tracing.StartSpan(
-        "mooncake.transfer.queue_wait", parent_context(),
+        "mooncake.transfer.submit_gap", parent_context(),
         {{"te.batch_id", std::to_string(batch_id)},
          {"batch.size", std::to_string(batch_size)}});
     if (!span.valid()) {
         return;
     }
-    queue_wait_context_ = span.context();
-    queue_wait_span_ = std::move(span);
+    submit_gap_context_ = span.context();
+    submit_gap_span_ = std::move(span);
 }
 
 void TransferTraceSession::MarkSubmitError() {
@@ -211,20 +211,20 @@ void TransferTraceSession::MarkSubmitError() {
     operation_span_.SetStatus("ERROR");
 }
 
-void TransferTraceSession::FinishQueueWait(ErrorCode error_code) {
-    if (!queue_wait_context_.valid()) {
+void TransferTraceSession::FinishSubmitGap(ErrorCode error_code) {
+    if (!submit_gap_context_.valid()) {
         return;
     }
 
-    queue_wait_span_.AddEvent(
-        "queue wait finished",
+    submit_gap_span_.AddEvent(
+        "submit gap finished",
         {{"result.code", std::to_string(static_cast<int>(error_code))}});
     if (error_code != ErrorCode::OK) {
-        queue_wait_span_.SetStatus("ERROR");
+        submit_gap_span_.SetStatus("ERROR");
     }
-    queue_wait_span_.End();
-    queue_wait_span_ = mooncake::tracing::Span();
-    queue_wait_context_ = {};
+    submit_gap_span_.End();
+    submit_gap_span_ = mooncake::tracing::Span();
+    submit_gap_context_ = {};
 }
 
 mooncake::tracing::Span* TransferTraceSession::EnsureWaitSpan(
@@ -234,7 +234,7 @@ mooncake::tracing::Span* TransferTraceSession::EnsureWaitSpan(
         return &wait_span_;
     }
 
-    FinishQueueWait(ErrorCode::OK);
+    FinishSubmitGap(ErrorCode::OK);
 
     auto span = tracing.StartSpan(
         "mooncake.transfer.wait_completion", parent_context(),
@@ -266,7 +266,7 @@ void TransferTraceSession::FinishWait(ErrorCode error_code) {
 
 void TransferTraceSession::Finish(mooncake::tracing::TracingFacade& tracing,
                                   ErrorCode error_code) {
-    FinishQueueWait(error_code);
+    FinishSubmitGap(error_code);
     auto complete_span = tracing.StartSpan(
         "mooncake.transfer.complete", parent_context(),
         {{"batch.size", std::to_string(batch_size_)},
@@ -846,7 +846,7 @@ std::optional<TransferFuture> TransferSubmitter::submitTransfer(
         return std::nullopt;
     }
 
-    trace_session.StartQueueWait(tracing, batch_id, batch_size);
+    trace_session.StartSubmitGap(tracing, batch_id, batch_size);
 
     // Create state with transfer engine context - no polling thread
     // needed

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -123,6 +123,130 @@ void FilereadWorkerPool::workerThread() {
 // Since memcpy is bound by memory bandwidth, we only need one worker thread.
 constexpr int kDefaultMemcpyWorkers = 1;
 
+size_t CalculateRequestBytes(const std::vector<TransferRequest>& requests) {
+    size_t total_bytes = 0;
+    for (const auto& request : requests) {
+        total_bytes += request.length;
+    }
+    return total_bytes;
+}
+
+const char* ToStoreTransferStatusName(TransferStatusEnum status) {
+    switch (status) {
+        case TransferStatusEnum::WAITING:
+            return "WAITING";
+        case TransferStatusEnum::PENDING:
+            return "PENDING";
+        case TransferStatusEnum::INVALID:
+            return "INVALID";
+        case TransferStatusEnum::CANCELED:
+            return "CANCELED";
+        case TransferStatusEnum::COMPLETED:
+            return "COMPLETED";
+        case TransferStatusEnum::TIMEOUT:
+            return "TIMEOUT";
+        case TransferStatusEnum::FAILED:
+            return "FAILED";
+    }
+    return "UNKNOWN";
+}
+
+TransferTraceSession TransferTraceSession::Start(
+    mooncake::tracing::TracingFacade& tracing,
+    const mooncake::tracing::TraceContext* trace_context, size_t batch_size,
+    size_t total_bytes) {
+    TransferTraceSession session;
+    session.batch_size_ = batch_size;
+
+    if (trace_context != nullptr && trace_context->valid()) {
+        session.parent_context_ = *trace_context;
+        return session;
+    }
+
+    session.operation_span_ = tracing.StartSpan(
+        "mooncake.transfer.operation", nullptr,
+        {{"batch.size", std::to_string(batch_size)},
+         {"bytes.total", std::to_string(total_bytes)}});
+    if (session.operation_span_.valid()) {
+        session.parent_context_ = session.operation_span_.context();
+    }
+    return session;
+}
+
+void TransferTraceSession::RecordBatch(BatchID batch_id) {
+    batch_id_ = batch_id;
+    if (!operation_span_.valid()) {
+        return;
+    }
+    operation_span_.SetAttribute("te.batch_id", std::to_string(batch_id_));
+}
+
+void TransferTraceSession::MarkSubmitError() {
+    if (!operation_span_.valid()) {
+        return;
+    }
+    if (batch_id_ != INVALID_BATCH_ID) {
+        operation_span_.AddEvent(
+            "transfer submit failed",
+            {{"te.batch_id", std::to_string(batch_id_)}});
+    }
+    operation_span_.SetStatus("ERROR");
+}
+
+mooncake::tracing::Span* TransferTraceSession::EnsureWaitSpan(
+    mooncake::tracing::TracingFacade& tracing, BatchID batch_id,
+    size_t batch_size) {
+    if (wait_context_.valid()) {
+        return &wait_span_;
+    }
+
+    auto span = tracing.StartSpan(
+        "mooncake.transfer.wait_completion", parent_context(),
+        {{"te.batch_id", std::to_string(batch_id)},
+         {"batch.size", std::to_string(batch_size)}});
+    if (!span.valid()) {
+        return nullptr;
+    }
+    wait_context_ = span.context();
+    wait_span_ = std::move(span);
+    return &wait_span_;
+}
+
+void TransferTraceSession::FinishWait(ErrorCode error_code) {
+    if (!wait_context_.valid()) {
+        return;
+    }
+
+    wait_span_.AddEvent(
+        "wait completion finished",
+        {{"result.code", std::to_string(static_cast<int>(error_code))}});
+    if (error_code != ErrorCode::OK) {
+        wait_span_.SetStatus("ERROR");
+    }
+    wait_span_.End();
+    wait_span_ = mooncake::tracing::Span();
+    wait_context_ = {};
+}
+
+void TransferTraceSession::Finish(ErrorCode error_code) {
+    if (!operation_span_.valid()) {
+        return;
+    }
+    if (batch_id_ != INVALID_BATCH_ID) {
+        operation_span_.SetAttribute("te.batch_id", std::to_string(batch_id_));
+    }
+    operation_span_.SetAttribute("batch.size", std::to_string(batch_size_));
+    operation_span_.SetAttribute(
+        "result.code", std::to_string(static_cast<int>(error_code)));
+    operation_span_.AddEvent(
+        "transfer operation completed",
+        {{"result.code", std::to_string(static_cast<int>(error_code))}});
+    if (error_code != ErrorCode::OK) {
+        operation_span_.SetStatus("ERROR");
+    }
+    operation_span_.End();
+}
+
 MemcpyWorkerPool::MemcpyWorkerPool() : shutdown_(false) {
     VLOG(1) << "Creating MemcpyWorkerPool with " << kDefaultMemcpyWorkers
             << " workers";
@@ -226,10 +350,8 @@ bool TransferEngineOperationState::is_completed() {
 void TransferEngineOperationState::check_task_status() {
     auto& tracing = mooncake::tracing::TracingFacade::Instance(
         "mooncake-store", "transfer-task");
-    auto span = tracing.StartSpan("mooncake.transfer.wait_completion",
-                                  trace_context_.valid() ? &trace_context_ : nullptr,
-                                  {{"te.batch_id", std::to_string(batch_id_)},
-                                   {"batch.size", std::to_string(batch_size_)}});
+    auto* wait_span =
+        trace_session_.EnsureWaitSpan(tracing, batch_id_, batch_size_);
     // Check all transfers in the batch
     bool all_completed = true;
     bool has_failure = false;
@@ -241,7 +363,13 @@ void TransferEngineOperationState::check_task_status() {
             LOG(ERROR) << "Failed to get transfer status for batch "
                        << batch_id_ << " task " << i << " with error "
                        << s.message();
-            span.SetStatus("ERROR");
+            if (wait_span != nullptr) {
+                wait_span->AddEvent(
+                    "status query failed",
+                    {{"task.id", std::to_string(i)},
+                     {"error.message", std::string(s.message())}});
+                wait_span->SetStatus("ERROR");
+            }
             set_result_internal(ErrorCode::TRANSFER_FAIL);
             return;
         }
@@ -259,7 +387,13 @@ void TransferEngineOperationState::check_task_status() {
                            << static_cast<int>(status.s);
 #endif
                 has_failure = true;
-                span.AddEvent("transfer failed", {{"task.id", std::to_string(i)}});
+                if (wait_span != nullptr) {
+                    wait_span->AddEvent(
+                        "transfer failed",
+                        {{"task.id", std::to_string(i)},
+                         {"status",
+                          std::string(ToStoreTransferStatusName(status.s))}});
+                }
                 break;
             default:
                 // Transfer is still pending (PENDING, RUNNING, etc.)
@@ -276,6 +410,9 @@ void TransferEngineOperationState::check_task_status() {
     }
 
     if (all_completed) {
+        if (wait_span != nullptr) {
+            wait_span->AddEvent("all transfers completed");
+        }
         set_result_internal(ErrorCode::OK);
         return;
     }
@@ -296,6 +433,8 @@ void TransferEngineOperationState::set_result_internal(ErrorCode error_code) {
     VLOG(1) << "Setting transfer result for batch " << batch_id_ << " to "
             << static_cast<int>(error_code);
     result_.emplace(error_code);
+    trace_session_.FinishWait(error_code);
+    trace_session_.Finish(error_code);
 }
 
 void TransferEngineOperationState::wait_for_completion() {
@@ -307,6 +446,9 @@ void TransferEngineOperationState::wait_for_completion() {
 
 #ifdef USE_EVENT_DRIVEN_COMPLETION
     VLOG(1) << "Waiting for transfer engine completion for batch " << batch_id_;
+    auto& tracing = mooncake::tracing::TracingFacade::Instance(
+        "mooncake-store", "transfer-task");
+    trace_session_.EnsureWaitSpan(tracing, batch_id_, batch_size_);
 
     // Wait directly on BatchDesc's condition variable.
     auto& batch_desc = Transport::toBatchDesc(batch_id_);
@@ -608,25 +750,34 @@ std::optional<TransferFuture> TransferSubmitter::submitTransfer(
     const tracing::TraceContext* trace_context) {
     auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
                                                      "transfer-task");
-    auto span = tracing.StartSpan(
-        "mooncake.transfer.prepare", trace_context,
-        {{"batch.size", std::to_string(requests.size())}});
-    // Allocate batch ID
     const size_t batch_size = requests.size();
+    const size_t total_bytes = CalculateRequestBytes(requests);
+    auto trace_session = TransferTraceSession::Start(
+        tracing, trace_context, batch_size, total_bytes);
+
+    auto span = tracing.StartSpan(
+        "mooncake.transfer.prepare", trace_session.parent_context(),
+        {{"batch.size", std::to_string(batch_size)},
+         {"bytes.total", std::to_string(total_bytes)}});
+    // Allocate batch ID
     BatchID batch_id = engine_.allocateBatchID(batch_size);
     if (batch_id == INVALID_BATCH_ID) {
         LOG(ERROR) << "Failed to allocate batch ID";
         span.SetStatus("ERROR");
+        trace_session.MarkSubmitError();
         return std::nullopt;
     }
     span.SetAttribute("te.batch_id", std::to_string(batch_id));
+    trace_session.RecordBatch(batch_id);
 
     // Submit transfer
-    Status s = engine_.submitTransfer(batch_id, requests);
+    Status s = engine_.submitTransfer(batch_id, requests,
+                                      trace_session.parent_context());
     if (!s.ok()) {
         LOG(ERROR) << "Failed to submit all transfers, error code is "
                    << s.code();
         span.SetStatus("ERROR");
+        trace_session.MarkSubmitError();
         // Note: batch_id will be freed by TransferEngineOperationState
         // destructor if we create the state object, otherwise we need to free
         // it here
@@ -642,7 +793,7 @@ std::optional<TransferFuture> TransferSubmitter::submitTransfer(
     // Create state with transfer engine context - no polling thread
     // needed
     auto state = std::make_shared<TransferEngineOperationState>(
-        engine_, batch_id, batch_size, span.context());
+        engine_, batch_id, batch_size, std::move(trace_session));
 
     return TransferFuture(state);
 }

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include "transfer_engine.h"
 #include "transport/transport.h"
+#include "tracing_facade.h"
 
 namespace mooncake {
 
@@ -223,6 +224,12 @@ bool TransferEngineOperationState::is_completed() {
 }
 
 void TransferEngineOperationState::check_task_status() {
+    auto& tracing = mooncake::tracing::TracingFacade::Instance(
+        "mooncake-store", "transfer-task");
+    auto span = tracing.StartSpan("mooncake.transfer.wait_completion",
+                                  trace_context_.valid() ? &trace_context_ : nullptr,
+                                  {{"te.batch_id", std::to_string(batch_id_)},
+                                   {"batch.size", std::to_string(batch_size_)}});
     // Check all transfers in the batch
     bool all_completed = true;
     bool has_failure = false;
@@ -234,6 +241,7 @@ void TransferEngineOperationState::check_task_status() {
             LOG(ERROR) << "Failed to get transfer status for batch "
                        << batch_id_ << " task " << i << " with error "
                        << s.message();
+            span.SetStatus("ERROR");
             set_result_internal(ErrorCode::TRANSFER_FAIL);
             return;
         }
@@ -251,6 +259,7 @@ void TransferEngineOperationState::check_task_status() {
                            << static_cast<int>(status.s);
 #endif
                 has_failure = true;
+                span.AddEvent("transfer failed", {{"task.id", std::to_string(i)}});
                 break;
             default:
                 // Transfer is still pending (PENDING, RUNNING, etc.)

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -163,11 +163,11 @@ TransferTraceSession TransferTraceSession::Start(
         return session;
     }
 
-    session.operation_span_ = tracing.StartSpan(
-        "mooncake.transfer.operation", nullptr,
-        {{"batch.size", std::to_string(batch_size)},
-         {"sampling.priority", "structural"},
-         {"bytes.total", std::to_string(total_bytes)}});
+    session.operation_span_ =
+        tracing.StartSpan("mooncake.transfer.operation", nullptr,
+                          {{"batch.size", std::to_string(batch_size)},
+                           {"sampling.priority", "structural"},
+                           {"bytes.total", std::to_string(total_bytes)}});
     if (session.operation_span_.valid()) {
         session.parent_context_ = session.operation_span_.context();
     }
@@ -189,10 +189,10 @@ void TransferTraceSession::StartSubmitGap(
         return;
     }
 
-    auto span = tracing.StartSpan(
-        "mooncake.transfer.submit_gap", parent_context(),
-        {{"te.batch_id", std::to_string(batch_id)},
-         {"batch.size", std::to_string(batch_size)}});
+    auto span =
+        tracing.StartSpan("mooncake.transfer.submit_gap", parent_context(),
+                          {{"te.batch_id", std::to_string(batch_id)},
+                           {"batch.size", std::to_string(batch_size)}});
     if (!span.valid()) {
         return;
     }
@@ -205,9 +205,8 @@ void TransferTraceSession::MarkSubmitError() {
         return;
     }
     if (batch_id_ != INVALID_BATCH_ID) {
-        operation_span_.AddEvent(
-            "transfer submit failed",
-            {{"te.batch_id", std::to_string(batch_id_)}});
+        operation_span_.AddEvent("transfer submit failed",
+                                 {{"te.batch_id", std::to_string(batch_id_)}});
     }
     operation_span_.SetStatus("ERROR");
 }
@@ -237,10 +236,10 @@ mooncake::tracing::Span* TransferTraceSession::EnsureWaitSpan(
 
     FinishSubmitGap(ErrorCode::OK);
 
-    auto span = tracing.StartSpan(
-        "mooncake.transfer.wait_completion", parent_context(),
-        {{"te.batch_id", std::to_string(batch_id)},
-         {"batch.size", std::to_string(batch_size)}});
+    auto span =
+        tracing.StartSpan("mooncake.transfer.wait_completion", parent_context(),
+                          {{"te.batch_id", std::to_string(batch_id)},
+                           {"batch.size", std::to_string(batch_size)}});
     if (!span.valid()) {
         return nullptr;
     }
@@ -274,7 +273,8 @@ void TransferTraceSession::Finish(mooncake::tracing::TracingFacade& tracing,
          {"result.code", std::to_string(static_cast<int>(error_code))}});
     if (complete_span.valid()) {
         if (batch_id_ != INVALID_BATCH_ID) {
-            complete_span.SetAttribute("te.batch_id", std::to_string(batch_id_));
+            complete_span.SetAttribute("te.batch_id",
+                                       std::to_string(batch_id_));
         }
         complete_span.AddEvent(
             "transfer operation completed",
@@ -291,8 +291,8 @@ void TransferTraceSession::Finish(mooncake::tracing::TracingFacade& tracing,
         operation_span_.SetAttribute("te.batch_id", std::to_string(batch_id_));
     }
     operation_span_.SetAttribute("batch.size", std::to_string(batch_size_));
-    operation_span_.SetAttribute(
-        "result.code", std::to_string(static_cast<int>(error_code)));
+    operation_span_.SetAttribute("result.code",
+                                 std::to_string(static_cast<int>(error_code)));
     operation_span_.AddEvent(
         "transfer operation completed",
         {{"result.code", std::to_string(static_cast<int>(error_code))}});
@@ -403,8 +403,8 @@ bool TransferEngineOperationState::is_completed() {
 }
 
 void TransferEngineOperationState::check_task_status() {
-    auto& tracing = mooncake::tracing::TracingFacade::Instance(
-        "mooncake-store", "transfer-task");
+    auto& tracing = mooncake::tracing::TracingFacade::Instance("mooncake-store",
+                                                               "transfer-task");
     auto* wait_span =
         trace_session_.EnsureWaitSpan(tracing, batch_id_, batch_size_);
     // Check all transfers in the batch
@@ -489,8 +489,8 @@ void TransferEngineOperationState::set_result_internal(ErrorCode error_code) {
             << static_cast<int>(error_code);
     result_.emplace(error_code);
     trace_session_.FinishWait(error_code);
-    auto& tracing = mooncake::tracing::TracingFacade::Instance(
-        "mooncake-store", "transfer-task");
+    auto& tracing = mooncake::tracing::TracingFacade::Instance("mooncake-store",
+                                                               "transfer-task");
     trace_session_.Finish(tracing, error_code);
 }
 
@@ -503,8 +503,8 @@ void TransferEngineOperationState::wait_for_completion() {
 
 #ifdef USE_EVENT_DRIVEN_COMPLETION
     VLOG(1) << "Waiting for transfer engine completion for batch " << batch_id_;
-    auto& tracing = mooncake::tracing::TracingFacade::Instance(
-        "mooncake-store", "transfer-task");
+    auto& tracing = mooncake::tracing::TracingFacade::Instance("mooncake-store",
+                                                               "transfer-task");
     trace_session_.EnsureWaitSpan(tracing, batch_id_, batch_size_);
 
     // Wait directly on BatchDesc's condition variable.
@@ -673,8 +673,8 @@ std::optional<TransferFuture> TransferSubmitter::submit(
                 return std::nullopt;
         }
     } else {
-        future = submitFileReadOperation(replica, slices, op_code,
-                                         trace_context);
+        future =
+            submitFileReadOperation(replica, slices, op_code, trace_context);
     }
 
     // Update metrics on successful submission
@@ -805,12 +805,12 @@ std::optional<TransferFuture> TransferSubmitter::submitMemcpyOperation(
 std::optional<TransferFuture> TransferSubmitter::submitTransfer(
     std::vector<TransferRequest>& requests,
     const tracing::TraceContext* trace_context) {
-    auto& tracing = tracing::TracingFacade::Instance("mooncake-store",
-                                                     "transfer-task");
+    auto& tracing =
+        tracing::TracingFacade::Instance("mooncake-store", "transfer-task");
     const size_t batch_size = requests.size();
     const size_t total_bytes = CalculateRequestBytes(requests);
-    auto trace_session = TransferTraceSession::Start(
-        tracing, trace_context, batch_size, total_bytes);
+    auto trace_session = TransferTraceSession::Start(tracing, trace_context,
+                                                     batch_size, total_bytes);
 
     auto span = tracing.StartSpan(
         "mooncake.transfer.prepare", trace_session.parent_context(),

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -181,6 +181,24 @@ void TransferTraceSession::RecordBatch(BatchID batch_id) {
     operation_span_.SetAttribute("te.batch_id", std::to_string(batch_id_));
 }
 
+void TransferTraceSession::StartQueueWait(
+    mooncake::tracing::TracingFacade& tracing, BatchID batch_id,
+    size_t batch_size) {
+    if (queue_wait_context_.valid() || wait_context_.valid()) {
+        return;
+    }
+
+    auto span = tracing.StartSpan(
+        "mooncake.transfer.queue_wait", parent_context(),
+        {{"te.batch_id", std::to_string(batch_id)},
+         {"batch.size", std::to_string(batch_size)}});
+    if (!span.valid()) {
+        return;
+    }
+    queue_wait_context_ = span.context();
+    queue_wait_span_ = std::move(span);
+}
+
 void TransferTraceSession::MarkSubmitError() {
     if (!operation_span_.valid()) {
         return;
@@ -193,12 +211,30 @@ void TransferTraceSession::MarkSubmitError() {
     operation_span_.SetStatus("ERROR");
 }
 
+void TransferTraceSession::FinishQueueWait(ErrorCode error_code) {
+    if (!queue_wait_context_.valid()) {
+        return;
+    }
+
+    queue_wait_span_.AddEvent(
+        "queue wait finished",
+        {{"result.code", std::to_string(static_cast<int>(error_code))}});
+    if (error_code != ErrorCode::OK) {
+        queue_wait_span_.SetStatus("ERROR");
+    }
+    queue_wait_span_.End();
+    queue_wait_span_ = mooncake::tracing::Span();
+    queue_wait_context_ = {};
+}
+
 mooncake::tracing::Span* TransferTraceSession::EnsureWaitSpan(
     mooncake::tracing::TracingFacade& tracing, BatchID batch_id,
     size_t batch_size) {
     if (wait_context_.valid()) {
         return &wait_span_;
     }
+
+    FinishQueueWait(ErrorCode::OK);
 
     auto span = tracing.StartSpan(
         "mooncake.transfer.wait_completion", parent_context(),
@@ -228,7 +264,25 @@ void TransferTraceSession::FinishWait(ErrorCode error_code) {
     wait_context_ = {};
 }
 
-void TransferTraceSession::Finish(ErrorCode error_code) {
+void TransferTraceSession::Finish(mooncake::tracing::TracingFacade& tracing,
+                                  ErrorCode error_code) {
+    FinishQueueWait(error_code);
+    auto complete_span = tracing.StartSpan(
+        "mooncake.transfer.complete", parent_context(),
+        {{"batch.size", std::to_string(batch_size_)},
+         {"result.code", std::to_string(static_cast<int>(error_code))}});
+    if (complete_span.valid()) {
+        if (batch_id_ != INVALID_BATCH_ID) {
+            complete_span.SetAttribute("te.batch_id", std::to_string(batch_id_));
+        }
+        complete_span.AddEvent(
+            "transfer operation completed",
+            {{"result.code", std::to_string(static_cast<int>(error_code))}});
+        if (error_code != ErrorCode::OK) {
+            complete_span.SetStatus("ERROR");
+        }
+    }
+
     if (!operation_span_.valid()) {
         return;
     }
@@ -434,7 +488,9 @@ void TransferEngineOperationState::set_result_internal(ErrorCode error_code) {
             << static_cast<int>(error_code);
     result_.emplace(error_code);
     trace_session_.FinishWait(error_code);
-    trace_session_.Finish(error_code);
+    auto& tracing = mooncake::tracing::TracingFacade::Instance(
+        "mooncake-store", "transfer-task");
+    trace_session_.Finish(tracing, error_code);
 }
 
 void TransferEngineOperationState::wait_for_completion() {
@@ -789,6 +845,8 @@ std::optional<TransferFuture> TransferSubmitter::submitTransfer(
         LOG(ERROR) << "Invalid batch ID for transfer engine operation";
         return std::nullopt;
     }
+
+    trace_session.StartQueueWait(tracing, batch_id, batch_size);
 
     // Create state with transfer engine context - no polling thread
     // needed

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -166,6 +166,7 @@ TransferTraceSession TransferTraceSession::Start(
     session.operation_span_ = tracing.StartSpan(
         "mooncake.transfer.operation", nullptr,
         {{"batch.size", std::to_string(batch_size)},
+         {"sampling.priority", "structural"},
          {"bytes.total", std::to_string(total_bytes)}});
     if (session.operation_span_.valid()) {
         session.parent_context_ = session.operation_span_.context();

--- a/mooncake-store/tests/task_manager_test.cpp
+++ b/mooncake-store/tests/task_manager_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <glog/logging.h>
+#include "rpc_types.h"
 #include "task_manager.h"
 #include <thread>
 
@@ -39,6 +40,28 @@ TEST_F(ClientTaskManagerTest, SubmitAndPopTask) {
     ASSERT_EQ(tasks.size(), 1);
     EXPECT_EQ(tasks[0].id, task_id);
     EXPECT_EQ(tasks[0].status, TaskStatus::PROCESSING);
+}
+
+TEST_F(ClientTaskManagerTest, SubmitTaskWithTracePreservesCarrierOnAssignment) {
+    ClientTaskManager manager({10000, 10000, 10000, 0, 0, 3});
+    UUID client_id = generate_uuid();
+    const std::string trace_carrier = "trace-1|span-1|corr-1";
+
+    auto task_id_exp =
+        manager.get_write_access()
+            .submit_task_typed_with_trace<TaskType::REPLICA_COPY>(
+                client_id,
+                ReplicaCopyPayload{
+                    .key = "trace_key", .source = "seg1", .targets = {"seg2"}},
+                trace_carrier);
+    ASSERT_TRUE(task_id_exp.has_value());
+
+    auto tasks = manager.get_write_access().pop_tasks(client_id, 1);
+    ASSERT_EQ(tasks.size(), 1u);
+
+    TaskAssignment assignment(tasks[0]);
+    EXPECT_EQ(assignment.trace_carrier, trace_carrier);
+    EXPECT_EQ(assignment.max_retry_attempts, 3u);
 }
 
 TEST_F(ClientTaskManagerTest, MarkTaskComplete) {
@@ -374,6 +397,37 @@ TEST_F(ClientTaskManagerTest, SerializerRoundTrip) {
               1);
     EXPECT_FALSE(task4->payload.empty());
     EXPECT_EQ(task4->assigned_client, client_id2);
+}
+
+TEST_F(ClientTaskManagerTest, SerializerPreservesTraceCarrierAndRetryCount) {
+    ClientTaskManager manager({10000, 10000, 10000, 0, 0, 7});
+    UUID client_id = generate_uuid();
+    const std::string trace_carrier = "trace-9|span-9|corr-9";
+
+    auto task_id = manager.get_write_access()
+                       .submit_task_typed_with_trace<TaskType::REPLICA_COPY>(
+                           client_id,
+                           ReplicaCopyPayload{
+                               .key = "key1",
+                               .source = "seg1",
+                               .targets = {"seg2"}},
+                           trace_carrier);
+    ASSERT_TRUE(task_id.has_value());
+
+    TaskManagerSerializer serializer(&manager);
+    auto serialized = serializer.Serialize();
+    ASSERT_TRUE(serialized.has_value());
+
+    ClientTaskManager restored({10000, 10000, 10000, 0, 0, 1});
+    TaskManagerSerializer restored_serializer(&restored);
+    auto result = restored_serializer.Deserialize(serialized.value());
+    ASSERT_TRUE(result.has_value());
+
+    auto restored_task =
+        restored.get_read_access().find_task_by_id(task_id.value());
+    ASSERT_TRUE(restored_task.has_value());
+    EXPECT_EQ(restored_task->trace_carrier, trace_carrier);
+    EXPECT_EQ(restored_task->max_retry_attempts, 7u);
 }
 
 TEST_F(ClientTaskManagerTest, SerializerEmptyManager) {

--- a/mooncake-store/tests/task_manager_test.cpp
+++ b/mooncake-store/tests/task_manager_test.cpp
@@ -404,14 +404,13 @@ TEST_F(ClientTaskManagerTest, SerializerPreservesTraceCarrierAndRetryCount) {
     UUID client_id = generate_uuid();
     const std::string trace_carrier = "trace-9|span-9|corr-9";
 
-    auto task_id = manager.get_write_access()
-                       .submit_task_typed_with_trace<TaskType::REPLICA_COPY>(
-                           client_id,
-                           ReplicaCopyPayload{
-                               .key = "key1",
-                               .source = "seg1",
-                               .targets = {"seg2"}},
-                           trace_carrier);
+    auto task_id =
+        manager.get_write_access()
+            .submit_task_typed_with_trace<TaskType::REPLICA_COPY>(
+                client_id,
+                ReplicaCopyPayload{
+                    .key = "key1", .source = "seg1", .targets = {"seg2"}},
+                trace_carrier);
     ASSERT_TRUE(task_id.has_value());
 
     TaskManagerSerializer serializer(&manager);

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -290,7 +290,7 @@ TEST_F(TransferTaskTest, TransferTraceSessionReusesSingleWaitCompletionSpan) {
     EXPECT_EQ(session.wait_context(), nullptr);
 }
 
-TEST_F(TransferTaskTest, TransferTraceSessionEmitsQueueWaitAndCompleteSpans) {
+TEST_F(TransferTaskTest, TransferTraceSessionEmitsSubmitGapAndCompleteSpans) {
     namespace fs = std::filesystem;
 
     auto trace_path =
@@ -308,7 +308,7 @@ TEST_F(TransferTaskTest, TransferTraceSessionEmitsQueueWaitAndCompleteSpans) {
         mooncake::tracing::TracingFacade facade(config);
         auto session = TransferTraceSession::Start(facade, nullptr, 2, 1024);
         session.RecordBatch(55);
-        session.StartQueueWait(facade, 55, 2);
+        session.StartSubmitGap(facade, 55, 2);
         ASSERT_NE(session.EnsureWaitSpan(facade, 55, 2), nullptr);
         session.FinishWait(ErrorCode::OK);
         session.Finish(facade, ErrorCode::OK);
@@ -316,7 +316,7 @@ TEST_F(TransferTaskTest, TransferTraceSessionEmitsQueueWaitAndCompleteSpans) {
 
     auto span_names = ReadSpanNamesFromJsonl(trace_path);
     EXPECT_EQ(CountSpanName(span_names, "mooncake.transfer.operation"), 1u);
-    EXPECT_EQ(CountSpanName(span_names, "mooncake.transfer.queue_wait"), 1u);
+    EXPECT_EQ(CountSpanName(span_names, "mooncake.transfer.submit_gap"), 1u);
     EXPECT_EQ(CountSpanName(span_names, "mooncake.transfer.wait_completion"),
               1u);
     EXPECT_EQ(CountSpanName(span_names, "mooncake.transfer.complete"), 1u);

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -4,19 +4,60 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <thread>
 #include <vector>
+
+#if __has_include(<jsoncpp/json/json.h>)
+#include <jsoncpp/json/json.h>
+#else
+#include <json/json.h>
+#endif
 
 #include "trace_exporter.h"
 #include "tracing_facade.h"
 #include "types.h"
 
 namespace mooncake {
+
+namespace {
+
+std::vector<std::string> ReadSpanNamesFromJsonl(
+    const std::filesystem::path& path) {
+    std::ifstream in(path);
+    std::vector<std::string> span_names;
+    std::string line;
+
+    while (std::getline(in, line)) {
+        Json::CharReaderBuilder builder;
+        Json::Value root;
+        std::string errors;
+        std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+        if (!reader->parse(line.data(), line.data() + line.size(), &root,
+                           &errors)) {
+            continue;
+        }
+        if (root.isMember("span.name")) {
+            span_names.push_back(root["span.name"].asString());
+        }
+    }
+    return span_names;
+}
+
+size_t CountSpanName(const std::vector<std::string>& span_names,
+                     const std::string& name) {
+    return static_cast<size_t>(
+        std::count(span_names.begin(), span_names.end(), name));
+}
+
+}  // namespace
 
 // Test fixture for TransferTask tests
 // TODO: Currently, this test does not cover TransferSubmitter and
@@ -249,6 +290,40 @@ TEST_F(TransferTaskTest, TransferTraceSessionReusesSingleWaitCompletionSpan) {
     EXPECT_EQ(session.wait_context(), nullptr);
 }
 
+TEST_F(TransferTaskTest, TransferTraceSessionEmitsQueueWaitAndCompleteSpans) {
+    namespace fs = std::filesystem;
+
+    auto trace_path =
+        fs::temp_directory_path() / "transfer-trace-session-spans.jsonl";
+    fs::remove(trace_path);
+
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.exporter_mode = "jsonl";
+    config.jsonl_path = trace_path.string();
+    config.service_name = "test-service";
+    config.process_role = "test-role";
+
+    {
+        mooncake::tracing::TracingFacade facade(config);
+        auto session = TransferTraceSession::Start(facade, nullptr, 2, 1024);
+        session.RecordBatch(55);
+        session.StartQueueWait(facade, 55, 2);
+        ASSERT_NE(session.EnsureWaitSpan(facade, 55, 2), nullptr);
+        session.FinishWait(ErrorCode::OK);
+        session.Finish(facade, ErrorCode::OK);
+    }
+
+    auto span_names = ReadSpanNamesFromJsonl(trace_path);
+    EXPECT_EQ(CountSpanName(span_names, "mooncake.transfer.operation"), 1u);
+    EXPECT_EQ(CountSpanName(span_names, "mooncake.transfer.queue_wait"), 1u);
+    EXPECT_EQ(CountSpanName(span_names, "mooncake.transfer.wait_completion"),
+              1u);
+    EXPECT_EQ(CountSpanName(span_names, "mooncake.transfer.complete"), 1u);
+
+    fs::remove(trace_path);
+}
+
 TEST_F(TransferTaskTest, AsyncRemoteExporterDropsWhenQueueIsFull) {
     mooncake::tracing::TraceConfig config;
     config.enabled = true;
@@ -264,7 +339,7 @@ TEST_F(TransferTaskTest, AsyncRemoteExporterDropsWhenQueueIsFull) {
     auto fallback = std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
     mooncake::tracing::AsyncRemoteTraceExporter exporter(
         config, fallback,
-        [](const mooncake::tracing::TraceRecord&, std::string*) {
+        [](const std::vector<mooncake::tracing::TraceRecord>&, std::string*) {
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
             return false;
         });
@@ -283,6 +358,80 @@ TEST_F(TransferTaskTest, AsyncRemoteExporterDropsWhenQueueIsFull) {
     EXPECT_GE(stats.dropped_records, 1u);
     EXPECT_GE(stats.retry_count, 1u);
     EXPECT_GE(stats.fallback_count, 1u);
+}
+
+TEST_F(TransferTaskTest,
+       AsyncRemoteExporterPrefersErrorSpanWhenQueueIsFull) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.exporter_mode = "remote";
+    config.service_name = "priority-service";
+    config.process_role = "test-role";
+    config.exporter_queue_max_items = 2;
+    config.exporter_queue_max_bytes = 2048;
+    config.exporter_retry_base_ms = 1;
+    config.exporter_retry_max_ms = 2;
+    config.exporter_retry_max_attempts = 0;
+
+    auto fallback = std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
+    std::atomic<bool> release_remote{false};
+    mooncake::tracing::AsyncRemoteTraceExporter exporter(
+        config, fallback,
+        [&release_remote](const std::vector<mooncake::tracing::TraceRecord>&,
+                          std::string*) {
+            while (!release_remote.load(std::memory_order_acquire)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            return false;
+        });
+
+    mooncake::tracing::TraceRecord low_inflight;
+    low_inflight.trace_id = "trace-low-inflight";
+    low_inflight.span_id = "span-low-inflight";
+    low_inflight.parent_span_id = "parent";
+    low_inflight.span_name = "low-inflight";
+
+    mooncake::tracing::TraceRecord low_queue_a;
+    low_queue_a.trace_id = "trace-low-a";
+    low_queue_a.span_id = "span-low-a";
+    low_queue_a.parent_span_id = "parent";
+    low_queue_a.span_name = "low-queue-a";
+
+    mooncake::tracing::TraceRecord low_queue_b;
+    low_queue_b.trace_id = "trace-low-b";
+    low_queue_b.span_id = "span-low-b";
+    low_queue_b.parent_span_id = "parent";
+    low_queue_b.span_name = "low-queue-b";
+
+    mooncake::tracing::TraceRecord error_record;
+    error_record.trace_id = "trace-error";
+    error_record.span_id = "span-error";
+    error_record.parent_span_id = "parent";
+    error_record.span_name = "high-priority-error";
+    error_record.status = "ERROR";
+
+    exporter.Export(low_inflight);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    exporter.Export(low_queue_a);
+    exporter.Export(low_queue_b);
+    exporter.Export(error_record);
+
+    release_remote.store(true, std::memory_order_release);
+    EXPECT_TRUE(exporter.FlushForTest(std::chrono::milliseconds(500)));
+
+    auto exported = fallback->Snapshot();
+    bool saw_error_span = false;
+    for (const auto& record : exported) {
+        if (record.span_name == "high-priority-error") {
+            saw_error_span = true;
+            break;
+        }
+    }
+
+    auto stats = exporter.SnapshotStats();
+    EXPECT_TRUE(saw_error_span);
+    EXPECT_GE(stats.queue_full_count, 1u);
+    EXPECT_GE(stats.dropped_records, 1u);
 }
 
 TEST_F(TransferTaskTest, TraceSamplerBaseModeKeepsErrorAndSlowSpan) {
@@ -348,7 +497,7 @@ TEST_F(TransferTaskTest, AsyncRemoteExporterSpoolsWhenConfiguredAndRemoteFails) 
 
     mooncake::tracing::AsyncRemoteTraceExporter exporter(
         config, std::make_shared<mooncake::tracing::InMemoryTraceExporter>(),
-        [](const mooncake::tracing::TraceRecord&, std::string*) {
+        [](const std::vector<mooncake::tracing::TraceRecord>&, std::string*) {
             return false;
         });
 
@@ -393,7 +542,7 @@ TEST_F(TransferTaskTest, AsyncRemoteExporterCountsQueueFullAndCollectorFailure) 
     auto fallback = std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
     mooncake::tracing::AsyncRemoteTraceExporter exporter(
         config, fallback,
-        [](const mooncake::tracing::TraceRecord&, std::string*) {
+        [](const std::vector<mooncake::tracing::TraceRecord>&, std::string*) {
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
             return false;
         });
@@ -414,6 +563,50 @@ TEST_F(TransferTaskTest, AsyncRemoteExporterCountsQueueFullAndCollectorFailure) 
     EXPECT_GE(stats.collector_unreachable_count, 1u);
     EXPECT_GE(stats.retry_count, 1u);
     EXPECT_GE(stats.fallback_count, 1u);
+}
+
+TEST_F(TransferTaskTest, AsyncRemoteExporterBatchesMultipleRecordsPerSend) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.exporter_mode = "remote";
+    config.service_name = "batch-service";
+    config.process_role = "test-role";
+    config.exporter_retry_base_ms = 1;
+    config.exporter_retry_max_ms = 2;
+    config.exporter_retry_max_attempts = 0;
+
+    std::atomic<int> remote_calls{0};
+    std::atomic<size_t> max_batch_size{0};
+    std::atomic<bool> release_remote{false};
+    mooncake::tracing::AsyncRemoteTraceExporter exporter(
+        config, std::make_shared<mooncake::tracing::InMemoryTraceExporter>(),
+        [&release_remote,
+         &remote_calls,
+         &max_batch_size](const std::vector<mooncake::tracing::TraceRecord>& records,
+                          std::string*) {
+            while (!release_remote.load(std::memory_order_acquire)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            remote_calls.fetch_add(1, std::memory_order_relaxed);
+            max_batch_size.store(
+                std::max(max_batch_size.load(std::memory_order_relaxed),
+                         records.size()),
+                std::memory_order_relaxed);
+            return true;
+        });
+
+    for (int i = 0; i < 8; ++i) {
+        mooncake::tracing::TraceRecord record;
+        record.trace_id = "trace-batch-" + std::to_string(i);
+        record.span_id = "span-batch-" + std::to_string(i);
+        record.span_name = "span-batch";
+        exporter.Export(record);
+    }
+
+    release_remote.store(true, std::memory_order_release);
+    EXPECT_TRUE(exporter.FlushForTest(std::chrono::milliseconds(200)));
+    EXPECT_LT(remote_calls.load(std::memory_order_relaxed), 8);
+    EXPECT_GT(max_batch_size.load(std::memory_order_relaxed), 1u);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -6,10 +6,14 @@
 
 #include <chrono>
 #include <cstring>
+#include <filesystem>
 #include <memory>
+#include <string>
 #include <thread>
 #include <vector>
 
+#include "trace_exporter.h"
+#include "tracing_facade.h"
 #include "types.h"
 
 namespace mooncake {
@@ -158,6 +162,195 @@ TEST_F(TransferTaskTest, TransferStrategyEnum) {
     oss.str("");
     oss << TransferStrategy::TRANSFER_ENGINE;
     EXPECT_EQ(oss.str(), "TRANSFER_ENGINE");
+}
+
+TEST_F(TransferTaskTest, StartSpanFromCarrierUsesCarrierSpanAsParent) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.exporter_mode = "inmemory";
+    config.service_name = "test-service";
+    config.process_role = "test-role";
+
+    mooncake::tracing::TracingFacade facade(config);
+    mooncake::tracing::TraceCarrier carrier{
+        .trace_id = "0123456789abcdef0123456789abcdef",
+        .span_id = "89abcdef01234567",
+        .correlation_id = "corr-1234"};
+
+    auto span = facade.StartSpanFromCarrier("child-span", carrier);
+    auto context = span.context();
+
+    EXPECT_EQ(context.trace_id, carrier.trace_id);
+    EXPECT_EQ(context.parent_span_id, carrier.span_id);
+    EXPECT_EQ(context.correlation_id, carrier.correlation_id);
+    EXPECT_NE(context.span_id, carrier.span_id);
+}
+
+TEST_F(TransferTaskTest, AsyncRemoteExporterDropsWhenQueueIsFull) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.exporter_mode = "remote";
+    config.service_name = "test-service";
+    config.process_role = "test-role";
+    config.exporter_queue_max_items = 1;
+    config.exporter_queue_max_bytes = 1024;
+    config.exporter_retry_base_ms = 1;
+    config.exporter_retry_max_ms = 2;
+    config.exporter_retry_max_attempts = 1;
+
+    auto fallback = std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
+    mooncake::tracing::AsyncRemoteTraceExporter exporter(
+        config, fallback,
+        [](const mooncake::tracing::TraceRecord&, std::string*) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            return false;
+        });
+
+    mooncake::tracing::TraceRecord record;
+    record.trace_id = "trace";
+    record.span_id = "span";
+    record.span_name = "span-name";
+
+    exporter.Export(record);
+    exporter.Export(record);
+    exporter.Export(record);
+    exporter.FlushForTest(std::chrono::milliseconds(200));
+
+    auto stats = exporter.SnapshotStats();
+    EXPECT_GE(stats.dropped_records, 1u);
+    EXPECT_GE(stats.retry_count, 1u);
+    EXPECT_GE(stats.fallback_count, 1u);
+}
+
+TEST_F(TransferTaskTest, TraceSamplerBaseModeKeepsErrorAndSlowSpan) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.sampling_mode = "base";
+    config.sampling_base_ratio = 0.0;
+    config.sampling_slow_threshold_ms = 10;
+
+    mooncake::tracing::TraceSampler sampler(config);
+
+    mooncake::tracing::TraceRecord error_record;
+    error_record.status = "ERROR";
+    EXPECT_TRUE(sampler.ShouldSample(error_record));
+
+    mooncake::tracing::TraceRecord slow_record;
+    slow_record.start_time_unix_nano = 0;
+    slow_record.end_time_unix_nano = 20 * 1000 * 1000;
+    EXPECT_TRUE(sampler.ShouldSample(slow_record));
+
+    mooncake::tracing::TraceRecord normal_record;
+    normal_record.trace_id = "trace-normal";
+    normal_record.start_time_unix_nano = 0;
+    normal_record.end_time_unix_nano = 1 * 1000 * 1000;
+    EXPECT_FALSE(sampler.ShouldSample(normal_record));
+}
+
+TEST_F(TransferTaskTest, TraceSamplerDiagKeepsEventfulSpan) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.sampling_mode = "diag";
+    config.sampling_base_ratio = 0.0;
+
+    mooncake::tracing::TraceSampler sampler(config);
+
+    mooncake::tracing::TraceRecord eventful_record;
+    eventful_record.trace_id = "trace-diag";
+    eventful_record.events.push_back(
+        mooncake::tracing::TraceEvent{"important-event", 1, {}});
+    EXPECT_TRUE(sampler.ShouldSample(eventful_record));
+
+    mooncake::tracing::TraceRecord normal_record;
+    normal_record.trace_id = "trace-normal";
+    EXPECT_FALSE(sampler.ShouldSample(normal_record));
+}
+
+TEST_F(TransferTaskTest, AsyncRemoteExporterSpoolsWhenConfiguredAndRemoteFails) {
+    namespace fs = std::filesystem;
+
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.exporter_mode = "remote";
+    config.service_name = "spool-service";
+    config.process_role = "test-role";
+    config.exporter_retry_base_ms = 1;
+    config.exporter_retry_max_ms = 2;
+    config.exporter_retry_max_attempts = 0;
+
+    auto spool_dir = fs::temp_directory_path() / "mooncake-tracing-spool-test";
+    fs::remove_all(spool_dir);
+    config.exporter_spool_dir = spool_dir.string();
+    config.jsonl_path = (spool_dir / "fallback.jsonl").string();
+
+    mooncake::tracing::AsyncRemoteTraceExporter exporter(
+        config, std::make_shared<mooncake::tracing::InMemoryTraceExporter>(),
+        [](const mooncake::tracing::TraceRecord&, std::string*) {
+            return false;
+        });
+
+    mooncake::tracing::TraceRecord record;
+    record.trace_id = "trace-spool";
+    record.span_id = "span-spool";
+    record.span_name = "span-name";
+
+    exporter.Export(record);
+    EXPECT_TRUE(exporter.FlushForTest(std::chrono::milliseconds(200)));
+
+    auto stats = exporter.SnapshotStats();
+    EXPECT_GE(stats.collector_unreachable_count, 1u);
+    EXPECT_GE(stats.spooled_records, 1u);
+    EXPECT_EQ(stats.fallback_count, 0u);
+
+    bool found_spool_file = false;
+    if (fs::exists(spool_dir)) {
+        for (const auto& entry : fs::directory_iterator(spool_dir)) {
+            if (entry.is_regular_file()) {
+                found_spool_file = true;
+                break;
+            }
+        }
+    }
+    EXPECT_TRUE(found_spool_file);
+    fs::remove_all(spool_dir);
+}
+
+TEST_F(TransferTaskTest, AsyncRemoteExporterCountsQueueFullAndCollectorFailure) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.exporter_mode = "remote";
+    config.service_name = "counter-service";
+    config.process_role = "test-role";
+    config.exporter_queue_max_items = 1;
+    config.exporter_queue_max_bytes = 1024;
+    config.exporter_retry_base_ms = 1;
+    config.exporter_retry_max_ms = 2;
+    config.exporter_retry_max_attempts = 1;
+
+    auto fallback = std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
+    mooncake::tracing::AsyncRemoteTraceExporter exporter(
+        config, fallback,
+        [](const mooncake::tracing::TraceRecord&, std::string*) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            return false;
+        });
+
+    mooncake::tracing::TraceRecord record;
+    record.trace_id = "trace-counter";
+    record.span_id = "span-counter";
+    record.span_name = "span-name";
+
+    exporter.Export(record);
+    exporter.Export(record);
+    exporter.Export(record);
+    EXPECT_TRUE(exporter.FlushForTest(std::chrono::milliseconds(200)));
+
+    auto stats = exporter.SnapshotStats();
+    EXPECT_GE(stats.dropped_records, 1u);
+    EXPECT_GE(stats.queue_full_count, 1u);
+    EXPECT_GE(stats.collector_unreachable_count, 1u);
+    EXPECT_GE(stats.retry_count, 1u);
+    EXPECT_GE(stats.fallback_count, 1u);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -229,7 +229,8 @@ TEST_F(TransferTaskTest, StartSpanFromCarrierUsesCarrierSpanAsParent) {
     EXPECT_TRUE(context.force_sample);
 }
 
-TEST_F(TransferTaskTest, TransferTraceSessionCreatesStandaloneRootWhenMissingParent) {
+TEST_F(TransferTaskTest,
+       TransferTraceSessionCreatesStandaloneRootWhenMissingParent) {
     mooncake::tracing::TraceConfig config;
     config.enabled = true;
     config.exporter_mode = "inmemory";
@@ -338,7 +339,8 @@ TEST_F(TransferTaskTest, AsyncRemoteExporterDropsWhenQueueIsFull) {
     config.exporter_retry_max_ms = 2;
     config.exporter_retry_max_attempts = 1;
 
-    auto fallback = std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
+    auto fallback =
+        std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
     mooncake::tracing::AsyncRemoteTraceExporter exporter(
         config, fallback,
         [](const std::vector<mooncake::tracing::TraceRecord>&, std::string*) {
@@ -362,8 +364,7 @@ TEST_F(TransferTaskTest, AsyncRemoteExporterDropsWhenQueueIsFull) {
     EXPECT_GE(stats.fallback_count, 1u);
 }
 
-TEST_F(TransferTaskTest,
-       AsyncRemoteExporterPrefersErrorSpanWhenQueueIsFull) {
+TEST_F(TransferTaskTest, AsyncRemoteExporterPrefersErrorSpanWhenQueueIsFull) {
     mooncake::tracing::TraceConfig config;
     config.enabled = true;
     config.exporter_mode = "remote";
@@ -375,7 +376,8 @@ TEST_F(TransferTaskTest,
     config.exporter_retry_max_ms = 2;
     config.exporter_retry_max_attempts = 0;
 
-    auto fallback = std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
+    auto fallback =
+        std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
     std::atomic<bool> release_remote{false};
     mooncake::tracing::AsyncRemoteTraceExporter exporter(
         config, fallback,
@@ -449,7 +451,8 @@ TEST_F(TransferTaskTest,
     config.exporter_retry_max_ms = 2;
     config.exporter_retry_max_attempts = 0;
 
-    auto fallback = std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
+    auto fallback =
+        std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
     std::atomic<bool> release_remote{false};
     mooncake::tracing::AsyncRemoteTraceExporter exporter(
         config, fallback,
@@ -568,7 +571,8 @@ TEST_F(TransferTaskTest, TraceSamplerDiagKeepsEventfulSpan) {
     EXPECT_FALSE(sampler.ShouldSample(normal_record));
 }
 
-TEST_F(TransferTaskTest, AsyncRemoteExporterSpoolsWhenConfiguredAndRemoteFails) {
+TEST_F(TransferTaskTest,
+       AsyncRemoteExporterSpoolsWhenConfiguredAndRemoteFails) {
     namespace fs = std::filesystem;
 
     mooncake::tracing::TraceConfig config;
@@ -617,7 +621,8 @@ TEST_F(TransferTaskTest, AsyncRemoteExporterSpoolsWhenConfiguredAndRemoteFails) 
     fs::remove_all(spool_dir);
 }
 
-TEST_F(TransferTaskTest, AsyncRemoteExporterCountsQueueFullAndCollectorFailure) {
+TEST_F(TransferTaskTest,
+       AsyncRemoteExporterCountsQueueFullAndCollectorFailure) {
     mooncake::tracing::TraceConfig config;
     config.enabled = true;
     config.exporter_mode = "remote";
@@ -629,7 +634,8 @@ TEST_F(TransferTaskTest, AsyncRemoteExporterCountsQueueFullAndCollectorFailure) 
     config.exporter_retry_max_ms = 2;
     config.exporter_retry_max_attempts = 1;
 
-    auto fallback = std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
+    auto fallback =
+        std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
     mooncake::tracing::AsyncRemoteTraceExporter exporter(
         config, fallback,
         [](const std::vector<mooncake::tracing::TraceRecord>&, std::string*) {
@@ -670,10 +676,9 @@ TEST_F(TransferTaskTest, AsyncRemoteExporterBatchesMultipleRecordsPerSend) {
     std::atomic<bool> release_remote{false};
     mooncake::tracing::AsyncRemoteTraceExporter exporter(
         config, std::make_shared<mooncake::tracing::InMemoryTraceExporter>(),
-        [&release_remote,
-         &remote_calls,
-         &max_batch_size](const std::vector<mooncake::tracing::TraceRecord>& records,
-                          std::string*) {
+        [&release_remote, &remote_calls, &max_batch_size](
+            const std::vector<mooncake::tracing::TraceRecord>& records,
+            std::string*) {
             while (!release_remote.load(std::memory_order_acquire)) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -216,7 +216,8 @@ TEST_F(TransferTaskTest, StartSpanFromCarrierUsesCarrierSpanAsParent) {
     mooncake::tracing::TraceCarrier carrier{
         .trace_id = "0123456789abcdef0123456789abcdef",
         .span_id = "89abcdef01234567",
-        .correlation_id = "corr-1234"};
+        .correlation_id = "corr-1234",
+        .force_sample = true};
 
     auto span = facade.StartSpanFromCarrier("child-span", carrier);
     auto context = span.context();
@@ -225,6 +226,7 @@ TEST_F(TransferTaskTest, StartSpanFromCarrierUsesCarrierSpanAsParent) {
     EXPECT_EQ(context.parent_span_id, carrier.span_id);
     EXPECT_EQ(context.correlation_id, carrier.correlation_id);
     EXPECT_NE(context.span_id, carrier.span_id);
+    EXPECT_TRUE(context.force_sample);
 }
 
 TEST_F(TransferTaskTest, TransferTraceSessionCreatesStandaloneRootWhenMissingParent) {
@@ -434,6 +436,76 @@ TEST_F(TransferTaskTest,
     EXPECT_GE(stats.dropped_records, 1u);
 }
 
+TEST_F(TransferTaskTest,
+       AsyncRemoteExporterRetainsStructuralSpanWhenQueueIsFull) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.exporter_mode = "remote";
+    config.service_name = "priority-service";
+    config.process_role = "test-role";
+    config.exporter_queue_max_items = 1;
+    config.exporter_queue_max_bytes = 2048;
+    config.exporter_retry_base_ms = 1;
+    config.exporter_retry_max_ms = 2;
+    config.exporter_retry_max_attempts = 0;
+
+    auto fallback = std::make_shared<mooncake::tracing::InMemoryTraceExporter>();
+    std::atomic<bool> release_remote{false};
+    mooncake::tracing::AsyncRemoteTraceExporter exporter(
+        config, fallback,
+        [&release_remote](const std::vector<mooncake::tracing::TraceRecord>&,
+                          std::string*) {
+            while (!release_remote.load(std::memory_order_acquire)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            return false;
+        });
+
+    mooncake::tracing::TraceRecord slow_inflight;
+    slow_inflight.trace_id = "trace-slow-inflight";
+    slow_inflight.span_id = "span-slow-inflight";
+    slow_inflight.parent_span_id = "parent";
+    slow_inflight.span_name = "slow-inflight";
+    slow_inflight.start_time_unix_nano = 0;
+    slow_inflight.end_time_unix_nano = 60 * 1000 * 1000;
+
+    mooncake::tracing::TraceRecord slow_queued;
+    slow_queued.trace_id = "trace-slow-queued";
+    slow_queued.span_id = "span-slow-queued";
+    slow_queued.parent_span_id = "parent";
+    slow_queued.span_name = "slow-queued";
+    slow_queued.start_time_unix_nano = 0;
+    slow_queued.end_time_unix_nano = 60 * 1000 * 1000;
+
+    mooncake::tracing::TraceRecord structural_record;
+    structural_record.trace_id = "trace-structural";
+    structural_record.span_id = "span-structural";
+    structural_record.parent_span_id = "parent";
+    structural_record.span_name = "structural-parent";
+    structural_record.attrs.emplace_back("sampling.priority", "structural");
+
+    exporter.Export(slow_inflight);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    exporter.Export(slow_queued);
+    exporter.Export(structural_record);
+
+    release_remote.store(true, std::memory_order_release);
+    EXPECT_TRUE(exporter.FlushForTest(std::chrono::milliseconds(500)));
+
+    auto exported = fallback->Snapshot();
+    bool saw_structural = false;
+    for (const auto& record : exported) {
+        if (record.span_name == "structural-parent") {
+            saw_structural = true;
+            break;
+        }
+    }
+
+    auto stats = exporter.SnapshotStats();
+    EXPECT_TRUE(saw_structural);
+    EXPECT_GE(stats.queue_full_count, 1u);
+}
+
 TEST_F(TransferTaskTest, TraceSamplerBaseModeKeepsErrorAndSlowSpan) {
     mooncake::tracing::TraceConfig config;
     config.enabled = true;
@@ -457,6 +529,24 @@ TEST_F(TransferTaskTest, TraceSamplerBaseModeKeepsErrorAndSlowSpan) {
     normal_record.start_time_unix_nano = 0;
     normal_record.end_time_unix_nano = 1 * 1000 * 1000;
     EXPECT_FALSE(sampler.ShouldSample(normal_record));
+}
+
+TEST_F(TransferTaskTest, TraceSamplerBaseModeKeepsStructuralSpan) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.sampling_mode = "base";
+    config.sampling_base_ratio = 0.0;
+    config.sampling_slow_threshold_ms = 50;
+
+    mooncake::tracing::TraceSampler sampler(config);
+
+    mooncake::tracing::TraceRecord structural_record;
+    structural_record.trace_id = "trace-structural";
+    structural_record.parent_span_id = "parent";
+    structural_record.start_time_unix_nano = 0;
+    structural_record.end_time_unix_nano = 1 * 1000 * 1000;
+    structural_record.force_sample = true;
+    EXPECT_TRUE(sampler.ShouldSample(structural_record));
 }
 
 TEST_F(TransferTaskTest, TraceSamplerDiagKeepsEventfulSpan) {

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -186,6 +186,69 @@ TEST_F(TransferTaskTest, StartSpanFromCarrierUsesCarrierSpanAsParent) {
     EXPECT_NE(context.span_id, carrier.span_id);
 }
 
+TEST_F(TransferTaskTest, TransferTraceSessionCreatesStandaloneRootWhenMissingParent) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.exporter_mode = "inmemory";
+    config.service_name = "test-service";
+    config.process_role = "test-role";
+
+    mooncake::tracing::TracingFacade facade(config);
+    auto session = TransferTraceSession::Start(facade, nullptr, 4, 4096);
+
+    ASSERT_TRUE(session.parent_context() != nullptr);
+    EXPECT_TRUE(session.parent_context()->valid());
+    EXPECT_TRUE(session.owns_operation_span());
+}
+
+TEST_F(TransferTaskTest, TransferTraceSessionReusesProvidedParentContext) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.exporter_mode = "inmemory";
+    config.service_name = "test-service";
+    config.process_role = "test-role";
+
+    mooncake::tracing::TracingFacade facade(config);
+    mooncake::tracing::TraceContext parent_context{
+        .trace_id = "trace-parent",
+        .span_id = "span-parent",
+        .parent_span_id = "",
+        .correlation_id = "corr-parent"};
+
+    auto session =
+        TransferTraceSession::Start(facade, &parent_context, 2, 1024);
+
+    ASSERT_TRUE(session.parent_context() != nullptr);
+    EXPECT_EQ(session.parent_context()->trace_id, parent_context.trace_id);
+    EXPECT_EQ(session.parent_context()->span_id, parent_context.span_id);
+    EXPECT_FALSE(session.owns_operation_span());
+}
+
+TEST_F(TransferTaskTest, TransferTraceSessionReusesSingleWaitCompletionSpan) {
+    mooncake::tracing::TraceConfig config;
+    config.enabled = true;
+    config.exporter_mode = "inmemory";
+    config.service_name = "test-service";
+    config.process_role = "test-role";
+
+    mooncake::tracing::TracingFacade facade(config);
+    auto session = TransferTraceSession::Start(facade, nullptr, 3, 2048);
+
+    auto* first_wait_span = session.EnsureWaitSpan(facade, 77, 3);
+    ASSERT_NE(first_wait_span, nullptr);
+    ASSERT_TRUE(session.wait_context() != nullptr);
+    auto first_context = *session.wait_context();
+
+    auto* second_wait_span = session.EnsureWaitSpan(facade, 77, 3);
+    ASSERT_NE(second_wait_span, nullptr);
+    ASSERT_TRUE(session.wait_context() != nullptr);
+    EXPECT_EQ(session.wait_context()->span_id, first_context.span_id);
+    EXPECT_EQ(session.wait_context()->trace_id, first_context.trace_id);
+
+    session.FinishWait(ErrorCode::OK);
+    EXPECT_EQ(session.wait_context(), nullptr);
+}
+
 TEST_F(TransferTaskTest, AsyncRemoteExporterDropsWhenQueueIsFull) {
     mooncake::tracing::TraceConfig config;
     config.enabled = true;

--- a/mooncake-tracing/CMakeLists.txt
+++ b/mooncake-tracing/CMakeLists.txt
@@ -1,0 +1,23 @@
+project(mooncake-tracing)
+
+add_library(mooncake-tracing
+    src/trace_context.cpp
+    src/trace_exporter_inmemory.cpp
+    src/trace_exporter_jsonl.cpp
+    src/trace_exporter_otlp_http.cpp
+    src/trace_config.cpp
+    src/tracing_facade.cpp)
+
+find_package(CURL REQUIRED)
+
+target_include_directories(mooncake-tracing
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${JsonCpp_INCLUDE_DIRS})
+
+target_link_libraries(
+    mooncake-tracing
+    PUBLIC
+        ${JsonCpp_LIBRARY}
+        ${CURL_LIBRARIES}
+        glog::glog)

--- a/mooncake-tracing/include/trace_config.h
+++ b/mooncake-tracing/include/trace_config.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+namespace mooncake::tracing {
+
+struct TraceConfig {
+    bool enabled{false};
+    std::string exporter_mode{"off"};
+    std::string jsonl_path;
+    std::string service_name;
+    std::string node_id;
+    std::string process_role;
+    std::string otlp_http_endpoint;
+    std::string otlp_http_path{"/v1/traces"};
+    std::string otlp_headers;
+    int otlp_timeout_ms{3000};
+};
+
+TraceConfig LoadTraceConfig(const std::string& service_name,
+                            const std::string& process_role = "");
+
+}  // namespace mooncake::tracing

--- a/mooncake-tracing/include/trace_config.h
+++ b/mooncake-tracing/include/trace_config.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
+#include <vector>
 
 namespace mooncake::tracing {
 
@@ -8,6 +10,7 @@ struct TraceConfig {
     bool enabled{false};
     std::string exporter_mode{"off"};
     std::string jsonl_path;
+    std::vector<std::string> remote_endpoints;
     std::string service_name;
     std::string node_id;
     std::string process_role;
@@ -15,6 +18,15 @@ struct TraceConfig {
     std::string otlp_http_path{"/v1/traces"};
     std::string otlp_headers;
     int otlp_timeout_ms{3000};
+    size_t exporter_queue_max_items{1024};
+    size_t exporter_queue_max_bytes{4 * 1024 * 1024};
+    int exporter_retry_base_ms{100};
+    int exporter_retry_max_ms{5000};
+    int exporter_retry_max_attempts{3};
+    std::string exporter_spool_dir;
+    std::string sampling_mode{"debug"};
+    double sampling_base_ratio{1.0};
+    int sampling_slow_threshold_ms{0};
 };
 
 TraceConfig LoadTraceConfig(const std::string& service_name,

--- a/mooncake-tracing/include/trace_context.h
+++ b/mooncake-tracing/include/trace_context.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+
+namespace mooncake::tracing {
+
+struct TraceContext {
+    std::string trace_id;
+    std::string span_id;
+    std::string parent_span_id;
+    std::string correlation_id;
+    bool context_missing{false};
+
+    bool valid() const { return !trace_id.empty() && !span_id.empty(); }
+};
+
+struct TraceCarrier {
+    std::string trace_id;
+    std::string span_id;
+    std::string correlation_id;
+
+    bool empty() const {
+        return trace_id.empty() && span_id.empty() && correlation_id.empty();
+    }
+};
+
+TraceCarrier ToCarrier(const TraceContext& ctx);
+TraceContext ChildContextFromCarrier(const TraceCarrier& carrier);
+TraceContext RootContext(const std::string& correlation_id = "");
+
+}  // namespace mooncake::tracing

--- a/mooncake-tracing/include/trace_context.h
+++ b/mooncake-tracing/include/trace_context.h
@@ -9,6 +9,7 @@ struct TraceContext {
     std::string span_id;
     std::string parent_span_id;
     std::string correlation_id;
+    bool force_sample{false};
     bool context_missing{false};
 
     bool valid() const { return !trace_id.empty() && !span_id.empty(); }
@@ -18,6 +19,7 @@ struct TraceCarrier {
     std::string trace_id;
     std::string span_id;
     std::string correlation_id;
+    bool force_sample{false};
 
     bool empty() const {
         return trace_id.empty() && span_id.empty() && correlation_id.empty();

--- a/mooncake-tracing/include/trace_context.h
+++ b/mooncake-tracing/include/trace_context.h
@@ -25,6 +25,8 @@ struct TraceCarrier {
 };
 
 TraceCarrier ToCarrier(const TraceContext& ctx);
+std::string EncodeTraceCarrier(const TraceCarrier& carrier);
+TraceCarrier DecodeTraceCarrier(const std::string& encoded);
 TraceContext ChildContextFromCarrier(const TraceCarrier& carrier);
 TraceContext RootContext(const std::string& correlation_id = "");
 

--- a/mooncake-tracing/include/trace_exporter.h
+++ b/mooncake-tracing/include/trace_exporter.h
@@ -1,10 +1,16 @@
 #pragma once
 
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
+#include "trace_config.h"
 #include "trace_record.h"
 
 namespace mooncake::tracing {
@@ -13,6 +19,27 @@ class TraceExporter {
    public:
     virtual ~TraceExporter() = default;
     virtual void Export(const TraceRecord& record) = 0;
+};
+
+struct TraceExporterStats {
+    size_t queued_records{0};
+    size_t queued_bytes{0};
+    size_t dropped_records{0};
+    size_t queue_full_count{0};
+    size_t retry_count{0};
+    size_t fallback_count{0};
+    size_t collector_unreachable_count{0};
+    size_t spooled_records{0};
+    size_t spool_failures{0};
+};
+
+class TraceSampler {
+   public:
+    explicit TraceSampler(TraceConfig config);
+    bool ShouldSample(const TraceRecord& record) const;
+
+   private:
+    TraceConfig config_;
 };
 
 class InMemoryTraceExporter : public TraceExporter {
@@ -40,6 +67,8 @@ class OtlpHttpTraceExporter : public TraceExporter {
     OtlpHttpTraceExporter(std::string endpoint, std::string path,
                           std::string headers, int timeout_ms);
     void Export(const TraceRecord& record) override;
+    bool TryExport(const TraceRecord& record,
+                   std::string* error_message = nullptr);
 
    private:
     std::string endpoint_;
@@ -47,6 +76,40 @@ class OtlpHttpTraceExporter : public TraceExporter {
     std::string headers_;
     int timeout_ms_{3000};
     std::mutex mutex_;
+};
+
+class AsyncRemoteTraceExporter : public TraceExporter {
+   public:
+    using RemoteSendFn =
+        std::function<bool(const TraceRecord&, std::string* error_message)>;
+
+    AsyncRemoteTraceExporter(TraceConfig config,
+                             std::shared_ptr<TraceExporter> fallback_exporter,
+                             RemoteSendFn send_fn = {});
+    ~AsyncRemoteTraceExporter() override;
+
+    void Export(const TraceRecord& record) override;
+    bool FlushForTest(std::chrono::milliseconds timeout);
+    TraceExporterStats SnapshotStats() const;
+
+   private:
+    size_t EstimateRecordBytes(const TraceRecord& record) const;
+    bool TrySendRemote(const TraceRecord& record, std::string* error_message);
+    bool TrySpool(const TraceRecord& record, std::string* error_message);
+    void WorkerMain();
+
+    TraceConfig config_;
+    std::shared_ptr<TraceExporter> fallback_exporter_;
+    std::vector<RemoteSendFn> remote_send_fns_;
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    std::condition_variable drained_cv_;
+    std::deque<TraceRecord> queue_;
+    size_t queued_bytes_{0};
+    bool stop_{false};
+    bool worker_busy_{false};
+    TraceExporterStats stats_;
+    std::thread worker_;
 };
 
 std::shared_ptr<TraceExporter> MakeDefaultExporter(

--- a/mooncake-tracing/include/trace_exporter.h
+++ b/mooncake-tracing/include/trace_exporter.h
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <curl/curl.h>
 #include <deque>
 #include <functional>
 #include <memory>
@@ -66,22 +67,30 @@ class OtlpHttpTraceExporter : public TraceExporter {
    public:
     OtlpHttpTraceExporter(std::string endpoint, std::string path,
                           std::string headers, int timeout_ms);
+    ~OtlpHttpTraceExporter() override;
     void Export(const TraceRecord& record) override;
+    void ExportBatch(const std::vector<TraceRecord>& records);
     bool TryExport(const TraceRecord& record,
                    std::string* error_message = nullptr);
+    bool TryExportBatch(const std::vector<TraceRecord>& records,
+                        std::string* error_message = nullptr);
 
    private:
+    bool EnsureCurlLocked();
+
     std::string endpoint_;
     std::string path_;
     std::string headers_;
     int timeout_ms_{3000};
     std::mutex mutex_;
+    CURL* curl_{nullptr};
+    curl_slist* header_list_{nullptr};
 };
 
 class AsyncRemoteTraceExporter : public TraceExporter {
    public:
-    using RemoteSendFn =
-        std::function<bool(const TraceRecord&, std::string* error_message)>;
+    using RemoteSendFn = std::function<bool(
+        const std::vector<TraceRecord>&, std::string* error_message)>;
 
     AsyncRemoteTraceExporter(TraceConfig config,
                              std::shared_ptr<TraceExporter> fallback_exporter,
@@ -94,7 +103,8 @@ class AsyncRemoteTraceExporter : public TraceExporter {
 
    private:
     size_t EstimateRecordBytes(const TraceRecord& record) const;
-    bool TrySendRemote(const TraceRecord& record, std::string* error_message);
+    bool TrySendRemote(const std::vector<TraceRecord>& records,
+                       std::string* error_message);
     bool TrySpool(const TraceRecord& record, std::string* error_message);
     void WorkerMain();
 

--- a/mooncake-tracing/include/trace_exporter.h
+++ b/mooncake-tracing/include/trace_exporter.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "trace_record.h"
+
+namespace mooncake::tracing {
+
+class TraceExporter {
+   public:
+    virtual ~TraceExporter() = default;
+    virtual void Export(const TraceRecord& record) = 0;
+};
+
+class InMemoryTraceExporter : public TraceExporter {
+   public:
+    void Export(const TraceRecord& record) override;
+    std::vector<TraceRecord> Snapshot() const;
+
+   private:
+    mutable std::mutex mutex_;
+    std::vector<TraceRecord> records_;
+};
+
+class JsonlTraceExporter : public TraceExporter {
+   public:
+    explicit JsonlTraceExporter(std::string file_path);
+    void Export(const TraceRecord& record) override;
+
+   private:
+    std::string file_path_;
+    std::mutex mutex_;
+};
+
+class OtlpHttpTraceExporter : public TraceExporter {
+   public:
+    OtlpHttpTraceExporter(std::string endpoint, std::string path,
+                          std::string headers, int timeout_ms);
+    void Export(const TraceRecord& record) override;
+
+   private:
+    std::string endpoint_;
+    std::string path_;
+    std::string headers_;
+    int timeout_ms_{3000};
+    std::mutex mutex_;
+};
+
+std::shared_ptr<TraceExporter> MakeDefaultExporter(
+    const std::string& service_name);
+
+}  // namespace mooncake::tracing

--- a/mooncake-tracing/include/trace_exporter.h
+++ b/mooncake-tracing/include/trace_exporter.h
@@ -89,8 +89,8 @@ class OtlpHttpTraceExporter : public TraceExporter {
 
 class AsyncRemoteTraceExporter : public TraceExporter {
    public:
-    using RemoteSendFn = std::function<bool(
-        const std::vector<TraceRecord>&, std::string* error_message)>;
+    using RemoteSendFn = std::function<bool(const std::vector<TraceRecord>&,
+                                            std::string* error_message)>;
 
     AsyncRemoteTraceExporter(TraceConfig config,
                              std::shared_ptr<TraceExporter> fallback_exporter,

--- a/mooncake-tracing/include/trace_record.h
+++ b/mooncake-tracing/include/trace_record.h
@@ -27,6 +27,7 @@ struct TraceRecord {
     int64_t start_time_unix_nano{0};
     int64_t end_time_unix_nano{0};
     std::string status{"OK"};
+    bool force_sample{false};
     TraceAttrs attrs;
     std::vector<TraceEvent> events;
 };

--- a/mooncake-tracing/include/trace_record.h
+++ b/mooncake-tracing/include/trace_record.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace mooncake::tracing {
+
+using TraceAttrs = std::vector<std::pair<std::string, std::string>>;
+
+struct TraceEvent {
+    std::string name;
+    int64_t unix_nano{0};
+    TraceAttrs attrs;
+};
+
+struct TraceRecord {
+    std::string trace_id;
+    std::string span_id;
+    std::string parent_span_id;
+    std::string correlation_id;
+    std::string service_name;
+    std::string node_id;
+    std::string process_role;
+    std::string span_name;
+    int64_t start_time_unix_nano{0};
+    int64_t end_time_unix_nano{0};
+    std::string status{"OK"};
+    TraceAttrs attrs;
+    std::vector<TraceEvent> events;
+};
+
+}  // namespace mooncake::tracing

--- a/mooncake-tracing/include/tracing_facade.h
+++ b/mooncake-tracing/include/tracing_facade.h
@@ -23,8 +23,7 @@ class Span {
     ~Span();
 
     void SetAttribute(const std::string& key, const std::string& value);
-    void AddEvent(const std::string& name,
-                  const TraceAttrs& attrs = {});
+    void AddEvent(const std::string& name, const TraceAttrs& attrs = {});
     void SetStatus(const std::string& status);
     TraceContext context() const;
     bool valid() const { return facade_ != nullptr; }
@@ -34,7 +33,7 @@ class Span {
     class TracingFacade* facade_{nullptr};
     std::unique_ptr<TraceRecord> record_;
     bool ended_{false};
-  };
+};
 
 class TracingFacade {
    public:
@@ -60,6 +59,6 @@ class TracingFacade {
     TraceConfig config_;
     std::shared_ptr<TraceExporter> exporter_;
     std::unique_ptr<TraceSampler> sampler_;
-  };
+};
 
 }  // namespace mooncake::tracing

--- a/mooncake-tracing/include/tracing_facade.h
+++ b/mooncake-tracing/include/tracing_facade.h
@@ -59,6 +59,7 @@ class TracingFacade {
    private:
     TraceConfig config_;
     std::shared_ptr<TraceExporter> exporter_;
+    std::unique_ptr<TraceSampler> sampler_;
   };
 
 }  // namespace mooncake::tracing

--- a/mooncake-tracing/include/tracing_facade.h
+++ b/mooncake-tracing/include/tracing_facade.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "trace_config.h"
+#include "trace_context.h"
+#include "trace_exporter.h"
+#include "trace_record.h"
+
+namespace mooncake::tracing {
+
+class Span {
+   public:
+    Span() = default;
+    Span(class TracingFacade* facade, TraceRecord record);
+    Span(Span&& other) noexcept;
+    Span& operator=(Span&& other) noexcept;
+    Span(const Span&) = delete;
+    Span& operator=(const Span&) = delete;
+    ~Span();
+
+    void SetAttribute(const std::string& key, const std::string& value);
+    void AddEvent(const std::string& name,
+                  const TraceAttrs& attrs = {});
+    void SetStatus(const std::string& status);
+    TraceContext context() const;
+    bool valid() const { return facade_ != nullptr; }
+    void End();
+
+   private:
+    class TracingFacade* facade_{nullptr};
+    std::unique_ptr<TraceRecord> record_;
+    bool ended_{false};
+  };
+
+class TracingFacade {
+   public:
+    explicit TracingFacade(TraceConfig config = {});
+
+    bool enabled() const { return config_.enabled; }
+    const TraceConfig& config() const { return config_; }
+
+    Span StartSpan(const std::string& span_name,
+                   const TraceContext* parent = nullptr,
+                   const TraceAttrs& attrs = {});
+
+    Span StartSpanFromCarrier(const std::string& span_name,
+                              const TraceCarrier& carrier,
+                              const TraceAttrs& attrs = {});
+
+    void Export(TraceRecord&& record);
+
+    static TracingFacade& Instance(const std::string& service_name,
+                                   const std::string& process_role = "");
+
+   private:
+    TraceConfig config_;
+    std::shared_ptr<TraceExporter> exporter_;
+  };
+
+}  // namespace mooncake::tracing

--- a/mooncake-tracing/src/trace_config.cpp
+++ b/mooncake-tracing/src/trace_config.cpp
@@ -1,0 +1,63 @@
+#include "trace_config.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#include <unistd.h>
+
+namespace mooncake::tracing {
+namespace {
+std::string NormalizeOtlpEndpoint(const char* endpoint) {
+    if (!endpoint || std::string(endpoint).empty()) {
+        return "http://127.0.0.1:4318";
+    }
+    return endpoint;
+}
+}  // namespace
+
+TraceConfig LoadTraceConfig(const std::string& service_name,
+                            const std::string& process_role) {
+    TraceConfig cfg;
+    const char* enabled = std::getenv("MC_TRACING_ENABLED");
+    cfg.enabled =
+        enabled && std::string(enabled) != "0" && std::string(enabled) != "false";
+    const char* mode = std::getenv("MC_TRACING_EXPORTER");
+    cfg.exporter_mode = mode ? mode : (cfg.enabled ? "jsonl" : "off");
+    const char* path = std::getenv("MC_TRACING_JSONL_PATH");
+    cfg.jsonl_path =
+        path ? path
+             : ("/tmp/mooncake-traces/" + service_name + "-" +
+                std::to_string(::getpid()) + ".jsonl");
+    cfg.service_name = service_name;
+    const char* node = std::getenv("MC_TRACING_NODE_ID");
+    cfg.node_id = node ? node : "unknown-node";
+    cfg.process_role = process_role;
+
+    const char* otlp_endpoint = std::getenv("OTEL_EXPORTER_OTLP_ENDPOINT");
+    const char* otlp_traces_endpoint =
+        std::getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+    cfg.otlp_http_endpoint = NormalizeOtlpEndpoint(
+        otlp_traces_endpoint ? otlp_traces_endpoint : otlp_endpoint);
+    cfg.otlp_http_path = "/v1/traces";
+    if (otlp_traces_endpoint &&
+        std::string(otlp_traces_endpoint).find("/v1/traces") !=
+            std::string::npos) {
+        cfg.otlp_http_path.clear();
+    }
+    const char* otlp_headers = std::getenv("OTEL_EXPORTER_OTLP_HEADERS");
+    const char* otlp_traces_headers =
+        std::getenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS");
+    cfg.otlp_headers =
+        otlp_traces_headers ? otlp_traces_headers : (otlp_headers ? otlp_headers : "");
+    const char* otlp_timeout = std::getenv("OTEL_EXPORTER_OTLP_TIMEOUT");
+    const char* otlp_traces_timeout =
+        std::getenv("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT");
+    const char* timeout_value =
+        otlp_traces_timeout ? otlp_traces_timeout : otlp_timeout;
+    if (timeout_value) {
+        cfg.otlp_timeout_ms = std::max(1, std::atoi(timeout_value));
+    }
+    return cfg;
+}
+
+}  // namespace mooncake::tracing

--- a/mooncake-tracing/src/trace_config.cpp
+++ b/mooncake-tracing/src/trace_config.cpp
@@ -39,8 +39,9 @@ std::vector<std::string> SplitCsv(const char* value) {
 }
 
 std::string ToLowerCopy(std::string value) {
-    std::transform(value.begin(), value.end(), value.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    std::transform(
+        value.begin(), value.end(), value.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     return value;
 }
 
@@ -56,8 +57,8 @@ TraceConfig LoadTraceConfig(const std::string& service_name,
                             const std::string& process_role) {
     TraceConfig cfg;
     const char* enabled = std::getenv("MC_TRACING_ENABLED");
-    cfg.enabled =
-        enabled && std::string(enabled) != "0" && std::string(enabled) != "false";
+    cfg.enabled = enabled && std::string(enabled) != "0" &&
+                  std::string(enabled) != "false";
     const char* mode = std::getenv("MC_TRACING_EXPORTER");
     cfg.exporter_mode = mode ? mode : (cfg.enabled ? "jsonl" : "off");
     cfg.service_name = service_name;
@@ -65,9 +66,9 @@ TraceConfig LoadTraceConfig(const std::string& service_name,
     cfg.node_id = node ? node : "unknown-node";
     cfg.process_role = process_role;
     const char* path = std::getenv("MC_TRACING_JSONL_PATH");
-    cfg.jsonl_path = path ? path
-                          : BuildLocalTraceFilePath(service_name, cfg.node_id,
-                                                    ".jsonl");
+    cfg.jsonl_path =
+        path ? path
+             : BuildLocalTraceFilePath(service_name, cfg.node_id, ".jsonl");
 
     const char* otlp_endpoint = std::getenv("OTEL_EXPORTER_OTLP_ENDPOINT");
     const char* otlp_traces_endpoint =
@@ -84,8 +85,8 @@ TraceConfig LoadTraceConfig(const std::string& service_name,
     const char* otlp_headers = std::getenv("OTEL_EXPORTER_OTLP_HEADERS");
     const char* otlp_traces_headers =
         std::getenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS");
-    cfg.otlp_headers =
-        otlp_traces_headers ? otlp_traces_headers : (otlp_headers ? otlp_headers : "");
+    cfg.otlp_headers = otlp_traces_headers ? otlp_traces_headers
+                                           : (otlp_headers ? otlp_headers : "");
     const char* otlp_timeout = std::getenv("OTEL_EXPORTER_OTLP_TIMEOUT");
     const char* otlp_traces_timeout =
         std::getenv("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT");
@@ -101,12 +102,12 @@ TraceConfig LoadTraceConfig(const std::string& service_name,
         cfg.remote_endpoints = std::move(parsed_endpoints);
     }
 
-    cfg.exporter_queue_max_items = ParseSizeTEnv(
-        std::getenv("MC_TRACING_EXPORTER_QUEUE_MAX_ITEMS"),
-        cfg.exporter_queue_max_items);
-    cfg.exporter_queue_max_bytes = ParseSizeTEnv(
-        std::getenv("MC_TRACING_EXPORTER_QUEUE_MAX_BYTES"),
-        cfg.exporter_queue_max_bytes);
+    cfg.exporter_queue_max_items =
+        ParseSizeTEnv(std::getenv("MC_TRACING_EXPORTER_QUEUE_MAX_ITEMS"),
+                      cfg.exporter_queue_max_items);
+    cfg.exporter_queue_max_bytes =
+        ParseSizeTEnv(std::getenv("MC_TRACING_EXPORTER_QUEUE_MAX_BYTES"),
+                      cfg.exporter_queue_max_bytes);
     if (const char* retry_base =
             std::getenv("MC_TRACING_EXPORTER_RETRY_BASE_MS")) {
         cfg.exporter_retry_base_ms = std::max(1, std::atoi(retry_base));
@@ -120,8 +121,7 @@ TraceConfig LoadTraceConfig(const std::string& service_name,
         cfg.exporter_retry_max_attempts =
             std::max(0, std::atoi(retry_attempts));
     }
-    if (const char* spool_dir =
-            std::getenv("MC_TRACING_EXPORTER_SPOOL_DIR")) {
+    if (const char* spool_dir = std::getenv("MC_TRACING_EXPORTER_SPOOL_DIR")) {
         cfg.exporter_spool_dir = spool_dir;
     }
 
@@ -130,7 +130,8 @@ TraceConfig LoadTraceConfig(const std::string& service_name,
     }
     if (const char* sampling_ratio =
             std::getenv("MC_TRACING_SAMPLING_BASE_RATIO")) {
-        cfg.sampling_base_ratio = std::clamp(std::atof(sampling_ratio), 0.0, 1.0);
+        cfg.sampling_base_ratio =
+            std::clamp(std::atof(sampling_ratio), 0.0, 1.0);
     }
     if (const char* slow_threshold =
             std::getenv("MC_TRACING_SLOW_THRESHOLD_MS")) {

--- a/mooncake-tracing/src/trace_config.cpp
+++ b/mooncake-tracing/src/trace_config.cpp
@@ -1,17 +1,54 @@
 #include "trace_config.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
+#include <sstream>
 #include <string>
 #include <unistd.h>
 
 namespace mooncake::tracing {
 namespace {
+std::string BuildLocalTraceFilePath(const std::string& service_name,
+                                    const std::string& node_id,
+                                    const std::string& suffix) {
+    return "/tmp/mooncake-traces/" + service_name + "-" + node_id + "-" +
+           std::to_string(::getpid()) + suffix;
+}
+
 std::string NormalizeOtlpEndpoint(const char* endpoint) {
     if (!endpoint || std::string(endpoint).empty()) {
         return "http://127.0.0.1:4318";
     }
     return endpoint;
+}
+
+std::vector<std::string> SplitCsv(const char* value) {
+    std::vector<std::string> result;
+    if (!value || !*value) {
+        return result;
+    }
+    std::stringstream ss(value);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        if (!item.empty()) {
+            result.push_back(item);
+        }
+    }
+    return result;
+}
+
+std::string ToLowerCopy(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return value;
+}
+
+size_t ParseSizeTEnv(const char* value, size_t default_value) {
+    if (!value || !*value) {
+        return default_value;
+    }
+    return static_cast<size_t>(std::strtoull(value, nullptr, 10));
 }
 }  // namespace
 
@@ -23,21 +60,21 @@ TraceConfig LoadTraceConfig(const std::string& service_name,
         enabled && std::string(enabled) != "0" && std::string(enabled) != "false";
     const char* mode = std::getenv("MC_TRACING_EXPORTER");
     cfg.exporter_mode = mode ? mode : (cfg.enabled ? "jsonl" : "off");
-    const char* path = std::getenv("MC_TRACING_JSONL_PATH");
-    cfg.jsonl_path =
-        path ? path
-             : ("/tmp/mooncake-traces/" + service_name + "-" +
-                std::to_string(::getpid()) + ".jsonl");
     cfg.service_name = service_name;
     const char* node = std::getenv("MC_TRACING_NODE_ID");
     cfg.node_id = node ? node : "unknown-node";
     cfg.process_role = process_role;
+    const char* path = std::getenv("MC_TRACING_JSONL_PATH");
+    cfg.jsonl_path = path ? path
+                          : BuildLocalTraceFilePath(service_name, cfg.node_id,
+                                                    ".jsonl");
 
     const char* otlp_endpoint = std::getenv("OTEL_EXPORTER_OTLP_ENDPOINT");
     const char* otlp_traces_endpoint =
         std::getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
     cfg.otlp_http_endpoint = NormalizeOtlpEndpoint(
         otlp_traces_endpoint ? otlp_traces_endpoint : otlp_endpoint);
+    cfg.remote_endpoints.push_back(cfg.otlp_http_endpoint);
     cfg.otlp_http_path = "/v1/traces";
     if (otlp_traces_endpoint &&
         std::string(otlp_traces_endpoint).find("/v1/traces") !=
@@ -56,6 +93,48 @@ TraceConfig LoadTraceConfig(const std::string& service_name,
         otlp_traces_timeout ? otlp_traces_timeout : otlp_timeout;
     if (timeout_value) {
         cfg.otlp_timeout_ms = std::max(1, std::atoi(timeout_value));
+    }
+
+    const char* remote_endpoints = std::getenv("MC_TRACING_REMOTE_ENDPOINTS");
+    auto parsed_endpoints = SplitCsv(remote_endpoints);
+    if (!parsed_endpoints.empty()) {
+        cfg.remote_endpoints = std::move(parsed_endpoints);
+    }
+
+    cfg.exporter_queue_max_items = ParseSizeTEnv(
+        std::getenv("MC_TRACING_EXPORTER_QUEUE_MAX_ITEMS"),
+        cfg.exporter_queue_max_items);
+    cfg.exporter_queue_max_bytes = ParseSizeTEnv(
+        std::getenv("MC_TRACING_EXPORTER_QUEUE_MAX_BYTES"),
+        cfg.exporter_queue_max_bytes);
+    if (const char* retry_base =
+            std::getenv("MC_TRACING_EXPORTER_RETRY_BASE_MS")) {
+        cfg.exporter_retry_base_ms = std::max(1, std::atoi(retry_base));
+    }
+    if (const char* retry_max =
+            std::getenv("MC_TRACING_EXPORTER_RETRY_MAX_MS")) {
+        cfg.exporter_retry_max_ms = std::max(1, std::atoi(retry_max));
+    }
+    if (const char* retry_attempts =
+            std::getenv("MC_TRACING_EXPORTER_RETRY_MAX_ATTEMPTS")) {
+        cfg.exporter_retry_max_attempts =
+            std::max(0, std::atoi(retry_attempts));
+    }
+    if (const char* spool_dir =
+            std::getenv("MC_TRACING_EXPORTER_SPOOL_DIR")) {
+        cfg.exporter_spool_dir = spool_dir;
+    }
+
+    if (const char* sampling_mode = std::getenv("MC_TRACING_SAMPLING_MODE")) {
+        cfg.sampling_mode = ToLowerCopy(sampling_mode);
+    }
+    if (const char* sampling_ratio =
+            std::getenv("MC_TRACING_SAMPLING_BASE_RATIO")) {
+        cfg.sampling_base_ratio = std::clamp(std::atof(sampling_ratio), 0.0, 1.0);
+    }
+    if (const char* slow_threshold =
+            std::getenv("MC_TRACING_SLOW_THRESHOLD_MS")) {
+        cfg.sampling_slow_threshold_ms = std::max(0, std::atoi(slow_threshold));
     }
     return cfg;
 }

--- a/mooncake-tracing/src/trace_context.cpp
+++ b/mooncake-tracing/src/trace_context.cpp
@@ -19,12 +19,13 @@ std::string RandomHex(size_t len) {
 }  // namespace
 
 TraceCarrier ToCarrier(const TraceContext& ctx) {
-    return TraceCarrier{ctx.trace_id, ctx.span_id, ctx.correlation_id};
+    return TraceCarrier{ctx.trace_id, ctx.span_id, ctx.correlation_id,
+                        ctx.force_sample};
 }
 
 std::string EncodeTraceCarrier(const TraceCarrier& carrier) {
     return carrier.trace_id + "|" + carrier.span_id + "|" +
-           carrier.correlation_id;
+           carrier.correlation_id + "|" + (carrier.force_sample ? "1" : "0");
 }
 
 TraceCarrier DecodeTraceCarrier(const std::string& encoded) {
@@ -36,10 +37,17 @@ TraceCarrier DecodeTraceCarrier(const std::string& encoded) {
     if (first_sep == std::string::npos || second_sep == std::string::npos) {
         return carrier;
     }
+    const auto third_sep = encoded.find('|', second_sep + 1);
     carrier.trace_id = encoded.substr(0, first_sep);
     carrier.span_id =
         encoded.substr(first_sep + 1, second_sep - first_sep - 1);
-    carrier.correlation_id = encoded.substr(second_sep + 1);
+    if (third_sep == std::string::npos) {
+        carrier.correlation_id = encoded.substr(second_sep + 1);
+        return carrier;
+    }
+    carrier.correlation_id =
+        encoded.substr(second_sep + 1, third_sep - second_sep - 1);
+    carrier.force_sample = encoded.substr(third_sep + 1) == "1";
     return carrier;
 }
 
@@ -53,7 +61,9 @@ TraceContext ChildContextFromCarrier(const TraceCarrier& carrier) {
     ctx.trace_id = carrier.trace_id.empty() ? RandomHex(32) : carrier.trace_id;
     ctx.parent_span_id = carrier.span_id;
     ctx.span_id = RandomHex(16);
-    ctx.correlation_id = carrier.correlation_id.empty() ? RandomHex(16) : carrier.correlation_id;
+    ctx.correlation_id =
+        carrier.correlation_id.empty() ? RandomHex(16) : carrier.correlation_id;
+    ctx.force_sample = carrier.force_sample;
     return ctx;
 }
 

--- a/mooncake-tracing/src/trace_context.cpp
+++ b/mooncake-tracing/src/trace_context.cpp
@@ -1,0 +1,48 @@
+#include "trace_context.h"
+
+#include <chrono>
+#include <random>
+#include <sstream>
+
+namespace mooncake::tracing {
+namespace {
+std::string RandomHex(size_t len) {
+    static thread_local std::mt19937_64 rng(std::random_device{}());
+    static constexpr char kHex[] = "0123456789abcdef";
+    std::string out;
+    out.reserve(len);
+    for (size_t i = 0; i < len; ++i) {
+        out.push_back(kHex[rng() & 0xF]);
+    }
+    return out;
+}
+}  // namespace
+
+TraceCarrier ToCarrier(const TraceContext& ctx) {
+    return TraceCarrier{ctx.trace_id, ctx.span_id, ctx.correlation_id};
+}
+
+TraceContext ChildContextFromCarrier(const TraceCarrier& carrier) {
+    if (carrier.empty()) {
+        auto root = RootContext();
+        root.context_missing = true;
+        return root;
+    }
+    TraceContext ctx;
+    ctx.trace_id = carrier.trace_id.empty() ? RandomHex(32) : carrier.trace_id;
+    ctx.parent_span_id = carrier.span_id;
+    ctx.span_id = RandomHex(16);
+    ctx.correlation_id = carrier.correlation_id.empty() ? RandomHex(16) : carrier.correlation_id;
+    return ctx;
+}
+
+TraceContext RootContext(const std::string& correlation_id) {
+    TraceContext ctx;
+    ctx.trace_id = RandomHex(32);
+    ctx.span_id = RandomHex(16);
+    ctx.parent_span_id.clear();
+    ctx.correlation_id = correlation_id.empty() ? RandomHex(16) : correlation_id;
+    return ctx;
+}
+
+}  // namespace mooncake::tracing

--- a/mooncake-tracing/src/trace_context.cpp
+++ b/mooncake-tracing/src/trace_context.cpp
@@ -22,6 +22,27 @@ TraceCarrier ToCarrier(const TraceContext& ctx) {
     return TraceCarrier{ctx.trace_id, ctx.span_id, ctx.correlation_id};
 }
 
+std::string EncodeTraceCarrier(const TraceCarrier& carrier) {
+    return carrier.trace_id + "|" + carrier.span_id + "|" +
+           carrier.correlation_id;
+}
+
+TraceCarrier DecodeTraceCarrier(const std::string& encoded) {
+    TraceCarrier carrier;
+    const auto first_sep = encoded.find('|');
+    const auto second_sep =
+        encoded.find('|', first_sep == std::string::npos ? first_sep
+                                                         : first_sep + 1);
+    if (first_sep == std::string::npos || second_sep == std::string::npos) {
+        return carrier;
+    }
+    carrier.trace_id = encoded.substr(0, first_sep);
+    carrier.span_id =
+        encoded.substr(first_sep + 1, second_sep - first_sep - 1);
+    carrier.correlation_id = encoded.substr(second_sep + 1);
+    return carrier;
+}
+
 TraceContext ChildContextFromCarrier(const TraceCarrier& carrier) {
     if (carrier.empty()) {
         auto root = RootContext();

--- a/mooncake-tracing/src/trace_context.cpp
+++ b/mooncake-tracing/src/trace_context.cpp
@@ -31,16 +31,14 @@ std::string EncodeTraceCarrier(const TraceCarrier& carrier) {
 TraceCarrier DecodeTraceCarrier(const std::string& encoded) {
     TraceCarrier carrier;
     const auto first_sep = encoded.find('|');
-    const auto second_sep =
-        encoded.find('|', first_sep == std::string::npos ? first_sep
-                                                         : first_sep + 1);
+    const auto second_sep = encoded.find(
+        '|', first_sep == std::string::npos ? first_sep : first_sep + 1);
     if (first_sep == std::string::npos || second_sep == std::string::npos) {
         return carrier;
     }
     const auto third_sep = encoded.find('|', second_sep + 1);
     carrier.trace_id = encoded.substr(0, first_sep);
-    carrier.span_id =
-        encoded.substr(first_sep + 1, second_sep - first_sep - 1);
+    carrier.span_id = encoded.substr(first_sep + 1, second_sep - first_sep - 1);
     if (third_sep == std::string::npos) {
         carrier.correlation_id = encoded.substr(second_sep + 1);
         return carrier;
@@ -72,7 +70,8 @@ TraceContext RootContext(const std::string& correlation_id) {
     ctx.trace_id = RandomHex(32);
     ctx.span_id = RandomHex(16);
     ctx.parent_span_id.clear();
-    ctx.correlation_id = correlation_id.empty() ? RandomHex(16) : correlation_id;
+    ctx.correlation_id =
+        correlation_id.empty() ? RandomHex(16) : correlation_id;
     return ctx;
 }
 

--- a/mooncake-tracing/src/trace_exporter_inmemory.cpp
+++ b/mooncake-tracing/src/trace_exporter_inmemory.cpp
@@ -1,0 +1,1 @@
+#include "trace_exporter.h"

--- a/mooncake-tracing/src/trace_exporter_jsonl.cpp
+++ b/mooncake-tracing/src/trace_exporter_jsonl.cpp
@@ -63,7 +63,8 @@ std::vector<TraceRecord> InMemoryTraceExporter::Snapshot() const {
 
 JsonlTraceExporter::JsonlTraceExporter(std::string file_path)
     : file_path_(std::move(file_path)) {
-    std::filesystem::create_directories(std::filesystem::path(file_path_).parent_path());
+    std::filesystem::create_directories(
+        std::filesystem::path(file_path_).parent_path());
 }
 void JsonlTraceExporter::Export(const TraceRecord& record) {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -84,8 +85,7 @@ std::shared_ptr<TraceExporter> MakeDefaultExporter(
         return std::make_shared<InMemoryTraceExporter>();
     }
     if (config.exporter_mode == "remote" ||
-        config.exporter_mode == "otlp_http" ||
-        config.exporter_mode == "otlp") {
+        config.exporter_mode == "otlp_http" || config.exporter_mode == "otlp") {
         return std::make_shared<AsyncRemoteTraceExporter>(
             config, std::make_shared<JsonlTraceExporter>(config.jsonl_path));
     }

--- a/mooncake-tracing/src/trace_exporter_jsonl.cpp
+++ b/mooncake-tracing/src/trace_exporter_jsonl.cpp
@@ -69,19 +69,20 @@ void JsonlTraceExporter::Export(const TraceRecord& record) {
 
 std::shared_ptr<TraceExporter> MakeDefaultExporter(
     const std::string& service_name) {
-    const char* mode = std::getenv("MC_TRACING_EXPORTER");
-    if (mode && std::string(mode) == "inmemory") {
+    TraceConfig config = LoadTraceConfig(service_name);
+    if (!config.enabled || config.exporter_mode == "off") {
+        return nullptr;
+    }
+    if (config.exporter_mode == "inmemory") {
         return std::make_shared<InMemoryTraceExporter>();
     }
-    const char* path = std::getenv("MC_TRACING_JSONL_PATH");
-    std::string jsonl_path;
-    if (path && *path) {
-        jsonl_path = path;
-    } else {
-        jsonl_path = "/tmp/mooncake-traces/" + service_name + "-" +
-                     std::to_string(::getpid()) + ".jsonl";
+    if (config.exporter_mode == "remote" ||
+        config.exporter_mode == "otlp_http" ||
+        config.exporter_mode == "otlp") {
+        return std::make_shared<AsyncRemoteTraceExporter>(
+            config, std::make_shared<JsonlTraceExporter>(config.jsonl_path));
     }
-    return std::make_shared<JsonlTraceExporter>(jsonl_path);
+    return std::make_shared<JsonlTraceExporter>(config.jsonl_path);
 }
 
 }  // namespace mooncake::tracing

--- a/mooncake-tracing/src/trace_exporter_jsonl.cpp
+++ b/mooncake-tracing/src/trace_exporter_jsonl.cpp
@@ -1,0 +1,87 @@
+#include "trace_exporter.h"
+
+#if __has_include(<jsoncpp/json/json.h>)
+#include <jsoncpp/json/json.h>
+#else
+#include <json/json.h>
+#endif
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <unistd.h>
+
+namespace mooncake::tracing {
+namespace {
+Json::Value ToJson(const TraceAttrs& attrs) {
+    Json::Value obj(Json::objectValue);
+    for (const auto& [k, v] : attrs) obj[k] = v;
+    return obj;
+}
+Json::Value ToJson(const TraceRecord& record) {
+    Json::Value root;
+    root["trace_id"] = record.trace_id;
+    root["span_id"] = record.span_id;
+    root["parent_span_id"] = record.parent_span_id;
+    root["correlation.id"] = record.correlation_id;
+    root["service.name"] = record.service_name;
+    root["node.id"] = record.node_id;
+    root["process.role"] = record.process_role;
+    root["span.name"] = record.span_name;
+    root["start_time_unix_nano"] = Json::Int64(record.start_time_unix_nano);
+    root["end_time_unix_nano"] = Json::Int64(record.end_time_unix_nano);
+    root["status"] = record.status;
+    root["attrs"] = ToJson(record.attrs);
+    Json::Value events(Json::arrayValue);
+    for (const auto& event : record.events) {
+        Json::Value e;
+        e["name"] = event.name;
+        e["unix_nano"] = Json::Int64(event.unix_nano);
+        e["attrs"] = ToJson(event.attrs);
+        events.append(e);
+    }
+    root["events"] = events;
+    return root;
+}
+}  // namespace
+
+void InMemoryTraceExporter::Export(const TraceRecord& record) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    records_.push_back(record);
+}
+std::vector<TraceRecord> InMemoryTraceExporter::Snapshot() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return records_;
+}
+
+JsonlTraceExporter::JsonlTraceExporter(std::string file_path)
+    : file_path_(std::move(file_path)) {
+    std::filesystem::create_directories(std::filesystem::path(file_path_).parent_path());
+}
+void JsonlTraceExporter::Export(const TraceRecord& record) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::ofstream out(file_path_, std::ios::app);
+    if (!out.is_open()) return;
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "";
+    out << Json::writeString(builder, ToJson(record)) << "\n";
+}
+
+std::shared_ptr<TraceExporter> MakeDefaultExporter(
+    const std::string& service_name) {
+    const char* mode = std::getenv("MC_TRACING_EXPORTER");
+    if (mode && std::string(mode) == "inmemory") {
+        return std::make_shared<InMemoryTraceExporter>();
+    }
+    const char* path = std::getenv("MC_TRACING_JSONL_PATH");
+    std::string jsonl_path;
+    if (path && *path) {
+        jsonl_path = path;
+    } else {
+        jsonl_path = "/tmp/mooncake-traces/" + service_name + "-" +
+                     std::to_string(::getpid()) + ".jsonl";
+    }
+    return std::make_shared<JsonlTraceExporter>(jsonl_path);
+}
+
+}  // namespace mooncake::tracing

--- a/mooncake-tracing/src/trace_exporter_jsonl.cpp
+++ b/mooncake-tracing/src/trace_exporter_jsonl.cpp
@@ -13,9 +13,16 @@
 
 namespace mooncake::tracing {
 namespace {
+constexpr char kSamplingPriorityAttr[] = "sampling.priority";
+
 Json::Value ToJson(const TraceAttrs& attrs) {
     Json::Value obj(Json::objectValue);
-    for (const auto& [k, v] : attrs) obj[k] = v;
+    for (const auto& [k, v] : attrs) {
+        if (k == kSamplingPriorityAttr) {
+            continue;
+        }
+        obj[k] = v;
+    }
     return obj;
 }
 Json::Value ToJson(const TraceRecord& record) {

--- a/mooncake-tracing/src/trace_exporter_otlp_http.cpp
+++ b/mooncake-tracing/src/trace_exporter_otlp_http.cpp
@@ -21,6 +21,9 @@
 
 namespace mooncake::tracing {
 namespace {
+constexpr size_t kMaxRemoteBatchItems = 256;
+constexpr size_t kMaxRemoteBatchBytes = 512 * 1024;
+
 std::string BuildSpoolFileName(const TraceConfig& config) {
     std::string file_name = config.service_name;
     if (!config.node_id.empty()) {
@@ -98,51 +101,8 @@ Json::Value RecordToJson(const TraceRecord& record) {
     root["events"] = events;
     return root;
 }
-}  // namespace
 
-OtlpHttpTraceExporter::OtlpHttpTraceExporter(std::string endpoint,
-                                             std::string path,
-                                             std::string headers,
-                                             int timeout_ms)
-    : endpoint_(std::move(endpoint)),
-      path_(std::move(path)),
-      headers_(std::move(headers)),
-      timeout_ms_(timeout_ms) {}
-
-void OtlpHttpTraceExporter::Export(const TraceRecord& record) {
-    std::string ignored_error;
-    (void)TryExport(record, &ignored_error);
-}
-
-bool OtlpHttpTraceExporter::TryExport(const TraceRecord& record,
-                                      std::string* error_message) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    CURL* curl = curl_easy_init();
-    if (!curl) {
-        LOG(ERROR) << "OTLP exporter: curl_easy_init failed";
-        if (error_message) {
-            *error_message = "curl_easy_init failed";
-        }
-        return false;
-    }
-
-    Json::Value root;
-    Json::Value resource_spans(Json::arrayValue);
-    Json::Value resource_span;
-    Json::Value resource_attrs(Json::arrayValue);
-    resource_attrs.append(AttrToJson({"service.name", record.service_name}));
-    if (!record.node_id.empty()) {
-        resource_attrs.append(AttrToJson({"service.instance.id", record.node_id}));
-    }
-    if (!record.process_role.empty()) {
-        resource_attrs.append(AttrToJson({"mooncake.process_role", record.process_role}));
-    }
-    resource_span["resource"]["attributes"] = resource_attrs;
-
-    Json::Value scope_spans(Json::arrayValue);
-    Json::Value scope_span;
-    scope_span["scope"]["name"] = "mooncake-tracing";
-    Json::Value spans(Json::arrayValue);
+Json::Value RecordToOtlpSpan(const TraceRecord& record) {
     Json::Value span;
     span["traceId"] = NormalizeTraceId(record.trace_id);
     span["spanId"] = NormalizeSpanId(record.span_id);
@@ -158,7 +118,9 @@ bool OtlpHttpTraceExporter::TryExport(const TraceRecord& record,
     if (!record.correlation_id.empty()) {
         attrs.append(AttrToJson({"correlation.id", record.correlation_id}));
     }
-    for (const auto& kv : record.attrs) attrs.append(AttrToJson(kv));
+    for (const auto& kv : record.attrs) {
+        attrs.append(AttrToJson(kv));
+    }
     span["attributes"] = attrs;
 
     Json::Value events(Json::arrayValue);
@@ -167,7 +129,9 @@ bool OtlpHttpTraceExporter::TryExport(const TraceRecord& record,
         event["name"] = ev.name;
         event["timeUnixNano"] = std::to_string(ev.unix_nano);
         Json::Value event_attrs(Json::arrayValue);
-        for (const auto& kv : ev.attrs) event_attrs.append(AttrToJson(kv));
+        for (const auto& kv : ev.attrs) {
+            event_attrs.append(AttrToJson(kv));
+        }
         event["attributes"] = event_attrs;
         events.append(event);
     }
@@ -178,70 +142,188 @@ bool OtlpHttpTraceExporter::TryExport(const TraceRecord& record,
     } else {
         span["status"]["code"] = 1;
     }
+    return span;
+}
 
-    spans.append(span);
-    scope_span["spans"] = spans;
-    scope_spans.append(scope_span);
-    resource_span["scopeSpans"] = scope_spans;
-    resource_spans.append(resource_span);
+std::string BuildOtlpUrl(const std::string& endpoint, const std::string& path) {
+    std::string url = endpoint;
+    if (!path.empty()) {
+        if (!url.empty() && url.back() == '/' && path.front() == '/') {
+            url.pop_back();
+        }
+        url += path;
+    }
+    return url;
+}
+
+std::string BuildOtlpPayload(const std::vector<TraceRecord>& records) {
+    Json::Value root;
+    Json::Value resource_spans(Json::arrayValue);
+    if (!records.empty()) {
+        const auto& first = records.front();
+        Json::Value resource_span;
+        Json::Value resource_attrs(Json::arrayValue);
+        resource_attrs.append(AttrToJson({"service.name", first.service_name}));
+        if (!first.node_id.empty()) {
+            resource_attrs.append(
+                AttrToJson({"service.instance.id", first.node_id}));
+        }
+        if (!first.process_role.empty()) {
+            resource_attrs.append(
+                AttrToJson({"mooncake.process_role", first.process_role}));
+        }
+        resource_span["resource"]["attributes"] = resource_attrs;
+
+        Json::Value scope_spans(Json::arrayValue);
+        Json::Value scope_span;
+        scope_span["scope"]["name"] = "mooncake-tracing";
+        Json::Value spans(Json::arrayValue);
+        for (const auto& record : records) {
+            spans.append(RecordToOtlpSpan(record));
+        }
+        scope_span["spans"] = spans;
+        scope_spans.append(scope_span);
+        resource_span["scopeSpans"] = scope_spans;
+        resource_spans.append(resource_span);
+    }
     root["resourceSpans"] = resource_spans;
 
     Json::StreamWriterBuilder builder;
     builder["indentation"] = "";
-    const std::string payload = Json::writeString(builder, root);
+    return Json::writeString(builder, root);
+}
 
-    std::string url = endpoint_;
-    if (!path_.empty()) {
-        if (!url.empty() && url.back() == '/' && path_.front() == '/') {
-            url.pop_back();
+bool IsHighPriorityRecord(const TraceRecord& record, const TraceConfig& config) {
+    if (record.parent_span_id.empty()) {
+        return true;
+    }
+    if (record.status == "ERROR") {
+        return true;
+    }
+    if (config.sampling_slow_threshold_ms > 0 &&
+        record.end_time_unix_nano > record.start_time_unix_nano) {
+        const auto duration_ms =
+            (record.end_time_unix_nano - record.start_time_unix_nano) / 1000000;
+        if (duration_ms >= config.sampling_slow_threshold_ms) {
+            return true;
         }
-        url += path_;
+    }
+    return false;
+}
+}  // namespace
+
+OtlpHttpTraceExporter::OtlpHttpTraceExporter(std::string endpoint,
+                                             std::string path,
+                                             std::string headers,
+                                             int timeout_ms)
+    : endpoint_(std::move(endpoint)),
+      path_(std::move(path)),
+      headers_(std::move(headers)),
+      timeout_ms_(timeout_ms) {}
+
+OtlpHttpTraceExporter::~OtlpHttpTraceExporter() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (header_list_ != nullptr) {
+        curl_slist_free_all(header_list_);
+        header_list_ = nullptr;
+    }
+    if (curl_ != nullptr) {
+        curl_easy_cleanup(curl_);
+        curl_ = nullptr;
+    }
+}
+
+void OtlpHttpTraceExporter::Export(const TraceRecord& record) {
+    std::string ignored_error;
+    (void)TryExport(record, &ignored_error);
+}
+
+void OtlpHttpTraceExporter::ExportBatch(const std::vector<TraceRecord>& records) {
+    std::string ignored_error;
+    (void)TryExportBatch(records, &ignored_error);
+}
+
+bool OtlpHttpTraceExporter::TryExport(const TraceRecord& record,
+                                      std::string* error_message) {
+    return TryExportBatch(std::vector<TraceRecord>{record}, error_message);
+}
+
+bool OtlpHttpTraceExporter::EnsureCurlLocked() {
+    if (curl_ != nullptr) {
+        return true;
     }
 
-    struct curl_slist* header_list = nullptr;
-    header_list = curl_slist_append(header_list, "Content-Type: application/json");
+    curl_ = curl_easy_init();
+    if (curl_ == nullptr) {
+        LOG(ERROR) << "OTLP exporter: curl_easy_init failed";
+        return false;
+    }
+
+    header_list_ = curl_slist_append(header_list_, "Content-Type: application/json");
     if (!headers_.empty()) {
         std::stringstream ss(headers_);
         std::string item;
         while (std::getline(ss, item, ',')) {
-            if (!item.empty()) header_list = curl_slist_append(header_list, item.c_str());
+            if (!item.empty()) {
+                header_list_ = curl_slist_append(header_list_, item.c_str());
+            }
         }
     }
 
+    const auto url = BuildOtlpUrl(endpoint_, path_);
+    curl_easy_setopt(curl_, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl_, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl_, CURLOPT_TIMEOUT_MS, timeout_ms_);
+    curl_easy_setopt(curl_, CURLOPT_CONNECTTIMEOUT_MS, timeout_ms_);
+    curl_easy_setopt(curl_, CURLOPT_DNS_CACHE_TIMEOUT, 300L);
+    curl_easy_setopt(curl_, CURLOPT_TCP_KEEPALIVE, 1L);
+    curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, header_list_);
+    curl_easy_setopt(curl_, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl_, CURLOPT_NOSIGNAL, 1L);
+    return true;
+}
+
+bool OtlpHttpTraceExporter::TryExportBatch(const std::vector<TraceRecord>& records,
+                                           std::string* error_message) {
+    if (records.empty()) {
+        return true;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!EnsureCurlLocked()) {
+        if (error_message) {
+            *error_message = "curl_easy_init failed";
+        }
+        return false;
+    }
+
+    const std::string payload = BuildOtlpPayload(records);
     std::string response;
     char errbuf[CURL_ERROR_SIZE] = {0};
-    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-    curl_easy_setopt(curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, payload.size());
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeout_ms_);
-    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, timeout_ms_);
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
-    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl_, CURLOPT_POSTFIELDS, payload.c_str());
+    curl_easy_setopt(curl_, CURLOPT_POSTFIELDSIZE, payload.size());
+    curl_easy_setopt(curl_, CURLOPT_WRITEDATA, &response);
+    curl_easy_setopt(curl_, CURLOPT_ERRORBUFFER, errbuf);
 
-    CURLcode rc = curl_easy_perform(curl);
+    CURLcode rc = curl_easy_perform(curl_);
     long code = 0;
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
+    curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &code);
     bool ok = rc == CURLE_OK && code >= 200 && code < 300;
     if (rc != CURLE_OK || code < 200 || code >= 300) {
+        const auto url = BuildOtlpUrl(endpoint_, path_);
         std::ostringstream oss;
         oss << "OTLP exporter POST failed url=" << url
             << " curl=" << curl_easy_strerror(rc) << " http=" << code
             << " errbuf=" << errbuf << " body=" << response;
-        LOG(ERROR) << "OTLP exporter POST failed url=" << url
-                   << " curl=" << curl_easy_strerror(rc)
-                   << " http=" << code << " errbuf=" << errbuf
-                   << " body=" << response;
+        LOG_EVERY_N(ERROR, 100)
+            << "OTLP exporter POST failed url=" << url
+            << " curl=" << curl_easy_strerror(rc)
+            << " http=" << code << " errbuf=" << errbuf
+            << " body=" << response << " batch_size=" << records.size();
         if (error_message) {
             *error_message = oss.str();
         }
     }
-
-    curl_slist_free_all(header_list);
-    curl_easy_cleanup(curl);
     return ok;
 }
 
@@ -265,8 +347,9 @@ AsyncRemoteTraceExporter::AsyncRemoteTraceExporter(
                 endpoint, config_.otlp_http_path, config_.otlp_headers,
                 config_.otlp_timeout_ms);
             remote_send_fns_.push_back(
-                [remote](const TraceRecord& record, std::string* error_message) {
-                    return remote->TryExport(record, error_message);
+                [remote](const std::vector<TraceRecord>& records,
+                         std::string* error_message) {
+                    return remote->TryExportBatch(records, error_message);
                 });
         }
     }
@@ -287,11 +370,46 @@ AsyncRemoteTraceExporter::~AsyncRemoteTraceExporter() {
 void AsyncRemoteTraceExporter::Export(const TraceRecord& record) {
     const auto record_bytes = EstimateRecordBytes(record);
     std::lock_guard<std::mutex> lock(mutex_);
-    if (queue_.size() >= config_.exporter_queue_max_items ||
-        queued_bytes_ + record_bytes > config_.exporter_queue_max_bytes) {
-        stats_.dropped_records++;
+    const bool queue_full =
+        queue_.size() >= config_.exporter_queue_max_items ||
+        queued_bytes_ + record_bytes > config_.exporter_queue_max_bytes;
+    if (queue_full) {
         stats_.queue_full_count++;
-        LOG_EVERY_N(WARNING, 100)
+
+        if (IsHighPriorityRecord(record, config_)) {
+            bool evicted = false;
+            while ((queue_.size() >= config_.exporter_queue_max_items ||
+                    queued_bytes_ + record_bytes >
+                        config_.exporter_queue_max_bytes) &&
+                   !queue_.empty()) {
+                auto it = std::find_if(queue_.begin(), queue_.end(),
+                                       [this](const TraceRecord& queued) {
+                                           return !IsHighPriorityRecord(
+                                               queued, config_);
+                                       });
+                if (it == queue_.end()) {
+                    break;
+                }
+                queued_bytes_ -=
+                    std::min(queued_bytes_, EstimateRecordBytes(*it));
+                queue_.erase(it);
+                stats_.dropped_records++;
+                evicted = true;
+            }
+            if (evicted && queue_.size() < config_.exporter_queue_max_items &&
+                queued_bytes_ + record_bytes <=
+                    config_.exporter_queue_max_bytes) {
+                queue_.push_back(record);
+                queued_bytes_ += record_bytes;
+                stats_.queued_records = queue_.size();
+                stats_.queued_bytes = queued_bytes_;
+                cv_.notify_one();
+                return;
+            }
+        }
+
+        stats_.dropped_records++;
+        LOG_EVERY_N(WARNING, 1000)
             << "Tracing queue full, dropping record span=" << record.span_name;
         return;
     }
@@ -336,12 +454,12 @@ size_t AsyncRemoteTraceExporter::EstimateRecordBytes(
     return total;
 }
 
-bool AsyncRemoteTraceExporter::TrySendRemote(const TraceRecord& record,
+bool AsyncRemoteTraceExporter::TrySendRemote(const std::vector<TraceRecord>& records,
                                              std::string* error_message) {
     std::ostringstream oss;
     for (size_t i = 0; i < remote_send_fns_.size(); ++i) {
         std::string endpoint_error;
-        if (remote_send_fns_[i](record, &endpoint_error)) {
+        if (remote_send_fns_[i](records, &endpoint_error)) {
             return true;
         }
         if (!endpoint_error.empty()) {
@@ -399,7 +517,7 @@ bool AsyncRemoteTraceExporter::TrySpool(const TraceRecord& record,
 
 void AsyncRemoteTraceExporter::WorkerMain() {
     while (true) {
-        TraceRecord record;
+        std::vector<TraceRecord> records;
         {
             std::unique_lock<std::mutex> lock(mutex_);
             cv_.wait(lock, [this] { return stop_ || !queue_.empty(); });
@@ -407,9 +525,18 @@ void AsyncRemoteTraceExporter::WorkerMain() {
                 break;
             }
             worker_busy_ = true;
-            record = std::move(queue_.front());
-            queued_bytes_ -= std::min(queued_bytes_, EstimateRecordBytes(record));
-            queue_.pop_front();
+            size_t batch_bytes = 0;
+            while (!queue_.empty() && records.size() < kMaxRemoteBatchItems) {
+                const auto next_bytes = EstimateRecordBytes(queue_.front());
+                if (!records.empty() &&
+                    batch_bytes + next_bytes > kMaxRemoteBatchBytes) {
+                    break;
+                }
+                batch_bytes += next_bytes;
+                queued_bytes_ -= std::min(queued_bytes_, next_bytes);
+                records.push_back(std::move(queue_.front()));
+                queue_.pop_front();
+            }
             stats_.queued_records = queue_.size();
             stats_.queued_bytes = queued_bytes_;
         }
@@ -419,7 +546,7 @@ void AsyncRemoteTraceExporter::WorkerMain() {
         int backoff_ms = std::max(1, config_.exporter_retry_base_ms);
         for (int attempt = 0; attempt <= config_.exporter_retry_max_attempts;
              ++attempt) {
-            if (TrySendRemote(record, &error_message)) {
+            if (TrySendRemote(records, &error_message)) {
                 exported = true;
                 break;
             }
@@ -436,36 +563,50 @@ void AsyncRemoteTraceExporter::WorkerMain() {
         }
 
         if (!exported) {
-            bool spooled = false;
+            size_t spooled_records = 0;
+            size_t fallback_records = 0;
+            size_t spool_failures = 0;
             std::string spool_error;
             {
                 std::lock_guard<std::mutex> lock(mutex_);
-                stats_.collector_unreachable_count++;
+                stats_.collector_unreachable_count += records.size();
             }
             LOG_EVERY_N(ERROR, 100)
                 << "Tracing remote exporter unavailable, span="
-                << record.span_name << " error=" << error_message;
+                << (records.empty() ? "" : records.front().span_name)
+                << " error=" << error_message
+                << " batch_size=" << records.size();
 
-            if (!config_.exporter_spool_dir.empty()) {
-                spooled = TrySpool(record, &spool_error);
-                std::lock_guard<std::mutex> lock(mutex_);
-                if (spooled) {
-                    stats_.spooled_records++;
-                } else {
-                    stats_.spool_failures++;
+            for (const auto& record : records) {
+                bool spooled = false;
+                std::string current_spool_error;
+                if (!config_.exporter_spool_dir.empty() &&
+                    IsHighPriorityRecord(record, config_)) {
+                    spooled = TrySpool(record, &current_spool_error);
+                    if (spooled) {
+                        ++spooled_records;
+                    } else if (!current_spool_error.empty()) {
+                        ++spool_failures;
+                        spool_error = current_spool_error;
+                    }
+                }
+
+                if (!spooled && fallback_exporter_) {
+                    fallback_exporter_->Export(record);
+                    ++fallback_records;
                 }
             }
 
-            if (!spooled && fallback_exporter_) {
-                fallback_exporter_->Export(record);
+            {
                 std::lock_guard<std::mutex> lock(mutex_);
-                stats_.fallback_count++;
+                stats_.spooled_records += spooled_records;
+                stats_.fallback_count += fallback_records;
+                stats_.spool_failures += spool_failures;
             }
 
-            if (!spooled && !spool_error.empty()) {
+            if (!spool_error.empty()) {
                 LOG_EVERY_N(ERROR, 100)
-                    << "Tracing spool failed, span=" << record.span_name
-                    << " error=" << spool_error;
+                    << "Tracing spool failed, error=" << spool_error;
             }
         }
 

--- a/mooncake-tracing/src/trace_exporter_otlp_http.cpp
+++ b/mooncake-tracing/src/trace_exporter_otlp_http.cpp
@@ -23,6 +23,8 @@ namespace mooncake::tracing {
 namespace {
 constexpr size_t kMaxRemoteBatchItems = 256;
 constexpr size_t kMaxRemoteBatchBytes = 512 * 1024;
+constexpr char kSamplingPriorityAttr[] = "sampling.priority";
+constexpr char kStructuralSamplingPriority[] = "structural";
 
 std::string BuildSpoolFileName(const TraceConfig& config) {
     std::string file_name = config.service_name;
@@ -67,12 +69,35 @@ Json::Value AttrToJson(const std::pair<std::string, std::string>& kv) {
     return attr;
 }
 
+bool IsInternalTraceAttr(const std::pair<std::string, std::string>& kv) {
+    return kv.first == kSamplingPriorityAttr;
+}
+
 Json::Value AttrsToObject(const TraceAttrs& attrs) {
     Json::Value obj(Json::objectValue);
     for (const auto& [key, value] : attrs) {
+        if (key == kSamplingPriorityAttr) {
+            continue;
+        }
         obj[key] = value;
     }
     return obj;
+}
+
+bool HasAttrValue(const TraceAttrs& attrs, const std::string& key,
+                  const std::string& value) {
+    return std::any_of(attrs.begin(), attrs.end(),
+                       [&key, &value](const auto& attr) {
+                           return attr.first == key && attr.second == value;
+                       });
+}
+
+bool IsStructuralRecord(const TraceRecord& record) {
+    if (record.force_sample) {
+        return true;
+    }
+    return HasAttrValue(record.attrs, kSamplingPriorityAttr,
+                        kStructuralSamplingPriority);
 }
 
 Json::Value RecordToJson(const TraceRecord& record) {
@@ -119,6 +144,9 @@ Json::Value RecordToOtlpSpan(const TraceRecord& record) {
         attrs.append(AttrToJson({"correlation.id", record.correlation_id}));
     }
     for (const auto& kv : record.attrs) {
+        if (IsInternalTraceAttr(kv)) {
+            continue;
+        }
         attrs.append(AttrToJson(kv));
     }
     span["attributes"] = attrs;
@@ -194,6 +222,9 @@ std::string BuildOtlpPayload(const std::vector<TraceRecord>& records) {
 }
 
 bool IsHighPriorityRecord(const TraceRecord& record, const TraceConfig& config) {
+    if (IsStructuralRecord(record)) {
+        return true;
+    }
     if (record.parent_span_id.empty()) {
         return true;
     }
@@ -370,11 +401,21 @@ AsyncRemoteTraceExporter::~AsyncRemoteTraceExporter() {
 void AsyncRemoteTraceExporter::Export(const TraceRecord& record) {
     const auto record_bytes = EstimateRecordBytes(record);
     std::lock_guard<std::mutex> lock(mutex_);
+    const bool structural = IsStructuralRecord(record);
     const bool queue_full =
         queue_.size() >= config_.exporter_queue_max_items ||
         queued_bytes_ + record_bytes > config_.exporter_queue_max_bytes;
     if (queue_full) {
         stats_.queue_full_count++;
+
+        if (structural) {
+            queue_.push_back(record);
+            queued_bytes_ += record_bytes;
+            stats_.queued_records = queue_.size();
+            stats_.queued_bytes = queued_bytes_;
+            cv_.notify_one();
+            return;
+        }
 
         if (IsHighPriorityRecord(record, config_)) {
             bool evicted = false;

--- a/mooncake-tracing/src/trace_exporter_otlp_http.cpp
+++ b/mooncake-tracing/src/trace_exporter_otlp_http.cpp
@@ -221,7 +221,8 @@ std::string BuildOtlpPayload(const std::vector<TraceRecord>& records) {
     return Json::writeString(builder, root);
 }
 
-bool IsHighPriorityRecord(const TraceRecord& record, const TraceConfig& config) {
+bool IsHighPriorityRecord(const TraceRecord& record,
+                          const TraceConfig& config) {
     if (IsStructuralRecord(record)) {
         return true;
     }
@@ -269,7 +270,8 @@ void OtlpHttpTraceExporter::Export(const TraceRecord& record) {
     (void)TryExport(record, &ignored_error);
 }
 
-void OtlpHttpTraceExporter::ExportBatch(const std::vector<TraceRecord>& records) {
+void OtlpHttpTraceExporter::ExportBatch(
+    const std::vector<TraceRecord>& records) {
     std::string ignored_error;
     (void)TryExportBatch(records, &ignored_error);
 }
@@ -290,7 +292,8 @@ bool OtlpHttpTraceExporter::EnsureCurlLocked() {
         return false;
     }
 
-    header_list_ = curl_slist_append(header_list_, "Content-Type: application/json");
+    header_list_ =
+        curl_slist_append(header_list_, "Content-Type: application/json");
     if (!headers_.empty()) {
         std::stringstream ss(headers_);
         std::string item;
@@ -314,8 +317,8 @@ bool OtlpHttpTraceExporter::EnsureCurlLocked() {
     return true;
 }
 
-bool OtlpHttpTraceExporter::TryExportBatch(const std::vector<TraceRecord>& records,
-                                           std::string* error_message) {
+bool OtlpHttpTraceExporter::TryExportBatch(
+    const std::vector<TraceRecord>& records, std::string* error_message) {
     if (records.empty()) {
         return true;
     }
@@ -348,9 +351,9 @@ bool OtlpHttpTraceExporter::TryExportBatch(const std::vector<TraceRecord>& recor
             << " errbuf=" << errbuf << " body=" << response;
         LOG_EVERY_N(ERROR, 100)
             << "OTLP exporter POST failed url=" << url
-            << " curl=" << curl_easy_strerror(rc)
-            << " http=" << code << " errbuf=" << errbuf
-            << " body=" << response << " batch_size=" << records.size();
+            << " curl=" << curl_easy_strerror(rc) << " http=" << code
+            << " errbuf=" << errbuf << " body=" << response
+            << " batch_size=" << records.size();
         if (error_message) {
             *error_message = oss.str();
         }
@@ -364,7 +367,8 @@ AsyncRemoteTraceExporter::AsyncRemoteTraceExporter(
     : config_(std::move(config)),
       fallback_exporter_(std::move(fallback_exporter)) {
     if (!fallback_exporter_) {
-        fallback_exporter_ = std::make_shared<JsonlTraceExporter>(config_.jsonl_path);
+        fallback_exporter_ =
+            std::make_shared<JsonlTraceExporter>(config_.jsonl_path);
     }
     if (send_fn) {
         remote_send_fns_.push_back(std::move(send_fn));
@@ -463,9 +467,8 @@ void AsyncRemoteTraceExporter::Export(const TraceRecord& record) {
 
 bool AsyncRemoteTraceExporter::FlushForTest(std::chrono::milliseconds timeout) {
     std::unique_lock<std::mutex> lock(mutex_);
-    return drained_cv_.wait_for(lock, timeout, [this] {
-        return queue_.empty() && !worker_busy_;
-    });
+    return drained_cv_.wait_for(
+        lock, timeout, [this] { return queue_.empty() && !worker_busy_; });
 }
 
 TraceExporterStats AsyncRemoteTraceExporter::SnapshotStats() const {
@@ -495,8 +498,8 @@ size_t AsyncRemoteTraceExporter::EstimateRecordBytes(
     return total;
 }
 
-bool AsyncRemoteTraceExporter::TrySendRemote(const std::vector<TraceRecord>& records,
-                                             std::string* error_message) {
+bool AsyncRemoteTraceExporter::TrySendRemote(
+    const std::vector<TraceRecord>& records, std::string* error_message) {
     std::ostringstream oss;
     for (size_t i = 0; i < remote_send_fns_.size(); ++i) {
         std::string endpoint_error;
@@ -600,7 +603,8 @@ void AsyncRemoteTraceExporter::WorkerMain() {
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
             backoff_ms =
-                std::min(backoff_ms * 2, std::max(backoff_ms, config_.exporter_retry_max_ms));
+                std::min(backoff_ms * 2,
+                         std::max(backoff_ms, config_.exporter_retry_max_ms));
         }
 
         if (!exported) {

--- a/mooncake-tracing/src/trace_exporter_otlp_http.cpp
+++ b/mooncake-tracing/src/trace_exporter_otlp_http.cpp
@@ -1,0 +1,178 @@
+#include "trace_exporter.h"
+
+#include <curl/curl.h>
+#include <glog/logging.h>
+
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+#include <string>
+
+#if __has_include(<jsoncpp/json/json.h>)
+#include <jsoncpp/json/json.h>
+#else
+#include <json/json.h>
+#endif
+
+namespace mooncake::tracing {
+namespace {
+std::string ToHex16(uint64_t value) {
+    std::ostringstream oss;
+    oss << std::hex << std::setw(16) << std::setfill('0') << value;
+    return oss.str();
+}
+
+std::string NormalizeTraceId(const std::string& trace_id) {
+    if (trace_id.size() >= 32) return trace_id.substr(trace_id.size() - 32);
+    std::hash<std::string> h;
+    return ToHex16(h(trace_id + ":hi")) + ToHex16(h(trace_id + ":lo"));
+}
+
+std::string NormalizeSpanId(const std::string& span_id) {
+    if (span_id.size() >= 16) return span_id.substr(span_id.size() - 16);
+    std::hash<std::string> h;
+    return ToHex16(h(span_id));
+}
+
+size_t WriteCallback(char* ptr, size_t size, size_t nmemb, void* userdata) {
+    auto* out = static_cast<std::string*>(userdata);
+    out->append(ptr, size * nmemb);
+    return size * nmemb;
+}
+
+Json::Value AttrToJson(const std::pair<std::string, std::string>& kv) {
+    Json::Value attr;
+    attr["key"] = kv.first;
+    attr["value"]["stringValue"] = kv.second;
+    return attr;
+}
+}  // namespace
+
+OtlpHttpTraceExporter::OtlpHttpTraceExporter(std::string endpoint,
+                                             std::string path,
+                                             std::string headers,
+                                             int timeout_ms)
+    : endpoint_(std::move(endpoint)),
+      path_(std::move(path)),
+      headers_(std::move(headers)),
+      timeout_ms_(timeout_ms) {}
+
+void OtlpHttpTraceExporter::Export(const TraceRecord& record) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        LOG(ERROR) << "OTLP exporter: curl_easy_init failed";
+        return;
+    }
+
+    Json::Value root;
+    Json::Value resource_spans(Json::arrayValue);
+    Json::Value resource_span;
+    Json::Value resource_attrs(Json::arrayValue);
+    resource_attrs.append(AttrToJson({"service.name", record.service_name}));
+    if (!record.node_id.empty()) {
+        resource_attrs.append(AttrToJson({"service.instance.id", record.node_id}));
+    }
+    if (!record.process_role.empty()) {
+        resource_attrs.append(AttrToJson({"mooncake.process_role", record.process_role}));
+    }
+    resource_span["resource"]["attributes"] = resource_attrs;
+
+    Json::Value scope_spans(Json::arrayValue);
+    Json::Value scope_span;
+    scope_span["scope"]["name"] = "mooncake-tracing";
+    Json::Value spans(Json::arrayValue);
+    Json::Value span;
+    span["traceId"] = NormalizeTraceId(record.trace_id);
+    span["spanId"] = NormalizeSpanId(record.span_id);
+    if (!record.parent_span_id.empty()) {
+        span["parentSpanId"] = NormalizeSpanId(record.parent_span_id);
+    }
+    span["name"] = record.span_name;
+    span["kind"] = 1;
+    span["startTimeUnixNano"] = std::to_string(record.start_time_unix_nano);
+    span["endTimeUnixNano"] = std::to_string(record.end_time_unix_nano);
+
+    Json::Value attrs(Json::arrayValue);
+    if (!record.correlation_id.empty()) {
+        attrs.append(AttrToJson({"correlation.id", record.correlation_id}));
+    }
+    for (const auto& kv : record.attrs) attrs.append(AttrToJson(kv));
+    span["attributes"] = attrs;
+
+    Json::Value events(Json::arrayValue);
+    for (const auto& ev : record.events) {
+        Json::Value event;
+        event["name"] = ev.name;
+        event["timeUnixNano"] = std::to_string(ev.unix_nano);
+        Json::Value event_attrs(Json::arrayValue);
+        for (const auto& kv : ev.attrs) event_attrs.append(AttrToJson(kv));
+        event["attributes"] = event_attrs;
+        events.append(event);
+    }
+    span["events"] = events;
+    if (record.status == "ERROR") {
+        span["status"]["code"] = 2;
+        span["status"]["message"] = "ERROR";
+    } else {
+        span["status"]["code"] = 1;
+    }
+
+    spans.append(span);
+    scope_span["spans"] = spans;
+    scope_spans.append(scope_span);
+    resource_span["scopeSpans"] = scope_spans;
+    resource_spans.append(resource_span);
+    root["resourceSpans"] = resource_spans;
+
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "";
+    const std::string payload = Json::writeString(builder, root);
+
+    std::string url = endpoint_;
+    if (!path_.empty()) {
+        if (!url.empty() && url.back() == '/' && path_.front() == '/') {
+            url.pop_back();
+        }
+        url += path_;
+    }
+
+    struct curl_slist* header_list = nullptr;
+    header_list = curl_slist_append(header_list, "Content-Type: application/json");
+    if (!headers_.empty()) {
+        std::stringstream ss(headers_);
+        std::string item;
+        while (std::getline(ss, item, ',')) {
+            if (!item.empty()) header_list = curl_slist_append(header_list, item.c_str());
+        }
+    }
+
+    std::string response;
+    char errbuf[CURL_ERROR_SIZE] = {0};
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, payload.size());
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeout_ms_);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, timeout_ms_);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+
+    CURLcode rc = curl_easy_perform(curl);
+    long code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
+    if (rc != CURLE_OK || code < 200 || code >= 300) {
+        LOG(ERROR) << "OTLP exporter POST failed url=" << url
+                   << " curl=" << curl_easy_strerror(rc)
+                   << " http=" << code << " errbuf=" << errbuf
+                   << " body=" << response;
+    }
+
+    curl_slist_free_all(header_list);
+    curl_easy_cleanup(curl);
+}
+
+}  // namespace mooncake::tracing

--- a/mooncake-tracing/src/trace_exporter_otlp_http.cpp
+++ b/mooncake-tracing/src/trace_exporter_otlp_http.cpp
@@ -3,10 +3,15 @@
 #include <curl/curl.h>
 #include <glog/logging.h>
 
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <thread>
+#include <unistd.h>
 
 #if __has_include(<jsoncpp/json/json.h>)
 #include <jsoncpp/json/json.h>
@@ -16,6 +21,18 @@
 
 namespace mooncake::tracing {
 namespace {
+std::string BuildSpoolFileName(const TraceConfig& config) {
+    std::string file_name = config.service_name;
+    if (!config.node_id.empty()) {
+        file_name += "-" + config.node_id;
+    }
+    if (!config.process_role.empty()) {
+        file_name += "-" + config.process_role;
+    }
+    file_name += "-" + std::to_string(::getpid()) + ".spool.jsonl";
+    return file_name;
+}
+
 std::string ToHex16(uint64_t value) {
     std::ostringstream oss;
     oss << std::hex << std::setw(16) << std::setfill('0') << value;
@@ -46,6 +63,41 @@ Json::Value AttrToJson(const std::pair<std::string, std::string>& kv) {
     attr["value"]["stringValue"] = kv.second;
     return attr;
 }
+
+Json::Value AttrsToObject(const TraceAttrs& attrs) {
+    Json::Value obj(Json::objectValue);
+    for (const auto& [key, value] : attrs) {
+        obj[key] = value;
+    }
+    return obj;
+}
+
+Json::Value RecordToJson(const TraceRecord& record) {
+    Json::Value root;
+    root["trace_id"] = record.trace_id;
+    root["span_id"] = record.span_id;
+    root["parent_span_id"] = record.parent_span_id;
+    root["correlation.id"] = record.correlation_id;
+    root["service.name"] = record.service_name;
+    root["node.id"] = record.node_id;
+    root["process.role"] = record.process_role;
+    root["span.name"] = record.span_name;
+    root["start_time_unix_nano"] = Json::Int64(record.start_time_unix_nano);
+    root["end_time_unix_nano"] = Json::Int64(record.end_time_unix_nano);
+    root["status"] = record.status;
+    root["attrs"] = AttrsToObject(record.attrs);
+
+    Json::Value events(Json::arrayValue);
+    for (const auto& event : record.events) {
+        Json::Value json_event;
+        json_event["name"] = event.name;
+        json_event["unix_nano"] = Json::Int64(event.unix_nano);
+        json_event["attrs"] = AttrsToObject(event.attrs);
+        events.append(json_event);
+    }
+    root["events"] = events;
+    return root;
+}
 }  // namespace
 
 OtlpHttpTraceExporter::OtlpHttpTraceExporter(std::string endpoint,
@@ -58,11 +110,20 @@ OtlpHttpTraceExporter::OtlpHttpTraceExporter(std::string endpoint,
       timeout_ms_(timeout_ms) {}
 
 void OtlpHttpTraceExporter::Export(const TraceRecord& record) {
+    std::string ignored_error;
+    (void)TryExport(record, &ignored_error);
+}
+
+bool OtlpHttpTraceExporter::TryExport(const TraceRecord& record,
+                                      std::string* error_message) {
     std::lock_guard<std::mutex> lock(mutex_);
     CURL* curl = curl_easy_init();
     if (!curl) {
         LOG(ERROR) << "OTLP exporter: curl_easy_init failed";
-        return;
+        if (error_message) {
+            *error_message = "curl_easy_init failed";
+        }
+        return false;
     }
 
     Json::Value root;
@@ -164,15 +225,258 @@ void OtlpHttpTraceExporter::Export(const TraceRecord& record) {
     CURLcode rc = curl_easy_perform(curl);
     long code = 0;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
+    bool ok = rc == CURLE_OK && code >= 200 && code < 300;
     if (rc != CURLE_OK || code < 200 || code >= 300) {
+        std::ostringstream oss;
+        oss << "OTLP exporter POST failed url=" << url
+            << " curl=" << curl_easy_strerror(rc) << " http=" << code
+            << " errbuf=" << errbuf << " body=" << response;
         LOG(ERROR) << "OTLP exporter POST failed url=" << url
                    << " curl=" << curl_easy_strerror(rc)
                    << " http=" << code << " errbuf=" << errbuf
                    << " body=" << response;
+        if (error_message) {
+            *error_message = oss.str();
+        }
     }
 
     curl_slist_free_all(header_list);
     curl_easy_cleanup(curl);
+    return ok;
+}
+
+AsyncRemoteTraceExporter::AsyncRemoteTraceExporter(
+    TraceConfig config, std::shared_ptr<TraceExporter> fallback_exporter,
+    RemoteSendFn send_fn)
+    : config_(std::move(config)),
+      fallback_exporter_(std::move(fallback_exporter)) {
+    if (!fallback_exporter_) {
+        fallback_exporter_ = std::make_shared<JsonlTraceExporter>(config_.jsonl_path);
+    }
+    if (send_fn) {
+        remote_send_fns_.push_back(std::move(send_fn));
+    } else {
+        auto endpoints = config_.remote_endpoints;
+        if (endpoints.empty()) {
+            endpoints.push_back(config_.otlp_http_endpoint);
+        }
+        for (const auto& endpoint : endpoints) {
+            auto remote = std::make_shared<OtlpHttpTraceExporter>(
+                endpoint, config_.otlp_http_path, config_.otlp_headers,
+                config_.otlp_timeout_ms);
+            remote_send_fns_.push_back(
+                [remote](const TraceRecord& record, std::string* error_message) {
+                    return remote->TryExport(record, error_message);
+                });
+        }
+    }
+    worker_ = std::thread(&AsyncRemoteTraceExporter::WorkerMain, this);
+}
+
+AsyncRemoteTraceExporter::~AsyncRemoteTraceExporter() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stop_ = true;
+    }
+    cv_.notify_all();
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+}
+
+void AsyncRemoteTraceExporter::Export(const TraceRecord& record) {
+    const auto record_bytes = EstimateRecordBytes(record);
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (queue_.size() >= config_.exporter_queue_max_items ||
+        queued_bytes_ + record_bytes > config_.exporter_queue_max_bytes) {
+        stats_.dropped_records++;
+        stats_.queue_full_count++;
+        LOG_EVERY_N(WARNING, 100)
+            << "Tracing queue full, dropping record span=" << record.span_name;
+        return;
+    }
+    queue_.push_back(record);
+    queued_bytes_ += record_bytes;
+    stats_.queued_records = queue_.size();
+    stats_.queued_bytes = queued_bytes_;
+    cv_.notify_one();
+}
+
+bool AsyncRemoteTraceExporter::FlushForTest(std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return drained_cv_.wait_for(lock, timeout, [this] {
+        return queue_.empty() && !worker_busy_;
+    });
+}
+
+TraceExporterStats AsyncRemoteTraceExporter::SnapshotStats() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto snapshot = stats_;
+    snapshot.queued_records = queue_.size();
+    snapshot.queued_bytes = queued_bytes_;
+    return snapshot;
+}
+
+size_t AsyncRemoteTraceExporter::EstimateRecordBytes(
+    const TraceRecord& record) const {
+    size_t total = record.trace_id.size() + record.span_id.size() +
+                   record.parent_span_id.size() + record.correlation_id.size() +
+                   record.service_name.size() + record.node_id.size() +
+                   record.process_role.size() + record.span_name.size() +
+                   record.status.size() + sizeof(record);
+    for (const auto& attr : record.attrs) {
+        total += attr.first.size() + attr.second.size();
+    }
+    for (const auto& event : record.events) {
+        total += event.name.size() + sizeof(event);
+        for (const auto& attr : event.attrs) {
+            total += attr.first.size() + attr.second.size();
+        }
+    }
+    return total;
+}
+
+bool AsyncRemoteTraceExporter::TrySendRemote(const TraceRecord& record,
+                                             std::string* error_message) {
+    std::ostringstream oss;
+    for (size_t i = 0; i < remote_send_fns_.size(); ++i) {
+        std::string endpoint_error;
+        if (remote_send_fns_[i](record, &endpoint_error)) {
+            return true;
+        }
+        if (!endpoint_error.empty()) {
+            if (oss.tellp() > 0) {
+                oss << " | ";
+            }
+            oss << endpoint_error;
+        }
+    }
+    if (error_message) {
+        *error_message = oss.str();
+    }
+    return false;
+}
+
+bool AsyncRemoteTraceExporter::TrySpool(const TraceRecord& record,
+                                        std::string* error_message) {
+    if (config_.exporter_spool_dir.empty()) {
+        if (error_message) {
+            *error_message = "spool not configured";
+        }
+        return false;
+    }
+
+    std::error_code ec;
+    std::filesystem::create_directories(config_.exporter_spool_dir, ec);
+    if (ec) {
+        if (error_message) {
+            *error_message = "create spool dir failed: " + ec.message();
+        }
+        return false;
+    }
+
+    const auto spool_path = std::filesystem::path(config_.exporter_spool_dir) /
+                            BuildSpoolFileName(config_);
+    std::ofstream out(spool_path, std::ios::app);
+    if (!out.is_open()) {
+        if (error_message) {
+            *error_message = "open spool file failed: " + spool_path.string();
+        }
+        return false;
+    }
+
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "";
+    out << Json::writeString(builder, RecordToJson(record)) << "\n";
+    if (!out.good()) {
+        if (error_message) {
+            *error_message = "write spool file failed: " + spool_path.string();
+        }
+        return false;
+    }
+    return true;
+}
+
+void AsyncRemoteTraceExporter::WorkerMain() {
+    while (true) {
+        TraceRecord record;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait(lock, [this] { return stop_ || !queue_.empty(); });
+            if (stop_ && queue_.empty()) {
+                break;
+            }
+            worker_busy_ = true;
+            record = std::move(queue_.front());
+            queued_bytes_ -= std::min(queued_bytes_, EstimateRecordBytes(record));
+            queue_.pop_front();
+            stats_.queued_records = queue_.size();
+            stats_.queued_bytes = queued_bytes_;
+        }
+
+        bool exported = false;
+        std::string error_message;
+        int backoff_ms = std::max(1, config_.exporter_retry_base_ms);
+        for (int attempt = 0; attempt <= config_.exporter_retry_max_attempts;
+             ++attempt) {
+            if (TrySendRemote(record, &error_message)) {
+                exported = true;
+                break;
+            }
+            if (attempt == config_.exporter_retry_max_attempts) {
+                break;
+            }
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                stats_.retry_count++;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
+            backoff_ms =
+                std::min(backoff_ms * 2, std::max(backoff_ms, config_.exporter_retry_max_ms));
+        }
+
+        if (!exported) {
+            bool spooled = false;
+            std::string spool_error;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                stats_.collector_unreachable_count++;
+            }
+            LOG_EVERY_N(ERROR, 100)
+                << "Tracing remote exporter unavailable, span="
+                << record.span_name << " error=" << error_message;
+
+            if (!config_.exporter_spool_dir.empty()) {
+                spooled = TrySpool(record, &spool_error);
+                std::lock_guard<std::mutex> lock(mutex_);
+                if (spooled) {
+                    stats_.spooled_records++;
+                } else {
+                    stats_.spool_failures++;
+                }
+            }
+
+            if (!spooled && fallback_exporter_) {
+                fallback_exporter_->Export(record);
+                std::lock_guard<std::mutex> lock(mutex_);
+                stats_.fallback_count++;
+            }
+
+            if (!spooled && !spool_error.empty()) {
+                LOG_EVERY_N(ERROR, 100)
+                    << "Tracing spool failed, span=" << record.span_name
+                    << " error=" << spool_error;
+            }
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            worker_busy_ = false;
+            if (queue_.empty()) {
+                drained_cv_.notify_all();
+            }
+        }
+    }
 }
 
 }  // namespace mooncake::tracing

--- a/mooncake-tracing/src/tracing_facade.cpp
+++ b/mooncake-tracing/src/tracing_facade.cpp
@@ -1,6 +1,7 @@
 #include "tracing_facade.h"
 
 #include <chrono>
+#include <functional>
 #include <utility>
 
 namespace mooncake::tracing {
@@ -9,6 +10,13 @@ int64_t NowUnixNano() {
     return std::chrono::duration_cast<std::chrono::nanoseconds>(
                std::chrono::system_clock::now().time_since_epoch())
         .count();
+}
+
+double DeterministicSampleValue(const TraceRecord& record) {
+    std::hash<std::string> hasher;
+    const auto seed = !record.trace_id.empty() ? record.trace_id : record.span_id;
+    const auto value = hasher(seed);
+    return static_cast<double>(value % 1000000ULL) / 1000000.0;
 }
 }  // namespace
 
@@ -42,6 +50,33 @@ TraceContext Span::context() const {
                         record_->parent_span_id, record_->correlation_id,
                         false};
 }
+
+TraceSampler::TraceSampler(TraceConfig config) : config_(std::move(config)) {}
+
+bool TraceSampler::ShouldSample(const TraceRecord& record) const {
+    if (config_.sampling_mode == "off") {
+        return false;
+    }
+    if (config_.sampling_mode == "debug") {
+        return true;
+    }
+    if (config_.sampling_mode == "diag" && !record.events.empty()) {
+        return true;
+    }
+    if (record.status == "ERROR") {
+        return true;
+    }
+    if (config_.sampling_slow_threshold_ms > 0 &&
+        record.end_time_unix_nano > record.start_time_unix_nano) {
+        const auto duration_ms =
+            (record.end_time_unix_nano - record.start_time_unix_nano) / 1000000;
+        if (duration_ms >= config_.sampling_slow_threshold_ms) {
+            return true;
+        }
+    }
+    return DeterministicSampleValue(record) < config_.sampling_base_ratio;
+}
+
 void Span::End() {
     if (!facade_ || !record_ || ended_) return;
     record_->end_time_unix_nano = NowUnixNano();
@@ -54,37 +89,34 @@ TracingFacade::TracingFacade(TraceConfig config) : config_(std::move(config)) {
     if (config_.enabled && config_.exporter_mode != "off") {
         if (config_.exporter_mode == "inmemory") {
             exporter_ = std::make_shared<InMemoryTraceExporter>();
+        } else if (config_.exporter_mode == "remote") {
+            exporter_ = std::make_shared<AsyncRemoteTraceExporter>(
+                config_, std::make_shared<JsonlTraceExporter>(config_.jsonl_path));
         } else if (config_.exporter_mode == "otlp_http" ||
                    config_.exporter_mode == "otlp") {
-            exporter_ = std::make_shared<OtlpHttpTraceExporter>(
-                config_.otlp_http_endpoint, config_.otlp_http_path,
-                config_.otlp_headers, config_.otlp_timeout_ms);
+            exporter_ = std::make_shared<AsyncRemoteTraceExporter>(
+                config_, std::make_shared<JsonlTraceExporter>(config_.jsonl_path));
         } else {
             exporter_ = std::make_shared<JsonlTraceExporter>(config_.jsonl_path);
         }
     }
+    sampler_ = std::make_unique<TraceSampler>(config_);
 }
 Span TracingFacade::StartSpan(const std::string& span_name,
                               const TraceContext* parent,
                               const TraceAttrs& attrs) {
     if (!config_.enabled || !exporter_) return Span();
-    TraceContext ctx = parent ? TraceContext{parent->trace_id,
-                                             parent->valid() ? RootContext().span_id
-                                                             : std::string(),
-                                             parent->span_id,
-                                             parent->correlation_id,
-                                             parent->context_missing}
-                              : RootContext();
+    const auto root = RootContext();
+    TraceContext ctx;
     if (!parent) {
-        ctx = RootContext();
+        ctx = root;
     } else {
-        ctx.trace_id = parent->trace_id.empty() ? RootContext().trace_id
-                                                : parent->trace_id;
+        ctx.trace_id = parent->trace_id.empty() ? root.trace_id : parent->trace_id;
         ctx.parent_span_id = parent->span_id;
-        ctx.span_id = RootContext().span_id;
-        ctx.correlation_id = parent->correlation_id.empty()
-                                 ? RootContext().correlation_id
-                                 : parent->correlation_id;
+        ctx.span_id = root.span_id;
+        ctx.correlation_id =
+            parent->correlation_id.empty() ? root.correlation_id
+                                           : parent->correlation_id;
         ctx.context_missing = parent->context_missing;
     }
     TraceRecord rec;
@@ -104,11 +136,22 @@ Span TracingFacade::StartSpan(const std::string& span_name,
 Span TracingFacade::StartSpanFromCarrier(const std::string& span_name,
                                          const TraceCarrier& carrier,
                                          const TraceAttrs& attrs) {
-    auto ctx = ChildContextFromCarrier(carrier);
-    return StartSpan(span_name, &ctx, attrs);
+    if (carrier.empty()) {
+        auto ctx = ChildContextFromCarrier(carrier);
+        return StartSpan(span_name, &ctx, attrs);
+    }
+    TraceContext parent;
+    parent.trace_id = carrier.trace_id;
+    parent.span_id = carrier.span_id;
+    parent.correlation_id = carrier.correlation_id;
+    return StartSpan(span_name, &parent, attrs);
 }
 void TracingFacade::Export(TraceRecord&& record) {
-    if (exporter_) exporter_->Export(record);
+    if (!exporter_) return;
+    if (sampler_ && !sampler_->ShouldSample(record)) {
+        return;
+    }
+    exporter_->Export(record);
 }
 TracingFacade& TracingFacade::Instance(const std::string& service_name,
                                        const std::string& process_role) {

--- a/mooncake-tracing/src/tracing_facade.cpp
+++ b/mooncake-tracing/src/tracing_facade.cpp
@@ -1,0 +1,128 @@
+#include "tracing_facade.h"
+
+#include <chrono>
+#include <utility>
+
+namespace mooncake::tracing {
+namespace {
+int64_t NowUnixNano() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+}  // namespace
+
+Span::Span(TracingFacade* facade, TraceRecord record)
+    : facade_(facade), record_(std::make_unique<TraceRecord>(std::move(record))) {}
+Span::Span(Span&& other) noexcept { *this = std::move(other); }
+Span& Span::operator=(Span&& other) noexcept {
+    if (this != &other) {
+        End();
+        facade_ = other.facade_;
+        record_ = std::move(other.record_);
+        ended_ = other.ended_;
+        other.facade_ = nullptr;
+        other.ended_ = true;
+    }
+    return *this;
+}
+Span::~Span() { End(); }
+void Span::SetAttribute(const std::string& key, const std::string& value) {
+    if (record_) record_->attrs.emplace_back(key, value);
+}
+void Span::AddEvent(const std::string& name, const TraceAttrs& attrs) {
+    if (record_) record_->events.push_back(TraceEvent{name, NowUnixNano(), attrs});
+}
+void Span::SetStatus(const std::string& status) {
+    if (record_) record_->status = status;
+}
+TraceContext Span::context() const {
+    if (!record_) return {};
+    return TraceContext{record_->trace_id, record_->span_id,
+                        record_->parent_span_id, record_->correlation_id,
+                        false};
+}
+void Span::End() {
+    if (!facade_ || !record_ || ended_) return;
+    record_->end_time_unix_nano = NowUnixNano();
+    facade_->Export(std::move(*record_));
+    record_.reset();
+    ended_ = true;
+}
+
+TracingFacade::TracingFacade(TraceConfig config) : config_(std::move(config)) {
+    if (config_.enabled && config_.exporter_mode != "off") {
+        if (config_.exporter_mode == "inmemory") {
+            exporter_ = std::make_shared<InMemoryTraceExporter>();
+        } else if (config_.exporter_mode == "otlp_http" ||
+                   config_.exporter_mode == "otlp") {
+            exporter_ = std::make_shared<OtlpHttpTraceExporter>(
+                config_.otlp_http_endpoint, config_.otlp_http_path,
+                config_.otlp_headers, config_.otlp_timeout_ms);
+        } else {
+            exporter_ = std::make_shared<JsonlTraceExporter>(config_.jsonl_path);
+        }
+    }
+}
+Span TracingFacade::StartSpan(const std::string& span_name,
+                              const TraceContext* parent,
+                              const TraceAttrs& attrs) {
+    if (!config_.enabled || !exporter_) return Span();
+    TraceContext ctx = parent ? TraceContext{parent->trace_id,
+                                             parent->valid() ? RootContext().span_id
+                                                             : std::string(),
+                                             parent->span_id,
+                                             parent->correlation_id,
+                                             parent->context_missing}
+                              : RootContext();
+    if (!parent) {
+        ctx = RootContext();
+    } else {
+        ctx.trace_id = parent->trace_id.empty() ? RootContext().trace_id
+                                                : parent->trace_id;
+        ctx.parent_span_id = parent->span_id;
+        ctx.span_id = RootContext().span_id;
+        ctx.correlation_id = parent->correlation_id.empty()
+                                 ? RootContext().correlation_id
+                                 : parent->correlation_id;
+        ctx.context_missing = parent->context_missing;
+    }
+    TraceRecord rec;
+    rec.trace_id = ctx.trace_id;
+    rec.span_id = ctx.span_id;
+    rec.parent_span_id = ctx.parent_span_id;
+    rec.correlation_id = ctx.correlation_id;
+    rec.service_name = config_.service_name;
+    rec.node_id = config_.node_id;
+    rec.process_role = config_.process_role;
+    rec.span_name = span_name;
+    rec.start_time_unix_nano = NowUnixNano();
+    rec.attrs = attrs;
+    if (ctx.context_missing) rec.attrs.emplace_back("context.missing", "true");
+    return Span(this, std::move(rec));
+}
+Span TracingFacade::StartSpanFromCarrier(const std::string& span_name,
+                                         const TraceCarrier& carrier,
+                                         const TraceAttrs& attrs) {
+    auto ctx = ChildContextFromCarrier(carrier);
+    return StartSpan(span_name, &ctx, attrs);
+}
+void TracingFacade::Export(TraceRecord&& record) {
+    if (exporter_) exporter_->Export(record);
+}
+TracingFacade& TracingFacade::Instance(const std::string& service_name,
+                                       const std::string& process_role) {
+    static std::mutex mutex;
+    static std::vector<std::unique_ptr<TracingFacade>> facades;
+    std::lock_guard<std::mutex> lock(mutex);
+    for (auto& facade : facades) {
+        if (facade->config().service_name == service_name &&
+            facade->config().process_role == process_role)
+            return *facade;
+    }
+    facades.push_back(std::make_unique<TracingFacade>(
+        LoadTraceConfig(service_name, process_role)));
+    return *facades.back();
+}
+
+}  // namespace mooncake::tracing

--- a/mooncake-tracing/src/tracing_facade.cpp
+++ b/mooncake-tracing/src/tracing_facade.cpp
@@ -26,14 +26,16 @@ bool HasAttrValue(const TraceAttrs& attrs, const std::string& key,
 
 double DeterministicSampleValue(const TraceRecord& record) {
     std::hash<std::string> hasher;
-    const auto seed = !record.trace_id.empty() ? record.trace_id : record.span_id;
+    const auto seed =
+        !record.trace_id.empty() ? record.trace_id : record.span_id;
     const auto value = hasher(seed);
     return static_cast<double>(value % 1000000ULL) / 1000000.0;
 }
 }  // namespace
 
 Span::Span(TracingFacade* facade, TraceRecord record)
-    : facade_(facade), record_(std::make_unique<TraceRecord>(std::move(record))) {}
+    : facade_(facade),
+      record_(std::make_unique<TraceRecord>(std::move(record))) {}
 Span::Span(Span&& other) noexcept { *this = std::move(other); }
 Span& Span::operator=(Span&& other) noexcept {
     if (this != &other) {
@@ -51,16 +53,17 @@ void Span::SetAttribute(const std::string& key, const std::string& value) {
     if (record_) record_->attrs.emplace_back(key, value);
 }
 void Span::AddEvent(const std::string& name, const TraceAttrs& attrs) {
-    if (record_) record_->events.push_back(TraceEvent{name, NowUnixNano(), attrs});
+    if (record_)
+        record_->events.push_back(TraceEvent{name, NowUnixNano(), attrs});
 }
 void Span::SetStatus(const std::string& status) {
     if (record_) record_->status = status;
 }
 TraceContext Span::context() const {
     if (!record_) return {};
-    return TraceContext{record_->trace_id, record_->span_id,
+    return TraceContext{record_->trace_id,       record_->span_id,
                         record_->parent_span_id, record_->correlation_id,
-                        record_->force_sample, false};
+                        record_->force_sample,   false};
 }
 
 TraceSampler::TraceSampler(TraceConfig config) : config_(std::move(config)) {}
@@ -110,13 +113,16 @@ TracingFacade::TracingFacade(TraceConfig config) : config_(std::move(config)) {
             exporter_ = std::make_shared<InMemoryTraceExporter>();
         } else if (config_.exporter_mode == "remote") {
             exporter_ = std::make_shared<AsyncRemoteTraceExporter>(
-                config_, std::make_shared<JsonlTraceExporter>(config_.jsonl_path));
+                config_,
+                std::make_shared<JsonlTraceExporter>(config_.jsonl_path));
         } else if (config_.exporter_mode == "otlp_http" ||
                    config_.exporter_mode == "otlp") {
             exporter_ = std::make_shared<AsyncRemoteTraceExporter>(
-                config_, std::make_shared<JsonlTraceExporter>(config_.jsonl_path));
+                config_,
+                std::make_shared<JsonlTraceExporter>(config_.jsonl_path));
         } else {
-            exporter_ = std::make_shared<JsonlTraceExporter>(config_.jsonl_path);
+            exporter_ =
+                std::make_shared<JsonlTraceExporter>(config_.jsonl_path);
         }
     }
     sampler_ = std::make_unique<TraceSampler>(config_);
@@ -130,16 +136,18 @@ Span TracingFacade::StartSpan(const std::string& span_name,
     if (!parent) {
         ctx = root;
     } else {
-        ctx.trace_id = parent->trace_id.empty() ? root.trace_id : parent->trace_id;
+        ctx.trace_id =
+            parent->trace_id.empty() ? root.trace_id : parent->trace_id;
         ctx.parent_span_id = parent->span_id;
         ctx.span_id = root.span_id;
-        ctx.correlation_id =
-            parent->correlation_id.empty() ? root.correlation_id
-                                           : parent->correlation_id;
+        ctx.correlation_id = parent->correlation_id.empty()
+                                 ? root.correlation_id
+                                 : parent->correlation_id;
         ctx.force_sample = parent->force_sample;
         ctx.context_missing = parent->context_missing;
     }
-    if (HasAttrValue(attrs, kSamplingPriorityAttr, kStructuralSamplingPriority)) {
+    if (HasAttrValue(attrs, kSamplingPriorityAttr,
+                     kStructuralSamplingPriority)) {
         ctx.force_sample = true;
     }
     TraceRecord rec;

--- a/mooncake-tracing/src/tracing_facade.cpp
+++ b/mooncake-tracing/src/tracing_facade.cpp
@@ -1,15 +1,27 @@
 #include "tracing_facade.h"
 
+#include <algorithm>
 #include <chrono>
 #include <functional>
 #include <utility>
 
 namespace mooncake::tracing {
 namespace {
+constexpr char kSamplingPriorityAttr[] = "sampling.priority";
+constexpr char kStructuralSamplingPriority[] = "structural";
+
 int64_t NowUnixNano() {
     return std::chrono::duration_cast<std::chrono::nanoseconds>(
                std::chrono::system_clock::now().time_since_epoch())
         .count();
+}
+
+bool HasAttrValue(const TraceAttrs& attrs, const std::string& key,
+                  const std::string& value) {
+    return std::any_of(attrs.begin(), attrs.end(),
+                       [&key, &value](const auto& attr) {
+                           return attr.first == key && attr.second == value;
+                       });
 }
 
 double DeterministicSampleValue(const TraceRecord& record) {
@@ -48,7 +60,7 @@ TraceContext Span::context() const {
     if (!record_) return {};
     return TraceContext{record_->trace_id, record_->span_id,
                         record_->parent_span_id, record_->correlation_id,
-                        false};
+                        record_->force_sample, false};
 }
 
 TraceSampler::TraceSampler(TraceConfig config) : config_(std::move(config)) {}
@@ -56,6 +68,13 @@ TraceSampler::TraceSampler(TraceConfig config) : config_(std::move(config)) {}
 bool TraceSampler::ShouldSample(const TraceRecord& record) const {
     if (config_.sampling_mode == "off") {
         return false;
+    }
+    if (record.force_sample) {
+        return true;
+    }
+    if (HasAttrValue(record.attrs, kSamplingPriorityAttr,
+                     kStructuralSamplingPriority)) {
+        return true;
     }
     if (config_.sampling_mode == "debug") {
         return true;
@@ -117,7 +136,11 @@ Span TracingFacade::StartSpan(const std::string& span_name,
         ctx.correlation_id =
             parent->correlation_id.empty() ? root.correlation_id
                                            : parent->correlation_id;
+        ctx.force_sample = parent->force_sample;
         ctx.context_missing = parent->context_missing;
+    }
+    if (HasAttrValue(attrs, kSamplingPriorityAttr, kStructuralSamplingPriority)) {
+        ctx.force_sample = true;
     }
     TraceRecord rec;
     rec.trace_id = ctx.trace_id;
@@ -129,6 +152,7 @@ Span TracingFacade::StartSpan(const std::string& span_name,
     rec.process_role = config_.process_role;
     rec.span_name = span_name;
     rec.start_time_unix_nano = NowUnixNano();
+    rec.force_sample = ctx.force_sample;
     rec.attrs = attrs;
     if (ctx.context_missing) rec.attrs.emplace_back("context.missing", "true");
     return Span(this, std::move(rec));
@@ -144,6 +168,7 @@ Span TracingFacade::StartSpanFromCarrier(const std::string& span_name,
     parent.trace_id = carrier.trace_id;
     parent.span_id = carrier.span_id;
     parent.correlation_id = carrier.correlation_id;
+    parent.force_sample = carrier.force_sample;
     return StartSpan(span_name, &parent, attrs);
 }
 void TracingFacade::Export(TraceRecord&& record) {

--- a/mooncake-tracing/tools/trace_offline_aggregator.py
+++ b/mooncake-tracing/tools/trace_offline_aggregator.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+import argparse
+import glob
+import json
+from pathlib import Path
+from typing import Any
+
+
+def expand_inputs(patterns: list[str]) -> list[Path]:
+    files: list[Path] = []
+    for pattern in patterns:
+        matches = glob.glob(pattern)
+        if matches:
+            files.extend(Path(match) for match in matches)
+        else:
+            files.append(Path(pattern))
+    deduped = sorted({path for path in files if path.exists()})
+    return deduped
+
+
+def load_records(paths: list[Path]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for path in paths:
+        with path.open("r", encoding="utf-8") as handle:
+            for line_no, line in enumerate(handle, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(f"{path}:{line_no}: invalid JSON: {exc}") from exc
+                payload["_source_file"] = str(path)
+                records.append(payload)
+    return records
+
+
+def filter_records(records: list[dict[str, Any]], correlation_id: str,
+                   trace_id: str) -> list[dict[str, Any]]:
+    filtered: list[dict[str, Any]] = []
+    for record in records:
+        if correlation_id and record.get("correlation.id") != correlation_id:
+            continue
+        if trace_id and record.get("trace_id") != trace_id:
+            continue
+        filtered.append(record)
+    return filtered
+
+
+def relative_ms(record: dict[str, Any], base_time: int) -> tuple[float, float]:
+    start = int(record.get("start_time_unix_nano", 0))
+    end = int(record.get("end_time_unix_nano", start))
+    start_ms = (start - base_time) / 1_000_000.0
+    duration_ms = max(0.0, (end - start) / 1_000_000.0)
+    return start_ms, duration_ms
+
+
+def build_markdown(records: list[dict[str, Any]]) -> str:
+    if not records:
+        return "# Trace Report\n\nNo matching spans.\n"
+
+    base_time = min(int(record.get("start_time_unix_nano", 0)) for record in records)
+    lines = [
+        "# Trace Report",
+        "",
+        f"- span_count: {len(records)}",
+        f"- trace_id: {records[0].get('trace_id', '')}",
+        f"- correlation.id: {records[0].get('correlation.id', '')}",
+        "",
+        "## Waterfall",
+        "",
+        "| start_ms | duration_ms | service | role | span | status |",
+        "| ---: | ---: | --- | --- | --- | --- |",
+    ]
+    for record in records:
+        start_ms, duration_ms = relative_ms(record, base_time)
+        lines.append(
+            "| "
+            f"{start_ms:.3f} | {duration_ms:.3f} | "
+            f"{record.get('service.name', '')} | "
+            f"{record.get('process.role', '')} | "
+            f"{record.get('span.name', '')} | "
+            f"{record.get('status', '')} |"
+        )
+
+    lines.extend(["", "## Phase Table", "",
+                  "| span | parent_span_id | node | source_file |",
+                  "| --- | --- | --- | --- |"])
+    for record in records:
+        lines.append(
+            "| "
+            f"{record.get('span.name', '')} | "
+            f"{record.get('parent_span_id', '')} | "
+            f"{record.get('node.id', '')} | "
+            f"{record.get('_source_file', '')} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Merge Mooncake trace JSONL files into a single report.")
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help="Input JSONL files or glob patterns, for example '/var/log/mooncake/*.jsonl'.",
+    )
+    parser.add_argument("--correlation-id", default="", help="Filter by correlation.id.")
+    parser.add_argument("--trace-id", default="", help="Filter by trace_id.")
+    parser.add_argument("--output-json", default="", help="Write merged JSON to this path.")
+    parser.add_argument("--output-md", default="", help="Write markdown report to this path.")
+    args = parser.parse_args()
+
+    if not args.correlation_id and not args.trace_id:
+        parser.error("one of --correlation-id or --trace-id is required")
+
+    input_paths = expand_inputs(args.inputs)
+    if not input_paths:
+        raise SystemExit("no input files matched")
+
+    records = load_records(input_paths)
+    records = filter_records(records, args.correlation_id, args.trace_id)
+    records.sort(key=lambda record: (
+        int(record.get("start_time_unix_nano", 0)),
+        str(record.get("span_id", "")),
+    ))
+
+    merged = {
+        "trace_id": records[0].get("trace_id", "") if records else "",
+        "correlation.id": records[0].get("correlation.id", "") if records else "",
+        "span_count": len(records),
+        "spans": records,
+    }
+
+    if args.output_json:
+        output_json = Path(args.output_json)
+        output_json.parent.mkdir(parents=True, exist_ok=True)
+        output_json.write_text(json.dumps(merged, indent=2), encoding="utf-8")
+
+    markdown = build_markdown(records)
+    if args.output_md:
+        output_md = Path(args.output_md)
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        output_md.write_text(markdown, encoding="utf-8")
+    else:
+        print(markdown)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mooncake-transfer-engine/CMakeLists.txt
+++ b/mooncake-transfer-engine/CMakeLists.txt
@@ -45,6 +45,7 @@ endif()
 
 include_directories(../mooncake-common/include)
 include_directories(include)
+include_directories(../mooncake-tracing/include)
 add_subdirectory(include)
 add_subdirectory(src)
 

--- a/mooncake-transfer-engine/include/multi_transport.h
+++ b/mooncake-transfer-engine/include/multi_transport.h
@@ -15,11 +15,174 @@
 #ifndef MULTI_TRANSPORT_H_
 #define MULTI_TRANSPORT_H_
 
+#include <mutex>
+#include <optional>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
+#include "trace_context.h"
 #include "transport/transport.h"
 
 namespace mooncake {
+class MultiTransportTraceRegistry {
+   public:
+    using BatchID = Transport::BatchID;
+
+    enum class SliceTerminalState {
+        kPending,
+        kCompleted,
+        kFailed,
+        kTimedOut,
+    };
+
+    struct TaskState {
+        tracing::TraceContext context;
+        std::string transport_name;
+        size_t slice_count{0};
+        size_t total_bytes{0};
+        bool terminal_recorded{false};
+        std::vector<bool> slice_queued;
+        std::vector<SliceTerminalState> slice_terminal_states;
+    };
+
+    struct BatchState {
+        tracing::TraceContext context;
+        bool terminal_recorded{false};
+        std::unordered_map<size_t, TaskState> tasks;
+    };
+
+    void RegisterBatch(BatchID batch_id, const tracing::TraceContext& context) {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto& batch = batches_[batch_id];
+        if (!batch.context.valid()) {
+            batch.context = context;
+        }
+    }
+
+    void ClearBatch(BatchID batch_id) {
+        std::lock_guard<std::mutex> guard(mutex_);
+        batches_.erase(batch_id);
+    }
+
+    std::optional<tracing::TraceContext> LookupBatchContext(
+        BatchID batch_id) const {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto it = batches_.find(batch_id);
+        if (it == batches_.end()) {
+            return std::nullopt;
+        }
+        return it->second.context;
+    }
+
+    void RegisterTask(BatchID batch_id, size_t task_id,
+                      const tracing::TraceContext& context,
+                      const std::string& transport_name, size_t slice_count,
+                      size_t total_bytes) {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto& task = batches_[batch_id].tasks[task_id];
+        task.context = context;
+        task.transport_name = transport_name;
+        task.slice_count = slice_count;
+        task.total_bytes = total_bytes;
+        task.terminal_recorded = false;
+        task.slice_queued.assign(slice_count, false);
+        task.slice_terminal_states.assign(slice_count,
+                                          SliceTerminalState::kPending);
+    }
+
+    std::optional<TaskState> LookupTask(BatchID batch_id,
+                                        size_t task_id) const {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto batch_it = batches_.find(batch_id);
+        if (batch_it == batches_.end()) {
+            return std::nullopt;
+        }
+        auto task_it = batch_it->second.tasks.find(task_id);
+        if (task_it == batch_it->second.tasks.end()) {
+            return std::nullopt;
+        }
+        return task_it->second;
+    }
+
+    bool MarkSliceQueued(BatchID batch_id, size_t task_id, size_t slice_id) {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto* task = FindTaskState(batch_id, task_id);
+        if (!task || slice_id >= task->slice_queued.size()) {
+            return false;
+        }
+        if (task->slice_queued[slice_id]) {
+            return false;
+        }
+        task->slice_queued[slice_id] = true;
+        return true;
+    }
+
+    bool MarkSliceTerminal(BatchID batch_id, size_t task_id, size_t slice_id,
+                           Transport::Slice::SliceStatus status) {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto* task = FindTaskState(batch_id, task_id);
+        if (!task || slice_id >= task->slice_terminal_states.size()) {
+            return false;
+        }
+        if (task->slice_terminal_states[slice_id] !=
+            SliceTerminalState::kPending) {
+            return false;
+        }
+        task->slice_terminal_states[slice_id] = MapSliceStatus(status);
+        return true;
+    }
+
+    bool MarkTaskTerminal(BatchID batch_id, size_t task_id) {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto* task = FindTaskState(batch_id, task_id);
+        if (!task || task->terminal_recorded) {
+            return false;
+        }
+        task->terminal_recorded = true;
+        return true;
+    }
+
+    bool MarkBatchTerminal(BatchID batch_id) {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto it = batches_.find(batch_id);
+        if (it == batches_.end() || it->second.terminal_recorded) {
+            return false;
+        }
+        it->second.terminal_recorded = true;
+        return true;
+    }
+
+   private:
+    static SliceTerminalState MapSliceStatus(Transport::Slice::SliceStatus status) {
+        switch (status) {
+            case Transport::Slice::SUCCESS:
+                return SliceTerminalState::kCompleted;
+            case Transport::Slice::FAILED:
+                return SliceTerminalState::kFailed;
+            case Transport::Slice::TIMEOUT:
+                return SliceTerminalState::kTimedOut;
+            default:
+                return SliceTerminalState::kPending;
+        }
+    }
+
+    TaskState* FindTaskState(BatchID batch_id, size_t task_id) {
+        auto batch_it = batches_.find(batch_id);
+        if (batch_it == batches_.end()) {
+            return nullptr;
+        }
+        auto task_it = batch_it->second.tasks.find(task_id);
+        if (task_it == batch_it->second.tasks.end()) {
+            return nullptr;
+        }
+        return &task_it->second;
+    }
+
+    mutable std::mutex mutex_;
+    std::unordered_map<BatchID, BatchState> batches_;
+};
+
 class MultiTransport {
    public:
     using BatchID = Transport::BatchID;
@@ -50,6 +213,21 @@ class MultiTransport {
 
     Status getBatchTransferStatus(BatchID batch_id, TransferStatus &status);
 
+    void SetBatchTraceContext(BatchID batch_id,
+                              const tracing::TraceContext& context) {
+        trace_registry_.RegisterBatch(batch_id, context);
+    }
+
+    std::optional<tracing::TraceContext> LookupBatchTraceContext(
+        BatchID batch_id) const {
+        return trace_registry_.LookupBatchContext(batch_id);
+    }
+
+    std::optional<MultiTransportTraceRegistry::TaskState> LookupTaskTraceState(
+        BatchID batch_id, size_t task_id) const {
+        return trace_registry_.LookupTask(batch_id, task_id);
+    }
+
     Transport *installTransport(const std::string &proto,
                                 std::shared_ptr<Topology> topo);
 
@@ -74,6 +252,7 @@ class MultiTransport {
     std::map<std::string, std::shared_ptr<Transport>> transport_map_;
     RWSpinlock batch_desc_lock_;
     std::unordered_map<BatchID, std::shared_ptr<BatchDesc>> batch_desc_set_;
+    MultiTransportTraceRegistry trace_registry_;
 };
 }  // namespace mooncake
 

--- a/mooncake-transfer-engine/include/multi_transport.h
+++ b/mooncake-transfer-engine/include/multi_transport.h
@@ -52,9 +52,9 @@ class MultiTransportTraceRegistry {
         std::unordered_map<size_t, TaskState> tasks;
     };
 
-    void RegisterBatch(BatchID batch_id, const tracing::TraceContext& context) {
+    void RegisterBatch(BatchID batch_id, const tracing::TraceContext &context) {
         std::lock_guard<std::mutex> guard(mutex_);
-        auto& batch = batches_[batch_id];
+        auto &batch = batches_[batch_id];
         if (!batch.context.valid()) {
             batch.context = context;
         }
@@ -76,11 +76,11 @@ class MultiTransportTraceRegistry {
     }
 
     void RegisterTask(BatchID batch_id, size_t task_id,
-                      const tracing::TraceContext& context,
-                      const std::string& transport_name, size_t slice_count,
+                      const tracing::TraceContext &context,
+                      const std::string &transport_name, size_t slice_count,
                       size_t total_bytes) {
         std::lock_guard<std::mutex> guard(mutex_);
-        auto& task = batches_[batch_id].tasks[task_id];
+        auto &task = batches_[batch_id].tasks[task_id];
         task.context = context;
         task.transport_name = transport_name;
         task.slice_count = slice_count;
@@ -107,7 +107,7 @@ class MultiTransportTraceRegistry {
 
     bool MarkSliceQueued(BatchID batch_id, size_t task_id, size_t slice_id) {
         std::lock_guard<std::mutex> guard(mutex_);
-        auto* task = FindTaskState(batch_id, task_id);
+        auto *task = FindTaskState(batch_id, task_id);
         if (!task || slice_id >= task->slice_queued.size()) {
             return false;
         }
@@ -121,7 +121,7 @@ class MultiTransportTraceRegistry {
     bool MarkSliceTerminal(BatchID batch_id, size_t task_id, size_t slice_id,
                            Transport::Slice::SliceStatus status) {
         std::lock_guard<std::mutex> guard(mutex_);
-        auto* task = FindTaskState(batch_id, task_id);
+        auto *task = FindTaskState(batch_id, task_id);
         if (!task || slice_id >= task->slice_terminal_states.size()) {
             return false;
         }
@@ -135,7 +135,7 @@ class MultiTransportTraceRegistry {
 
     bool MarkTaskTerminal(BatchID batch_id, size_t task_id) {
         std::lock_guard<std::mutex> guard(mutex_);
-        auto* task = FindTaskState(batch_id, task_id);
+        auto *task = FindTaskState(batch_id, task_id);
         if (!task || task->terminal_recorded) {
             return false;
         }
@@ -154,7 +154,8 @@ class MultiTransportTraceRegistry {
     }
 
    private:
-    static SliceTerminalState MapSliceStatus(Transport::Slice::SliceStatus status) {
+    static SliceTerminalState MapSliceStatus(
+        Transport::Slice::SliceStatus status) {
         switch (status) {
             case Transport::Slice::SUCCESS:
                 return SliceTerminalState::kCompleted;
@@ -167,7 +168,7 @@ class MultiTransportTraceRegistry {
         }
     }
 
-    TaskState* FindTaskState(BatchID batch_id, size_t task_id) {
+    TaskState *FindTaskState(BatchID batch_id, size_t task_id) {
         auto batch_it = batches_.find(batch_id);
         if (batch_it == batches_.end()) {
             return nullptr;
@@ -214,7 +215,7 @@ class MultiTransport {
     Status getBatchTransferStatus(BatchID batch_id, TransferStatus &status);
 
     void SetBatchTraceContext(BatchID batch_id,
-                              const tracing::TraceContext& context) {
+                              const tracing::TraceContext &context) {
         trace_registry_.RegisterBatch(batch_id, context);
     }
 

--- a/mooncake-transfer-engine/include/trace_support.h
+++ b/mooncake-transfer-engine/include/trace_support.h
@@ -5,18 +5,11 @@
 namespace mooncake::tracing {
 
 inline std::string EncodeCarrierString(const TraceCarrier& carrier) {
-    return carrier.trace_id + "|" + carrier.span_id + "|" + carrier.correlation_id;
+    return EncodeTraceCarrier(carrier);
 }
 
 inline TraceCarrier DecodeCarrierString(const std::string& encoded) {
-    TraceCarrier carrier;
-    auto p1 = encoded.find('|');
-    auto p2 = encoded.find('|', p1 == std::string::npos ? p1 : p1 + 1);
-    if (p1 == std::string::npos || p2 == std::string::npos) return carrier;
-    carrier.trace_id = encoded.substr(0, p1);
-    carrier.span_id = encoded.substr(p1 + 1, p2 - p1 - 1);
-    carrier.correlation_id = encoded.substr(p2 + 1);
-    return carrier;
+    return DecodeTraceCarrier(encoded);
 }
 
 }  // namespace mooncake::tracing

--- a/mooncake-transfer-engine/include/trace_support.h
+++ b/mooncake-transfer-engine/include/trace_support.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <string>
+#include "trace_context.h"
+
+namespace mooncake::tracing {
+
+inline std::string EncodeCarrierString(const TraceCarrier& carrier) {
+    return carrier.trace_id + "|" + carrier.span_id + "|" + carrier.correlation_id;
+}
+
+inline TraceCarrier DecodeCarrierString(const std::string& encoded) {
+    TraceCarrier carrier;
+    auto p1 = encoded.find('|');
+    auto p2 = encoded.find('|', p1 == std::string::npos ? p1 : p1 + 1);
+    if (p1 == std::string::npos || p2 == std::string::npos) return carrier;
+    carrier.trace_id = encoded.substr(0, p1);
+    carrier.span_id = encoded.substr(p1 + 1, p2 - p1 - 1);
+    carrier.correlation_id = encoded.substr(p2 + 1);
+    return carrier;
+}
+
+}  // namespace mooncake::tracing

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -17,6 +17,7 @@
 
 #include "memory_location.h"
 #include "multi_transport.h"
+#include "trace_context.h"
 #include "transfer_metadata.h"
 #include "transport/transport.h"
 
@@ -98,11 +99,14 @@ class TransferEngine {
     int unregisterLocalMemory(void* addr, bool update_metadata = true);
 
     Status submitTransfer(BatchID batch_id,
-                          const std::vector<TransferRequest>& entries);
+                          const std::vector<TransferRequest>& entries,
+                          const tracing::TraceContext* trace_context = nullptr);
 
     Status submitTransferWithNotify(BatchID batch_id,
                                     const std::vector<TransferRequest>& entries,
-                                    TransferMetadata::NotifyDesc notify_msg);
+                                    TransferMetadata::NotifyDesc notify_msg,
+                                    const tracing::TraceContext* trace_context =
+                                        nullptr);
 
 #ifdef ENABLE_MULTI_PROTOCOL
     // Multi-protocol API

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -102,11 +102,10 @@ class TransferEngine {
                           const std::vector<TransferRequest>& entries,
                           const tracing::TraceContext* trace_context = nullptr);
 
-    Status submitTransferWithNotify(BatchID batch_id,
-                                    const std::vector<TransferRequest>& entries,
-                                    TransferMetadata::NotifyDesc notify_msg,
-                                    const tracing::TraceContext* trace_context =
-                                        nullptr);
+    Status submitTransferWithNotify(
+        BatchID batch_id, const std::vector<TransferRequest>& entries,
+        TransferMetadata::NotifyDesc notify_msg,
+        const tracing::TraceContext* trace_context = nullptr);
 
 #ifdef ENABLE_MULTI_PROTOCOL
     // Multi-protocol API

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -54,6 +54,100 @@ using BufferEntry = Transport::BufferEntry;
 using RegisteredBuffer = TransferEngine::RegisteredBuffer;
 #endif
 
+inline const char* ToTransferStatusName(TransferStatusEnum status) {
+    switch (status) {
+        case TransferStatusEnum::WAITING:
+            return "WAITING";
+        case TransferStatusEnum::PENDING:
+            return "PENDING";
+        case TransferStatusEnum::INVALID:
+            return "INVALID";
+        case TransferStatusEnum::CANCELED:
+            return "CANCELED";
+        case TransferStatusEnum::COMPLETED:
+            return "COMPLETED";
+        case TransferStatusEnum::TIMEOUT:
+            return "TIMEOUT";
+        case TransferStatusEnum::FAILED:
+            return "FAILED";
+    }
+    return "UNKNOWN";
+}
+
+class ActiveBatchTraceRegistry {
+   public:
+    struct EnsureResult {
+        mooncake::tracing::TraceContext context;
+        bool created{false};
+    };
+
+    EnsureResult EnsureRoot(mooncake::tracing::TracingFacade& tracing,
+                            BatchID batch_id) {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto it = spans_.find(batch_id);
+        if (it != spans_.end()) {
+            return {it->second.context, false};
+        }
+
+        auto root = tracing.StartSpan("te.batch", nullptr,
+                                      {{"te.batch_id",
+                                        std::to_string(batch_id)}});
+        if (!root.valid()) {
+            return {};
+        }
+        root.AddEvent("batch trace root established");
+
+        auto [inserted, ok] = spans_.try_emplace(batch_id);
+        inserted->second.context = root.context();
+        inserted->second.span = std::move(root);
+        return {inserted->second.context, ok};
+    }
+
+    std::optional<mooncake::tracing::TraceContext> LookupContext(
+        BatchID batch_id) const {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto it = spans_.find(batch_id);
+        if (it == spans_.end()) {
+            return std::nullopt;
+        }
+        return it->second.context;
+    }
+
+    bool Finish(BatchID batch_id, const std::string& event_name,
+                const mooncake::tracing::TraceAttrs& attrs = {},
+                bool error = false) {
+        std::optional<ActiveBatchSpan> active;
+        {
+            std::lock_guard<std::mutex> guard(mutex_);
+            auto it = spans_.find(batch_id);
+            if (it == spans_.end()) {
+                return false;
+            }
+            active.emplace(std::move(it->second));
+            spans_.erase(it);
+        }
+
+        for (const auto& attr : attrs) {
+            active->span.SetAttribute(attr.first, attr.second);
+        }
+        active->span.AddEvent(event_name, attrs);
+        if (error) {
+            active->span.SetStatus("ERROR");
+        }
+        active->span.End();
+        return true;
+    }
+
+   private:
+    struct ActiveBatchSpan {
+        mooncake::tracing::Span span;
+        mooncake::tracing::TraceContext context;
+    };
+
+    mutable std::mutex mutex_;
+    std::unordered_map<BatchID, ActiveBatchSpan> spans_;
+};
+
 class TransferEngineImpl {
    public:
     TransferEngineImpl(bool auto_discover = false)
@@ -247,11 +341,31 @@ class TransferEngineImpl {
     }
 
     Status freeBatchID(BatchID batch_id) {
-        {
-            std::lock_guard<std::mutex> guard(span_contexts_lock_);
-            span_contexts_.erase(batch_id);
+        TransferStatus batch_status;
+        const Status status_before_free =
+            multi_transports_->getBatchTransferStatus(batch_id, batch_status);
+        const Status free_status = multi_transports_->freeBatchID(batch_id);
+        if (!free_status.ok()) {
+            return free_status;
         }
-        return multi_transports_->freeBatchID(batch_id);
+        if (status_before_free.ok() &&
+            (batch_status.s == TransferStatusEnum::COMPLETED ||
+             batch_status.s == TransferStatusEnum::FAILED ||
+             batch_status.s == TransferStatusEnum::TIMEOUT ||
+             batch_status.s == TransferStatusEnum::CANCELED)) {
+            const bool error = batch_status.s != TransferStatusEnum::COMPLETED;
+            active_batch_traces_.Finish(
+                batch_id, "batch terminal status",
+                {{"status", ToTransferStatusName(batch_status.s)},
+                 {"transferred.bytes",
+                  std::to_string(batch_status.transferred_bytes)}},
+                error);
+        } else {
+            active_batch_traces_.Finish(
+                batch_id, "batch released before terminal",
+                {{"status", "UNKNOWN"}}, true);
+        }
+        return free_status;
     }
 
     int getNotifies(std::vector<TransferMetadata::NotifyDesc>& notifies);
@@ -339,39 +453,42 @@ class TransferEngineImpl {
             }
         }
 #endif
-        if (result.ok() && status.s == TransferStatusEnum::COMPLETED) {
-            std::optional<mooncake::tracing::TraceContext> batch_context;
-            {
-                std::lock_guard<std::mutex> guard(span_contexts_lock_);
-                auto it_ctx = span_contexts_.find(batch_id);
-                if (it_ctx != span_contexts_.end()) {
-                    batch_context = it_ctx->second;
-                }
-            }
+        if (result.ok() &&
+            (status.s == TransferStatusEnum::COMPLETED ||
+             status.s == TransferStatusEnum::FAILED ||
+             status.s == TransferStatusEnum::TIMEOUT ||
+             status.s == TransferStatusEnum::CANCELED)) {
+            auto batch_context = active_batch_traces_.LookupContext(batch_id);
             auto& tracing = mooncake::tracing::TracingFacade::Instance(
                 "mooncake-transfer-engine", "transfer-engine");
-            auto span = batch_context.has_value()
-                            ? tracing.StartSpan(
-                                  "getBatchTransferStatus",
-                                  &batch_context.value(),
-                                  {{"te.batch_id", std::to_string(batch_id)},
-                                   {"status", "COMPLETED"}})
-                            : tracing.StartSpan(
-                                  "getBatchTransferStatus", nullptr,
-                                  {{"te.batch_id", std::to_string(batch_id)},
-                                   {"status", "COMPLETED"}});
-            span.AddEvent("batch terminal status");
-            // send notify
-            RWSpinlock::WriteGuard guard(send_notifies_lock_);
-            if (!notifies_to_send_.count(batch_id)) return result;
-            auto value = notifies_to_send_[batch_id];
-            auto rc = sendNotifyByID(value.first, value.second);
-            if (rc) {
-                LOG(ERROR) << "Failed to send notify message, error code: "
-                           << rc;
-                span.SetStatus("ERROR");
+            mooncake::tracing::Span span;
+            if (batch_context.has_value()) {
+                span = tracing.StartSpan(
+                    "getBatchTransferStatus", &batch_context.value(),
+                    {{"te.batch_id", std::to_string(batch_id)},
+                     {"status", ToTransferStatusName(status.s)}});
+                span.AddEvent("batch terminal status");
             }
-            notifies_to_send_.erase(batch_id);
+            if (status.s == TransferStatusEnum::COMPLETED) {
+                RWSpinlock::WriteGuard guard(send_notifies_lock_);
+                auto it = notifies_to_send_.find(batch_id);
+                if (it != notifies_to_send_.end()) {
+                    auto rc = sendNotifyByID(it->second.first, it->second.second);
+                    if (rc) {
+                        LOG(ERROR) << "Failed to send notify message, error code: "
+                                   << rc;
+                        span.SetStatus("ERROR");
+                    }
+                    notifies_to_send_.erase(it);
+                }
+            }
+            const bool error = status.s != TransferStatusEnum::COMPLETED;
+            active_batch_traces_.Finish(
+                batch_id, "batch terminal status",
+                {{"status", ToTransferStatusName(status.s)},
+                 {"transferred.bytes",
+                  std::to_string(status.transferred_bytes)}},
+                error);
         }
         return result;
     }
@@ -416,41 +533,16 @@ class TransferEngineImpl {
     }
 
    private:
-    std::optional<mooncake::tracing::TraceContext> LookupBatchTraceContext(
-        BatchID batch_id) const {
-        std::lock_guard<std::mutex> guard(span_contexts_lock_);
-        auto it = span_contexts_.find(batch_id);
-        if (it == span_contexts_.end()) {
-            return std::nullopt;
-        }
-        return it->second;
-    }
-
-    std::optional<mooncake::tracing::TraceContext> RegisterBatchTraceContext(
-        BatchID batch_id, const mooncake::tracing::TraceContext& context) {
-        std::lock_guard<std::mutex> guard(span_contexts_lock_);
-        auto [it, inserted] = span_contexts_.emplace(batch_id, context);
-        if (inserted) {
-            multi_transports_->SetBatchTraceContext(batch_id, context);
-        }
-        return it->second;
-    }
-
     mooncake::tracing::Span StartBatchOperationSpan(
         const std::string& span_name, BatchID batch_id,
         const mooncake::tracing::TraceAttrs& attrs) {
         auto& tracing = mooncake::tracing::TracingFacade::Instance(
             "mooncake-transfer-engine", "transfer-engine");
-        auto batch_context = LookupBatchTraceContext(batch_id);
-        if (!batch_context.has_value()) {
-            auto batch_root = tracing.StartSpan(
-                "te.batch", nullptr,
-                {{"te.batch_id", std::to_string(batch_id)}});
-            batch_root.AddEvent("batch trace root established");
-            batch_context =
-                RegisterBatchTraceContext(batch_id, batch_root.context());
+        auto ensured = active_batch_traces_.EnsureRoot(tracing, batch_id);
+        if (ensured.created) {
+            multi_transports_->SetBatchTraceContext(batch_id, ensured.context);
         }
-        return tracing.StartSpan(span_name, &batch_context.value(), attrs);
+        return tracing.StartSpan(span_name, &ensured.context, attrs);
     }
 
     struct MemoryRegion {
@@ -472,8 +564,7 @@ class TransferEngineImpl {
                        std::pair<SegmentID, TransferMetadata::NotifyDesc>>
         notifies_to_send_;
 
-    mutable std::mutex span_contexts_lock_;
-    std::unordered_map<BatchID, mooncake::tracing::TraceContext> span_contexts_;
+    ActiveBatchTraceRegistry active_batch_traces_;
 
     // Discover topology and install transports automatically when it's true.
     // Set it to false only for testing.

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -81,10 +81,9 @@ class ActiveBatchTraceRegistry {
         bool created{false};
     };
 
-    EnsureResult EnsureRoot(mooncake::tracing::TracingFacade& tracing,
-                            BatchID batch_id,
-                            const mooncake::tracing::TraceContext* parent =
-                                nullptr) {
+    EnsureResult EnsureRoot(
+        mooncake::tracing::TracingFacade& tracing, BatchID batch_id,
+        const mooncake::tracing::TraceContext* parent = nullptr) {
         std::lock_guard<std::mutex> guard(mutex_);
         auto it = spans_.find(batch_id);
         if (it != spans_.end()) {
@@ -93,9 +92,8 @@ class ActiveBatchTraceRegistry {
 
         auto root = tracing.StartSpan(
             "te.batch", parent && parent->valid() ? parent : nullptr,
-                                      {{"te.batch_id",
-                                        std::to_string(batch_id)},
-                                       {"sampling.priority", "structural"}});
+            {{"te.batch_id", std::to_string(batch_id)},
+             {"sampling.priority", "structural"}});
         if (!root.valid()) {
             return {};
         }
@@ -118,10 +116,10 @@ class ActiveBatchTraceRegistry {
             return {it->second.data_plane_context, false};
         }
 
-        auto span = tracing.StartSpan("te.batch.execute", &it->second.context,
-                                      {{"te.batch_id",
-                                        std::to_string(batch_id)},
-                                       {"sampling.priority", "structural"}});
+        auto span =
+            tracing.StartSpan("te.batch.execute", &it->second.context,
+                              {{"te.batch_id", std::to_string(batch_id)},
+                               {"sampling.priority", "structural"}});
         if (!span.valid()) {
             return {};
         }
@@ -163,7 +161,8 @@ class ActiveBatchTraceRegistry {
             for (const auto& attr : attrs) {
                 active->data_plane_span.SetAttribute(attr.first, attr.second);
             }
-            active->data_plane_span.AddEvent("batch data plane finished", attrs);
+            active->data_plane_span.AddEvent("batch data plane finished",
+                                             attrs);
             if (error) {
                 active->data_plane_span.SetStatus("ERROR");
             }
@@ -252,10 +251,9 @@ class TransferEngineImpl {
 
     int unregisterLocalMemory(void* addr, bool update_metadata = true);
 
-    Status submitTransfer(BatchID batch_id,
-                          const std::vector<TransferRequest>& entries,
-                          const mooncake::tracing::TraceContext* trace_context =
-                              nullptr) {
+    Status submitTransfer(
+        BatchID batch_id, const std::vector<TransferRequest>& entries,
+        const mooncake::tracing::TraceContext* trace_context = nullptr) {
         auto span = StartBatchOperationSpan(
             "submitTransfer", batch_id, trace_context,
             {{"te.batch_id", std::to_string(batch_id)},
@@ -276,11 +274,10 @@ class TransferEngineImpl {
         return s;
     }
 
-    Status submitTransferWithNotify(BatchID batch_id,
-                                    const std::vector<TransferRequest>& entries,
-                                    TransferMetadata::NotifyDesc notify_msg,
-                                    const mooncake::tracing::TraceContext* trace_context =
-                                        nullptr) {
+    Status submitTransferWithNotify(
+        BatchID batch_id, const std::vector<TransferRequest>& entries,
+        TransferMetadata::NotifyDesc notify_msg,
+        const mooncake::tracing::TraceContext* trace_context = nullptr) {
         auto span = StartBatchOperationSpan(
             "submitTransferWithNotify", batch_id, trace_context,
             {{"te.batch_id", std::to_string(batch_id)}});
@@ -407,9 +404,9 @@ class TransferEngineImpl {
                   std::to_string(batch_status.transferred_bytes)}},
                 error);
         } else {
-            active_batch_traces_.Finish(
-                batch_id, "batch released before terminal",
-                {{"status", "UNKNOWN"}}, true);
+            active_batch_traces_.Finish(batch_id,
+                                        "batch released before terminal",
+                                        {{"status", "UNKNOWN"}}, true);
         }
         return free_status;
     }
@@ -429,11 +426,10 @@ class TransferEngineImpl {
         Status result =
             multi_transports_->getTransferStatus(batch_id, task_id, status);
         const bool is_terminal =
-            result.ok() &&
-            (status.s == TransferStatusEnum::COMPLETED ||
-             status.s == TransferStatusEnum::FAILED ||
-             status.s == TransferStatusEnum::TIMEOUT ||
-             status.s == TransferStatusEnum::CANCELED);
+            result.ok() && (status.s == TransferStatusEnum::COMPLETED ||
+                            status.s == TransferStatusEnum::FAILED ||
+                            status.s == TransferStatusEnum::TIMEOUT ||
+                            status.s == TransferStatusEnum::CANCELED);
         if (!result.ok() || is_terminal) {
             auto span = StartBatchOperationSpan(
                 "getTransferStatus", batch_id, nullptr,
@@ -443,9 +439,10 @@ class TransferEngineImpl {
                   result.ok() ? ToTransferStatusName(status.s) : "ERROR"}});
             if (!result.ok()) {
                 span.SetStatus("ERROR");
-                span.AddEvent("status query failed",
-                              {{"task.id", std::to_string(task_id)},
-                               {"error.message", std::string(result.message())}});
+                span.AddEvent(
+                    "status query failed",
+                    {{"task.id", std::to_string(task_id)},
+                     {"error.message", std::string(result.message())}});
             } else {
                 span.AddEvent("task terminal status",
                               {{"task.id", std::to_string(task_id)},
@@ -528,11 +525,10 @@ class TransferEngineImpl {
             }
         }
 #endif
-        if (result.ok() &&
-            (status.s == TransferStatusEnum::COMPLETED ||
-             status.s == TransferStatusEnum::FAILED ||
-             status.s == TransferStatusEnum::TIMEOUT ||
-             status.s == TransferStatusEnum::CANCELED)) {
+        if (result.ok() && (status.s == TransferStatusEnum::COMPLETED ||
+                            status.s == TransferStatusEnum::FAILED ||
+                            status.s == TransferStatusEnum::TIMEOUT ||
+                            status.s == TransferStatusEnum::CANCELED)) {
             auto batch_context = active_batch_traces_.LookupContext(batch_id);
             auto& tracing = mooncake::tracing::TracingFacade::Instance(
                 "mooncake-transfer-engine", "transfer-engine");
@@ -548,10 +544,12 @@ class TransferEngineImpl {
                 RWSpinlock::WriteGuard guard(send_notifies_lock_);
                 auto it = notifies_to_send_.find(batch_id);
                 if (it != notifies_to_send_.end()) {
-                    auto rc = sendNotifyByID(it->second.first, it->second.second);
+                    auto rc =
+                        sendNotifyByID(it->second.first, it->second.second);
                     if (rc) {
-                        LOG(ERROR) << "Failed to send notify message, error code: "
-                                   << rc;
+                        LOG(ERROR)
+                            << "Failed to send notify message, error code: "
+                            << rc;
                         span.SetStatus("ERROR");
                     }
                     notifies_to_send_.erase(it);
@@ -618,11 +616,14 @@ class TransferEngineImpl {
             active_batch_traces_.EnsureRoot(tracing, batch_id, trace_context);
         if (span_name == "submitTransfer" ||
             span_name == "submitTransferWithNotify") {
-            auto data_plane = active_batch_traces_.EnsureDataPlane(tracing, batch_id);
-            auto transport_context =
-                data_plane.context.valid() ? data_plane.context : ensured.context;
+            auto data_plane =
+                active_batch_traces_.EnsureDataPlane(tracing, batch_id);
+            auto transport_context = data_plane.context.valid()
+                                         ? data_plane.context
+                                         : ensured.context;
             if (ensured.created && transport_context.valid()) {
-                multi_transports_->SetBatchTraceContext(batch_id, transport_context);
+                multi_transports_->SetBatchTraceContext(batch_id,
+                                                        transport_context);
             }
         } else if (ensured.created && ensured.context.valid()) {
             multi_transports_->SetBatchTraceContext(batch_id, ensured.context);

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -25,6 +25,7 @@
 #include <shared_mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "memory_location.h"
@@ -32,6 +33,8 @@
 #include "transfer_metadata.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
+#include "trace_support.h"
+#include "tracing_facade.h"
 #ifdef WITH_METRICS
 #include "ylt/metric/counter.hpp"
 #include "ylt/metric/histogram.hpp"
@@ -114,7 +117,14 @@ class TransferEngineImpl {
 
     Status submitTransfer(BatchID batch_id,
                           const std::vector<TransferRequest>& entries) {
+        auto& tracing = mooncake::tracing::TracingFacade::Instance(
+            "mooncake-transfer-engine", "transfer-engine");
+        auto span = tracing.StartSpan(
+            "submitTransfer", nullptr,
+            {{"te.batch_id", std::to_string(batch_id)},
+             {"transfer.count", std::to_string(entries.size())}});
         Status s = multi_transports_->submitTransfer(batch_id, entries);
+        if (!s.ok()) span.SetStatus("ERROR");
 #ifdef WITH_METRICS
         if (metrics_enabled_ && s.ok()) {
             auto& batch = Transport::toBatchDesc(batch_id);
@@ -126,14 +136,28 @@ class TransferEngineImpl {
             }
         }
 #endif
+        if (s.ok()) {
+            span_contexts_[batch_id] = span.context();
+        }
         return s;
     }
 
     Status submitTransferWithNotify(BatchID batch_id,
                                     const std::vector<TransferRequest>& entries,
                                     TransferMetadata::NotifyDesc notify_msg) {
+        auto& tracing = mooncake::tracing::TracingFacade::Instance(
+            "mooncake-transfer-engine", "transfer-engine");
+        auto parent = span_contexts_.find(batch_id);
+        mooncake::tracing::Span span = parent != span_contexts_.end()
+            ? tracing.StartSpan("submitTransferWithNotify", &parent->second,
+                                {{"te.batch_id", std::to_string(batch_id)}})
+            : tracing.StartSpan("submitTransferWithNotify", nullptr,
+                                {{"te.batch_id", std::to_string(batch_id)}});
         auto target_id = entries[0].target_id;
+        notify_msg.trace_carrier = mooncake::tracing::EncodeCarrierString(
+            mooncake::tracing::ToCarrier(span.context()));
         Status s = multi_transports_->submitTransfer(batch_id, entries);
+        if (!s.ok()) span.SetStatus("ERROR");
         if (!s.ok()) {
             return s;
         }
@@ -316,6 +340,17 @@ class TransferEngineImpl {
         }
 #endif
         if (result.ok() && status.s == TransferStatusEnum::COMPLETED) {
+            auto it_ctx = span_contexts_.find(batch_id);
+            auto& tracing = mooncake::tracing::TracingFacade::Instance(
+                "mooncake-transfer-engine", "transfer-engine");
+            auto span = it_ctx != span_contexts_.end()
+                ? tracing.StartSpan("getBatchTransferStatus", &it_ctx->second,
+                                    {{"te.batch_id", std::to_string(batch_id)},
+                                     {"status", "COMPLETED"}})
+                : tracing.StartSpan("getBatchTransferStatus", nullptr,
+                                    {{"te.batch_id", std::to_string(batch_id)},
+                                     {"status", "COMPLETED"}});
+            span.AddEvent("batch terminal status");
             // send notify
             RWSpinlock::WriteGuard guard(send_notifies_lock_);
             if (!notifies_to_send_.count(batch_id)) return result;
@@ -388,6 +423,8 @@ class TransferEngineImpl {
     std::unordered_map<BatchID,
                        std::pair<SegmentID, TransferMetadata::NotifyDesc>>
         notifies_to_send_;
+
+    std::unordered_map<BatchID, mooncake::tracing::TraceContext> span_contexts_;
 
     // Discover topology and install transports automatically when it's true.
     // Set it to false only for testing.

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -94,7 +94,8 @@ class ActiveBatchTraceRegistry {
         auto root = tracing.StartSpan(
             "te.batch", parent && parent->valid() ? parent : nullptr,
                                       {{"te.batch_id",
-                                        std::to_string(batch_id)}});
+                                        std::to_string(batch_id)},
+                                       {"sampling.priority", "structural"}});
         if (!root.valid()) {
             return {};
         }
@@ -119,7 +120,8 @@ class ActiveBatchTraceRegistry {
 
         auto span = tracing.StartSpan("te.batch.execute", &it->second.context,
                                       {{"te.batch_id",
-                                        std::to_string(batch_id)}});
+                                        std::to_string(batch_id)},
+                                       {"sampling.priority", "structural"}});
         if (!span.valid()) {
             return {};
         }

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -82,14 +82,17 @@ class ActiveBatchTraceRegistry {
     };
 
     EnsureResult EnsureRoot(mooncake::tracing::TracingFacade& tracing,
-                            BatchID batch_id) {
+                            BatchID batch_id,
+                            const mooncake::tracing::TraceContext* parent =
+                                nullptr) {
         std::lock_guard<std::mutex> guard(mutex_);
         auto it = spans_.find(batch_id);
         if (it != spans_.end()) {
             return {it->second.context, false};
         }
 
-        auto root = tracing.StartSpan("te.batch", nullptr,
+        auto root = tracing.StartSpan(
+            "te.batch", parent && parent->valid() ? parent : nullptr,
                                       {{"te.batch_id",
                                         std::to_string(batch_id)}});
         if (!root.valid()) {
@@ -248,9 +251,11 @@ class TransferEngineImpl {
     int unregisterLocalMemory(void* addr, bool update_metadata = true);
 
     Status submitTransfer(BatchID batch_id,
-                          const std::vector<TransferRequest>& entries) {
+                          const std::vector<TransferRequest>& entries,
+                          const mooncake::tracing::TraceContext* trace_context =
+                              nullptr) {
         auto span = StartBatchOperationSpan(
-            "submitTransfer", batch_id,
+            "submitTransfer", batch_id, trace_context,
             {{"te.batch_id", std::to_string(batch_id)},
              {"transfer.count", std::to_string(entries.size())}});
         Status s = multi_transports_->submitTransfer(batch_id, entries);
@@ -271,9 +276,11 @@ class TransferEngineImpl {
 
     Status submitTransferWithNotify(BatchID batch_id,
                                     const std::vector<TransferRequest>& entries,
-                                    TransferMetadata::NotifyDesc notify_msg) {
+                                    TransferMetadata::NotifyDesc notify_msg,
+                                    const mooncake::tracing::TraceContext* trace_context =
+                                        nullptr) {
         auto span = StartBatchOperationSpan(
-            "submitTransferWithNotify", batch_id,
+            "submitTransferWithNotify", batch_id, trace_context,
             {{"te.batch_id", std::to_string(batch_id)}});
         auto target_id = entries[0].target_id;
         notify_msg.trace_carrier = mooncake::tracing::EncodeCarrierString(
@@ -572,10 +579,12 @@ class TransferEngineImpl {
    private:
     mooncake::tracing::Span StartBatchOperationSpan(
         const std::string& span_name, BatchID batch_id,
+        const mooncake::tracing::TraceContext* trace_context,
         const mooncake::tracing::TraceAttrs& attrs) {
         auto& tracing = mooncake::tracing::TracingFacade::Instance(
             "mooncake-transfer-engine", "transfer-engine");
-        auto ensured = active_batch_traces_.EnsureRoot(tracing, batch_id);
+        auto ensured =
+            active_batch_traces_.EnsureRoot(tracing, batch_id, trace_context);
         if (span_name == "submitTransfer" ||
             span_name == "submitTransferWithNotify") {
             auto data_plane = active_batch_traces_.EnsureDataPlane(tracing, batch_id);

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -103,6 +103,30 @@ class ActiveBatchTraceRegistry {
         return {inserted->second.context, ok};
     }
 
+    EnsureResult EnsureDataPlane(mooncake::tracing::TracingFacade& tracing,
+                                 BatchID batch_id) {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto it = spans_.find(batch_id);
+        if (it == spans_.end()) {
+            return {};
+        }
+        if (it->second.data_plane_started) {
+            return {it->second.data_plane_context, false};
+        }
+
+        auto span = tracing.StartSpan("te.batch.execute", &it->second.context,
+                                      {{"te.batch_id",
+                                        std::to_string(batch_id)}});
+        if (!span.valid()) {
+            return {};
+        }
+
+        it->second.data_plane_context = span.context();
+        it->second.data_plane_span = std::move(span);
+        it->second.data_plane_started = true;
+        return {it->second.data_plane_context, true};
+    }
+
     std::optional<mooncake::tracing::TraceContext> LookupContext(
         BatchID batch_id) const {
         std::lock_guard<std::mutex> guard(mutex_);
@@ -130,6 +154,16 @@ class ActiveBatchTraceRegistry {
         for (const auto& attr : attrs) {
             active->span.SetAttribute(attr.first, attr.second);
         }
+        if (active->data_plane_started) {
+            for (const auto& attr : attrs) {
+                active->data_plane_span.SetAttribute(attr.first, attr.second);
+            }
+            active->data_plane_span.AddEvent("batch data plane finished", attrs);
+            if (error) {
+                active->data_plane_span.SetStatus("ERROR");
+            }
+            active->data_plane_span.End();
+        }
         active->span.AddEvent(event_name, attrs);
         if (error) {
             active->span.SetStatus("ERROR");
@@ -142,6 +176,9 @@ class ActiveBatchTraceRegistry {
     struct ActiveBatchSpan {
         mooncake::tracing::Span span;
         mooncake::tracing::TraceContext context;
+        mooncake::tracing::Span data_plane_span;
+        mooncake::tracing::TraceContext data_plane_context;
+        bool data_plane_started{false};
     };
 
     mutable std::mutex mutex_;
@@ -539,7 +576,15 @@ class TransferEngineImpl {
         auto& tracing = mooncake::tracing::TracingFacade::Instance(
             "mooncake-transfer-engine", "transfer-engine");
         auto ensured = active_batch_traces_.EnsureRoot(tracing, batch_id);
-        if (ensured.created) {
+        if (span_name == "submitTransfer" ||
+            span_name == "submitTransferWithNotify") {
+            auto data_plane = active_batch_traces_.EnsureDataPlane(tracing, batch_id);
+            auto transport_context =
+                data_plane.context.valid() ? data_plane.context : ensured.context;
+            if (ensured.created && transport_context.valid()) {
+                multi_transports_->SetBatchTraceContext(batch_id, transport_context);
+            }
+        } else if (ensured.created && ensured.context.valid()) {
             multi_transports_->SetBatchTraceContext(batch_id, ensured.context);
         }
         return tracing.StartSpan(span_name, &ensured.context, attrs);

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <thread>
@@ -117,10 +118,8 @@ class TransferEngineImpl {
 
     Status submitTransfer(BatchID batch_id,
                           const std::vector<TransferRequest>& entries) {
-        auto& tracing = mooncake::tracing::TracingFacade::Instance(
-            "mooncake-transfer-engine", "transfer-engine");
-        auto span = tracing.StartSpan(
-            "submitTransfer", nullptr,
+        auto span = StartBatchOperationSpan(
+            "submitTransfer", batch_id,
             {{"te.batch_id", std::to_string(batch_id)},
              {"transfer.count", std::to_string(entries.size())}});
         Status s = multi_transports_->submitTransfer(batch_id, entries);
@@ -136,26 +135,21 @@ class TransferEngineImpl {
             }
         }
 #endif
-        if (s.ok()) {
-            span_contexts_[batch_id] = span.context();
-        }
         return s;
     }
 
     Status submitTransferWithNotify(BatchID batch_id,
                                     const std::vector<TransferRequest>& entries,
                                     TransferMetadata::NotifyDesc notify_msg) {
-        auto& tracing = mooncake::tracing::TracingFacade::Instance(
-            "mooncake-transfer-engine", "transfer-engine");
-        auto parent = span_contexts_.find(batch_id);
-        mooncake::tracing::Span span = parent != span_contexts_.end()
-            ? tracing.StartSpan("submitTransferWithNotify", &parent->second,
-                                {{"te.batch_id", std::to_string(batch_id)}})
-            : tracing.StartSpan("submitTransferWithNotify", nullptr,
-                                {{"te.batch_id", std::to_string(batch_id)}});
+        auto span = StartBatchOperationSpan(
+            "submitTransferWithNotify", batch_id,
+            {{"te.batch_id", std::to_string(batch_id)}});
         auto target_id = entries[0].target_id;
         notify_msg.trace_carrier = mooncake::tracing::EncodeCarrierString(
             mooncake::tracing::ToCarrier(span.context()));
+        span.AddEvent("carrier encode",
+                      {{"trace_carrier.present",
+                        notify_msg.trace_carrier.empty() ? "false" : "true"}});
         Status s = multi_transports_->submitTransfer(batch_id, entries);
         if (!s.ok()) span.SetStatus("ERROR");
         if (!s.ok()) {
@@ -177,6 +171,8 @@ class TransferEngineImpl {
         // store notify
         RWSpinlock::WriteGuard guard(send_notifies_lock_);
         notifies_to_send_[batch_id] = std::make_pair(target_id, notify_msg);
+        span.AddEvent("notify queued",
+                      {{"target.id", std::to_string(target_id)}});
 
         return s;
     }
@@ -251,6 +247,10 @@ class TransferEngineImpl {
     }
 
     Status freeBatchID(BatchID batch_id) {
+        {
+            std::lock_guard<std::mutex> guard(span_contexts_lock_);
+            span_contexts_.erase(batch_id);
+        }
         return multi_transports_->freeBatchID(batch_id);
     }
 
@@ -340,16 +340,26 @@ class TransferEngineImpl {
         }
 #endif
         if (result.ok() && status.s == TransferStatusEnum::COMPLETED) {
-            auto it_ctx = span_contexts_.find(batch_id);
+            std::optional<mooncake::tracing::TraceContext> batch_context;
+            {
+                std::lock_guard<std::mutex> guard(span_contexts_lock_);
+                auto it_ctx = span_contexts_.find(batch_id);
+                if (it_ctx != span_contexts_.end()) {
+                    batch_context = it_ctx->second;
+                }
+            }
             auto& tracing = mooncake::tracing::TracingFacade::Instance(
                 "mooncake-transfer-engine", "transfer-engine");
-            auto span = it_ctx != span_contexts_.end()
-                ? tracing.StartSpan("getBatchTransferStatus", &it_ctx->second,
-                                    {{"te.batch_id", std::to_string(batch_id)},
-                                     {"status", "COMPLETED"}})
-                : tracing.StartSpan("getBatchTransferStatus", nullptr,
-                                    {{"te.batch_id", std::to_string(batch_id)},
-                                     {"status", "COMPLETED"}});
+            auto span = batch_context.has_value()
+                            ? tracing.StartSpan(
+                                  "getBatchTransferStatus",
+                                  &batch_context.value(),
+                                  {{"te.batch_id", std::to_string(batch_id)},
+                                   {"status", "COMPLETED"}})
+                            : tracing.StartSpan(
+                                  "getBatchTransferStatus", nullptr,
+                                  {{"te.batch_id", std::to_string(batch_id)},
+                                   {"status", "COMPLETED"}});
             span.AddEvent("batch terminal status");
             // send notify
             RWSpinlock::WriteGuard guard(send_notifies_lock_);
@@ -359,6 +369,7 @@ class TransferEngineImpl {
             if (rc) {
                 LOG(ERROR) << "Failed to send notify message, error code: "
                            << rc;
+                span.SetStatus("ERROR");
             }
             notifies_to_send_.erase(batch_id);
         }
@@ -405,6 +416,43 @@ class TransferEngineImpl {
     }
 
    private:
+    std::optional<mooncake::tracing::TraceContext> LookupBatchTraceContext(
+        BatchID batch_id) const {
+        std::lock_guard<std::mutex> guard(span_contexts_lock_);
+        auto it = span_contexts_.find(batch_id);
+        if (it == span_contexts_.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
+    std::optional<mooncake::tracing::TraceContext> RegisterBatchTraceContext(
+        BatchID batch_id, const mooncake::tracing::TraceContext& context) {
+        std::lock_guard<std::mutex> guard(span_contexts_lock_);
+        auto [it, inserted] = span_contexts_.emplace(batch_id, context);
+        if (inserted) {
+            multi_transports_->SetBatchTraceContext(batch_id, context);
+        }
+        return it->second;
+    }
+
+    mooncake::tracing::Span StartBatchOperationSpan(
+        const std::string& span_name, BatchID batch_id,
+        const mooncake::tracing::TraceAttrs& attrs) {
+        auto& tracing = mooncake::tracing::TracingFacade::Instance(
+            "mooncake-transfer-engine", "transfer-engine");
+        auto batch_context = LookupBatchTraceContext(batch_id);
+        if (!batch_context.has_value()) {
+            auto batch_root = tracing.StartSpan(
+                "te.batch", nullptr,
+                {{"te.batch_id", std::to_string(batch_id)}});
+            batch_root.AddEvent("batch trace root established");
+            batch_context =
+                RegisterBatchTraceContext(batch_id, batch_root.context());
+        }
+        return tracing.StartSpan(span_name, &batch_context.value(), attrs);
+    }
+
     struct MemoryRegion {
         void* addr;
         uint64_t length;
@@ -424,6 +472,7 @@ class TransferEngineImpl {
                        std::pair<SegmentID, TransferMetadata::NotifyDesc>>
         notifies_to_send_;
 
+    mutable std::mutex span_contexts_lock_;
     std::unordered_map<BatchID, mooncake::tracing::TraceContext> span_contexts_;
 
     // Discover topology and install transports automatically when it's true.

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -426,6 +426,35 @@ class TransferEngineImpl {
                              TransferStatus& status) {
         Status result =
             multi_transports_->getTransferStatus(batch_id, task_id, status);
+        const bool is_terminal =
+            result.ok() &&
+            (status.s == TransferStatusEnum::COMPLETED ||
+             status.s == TransferStatusEnum::FAILED ||
+             status.s == TransferStatusEnum::TIMEOUT ||
+             status.s == TransferStatusEnum::CANCELED);
+        if (!result.ok() || is_terminal) {
+            auto span = StartBatchOperationSpan(
+                "getTransferStatus", batch_id, nullptr,
+                {{"te.batch_id", std::to_string(batch_id)},
+                 {"task.id", std::to_string(task_id)},
+                 {"status",
+                  result.ok() ? ToTransferStatusName(status.s) : "ERROR"}});
+            if (!result.ok()) {
+                span.SetStatus("ERROR");
+                span.AddEvent("status query failed",
+                              {{"task.id", std::to_string(task_id)},
+                               {"error.message", std::string(result.message())}});
+            } else {
+                span.AddEvent("task terminal status",
+                              {{"task.id", std::to_string(task_id)},
+                               {"status", ToTransferStatusName(status.s)},
+                               {"transferred.bytes",
+                                std::to_string(status.transferred_bytes)}});
+                if (status.s != TransferStatusEnum::COMPLETED) {
+                    span.SetStatus("ERROR");
+                }
+            }
+        }
 #ifdef WITH_METRICS
         if (!metrics_enabled_ || !result.ok()) {
             goto metrics_done;

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -135,6 +135,7 @@ class TransferMetadata {
     struct NotifyDesc {
         std::string name;
         std::string notify_msg;
+        std::string trace_carrier;
     };
 
    public:

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -166,9 +166,9 @@ class Transport {
        public:
         void ResetTraceState();
 
-        void StartTrace(const tracing::TraceContext& parent_context,
+        void StartTrace(const tracing::TraceContext &parent_context,
                         BatchID batch_id, size_t task_id, size_t slice_id,
-                        const std::string& transport_name);
+                        const std::string &transport_name);
 
         void markSuccess();
 
@@ -184,7 +184,7 @@ class Transport {
         volatile int64_t ts;
 
        private:
-        void FinishTrace(const char* status_name, bool error);
+        void FinishTrace(const char *status_name, bool error);
 
         inline void check_batch_completion(bool is_failed) {
 #ifdef USE_EVENT_DRIVEN_COMPLETION

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -32,6 +32,7 @@
 #include <condition_variable>
 
 #include "common/base/status.h"
+#include "tracing_facade.h"
 #include "transfer_metadata.h"
 
 namespace mooncake {
@@ -163,25 +164,28 @@ class Transport {
         };
 
        public:
-        void markSuccess() {
-            status = Slice::SUCCESS;
-            __atomic_fetch_add(&task->transferred_bytes, length,
-                               __ATOMIC_RELAXED);
-            __atomic_fetch_add(&task->success_slice_count, 1, __ATOMIC_RELAXED);
+        void ResetTraceState();
 
-            check_batch_completion(false);
-        }
+        void StartTrace(const tracing::TraceContext& parent_context,
+                        BatchID batch_id, size_t task_id, size_t slice_id,
+                        const std::string& transport_name);
 
-        void markFailed() {
-            status = Slice::FAILED;
-            __atomic_fetch_add(&task->failed_slice_count, 1, __ATOMIC_RELAXED);
+        void markSuccess();
 
-            check_batch_completion(true);
+        void markFailed();
+
+        void markTimeoutForTrace();
+
+        bool has_active_trace_for_test() const { return trace_started_; }
+        bool trace_terminal_recorded_for_test() const {
+            return trace_terminal_recorded_;
         }
 
         volatile int64_t ts;
 
        private:
+        void FinishTrace(const char* status_name, bool error);
+
         inline void check_batch_completion(bool is_failed) {
 #ifdef USE_EVENT_DRIVEN_COMPLETION
             auto &batch_desc = toBatchDesc(task->batch_id);
@@ -235,6 +239,14 @@ class Transport {
             }
 #endif
         }
+
+        BatchID trace_batch_id_{0};
+        size_t trace_task_id_{0};
+        size_t trace_slice_id_{0};
+        std::string trace_transport_name_;
+        tracing::Span trace_span_;
+        bool trace_started_{false};
+        bool trace_terminal_recorded_{false};
     };
 
     struct ThreadLocalSliceCache {
@@ -260,6 +272,8 @@ class Transport {
                 tail_++;
                 slice->from_cache = true;
             }
+
+            slice->ResetTraceState();
 
             return slice;
         }

--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -55,7 +55,8 @@ target_link_libraries(
          JsonCpp::JsonCpp
          numa
          asio_shared
-         yalantinglibs::yalantinglibs)
+         yalantinglibs::yalantinglibs
+         mooncake-tracing)
 
 if(USE_BAREX)
   target_link_libraries(transfer_engine PUBLIC barex_transport)

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -223,6 +223,8 @@ Status MultiTransport::submitTransfer(
         for (size_t slice_idx = 0; slice_idx < task.slice_list.size();
              ++slice_idx) {
             auto* slice = task.slice_list[slice_idx];
+            slice->StartTrace(task_context, batch_id, idx, slice_idx,
+                              task_transport_names[idx]);
             if (!trace_registry_.MarkSliceQueued(batch_id, idx, slice_idx)) {
                 continue;
             }
@@ -343,6 +345,9 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             if (!trace_registry_.MarkSliceTerminal(batch_id, task_id, slice_idx,
                                                    slice->status)) {
                 continue;
+            }
+            if (slice->status == Transport::Slice::TIMEOUT) {
+                slice->markTimeoutForTrace();
             }
             pending_events.emplace_back(
                 slice->status == Transport::Slice::SUCCESS

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "multi_transport.h"
+
 #include <algorithm>
 #include <sstream>
 #include <string>
@@ -105,6 +106,36 @@ const char* ToSliceStatusName(Transport::Slice::SliceStatus status) {
 const char* ToOpcodeName(Transport::TransferRequest::OpCode opcode) {
     return opcode == Transport::TransferRequest::READ ? "READ" : "WRITE";
 }
+
+struct ObservedTaskState {
+    uint64_t success_slice_count{0};
+    uint64_t failed_slice_count{0};
+    uint64_t successful_bytes{0};
+    bool timed_out{false};
+};
+
+ObservedTaskState ObserveTaskState(
+    const std::vector<Transport::Slice*>& slice_list) {
+    ObservedTaskState observed;
+    for (const auto* slice : slice_list) {
+        switch (slice->status) {
+            case Transport::Slice::SUCCESS:
+                ++observed.success_slice_count;
+                observed.successful_bytes += slice->length;
+                break;
+            case Transport::Slice::FAILED:
+                ++observed.failed_slice_count;
+                break;
+            case Transport::Slice::TIMEOUT:
+                observed.timed_out = true;
+                break;
+            case Transport::Slice::PENDING:
+            case Transport::Slice::POSTED:
+                break;
+        }
+    }
+    return observed;
+}
 }  // namespace
 
 MultiTransport::MultiTransport(std::shared_ptr<TransferMetadata> metadata,
@@ -186,11 +217,13 @@ Status MultiTransport::submitTransfer(
                                  ? tracing.StartSpan(
                                        "te.batch.submit", &batch_context.value(),
                                        {{"te.batch_id", std::to_string(batch_id)},
+                                        {"sampling.priority", "structural"},
                                         {"task.count",
                                          std::to_string(entries.size())}})
                                  : tracing.StartSpan(
                                        "te.batch.submit", nullptr,
                                        {{"te.batch_id", std::to_string(batch_id)},
+                                        {"sampling.priority", "structural"},
                                         {"task.count",
                                          std::to_string(entries.size())}});
     auto batch_submit_context = batch_submit_span.context();
@@ -210,6 +243,7 @@ Status MultiTransport::submitTransfer(
         auto task_span = tracing.StartSpan(
             "te.task.submit", &batch_submit_context,
             {{"te.batch_id", std::to_string(batch_id)},
+             {"sampling.priority", "structural"},
              {"task.id", std::to_string(idx)},
              {"transport.name", task_transport_names[idx]},
              {"transfer.op", ToOpcodeName(task.request->opcode)},
@@ -298,12 +332,20 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
     assert(task.slice_count);
-    if (success_slice_count + failed_slice_count == task.slice_count) {
-        if (failed_slice_count) {
-            status.s = Transport::TransferStatusEnum::FAILED;
-        } else {
-            status.s = Transport::TransferStatusEnum::COMPLETED;
-        }
+    const auto observed = ObserveTaskState(task.slice_list);
+    success_slice_count =
+        std::max<uint64_t>(success_slice_count, observed.success_slice_count);
+    failed_slice_count =
+        std::max<uint64_t>(failed_slice_count, observed.failed_slice_count);
+    status.transferred_bytes =
+        std::max<uint64_t>(status.transferred_bytes, observed.successful_bytes);
+
+    if (observed.timed_out) {
+        status.s = Transport::TransferStatusEnum::TIMEOUT;
+        task.is_finished = true;
+    } else if (success_slice_count + failed_slice_count == task.slice_count) {
+        status.s = failed_slice_count ? Transport::TransferStatusEnum::FAILED
+                                      : Transport::TransferStatusEnum::COMPLETED;
         task.is_finished = true;
     } else {
         if (globalConfig().slice_timeout > 0) {
@@ -383,7 +425,9 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             for (const auto& event : pending_events) {
                 span.AddEvent(event.first, event.second);
             }
-            if (status.s != Transport::TransferStatusEnum::COMPLETED) {
+            if (status.s == Transport::TransferStatusEnum::FAILED ||
+                status.s == Transport::TransferStatusEnum::TIMEOUT ||
+                status.s == Transport::TransferStatusEnum::CANCELED) {
                 span.SetStatus("ERROR");
             }
         }

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "config.h"
+#include "tracing_facade.h"
 #include "transport/rdma_transport/rdma_transport.h"
 #ifdef USE_BAREX
 #include "transport/barex_transport/barex_transport.h"
@@ -64,6 +65,48 @@
 #include <cassert>
 
 namespace mooncake {
+namespace {
+const char* ToTransferStatusName(Transport::TransferStatusEnum status) {
+    switch (status) {
+        case Transport::TransferStatusEnum::WAITING:
+            return "WAITING";
+        case Transport::TransferStatusEnum::PENDING:
+            return "PENDING";
+        case Transport::TransferStatusEnum::INVALID:
+            return "INVALID";
+        case Transport::TransferStatusEnum::CANCELED:
+            return "CANCELED";
+        case Transport::TransferStatusEnum::COMPLETED:
+            return "COMPLETED";
+        case Transport::TransferStatusEnum::TIMEOUT:
+            return "TIMEOUT";
+        case Transport::TransferStatusEnum::FAILED:
+            return "FAILED";
+    }
+    return "UNKNOWN";
+}
+
+const char* ToSliceStatusName(Transport::Slice::SliceStatus status) {
+    switch (status) {
+        case Transport::Slice::PENDING:
+            return "PENDING";
+        case Transport::Slice::POSTED:
+            return "POSTED";
+        case Transport::Slice::SUCCESS:
+            return "SUCCESS";
+        case Transport::Slice::TIMEOUT:
+            return "TIMEOUT";
+        case Transport::Slice::FAILED:
+            return "FAILED";
+    }
+    return "UNKNOWN";
+}
+
+const char* ToOpcodeName(Transport::TransferRequest::OpCode opcode) {
+    return opcode == Transport::TransferRequest::READ ? "READ" : "WRITE";
+}
+}  // namespace
+
 MultiTransport::MultiTransport(std::shared_ptr<TransferMetadata> metadata,
                                std::string &local_server_name)
     : metadata_(metadata), local_server_name_(local_server_name) {}
@@ -99,22 +142,25 @@ Status MultiTransport::freeBatchID(BatchID batch_id) {
     RWSpinlock::WriteGuard guard(batch_desc_lock_);
     batch_desc_set_.erase(batch_id);
 #endif
+    trace_registry_.ClearBatch(batch_id);
     return Status::OK();
 }
 
 Status MultiTransport::submitTransfer(
     BatchID batch_id, const std::vector<TransferRequest> &entries) {
     auto &batch_desc = *((BatchDesc *)(batch_id));
-    if (batch_desc.task_list.size() + entries.size() > batch_desc.batch_size) {
+    const size_t task_begin = batch_desc.task_list.size();
+    if (task_begin + entries.size() > batch_desc.batch_size) {
         return Status::TooManyRequests(
             "Exceed the limitation of batch capacity");
     }
 
-    size_t task_id = batch_desc.task_list.size();
+    size_t task_id = task_begin;
     batch_desc.task_list.resize(task_id + entries.size());
 
     std::unordered_map<Transport *, std::vector<Transport::TransferTask *> >
         submit_tasks;
+    std::vector<std::string> task_transport_names(batch_desc.task_list.size());
     for (auto &request : entries) {
         Transport *transport = nullptr;
         auto status = selectTransport(request, transport);
@@ -122,14 +168,32 @@ Status MultiTransport::submitTransfer(
         assert(transport);
         auto &task = batch_desc.task_list[task_id];
         task.batch_id = batch_id;
+        task.total_bytes = request.length;
 #ifdef USE_ASCEND_HETEROGENEOUS
         task.request = const_cast<Transport::TransferRequest *>(&request);
 #else
         task.request = &request;
 #endif
+        task_transport_names[task_id] = transport->getName();
         ++task_id;
         submit_tasks[transport].push_back(&task);
     }
+
+    auto batch_context = trace_registry_.LookupBatchContext(batch_id);
+    auto& tracing = tracing::TracingFacade::Instance("mooncake-transfer-engine",
+                                                     "multi-transport");
+    auto batch_submit_span = batch_context.has_value()
+                                 ? tracing.StartSpan(
+                                       "te.batch.submit", &batch_context.value(),
+                                       {{"te.batch_id", std::to_string(batch_id)},
+                                        {"task.count",
+                                         std::to_string(entries.size())}})
+                                 : tracing.StartSpan(
+                                       "te.batch.submit", nullptr,
+                                       {{"te.batch_id", std::to_string(batch_id)},
+                                        {"task.count",
+                                         std::to_string(entries.size())}});
+    auto batch_submit_context = batch_submit_span.context();
     Status overall_status = Status::OK();
     for (auto &entry : submit_tasks) {
         auto status = entry.first->submitTransferTask(entry.second);
@@ -138,6 +202,40 @@ Status MultiTransport::submitTransfer(
             //            << entry.first->getName();
             overall_status = status;
         }
+    }
+
+    for (size_t idx = task_begin; idx < batch_desc.task_list.size(); ++idx) {
+        auto& task = batch_desc.task_list[idx];
+        mooncake::tracing::TraceContext task_context;
+        auto task_span = tracing.StartSpan(
+            "te.task.submit", &batch_submit_context,
+            {{"te.batch_id", std::to_string(batch_id)},
+             {"task.id", std::to_string(idx)},
+             {"transport.name", task_transport_names[idx]},
+             {"transfer.op", ToOpcodeName(task.request->opcode)},
+             {"bytes.total", std::to_string(task.total_bytes)}});
+        task_context = task_span.context();
+        trace_registry_.RegisterTask(batch_id, idx, task_context,
+                                     task_transport_names[idx],
+                                     task.slice_list.size(), task.total_bytes);
+        task_span.AddEvent("transport selected",
+                           {{"transport.name", task_transport_names[idx]}});
+        for (size_t slice_idx = 0; slice_idx < task.slice_list.size();
+             ++slice_idx) {
+            auto* slice = task.slice_list[slice_idx];
+            if (!trace_registry_.MarkSliceQueued(batch_id, idx, slice_idx)) {
+                continue;
+            }
+            task_span.AddEvent(
+                "slice queued",
+                {{"slice.id", std::to_string(slice_idx)},
+                 {"slice.length", std::to_string(slice->length)},
+                 {"slice.status", ToSliceStatusName(slice->status)}});
+        }
+    }
+
+    if (!overall_status.ok()) {
+        batch_submit_span.SetStatus("ERROR");
     }
     return overall_status;
 }
@@ -193,6 +291,7 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
         return Status::InvalidArgument("Task ID out of range");
     }
     auto &task = batch_desc.task_list[task_id];
+    status.s = Transport::TransferStatusEnum::WAITING;
     status.transferred_bytes = task.transferred_bytes;
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
@@ -214,12 +313,75 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
                 if (ts > 0 && current_ts > ts &&
                     current_ts - ts > kPacketDeliveryTimeout) {
                     LOG(INFO) << "Slice timeout detected";
+                    slice->status = Transport::Slice::TIMEOUT;
                     status.s = Transport::TransferStatusEnum::TIMEOUT;
-                    return Status::OK();
+                    task.is_finished = true;
+                    break;
                 }
             }
         }
-        status.s = Transport::TransferStatusEnum::WAITING;
+        if (status.s != Transport::TransferStatusEnum::TIMEOUT) {
+            status.s = Transport::TransferStatusEnum::WAITING;
+        }
+    }
+
+    auto task_trace = trace_registry_.LookupTask(batch_id, task_id);
+    if (task_trace.has_value()) {
+        auto& tracing_facade = tracing::TracingFacade::Instance(
+            "mooncake-transfer-engine", "multi-transport");
+        std::vector<std::pair<std::string, tracing::TraceAttrs>> pending_events;
+        pending_events.reserve(task.slice_list.size() + 1);
+
+        for (size_t slice_idx = 0; slice_idx < task.slice_list.size();
+             ++slice_idx) {
+            auto* slice = task.slice_list[slice_idx];
+            if (slice->status != Transport::Slice::SUCCESS &&
+                slice->status != Transport::Slice::FAILED &&
+                slice->status != Transport::Slice::TIMEOUT) {
+                continue;
+            }
+            if (!trace_registry_.MarkSliceTerminal(batch_id, task_id, slice_idx,
+                                                   slice->status)) {
+                continue;
+            }
+            pending_events.emplace_back(
+                slice->status == Transport::Slice::SUCCESS
+                    ? "slice completed"
+                    : (slice->status == Transport::Slice::FAILED
+                           ? "slice failed"
+                           : "slice timeout detected"),
+                tracing::TraceAttrs{{"slice.id", std::to_string(slice_idx)},
+                                    {"slice.length", std::to_string(slice->length)},
+                                    {"slice.status",
+                                     ToSliceStatusName(slice->status)}});
+        }
+
+        if ((status.s == Transport::TransferStatusEnum::COMPLETED ||
+             status.s == Transport::TransferStatusEnum::FAILED ||
+             status.s == Transport::TransferStatusEnum::TIMEOUT) &&
+            trace_registry_.MarkTaskTerminal(batch_id, task_id)) {
+            pending_events.emplace_back(
+                "task terminal status",
+                tracing::TraceAttrs{{"task.id", std::to_string(task_id)},
+                                    {"status", ToTransferStatusName(status.s)},
+                                    {"transferred.bytes",
+                                     std::to_string(status.transferred_bytes)}});
+        }
+
+        if (!pending_events.empty()) {
+            auto span = tracing_facade.StartSpan(
+                "te.task.status", &task_trace->context,
+                {{"te.batch_id", std::to_string(batch_id)},
+                 {"task.id", std::to_string(task_id)},
+                 {"transport.name", task_trace->transport_name},
+                 {"status", ToTransferStatusName(status.s)}});
+            for (const auto& event : pending_events) {
+                span.AddEvent(event.first, event.second);
+            }
+            if (status.s != Transport::TransferStatusEnum::COMPLETED) {
+                span.SetStatus("ERROR");
+            }
+        }
     }
     return Status::OK();
 }
@@ -251,6 +413,9 @@ Status MultiTransport::getBatchTransferStatus(BatchID batch_id,
         if (task_status.s == Transport::TransferStatusEnum::COMPLETED) {
             status.transferred_bytes += task_status.transferred_bytes;
             success_count++;
+        } else if (task_status.s == Transport::TransferStatusEnum::TIMEOUT) {
+            status.s = Transport::TransferStatusEnum::TIMEOUT;
+            return Status::OK();
         } else if (task_status.s == Transport::TransferStatusEnum::FAILED) {
             status.s = Transport::TransferStatusEnum::FAILED;
             return Status::OK();
@@ -266,6 +431,33 @@ Status MultiTransport::getBatchTransferStatus(BatchID batch_id,
                                                  std::memory_order_release);
     } else if (status.s == Transport::TransferStatusEnum::FAILED) {
         batch_desc.has_failure.store(true, std::memory_order_release);
+    }
+
+    if ((status.s == Transport::TransferStatusEnum::COMPLETED ||
+         status.s == Transport::TransferStatusEnum::FAILED ||
+         status.s == Transport::TransferStatusEnum::TIMEOUT) &&
+        trace_registry_.MarkBatchTerminal(batch_id)) {
+        auto batch_context = trace_registry_.LookupBatchContext(batch_id);
+        auto& tracing = tracing::TracingFacade::Instance(
+            "mooncake-transfer-engine", "multi-transport");
+        auto span = batch_context.has_value()
+                        ? tracing.StartSpan(
+                              "te.batch.status", &batch_context.value(),
+                              {{"te.batch_id", std::to_string(batch_id)},
+                               {"status", ToTransferStatusName(status.s)},
+                               {"transferred.bytes",
+                                std::to_string(status.transferred_bytes)}})
+                        : tracing.StartSpan(
+                              "te.batch.status", nullptr,
+                              {{"te.batch_id", std::to_string(batch_id)},
+                               {"status", ToTransferStatusName(status.s)},
+                               {"transferred.bytes",
+                                std::to_string(status.transferred_bytes)}});
+        span.AddEvent("batch terminal status",
+                      {{"status", ToTransferStatusName(status.s)}});
+        if (status.s != Transport::TransferStatusEnum::COMPLETED) {
+            span.SetStatus("ERROR");
+        }
     }
     return Status::OK();
 }

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -67,7 +67,7 @@
 
 namespace mooncake {
 namespace {
-const char* ToTransferStatusName(Transport::TransferStatusEnum status) {
+const char *ToTransferStatusName(Transport::TransferStatusEnum status) {
     switch (status) {
         case Transport::TransferStatusEnum::WAITING:
             return "WAITING";
@@ -87,7 +87,7 @@ const char* ToTransferStatusName(Transport::TransferStatusEnum status) {
     return "UNKNOWN";
 }
 
-const char* ToSliceStatusName(Transport::Slice::SliceStatus status) {
+const char *ToSliceStatusName(Transport::Slice::SliceStatus status) {
     switch (status) {
         case Transport::Slice::PENDING:
             return "PENDING";
@@ -103,7 +103,7 @@ const char* ToSliceStatusName(Transport::Slice::SliceStatus status) {
     return "UNKNOWN";
 }
 
-const char* ToOpcodeName(Transport::TransferRequest::OpCode opcode) {
+const char *ToOpcodeName(Transport::TransferRequest::OpCode opcode) {
     return opcode == Transport::TransferRequest::READ ? "READ" : "WRITE";
 }
 
@@ -115,9 +115,9 @@ struct ObservedTaskState {
 };
 
 ObservedTaskState ObserveTaskState(
-    const std::vector<Transport::Slice*>& slice_list) {
+    const std::vector<Transport::Slice *> &slice_list) {
     ObservedTaskState observed;
-    for (const auto* slice : slice_list) {
+    for (const auto *slice : slice_list) {
         switch (slice->status) {
             case Transport::Slice::SUCCESS:
                 ++observed.success_slice_count;
@@ -189,7 +189,7 @@ Status MultiTransport::submitTransfer(
     size_t task_id = task_begin;
     batch_desc.task_list.resize(task_id + entries.size());
 
-    std::unordered_map<Transport *, std::vector<Transport::TransferTask *> >
+    std::unordered_map<Transport *, std::vector<Transport::TransferTask *>>
         submit_tasks;
     std::vector<std::string> task_transport_names(batch_desc.task_list.size());
     for (auto &request : entries) {
@@ -211,21 +211,20 @@ Status MultiTransport::submitTransfer(
     }
 
     auto batch_context = trace_registry_.LookupBatchContext(batch_id);
-    auto& tracing = tracing::TracingFacade::Instance("mooncake-transfer-engine",
+    auto &tracing = tracing::TracingFacade::Instance("mooncake-transfer-engine",
                                                      "multi-transport");
-    auto batch_submit_span = batch_context.has_value()
-                                 ? tracing.StartSpan(
-                                       "te.batch.submit", &batch_context.value(),
-                                       {{"te.batch_id", std::to_string(batch_id)},
-                                        {"sampling.priority", "structural"},
-                                        {"task.count",
-                                         std::to_string(entries.size())}})
-                                 : tracing.StartSpan(
-                                       "te.batch.submit", nullptr,
-                                       {{"te.batch_id", std::to_string(batch_id)},
-                                        {"sampling.priority", "structural"},
-                                        {"task.count",
-                                         std::to_string(entries.size())}});
+    auto batch_submit_span =
+        batch_context.has_value()
+            ? tracing.StartSpan(
+                  "te.batch.submit", &batch_context.value(),
+                  {{"te.batch_id", std::to_string(batch_id)},
+                   {"sampling.priority", "structural"},
+                   {"task.count", std::to_string(entries.size())}})
+            : tracing.StartSpan(
+                  "te.batch.submit", nullptr,
+                  {{"te.batch_id", std::to_string(batch_id)},
+                   {"sampling.priority", "structural"},
+                   {"task.count", std::to_string(entries.size())}});
     auto batch_submit_context = batch_submit_span.context();
     Status overall_status = Status::OK();
     for (auto &entry : submit_tasks) {
@@ -238,7 +237,7 @@ Status MultiTransport::submitTransfer(
     }
 
     for (size_t idx = task_begin; idx < batch_desc.task_list.size(); ++idx) {
-        auto& task = batch_desc.task_list[idx];
+        auto &task = batch_desc.task_list[idx];
         mooncake::tracing::TraceContext task_context;
         auto task_span = tracing.StartSpan(
             "te.task.submit", &batch_submit_context,
@@ -256,7 +255,7 @@ Status MultiTransport::submitTransfer(
                            {{"transport.name", task_transport_names[idx]}});
         for (size_t slice_idx = 0; slice_idx < task.slice_list.size();
              ++slice_idx) {
-            auto* slice = task.slice_list[slice_idx];
+            auto *slice = task.slice_list[slice_idx];
             slice->StartTrace(task_context, batch_id, idx, slice_idx,
                               task_transport_names[idx]);
             if (!trace_registry_.MarkSliceQueued(batch_id, idx, slice_idx)) {
@@ -289,7 +288,7 @@ Status MultiTransport::mp_submitTransfer(
     size_t task_id = batch_desc.task_list.size();
     batch_desc.task_list.resize(task_id + entries.size());
 
-    std::unordered_map<Transport *, std::vector<Transport::TransferTask *> >
+    std::unordered_map<Transport *, std::vector<Transport::TransferTask *>>
         submit_tasks;
     for (auto &request : entries) {
         Transport *transport = nullptr;
@@ -344,8 +343,9 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
         status.s = Transport::TransferStatusEnum::TIMEOUT;
         task.is_finished = true;
     } else if (success_slice_count + failed_slice_count == task.slice_count) {
-        status.s = failed_slice_count ? Transport::TransferStatusEnum::FAILED
-                                      : Transport::TransferStatusEnum::COMPLETED;
+        status.s = failed_slice_count
+                       ? Transport::TransferStatusEnum::FAILED
+                       : Transport::TransferStatusEnum::COMPLETED;
         task.is_finished = true;
     } else {
         if (globalConfig().slice_timeout > 0) {
@@ -371,14 +371,14 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
 
     auto task_trace = trace_registry_.LookupTask(batch_id, task_id);
     if (task_trace.has_value()) {
-        auto& tracing_facade = tracing::TracingFacade::Instance(
+        auto &tracing_facade = tracing::TracingFacade::Instance(
             "mooncake-transfer-engine", "multi-transport");
         std::vector<std::pair<std::string, tracing::TraceAttrs>> pending_events;
         pending_events.reserve(task.slice_list.size() + 1);
 
         for (size_t slice_idx = 0; slice_idx < task.slice_list.size();
              ++slice_idx) {
-            auto* slice = task.slice_list[slice_idx];
+            auto *slice = task.slice_list[slice_idx];
             if (slice->status != Transport::Slice::SUCCESS &&
                 slice->status != Transport::Slice::FAILED &&
                 slice->status != Transport::Slice::TIMEOUT) {
@@ -397,10 +397,10 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
                     : (slice->status == Transport::Slice::FAILED
                            ? "slice failed"
                            : "slice timeout detected"),
-                tracing::TraceAttrs{{"slice.id", std::to_string(slice_idx)},
-                                    {"slice.length", std::to_string(slice->length)},
-                                    {"slice.status",
-                                     ToSliceStatusName(slice->status)}});
+                tracing::TraceAttrs{
+                    {"slice.id", std::to_string(slice_idx)},
+                    {"slice.length", std::to_string(slice->length)},
+                    {"slice.status", ToSliceStatusName(slice->status)}});
         }
 
         if ((status.s == Transport::TransferStatusEnum::COMPLETED ||
@@ -409,10 +409,11 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             trace_registry_.MarkTaskTerminal(batch_id, task_id)) {
             pending_events.emplace_back(
                 "task terminal status",
-                tracing::TraceAttrs{{"task.id", std::to_string(task_id)},
-                                    {"status", ToTransferStatusName(status.s)},
-                                    {"transferred.bytes",
-                                     std::to_string(status.transferred_bytes)}});
+                tracing::TraceAttrs{
+                    {"task.id", std::to_string(task_id)},
+                    {"status", ToTransferStatusName(status.s)},
+                    {"transferred.bytes",
+                     std::to_string(status.transferred_bytes)}});
         }
 
         if (!pending_events.empty()) {
@@ -422,7 +423,7 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
                  {"task.id", std::to_string(task_id)},
                  {"transport.name", task_trace->transport_name},
                  {"status", ToTransferStatusName(status.s)}});
-            for (const auto& event : pending_events) {
+            for (const auto &event : pending_events) {
                 span.AddEvent(event.first, event.second);
             }
             if (status.s == Transport::TransferStatusEnum::FAILED ||
@@ -487,7 +488,7 @@ Status MultiTransport::getBatchTransferStatus(BatchID batch_id,
          status.s == Transport::TransferStatusEnum::TIMEOUT) &&
         trace_registry_.MarkBatchTerminal(batch_id)) {
         auto batch_context = trace_registry_.LookupBatchContext(batch_id);
-        auto& tracing = tracing::TracingFacade::Instance(
+        auto &tracing = tracing::TracingFacade::Instance(
             "mooncake-transfer-engine", "multi-transport");
         auto span = batch_context.has_value()
                         ? tracing.StartSpan(

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -88,14 +88,17 @@ int TransferEngine::unregisterLocalMemory(void* addr, bool update_metadata) {
 }
 
 Status TransferEngine::submitTransfer(
-    BatchID batch_id, const std::vector<TransferRequest>& entries) {
-    return impl_->submitTransfer(batch_id, entries);
+    BatchID batch_id, const std::vector<TransferRequest>& entries,
+    const tracing::TraceContext* trace_context) {
+    return impl_->submitTransfer(batch_id, entries, trace_context);
 }
 
 Status TransferEngine::submitTransferWithNotify(
     BatchID batch_id, const std::vector<TransferRequest>& entries,
-    TransferMetadata::NotifyDesc notify_msg) {
-    return impl_->submitTransferWithNotify(batch_id, entries, notify_msg);
+    TransferMetadata::NotifyDesc notify_msg,
+    const tracing::TraceContext* trace_context) {
+    return impl_->submitTransferWithNotify(batch_id, entries, notify_msg,
+                                           trace_context);
 }
 
 #ifdef ENABLE_MULTI_PROTOCOL
@@ -437,7 +440,9 @@ Status TransferEngine::freeBatchID(BatchID batch_id) {
 }
 
 Status TransferEngine::submitTransfer(
-    BatchID batch_id, const std::vector<TransferRequest>& entries) {
+    BatchID batch_id, const std::vector<TransferRequest>& entries,
+    const tracing::TraceContext* trace_context) {
+    (void)trace_context;
     if (use_tent_) {
         std::vector<mooncake::tent::Request> requests;
         for (auto& item : entries) {
@@ -455,13 +460,15 @@ Status TransferEngine::submitTransfer(
         else
             return Status::OK();
     } else {
-        return impl_->submitTransfer(batch_id, entries);
+        return impl_->submitTransfer(batch_id, entries, trace_context);
     }
 }
 
 Status TransferEngine::submitTransferWithNotify(
     BatchID batch_id, const std::vector<TransferRequest>& entries,
-    TransferMetadata::NotifyDesc notify_msg) {
+    TransferMetadata::NotifyDesc notify_msg,
+    const tracing::TraceContext* trace_context) {
+    (void)trace_context;
     if (use_tent_) {
         std::vector<mooncake::tent::Request> requests;
         for (auto& item : entries) {
@@ -482,7 +489,8 @@ Status TransferEngine::submitTransferWithNotify(
         else
             return Status::OK();
     } else {
-        return impl_->submitTransferWithNotify(batch_id, entries, notify_msg);
+        return impl_->submitTransferWithNotify(batch_id, entries, notify_msg,
+                                               trace_context);
     }
 }
 

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -400,10 +400,12 @@ int TransferEngineImpl::sendNotifyByID(
     auto& tracing = mooncake::tracing::TracingFacade::Instance(
         "mooncake-transfer-engine", "transfer-engine");
     auto span = tracing.StartSpanFromCarrier(
-        "notify.sent", carrier,
-        {{"target.id", std::to_string(target_id)}});
+        "sendNotifyByID", carrier,
+        {{"target.id", std::to_string(target_id)},
+         {"notify.name", notify_msg.name}});
     span.AddEvent("notify sent",
-                  {{"target.id", std::to_string(target_id)}});
+                  {{"target.id", std::to_string(target_id)},
+                   {"notify.name", notify_msg.name}});
     auto desc = metadata_->getSegmentDescByID(target_id);
     Transport::NotifyDesc peer_desc;
     int ret = metadata_->sendNotify(desc->name, notify_msg, peer_desc);
@@ -420,9 +422,11 @@ int TransferEngineImpl::sendNotifyByName(
     auto& tracing = mooncake::tracing::TracingFacade::Instance(
         "mooncake-transfer-engine", "transfer-engine");
     auto span = tracing.StartSpanFromCarrier(
-        "notify.sent", carrier,
-        {{"target.name", remote_agent}});
-    span.AddEvent("notify sent", {{"target.name", remote_agent}});
+        "sendNotifyByName", carrier,
+        {{"target.name", remote_agent},
+         {"notify.name", notify_msg.name}});
+    span.AddEvent("notify sent", {{"target.name", remote_agent},
+                                   {"notify.name", notify_msg.name}});
     Transport::NotifyDesc peer_desc;
     int ret = metadata_->sendNotify(remote_agent, notify_msg, peer_desc);
     if (ret != 0) {

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -399,13 +399,12 @@ int TransferEngineImpl::sendNotifyByID(
         mooncake::tracing::DecodeCarrierString(notify_msg.trace_carrier);
     auto& tracing = mooncake::tracing::TracingFacade::Instance(
         "mooncake-transfer-engine", "transfer-engine");
-    auto span = tracing.StartSpanFromCarrier(
-        "sendNotifyByID", carrier,
-        {{"target.id", std::to_string(target_id)},
-         {"notify.name", notify_msg.name}});
-    span.AddEvent("notify sent",
-                  {{"target.id", std::to_string(target_id)},
-                   {"notify.name", notify_msg.name}});
+    auto span =
+        tracing.StartSpanFromCarrier("sendNotifyByID", carrier,
+                                     {{"target.id", std::to_string(target_id)},
+                                      {"notify.name", notify_msg.name}});
+    span.AddEvent("notify sent", {{"target.id", std::to_string(target_id)},
+                                  {"notify.name", notify_msg.name}});
     auto desc = metadata_->getSegmentDescByID(target_id);
     Transport::NotifyDesc peer_desc;
     int ret = metadata_->sendNotify(desc->name, notify_msg, peer_desc);
@@ -423,10 +422,9 @@ int TransferEngineImpl::sendNotifyByName(
         "mooncake-transfer-engine", "transfer-engine");
     auto span = tracing.StartSpanFromCarrier(
         "sendNotifyByName", carrier,
-        {{"target.name", remote_agent},
-         {"notify.name", notify_msg.name}});
+        {{"target.name", remote_agent}, {"notify.name", notify_msg.name}});
     span.AddEvent("notify sent", {{"target.name", remote_agent},
-                                   {"notify.name", notify_msg.name}});
+                                  {"notify.name", notify_msg.name}});
     Transport::NotifyDesc peer_desc;
     int ret = metadata_->sendNotify(remote_agent, notify_msg, peer_desc);
     if (ret != 0) {

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -395,16 +395,39 @@ int TransferEngineImpl::getNotifies(
 
 int TransferEngineImpl::sendNotifyByID(
     SegmentID target_id, TransferMetadata::NotifyDesc notify_msg) {
+    auto carrier =
+        mooncake::tracing::DecodeCarrierString(notify_msg.trace_carrier);
+    auto& tracing = mooncake::tracing::TracingFacade::Instance(
+        "mooncake-transfer-engine", "transfer-engine");
+    auto span = tracing.StartSpanFromCarrier(
+        "notify.sent", carrier,
+        {{"target.id", std::to_string(target_id)}});
+    span.AddEvent("notify sent",
+                  {{"target.id", std::to_string(target_id)}});
     auto desc = metadata_->getSegmentDescByID(target_id);
     Transport::NotifyDesc peer_desc;
     int ret = metadata_->sendNotify(desc->name, notify_msg, peer_desc);
+    if (ret != 0) {
+        span.SetStatus("ERROR");
+    }
     return ret;
 }
 
 int TransferEngineImpl::sendNotifyByName(
     std::string remote_agent, TransferMetadata::NotifyDesc notify_msg) {
+    auto carrier =
+        mooncake::tracing::DecodeCarrierString(notify_msg.trace_carrier);
+    auto& tracing = mooncake::tracing::TracingFacade::Instance(
+        "mooncake-transfer-engine", "transfer-engine");
+    auto span = tracing.StartSpanFromCarrier(
+        "notify.sent", carrier,
+        {{"target.name", remote_agent}});
+    span.AddEvent("notify sent", {{"target.name", remote_agent}});
     Transport::NotifyDesc peer_desc;
     int ret = metadata_->sendNotify(remote_agent, notify_msg, peer_desc);
+    if (ret != 0) {
+        span.SetStatus("ERROR");
+    }
     return ret;
 }
 

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -62,7 +62,9 @@ struct TransferNotifyUtil {
     static int decode(Json::Value root, TransferMetadata::NotifyDesc &desc) {
         desc.name = root["name"].asString();
         desc.notify_msg = root["notify_msg"].asString();
-        desc.trace_carrier = root.isMember("trace_carrier") ? root["trace_carrier"].asString() : "";
+        desc.trace_carrier = root.isMember("trace_carrier")
+                                 ? root["trace_carrier"].asString()
+                                 : "";
         return 0;
     }
 };
@@ -179,16 +181,19 @@ int TransferMetadata::receivePeerNotify(const Json::Value &peer_json,
                                         Json::Value &local_json) {
     TransferMetadata::NotifyDesc peer_notify, local_reply;
     TransferNotifyUtil::decode(peer_json, peer_notify);
-    auto carrier = mooncake::tracing::DecodeCarrierString(peer_notify.trace_carrier);
-    auto& tracing = mooncake::tracing::TracingFacade::Instance(
+    auto carrier =
+        mooncake::tracing::DecodeCarrierString(peer_notify.trace_carrier);
+    auto &tracing = mooncake::tracing::TracingFacade::Instance(
         "mooncake-transfer-engine", "transfer-metadata");
-    auto span = tracing.StartSpanFromCarrier("notify.received", carrier,
-                                             {{"notify.name", peer_notify.name}});
-    span.AddEvent("carrier decode", {{"trace_carrier.present", peer_notify.trace_carrier.empty() ? "false" : "true"}});
+    auto span = tracing.StartSpanFromCarrier(
+        "notify.received", carrier, {{"notify.name", peer_notify.name}});
+    span.AddEvent("carrier decode",
+                  {{"trace_carrier.present",
+                    peer_notify.trace_carrier.empty() ? "false" : "true"}});
     span.AddEvent("notify received", {{"notify.name", peer_notify.name}});
     {
-      RWSpinlock::WriteGuard guard(notify_lock_);
-      notifys.push_back(peer_notify);
+        RWSpinlock::WriteGuard guard(notify_lock_);
+        notifys.push_back(peer_notify);
     }
     // reply
     local_reply.name = "";

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -24,6 +24,8 @@
 #include "config.h"
 #include "error.h"
 #include "transfer_metadata_plugin.h"
+#include "trace_support.h"
+#include "tracing_facade.h"
 
 namespace mooncake {
 #ifdef ENABLE_MULTI_PROTOCOL
@@ -53,12 +55,14 @@ struct TransferNotifyUtil {
         Json::Value root;
         root["name"] = desc.name;
         root["notify_msg"] = desc.notify_msg;
+        root["trace_carrier"] = desc.trace_carrier;
         return root;
     }
 
     static int decode(Json::Value root, TransferMetadata::NotifyDesc &desc) {
         desc.name = root["name"].asString();
         desc.notify_msg = root["notify_msg"].asString();
+        desc.trace_carrier = root.isMember("trace_carrier") ? root["trace_carrier"].asString() : "";
         return 0;
     }
 };
@@ -173,13 +177,22 @@ std::string TransferMetadata::getFullMetadataKey(
 
 int TransferMetadata::receivePeerNotify(const Json::Value &peer_json,
                                         Json::Value &local_json) {
-    RWSpinlock::WriteGuard guard(notify_lock_);
     TransferMetadata::NotifyDesc peer_notify, local_reply;
     TransferNotifyUtil::decode(peer_json, peer_notify);
-    notifys.push_back(peer_notify);
+    auto carrier = mooncake::tracing::DecodeCarrierString(peer_notify.trace_carrier);
+    auto& tracing = mooncake::tracing::TracingFacade::Instance(
+        "mooncake-transfer-engine", "transfer-metadata");
+    auto span = tracing.StartSpanFromCarrier("notify.received", carrier,
+                                             {{"notify.name", peer_notify.name}});
+    span.AddEvent("carrier decode", {{"trace_carrier.present", peer_notify.trace_carrier.empty() ? "false" : "true"}});
+    {
+      RWSpinlock::WriteGuard guard(notify_lock_);
+      notifys.push_back(peer_notify);
+    }
     // reply
     local_reply.name = "";
     local_reply.notify_msg = "success";
+    local_reply.trace_carrier = peer_notify.trace_carrier;
     local_json = TransferNotifyUtil::encode(local_reply);
     return 0;
 }

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -185,6 +185,7 @@ int TransferMetadata::receivePeerNotify(const Json::Value &peer_json,
     auto span = tracing.StartSpanFromCarrier("notify.received", carrier,
                                              {{"notify.name", peer_notify.name}});
     span.AddEvent("carrier decode", {{"trace_carrier.present", peer_notify.trace_carrier.empty() ? "false" : "true"}});
+    span.AddEvent("notify received", {{"notify.name", peer_notify.name}});
     {
       RWSpinlock::WriteGuard guard(notify_lock_);
       notifys.push_back(peer_notify);

--- a/mooncake-transfer-engine/src/transport/transport.cpp
+++ b/mooncake-transfer-engine/src/transport/transport.cpp
@@ -18,7 +18,115 @@
 #include "transfer_engine.h"
 
 namespace mooncake {
+namespace {
+const char* ToSliceStatusName(Transport::Slice::SliceStatus status) {
+    switch (status) {
+        case Transport::Slice::PENDING:
+            return "PENDING";
+        case Transport::Slice::POSTED:
+            return "POSTED";
+        case Transport::Slice::SUCCESS:
+            return "SUCCESS";
+        case Transport::Slice::TIMEOUT:
+            return "TIMEOUT";
+        case Transport::Slice::FAILED:
+            return "FAILED";
+    }
+    return "UNKNOWN";
+}
+}  // namespace
+
 thread_local static Transport::ThreadLocalSliceCache tl_slice_cache;
+
+void Transport::Slice::ResetTraceState() {
+    trace_batch_id_ = 0;
+    trace_task_id_ = 0;
+    trace_slice_id_ = 0;
+    trace_transport_name_.clear();
+    trace_span_ = tracing::Span();
+    trace_started_ = false;
+    trace_terminal_recorded_ = false;
+}
+
+void Transport::Slice::StartTrace(const tracing::TraceContext& parent_context,
+                                  BatchID batch_id, size_t task_id,
+                                  size_t slice_id,
+                                  const std::string& transport_name) {
+    if (trace_started_) {
+        return;
+    }
+
+    trace_batch_id_ = batch_id;
+    trace_task_id_ = task_id;
+    trace_slice_id_ = slice_id;
+    trace_transport_name_ = transport_name;
+
+    auto& tracing = tracing::TracingFacade::Instance("mooncake-transfer-engine",
+                                                     "multi-transport");
+    trace_span_ = tracing.StartSpan(
+        "te.slice", &parent_context,
+        {{"te.batch_id", std::to_string(batch_id)},
+         {"task.id", std::to_string(task_id)},
+         {"slice.id", std::to_string(slice_id)},
+         {"transport.name", transport_name},
+         {"slice.length", std::to_string(length)},
+         {"slice.status", ToSliceStatusName(status)}});
+    if (!trace_span_.valid()) {
+        return;
+    }
+
+    trace_started_ = true;
+    trace_span_.AddEvent("slice execution started",
+                         {{"slice.status", ToSliceStatusName(status)}});
+
+    if (status == Slice::SUCCESS) {
+        FinishTrace("SUCCESS", false);
+    } else if (status == Slice::FAILED) {
+        FinishTrace("FAILED", true);
+    } else if (status == Slice::TIMEOUT) {
+        FinishTrace("TIMEOUT", true);
+    }
+}
+
+void Transport::Slice::markSuccess() {
+    status = Slice::SUCCESS;
+    __atomic_fetch_add(&task->transferred_bytes, length, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&task->success_slice_count, 1, __ATOMIC_RELAXED);
+
+    FinishTrace("SUCCESS", false);
+    check_batch_completion(false);
+}
+
+void Transport::Slice::markFailed() {
+    status = Slice::FAILED;
+    __atomic_fetch_add(&task->failed_slice_count, 1, __ATOMIC_RELAXED);
+
+    FinishTrace("FAILED", true);
+    check_batch_completion(true);
+}
+
+void Transport::Slice::markTimeoutForTrace() { FinishTrace("TIMEOUT", true); }
+
+void Transport::Slice::FinishTrace(const char* status_name, bool error) {
+    if (!trace_started_ || trace_terminal_recorded_) {
+        return;
+    }
+
+    trace_span_.SetAttribute("status", status_name);
+    trace_span_.AddEvent(
+        "slice terminal status",
+        {{"te.batch_id", std::to_string(trace_batch_id_)},
+         {"task.id", std::to_string(trace_task_id_)},
+         {"slice.id", std::to_string(trace_slice_id_)},
+         {"transport.name", trace_transport_name_},
+         {"slice.length", std::to_string(length)},
+         {"status", status_name}});
+    if (error) {
+        trace_span_.SetStatus("ERROR");
+    }
+    trace_span_.End();
+    trace_terminal_recorded_ = true;
+}
 
 Transport::ThreadLocalSliceCache &Transport::getSliceCache() {
     return tl_slice_cache;

--- a/mooncake-transfer-engine/src/transport/transport.cpp
+++ b/mooncake-transfer-engine/src/transport/transport.cpp
@@ -63,14 +63,14 @@ void Transport::Slice::StartTrace(const tracing::TraceContext& parent_context,
 
     auto& tracing = tracing::TracingFacade::Instance("mooncake-transfer-engine",
                                                      "multi-transport");
-    trace_span_ = tracing.StartSpan(
-        "te.slice", &parent_context,
-        {{"te.batch_id", std::to_string(batch_id)},
-         {"task.id", std::to_string(task_id)},
-         {"slice.id", std::to_string(slice_id)},
-         {"transport.name", transport_name},
-         {"slice.length", std::to_string(length)},
-         {"slice.status", ToSliceStatusName(status)}});
+    trace_span_ =
+        tracing.StartSpan("te.slice", &parent_context,
+                          {{"te.batch_id", std::to_string(batch_id)},
+                           {"task.id", std::to_string(task_id)},
+                           {"slice.id", std::to_string(slice_id)},
+                           {"transport.name", transport_name},
+                           {"slice.length", std::to_string(length)},
+                           {"slice.status", ToSliceStatusName(status)}});
     if (!trace_span_.valid()) {
         return;
     }
@@ -113,14 +113,13 @@ void Transport::Slice::FinishTrace(const char* status_name, bool error) {
     }
 
     trace_span_.SetAttribute("status", status_name);
-    trace_span_.AddEvent(
-        "slice terminal status",
-        {{"te.batch_id", std::to_string(trace_batch_id_)},
-         {"task.id", std::to_string(trace_task_id_)},
-         {"slice.id", std::to_string(trace_slice_id_)},
-         {"transport.name", trace_transport_name_},
-         {"slice.length", std::to_string(length)},
-         {"status", status_name}});
+    trace_span_.AddEvent("slice terminal status",
+                         {{"te.batch_id", std::to_string(trace_batch_id_)},
+                          {"task.id", std::to_string(trace_task_id_)},
+                          {"slice.id", std::to_string(trace_slice_id_)},
+                          {"transport.name", trace_transport_name_},
+                          {"slice.length", std::to_string(length)},
+                          {"status", status_name}});
     if (error) {
         trace_span_.SetStatus("ERROR");
     }
@@ -128,7 +127,7 @@ void Transport::Slice::FinishTrace(const char* status_name, bool error) {
     trace_terminal_recorded_ = true;
 }
 
-Transport::ThreadLocalSliceCache &Transport::getSliceCache() {
+Transport::ThreadLocalSliceCache& Transport::getSliceCache() {
     return tl_slice_cache;
 }
 
@@ -148,7 +147,7 @@ Transport::BatchID Transport::allocateBatchID(size_t batch_size) {
 }
 
 Status Transport::freeBatchID(BatchID batch_id) {
-    auto &batch_desc = *((BatchDesc *)(batch_id));
+    auto& batch_desc = *((BatchDesc*)(batch_id));
     const size_t task_count = batch_desc.task_list.size();
     for (size_t task_id = 0; task_id < task_count; task_id++) {
         if (!batch_desc.task_list[task_id].is_finished) {
@@ -165,7 +164,7 @@ Status Transport::freeBatchID(BatchID batch_id) {
     return Status::OK();
 }
 
-int Transport::install(std::string &local_server_name,
+int Transport::install(std::string& local_server_name,
                        std::shared_ptr<TransferMetadata> meta,
                        std::shared_ptr<Topology> topo) {
     local_server_name_ = local_server_name;

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -25,6 +25,7 @@
 #include "multi_transport.h"
 #include "trace_context.h"
 #include "transfer_engine.h"
+#include "transfer_engine_impl.h"
 #include "transport/transport.h"
 
 using namespace mooncake;
@@ -263,6 +264,36 @@ TEST_F(TransportTest, BatchTraceRegistryKeepsFirstBatchContext) {
     ASSERT_TRUE(batch_context.has_value());
     EXPECT_EQ(batch_context->span_id, "root-span");
     EXPECT_EQ(batch_context->trace_id, "trace-root");
+}
+
+TEST_F(TransportTest, ActiveBatchTraceRegistryKeepsRootAliveUntilFinish) {
+    tracing::TracingFacade tracing({.enabled = true,
+                                    .exporter_mode = "inmemory",
+                                    .service_name = "test-te",
+                                    .node_id = "node-a",
+                                    .process_role = "unit-test"});
+    ActiveBatchTraceRegistry registry;
+    Transport::BatchID batch_id = 123;
+
+    auto first = registry.EnsureRoot(tracing, batch_id);
+    ASSERT_TRUE(first.context.valid());
+    EXPECT_TRUE(first.created);
+
+    auto second = registry.EnsureRoot(tracing, batch_id);
+    ASSERT_TRUE(second.context.valid());
+    EXPECT_FALSE(second.created);
+    EXPECT_EQ(second.context.trace_id, first.context.trace_id);
+    EXPECT_EQ(second.context.span_id, first.context.span_id);
+
+    EXPECT_TRUE(registry.Finish(batch_id, "batch terminal status",
+                                {{"status", "COMPLETED"}}, false));
+    EXPECT_FALSE(registry.Finish(batch_id, "batch terminal status",
+                                 {{"status", "COMPLETED"}}, false));
+
+    auto third = registry.EnsureRoot(tracing, batch_id);
+    ASSERT_TRUE(third.context.valid());
+    EXPECT_TRUE(third.created);
+    EXPECT_NE(third.context.span_id, first.context.span_id);
 }
 }  // namespace mooncake
 

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -306,6 +306,29 @@ TEST_F(TransportTest, ActiveBatchTraceRegistryKeepsRootAliveUntilFinish) {
     EXPECT_NE(third.context.span_id, first.context.span_id);
 }
 
+TEST_F(TransportTest, ActiveBatchTraceRegistryUsesProvidedParentContext) {
+    tracing::TracingFacade tracing({.enabled = true,
+                                    .exporter_mode = "inmemory",
+                                    .service_name = "test-te",
+                                    .node_id = "node-a",
+                                    .process_role = "unit-test"});
+    ActiveBatchTraceRegistry registry;
+    Transport::BatchID batch_id = 321;
+
+    tracing::TraceContext parent_context{
+        .trace_id = "trace-parent",
+        .span_id = "parent-span",
+        .parent_span_id = "",
+        .correlation_id = "corr-parent"};
+
+    auto root = registry.EnsureRoot(tracing, batch_id, &parent_context);
+    ASSERT_TRUE(root.context.valid());
+    EXPECT_TRUE(root.created);
+    EXPECT_EQ(root.context.trace_id, parent_context.trace_id);
+    EXPECT_EQ(root.context.parent_span_id, parent_context.span_id);
+    EXPECT_EQ(root.context.correlation_id, parent_context.correlation_id);
+}
+
 TEST_F(TransportTest, SliceTraceLifecycleTracksSuccessAndTimeout) {
     setenv("MC_TRACING_ENABLED", "1", 1);
     setenv("MC_TRACING_EXPORTER", "jsonl", 1);

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -329,6 +329,37 @@ TEST_F(TransportTest, ActiveBatchTraceRegistryUsesProvidedParentContext) {
     EXPECT_EQ(root.context.correlation_id, parent_context.correlation_id);
 }
 
+TEST_F(TransportTest,
+       GetTransferStatusTreatsObservedSuccessfulSliceAsCompleted) {
+    std::string local_server_name = "127.0.0.1:12345";
+    MultiTransport multi_transport(nullptr, local_server_name);
+
+    auto* batch_desc = new Transport::BatchDesc();
+    batch_desc->id = reinterpret_cast<Transport::BatchID>(batch_desc);
+    batch_desc->batch_size = 1;
+    batch_desc->task_list.resize(1);
+
+    auto& task = batch_desc->task_list[0];
+    task.batch_id = batch_desc->id;
+    task.slice_count = 1;
+    task.total_bytes = 4096;
+
+    auto* slice = new Transport::Slice();
+    slice->task = &task;
+    slice->length = 4096;
+    slice->status = Transport::Slice::SUCCESS;
+    task.slice_list.push_back(slice);
+
+    Transport::TransferStatus status;
+    ASSERT_TRUE(
+        multi_transport.getTransferStatus(batch_desc->id, 0, status).ok());
+    EXPECT_EQ(status.s, Transport::TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(status.transferred_bytes, 4096u);
+    EXPECT_TRUE(task.is_finished);
+
+    delete batch_desc;
+}
+
 TEST_F(TransportTest, SliceTraceLifecycleTracksSuccessAndTimeout) {
     setenv("MC_TRACING_ENABLED", "1", 1);
     setenv("MC_TRACING_EXPORTER", "jsonl", 1);

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -22,6 +22,8 @@
 #include <iomanip>
 #include <memory>
 
+#include "multi_transport.h"
+#include "trace_context.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
 
@@ -170,6 +172,97 @@ TEST_F(TransportTest, ReadEmptyFile) {
     EXPECT_EQ(bytesRead, static_cast<ssize_t>(0));
 
     close(fd);
+}
+
+TEST_F(TransportTest, BatchTraceRegistryDeduplicatesSliceAndTaskTerminal) {
+    MultiTransportTraceRegistry registry;
+    Transport::BatchID batch_id = 42;
+
+    tracing::TraceContext batch_context{
+        .trace_id = "trace-1",
+        .span_id = "batch-span",
+        .parent_span_id = "",
+        .correlation_id = "corr-1"};
+    tracing::TraceContext task_context{
+        .trace_id = "trace-1",
+        .span_id = "task-span",
+        .parent_span_id = "batch-span",
+        .correlation_id = "corr-1"};
+
+    registry.RegisterBatch(batch_id, batch_context);
+    registry.RegisterTask(batch_id, 0, task_context, "tcp", 2, 1024);
+
+    auto task = registry.LookupTask(batch_id, 0);
+    ASSERT_TRUE(task.has_value());
+    EXPECT_EQ(task->transport_name, "tcp");
+    EXPECT_EQ(task->slice_terminal_states.size(), 2u);
+
+    EXPECT_TRUE(registry.MarkSliceQueued(batch_id, 0, 0));
+    EXPECT_FALSE(registry.MarkSliceQueued(batch_id, 0, 0));
+
+    EXPECT_TRUE(registry.MarkSliceTerminal(
+        batch_id, 0, 0, Transport::Slice::SUCCESS));
+    EXPECT_FALSE(registry.MarkSliceTerminal(
+        batch_id, 0, 0, Transport::Slice::SUCCESS));
+
+    EXPECT_TRUE(registry.MarkTaskTerminal(batch_id, 0));
+    EXPECT_FALSE(registry.MarkTaskTerminal(batch_id, 0));
+
+    EXPECT_TRUE(registry.MarkBatchTerminal(batch_id));
+    EXPECT_FALSE(registry.MarkBatchTerminal(batch_id));
+}
+
+TEST_F(TransportTest, BatchTraceRegistryTracksTimeoutAsDistinctTerminal) {
+    MultiTransportTraceRegistry registry;
+    Transport::BatchID batch_id = 7;
+
+    tracing::TraceContext batch_context{
+        .trace_id = "trace-2",
+        .span_id = "batch-2",
+        .parent_span_id = "",
+        .correlation_id = "corr-2"};
+    tracing::TraceContext task_context{
+        .trace_id = "trace-2",
+        .span_id = "task-2",
+        .parent_span_id = "batch-2",
+        .correlation_id = "corr-2"};
+
+    registry.RegisterBatch(batch_id, batch_context);
+    registry.RegisterTask(batch_id, 1, task_context, "rdma", 1, 4096);
+
+    EXPECT_TRUE(registry.MarkSliceTerminal(
+        batch_id, 1, 0, Transport::Slice::TIMEOUT));
+    EXPECT_FALSE(registry.MarkSliceTerminal(
+        batch_id, 1, 0, Transport::Slice::FAILED));
+
+    auto task = registry.LookupTask(batch_id, 1);
+    ASSERT_TRUE(task.has_value());
+    EXPECT_EQ(task->slice_terminal_states[0],
+              MultiTransportTraceRegistry::SliceTerminalState::kTimedOut);
+}
+
+TEST_F(TransportTest, BatchTraceRegistryKeepsFirstBatchContext) {
+    MultiTransportTraceRegistry registry;
+    Transport::BatchID batch_id = 99;
+
+    tracing::TraceContext root_context{
+        .trace_id = "trace-root",
+        .span_id = "root-span",
+        .parent_span_id = "",
+        .correlation_id = "corr-root"};
+    tracing::TraceContext later_context{
+        .trace_id = "trace-root",
+        .span_id = "later-span",
+        .parent_span_id = "root-span",
+        .correlation_id = "corr-root"};
+
+    registry.RegisterBatch(batch_id, root_context);
+    registry.RegisterBatch(batch_id, later_context);
+
+    auto batch_context = registry.LookupBatchContext(batch_id);
+    ASSERT_TRUE(batch_context.has_value());
+    EXPECT_EQ(batch_context->span_id, "root-span");
+    EXPECT_EQ(batch_context->trace_id, "trace-root");
 }
 }  // namespace mooncake
 

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -285,6 +285,16 @@ TEST_F(TransportTest, ActiveBatchTraceRegistryKeepsRootAliveUntilFinish) {
     EXPECT_EQ(second.context.trace_id, first.context.trace_id);
     EXPECT_EQ(second.context.span_id, first.context.span_id);
 
+    auto data_plane = registry.EnsureDataPlane(tracing, batch_id);
+    ASSERT_TRUE(data_plane.context.valid());
+    EXPECT_TRUE(data_plane.created);
+    EXPECT_EQ(data_plane.context.trace_id, first.context.trace_id);
+
+    auto data_plane_again = registry.EnsureDataPlane(tracing, batch_id);
+    ASSERT_TRUE(data_plane_again.context.valid());
+    EXPECT_FALSE(data_plane_again.created);
+    EXPECT_EQ(data_plane_again.context.span_id, data_plane.context.span_id);
+
     EXPECT_TRUE(registry.Finish(batch_id, "batch terminal status",
                                 {{"status", "COMPLETED"}}, false));
     EXPECT_FALSE(registry.Finish(batch_id, "batch terminal status",

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -179,16 +179,14 @@ TEST_F(TransportTest, BatchTraceRegistryDeduplicatesSliceAndTaskTerminal) {
     MultiTransportTraceRegistry registry;
     Transport::BatchID batch_id = 42;
 
-    tracing::TraceContext batch_context{
-        .trace_id = "trace-1",
-        .span_id = "batch-span",
-        .parent_span_id = "",
-        .correlation_id = "corr-1"};
-    tracing::TraceContext task_context{
-        .trace_id = "trace-1",
-        .span_id = "task-span",
-        .parent_span_id = "batch-span",
-        .correlation_id = "corr-1"};
+    tracing::TraceContext batch_context{.trace_id = "trace-1",
+                                        .span_id = "batch-span",
+                                        .parent_span_id = "",
+                                        .correlation_id = "corr-1"};
+    tracing::TraceContext task_context{.trace_id = "trace-1",
+                                       .span_id = "task-span",
+                                       .parent_span_id = "batch-span",
+                                       .correlation_id = "corr-1"};
 
     registry.RegisterBatch(batch_id, batch_context);
     registry.RegisterTask(batch_id, 0, task_context, "tcp", 2, 1024);
@@ -201,10 +199,10 @@ TEST_F(TransportTest, BatchTraceRegistryDeduplicatesSliceAndTaskTerminal) {
     EXPECT_TRUE(registry.MarkSliceQueued(batch_id, 0, 0));
     EXPECT_FALSE(registry.MarkSliceQueued(batch_id, 0, 0));
 
-    EXPECT_TRUE(registry.MarkSliceTerminal(
-        batch_id, 0, 0, Transport::Slice::SUCCESS));
-    EXPECT_FALSE(registry.MarkSliceTerminal(
-        batch_id, 0, 0, Transport::Slice::SUCCESS));
+    EXPECT_TRUE(
+        registry.MarkSliceTerminal(batch_id, 0, 0, Transport::Slice::SUCCESS));
+    EXPECT_FALSE(
+        registry.MarkSliceTerminal(batch_id, 0, 0, Transport::Slice::SUCCESS));
 
     EXPECT_TRUE(registry.MarkTaskTerminal(batch_id, 0));
     EXPECT_FALSE(registry.MarkTaskTerminal(batch_id, 0));
@@ -217,24 +215,22 @@ TEST_F(TransportTest, BatchTraceRegistryTracksTimeoutAsDistinctTerminal) {
     MultiTransportTraceRegistry registry;
     Transport::BatchID batch_id = 7;
 
-    tracing::TraceContext batch_context{
-        .trace_id = "trace-2",
-        .span_id = "batch-2",
-        .parent_span_id = "",
-        .correlation_id = "corr-2"};
-    tracing::TraceContext task_context{
-        .trace_id = "trace-2",
-        .span_id = "task-2",
-        .parent_span_id = "batch-2",
-        .correlation_id = "corr-2"};
+    tracing::TraceContext batch_context{.trace_id = "trace-2",
+                                        .span_id = "batch-2",
+                                        .parent_span_id = "",
+                                        .correlation_id = "corr-2"};
+    tracing::TraceContext task_context{.trace_id = "trace-2",
+                                       .span_id = "task-2",
+                                       .parent_span_id = "batch-2",
+                                       .correlation_id = "corr-2"};
 
     registry.RegisterBatch(batch_id, batch_context);
     registry.RegisterTask(batch_id, 1, task_context, "rdma", 1, 4096);
 
-    EXPECT_TRUE(registry.MarkSliceTerminal(
-        batch_id, 1, 0, Transport::Slice::TIMEOUT));
-    EXPECT_FALSE(registry.MarkSliceTerminal(
-        batch_id, 1, 0, Transport::Slice::FAILED));
+    EXPECT_TRUE(
+        registry.MarkSliceTerminal(batch_id, 1, 0, Transport::Slice::TIMEOUT));
+    EXPECT_FALSE(
+        registry.MarkSliceTerminal(batch_id, 1, 0, Transport::Slice::FAILED));
 
     auto task = registry.LookupTask(batch_id, 1);
     ASSERT_TRUE(task.has_value());
@@ -246,16 +242,14 @@ TEST_F(TransportTest, BatchTraceRegistryKeepsFirstBatchContext) {
     MultiTransportTraceRegistry registry;
     Transport::BatchID batch_id = 99;
 
-    tracing::TraceContext root_context{
-        .trace_id = "trace-root",
-        .span_id = "root-span",
-        .parent_span_id = "",
-        .correlation_id = "corr-root"};
-    tracing::TraceContext later_context{
-        .trace_id = "trace-root",
-        .span_id = "later-span",
-        .parent_span_id = "root-span",
-        .correlation_id = "corr-root"};
+    tracing::TraceContext root_context{.trace_id = "trace-root",
+                                       .span_id = "root-span",
+                                       .parent_span_id = "",
+                                       .correlation_id = "corr-root"};
+    tracing::TraceContext later_context{.trace_id = "trace-root",
+                                        .span_id = "later-span",
+                                        .parent_span_id = "root-span",
+                                        .correlation_id = "corr-root"};
 
     registry.RegisterBatch(batch_id, root_context);
     registry.RegisterBatch(batch_id, later_context);
@@ -315,11 +309,10 @@ TEST_F(TransportTest, ActiveBatchTraceRegistryUsesProvidedParentContext) {
     ActiveBatchTraceRegistry registry;
     Transport::BatchID batch_id = 321;
 
-    tracing::TraceContext parent_context{
-        .trace_id = "trace-parent",
-        .span_id = "parent-span",
-        .parent_span_id = "",
-        .correlation_id = "corr-parent"};
+    tracing::TraceContext parent_context{.trace_id = "trace-parent",
+                                         .span_id = "parent-span",
+                                         .parent_span_id = "",
+                                         .correlation_id = "corr-parent"};
 
     auto root = registry.EnsureRoot(tracing, batch_id, &parent_context);
     ASSERT_TRUE(root.context.valid());
@@ -364,11 +357,10 @@ TEST_F(TransportTest, SliceTraceLifecycleTracksSuccessAndTimeout) {
     setenv("MC_TRACING_ENABLED", "1", 1);
     setenv("MC_TRACING_EXPORTER", "jsonl", 1);
 
-    tracing::TraceContext parent_context{
-        .trace_id = "trace-slice",
-        .span_id = "task-span",
-        .parent_span_id = "batch-span",
-        .correlation_id = "corr-slice"};
+    tracing::TraceContext parent_context{.trace_id = "trace-slice",
+                                         .span_id = "task-span",
+                                         .parent_span_id = "batch-span",
+                                         .correlation_id = "corr-slice"};
 
     Transport::BatchDesc success_batch;
     success_batch.batch_size = 1;
@@ -381,7 +373,8 @@ TEST_F(TransportTest, SliceTraceLifecycleTracksSuccessAndTimeout) {
     success_slice.length = 512;
     success_slice.status = Transport::Slice::PENDING;
 
-    success_slice.StartTrace(parent_context, success_task.batch_id, 3, 0, "tcp");
+    success_slice.StartTrace(parent_context, success_task.batch_id, 3, 0,
+                             "tcp");
     EXPECT_TRUE(success_slice.has_active_trace_for_test());
     EXPECT_FALSE(success_slice.trace_terminal_recorded_for_test());
 

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -295,6 +295,55 @@ TEST_F(TransportTest, ActiveBatchTraceRegistryKeepsRootAliveUntilFinish) {
     EXPECT_TRUE(third.created);
     EXPECT_NE(third.context.span_id, first.context.span_id);
 }
+
+TEST_F(TransportTest, SliceTraceLifecycleTracksSuccessAndTimeout) {
+    setenv("MC_TRACING_ENABLED", "1", 1);
+    setenv("MC_TRACING_EXPORTER", "jsonl", 1);
+
+    tracing::TraceContext parent_context{
+        .trace_id = "trace-slice",
+        .span_id = "task-span",
+        .parent_span_id = "batch-span",
+        .correlation_id = "corr-slice"};
+
+    Transport::BatchDesc success_batch;
+    success_batch.batch_size = 1;
+    Transport::TransferTask success_task;
+    success_task.batch_id =
+        reinterpret_cast<Transport::BatchID>(&success_batch);
+    success_task.slice_count = 1;
+    Transport::Slice success_slice;
+    success_slice.task = &success_task;
+    success_slice.length = 512;
+    success_slice.status = Transport::Slice::PENDING;
+
+    success_slice.StartTrace(parent_context, success_task.batch_id, 3, 0, "tcp");
+    EXPECT_TRUE(success_slice.has_active_trace_for_test());
+    EXPECT_FALSE(success_slice.trace_terminal_recorded_for_test());
+
+    success_slice.markSuccess();
+    EXPECT_TRUE(success_slice.trace_terminal_recorded_for_test());
+    EXPECT_EQ(success_task.success_slice_count, 1u);
+    EXPECT_EQ(success_task.transferred_bytes, 512u);
+
+    Transport::BatchDesc timeout_batch;
+    timeout_batch.batch_size = 1;
+    Transport::TransferTask timeout_task;
+    timeout_task.batch_id =
+        reinterpret_cast<Transport::BatchID>(&timeout_batch);
+    Transport::Slice timeout_slice;
+    timeout_slice.task = &timeout_task;
+    timeout_slice.length = 256;
+    timeout_slice.status = Transport::Slice::TIMEOUT;
+
+    timeout_slice.StartTrace(parent_context, timeout_task.batch_id, 4, 1,
+                             "rdma");
+    EXPECT_TRUE(timeout_slice.has_active_trace_for_test());
+    EXPECT_TRUE(timeout_slice.trace_terminal_recorded_for_test());
+
+    timeout_slice.markTimeoutForTrace();
+    EXPECT_TRUE(timeout_slice.trace_terminal_recorded_for_test());
+}
 }  // namespace mooncake
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Description
Introduce end-to-end tracing pipeline for Mooncake transfers for #1850 
## Summary

  This PR introduces an end-to-end tracing pipeline for Mooncake transfers, spanning `mooncake-store`,
  `mooncake-transfer-engine`, and a new `mooncake-tracing` module.

  The main goal is to make transfer execution observable as a single traceable workflow instead of a set of
  disconnected control-plane and data-plane events. With this change, a transfer can be followed from the
  store-facing operation root, through transfer-engine batch/task orchestration, down to transport slice
  execution and terminal status reporting.

  ## Why

  Before this change, transfer debugging relied mostly on logs and metrics. That made it hard to answer
  questions like:

  - Where did a transfer spend its time?
  - Did latency come from submit gaps, queueing, execution, or completion waits?
  - Which transport handled a task?
  - Which slice timed out or failed?
  - Did we lose trace continuity between store and transfer engine?

  This PR adds the missing tracing substrate and propagation path so these questions can be answered
  consistently.

  ## What changed

  ### 1. Added a dedicated tracing module
  Introduced `mooncake-tracing` with:

  - `TracingFacade` and RAII `Span`
  - `TraceContext` / carrier propagation utilities
  - configurable exporters
  - trace sampling support
  - async remote export pipeline with queueing, retry, and spool support
  - JSONL and OTLP/HTTP exporters
  - an offline trace aggregation tool for postmortem analysis

  ### 2. Added store-level transfer tracing
  Instrumented `mooncake-store` transfer flows to create and manage higher-level operation spans, including:

  - operation root span creation when no parent exists
  - parent-context reuse when upstream context is provided
  - explicit submit-gap and wait-completion spans
  - propagation of trace context into transfer-engine submission paths

  ### 3. Added transfer-engine batch tracing
  Instrumented `mooncake-transfer-engine` to model transfer execution as a stable batch hierarchy:

  - persistent `te.batch` root span
  - persistent `te.batch.execute` data-plane span
  - child spans for submit / notify / status phases
  - explicit trace-context registration and lookup for batches
  - support for external parent context on `submitTransfer*`

  ### 4. Added task/slice-level transport tracing
  Instrumented `MultiTransport` and transport-facing task handling with:

  - `te.batch.submit`
  - `te.task.submit`
  - per-slice queued / terminal events
  - per-task terminal status spans
  - batch terminal status spans
  - deduped terminal recording for batch / task / slice state

  ### 5. Improved trace completeness and sampling semantics
  Refined tracing behavior to make traces structurally complete and easier to reason about:

  - keep batch spans alive until terminal state
  - distinguish timeout from generic failure
  - infer terminal state from observed slice status when needed
  - mark structural spans with explicit sampling priority
  - preserve trace continuity across store → engine → transport boundaries

  ### 6. Added test coverage
  Added or expanded tests around:

  - trace carrier parenting
  - store-side trace session behavior
  - trace registry deduplication
  - timeout tracking
  - transfer-task trace emission
  - transport trace registry semantics

  ## Scope / Non-goals

  This PR focuses on observability and trace continuity.
  It does **not** aim to change transfer semantics, scheduling policy, or transport selection behavior.

  ## Reviewer guide

  Suggested review order:

  1. `mooncake-tracing/`
  2. `mooncake-store/include/transfer_task.h`
  3. `mooncake-store/src/transfer_task.cpp`
  4. `mooncake-transfer-engine/include/transfer_engine_impl.h`
  5. `mooncake-transfer-engine/src/multi_transport.cpp`
  6. tests

  ## Risks

  - Additional tracing overhead on hot transfer paths
  - More lifecycle coordination between store, transfer-engine, and transport tracing state
  - Export-path backpressure / failure behavior if remote collectors are unavailable

  ## Mitigations

  - tracing is config-gated
  - exporters support local JSONL fallback and async remote delivery
  - terminal events are deduplicated
  - structural spans are explicitly modeled instead of inferred from logs

  ## Follow-ups

  - document the recommended collector / dashboard workflow
  - add more end-to-end trace validation in integration tests
  - consider further unifying trace lifecycle ownership across store and transfer-engine


## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
