### PR TITLE
[WIP][Store] Fix stale metadata after autonomous SSD bucket eviction

### DIFF
--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -206,6 +206,24 @@ class TieredBackend {
                                            UUID dest_tier_id,
                                            bool record_access = true);
 
+    /**
+     * @brief Notify the backend that a StorageTier bucket was autonomously
+     * evicted to free disk space.
+     *
+     * Removes the storage-tier replica from metadata_index_ for each evicted
+     * key and notifies the scheduler via OnDelete. The AllocationHandle
+     * destructor calls StorageTier::Free, which performs the correct per-key
+     * decrement of persisted_live_data_bytes_.
+     *
+     * Does NOT invoke remove_replica_callback_ (no master notification needed
+     * for autonomous local eviction in P2P mode).
+     *
+     * @param evicted_keys Keys that were in the evicted bucket.
+     * @param storage_tier_id UUID of the StorageTier that evicted the bucket.
+     */
+    void NotifyBucketEviction(const std::vector<std::string>& evicted_keys,
+                              UUID storage_tier_id);
+
     // --- Introspection & Internal ---
 
     std::vector<TierView> GetTierViews() const;

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -927,12 +927,14 @@ void TieredBackend::NotifyBucketEviction(
         }
 
         // If the entry became empty, upgrade to a global write lock to remove
