### PR TITLE
[Store] K8s-native Leader Election

### DIFF
--- a/docs/source/deployment/k8s-ha-deployment.md
+++ b/docs/source/deployment/k8s-ha-deployment.md
@@ -1,0 +1,176 @@
+# Kubernetes High Availability Deployment
+
+This guide covers deploying Mooncake Store with K8s-native leader election. The K8s Lease backend uses `coordination.k8s.io/v1` Lease objects for leader election, removing the need for an external etcd cluster when running on Kubernetes.
+
+## Overview
+
+In HA mode, multiple Mooncake Master replicas run as a StatefulSet. One master is elected leader and serves requests; the others remain on standby. If the leader fails, a standby acquires the Lease and becomes the new leader.
+
+The K8s Lease backend leverages the standard `client-go` leader election library. Lease parameters are: duration 5s, renew deadline 3s, retry period 1s.
+
+## Build
+
+Enable the K8s Lease backend at build time:
+
+```bash
+cmake .. -DSTORE_USE_K8S_LEASE=ON
+```
+
+> **Note:** Do not enable `STORE_USE_K8S_LEASE` and `STORE_USE_ETCD` simultaneously. Both backends compile as Go shared libraries with separate Go runtimes, and loading two Go runtimes in a single process is unsupported.
+
+## RBAC Requirements
+
+The master pods need a ServiceAccount with permission to manage Lease objects in their namespace:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mooncake
+  namespace: <namespace>
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mooncake-lease-manager
+  namespace: <namespace>
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "create", "update", "list", "watch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mooncake-lease-manager
+  namespace: <namespace>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mooncake-lease-manager
+subjects:
+- kind: ServiceAccount
+  name: mooncake
+  namespace: <namespace>
+```
+
+## Master Configuration
+
+Master startup flags for K8s HA:
+
+- `--enable_ha` (bool, default `false`): Enable HA mode.
+- `--ha_backend_type` (str, default `etcd`): HA backend. Set to `k8s` for K8s Lease.
+- `--ha_backend_connstring` (str): Connection string for the HA backend. For K8s Lease, use the format `<namespace>/<lease-name>` (e.g., `mooncake-ha/mooncake-leader`).
+- `--rpc_address` (str, default `0.0.0.0`): RPC bind address. The Lease `holderIdentity` is set to `<rpc_address>:<rpc_port>`, so it must be the pod IP, not `0.0.0.0`. Use the Downward API to inject `status.podIP` (see StatefulSet example below).
+- `--enable_http_metadata_server` (bool, default `false`): Enable the embedded HTTP metadata server. Required for transfer engine metadata in HA mode.
+
+Example:
+
+```bash
+mooncake_master \
+  --enable_ha=true \
+  --ha_backend_type=k8s \
+  --ha_backend_connstring=mooncake-ha/mooncake-leader \
+  --rpc_address=$(POD_IP) \
+  --enable_http_metadata_server=true
+```
+
+```yaml
+enable_ha: true
+ha_backend_type: "k8s"
+ha_backend_connstring: "mooncake-ha/mooncake-leader"
+enable_http_metadata_server: true
+```
+
+## Kubernetes Manifests
+
+A complete deployment consists of: Namespace, RBAC (above), headless Service, StatefulSet, and optionally a client pod for testing.
+
+### Headless Service
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mooncake-master
+  namespace: <namespace>
+spec:
+  clusterIP: None
+  selector:
+    app: mooncake-master
+  ports:
+  - port: 50051
+    name: rpc
+  - port: 8080
+    name: http
+```
+
+### StatefulSet
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mooncake-master
+  namespace: <namespace>
+spec:
+  serviceName: mooncake-master
+  replicas: 3
+  selector:
+    matchLabels:
+      app: mooncake-master
+  template:
+    metadata:
+      labels:
+        app: mooncake-master
+    spec:
+      serviceAccountName: mooncake
+      containers:
+      - name: master
+        image: <your-mooncake-image>
+        command: ["mooncake_master"]
+        args:
+        - --enable_ha=true
+        - --ha_backend_type=k8s
+        - --ha_backend_connstring=<namespace>/mooncake-leader
+        - --rpc_address=$(POD_IP)
+        - --rpc_port=50051
+        - --enable_http_metadata_server=true
+        - --http_metadata_server_port=8080
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/lib
+        ports:
+        - containerPort: 50051
+          name: rpc
+        - containerPort: 8080
+          name: http
+```
+
+See `k8s-test/manifests.yaml` for a complete working example.
+
+## Client Discovery
+
+Clients connect to the HA cluster using a `k8s://` connection string:
+
+```python
+import mooncake
+
+client = mooncake.Client()
+client.setup(
+    metadata_server="http://<leader-ip>:8080/metadata",
+    master_server_addr="k8s://<namespace>/<lease-name>",
+)
+```
+
+The `master_server_addr` parameter accepts the format `k8s://<namespace>/<lease-name>`. The client reads the K8s Lease to discover the current leader's address for RPC operations.
+
+> **Note:** The `metadata_server` parameter currently requires the leader's IP directly. On failover, the client's heartbeat thread automatically discovers the new leader via the Lease and reconnects. See [Known Limitations](#known-limitations) for details.
+
+## Known Limitations
+
+- **Metadata server routing**: The `metadata_server` parameter (`http://<leader-ip>:8080/metadata`) is currently bound to the leader's pod IP and does not automatically follow leader changes. On failover, the client's heartbeat thread discovers the new leader and reconnects, but the initial `metadata_server` URL must point to a reachable leader. A future enhancement will use K8s label-based routing (a Service selecting `mooncake-role: leader`) to provide a stable metadata endpoint that survives failover.

--- a/docs/source/deployment/k8s-ha-deployment.md
+++ b/docs/source/deployment/k8s-ha-deployment.md
@@ -38,6 +38,9 @@ rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "create", "update", "list", "watch", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -88,6 +91,8 @@ A complete deployment consists of: Namespace, RBAC (above), headless Service, St
 
 ### Headless Service
 
+Required for StatefulSet DNS (individual pod addressing):
+
 ```yaml
 apiVersion: v1
 kind: Service
@@ -103,6 +108,27 @@ spec:
     name: rpc
   - port: 8080
     name: http
+```
+
+### Leader Service
+
+Routes traffic to the current leader only. The `mooncake.io/store-role: leader` label is managed automatically by the master process — it is set when a pod becomes the leader and removed when leadership is lost.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mooncake-master-leader
+  namespace: <namespace>
+spec:
+  selector:
+    app: mooncake-master
+    mooncake.io/store-role: leader
+  ports:
+  - port: 8080
+    name: http
+  - port: 50051
+    name: rpc
 ```
 
 ### StatefulSet
@@ -142,6 +168,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: LD_LIBRARY_PATH
           value: /usr/local/lib
         ports:
@@ -155,22 +189,20 @@ See `k8s-test/manifests.yaml` for a complete working example.
 
 ## Client Discovery
 
-Clients connect to the HA cluster using a `k8s://` connection string:
+Clients connect to the HA cluster using a `k8s://` connection string. The `mooncake-master-leader` Service routes metadata requests to the current leader via label-based routing:
 
 ```python
 import mooncake
 
 client = mooncake.Client()
 client.setup(
-    metadata_server="http://<leader-ip>:8080/metadata",
+    metadata_server="http://mooncake-master-leader.<namespace>.svc:8080/metadata",
     master_server_addr="k8s://<namespace>/<lease-name>",
 )
 ```
 
 The `master_server_addr` parameter accepts the format `k8s://<namespace>/<lease-name>`. The client reads the K8s Lease to discover the current leader's address for RPC operations.
 
-> **Note:** The `metadata_server` parameter currently requires the leader's IP directly. On failover, the client's heartbeat thread automatically discovers the new leader via the Lease and reconnects. See [Known Limitations](#known-limitations) for details.
+The `metadata_server` parameter uses the `mooncake-master-leader` Service, which automatically follows leader changes via the `mooncake.io/store-role: leader` pod label. On failover, the label moves to the new leader, and the Service endpoint updates accordingly.
 
-## Known Limitations
-
-- **Metadata server routing**: The `metadata_server` parameter (`http://<leader-ip>:8080/metadata`) is currently bound to the leader's pod IP and does not automatically follow leader changes. On failover, the client's heartbeat thread discovers the new leader and reconnects, but the initial `metadata_server` URL must point to a reachable leader. A future enhancement will use K8s label-based routing (a Service selecting `mooncake-role: leader`) to provide a stable metadata endpoint that survives failover.
+> **Note:** You can also use the leader's pod IP directly (`http://<leader-ip>:8080/metadata`), but the Service-based URL is recommended for production as it survives failover without client restarts.

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -34,10 +34,14 @@ This page summarizes useful flags, environment variables, and HTTP endpoints to 
   - `--eviction_high_watermark_ratio` (double, default `0.95`): Usage ratio to trigger eviction.
 
 - High Availability (optional)
-  - `--enable_ha` (bool, default `false`): Enable HA (requires etcd).
-  - `--etcd_endpoints` (str, default empty unless HA config): etcd endpoints, semicolon separated.
+  - `--enable_ha` (bool, default `false`): Enable HA mode.
+  - `--ha_backend_type` (str, default `etcd`): HA backend type. Supported values: `etcd`, `redis`, `k8s`.
+  - `--ha_backend_connstring` (str, default empty): Connection string for the HA backend. For etcd: semicolon-separated endpoints. For K8s Lease: `<namespace>/<lease-name>`. If empty, falls back to `--etcd_endpoints`.
+  - `--etcd_endpoints` (str, default empty): etcd endpoints, semicolon separated. Used as fallback when `--ha_backend_connstring` is empty.
   - `--client_ttl` (int64, default `10` s): Client alive TTL after last ping (HA mode).
   - `--cluster_id` (str, default `mooncake_cluster`): Cluster ID for persistence in HA mode.
+
+  > **Note:** For K8s-native deployments using Lease-based leader election, see the [Kubernetes HA Deployment Guide](k8s-ha-deployment.md).
 
 - Task Manager (optional)
   - `--max_total_finished_tasks` (uint32, default `10000`): Maximum number of finished tasks to keep in memory. When this limit is reached, the oldest finished tasks will be pruned from memory.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -133,6 +133,7 @@ troubleshooting/troubleshooting
 :maxdepth: 2
 
 deployment/mooncake-store-deployment-guide
+deployment/k8s-ha-deployment
 :::
 
 % Community

--- a/mooncake-common/k8s-lease/k8s_lease_wrapper.go
+++ b/mooncake-common/k8s-lease/k8s_lease_wrapper.go
@@ -20,6 +20,7 @@ import "C"
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"sync"
@@ -29,6 +30,7 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -483,6 +485,64 @@ func K8sLeaseCancelWatch(
 	}
 
 	state.cancel()
+	return 0
+}
+
+// patchPodLabel sets or removes a label on a pod using a JSON merge patch.
+// If value is non-nil, the label is set; if nil, the label is removed.
+func patchPodLabel(namespace, podName, labelKey string, value interface{}) error {
+	if globalClient == nil {
+		return fmt.Errorf("k8s client not initialized")
+	}
+
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": map[string]interface{}{
+				labelKey: value,
+			},
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal label patch: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = globalClient.CoreV1().Pods(namespace).Patch(
+		ctx, podName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch pod label: %w", err)
+	}
+	return nil
+}
+
+//export K8sPatchPodLabel
+func K8sPatchPodLabel(
+	ns, podName, labelKey, labelValue *C.char,
+	errMsg **C.char,
+) C.int {
+	err := patchPodLabel(C.GoString(ns), C.GoString(podName),
+		C.GoString(labelKey), C.GoString(labelValue))
+	if err != nil {
+		*errMsg = C.CString(err.Error())
+		return -1
+	}
+	return 0
+}
+
+//export K8sRemovePodLabel
+func K8sRemovePodLabel(
+	ns, podName, labelKey *C.char,
+	errMsg **C.char,
+) C.int {
+	err := patchPodLabel(C.GoString(ns), C.GoString(podName),
+		C.GoString(labelKey), nil)
+	if err != nil {
+		*errMsg = C.CString(err.Error())
+		return -1
+	}
 	return 0
 }
 

--- a/mooncake-common/k8s-lease/k8s_lease_wrapper.go
+++ b/mooncake-common/k8s-lease/k8s_lease_wrapper.go
@@ -374,8 +374,8 @@ func K8sLeaseWatchHolder(
 		*errMsg = C.CString("callback function is nil")
 		return -1
 	}
