### PR TITLE
[CI] Restore slash command handler for /run-ci and /run-e2e-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
@@ -764,3 +765,22 @@ jobs:
           echo "All checks passed or were acceptably skipped."
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+
+  cleanup-label:
+    name: Cleanup CI Label
+    if: >
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.action == 'labeled' &&
+      contains(github.event.pull_request.labels.*.name, 'run-ci')
+    needs:
+      - ci-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove run-ci label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "run-ci" 2>/dev/null || true

--- a/.github/workflows/slash-command-handler.yml
+++ b/.github/workflows/slash-command-handler.yml
@@ -1,0 +1,65 @@
+name: Slash Command Handler
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  handle:
+    if: >
+      github.event.issue.pull_request &&
+      (contains(github.event.comment.body, '/run-ci') ||
+       contains(github.event.comment.body, '/run-e2e-ci'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add reaction to acknowledge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content='eyes'
+
+      - name: Check commenter permissions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PERM=$(gh api repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission --jq '.permission')
+          if [[ "$PERM" != "admin" && "$PERM" != "maintain" && "$PERM" != "write" ]]; then
+            echo "::error::User ${{ github.event.comment.user.login }} lacks write permission (has: $PERM)"
+            exit 1
+          fi
+
+      - name: Parse commands and add labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMENT="${{ github.event.comment.body }}"
+          PR_NUMBER=${{ github.event.issue.number }}
+          LABELS=""
+
+          # Use word-boundary matching to avoid /run-e2e-ci triggering /run-ci
+          if echo "$COMMENT" | grep -qw '/run-e2e-ci'; then
+            LABELS="run-e2e-ci"
+          fi
+
+          if echo "$COMMENT" | grep -qw '/run-ci'; then
+            LABELS="${LABELS:+$LABELS,}run-ci"
+          fi
+
+          if [ -n "$LABELS" ]; then
+            gh pr edit "$PR_NUMBER" \
+              --repo ${{ github.repository }} \
+              --add-label "$LABELS"
+          fi
+
+      - name: React with rocket on success
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content='rocket'


### PR DESCRIPTION
## Description

Restore slash command support for triggering CI via PR comments.

The previous handler (removed in #1859) failed for fork PRs because it used
`gh workflow run --ref <fork-branch>`, and fork branches don't exist in the
main repo.

### How mainstream projects handle this

Projects like Kubernetes (Prow `/test`), PyTorch, and many CNCF projects
support slash commands for fork PRs. The common pattern is:

1. `issue_comment` triggers a handler workflow on the **main repo**
2. Handler verifies commenter permissions
3. Handler dispatches the target CI workflow (or adds a label to trigger it)

The key insight is that `issue_comment` always fires on the main repo context,
regardless of whether the PR comes from a fork. The old handler's bug was in
step 3: it used `gh workflow run --ref <fork-branch>`, which fails because
fork branches don't exist in the main repo. Most projects either use
`--ref main` with a SHA parameter, or (as we do here) translate the command
into a label that triggers `pull_request_target`.

### What this PR does

This new handler translates slash commands into labels via
`gh pr edit --add-label`, reusing the existing label-based trigger chain
introduced in #1859. This keeps the label infrastructure intact while
restoring the familiar `/run-ci` and `/run-e2e-ci` comment UX.

Changes:
- Add `slash-command-handler.yml`: listens for `/run-ci` and `/run-e2e-ci`
  comments, checks commenter permissions (write+), adds the corresponding label
- Add `run-ci` label cleanup job to `ci.yml` (`e2e-ci.yml` already has cleanup
  for `run-e2e-ci`). Without cleanup, the sticky label causes every subsequent
  push to bypass path filters and run full CI
- Uses `grep -qw` for word-boundary matching so `/run-e2e-ci` does not
  accidentally trigger `/run-ci`

## Module

- [x] CI/CD

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- Verified `grep -qw` word-boundary matching: `/run-e2e-ci` does NOT match
  `/run-ci`, `/run-ci` matches only itself, both commands in one comment
  are handled independently
- YAML syntax validated with `yaml.safe_load()`
- Existing `ci.yml` and `e2e-ci.yml` label trigger logic is unchanged

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.