### PR TITLE
[Store] Support SSD offload via Python setup() interface

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1608,7 +1608,8 @@ PYBIND11_MODULE(store, m) {
             "  protocol: Transfer protocol (default 'tcp').\n"
             "  rdma_devices: RDMA device list.\n"
             "  master_server_addr: Master server address.\n"
-            "  ipc_socket_path: IPC socket path.")
+            "  ipc_socket_path: IPC socket path.\n"
+            "  enable_ssd_offload: Enable SSD offload (default false).")
         .def(
             "setup_dummy",
             [](MooncakeStorePyWrapper &self, size_t mem_pool_size,

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1573,8 +1573,7 @@ PYBIND11_MODULE(store, m) {
                 return real_client->setup_real(
                     local_hostname, metadata_server, global_segment_size,
                     local_buffer_size, protocol, rdma_devices,
-                    master_server_addr, transfer_engine, "",
-                    enable_offload);
+                    master_server_addr, transfer_engine, "", enable_offload);
             },
             py::arg("local_hostname"), py::arg("metadata_server"),
             py::arg("global_segment_size"), py::arg("local_buffer_size"),

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1562,7 +1562,7 @@ PYBIND11_MODULE(store, m) {
                const std::string &rdma_devices = "",
                const std::string &master_server_addr = "127.0.0.1:50051",
                const py::object &engine = py::none(),
-               bool enable_offload = false) {
+               bool enable_ssd_offload = false) {
                 auto real_client = self.init_real_client();
                 std::shared_ptr<mooncake::TransferEngine> transfer_engine =
                     nullptr;
@@ -1573,13 +1573,14 @@ PYBIND11_MODULE(store, m) {
                 return real_client->setup_real(
                     local_hostname, metadata_server, global_segment_size,
                     local_buffer_size, protocol, rdma_devices,
-                    master_server_addr, transfer_engine, "", enable_offload);
+                    master_server_addr, transfer_engine, "",
+                    enable_ssd_offload);
             },
             py::arg("local_hostname"), py::arg("metadata_server"),
             py::arg("global_segment_size"), py::arg("local_buffer_size"),
             py::arg("protocol"), py::arg("rdma_devices"),
             py::arg("master_server_addr"), py::arg("engine") = py::none(),
-            py::arg("enable_offload") = false)
+            py::arg("enable_ssd_offload") = false)
         .def(
             "setup",
             [](MooncakeStorePyWrapper &self, const py::dict &config_dict) {

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1561,7 +1561,8 @@ PYBIND11_MODULE(store, m) {
                const std::string &protocol = "tcp",
                const std::string &rdma_devices = "",
                const std::string &master_server_addr = "127.0.0.1:50051",
-               const py::object &engine = py::none()) {
+               const py::object &engine = py::none(),
+               bool enable_offload = false) {
                 auto real_client = self.init_real_client();
                 std::shared_ptr<mooncake::TransferEngine> transfer_engine =
                     nullptr;
@@ -1572,12 +1573,14 @@ PYBIND11_MODULE(store, m) {
                 return real_client->setup_real(
                     local_hostname, metadata_server, global_segment_size,
                     local_buffer_size, protocol, rdma_devices,
-                    master_server_addr, transfer_engine, "");
+                    master_server_addr, transfer_engine, "",
+                    enable_offload);
             },
             py::arg("local_hostname"), py::arg("metadata_server"),
             py::arg("global_segment_size"), py::arg("local_buffer_size"),
             py::arg("protocol"), py::arg("rdma_devices"),
-            py::arg("master_server_addr"), py::arg("engine") = py::none())
+            py::arg("master_server_addr"), py::arg("engine") = py::none(),
+            py::arg("enable_offload") = false)
         .def(
             "setup",
             [](MooncakeStorePyWrapper &self, const py::dict &config_dict) {

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -25,7 +25,7 @@ class DummyClient : public PyClient {
                    const std::string &master_server_addr,
                    const std::shared_ptr<TransferEngine> &transfer_engine,
                    const std::string &ipc_socket_path,
-                   bool enable_offload = false) {
+                   bool enable_ssd_offload = false) {
         // Dummy client does not support real setup
         return -1;
     };

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -24,7 +24,8 @@ class DummyClient : public PyClient {
                    const std::string &protocol, const std::string &rdma_devices,
                    const std::string &master_server_addr,
                    const std::shared_ptr<TransferEngine> &transfer_engine,
-                   const std::string &ipc_socket_path) {
+                   const std::string &ipc_socket_path,
+                   bool enable_offload = false) {
         // Dummy client does not support real setup
         return -1;
     };

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -137,7 +137,8 @@ class PyClient {
         const std::string &protocol, const std::string &rdma_devices,
         const std::string &master_server_addr,
         const std::shared_ptr<TransferEngine> &transfer_engine,
-        const std::string &ipc_socket_path, bool enable_offload = false) = 0;
+        const std::string &ipc_socket_path,
+        bool enable_ssd_offload = false) = 0;
 
     virtual int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                             const std::string &server_address,

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -137,8 +137,7 @@ class PyClient {
         const std::string &protocol, const std::string &rdma_devices,
         const std::string &master_server_addr,
         const std::shared_ptr<TransferEngine> &transfer_engine,
-        const std::string &ipc_socket_path,
-        bool enable_offload = false) = 0;
+        const std::string &ipc_socket_path, bool enable_offload = false) = 0;
 
     virtual int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                             const std::string &server_address,

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -137,7 +137,8 @@ class PyClient {
         const std::string &protocol, const std::string &rdma_devices,
         const std::string &master_server_addr,
         const std::shared_ptr<TransferEngine> &transfer_engine,
-        const std::string &ipc_socket_path) = 0;
+        const std::string &ipc_socket_path,
+        bool enable_offload = false) = 0;
 
     virtual int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                             const std::string &server_address,

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -16,6 +16,7 @@
 #include "utils.h"
 #include "rpc_types.h"
 #include <ylt/coro_http/coro_http_server.hpp>