-	if err := ensureClientInitialized(); err != nil {
-		*errMsg = C.CString(err.Error())
+	if globalClient == nil {
+		*errMsg = C.CString("k8s client not initialized")
 		return -1
 	}
 

--- a/mooncake-common/k8s-lease/k8s_lease_wrapper.go
+++ b/mooncake-common/k8s-lease/k8s_lease_wrapper.go
@@ -374,8 +374,8 @@ func K8sLeaseWatchHolder(
 		*errMsg = C.CString("callback function is nil")
 		return -1
 	}
-	if globalClient == nil {
-		*errMsg = C.CString("k8s client not initialized")
+	if err := ensureClientInitialized(); err != nil {
+		*errMsg = C.CString(err.Error())
 		return -1
 	}
 
@@ -491,8 +491,8 @@ func K8sLeaseCancelWatch(
 // patchPodLabel sets or removes a label on a pod using a JSON merge patch.
 // If value is non-nil, the label is set; if nil, the label is removed.
 func patchPodLabel(namespace, podName, labelKey string, value interface{}) error {
-	if globalClient == nil {
-		return fmt.Errorf("k8s client not initialized")
+	if err := ensureClientInitialized(); err != nil {
+		return err
 	}
 
 	patch := map[string]interface{}{

--- a/mooncake-common/k8s-lease/k8s_lease_wrapper_test.go
+++ b/mooncake-common/k8s-lease/k8s_lease_wrapper_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -19,6 +20,14 @@ func swapClient(newClient kubernetes.Interface) kubernetes.Interface {
 	defer clientMutex.Unlock()
 	old := globalClient
 	globalClient = newClient
+	return old
+}
+
+func swapInitClientFn(newFn func() error) func() error {
+	clientMutex.Lock()
+	defer clientMutex.Unlock()
+	old := initClientFn
+	initClientFn = newFn
 	return old
 }
 
@@ -50,6 +59,61 @@ func TestGetHolderWithFakeClient(t *testing.T) {
 	}
 	if trans != int64(transitions) {
 		t.Errorf("expected transitions %d, got %d", transitions, trans)
+	}
+}
+
+func TestPatchPodLabelAutoInitializesClient(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	})
+
+	oldClient := swapClient(nil)
+	defer swapClient(oldClient)
+
+	initCalls := 0
+	oldInitFn := swapInitClientFn(func() error {
+		initCalls++
+		clientMutex.Lock()
+		globalClient = fakeClient
+		clientMutex.Unlock()
+		return nil
+	})
+	defer swapInitClientFn(oldInitFn)
+
+	const labelKey = "mooncake.io/store-role"
+	if err := patchPodLabel("default", "test-pod", labelKey, "leader"); err != nil {
+		t.Fatalf("patchPodLabel(set) failed: %v", err)
+	}
+	if initCalls != 1 {
+		t.Fatalf("initClientFn calls = %d, want 1", initCalls)
+	}
+
+	pod, err := fakeClient.CoreV1().Pods("default").Get(
+		context.Background(), "test-pod", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pod after label set failed: %v", err)
+	}
+	if got := pod.Labels[labelKey]; got != "leader" {
+		t.Fatalf("label %q = %q, want %q", labelKey, got, "leader")
+	}
+
+	if err := patchPodLabel("default", "test-pod", labelKey, nil); err != nil {
+		t.Fatalf("patchPodLabel(remove) failed: %v", err)
+	}
+	if initCalls != 1 {
+		t.Fatalf("initClientFn calls after second patch = %d, want 1", initCalls)
+	}
+
+	pod, err = fakeClient.CoreV1().Pods("default").Get(
+		context.Background(), "test-pod", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pod after label removal failed: %v", err)
+	}
+	if _, exists := pod.Labels[labelKey]; exists {
+		t.Fatalf("label %q still present after removal", labelKey)
 	}
 }
 

--- a/mooncake-store/CMakeLists.txt
+++ b/mooncake-store/CMakeLists.txt
@@ -10,13 +10,18 @@ if (STORE_USE_ETCD)
     set(ETCD_WRAPPER_LIB ${CMAKE_CURRENT_BINARY_DIR}/../mooncake-common/etcd/libetcd_wrapper.so)
 endif()
 
+if (STORE_USE_K8S_LEASE)
+    set(K8S_LEASE_WRAPPER_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/../mooncake-common/k8s-lease/)
+    set(K8S_LEASE_WRAPPER_LIB ${CMAKE_CURRENT_BINARY_DIR}/../mooncake-common/k8s-lease/libk8s_lease_wrapper.so)
+endif()
+
 if (STORE_USE_REDIS)
     find_path(MOONCAKE_STORE_HIREDIS_INCLUDE_DIR hiredis/hiredis.h REQUIRED)
     find_library(MOONCAKE_STORE_HIREDIS_LIBRARY hiredis REQUIRED)
     message(STATUS "Redis HA backend: Enabled")
 endif()
 
-if (NOT STORE_USE_ETCD AND NOT STORE_USE_REDIS)
+if (NOT STORE_USE_ETCD AND NOT STORE_USE_REDIS AND NOT STORE_USE_K8S_LEASE)
     message(STATUS "Store HA backends are disabled")
 endif()
 

--- a/mooncake-store/include/ha/leadership/backends/k8s/k8s_leader_coordinator.h
+++ b/mooncake-store/include/ha/leadership/backends/k8s/k8s_leader_coordinator.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "k8s_lease_helper.h"
+#include "ha/leadership/leader_coordinator.h"
+
+namespace mooncake {
+namespace ha {
+namespace backends {
+namespace k8s {
+
+class K8sLeaderCoordinator final : public LeaderCoordinator {
+   public:
+    explicit K8sLeaderCoordinator(const HABackendSpec& spec);
+    ~K8sLeaderCoordinator() override;
+
+    ErrorCode Connect();
+
+    tl::expected<std::optional<MasterView>, ErrorCode> ReadCurrentView()
+        override;
+
+    tl::expected<AcquireLeadershipResult, ErrorCode> TryAcquireLeadership(
+        const std::string& leader_address) override;
+
+    tl::expected<bool, ErrorCode> RenewLeadership(
+        const LeadershipSession& session) override;
+
+    tl::expected<ViewChangeResult, ErrorCode> WaitForViewChange(
+        std::optional<ViewVersionId> known_version,
+        std::chrono::milliseconds timeout) override;
+
+    tl::expected<std::unique_ptr<LeadershipMonitorHandle>, ErrorCode>
+    StartLeadershipMonitor(const LeadershipSession& session,
+                           LeadershipLostCallback on_leadership_lost) override;
+
+    ErrorCode ReleaseLeadership(const LeadershipSession& session) override;
+
+   private:
+    ErrorCode EnsureConnected();
+    ErrorCode ShutdownElection();
+    void ClearLeadershipMonitorStateLocked();
+    bool IsSameViewVersion(const std::optional<MasterView>& current_view,
+                           std::optional<ViewVersionId> known_version) const;
+    static std::pair<std::string, std::string> ParseConnstring(
+        const std::string& connstring);
+
+    HABackendSpec spec_;
+    std::string namespace_;
+    std::string lease_name_;
+    bool connected_ = false;
+
+    std::mutex election_mutex_;
+    std::thread election_monitor_thread_;
+    std::string election_identity_;
+    bool election_active_ = false;
+    bool election_shutdown_requested_ = false;
+    LeadershipLostCallback leadership_monitor_callback_;
+    std::shared_ptr<std::atomic<bool>> leadership_monitor_armed_;
+    OwnerToken leadership_monitor_owner_token_;
+};
+
+}  // namespace k8s
+}  // namespace backends
+}  // namespace ha
+}  // namespace mooncake

--- a/mooncake-store/include/ha/leadership/backends/k8s/k8s_leader_coordinator.h
+++ b/mooncake-store/include/ha/leadership/backends/k8s/k8s_leader_coordinator.h
@@ -56,7 +56,9 @@ class K8sLeaderCoordinator final : public LeaderCoordinator {
     std::mutex election_mutex_;
     std::thread election_monitor_thread_;
     std::string election_identity_;
+    OwnerToken election_owner_token_;
     bool election_active_ = false;
+    bool election_monitor_stopped_ = false;
     bool election_shutdown_requested_ = false;
     LeadershipLostCallback leadership_monitor_callback_;
     std::shared_ptr<std::atomic<bool>> leadership_monitor_armed_;

--- a/mooncake-store/include/k8s_lease_helper.h
+++ b/mooncake-store/include/k8s_lease_helper.h
@@ -36,6 +36,14 @@ class K8sLeaseHelper {
     static ErrorCode CancelWatch(const std::string& ns,
                                  const std::string& lease);
 
+    static ErrorCode SetPodLabel(const std::string& ns, const std::string& pod,
+                                 const std::string& key,
+                                 const std::string& value);
+
+    static ErrorCode ClearPodLabel(const std::string& ns,
+                                   const std::string& pod,
+                                   const std::string& key);
+
    private:
     static std::mutex init_mutex_;
     static bool initialized_;

--- a/mooncake-store/include/k8s_lease_helper.h
+++ b/mooncake-store/include/k8s_lease_helper.h
@@ -14,29 +14,23 @@ class K8sLeaseHelper {
 
     static ErrorCode RunElection(const std::string& ns,
                                  const std::string& lease,
-                                 const std::string& identity,
-                                 int lease_dur, int renew_deadline,
-                                 int retry_period);
+                                 const std::string& identity, int lease_dur,
+                                 int renew_deadline, int retry_period);
 
     static ErrorCode WaitElected(const std::string& ns,
-                                 const std::string& lease,
-                                 int timeout_sec,
+                                 const std::string& lease, int timeout_sec,
                                  int64_t& lease_transitions);
 
-    static ErrorCode WaitLost(const std::string& ns,
-                              const std::string& lease);
+    static ErrorCode WaitLost(const std::string& ns, const std::string& lease);
 
     static ErrorCode CancelElection(const std::string& ns,
                                     const std::string& lease);
 
-    static ErrorCode GetHolder(const std::string& ns,
-                               const std::string& lease,
-                               std::string& holder,
-                               int64_t& lease_transitions);
+    static ErrorCode GetHolder(const std::string& ns, const std::string& lease,
+                               std::string& holder, int64_t& lease_transitions);
 
     static ErrorCode WatchHolder(
-        const std::string& ns, const std::string& lease,
-        void* callback_context,
+        const std::string& ns, const std::string& lease, void* callback_context,
         void (*callback_func)(void*, const char*, size_t, int64_t));
 
     static ErrorCode CancelWatch(const std::string& ns,

--- a/mooncake-store/include/k8s_lease_helper.h
+++ b/mooncake-store/include/k8s_lease_helper.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+
+#include "types.h"
+
+namespace mooncake {
+
+class K8sLeaseHelper {
+   public:
+    static ErrorCode Init();
+
+    static ErrorCode RunElection(const std::string& ns,
+                                 const std::string& lease,
+                                 const std::string& identity,
+                                 int lease_dur, int renew_deadline,
+                                 int retry_period);
+
+    static ErrorCode WaitElected(const std::string& ns,
+                                 const std::string& lease,
+                                 int timeout_sec,
+                                 int64_t& lease_transitions);
+
+    static ErrorCode WaitLost(const std::string& ns,
+                              const std::string& lease);
+
+    static ErrorCode CancelElection(const std::string& ns,
+                                    const std::string& lease);
+
+    static ErrorCode GetHolder(const std::string& ns,
+                               const std::string& lease,
+                               std::string& holder,
+                               int64_t& lease_transitions);
+
+    static ErrorCode WatchHolder(
+        const std::string& ns, const std::string& lease,
+        void* callback_context,
+        void (*callback_func)(void*, const char*, size_t, int64_t));
+
+    static ErrorCode CancelWatch(const std::string& ns,
+                                 const std::string& lease);
+
+   private:
+    static std::mutex init_mutex_;
+    static bool initialized_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <stdexcept>
+#include <string_view>
 
 #include <glog/logging.h>
 
@@ -9,6 +10,18 @@
 #include "types.h"
 
 namespace mooncake {
+
+inline std::string ResolveConfiguredHABackendConnstring(
+    std::string_view ha_backend_type, std::string_view ha_backend_connstring,
+    std::string_view etcd_endpoints) {
+    if (!ha_backend_connstring.empty()) {
+        return std::string(ha_backend_connstring);
+    }
+    if (ha_backend_type == "etcd") {
+        return std::string(etcd_endpoints);
+    }
+    return {};
+}
 
 // The configuration for the master server
 struct MasterConfig {
@@ -180,11 +193,9 @@ class MasterServiceSupervisorConfig {
             std::chrono::seconds(config.rpc_conn_timeout_seconds);
         rpc_enable_tcp_no_delay = config.rpc_enable_tcp_no_delay;
         ha_backend_type = config.ha_backend_type;
-        ha_backend_connstring = config.ha_backend_connstring;
         etcd_endpoints = config.etcd_endpoints;
-        if (ha_backend_connstring.empty()) {
-            ha_backend_connstring = etcd_endpoints;
-        }
+        ha_backend_connstring = ResolveConfiguredHABackendConnstring(
+            ha_backend_type, config.ha_backend_connstring, etcd_endpoints);
         local_hostname = rpc_address + ":" + std::to_string(rpc_port);
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;
@@ -346,10 +357,9 @@ class WrappedMasterServiceConfig {
         offload_on_evict = config.offload_on_evict;
         offload_force_evict = config.offload_force_evict;
         ha_backend_type = config.ha_backend_type;
-        ha_backend_connstring = config.ha_backend_connstring;
-        if (ha_backend_connstring.empty()) {
-            ha_backend_connstring = config.etcd_endpoints;
-        }
+        ha_backend_connstring = ResolveConfiguredHABackendConnstring(
+            ha_backend_type, config.ha_backend_connstring,
+            config.etcd_endpoints);
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;
         global_file_segment_size = config.global_file_segment_size;
@@ -426,10 +436,9 @@ class WrappedMasterServiceConfig {
         offload_on_evict = config.offload_on_evict;
         offload_force_evict = config.offload_force_evict;
         ha_backend_type = config.ha_backend_type;
-        ha_backend_connstring = config.ha_backend_connstring;
-        if (ha_backend_connstring.empty()) {
-            ha_backend_connstring = config.etcd_endpoints;
-        }
+        ha_backend_connstring = ResolveConfiguredHABackendConnstring(
+            ha_backend_type, config.ha_backend_connstring,
+            config.etcd_endpoints);
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;
         global_file_segment_size = config.global_file_segment_size;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -45,6 +45,10 @@ struct MasterConfig {
     uint32_t http_metadata_server_port;
     std::string http_metadata_server_host;
 
+    // Pod identity for K8s label-based routing
+    std::string pod_name;
+    std::string pod_namespace;
+
     uint64_t put_start_discard_timeout_sec;
     uint64_t put_start_release_timeout_sec;
 
@@ -146,6 +150,10 @@ class MasterServiceSupervisorConfig {
     bool enable_cxl = false;
     bool offload_on_evict = false;
     bool offload_force_evict = false;
+
+    // Pod identity for K8s label-based routing
+    std::string pod_name;
+    std::string pod_namespace;
     MasterServiceSupervisorConfig() = default;
 
     // From MasterConfig
@@ -214,6 +222,9 @@ class MasterServiceSupervisorConfig {
         cxl_path = config.cxl_path;
         cxl_size = config.cxl_size;
         enable_cxl = config.enable_cxl;
+
+        pod_name = config.pod_name;
+        pod_namespace = config.pod_namespace;
         validate();
     }
 

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -270,6 +270,8 @@ enum class ErrorCode : int32_t {
     ETCD_CTX_CANCELLED = -1003,     ///< etcd context cancelled.
     OPLOG_ENTRY_NOT_FOUND =
         -1004,  ///< OpLog entry not found (backend-agnostic).
+    K8S_LEASE_OPERATION_ERROR = -1005,  ///< K8s Lease operation failed.
+    K8S_LEASE_NOT_FOUND = -1006,        ///< K8s Lease not found.
     UNAVAILABLE_IN_CURRENT_STATUS =
         -1010,  ///< Request cannot be done in current status.
     UNAVAILABLE_IN_CURRENT_MODE =

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -137,6 +137,13 @@ if(STORE_USE_REDIS)
   list(APPEND EXTRA_LIBS ${MOONCAKE_STORE_HIREDIS_LIBRARY})
 endif()
 
+if(STORE_USE_K8S_LEASE)
+  list(APPEND MOONCAKE_STORE_SOURCES
+    k8s_lease_helper.cpp
+    ha/leadership/backends/k8s/k8s_leader_coordinator.cpp)
+  list(APPEND EXTRA_LIBS ${K8S_LEASE_WRAPPER_LIB})
+endif()
+
 # The cache_allocator library
 include_directories(${Python3_INCLUDE_DIRS})
 add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
@@ -162,6 +169,9 @@ target_link_libraries(mooncake_store
 )
 if(STORE_USE_ETCD)
     add_dependencies(mooncake_store build_etcd_wrapper)
+endif()
+if(STORE_USE_K8S_LEASE)
+    add_dependencies(mooncake_store build_k8s_lease_wrapper)
 endif()
 
 if(URING_LIB AND URING_INCLUDE)

--- a/mooncake-store/src/ha/leadership/backends/k8s/k8s_leader_coordinator.cpp
+++ b/mooncake-store/src/ha/leadership/backends/k8s/k8s_leader_coordinator.cpp
@@ -1,0 +1,366 @@
+#include "ha/leadership/backends/k8s/k8s_leader_coordinator.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <optional>
+#include <thread>
+
+#include <glog/logging.h>
+#include <ylt/util/tl/expected.hpp>
+
+namespace mooncake {
+namespace ha {
+namespace backends {
+namespace k8s {
+
+namespace {
+
+constexpr int kDefaultLeaseDurationSec = 5;
+constexpr int kDefaultRenewDeadlineSec = 3;
+constexpr int kDefaultRetryPeriodSec = 1;
+constexpr auto kViewChangePollInterval = std::chrono::milliseconds(200);
+
+class K8sLeadershipMonitorHandle final : public LeadershipMonitorHandle {
+   public:
+    explicit K8sLeadershipMonitorHandle(
+        std::shared_ptr<std::atomic<bool>> armed)
+        : armed_(std::move(armed)) {}
+
+    void Stop() override {
+        if (armed_ != nullptr) {
+            armed_->store(false);
+        }
+    }
+
+   private:
+    std::shared_ptr<std::atomic<bool>> armed_;
+};
+
+}  // namespace
+
+K8sLeaderCoordinator::K8sLeaderCoordinator(const HABackendSpec& spec)
+    : spec_(spec) {
+    auto [ns, name] = ParseConnstring(spec.connstring);
+    namespace_ = std::move(ns);
+    lease_name_ = std::move(name);
+}
+
+K8sLeaderCoordinator::~K8sLeaderCoordinator() { ShutdownElection(); }
+
+ErrorCode K8sLeaderCoordinator::Connect() {
+    if (connected_) {
+        return ErrorCode::OK;
+    }
+
+    auto err = K8sLeaseHelper::Init();
+    if (err == ErrorCode::OK) {
+        connected_ = true;
+    }
+    return err;
+}
+
+tl::expected<std::optional<MasterView>, ErrorCode>
+K8sLeaderCoordinator::ReadCurrentView() {
+    auto err = EnsureConnected();
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+
+    std::string holder;
+    int64_t transitions = 0;
+    err = K8sLeaseHelper::GetHolder(namespace_, lease_name_, holder,
+                                    transitions);
+    if (err == ErrorCode::K8S_LEASE_NOT_FOUND) {
+        return std::optional<MasterView>{std::nullopt};
+    }
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+
+    if (holder.empty()) {
+        return std::optional<MasterView>{std::nullopt};
+    }
+
+    return std::optional<MasterView>{
+        MasterView{.leader_address = std::move(holder),
+                   .view_version = static_cast<ViewVersionId>(transitions)}};
+}
+
+tl::expected<AcquireLeadershipResult, ErrorCode>
+K8sLeaderCoordinator::TryAcquireLeadership(
+    const std::string& leader_address) {
+    auto err = EnsureConnected();
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+
+    // Start election goroutine
+    err = K8sLeaseHelper::RunElection(namespace_, lease_name_, leader_address,
+                                      kDefaultLeaseDurationSec,
+                                      kDefaultRenewDeadlineSec,
+                                      kDefaultRetryPeriodSec);
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+
+    constexpr int kElectionTimeoutSec = 2 * kDefaultLeaseDurationSec;
+    int64_t transitions = 0;
+    err = K8sLeaseHelper::WaitElected(namespace_, lease_name_,
+                                      kElectionTimeoutSec, transitions);
+    if (err != ErrorCode::OK) {
+        // Election failed — we are not the leader
+        K8sLeaseHelper::CancelElection(namespace_, lease_name_);
+
+        auto observed_view = ReadCurrentView();
+        if (!observed_view) {
+            return tl::make_unexpected(observed_view.error());
+        }
+        return AcquireLeadershipResult{
+            .status = AcquireLeadershipStatus::CONTENDED,
+            .session = std::nullopt,
+            .observed_view = observed_view.value(),
+        };
+    }
+
+    // We are the leader
+    OwnerToken token = namespace_ + "/" + lease_name_;
+    LeadershipSession session{
+        .view = MasterView{.leader_address = leader_address,
+                           .view_version =
+                               static_cast<ViewVersionId>(transitions)},
+        .owner_token = token,
+        .lease_ttl = std::chrono::seconds(kDefaultLeaseDurationSec),
+    };
+
+    {
+        std::lock_guard<std::mutex> lock(election_mutex_);
+        election_identity_ = leader_address;
+        election_active_ = true;
+        election_shutdown_requested_ = false;
+        ClearLeadershipMonitorStateLocked();
+    }
+
+    return AcquireLeadershipResult{
+        .status = AcquireLeadershipStatus::ACQUIRED,
+        .session = std::move(session),
+        .observed_view = std::nullopt,
+    };
+}
+
+tl::expected<bool, ErrorCode> K8sLeaderCoordinator::RenewLeadership(
+    const LeadershipSession& session) {
+    auto err = EnsureConnected();
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+
+    std::lock_guard<std::mutex> lock(election_mutex_);
+
+    if (election_shutdown_requested_) {
+        return false;
+    }
+    if (!election_active_) {
+        return false;
+    }
+
+    // client-go handles renewal internally. If election is still active,
+    // leadership is being renewed. Start the monitor thread if not running.
+    if (!election_monitor_thread_.joinable()) {
+        election_monitor_thread_ = std::thread([this, token = session.owner_token]() {
+            auto rc = K8sLeaseHelper::WaitLost(namespace_, lease_name_);
+
+            std::shared_ptr<std::atomic<bool>> monitor_armed;
+            LeadershipLostCallback on_leadership_lost;
+            LeadershipLossReason loss_reason =
+                (rc == ErrorCode::OK)
+                    ? LeadershipLossReason::kLostLeadership
+                    : LeadershipLossReason::kRenewError;
+            {
+                std::lock_guard<std::mutex> lock(election_mutex_);
+                election_active_ = false;
+                if (!election_shutdown_requested_ &&
+                    leadership_monitor_owner_token_ == token) {
+                    monitor_armed = leadership_monitor_armed_;
+                    on_leadership_lost =
+                        std::move(leadership_monitor_callback_);
+                    leadership_monitor_armed_.reset();
+                    leadership_monitor_owner_token_.clear();
+                }
+            }
+
+            if (monitor_armed != nullptr &&
+                monitor_armed->exchange(false) &&
+                on_leadership_lost != nullptr) {
+                on_leadership_lost(loss_reason);
+            }
+        });
+    }
+
+    return true;
+}
+
+tl::expected<ViewChangeResult, ErrorCode>
+K8sLeaderCoordinator::WaitForViewChange(
+    std::optional<ViewVersionId> known_version,
+    std::chrono::milliseconds timeout) {
+    auto err = EnsureConnected();
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (true) {
+        auto current_view = ReadCurrentView();
+        if (!current_view) {
+            return tl::make_unexpected(current_view.error());
+        }
+
+        if (!IsSameViewVersion(current_view.value(), known_version)) {
+            return ViewChangeResult{
+                .changed = true,
+                .timed_out = false,
+                .current_view = current_view.value(),
+            };
+        }
+
+        if (timeout <= std::chrono::milliseconds::zero() ||
+            std::chrono::steady_clock::now() >= deadline) {
+            return ViewChangeResult{
+                .changed = false,
+                .timed_out = true,
+                .current_view = std::nullopt,
+            };
+        }
+
+        const auto remaining =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                deadline - std::chrono::steady_clock::now());
+        std::this_thread::sleep_for(
+            std::min(kViewChangePollInterval, remaining));
+    }
+}
+
+tl::expected<std::unique_ptr<LeadershipMonitorHandle>, ErrorCode>
+K8sLeaderCoordinator::StartLeadershipMonitor(
+    const LeadershipSession& session,
+    LeadershipLostCallback on_leadership_lost) {
+    auto err = EnsureConnected();
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+    if (!on_leadership_lost) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::lock_guard<std::mutex> lock(election_mutex_);
+    if (election_shutdown_requested_) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
+    if (!election_active_) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
+    if (leadership_monitor_armed_ != nullptr &&
+        leadership_monitor_armed_->load()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    leadership_monitor_owner_token_ = session.owner_token;
+    leadership_monitor_callback_ = std::move(on_leadership_lost);
+    leadership_monitor_armed_ = std::make_shared<std::atomic<bool>>(true);
+    return std::unique_ptr<LeadershipMonitorHandle>(
+        std::make_unique<K8sLeadershipMonitorHandle>(
+            leadership_monitor_armed_));
+}
+
+ErrorCode K8sLeaderCoordinator::ReleaseLeadership(
+    const LeadershipSession& session) {
+    std::thread thread_to_join;
+    {
+        std::lock_guard<std::mutex> lock(election_mutex_);
+        election_shutdown_requested_ = true;
+        election_active_ = false;
+        ClearLeadershipMonitorStateLocked();
+        if (election_monitor_thread_.joinable()) {
+            thread_to_join = std::move(election_monitor_thread_);
+        }
+    }
+
+    // Cancel the election goroutine (triggers WaitLost to return)
+    auto err = K8sLeaseHelper::CancelElection(namespace_, lease_name_);
+
+    if (thread_to_join.joinable()) {
+        thread_to_join.join();
+    }
+
+    return err;
+}
+
+ErrorCode K8sLeaderCoordinator::EnsureConnected() {
+    if (connected_) {
+        return ErrorCode::OK;
+    }
+    return Connect();
+}
+
+ErrorCode K8sLeaderCoordinator::ShutdownElection() {
+    std::thread thread_to_join;
+    bool should_cancel = false;
+    {
+        std::lock_guard<std::mutex> lock(election_mutex_);
+        election_shutdown_requested_ = true;
+        should_cancel = election_active_;
+        election_active_ = false;
+        ClearLeadershipMonitorStateLocked();
+        if (election_monitor_thread_.joinable()) {
+            thread_to_join = std::move(election_monitor_thread_);
+        }
+    }
+
+    if (should_cancel) {
+        K8sLeaseHelper::CancelElection(namespace_, lease_name_);
+    }
+
+    if (thread_to_join.joinable()) {
+        thread_to_join.join();
+    }
+
+    return ErrorCode::OK;
+}
+
+void K8sLeaderCoordinator::ClearLeadershipMonitorStateLocked() {
+    if (leadership_monitor_armed_ != nullptr) {
+        leadership_monitor_armed_->store(false);
+        leadership_monitor_armed_.reset();
+    }
+    leadership_monitor_callback_ = nullptr;
+    leadership_monitor_owner_token_.clear();
+}
+
+bool K8sLeaderCoordinator::IsSameViewVersion(
+    const std::optional<MasterView>& current_view,
+    std::optional<ViewVersionId> known_version) const {
+    if (!current_view.has_value() && !known_version.has_value()) {
+        return true;
+    }
+    if (!current_view.has_value() || !known_version.has_value()) {
+        return false;
+    }
+    return current_view->view_version == known_version.value();
+}
+
+std::pair<std::string, std::string> K8sLeaderCoordinator::ParseConnstring(
+    const std::string& connstring) {
+    // Format: "namespace/lease-name"
+    auto pos = connstring.find('/');
+    if (pos == std::string::npos) {
+        // Default namespace
+        return {"default", connstring};
+    }
+    return {connstring.substr(0, pos), connstring.substr(pos + 1)};
+}
+
+}  // namespace k8s
+}  // namespace backends
+}  // namespace ha
+}  // namespace mooncake

--- a/mooncake-store/src/ha/leadership/backends/k8s/k8s_leader_coordinator.cpp
+++ b/mooncake-store/src/ha/leadership/backends/k8s/k8s_leader_coordinator.cpp
@@ -69,8 +69,8 @@ K8sLeaderCoordinator::ReadCurrentView() {
 
     std::string holder;
     int64_t transitions = 0;
-    err = K8sLeaseHelper::GetHolder(namespace_, lease_name_, holder,
-                                    transitions);
+    err =
+        K8sLeaseHelper::GetHolder(namespace_, lease_name_, holder, transitions);
     if (err == ErrorCode::K8S_LEASE_NOT_FOUND) {
         return std::optional<MasterView>{std::nullopt};
     }
@@ -88,18 +88,16 @@ K8sLeaderCoordinator::ReadCurrentView() {
 }
 
 tl::expected<AcquireLeadershipResult, ErrorCode>
-K8sLeaderCoordinator::TryAcquireLeadership(
-    const std::string& leader_address) {
+K8sLeaderCoordinator::TryAcquireLeadership(const std::string& leader_address) {
     auto err = EnsureConnected();
     if (err != ErrorCode::OK) {
         return tl::make_unexpected(err);
     }
 
     // Start election goroutine
-    err = K8sLeaseHelper::RunElection(namespace_, lease_name_, leader_address,
-                                      kDefaultLeaseDurationSec,
-                                      kDefaultRenewDeadlineSec,
-                                      kDefaultRetryPeriodSec);
+    err = K8sLeaseHelper::RunElection(
+        namespace_, lease_name_, leader_address, kDefaultLeaseDurationSec,
+        kDefaultRenewDeadlineSec, kDefaultRetryPeriodSec);
     if (err != ErrorCode::OK) {
         return tl::make_unexpected(err);
     }
@@ -126,9 +124,9 @@ K8sLeaderCoordinator::TryAcquireLeadership(
     // We are the leader
     OwnerToken token = namespace_ + "/" + lease_name_;
     LeadershipSession session{
-        .view = MasterView{.leader_address = leader_address,
-                           .view_version =
-                               static_cast<ViewVersionId>(transitions)},
+        .view =
+            MasterView{.leader_address = leader_address,
+                       .view_version = static_cast<ViewVersionId>(transitions)},
         .owner_token = token,
         .lease_ttl = std::chrono::seconds(kDefaultLeaseDurationSec),
     };
@@ -167,15 +165,15 @@ tl::expected<bool, ErrorCode> K8sLeaderCoordinator::RenewLeadership(
     // client-go handles renewal internally. If election is still active,
     // leadership is being renewed. Start the monitor thread if not running.
     if (!election_monitor_thread_.joinable()) {
-        election_monitor_thread_ = std::thread([this, token = session.owner_token]() {
+        election_monitor_thread_ = std::thread([this,
+                                                token = session.owner_token]() {
             auto rc = K8sLeaseHelper::WaitLost(namespace_, lease_name_);
 
             std::shared_ptr<std::atomic<bool>> monitor_armed;
             LeadershipLostCallback on_leadership_lost;
             LeadershipLossReason loss_reason =
-                (rc == ErrorCode::OK)
-                    ? LeadershipLossReason::kLostLeadership
-                    : LeadershipLossReason::kRenewError;
+                (rc == ErrorCode::OK) ? LeadershipLossReason::kLostLeadership
+                                      : LeadershipLossReason::kRenewError;
             {
                 std::lock_guard<std::mutex> lock(election_mutex_);
                 election_active_ = false;
@@ -189,8 +187,7 @@ tl::expected<bool, ErrorCode> K8sLeaderCoordinator::RenewLeadership(
                 }
             }
 
-            if (monitor_armed != nullptr &&
-                monitor_armed->exchange(false) &&
+            if (monitor_armed != nullptr && monitor_armed->exchange(false) &&
                 on_leadership_lost != nullptr) {
                 on_leadership_lost(loss_reason);
             }

--- a/mooncake-store/src/ha/leadership/backends/k8s/k8s_leader_coordinator.cpp
+++ b/mooncake-store/src/ha/leadership/backends/k8s/k8s_leader_coordinator.cpp
@@ -3,7 +3,9 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <optional>
+#include <string>
 #include <thread>
 
 #include <glog/logging.h>
@@ -20,6 +22,19 @@ constexpr int kDefaultLeaseDurationSec = 5;
 constexpr int kDefaultRenewDeadlineSec = 3;
 constexpr int kDefaultRetryPeriodSec = 1;
 constexpr auto kViewChangePollInterval = std::chrono::milliseconds(200);
+
+std::atomic<uint64_t> g_session_sequence{0};
+
+OwnerToken MakeOwnerToken(const std::string& namespace_name,
+                          const std::string& lease_name,
+                          const std::string& leader_address,
+                          int64_t lease_transitions) {
+    const auto sequence =
+        g_session_sequence.fetch_add(1, std::memory_order_relaxed) + 1;
+    return namespace_name + "/" + lease_name + "/" +
+           std::to_string(lease_transitions) + "/" + std::to_string(sequence) +
+           "/" + leader_address;
+}
 
 class K8sLeadershipMonitorHandle final : public LeadershipMonitorHandle {
    public:
@@ -122,7 +137,8 @@ K8sLeaderCoordinator::TryAcquireLeadership(const std::string& leader_address) {
     }
 
     // We are the leader
-    OwnerToken token = namespace_ + "/" + lease_name_;
+    OwnerToken token =
+        MakeOwnerToken(namespace_, lease_name_, leader_address, transitions);
     LeadershipSession session{
         .view =
             MasterView{.leader_address = leader_address,
@@ -131,12 +147,22 @@ K8sLeaderCoordinator::TryAcquireLeadership(const std::string& leader_address) {
         .lease_ttl = std::chrono::seconds(kDefaultLeaseDurationSec),
     };
 
+    std::thread thread_to_join;
     {
         std::lock_guard<std::mutex> lock(election_mutex_);
+        if (election_monitor_thread_.joinable() && election_monitor_stopped_) {
+            thread_to_join = std::move(election_monitor_thread_);
+        }
         election_identity_ = leader_address;
+        election_owner_token_ = session.owner_token;
         election_active_ = true;
+        election_monitor_stopped_ = false;
         election_shutdown_requested_ = false;
         ClearLeadershipMonitorStateLocked();
+    }
+
+    if (thread_to_join.joinable()) {
+        thread_to_join.join();
     }
 
     return AcquireLeadershipResult{
@@ -152,46 +178,72 @@ tl::expected<bool, ErrorCode> K8sLeaderCoordinator::RenewLeadership(
     if (err != ErrorCode::OK) {
         return tl::make_unexpected(err);
     }
-
-    std::lock_guard<std::mutex> lock(election_mutex_);
-
-    if (election_shutdown_requested_) {
-        return false;
-    }
-    if (!election_active_) {
-        return false;
+    if (session.owner_token.empty()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    // client-go handles renewal internally. If election is still active,
-    // leadership is being renewed. Start the monitor thread if not running.
-    if (!election_monitor_thread_.joinable()) {
-        election_monitor_thread_ = std::thread([this,
-                                                token = session.owner_token]() {
-            auto rc = K8sLeaseHelper::WaitLost(namespace_, lease_name_);
+    std::thread thread_to_join;
+    {
+        std::lock_guard<std::mutex> lock(election_mutex_);
 
-            std::shared_ptr<std::atomic<bool>> monitor_armed;
-            LeadershipLostCallback on_leadership_lost;
-            LeadershipLossReason loss_reason =
-                (rc == ErrorCode::OK) ? LeadershipLossReason::kLostLeadership
-                                      : LeadershipLossReason::kRenewError;
-            {
-                std::lock_guard<std::mutex> lock(election_mutex_);
-                election_active_ = false;
-                if (!election_shutdown_requested_ &&
-                    leadership_monitor_owner_token_ == token) {
-                    monitor_armed = leadership_monitor_armed_;
-                    on_leadership_lost =
-                        std::move(leadership_monitor_callback_);
-                    leadership_monitor_armed_.reset();
-                    leadership_monitor_owner_token_.clear();
-                }
-            }
+        if (election_shutdown_requested_) {
+            return false;
+        }
+        if (!election_active_) {
+            return false;
+        }
+        if (election_owner_token_ != session.owner_token) {
+            return false;
+        }
 
-            if (monitor_armed != nullptr && monitor_armed->exchange(false) &&
-                on_leadership_lost != nullptr) {
-                on_leadership_lost(loss_reason);
+        // client-go handles renewal internally. If election is still active,
+        // leadership is being renewed. Start the monitor thread if not running.
+        if (election_monitor_thread_.joinable()) {
+            if (!election_monitor_stopped_) {
+                return true;
             }
-        });
+            thread_to_join = std::move(election_monitor_thread_);
+            election_monitor_stopped_ = false;
+        }
+
+        if (!election_monitor_thread_.joinable()) {
+            election_monitor_thread_ =
+                std::thread([this, token = session.owner_token]() {
+                    auto rc = K8sLeaseHelper::WaitLost(namespace_, lease_name_);
+
+                    std::shared_ptr<std::atomic<bool>> monitor_armed;
+                    LeadershipLostCallback on_leadership_lost;
+                    LeadershipLossReason loss_reason =
+                        (rc == ErrorCode::OK)
+                            ? LeadershipLossReason::kLostLeadership
+                            : LeadershipLossReason::kRenewError;
+                    {
+                        std::lock_guard<std::mutex> lock(election_mutex_);
+                        election_monitor_stopped_ = true;
+                        if (election_owner_token_ == token) {
+                            election_active_ = false;
+                        }
+                        if (!election_shutdown_requested_ &&
+                            leadership_monitor_owner_token_ == token) {
+                            monitor_armed = leadership_monitor_armed_;
+                            on_leadership_lost =
+                                std::move(leadership_monitor_callback_);
+                            leadership_monitor_armed_.reset();
+                            leadership_monitor_owner_token_.clear();
+                        }
+                    }
+
+                    if (monitor_armed != nullptr &&
+                        monitor_armed->exchange(false) &&
+                        on_leadership_lost != nullptr) {
+                        on_leadership_lost(loss_reason);
+                    }
+                });
+        }
+    }
+
+    if (thread_to_join.joinable()) {
+        thread_to_join.join();
     }
 
     return true;
@@ -254,7 +306,13 @@ K8sLeaderCoordinator::StartLeadershipMonitor(
     if (election_shutdown_requested_) {
         return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
     }
+    if (session.owner_token.empty()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
     if (!election_active_) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
+    if (election_owner_token_ != session.owner_token) {
         return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
     }
     if (leadership_monitor_armed_ != nullptr &&
@@ -272,11 +330,21 @@ K8sLeaderCoordinator::StartLeadershipMonitor(
 
 ErrorCode K8sLeaderCoordinator::ReleaseLeadership(
     const LeadershipSession& session) {
+    if (session.owner_token.empty()) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+
     std::thread thread_to_join;
     {
         std::lock_guard<std::mutex> lock(election_mutex_);
+        if (!election_owner_token_.empty() &&
+            election_owner_token_ != session.owner_token) {
+            return ErrorCode::INVALID_PARAMS;
+        }
         election_shutdown_requested_ = true;
         election_active_ = false;
+        election_monitor_stopped_ = true;
+        election_owner_token_.clear();
         ClearLeadershipMonitorStateLocked();
         if (election_monitor_thread_.joinable()) {
             thread_to_join = std::move(election_monitor_thread_);
@@ -308,6 +376,8 @@ ErrorCode K8sLeaderCoordinator::ShutdownElection() {
         election_shutdown_requested_ = true;
         should_cancel = election_active_;
         election_active_ = false;
+        election_monitor_stopped_ = true;
+        election_owner_token_.clear();
         ClearLeadershipMonitorStateLocked();
         if (election_monitor_thread_.joinable()) {
             thread_to_join = std::move(election_monitor_thread_);

--- a/mooncake-store/src/ha/leadership/leader_coordinator_factory.cpp
+++ b/mooncake-store/src/ha/leadership/leader_coordinator_factory.cpp
@@ -2,6 +2,9 @@
 
 #include "ha/leadership/backends/etcd/etcd_leader_coordinator.h"
 #include "ha/leadership/backends/redis/redis_leader_coordinator.h"
+#ifdef STORE_USE_K8S_LEASE
+#include "ha/leadership/backends/k8s/k8s_leader_coordinator.h"
+#endif
 
 namespace mooncake {
 namespace ha {
@@ -29,8 +32,19 @@ CreateLeaderCoordinator(const HABackendSpec& spec) {
             }
             return std::unique_ptr<LeaderCoordinator>(std::move(coordinator));
         }
-        case HABackendType::K8S:
+        case HABackendType::K8S: {
+#ifdef STORE_USE_K8S_LEASE
+            auto coordinator =
+                std::make_unique<backends::k8s::K8sLeaderCoordinator>(spec);
+            auto err = coordinator->Connect();
+            if (err != ErrorCode::OK) {
+                return tl::make_unexpected(err);
+            }
+            return std::unique_ptr<LeaderCoordinator>(std::move(coordinator));
+#else
             return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+#endif
+        }
     }
 
     return tl::make_unexpected(ErrorCode::INVALID_PARAMS);

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -34,18 +34,19 @@ bool HasPodIdentity(const MasterServiceSupervisorConfig& config) {
 
 void TrySetLeaderLabel(const MasterServiceSupervisorConfig& config) {
     if (!HasPodIdentity(config)) return;
-    auto err = K8sLeaseHelper::SetPodLabel(config.pod_namespace, config.pod_name,
-                                           kLeaderLabelKey, kLeaderLabelValue);
+    auto err =
+        K8sLeaseHelper::SetPodLabel(config.pod_namespace, config.pod_name,
+                                    kLeaderLabelKey, kLeaderLabelValue);
     if (err != ErrorCode::OK) {
-        LOG(WARNING) << "Failed to set leader label on pod "
-                     << config.pod_name << ": " << toString(err);
+        LOG(WARNING) << "Failed to set leader label on pod " << config.pod_name
+                     << ": " << toString(err);
     }
 }
 
 void TryClearLeaderLabel(const MasterServiceSupervisorConfig& config) {
     if (!HasPodIdentity(config)) return;
-    auto err = K8sLeaseHelper::ClearPodLabel(
-        config.pod_namespace, config.pod_name, kLeaderLabelKey);
+    auto err = K8sLeaseHelper::ClearPodLabel(config.pod_namespace,
+                                             config.pod_name, kLeaderLabelKey);
     if (err != ErrorCode::OK) {
         LOG(WARNING) << "Failed to clear leader label on pod "
                      << config.pod_name << ": " << toString(err);
@@ -154,10 +155,9 @@ void SetRuntimeState(MasterAdminServer& admin_server,
               << ", role=" << MasterRuntimeRoleToString(state);
 }
 
-void ActivateServingState(
-    MasterAdminServer& admin_server,
-    const std::shared_ptr<WrappedMasterService>& service,
-    const MasterServiceSupervisorConfig& config) {
+void ActivateServingState(MasterAdminServer& admin_server,
+                          const std::shared_ptr<WrappedMasterService>& service,
+                          const MasterServiceSupervisorConfig& config) {
     admin_server.SetServiceDelegate(service);
     admin_server.SetServiceAvailable(true);
     SetRuntimeState(admin_server, MasterRuntimeState::kServing);

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -55,10 +55,9 @@ void TryClearLeaderLabel(const MasterServiceSupervisorConfig& config) {
 
 std::string ResolveHABackendConnstring(
     const MasterServiceSupervisorConfig& config) {
-    if (!config.ha_backend_connstring.empty()) {
-        return config.ha_backend_connstring;
-    }
-    return config.etcd_endpoints;
+    return ResolveConfiguredHABackendConnstring(config.ha_backend_type,
+                                                config.ha_backend_connstring,
+                                                config.etcd_endpoints);
 }
 
 tl::expected<HABackendSpec, ErrorCode> BuildHABackendSpec(

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -13,6 +13,7 @@
 
 #include "ha/leadership/leader_coordinator_factory.h"
 #include "ha/standby_controller.h"
+#include "k8s_lease_helper.h"
 #include "rpc_service.h"
 
 namespace mooncake {
@@ -23,6 +24,33 @@ namespace {
 constexpr auto kAcquireRetryInterval = std::chrono::seconds(1);
 constexpr auto kRenewCheckInterval = std::chrono::seconds(1);
 constexpr auto kSupervisorRetryInterval = std::chrono::seconds(1);
+constexpr char kLeaderLabelKey[] = "mooncake.io/store-role";
+constexpr char kLeaderLabelValue[] = "leader";
+
+bool HasPodIdentity(const MasterServiceSupervisorConfig& config) {
+    return !config.pod_name.empty() && !config.pod_namespace.empty() &&
+           config.ha_backend_type == "k8s";
+}
+
+void TrySetLeaderLabel(const MasterServiceSupervisorConfig& config) {
+    if (!HasPodIdentity(config)) return;
+    auto err = K8sLeaseHelper::SetPodLabel(config.pod_namespace, config.pod_name,
+                                           kLeaderLabelKey, kLeaderLabelValue);
+    if (err != ErrorCode::OK) {
+        LOG(WARNING) << "Failed to set leader label on pod "
+                     << config.pod_name << ": " << toString(err);
+    }
+}
+
+void TryClearLeaderLabel(const MasterServiceSupervisorConfig& config) {
+    if (!HasPodIdentity(config)) return;
+    auto err = K8sLeaseHelper::ClearPodLabel(
+        config.pod_namespace, config.pod_name, kLeaderLabelKey);
+    if (err != ErrorCode::OK) {
+        LOG(WARNING) << "Failed to clear leader label on pod "
+                     << config.pod_name << ": " << toString(err);
+    }
+}
 
 std::string ResolveHABackendConnstring(
     const MasterServiceSupervisorConfig& config) {
@@ -128,15 +156,19 @@ void SetRuntimeState(MasterAdminServer& admin_server,
 
 void ActivateServingState(
     MasterAdminServer& admin_server,
-    const std::shared_ptr<WrappedMasterService>& service) {
+    const std::shared_ptr<WrappedMasterService>& service,
+    const MasterServiceSupervisorConfig& config) {
     admin_server.SetServiceDelegate(service);
     admin_server.SetServiceAvailable(true);
     SetRuntimeState(admin_server, MasterRuntimeState::kServing);
+    TrySetLeaderLabel(config);
 }
 
-void DeactivateServingState(MasterAdminServer& admin_server) {
+void DeactivateServingState(MasterAdminServer& admin_server,
+                            const MasterServiceSupervisorConfig& config) {
     admin_server.SetServiceAvailable(false);
     admin_server.SetServiceDelegate(nullptr);
+    TryClearLeaderLabel(config);
 }
 
 void StopLeadershipMonitor(std::unique_ptr<LeadershipMonitorHandle>& monitor) {
@@ -186,6 +218,7 @@ void EnterStandbyMode(MasterAdminServer& admin_server,
 int RunSupervisorLoop(const HABackendSpec& spec,
                       const MasterServiceSupervisorConfig& config,
                       MasterAdminServer& admin_server) {
+    TryClearLeaderLabel(config);
     SetRuntimeState(admin_server, MasterRuntimeState::kStarting);
     auto standby_controller = CreateStandbyController(spec, config);
     std::atomic<bool> accept_standby_runtime_updates{false};
@@ -353,7 +386,7 @@ int RunSupervisorLoop(const HABackendSpec& spec,
         auto serve_preflight =
             leader_coordinator.RenewLeadership(*leadership_session);
         if (!serve_preflight) {
-            DeactivateServingState(admin_server);
+            DeactivateServingState(admin_server, config);
             EnterStandbyMode(admin_server, *standby_controller,
                              accept_standby_runtime_updates,
                              leadership_session->view);
@@ -366,7 +399,7 @@ int RunSupervisorLoop(const HABackendSpec& spec,
             continue;
         }
         if (!serve_preflight.value()) {
-            DeactivateServingState(admin_server);
+            DeactivateServingState(admin_server, config);
             EnterStandbyMode(admin_server, *standby_controller,
                              accept_standby_runtime_updates, std::nullopt);
             LogLeadershipReleaseWarning(
@@ -380,16 +413,18 @@ int RunSupervisorLoop(const HABackendSpec& spec,
         std::atomic<bool> serve_shutdown_requested{false};
         auto leadership_monitor = leader_coordinator.StartLeadershipMonitor(
             *leadership_session,
-            [&server, &admin_server, &serve_shutdown_requested](auto reason) {
+            [&server, &admin_server, &serve_shutdown_requested,
+             &config](auto reason) {
                 serve_shutdown_requested.store(true, std::memory_order_release);
                 admin_server.SetServiceAvailable(false);
+                TryClearLeaderLabel(config);
                 SetRuntimeState(admin_server, MasterRuntimeState::kStandby);
                 LOG(INFO) << "Trying to stop server, reason="
                           << LeadershipLossReasonToString(reason);
                 server.stop();
             });
         if (!leadership_monitor) {
-            DeactivateServingState(admin_server);
+            DeactivateServingState(admin_server, config);
             EnterStandbyMode(admin_server, *standby_controller,
                              accept_standby_runtime_updates,
                              leadership_session->view);
@@ -408,7 +443,7 @@ int RunSupervisorLoop(const HABackendSpec& spec,
             LOG(ERROR) << "Failed to start master service: "
                        << ec.result().value();
             StopLeadershipMonitor(leadership_monitor_handle);
-            DeactivateServingState(admin_server);
+            DeactivateServingState(admin_server, config);
             EnterStandbyMode(admin_server, *standby_controller,
                              accept_standby_runtime_updates,
                              leadership_session->view);
@@ -421,14 +456,14 @@ int RunSupervisorLoop(const HABackendSpec& spec,
         }
 
         if (!serve_shutdown_requested.load(std::memory_order_acquire)) {
-            ActivateServingState(admin_server, wrapped_master_service);
+            ActivateServingState(admin_server, wrapped_master_service, config);
         }
 
         auto server_err = std::move(ec).get();
         LOG(ERROR) << "Master service stopped: " << server_err;
 
         StopLeadershipMonitor(leadership_monitor_handle);
-        DeactivateServingState(admin_server);
+        DeactivateServingState(admin_server, config);
         auto err = leader_coordinator.ReleaseLeadership(*leadership_session);
         LOG(INFO) << "Release leadership: " << toString(err);
         auto current_view = leader_coordinator.ReadCurrentView();

--- a/mooncake-store/src/k8s_lease_helper.cpp
+++ b/mooncake-store/src/k8s_lease_helper.cpp
@@ -149,6 +149,38 @@ ErrorCode K8sLeaseHelper::CancelWatch(const std::string& ns,
     return ErrorCode::OK;
 }
 
+ErrorCode K8sLeaseHelper::SetPodLabel(const std::string& ns,
+                                      const std::string& pod,
+                                      const std::string& key,
+                                      const std::string& value) {
+    char* err_msg = nullptr;
+    int ret = K8sPatchPodLabel(const_cast<char*>(ns.c_str()),
+                               const_cast<char*>(pod.c_str()),
+                               const_cast<char*>(key.c_str()),
+                               const_cast<char*>(value.c_str()), &err_msg);
+    if (ret != 0) {
+        LOG(ERROR) << "SetPodLabel failed: " << err_msg;
+        free(err_msg);
+        return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode K8sLeaseHelper::ClearPodLabel(const std::string& ns,
+                                        const std::string& pod,
+                                        const std::string& key) {
+    char* err_msg = nullptr;
+    int ret = K8sRemovePodLabel(const_cast<char*>(ns.c_str()),
+                                const_cast<char*>(pod.c_str()),
+                                const_cast<char*>(key.c_str()), &err_msg);
+    if (ret != 0) {
+        LOG(ERROR) << "ClearPodLabel failed: " << err_msg;
+        free(err_msg);
+        return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
 #else  // !STORE_USE_K8S_LEASE
 
 ErrorCode K8sLeaseHelper::Init() {
@@ -194,6 +226,18 @@ ErrorCode K8sLeaseHelper::WatchHolder(const std::string&, const std::string&,
 }
 
 ErrorCode K8sLeaseHelper::CancelWatch(const std::string&, const std::string&) {
+    LOG(FATAL) << "K8s Lease is not enabled in compilation";
+    return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+}
+
+ErrorCode K8sLeaseHelper::SetPodLabel(const std::string&, const std::string&,
+                                      const std::string&, const std::string&) {
+    LOG(FATAL) << "K8s Lease is not enabled in compilation";
+    return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+}
+
+ErrorCode K8sLeaseHelper::ClearPodLabel(const std::string&, const std::string&,
+                                        const std::string&) {
     LOG(FATAL) << "K8s Lease is not enabled in compilation";
     return ErrorCode::K8S_LEASE_OPERATION_ERROR;
 }

--- a/mooncake-store/src/k8s_lease_helper.cpp
+++ b/mooncake-store/src/k8s_lease_helper.cpp
@@ -1,0 +1,218 @@
+#include "k8s_lease_helper.h"
+
+#ifdef STORE_USE_K8S_LEASE
+#include "libk8s_lease_wrapper.h"
+#endif
+
+#include <glog/logging.h>
+
+namespace mooncake {
+
+std::mutex K8sLeaseHelper::init_mutex_;
+bool K8sLeaseHelper::initialized_ = false;
+
+#ifdef STORE_USE_K8S_LEASE
+
+ErrorCode K8sLeaseHelper::Init() {
+    std::lock_guard<std::mutex> lock(init_mutex_);
+    if (initialized_) {
+        return ErrorCode::OK;
+    }
+    char* err_msg = nullptr;
+    int ret = K8sLeaseInit(&err_msg);
+    if (ret != 0) {
+        LOG(ERROR) << "Failed to initialize K8s client: " << err_msg;
+        free(err_msg);
+        return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+    }
+    initialized_ = true;
+    return ErrorCode::OK;
+}
+
+ErrorCode K8sLeaseHelper::RunElection(const std::string& ns,
+                                      const std::string& lease,
+                                      const std::string& identity,
+                                      int lease_dur, int renew_deadline,
+                                      int retry_period) {
+    char* err_msg = nullptr;
+    int ret = K8sLeaseRunElection(
+        const_cast<char*>(ns.c_str()),
+        const_cast<char*>(lease.c_str()),
+        const_cast<char*>(identity.c_str()),
+        lease_dur, renew_deadline, retry_period, &err_msg);
+    if (ret != 0) {
+        LOG(ERROR) << "RunElection failed: " << err_msg;
+        free(err_msg);
+        return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode K8sLeaseHelper::WaitElected(const std::string& ns,
+                                      const std::string& lease,
+                                      int timeout_sec,
+                                      int64_t& lease_transitions) {
+    char* err_msg = nullptr;
+    long long transitions = 0;
+    int ret = K8sLeaseWaitElected(
+        const_cast<char*>(ns.c_str()),
+        const_cast<char*>(lease.c_str()),
+        timeout_sec,
+        &transitions, &err_msg);
+    if (ret != 0) {
+        LOG(ERROR) << "WaitElected failed: " << err_msg;
+        free(err_msg);
+        return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+    }
+    lease_transitions = static_cast<int64_t>(transitions);
+    return ErrorCode::OK;
+}
+
+ErrorCode K8sLeaseHelper::WaitLost(const std::string& ns,
+                                   const std::string& lease) {
+    char* err_msg = nullptr;
+    int ret = K8sLeaseWaitLost(
+        const_cast<char*>(ns.c_str()),
+        const_cast<char*>(lease.c_str()),
+        &err_msg);
+    if (ret != 0) {
+        LOG(ERROR) << "WaitLost failed: " << err_msg;
+        free(err_msg);
+        return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode K8sLeaseHelper::CancelElection(const std::string& ns,
+                                         const std::string& lease) {
+    char* err_msg = nullptr;
+    int ret = K8sLeaseCancelElection(
+        const_cast<char*>(ns.c_str()),
+        const_cast<char*>(lease.c_str()),
+        &err_msg);
+    if (ret != 0) {
+        LOG(ERROR) << "CancelElection failed: " << err_msg;
+        free(err_msg);
+        return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode K8sLeaseHelper::GetHolder(const std::string& ns,
+                                    const std::string& lease,
+                                    std::string& holder,
+                                    int64_t& lease_transitions) {
+    char* err_msg = nullptr;
+    char* holder_ptr = nullptr;
+    long long transitions = 0;
+    int ret = K8sLeaseGetHolder(
+        const_cast<char*>(ns.c_str()),
+        const_cast<char*>(lease.c_str()),
+        &holder_ptr, &transitions, &err_msg);
+    if (ret == 1) {
+        holder.clear();
+        lease_transitions = 0;
+        return ErrorCode::K8S_LEASE_NOT_FOUND;
+    }
+    if (ret != 0) {
+        LOG(ERROR) << "GetHolder failed: " << err_msg;
+        free(err_msg);
+        return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+    }
+    if (holder_ptr != nullptr) {
+        holder = std::string(holder_ptr);
+        free(holder_ptr);
+    } else {
+        holder.clear();
+    }
+    lease_transitions = static_cast<int64_t>(transitions);
+    return ErrorCode::OK;
+}
+
+ErrorCode K8sLeaseHelper::WatchHolder(
+    const std::string& ns, const std::string& lease,
+    void* callback_context,
+    void (*callback_func)(void*, const char*, size_t, int64_t)) {
+    char* err_msg = nullptr;
+    int ret = K8sLeaseWatchHolder(
+        const_cast<char*>(ns.c_str()),
+        const_cast<char*>(lease.c_str()),
+        callback_context,
+        reinterpret_cast<void*>(callback_func),
+        &err_msg);
+    if (ret != 0) {
+        LOG(ERROR) << "WatchHolder failed: " << err_msg;
+        free(err_msg);
+        return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode K8sLeaseHelper::CancelWatch(const std::string& ns,
+                                      const std::string& lease) {
+    char* err_msg = nullptr;
+    int ret = K8sLeaseCancelWatch(
+        const_cast<char*>(ns.c_str()),
+        const_cast<char*>(lease.c_str()),
+        &err_msg);
+    if (ret != 0) {
+        LOG(ERROR) << "CancelWatch failed: " << err_msg;
+        free(err_msg);
+        return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+#else  // !STORE_USE_K8S_LEASE
+
+ErrorCode K8sLeaseHelper::Init() {
+    LOG(FATAL) << "K8s Lease is not enabled in compilation";
+    return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+}
+
+ErrorCode K8sLeaseHelper::RunElection(const std::string&, const std::string&,
+                                      const std::string&, int, int, int) {
+    LOG(FATAL) << "K8s Lease is not enabled in compilation";
+    return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+}
+
+ErrorCode K8sLeaseHelper::WaitElected(const std::string&, const std::string&,
+                                      int, int64_t&) {
+    LOG(FATAL) << "K8s Lease is not enabled in compilation";
+    return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+}
+
+ErrorCode K8sLeaseHelper::WaitLost(const std::string&, const std::string&) {
+    LOG(FATAL) << "K8s Lease is not enabled in compilation";
+    return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+}
+
+ErrorCode K8sLeaseHelper::CancelElection(const std::string&,
+                                         const std::string&) {
+    LOG(FATAL) << "K8s Lease is not enabled in compilation";
+    return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+}
+
+ErrorCode K8sLeaseHelper::GetHolder(const std::string&, const std::string&,
+                                    std::string&, int64_t&) {
+    LOG(FATAL) << "K8s Lease is not enabled in compilation";
+    return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+}
+
+ErrorCode K8sLeaseHelper::WatchHolder(const std::string&, const std::string&,
+                                      void*,
+                                      void (*)(void*, const char*, size_t,
+                                               int64_t)) {
+    LOG(FATAL) << "K8s Lease is not enabled in compilation";
+    return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+}
+
+ErrorCode K8sLeaseHelper::CancelWatch(const std::string&,
+                                      const std::string&) {
+    LOG(FATAL) << "K8s Lease is not enabled in compilation";
+    return ErrorCode::K8S_LEASE_OPERATION_ERROR;
+}
+
+#endif  // STORE_USE_K8S_LEASE
+
+}  // namespace mooncake

--- a/mooncake-store/src/k8s_lease_helper.cpp
+++ b/mooncake-store/src/k8s_lease_helper.cpp
@@ -125,9 +125,9 @@ ErrorCode K8sLeaseHelper::WatchHolder(
     const std::string& ns, const std::string& lease, void* callback_context,
     void (*callback_func)(void*, const char*, size_t, int64_t)) {
     char* err_msg = nullptr;
-    int ret = K8sLeaseWatchHolder(
-        const_cast<char*>(ns.c_str()), const_cast<char*>(lease.c_str()),
-        callback_context, reinterpret_cast<void*>(callback_func), &err_msg);
+    int ret = K8sLeaseWatchHolder(const_cast<char*>(ns.c_str()),
+                                  const_cast<char*>(lease.c_str()),
+                                  callback_context, callback_func, &err_msg);
     if (ret != 0) {
         LOG(ERROR) << "WatchHolder failed: " << err_msg;
         free(err_msg);

--- a/mooncake-store/src/k8s_lease_helper.cpp
+++ b/mooncake-store/src/k8s_lease_helper.cpp
@@ -36,10 +36,9 @@ ErrorCode K8sLeaseHelper::RunElection(const std::string& ns,
                                       int retry_period) {
     char* err_msg = nullptr;
     int ret = K8sLeaseRunElection(
-        const_cast<char*>(ns.c_str()),
-        const_cast<char*>(lease.c_str()),
-        const_cast<char*>(identity.c_str()),
-        lease_dur, renew_deadline, retry_period, &err_msg);
+        const_cast<char*>(ns.c_str()), const_cast<char*>(lease.c_str()),
+        const_cast<char*>(identity.c_str()), lease_dur, renew_deadline,
+        retry_period, &err_msg);
     if (ret != 0) {
         LOG(ERROR) << "RunElection failed: " << err_msg;
         free(err_msg);
@@ -49,16 +48,13 @@ ErrorCode K8sLeaseHelper::RunElection(const std::string& ns,
 }
 
 ErrorCode K8sLeaseHelper::WaitElected(const std::string& ns,
-                                      const std::string& lease,
-                                      int timeout_sec,
+                                      const std::string& lease, int timeout_sec,
                                       int64_t& lease_transitions) {
     char* err_msg = nullptr;
     long long transitions = 0;
-    int ret = K8sLeaseWaitElected(
-        const_cast<char*>(ns.c_str()),
-        const_cast<char*>(lease.c_str()),
-        timeout_sec,
-        &transitions, &err_msg);
+    int ret = K8sLeaseWaitElected(const_cast<char*>(ns.c_str()),
+                                  const_cast<char*>(lease.c_str()), timeout_sec,
+                                  &transitions, &err_msg);
     if (ret != 0) {
         LOG(ERROR) << "WaitElected failed: " << err_msg;
         free(err_msg);
@@ -71,10 +67,8 @@ ErrorCode K8sLeaseHelper::WaitElected(const std::string& ns,
 ErrorCode K8sLeaseHelper::WaitLost(const std::string& ns,
                                    const std::string& lease) {
     char* err_msg = nullptr;
-    int ret = K8sLeaseWaitLost(
-        const_cast<char*>(ns.c_str()),
-        const_cast<char*>(lease.c_str()),
-        &err_msg);
+    int ret = K8sLeaseWaitLost(const_cast<char*>(ns.c_str()),
+                               const_cast<char*>(lease.c_str()), &err_msg);
     if (ret != 0) {
         LOG(ERROR) << "WaitLost failed: " << err_msg;
         free(err_msg);
@@ -86,10 +80,9 @@ ErrorCode K8sLeaseHelper::WaitLost(const std::string& ns,
 ErrorCode K8sLeaseHelper::CancelElection(const std::string& ns,
                                          const std::string& lease) {
     char* err_msg = nullptr;
-    int ret = K8sLeaseCancelElection(
-        const_cast<char*>(ns.c_str()),
-        const_cast<char*>(lease.c_str()),
-        &err_msg);
+    int ret =
+        K8sLeaseCancelElection(const_cast<char*>(ns.c_str()),
+                               const_cast<char*>(lease.c_str()), &err_msg);
     if (ret != 0) {
         LOG(ERROR) << "CancelElection failed: " << err_msg;
         free(err_msg);
@@ -105,10 +98,9 @@ ErrorCode K8sLeaseHelper::GetHolder(const std::string& ns,
     char* err_msg = nullptr;
     char* holder_ptr = nullptr;
     long long transitions = 0;
-    int ret = K8sLeaseGetHolder(
-        const_cast<char*>(ns.c_str()),
-        const_cast<char*>(lease.c_str()),
-        &holder_ptr, &transitions, &err_msg);
+    int ret = K8sLeaseGetHolder(const_cast<char*>(ns.c_str()),
+                                const_cast<char*>(lease.c_str()), &holder_ptr,
+                                &transitions, &err_msg);
     if (ret == 1) {
         holder.clear();
         lease_transitions = 0;
@@ -130,16 +122,12 @@ ErrorCode K8sLeaseHelper::GetHolder(const std::string& ns,
 }
 
 ErrorCode K8sLeaseHelper::WatchHolder(
-    const std::string& ns, const std::string& lease,
-    void* callback_context,
+    const std::string& ns, const std::string& lease, void* callback_context,
     void (*callback_func)(void*, const char*, size_t, int64_t)) {
     char* err_msg = nullptr;
     int ret = K8sLeaseWatchHolder(
-        const_cast<char*>(ns.c_str()),
-        const_cast<char*>(lease.c_str()),
-        callback_context,
-        reinterpret_cast<void*>(callback_func),
-        &err_msg);
+        const_cast<char*>(ns.c_str()), const_cast<char*>(lease.c_str()),
+        callback_context, reinterpret_cast<void*>(callback_func), &err_msg);
     if (ret != 0) {
         LOG(ERROR) << "WatchHolder failed: " << err_msg;
         free(err_msg);
@@ -151,10 +139,8 @@ ErrorCode K8sLeaseHelper::WatchHolder(
 ErrorCode K8sLeaseHelper::CancelWatch(const std::string& ns,
                                       const std::string& lease) {
     char* err_msg = nullptr;
-    int ret = K8sLeaseCancelWatch(
-        const_cast<char*>(ns.c_str()),
-        const_cast<char*>(lease.c_str()),
-        &err_msg);
+    int ret = K8sLeaseCancelWatch(const_cast<char*>(ns.c_str()),
+                                  const_cast<char*>(lease.c_str()), &err_msg);
     if (ret != 0) {
         LOG(ERROR) << "CancelWatch failed: " << err_msg;
         free(err_msg);
@@ -207,8 +193,7 @@ ErrorCode K8sLeaseHelper::WatchHolder(const std::string&, const std::string&,
     return ErrorCode::K8S_LEASE_OPERATION_ERROR;
 }
 
-ErrorCode K8sLeaseHelper::CancelWatch(const std::string&,
-                                      const std::string&) {
+ErrorCode K8sLeaseHelper::CancelWatch(const std::string&, const std::string&) {
     LOG(FATAL) << "K8s Lease is not enabled in compilation";
     return ErrorCode::K8S_LEASE_OPERATION_ERROR;
 }

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -125,6 +125,11 @@ DEFINE_int64(client_ttl, mooncake::DEFAULT_CLIENT_LIVE_TTL_SEC,
              "How long a client is considered alive after the last ping, only "
              "used in HA mode");
 
+DEFINE_string(pod_name, "",
+              "Pod name for K8s label-based routing (default: $POD_NAME)");
+DEFINE_string(pod_namespace, "",
+              "Pod namespace for K8s label-based routing "
+              "(default: $POD_NAMESPACE)");
 DEFINE_string(root_fs_dir, mooncake::DEFAULT_ROOT_FS_DIR,
               "Root directory for storage backend, used in HA mode");
 DEFINE_int64(global_file_segment_size,
@@ -331,6 +336,10 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetString("http_metadata_server_host",
                              &master_config.http_metadata_server_host,
                              FLAGS_http_metadata_server_host);
+    default_config.GetString("pod_name", &master_config.pod_name,
+                             FLAGS_pod_name);
+    default_config.GetString("pod_namespace", &master_config.pod_namespace,
+                             FLAGS_pod_namespace);
     default_config.GetUInt64("put_start_discard_timeout_sec",
                              &master_config.put_start_discard_timeout_sec,
                              FLAGS_put_start_discard_timeout_sec);
@@ -606,6 +615,16 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         master_config.http_metadata_server_host =
             FLAGS_http_metadata_server_host;
     }
+    if ((google::GetCommandLineFlagInfo("pod_name", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.pod_name = FLAGS_pod_name;
+    }
+    if ((google::GetCommandLineFlagInfo("pod_namespace", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.pod_namespace = FLAGS_pod_namespace;
+    }
     if ((google::GetCommandLineFlagInfo("put_start_discard_timeout_sec",
                                         &info) &&
          !info.is_default) ||
@@ -827,6 +846,16 @@ int main(int argc, char* argv[]) {
     }
     LoadConfigFromCmdline(master_config, !conf_path.empty());
     ResolveRpcAddressFromInterfaceOrDie(master_config);
+
+    // Fall back to environment variables for pod identity (K8s Downward API)
+    if (master_config.pod_name.empty()) {
+        const char* env = std::getenv("POD_NAME");
+        if (env) master_config.pod_name = env;
+    }
+    if (master_config.pod_namespace.empty()) {
+        const char* env = std::getenv("POD_NAMESPACE");
+        if (env) master_config.pod_namespace = env;
+    }
 
     const std::string ha_backend_connstring =
         ResolveHABackendConnstring(master_config);

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -107,7 +107,7 @@ DEFINE_validator(eviction_ratio, [](const char* flagname, double value) {
     return true;
 });
 DEFINE_bool(enable_ha, false,
-            "Enable high availability, which depends on etcd");
+            "Enable high availability using the configured HA backend");
 DEFINE_bool(enable_offload, false, "Enable offload availability");
 DEFINE_bool(offload_on_evict, false,
             "Defer LOCAL_DISK offload to eviction time instead of PutEnd");
@@ -116,8 +116,8 @@ DEFINE_bool(offload_force_evict, false,
 DEFINE_string(ha_backend_type, "etcd",
               "HA backend type, e.g. etcd | redis | k8s");
 DEFINE_string(ha_backend_connstring, "",
-              "HA backend connection string. If unset, fallback to "
-              "etcd_endpoints for backward compatibility");
+              "HA backend connection string. If unset, only backend_type=etcd "
+              "falls back to etcd_endpoints for backward compatibility");
 DEFINE_string(
     etcd_endpoints, "",
     "Endpoints of ETCD server, separated by semicolon, required in HA mode");
@@ -219,10 +219,9 @@ namespace {
 
 std::string ResolveHABackendConnstring(
     const mooncake::MasterConfig& master_config) {
-    if (!master_config.ha_backend_connstring.empty()) {
-        return master_config.ha_backend_connstring;
-    }
-    return master_config.etcd_endpoints;
+    return mooncake::ResolveConfiguredHABackendConnstring(
+        master_config.ha_backend_type, master_config.ha_backend_connstring,
+        master_config.etcd_endpoints);
 }
 
 void ResolveRpcAddressFromInterfaceOrDie(
@@ -861,7 +860,10 @@ int main(int argc, char* argv[]) {
         ResolveHABackendConnstring(master_config);
     if (master_config.enable_ha && ha_backend_connstring.empty()) {
         LOG(FATAL) << "HA backend connection string must be set when "
-                   << "enable_ha is true";
+                   << "enable_ha is true, backend_type="
+                   << master_config.ha_backend_type
+                   << ". Only backend_type=etcd may fall back to "
+                   << "etcd_endpoints";
         return 1;
     }
     if (!master_config.enable_ha && (!ha_backend_connstring.empty() ||

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -104,8 +104,15 @@ if(STORE_USE_REDIS)
     add_test(NAME redis_snapshot_catalog_store_test
              COMMAND redis_snapshot_catalog_store_test)
 endif()
+if(STORE_USE_K8S_LEASE)
+    target_sources(high_availability_test PRIVATE
+        ha/leadership/backends/k8s/high_availability_k8s_test.cpp)
+endif()
 target_link_libraries(high_availability_test PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gtest gtest_main pthread)
-if (STORE_USE_ETCD OR STORE_USE_REDIS)
+if(STORE_USE_K8S_LEASE)
+    target_link_libraries(high_availability_test PRIVATE ${K8S_LEASE_WRAPPER_LIB})
+endif()
+if (STORE_USE_ETCD OR STORE_USE_REDIS OR STORE_USE_K8S_LEASE)
     add_test(NAME high_availability_test COMMAND high_availability_test)
 endif()
 

--- a/mooncake-store/tests/e2e/e2e_utils.h
+++ b/mooncake-store/tests/e2e/e2e_utils.h
@@ -33,7 +33,7 @@ namespace testing {
                   "HA backend type for tests: etcd | redis | k8s");
 #define FLAG_ha_backend_connstring                                          \
     DEFINE_string(ha_backend_connstring, "",                                \
-                  "HA backend connection string for tests; if unset, only "  \
+                  "HA backend connection string for tests; if unset, only " \
                   "backend_type=etcd falls back to etcd_endpoints");
 #define FLAG_master_path                                               \
     DEFINE_string(master_path, "./mooncake-store/src/mooncake_master", \
@@ -50,9 +50,9 @@ namespace testing {
                  "Random seed, 0 means use current time as seed");
 
 inline std::string ResolveTestHABackendConnstring() {
-    return ResolveConfiguredHABackendConnstring(
-        ::FLAGS_ha_backend_type, ::FLAGS_ha_backend_connstring,
-        ::FLAGS_etcd_endpoints);
+    return ResolveConfiguredHABackendConnstring(::FLAGS_ha_backend_type,
+                                                ::FLAGS_ha_backend_connstring,
+                                                ::FLAGS_etcd_endpoints);
 }
 
 inline std::string NormalizeConnstringScheme(const std::string& connstring) {

--- a/mooncake-store/tests/e2e/e2e_utils.h
+++ b/mooncake-store/tests/e2e/e2e_utils.h
@@ -3,6 +3,8 @@
 #include <gflags/gflags.h>
 #include <string>
 
+#include "master_config.h"
+
 DECLARE_string(etcd_endpoints);
 DECLARE_string(ha_backend_type);
 DECLARE_string(ha_backend_connstring);
@@ -31,8 +33,8 @@ namespace testing {
                   "HA backend type for tests: etcd | redis | k8s");
 #define FLAG_ha_backend_connstring                                          \
     DEFINE_string(ha_backend_connstring, "",                                \
-                  "HA backend connection string for tests; if unset, fall " \
-                  "back to etcd_endpoints");
+                  "HA backend connection string for tests; if unset, only "  \
+                  "backend_type=etcd falls back to etcd_endpoints");
 #define FLAG_master_path                                               \
     DEFINE_string(master_path, "./mooncake-store/src/mooncake_master", \
                   "Path to the master executable");
@@ -48,10 +50,9 @@ namespace testing {
                  "Random seed, 0 means use current time as seed");
 
 inline std::string ResolveTestHABackendConnstring() {
-    if (!::FLAGS_ha_backend_connstring.empty()) {
-        return ::FLAGS_ha_backend_connstring;
-    }
-    return ::FLAGS_etcd_endpoints;
+    return ResolveConfiguredHABackendConnstring(
+        ::FLAGS_ha_backend_type, ::FLAGS_ha_backend_connstring,
+        ::FLAGS_etcd_endpoints);
 }
 
 inline std::string NormalizeConnstringScheme(const std::string& connstring) {

--- a/mooncake-store/tests/e2e/process_handler.cpp
+++ b/mooncake-store/tests/e2e/process_handler.cpp
@@ -13,16 +13,17 @@
 #include <sstream>
 #include <vector>
 
+#include "master_config.h"
+
 namespace mooncake {
 namespace testing {
 
 namespace {
 
 std::string ResolveMasterBackendConnstring(const MasterRunnerConfig& config) {
-    if (!config.ha_backend_connstring.empty()) {
-        return config.ha_backend_connstring;
-    }
-    return config.etcd_endpoints;
+    return ResolveConfiguredHABackendConnstring(
+        config.ha_backend_type, config.ha_backend_connstring,
+        config.etcd_endpoints);
 }
 
 }  // namespace

--- a/mooncake-store/tests/e2e/process_handler.cpp
+++ b/mooncake-store/tests/e2e/process_handler.cpp
@@ -21,9 +21,9 @@ namespace testing {
 namespace {
 
 std::string ResolveMasterBackendConnstring(const MasterRunnerConfig& config) {
-    return ResolveConfiguredHABackendConnstring(
-        config.ha_backend_type, config.ha_backend_connstring,
-        config.etcd_endpoints);
+    return ResolveConfiguredHABackendConnstring(config.ha_backend_type,
+                                                config.ha_backend_connstring,
+                                                config.etcd_endpoints);
 }
 
 }  // namespace

--- a/mooncake-store/tests/ha/leadership/backends/k8s/high_availability_k8s_test.cpp
+++ b/mooncake-store/tests/ha/leadership/backends/k8s/high_availability_k8s_test.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <future>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 

--- a/mooncake-store/tests/ha/leadership/backends/k8s/high_availability_k8s_test.cpp
+++ b/mooncake-store/tests/ha/leadership/backends/k8s/high_availability_k8s_test.cpp
@@ -1,0 +1,198 @@
+#include <gflags/gflags.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <future>
+#include <memory>
+#include <string>
+#include <thread>
+
+#ifdef STORE_USE_K8S_LEASE
+#include "k8s_lease_helper.h"
+#endif
+#include "ha/leadership/leader_coordinator_factory.h"
+#include "ha/leadership/high_availability_test_fixture.h"
+#include "types.h"
+
+namespace mooncake {
+namespace testing {
+
+DEFINE_string(k8s_namespace, "default",
+              "K8s namespace for HA integration tests");
+DEFINE_string(k8s_lease_name, "mooncake-ha-test",
+              "K8s Lease name for HA integration tests");
+
+namespace {
+
+std::optional<std::string> GetK8sSkipReason() {
+#ifdef STORE_USE_K8S_LEASE
+    // Probe: try to init K8s client and read a lease.
+    auto err = K8sLeaseHelper::Init();
+    if (err != ErrorCode::OK) {
+        return "K8s API not reachable (Init failed)";
+    }
+    std::string holder;
+    int64_t transitions = 0;
+    err = K8sLeaseHelper::GetHolder(FLAGS_k8s_namespace, FLAGS_k8s_lease_name,
+                                    holder, transitions);
+    if (err != ErrorCode::OK &&
+        err != ErrorCode::K8S_LEASE_NOT_FOUND) {
+        return "K8s API not reachable (GetHolder probe failed)";
+    }
+    return std::nullopt;
+#else
+    return "K8s Lease HA backend is not enabled in this build";
+#endif
+}
+
+ha::HABackendSpec MakeK8sBackendSpec(const std::string& ns,
+                                     const std::string& lease_name) {
+    return ha::HABackendSpec{
+        .type = ha::HABackendType::K8S,
+        .connstring = ns + "/" + lease_name,
+        .cluster_namespace = "",
+    };
+}
+
+std::unique_ptr<ha::LeaderCoordinator> CreateK8sCoordinatorOrNull(
+    const std::string& ns, const std::string& lease_name) {
+    auto coordinator =
+        ha::CreateLeaderCoordinator(MakeK8sBackendSpec(ns, lease_name));
+    if (!coordinator) {
+        return nullptr;
+    }
+    return std::move(coordinator.value());
+}
+
+std::string MakeK8sTestLeaseName(const std::string& suffix) {
+    return FLAGS_k8s_lease_name + "-" + suffix;
+}
+
+}  // namespace
+
+TEST_F(HighAvailabilityTest, K8sBasicMasterViewOperations) {
+    if (auto skip_reason = GetK8sSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    const auto lease_name = MakeK8sTestLeaseName("basic");
+    auto coordinator =
+        CreateK8sCoordinatorOrNull(FLAGS_k8s_namespace, lease_name);
+    ASSERT_NE(coordinator, nullptr);
+
+    // Initially, the master view should be empty (no leader)
+    auto initial_view = coordinator->ReadCurrentView();
+    ASSERT_TRUE(initial_view.has_value());
+    // Note: may or may not have value depending on prior test state
+
+    // Acquire leadership
+    auto acquire = coordinator->TryAcquireLeadership("127.0.0.1:8899");
+    ASSERT_TRUE(acquire.has_value());
+    ASSERT_EQ(ha::AcquireLeadershipStatus::ACQUIRED, acquire->status);
+    ASSERT_TRUE(acquire->session.has_value());
+
+    // Read current view — should show our address
+    auto current_view = coordinator->ReadCurrentView();
+    ASSERT_TRUE(current_view.has_value());
+    ASSERT_TRUE(current_view->has_value());
+    EXPECT_EQ("127.0.0.1:8899", current_view->value().leader_address);
+
+    // Renew
+    auto renewed = coordinator->RenewLeadership(*acquire->session);
+    ASSERT_TRUE(renewed.has_value());
+    EXPECT_TRUE(renewed.value());
+
+    // WaitForViewChange — should time out since nothing changed
+    auto no_change = coordinator->WaitForViewChange(
+        acquire->session->view.view_version, std::chrono::milliseconds(200));
+    ASSERT_TRUE(no_change.has_value());
+    ASSERT_FALSE(no_change->changed);
+    ASSERT_TRUE(no_change->timed_out);
+
+    // Release
+    ASSERT_EQ(ErrorCode::OK, coordinator->ReleaseLeadership(*acquire->session));
+
+    // After release, view should eventually show no leader or a different
+    // transitions count
+    auto released = coordinator->WaitForViewChange(
+        acquire->session->view.view_version, std::chrono::seconds(10));
+    ASSERT_TRUE(released.has_value());
+    ASSERT_TRUE(released->changed);
+}
+
+TEST_F(HighAvailabilityTest, K8sLeadershipMonitorIgnoresExplicitRelease) {
+    if (auto skip_reason = GetK8sSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    const auto lease_name = MakeK8sTestLeaseName("monitor-release");
+    auto coordinator =
+        CreateK8sCoordinatorOrNull(FLAGS_k8s_namespace, lease_name);
+    ASSERT_NE(coordinator, nullptr);
+
+    auto acquire = coordinator->TryAcquireLeadership("127.0.0.1:9922");
+    ASSERT_TRUE(acquire.has_value());
+    ASSERT_EQ(ha::AcquireLeadershipStatus::ACQUIRED, acquire->status);
+    ASSERT_TRUE(acquire->session.has_value());
+    const auto session = *acquire->session;
+
+    auto renew = coordinator->RenewLeadership(session);
+    ASSERT_TRUE(renew.has_value());
+    ASSERT_TRUE(renew.value());
+
+    auto callback_fired = std::make_shared<std::atomic<bool>>(false);
+    auto monitor = coordinator->StartLeadershipMonitor(
+        session, [callback_fired](ha::LeadershipLossReason) {
+            callback_fired->store(true);
+        });
+    ASSERT_TRUE(monitor.has_value());
+
+    // Explicit release should NOT fire the monitor callback
+    ASSERT_EQ(ErrorCode::OK, coordinator->ReleaseLeadership(session));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    EXPECT_FALSE(callback_fired->load());
+}
+
+TEST_F(HighAvailabilityTest, K8sCanReacquireAfterRelease) {
+    if (auto skip_reason = GetK8sSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    const auto lease_name = MakeK8sTestLeaseName("reacquire");
+    auto coordinator =
+        CreateK8sCoordinatorOrNull(FLAGS_k8s_namespace, lease_name);
+    ASSERT_NE(coordinator, nullptr);
+
+    // First acquisition
+    auto first_acquire = coordinator->TryAcquireLeadership("127.0.0.1:9933");
+    ASSERT_TRUE(first_acquire.has_value());
+    ASSERT_EQ(ha::AcquireLeadershipStatus::ACQUIRED, first_acquire->status);
+    ASSERT_TRUE(first_acquire->session.has_value());
+
+    auto first_renew = coordinator->RenewLeadership(*first_acquire->session);
+    ASSERT_TRUE(first_renew.has_value());
+    ASSERT_TRUE(first_renew.value());
+
+    ASSERT_EQ(ErrorCode::OK,
+              coordinator->ReleaseLeadership(*first_acquire->session));
+
+    // Wait for lease to expire
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // Second acquisition
+    auto second_acquire = coordinator->TryAcquireLeadership("127.0.0.1:9944");
+    ASSERT_TRUE(second_acquire.has_value());
+    ASSERT_EQ(ha::AcquireLeadershipStatus::ACQUIRED, second_acquire->status);
+    ASSERT_TRUE(second_acquire->session.has_value());
+
+    auto second_renew = coordinator->RenewLeadership(*second_acquire->session);
+    ASSERT_TRUE(second_renew.has_value());
+    ASSERT_TRUE(second_renew.value());
+
+    ASSERT_EQ(ErrorCode::OK,
+              coordinator->ReleaseLeadership(*second_acquire->session));
+}
+
+}  // namespace testing
+}  // namespace mooncake

--- a/mooncake-store/tests/ha/leadership/backends/k8s/high_availability_k8s_test.cpp
+++ b/mooncake-store/tests/ha/leadership/backends/k8s/high_availability_k8s_test.cpp
@@ -36,8 +36,7 @@ std::optional<std::string> GetK8sSkipReason() {
     int64_t transitions = 0;
     err = K8sLeaseHelper::GetHolder(FLAGS_k8s_namespace, FLAGS_k8s_lease_name,
                                     holder, transitions);
-    if (err != ErrorCode::OK &&
-        err != ErrorCode::K8S_LEASE_NOT_FOUND) {
+    if (err != ErrorCode::OK && err != ErrorCode::K8S_LEASE_NOT_FOUND) {
         return "K8s API not reachable (GetHolder probe failed)";
     }
     return std::nullopt;

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -423,14 +423,13 @@ TEST_F(SnapshotChildProcessTest, LegacyEtcdConnstringFallbackIsPreserved) {
               legacy_config.etcd_endpoints);
 }
 
-TEST_F(SnapshotChildProcessTest,
-       NonEtcdBackendsDoNotFallbackToEtcdEndpoints) {
-    EXPECT_TRUE(ResolveConfiguredHABackendConnstring(
-                    "k8s", "", "127.0.0.1:2379")
-                    .empty());
-    EXPECT_TRUE(ResolveConfiguredHABackendConnstring(
-                    "redis", "", "127.0.0.1:2379")
-                    .empty());
+TEST_F(SnapshotChildProcessTest, NonEtcdBackendsDoNotFallbackToEtcdEndpoints) {
+    EXPECT_TRUE(
+        ResolveConfiguredHABackendConnstring("k8s", "", "127.0.0.1:2379")
+            .empty());
+    EXPECT_TRUE(
+        ResolveConfiguredHABackendConnstring("redis", "", "127.0.0.1:2379")
+            .empty());
 
     MasterConfig config;
     config.enable_ha = true;

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -423,6 +423,28 @@ TEST_F(SnapshotChildProcessTest, LegacyEtcdConnstringFallbackIsPreserved) {
               legacy_config.etcd_endpoints);
 }
 
+TEST_F(SnapshotChildProcessTest,
+       NonEtcdBackendsDoNotFallbackToEtcdEndpoints) {
+    EXPECT_TRUE(ResolveConfiguredHABackendConnstring(
+                    "k8s", "", "127.0.0.1:2379")
+                    .empty());
+    EXPECT_TRUE(ResolveConfiguredHABackendConnstring(
+                    "redis", "", "127.0.0.1:2379")
+                    .empty());
+
+    MasterConfig config;
+    config.enable_ha = true;
+    config.ha_backend_type = "k8s";
+    config.ha_backend_connstring.clear();
+    config.etcd_endpoints = "127.0.0.1:2379";
+
+    WrappedMasterServiceConfig wrapped_config(config, 12);
+    EXPECT_TRUE(wrapped_config.ha_backend_connstring.empty());
+
+    MasterServiceConfig service_config(wrapped_config);
+    EXPECT_TRUE(service_config.ha_backend_connstring.empty());
+}
+
 #ifdef STORE_USE_ETCD
 TEST_F(SnapshotChildProcessTest,
        PersistState_UsesEtcdOplogBoundaryInSnapshotDescriptor) {


### PR DESCRIPTION
## Description

This is upstream PR. The functionality will be split into PR's:
* Go shared library for k8s election: https://github.com/kvcache-ai/Mooncake/pull/1910
* C++ coordinator: https://github.com/kvcache-ai/Mooncake/pull/1956
* self-labeling for routing: TBD
* k8s HA docs: TBD

Implements the K8s Lease HA backend proposed in https://github.com/kvcache-ai/Mooncake/issues/1648.

Adds a new `k8s` leader election backend that uses `coordination.k8s.io/v1` Lease objects, removing the external etcd dependency for HA-mode when running on Kubernetes. Masters elect via `client-go` leader election, clients discover the leader via `k8s://<ns>/<lease>` connstring.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [x] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [x] Other

## How Has This Been Tested?

Three-level test suite:
  - Go unit tests
  - Go integration tests (envtest with real kube-apiserver)
  - C++ gtest (envtest-server subprocess)

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
