### PR TITLE
[PG][TENT] Fix CUDA collective wait semantics and NVLink small-transfer completion

### DIFF
--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -125,17 +125,33 @@ class MooncakeBackend final : public ::c10d::Backend {
     }
 
     std::string getPreferredHca(std::string location) {
-        auto matrix = engine_->getLocalTopology()->getMatrix();
+        static std::once_flag topo_once;
+        static std::shared_ptr<Topology> topology;
+        static TopologyMatrix matrix;
+        std::call_once(topo_once, [this] {
+            // FIXME: getLocalTopology is deprecated in TENT
+            topology = engine_->getLocalTopology();
+            if (topology) {
+                matrix = topology->getMatrix();
+            }
+            if (!topology || matrix.empty()) {
+                topology = std::make_shared<Topology>();
+                topology->discover();
+                matrix = topology->getMatrix();
+            }
+        });
+
         auto it = matrix.find(location);
         if (it == matrix.end()) {
-            LOG(INFO) << "Topology is "
-                      << engine_->getLocalTopology()->toJson();
+            LOG(INFO) << "Topology is " << topology->toJson();
             LOG(ERROR) << "Topology entry not found for location: " << location;
-        } else if (it->second.preferred_hca.empty()) {
-            LOG(INFO) << "Topology is "
-                      << engine_->getLocalTopology()->toJson();
+            return "";
+        }
+        if (it->second.preferred_hca.empty()) {
+            LOG(INFO) << "Topology is " << topology->toJson();
             LOG(ERROR) << "Preferred HCA list is empty for location: "
                        << location;
+            return "";
         }
         return it->second.preferred_hca[0];
     }

--- a/mooncake-pg/include/mooncake_worker.cuh
+++ b/mooncake-pg/include/mooncake_worker.cuh
@@ -11,9 +11,11 @@
 #include <transfer_engine.h>
 
 #include <memory>
+#include <atomic>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 namespace mooncake {
 
@@ -51,6 +53,7 @@ __global__ struct Task {
     size_t tensorSize;  // In bytes
     int64_t broadcastRoot;
     int bufferOffset;
+    uint64_t submit_sequence = 0;
     BatchID batchID;
     void* transferGroupMeta;
 };
@@ -64,6 +67,12 @@ void launchReduceCpu(at::Tensor dst, size_t pos, size_t realSize, void* src,
 void preloadReduceKernels();
 
 class ConnectionContext;
+
+struct CudaTaskSubmissionToken {
+    size_t task_id;
+    uint64_t sequence;
+};
+
 class MooncakeWorker {
    public:
     explicit MooncakeWorker(int cuda_device_index = -1);
@@ -104,6 +113,10 @@ class MooncakeWorker {
      */
     bool drainTasks(const TransferGroupMeta* meta) const;
 
+    bool waitUntilTasksSubmitted(
+        const std::vector<CudaTaskSubmissionToken>& tasks,
+        std::chrono::milliseconds timeout) const;
+
    private:
     void startWorker();
 
@@ -122,6 +135,8 @@ class MooncakeWorker {
 
     int cpuTaskCount = 0;
     int cudaTaskCount = 0;
+    std::atomic<uint64_t> next_cuda_task_sequence_{1};
+    std::atomic<uint64_t> submitted_task_sequence_[kNumTasks_]{};
 
     std::thread worker_thread_;
 };

--- a/mooncake-pg/include/mooncake_worker.cuh
+++ b/mooncake-pg/include/mooncake_worker.cuh
@@ -91,11 +91,11 @@ class MooncakeWorker {
         c10d::OpType opType, size_t tensorSize, int64_t broadcastRoot,
         const std::shared_ptr<TransferGroupMeta>& meta,
         const std::shared_ptr<ConnectionContext>& connection_ctx,
-        const at::cuda::CUDAStream& stream,
-        const std::function<void(void* dst, size_t pos, size_t realSize)>&
-            tensorToBuffer,
-        const std::function<void(void* src, size_t pos, size_t realSize)>&
-            bufferToTensor);
+        const at::cuda::CUDAStream& issue_stream,
+        const std::function<void(void* dst, size_t pos, size_t realSize,
+                                 const at::cuda::CUDAStream&)>& tensorToBuffer,
+        const std::function<void(void* src, size_t pos, size_t realSize,
+                                 const at::cuda::CUDAStream&)>& bufferToTensor);
 
     void Start();
 

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -391,15 +391,18 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::broadcast(
         return worker_->putTaskCuda(
             c10d::OpType::BROADCAST, tensorSize, root, meta_, connection_ctx_,
             stream,
-            [=](void* dst, size_t pos, size_t realSize) {
+            [=](void* dst, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 if (isRoot) {
                     cudaMemcpyAsync(dst, (char*)tensor.data_ptr() + pos,
-                                    realSize, cudaMemcpyDeviceToDevice, stream);
+                                    realSize, cudaMemcpyDeviceToDevice,
+                                    enq_stream);
                 }
             },
-            [=](void* src, size_t pos, size_t realSize) {
+            [=](void* src, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync((char*)tensor.data_ptr() + pos, src, realSize,
-                                cudaMemcpyDeviceToDevice, stream);
+                                cudaMemcpyDeviceToDevice, enq_stream);
             });
     }
 }
@@ -427,16 +430,18 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::allreduce(
         return worker_->putTaskCuda(
             c10d::OpType::ALLREDUCE, tensorSize, 0, meta_, connection_ctx_,
             stream,
-            [=](void* dst, size_t pos, size_t realSize) {
+            [=](void* dst, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync(dst, (char*)tensor.data_ptr() + pos, realSize,
-                                cudaMemcpyDeviceToDevice, stream);
+                                cudaMemcpyDeviceToDevice, enq_stream);
             },
-            [=, this](void* src, size_t pos, size_t realSize) {
+            [=, this](void* src, size_t pos, size_t realSize,
+                      const at::cuda::CUDAStream& enq_stream) {
                 cudaMemsetAsync((char*)tensor.data_ptr() + pos, 0, realSize,
-                                stream);
+                                enq_stream);
                 launchReduceKernel(tensor, pos, realSize, src, meta_->size,
                                    opts.reduceOp, meta_->activeRanksDevice,
-                                   stream);
+                                   enq_stream);
             });
     }
 }
@@ -467,15 +472,17 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::allgather(
         return worker_->putTaskCuda(
             c10d::OpType::ALLGATHER, tensorSize, 0, meta_, connection_ctx_,
             stream,
-            [=](void* dst, size_t pos, size_t realSize) {
+            [=](void* dst, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync(dst, (char*)inputTensor.data_ptr() + pos,
-                                realSize, cudaMemcpyDeviceToDevice, stream);
+                                realSize, cudaMemcpyDeviceToDevice, enq_stream);
             },
-            [=](void* src, size_t pos, size_t realSize) {
+            [=](void* src, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 for (const auto j : c10::irange(outputTensors_.size())) {
                     cudaMemcpyAsync((char*)outputTensors_[j].data_ptr() + pos,
                                     (char*)src + j * realSize, realSize,
-                                    cudaMemcpyDeviceToDevice, stream);
+                                    cudaMemcpyDeviceToDevice, enq_stream);
                 }
             });
     }
@@ -506,16 +513,18 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::_allgather_base(
         return worker_->putTaskCuda(
             c10d::OpType::_ALLGATHER_BASE, tensorSize, 0, meta_,
             connection_ctx_, stream,
-            [=](void* dst, size_t pos, size_t realSize) {
+            [=](void* dst, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync(dst, (char*)inputBuffer.data_ptr() + pos,
-                                realSize, cudaMemcpyDeviceToDevice, stream);
+                                realSize, cudaMemcpyDeviceToDevice, enq_stream);
             },
-            [=, this](void* src, size_t pos, size_t realSize) {
+            [=, this](void* src, size_t pos, size_t realSize,
+                      const at::cuda::CUDAStream& enq_stream) {
                 for (const auto j : c10::irange(meta_->size)) {
                     cudaMemcpyAsync(
                         (char*)outputBuffer.data_ptr() + j * tensorSize + pos,
                         (char*)src + j * realSize, realSize,
-                        cudaMemcpyDeviceToDevice, stream);
+                        cudaMemcpyDeviceToDevice, enq_stream);
                 }
             });
     }