+#include <ylt/coro_rpc/coro_rpc_server.hpp>
 
 namespace mooncake {
 
@@ -75,7 +76,8 @@ class RealClient : public PyClient {
         const std::string &rdma_devices = "",
         const std::string &master_server_addr = "127.0.0.1:50051",
         const std::shared_ptr<TransferEngine> &transfer_engine = nullptr,
-        const std::string &ipc_socket_path = "");
+        const std::string &ipc_socket_path = "",
+        bool enable_offload = false);
 
     int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                     const std::string &server_address,
@@ -458,7 +460,8 @@ class RealClient : public PyClient {
         const std::string &master_server_addr = "127.0.0.1:50051",
         const std::shared_ptr<TransferEngine> &transfer_engine = nullptr,
         const std::string &ipc_socket_path = "", int local_rpc_port = 50052,
-        bool enable_offload = false);
+        bool enable_offload = false,
+        bool start_offload_rpc_server = false);
 
     // Overload that accepts a configuration dictionary
     tl::expected<void, ErrorCode> setup_internal(const ConfigDict &config);
@@ -646,6 +649,8 @@ class RealClient : public PyClient {
     std::string device_name;
     std::string local_hostname;
     std::string local_rpc_addr;
+    std::unique_ptr<coro_rpc::coro_rpc_server> offload_rpc_server_;
+    int offload_rpc_port_ = 0;
     bool use_hugepage_ = false;
 
     struct MappedShm {

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -76,7 +76,8 @@ class RealClient : public PyClient {
         const std::string &rdma_devices = "",
         const std::string &master_server_addr = "127.0.0.1:50051",
         const std::shared_ptr<TransferEngine> &transfer_engine = nullptr,
-        const std::string &ipc_socket_path = "", bool enable_offload = false);
+        const std::string &ipc_socket_path = "",
+        bool enable_ssd_offload = false);
 
     int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                     const std::string &server_address,
@@ -459,7 +460,7 @@ class RealClient : public PyClient {
         const std::string &master_server_addr = "127.0.0.1:50051",
         const std::shared_ptr<TransferEngine> &transfer_engine = nullptr,
         const std::string &ipc_socket_path = "", int local_rpc_port = 50052,
-        bool enable_offload = false, bool start_offload_rpc_server = false);
+        bool enable_ssd_offload = false, bool start_offload_rpc_server = false);
 
     // Overload that accepts a configuration dictionary
     tl::expected<void, ErrorCode> setup_internal(const ConfigDict &config);

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -76,8 +76,7 @@ class RealClient : public PyClient {
         const std::string &rdma_devices = "",
         const std::string &master_server_addr = "127.0.0.1:50051",
         const std::shared_ptr<TransferEngine> &transfer_engine = nullptr,
-        const std::string &ipc_socket_path = "",
-        bool enable_offload = false);
+        const std::string &ipc_socket_path = "", bool enable_offload = false);
 
     int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                     const std::string &server_address,
