### PR TITLE
[Store] add streaming scatter transfer support

### DIFF
--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -410,6 +410,7 @@ In the example above:
 **Current limitation:** true ranged items currently require the selected source replica to be memory-backed. Whole-object reads still follow the normal full-read path, but partial reads through `get_into_ranges()` do not support non-memory replicas.
 
 ---
+---
 
 ## ReplicateConfig Configuration
 
@@ -2630,6 +2631,123 @@ store.unregister_buffer(tensor.data_ptr())
 store.unregister_buffer(target_tensor.data_ptr())
 ```
 </details>
+
+---
+
+### Streaming Zero-Copy Reads
+
+Mooncake also exposes streaming read handles for workloads that want to overlap transfer with compute instead of blocking until the full read completes.
+
+#### progressive_get()
+
+Start a chunked sequential read into a registered buffer.
+
+```python
+def progressive_get(self, key: str, buffer_ptr: int, size: int, chunk_size: int) -> Optional[ProgressiveGetHandle]
+```
+
+**Parameters:**
+- `key` (str): Object identifier.
+- `buffer_ptr` (int): Base address of a registered destination buffer.
+- `size` (int): Total number of bytes to read.
+- `chunk_size` (int): Chunk size used for incremental completion.
+
+**Returns:**
+- `ProgressiveGetHandle | None`: A handle on success, or `None` if submission fails.
+
+**Handle methods:**
+- `num_chunks`: Number of logical chunks in the request.
+- `is_chunk_ready(chunk_index) -> bool`: Poll one chunk.
+- `completed_count() -> int`: Number of completed chunks.
+- `wait_chunk(chunk_index) -> int`: Wait for one chunk and return an error code.
+- `wait_all() -> int`: Wait for the full request and return an error code.
+
+#### streaming_batch_get_buffer_ranges()
+
+Start a streaming scatter read from multiple keys into different ranges of a single registered destination buffer.
+
+```python
+def streaming_batch_get_buffer_ranges(
+    self,
+    keys: List[str],
+    buffer: int,
+    dest_offsets: List[int],
+    src_offsets: List[int],
+    sizes: List[int],
+) -> Optional[ScatterReadHandle]
+```
+
+Each element describes one range read:
+- read `[src_offsets[i], src_offsets[i] + sizes[i])` from `keys[i]`
+- write it into `[dest_offsets[i], dest_offsets[i] + sizes[i])` of `buffer`
+
+**Parameters:**
+- `keys` (List[str]): Keys to read from. Keys may repeat.
+- `buffer` (int): Base address of a registered destination buffer.
+- `dest_offsets` (List[int]): Destination offsets into `buffer`.
+- `src_offsets` (List[int]): Source offsets inside each object.
+- `sizes` (List[int]): Number of bytes for each range.
+
+**Returns:**
+- `ScatterReadHandle | None`: A handle on success, or `None` if validation or submission fails.
+
+**Notes:**
+- All four lists must have the same length.
+- The destination buffer must be registered with `register_buffer()` before calling this API.
+- `num_chunks` reports logical streaming chunks managed by the transfer layer. Do not assume it is always equal to the number of requested ranges.
+
+**Handle methods:**
+- `num_chunks`: Number of logical chunks in the request.
+- `is_chunk_ready(chunk_index) -> bool`: Poll one chunk.
+- `completed_count() -> int`: Number of completed chunks.
+- `wait_chunk(chunk_index) -> int`: Wait for one chunk and return an error code.
+- `wait_all() -> int`: Wait for the full scatter read and return an error code.
+
+**Example:**
+
+```python
+import ctypes
+from mooncake.store import MooncakeDistributedStore
+
+store = MooncakeDistributedStore()
+store.setup(
+    "localhost",
+    "http://localhost:8080/metadata",
+    512 * 1024 * 1024,
+    128 * 1024 * 1024,
+    "tcp",
+    "",
+    "localhost:50051",
+)
+
+store.put("obj_a", b"A" * 4096)
+store.put("obj_b", b"B" * 4096)
+
+buffer = (ctypes.c_ubyte * 2048)()
+buffer_ptr = ctypes.addressof(buffer)
+store.register_buffer(buffer_ptr, 2048)
+
+handle = store.streaming_batch_get_buffer_ranges(
+    ["obj_a", "obj_b"],
+    buffer_ptr,
+    [0, 1024],
+    [0, 0],
+    [1024, 1024],
+)
+
+if handle is None:
+    raise RuntimeError("scatter streaming submission failed")
+
+rc = handle.wait_all()
+if rc != 0:
+    raise RuntimeError(f"scatter streaming failed: {rc}")
+
+assert bytes(buffer[:1024]) == b"A" * 1024
+assert bytes(buffer[1024:2048]) == b"B" * 1024
+
+store.unregister_buffer(buffer_ptr)
+store.close()
+```
 
 ## MooncakeHostMemAllocator Class
 

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1804,6 +1804,60 @@ PYBIND11_MODULE(store, m) {
             })
         .def_readwrite("parallelism", &ReadTargetSpec::parallelism);
 
+    // Progressive get handle for per-chunk completion tracking
+    py::class_<ProgressiveGetHandle>(m, "ProgressiveGetHandle")
+        .def_property_readonly("num_chunks", &ProgressiveGetHandle::num_chunks)
+        .def(
+            "is_chunk_ready",
+            [](ProgressiveGetHandle &self, size_t idx) {
+                py::gil_scoped_release release;
+                return self.is_chunk_ready(idx);
+            },
+            py::arg("chunk_index"))
+        .def("completed_count",
+             [](ProgressiveGetHandle &self) {
+                 py::gil_scoped_release release;
+                 return self.completed_count();
+             })
+        .def(
+            "wait_chunk",
+            [](ProgressiveGetHandle &self, size_t idx) {
+                py::gil_scoped_release release;
+                return static_cast<int>(self.wait_chunk(idx));
+            },
+            py::arg("chunk_index"))
+        .def("wait_all", [](ProgressiveGetHandle &self) {
+            py::gil_scoped_release release;
+            return static_cast<int>(self.wait_all());
+        });
+
+    // Scatter read handle for per-chunk completion tracking
+    py::class_<ScatterReadHandle>(m, "ScatterReadHandle")
+        .def_property_readonly("num_chunks", &ScatterReadHandle::num_chunks)
+        .def(
+            "is_chunk_ready",
+            [](ScatterReadHandle &self, size_t idx) {
+                py::gil_scoped_release release;
+                return self.is_chunk_ready(idx);
+            },
+            py::arg("chunk_index"))
+        .def("completed_count",
+             [](ScatterReadHandle &self) {
+                 py::gil_scoped_release release;
+                 return self.completed_count();
+             })
+        .def(
+            "wait_chunk",
+            [](ScatterReadHandle &self, size_t idx) {
+                py::gil_scoped_release release;
+                return static_cast<int>(self.wait_chunk(idx));
+            },
+            py::arg("chunk_index"))
+        .def("wait_all", [](ScatterReadHandle &self) {
+            py::gil_scoped_release release;
+            return static_cast<int>(self.wait_all());
+        });
+
     // Create a wrapper that exposes DistributedObjectStore with Python-specific
     // methods
     // Helper function to extract PyClient shared_ptr from
@@ -1945,6 +1999,59 @@ PYBIND11_MODULE(store, m) {
              })
         .def("get", &mooncake::MooncakeStorePyWrapper::get)
         .def("get_batch", &mooncake::MooncakeStorePyWrapper::get_batch)
+        .def(
+            "progressive_get",
+            [](MooncakeStorePyWrapper &self, const std::string &key,
+               uintptr_t buffer_ptr, size_t size, size_t chunk_size) {
+                if (!self.is_client_initialized()) {
+                    LOG(ERROR) << "Client is not initialized";
+                    return py::cast<py::object>(py::none());
+                }
+                void *buffer = reinterpret_cast<void *>(buffer_ptr);
+                std::optional<ProgressiveGetHandle> handle;
+                {
+                    py::gil_scoped_release release;
+                    handle = self.store_->progressive_get(key, buffer, size,
+                                                          chunk_size);
+                }
+                if (!handle) {
+                    return py::cast<py::object>(py::none());
+                }
+                return py::cast(std::move(*handle));
+            },
+            py::arg("key"), py::arg("buffer"), py::arg("size"),
+            py::arg("chunk_size"),
+            "Start a progressive (chunked) get. Returns a "
+            "ProgressiveGetHandle or None on failure.\n"
+            "The buffer must be a registered memory address (uintptr_t).")
+        .def(
+            "streaming_batch_get_buffer_ranges",
+            [](MooncakeStorePyWrapper &self,
+               const std::vector<std::string> &keys, uintptr_t buffer_ptr,
+               const std::vector<size_t> &dest_offsets,
+               const std::vector<size_t> &src_offsets,
+               const std::vector<size_t> &sizes) {
+                if (!self.is_client_initialized()) {
+                    LOG(ERROR) << "Client is not initialized";
+                    return py::cast<py::object>(py::none());
+                }
+                void *buffer = reinterpret_cast<void *>(buffer_ptr);
+                std::optional<ScatterReadHandle> handle;
+                {
+                    py::gil_scoped_release release;
+                    handle = self.store_->streaming_batch_get_buffer_ranges(
+                        keys, buffer, dest_offsets, src_offsets, sizes);
+                }
+                if (!handle) {
+                    return py::cast<py::object>(py::none());
+                }
+                return py::cast(std::move(*handle));
+            },
+            py::arg("keys"), py::arg("buffer"), py::arg("dest_offsets"),
+            py::arg("src_offsets"), py::arg("sizes"),
+            "Start a streaming scatter read. Returns a "
+            "ScatterReadHandle or None on failure.\n"
+            "The buffer must be a registered memory address (uintptr_t).")
         .def(
             "get_buffer",
             [](MooncakeStorePyWrapper &self, const std::string &key) {

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1807,6 +1807,9 @@ PYBIND11_MODULE(store, m) {
     // Progressive get handle for per-chunk completion tracking
     py::class_<ProgressiveGetHandle>(m, "ProgressiveGetHandle")
         .def_property_readonly("num_chunks", &ProgressiveGetHandle::num_chunks)
+        .def_property_readonly(
+            "completed_count",
+            [](ProgressiveGetHandle &self) { return self.completed_count(); })
         .def(
             "is_chunk_ready",
             [](ProgressiveGetHandle &self, size_t idx) {
@@ -1814,11 +1817,6 @@ PYBIND11_MODULE(store, m) {
                 return self.is_chunk_ready(idx);
             },
             py::arg("chunk_index"))
-        .def("completed_count",
-             [](ProgressiveGetHandle &self) {
-                 py::gil_scoped_release release;
-                 return self.completed_count();
-             })
         .def(
             "wait_chunk",
             [](ProgressiveGetHandle &self, size_t idx) {
@@ -1834,6 +1832,9 @@ PYBIND11_MODULE(store, m) {
     // Scatter read handle for per-chunk completion tracking
     py::class_<ScatterReadHandle>(m, "ScatterReadHandle")
         .def_property_readonly("num_chunks", &ScatterReadHandle::num_chunks)
+        .def_property_readonly(
+            "completed_count",
+            [](ScatterReadHandle &self) { return self.completed_count(); })
         .def(
             "is_chunk_ready",
             [](ScatterReadHandle &self, size_t idx) {
@@ -1841,11 +1842,6 @@ PYBIND11_MODULE(store, m) {
                 return self.is_chunk_ready(idx);
             },
             py::arg("chunk_index"))
-        .def("completed_count",
-             [](ScatterReadHandle &self) {
-                 py::gil_scoped_release release;
-                 return self.completed_count();
-             })
         .def(
             "wait_chunk",
             [](ScatterReadHandle &self, size_t idx) {
@@ -1856,6 +1852,33 @@ PYBIND11_MODULE(store, m) {
         .def("wait_all", [](ScatterReadHandle &self) {
             py::gil_scoped_release release;
             return static_cast<int>(self.wait_all());
+        });
+
+    // Progressive put handle for per-chunk streaming writes
+    py::class_<ProgressivePutHandle>(m, "ProgressivePutHandle")
+        .def_property_readonly("num_chunks", &ProgressivePutHandle::num_chunks)
+        .def_property_readonly("completed_count",
+                               &ProgressivePutHandle::completed_count)
+        .def_property_readonly("is_sealed", &ProgressivePutHandle::is_sealed)
+        .def(
+            "write_chunk",
+            [](ProgressivePutHandle &self, uintptr_t data_ptr, size_t offset,
+               size_t size) {
+                py::gil_scoped_release release;
+                return static_cast<int>(self.write_chunk(
+                    reinterpret_cast<void *>(data_ptr), offset, size));
+            },
+            py::arg("data_ptr"), py::arg("offset"), py::arg("size"),
+            "Write a chunk at the specified byte offset within the "
+            "preallocated object.\n"
+            "Args:\n"
+            "    data_ptr: Source buffer pointer (must be registered memory)\n"
+            "    offset: Byte offset within the object\n"
+            "    size: Number of bytes to write\n"
+            "Returns: 0 on success, negative error code on failure")
+        .def("seal", [](ProgressivePutHandle &self) {
+            py::gil_scoped_release release;
+            return static_cast<int>(self.seal());
         });
 
     // Create a wrapper that exposes DistributedObjectStore with Python-specific
@@ -2052,6 +2075,31 @@ PYBIND11_MODULE(store, m) {
             "Start a streaming scatter read. Returns a "
             "ScatterReadHandle or None on failure.\n"
             "The buffer must be a registered memory address (uintptr_t).")
+        .def(
+            "progressive_put",
+            [](MooncakeStorePyWrapper &self, const std::string &key,
+               size_t total_size, size_t num_chunks,
+               const ReplicateConfig &config) {
+                if (!self.is_client_initialized()) {
+                    LOG(ERROR) << "Client is not initialized";
+                    return py::cast<py::object>(py::none());
+                }
+                std::optional<ProgressivePutHandle> handle;
+                {
+                    py::gil_scoped_release release;
+                    handle = self.store_->progressive_put(key, total_size,
+                                                          num_chunks, config);
+                }
+                if (!handle) {
+                    return py::cast<py::object>(py::none());
+                }
+                return py::cast(std::move(*handle));
+            },
+            py::arg("key"), py::arg("total_size"), py::arg("num_chunks"),
+            py::arg("config") = ReplicateConfig{},
+            "Start a progressive (chunked) put. Preallocates an object of\n"
+            "total_size bytes and returns a ProgressivePutHandle for writing\n"
+            "chunks at arbitrary offsets. Returns None on failure.")
         .def(
             "get_buffer",
             [](MooncakeStorePyWrapper &self, const std::string &key) {

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -188,6 +188,43 @@ class Client {
         bool prefer_same_node = false);
 
     /**
+     * @brief Start a progressive (chunked) get for per-chunk completion
+     * tracking
+     * @param key Object key
+     * @param dest_buffer Destination buffer (must be registered)
+     * @param buffer_size Size of the destination buffer
+     * @param chunk_size Size per chunk; the transfer is split into
+     *        ceil(object_size/chunk_size) independently trackable tasks
+     * @return ProgressiveGetHandle for per-chunk polling, or nullopt on failure
+     */
+    std::optional<ProgressiveGetHandle> ProgressiveGet(const std::string& key,
+                                                       void* dest_buffer,
+                                                       size_t buffer_size,
+                                                       size_t chunk_size);
+
+    std::optional<ScatterReadHandle> StreamingBatchTransferReadRanges(
+        void* dest_buffer,
+        const std::vector<
+            std::pair<Replica::Descriptor,
+                      std::vector<std::tuple<size_t, size_t, size_t>>>>&
+            key_ranges);
+
+    /**
+     * @brief Batch transfer read of multiple non-contiguous ranges from
+     * multiple keys in a single transfer batch.
+     * @param dest_buffer Base pointer of destination buffer
+     * @param key_ranges For each key: (replica, [(dest_offset, src_offset,
+     * size), ...])
+     * @return ErrorCode::OK on success
+     */
+    ErrorCode BatchTransferReadRanges(
+        void* dest_buffer,
+        const std::vector<
+            std::pair<Replica::Descriptor,
+                      std::vector<std::tuple<size_t, size_t, size_t>>>>&
+            key_ranges);
+
+    /**
      * @brief Stores data with replication
      * @param key Object key
      * @param slices Vector of data slices to store

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -225,6 +225,23 @@ class Client {
             key_ranges);
 
     /**
+     * @brief Start a progressive (chunked) put for streaming writes.
+     *
+     * Preallocates an object of `total_size` bytes and returns a handle that
+     * allows writing chunks at arbitrary offsets. The object becomes readable
+     * chunk-by-chunk as writes complete (tracked via a sideband progress key).
+     *
+     * @param key Object key
+     * @param total_size Total preallocated size in bytes
+     * @param num_chunks Expected number of chunks (for progress tracking)
+     * @param config Replication configuration
+     * @return ProgressivePutHandle for per-chunk writing, or nullopt on failure
+     */
+    std::optional<ProgressivePutHandle> ProgressivePut(
+        const std::string& key, size_t total_size, size_t num_chunks,
+        const ReplicateConfig& config);
+
+    /**
      * @brief Stores data with replication
      * @param key Object key
      * @param slices Vector of data slices to store
@@ -743,7 +760,7 @@ class Client {
     // Core components
     std::shared_ptr<TransferEngine> transfer_engine_;
     MasterClient master_client_;
-    std::unique_ptr<TransferSubmitter> transfer_submitter_;
+    std::shared_ptr<TransferSubmitter> transfer_submitter_;
 
     // Mutex to protect mounted_segments_
     mutable std::mutex mounted_segments_mutex_;

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -63,6 +63,10 @@ class DummyClient : public PyClient {
         const std::vector<std::vector<std::vector<size_t>>> &all_sizes)
         override;
 
+    int64_t get_into_range(const std::string &key, void *buffer,
+                           size_t dst_offset, size_t src_offset,
+                           size_t size) override;
+
     std::vector<int64_t> batch_get_into(const std::vector<std::string> &keys,
                                         const std::vector<void *> &buffers,
                                         const std::vector<size_t> &sizes);
@@ -96,6 +100,12 @@ class DummyClient : public PyClient {
 
     std::vector<std::shared_ptr<BufferHandle>> batch_get_buffer(
         const std::vector<std::string> &keys);
+
+    std::vector<int64_t> batch_get_buffer_ranges(
+        const std::vector<std::string> &keys, void *dest_buffer,
+        const std::vector<size_t> &dest_offsets,
+        const std::vector<size_t> &src_offsets,
+        const std::vector<size_t> &sizes) override;
 
     int put_parts(const std::string &key,
                   std::vector<std::span<const char>> values,
@@ -157,6 +167,23 @@ class DummyClient : public PyClient {
         const std::vector<std::string> &keys,
         const std::string &segment_name = "") override {
         return {};
+    }
+
+    std::optional<ProgressiveGetHandle> progressive_get(
+        const std::string &key, void *buffer, size_t size,
+        size_t chunk_size) override {
+        LOG(ERROR) << "progressive_get not supported for DummyClient";
+        return std::nullopt;
+    }
+
+    std::optional<ScatterReadHandle> streaming_batch_get_buffer_ranges(
+        const std::vector<std::string> &keys, void *dest_buffer,
+        const std::vector<size_t> &dest_offsets,
+        const std::vector<size_t> &src_offsets,
+        const std::vector<size_t> &sizes) override {
+        LOG(ERROR) << "streaming_batch_get_buffer_ranges not supported for "
+                      "DummyClient";
+        return std::nullopt;
     }
 
     int tearDownAll();

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -176,6 +176,13 @@ class DummyClient : public PyClient {
         return std::nullopt;
     }
 
+    std::optional<ProgressivePutHandle> progressive_put(
+        const std::string &key, size_t total_size, size_t num_chunks,
+        const ReplicateConfig &config = ReplicateConfig{}) override {
+        LOG(ERROR) << "progressive_put not supported for DummyClient";
+        return std::nullopt;
+    }
+
     std::optional<ScatterReadHandle> streaming_batch_get_buffer_ranges(
         const std::vector<std::string> &keys, void *dest_buffer,
         const std::vector<size_t> &dest_offsets,

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -356,6 +356,10 @@ class PyClient {
         const std::string &key, void *buffer, size_t size,
         size_t chunk_size) = 0;
 
+    virtual std::optional<ProgressivePutHandle> progressive_put(
+        const std::string &key, size_t total_size, size_t num_chunks,
+        const ReplicateConfig &config = ReplicateConfig{}) = 0;
+
     virtual std::optional<ScatterReadHandle> streaming_batch_get_buffer_ranges(
         const std::vector<std::string> &keys, void *dest_buffer,
         const std::vector<size_t> &dest_offsets,

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -244,6 +244,15 @@ class PyClient {
         const std::vector<std::vector<std::vector<size_t>>> &all_src_offsets,
         const std::vector<std::vector<std::vector<size_t>>> &all_sizes) = 0;
 
+    /**
+     * Read a range [src_offset, src_offset+size) from key into
+     * (buffer + dst_offset). For zero-copy, buffer must be registered.
+     * @return bytes read on success, negative on error
+     */
+    virtual int64_t get_into_range(const std::string &key, void *buffer,
+                                   size_t dst_offset, size_t src_offset,
+                                   size_t size) = 0;
+
     virtual std::vector<int64_t> batch_get_into(
         const std::vector<std::string> &keys,
         const std::vector<void *> &buffers,
@@ -254,6 +263,12 @@ class PyClient {
         const std::vector<std::vector<void *>> &all_buffers,
         const std::vector<std::vector<size_t>> &all_sizes,
         bool prefer_same_node) = 0;
+
+    virtual std::vector<int64_t> batch_get_buffer_ranges(
+        const std::vector<std::string> &keys, void *dest_buffer,
+        const std::vector<size_t> &dest_offsets,
+        const std::vector<size_t> &src_offsets,
+        const std::vector<size_t> &sizes) = 0;
 
     virtual int put_from(const std::string &key, void *buffer, size_t size,
                          const ReplicateConfig &config = ReplicateConfig{}) = 0;
@@ -336,6 +351,16 @@ class PyClient {
     virtual std::vector<std::string> batch_replica_clear(
         const std::vector<std::string> &keys,
         const std::string &segment_name = "") = 0;
+
+    virtual std::optional<ProgressiveGetHandle> progressive_get(
+        const std::string &key, void *buffer, size_t size,
+        size_t chunk_size) = 0;
+
+    virtual std::optional<ScatterReadHandle> streaming_batch_get_buffer_ranges(
+        const std::vector<std::string> &keys, void *dest_buffer,
+        const std::vector<size_t> &dest_offsets,
+        const std::vector<size_t> &src_offsets,
+        const std::vector<size_t> &sizes) = 0;
 
     virtual int tearDownAll() = 0;
 

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -305,6 +305,10 @@ class RealClient : public PyClient {
         const std::string &key, void *buffer, size_t size,
         size_t chunk_size) override;
 
+    std::optional<ProgressivePutHandle> progressive_put(
+        const std::string &key, size_t total_size, size_t num_chunks,
+        const ReplicateConfig &config = ReplicateConfig{}) override;
+
     std::optional<ScatterReadHandle> streaming_batch_get_buffer_ranges(
         const std::vector<std::string> &keys, void *dest_buffer,
         const std::vector<size_t> &dest_offsets,

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -132,6 +132,10 @@ class RealClient : public PyClient {
         const std::vector<std::vector<std::vector<size_t>>> &all_sizes)
         override;
 
+    int64_t get_into_range(const std::string &key, void *buffer,
+                           size_t dst_offset, size_t src_offset,
+                           size_t size) override;
+
     /**
      * @brief Get object data directly into pre-allocated buffers for multiple
      * keys (batch version)
@@ -281,6 +285,32 @@ class RealClient : public PyClient {
     std::vector<std::shared_ptr<BufferHandle>> batch_get_buffer(
         const std::vector<std::string> &keys);
 
+    /**
+     * @brief Batch get multiple non-contiguous ranges from multiple keys into
+     * a single buffer.
+     * @param keys Keys (may repeat for multiple ranges from same key)
+     * @param dest_buffer Base pointer of destination buffer
+     * @param dest_offsets Dest offset for each range
+     * @param src_offsets Source offset in object for each range
+     * @param sizes Size in bytes for each range
+     * @return Vector of int64_t: bytes read per range, or negative error code
+     */
+    std::vector<int64_t> batch_get_buffer_ranges(
+        const std::vector<std::string> &keys, void *dest_buffer,
+        const std::vector<size_t> &dest_offsets,
+        const std::vector<size_t> &src_offsets,
+        const std::vector<size_t> &sizes);
+
+    std::optional<ProgressiveGetHandle> progressive_get(
+        const std::string &key, void *buffer, size_t size,
+        size_t chunk_size) override;
+
+    std::optional<ScatterReadHandle> streaming_batch_get_buffer_ranges(
+        const std::vector<std::string> &keys, void *dest_buffer,
+        const std::vector<size_t> &dest_offsets,
+        const std::vector<size_t> &src_offsets,
+        const std::vector<size_t> &sizes) override;
+
     int remove(const std::string &key, bool force = false);
 
     long removeByRegex(const std::string &str, bool force = false);
@@ -422,6 +452,10 @@ class RealClient : public PyClient {
                                 const std::vector<uint64_t> &buffers,
                                 const std::vector<size_t> &sizes,
                                 int32_t device_id, const UUID &client_id);
+
+    tl::expected<int64_t, ErrorCode> get_into_range_dummy_helper(
+        const std::string &key, uint64_t buffer, size_t dst_offset,
+        size_t src_offset, size_t size, const UUID &client_id);
 
     std::vector<tl::expected<void, ErrorCode>> batch_put_from_dummy_helper(
         const std::vector<std::string> &keys,
@@ -798,6 +832,27 @@ class RealClient : public PyClient {
     };
     mutable std::shared_mutex dummy_client_mutex_;
     std::unordered_map<UUID, ShmContext, boost::hash<UUID>> shm_contexts_;
+
+    using BatchRangeGroup =
+        std::pair<Replica::Descriptor,
+                  std::vector<std::tuple<size_t, size_t, size_t>>>;
+
+    struct PreparedBatchRangeReadRequest {
+        std::vector<BatchRangeGroup> key_ranges;
+        std::vector<bool> participated;
+    };
+
+    tl::expected<size_t, ErrorCode> get_registered_buffer_size(
+        void *buffer, const char *api_name) const;
+
+    tl::expected<PreparedBatchRangeReadRequest, ErrorCode>
+    prepare_batch_range_read_request(const std::vector<std::string> &keys,
+                                     void *dest_buffer,
+                                     const std::vector<size_t> &dest_offsets,
+                                     const std::vector<size_t> &src_offsets,
+                                     const std::vector<size_t> &sizes,
+                                     const char *api_name,
+                                     std::vector<int64_t> *results = nullptr);
 
     mutable std::shared_mutex registered_buffer_mutex_;
     std::unordered_map<void *, size_t> registered_buffer_sizes_;

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -179,7 +179,7 @@ class TransferEngineOperationState : public OperationState {
           batch_size_(batch_size),
           start_ts_(getCurrentTimeInMilli()) {}
 
-    ~TransferEngineOperationState() { engine_.freeBatchID(batch_id_); }
+    ~TransferEngineOperationState() override;
 
     bool is_completed() override;
 
@@ -365,6 +365,7 @@ class FilereadWorkerPool {
  * Each chunk maps 1:1 to a TransferEngine task within a single batch.
  * Callers poll individual chunk completion to overlap transfer with compute.
  */
+struct ScatterReadBuildResult;
 class ChunkedReadSession;
 
 class ProgressiveGetHandle {

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -4,6 +4,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -429,6 +430,104 @@ class ScatterReadHandle {
 };
 
 /**
+ * @brief Handle for tracking per-chunk completion of a progressive put
+ *
+ * Allows the writer to append chunks at specified offsets to a preallocated
+ * object. Each write_chunk issues an RDMA WRITE at the given offset.
+ * After each chunk completes, an internal progress counter is incremented.
+ * Readers can observe chunk readiness via a sideband progress key.
+ */
+class TransferSubmitter;  // forward declare for ProgressivePutSession
+
+class ProgressivePutSession {
+   public:
+    using ProgressCallback = std::function<void(uint64_t completed_chunks)>;
+    using SealCallback = std::function<ErrorCode()>;
+
+    ProgressivePutSession(std::shared_ptr<TransferSubmitter> submitter,
+                          Replica::Descriptor replica, size_t total_size,
+                          size_t num_chunks,
+                          ProgressCallback progress_cb = nullptr,
+                          SealCallback seal_cb = nullptr)
+        : submitter_(std::move(submitter)),
+          replica_(std::move(replica)),
+          total_size_(total_size),
+          num_chunks_(num_chunks),
+          completed_count_(0),
+          sealed_(false),
+          progress_cb_(std::move(progress_cb)),
+          seal_cb_(std::move(seal_cb)) {}
+
+    size_t num_chunks() const { return num_chunks_; }
+
+    size_t completed_count() const {
+        return completed_count_.load(std::memory_order_acquire);
+    }
+
+    bool is_sealed() const { return sealed_.load(std::memory_order_acquire); }
+
+    ErrorCode write_chunk(void* data, size_t offset, size_t size);
+
+    ErrorCode seal();
+
+   private:
+    std::shared_ptr<TransferSubmitter> submitter_;
+    Replica::Descriptor replica_;
+    size_t total_size_;
+    size_t num_chunks_;
+    std::atomic<size_t> completed_count_;
+    std::atomic<bool> sealed_;
+    ProgressCallback progress_cb_;
+    SealCallback seal_cb_;
+    std::mutex write_mutex_;  // serialize write_chunk + progress updates
+};
+
+class ProgressivePutHandle {
+   public:
+    explicit ProgressivePutHandle(
+        std::shared_ptr<ProgressivePutSession> session);
+
+    ~ProgressivePutHandle();
+
+    // Non-copyable, movable
+    ProgressivePutHandle(const ProgressivePutHandle&) = delete;
+    ProgressivePutHandle& operator=(const ProgressivePutHandle&) = delete;
+    ProgressivePutHandle(ProgressivePutHandle&& other) noexcept;
+    ProgressivePutHandle& operator=(ProgressivePutHandle&& other) noexcept;
+
+    size_t num_chunks() const;
+
+    /**
+     * @brief Number of chunks that have been successfully written
+     */
+    size_t completed_count() const;
+
+    /**
+     * @brief Write a chunk at the specified byte offset within the object.
+     * @param data Source buffer pointer (must be registered memory)
+     * @param offset Byte offset within the preallocated object
+     * @param size Number of bytes to write
+     * @return ErrorCode::OK on success
+     */
+    ErrorCode write_chunk(void* data, size_t offset, size_t size);
+
+    /**
+     * @brief Seal the progressive put: finalize the object metadata.
+     * After sealing, no more writes are allowed.
+     * @return ErrorCode::OK on success
+     */
+    ErrorCode seal();
+
+    /**
+     * @brief Check if the session has been sealed
+     */
+    bool is_sealed() const;
+
+   private:
+    std::shared_ptr<ProgressivePutSession> session_;
+};
+
+/**
  * @brief Submitter class for asynchronous transfer operations
  *
  * This class analyzes transfer requirements, selects optimal strategies, and
@@ -536,6 +635,18 @@ class TransferSubmitter {
                       std::vector<std::tuple<size_t, size_t, size_t>>>>&
             key_ranges,
         bool enable_task_grouping = false);
+
+    /**
+     * @brief Submit a single chunk write at the specified offset within a
+     * preallocated object. Used internally by ProgressivePutSession.
+     * @param replica Replica descriptor of the preallocated object
+     * @param data Source buffer (must be registered)
+     * @param offset Byte offset within the object
+     * @param size Bytes to write
+     * @return ErrorCode::OK on success
+     */
+    ErrorCode submitChunkWrite(const Replica::Descriptor& replica, void* data,
+                               size_t offset, size_t size);
 
    private:
     TransferEngine& engine_;

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -360,12 +360,89 @@ class FilereadWorkerPool {
 };
 
 /**
+ * @brief Handle for tracking per-chunk completion of a progressive get
+ *
+ * Each chunk maps 1:1 to a TransferEngine task within a single batch.
+ * Callers poll individual chunk completion to overlap transfer with compute.
+ */
+class ChunkedReadSession;
+
+class ProgressiveGetHandle {
+   public:
+    explicit ProgressiveGetHandle(std::shared_ptr<ChunkedReadSession> session);
+
+    ~ProgressiveGetHandle();
+
+    // Non-copyable, movable
+    ProgressiveGetHandle(const ProgressiveGetHandle&) = delete;
+    ProgressiveGetHandle& operator=(const ProgressiveGetHandle&) = delete;
+    ProgressiveGetHandle(ProgressiveGetHandle&& other) noexcept;
+    ProgressiveGetHandle& operator=(ProgressiveGetHandle&& other) noexcept;
+
+    size_t num_chunks() const;
+
+    /**
+     * @brief Check if a specific chunk has completed (non-blocking)
+     */
+    bool is_chunk_ready(size_t chunk_index);
+
+    /**
+     * @brief Count how many chunks have completed so far (non-blocking)
+     */
+    size_t completed_count();
+
+    /**
+     * @brief Block until chunk_index is done; return error code
+     */
+    ErrorCode wait_chunk(size_t chunk_index);
+
+    /**
+     * @brief Block until all chunks done
+     */
+    ErrorCode wait_all();
+
+   private:
+    std::shared_ptr<ChunkedReadSession> session_;
+};
+
+class ScatterReadHandle {
+   public:
+    explicit ScatterReadHandle(std::shared_ptr<ChunkedReadSession> session);
+
+    ~ScatterReadHandle();
+
+    // Non-copyable, movable
+    ScatterReadHandle(const ScatterReadHandle&) = delete;
+    ScatterReadHandle& operator=(const ScatterReadHandle&) = delete;
+    ScatterReadHandle(ScatterReadHandle&& other) noexcept;
+    ScatterReadHandle& operator=(ScatterReadHandle&& other) noexcept;
+
+    size_t num_chunks() const;
+    bool is_chunk_ready(size_t chunk_index);
+    size_t completed_count();
+    ErrorCode wait_chunk(size_t chunk_index);
+    ErrorCode wait_all();
+
+   private:
+    std::shared_ptr<ChunkedReadSession> session_;
+};
+
+/**
  * @brief Submitter class for asynchronous transfer operations
  *
  * This class analyzes transfer requirements, selects optimal strategies, and
  * immediately submits operations returning TransferFuture objects for result
  * tracking.
  */
+struct TransferTaskTestHooks {
+    std::function<bool()> fail_next_progressive_submit;
+    std::function<bool()> fail_next_streaming_scatter_submit;
+    std::function<void(BatchID)> on_batch_allocated;
+    std::function<void(BatchID)> on_batch_freed;
+};
+
+void SetTransferTaskTestHooks(TransferTaskTestHooks* hooks);
+
 class TransferSubmitter {
    public:
     explicit TransferSubmitter(TransferEngine& engine,
@@ -422,6 +499,43 @@ class TransferSubmitter {
     static bool isSameProcessEndpoint(const std::string& handle_endpoint,
                                       const std::string& local_endpoint);
 
+    /**
+     * @brief Submit batch read of multiple non-contiguous ranges from
+     * multiple keys in a single transfer batch.
+     * @param dest_buffer Base pointer of destination buffer
+     * @param key_ranges For each key: (replica, [(dest_offset, src_offset,
+     * size), ...])
+     * @return TransferFuture or nullopt on failure
+     */
+    std::optional<TransferFuture> submitBatchReadRanges(
+        void* dest_buffer,
+        const std::vector<
+            std::pair<Replica::Descriptor,
+                      std::vector<std::tuple<size_t, size_t, size_t>>>>&
+            key_ranges,
+        bool enable_task_grouping = false);
+
+    /**
+     * @brief Submit a progressive read that splits the transfer into
+     * independently trackable chunks.
+     * @param replica Source replica descriptor
+     * @param dest_buffer Destination buffer
+     * @param total_size Total bytes to read
+     * @param chunk_size Size of each chunk (last chunk may be smaller)
+     * @return ProgressiveGetHandle for per-chunk polling, or nullopt on failure
+     */
+    std::optional<ProgressiveGetHandle> submitProgressiveRead(
+        const Replica::Descriptor& replica, void* dest_buffer,
+        size_t total_size, size_t chunk_size);
+
+    std::optional<ScatterReadHandle> submitStreamingBatchReadRanges(
+        void* dest_buffer,
+        const std::vector<
+            std::pair<Replica::Descriptor,
+                      std::vector<std::tuple<size_t, size_t, size_t>>>>&
+            key_ranges,
+        bool enable_task_grouping = false);
+
    private:
     TransferEngine& engine_;
     // Cached at construction: the local transport endpoint never changes for
@@ -453,6 +567,7 @@ class TransferSubmitter {
 
     /**
      * @brief Submit memcpy operation asynchronously
+     * @param src_offset Optional offset in source buffer (default 0)
      */
     std::optional<TransferFuture> submitMemcpyOperation(
         const AllocatedBuffer::Descriptor& handle,
@@ -482,8 +597,12 @@ class TransferSubmitter {
     void updateTransferMetrics(const std::vector<Slice>& slices,
                                TransferRequest::OpCode op);
 
+    void updateReadRequestMetrics(const std::vector<TransferRequest>& requests);
+
+    void updateReadBytes(size_t total_bytes);
+
     std::optional<TransferFuture> submitTransfer(
-        std::vector<TransferRequest>& requests);
+        std::vector<TransferRequest>& requests, size_t batch_task_count = 0);
 };
 
 }  // namespace mooncake

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -904,6 +904,41 @@ tl::expected<void, ErrorCode> Client::Get(const std::string& object_key,
     return {};
 }
 
+std::optional<ProgressiveGetHandle> Client::ProgressiveGet(
+    const std::string& key, void* dest_buffer, size_t buffer_size,
+    size_t chunk_size) {
+    auto query_result = Query(key);
+    if (!query_result) {
+        LOG(ERROR) << "ProgressiveGet: query failed for key=" << key
+                   << " error=" << toString(query_result.error());
+        return std::nullopt;
+    }
+
+    Replica::Descriptor replica;
+    ErrorCode err = FindFirstCompleteReplica(query_result->replicas, replica);
+    if (err != ErrorCode::OK) {
+        LOG(ERROR) << "ProgressiveGet: no complete replica for key=" << key;
+        return std::nullopt;
+    }
+
+    if (!replica.is_memory_replica()) {
+        LOG(ERROR) << "ProgressiveGet: only memory replicas supported, key="
+                   << key;
+        return std::nullopt;
+    }
+
+    uint64_t object_size =
+        replica.get_memory_descriptor().buffer_descriptor.size_;
+    if (buffer_size < object_size) {
+        LOG(ERROR) << "ProgressiveGet: buffer too small (" << buffer_size
+                   << " < " << object_size << ") for key=" << key;
+        return std::nullopt;
+    }
+
+    return transfer_submitter_->submitProgressiveRead(replica, dest_buffer,
+                                                      object_size, chunk_size);
+}
+
 struct BatchGetOperation {
     std::vector<Replica::Descriptor> replicas;
     std::vector<std::vector<Slice>> batched_slices;
@@ -1028,6 +1063,24 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchGetWhenPreferSameNode(
         }
     }
     return results;
+}
+
+std::optional<ScatterReadHandle> Client::StreamingBatchTransferReadRanges(
+    void* dest_buffer,
+    const std::vector<std::pair<
+        Replica::Descriptor, std::vector<std::tuple<size_t, size_t, size_t>>>>&
+        key_ranges) {
+    if (!transfer_submitter_) {
+        LOG(ERROR) << "TransferSubmitter not initialized";
+        return std::nullopt;
+    }
+    auto handle = transfer_submitter_->submitStreamingBatchReadRanges(
+        dest_buffer, key_ranges, protocol_ == "rdma");
+    if (!handle) {
+        LOG(ERROR) << "Failed to submit streaming batch read ranges";
+        return std::nullopt;
+    }
+    return handle;
 }
 
 std::vector<tl::expected<void, ErrorCode>> Client::BatchGet(
@@ -1182,6 +1235,24 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchGet(
         VLOG(1) << "BatchGet completed for " << object_keys.size() << " keys";
     }
     return results;
+}
+
+ErrorCode Client::BatchTransferReadRanges(
+    void* dest_buffer,
+    const std::vector<std::pair<
+        Replica::Descriptor, std::vector<std::tuple<size_t, size_t, size_t>>>>&
+        key_ranges) {
+    if (!transfer_submitter_) {
+        LOG(ERROR) << "TransferSubmitter not initialized";
+        return ErrorCode::INVALID_PARAMS;
+    }
+    auto future = transfer_submitter_->submitBatchReadRanges(
+        dest_buffer, key_ranges, protocol_ == "rdma");
+    if (!future) {
+        LOG(ERROR) << "Failed to submit batch read ranges";
+        return ErrorCode::TRANSFER_FAIL;
+    }
+    return future->get();
 }
 
 bool Client::RedirectToHotCache(const std::string& key,
@@ -2821,7 +2892,19 @@ ErrorCode Client::TransferRead(const Replica::Descriptor& replica_descriptor,
 ErrorCode Client::TransferReadRange(
     const Replica::Descriptor& replica_descriptor, std::vector<Slice>& slices,
     uint64_t src_offset) {
-    return TransferReadInternal(replica_descriptor, slices, src_offset);
+    if (!transfer_submitter_) {
+        LOG(ERROR) << "TransferSubmitter not initialized";
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    auto future = transfer_submitter_->submitRangeRead(replica_descriptor,
+                                                       slices, src_offset);
+    if (!future) {
+        LOG(ERROR) << "Failed to submit range read operation";
+        return ErrorCode::TRANSFER_FAIL;
+    }
+
+    return future->get();
 }
 
 void Client::PollAndDispatchTasks() {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -576,7 +576,7 @@ void Client::InitTransferSubmitter() {
     // Initialize TransferSubmitter after transfer engine is ready
     // Keep using logical local_hostname for name-based behaviors; endpoint is
     // used separately where needed.
-    transfer_submitter_ = std::make_unique<TransferSubmitter>(
+    transfer_submitter_ = std::make_shared<TransferSubmitter>(
         *transfer_engine_, storage_backend_, local_hostname_,
         metrics_ ? &metrics_->transfer_metric : nullptr);
 }
@@ -937,6 +937,142 @@ std::optional<ProgressiveGetHandle> Client::ProgressiveGet(
 
     return transfer_submitter_->submitProgressiveRead(replica, dest_buffer,
                                                       object_size, chunk_size);
+}
+
+std::optional<ProgressivePutHandle> Client::ProgressivePut(
+    const std::string& key, size_t total_size, size_t num_chunks,
+    const ReplicateConfig& config) {
+    if (total_size == 0 || num_chunks == 0) {
+        LOG(ERROR) << "ProgressivePut: invalid params (total_size="
+                   << total_size << ", num_chunks=" << num_chunks << ")";
+        return std::nullopt;
+    }
+
+    if (!transfer_submitter_) {
+        LOG(ERROR) << "ProgressivePut: TransferSubmitter not initialized";
+        return std::nullopt;
+    }
+
+    // Allocate the full object via PutStart (single slice of total_size)
+    std::vector<size_t> slice_lengths = {total_size};
+    ReplicateConfig client_cfg = config;
+    if (protocol_ == "cxl") {
+        client_cfg.preferred_segment = local_hostname_;
+    }
+
+    auto start_result = master_client_.PutStart(key, slice_lengths, client_cfg);
+    if (!start_result) {
+        ErrorCode err = start_result.error();
+        LOG(ERROR) << "ProgressivePut: PutStart failed for key=" << key << ": "
+                   << toString(err);
+        return std::nullopt;
+    }
+
+    // Find the memory replica descriptor
+    Replica::Descriptor memory_replica;
+    bool found = false;
+    for (const auto& replica : start_result.value()) {
+        if (replica.is_memory_replica()) {
+            memory_replica = replica;
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        LOG(ERROR) << "ProgressivePut: no memory replica allocated for key="
+                   << key;
+        master_client_.PutRevoke(key, ReplicaType::MEMORY);
+        return std::nullopt;
+    }
+
+    // Create the sideband progress key with initial value 0.
+    // We use manual PutStart/TransferWrite/PutEnd to capture the replica
+    // descriptor, enabling direct writes in the progress callback without
+    // needing a Client* reference (lifetime safety).
+    // Force local allocation: the progress callback writes from a stack buffer
+    // which is not RDMA-registered, so the key must be on a local segment
+    // (LOCAL_MEMCPY path).
+    std::string progress_key = key + "/__progress__";
+    std::vector<size_t> progress_lengths = {sizeof(uint64_t)};
+    Replica::Descriptor progress_replica;
+    bool has_progress = false;
+
+    ReplicateConfig progress_cfg = client_cfg;
+    progress_cfg.preferred_segment = local_hostname_;
+    auto progress_start =
+        master_client_.PutStart(progress_key, progress_lengths, progress_cfg);
+    if (progress_start) {
+        for (const auto& replica : progress_start.value()) {
+            if (replica.is_memory_replica()) {
+                progress_replica = replica;
+                has_progress = true;
+                break;
+            }
+        }
+        if (has_progress) {
+            uint64_t initial = 0;
+            std::vector<Slice> init_slices{Slice{&initial, sizeof(uint64_t)}};
+            ErrorCode write_err = TransferWrite(progress_replica, init_slices);
+            if (write_err == ErrorCode::OK) {
+                auto pe =
+                    master_client_.PutEnd(progress_key, ReplicaType::MEMORY);
+                if (!pe) {
+                    master_client_.PutRevoke(progress_key, ReplicaType::MEMORY);
+                    has_progress = false;
+                }
+            } else {
+                master_client_.PutRevoke(progress_key, ReplicaType::MEMORY);
+                has_progress = false;
+            }
+        } else {
+            master_client_.PutRevoke(progress_key, ReplicaType::MEMORY);
+        }
+    }
+    if (!has_progress) {
+        LOG(WARNING) << "ProgressivePut: failed to create progress key for "
+                     << key << ", proceeding without progress tracking";
+    }
+
+    // Finalize the main object metadata. This makes it discoverable by
+    // readers. Safety: readers check the progress key (initially 0) to know
+    // which chunks are ready, so they won't read uninitialized data.
+    auto end_result = master_client_.PutEnd(key, ReplicaType::MEMORY);
+    if (!end_result) {
+        LOG(ERROR) << "ProgressivePut: PutEnd failed for key=" << key;
+        master_client_.PutRevoke(key, ReplicaType::MEMORY);
+        return std::nullopt;
+    }
+
+    // Create progress callback. Captures shared_ptr<TransferSubmitter> and
+    // progress replica descriptor by value — no Client* dependency.
+    ProgressivePutSession::ProgressCallback progress_cb = nullptr;
+    if (has_progress) {
+        progress_cb = [submitter = transfer_submitter_,
+                       prog_replica =
+                           progress_replica](uint64_t completed_chunks) {
+            uint64_t val = completed_chunks;
+            std::vector<Slice> slices{Slice{&val, sizeof(uint64_t)}};
+            auto future =
+                submitter->submit(prog_replica, slices, TransferRequest::WRITE);
+            if (!future) {
+                LOG(WARNING)
+                    << "ProgressivePut: failed to submit progress update ("
+                    << completed_chunks << " chunks)";
+                return;
+            }
+            auto result = future->get();
+            if (result != ErrorCode::OK) {
+                LOG(WARNING) << "ProgressivePut: progress write failed ("
+                             << completed_chunks << " chunks)";
+            }
+        };
+    }
+
+    // Create the session and return the handle
+    auto session = std::make_shared<ProgressivePutSession>(
+        transfer_submitter_, std::move(memory_replica), total_size, num_chunks,
+        std::move(progress_cb));
+    return ProgressivePutHandle(std::move(session));
 }
 
 struct BatchGetOperation {
@@ -2625,29 +2761,31 @@ tl::expected<void, ErrorCode> Client::ExecuteReplicaTransfer(
 tl::expected<void, ErrorCode> Client::Copy(
     const std::string& key, const std::string& source,
     const std::vector<std::string>& targets) {
-    LOG(INFO) << "action=replica_copy_start" << ", key=" << key
-              << ", targets_count=" << targets.size();
+    LOG(INFO) << "action=replica_copy_start"
+              << ", key=" << key << ", targets_count=" << targets.size();
 
     // Call CopyStart first - it validates existence and allocates replicas
     auto start_result = master_client_.CopyStart(key, source, targets);
     if (!start_result.has_value()) {
         ErrorCode error = start_result.error();
-        LOG(ERROR) << "action=replica_copy_failed" << ", key=" << key
-                   << ", source=" << source << ", error=copy_start_failed"
+        LOG(ERROR) << "action=replica_copy_failed"
+                   << ", key=" << key << ", source=" << source
+                   << ", error=copy_start_failed"
                    << ", error_code=" << error;
         return tl::unexpected(error);
     }
 
     const auto& response = start_result.value();
     if (response.targets.empty()) {
-        LOG(INFO) << "action=replica_copy_skipped" << ", key=" << key
-                  << ", info=target_replicas_already_exist";
+        LOG(INFO) << "action=replica_copy_skipped"
+                  << ", key=" << key << ", info=target_replicas_already_exist";
         // Target replicas already exist, consider it success
         auto copy_end_result = master_client_.CopyEnd(key);
         if (!copy_end_result.has_value()) {
             ErrorCode error = copy_end_result.error();
-            LOG(ERROR) << "action=replica_copy_failed" << ", key=" << key
-                       << ", error=copy_end_failed" << ", error_code=" << error;
+            LOG(ERROR) << "action=replica_copy_failed"
+                       << ", key=" << key << ", error=copy_end_failed"
+                       << ", error_code=" << error;
             return tl::unexpected(error);
         }
         return {};
@@ -2659,7 +2797,8 @@ tl::expected<void, ErrorCode> Client::Copy(
         response.targets);
 
     if (result.has_value()) {
-        LOG(INFO) << "action=replica_copy_success" << ", key=" << key
+        LOG(INFO) << "action=replica_copy_success"
+                  << ", key=" << key
                   << ", target_count=" << response.targets.size();
     }
 
@@ -2669,30 +2808,33 @@ tl::expected<void, ErrorCode> Client::Copy(
 tl::expected<void, ErrorCode> Client::Move(const std::string& key,
                                            const std::string& source,
                                            const std::string& target) {
-    LOG(INFO) << "action=replica_move_start" << ", key=" << key
-              << ", source_segment=" << source << ", target_segment=" << target;
+    LOG(INFO) << "action=replica_move_start"
+              << ", key=" << key << ", source_segment=" << source
+              << ", target_segment=" << target;
 
     // Call MoveStart first - it validates existence and allocates replica if
     // needed
     auto move_start_result = master_client_.MoveStart(key, source, target);
     if (!move_start_result.has_value()) {
         ErrorCode error = move_start_result.error();
-        LOG(ERROR) << "action=replica_move_failed" << ", key=" << key
-                   << ", error=move_start_failed" << ", error_code=" << error;
+        LOG(ERROR) << "action=replica_move_failed"
+                   << ", key=" << key << ", error=move_start_failed"
+                   << ", error_code=" << error;
         // MoveStart already validated existence, so we just return the error
         return tl::unexpected(error);
     }
 
     const auto& response = move_start_result.value();
     if (!response.target.has_value()) {
-        LOG(INFO) << "action=replica_move_skipped" << ", key=" << key
-                  << ", info=target_replica_already_exists";
+        LOG(INFO) << "action=replica_move_skipped"
+                  << ", key=" << key << ", info=target_replica_already_exists";
         // Target already exists, consider it success
         auto move_end_result = master_client_.MoveEnd(key);
         if (!move_end_result.has_value()) {
             ErrorCode error = move_end_result.error();
-            LOG(ERROR) << "action=replica_move_failed" << ", key=" << key
-                       << ", error=move_end_failed" << ", error_code=" << error;
+            LOG(ERROR) << "action=replica_move_failed"
+                       << ", key=" << key << ", error=move_end_failed"
+                       << ", error_code=" << error;
             return tl::unexpected(error);
         }
         return {};
@@ -2706,8 +2848,8 @@ tl::expected<void, ErrorCode> Client::Move(const std::string& key,
         targets);
 
     if (result.has_value()) {
-        LOG(INFO) << "action=replica_move_success" << ", key=" << key
-                  << ", source_segment=" << source
+        LOG(INFO) << "action=replica_move_success"
+                  << ", key=" << key << ", source_segment=" << source
                   << ", target_segment=" << target;
     }
 
@@ -2924,8 +3066,8 @@ void Client::PollAndDispatchTasks() {
             // Only log if it's not an RPC failure (which is expected
             // during connection failures)
             if (error != ErrorCode::RPC_FAIL) {
-                LOG(WARNING)
-                    << "action=task_poll_failed" << ", error_code=" << error;
+                LOG(WARNING) << "action=task_poll_failed"
+                             << ", error_code=" << error;
             }
         }
     }
@@ -2942,7 +3084,8 @@ void Client::TaskPollThreadMain() {
 
 void Client::SubmitTask(const TaskAssignment& assignment) {
     if (!task_running_.load()) {
-        LOG(WARNING) << "action=task_rejected" << ", task_id=" << assignment.id
+        LOG(WARNING) << "action=task_rejected"
+                     << ", task_id=" << assignment.id
                      << ", reason=executor_stopped";
         return;
     }

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -989,6 +989,15 @@ std::vector<std::shared_ptr<BufferHandle>> DummyClient::batch_get_buffer(
     return results;
 }
 
+std::vector<int64_t> DummyClient::batch_get_buffer_ranges(
+    const std::vector<std::string>& keys, void* dest_buffer,
+    const std::vector<size_t>& dest_offsets,
+    const std::vector<size_t>& src_offsets, const std::vector<size_t>& sizes) {
+    LOG(ERROR) << "batch_get_buffer_ranges is not supported for dummy client";
+    return std::vector<int64_t>(
+        keys.size(), -static_cast<int64_t>(ErrorCode::INVALID_PARAMS));
+}
+
 int64_t DummyClient::get_into(const std::string& key, void* buffer,
                               size_t size) {
     uint64_t buf_addr = reinterpret_cast<uint64_t>(buffer);
@@ -1036,6 +1045,19 @@ std::vector<std::vector<std::vector<int64_t>>> DummyClient::get_into_ranges(
                               total_bytes, elapsed_us_since(start_time), true);
     }
     return results;
+}
+
+int64_t DummyClient::get_into_range(const std::string& key, void* buffer,
+                                    size_t dst_offset, size_t src_offset,
+                                    size_t size) {
+    uint64_t buf_addr = reinterpret_cast<uint64_t>(buffer);
+    auto result = invoke_rpc<&RealClient::get_into_range_dummy_helper,
+                             tl::expected<int64_t, ErrorCode>>(
+        key, buf_addr, dst_offset, src_offset, size, client_id_);
+    if (!result) {
+        return static_cast<int64_t>(toInt(result.error()));
+    }
+    return to_py_ret(*result);
 }
 
 std::string DummyClient::get_hostname() const {

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2035,6 +2035,16 @@ std::optional<ProgressiveGetHandle> RealClient::progressive_get(
     return client_->ProgressiveGet(key, buffer, size, chunk_size);
 }
 
+std::optional<ProgressivePutHandle> RealClient::progressive_put(
+    const std::string &key, size_t total_size, size_t num_chunks,
+    const ReplicateConfig &config) {
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return std::nullopt;
+    }
+    return client_->ProgressivePut(key, total_size, num_chunks, config);
+}
+
 std::optional<ScatterReadHandle> RealClient::streaming_batch_get_buffer_ranges(
     const std::vector<std::string> &keys, void *dest_buffer,
     const std::vector<size_t> &dest_offsets,

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -323,6 +323,130 @@ inline QueryResult FilterQueryResult(const QueryResult &qr,
 
 PyClient::~PyClient() {}
 
+tl::expected<size_t, ErrorCode> RealClient::get_registered_buffer_size(
+    void *buffer, const char *api_name) const {
+    if (buffer == nullptr) {
+        LOG(ERROR) << api_name << ": buffer is null";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::shared_lock<std::shared_mutex> lock(registered_buffer_mutex_);
+    auto it = registered_buffer_sizes_.find(buffer);
+    if (it == registered_buffer_sizes_.end()) {
+        LOG(ERROR) << api_name << ": buffer is not registered";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    return it->second;
+}
+
+tl::expected<RealClient::PreparedBatchRangeReadRequest, ErrorCode>
+RealClient::prepare_batch_range_read_request(
+    const std::vector<std::string> &keys, void *dest_buffer,
+    const std::vector<size_t> &dest_offsets,
+    const std::vector<size_t> &src_offsets, const std::vector<size_t> &sizes,
+    const char *api_name, std::vector<int64_t> *results) {
+    const size_t n = keys.size();
+    PreparedBatchRangeReadRequest prepared;
+    prepared.participated.assign(n, false);
+
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    if (n != dest_offsets.size() || n != src_offsets.size() ||
+        n != sizes.size()) {
+        LOG(ERROR) << api_name << ": size mismatch";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    if (n == 0) {
+        LOG(ERROR) << api_name << ": empty input";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    auto buffer_size_result = get_registered_buffer_size(dest_buffer, api_name);
+    if (!buffer_size_result) {
+        return tl::unexpected(buffer_size_result.error());
+    }
+    const size_t buffer_size = *buffer_size_result;
+
+    std::vector<std::string> unique_keys;
+    unique_keys.reserve(n);
+    std::unordered_map<std::string, size_t> key_to_query_idx;
+    key_to_query_idx.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        const auto &key = keys[i];
+        auto [it, inserted] = key_to_query_idx.emplace(key, unique_keys.size());
+        if (inserted) {
+            unique_keys.push_back(key);
+        }
+    }
+
+    auto query_results = client_->BatchQuery(unique_keys);
+
+    std::unordered_map<std::string, BatchRangeGroup> key_ranges_map;
+    for (size_t i = 0; i < n; ++i) {
+        const auto &key = keys[i];
+        const size_t dest_off = dest_offsets[i];
+        const size_t src_off = src_offsets[i];
+        const size_t sz = sizes[i];
+        if (sz == 0) {
+            if (results != nullptr) {
+                (*results)[i] = 0;
+            }
+            continue;
+        }
+        if (dest_off > buffer_size || sz > buffer_size - dest_off) {
+            LOG(ERROR) << "Destination overflow: dst_offset=" << dest_off
+                       << " size=" << sz << " buffer_size=" << buffer_size;
+            continue;
+        }
+
+        auto qit = key_to_query_idx.find(key);
+        if (qit == key_to_query_idx.end()) {
+            continue;
+        }
+        const size_t qidx = qit->second;
+        if (qidx >= query_results.size() || !query_results[qidx]) {
+            continue;
+        }
+        const auto &qr = query_results[qidx].value();
+        if (qr.replicas.empty()) {
+            continue;
+        }
+
+        const auto &replica_res = client_->GetPreferredReplica(qr.replicas);
+        if (!replica_res) {
+            continue;
+        }
+        const auto &replica = replica_res.value();
+        if (!replica.is_memory_replica()) {
+            LOG(ERROR) << api_name << ": disk replicas not supported";
+            continue;
+        }
+
+        auto &entry = key_ranges_map[key];
+        if (entry.second.empty()) {
+            entry.first = replica;
+        }
+        entry.second.emplace_back(dest_off, src_off, sz);
+        prepared.participated[i] = true;
+    }
+
+    if (key_ranges_map.empty()) {
+        LOG(ERROR) << api_name << ": no valid ranges";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    prepared.key_ranges.reserve(key_ranges_map.size());
+    for (const auto &key : unique_keys) {
+        auto it = key_ranges_map.find(key);
+        if (it != key_ranges_map.end()) {
+            prepared.key_ranges.emplace_back(std::move(it->second));
+        }
+    }
+    return prepared;
+}
+
 bool RealClient::map_dummy_range_in_shm(const MappedShm &shm,
                                         uint64_t dummy_addr, size_t offset,
                                         size_t size, void *&out_real) const {
@@ -1902,6 +2026,29 @@ tl::expected<void, ErrorCode> RealClient::remove_internal(
     return {};
 }
 
+std::optional<ProgressiveGetHandle> RealClient::progressive_get(
+    const std::string &key, void *buffer, size_t size, size_t chunk_size) {
+    if (!client_) {
+        LOG(ERROR) << "Client is not initialized";
+        return std::nullopt;
+    }
+    return client_->ProgressiveGet(key, buffer, size, chunk_size);
+}
+
+std::optional<ScatterReadHandle> RealClient::streaming_batch_get_buffer_ranges(
+    const std::vector<std::string> &keys, void *dest_buffer,
+    const std::vector<size_t> &dest_offsets,
+    const std::vector<size_t> &src_offsets, const std::vector<size_t> &sizes) {
+    auto prepared = prepare_batch_range_read_request(
+        keys, dest_buffer, dest_offsets, src_offsets, sizes,
+        "streaming_batch_get_buffer_ranges");
+    if (!prepared) {
+        return std::nullopt;
+    }
+    return client_->StreamingBatchTransferReadRanges(dest_buffer,
+                                                     prepared->key_ranges);
+}
+
 int RealClient::remove(const std::string &key, bool force) {
     return to_py_ret(remove_internal(key, force));
 }
@@ -2975,6 +3122,40 @@ std::vector<std::shared_ptr<BufferHandle>> RealClient::batch_get_buffer(
         });
 }
 
+std::vector<int64_t> RealClient::batch_get_buffer_ranges(
+    const std::vector<std::string> &keys, void *dest_buffer,
+    const std::vector<size_t> &dest_offsets,
+    const std::vector<size_t> &src_offsets, const std::vector<size_t> &sizes) {
+    const size_t n = keys.size();
+    std::vector<int64_t> results(
+        n, -static_cast<int64_t>(ErrorCode::INVALID_PARAMS));
+
+    auto prepared = prepare_batch_range_read_request(
+        keys, dest_buffer, dest_offsets, src_offsets, sizes,
+        "batch_get_buffer_ranges", &results);
+    if (!prepared) {
+        return results;
+    }
+
+    ErrorCode err =
+        client_->BatchTransferReadRanges(dest_buffer, prepared->key_ranges);
+    if (err != ErrorCode::OK) {
+        for (size_t i = 0; i < n; ++i) {
+            if (prepared->participated[i]) {
+                results[i] = -static_cast<int64_t>(err);
+            }
+        }
+        return results;
+    }
+
+    for (size_t i = 0; i < n; ++i) {
+        if (prepared->participated[i]) {
+            results[i] = static_cast<int64_t>(sizes[i]);
+        }
+    }
+    return results;
+}
+
 tl::expected<void, ErrorCode> RealClient::register_buffer_internal(
     void *buffer, size_t size) {
     if (!client_) {
@@ -3248,6 +3429,21 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
 tl::expected<int64_t, ErrorCode> RealClient::get_into_range_internal(
     const std::string &key, void *buffer, size_t dst_offset, size_t src_offset,
     size_t size, bool size_is_buffer_capacity) {
+    auto buffer_size_result =
+        get_registered_buffer_size(buffer, size_is_buffer_capacity ? "get_into"
+                                                                  : "get_into_range");
+    if (!buffer_size_result) {
+        return tl::unexpected(buffer_size_result.error());
+    }
+    const size_t buffer_size = *buffer_size_result;
+
+    if (!size_is_buffer_capacity &&
+        (dst_offset > buffer_size || size > buffer_size - dst_offset)) {
+        LOG(ERROR) << "Destination overflow: dst_offset=" << dst_offset
+                   << " size=" << size << " buffer_size=" << buffer_size;
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
     auto metadata_result = resolve_ranged_read_metadata(key);
     if (!metadata_result) {
         if ((metadata_result.error() == ErrorCode::OBJECT_NOT_FOUND ||
@@ -3304,6 +3500,9 @@ RealClient::get_into_ranges_internal(
     if (!prepared.top_level_valid) {
         return std::move(prepared.results);
     }
+    if (!prepared.has_any_valid_fragment) {
+        return std::move(prepared.results);
+    }
 
     std::vector<size_t> resolved_buffer_capacities;
     if (buffer_capacities != nullptr) {
@@ -3340,9 +3539,14 @@ RealClient::get_into_ranges_internal(
         }
 
         for (size_t j = 0; j < key_count; ++j) {
-            auto [metadata_it, inserted] = metadata_cache.try_emplace(
-                all_keys[i][j], resolve_ranged_read_metadata(all_keys[i][j]));
-            (void)inserted;
+            auto metadata_it = metadata_cache.find(all_keys[i][j]);
+            if (metadata_it == metadata_cache.end()) {
+                metadata_it =
+                    metadata_cache
+                        .emplace(all_keys[i][j],
+                                 resolve_ranged_read_metadata(all_keys[i][j]))
+                        .first;
+            }
             auto &metadata_result = metadata_it->second;
 
             for (size_t k = 0; k < prepared.results[i][j].size(); ++k) {
@@ -3409,6 +3613,13 @@ std::vector<std::vector<std::vector<int64_t>>> RealClient::get_into_ranges(
                     sum_positive_ranges(ret), latency_us);
             });
     return results;
+}
+
+int64_t RealClient::get_into_range(const std::string &key, void *buffer,
+                                   size_t dst_offset, size_t src_offset,
+                                   size_t size) {
+    return to_py_ret(get_into_range_internal(key, buffer, dst_offset,
+                                             src_offset, size, false));
 }
 
 std::string RealClient::get_hostname() const { return local_hostname; }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3429,9 +3429,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
 tl::expected<int64_t, ErrorCode> RealClient::get_into_range_internal(
     const std::string &key, void *buffer, size_t dst_offset, size_t src_offset,
     size_t size, bool size_is_buffer_capacity) {
-    auto buffer_size_result =
-        get_registered_buffer_size(buffer, size_is_buffer_capacity ? "get_into"
-                                                                  : "get_into_range");
+    auto buffer_size_result = get_registered_buffer_size(
+        buffer, size_is_buffer_capacity ? "get_into" : "get_into_range");
     if (!buffer_size_result) {
         return tl::unexpected(buffer_size_result.error());
     }

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -395,8 +395,7 @@ void TransferEngineOperationState::wait_for_completion() {
     VLOG(1) << "Starting transfer engine futex wait for batch " << batch_id_;
 
     auto& batch_desc = Transport::toBatchDesc(batch_id_);
-    auto* futex_word =
-        reinterpret_cast<uint32_t*>(&batch_desc.finished_task_count);
+    auto* futex_word = reinterpret_cast<uint32_t*>(&batch_desc.progress_futex);
     const auto deadline = std::chrono::steady_clock::now() +
                           std::chrono::milliseconds(timeout_milliseconds);
 
@@ -456,6 +455,7 @@ using ScatterKeyRanges =
 struct ScatterReadBuildResult {
     std::vector<TransferRequest> flat_requests;
     std::vector<std::vector<TransferRequest>> logical_groups;
+    std::vector<SegmentHandle> opened_segments;
 };
 
 std::optional<ScatterReadBuildResult> buildScatterReadRequests(
@@ -471,6 +471,7 @@ std::optional<ScatterReadBuildResult> buildScatterReadRequests(
     if (enable_task_grouping) {
         result.logical_groups.reserve(key_ranges.size());
     }
+    result.opened_segments.reserve(key_ranges.size());
 
     uint64_t next_task_group_id = 0;
     char* dest_base = static_cast<char*>(dest_buffer);
@@ -492,6 +493,7 @@ std::optional<ScatterReadBuildResult> buildScatterReadRequests(
                        << handle.transport_endpoint_;
             return std::nullopt;
         }
+        result.opened_segments.push_back(seg);
 
         uint64_t base_address = static_cast<uint64_t>(handle.buffer_address_);
         std::vector<TransferRequest> group_requests;
@@ -551,12 +553,14 @@ class ChunkedReadSession {
 
     ChunkedReadSession(TransferEngine& engine, BatchID batch_id,
                        std::vector<std::vector<TransferRequest>> chunk_groups,
+                       std::vector<SegmentHandle> opened_segments,
                        size_t initial_window, std::string submit_context,
                        ChunkSubmitFailureHook fail_next_submit)
         : engine_(&engine),
           batch_id_(batch_id),
           num_chunks_(chunk_groups.size()),
           chunk_groups_(std::move(chunk_groups)),
+          opened_segments_(std::move(opened_segments)),
           chunk_done_(num_chunks_, 0),
           chunk_results_(num_chunks_, ErrorCode::OK),
           completed_count_(0),
@@ -580,7 +584,9 @@ class ChunkedReadSession {
         if (chunk_index >= num_chunks_) {
             return false;
         }
-        return poll_chunk(chunk_index);
+        maybe_submit_more(chunk_index + 1);
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        return poll_chunk_locked(chunk_index);
     }
 
     size_t completed_count() {
@@ -589,13 +595,14 @@ class ChunkedReadSession {
         }
         maybe_submit_more(submitted_chunks_.load(std::memory_order_acquire) +
                           window_size_);
+        std::lock_guard<std::mutex> lock(state_mutex_);
         size_t current = completed_count_.load(std::memory_order_relaxed);
         if (current == num_chunks_) {
             return current;
         }
         size_t observed_finished = observed_batch_finished_count();
         if (observed_finished > current) {
-            return drain_completed_chunks(observed_finished);
+            return drain_completed_chunks_locked(observed_finished);
         }
         return current;
     }
@@ -609,13 +616,16 @@ class ChunkedReadSession {
         }
 
         maybe_submit_more(chunk_index + 1);
-        if (poll_chunk(chunk_index)) {
-            return chunk_results_[chunk_index];
+        {
+            std::lock_guard<std::mutex> lock(state_mutex_);
+            if (poll_chunk_locked(chunk_index)) {
+                return chunk_results_[chunk_index];
+            }
         }
 
         auto& batch_desc = Transport::toBatchDesc(batch_id_);
         auto* futex_word =
-            reinterpret_cast<uint32_t*>(&batch_desc.finished_task_count);
+            reinterpret_cast<uint32_t*>(&batch_desc.progress_futex);
         const auto deadline =
             std::chrono::steady_clock::now() +
             std::chrono::seconds(kProgressiveGetTimeoutSeconds);
@@ -624,17 +634,20 @@ class ChunkedReadSession {
             uint32_t snapshot = __atomic_load_n(futex_word, __ATOMIC_ACQUIRE);
 
             maybe_submit_more(chunk_index + 1);
-            size_t observed_finished = observed_batch_finished_count();
-            if (observed_finished >
-                completed_count_.load(std::memory_order_relaxed)) {
-                drain_completed_chunks(observed_finished);
-                if (chunk_done_[chunk_index]) {
+            {
+                std::lock_guard<std::mutex> lock(state_mutex_);
+                size_t observed_finished = observed_batch_finished_count();
+                if (observed_finished >
+                    completed_count_.load(std::memory_order_relaxed)) {
+                    drain_completed_chunks_locked(observed_finished);
+                    if (chunk_done_[chunk_index]) {
+                        return chunk_results_[chunk_index];
+                    }
+                }
+
+                if (materialize_chunk_result_locked(chunk_index)) {
                     return chunk_results_[chunk_index];
                 }
-            }
-
-            if (materialize_chunk_result(chunk_index)) {
-                return chunk_results_[chunk_index];
             }
 
             auto now = std::chrono::steady_clock::now();
@@ -652,20 +665,24 @@ class ChunkedReadSession {
                       nullptr, 0);
         }
 
-        mark_chunk_done(chunk_index, ErrorCode::TRANSFER_FAIL);
+        {
+            std::lock_guard<std::mutex> lock(state_mutex_);
+            mark_chunk_done_locked(chunk_index, ErrorCode::TRANSFER_FAIL);
+        }
         seal_batch();
         return ErrorCode::TRANSFER_FAIL;
     }
 
     ErrorCode wait_all() {
         if (precompleted_) {
-            return aggregate_result();
+            std::lock_guard<std::mutex> lock(state_mutex_);
+            return aggregate_result_locked();
         }
 
         maybe_submit_more(num_chunks_);
         auto& batch_desc = Transport::toBatchDesc(batch_id_);
         auto* futex_word =
-            reinterpret_cast<uint32_t*>(&batch_desc.finished_task_count);
+            reinterpret_cast<uint32_t*>(&batch_desc.progress_futex);
         const auto deadline =
             std::chrono::steady_clock::now() +
             std::chrono::seconds(kProgressiveGetTimeoutSeconds);
@@ -673,10 +690,13 @@ class ChunkedReadSession {
         size_t current = completed_count_.load(std::memory_order_relaxed);
         while (current < num_chunks_) {
             maybe_submit_more(num_chunks_);
-            size_t observed_finished = observed_batch_finished_count();
-            if (observed_finished > current) {
-                current = drain_completed_chunks(observed_finished);
-                continue;
+            {
+                std::lock_guard<std::mutex> lock(state_mutex_);
+                size_t observed_finished = observed_batch_finished_count();
+                if (observed_finished > current) {
+                    current = drain_completed_chunks_locked(observed_finished);
+                    continue;
+                }
             }
 
             auto now = std::chrono::steady_clock::now();
@@ -697,17 +717,21 @@ class ChunkedReadSession {
             current = completed_count_.load(std::memory_order_relaxed);
         }
 
-        if (observed_batch_finished_count() ==
-            submitted_chunks_.load(std::memory_order_acquire)) {
-            drain_completed_chunks(num_chunks_, true);
-        }
+        {
+            std::lock_guard<std::mutex> lock(state_mutex_);
+            if (observed_batch_finished_count() ==
+                submitted_chunks_.load(std::memory_order_acquire)) {
+                drain_completed_chunks_locked(num_chunks_, true);
+            }
 
-        if (completed_count_.load(std::memory_order_relaxed) != num_chunks_) {
-            mark_remaining_chunks_failed();
-        }
+            if (completed_count_.load(std::memory_order_relaxed) !=
+                num_chunks_) {
+                mark_remaining_chunks_failed_locked();
+            }
 
-        seal_batch();
-        return aggregate_result();
+            seal_batch();
+            return aggregate_result_locked();
+        }
     }
 
    private:
@@ -726,6 +750,12 @@ class ChunkedReadSession {
                    g_transfer_task_test_hooks->on_batch_freed) {
             g_transfer_task_test_hooks->on_batch_freed(batch_id);
         }
+        for (SegmentHandle seg : opened_segments_) {
+            if (engine_->closeSegment(seg) != 0) {
+                LOG(ERROR) << "Failed to close chunked read segment " << seg;
+            }
+        }
+        opened_segments_.clear();
         chunk_groups_.clear();
         engine_ = nullptr;
         batch_id_ = INVALID_BATCH_ID;
@@ -762,7 +792,7 @@ class ChunkedReadSession {
         if (fail_next_submit_ && fail_next_submit_()) {
             submit_failed_ = true;
             for (size_t i = submitted; i < num_chunks_; ++i) {
-                mark_chunk_done(i, ErrorCode::TRANSFER_FAIL);
+                mark_chunk_done_locked(i, ErrorCode::TRANSFER_FAIL);
             }
             submitted_chunks_.store(num_chunks_, std::memory_order_release);
             seal_batch_locked();
@@ -776,7 +806,7 @@ class ChunkedReadSession {
                        << s.message();
             submit_failed_ = true;
             for (size_t i = submitted; i < num_chunks_; ++i) {
-                mark_chunk_done(i, ErrorCode::TRANSFER_FAIL);
+                mark_chunk_done_locked(i, ErrorCode::TRANSFER_FAIL);
             }
             submitted_chunks_.store(num_chunks_, std::memory_order_release);
             seal_batch_locked();
@@ -822,7 +852,7 @@ class ChunkedReadSession {
         return std::min(finished, submitted);
     }
 
-    void mark_chunk_done(size_t chunk_index, ErrorCode result) {
+    void mark_chunk_done_locked(size_t chunk_index, ErrorCode result) {
         if (chunk_done_[chunk_index]) {
             return;
         }
@@ -831,7 +861,7 @@ class ChunkedReadSession {
         completed_count_.fetch_add(1, std::memory_order_relaxed);
     }
 
-    bool materialize_chunk_result(size_t chunk_index) {
+    bool materialize_chunk_result_locked(size_t chunk_index) {
         if (chunk_done_[chunk_index]) {
             return true;
         }
@@ -845,27 +875,27 @@ class ChunkedReadSession {
             LOG(ERROR)
                 << "Failed to get chunked read transfer status for batch "
                 << batch_id_ << " chunk " << chunk_index;
-            mark_chunk_done(chunk_index, ErrorCode::TRANSFER_FAIL);
+            mark_chunk_done_locked(chunk_index, ErrorCode::TRANSFER_FAIL);
             return true;
         }
 
         switch (status.s) {
             case TransferStatusEnum::COMPLETED:
-                mark_chunk_done(chunk_index, ErrorCode::OK);
+                mark_chunk_done_locked(chunk_index, ErrorCode::OK);
                 return true;
             case TransferStatusEnum::FAILED:
             case TransferStatusEnum::CANCELED:
             case TransferStatusEnum::INVALID:
             case TransferStatusEnum::TIMEOUT:
-                mark_chunk_done(chunk_index, ErrorCode::TRANSFER_FAIL);
+                mark_chunk_done_locked(chunk_index, ErrorCode::TRANSFER_FAIL);
                 return true;
             default:
                 return false;
         }
     }
 
-    size_t drain_completed_chunks(size_t observed_finished_count,
-                                  bool force_full_scan = false) {
+    size_t drain_completed_chunks_locked(size_t observed_finished_count,
+                                         bool force_full_scan = false) {
         size_t completed = completed_count_.load(std::memory_order_relaxed);
         if (completed >= num_chunks_) {
             return completed;
@@ -885,7 +915,7 @@ class ChunkedReadSession {
         size_t scanned = 0;
         while (scanned < submitted &&
                (force_full_scan || completed < scan_limit)) {
-            if (!chunk_done_[idx] && materialize_chunk_result(idx)) {
+            if (!chunk_done_[idx] && materialize_chunk_result_locked(idx)) {
                 completed = completed_count_.load(std::memory_order_relaxed);
             }
             idx = (idx + 1) % submitted;
@@ -896,16 +926,16 @@ class ChunkedReadSession {
         return completed_count_.load(std::memory_order_relaxed);
     }
 
-    void mark_remaining_chunks_failed() {
+    void mark_remaining_chunks_failed_locked() {
         for (size_t i = 0; i < num_chunks_; ++i) {
             if (!chunk_done_[i]) {
-                mark_chunk_done(i, ErrorCode::TRANSFER_FAIL);
+                mark_chunk_done_locked(i, ErrorCode::TRANSFER_FAIL);
             }
         }
         drain_cursor_ = num_chunks_;
     }
 
-    ErrorCode aggregate_result() const {
+    ErrorCode aggregate_result_locked() const {
         for (size_t i = 0; i < num_chunks_; ++i) {
             if (chunk_results_[i] != ErrorCode::OK) {
                 return chunk_results_[i];
@@ -914,7 +944,7 @@ class ChunkedReadSession {
         return ErrorCode::OK;
     }
 
-    bool poll_chunk(size_t chunk_index) {
+    bool poll_chunk_locked(size_t chunk_index) {
         if (chunk_done_[chunk_index]) {
             return true;
         }
@@ -923,7 +953,7 @@ class ChunkedReadSession {
         size_t observed_finished = observed_batch_finished_count();
         size_t completed = completed_count_.load(std::memory_order_relaxed);
         if (observed_finished > completed) {
-            completed = drain_completed_chunks(observed_finished);
+            completed = drain_completed_chunks_locked(observed_finished);
         }
 
         if (chunk_done_[chunk_index]) {
@@ -936,13 +966,14 @@ class ChunkedReadSession {
             return false;
         }
 
-        return materialize_chunk_result(chunk_index);
+        return materialize_chunk_result_locked(chunk_index);
     }
 
     TransferEngine* engine_ = nullptr;
     BatchID batch_id_ = INVALID_BATCH_ID;
     size_t num_chunks_ = 0;
     std::vector<std::vector<TransferRequest>> chunk_groups_;
+    std::vector<SegmentHandle> opened_segments_;
     std::vector<uint8_t> chunk_done_;
     std::vector<ErrorCode> chunk_results_;
     std::atomic<size_t> completed_count_{0};
@@ -955,13 +986,15 @@ class ChunkedReadSession {
     std::string submit_context_;
     ChunkSubmitFailureHook fail_next_submit_;
     std::mutex submit_mutex_;
+    std::mutex state_mutex_;
 };
 
 template <typename Handle>
 std::optional<Handle> create_chunked_read_handle(
-    TransferEngine& engine, std::vector<std::vector<TransferRequest>> chunk_groups,
-    size_t initial_window, const char* submit_context,
-    ChunkSubmitFailureHook fail_next_submit) {
+    TransferEngine& engine,
+    std::vector<std::vector<TransferRequest>> chunk_groups,
+    std::vector<SegmentHandle> opened_segments, size_t initial_window,
+    const char* submit_context, ChunkSubmitFailureHook fail_next_submit) {
     BatchID batch_id = engine.allocateBatchID(chunk_groups.size());
     if (batch_id == INVALID_BATCH_ID) {
         LOG(ERROR) << submit_context << ": failed to allocate batch ID";
@@ -973,8 +1006,8 @@ std::optional<Handle> create_chunked_read_handle(
     }
 
     auto session = std::make_shared<ChunkedReadSession>(
-        engine, batch_id, std::move(chunk_groups), initial_window,
-        submit_context, std::move(fail_next_submit));
+        engine, batch_id, std::move(chunk_groups), std::move(opened_segments),
+        initial_window, submit_context, std::move(fail_next_submit));
     if (!session->submit_initial_window()) {
         return std::nullopt;
     }
@@ -1589,6 +1622,7 @@ TransferSubmitter::submitStreamingBatchReadRanges(
 
     auto handle = create_chunked_read_handle<ScatterReadHandle>(
         engine_, std::move(chunk_groups),
+        std::move(build_result->opened_segments),
         std::min<size_t>(requests.size(), kProgressiveGetWindowChunks),
         "submitStreamingBatchReadRanges", []() {
             return g_transfer_task_test_hooks &&
@@ -1653,7 +1687,7 @@ std::optional<ProgressiveGetHandle> TransferSubmitter::submitProgressiveRead(
     }
 
     auto progressive_handle = create_chunked_read_handle<ProgressiveGetHandle>(
-        engine_, std::move(chunk_groups),
+        engine_, std::move(chunk_groups), {seg},
         std::min(num_chunks, kProgressiveGetWindowChunks),
         "submitProgressiveRead", []() {
             return g_transfer_task_test_hooks &&

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -1,8 +1,14 @@
 #include "transfer_task.h"
 
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
 #include <glog/logging.h>
 
 #include <algorithm>
+#include <cassert>
+#include <climits>
 #include <cstdlib>
 #include <sstream>
 #include <string>
@@ -342,9 +348,6 @@ void TransferEngineOperationState::wait_for_completion() {
     bool completed;
     bool failed = false;
 
-    // Fast path: if already finished, avoid taking the mutex and waiting.
-    // Use acquire here to pair with the writer's release-store, because this
-    // path may skip taking the mutex. It ensures all prior updates are visible.
     completed = batch_desc.is_finished.load(std::memory_order_acquire);
     if (!completed) {
         // Use the same mutex as the notifier when updating the predicate to
@@ -389,10 +392,28 @@ void TransferEngineOperationState::wait_for_completion() {
                    << batch_id_;
     }
 #else
-    VLOG(1) << "Starting transfer engine polling for batch " << batch_id_;
+    VLOG(1) << "Starting transfer engine futex wait for batch " << batch_id_;
+
+    auto& batch_desc = Transport::toBatchDesc(batch_id_);
+    auto* futex_word =
+        reinterpret_cast<uint32_t*>(&batch_desc.finished_task_count);
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(timeout_milliseconds);
 
     while (true) {
-        if (getCurrentTimeInMilli() - start_ts_ > timeout_milliseconds) {
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            check_task_status();
+            if (result_.has_value()) {
+                VLOG(1) << "Transfer engine operation completed for batch "
+                        << batch_id_ << " with result: "
+                        << static_cast<int>(result_.value());
+                break;
+            }
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) {
             LOG(ERROR) << "Failed to complete transfers after "
                        << timeout_milliseconds << " milliseconds for batch "
                        << batch_id_;
@@ -400,20 +421,623 @@ void TransferEngineOperationState::wait_for_completion() {
             return;
         }
 
-        std::unique_lock<std::mutex> lock(mutex_);
-        check_task_status();
-        if (result_.has_value()) {
-            VLOG(1) << "Transfer engine operation completed for batch "
-                    << batch_id_
-                    << " with result: " << static_cast<int>(result_.value());
-            break;
-        }
-        // Continue polling
-        VLOG(1) << "Transfer engine operation still pending for batch "
-                << batch_id_;
+        uint32_t snapshot = __atomic_load_n(futex_word, __ATOMIC_ACQUIRE);
+        // 100ms timeout as fallback for transports (e.g. TENT) that may not
+        // wake via the standard Slice completion path.
+        struct timespec ts = {0, 100 * 1000 * 1000};
+        ::syscall(SYS_futex, futex_word, FUTEX_WAIT_PRIVATE, snapshot, &ts,
+                  nullptr, 0);
     }
 #endif
 }
+
+// ============================================================================
+// ProgressiveGetHandle Implementation
+// ============================================================================
+
+namespace {
+constexpr size_t kProgressiveGetWindowChunks = 8;
+constexpr int64_t kProgressiveGetTimeoutSeconds = 60;
+
+TransferTaskTestHooks* g_transfer_task_test_hooks = nullptr;
+
+}  // namespace
+
+void SetTransferTaskTestHooks(TransferTaskTestHooks* hooks) {
+    g_transfer_task_test_hooks = hooks;
+}
+
+namespace {
+
+using ScatterRange = std::tuple<size_t, size_t, size_t>;
+using ScatterKeyRanges =
+    std::vector<std::pair<Replica::Descriptor, std::vector<ScatterRange>>>;
+
+struct ScatterReadBuildResult {
+    std::vector<TransferRequest> flat_requests;
+    std::vector<std::vector<TransferRequest>> logical_groups;
+};
+
+std::optional<ScatterReadBuildResult> buildScatterReadRequests(
+    TransferEngine& engine, void* dest_buffer,
+    const ScatterKeyRanges& key_ranges, bool enable_task_grouping,
+    const char* log_context) {
+    ScatterReadBuildResult result;
+    size_t total_ranges = 0;
+    for (const auto& [_, ranges] : key_ranges) {
+        total_ranges += ranges.size();
+    }
+    result.flat_requests.reserve(total_ranges);
+    if (enable_task_grouping) {
+        result.logical_groups.reserve(key_ranges.size());
+    }
+
+    uint64_t next_task_group_id = 0;
+    char* dest_base = static_cast<char*>(dest_buffer);
+
+    for (const auto& [replica, ranges] : key_ranges) {
+        if (!replica.is_memory_replica()) {
+            LOG(ERROR) << log_context << ": disk replicas not supported";
+            return std::nullopt;
+        }
+        const auto& handle = replica.get_memory_descriptor().buffer_descriptor;
+        if (handle.transport_endpoint_.empty()) {
+            LOG(ERROR) << log_context << ": empty transport endpoint";
+            return std::nullopt;
+        }
+
+        SegmentHandle seg = engine.openSegment(handle.transport_endpoint_);
+        if (seg == static_cast<uint64_t>(ERR_INVALID_ARGUMENT)) {
+            LOG(ERROR) << log_context << ": failed to open segment for "
+                       << handle.transport_endpoint_;
+            return std::nullopt;
+        }
+
+        uint64_t base_address = static_cast<uint64_t>(handle.buffer_address_);
+        std::vector<TransferRequest> group_requests;
+        if (enable_task_grouping) {
+            group_requests.reserve(ranges.size());
+        }
+        const uint64_t task_group_id = enable_task_grouping
+                                           ? next_task_group_id++
+                                           : TransferRequest::kNoTaskGroup;
+
+        for (const auto& [dest_offset, src_offset, size] : ranges) {
+            if (size == 0) {
+                continue;
+            }
+            TransferRequest request;
+            request.opcode = TransferRequest::READ;
+            request.source = dest_base + dest_offset;
+            request.target_id = seg;
+            request.target_offset = base_address + src_offset;
+            request.length = size;
+            request.task_group_id = task_group_id;
+            result.flat_requests.emplace_back(request);
+            if (enable_task_grouping) {
+                group_requests.emplace_back(request);
+            }
+        }
+
+        if (enable_task_grouping && !group_requests.empty()) {
+            result.logical_groups.emplace_back(std::move(group_requests));
+        }
+    }
+
+    return result;
+}
+}  // namespace
+
+using ChunkSubmitFailureHook = std::function<bool()>;
+
+size_t sum_request_bytes(const std::vector<TransferRequest>& requests) {
+    size_t total_bytes = 0;
+    for (const auto& request : requests) {
+        total_bytes += request.length;
+    }
+    return total_bytes;
+}
+
+class ChunkedReadSession {
+   public:
+    ChunkedReadSession(size_t num_chunks, ErrorCode result)
+        : num_chunks_(num_chunks),
+          chunk_done_(num_chunks, 1),
+          chunk_results_(num_chunks, result),
+          completed_count_(num_chunks),
+          submitted_chunks_(num_chunks),
+          sealed_(true),
+          precompleted_(true) {}
+
+    ChunkedReadSession(TransferEngine& engine, BatchID batch_id,
+                       std::vector<std::vector<TransferRequest>> chunk_groups,
+                       size_t initial_window, std::string submit_context,
+                       ChunkSubmitFailureHook fail_next_submit)
+        : engine_(&engine),
+          batch_id_(batch_id),
+          num_chunks_(chunk_groups.size()),
+          chunk_groups_(std::move(chunk_groups)),
+          chunk_done_(num_chunks_, 0),
+          chunk_results_(num_chunks_, ErrorCode::OK),
+          completed_count_(0),
+          window_size_(std::max<size_t>(1, initial_window)),
+          submit_context_(std::move(submit_context)),
+          fail_next_submit_(std::move(fail_next_submit)) {}
+
+    ~ChunkedReadSession() { cleanup(); }
+
+    bool submit_initial_window() {
+        if (precompleted_) {
+            return true;
+        }
+        maybe_submit_more(window_size_);
+        return !submit_failed_;
+    }
+
+    size_t num_chunks() const { return num_chunks_; }
+
+    bool is_chunk_ready(size_t chunk_index) {
+        if (chunk_index >= num_chunks_) {
+            return false;
+        }
+        return poll_chunk(chunk_index);
+    }
+
+    size_t completed_count() {
+        if (precompleted_) {
+            return completed_count_.load(std::memory_order_relaxed);
+        }
+        maybe_submit_more(submitted_chunks_.load(std::memory_order_acquire) +
+                          window_size_);
+        size_t current = completed_count_.load(std::memory_order_relaxed);
+        if (current == num_chunks_) {
+            return current;
+        }
+        size_t observed_finished = observed_batch_finished_count();
+        if (observed_finished > current) {
+            return drain_completed_chunks(observed_finished);
+        }
+        return current;
+    }
+
+    ErrorCode wait_chunk(size_t chunk_index) {
+        if (chunk_index >= num_chunks_) {
+            return ErrorCode::INVALID_PARAMS;
+        }
+        if (precompleted_) {
+            return chunk_results_[chunk_index];
+        }
+
+        maybe_submit_more(chunk_index + 1);
+        if (poll_chunk(chunk_index)) {
+            return chunk_results_[chunk_index];
+        }
+
+        auto& batch_desc = Transport::toBatchDesc(batch_id_);
+        auto* futex_word =
+            reinterpret_cast<uint32_t*>(&batch_desc.finished_task_count);
+        const auto deadline =
+            std::chrono::steady_clock::now() +
+            std::chrono::seconds(kProgressiveGetTimeoutSeconds);
+
+        while (true) {
+            uint32_t snapshot = __atomic_load_n(futex_word, __ATOMIC_ACQUIRE);
+
+            maybe_submit_more(chunk_index + 1);
+            size_t observed_finished = observed_batch_finished_count();
+            if (observed_finished >
+                completed_count_.load(std::memory_order_relaxed)) {
+                drain_completed_chunks(observed_finished);
+                if (chunk_done_[chunk_index]) {
+                    return chunk_results_[chunk_index];
+                }
+            }
+
+            if (materialize_chunk_result(chunk_index)) {
+                return chunk_results_[chunk_index];
+            }
+
+            auto now = std::chrono::steady_clock::now();
+            if (now >= deadline) {
+                break;
+            }
+            auto remaining =
+                std::chrono::duration_cast<std::chrono::nanoseconds>(deadline -
+                                                                     now);
+            struct timespec ts;
+            ts.tv_sec = remaining.count() / 1000000000LL;
+            ts.tv_nsec = remaining.count() % 1000000000LL;
+
+            ::syscall(SYS_futex, futex_word, FUTEX_WAIT_PRIVATE, snapshot, &ts,
+                      nullptr, 0);
+        }
+
+        mark_chunk_done(chunk_index, ErrorCode::TRANSFER_FAIL);
+        seal_batch();
+        return ErrorCode::TRANSFER_FAIL;
+    }
+
+    ErrorCode wait_all() {
+        if (precompleted_) {
+            return aggregate_result();
+        }
+
+        maybe_submit_more(num_chunks_);
+        auto& batch_desc = Transport::toBatchDesc(batch_id_);
+        auto* futex_word =
+            reinterpret_cast<uint32_t*>(&batch_desc.finished_task_count);
+        const auto deadline =
+            std::chrono::steady_clock::now() +
+            std::chrono::seconds(kProgressiveGetTimeoutSeconds);
+
+        size_t current = completed_count_.load(std::memory_order_relaxed);
+        while (current < num_chunks_) {
+            maybe_submit_more(num_chunks_);
+            size_t observed_finished = observed_batch_finished_count();
+            if (observed_finished > current) {
+                current = drain_completed_chunks(observed_finished);
+                continue;
+            }
+
+            auto now = std::chrono::steady_clock::now();
+            if (now >= deadline) {
+                break;
+            }
+
+            uint32_t snapshot = __atomic_load_n(futex_word, __ATOMIC_ACQUIRE);
+            auto remaining =
+                std::chrono::duration_cast<std::chrono::nanoseconds>(deadline -
+                                                                     now);
+            struct timespec ts;
+            ts.tv_sec = remaining.count() / 1000000000LL;
+            ts.tv_nsec = remaining.count() % 1000000000LL;
+
+            ::syscall(SYS_futex, futex_word, FUTEX_WAIT_PRIVATE, snapshot, &ts,
+                      nullptr, 0);
+            current = completed_count_.load(std::memory_order_relaxed);
+        }
+
+        if (observed_batch_finished_count() ==
+            submitted_chunks_.load(std::memory_order_acquire)) {
+            drain_completed_chunks(num_chunks_, true);
+        }
+
+        if (completed_count_.load(std::memory_order_relaxed) != num_chunks_) {
+            mark_remaining_chunks_failed();
+        }
+
+        seal_batch();
+        return aggregate_result();
+    }
+
+   private:
+    void cleanup() {
+        if (precompleted_ || !engine_ || batch_id_ == INVALID_BATCH_ID) {
+            return;
+        }
+
+        wait_all();
+        BatchID batch_id = batch_id_;
+        Status free_status = engine_->freeBatchID(batch_id);
+        if (!free_status.ok()) {
+            LOG(ERROR) << "Failed to free chunked read batch " << batch_id
+                       << ": " << free_status.message();
+        } else if (g_transfer_task_test_hooks &&
+                   g_transfer_task_test_hooks->on_batch_freed) {
+            g_transfer_task_test_hooks->on_batch_freed(batch_id);
+        }
+        chunk_groups_.clear();
+        engine_ = nullptr;
+        batch_id_ = INVALID_BATCH_ID;
+    }
+
+    void maybe_submit_more(size_t required_chunks) {
+        if (precompleted_) {
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(submit_mutex_);
+        if (sealed_) {
+            return;
+        }
+
+        size_t submitted = submitted_chunks_.load(std::memory_order_acquire);
+        size_t target = std::min(
+            num_chunks_, std::max(required_chunks, submitted + window_size_));
+        if (target <= submitted) {
+            return;
+        }
+
+        std::vector<TransferRequest> window;
+        size_t raw_request_count = 0;
+        for (size_t i = submitted; i < target; ++i) {
+            raw_request_count += chunk_groups_[i].size();
+        }
+        window.reserve(raw_request_count);
+        for (size_t i = submitted; i < target; ++i) {
+            window.insert(window.end(), chunk_groups_[i].begin(),
+                          chunk_groups_[i].end());
+        }
+
+        if (fail_next_submit_ && fail_next_submit_()) {
+            submit_failed_ = true;
+            for (size_t i = submitted; i < num_chunks_; ++i) {
+                mark_chunk_done(i, ErrorCode::TRANSFER_FAIL);
+            }
+            submitted_chunks_.store(num_chunks_, std::memory_order_release);
+            seal_batch_locked();
+            return;
+        }
+
+        Status s = engine_->submitTransfer(batch_id_, window);
+        if (!s.ok()) {
+            LOG(ERROR) << "Failed to submit " << submit_context_
+                       << " window for batch " << batch_id_ << ": "
+                       << s.message();
+            submit_failed_ = true;
+            for (size_t i = submitted; i < num_chunks_; ++i) {
+                mark_chunk_done(i, ErrorCode::TRANSFER_FAIL);
+            }
+            submitted_chunks_.store(num_chunks_, std::memory_order_release);
+            seal_batch_locked();
+            return;
+        }
+
+        submitted_chunks_.store(target, std::memory_order_release);
+        if (target == num_chunks_) {
+            seal_batch_locked();
+        }
+    }
+
+    void seal_batch() {
+        if (precompleted_) {
+            return;
+        }
+        std::lock_guard<std::mutex> lock(submit_mutex_);
+        seal_batch_locked();
+    }
+
+    void seal_batch_locked() {
+        if (sealed_) {
+            return;
+        }
+        auto& batch_desc = Transport::toBatchDesc(batch_id_);
+        {
+            std::lock_guard<std::mutex> lifecycle_lock(
+                batch_desc.lifecycle_mutex);
+            batch_desc.sealed.store(true, std::memory_order_release);
+            batch_desc.publish_completion_if_ready_locked();
+        }
+#ifdef USE_EVENT_DRIVEN_COMPLETION
+        batch_desc.completion_cv.notify_all();
+#endif
+        sealed_ = true;
+    }
+
+    size_t observed_batch_finished_count() const {
+        const auto& batch_desc = Transport::toBatchDesc(batch_id_);
+        size_t finished = static_cast<size_t>(
+            batch_desc.finished_task_count.load(std::memory_order_acquire));
+        size_t submitted = submitted_chunks_.load(std::memory_order_acquire);
+        return std::min(finished, submitted);
+    }
+
+    void mark_chunk_done(size_t chunk_index, ErrorCode result) {
+        if (chunk_done_[chunk_index]) {
+            return;
+        }
+        chunk_done_[chunk_index] = 1;
+        chunk_results_[chunk_index] = result;
+        completed_count_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    bool materialize_chunk_result(size_t chunk_index) {
+        if (chunk_done_[chunk_index]) {
+            return true;
+        }
+        if (chunk_index >= submitted_chunks_.load(std::memory_order_acquire)) {
+            return false;
+        }
+
+        TransferStatus status;
+        Status s = engine_->getTransferStatus(batch_id_, chunk_index, status);
+        if (!s.ok()) {
+            LOG(ERROR)
+                << "Failed to get chunked read transfer status for batch "
+                << batch_id_ << " chunk " << chunk_index;
+            mark_chunk_done(chunk_index, ErrorCode::TRANSFER_FAIL);
+            return true;
+        }
+
+        switch (status.s) {
+            case TransferStatusEnum::COMPLETED:
+                mark_chunk_done(chunk_index, ErrorCode::OK);
+                return true;
+            case TransferStatusEnum::FAILED:
+            case TransferStatusEnum::CANCELED:
+            case TransferStatusEnum::INVALID:
+            case TransferStatusEnum::TIMEOUT:
+                mark_chunk_done(chunk_index, ErrorCode::TRANSFER_FAIL);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    size_t drain_completed_chunks(size_t observed_finished_count,
+                                  bool force_full_scan = false) {
+        size_t completed = completed_count_.load(std::memory_order_relaxed);
+        if (completed >= num_chunks_) {
+            return completed;
+        }
+        if (observed_finished_count <= completed && !force_full_scan) {
+            return completed;
+        }
+
+        size_t submitted = submitted_chunks_.load(std::memory_order_acquire);
+        size_t scan_limit =
+            force_full_scan ? submitted : observed_finished_count;
+        if (scan_limit == 0) {
+            return completed;
+        }
+
+        size_t idx = drain_cursor_ < submitted ? drain_cursor_ : 0;
+        size_t scanned = 0;
+        while (scanned < submitted &&
+               (force_full_scan || completed < scan_limit)) {
+            if (!chunk_done_[idx] && materialize_chunk_result(idx)) {
+                completed = completed_count_.load(std::memory_order_relaxed);
+            }
+            idx = (idx + 1) % submitted;
+            ++scanned;
+        }
+
+        drain_cursor_ = submitted == 0 ? 0 : idx;
+        return completed_count_.load(std::memory_order_relaxed);
+    }
+
+    void mark_remaining_chunks_failed() {
+        for (size_t i = 0; i < num_chunks_; ++i) {
+            if (!chunk_done_[i]) {
+                mark_chunk_done(i, ErrorCode::TRANSFER_FAIL);
+            }
+        }
+        drain_cursor_ = num_chunks_;
+    }
+
+    ErrorCode aggregate_result() const {
+        for (size_t i = 0; i < num_chunks_; ++i) {
+            if (chunk_results_[i] != ErrorCode::OK) {
+                return chunk_results_[i];
+            }
+        }
+        return ErrorCode::OK;
+    }
+
+    bool poll_chunk(size_t chunk_index) {
+        if (chunk_done_[chunk_index]) {
+            return true;
+        }
+        maybe_submit_more(chunk_index + 1);
+
+        size_t observed_finished = observed_batch_finished_count();
+        size_t completed = completed_count_.load(std::memory_order_relaxed);
+        if (observed_finished > completed) {
+            completed = drain_completed_chunks(observed_finished);
+        }
+
+        if (chunk_done_[chunk_index]) {
+            return true;
+        }
+        if (completed >= num_chunks_) {
+            return false;
+        }
+        if (observed_finished == completed) {
+            return false;
+        }
+
+        return materialize_chunk_result(chunk_index);
+    }
+
+    TransferEngine* engine_ = nullptr;
+    BatchID batch_id_ = INVALID_BATCH_ID;
+    size_t num_chunks_ = 0;
+    std::vector<std::vector<TransferRequest>> chunk_groups_;
+    std::vector<uint8_t> chunk_done_;
+    std::vector<ErrorCode> chunk_results_;
+    std::atomic<size_t> completed_count_{0};
+    std::atomic<size_t> submitted_chunks_{0};
+    size_t drain_cursor_{0};
+    size_t window_size_ = 1;
+    bool sealed_ = false;
+    bool precompleted_ = false;
+    bool submit_failed_ = false;
+    std::string submit_context_;
+    ChunkSubmitFailureHook fail_next_submit_;
+    std::mutex submit_mutex_;
+};
+
+template <typename Handle>
+std::optional<Handle> create_chunked_read_handle(
+    TransferEngine& engine, std::vector<std::vector<TransferRequest>> chunk_groups,
+    size_t initial_window, const char* submit_context,
+    ChunkSubmitFailureHook fail_next_submit) {
+    BatchID batch_id = engine.allocateBatchID(chunk_groups.size());
+    if (batch_id == INVALID_BATCH_ID) {
+        LOG(ERROR) << submit_context << ": failed to allocate batch ID";
+        return std::nullopt;
+    }
+    if (g_transfer_task_test_hooks &&
+        g_transfer_task_test_hooks->on_batch_allocated) {
+        g_transfer_task_test_hooks->on_batch_allocated(batch_id);
+    }
+
+    auto session = std::make_shared<ChunkedReadSession>(
+        engine, batch_id, std::move(chunk_groups), initial_window,
+        submit_context, std::move(fail_next_submit));
+    if (!session->submit_initial_window()) {
+        return std::nullopt;
+    }
+    return Handle(std::move(session));
+}
+
+ProgressiveGetHandle::ProgressiveGetHandle(
+    std::shared_ptr<ChunkedReadSession> session)
+    : session_(std::move(session)) {}
+
+ProgressiveGetHandle::~ProgressiveGetHandle() = default;
+
+ProgressiveGetHandle::ProgressiveGetHandle(
+    ProgressiveGetHandle&& other) noexcept = default;
+
+ProgressiveGetHandle& ProgressiveGetHandle::operator=(
+    ProgressiveGetHandle&& other) noexcept = default;
+
+size_t ProgressiveGetHandle::num_chunks() const {
+    return session_->num_chunks();
+}
+
+bool ProgressiveGetHandle::is_chunk_ready(size_t chunk_index) {
+    return session_->is_chunk_ready(chunk_index);
+}
+
+size_t ProgressiveGetHandle::completed_count() {
+    return session_->completed_count();
+}
+
+ErrorCode ProgressiveGetHandle::wait_chunk(size_t chunk_index) {
+    return session_->wait_chunk(chunk_index);
+}
+
+ErrorCode ProgressiveGetHandle::wait_all() { return session_->wait_all(); }
+
+ScatterReadHandle::ScatterReadHandle(
+    std::shared_ptr<ChunkedReadSession> session)
+    : session_(std::move(session)) {}
+
+ScatterReadHandle::~ScatterReadHandle() = default;
+
+ScatterReadHandle::ScatterReadHandle(ScatterReadHandle&& other) noexcept =
+    default;
+
+ScatterReadHandle& ScatterReadHandle::operator=(
+    ScatterReadHandle&& other) noexcept = default;
+
+size_t ScatterReadHandle::num_chunks() const { return session_->num_chunks(); }
+
+bool ScatterReadHandle::is_chunk_ready(size_t chunk_index) {
+    return session_->is_chunk_ready(chunk_index);
+}
+
+size_t ScatterReadHandle::completed_count() {
+    return session_->completed_count();
+}
+
+ErrorCode ScatterReadHandle::wait_chunk(size_t chunk_index) {
+    return session_->wait_chunk(chunk_index);
+}
+
+ErrorCode ScatterReadHandle::wait_all() { return session_->wait_all(); }
 
 // ============================================================================
 // TransferFuture Implementation
@@ -532,6 +1156,51 @@ std::optional<TransferFuture> TransferSubmitter::submit(
     return future;
 }
 
+std::optional<TransferFuture> TransferSubmitter::submitRangeRead(
+    const Replica::Descriptor& replica, std::vector<Slice>& slices,
+    uint64_t src_offset) {
+    std::optional<TransferFuture> future;
+
+    if (replica.is_memory_replica()) {
+        auto& mem_desc = replica.get_memory_descriptor();
+        auto& handle = mem_desc.buffer_descriptor;
+
+        size_t slices_size = 0;
+        for (const auto& s : slices) slices_size += s.size;
+        if (src_offset + slices_size > handle.size_) {
+            LOG(ERROR) << "Range read overflow: src_offset=" << src_offset
+                       << " + slices_size=" << slices_size
+                       << " > handle.size_=" << handle.size_;
+            return std::nullopt;
+        }
+
+        TransferStrategy strategy = selectStrategy(handle, slices);
+
+        if (strategy == TransferStrategy::LOCAL_MEMCPY) {
+            future = submitMemcpyOperation(handle, slices,
+                                           TransferRequest::READ, src_offset);
+        } else if (strategy == TransferStrategy::TRANSFER_ENGINE) {
+            future = submitTransferEngineOperation(
+                handle, slices, TransferRequest::READ, src_offset);
+        } else {
+            LOG(ERROR) << "Range read only supports LOCAL_MEMCPY or "
+                          "TRANSFER_ENGINE, got: "
+                       << strategy;
+            return std::nullopt;
+        }
+    } else if (replica.is_disk_replica() || replica.is_local_disk_replica()) {
+        LOG(ERROR)
+            << "Range read not supported for disk replicas (use full read)";
+        return std::nullopt;
+    }
+
+    if (future.has_value()) {
+        updateTransferMetrics(slices, TransferRequest::READ);
+    }
+
+    return future;
+}
+
 std::optional<TransferFuture> TransferSubmitter::submit_batch(
     const std::vector<Replica::Descriptor>& replicas,
     std::vector<std::vector<Slice>>& all_slices,
@@ -614,6 +1283,33 @@ TransferSubmitter::submit_batch_get_offload_object(
     return submitTransfer(requests);
 }
 
+std::optional<TransferFuture> TransferSubmitter::submitBatchReadRanges(
+    void* dest_buffer,
+    const std::vector<std::pair<
+        Replica::Descriptor, std::vector<std::tuple<size_t, size_t, size_t>>>>&
+        key_ranges,
+    bool enable_task_grouping) {
+    auto build_result =
+        buildScatterReadRequests(engine_, dest_buffer, key_ranges,
+                                 enable_task_grouping, "submitBatchReadRanges");
+    if (!build_result) {
+        return std::nullopt;
+    }
+
+    auto& requests = build_result->flat_requests;
+    if (requests.empty()) {
+        return TransferFuture(std::make_shared<EmptyOperationState>());
+    }
+
+    const size_t grouped_task_count = build_result->logical_groups.size();
+    auto future =
+        submitTransfer(requests, enable_task_grouping ? grouped_task_count : 0);
+    if (future) {
+        updateReadRequestMetrics(requests);
+    }
+    return future;
+}
+
 std::optional<TransferFuture> TransferSubmitter::submitMemcpyOperation(
     const AllocatedBuffer::Descriptor& handle, const std::vector<Slice>& slices,
     const TransferRequest::OpCode op_code, uint64_t src_offset) {
@@ -658,9 +1354,11 @@ std::optional<TransferFuture> TransferSubmitter::submitMemcpyOperation(
 }
 
 std::optional<TransferFuture> TransferSubmitter::submitTransfer(
-    std::vector<TransferRequest>& requests) {
-    // Allocate batch ID
-    const size_t batch_size = requests.size();
+    std::vector<TransferRequest>& requests, size_t batch_task_count) {
+    // Allocate batch ID using the actual logical task count when callers
+    // intentionally group multiple requests into one transfer task.
+    const size_t batch_size =
+        batch_task_count == 0 ? requests.size() : batch_task_count;
     BatchID batch_id = engine_.allocateBatchID(batch_size);
     if (batch_id == INVALID_BATCH_ID) {
         LOG(ERROR) << "Failed to allocate batch ID";
@@ -748,38 +1446,6 @@ std::optional<TransferFuture> TransferSubmitter::submitMemoryReadOperation(
     LOG(ERROR) << "Read only supports LOCAL_MEMCPY or TRANSFER_ENGINE, got: "
                << strategy;
     return std::nullopt;
-}
-
-std::optional<TransferFuture> TransferSubmitter::submitRangeRead(
-    const Replica::Descriptor& replica, std::vector<Slice>& slices,
-    uint64_t src_offset) {
-    std::optional<TransferFuture> future;
-
-    if (replica.is_memory_replica()) {
-        auto& mem_desc = replica.get_memory_descriptor();
-        auto& handle = mem_desc.buffer_descriptor;
-
-        size_t slices_size = 0;
-        for (const auto& s : slices) slices_size += s.size;
-        if (src_offset + slices_size > handle.size_) {
-            LOG(ERROR) << "Range read overflow: src_offset=" << src_offset
-                       << " + slices_size=" << slices_size
-                       << " > handle.size_=" << handle.size_;
-            return std::nullopt;
-        }
-
-        future = submitMemoryReadOperation(handle, slices, src_offset);
-    } else if (replica.is_disk_replica() || replica.is_local_disk_replica()) {
-        LOG(ERROR)
-            << "Range read not supported for disk replicas (use full read)";
-        return std::nullopt;
-    }
-
-    if (future.has_value()) {
-        updateTransferMetrics(slices, TransferRequest::READ);
-    }
-
-    return future;
 }
 
 std::optional<TransferFuture> TransferSubmitter::submitFileReadOperation(
@@ -893,6 +1559,113 @@ bool TransferSubmitter::validateTransferParams(
     return true;
 }
 
+std::optional<ScatterReadHandle>
+TransferSubmitter::submitStreamingBatchReadRanges(
+    void* dest_buffer,
+    const std::vector<std::pair<
+        Replica::Descriptor, std::vector<std::tuple<size_t, size_t, size_t>>>>&
+        key_ranges,
+    bool enable_task_grouping) {
+    auto build_result = buildScatterReadRequests(
+        engine_, dest_buffer, key_ranges, enable_task_grouping,
+        "submitStreamingBatchReadRanges");
+    if (!build_result) {
+        return std::nullopt;
+    }
+
+    auto chunk_groups = std::move(build_result->logical_groups);
+    auto& requests = build_result->flat_requests;
+    if (requests.empty()) {
+        return ScatterReadHandle(
+            std::make_shared<ChunkedReadSession>(0, ErrorCode::OK));
+    }
+
+    if (!enable_task_grouping) {
+        chunk_groups.reserve(requests.size());
+        for (auto& request : requests) {
+            chunk_groups.push_back({request});
+        }
+    }
+
+    auto handle = create_chunked_read_handle<ScatterReadHandle>(
+        engine_, std::move(chunk_groups),
+        std::min<size_t>(requests.size(), kProgressiveGetWindowChunks),
+        "submitStreamingBatchReadRanges", []() {
+            return g_transfer_task_test_hooks &&
+                   g_transfer_task_test_hooks
+                       ->fail_next_streaming_scatter_submit &&
+                   g_transfer_task_test_hooks
+                       ->fail_next_streaming_scatter_submit();
+        });
+    if (handle) {
+        updateReadRequestMetrics(requests);
+    }
+    return handle;
+}
+
+std::optional<ProgressiveGetHandle> TransferSubmitter::submitProgressiveRead(
+    const Replica::Descriptor& replica, void* dest_buffer, size_t total_size,
+    size_t chunk_size) {
+    if (!replica.is_memory_replica()) {
+        LOG(ERROR) << "submitProgressiveRead: only memory replicas supported";
+        return std::nullopt;
+    }
+    if (chunk_size == 0 || total_size == 0) {
+        LOG(ERROR) << "submitProgressiveRead: invalid sizes (total_size="
+                   << total_size << ", chunk_size=" << chunk_size << ")";
+        return std::nullopt;
+    }
+
+    const auto& handle = replica.get_memory_descriptor().buffer_descriptor;
+    if (handle.transport_endpoint_.empty()) {
+        LOG(ERROR) << "submitProgressiveRead: empty transport endpoint";
+        return std::nullopt;
+    }
+
+    size_t num_chunks = (total_size + chunk_size - 1) / chunk_size;
+    uint64_t base_address = static_cast<uint64_t>(handle.buffer_address_);
+    char* dest_base = static_cast<char*>(dest_buffer);
+
+    SegmentHandle seg = engine_.openSegment(handle.transport_endpoint_);
+    if (seg == static_cast<uint64_t>(ERR_INVALID_ARGUMENT)) {
+        LOG(ERROR) << "submitProgressiveRead: failed to open segment for "
+                   << handle.transport_endpoint_;
+        return std::nullopt;
+    }
+
+    std::vector<std::vector<TransferRequest>> chunk_groups;
+    chunk_groups.reserve(num_chunks);
+    std::vector<TransferRequest> requests;
+    requests.reserve(num_chunks);
+
+    for (size_t i = 0; i < num_chunks; ++i) {
+        size_t offset = i * chunk_size;
+        size_t length = std::min(chunk_size, total_size - offset);
+
+        TransferRequest request;
+        request.opcode = TransferRequest::READ;
+        request.source = dest_base + offset;
+        request.target_id = seg;
+        request.target_offset = base_address + offset;
+        request.length = length;
+        requests.emplace_back(request);
+        chunk_groups.push_back({request});
+    }
+
+    auto progressive_handle = create_chunked_read_handle<ProgressiveGetHandle>(
+        engine_, std::move(chunk_groups),
+        std::min(num_chunks, kProgressiveGetWindowChunks),
+        "submitProgressiveRead", []() {
+            return g_transfer_task_test_hooks &&
+                   g_transfer_task_test_hooks->fail_next_progressive_submit &&
+                   g_transfer_task_test_hooks->fail_next_progressive_submit();
+        });
+    if (progressive_handle) {
+        updateReadBytes(total_size);
+    }
+    return progressive_handle;
+}
+
 void TransferSubmitter::updateTransferMetrics(const std::vector<Slice>& slices,
                                               TransferRequest::OpCode op_code) {
     size_t total_bytes = 0;
@@ -910,6 +1683,18 @@ void TransferSubmitter::updateTransferMetrics(const std::vector<Slice>& slices,
     } else if (op_code == TransferRequest::WRITE) {
         transfer_metric_->total_write_bytes.inc(total_bytes);
     }
+}
+
+void TransferSubmitter::updateReadRequestMetrics(
+    const std::vector<TransferRequest>& requests) {
+    updateReadBytes(sum_request_bytes(requests));
+}
+
+void TransferSubmitter::updateReadBytes(size_t total_bytes) {
+    if (transfer_metric_ == nullptr) {
+        return;
+    }
+    transfer_metric_->total_read_bytes.inc(total_bytes);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -1731,4 +1731,128 @@ void TransferSubmitter::updateReadBytes(size_t total_bytes) {
     transfer_metric_->total_read_bytes.inc(total_bytes);
 }
 
+// ============================================================================
+// ProgressivePutSession + ProgressivePutHandle Implementation
+// ============================================================================
+
+ErrorCode ProgressivePutSession::write_chunk(void* data, size_t offset,
+                                             size_t size) {
+    if (data == nullptr || size == 0) {
+        LOG(ERROR) << "ProgressivePutSession: invalid params (data=" << data
+                   << ", size=" << size << ")";
+        return ErrorCode::INVALID_PARAMS;
+    }
+    if (size > total_size_ || offset > total_size_ - size) {
+        LOG(ERROR) << "ProgressivePutSession: overflow offset=" << offset
+                   << " + size=" << size << " > total=" << total_size_;
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    std::lock_guard<std::mutex> lock(write_mutex_);
+
+    if (sealed_.load(std::memory_order_relaxed)) {
+        LOG(ERROR) << "ProgressivePutSession: cannot write after seal";
+        return ErrorCode::INVALID_PARAMS;
+    }
+    if (completed_count_.load(std::memory_order_relaxed) >= num_chunks_) {
+        LOG(ERROR) << "ProgressivePutSession: all chunks already written";
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    ErrorCode err = submitter_->submitChunkWrite(replica_, data, offset, size);
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+
+    uint64_t new_count =
+        completed_count_.fetch_add(1, std::memory_order_release) + 1;
+
+    // Progress callback inside the lock to guarantee monotonic counter
+    // updates. This is acceptable because the progress key is forced to
+    // the local segment (LOCAL_MEMCPY path — sub-microsecond).
+    if (progress_cb_) {
+        progress_cb_(new_count);
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode ProgressivePutSession::seal() {
+    std::lock_guard<std::mutex> lock(write_mutex_);
+    sealed_.store(true, std::memory_order_release);
+    if (seal_cb_) {
+        return seal_cb_();
+    }
+    return ErrorCode::OK;
+}
+
+ProgressivePutHandle::ProgressivePutHandle(
+    std::shared_ptr<ProgressivePutSession> session)
+    : session_(std::move(session)) {}
+
+ProgressivePutHandle::~ProgressivePutHandle() {
+    if (session_ && !session_->is_sealed() &&
+        session_->completed_count() < session_->num_chunks()) {
+        LOG(WARNING) << "ProgressivePutHandle destroyed without seal: "
+                     << session_->completed_count() << "/"
+                     << session_->num_chunks() << " chunks written";
+    }
+}
+
+ProgressivePutHandle::ProgressivePutHandle(
+    ProgressivePutHandle&& other) noexcept = default;
+
+ProgressivePutHandle& ProgressivePutHandle::operator=(
+    ProgressivePutHandle&& other) noexcept = default;
+
+size_t ProgressivePutHandle::num_chunks() const {
+    return session_->num_chunks();
+}
+
+size_t ProgressivePutHandle::completed_count() const {
+    return session_->completed_count();
+}
+
+ErrorCode ProgressivePutHandle::write_chunk(void* data, size_t offset,
+                                            size_t size) {
+    return session_->write_chunk(data, offset, size);
+}
+
+ErrorCode ProgressivePutHandle::seal() { return session_->seal(); }
+
+bool ProgressivePutHandle::is_sealed() const { return session_->is_sealed(); }
+
+ErrorCode TransferSubmitter::submitChunkWrite(
+    const Replica::Descriptor& replica, void* data, size_t offset,
+    size_t size) {
+    const auto& handle = replica.get_memory_descriptor().buffer_descriptor;
+    if (size > handle.size_ || offset > handle.size_ - size) {
+        LOG(ERROR) << "submitChunkWrite: overflow offset=" << offset
+                   << " + size=" << size << " > buffer=" << handle.size_;
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    Slice slice{data, size};
+    std::vector<Slice> slices{slice};
+
+    std::optional<TransferFuture> future;
+    TransferStrategy strategy = selectStrategy(handle, slices);
+    if (strategy == TransferStrategy::LOCAL_MEMCPY) {
+        future = submitMemcpyOperation(handle, slices, TransferRequest::WRITE,
+                                       offset);
+    } else {
+        future = submitTransferEngineOperation(handle, slices,
+                                               TransferRequest::WRITE, offset);
+    }
+
+    if (!future) {
+        return ErrorCode::TRANSFER_FAIL;
+    }
+
+    ErrorCode result = future->get();
+    if (result == ErrorCode::OK && transfer_metric_) {
+        transfer_metric_->total_write_bytes.inc(size);
+    }
+    return result;
+}
+
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -216,14 +216,10 @@ class Transport {
 
             batch_desc.finished_task_count.fetch_add(1,
                                                      std::memory_order_release);
+            batch_desc.progress_futex.fetch_add(1, std::memory_order_release);
 
-            // Wake ProgressiveGetHandle futex waiters (unconditional).
-            static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
-                          "futex on low-32 of uint64_t requires little-endian");
-            ::syscall(
-                SYS_futex,
-                reinterpret_cast<uint32_t *>(&batch_desc.finished_task_count),
-                FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0);
+            ::syscall(SYS_futex, &batch_desc.progress_futex, FUTEX_WAKE_PRIVATE,
+                      INT_MAX, nullptr, nullptr, 0);
 
 #ifdef USE_EVENT_DRIVEN_COMPLETION
             {
@@ -336,8 +332,8 @@ class Transport {
         std::atomic<uint64_t> finished_transfer_bytes{0};
 
         // Always present: per-task completion counter.
-        // Low 32 bits used as futex word by ProgressiveGetHandle.
         std::atomic<uint64_t> finished_task_count{0};
+        std::atomic<uint32_t> progress_futex{0};
 
         bool is_complete() const {
             return sealed.load(std::memory_order_acquire) &&

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -20,6 +20,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <climits>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
@@ -58,12 +63,21 @@ class Transport {
     struct TransferRequest {
         enum OpCode { READ, WRITE };
 
+        /// Sentinel value indicating a request does not belong to any group.
+        static constexpr uint64_t kNoTaskGroup = 0;
+
         OpCode opcode;
         void *source;
         SegmentID target_id;
         uint64_t target_offset;
         size_t length;
         int advise_retry_cnt = 0;
+
+        /// Optional task group identifier.  Adjacent requests that share the
+        /// same non-default task_group_id *and* resolve to the same Transport
+        /// are coalesced into a single logical task inside submitTransfer().
+        /// The default (kNoTaskGroup) means the request is standalone.
+        uint64_t task_group_id = kNoTaskGroup;
     };
 
     enum TransferStatusEnum {
@@ -185,56 +199,38 @@ class Transport {
 
        private:
         inline void check_batch_completion(bool is_failed) {
-#ifdef USE_EVENT_DRIVEN_COMPLETION
             auto &batch_desc = toBatchDesc(task->batch_id);
             if (is_failed) {
                 batch_desc.has_failure.store(true, std::memory_order_relaxed);
             }
 
-            // When the last slice of a task completes, check if the entire task
-            // is done using a single atomic counter to avoid reading
-            // inconsistent results.
             uint64_t prev_completed = __atomic_fetch_add(
                 &task->completed_slice_count, 1, __ATOMIC_RELAXED);
 
-            // Only the thread completing the final slice will see prev+1 ==
-            // slice_count.
-            if (prev_completed + 1 == task->slice_count) {
-                __atomic_store_n(&task->is_finished, true, __ATOMIC_RELAXED);
-
-                // Increment the number of finished tasks in the batch
-                // (relaxed). This counter does not itself publish data; only
-                // the thread that observes the last task completion performs
-                // the release-store on batch_desc.is_finished below. The waiter
-                // pairs this with an acquire load, which makes all prior writes
-                // (including relaxed increments) visible.
-                //
-                // check if this is the last task in the batch
-                auto prev = batch_desc.finished_task_count.fetch_add(
-                    1, std::memory_order_relaxed);
-
-                // Last task in the batch: wake up waiting thread directly
-                if (prev + 1 == batch_desc.batch_size) {
-                    // Publish completion of the entire batch under the same
-                    // mutex used by the waiter to avoid lost notifications.
-                    //
-                    // Keep a release-store because the reader has a fast path
-                    // that may observe completion without taking the mutex. The
-                    // acquire load in that fast path pairs with this release to
-                    // make all prior updates visible. For the predicate checked
-                    // under the mutex, relaxed would suffice since the mutex
-                    // acquire provides the necessary visibility.
-                    {
-                        std::lock_guard<std::mutex> lock(
-                            batch_desc.completion_mutex);
-                        batch_desc.is_finished.store(true,
-                                                     std::memory_order_release);
-                    }
-                    // Notify after releasing the lock to avoid waking threads
-                    // only to block again on the mutex.
-                    batch_desc.completion_cv.notify_all();
-                }
+            if (prev_completed + 1 != task->slice_count) {
+                return;
             }
+
+            // --- Task complete ---
+            __atomic_store_n(&task->is_finished, true, __ATOMIC_RELAXED);
+
+            batch_desc.finished_task_count.fetch_add(1,
+                                                     std::memory_order_release);
+
+            // Wake ProgressiveGetHandle futex waiters (unconditional).
+            static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+                          "futex on low-32 of uint64_t requires little-endian");
+            ::syscall(
+                SYS_futex,
+                reinterpret_cast<uint32_t *>(&batch_desc.finished_task_count),
+                FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0);
+
+#ifdef USE_EVENT_DRIVEN_COMPLETION
+            {
+                std::lock_guard<std::mutex> lock(batch_desc.lifecycle_mutex);
+                batch_desc.publish_completion_if_ready_locked();
+            }
+            batch_desc.completion_cv.notify_all();
 #endif
         }
     };
@@ -299,9 +295,7 @@ class Transport {
         std::chrono::steady_clock::time_point start_time;
 #endif
 
-#ifdef USE_EVENT_DRIVEN_COMPLETION
         volatile uint64_t completed_slice_count = 0;
-#endif
 
         // record the origin request
 #ifdef USE_ASCEND_HETEROGENEOUS
@@ -311,6 +305,10 @@ class Transport {
 #else
         const TransferRequest *request = nullptr;
 #endif
+        // Grouped logical tasks may carry multiple adjacent requests that
+        // should be submitted as one transport task.
+        std::vector<TransferRequest> request_group;
+
         // record the slice list for freeing objects
         std::vector<Slice *> slice_list;
         ~TransferTask() {
@@ -326,18 +324,34 @@ class Transport {
         void *context;  // for transport implementers.
         int64_t start_timestamp;
 
+        // Mutable batch lifecycle state for incremental append-style submit.
+        mutable std::mutex lifecycle_mutex;
+        std::atomic<uint64_t> submitted_task_count{0};
+        std::atomic<bool> sealed{false};
+
         // Track batch progress and notifies waiters
         std::atomic<bool> has_failure{false};
         std::atomic<bool> is_finished{
             false};  // Completion flag for wait predicate
         std::atomic<uint64_t> finished_transfer_bytes{0};
 
-#ifdef USE_EVENT_DRIVEN_COMPLETION
-        // Event-driven completion: tracks batch progress and notifies waiters
+        // Always present: per-task completion counter.
+        // Low 32 bits used as futex word by ProgressiveGetHandle.
         std::atomic<uint64_t> finished_task_count{0};
 
-        // Synchronization primitives for direct notification
-        std::mutex completion_mutex;
+        bool is_complete() const {
+            return sealed.load(std::memory_order_acquire) &&
+                   finished_task_count.load(std::memory_order_acquire) ==
+                       submitted_task_count.load(std::memory_order_acquire);
+        }
+
+        void publish_completion_if_ready_locked() {
+            if (is_complete()) {
+                is_finished.store(true, std::memory_order_release);
+            }
+        }
+
+#ifdef USE_EVENT_DRIVEN_COMPLETION
         std::condition_variable completion_cv;
 #endif
     };

--- a/mooncake-wheel/tests/test_distributed_object_store.py
+++ b/mooncake-wheel/tests/test_distributed_object_store.py
@@ -294,6 +294,41 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         self.assertEqual(self.store.remove(key1), 0)
         self.assertEqual(self.store.remove(key2), 0)
 
+    def test_streaming_batch_get_buffer_ranges(self):
+        """Test the streaming scatter read interface through the Python API."""
+        import ctypes
+
+        key1 = "test_streaming_batch_get_buffer_ranges_key_1"
+        key2 = "test_streaming_batch_get_buffer_ranges_key_2"
+        data1 = b"A" * 4096
+        data2 = b"B" * 4096
+
+        self.assertEqual(self.store.put(key1, data1), 0)
+        self.assertEqual(self.store.put(key2, data2), 0)
+
+        buffer_size = 2048
+        buffer = (ctypes.c_ubyte * buffer_size)()
+        buffer_ptr = ctypes.addressof(buffer)
+        self.assertEqual(self.store.register_buffer(buffer_ptr, buffer_size), 0)
+
+        handle = self.store.streaming_batch_get_buffer_ranges(
+            [key1, key2],
+            buffer_ptr,
+            [0, 1024],
+            [0, 0],
+            [1024, 1024],
+        )
+        self.assertIsNotNone(handle)
+        self.assertEqual(handle.wait_all(), 0)
+
+        self.assertEqual(bytes(buffer[0:1024]), b"A" * 1024)
+        self.assertEqual(bytes(buffer[1024:2048]), b"B" * 1024)
+
+        self.assertEqual(self.store.unregister_buffer(buffer_ptr), 0)
+        time.sleep(default_kv_lease_ttl / 1000)
+        self.assertEqual(self.store.remove(key1), 0)
+        self.assertEqual(self.store.remove(key2), 0)
+
     def test_batch_get_into_operations(self):
         """Test batch_get_into operations for multiple keys."""
         import ctypes

--- a/mooncake-wheel/tests/test_streaming_transfer.py
+++ b/mooncake-wheel/tests/test_streaming_transfer.py
@@ -1,0 +1,428 @@
+"""
+Tests for streaming transfer: progressive put + progressive get.
+
+These tests verify the streaming write (ProgressivePutHandle) and
+streaming read (ProgressiveGetHandle, ScatterReadHandle) functionality.
+
+Requirements:
+- A running mooncake master server
+- A running metadata server (etcd/redis/p2p)
+- Environment variables: LOCAL_HOSTNAME, MC_METADATA_SERVER, MASTER_SERVER
+"""
+
+import ctypes
+import os
+import struct
+import threading
+import time
+import unittest
+
+from mooncake.store import MooncakeDistributedStore
+
+
+def get_client(store, local_buffer_size_param=None):
+    """Initialize and setup the distributed store client."""
+    protocol = os.getenv("PROTOCOL", "tcp")
+    device_name = os.getenv("DEVICE_NAME", "ibp6s0")
+    local_hostname = os.getenv("LOCAL_HOSTNAME", "localhost")
+    metadata_server = os.getenv(
+        "MC_METADATA_SERVER", "http://127.0.0.1:8080/metadata"
+    )
+    global_segment_size = 3200 * 1024 * 1024  # 3200 MB
+    local_buffer_size = (
+        local_buffer_size_param
+        if local_buffer_size_param is not None
+        else 512 * 1024 * 1024  # 512 MB
+    )
+    master_server_address = os.getenv("MASTER_SERVER", "127.0.0.1:50051")
+
+    retcode = store.setup(
+        local_hostname,
+        metadata_server,
+        global_segment_size,
+        local_buffer_size,
+        protocol,
+        device_name,
+        master_server_address,
+    )
+
+    if retcode:
+        raise RuntimeError(
+            f"Failed to setup store client. Return code: {retcode}"
+        )
+
+
+def allocate_registered_buffer(store, size):
+    """Allocate a buffer from the store's memory pool and return ptr."""
+    ptr = store.alloc(size)
+    if ptr == 0:
+        raise RuntimeError(f"Failed to allocate {size} bytes from memory pool")
+    return ptr
+
+
+def read_range_via_get_into_ranges(store, key, buffer_ptr, dst_offset,
+                                   src_offset, size):
+    """Read a single range using get_into_ranges API.
+
+    Returns bytes_read (positive) or error code (negative).
+    """
+    # get_into_ranges signature:
+    #   buffer_ptrs: [ptr]
+    #   all_keys: [[key]]
+    #   all_dst_offsets: [[[dst_offset]]]
+    #   all_src_offsets: [[[src_offset]]]
+    #   all_sizes: [[[size]]]
+    results = store.get_into_ranges(
+        [buffer_ptr],
+        [[key]],
+        [[[dst_offset]]],
+        [[[src_offset]]],
+        [[[size]]],
+    )
+    # results shape: [1][1][1] -> single value
+    return results[0][0][0]
+
+
+class TestProgressivePut(unittest.TestCase):
+    """Test progressive (streaming) put operations."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.store = MooncakeDistributedStore()
+        get_client(cls.store)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.store.close()
+
+    def test_progressive_put_basic(self):
+        """Test basic progressive put: write chunks then verify readback."""
+        key = "test_progressive_put_basic"
+        chunk_size = 4096
+        num_chunks = 4
+        total_size = chunk_size * num_chunks
+
+        # Start progressive put
+        handle = self.store.progressive_put(key, total_size, num_chunks)
+        self.assertIsNotNone(handle, "progressive_put should return a handle")
+        self.assertEqual(handle.num_chunks, num_chunks)
+        self.assertEqual(handle.completed_count, 0)
+        self.assertFalse(handle.is_sealed)
+
+        # Write chunks with known data pattern
+        src_ptr = allocate_registered_buffer(self.store, total_size)
+        for i in range(num_chunks):
+            # Fill chunk with pattern: each byte = chunk_index + 1
+            offset = i * chunk_size
+            ctypes.memset(src_ptr + offset, i + 1, chunk_size)
+            ret = handle.write_chunk(src_ptr + offset, offset, chunk_size)
+            self.assertEqual(ret, 0, f"write_chunk {i} should succeed")
+            self.assertEqual(handle.completed_count, i + 1)
+
+        # Seal
+        ret = handle.seal()
+        self.assertEqual(ret, 0, "seal should succeed")
+        self.assertTrue(handle.is_sealed)
+
+        # Read back full object and verify
+        dst_ptr = allocate_registered_buffer(self.store, total_size)
+        ctypes.memset(dst_ptr, 0, total_size)
+        bytes_read = self.store.get_into(key, dst_ptr, total_size)
+        self.assertEqual(bytes_read, total_size)
+
+        # Verify data pattern
+        dst_buf = (ctypes.c_char * total_size).from_address(dst_ptr)
+        for i in range(num_chunks):
+            offset = i * chunk_size
+            expected = bytes([i + 1]) * chunk_size
+            self.assertEqual(
+                dst_buf[offset : offset + chunk_size], expected,
+                f"Chunk {i} data mismatch"
+            )
+
+        # Cleanup
+        self.store.remove(key)
+        self.store.remove(key + "/__progress__")
+
+    def test_progressive_put_progress_tracking(self):
+        """Test that the sideband progress key is updated after each chunk."""
+        key = "test_progressive_put_progress"
+        chunk_size = 1024
+        num_chunks = 3
+        total_size = chunk_size * num_chunks
+
+        handle = self.store.progressive_put(key, total_size, num_chunks)
+        self.assertIsNotNone(handle)
+
+        progress_key = key + "/__progress__"
+        src_ptr = allocate_registered_buffer(self.store, total_size)
+
+        for i in range(num_chunks):
+            offset = i * chunk_size
+            ctypes.memset(src_ptr + offset, 0xAB, chunk_size)
+            ret = handle.write_chunk(src_ptr + offset, offset, chunk_size)
+            self.assertEqual(ret, 0)
+
+            # Read progress key - should contain (i+1) as uint64_t
+            progress_buf = allocate_registered_buffer(self.store, 8)
+            bytes_read = self.store.get_into(progress_key, progress_buf, 8)
+            self.assertEqual(bytes_read, 8, "Progress key should be 8 bytes")
+            progress_val = struct.unpack(
+                "Q", (ctypes.c_char * 8).from_address(progress_buf)[:]
+            )[0]
+            self.assertEqual(
+                progress_val, i + 1,
+                f"Progress should be {i+1} after writing chunk {i}"
+            )
+
+        handle.seal()
+        self.store.remove(key)
+        self.store.remove(progress_key)
+
+    def test_progressive_put_seal_prevents_further_writes(self):
+        """Test that write_chunk fails after seal."""
+        key = "test_progressive_put_seal_block"
+        chunk_size = 1024
+        num_chunks = 2
+        total_size = chunk_size * num_chunks
+
+        handle = self.store.progressive_put(key, total_size, num_chunks)
+        self.assertIsNotNone(handle)
+
+        src_ptr = allocate_registered_buffer(self.store, chunk_size)
+        ctypes.memset(src_ptr, 0xFF, chunk_size)
+
+        # Write first chunk
+        ret = handle.write_chunk(src_ptr, 0, chunk_size)
+        self.assertEqual(ret, 0)
+
+        # Seal
+        handle.seal()
+
+        # Attempt to write after seal should fail
+        ret = handle.write_chunk(src_ptr, chunk_size, chunk_size)
+        self.assertNotEqual(ret, 0, "write_chunk after seal should fail")
+
+        self.store.remove(key)
+        self.store.remove(key + "/__progress__")
+
+
+class TestProgressiveGet(unittest.TestCase):
+    """Test progressive (streaming) get operations."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.store = MooncakeDistributedStore()
+        get_client(cls.store)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.store.close()
+
+    def test_progressive_get_basic(self):
+        """Test progressive get with per-chunk completion tracking."""
+        key = "test_progressive_get_basic"
+        chunk_size = 4096
+        data = bytes([i % 256 for i in range(chunk_size * 4)])
+
+        # Put full object
+        ret = self.store.put(key, data)
+        self.assertEqual(ret, 0)
+
+        # Progressive get
+        total_size = len(data)
+        dst_ptr = allocate_registered_buffer(self.store, total_size)
+        handle = self.store.progressive_get(key, dst_ptr, total_size, chunk_size)
+        self.assertIsNotNone(handle, "progressive_get should return a handle")
+        self.assertEqual(handle.num_chunks, 4)
+
+        # Wait for all chunks
+        ret = handle.wait_all()
+        self.assertEqual(ret, 0, "wait_all should succeed")
+        self.assertEqual(handle.completed_count, 4)
+
+        # Verify data
+        dst_buf = (ctypes.c_char * total_size).from_address(dst_ptr)
+        self.assertEqual(dst_buf[:], data)
+
+        self.store.remove(key)
+
+    def test_progressive_get_per_chunk_wait(self):
+        """Test waiting for individual chunks."""
+        key = "test_progressive_get_per_chunk"
+        chunk_size = 2048
+        num_chunks = 3
+        total_size = chunk_size * num_chunks
+        data = os.urandom(total_size)
+
+        ret = self.store.put(key, data)
+        self.assertEqual(ret, 0)
+
+        dst_ptr = allocate_registered_buffer(self.store, total_size)
+        handle = self.store.progressive_get(key, dst_ptr, total_size, chunk_size)
+        self.assertIsNotNone(handle)
+
+        # Wait for each chunk individually
+        for i in range(num_chunks):
+            ret = handle.wait_chunk(i)
+            self.assertEqual(ret, 0, f"wait_chunk({i}) should succeed")
+            self.assertTrue(handle.is_chunk_ready(i))
+
+        self.store.remove(key)
+
+
+class TestStreamingScatterRead(unittest.TestCase):
+    """Test streaming batch scatter read operations."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.store = MooncakeDistributedStore()
+        get_client(cls.store)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.store.close()
+
+    def test_streaming_scatter_read_basic(self):
+        """Test scatter read of multiple ranges from multiple keys."""
+        keys = ["scatter_key_0", "scatter_key_1"]
+        chunk_size = 4096
+        data = [os.urandom(chunk_size * 2) for _ in keys]
+
+        # Put objects
+        for k, d in zip(keys, data):
+            ret = self.store.put(k, d)
+            self.assertEqual(ret, 0)
+
+        # Scatter read: read first half of each key
+        total_read_size = chunk_size * len(keys)
+        dst_ptr = allocate_registered_buffer(self.store, total_read_size)
+        dest_offsets = [0, chunk_size]
+        src_offsets = [0, 0]
+        sizes = [chunk_size, chunk_size]
+
+        handle = self.store.streaming_batch_get_buffer_ranges(
+            keys, dst_ptr, dest_offsets, src_offsets, sizes
+        )
+        self.assertIsNotNone(handle)
+        self.assertEqual(handle.num_chunks, 2)
+
+        ret = handle.wait_all()
+        self.assertEqual(ret, 0)
+
+        # Verify data
+        dst_buf = (ctypes.c_char * total_read_size).from_address(dst_ptr)
+        self.assertEqual(dst_buf[0:chunk_size], data[0][:chunk_size])
+        self.assertEqual(
+            dst_buf[chunk_size : chunk_size * 2], data[1][:chunk_size]
+        )
+
+        for k in keys:
+            self.store.remove(k)
+
+
+class TestStreamingPutGetIntegration(unittest.TestCase):
+    """Integration test: writer and reader interleaved via progress key."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.store = MooncakeDistributedStore()
+        get_client(cls.store)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.store.close()
+
+    def test_writer_reader_interleaved(self):
+        """Writer progressively puts chunks; reader polls progress and reads
+        completed chunks using get_into_ranges."""
+        key = "test_streaming_interleaved"
+        progress_key = key + "/__progress__"
+        chunk_size = 4096
+        num_chunks = 4
+        total_size = chunk_size * num_chunks
+
+        # Writer: progressive put in a thread
+        src_ptr = allocate_registered_buffer(self.store, total_size)
+        for i in range(num_chunks):
+            ctypes.memset(src_ptr + i * chunk_size, i + 10, chunk_size)
+
+        write_done = threading.Event()
+        write_errors = []
+
+        def writer():
+            try:
+                handle = self.store.progressive_put(
+                    key, total_size, num_chunks
+                )
+                if handle is None:
+                    write_errors.append("progressive_put returned None")
+                    return
+                for i in range(num_chunks):
+                    offset = i * chunk_size
+                    ret = handle.write_chunk(
+                        src_ptr + offset, offset, chunk_size
+                    )
+                    if ret != 0:
+                        write_errors.append(f"write_chunk {i} failed: {ret}")
+                        return
+                    time.sleep(0.01)  # Simulate async write delay
+                handle.seal()
+            finally:
+                write_done.set()
+
+        writer_thread = threading.Thread(target=writer)
+        writer_thread.start()
+
+        # Reader: poll progress key, then read completed chunks
+        dst_ptr = allocate_registered_buffer(self.store, total_size)
+        ctypes.memset(dst_ptr, 0, total_size)
+        progress_buf = allocate_registered_buffer(self.store, 8)
+        chunks_verified = 0
+
+        deadline = time.time() + 10.0  # 10s timeout
+        while chunks_verified < num_chunks and time.time() < deadline:
+            bytes_read = self.store.get_into(progress_key, progress_buf, 8)
+            if bytes_read != 8:
+                time.sleep(0.005)
+                continue
+            progress_val = struct.unpack(
+                "Q", (ctypes.c_char * 8).from_address(progress_buf)[:]
+            )[0]
+
+            # Read newly available chunks using get_into_ranges
+            while chunks_verified < progress_val:
+                offset = chunks_verified * chunk_size
+                result = read_range_via_get_into_ranges(
+                    self.store, key, dst_ptr, offset, offset, chunk_size
+                )
+                self.assertEqual(
+                    result, chunk_size,
+                    f"get_into_ranges for chunk {chunks_verified} failed: "
+                    f"{result}"
+                )
+                chunks_verified += 1
+
+            time.sleep(0.005)
+
+        writer_thread.join(timeout=5.0)
+        self.assertFalse(writer_thread.is_alive())
+        self.assertEqual(write_errors, [])
+        self.assertEqual(chunks_verified, num_chunks)
+
+        # Verify all data
+        dst_buf = (ctypes.c_char * total_size).from_address(dst_ptr)
+        for i in range(num_chunks):
+            offset = i * chunk_size
+            expected = bytes([i + 10]) * chunk_size
+            self.assertEqual(
+                dst_buf[offset : offset + chunk_size], expected,
+                f"Chunk {i} data mismatch in reader"
+            )
+
+        self.store.remove(key)
+        self.store.remove(progress_key)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Description

  This PR adds streaming scatter read support on top of the existing ranged-read APIs.

  Main changes:
  - add streaming scatter transfer execution path in store transfer tasks
  - expose streaming scatter read support through store client interfaces and Python bindings
  - add progressive/scatter streaming tests and cross-node benchmark coverage
  - update the Python API reference for the new ranged-read/streaming behavior

  This branch was also cleaned up before submission:
  - removed the extra public single-key multi-range API so the public surface stays centered on the generalized
  ranged-read interfaces
  - unified the single-range validation path with the shared internal helper path
  - removed duplicated `submitRangeRead(...)` implementation
  - kept docs/tests/bindings aligned with the final API surface

  ## Module

  - [x] Transfer Engine (`mooncake-transfer-engine`)
  - [x] Mooncake Store (`mooncake-store`)
  - [x] Integration (`mooncake-integration`)
  - [x] Python Wheel (`mooncake-wheel`)
  - [x] Docs
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [ ] PyTorch Backend (`mooncake-pg`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [x] Refactor
  - [ ] Breaking change
  - [x] Documentation update
  - [ ] Other

  ## How Has This Been Tested?

  Tested locally with focused build/test runs on the migrated branch:
  - `transfer_task_test`
  - `scatter_streaming_test`
  - `progressive_get_test`
  - `pybind_client_test`

  Also checked:
  - `git diff --check`

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
  - [x] I have updated the documentation.
  - [x] I have added tests to prove my changes are effective.