@@ -548,20 +557,22 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::_reduce_scatter_base(
         return worker_->putTaskCuda(
             c10d::OpType::_REDUCE_SCATTER_BASE, tensorSize, 0, meta_,
             connection_ctx_, stream,
-            [=, this](void* dst, size_t pos, size_t realSize) {
+            [=, this](void* dst, size_t pos, size_t realSize,
+                      const at::cuda::CUDAStream& enq_stream) {
                 for (const auto j : c10::irange(meta_->size)) {
                     cudaMemcpyAsync(
                         (char*)dst + j * realSize,
                         (char*)inputBuffer.data_ptr() + j * tensorSize + pos,
-                        realSize, cudaMemcpyDeviceToDevice, stream);
+                        realSize, cudaMemcpyDeviceToDevice, enq_stream);
                 }
             },
-            [=, this](void* src, size_t pos, size_t realSize) {
+            [=, this](void* src, size_t pos, size_t realSize,
+                      const at::cuda::CUDAStream& enq_stream) {
                 cudaMemsetAsync((char*)outputBuffer.data_ptr() + pos, 0,
-                                realSize, stream);
+                                realSize, enq_stream);
                 launchReduceKernel(outputBuffer, pos, realSize, src,
                                    meta_->size, opts.reduceOp,
-                                   meta_->activeRanksDevice, stream);
+                                   meta_->activeRanksDevice, enq_stream);
             });
     }
 }
@@ -592,18 +603,21 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::alltoall(
         return worker_->putTaskCuda(
             c10d::OpType::ALLTOALL, tensorSize, 0, meta_, connection_ctx_,
             stream,
-            [=](void* dst, size_t pos, size_t realSize) {
+            [=](void* dst, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 for (const auto j : c10::irange(inputTensors.size())) {
                     cudaMemcpyAsync((char*)dst + j * realSize,
                                     (char*)inputTensors[j].data_ptr() + pos,
-                                    realSize, cudaMemcpyDeviceToDevice, stream);
+                                    realSize, cudaMemcpyDeviceToDevice,
+                                    enq_stream);
                 }
             },
-            [=](void* src, size_t pos, size_t realSize) {
+            [=](void* src, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 for (const auto j : c10::irange(outputTensors.size())) {
                     cudaMemcpyAsync((char*)outputTensors[j].data_ptr() + pos,
                                     (char*)src + j * realSize, realSize,
-                                    cudaMemcpyDeviceToDevice, stream);
+                                    cudaMemcpyDeviceToDevice, enq_stream);
                 }
             });
     }
@@ -622,8 +636,9 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::barrier(
         auto stream = at::cuda::getCurrentCUDAStream(device_index);
         return worker_->putTaskCuda(
             c10d::OpType::BARRIER, kBarrierDummyTensorSize, 0, meta_,
-            connection_ctx_, stream, [=](void*, size_t, size_t) {},
-            [=](void*, size_t, size_t) {});
+            connection_ctx_, stream,
+            [=](void*, size_t, size_t, const at::cuda::CUDAStream&) {},
+            [=](void*, size_t, size_t, const at::cuda::CUDAStream&) {});
     }
 }
 
@@ -653,17 +668,19 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::reduce(
         return worker_->putTaskCuda(
             c10d::OpType::REDUCE, tensorSize, root, meta_, connection_ctx_,
             stream,
-            [=](void* dst, size_t pos, size_t realSize) {
+            [=](void* dst, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync(dst, (char*)tensor.data_ptr() + pos, realSize,
-                                cudaMemcpyDeviceToDevice, stream);
+                                cudaMemcpyDeviceToDevice, enq_stream);
             },
-            [=, this](void* src, size_t pos, size_t realSize) {
+            [=, this](void* src, size_t pos, size_t realSize,
+                      const at::cuda::CUDAStream& enq_stream) {
                 if (isRoot) {
                     cudaMemsetAsync((char*)tensor.data_ptr() + pos, 0, realSize,
-                                    stream);
+                                    enq_stream);
                     launchReduceKernel(tensor, pos, realSize, src, meta_->size,
                                        opts.reduceOp, meta_->activeRanksDevice,
-                                       stream);
+                                       enq_stream);
                 }
             });
     }