@@ -460,8 +459,7 @@ class RealClient : public PyClient {
         const std::string &master_server_addr = "127.0.0.1:50051",
         const std::shared_ptr<TransferEngine> &transfer_engine = nullptr,
         const std::string &ipc_socket_path = "", int local_rpc_port = 50052,
-        bool enable_offload = false,
-        bool start_offload_rpc_server = false);
+        bool enable_offload = false, bool start_offload_rpc_server = false);
 
     // Overload that accepts a configuration dictionary
     tl::expected<void, ErrorCode> setup_internal(const ConfigDict &config);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -323,8 +323,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     const std::string &protocol, const std::string &rdma_devices,
     const std::string &master_server_addr,
     const std::shared_ptr<TransferEngine> &transfer_engine,
-    const std::string &ipc_socket_path, int local_rpc_port, bool enable_offload,
-    bool start_offload_rpc_server) {
+    const std::string &ipc_socket_path, int local_rpc_port,
+    bool enable_ssd_offload, bool start_offload_rpc_server) {
     this->protocol = protocol;
     this->ipc_socket_path_ = ipc_socket_path;
     const bool should_use_hugepage = use_hugepage_ &&
@@ -554,50 +554,27 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         }
         LOG(INFO) << "Starting IPC server at " << ipc_socket_path_;
     }