-        // the zombie entry from the index (same double-check pattern as Delete).
+        // the zombie entry from the index (same double-check pattern as
+        // Delete).
         if (need_cleanup) {
             std::unique_lock<std::shared_mutex> write_lock(map_mutex_);
             auto it = metadata_index_.find(key);
             if (it != metadata_index_.end()) {
-                std::unique_lock<std::shared_mutex> entry_lock(it->second->mutex);
+                std::unique_lock<std::shared_mutex> entry_lock(
+                    it->second->mutex);
                 if (it->second->replicas.empty()) {
                     metadata_index_.erase(it);
                 }

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -892,4 +892,68 @@ const DataCopier& TieredBackend::GetDataCopier() const {
     return *data_copier_;
 }
 
+void TieredBackend::NotifyBucketEviction(
+    const std::vector<std::string>& evicted_keys, UUID storage_tier_id) {
+    for (const auto& key : evicted_keys) {
+        AllocationHandle handle_to_release;
+        bool found_tier = false;
+        bool need_cleanup = false;
+
+        // Remove the storage-tier replica under the narrowest possible lock
+        // scope (Global Read Lock + per-entry Write Lock), matching the pattern
+        // used by Delete(key, tier_id).
+        {
+            std::shared_lock<std::shared_mutex> read_lock(map_mutex_);
+            auto it = metadata_index_.find(key);
+            if (it == metadata_index_.end()) {
+                // Key was already removed (e.g. logically deleted before the
+                // bucket was evicted).
+                continue;
+            }
+            auto entry = it->second;
+
+            std::unique_lock<std::shared_mutex> entry_write_lock(entry->mutex);
+            for (auto rep_it = entry->replicas.begin();
+                 rep_it != entry->replicas.end(); ++rep_it) {
+                if (rep_it->first == storage_tier_id) {
+                    handle_to_release = std::move(rep_it->second);
+                    entry->replicas.erase(rep_it);
+                    entry->version++;
+                    found_tier = true;
+                    break;
+                }
+            }
+            need_cleanup = found_tier && entry->replicas.empty();
+        }
+
+        // If the entry became empty, upgrade to a global write lock to remove
+        // the zombie entry from the index (same double-check pattern as Delete).
+        if (need_cleanup) {
+            std::unique_lock<std::shared_mutex> write_lock(map_mutex_);
+            auto it = metadata_index_.find(key);
+            if (it != metadata_index_.end()) {
+                std::unique_lock<std::shared_mutex> entry_lock(it->second->mutex);
+                if (it->second->replicas.empty()) {
+                    metadata_index_.erase(it);
+                }
+            }
+        }
+
+        if (!found_tier) {
+            // Storage-tier replica not found (already cleaned up elsewhere).
+            continue;
+        }
+
+        // Release the handle outside all locks.
+        // ~AllocationEntry -> StorageTier::Free -> persisted_live_data_bytes_
+        // is decremented correctly per-key. MarkKeyDeleted is a no-op for keys
+        // already removed from object_bucket_map_ by EvictBucket.
+        handle_to_release = nullptr;
+
+        if (scheduler_) {
+            scheduler_->OnDelete(key, storage_tier_id);
+        }
+    }
+}
+
 }  // namespace mooncake

--- a/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 
 #include "tiered_cache/tiers/storage_tier.h"
+#include "tiered_cache/tiered_backend.h"
 #include "tiered_cache/copier_registry.h"
 #include "utils.h"
 
@@ -390,6 +391,16 @@ tl::expected<size_t, ErrorCode> StorageTier::TriggerBucketEviction(
         }
 
         int64_t bucket_id = select_res.value();
+
+        // Collect keys BEFORE eviction so we can clean up metadata afterwards.
+        std::vector<std::string> bucket_keys;
+        auto keys_res = bucket_backend->GetBucketKeys(bucket_id, bucket_keys);
+        if (!keys_res) {
+            LOG(WARNING) << "Failed to get keys for bucket " << bucket_id
+                         << " before eviction: " << keys_res.error();
+            bucket_keys.clear();
+        }
+
         auto evict_res = bucket_backend->EvictBucket(bucket_id);
         if (!evict_res) {
             LOG(ERROR) << "Failed to evict bucket " << bucket_id << ": "
@@ -399,10 +410,14 @@ tl::expected<size_t, ErrorCode> StorageTier::TriggerBucketEviction(
 
         total_freed = evict_res.value();
 
-        // Update live persisted bytes to reflect cache-visible space freed by
-        // eviction.
-        persisted_live_data_bytes_.fetch_sub(total_freed,
-                                             std::memory_order_acq_rel);
+        // Notify TieredBackend to remove the evicted keys from metadata_index_
+        // and the scheduler's key_cache. The released AllocationHandle
+        // destructors call StorageTier::Free, which decrements
+        // persisted_live_data_bytes_ per-key. Do NOT subtract here to avoid
+        // double-counting.
+        if (backend_ && !bucket_keys.empty()) {
+            backend_->NotifyBucketEviction(bucket_keys, tier_id_);
+        }
 
         LOG(INFO) << "Evicted 1 bucket, freed " << total_freed << " bytes";
         return total_freed;
@@ -425,6 +440,16 @@ tl::expected<size_t, ErrorCode> StorageTier::TriggerBucketEviction(
         }
 
         int64_t bucket_id = select_res.value();
+
+        // Collect keys BEFORE eviction so we can clean up metadata afterwards.
+        std::vector<std::string> bucket_keys;
+        auto keys_res = bucket_backend->GetBucketKeys(bucket_id, bucket_keys);
+        if (!keys_res) {
+            LOG(WARNING) << "Failed to get keys for bucket " << bucket_id
+                         << " before eviction: " << keys_res.error();
+            bucket_keys.clear();
+        }
+
         auto evict_res = bucket_backend->EvictBucket(bucket_id);
         if (!evict_res) {
             LOG(ERROR) << "Failed to evict bucket " << bucket_id << ": "
@@ -438,9 +463,12 @@ tl::expected<size_t, ErrorCode> StorageTier::TriggerBucketEviction(
         total_freed += freed;
         attempts++;
 
-        // Update live persisted bytes to reflect cache-visible space freed by
-        // eviction.
-        persisted_live_data_bytes_.fetch_sub(freed, std::memory_order_acq_rel);
+        // Notify TieredBackend to remove evicted keys from metadata_index_ and
+        // the scheduler. Handles are released here; their destructors decrement
+        // persisted_live_data_bytes_ per-key. Do NOT subtract here.
+        if (backend_ && !bucket_keys.empty()) {
+            backend_->NotifyBucketEviction(bucket_keys, tier_id_);
+        }
 
         LOG(INFO) << "Evicted bucket " << bucket_id << ", freed " << freed
                   << " bytes (total: " << total_freed << "/" << target_free_size

--- a/mooncake-store/tests/tiered_backend_test.cpp
+++ b/mooncake-store/tests/tiered_backend_test.cpp
@@ -1353,4 +1353,214 @@ TEST_F(TieredBackendTest, StoragePrefetch) {
     std::filesystem::remove_all("/tmp/mooncake_test_prefetch");
 }
 
+// ============================================================================
+// Bucket Eviction Metadata Cleanup Tests
+// ============================================================================
+
+// Test that bucket eviction removes stale entries from metadata_index_.
+// Before the fix, TriggerBucketEviction deleted bucket files but left zombie
+// AllocationHandles in metadata_index_ and stale entries in key_cache_shards_.
+// After the fix, NotifyBucketEviction cleans both structures atomically.
+TEST_F(TieredBackendTest, BucketEvictionCleansMetadataIndex) {
+    namespace fs = std::filesystem;
+    const char* test_dir = "/tmp/mooncake_test_bucket_eviction_meta";
+    fs::remove_all(test_dir);
+    fs::create_directories(test_dir);
+
+    // Use bucket storage backend (the default); set a tiny capacity so that
+    // allocating a second round of keys triggers automatic bucket eviction.
+    setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
+           "bucket_storage_backend", 1);
+    setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", test_dir, 1);
+    // 128 KB staging buffer is plenty for a small test.
+    setenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES", "131072", 1);
+
+    // 20 KB SSD capacity: holds ~20 × 1 KB keys.
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "STORAGE",
+                "capacity": 20480,
+                "priority": 5,
+                "tags": ["ssd"]
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    {
+        TieredBackend backend;
+        ASSERT_TRUE(InitTieredBackendForTest(backend, config).has_value());
+
+        UUID storage_id = GetTierIdByPriority(backend, 5).value();
+
+        // --- Step 1: Write 20 keys of 1 KB each to fill the tier ---
+        std::vector<std::string> first_batch_keys;
+        for (int i = 0; i < 20; ++i) {
+            std::string key = "evict_key_" + std::to_string(i);
+            first_batch_keys.push_back(key);
+
+            auto buf = CreateTestBuffer(1024);
+            auto h = AllocateAndWrite(backend, 1024, buf.get(), storage_id);
+            ASSERT_TRUE(h.has_value()) << "Allocation failed for " << key;
+            ASSERT_TRUE(backend.Commit(key, h.value()).has_value());
+        }
+
+        // Flush so data is persisted and staging memory is freed.
+        const_cast<CacheTier*>(backend.GetTier(storage_id))->Flush();
+
+        // All keys should exist before eviction.
+        for (const auto& key : first_batch_keys) {
+            EXPECT_TRUE(backend.Exist(key))
+                << key << " should exist before eviction";
+        }
+
+        // Record usage before eviction.
+        size_t usage_before = 0;
+        for (const auto& tv : backend.GetTierViews()) {
+            if (tv.id == storage_id) usage_before = tv.usage;
+        }
+        EXPECT_GT(usage_before, 0u);
+
+        // --- Step 2: Allocate 5 KB more — triggers TriggerBucketEviction ---
+        auto extra = AllocateAndWrite(backend, 5 * 1024,
+                                      CreateTestBuffer(5 * 1024).get(),
+                                      storage_id);
+        ASSERT_TRUE(extra.has_value())
+            << "Allocation after eviction should succeed";
+        ASSERT_TRUE(backend.Commit("evict_extra_key", extra.value()).has_value());
+
+        // --- Step 3: Verify metadata was cleaned up ---
+
+        // At least some of the original keys must have been evicted.
+        int evicted_count = 0;
+        for (const auto& key : first_batch_keys) {
+            if (!backend.Exist(key)) {
+                ++evicted_count;
+                // Get() must also fail for evicted keys (no zombie handle).
+                auto get_res = backend.Get(key);
+                EXPECT_FALSE(get_res.has_value())
+                    << key << ": Get() should return error for evicted key";
+                if (!get_res.has_value()) {
+                    EXPECT_EQ(get_res.error(), ErrorCode::OBJECT_NOT_FOUND)
+                        << key << ": expected OBJECT_NOT_FOUND";
+                }
+            }
+        }
+        EXPECT_GT(evicted_count, 0) << "At least one key should have been evicted";
+
+        // Tier usage must not underflow (was the double-decrement bug).
+        for (const auto& tv : backend.GetTierViews()) {
+            if (tv.id == storage_id) {
+                EXPECT_LT(tv.usage, usage_before)
+                    << "Usage should decrease after eviction";
+                // usage is a size_t — if it wrapped around (underflow) it would
+                // be an astronomically large number.
+                // If usage wrapped around (underflow) it would be huge.
+                constexpr size_t kSanityLimit = 1ULL << 40;
+                EXPECT_LT(tv.usage, kSanityLimit)
+                    << "Usage underflow detected (double-decrement bug)";
+            }
+        }
+    }
+
+    fs::remove_all(test_dir);
+    unsetenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES");
+}
+
+// Test that bucket eviction of the SSD replica does NOT remove a concurrent
+// DRAM replica of the same key (only the SSD handle is cleaned up).
+TEST_F(TieredBackendTest, BucketEvictionPreservesDRAMReplica) {
+    namespace fs = std::filesystem;
+    const char* test_dir = "/tmp/mooncake_test_bucket_eviction_dram";
+    fs::remove_all(test_dir);
+    fs::create_directories(test_dir);
+
+    setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
+           "bucket_storage_backend", 1);
+    setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", test_dir, 1);
+    setenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES", "131072", 1);
+
+    // Two tiers: DRAM (high priority) + a tiny STORAGE tier (20 KB).
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": 104857600,
+                "priority": 100,
+                "tags": ["dram"],
+                "allocator_type": "OFFSET"
+            },
+            {
+                "type": "STORAGE",
+                "capacity": 20480,
+                "priority": 5,
+                "tags": ["ssd"]
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    {
+        TieredBackend backend;
+        ASSERT_TRUE(InitTieredBackendForTest(backend, config).has_value());
+
+        UUID dram_id = GetTierIdByPriority(backend, 100).value();
+        UUID storage_id = GetTierIdByPriority(backend, 5).value();
+
+        // Write "shared_key" to DRAM.
+        auto buf_dram = CreateTestBuffer(1024);
+        auto h_dram =
+            AllocateAndWrite(backend, 1024, buf_dram.get(), dram_id);
+        ASSERT_TRUE(h_dram.has_value());
+        ASSERT_TRUE(backend.Commit("shared_key", h_dram.value()).has_value());
+
+        // Also create a SSD replica for "shared_key" (simulates MIGRATE).
+        auto buf_ssd = CreateTestBuffer(1024);
+        DataSource src;
+        src.buffer =
+            std::make_unique<TempDRAMBuffer>(std::move(buf_ssd), 1024);
+        src.type = MemoryType::DRAM;
+        ASSERT_TRUE(backend.CopyData("shared_key", src, storage_id).has_value())
+            << "CopyData to SSD failed";
+
+        // Fill the rest of the SSD tier with other keys so eviction is forced.
+        for (int i = 0; i < 19; ++i) {
+            std::string key = "filler_" + std::to_string(i);
+            auto buf = CreateTestBuffer(1024);
+            auto h = AllocateAndWrite(backend, 1024, buf.get(), storage_id);
+            ASSERT_TRUE(h.has_value()) << "Allocation failed for " << key;
+            ASSERT_TRUE(backend.Commit(key, h.value()).has_value());
+        }
+
+        const_cast<CacheTier*>(backend.GetTier(storage_id))->Flush();
+
+        // Trigger eviction by allocating beyond SSD capacity.
+        auto extra =
+            AllocateAndWrite(backend, 5 * 1024,
+                             CreateTestBuffer(5 * 1024).get(), storage_id);
+        ASSERT_TRUE(extra.has_value()) << "Allocation triggering eviction failed";
+        ASSERT_TRUE(
+            backend.Commit("evict_trigger_key", extra.value()).has_value());
+
+        // Regardless of whether "shared_key"'s SSD replica was evicted,
+        // the DRAM replica must always survive.
+        auto dram_get = backend.Get("shared_key", dram_id);
+        EXPECT_TRUE(dram_get.has_value())
+            << "DRAM replica of shared_key must survive SSD bucket eviction";
+        if (dram_get.has_value()) {
+            EXPECT_EQ(dram_get.value()->loc.tier->GetTierId(), dram_id);
+        }
+
+        // The top-level Exist() should still be true (DRAM replica lives).
+        EXPECT_TRUE(backend.Exist("shared_key"))
+            << "shared_key must still exist via DRAM replica";
+    }
+
+    fs::remove_all(test_dir);
+    unsetenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES");
+}
+
 }  // namespace mooncake

--- a/mooncake-store/tests/tiered_backend_test.cpp
+++ b/mooncake-store/tests/tiered_backend_test.cpp
@@ -1424,12 +1424,12 @@ TEST_F(TieredBackendTest, BucketEvictionCleansMetadataIndex) {
         EXPECT_GT(usage_before, 0u);
 
         // --- Step 2: Allocate 5 KB more — triggers TriggerBucketEviction ---
-        auto extra = AllocateAndWrite(backend, 5 * 1024,
-                                      CreateTestBuffer(5 * 1024).get(),
-                                      storage_id);
+        auto extra = AllocateAndWrite(
+            backend, 5 * 1024, CreateTestBuffer(5 * 1024).get(), storage_id);
         ASSERT_TRUE(extra.has_value())
             << "Allocation after eviction should succeed";
-        ASSERT_TRUE(backend.Commit("evict_extra_key", extra.value()).has_value());
+        ASSERT_TRUE(
+            backend.Commit("evict_extra_key", extra.value()).has_value());
 
         // --- Step 3: Verify metadata was cleaned up ---
 
@@ -1448,7 +1448,8 @@ TEST_F(TieredBackendTest, BucketEvictionCleansMetadataIndex) {
                 }
             }
         }
-        EXPECT_GT(evicted_count, 0) << "At least one key should have been evicted";
+        EXPECT_GT(evicted_count, 0)
+            << "At least one key should have been evicted";
 
         // Tier usage must not underflow (was the double-decrement bug).
         for (const auto& tv : backend.GetTierViews()) {
@@ -1512,16 +1513,14 @@ TEST_F(TieredBackendTest, BucketEvictionPreservesDRAMReplica) {
 
         // Write "shared_key" to DRAM.
         auto buf_dram = CreateTestBuffer(1024);
-        auto h_dram =
-            AllocateAndWrite(backend, 1024, buf_dram.get(), dram_id);
+        auto h_dram = AllocateAndWrite(backend, 1024, buf_dram.get(), dram_id);
         ASSERT_TRUE(h_dram.has_value());
         ASSERT_TRUE(backend.Commit("shared_key", h_dram.value()).has_value());
 
         // Also create a SSD replica for "shared_key" (simulates MIGRATE).
         auto buf_ssd = CreateTestBuffer(1024);
         DataSource src;
-        src.buffer =
-            std::make_unique<TempDRAMBuffer>(std::move(buf_ssd), 1024);
+        src.buffer = std::make_unique<TempDRAMBuffer>(std::move(buf_ssd), 1024);
         src.type = MemoryType::DRAM;
         ASSERT_TRUE(backend.CopyData("shared_key", src, storage_id).has_value())
             << "CopyData to SSD failed";
@@ -1538,10 +1537,10 @@ TEST_F(TieredBackendTest, BucketEvictionPreservesDRAMReplica) {
         const_cast<CacheTier*>(backend.GetTier(storage_id))->Flush();
 
         // Trigger eviction by allocating beyond SSD capacity.
-        auto extra =
-            AllocateAndWrite(backend, 5 * 1024,
-                             CreateTestBuffer(5 * 1024).get(), storage_id);
-        ASSERT_TRUE(extra.has_value()) << "Allocation triggering eviction failed";
+        auto extra = AllocateAndWrite(
+            backend, 5 * 1024, CreateTestBuffer(5 * 1024).get(), storage_id);
+        ASSERT_TRUE(extra.has_value())
+            << "Allocation triggering eviction failed";
         ASSERT_TRUE(
             backend.Commit("evict_trigger_key", extra.value()).has_value());
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Problem

When `StorageTier::TriggerBucketEviction` evicted a bucket to reclaim SSD
space, it deleted the bucket files and decremented `persisted_live_data_bytes_`
directly, but **never removed** the corresponding `AllocationHandle`s from
`TieredBackend::metadata_index_` or the scheduler's `key_cache_shards_`.

This caused four concrete bugs:

1. **Data loss on DRAM eviction**: The LRU scheduler checked `key_cache_shards_`
   to decide if a DRAM entry had an SSD backup before evicting it. With stale
   entries, it would evict DRAM data believing a safe SSD copy existed — when it
   had already been deleted.
2. **Silent data loss in `TryFastReclaim`**: The same stale entries caused
   `TryFastReclaim` to discard live DRAM allocations for keys it wrongly believed
   were backed by SSD.
3. **`key_cache_shards_` memory leak**: Evicted keys accumulated in the scheduler
   cache indefinitely, never being cleaned up.
4. **`persisted_live_data_bytes_` double-decrement**: `TriggerBucketEviction`
   did a direct `fetch_sub` on `persisted_live_data_bytes_`, and then releasing
   the stale `AllocationHandle` (e.g., at backend shutdown) would invoke
   `StorageTier::Free` → another `fetch_sub` for the same bytes, causing an
   integer underflow.

## Fix

**`TieredBackend::NotifyBucketEviction`** (new method):

Atomically removes each evicted key's SSD replica from `metadata_index_`,
bumps the entry version (invalidating any concurrent readers), removes the key
entry entirely if no replicas remain, and calls `scheduler_->OnDelete` for
cache invalidation. The released `AllocationHandle` destructors call
`StorageTier::Free`, which performs the `persisted_live_data_bytes_` decrement
exactly once per key.

Does **not** invoke `remove_replica_callback_` — no master RPC is needed for
autonomous local eviction in P2P mode.

**`StorageTier::TriggerBucketEviction`** (both the single-bucket and loop paths):

1. Call `GetBucketKeys(bucket_id)` **before** `EvictBucket` to snapshot the key
   list while the bucket is still tracked in `object_bucket_map_`.
2. After successful eviction, call `backend_->NotifyBucketEviction(bucket_keys, tier_id_)`.
3. Remove the now-incorrect direct `persisted_live_data_bytes_.fetch_sub` calls —
   `StorageTier::Free` handles accounting once per key via the handle destructor.

## Files Changed

| File                                                       | Change                                                                                                                                            |
| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mooncake-store/include/tiered_cache/tiered_backend.h`   | Declare `NotifyBucketEviction` public method                                                                                                    |
| `mooncake-store/src/tiered_cache/tiered_backend.cpp`     | Implement `NotifyBucketEviction`                                                                                                                |
| `mooncake-store/src/tiered_cache/tiers/storage_tier.cpp` | Add `#include "tiered_cache/tiered_backend.h"`; collect bucket keys before eviction; call `NotifyBucketEviction`; remove direct `fetch_sub` |
| `mooncake-store/tests/tiered_backend_test.cpp`           | Add two new unit tests                                                                                                                            |

## Tests

Two new tests in `TieredBackendTest`:

**`BucketEvictionCleansMetadataIndex`**

- Creates a 20 KB STORAGE-only backend, writes 20 × 1 KB keys, flushes to disk.
- Triggers automatic bucket eviction by allocating 5 KB more (exceeds capacity).
- Asserts that evicted keys are no longer reachable via `Exist()` or `Get()` (no
  zombie handles).
- Asserts that `persisted_live_data_bytes_` did not underflow (the
  double-decrement bug).

**`BucketEvictionPreservesDRAMReplica`**

- Creates a DRAM + STORAGE backend; writes `shared_key` to both tiers (simulates
  a MIGRATE operation), then fills the SSD tier with filler keys.
- Triggers SSD bucket eviction by allocating beyond SSD capacity.
- Asserts that the DRAM replica of `shared_key` is still accessible after
  the SSD replica is evicted — only the SSD handle must be removed.

All 32 previously passing tests in `tiered_backend_test` continue to pass.
(`DRAMTierWithNUMA` was already failing in the CI environment due to absent
NUMA hardware — unrelated to this change.)

## Test Plan

```bash
# Inside devcontainer
cd /workspaces/Mooncake/build
cmake .. -DBUILD_UNIT_TESTS=ON -DWITH_P2P_STORE=ON
make -j2 tiered_backend_test storage_tier_test
./mooncake-store/tests/tiered_backend_test --gtest_filter='*BucketEviction*'
./mooncake-store/tests/tiered_backend_test
./mooncake-store/tests/storage_tier_test --gtest_filter='*Eviction*'
```

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [X] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [X] I have updated the documentation.
- [X] I have added tests to prove my changes are effective.
