### PR TITLE
[TransferEngine] Add retry, async execution, and graceful shutdown for TENT TCP transport

### DIFF
--- a/mooncake-transfer-engine/tent/config/transfer-engine.json
+++ b/mooncake-transfer-engine/tent/config/transfer-engine.json
@@ -69,6 +69,13 @@
                 "rail_topo_path": "/path/to/rail_topo.json"
             }
         },
+        "tcp": {
+            "enable": true,
+            "max_retry_count": 3,
+            "retry_base_delay_ms": 100,
+            "retry_max_delay_ms": 2000,
+            "max_concurrent_tasks": 16
+        },
         "gds": {
             "enable" : true
         },

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
@@ -15,22 +15,42 @@
 #ifndef TCP_TRANSPORT_H_
 #define TCP_TRANSPORT_H_
 
+#include <atomic>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <queue>
 #include <string>
 
+#include "tent/common/concurrent/thread_pool.h"
 #include "tent/runtime/control_plane.h"
 #include "tent/runtime/transport.h"
 
 namespace mooncake {
 namespace tent {
 
+struct TcpParams {
+    size_t max_retry_count = 3;
+    uint64_t retry_base_delay_ms = 100;   // 100ms initial backoff
+    uint64_t retry_max_delay_ms = 2'000;  // 2s max backoff
+    size_t max_concurrent_tasks = 16;     // worker thread pool size
+};
+
 struct TcpTask {
     Request request;
-    volatile TransferStatusEnum status_word;
-    volatile size_t transferred_bytes;
+    std::atomic<TransferStatusEnum> status_word{TransferStatusEnum::PENDING};
+    std::atomic<size_t> transferred_bytes{0};
     uint64_t target_addr = 0;
+
+    TcpTask() = default;
+    TcpTask(TcpTask &&other) noexcept
+        : request(std::move(other.request)),
+          status_word(other.status_word.load(std::memory_order_relaxed)),
+          transferred_bytes(
+              other.transferred_bytes.load(std::memory_order_relaxed)),
+          target_addr(other.target_addr) {}
+    TcpTask(const TcpTask &) = delete;
+    TcpTask &operator=(const TcpTask &) = delete;
 };
 
 struct TcpSubBatch : public Transport::SubBatch {
@@ -79,6 +99,8 @@ class TcpTransport : public Transport {
    private:
     void startTransfer(TcpTask *task);
 
+    Status doTransferWithRetry(TcpTask *task);
+
     Status findRemoteSegment(uint64_t dest_addr, uint64_t length,
                              uint64_t target_id, std::string &rpc_server_addr);
 
@@ -87,6 +109,9 @@ class TcpTransport : public Transport {
     std::string local_segment_name_;
     std::shared_ptr<Topology> local_topology_;
     std::shared_ptr<ControlService> metadata_;
+    TcpParams params_;
+    std::unique_ptr<ThreadPool> thread_pool_;
+    std::atomic<bool> shutting_down_{false};
 
     RWSpinlock notify_lock_;
     std::vector<Notification> notify_list_;

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -19,14 +19,16 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iomanip>
 #include <memory>
+#include <thread>
 
 #include "tent/common/status.h"
-#include "tent/runtime/slab.h"
 #include "tent/runtime/control_plane.h"
+#include "tent/runtime/slab.h"
 
 namespace mooncake {
 namespace tent {
@@ -71,6 +73,21 @@ Status TcpTransport::install(std::string &local_segment_name,
     metadata_ = metadata;
     local_segment_name_ = local_segment_name;
     local_topology_ = local_topology;
+
+    if (conf) {
+        params_.max_retry_count = conf->get("transports/tcp/max_retry_count",
+                                            params_.max_retry_count);
+        params_.retry_base_delay_ms = conf->get(
+            "transports/tcp/retry_base_delay_ms", params_.retry_base_delay_ms);
+        params_.retry_max_delay_ms = conf->get(
+            "transports/tcp/retry_max_delay_ms", params_.retry_max_delay_ms);
+        params_.max_concurrent_tasks =
+            conf->get("transports/tcp/max_concurrent_tasks",
+                      params_.max_concurrent_tasks);
+    }
+
+    thread_pool_ = std::make_unique<ThreadPool>(params_.max_concurrent_tasks);
+
     installed_ = true;
     metadata_->setNotifyCallback([&](const Notification &message) -> int {
         RWSpinlock::WriteGuard guard(notify_lock_);
@@ -84,11 +101,18 @@ Status TcpTransport::install(std::string &local_segment_name,
         caps.gpu_to_dram = true;
         caps.gpu_to_gpu = true;
     }
+
+    LOG(INFO) << "TCP transport installed: max_retry_count="
+              << params_.max_retry_count
+              << " max_concurrent_tasks=" << params_.max_concurrent_tasks;
     return Status::OK();
 }
 
 Status TcpTransport::uninstall() {
     if (installed_) {
+        if (metadata_) metadata_->setNotifyCallback(nullptr);
+        shutting_down_.store(true, std::memory_order_release);
+        thread_pool_.reset();
         metadata_.reset();
         installed_ = false;
     }
@@ -121,14 +145,21 @@ Status TcpTransport::submitTransferTasks(
         return Status::InvalidArgument("Invalid TCP sub-batch" LOC_MARK);
     if (request_list.size() + tcp_batch->task_list.size() > tcp_batch->max_size)
         return Status::TooManyRequests("Exceed batch capacity" LOC_MARK);
+
+    // Emplace all tasks first, then dispatch — pointers are stable because
+    // task_list was reserved to max_size in allocateSubBatch.
+    size_t start_idx = tcp_batch->task_list.size();
     for (auto &request : request_list) {
-        tcp_batch->task_list.push_back(TcpTask{});
-        auto &task = tcp_batch->task_list[tcp_batch->task_list.size() - 1];
-        uint64_t target_addr = request.target_offset;
-        task.target_addr = target_addr;
+        tcp_batch->task_list.emplace_back();
+        auto &task = tcp_batch->task_list.back();
         task.request = request;
-        task.status_word = TransferStatusEnum::PENDING;
-        startTransfer(&task);
+        task.status_word.store(TransferStatusEnum::PENDING,
+                               std::memory_order_release);
+    }
+
+    for (size_t i = start_idx; i < tcp_batch->task_list.size(); ++i) {
+        TcpTask *task_ptr = &tcp_batch->task_list[i];
+        thread_pool_->enqueue([this, task_ptr]() { startTransfer(task_ptr); });
     }
     return Status::OK();
 }
@@ -140,7 +171,9 @@ Status TcpTransport::getTransferStatus(SubBatchRef batch, int task_id,
         return Status::InvalidArgument("Invalid task id" LOC_MARK);
     }
     auto &task = tcp_batch->task_list[task_id];
-    status = TransferStatus{task.status_word, task.transferred_bytes};
+    status.s = task.status_word.load(std::memory_order_acquire);
+    status.transferred_bytes =
+        task.transferred_bytes.load(std::memory_order_acquire);
     return Status::OK();
 }
 
@@ -164,29 +197,82 @@ void TcpTransport::startTransfer(TcpTask *task) {
                "MC_STORE_MEMCPY=0, TCP local transfers will fail. Enable "
                "MC_STORE_MEMCPY or SHM, or use a non-loopback address.";
     }
+
+    auto status = doTransferWithRetry(task);
+    if (status.ok()) {
+        // Store bytes before status: a reader who acquires COMPLETED will
+        // also see the final transferred_bytes value.
+        task->transferred_bytes.store(task->request.length,
+                                      std::memory_order_release);
+        task->status_word.store(TransferStatusEnum::COMPLETED,
+                                std::memory_order_release);
+    } else {
+        LOG(WARNING) << "TCP transfer failed after " << params_.max_retry_count
+                     << " retries: " << status.ToString();
+        task->status_word.store(TransferStatusEnum::FAILED,
+                                std::memory_order_release);
+    }
+}
+
+Status TcpTransport::doTransferWithRetry(TcpTask *task) {
     std::string rpc_server_addr;
     auto status =
         findRemoteSegment(task->request.target_offset, task->request.length,
                           task->request.target_id, rpc_server_addr);
-    if (!status.ok()) {
-        task->status_word = TransferStatusEnum::FAILED;
-        return;
+    if (!status.ok()) return status;
+
+    Status last_error;
+    uint64_t delay_ms = params_.retry_base_delay_ms;
+
+    for (size_t attempt = 0; attempt <= params_.max_retry_count; ++attempt) {
+        if (shutting_down_.load(std::memory_order_acquire))
+            return Status::InternalError("Transport shutting down");
+
+        if (attempt > 0) {
+            LOG(INFO) << "TCP transfer retry attempt " << attempt << "/"
+                      << params_.max_retry_count << ", backoff " << delay_ms
+                      << "ms";
+            // Sleep in small increments so shutdown is not delayed
+            for (uint64_t i = 0; i < delay_ms; i += 100) {
+                if (shutting_down_.load(std::memory_order_acquire))
+                    return Status::InternalError("Transport shutting down");
+                std::this_thread::sleep_for(std::chrono::milliseconds(
+                    std::min(static_cast<uint64_t>(100), delay_ms - i)));
+            }
+            delay_ms = std::min(delay_ms * 2, params_.retry_max_delay_ms);
+        }
+
+        if (task->request.opcode == Request::WRITE) {
+            status = ControlClient::sendData(
+                rpc_server_addr, task->request.target_offset,
+                task->request.source, task->request.length);
+        } else {
+            status = ControlClient::recvData(
+                rpc_server_addr, task->request.target_offset,
+                task->request.source, task->request.length);
+        }
+
+        if (status.ok()) return Status::OK();
+
+        last_error = status;
+        LOG(WARNING) << "TCP transfer attempt " << attempt
+                     << " failed: " << status.ToString();
+
+        if (!status.IsRpcServiceError() && !status.IsInternalError()) {
+            return status;
+        }
+
+        // Peer may have restarted with a new address; re-resolve before retry
+        if (status.IsRpcServiceError()) {
+            rpc_server_addr.clear();
+            auto resolve = findRemoteSegment(
+                task->request.target_offset, task->request.length,
+                task->request.target_id, rpc_server_addr);
+            if (!resolve.ok()) return resolve;
+        }
     }
-    if (task->request.opcode == Request::WRITE) {
-        status = ControlClient::sendData(
-            rpc_server_addr, task->request.target_offset, task->request.source,
-            task->request.length);
-    } else {
-        status = ControlClient::recvData(
-            rpc_server_addr, task->request.target_offset, task->request.source,
-            task->request.length);
-    }
-    if (!status.ok()) {
-        task->status_word = TransferStatusEnum::FAILED;
-        return;
-    }
-    task->transferred_bytes = task->request.length;
-    task->status_word = TransferStatusEnum::COMPLETED;
+
+    return last_error;
 }
 
 Status TcpTransport::findRemoteSegment(uint64_t dest_addr, uint64_t length,
@@ -230,7 +316,7 @@ Status TcpTransport::sendNotification(SegmentID target_id,
 
 Status TcpTransport::receiveNotification(
     std::vector<Notification> &notify_list) {
-    RWSpinlock::ReadGuard guard(notify_lock_);
+    RWSpinlock::WriteGuard guard(notify_lock_);
     notify_list.clear();
     notify_list.swap(notify_list_);
     return Status::OK();

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -31,3 +31,9 @@ target_include_directories(transfer_engine_config_override_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME transfer_engine_config_override_test
          COMMAND transfer_engine_config_override_test)
+
+add_executable(tent_tcp_transport_test tcp_transport_test.cpp)
+target_link_libraries(tent_tcp_transport_test PRIVATE tent gtest gtest_main)
+target_include_directories(tent_tcp_transport_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_tcp_transport_test COMMAND tent_tcp_transport_test)

--- a/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
@@ -1,0 +1,215 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/transport/tcp/tcp_transport.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// ---------------------------------------------------------------------------
+// TcpParams unit tests
+// ---------------------------------------------------------------------------
+
+TEST(TcpParamsTest, DefaultValues) {
+    TcpParams params;
+    EXPECT_EQ(params.max_retry_count, 3);
+    EXPECT_EQ(params.retry_base_delay_ms, 100ULL);
+    EXPECT_EQ(params.retry_max_delay_ms, 2'000ULL);
+    EXPECT_EQ(params.max_concurrent_tasks, 16);
+}
+
+// ---------------------------------------------------------------------------
+// TcpTask unit tests — atomic semantics
+// ---------------------------------------------------------------------------
+
+TEST(TcpTaskTest, DefaultConstruction) {
+    TcpTask task;
+    EXPECT_EQ(task.status_word.load(), TransferStatusEnum::PENDING);
+    EXPECT_EQ(task.transferred_bytes.load(), 0u);
+    EXPECT_EQ(task.target_addr, 0u);
+}
+
+TEST(TcpTaskTest, AtomicStatusTransitions) {
+    TcpTask task;
+    EXPECT_EQ(task.status_word.load(std::memory_order_acquire),
+              TransferStatusEnum::PENDING);
+
+    task.status_word.store(TransferStatusEnum::COMPLETED,
+                           std::memory_order_release);
+    EXPECT_EQ(task.status_word.load(std::memory_order_acquire),
+              TransferStatusEnum::COMPLETED);
+
+    task.status_word.store(TransferStatusEnum::FAILED,
+                           std::memory_order_release);
+    EXPECT_EQ(task.status_word.load(std::memory_order_acquire),
+              TransferStatusEnum::FAILED);
+}
+
+TEST(TcpTaskTest, AtomicTransferredBytes) {
+    TcpTask task;
+    constexpr size_t kPayload = 1024 * 1024;
+    task.transferred_bytes.store(kPayload, std::memory_order_release);
+    EXPECT_EQ(task.transferred_bytes.load(std::memory_order_acquire), kPayload);
+}
+
+TEST(TcpTaskTest, MoveConstruction) {
+    TcpTask a;
+    a.status_word.store(TransferStatusEnum::COMPLETED,
+                        std::memory_order_relaxed);
+    a.transferred_bytes.store(4096, std::memory_order_relaxed);
+    a.target_addr = 0xdeadbeef;
+
+    TcpTask b(std::move(a));
+    EXPECT_EQ(b.status_word.load(), TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(b.transferred_bytes.load(), 4096u);
+    EXPECT_EQ(b.target_addr, 0xdeadbeef);
+}
+
+// ---------------------------------------------------------------------------
+// TcpSubBatch unit tests
+// ---------------------------------------------------------------------------
+
+TEST(TcpSubBatchTest, EmptyBatch) {
+    TcpSubBatch batch;
+    batch.max_size = 64;
+    EXPECT_EQ(batch.size(), 0u);
+}
+
+TEST(TcpSubBatchTest, EmplaceAndSize) {
+    TcpSubBatch batch;
+    batch.max_size = 64;
+    batch.task_list.reserve(batch.max_size);
+
+    batch.task_list.emplace_back();
+    batch.task_list.emplace_back();
+    batch.task_list.emplace_back();
+    EXPECT_EQ(batch.size(), 3u);
+}
+
+TEST(TcpSubBatchTest, PointerStabilityAfterReserve) {
+    // Verify that pointers taken after reserve remain valid when more
+    // tasks are emplaced (important for async dispatch correctness).
+    TcpSubBatch batch;
+    batch.max_size = 8;
+    batch.task_list.reserve(batch.max_size);
+
+    batch.task_list.emplace_back();
+    TcpTask* first = &batch.task_list[0];
+    first->target_addr = 42;
+
+    // Add more tasks (within reserved capacity)
+    for (int i = 1; i < 8; ++i) {
+        batch.task_list.emplace_back();
+    }
+
+    // First pointer must still be valid
+    EXPECT_EQ(first->target_addr, 42u);
+    EXPECT_EQ(&batch.task_list[0], first);
+}
+
+// ---------------------------------------------------------------------------
+// TcpTransport config loading test
+// ---------------------------------------------------------------------------
+
+TEST(TcpTransportConfigTest, ConfigOverridesDefaults) {
+    auto conf = std::make_shared<Config>();
+    conf->set("transports/tcp/max_retry_count", 5);
+    conf->set("transports/tcp/retry_base_delay_ms", 200ULL);
+    conf->set("transports/tcp/retry_max_delay_ms", 4000ULL);
+    conf->set("transports/tcp/max_concurrent_tasks", 32);
+
+    EXPECT_EQ(conf->get("transports/tcp/max_retry_count", 0), 5);
+    EXPECT_EQ(conf->get("transports/tcp/retry_base_delay_ms", 0ULL), 200ULL);
+    EXPECT_EQ(conf->get("transports/tcp/retry_max_delay_ms", 0ULL), 4000ULL);
+    EXPECT_EQ(conf->get("transports/tcp/max_concurrent_tasks", 0), 32);
+}
+
+TEST(TcpTransportConfigTest, MissingConfigUsesDefaults) {
+    auto conf = std::make_shared<Config>();
+
+    TcpParams defaults;
+    EXPECT_EQ(
+        conf->get("transports/tcp/max_retry_count", defaults.max_retry_count),
+        3);
+    EXPECT_EQ(conf->get("transports/tcp/max_concurrent_tasks",
+                        defaults.max_concurrent_tasks),
+              16);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-thread visibility test (verifies atomic correctness)
+// ---------------------------------------------------------------------------
+
+TEST(TcpTaskTest, CrossThreadVisibility) {
+    TcpTask task;
+    std::atomic<bool> writer_done{false};
+
+    std::thread writer([&]() {
+        task.transferred_bytes.store(8192, std::memory_order_release);
+        task.status_word.store(TransferStatusEnum::COMPLETED,
+                               std::memory_order_release);
+        writer_done.store(true, std::memory_order_release);
+    });
+
+    // Spin until writer signals done
+    while (!writer_done.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    EXPECT_EQ(task.status_word.load(std::memory_order_acquire),
+              TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(task.transferred_bytes.load(std::memory_order_acquire), 8192u);
+
+    writer.join();
+}
+
+// ---------------------------------------------------------------------------
+// Exponential backoff calculation test
+// ---------------------------------------------------------------------------
+
+TEST(TcpRetryBackoffTest, ExponentialGrowthWithCap) {
+    // Simulate the backoff logic from doTransferWithRetry
+    const uint64_t base = 100;
+    const uint64_t cap = 2000;
+    uint64_t delay = base;
+
+    std::vector<uint64_t> delays;
+    for (int attempt = 0; attempt < 6; ++attempt) {
+        delays.push_back(delay);
+        delay = std::min(delay * 2, cap);
+    }
+
+    // 100 → 200 → 400 → 800 → 1600 → 2000 (capped)
+    EXPECT_EQ(delays[0], 100u);
+    EXPECT_EQ(delays[1], 200u);
+    EXPECT_EQ(delays[2], 400u);
+    EXPECT_EQ(delays[3], 800u);
+    EXPECT_EQ(delays[4], 1600u);
+    EXPECT_EQ(delays[5], 2000u);  // capped at retry_max_delay_ms
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

Harden the TENT TCP transport with retry, async dispatch, and proper concurrency primitives.

- Replace `volatile` with `std::atomic` for `TcpTask::status_word` and `transferred_bytes`, fixing undefined behavior on concurrent reads from status pollers and writes from thread pool workers
- Add configurable retry with exponential backoff (`doTransferWithRetry`): resolve segment once via `withCachedSegment` (which handles cache staleness internally), retry only the RPC send/recv, and re-resolve on `RpcServiceError` (peer may have restarted with a new address)
- Dispatch transfers to a `ThreadPool` instead of running synchronously in `submitTransferTasks`
- Add `TcpParams` config struct loaded from JSON (`max_retry_count`, `retry_base_delay_ms`, `retry_max_delay_ms`, `max_concurrent_tasks`)
- Add `shutting_down_` atomic flag so thread pool workers exit promptly on `uninstall()` instead of blocking on backoff sleep
- Fix `receiveNotification`: `ReadGuard` → `WriteGuard` (swap mutates the list)

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix
- [x] New feature

## How Has This Been Tested?

- Added `tent_tcp_transport_test` unit tests covering:
  - `TcpParams` default values
  - `TcpTask` atomic semantics (construction, status transitions, move, cross-thread visibility)
  - `TcpSubBatch` pointer stability after reserve
  - Config override and missing-config-uses-defaults round-tripping
  - Exponential backoff calculation with cap

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.