-    if (enable_offload && start_offload_rpc_server) {
+    if (enable_ssd_offload && start_offload_rpc_server) {
         // Start RPC server for offload operations (batch_get / release_buffer).
-        // Use AutoPortBinder to find an available port, then start the server.
-        const int kMaxRetries = 10;
-        bool rpc_started = false;
-        for (int retry = 0; retry < kMaxRetries; ++retry) {
-            int port;
-            {
-                AutoPortBinder port_binder;
-                port = port_binder.getPort();
-                if (port < 0) {
-                    LOG(WARNING) << "Failed to bind offload RPC port, retry "
-                                 << (retry + 1) << "/" << kMaxRetries;
-                    continue;
-                }
-            }  // port_binder destroyed here, releasing the port
-
-            offload_rpc_server_ =
-                std::make_unique<coro_rpc::coro_rpc_server>(1, port, "0.0.0.0");
-            offload_rpc_server_
-                ->register_handler<&RealClient::batch_get_offload_object>(this);
-            offload_rpc_server_
-                ->register_handler<&RealClient::release_offload_buffer>(this);
-            offload_rpc_server_->async_start();
-            auto err = offload_rpc_server_->get_errc();
-            if (err) {
-                LOG(WARNING) << "Failed to start offload RPC server on port "
-                             << port << ": " << err.message() << ", retry "
-                             << (retry + 1) << "/" << kMaxRetries;
-                offload_rpc_server_.reset();
-                continue;
-            }
-            offload_rpc_port_ = port;
-            rpc_started = true;
-            LOG(INFO) << "Offload RPC server started on port " << port;
-            break;
-        }
-        if (!rpc_started) {
-            LOG(ERROR) << "Failed to start offload RPC server after "
-                       << kMaxRetries << " retries";
+        // Use port 0 to let the OS auto-allocate an available port.
+        offload_rpc_server_ =
+            std::make_unique<coro_rpc::coro_rpc_server>(1, 0, "0.0.0.0");
+        offload_rpc_server_
+            ->register_handler<&RealClient::batch_get_offload_object>(this);
+        offload_rpc_server_
+            ->register_handler<&RealClient::release_offload_buffer>(this);
+        offload_rpc_server_->async_start();
+        auto err = offload_rpc_server_->get_errc();
+        if (err) {
+            LOG(ERROR) << "Failed to start offload RPC server: "
+                       << err.message();
+            offload_rpc_server_.reset();
             return tl::unexpected(ErrorCode::INTERNAL_ERROR);
         }
+        offload_rpc_port_ = offload_rpc_server_->port();
+        LOG(INFO) << "Offload RPC server started on port " << offload_rpc_port_;
 
-        // Extract hostname (without port) for local_rpc_addr
+        // Build local_rpc_addr from hostname + auto-allocated port
         std::string rpc_host = this->local_hostname;
         auto pos = rpc_host.find(':');
         if (pos != std::string::npos) {
@@ -606,7 +583,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         this->local_rpc_addr =
             rpc_host + ":" + std::to_string(offload_rpc_port_);
     }
-    if (enable_offload) {
+    if (enable_ssd_offload) {
         auto file_storage_config = FileStorageConfig::FromEnvironment();
         file_storage_ = std::make_shared<FileStorage>(
             file_storage_config, client_, this->local_rpc_addr);
@@ -634,11 +611,11 @@ int RealClient::setup_real(
     const std::string &protocol, const std::string &rdma_devices,
     const std::string &master_server_addr,
     const std::shared_ptr<TransferEngine> &transfer_engine,
-    const std::string &ipc_socket_path, bool enable_offload) {
+    const std::string &ipc_socket_path, bool enable_ssd_offload) {
     return to_py_ret(setup_internal(
         local_hostname, metadata_server, global_segment_size, local_buffer_size,
         protocol, rdma_devices, master_server_addr, transfer_engine,
-        ipc_socket_path, 50052, enable_offload, true));
+        ipc_socket_path, 50052, enable_ssd_offload, true));
 }
 
 namespace {
@@ -729,15 +706,18 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    std::string enable_offload_str =
-        get_config(config, "enable_offload", "false");
-    bool enable_offload =
-        (enable_offload_str == "true" || enable_offload_str == "1");
+    std::string enable_ssd_offload_str =
+        get_config(config, "enable_ssd_offload", "false");
+    std::transform(enable_ssd_offload_str.begin(), enable_ssd_offload_str.end(),
+                   enable_ssd_offload_str.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    bool enable_ssd_offload =
+        (enable_ssd_offload_str == "true" || enable_ssd_offload_str == "1");
 
     return setup_internal(local_hostname, metadata_server, global_segment_size,
                           local_buffer_size, protocol, rdma_devices,
                           master_server_addr, nullptr, ipc_socket_path, 50052,
-                          enable_offload, true);
+                          enable_ssd_offload, true);
 }
 
 tl::expected<void, ErrorCode> RealClient::initAll_internal(

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -323,8 +323,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     const std::string &protocol, const std::string &rdma_devices,
     const std::string &master_server_addr,
     const std::shared_ptr<TransferEngine> &transfer_engine,
-    const std::string &ipc_socket_path, int local_rpc_port,
-    bool enable_offload,
+    const std::string &ipc_socket_path, int local_rpc_port, bool enable_offload,
     bool start_offload_rpc_server) {
     this->protocol = protocol;
     this->ipc_socket_path_ = ipc_socket_path;
@@ -574,16 +573,16 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
 
             offload_rpc_server_ =
                 std::make_unique<coro_rpc::coro_rpc_server>(1, port, "0.0.0.0");
-            offload_rpc_server_->register_handler<
-                &RealClient::batch_get_offload_object>(this);
-            offload_rpc_server_->register_handler<
-                &RealClient::release_offload_buffer>(this);
+            offload_rpc_server_
+                ->register_handler<&RealClient::batch_get_offload_object>(this);
+            offload_rpc_server_
+                ->register_handler<&RealClient::release_offload_buffer>(this);
             offload_rpc_server_->async_start();
             auto err = offload_rpc_server_->get_errc();
             if (err) {
                 LOG(WARNING) << "Failed to start offload RPC server on port "
-                             << port << ": " << err.message()
-                             << ", retry " << (retry + 1) << "/" << kMaxRetries;
+                             << port << ": " << err.message() << ", retry "
+                             << (retry + 1) << "/" << kMaxRetries;
                 offload_rpc_server_.reset();
                 continue;
             }
@@ -606,7 +605,6 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         }
         this->local_rpc_addr =
             rpc_host + ":" + std::to_string(offload_rpc_port_);
-
     }
     if (enable_offload) {
         auto file_storage_config = FileStorageConfig::FromEnvironment();
@@ -637,11 +635,10 @@ int RealClient::setup_real(
     const std::string &master_server_addr,
     const std::shared_ptr<TransferEngine> &transfer_engine,
     const std::string &ipc_socket_path, bool enable_offload) {
-    return to_py_ret(setup_internal(local_hostname, metadata_server,
-                                    global_segment_size, local_buffer_size,
-                                    protocol, rdma_devices, master_server_addr,
-                                    transfer_engine, ipc_socket_path,
-                                    50052, enable_offload, true));
+    return to_py_ret(setup_internal(
+        local_hostname, metadata_server, global_segment_size, local_buffer_size,
+        protocol, rdma_devices, master_server_addr, transfer_engine,
+        ipc_socket_path, 50052, enable_offload, true));
 }
 
 namespace {
@@ -739,8 +736,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
 
     return setup_internal(local_hostname, metadata_server, global_segment_size,
                           local_buffer_size, protocol, rdma_devices,
-                          master_server_addr, nullptr, ipc_socket_path,
-                          50052, enable_offload, true);
+                          master_server_addr, nullptr, ipc_socket_path, 50052,
+                          enable_offload, true);
 }
 
 tl::expected<void, ErrorCode> RealClient::initAll_internal(

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -288,6 +288,10 @@ RealClient::RealClient() {
 }
 
 RealClient::~RealClient() {
+    if (offload_rpc_server_) {
+        offload_rpc_server_->stop();
+        offload_rpc_server_.reset();
+    }
     // Ensure resources are cleaned even if not explicitly closed
     stop_http_server();
     tearDownAll_internal();
@@ -320,7 +324,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     const std::string &master_server_addr,
     const std::shared_ptr<TransferEngine> &transfer_engine,
     const std::string &ipc_socket_path, int local_rpc_port,
-    bool enable_offload) {
+    bool enable_offload,
+    bool start_offload_rpc_server) {
     this->protocol = protocol;
     this->ipc_socket_path_ = ipc_socket_path;
     const bool should_use_hugepage = use_hugepage_ &&
@@ -550,6 +555,59 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         }
         LOG(INFO) << "Starting IPC server at " << ipc_socket_path_;
     }
+    if (enable_offload && start_offload_rpc_server) {
+        // Start RPC server for offload operations (batch_get / release_buffer).
+        // Use AutoPortBinder to find an available port, then start the server.
+        const int kMaxRetries = 10;
+        bool rpc_started = false;
+        for (int retry = 0; retry < kMaxRetries; ++retry) {
+            int port;
+            {
+                AutoPortBinder port_binder;
+                port = port_binder.getPort();
+                if (port < 0) {
+                    LOG(WARNING) << "Failed to bind offload RPC port, retry "
+                                 << (retry + 1) << "/" << kMaxRetries;
+                    continue;
+                }
+            }  // port_binder destroyed here, releasing the port
+
+            offload_rpc_server_ =
+                std::make_unique<coro_rpc::coro_rpc_server>(1, port, "0.0.0.0");
+            offload_rpc_server_->register_handler<
+                &RealClient::batch_get_offload_object>(this);
+            offload_rpc_server_->register_handler<
+                &RealClient::release_offload_buffer>(this);
+            offload_rpc_server_->async_start();
+            auto err = offload_rpc_server_->get_errc();
+            if (err) {
+                LOG(WARNING) << "Failed to start offload RPC server on port "
+                             << port << ": " << err.message()
+                             << ", retry " << (retry + 1) << "/" << kMaxRetries;
+                offload_rpc_server_.reset();
+                continue;
+            }
+            offload_rpc_port_ = port;
+            rpc_started = true;
+            LOG(INFO) << "Offload RPC server started on port " << port;
+            break;
+        }
+        if (!rpc_started) {
+            LOG(ERROR) << "Failed to start offload RPC server after "
+                       << kMaxRetries << " retries";
+            return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+
+        // Extract hostname (without port) for local_rpc_addr
+        std::string rpc_host = this->local_hostname;
+        auto pos = rpc_host.find(':');
+        if (pos != std::string::npos) {
+            rpc_host = rpc_host.substr(0, pos);
+        }
+        this->local_rpc_addr =
+            rpc_host + ":" + std::to_string(offload_rpc_port_);
+
+    }
     if (enable_offload) {
         auto file_storage_config = FileStorageConfig::FromEnvironment();
         file_storage_ = std::make_shared<FileStorage>(
@@ -578,11 +636,12 @@ int RealClient::setup_real(
     const std::string &protocol, const std::string &rdma_devices,
     const std::string &master_server_addr,
     const std::shared_ptr<TransferEngine> &transfer_engine,
-    const std::string &ipc_socket_path) {
+    const std::string &ipc_socket_path, bool enable_offload) {
     return to_py_ret(setup_internal(local_hostname, metadata_server,
                                     global_segment_size, local_buffer_size,
                                     protocol, rdma_devices, master_server_addr,
-                                    transfer_engine, ipc_socket_path));
+                                    transfer_engine, ipc_socket_path,
+                                    50052, enable_offload, true));
 }
 
 namespace {
@@ -673,9 +732,15 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
+    std::string enable_offload_str =
+        get_config(config, "enable_offload", "false");
+    bool enable_offload =
+        (enable_offload_str == "true" || enable_offload_str == "1");
+
     return setup_internal(local_hostname, metadata_server, global_segment_size,
                           local_buffer_size, protocol, rdma_devices,
-                          master_server_addr, nullptr, ipc_socket_path);
+                          master_server_addr, nullptr, ipc_socket_path,
+                          50052, enable_offload, true);
 }
 
 tl::expected<void, ErrorCode> RealClient::initAll_internal(


### PR DESCRIPTION
Add enable_offload parameter to the Python setup() API. When enabled, an internal coro_rpc_server is automatically started with dynamic port allocation (via AutoPortBinder) to serve offload RPC operations (batch_get_offload_object / release_offload_buffer). FileStorage configuration continues to be loaded from environment variables.

A separate start_offload_rpc_server flag in setup_internal ensures the standalone real_client_main.cpp path is not affected, as it manages its own RPC server externally.

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [✅ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [✅ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [✅ ] I have performed a self-review of my own code.
- [ ✅] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.

Description                                                                                                                  
                                                                                                                               
  Support SSD offload in the Python embedded RealClient mode by adding enable_offload parameter to setup().                    
   
  Problem: SSD offload requires an RPC server for batch_get_offload_object / release_offload_buffer, but the Python setup()    
  path never starts one.
                                                                                                                               
  Solution: When enable_offload=True, automatically start an internal coro_rpc_server with dynamic port allocation             
  (AutoPortBinder, retry up to 10 times). A start_offload_rpc_server flag in setup_internal() ensures standalone
  real_client_main.cpp is unaffected. FileStorage config continues via env vars.                                               
                  
  Usage:
  store.setup(..., enable_offload=True)
  # or                                 
  store.setup({"local_hostname": "...", "enable_offload": "true"})                                                             
   
  Module                                                                                                                       
                  
  - Mooncake Store (mooncake-store)                                                                                            
  - Integration (mooncake-integration)