@@ -701,18 +718,20 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::gather(
         return worker_->putTaskCuda(
             c10d::OpType::GATHER, tensorSize, root, meta_, connection_ctx_,
             stream,
-            [=](void* dst, size_t pos, size_t realSize) {
+            [=](void* dst, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync(dst, (char*)inputTensor.data_ptr() + pos,
-                                realSize, cudaMemcpyDeviceToDevice, stream);
+                                realSize, cudaMemcpyDeviceToDevice, enq_stream);
             },
-            [=](void* src, size_t pos, size_t realSize) {
+            [=](void* src, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 if (isRoot) {
                     auto outputTensors_ = outputTensors.back();
                     for (const auto j : c10::irange(outputTensors_.size())) {
                         cudaMemcpyAsync(
                             (char*)outputTensors_[j].data_ptr() + pos,
                             (char*)src + j * realSize, realSize,
-                            cudaMemcpyDeviceToDevice, stream);
+                            cudaMemcpyDeviceToDevice, enq_stream);
                     }
                 }
             });
@@ -753,20 +772,22 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::scatter(
         return worker_->putTaskCuda(
             c10d::OpType::SCATTER, tensorSize, root, meta_, connection_ctx_,
             stream,
-            [=](void* dst, size_t pos, size_t realSize) {
+            [=](void* dst, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 if (isRoot) {
                     auto inputTensors_ = inputTensors.back();
                     for (const auto j : c10::irange(inputTensors_.size())) {
                         cudaMemcpyAsync(
                             (char*)dst + j * realSize,
                             (char*)inputTensors_[j].data_ptr() + pos, realSize,
-                            cudaMemcpyDeviceToDevice, stream);
+                            cudaMemcpyDeviceToDevice, enq_stream);
                     }
                 }
             },
-            [=](void* src, size_t pos, size_t realSize) {
+            [=](void* src, size_t pos, size_t realSize,
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync((char*)outputTensor.data_ptr() + pos, src,
-                                realSize, cudaMemcpyDeviceToDevice, stream);
+                                realSize, cudaMemcpyDeviceToDevice, enq_stream);
             });
     }
 }

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -103,17 +103,18 @@ MooncakeBackend::MooncakeBackend(
     const int size = distBackendOpts.group_size;
     const auto& globalRanks = distBackendOpts.global_ranks_in_group;
 
-    // Get device data
-    std::string location;
-    int deviceCount = 0;
-    cudaError_t err = cudaGetDeviceCount(&deviceCount);
-    if (err != cudaSuccess || deviceCount == 0) {
-        location = kWildcardLocation;
-    } else {
-        int deviceId_;
-        err = cudaGetDevice(&deviceId_);
-        TORCH_CHECK(!err, c10::str("Failed to get device id"));
-        location = GPU_PREFIX + std::to_string(deviceId_);
+    // Memory location for device specific buffers
+    // always kWildcardLocation for cpu backend
+    std::string location = kWildcardLocation;
+    if (!isCpu) {
+        int deviceCount = 0;
+        cudaError_t err = cudaGetDeviceCount(&deviceCount);
+        if (err == cudaSuccess && deviceCount != 0) {
+            int deviceId_;
+            err = cudaGetDevice(&deviceId_);
+            TORCH_CHECK(!err, c10::str("Failed to get device id"));
+            location = GPU_PREFIX + std::to_string(deviceId_);
+        }
     }
 
     // Initialize transfer engine

--- a/mooncake-pg/src/mooncake_worker.cu
+++ b/mooncake-pg/src/mooncake_worker.cu
@@ -4,6 +4,8 @@
 #include <thread>
 #include <mooncake_worker.cuh>
 
+#include "pg_utils.h"
+
 namespace mooncake {
 
 class MooncakeWorkCpu : public ::c10d::Work {
@@ -65,18 +67,9 @@ class MooncakeBarrierWorkCuda : public MooncakeWorkCuda {
             return true;
         }
 
-        auto start = std::chrono::steady_clock::now();
-        while (!event_->query()) {
-            auto now = std::chrono::steady_clock::now();
-            auto elapsed =
-                std::chrono::duration_cast<std::chrono::milliseconds>(now -
-                                                                      start);
-            if (elapsed >= timeout) {
-                return false;
-            }
-            std::this_thread::sleep_for(std::chrono::microseconds(10));
-        }
-        return true;
+        BackoffWaiter waiter(
+            BackoffWaiterConfig::constantSleep(std::chrono::microseconds(10)));
+        return waiter.wait_for(timeout, [this] { return event_->query(); });
     }
 };
 

--- a/mooncake-pg/src/mooncake_worker.cu
+++ b/mooncake-pg/src/mooncake_worker.cu
@@ -44,10 +44,49 @@ class MooncakeWorkCuda : public ::c10d::Work {
     bool isCompleted() override { return event_->query(); }
 
     bool wait(std::chrono::milliseconds timeout) override {
-        if (!worker_ || submitted_tasks_.empty()) {
-            return true;
-        }
-        return worker_->waitUntilTasksSubmitted(submitted_tasks_, timeout);
+        // Wait until the task has been submitted to TransferEngine:
+        // This ensures that the CUDA kernels required for the transfer
+        // have been launched by the time `waitUntilTasksSubmitted` returns.
+        // Although this is not required for CPU-only transports such as
+        // RdmaTransport, we keep this behavior to avoid invasive changes
+        // to TE/TENT.
+        //
+        // Please note that this logic relies on the assumption that TE/TENT
+        // will launch all CUDA operations in `submitTransfer`.
+        // Unfortunately, TcpTransport in TE and TENT currently violates this
+        // assumption (cudaMemcpy(Async) may be called from a callback), which
+        // can cause hangs in PG when a CUDA operation such as `x.cpu().item()`
+        // follows the collective. For TE's TcpTransport, the use of cudaMemcpy
+        // on the default stream may also contribute to the hang.
+        //
+        // This wait is primarily needed for two reasons:
+        //   1. PyTorch documents that `wait` should ensure the operation is
+        //      issued, though not necessarily completed, for CUDA work.
+        //      In practice, this means the transfer kernel must at least be
+        //      launched; otherwise, a hang may occur.
+        //   2. The current stream is blocked on the event below. Any subsequent
+        //      work on `current_stream` will wait on that event, which
+        //      effectively waits for the task to be done. Therefore, we must
+        //      not block until all kernels needed for the transfer task have
+        //      been launched, in case TE/TENT use `current_stream` to
+        //      launch those kernels (though rare).
+        auto submitted =
+            worker_->waitUntilTasksSubmitted(submitted_tasks_, timeout);
+        if (!submitted) return false;
+
+        // Once all tasks have been submitted, create an event to synchronize
+        // the current stream and the enqueue stream, but do not wait on this
+        // event.
+        //
+        // See PyTorch docs for more details:
+        // https://docs.pytorch.org/docs/stable/distributed.html#synchronous-and-asynchronous-collective-operations
+        //   "wait() - in the case of CPU collectives, will block the process
+        //    until the operation is completed. In the case of CUDA collectives,
+        //    will block the currently active CUDA stream until the operation
+        //    is completed (but will not block the CPU)."
+        auto current_stream = at::cuda::getCurrentCUDAStream();
+        event_->block(current_stream);
+        return true;
     }
 
    protected:
@@ -408,16 +447,28 @@ c10::intrusive_ptr<c10d::Work> MooncakeWorker::putTaskCuda(
     c10d::OpType opType, size_t tensorSize, int64_t broadcastRoot,
     const std::shared_ptr<TransferGroupMeta>& meta,
     const std::shared_ptr<ConnectionContext>& connection_ctx,
-    const at::cuda::CUDAStream& stream,
-    const std::function<void(void* dst, size_t pos, size_t realSize)>&
-        tensorToBuffer,
-    const std::function<void(void* src, size_t pos, size_t realSize)>&
-        bufferToTensor) {
+    const at::cuda::CUDAStream& issue_stream,
+    const std::function<void(void* dst, size_t pos, size_t realSize,
+                             const at::cuda::CUDAStream&)>& tensorToBuffer,
+    const std::function<void(void* src, size_t pos, size_t realSize,
+                             const at::cuda::CUDAStream&)>& bufferToTensor) {
     connection_ctx->waitUntilNewRanksConnected();
 
     // TORCH_CHECK(tensorSize * meta->size < kBufferSize, "Too large!");
     //  Alternately use even-odd items to maintain tasks
     size_t chunkSize = ((kBufferSize - 1) / meta->size) & ~(size_t)7;
+
+    // Get a non-blocking stream for enqueue:
+    //   The incoming `issue_stream` may be the Null Stream, which enforces
+    //   implicit synchronization semantics. Launching a spin-wait kernel
+    //   (enqueueTaskKernel) on such a stream can introduce potential deadlock.
+    at::cuda::CUDAStream enq_stream =
+        at::cuda::getStreamFromPool(false, issue_stream.device_index());
+
+    // Synchronize: enq_stream waits for issue_stream
+    auto event_start = std::make_shared<torch::Event>(torch::kCUDA);
+    event_start->record(issue_stream);
+    event_start->block(enq_stream);
 
     std::vector<CudaTaskSubmissionToken> submitted_tasks;
     submitted_tasks.reserve((tensorSize + chunkSize - 1) / chunkSize);
@@ -431,28 +482,29 @@ c10::intrusive_ptr<c10d::Work> MooncakeWorker::putTaskCuda(
             {.task_id = static_cast<size_t>(taskId), .sequence = taskSequence});
         tensorToBuffer(
             (void*)meta->segmentInfos[meta->rank].send_buffer[bufferOffset],
-            pos, realSize);
+            pos, realSize, enq_stream);
 
         hasCallback_[taskId] = false;
-        enqueueTaskKernel<<<1, 1, 0, stream>>>(
+        enqueueTaskKernel<<<1, 1, 0, enq_stream>>>(
             opType, realSize, broadcastRoot, bufferOffset, taskSequence,
             meta.get(), tasks_device_, meta->size, meta->activeRanksDevice,
             meta->activeRanksTensor.data_ptr<int>(), taskId);
         bufferToTensor(
             (void*)meta->segmentInfos[meta->rank].recv_buffer[bufferOffset],
-            pos, realSize);
+            pos, realSize, enq_stream);
 
         ++cudaTaskCount;
         ++meta->taskCount;
     }
 
-    auto event = std::make_shared<torch::Event>(torch::kCUDA);
-    event->record(stream);
+    auto event_end = std::make_shared<torch::Event>(torch::kCUDA);
+    event_end->record(enq_stream);
+
     if (opType == c10d::OpType::BARRIER) {
         return c10::make_intrusive<MooncakeBarrierWorkCuda>(
-            opType, event, meta, this, std::move(submitted_tasks));
+            opType, event_end, meta, this, std::move(submitted_tasks));
     }
-    return c10::make_intrusive<MooncakeWorkCuda>(opType, event, meta, this,
+    return c10::make_intrusive<MooncakeWorkCuda>(opType, event_end, meta, this,
                                                  std::move(submitted_tasks));
 }
 

--- a/mooncake-pg/src/mooncake_worker.cu
+++ b/mooncake-pg/src/mooncake_worker.cu
@@ -29,19 +29,30 @@ class MooncakeWorkCpu : public ::c10d::Work {
 
 class MooncakeWorkCuda : public ::c10d::Work {
    public:
-    MooncakeWorkCuda(c10d::OpType opType, std::shared_ptr<torch::Event> event,
-                     std::shared_ptr<TransferGroupMeta> meta)
-        : Work(-1, opType), event_(std::move(event)), meta_(std::move(meta)) {}
+    MooncakeWorkCuda(
+        c10d::OpType opType, std::shared_ptr<torch::Event> event,
+        std::shared_ptr<TransferGroupMeta> meta, const MooncakeWorker* worker,
+        std::vector<CudaTaskSubmissionToken> submitted_tasks)
+        : Work(-1, opType),
+          event_(std::move(event)),
+          meta_(std::move(meta)),
+          worker_(worker),
+          submitted_tasks_(std::move(submitted_tasks)) {}
 
     bool isCompleted() override { return event_->query(); }
 
     bool wait(std::chrono::milliseconds timeout) override {
-        return true;  // This should be a no-op
+        if (!worker_ || submitted_tasks_.empty()) {
+            return true;
+        }
+        return worker_->waitUntilTasksSubmitted(submitted_tasks_, timeout);
     }
 
    protected:
     std::shared_ptr<torch::Event> event_;
     std::shared_ptr<TransferGroupMeta> meta_;
+    const MooncakeWorker* worker_;
+    std::vector<CudaTaskSubmissionToken> submitted_tasks_;
 };
 
 class MooncakeBarrierWorkCuda : public MooncakeWorkCuda {
@@ -71,7 +82,8 @@ class MooncakeBarrierWorkCuda : public MooncakeWorkCuda {
 
 __global__ void enqueueTaskKernel(c10d::OpType opType, size_t tensorSize,
                                   int64_t broadcastRoot, int bufferOffset,
-                                  void* meta, Task* tasks, int numRanks,
+                                  uint64_t submitSequence, void* meta,
+                                  Task* tasks, int numRanks,
                                   const bool* activeRanks,
                                   int* activeRanksTensor, size_t taskId) {
     // Copy task into slot
@@ -79,15 +91,16 @@ __global__ void enqueueTaskKernel(c10d::OpType opType, size_t tensorSize,
     tasks[taskId].tensorSize = tensorSize;
     tasks[taskId].broadcastRoot = broadcastRoot;
     tasks[taskId].bufferOffset = bufferOffset;
+    tasks[taskId].submit_sequence = submitSequence;
     tasks[taskId].transferGroupMeta = meta;
 
-    // Mark active
-    __threadfence();  // Ensure writes visible to host
+    // Publish task metadata before notifying the host worker thread.
+    __threadfence_system();
     tasks[taskId].active = true;
 
     // Spin-wait until CPU proxy sets DONE
     while (tasks[taskId].active) {
-        __threadfence();
+        __threadfence_system();
     }
     for (int i = 0; i < numRanks; ++i) {
         activeRanksTensor[i] = activeRanks[i] ? 1 : 0;
@@ -311,6 +324,8 @@ MooncakeWorker::MooncakeWorker(int cuda_device_index)
     }
     for (size_t i = 0; i < kNumTasks_; ++i) {
         tasks_[i].active = false;
+        tasks_[i].submit_sequence = 0;
+        submitted_task_sequence_[i].store(0, std::memory_order_relaxed);
     }
 }
 
@@ -411,18 +426,24 @@ c10::intrusive_ptr<c10d::Work> MooncakeWorker::putTaskCuda(
     //  Alternately use even-odd items to maintain tasks
     size_t chunkSize = ((kBufferSize - 1) / meta->size) & ~(size_t)7;
 
+    std::vector<CudaTaskSubmissionToken> submitted_tasks;
+    submitted_tasks.reserve((tensorSize + chunkSize - 1) / chunkSize);
     for (size_t pos = 0; pos < tensorSize; pos += chunkSize) {
         size_t realSize = min(tensorSize, pos + chunkSize) - pos;
         int taskId = cudaTaskCount % 2 + 2;
         int bufferOffset = meta->taskCount % 2;
+        const uint64_t taskSequence =
+            next_cuda_task_sequence_.fetch_add(1, std::memory_order_relaxed);
+        submitted_tasks.push_back(
+            {.task_id = static_cast<size_t>(taskId), .sequence = taskSequence});
         tensorToBuffer(
             (void*)meta->segmentInfos[meta->rank].send_buffer[bufferOffset],
             pos, realSize);
 
         hasCallback_[taskId] = false;
         enqueueTaskKernel<<<1, 1, 0, stream>>>(
-            opType, realSize, broadcastRoot, bufferOffset, meta.get(),
-            tasks_device_, meta->size, meta->activeRanksDevice,
+            opType, realSize, broadcastRoot, bufferOffset, taskSequence,
+            meta.get(), tasks_device_, meta->size, meta->activeRanksDevice,
             meta->activeRanksTensor.data_ptr<int>(), taskId);
         bufferToTensor(
             (void*)meta->segmentInfos[meta->rank].recv_buffer[bufferOffset],
@@ -435,10 +456,11 @@ c10::intrusive_ptr<c10d::Work> MooncakeWorker::putTaskCuda(
     auto event = std::make_shared<torch::Event>(torch::kCUDA);
     event->record(stream);
     if (opType == c10d::OpType::BARRIER) {
-        return c10::make_intrusive<MooncakeBarrierWorkCuda>(opType, event,
-                                                            meta);
+        return c10::make_intrusive<MooncakeBarrierWorkCuda>(
+            opType, event, meta, this, std::move(submitted_tasks));
     }
-    return c10::make_intrusive<MooncakeWorkCuda>(opType, event, meta);
+    return c10::make_intrusive<MooncakeWorkCuda>(
+        opType, event, meta, this, std::move(submitted_tasks));
 }
 
 }  // namespace mooncake

--- a/mooncake-pg/src/mooncake_worker.cu
+++ b/mooncake-pg/src/mooncake_worker.cu
@@ -29,10 +29,10 @@ class MooncakeWorkCpu : public ::c10d::Work {
 
 class MooncakeWorkCuda : public ::c10d::Work {
    public:
-    MooncakeWorkCuda(
-        c10d::OpType opType, std::shared_ptr<torch::Event> event,
-        std::shared_ptr<TransferGroupMeta> meta, const MooncakeWorker* worker,
-        std::vector<CudaTaskSubmissionToken> submitted_tasks)
+    MooncakeWorkCuda(c10d::OpType opType, std::shared_ptr<torch::Event> event,
+                     std::shared_ptr<TransferGroupMeta> meta,
+                     const MooncakeWorker* worker,
+                     std::vector<CudaTaskSubmissionToken> submitted_tasks)
         : Work(-1, opType),
           event_(std::move(event)),
           meta_(std::move(meta)),
@@ -459,8 +459,8 @@ c10::intrusive_ptr<c10d::Work> MooncakeWorker::putTaskCuda(
         return c10::make_intrusive<MooncakeBarrierWorkCuda>(
             opType, event, meta, this, std::move(submitted_tasks));
     }
-    return c10::make_intrusive<MooncakeWorkCuda>(
-        opType, event, meta, this, std::move(submitted_tasks));
+    return c10::make_intrusive<MooncakeWorkCuda>(opType, event, meta, this,
+                                                 std::move(submitted_tasks));
 }
 
 }  // namespace mooncake

--- a/mooncake-pg/src/mooncake_worker_thread.cpp
+++ b/mooncake-pg/src/mooncake_worker_thread.cpp
@@ -35,6 +35,35 @@ bool MooncakeWorker::drainTasks(const TransferGroupMeta* meta) const {
         });
 }
 
+bool MooncakeWorker::waitUntilTasksSubmitted(
+    const std::vector<CudaTaskSubmissionToken>& tasks,
+    std::chrono::milliseconds timeout) const {
+    if (tasks.empty()) {
+        return true;
+    }
+
+    auto submitted = [this, &tasks] {
+        for (const auto& task : tasks) {
+            if (task.task_id >= kNumTasks_) {
+                return false;
+            }
+            if (submitted_task_sequence_[task.task_id].load(
+                    std::memory_order_acquire) < task.sequence) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    BackoffWaiter waiter(BackoffWaiterConfig::constantSleep(
+        std::chrono::microseconds(10)));
+    if (timeout == kNoTimeout) {
+        waiter.wait(submitted);
+        return true;
+    }
+    return waiter.wait_for(timeout, submitted);
+}
+
 void MooncakeWorker::startWorker() {
     running_ = true;
     worker_thread_ = std::thread([this] {
@@ -61,7 +90,10 @@ void MooncakeWorker::startWorker() {
                                      group->rank != task.broadcastRoot) ||
                                     task.opType == c10d::OpType::BARRIER;
                 if (task_status[i].load(std::memory_order_acquire) == IDLE) {
+                    const auto submit_sequence = task.submit_sequence;
                     if (skipTransfer) {
+                        submitted_task_sequence_[i].store(
+                            submit_sequence, std::memory_order_release);
                         task_status[i].store(TRANSFERRED_1,
                                              std::memory_order_release);
                         continue;
@@ -133,6 +165,8 @@ void MooncakeWorker::startWorker() {
                     task.batchID =
                         group->engine->allocateBatchID(entries.size());
                     group->engine->submitTransfer(task.batchID, entries);
+                    submitted_task_sequence_[i].store(
+                        submit_sequence, std::memory_order_release);
                     activeTime[i] = clock::now();
                     task_status[i].store(TRANSFERRED_1,
                                          std::memory_order_release);

--- a/mooncake-pg/src/mooncake_worker_thread.cpp
+++ b/mooncake-pg/src/mooncake_worker_thread.cpp
@@ -55,8 +55,8 @@ bool MooncakeWorker::waitUntilTasksSubmitted(
         return true;
     };
 
-    BackoffWaiter waiter(BackoffWaiterConfig::constantSleep(
-        std::chrono::microseconds(10)));
+    BackoffWaiter waiter(
+        BackoffWaiterConfig::constantSleep(std::chrono::microseconds(10)));
     if (timeout == kNoTimeout) {
         waiter.wait(submitted);
         return true;

--- a/mooncake-pg/src/mooncake_worker_thread.cpp
+++ b/mooncake-pg/src/mooncake_worker_thread.cpp
@@ -45,7 +45,8 @@ bool MooncakeWorker::waitUntilTasksSubmitted(
     auto submitted = [this, &tasks] {
         for (const auto& task : tasks) {
             if (task.task_id >= kNumTasks_) {
-                return false;
+                LOG(ERROR) << "Invalid task id.";
+                return true;
             }
             if (submitted_task_sequence_[task.task_id].load(
                     std::memory_order_acquire) < task.sequence) {

--- a/mooncake-transfer-engine/tent/include/tent/platform/cuda.h
+++ b/mooncake-transfer-engine/tent/include/tent/platform/cuda.h
@@ -17,9 +17,88 @@
 
 #include "tent/runtime/platform.h"
 #include "tent/common/config.h"
+#include "tent/common/concurrent/rw_spinlock.h"
+
+#include <cuda_runtime.h>
 
 namespace mooncake {
 namespace tent {
+
+class CUDAStreamPool;
+
+// RAII Wrapper for cudaStream_t.
+// When this handle destructs, the stream is automatically returned to the pool.
+class CUDAStreamHandle {
+   public:
+    CUDAStreamHandle() = default;
+
+    CUDAStreamHandle(cudaStream_t stream, int deviceId, CUDAStreamPool* pool)
+        : stream_(stream), deviceId_(deviceId), pool_(pool) {}
+
+    // exclusive ownership
+    CUDAStreamHandle(const CUDAStreamHandle&) = delete;
+    CUDAStreamHandle& operator=(const CUDAStreamHandle&) = delete;
+
+    CUDAStreamHandle(CUDAStreamHandle&& other) noexcept
+        : stream_(other.stream_),
+          deviceId_(other.deviceId_),
+          pool_(other.pool_) {
+        other.stream_ = nullptr;
+        other.pool_ = nullptr;
+    }
+
+    CUDAStreamHandle& operator=(CUDAStreamHandle&& other) noexcept;
+    ~CUDAStreamHandle();
+
+    // Get the underlying CUDA stream
+    [[nodiscard]] cudaStream_t get() const { return stream_; }
+
+   private:
+    void releaseToPool();
+
+    cudaStream_t stream_ = nullptr;
+    int deviceId_ = -1;
+    CUDAStreamPool* pool_ = nullptr;
+};
+
+// CUDA Stream Pool managing all devices.
+class CUDAStreamPool {
+    friend class CUDAStreamHandle;
+
+   public:
+    CUDAStreamPool() = default;
+    ~CUDAStreamPool() = default;
+
+    // Non-copyable
+    CUDAStreamPool(const CUDAStreamPool&) = delete;
+    CUDAStreamPool& operator=(const CUDAStreamPool&) = delete;
+
+    // Acquires a stream for the specified device.
+    static constexpr int kCurrentDevice = -1;
+    Status acquire(CUDAStreamHandle& outHandle, int deviceId = kCurrentDevice);
+
+   private:
+    class DevicePool {
+       public:
+        explicit DevicePool(int deviceId);
+        ~DevicePool();
+
+        Status acquire(cudaStream_t& outStream);
+        void release(cudaStream_t stream);
+
+       private:
+        int deviceId_;
+        RWSpinlock dev_lock_;
+        std::vector<cudaStream_t> availableStreams_;
+    };
+
+    // called by CUDAStreamHandle::releaseToPool
+    void release(int deviceId, cudaStream_t stream);
+    DevicePool* getDevicePool(int deviceId);
+
+    RWSpinlock pools_lock_;
+    std::vector<std::unique_ptr<DevicePool>> devicePools_;
+};
 
 class CudaPlatform : public Platform {
    public:
@@ -27,24 +106,28 @@ class CudaPlatform : public Platform {
 
     virtual ~CudaPlatform() {}
 
-    virtual Status probe(std::vector<Topology::NicEntry> &nic_list,
-                         std::vector<Topology::MemEntry> &mem_list);
+    virtual Status probe(std::vector<Topology::NicEntry>& nic_list,
+                         std::vector<Topology::MemEntry>& mem_list);
 
-    virtual Status allocate(void **pptr, size_t size, MemoryOptions &options);
+    virtual Status allocate(void** pptr, size_t size, MemoryOptions& options);
 
-    virtual Status free(void *ptr, size_t size);
+    virtual Status free(void* ptr, size_t size);
 
-    virtual Status copy(void *dst, void *src, size_t length);
+    virtual Status copy(void* dst, void* src, size_t length);
 
-    virtual MemoryType getMemoryType(void *addr);
+    virtual MemoryType getMemoryType(void* addr);
 
     virtual const std::vector<RangeLocation> getLocation(
-        void *start, size_t len, bool skip_prefault = false);
+        void* start, size_t len, bool skip_prefault = false);
 
     virtual const std::string type() const { return "cuda"; }
 
+    Status getStreamFromPool(CUDAStreamHandle& outHandle,
+                             int deviceId = CUDAStreamPool::kCurrentDevice);
+
    private:
     std::shared_ptr<Config> conf;
+    CUDAStreamPool stream_pool;
 };
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
@@ -26,6 +26,7 @@
 
 #include "tent/runtime/control_plane.h"
 #include "tent/runtime/transport.h"
+#include "tent/platform/cuda.h"
 
 namespace mooncake {
 namespace tent {
@@ -41,7 +42,8 @@ struct MnnvlTask {
 struct MnnvlSubBatch : public Transport::SubBatch {
     std::vector<MnnvlTask> task_list;
     size_t max_size;
-    cudaStream_t stream;
+    CUDAStreamHandle sync_stream;
+    CUDAStreamHandle async_stream;
     virtual size_t size() const { return task_list.size(); }
 };
 
@@ -95,6 +97,7 @@ class MnnvlTransport : public Transport {
     std::string local_segment_name_;
     std::shared_ptr<Topology> local_topology_;
     std::shared_ptr<ControlService> metadata_;
+    CudaPlatform *platform_;
 
     struct OpenedMnnvlEntry {
         void *mnnvl_addr;

--- a/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
@@ -28,6 +28,7 @@
 #include "tent/common/concurrent/ticket_lock.h"
 #include "tent/runtime/control_plane.h"
 #include "tent/runtime/transport.h"
+#include "tent/platform/cuda.h"
 
 namespace mooncake {
 namespace tent {
@@ -44,7 +45,8 @@ struct NVLinkTask {
 struct NVLinkSubBatch : public Transport::SubBatch {
     std::vector<NVLinkTask> task_list;
     size_t max_size;
-    cudaStream_t stream;
+    CUDAStreamHandle sync_stream;
+    CUDAStreamHandle async_stream;
     virtual size_t size() const { return task_list.size(); }
 };
 
@@ -93,6 +95,7 @@ class NVLinkTransport : public Transport {
     std::string local_segment_name_;
     std::shared_ptr<Topology> local_topology_;
     std::shared_ptr<ControlService> metadata_;
+    CudaPlatform *platform_;
 
     struct OpenedShmEntry {
         void *shm_addr;

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -56,7 +56,15 @@ Status CudaPlatform::free(void* ptr, size_t size) {
 }
 
 Status CudaPlatform::copy(void* dst, void* src, size_t length) {
-    CHECK_CUDA(cudaMemcpy(dst, src, length, cudaMemcpyDefault));
+    // Use cudaMemcpyAsync with a non-blocking stream instead of cudaMemcpy(),
+    // as the latter relies on the legacy default stream and can introduce
+    // unintended synchronization or even deadlocks in downstream
+    // components (e.g. mooncake-pg).
+    CUDAStreamHandle stream;
+    CHECK_STATUS(getStreamFromPool(stream));
+    CHECK_CUDA(
+        cudaMemcpyAsync(dst, src, length, cudaMemcpyDefault, stream.get()));
+    CHECK_CUDA(cudaStreamSynchronize(stream.get()));
     return Status::OK();
 }
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_stream_pool.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_stream_pool.cpp
@@ -1,0 +1,161 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/platform/cuda.h"
+
+namespace mooncake {
+namespace tent {
+
+CUDAStreamHandle& CUDAStreamHandle::operator=(
+    CUDAStreamHandle&& other) noexcept {
+    if (this != &other) {
+        // Release current resource if any
+        releaseToPool();
+        stream_ = other.stream_;
+        deviceId_ = other.deviceId_;
+        pool_ = other.pool_;
+
+        other.stream_ = nullptr;
+        other.pool_ = nullptr;
+    }
+    return *this;
+}
+
+CUDAStreamHandle::~CUDAStreamHandle() { releaseToPool(); }
+
+void CUDAStreamHandle::releaseToPool() {
+    if (stream_ != nullptr && pool_ != nullptr) {
+        pool_->release(deviceId_, stream_);
+        stream_ = nullptr;
+        pool_ = nullptr;
+    }
+}
+
+CUDAStreamPool::DevicePool::DevicePool(int deviceId) : deviceId_(deviceId) {}
+
+CUDAStreamPool::DevicePool::~DevicePool() {
+    int currentDevice;
+    if (cudaGetDevice(&currentDevice) == cudaSuccess) {
+        cudaSetDevice(deviceId_);
+        for (cudaStream_t stream : availableStreams_) {
+            cudaStreamDestroy(stream);
+        }
+        cudaSetDevice(currentDevice);
+    }
+}
+
+Status CUDAStreamPool::DevicePool::acquire(cudaStream_t& outStream) {
+    {
+        RWSpinlock::WriteGuard guard(dev_lock_);
+        if (!availableStreams_.empty()) {
+            outStream = availableStreams_.back();
+            availableStreams_.pop_back();
+            return Status::OK();
+        }
+    }
+
+    // Lazy creation: avoid holding the lock so we don't block other threads
+    // checking out streams.
+    int currentDevice;
+    CHECK_CUDA(cudaGetDevice(&currentDevice));
+
+    if (currentDevice != deviceId_) {
+        CHECK_CUDA(cudaSetDevice(deviceId_));
+    }
+
+    CHECK_CUDA(cudaStreamCreateWithFlags(&outStream, cudaStreamNonBlocking));
+
+    // Restore previous device
+    if (currentDevice != deviceId_) {
+        CHECK_CUDA(cudaSetDevice(currentDevice));
+    }
+
+    return Status::OK();
+}
+
+void CUDAStreamPool::DevicePool::release(cudaStream_t stream) {
+    RWSpinlock::WriteGuard guard(dev_lock_);
+    availableStreams_.push_back(stream);
+}
+
+Status CUDAStreamPool::acquire(CUDAStreamHandle& outHandle, int deviceId) {
+    if (deviceId == kCurrentDevice) {
+        if (cudaGetDevice(&deviceId) != cudaSuccess) {
+            return Status::InternalError("Failed to get current device ID");
+        }
+    } else if (deviceId < 0) {
+        return Status::InternalError("Invalid device ID");
+    }
+
+    DevicePool* devicePool = getDevicePool(deviceId);
+
+    if (!devicePool) {
+        return Status::InternalError("Failed to get device pool");
+    }
+
+    cudaStream_t rawStream;
+    CHECK_STATUS(devicePool->acquire(rawStream));
+
+    outHandle = CUDAStreamHandle(rawStream, deviceId, this);
+    return Status::OK();
+}
+
+void CUDAStreamPool::release(int deviceId, cudaStream_t stream) {
+    DevicePool* devicePool = getDevicePool(deviceId);
+    if (devicePool) devicePool->release(stream);
+}
+
+CUDAStreamPool::DevicePool* CUDAStreamPool::getDevicePool(int deviceId) {
+    // check if the device pool already exists
+    {
+        RWSpinlock::ReadGuard readGuard(pools_lock_);
+        if (static_cast<size_t>(deviceId) < devicePools_.size() &&
+            devicePools_[deviceId]) {
+            return devicePools_[deviceId].get();
+        }
+    }
+
+    // write lock to resize vector and create DevicePool
+    RWSpinlock::WriteGuard writeGuard(pools_lock_);
+
+    // Double-check devicePools_[deviceId] after acquiring the lock,
+    // since another thread may have created it in the meantime.
+    if (static_cast<size_t>(deviceId) < devicePools_.size() &&
+        devicePools_[deviceId]) {
+        return devicePools_[deviceId].get();
+    }
+
+    // consistency check on deviceId
+    int actualDeviceCount = 0;
+    if (cudaGetDeviceCount(&actualDeviceCount) != cudaSuccess ||
+        deviceId >= actualDeviceCount) {
+        LOG(ERROR) << "Invalid cuda device id " << deviceId;
+        return nullptr;
+    }
+
+    if (static_cast<size_t>(deviceId) >= devicePools_.size()) {
+        devicePools_.resize(deviceId + 1);
+    }
+
+    devicePools_[deviceId] = std::make_unique<DevicePool>(deviceId);
+    return devicePools_[deviceId].get();
+}
+
+Status CudaPlatform::getStreamFromPool(CUDAStreamHandle& outHandle,
+                                       int deviceId) {
+    return stream_pool.acquire(outHandle, deviceId);
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -228,19 +228,32 @@ void setLogLevel(const std::string level) {
         FLAGS_minloglevel = google::ERROR;
 }
 
+static std::string readIdentityFile(const char* path) {
+    std::ifstream file(path);
+    if (!file) return "";
+    std::string content((std::istreambuf_iterator<char>(file)),
+                        std::istreambuf_iterator<char>());
+    if (!content.empty() && content.back() == '\n') content.pop_back();
+    return content;
+}
+
 std::string getMachineID() {
-    std::ifstream file("/etc/machine-id");
-    if (file) {
-        std::string content((std::istreambuf_iterator<char>(file)),
-                            std::istreambuf_iterator<char>());
-        if (!content.empty() && content.back() == '\n') content.pop_back();
-        return content;
-    } else {
-        std::string content = "undefined_machine_";
-        for (int i = 0; i < 16; ++i)
-            content += 'a' + SimpleRandom::Get().next(26);
-        return content;
+    const std::string boot_id =
+        readIdentityFile("/proc/sys/kernel/random/boot_id");
+    const std::string machine_id = readIdentityFile("/etc/machine-id");
+
+    if (!boot_id.empty() && !machine_id.empty()) {
+        return boot_id + ":" + machine_id;
     }
+
+    if (!boot_id.empty()) return boot_id;
+    if (!machine_id.empty()) return machine_id;
+
+    std::string content = "undefined_machine_";
+    for (int i = 0; i < 16; ++i)
+        content += 'a' + SimpleRandom::Get().next(26);
+    LOG(WARNING) << "TENT getMachineID source=fallback value=" << content;
+    return content;
 }
 
 Status TransferEngineImpl::setupLocalSegment() {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -250,8 +250,7 @@ std::string getMachineID() {
     if (!machine_id.empty()) return machine_id;
 
     std::string content = "undefined_machine_";
-    for (int i = 0; i < 16; ++i)
-        content += 'a' + SimpleRandom::Get().next(26);
+    for (int i = 0; i < 16; ++i) content += 'a' + SimpleRandom::Get().next(26);
     LOG(WARNING) << "TENT getMachineID source=fallback value=" << content;
     return content;
 }

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -101,6 +101,7 @@ Status MnnvlTransport::install(std::string &local_segment_name,
             "CUDA Fabric handle type not supported " LOC_MARK);
     }
 
+    platform_ = dynamic_cast<CudaPlatform *>(&Platform::getLoader());
     metadata_ = metadata;
     local_segment_name_ = local_segment_name;
     local_topology_ = local_topology;
@@ -137,16 +138,6 @@ Status MnnvlTransport::uninstall() {
     return Status::OK();
 }
 
-struct CudaStreamMnnvlRAII {
-    cudaStream_t stream_;
-    CudaStreamMnnvlRAII() {
-        cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking);
-    }
-    ~CudaStreamMnnvlRAII() { cudaStreamDestroy(stream_); }
-};
-
-thread_local CudaStreamMnnvlRAII tl_stream_mnnvl;
-
 Status MnnvlTransport::allocateSubBatch(SubBatchRef &batch, size_t max_size) {
     auto mnnvl_batch = Slab<MnnvlSubBatch>::Get().allocate();
     if (!mnnvl_batch)
@@ -154,9 +145,8 @@ Status MnnvlTransport::allocateSubBatch(SubBatchRef &batch, size_t max_size) {
     batch = mnnvl_batch;
     mnnvl_batch->task_list.reserve(max_size);
     mnnvl_batch->max_size = max_size;
-    mnnvl_batch->stream = tl_stream_mnnvl.stream_;
-    // CHECK_CUDA(cudaStreamCreateWithFlags(&mnnvl_batch->stream,
-    // cudaStreamNonBlocking));
+    CHECK_STATUS(platform_->getStreamFromPool(mnnvl_batch->sync_stream));
+    CHECK_STATUS(platform_->getStreamFromPool(mnnvl_batch->async_stream));
     return Status::OK();
 }
 
@@ -238,17 +228,26 @@ void MnnvlTransport::startTransfer(MnnvlTask *task, MnnvlSubBatch *batch) {
     }
 
     if (!is_async) {
-        err = cudaMemcpy(dst, src, task->request.length, kind);
+        err = cudaMemcpyAsync(dst, src, task->request.length, kind,
+                              batch->sync_stream.get());
         if (err != cudaSuccess) {
             task->status_word = TransferStatusEnum::FAILED;
-        } else {
-            task->transferred_bytes = task->request.length;
-            task->status_word = TransferStatusEnum::COMPLETED;
+            return;
         }
+
+        err = cudaStreamSynchronize(batch->sync_stream.get());
+        if (err != cudaSuccess) {
+            task->status_word = TransferStatusEnum::FAILED;
+            return;
+        }
+
+        task->transferred_bytes = task->request.length;
+        task->status_word = TransferStatusEnum::COMPLETED;
         return;
     }
 
-    err = cudaMemcpyAsync(dst, src, task->request.length, kind, batch->stream);
+    err = cudaMemcpyAsync(dst, src, task->request.length, kind,
+                          batch->async_stream.get());
 
     if (err != cudaSuccess) task->status_word = TransferStatusEnum::FAILED;
 }
@@ -262,9 +261,9 @@ Status MnnvlTransport::getTransferStatus(SubBatchRef batch, int task_id,
     auto &task = mnnvl_batch->task_list[task_id];
     status = TransferStatus{task.status_word, task.transferred_bytes};
     if (task.status_word == TransferStatusEnum::PENDING) {
-        auto err = cudaStreamQuery(mnnvl_batch->stream);
+        auto err = cudaStreamQuery(mnnvl_batch->async_stream.get());
         if (err == cudaSuccess) {
-            cudaStreamSynchronize(mnnvl_batch->stream);
+            cudaStreamSynchronize(mnnvl_batch->async_stream.get());
             task.transferred_bytes = task.request.length;
             task.status_word = TransferStatusEnum::COMPLETED;
         } else if (err != cudaErrorNotReady) {

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -172,8 +172,8 @@ void NVLinkTransport::startTransfer(NVLinkTask* task, NVLinkSubBatch* batch) {
     }
 
     if (!is_async) {
-        err =
-            cudaMemcpyAsync(dst, src, task->request.length, kind, batch->stream);
+        err = cudaMemcpyAsync(dst, src, task->request.length, kind,
+                              batch->stream);
         if (err != cudaSuccess) {
             task->status_word = TransferStatusEnum::FAILED;
             return;

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -47,6 +47,7 @@ Status NVLinkTransport::install(std::string& local_segment_name,
             "NVLink transport has been installed" LOC_MARK);
     }
 
+    platform_ = dynamic_cast<CudaPlatform*>(&Platform::getLoader());
     metadata_ = metadata;
     local_segment_name_ = local_segment_name;
     local_topology_ = local_topology;
@@ -76,16 +77,6 @@ Status NVLinkTransport::uninstall() {
     return Status::OK();
 }
 
-struct CudaStreamNVLinkRAII {
-    cudaStream_t stream_;
-    CudaStreamNVLinkRAII() {
-        cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking);
-    }
-    ~CudaStreamNVLinkRAII() { cudaStreamDestroy(stream_); }
-};
-
-thread_local CudaStreamNVLinkRAII tl_stream_nvlink;
-
 Status NVLinkTransport::allocateSubBatch(SubBatchRef& batch, size_t max_size) {
     auto shm_batch = Slab<NVLinkSubBatch>::Get().allocate();
     if (!shm_batch)
@@ -93,9 +84,8 @@ Status NVLinkTransport::allocateSubBatch(SubBatchRef& batch, size_t max_size) {
     batch = shm_batch;
     shm_batch->task_list.reserve(max_size);
     shm_batch->max_size = max_size;
-    shm_batch->stream = tl_stream_nvlink.stream_;
-    // CHECK_CUDA(cudaStreamCreateWithFlags(&shm_batch->stream,
-    // cudaStreamNonBlocking));
+    CHECK_STATUS(platform_->getStreamFromPool(shm_batch->sync_stream));
+    CHECK_STATUS(platform_->getStreamFromPool(shm_batch->async_stream));
     return Status::OK();
 }
 
@@ -173,13 +163,13 @@ void NVLinkTransport::startTransfer(NVLinkTask* task, NVLinkSubBatch* batch) {
 
     if (!is_async) {
         err = cudaMemcpyAsync(dst, src, task->request.length, kind,
-                              batch->stream);
+                              batch->sync_stream.get());
         if (err != cudaSuccess) {
             task->status_word = TransferStatusEnum::FAILED;
             return;
         }
 
-        err = cudaStreamSynchronize(batch->stream);
+        err = cudaStreamSynchronize(batch->sync_stream.get());
         if (err != cudaSuccess) {
             task->status_word = TransferStatusEnum::FAILED;
             return;
@@ -190,7 +180,8 @@ void NVLinkTransport::startTransfer(NVLinkTask* task, NVLinkSubBatch* batch) {
         return;
     }
 
-    err = cudaMemcpyAsync(dst, src, task->request.length, kind, batch->stream);
+    err = cudaMemcpyAsync(dst, src, task->request.length, kind,
+                          batch->async_stream.get());
 
     if (err != cudaSuccess) task->status_word = TransferStatusEnum::FAILED;
 }
@@ -204,9 +195,9 @@ Status NVLinkTransport::getTransferStatus(SubBatchRef batch, int task_id,
     auto& task = shm_batch->task_list[task_id];
     status = TransferStatus{task.status_word, task.transferred_bytes};
     if (task.status_word == TransferStatusEnum::PENDING) {
-        auto err = cudaStreamQuery(shm_batch->stream);
+        auto err = cudaStreamQuery(shm_batch->async_stream.get());
         if (err == cudaSuccess) {
-            cudaStreamSynchronize(shm_batch->stream);
+            cudaStreamSynchronize(shm_batch->async_stream.get());
             task.transferred_bytes = task.request.length;
             task.status_word = TransferStatusEnum::COMPLETED;
         } else if (err != cudaErrorNotReady) {

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -172,13 +172,21 @@ void NVLinkTransport::startTransfer(NVLinkTask* task, NVLinkSubBatch* batch) {
     }
 
     if (!is_async) {
-        err = cudaMemcpy(dst, src, task->request.length, kind);
+        err =
+            cudaMemcpyAsync(dst, src, task->request.length, kind, batch->stream);
         if (err != cudaSuccess) {
             task->status_word = TransferStatusEnum::FAILED;
-        } else {
-            task->transferred_bytes = task->request.length;
-            task->status_word = TransferStatusEnum::COMPLETED;
+            return;
         }
+
+        err = cudaStreamSynchronize(batch->stream);
+        if (err != cudaSuccess) {
+            task->status_word = TransferStatusEnum::FAILED;
+            return;
+        }
+
+        task->transferred_bytes = task->request.length;
+        task->status_word = TransferStatusEnum::COMPLETED;
         return;
     }
 


### PR DESCRIPTION
## Description

This PR fixes a hang in Mooncake-PG CUDA collectives when running with TENT, and also fixes incorrect completion semantics in TENT NVLink's small-transfer path.

The main issue was that `MooncakeWorkCuda::wait()` was effectively a no-op for normal CUDA collectives. This is unsafe for synchronous collectives (`async_op=False`).

This change follows PyTorch's documented semantics for CUDA collectives:

- for synchronous collectives, "When the function returns, it is guaranteed that the collective operation is performed", but "for CUDA operations, it is not guaranteed that the CUDA operation is completed";
- for CUDA `Work.wait()`, PyTorch documents that it "will block the currently active CUDA stream until the operation is completed (but will not block the CPU)".

Reference:

- PyTorch distributed docs, "Synchronous and asynchronous collective operations":
  https://docs.pytorch.org/docs/stable/distributed.html#synchronous-and-asynchronous-collective-operations

In practice, PyTorch still creates a `Work` object and calls `work.wait()` before returning from synchronous `dist.*` calls. If Mooncake's `wait()` returns before the background worker has even consumed and submitted the transfer, the host-side synchronous path can advance before the transfer handoff has been established.

In Mooncake, device-side ordering is already enforced by the existing spin-kernel design on the caller stream, so we do **not** want to turn `wait()` into a full CPU-blocking "wait until the GPU work fully completes" barrier. What we need instead is a host-side handoff boundary: when `wait()` returns, all CUDA work required to publish the transfer task has already been launched on the user stream, and the worker has already observed that task and submitted the corresponding transfer to the engine.

This PR adds that missing handoff boundary:

1. each CUDA chunk gets a monotonically increasing `submit_sequence`;
2. the sequence is published together with the task by `enqueueTaskKernel(...)`;
3. after `submitTransfer(...)`, the worker records that sequence into `submitted_task_sequence_[slot]`;
4. `MooncakeWorkCuda::wait()` waits until all chunks in this `Work` have been submitted.

More precisely, the property we need here is that all CUDA kernels required to hand the collective off to the transfer path have already been launched before `wait()` returns. That requirement is specific to CUDA-backed handoff paths; it is not inherently needed for purely CPU-side submission paths such as plain RDMA request submission. However, transport resolution happens later in the transfer path, so at the `Work.wait()` layer we do not reliably know which transport will ultimately be used. For that reason, this PR uses one uniform rule and waits until the worker has submitted all tasks, which conservatively covers both cases while, most importantly, ensuring that the CUDA-dependent handoff has already been established.

This keeps Mooncake aligned with CUDA collective semantics:

- same-stream ordering is still provided by the existing stream/spin-kernel mechanism;
- the host path no longer returns before the worker has established the transfer;
- `barrier` retains its stronger event-based semantics.

This PR also fixes TENT NVLink's small-copy path. Previously, small transfers used plain `cudaMemcpy(...)` and were marked `COMPLETED` immediately, while large transfers used `cudaMemcpyAsync(..., batch->stream)` and only transitioned to `COMPLETED` after `cudaStreamQuery(batch->stream)`.

That behavior was unsafe. The original implementation treated a successful return from `cudaMemcpy(...)` as proof that the transfer had completed, but this is not true in general. NVIDIA's CUDA runtime documentation explicitly states that for synchronous memcpy behavior, "For transfers from device memory to device memory, no host-side synchronization is performed."


Reference:

- CUDA Runtime API, "API synchronization behavior":
  https://docs.nvidia.com/cuda/cuda-runtime-api/api-sync-behavior.html

As a result, the old small-transfer path could mark a D2D NVLink copy as `COMPLETED` even though the copy had not actually completed from the host's point of view. This made completion semantics payload-size dependent and was not just theoretical: we were able to reproduce incorrect results for tiny collectives such as `all_gather_list`, where the output still contained stale values.

Although the stale-result bug was reproduced on CUDA D2D transfers, this code path is not limited to D2D. `NVLinkTransport::startTransfer()` derives `cudaMemcpyKind` from the source and destination pointer types at runtime, so the same small-transfer logic also applies to host-involved locations (`cpu` <-> `cuda`) handled by this path. This PR therefore intentionally makes completion semantics consistent for those location combinations as well.

To fix that, NVLink now uses one consistent completion model:

- small transfers: `cudaMemcpyAsync(..., batch->stream)` + `cudaStreamSynchronize(batch->stream)` + mark complete;
- large transfers: `cudaMemcpyAsync(..., batch->stream)` + completion via `getTransferStatus()`.

Additionally, this PR fixes CPU-backend memory location selection in `MooncakeBackend`: CPU backend buffers now remain on `kWildcardLocation`, instead of incorrectly inheriting a GPU-specific location when CUDA is available.



## Changes

### Mooncake-PG

Files:

- `mooncake-pg/include/mooncake_worker.cuh`
- `mooncake-pg/src/mooncake_worker.cu`
- `mooncake-pg/src/mooncake_worker_thread.cpp`

Changes:

- introduce `CudaTaskSubmissionToken { task_id, sequence }`
- add `Task::submit_sequence`
- add `next_cuda_task_sequence_` and `submitted_task_sequence_[kNumTasks_]`
- publish `submit_sequence` from `enqueueTaskKernel(...)` before `active = true`
- record submission progress immediately after `submitTransfer(...)`
- make `MooncakeWorkCuda::wait()` call `waitUntilTasksSubmitted(...)`
- preserve the stronger event-based semantics for `MooncakeBarrierWorkCuda::wait()`

Why sequence numbers are needed:

- CUDA task slots are reused
- a plain slot-state check is not enough
- `submit_sequence` lets `wait()` distinguish the current logical task from a later reuse of the same slot

### TENT NVLink

File:

- `mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp`

Changes:

- remove the plain `cudaMemcpy(...)` fast path for small transfers
- issue both small and large transfers on `batch->stream`
- for small transfers, synchronize `batch->stream` before marking completion

This makes NVLink completion semantics consistent across payload sizes and fixes the observed stale-output issue.

## Why This Wait Is Needed

For synchronous CUDA collectives, PyTorch still executes the `Work.wait()` path before returning from `dist.*`. In Mooncake, a no-op `wait()` means the host path can finish before the background worker has even established the CUDA-to-worker handoff, which is too early.

At the same time, a full CPU-side completion wait is unnecessary for normal CUDA collectives, because Mooncake already enforces same-stream ordering through the spin-kernel path on the caller stream.

So the right boundary here is:

- not "GPU copy fully completed"
- but "all CUDA work required for task publication has been launched, and the worker has consumed the task and submitted the transfer"

### Related Transport-Selection Fix

  File:

  - `mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp`

  Change:

  - update `getMachineID()` to use `boot_id + machine-id` instead of `/etc/machine-id` alone

  This helps TENT avoid false same-host detection in containerized or cloned environments and reduces incorrect cross-node `NVLINK` or `SHM` selection.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Tested with Mooncake-PG + TENT using:

1. `TestMooncakePGCollectivesCUDA.test_allreduce_sum`
2. `TestMooncakePGCollectivesCUDA.test_all_gather_list` with `nvlink.async_memcpy_threshold=1`
3. `TestMooncakePGCollectivesCUDA.test_all_gather_list` with `nvlink.async_memcpy_threshold=0`

The `all_gather_list` reproduction is especially important here: with the old NVLink small-copy path, we could reproduce stale outputs for tiny transfers, e.g. observed values such as `[0, 0]` where `[0, 1]` was expected.

Representative commands:

```bash
MOONCAKE_PGTEST_DEVICE_FILTERS=mlx5_gdr_0,mlx5_gdr_1,mlx5_gdr_2,mlx5_gdr_3,mlx5_gdr_4,mlx5_gdr_5,mlx5_gdr_6,mlx5_gdr_7 \
MC_TENT_CONF='{"topology": {"rdma_blacklist": ["mlx5_8", "mlx5_bond_0"]}, "transports": {"rdma": {"device": {"gid_index": 3}}, "nvlink": {"async_memcpy_threshold": 0,"enable": true}},"verbose": false}' \
MC_USE_TENT=1 \
python mooncake-pg/tests/test_pg_collectives.py
```

```bash
MOONCAKE_PGTEST_DEVICE_FILTERS=mlx5_gdr_0,mlx5_gdr_1,mlx5_gdr_2,mlx5_gdr_3,mlx5_gdr_4,mlx5_gdr_5,mlx5_gdr_6,mlx5_gdr_7 \
MC_TENT_CONF='{"topology": {"rdma_blacklist": ["mlx5_8", "mlx5_bond_0"]}, "transports": {"rdma": {"device": {"gid_index": 3}}, "nvlink": {"async_memcpy_threshold": 0,"enable": true}},"verbose": false}' \
MC_USE_TENT=1 \
python mooncake-pg/tests/test_pg_collectives.py
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
