### PR TITLE
[Bug fix] Prevent redundant replica pinning during offloading

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2121,10 +2121,13 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
             offloading_queue_limit_) {
             return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
         }
-        local_disk_segment_it->second->offloading_objects.emplace(
+        auto res = local_disk_segment_it->second->offloading_objects.emplace(
             key, replica.get_descriptor()
                      .get_memory_descriptor()
                      .buffer_descriptor.size_);
+        if (!res.second) {
+            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+        }
     }
     return {};
 }


### PR DESCRIPTION
## Description

This PR fixes a memory pinning issue where object replicas were incorrectly held in memory due to redundant reference count increments during the offloading process. 

### Reproduction Scenario
The issue is consistently reproducible in environments where **asynchronous offloading** is enabled alongside **multi-tier storage** (e.g., Master with `root_fs_dir` enabled).

1.  **Configuration**: Master started with `--enable-offload=true` and `--root_fs_dir` (local SSD path). 
2.  **Write Sequence**:
    *   An object is written. The Master creates one `MEMORY` replica and one `DISK` replica (for the `root_fs_dir`).
    *   When memory transfer is done, [PutEnd(MEMORY)](cci:1://file:///root/code/Mooncake/mooncake-store/src/master_service.cpp:855:0-908:1) is called. The `MEMORY` replica is pinned (**refcnt=1**) and queued for offloading.
    *   When the disk write to `root_fs_dir` is done, [PutEnd(DISK)](cci:1://file:///root/code/Mooncake/mooncake-store/src/master_service.cpp:855:0-908:1) is called. 
3.  **The Leak**: 
    *   Due to the lack of idempotency, the [PutEnd(DISK)](cci:1://file:///root/code/Mooncake/mooncake-store/src/master_service.cpp:855:0-908:1) call triggers the offload logic again. 
    *   It scans all completed replicas, finding both `MEMORY` and `DISK`.
    *   The `MEMORY` replica is pinned **a second time** (**refcnt=2**), while the `DISK` replica is also pinned (**refcnt=1**).
4.  **Consequence**: 
    *   When the offload task successfully completes, [NotifyOffloadSuccess](cci:1://file:///root/code/Mooncake/mooncake-store/src/master_service.cpp:2050:0-2087:1) only decrements the reference count **once**. 
    *   The `MEMORY` replica remains pinned at `refcnt=1` and becomes **non-evictable**. 
    *   Under heavy load, this leads to a "Memory Leak" where the storage becomes full of untransferable objects, eventually causing `memory_ratio=1` and blocking all new writes.

### Root Cause
In `MasterService::PutEnd`, the offloading logic was triggered unconditionally for all completed replicas every time the function was called. Since [PushOffloadingQueue](cci:1://file:///root/code/Mooncake/mooncake-store/src/master_service.cpp:2089:0-2132:1) did not check if an object was already in the offloading queue, it would return success multiple times for the same object, cause [PutEnd](cci:1://file:///root/code/Mooncake/mooncake-store/src/master_service.cpp:855:0-908:1) to call `replica.inc_refcnt()` repeatedly. 

This resulted in replicas (especially Memory replicas) having a [refcnt](cci:1://file:///root/code/Mooncake/mooncake-store/include/replica.h:319:4-319:58) greater than 1, preventing them from being evicted by the [BatchEvict](cci:1://file:///root/code/Mooncake/mooncake-store/src/master_service.cpp:3386:0-3643:1) thread even after their leases expired.

### Fix
Implemented an idempotency check in `MasterService::PushOffloadingQueue` using the `emplace` method on the `offloading_objects` map. If a key is already present in the offloading queue, the function now returns `ErrorCode::OBJECT_ALREADY_EXISTS`, which prevents [PutEnd](cci:1://file:///root/code/Mooncake/mooncake-store/src/master_service.cpp:855:0-908:1) from further incrementing the reference count.

---

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

The fix was verified using a stress test with `enable_offload=true`. We used custom diagnostic logging in [BatchEvict](cci:1://file:///root/code/Mooncake/mooncake-store/src/master_service.cpp:3386:0-3643:1) to track pinned objects and confirmed that:
1. `MEMORY` replicas no longer accumulate redundant reference counts.
2. The reference count correctly returns to 0 after [NotifyOffloadSuccess](cci:1://file:///root/code/Mooncake/mooncake-store/src/master_service.cpp:2050:0-2087:1) is called.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.