### PR TITLE
Adding support for prefix queries

### DIFF
--- a/mooncake-store/include/prefix_index.h
+++ b/mooncake-store/include/prefix_index.h
@@ -1,0 +1,352 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "mutex.h"
+#include "types.h"
+
+namespace mooncake {
+
+/**
+ * @brief Summary fields stored at terminal radix nodes (not full metadata).
+ *
+ * Contract: written on first insert for a key; on duplicate insert the
+ * entire struct is replaced (upsert). `size` and `client_id` may both
+ * change when the same key is re-registered (e.g. different tenant).
+ * This is not a snapshot of ObjectMetadata at a single point in time —
+ * it tracks whatever the trie was told last. No replica data; replicas
+ * always come from the hash-sharded index.
+ */
+struct TrieLeafData {
+    /// Object size in bytes from the last successful insert/upsert.
+    uint64_t size;
+
+    /// Client UUID from the last successful insert/upsert.
+    UUID client_id;
+};
+
+/**
+ * @brief A node in the compressed radix tree (Patricia trie).
+ *
+ * Each node represents a compressed edge from its parent. The full key
+ * for a terminal node is reconstructed by concatenating edge_label values
+ * from root to that node.
+ *
+ * Example tree for keys "llama-70b/layer.0/q_proj.weight" and
+ * "llama-70b/layer.1/q_proj.weight":
+ *
+ *   root
+ *    └── "llama-70b/layer." (internal, subtree_count=2)
+ *          ├── "0/q_proj.weight" (terminal)
+ *          └── "1/q_proj.weight" (terminal)
+ */
+struct RadixNode {
+    /// The compressed key segment on the edge FROM parent TO this node.
+    /// For the root node this is always empty.
+    std::string edge_label;
+
+    /// Present (has_value() == true) only when a complete stored key ends
+    /// at this node. A node can be both terminal and have children (e.g.
+    /// "llama-70b/" is a stored key and also a prefix of longer keys).
+    std::optional<TrieLeafData> leaf_data;
+
+    /// Number of terminal nodes in this subtree (including self).
+    /// Enables O(prefix_length) CountByPrefix.
+    size_t subtree_count{0};
+
+    /// Sum of TrieLeafData::size across all terminal nodes in this subtree.
+    /// Enables O(prefix_length) BytesByPrefix for quota checks.
+    uint64_t subtree_bytes{0};
+
+    /// Weak pointer to the parent node. Used for self-cleaning cascade
+    /// on remove. Root node's parent is expired (no parent).
+    std::weak_ptr<RadixNode> parent;
+
+    /// Child nodes keyed on the first character of the child's edge_label.
+    /// In a radix tree no two children can share the same first character.
+    /// std::map keeps children sorted for deterministic iteration order.
+    std::map<char, std::shared_ptr<RadixNode>> children;
+
+    /// @return true if a complete stored key ends at this node.
+    bool is_terminal() const { return leaf_data.has_value(); }
+};
+
+/**
+ * @brief A compressed radix tree (Patricia trie) index for efficient
+ * prefix-based key enumeration, counting, and quota aggregation.
+ *
+ * This is a secondary index alongside the existing hash-sharded
+ * metadata_shards_ in MasterService. It stores only lightweight
+ * TrieLeafData at terminal nodes — no replica information. Replica
+ * data is always read from the authoritative hash-sharded index.
+ *
+ * Thread safety: All public methods are thread-safe. A single SharedMutex
+ * protects the entire trie. Write operations (insert, remove, clear) take
+ * an exclusive lock. Read operations (list_keys_by_prefix,
+ * list_prefix_continuations, count_by_prefix, bytes_by_prefix) take a
+ * shared lock.
+ *
+ * Intended future service/API mapping:
+ * - ListByPrefix            -> list_keys_by_prefix
+ * - GetByPrefix            -> list_entries_by_prefix
+ * - CountByPrefix          -> count_by_prefix
+ * - BytesByPrefix          -> bytes_by_prefix
+ * - ListPrefixContinuations -> list_prefix_continuations
+ *
+ * Lock ordering when used with MasterService:
+ *   1. metadata_shards_[i].mutex  (shard lock, acquired first)
+ *   2. trie_mutex_                (trie lock, acquired inside PrefixIndex)
+ */
+class PrefixIndex {
+   public:
+    PrefixIndex();
+
+    /**
+     * @brief Insert a key into the trie with associated leaf data.
+     *
+     * Handles three cases during traversal:
+     * - Full edge match: consume edge, recurse into matching child.
+     * - Partial edge match: split the existing edge, create intermediate
+     *   node that inherits subtree stats from the split node.
+     * - No match: create a new terminal leaf as a child.
+     *
+     * Increments subtree_count by 1 and adds size to subtree_bytes
+     * on the new terminal node and all ancestors up to root.
+     *
+     * If the key already exists, leaf_data is updated to the new
+     * values (upsert semantics). This ensures client_id stays in
+     * sync when ownership changes on re-register. subtree_bytes
+     * is adjusted if size differs; subtree_count stays unchanged.
+     *
+     * @param key    The full object key string. Must not be empty.
+     * @param size   Object size in bytes (from ObjectMetadata on insert).
+     * @param client_id  Client UUID for this registration (may change on upsert).
+     */
+    void insert(const std::string& key, uint64_t size, const UUID& client_id);
+
+    /**
+     * @brief Remove a key from the trie and trigger self-cleaning cascade.
+     *
+     * Clears leaf_data on the terminal node, decrements subtree_count
+     * and subtree_bytes on all ancestors, then walks upward deleting
+     * any node that is both non-terminal and childless. Stops as soon
+     * as a useful node (has children or leaf_data) is reached.
+     *
+     * Single-child internal nodes are intentionally NOT merged — this
+     * keeps cascade logic simple and future-compatible with fine-grained
+     * locking.
+     *
+     * If the key does not exist, this is a no-op.
+     *
+     * @param key  The full object key string to remove. Must not be empty.
+     */
+    void remove(const std::string& key);
+
+    /**
+     * @brief Remove all keys from the trie.
+     *
+     * Replaces the root with a fresh empty node. All shared_ptr references
+     * to old nodes are released.
+     */
+    void clear();
+
+    /**
+     * @brief Enumerate all stored keys that start with the given prefix.
+     *
+     * Walks the trie to the prefix node, then performs a DFS collecting
+     * all terminal node keys by concatenating edge_labels along the path.
+     *
+     * @param prefix  The prefix to search for. Empty string returns all keys.
+     * @return Vector of full key strings under the prefix, in sorted order
+     *         (due to std::map ordering of children).
+     */
+    std::vector<std::string> list_keys_by_prefix(
+        const std::string& prefix) const;
+
+    /**
+     * @brief Enumerate all stored entries (key + leaf data) under a prefix.
+     *
+     * Same traversal as list_keys_by_prefix but also captures the
+     * TrieLeafData at each terminal node. Collected in a single DFS pass
+     * under one shared-lock acquisition, so the result is a consistent
+     * snapshot of the trie at the time of the call.
+     *
+     * @param prefix  The prefix to search for. Empty string returns all entries.
+     * @return Vector of (key, TrieLeafData) pairs, sorted by key.
+     */
+    std::vector<std::pair<std::string, TrieLeafData>> list_entries_by_prefix(
+        const std::string& prefix) const;
+
+    /**
+     * @brief Enumerate ways to extend `prefix` toward stored keys.
+     *
+     * This is NOT "one output per trie child node" in all cases. Each
+     * returned string `s` is a continuation: `prefix + s` is a prefix of
+     * at least one stored key (or equals a stored key when `s` is the
+     * sole terminal continuation). Results are sorted lexicographically.
+     *
+     * At an internal node boundary, outputs are typically each child's
+     * `edge_label` (possibly with a mid-edge prefix prepended). On a
+     * mid-edge match, the implementation may synthesize continuations that
+     * are not raw child edge labels (e.g. terminal suffix `"c"` when
+     * only `"abc"` exists and the query is `"ab"`).
+     *
+     * Examples:
+     *   list_prefix_continuations("llama-70b/") → ["layer.0/...", ...]
+     *   list_prefix_continuations("ab") with keys "abc/one","abc/two"
+     *     → ["c/one", "c/two"]
+     *   list_prefix_continuations("ab") with only "abc" → ["c"]
+     *
+     * @param prefix  Prefix to extend from (empty = from the root).
+     */
+    std::vector<std::string> list_prefix_continuations(
+        const std::string& prefix) const;
+
+    /**
+     * @brief Count the number of stored keys under a prefix.
+     *
+     * O(prefix_length) — reads subtree_count directly from the prefix node.
+     *
+     * @param prefix  The prefix to count under. Empty string counts all keys.
+     * @return Number of terminal nodes (stored keys) under the prefix.
+     */
+    size_t count_by_prefix(const std::string& prefix) const;
+
+    /**
+     * @brief Get the total bytes of all stored objects under a prefix.
+     *
+     * O(prefix_length) — reads subtree_bytes directly from the prefix node.
+     * Useful for multi-tenant quota checks.
+     *
+     * @param prefix  The prefix to aggregate under.
+     * @return Sum of TrieLeafData::size for all terminal nodes under prefix.
+     */
+    uint64_t bytes_by_prefix(const std::string& prefix) const;
+
+    /**
+     * @brief Get the total number of keys in the trie.
+     * @return The root's subtree_count.
+     */
+    size_t size() const;
+
+   private:
+    /// Root node of the trie. Always non-null. Has empty edge_label
+    /// and expired parent weak_ptr.
+    std::shared_ptr<RadixNode> root_;
+
+    /// Protects the entire trie. Write ops take exclusive lock, read ops
+    /// take shared lock.
+    mutable SharedMutex trie_mutex_;
+
+    /**
+     * @brief Navigate the trie to find the node matching a prefix.
+     *
+     * Handles partial edge matches: if the prefix ends in the middle of
+     * an edge_label, the node owning that edge is returned (the prefix
+     * is a valid prefix of keys under that node).
+     *
+     * @param prefix     The prefix string to navigate to.
+     * @param node_path  If non-null, set to the full concatenation of
+     *                   edge_labels from root to the returned node. This
+     *                   may be longer than prefix when the prefix ends
+     *                   mid-edge (e.g. prefix="mistral" → node_path=
+     *                   "mistral-7b/layer.0/q_proj.weight").
+     * @return The node at the end of the prefix path, or nullptr if not found.
+     */
+    std::shared_ptr<RadixNode> find_prefix_node(
+        const std::string& prefix,
+        std::string* node_path = nullptr) const NO_THREAD_SAFETY_ANALYSIS;
+
+    /**
+     * @brief Recursively collect all terminal key strings under a node.
+     *
+     * @param node         Current node being visited.
+     * @param accumulated  Key string built so far (concatenation of edge_labels
+     *                     from root to current node).
+     * @param out          Output vector to append found keys to.
+     */
+    void dfs_collect_keys(const std::shared_ptr<RadixNode>& node,
+                          const std::string& accumulated,
+                          std::vector<std::string>& out) const;
+
+    /**
+     * @brief Recursively collect all terminal entries (key + leaf data).
+     *
+     * @param node         Current node being visited.
+     * @param accumulated  Key string built so far (concatenation of edge_labels
+     *                     from root to current node).
+     * @param out          Output vector to append (key, TrieLeafData) pairs to.
+     */
+    void dfs_collect_entries(
+        const std::shared_ptr<RadixNode>& node, const std::string& accumulated,
+        std::vector<std::pair<std::string, TrieLeafData>>& out) const;
+
+    /**
+     * @brief Insert implementation without locking (caller must hold
+     *        exclusive lock).
+     *
+     * @param key        The full key to insert.
+     * @param size       Object size in bytes.
+     * @param client_id  Client UUID.
+     */
+    void insert_locked(const std::string& key, uint64_t size,
+                       const UUID& client_id) NO_THREAD_SAFETY_ANALYSIS;
+
+    /**
+     * @brief Remove implementation without locking (caller must hold
+     *        exclusive lock).
+     *
+     * @param key  The full key to remove.
+     */
+    void remove_locked(const std::string& key) NO_THREAD_SAFETY_ANALYSIS;
+
+    /**
+     * @brief Walk upward from a node deleting empty childless nodes.
+     *
+     * No merge of single-child nodes — this keeps the logic simple and
+     * future-compatible with fine-grained (hand-over-hand) locking,
+     * where merge requires locking parent + node + child simultaneously.
+     * The trie may remain slightly less compressed, but correctness
+     * and traversal are unaffected.
+     *
+     * @param node  The node to start cleanup from (the node whose leaf_data
+     *              was just cleared).
+     */
+    void cascade_cleanup(std::shared_ptr<RadixNode> node)
+        NO_THREAD_SAFETY_ANALYSIS;
+
+    /**
+     * @brief Add count and bytes to every ancestor from node up to root.
+     *
+     * All arithmetic is unsigned — no signed-to-unsigned casts needed.
+     *
+     * @param node   The node to start propagation from (inclusive).
+     * @param count  Number of keys added (typically 0 or 1).
+     * @param bytes  Total bytes added.
+     */
+    void increment_ancestors(std::shared_ptr<RadixNode> node, size_t count,
+                             uint64_t bytes) NO_THREAD_SAFETY_ANALYSIS;
+
+    /**
+     * @brief Subtract count and bytes from every ancestor from node up
+     *        to root.
+     *
+     * Asserts that each node's counters are large enough before
+     * subtracting. A firing assert indicates a double-remove or
+     * mismatched size bug.
+     *
+     * @param node   The node to start propagation from (inclusive).
+     * @param count  Number of keys removed (typically 0 or 1).
+     * @param bytes  Total bytes removed.
+     */
+    void decrement_ancestors(std::shared_ptr<RadixNode> node, size_t count,
+                             uint64_t bytes) NO_THREAD_SAFETY_ANALYSIS;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/prefix_index.h
+++ b/mooncake-store/include/prefix_index.h
@@ -126,7 +126,8 @@ class PrefixIndex {
      *
      * @param key    The full object key string. Must not be empty.
      * @param size   Object size in bytes (from ObjectMetadata on insert).
-     * @param client_id  Client UUID for this registration (may change on upsert).
+     * @param client_id  Client UUID for this registration (may change on
+     * upsert).
      */
     void insert(const std::string& key, uint64_t size, const UUID& client_id);
 
@@ -177,7 +178,8 @@ class PrefixIndex {
      * under one shared-lock acquisition, so the result is a consistent
      * snapshot of the trie at the time of the call.
      *
-     * @param prefix  The prefix to search for. Empty string returns all entries.
+     * @param prefix  The prefix to search for. Empty string returns all
+     * entries.
      * @return Vector of (key, TrieLeafData) pairs, sorted by key.
      */
     std::vector<std::pair<std::string, TrieLeafData>> list_entries_by_prefix(

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -1,217 +1,210 @@
-# Find Python package
+#Find Python package
 add_subdirectory(cachelib_memory_allocator)
 
-set(MOONCAKE_STORE_SOURCES
-    allocator.cpp
-    master_service.cpp
-    client_service.cpp
-    client_metric.cpp
-    types.cpp
-    master_client.cpp
-    utils.cpp
-    master_metric_manager.cpp
-    storage_backend.cpp
-    thread_pool.cpp
-    etcd_helper.cpp
-    segment.cpp
-    transfer_task.cpp
-    rpc_service.cpp
-    offset_allocator.cpp
-    posix_file.cpp
-    client_buffer.cpp
-    aligned_client_buffer.cpp
-    real_client.cpp
-    dummy_client.cpp
-    shm_helper.cpp
-    http_metadata_server.cpp
-    file_storage.cpp
-    serialize/serializer.cpp
-    ha/leadership/leader_coordinator_factory.cpp
-    ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
-    ha/common/redis/redis_connection.cpp
-    ha/leadership/backends/redis/redis_leader_coordinator.cpp
-    ha/leadership/master_service_supervisor.cpp
-    ha/standby_controller.cpp
-    ha/snapshot/catalog_backed_snapshot_provider.cpp
-    ha/snapshot/object/snapshot_object_store.cpp
-    ha/snapshot/object/backends/local/local_file_snapshot_object_store.cpp
-    ha/snapshot/object/backends/s3/s3_snapshot_object_store.cpp
-    ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store.cpp
-    ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.cpp
-    utils/type_util.cpp
-    utils/file_util.cpp
-    task_manager.cpp
-    local_hot_cache.cpp
-    ha/oplog/oplog_manager.cpp
-    ha/oplog/etcd_oplog_store.cpp
-    ha/oplog/etcd_oplog_change_notifier.cpp
-    ha/oplog/oplog_serializer.cpp
-    ha/oplog/oplog_store_factory.cpp
-    ha/oplog/oplog_replicator.cpp
-    ha/oplog/oplog_applier.cpp
-    ha/oplog/localfs_oplog_store.cpp
-    ha/oplog/polling_oplog_change_notifier.cpp
-    hot_standby_service.cpp
-    standby_state_machine.cpp
-    ha_metric_manager.cpp
-    store_c.cpp
-    prefix_index.cpp)
+    set(MOONCAKE_STORE_SOURCES allocator.cpp master_service.cpp client_service
+            .cpp client_metric.cpp types.cpp master_client.cpp utils
+            .cpp master_metric_manager.cpp storage_backend.cpp thread_pool
+            .cpp etcd_helper.cpp segment.cpp transfer_task.cpp rpc_service
+            .cpp offset_allocator.cpp posix_file.cpp client_buffer
+            .cpp aligned_client_buffer.cpp real_client.cpp dummy_client
+            .cpp shm_helper.cpp http_metadata_server.cpp file_storage
+            .cpp serialize /
+        serializer.cpp ha / leadership / leader_coordinator_factory.cpp ha /
+        leadership / backends / etcd / etcd_leader_coordinator.cpp ha / common /
+        redis / redis_connection.cpp ha / leadership / backends / redis /
+        redis_leader_coordinator.cpp ha / leadership /
+        master_service_supervisor.cpp ha / standby_controller.cpp ha /
+        snapshot / catalog_backed_snapshot_provider.cpp ha / snapshot / object /
+        snapshot_object_store.cpp ha / snapshot / object / backends / local /
+        local_file_snapshot_object_store.cpp ha / snapshot / object / backends /
+        s3 / s3_snapshot_object_store.cpp ha / snapshot / catalog / backends /
+        embedded / embedded_snapshot_catalog_store.cpp ha / snapshot / catalog /
+        backends / redis / redis_snapshot_catalog_store.cpp utils /
+        type_util.cpp utils /
+        file_util.cpp task_manager.cpp local_hot_cache.cpp ha / oplog /
+        oplog_manager.cpp ha / oplog / etcd_oplog_store.cpp ha / oplog /
+        etcd_oplog_change_notifier.cpp ha / oplog / oplog_serializer.cpp ha /
+        oplog / oplog_store_factory.cpp ha / oplog / oplog_replicator.cpp ha /
+        oplog / oplog_applier.cpp ha / oplog / localfs_oplog_store.cpp ha /
+        oplog /
+        polling_oplog_change_notifier.cpp hot_standby_service
+            .cpp standby_state_machine.cpp ha_metric_manager.cpp store_c
+            .cpp prefix_index.cpp)
 
-set(EXTRA_LIBS "")
+        set(EXTRA_LIBS "")
 
-# Find AWS SDK
-find_package(AWSSDK QUIET COMPONENTS s3)
-if(AWSSDK_FOUND)
-  message(STATUS "AWS SDK found: ${AWSSDK_VERSION}")
-  set(HAVE_AWS_SDK TRUE)
-  # Add S3 related source files
-  list(APPEND MOONCAKE_STORE_SOURCES utils/s3_helper.cpp)
-else()
-  message(STATUS "AWS SDK not found, S3 functionality will be disabled")
-  set(HAVE_AWS_SDK FALSE)
-endif()
+#Find AWS SDK
+            find_package(AWSSDK QUIET COMPONENTS s3) if (AWSSDK_FOUND) message(
+                STATUS
+                "AWS SDK found: ${AWSSDK_VERSION}") set(HAVE_AWS_SDK TRUE)
+#Add S3 related source files
+                list(
+                    APPEND MOONCAKE_STORE_SOURCES utils /
+                    s3_helper.cpp) else() message(STATUS
+                                                  "AWS SDK not found, S3 "
+                                                  "functionality will be "
+                                                  "disabled") set(HAVE_AWS_SDK
+                                                                      FALSE) endif()
 
-# Find zstd library
-find_library(ZSTD_LIBRARY NAMES zstd)
-if(NOT ZSTD_LIBRARY)
-  message(FATAL_ERROR "zstd library not found")
-endif()
+#Find zstd library
+                    find_library(ZSTD_LIBRARY NAMES zstd) if (
+                        NOT ZSTD_LIBRARY) message(FATAL_ERROR
+                                                  "zstd library not found") endif()
 
-set(EXTRA_LIBS ${ZSTD_LIBRARY})
+                        set(EXTRA_LIBS ${ZSTD_LIBRARY})
 
-# If AWS SDK is found, add it to EXTRA_LIBS
-if(HAVE_AWS_SDK)
-  list(APPEND EXTRA_LIBS ${AWSSDK_LINK_LIBRARIES})
-  add_definitions(-DHAVE_AWS_SDK)
-  if(AWS_S3_LIB AND AWS_CORE_LIB)
-    list(APPEND EXTRA_LIBS ${AWS_S3_LIB} ${AWS_CORE_LIB})
-    add_definitions(-DHAVE_AWS_SDK)
-  endif()
-endif()
+#If AWS SDK is found, add it to EXTRA_LIBS
+                            if (HAVE_AWS_SDK) list(APPEND EXTRA_LIBS ${AWSSDK_LINK_LIBRARIES}) add_definitions(
+                                -DHAVE_AWS_SDK) if (AWS_S3_LIB AND
+                                                        AWS_CORE_LIB) list(APPEND EXTRA_LIBS ${
+                                AWS_S3_LIB} ${
+                                AWS_CORE_LIB}) add_definitions(-DHAVE_AWS_SDK) endif() endif()
 
-# Find xxHash (required for ComputeChecksum)
-find_path(
-  XXHASH_INCLUDE_DIR
-  NAMES xxhash.h
-  PATHS /usr/include /usr/local/include)
-find_library(
-  XXHASH_LIBRARY
-  NAMES xxhash libxxhash
-  PATHS /usr/lib /usr/local/lib /usr/lib64)
-if(XXHASH_INCLUDE_DIR AND XXHASH_LIBRARY)
-  message(
-    STATUS "Found xxHash: include=${XXHASH_INCLUDE_DIR} lib=${XXHASH_LIBRARY}")
-  list(APPEND MASTER_EXTRA_INCS ${XXHASH_INCLUDE_DIR})
-else()
-  message(
-    FATAL_ERROR
-      "xxHash library/header not found. Please install xxhash (development headers) and try again."
-  )
-endif()
+#Find xxHash(required for ComputeChecksum)
+                                find_path(
+                                    XXHASH_INCLUDE_DIR NAMES xxhash.h PATHS /
+                                    usr / include / usr / local / include)
+                                    find_library(
+                                        XXHASH_LIBRARY NAMES xxhash libxxhash
+                                            PATHS /
+                                        usr / lib / usr / local / lib / usr /
+                                        lib64) if (XXHASH_INCLUDE_DIR AND
+                                                       XXHASH_LIBRARY) message(STATUS
+                                                                               "Found xxHash: include=${XXHASH_INCLUDE_DIR} lib=${XXHASH_LIBRARY}")
+                                        list(APPEND MASTER_EXTRA_INCS ${XXHASH_INCLUDE_DIR}) else() message(
+                                            FATAL_ERROR
+                                            "xxHash library/header not found. "
+                                            "Please install xxhash "
+                                            "(development headers) and try "
+                                            "again.") endif()
 
-if(USE_3FS)
-  add_subdirectory(hf3fs)
-  list(APPEND MOONCAKE_STORE_SOURCES ${HF3FS_SOURCES})
-  find_library(
-    HF3FS_API_LIB hf3fs_api_shared
-    PATHS /usr/lib
-    NO_DEFAULT_PATH)
-  if(NOT HF3FS_API_LIB)
-    message(FATAL_ERROR "hf3fs_api_shared library not found in /usr/lib")
-  endif()
-  set(EXTRA_LIBS ${HF3FS_API_LIB})
-endif()
+                                            if (USE_3FS) add_subdirectory(hf3fs) list(APPEND MOONCAKE_STORE_SOURCES ${HF3FS_SOURCES}) find_library(
+                                                HF3FS_API_LIB hf3fs_api_shared
+                                                    PATHS /
+                                                usr /
+                                                lib NO_DEFAULT_PATH) if (NOT HF3FS_API_LIB)
+                                                message(
+                                                    FATAL_ERROR
+                                                    "hf3fs_api_shared library "
+                                                    "not found in /usr/lib") endif() set(EXTRA_LIBS ${
+                                                    HF3FS_API_LIB}) endif()
 
-# io_uring support (auto-detected)
-find_library(URING_LIB uring PATHS /usr/lib /usr/lib64 /usr/local/lib
-                                   /usr/local/lib64)
-find_path(URING_INCLUDE liburing.h PATHS /usr/include /usr/local/include)
-if(URING_LIB AND URING_INCLUDE)
-  message(STATUS "io_uring: Enabled for mooncake_store")
-  list(APPEND MOONCAKE_STORE_SOURCES uring_file.cpp)
-  list(APPEND EXTRA_LIBS ${URING_LIB})
-else()
-  message(STATUS "io_uring: Disabled (liburing not found)")
-endif()
+#io_uring support(auto - detected)
+                                                    find_library(URING_LIB uring
+                                                                     PATHS /
+                                                                 usr / lib /
+                                                                 usr / lib64 /
+                                                                 usr / local /
+                                                                 lib / usr /
+                                                                 local /
+                                                                 lib64)
+                                                        find_path(
+                                                            URING_INCLUDE
+                                                                liburing
+                                                                    .h PATHS /
+                                                            usr / include /
+                                                            usr / local /
+                                                            include) if (URING_LIB AND
+                                                                             URING_INCLUDE)
+                                                            message(
+                                                                STATUS
+                                                                "io_uring: "
+                                                                "Enabled for "
+                                                                "mooncake_"
+                                                                "store") list(APPEND MOONCAKE_STORE_SOURCES uring_file
+                                                                                  .cpp) list(APPEND EXTRA_LIBS ${
+                                                                URING_LIB}) else() message(STATUS
+                                                                                           "io_uring: Disabled (liburing not found)") endif()
 
-if(STORE_USE_REDIS)
-  list(APPEND EXTRA_LIBS ${MOONCAKE_STORE_HIREDIS_LIBRARY})
-endif()
+                                                                if (STORE_USE_REDIS) list(
+                                                                    APPEND EXTRA_LIBS
+                                                                        ${MOONCAKE_STORE_HIREDIS_LIBRARY}) endif()
 
-# The cache_allocator library
-include_directories(${Python3_INCLUDE_DIRS})
-add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
-target_include_directories(mooncake_store PUBLIC ${XXHASH_INCLUDE_DIR})
-target_link_libraries(mooncake_store PUBLIC ${XXHASH_LIBRARY})
-if(STORE_USE_REDIS)
-    target_include_directories(mooncake_store PRIVATE
-        ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
-endif()
-# Note: transfer_engine is PRIVATE to avoid propagating its dependencies (e.g., vendor-specific hardware)
-# to targets that don't need it (e.g., mooncake_master).
-# Targets that need transfer_engine should link it explicitly.
-target_link_libraries(mooncake_store
-    PUBLIC
-        cachelib_memory_allocator
-        ${ETCD_WRAPPER_LIB}
-        glog::glog
-        gflags::gflags
-        ${EXTRA_LIBS}
-        asio_shared
-    PRIVATE
-        transfer_engine
-)
-if(STORE_USE_ETCD)
-    add_dependencies(mooncake_store build_etcd_wrapper)
-endif()
+#The cache_allocator library
+                                                                    include_directories(
+                                                                        ${Python3_INCLUDE_DIRS}) add_library(mooncake_store ${
+                                                                        MOONCAKE_STORE_SOURCES}) target_include_directories(mooncake_store PUBLIC ${
+                                                                        XXHASH_INCLUDE_DIR}) target_link_libraries(mooncake_store PUBLIC ${
+                                                                        XXHASH_LIBRARY}) if (STORE_USE_REDIS)
+                                                                        target_include_directories(
+                                                                            mooncake_store PRIVATE
+                                                                                ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR}) endif()
+#Note : transfer_engine is PRIVATE to avoid propagating its dependencies( \
+    e.g., vendor - specific hardware)
+#to targets that don't need it (e.g., mooncake_master).
+#Targets that need transfer_engine should link it explicitly.
+                                                                            target_link_libraries(
+                                                                                mooncake_store PUBLIC cachelib_memory_allocator
+                                                                                    ${ETCD_WRAPPER_LIB} glog::
+                                                                                        glog gflags::gflags
+                                                                                            ${
+                                                                                                EXTRA_LIBS} asio_shared PRIVATE transfer_engine) if (STORE_USE_ETCD) add_dependencies(mooncake_store
+                                                                                                                                                                                          build_etcd_wrapper) endif()
 
-if(URING_LIB AND URING_INCLUDE)
-  target_compile_definitions(mooncake_store PUBLIC USE_URING)
-  target_include_directories(mooncake_store PRIVATE ${URING_INCLUDE})
-endif()
+                                                                                if (URING_LIB AND URING_INCLUDE) target_compile_definitions(
+                                                                                    mooncake_store PUBLIC
+                                                                                        USE_URING) target_include_directories(mooncake_store PRIVATE ${
+                                                                                    URING_INCLUDE}) endif()
 
-if(BUILD_SHARED_LIBS)
-  install(TARGETS mooncake_store DESTINATION lib)
-endif()
+                                                                                    if (BUILD_SHARED_LIBS) install(
+                                                                                        TARGETS
+                                                                                            mooncake_store DESTINATION
+                                                                                                lib) endif()
 
-# Master binary
-add_executable(mooncake_master master.cpp)
+#Master binary
+                                                                                        add_executable(
+                                                                                            mooncake_master
+                                                                                                master
+                                                                                                    .cpp)
 
-set(MASTER_EXTRA_INCS)
-set(MASTER_EXTRA_LIBS)
+                                                                                            set(MASTER_EXTRA_INCS) set(
+                                                                                                MASTER_EXTRA_LIBS)
 
-if(STORE_USE_JEMALLOC)
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(JEMALLOC REQUIRED jemalloc)
-  list(APPEND MASTER_EXTRA_INCS ${JEMALLOC_INCLUDE_DIRS})
-  list(APPEND MASTER_EXTRA_LIBS ${JEMALLOC_STATIC_LIBRARIES})
-endif()
+                                                                                                if (STORE_USE_JEMALLOC) find_package(PkgConfig
+                                                                                                                                         REQUIRED) pkg_check_modules(JEMALLOC
+                                                                                                                                                                         REQUIRED
+                                                                                                                                                                             jemalloc) list(APPEND MASTER_EXTRA_INCS ${JEMALLOC_INCLUDE_DIRS}) list(APPEND MASTER_EXTRA_LIBS
+                                                                                                                                                                                                                                                        ${JEMALLOC_STATIC_LIBRARIES}) endif()
 
-target_include_directories(mooncake_master PRIVATE ${MASTER_EXTRA_INCS})
-target_link_libraries(
-  mooncake_master
-  PRIVATE mooncake_store
-          cachelib_memory_allocator
-          pthread
-          ibverbs
-          mooncake_common
-          ${ETCD_WRAPPER_LIB}
-          ${MASTER_EXTRA_LIBS}
-          asio_shared)
+                                                                                                    target_include_directories(mooncake_master PRIVATE ${MASTER_EXTRA_INCS}) target_link_libraries(mooncake_master
+                                                                                                                                                                                                       PRIVATE mooncake_store
+                                                                                                                                                                                                           cachelib_memory_allocator pthread ibverbs mooncake_common ${
+                                                                                                                                                                                                               ETCD_WRAPPER_LIB} ${
+                                                                                                                                                                                                               MASTER_EXTRA_LIBS} asio_shared)
 
-if(STORE_USE_ETCD)
-  add_dependencies(mooncake_master build_etcd_wrapper)
-endif()
+                                                                                                        if (STORE_USE_ETCD)
+                                                                                                            add_dependencies(
+                                                                                                                mooncake_master
+                                                                                                                    build_etcd_wrapper)
+                                                                                                                endif()
 
-target_compile_options(mooncake_master PRIVATE -Os)
-target_link_options(mooncake_master PRIVATE -Os -s)
+                                                                                                                    target_compile_options(
+                                                                                                                        mooncake_master
+                                                                                                                            PRIVATE -
+                                                                                                                        Os)
+                                                                                                                        target_link_options(
+                                                                                                                            mooncake_master
+                                                                                                                                PRIVATE -
+                                                                                                                            Os -
+                                                                                                                            s)
 
-# Client server binary
-add_executable(mooncake_client real_client_main.cpp)
-# Client needs transfer_engine for data transfer operations
-target_link_libraries(mooncake_client PRIVATE mooncake_store transfer_engine
-                                              asio_shared)
-target_compile_options(mooncake_client PRIVATE -Os)
-target_link_options(mooncake_client PRIVATE -Os -s)
+#Client server binary
+                                                                                                                            add_executable(
+                                                                                                                                mooncake_client
+                                                                                                                                    real_client_main
+                                                                                                                                        .cpp)
+#Client needs transfer_engine for data transfer operations
+                                                                                                                                target_link_libraries(mooncake_client PRIVATE mooncake_store transfer_engine asio_shared) target_compile_options(mooncake_client
+                                                                                                                                                                                                                                                     PRIVATE -
+                                                                                                                                                                                                                                                 Os)
+                                                                                                                                    target_link_options(
+                                                                                                                                        mooncake_client
+                                                                                                                                            PRIVATE -
+                                                                                                                                        Os -
+                                                                                                                                        s)
 
-install(TARGETS mooncake_master mooncake_client DESTINATION bin)
+                                                                                                                                        install(
+                                                                                                                                            TARGETS mooncake_master
+                                                                                                                                                mooncake_client
+                                                                                                                                                    DESTINATION
+                                                                                                                                                        bin)

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -1,210 +1,215 @@
-#Find Python package
+# Find Python package
 add_subdirectory(cachelib_memory_allocator)
 
-    set(MOONCAKE_STORE_SOURCES allocator.cpp master_service.cpp client_service
-            .cpp client_metric.cpp types.cpp master_client.cpp utils
-            .cpp master_metric_manager.cpp storage_backend.cpp thread_pool
-            .cpp etcd_helper.cpp segment.cpp transfer_task.cpp rpc_service
-            .cpp offset_allocator.cpp posix_file.cpp client_buffer
-            .cpp aligned_client_buffer.cpp real_client.cpp dummy_client
-            .cpp shm_helper.cpp http_metadata_server.cpp file_storage
-            .cpp serialize /
-        serializer.cpp ha / leadership / leader_coordinator_factory.cpp ha /
-        leadership / backends / etcd / etcd_leader_coordinator.cpp ha / common /
-        redis / redis_connection.cpp ha / leadership / backends / redis /
-        redis_leader_coordinator.cpp ha / leadership /
-        master_service_supervisor.cpp ha / standby_controller.cpp ha /
-        snapshot / catalog_backed_snapshot_provider.cpp ha / snapshot / object /
-        snapshot_object_store.cpp ha / snapshot / object / backends / local /
-        local_file_snapshot_object_store.cpp ha / snapshot / object / backends /
-        s3 / s3_snapshot_object_store.cpp ha / snapshot / catalog / backends /
-        embedded / embedded_snapshot_catalog_store.cpp ha / snapshot / catalog /
-        backends / redis / redis_snapshot_catalog_store.cpp utils /
-        type_util.cpp utils /
-        file_util.cpp task_manager.cpp local_hot_cache.cpp ha / oplog /
-        oplog_manager.cpp ha / oplog / etcd_oplog_store.cpp ha / oplog /
-        etcd_oplog_change_notifier.cpp ha / oplog / oplog_serializer.cpp ha /
-        oplog / oplog_store_factory.cpp ha / oplog / oplog_replicator.cpp ha /
-        oplog / oplog_applier.cpp ha / oplog / localfs_oplog_store.cpp ha /
-        oplog /
-        polling_oplog_change_notifier.cpp hot_standby_service
-            .cpp standby_state_machine.cpp ha_metric_manager.cpp store_c
-            .cpp prefix_index.cpp)
+set(MOONCAKE_STORE_SOURCES
+    allocator.cpp
+    master_service.cpp
+    client_service.cpp
+    client_metric.cpp
+    types.cpp
+    master_client.cpp
+    utils.cpp
+    master_metric_manager.cpp
+    storage_backend.cpp
+    thread_pool.cpp
+    etcd_helper.cpp
+    segment.cpp
+    transfer_task.cpp
+    rpc_service.cpp
+    offset_allocator.cpp
+    posix_file.cpp
+    client_buffer.cpp
+    aligned_client_buffer.cpp
+    real_client.cpp
+    dummy_client.cpp
+    shm_helper.cpp
+    http_metadata_server.cpp
+    file_storage.cpp
+    serialize/serializer.cpp
+    ha/leadership/leader_coordinator_factory.cpp
+    ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
+    ha/common/redis/redis_connection.cpp
+    ha/leadership/backends/redis/redis_leader_coordinator.cpp
+    ha/leadership/master_service_supervisor.cpp
+    ha/standby_controller.cpp
+    ha/snapshot/catalog_backed_snapshot_provider.cpp
+    ha/snapshot/object/snapshot_object_store.cpp
+    ha/snapshot/object/backends/local/local_file_snapshot_object_store.cpp
+    ha/snapshot/object/backends/s3/s3_snapshot_object_store.cpp
+    ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store.cpp
+    ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.cpp
+    utils/type_util.cpp
+    utils/file_util.cpp
+    task_manager.cpp
+    local_hot_cache.cpp
+    ha/oplog/oplog_manager.cpp
+    ha/oplog/etcd_oplog_store.cpp
+    ha/oplog/etcd_oplog_change_notifier.cpp
+    ha/oplog/oplog_serializer.cpp
+    ha/oplog/oplog_store_factory.cpp
+    ha/oplog/oplog_replicator.cpp
+    ha/oplog/oplog_applier.cpp
+    ha/oplog/localfs_oplog_store.cpp
+    ha/oplog/polling_oplog_change_notifier.cpp
+    hot_standby_service.cpp
+    standby_state_machine.cpp
+    ha_metric_manager.cpp
+    store_c.cpp
+    prefix_index.cpp)
 
-        set(EXTRA_LIBS "")
+set(EXTRA_LIBS "")
 
-#Find AWS SDK
-            find_package(AWSSDK QUIET COMPONENTS s3) if (AWSSDK_FOUND) message(
-                STATUS
-                "AWS SDK found: ${AWSSDK_VERSION}") set(HAVE_AWS_SDK TRUE)
-#Add S3 related source files
-                list(
-                    APPEND MOONCAKE_STORE_SOURCES utils /
-                    s3_helper.cpp) else() message(STATUS
-                                                  "AWS SDK not found, S3 "
-                                                  "functionality will be "
-                                                  "disabled") set(HAVE_AWS_SDK
-                                                                      FALSE) endif()
+# Find AWS SDK
+find_package(AWSSDK QUIET COMPONENTS s3)
+if(AWSSDK_FOUND)
+  message(STATUS "AWS SDK found: ${AWSSDK_VERSION}")
+  set(HAVE_AWS_SDK TRUE)
+  # Add S3 related source files
+  list(APPEND MOONCAKE_STORE_SOURCES utils/s3_helper.cpp)
+else()
+  message(STATUS "AWS SDK not found, S3 functionality will be disabled")
+  set(HAVE_AWS_SDK FALSE)
+endif()
 
-#Find zstd library
-                    find_library(ZSTD_LIBRARY NAMES zstd) if (
-                        NOT ZSTD_LIBRARY) message(FATAL_ERROR
-                                                  "zstd library not found") endif()
+# Find zstd library
+find_library(ZSTD_LIBRARY NAMES zstd)
+if(NOT ZSTD_LIBRARY)
+  message(FATAL_ERROR "zstd library not found")
+endif()
 
-                        set(EXTRA_LIBS ${ZSTD_LIBRARY})
+set(EXTRA_LIBS ${ZSTD_LIBRARY})
 
-#If AWS SDK is found, add it to EXTRA_LIBS
-                            if (HAVE_AWS_SDK) list(APPEND EXTRA_LIBS ${AWSSDK_LINK_LIBRARIES}) add_definitions(
-                                -DHAVE_AWS_SDK) if (AWS_S3_LIB AND
-                                                        AWS_CORE_LIB) list(APPEND EXTRA_LIBS ${
-                                AWS_S3_LIB} ${
-                                AWS_CORE_LIB}) add_definitions(-DHAVE_AWS_SDK) endif() endif()
+# If AWS SDK is found, add it to EXTRA_LIBS
+if(HAVE_AWS_SDK)
+  list(APPEND EXTRA_LIBS ${AWSSDK_LINK_LIBRARIES})
+  add_definitions(-DHAVE_AWS_SDK)
+  if(AWS_S3_LIB AND AWS_CORE_LIB)
+    list(APPEND EXTRA_LIBS ${AWS_S3_LIB} ${AWS_CORE_LIB})
+    add_definitions(-DHAVE_AWS_SDK)
+  endif()
+endif()
 
-#Find xxHash(required for ComputeChecksum)
-                                find_path(
-                                    XXHASH_INCLUDE_DIR NAMES xxhash.h PATHS /
-                                    usr / include / usr / local / include)
-                                    find_library(
-                                        XXHASH_LIBRARY NAMES xxhash libxxhash
-                                            PATHS /
-                                        usr / lib / usr / local / lib / usr /
-                                        lib64) if (XXHASH_INCLUDE_DIR AND
-                                                       XXHASH_LIBRARY) message(STATUS
-                                                                               "Found xxHash: include=${XXHASH_INCLUDE_DIR} lib=${XXHASH_LIBRARY}")
-                                        list(APPEND MASTER_EXTRA_INCS ${XXHASH_INCLUDE_DIR}) else() message(
-                                            FATAL_ERROR
-                                            "xxHash library/header not found. "
-                                            "Please install xxhash "
-                                            "(development headers) and try "
-                                            "again.") endif()
+# Find xxHash (required for ComputeChecksum)
+find_path(
+  XXHASH_INCLUDE_DIR
+  NAMES xxhash.h
+  PATHS /usr/include /usr/local/include)
+find_library(
+  XXHASH_LIBRARY
+  NAMES xxhash libxxhash
+  PATHS /usr/lib /usr/local/lib /usr/lib64)
+if(XXHASH_INCLUDE_DIR AND XXHASH_LIBRARY)
+  message(
+    STATUS "Found xxHash: include=${XXHASH_INCLUDE_DIR} lib=${XXHASH_LIBRARY}")
+  list(APPEND MASTER_EXTRA_INCS ${XXHASH_INCLUDE_DIR})
+else()
+  message(
+    FATAL_ERROR
+      "xxHash library/header not found. Please install xxhash (development headers) and try again."
+  )
+endif()
 
-                                            if (USE_3FS) add_subdirectory(hf3fs) list(APPEND MOONCAKE_STORE_SOURCES ${HF3FS_SOURCES}) find_library(
-                                                HF3FS_API_LIB hf3fs_api_shared
-                                                    PATHS /
-                                                usr /
-                                                lib NO_DEFAULT_PATH) if (NOT HF3FS_API_LIB)
-                                                message(
-                                                    FATAL_ERROR
-                                                    "hf3fs_api_shared library "
-                                                    "not found in /usr/lib") endif() set(EXTRA_LIBS ${
-                                                    HF3FS_API_LIB}) endif()
+if(USE_3FS)
+  add_subdirectory(hf3fs)
+  list(APPEND MOONCAKE_STORE_SOURCES ${HF3FS_SOURCES})
+  find_library(
+    HF3FS_API_LIB hf3fs_api_shared
+    PATHS /usr/lib
+    NO_DEFAULT_PATH)
+  if(NOT HF3FS_API_LIB)
+    message(FATAL_ERROR "hf3fs_api_shared library not found in /usr/lib")
+  endif()
+  set(EXTRA_LIBS ${HF3FS_API_LIB})
+endif()
 
-#io_uring support(auto - detected)
-                                                    find_library(URING_LIB uring
-                                                                     PATHS /
-                                                                 usr / lib /
-                                                                 usr / lib64 /
-                                                                 usr / local /
-                                                                 lib / usr /
-                                                                 local /
-                                                                 lib64)
-                                                        find_path(
-                                                            URING_INCLUDE
-                                                                liburing
-                                                                    .h PATHS /
-                                                            usr / include /
-                                                            usr / local /
-                                                            include) if (URING_LIB AND
-                                                                             URING_INCLUDE)
-                                                            message(
-                                                                STATUS
-                                                                "io_uring: "
-                                                                "Enabled for "
-                                                                "mooncake_"
-                                                                "store") list(APPEND MOONCAKE_STORE_SOURCES uring_file
-                                                                                  .cpp) list(APPEND EXTRA_LIBS ${
-                                                                URING_LIB}) else() message(STATUS
-                                                                                           "io_uring: Disabled (liburing not found)") endif()
+# io_uring support (auto-detected)
+find_library(URING_LIB uring PATHS /usr/lib /usr/lib64 /usr/local/lib
+                                   /usr/local/lib64)
+find_path(URING_INCLUDE liburing.h PATHS /usr/include /usr/local/include)
+if(URING_LIB AND URING_INCLUDE)
+  message(STATUS "io_uring: Enabled for mooncake_store")
+  list(APPEND MOONCAKE_STORE_SOURCES uring_file.cpp)
+  list(APPEND EXTRA_LIBS ${URING_LIB})
+else()
+  message(STATUS "io_uring: Disabled (liburing not found)")
+endif()
 
-                                                                if (STORE_USE_REDIS) list(
-                                                                    APPEND EXTRA_LIBS
-                                                                        ${MOONCAKE_STORE_HIREDIS_LIBRARY}) endif()
+if(STORE_USE_REDIS)
+  list(APPEND EXTRA_LIBS ${MOONCAKE_STORE_HIREDIS_LIBRARY})
+endif()
 
-#The cache_allocator library
-                                                                    include_directories(
-                                                                        ${Python3_INCLUDE_DIRS}) add_library(mooncake_store ${
-                                                                        MOONCAKE_STORE_SOURCES}) target_include_directories(mooncake_store PUBLIC ${
-                                                                        XXHASH_INCLUDE_DIR}) target_link_libraries(mooncake_store PUBLIC ${
-                                                                        XXHASH_LIBRARY}) if (STORE_USE_REDIS)
-                                                                        target_include_directories(
-                                                                            mooncake_store PRIVATE
-                                                                                ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR}) endif()
-#Note : transfer_engine is PRIVATE to avoid propagating its dependencies( \
-    e.g., vendor - specific hardware)
-#to targets that don't need it (e.g., mooncake_master).
-#Targets that need transfer_engine should link it explicitly.
-                                                                            target_link_libraries(
-                                                                                mooncake_store PUBLIC cachelib_memory_allocator
-                                                                                    ${ETCD_WRAPPER_LIB} glog::
-                                                                                        glog gflags::gflags
-                                                                                            ${
-                                                                                                EXTRA_LIBS} asio_shared PRIVATE transfer_engine) if (STORE_USE_ETCD) add_dependencies(mooncake_store
-                                                                                                                                                                                          build_etcd_wrapper) endif()
+# The cache_allocator library
+include_directories(${Python3_INCLUDE_DIRS})
+add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
+target_include_directories(mooncake_store PUBLIC ${XXHASH_INCLUDE_DIR})
+target_link_libraries(mooncake_store PUBLIC ${XXHASH_LIBRARY})
+if(STORE_USE_REDIS)
+  target_include_directories(mooncake_store PRIVATE
+                             ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
+endif()
+# Note: transfer_engine is PRIVATE to avoid propagating its dependencies (e.g., vendor-specific hardware)
+# to targets that don't need it (e.g., mooncake_master).
+# Targets that need transfer_engine should link it explicitly.
+target_link_libraries(
+  mooncake_store
+  PUBLIC cachelib_memory_allocator
+         ${ETCD_WRAPPER_LIB}
+         glog::glog
+         gflags::gflags
+         ${EXTRA_LIBS}
+         asio_shared
+  PRIVATE transfer_engine)
+if(STORE_USE_ETCD)
+  add_dependencies(mooncake_store build_etcd_wrapper)
+endif()
 
-                                                                                if (URING_LIB AND URING_INCLUDE) target_compile_definitions(
-                                                                                    mooncake_store PUBLIC
-                                                                                        USE_URING) target_include_directories(mooncake_store PRIVATE ${
-                                                                                    URING_INCLUDE}) endif()
+if(URING_LIB AND URING_INCLUDE)
+  target_compile_definitions(mooncake_store PUBLIC USE_URING)
+  target_include_directories(mooncake_store PRIVATE ${URING_INCLUDE})
+endif()
 
-                                                                                    if (BUILD_SHARED_LIBS) install(
-                                                                                        TARGETS
-                                                                                            mooncake_store DESTINATION
-                                                                                                lib) endif()
+if(BUILD_SHARED_LIBS)
+  install(TARGETS mooncake_store DESTINATION lib)
+endif()
 
-#Master binary
-                                                                                        add_executable(
-                                                                                            mooncake_master
-                                                                                                master
-                                                                                                    .cpp)
+# Master binary
+add_executable(mooncake_master master.cpp)
 
-                                                                                            set(MASTER_EXTRA_INCS) set(
-                                                                                                MASTER_EXTRA_LIBS)
+set(MASTER_EXTRA_INCS)
+set(MASTER_EXTRA_LIBS)
 
-                                                                                                if (STORE_USE_JEMALLOC) find_package(PkgConfig
-                                                                                                                                         REQUIRED) pkg_check_modules(JEMALLOC
-                                                                                                                                                                         REQUIRED
-                                                                                                                                                                             jemalloc) list(APPEND MASTER_EXTRA_INCS ${JEMALLOC_INCLUDE_DIRS}) list(APPEND MASTER_EXTRA_LIBS
-                                                                                                                                                                                                                                                        ${JEMALLOC_STATIC_LIBRARIES}) endif()
+if(STORE_USE_JEMALLOC)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(JEMALLOC REQUIRED jemalloc)
+  list(APPEND MASTER_EXTRA_INCS ${JEMALLOC_INCLUDE_DIRS})
+  list(APPEND MASTER_EXTRA_LIBS ${JEMALLOC_STATIC_LIBRARIES})
+endif()
 
-                                                                                                    target_include_directories(mooncake_master PRIVATE ${MASTER_EXTRA_INCS}) target_link_libraries(mooncake_master
-                                                                                                                                                                                                       PRIVATE mooncake_store
-                                                                                                                                                                                                           cachelib_memory_allocator pthread ibverbs mooncake_common ${
-                                                                                                                                                                                                               ETCD_WRAPPER_LIB} ${
-                                                                                                                                                                                                               MASTER_EXTRA_LIBS} asio_shared)
+target_include_directories(mooncake_master PRIVATE ${MASTER_EXTRA_INCS})
+target_link_libraries(
+  mooncake_master
+  PRIVATE mooncake_store
+          cachelib_memory_allocator
+          pthread
+          ibverbs
+          mooncake_common
+          ${ETCD_WRAPPER_LIB}
+          ${MASTER_EXTRA_LIBS}
+          asio_shared)
 
-                                                                                                        if (STORE_USE_ETCD)
-                                                                                                            add_dependencies(
-                                                                                                                mooncake_master
-                                                                                                                    build_etcd_wrapper)
-                                                                                                                endif()
+if(STORE_USE_ETCD)
+  add_dependencies(mooncake_master build_etcd_wrapper)
+endif()
 
-                                                                                                                    target_compile_options(
-                                                                                                                        mooncake_master
-                                                                                                                            PRIVATE -
-                                                                                                                        Os)
-                                                                                                                        target_link_options(
-                                                                                                                            mooncake_master
-                                                                                                                                PRIVATE -
-                                                                                                                            Os -
-                                                                                                                            s)
+target_compile_options(mooncake_master PRIVATE -Os)
+target_link_options(mooncake_master PRIVATE -Os -s)
 
-#Client server binary
-                                                                                                                            add_executable(
-                                                                                                                                mooncake_client
-                                                                                                                                    real_client_main
-                                                                                                                                        .cpp)
-#Client needs transfer_engine for data transfer operations
-                                                                                                                                target_link_libraries(mooncake_client PRIVATE mooncake_store transfer_engine asio_shared) target_compile_options(mooncake_client
-                                                                                                                                                                                                                                                     PRIVATE -
-                                                                                                                                                                                                                                                 Os)
-                                                                                                                                    target_link_options(
-                                                                                                                                        mooncake_client
-                                                                                                                                            PRIVATE -
-                                                                                                                                        Os -
-                                                                                                                                        s)
+# Client server binary
+add_executable(mooncake_client real_client_main.cpp)
+# Client needs transfer_engine for data transfer operations
+target_link_libraries(mooncake_client PRIVATE mooncake_store transfer_engine
+                                              asio_shared)
+target_compile_options(mooncake_client PRIVATE -Os)
+target_link_options(mooncake_client PRIVATE -Os -s)
 
-                                                                                                                                        install(
-                                                                                                                                            TARGETS mooncake_master
-                                                                                                                                                mooncake_client
-                                                                                                                                                    DESTINATION
-                                                                                                                                                        bin)
+install(TARGETS mooncake_master mooncake_client DESTINATION bin)

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -144,23 +144,25 @@ add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
 target_include_directories(mooncake_store PUBLIC ${XXHASH_INCLUDE_DIR})
 target_link_libraries(mooncake_store PUBLIC ${XXHASH_LIBRARY})
 if(STORE_USE_REDIS)
-  target_include_directories(mooncake_store PRIVATE
-                             ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
+    target_include_directories(mooncake_store PRIVATE
+        ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
 endif()
 # Note: transfer_engine is PRIVATE to avoid propagating its dependencies (e.g., vendor-specific hardware)
 # to targets that don't need it (e.g., mooncake_master).
 # Targets that need transfer_engine should link it explicitly.
-target_link_libraries(
-  mooncake_store
-  PUBLIC cachelib_memory_allocator
-         ${ETCD_WRAPPER_LIB}
-         glog::glog
-         gflags::gflags
-         ${EXTRA_LIBS}
-         asio_shared
-  PRIVATE transfer_engine)
+target_link_libraries(mooncake_store
+    PUBLIC
+        cachelib_memory_allocator
+        ${ETCD_WRAPPER_LIB}
+        glog::glog
+        gflags::gflags
+        ${EXTRA_LIBS}
+        asio_shared
+    PRIVATE
+        transfer_engine
+)
 if(STORE_USE_ETCD)
-  add_dependencies(mooncake_store build_etcd_wrapper)
+    add_dependencies(mooncake_store build_etcd_wrapper)
 endif()
 
 if(URING_LIB AND URING_INCLUDE)

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -54,7 +54,8 @@ set(MOONCAKE_STORE_SOURCES
     hot_standby_service.cpp
     standby_state_machine.cpp
     ha_metric_manager.cpp
-    store_c.cpp)
+    store_c.cpp
+    prefix_index.cpp)
 
 set(EXTRA_LIBS "")
 

--- a/mooncake-store/src/prefix_index.cpp
+++ b/mooncake-store/src/prefix_index.cpp
@@ -1,0 +1,431 @@
+#include "prefix_index.h"
+
+#include <algorithm>
+#include <cassert>
+
+namespace mooncake {
+
+PrefixIndex::PrefixIndex() : root_(std::make_shared<RadixNode>()) {}
+
+void PrefixIndex::insert(const std::string& key, uint64_t size,
+                         const UUID& client_id) {
+    if (key.empty()) return;
+    SharedMutexLocker lock(&trie_mutex_);
+    insert_locked(key, size, client_id);
+}
+
+void PrefixIndex::remove(const std::string& key) {
+    if (key.empty()) return;
+    SharedMutexLocker lock(&trie_mutex_);
+    remove_locked(key);
+}
+
+void PrefixIndex::clear() {
+    SharedMutexLocker lock(&trie_mutex_);
+    // Discard entire tree; old nodes are freed when last shared_ptr drops.
+    root_ = std::make_shared<RadixNode>();
+}
+
+std::vector<std::string> PrefixIndex::list_keys_by_prefix(
+    const std::string& prefix) const {
+    SharedMutexLocker lock(&trie_mutex_, shared_lock);
+    std::vector<std::string> result;
+
+    if (prefix.empty()) {
+        dfs_collect_keys(root_, "", result);
+        return result;
+    }
+
+    // find_prefix_node may land mid-edge (e.g. prefix="mistral" lands
+    // on node with edge="mistral-7b/..."). node_path is the full
+    // concatenation of edge_labels from root to that node, which may
+    // be longer than prefix. We must use node_path (not prefix) as
+    // the DFS accumulator so emitted keys are reconstructed correctly.
+    std::string node_path;
+    auto node = find_prefix_node(prefix, &node_path);
+    if (!node) return result;
+    dfs_collect_keys(node, node_path, result);
+    return result;
+}
+
+std::vector<std::pair<std::string, TrieLeafData>>
+PrefixIndex::list_entries_by_prefix(const std::string& prefix) const {
+    SharedMutexLocker lock(&trie_mutex_, shared_lock);
+    std::vector<std::pair<std::string, TrieLeafData>> result;
+
+    if (prefix.empty()) {
+        dfs_collect_entries(root_, "", result);
+        return result;
+    }
+
+    std::string node_path;
+    auto node = find_prefix_node(prefix, &node_path);
+    if (!node) return result;
+    dfs_collect_entries(node, node_path, result);
+    return result;
+}
+
+std::vector<std::string> PrefixIndex::list_prefix_continuations(
+    const std::string& prefix) const {
+    SharedMutexLocker lock(&trie_mutex_, shared_lock);
+
+    std::shared_ptr<RadixNode> node;
+    std::string unmatched_suffix;
+
+    if (prefix.empty()) {
+        node = root_;
+    } else {
+        std::string node_path;
+        node = find_prefix_node(prefix, &node_path);
+        if (!node) return {};
+        // When the prefix ends mid-edge (e.g. prefix="ab", node edge=
+        // "abc/"), node_path is "abc/" and the unmatched suffix is "c/".
+        // We prepend this suffix to each child's edge_label so results
+        // are relative to the user's prefix, not the internal node.
+        if (node_path.size() > prefix.size()) {
+            unmatched_suffix = node_path.substr(prefix.size());
+        }
+    }
+    if (!node) return {};
+
+    std::vector<std::string> result;
+
+    // When the prefix lands mid-edge on a terminal node, the unmatched
+    // suffix itself is a continuation (it represents a stored key that
+    // extends the user's prefix). For example, with only "abc" stored,
+    // list_prefix_continuations("ab") should return ["c"] because the key "abc"
+    // continues the prefix "ab" by "c".
+    if (!unmatched_suffix.empty() && node->is_terminal()) {
+        result.push_back(unmatched_suffix);
+    }
+
+    result.reserve(result.size() + node->children.size());
+    for (const auto& [ch, child] : node->children) {
+        result.push_back(unmatched_suffix + child->edge_label);
+    }
+    return result;
+}
+
+size_t PrefixIndex::count_by_prefix(const std::string& prefix) const {
+    SharedMutexLocker lock(&trie_mutex_, shared_lock);
+
+    // O(1) read from root for the empty-prefix case.
+    if (prefix.empty()) return root_->subtree_count;
+
+    auto node = find_prefix_node(prefix);
+    if (!node) return 0;
+    // subtree_count is maintained incrementally by insert/remove,
+    // so this is O(prefix_length) for traversal, O(1) for the read.
+    return node->subtree_count;
+}
+
+uint64_t PrefixIndex::bytes_by_prefix(const std::string& prefix) const {
+    SharedMutexLocker lock(&trie_mutex_, shared_lock);
+
+    if (prefix.empty()) return root_->subtree_bytes;
+
+    auto node = find_prefix_node(prefix);
+    if (!node) return 0;
+    return node->subtree_bytes;
+}
+
+size_t PrefixIndex::size() const {
+    SharedMutexLocker lock(&trie_mutex_, shared_lock);
+    return root_->subtree_count;
+}
+
+std::shared_ptr<RadixNode> PrefixIndex::find_prefix_node(
+    const std::string& prefix, std::string* node_path) const {
+    auto current = root_;
+    size_t pos = 0;
+    // Tracks the full concatenation of edge_labels from root to the
+    // current node. Needed because the prefix may end mid-edge, and
+    // callers (list_keys_by_prefix) need the true path, not the
+    // truncated user prefix.
+    std::string path;
+
+    while (pos < prefix.size()) {
+        // Radix tree invariant: no two children share the same first
+        // character, so lookup by prefix[pos] is unambiguous.
+        char next_char = prefix[pos];
+        auto it = current->children.find(next_char);
+        if (it == current->children.end()) return nullptr;
+
+        auto& child = it->second;
+        const auto& label = child->edge_label;
+
+        // Compare as many characters as both the edge and the remaining
+        // prefix have in common.
+        size_t remaining = prefix.size() - pos;
+        size_t match_len = std::min(label.size(), remaining);
+
+        for (size_t i = 0; i < match_len; ++i) {
+            if (label[i] != prefix[pos + i]) {
+                // Mismatch inside the edge — no node for this prefix.
+                return nullptr;
+            }
+        }
+
+        if (remaining <= label.size()) {
+            // Prefix is fully consumed within (or exactly at the end of)
+            // this edge. The child is the root of the prefix subtree.
+            // node_path includes the FULL edge_label, not just the
+            // matched portion — all keys below this node share it.
+            if (node_path) *node_path = path + label;
+            return child;
+        }
+
+        // Edge fully matched but prefix has more characters — descend.
+        path += label;
+        pos += label.size();
+        current = child;
+    }
+
+    if (node_path) *node_path = path;
+    return current;
+}
+
+void PrefixIndex::dfs_collect_keys(const std::shared_ptr<RadixNode>& node,
+                                   const std::string& accumulated,
+                                   std::vector<std::string>& out) const {
+    if (node->is_terminal()) {
+        out.push_back(accumulated);
+    }
+    for (const auto& [ch, child] : node->children) {
+        dfs_collect_keys(child, accumulated + child->edge_label, out);
+    }
+}
+
+void PrefixIndex::dfs_collect_entries(
+    const std::shared_ptr<RadixNode>& node, const std::string& accumulated,
+    std::vector<std::pair<std::string, TrieLeafData>>& out) const {
+    if (node->is_terminal()) {
+        out.emplace_back(accumulated, node->leaf_data.value());
+    }
+    for (const auto& [ch, child] : node->children) {
+        dfs_collect_entries(child, accumulated + child->edge_label, out);
+    }
+}
+
+void PrefixIndex::increment_ancestors(std::shared_ptr<RadixNode> node,
+                                      size_t count, uint64_t bytes) {
+    while (node) {
+        node->subtree_count += count;
+        node->subtree_bytes += bytes;
+        node = node->parent.lock();
+    }
+}
+
+void PrefixIndex::decrement_ancestors(std::shared_ptr<RadixNode> node,
+                                      size_t count, uint64_t bytes) {
+    while (node) {
+        assert(node->subtree_count >= count);
+        assert(node->subtree_bytes >= bytes);
+        node->subtree_count -= count;
+        node->subtree_bytes -= bytes;
+        node = node->parent.lock();
+    }
+}
+
+void PrefixIndex::insert_locked(const std::string& key, uint64_t size,
+                                const UUID& client_id) {
+    auto current = root_;
+    size_t pos = 0;  // characters of `key` consumed so far
+
+    while (pos < key.size()) {
+        char next_char = key[pos];
+        auto it = current->children.find(next_char);
+
+        if (it == current->children.end()) {
+            // --- Case C: no child starts with this character ---
+            // Create a new leaf whose edge_label is the entire remaining
+            // key suffix. This is the common fast path for disjoint keys.
+            auto leaf = std::make_shared<RadixNode>();
+            leaf->edge_label = key.substr(pos);
+            leaf->leaf_data = TrieLeafData{size, client_id};
+            leaf->subtree_count = 1;
+            leaf->subtree_bytes = size;
+            leaf->parent = current;
+            current->children[next_char] = leaf;
+            increment_ancestors(current, 1, size);
+            return;
+        }
+
+        auto& child = it->second;
+        const auto& label = child->edge_label;
+        size_t remaining = key.size() - pos;
+
+        // Count how many characters the edge and remaining key share.
+        size_t common = 0;
+        size_t limit = std::min(label.size(), remaining);
+        while (common < limit && label[common] == key[pos + common]) {
+            ++common;
+        }
+
+        if (common == label.size()) {
+            if (common == remaining) {
+                // Key ends exactly at this existing node.
+                if (child->is_terminal()) {
+                    // Key already exists — update leaf_data to reflect
+                    // current ownership. client_id can change when a
+                    // different tenant re-registers the same key.
+                    uint64_t old_size = child->leaf_data->size;
+                    child->leaf_data = TrieLeafData{size, client_id};
+                    if (size > old_size) {
+                        increment_ancestors(child, 0, size - old_size);
+                    } else if (size < old_size) {
+                        decrement_ancestors(child, 0, old_size - size);
+                    }
+                    return;
+                }
+                // Node exists as internal; promote it to terminal.
+                child->leaf_data = TrieLeafData{size, client_id};
+                increment_ancestors(child, 1, size);
+                return;
+            }
+            // --- Case A: full edge consumed, key continues ---
+            // Advance past this edge and keep walking.
+            pos += label.size();
+            current = child;
+            continue;
+        }
+
+        // --- Case B: partial edge match — split required ---
+        //
+        // The edge and the remaining key diverge at position `common`.
+        // We must split the existing edge into a shared prefix (mid)
+        // and the diverging suffix (child keeps the tail).
+
+        // Create the intermediate node for the shared prefix.
+        auto mid = std::make_shared<RadixNode>();
+        mid->edge_label = label.substr(0, common);
+        mid->parent = current;
+        // mid inherits the existing subtree stats — the original child's
+        // entire subtree still hangs below mid.
+        mid->subtree_count = child->subtree_count;
+        mid->subtree_bytes = child->subtree_bytes;
+
+        // Shrink the original child's edge to only the diverging suffix.
+        child->edge_label = label.substr(common);
+        child->parent = mid;
+        mid->children[child->edge_label[0]] = child;
+
+        if (common == remaining) {
+            // The new key ends exactly at the split point — mid itself
+            // becomes the terminal node. No separate leaf needed.
+            //
+            // Example: existing edge "abcdef", insert key "abc"
+            //   Before: current --> child("abcdef")
+            //   After:  current --> mid("abc", terminal)
+            //                         └── child("def")
+            mid->leaf_data = TrieLeafData{size, client_id};
+        } else {
+            // The new key diverges — create a separate leaf for the
+            // remaining suffix after the split point.
+            //
+            // Example: existing edge "abcdef", insert key "abcxyz"
+            //   Before: current --> child("abcdef")
+            //   After:  current --> mid("abc")
+            //                         ├── child("def")
+            //                         └── leaf("xyz", terminal)
+            auto leaf = std::make_shared<RadixNode>();
+            leaf->edge_label = key.substr(pos + common);
+            leaf->leaf_data = TrieLeafData{size, client_id};
+            leaf->subtree_count = 1;
+            leaf->subtree_bytes = size;
+            leaf->parent = mid;
+            mid->children[leaf->edge_label[0]] = leaf;
+        }
+
+        // Swap mid into parent's children map (replaces old child entry).
+        current->children[mid->edge_label[0]] = mid;
+
+        // Propagate the new terminal's stats from mid upward to root.
+        increment_ancestors(mid, 1, size);
+        return;
+    }
+
+    // Entire key was consumed by traversal (key is a prefix of an
+    // existing longer key). Mark current node as terminal.
+    if (current->is_terminal()) {
+        // Duplicate — update leaf_data (same logic as above).
+        uint64_t old_size = current->leaf_data->size;
+        current->leaf_data = TrieLeafData{size, client_id};
+        if (size > old_size) {
+            increment_ancestors(current, 0, size - old_size);
+        } else if (size < old_size) {
+            decrement_ancestors(current, 0, old_size - size);
+        }
+    } else {
+        current->leaf_data = TrieLeafData{size, client_id};
+        increment_ancestors(current, 1, size);
+    }
+}
+
+void PrefixIndex::remove_locked(const std::string& key) {
+    auto current = root_;
+    size_t pos = 0;
+
+    while (pos < key.size()) {
+        char next_char = key[pos];
+        auto it = current->children.find(next_char);
+        if (it == current->children.end()) return;  // key not in trie
+
+        auto& child = it->second;
+        const auto& label = child->edge_label;
+        size_t remaining = key.size() - pos;
+
+        // Key is shorter than this edge — can't match any stored key.
+        if (remaining < label.size()) return;
+
+        // Verify the edge label matches the corresponding key segment.
+        if (key.compare(pos, label.size(), label) != 0) return;
+
+        if (label.size() == remaining) {
+            // Reached the node for this key.
+            if (!child->is_terminal()) return;  // internal-only node
+
+            uint64_t removed_size = child->leaf_data->size;
+            // Clear terminal status — node becomes internal-only.
+            child->leaf_data.reset();
+            decrement_ancestors(child, 1, removed_size);
+            // Clean up any now-empty childless nodes upward.
+            cascade_cleanup(child);
+            return;
+        }
+
+        // Edge fully matched but key has more characters — descend.
+        pos += label.size();
+        current = child;
+    }
+
+    // Key was consumed at current node (e.g. "ab" when "ab" is terminal
+    // and "abcdef" also exists).
+    if (current->is_terminal()) {
+        uint64_t removed_size = current->leaf_data->size;
+        current->leaf_data.reset();
+        decrement_ancestors(current, 1, removed_size);
+        cascade_cleanup(current);
+    }
+}
+
+void PrefixIndex::cascade_cleanup(std::shared_ptr<RadixNode> node) {
+    // Walk upward, deleting nodes that are both non-terminal and
+    // childless. Stop as soon as a node is useful (has children or
+    // leaf_data). No single-child merge — intentionally omitted so
+    // future fine-grained locking only needs parent → delete-child,
+    // not the three-node restructure that merge requires.
+    while (node && !node->parent.expired()) {
+        if (node->is_terminal() || !node->children.empty()) break;
+
+        auto parent = node->parent.lock();
+        if (!parent) break;
+
+        // Remove this empty node from parent's children map.
+        parent->children.erase(node->edge_label[0]);
+        // Continue checking parent — it may now be empty too.
+        node = parent;
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/prefix_index.cpp
+++ b/mooncake-store/src/prefix_index.cpp
@@ -345,21 +345,6 @@ void PrefixIndex::insert_locked(const std::string& key, uint64_t size,
         return;
     }
 
-    // Entire key was consumed by traversal (key is a prefix of an
-    // existing longer key). Mark current node as terminal.
-    if (current->is_terminal()) {
-        // Duplicate — update leaf_data (same logic as above).
-        uint64_t old_size = current->leaf_data->size;
-        current->leaf_data = TrieLeafData{size, client_id};
-        if (size > old_size) {
-            increment_ancestors(current, 0, size - old_size);
-        } else if (size < old_size) {
-            decrement_ancestors(current, 0, old_size - size);
-        }
-    } else {
-        current->leaf_data = TrieLeafData{size, client_id};
-        increment_ancestors(current, 1, size);
-    }
 }
 
 void PrefixIndex::remove_locked(const std::string& key) {
@@ -399,14 +384,6 @@ void PrefixIndex::remove_locked(const std::string& key) {
         current = child;
     }
 
-    // Key was consumed at current node (e.g. "ab" when "ab" is terminal
-    // and "abcdef" also exists).
-    if (current->is_terminal()) {
-        uint64_t removed_size = current->leaf_data->size;
-        current->leaf_data.reset();
-        decrement_ancestors(current, 1, removed_size);
-        cascade_cleanup(current);
-    }
 }
 
 void PrefixIndex::cascade_cleanup(std::shared_ptr<RadixNode> node) {

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -1,151 +1,205 @@
-function(add_store_test name)
-  add_executable(${name} ${ARGN})
-  target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-  target_link_libraries(
-    ${name}
-    PUBLIC mooncake_store
-           transfer_engine
-           cachelib_memory_allocator
-           ${ETCD_WRAPPER_LIB}
-           glog
-           ibverbs
-           gtest
-           gtest_main
-           pthread)
-  add_test(NAME ${name} COMMAND ${name})
-endfunction()
+function(add_store_test name) add_executable(${name} ${
+    ARGN}) target_include_directories(${name} PRIVATE ${
+    CMAKE_CURRENT_SOURCE_DIR}) target_link_libraries(${
+    name} PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${
+    ETCD_WRAPPER_LIB} glog ibverbs gtest gtest_main pthread) add_test(NAME ${
+    name} COMMAND ${name}) endfunction()
 
-function(add_ha_test name)
-  add_executable(${name} ${ARGN})
-  target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-  target_link_libraries(
-    ${name}
-    PUBLIC mooncake_store
-           transfer_engine
-           cachelib_memory_allocator
-           ${ETCD_WRAPPER_LIB}
-           glog
-           gflags
-           ibverbs
-           gtest
-           gtest_main
-           pthread)
-  add_test(NAME ${name} COMMAND ${name})
-endfunction()
+    function(add_ha_test name) add_executable(${name} ${
+        ARGN}) target_include_directories(${name} PRIVATE ${
+        CMAKE_CURRENT_SOURCE_DIR}) target_link_libraries(${
+        name} PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${
+        ETCD_WRAPPER_LIB} glog gflags ibverbs gtest gtest_main
+                                                             pthread) add_test(NAME ${
+        name} COMMAND ${name}) endfunction()
 
-add_store_test(buffer_allocator_test buffer_allocator_test.cpp)
-add_store_test(allocation_strategy_test allocation_strategy_test.cpp)
-add_store_test(eviction_strategy_test eviction_strategy_test.cpp)
-add_store_test(master_service_test master_service_test.cpp)
-add_store_test(batch_remove_test batch_remove_test.cpp)
-add_store_test(master_service_ssd_test master_service_ssd_test.cpp)
-add_store_test(master_service_ssd_test_for_snapshot
-               ha/snapshot/master_service_ssd_test_for_snapshot.cpp)
-add_store_test(client_integration_test client_integration_test.cpp)
-if(USE_CXL)
-  add_store_test(cxl_client_integration_test cxl_client_integration_test.cpp)
-endif()
-add_store_test(master_metrics_test master_metrics_test.cpp)
-add_store_test(posix_file_test posix_file_test.cpp)
-add_store_test(thread_pool_test thread_pool_test.cpp)
-add_store_test(transfer_task_test transfer_task_test.cpp)
-add_store_test(segment_test segment_test.cpp)
-add_store_test(offset_allocator_test offset_allocator_test.cpp)
-add_store_test(utils_test utils_test.cpp)
-add_store_test(client_buffer_test client_buffer_test.cpp)
-add_store_test(client_local_hot_cache_test client_local_hot_cache_test.cpp)
-add_store_test(pybind_client_test pybind_client_test.cpp)
-add_store_test(ipv6_client_test ipv6_client_test.cpp)
-add_store_test(client_metrics_test client_metrics_test.cpp)
-add_store_test(serializer_test serializer_test.cpp)
-add_store_test(embedded_snapshot_catalog_store_test
-               ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store_test.cpp)
-add_store_test(zstd_util_test zstd_util_test.cpp)
-add_store_test(local_file_snapshot_object_store_test
-               ha/snapshot/object/backends/local/local_file_snapshot_object_store_test.cpp)
-add_store_test(file_util_test file_util_test.cpp)
-add_store_test(snapshot_child_process_test
-               ha/snapshot/snapshot_child_process_test.cpp)
-add_store_test(master_service_test_for_snapshot
-               ha/snapshot/master_service_test_for_snapshot.cpp)
-add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
-add_store_test(storage_backend_test storage_backend_test.cpp)
-add_store_test(mutex_test mutex_test.cpp)
-add_store_test(file_storage_test file_storage_test.cpp)
-add_store_test(task_manager_test task_manager_test.cpp)
-add_store_test(task_executor_test task_executor_test.cpp)
-add_store_test(task_integration_test task_integration_test.cpp)
-add_store_test(dummy_client_get_buffer_test dummy_client_get_buffer_test.cpp)
-add_store_test(health_check_test health_check_test.cpp)
-add_store_test(prefix_index_test prefix_index_test.cpp)
-add_subdirectory(e2e)
+        add_store_test(buffer_allocator_test buffer_allocator_test.cpp) add_store_test(
+            allocation_strategy_test allocation_strategy_test
+                .cpp) add_store_test(eviction_strategy_test eviction_strategy_test
+                                         .cpp) add_store_test(master_service_test
+                                                                  master_service_test
+                                                                      .cpp)
+            add_store_test(
+                batch_remove_test batch_remove_test
+                    .cpp) add_store_test(master_service_ssd_test
+                                             master_service_ssd_test.cpp)
+                add_store_test(master_service_ssd_test_for_snapshot ha /
+                               snapshot / master_service_ssd_test_for_snapshot.cpp) add_store_test(client_integration_test client_integration_test
+                                                                                                       .cpp) if (USE_CXL) add_store_test(cxl_client_integration_test cxl_client_integration_test
+                                                                                                                                             .cpp) endif() add_store_test(master_metrics_test master_metrics_test
+                                                                                                                                                                              .cpp) add_store_test(posix_file_test
+                                                                                                                                                                                                       posix_file_test
+                                                                                                                                                                                                           .cpp) add_store_test(thread_pool_test
+                                                                                                                                                                                                                                    thread_pool_test
+                                                                                                                                                                                                                                        .cpp) add_store_test(transfer_task_test transfer_task_test
+                                                                                                                                                                                                                                                                 .cpp) add_store_test(segment_test segment_test
+                                                                                                                                                                                                                                                                                          .cpp) add_store_test(offset_allocator_test
+                                                                                                                                                                                                                                                                                                                   offset_allocator_test
+                                                                                                                                                                                                                                                                                                                       .cpp) add_store_test(utils_test utils_test
+                                                                                                                                                                                                                                                                                                                                                .cpp) add_store_test(client_buffer_test
+                                                                                                                                                                                                                                                                                                                                                                         client_buffer_test
+                                                                                                                                                                                                                                                                                                                                                                             .cpp) add_store_test(client_local_hot_cache_test
+                                                                                                                                                                                                                                                                                                                                                                                                      client_local_hot_cache_test
+                                                                                                                                                                                                                                                                                                                                                                                                          .cpp) add_store_test(pybind_client_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                   pybind_client_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                       .cpp) add_store_test(ipv6_client_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                ipv6_client_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                    .cpp) add_store_test(client_metrics_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             client_metrics_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 .cpp) add_store_test(serializer_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          serializer_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              .cpp) add_store_test(embedded_snapshot_catalog_store_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       ha /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   snapshot /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   catalog /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   backends /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   embedded /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   embedded_snapshot_catalog_store_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       .cpp) add_store_test(zstd_util_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                zstd_util_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    .cpp) add_store_test(local_file_snapshot_object_store_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             ha /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         snapshot /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         object /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         backends /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         local /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         local_file_snapshot_object_store_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             .cpp) add_store_test(file_util_test file_util_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      .cpp) add_store_test(snapshot_child_process_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               ha /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           snapshot /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           snapshot_child_process_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               .cpp) add_store_test(master_service_test_for_snapshot
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ha /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    snapshot /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    master_service_test_for_snapshot
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        .cpp) add_store_test(non_ha_reconnect_test non_ha_reconnect_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 .cpp) add_store_test(storage_backend_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          storage_backend_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              .cpp) add_store_test(mutex_test mutex_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       .cpp) add_store_test(file_storage_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                file_storage_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    .cpp) add_store_test(task_manager_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             task_manager_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 .cpp) add_store_test(task_executor_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          task_executor_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              .cpp) add_store_test(task_integration_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       task_integration_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           .cpp) add_store_test(dummy_client_get_buffer_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    dummy_client_get_buffer_test
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        .cpp)
+                    add_store_test(
+                        health_check_test health_check_test
+                            .cpp) add_store_test(prefix_index_test
+                                                     prefix_index_test.cpp) add_subdirectory(e2e)
 
-add_executable(high_availability_test ha/leadership/high_availability_test.cpp)
-target_include_directories(high_availability_test PRIVATE
-                           ${CMAKE_CURRENT_SOURCE_DIR})
-if(STORE_USE_REDIS)
-    target_sources(high_availability_test PRIVATE
-        ha/leadership/backends/redis/high_availability_redis_test.cpp)
-    target_include_directories(high_availability_test PRIVATE
-        ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
-    target_link_libraries(high_availability_test PRIVATE
-        ${MOONCAKE_STORE_HIREDIS_LIBRARY})
+                        add_executable(
+                            high_availability_test
+                                ha /
+                            leadership /
+                            high_availability_test
+                                .cpp) target_include_directories(high_availability_test PRIVATE ${
+                            CMAKE_CURRENT_SOURCE_DIR}) if (STORE_USE_REDIS)
+                            target_sources(
+                                high_availability_test
+                                    PRIVATE
+                                        ha /
+                                leadership / backends /
+                                redis /
+                                high_availability_redis_test
+                                    .cpp) target_include_directories(high_availability_test PRIVATE ${
+                                MOONCAKE_STORE_HIREDIS_INCLUDE_DIR}) target_link_libraries(high_availability_test PRIVATE ${
+                                MOONCAKE_STORE_HIREDIS_LIBRARY})
 
-    add_executable(redis_snapshot_catalog_store_test
-                   ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store_test.cpp)
-    target_include_directories(redis_snapshot_catalog_store_test PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
-    target_link_libraries(redis_snapshot_catalog_store_test
-        PUBLIC mooncake_store transfer_engine cachelib_memory_allocator
-               ${ETCD_WRAPPER_LIB} glog gflags ibverbs gtest pthread
-        PRIVATE ${MOONCAKE_STORE_HIREDIS_LIBRARY})
-    add_test(NAME redis_snapshot_catalog_store_test
-             COMMAND redis_snapshot_catalog_store_test)
-endif()
-target_link_libraries(high_availability_test PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gtest gtest_main pthread)
-if (STORE_USE_ETCD OR STORE_USE_REDIS)
-    add_test(NAME high_availability_test COMMAND high_availability_test)
-endif()
+                                add_executable(
+                                    redis_snapshot_catalog_store_test ha /
+                                    snapshot / catalog / backends /
+                                    redis /
+                                    redis_snapshot_catalog_store_test
+                                        .cpp) target_include_directories(redis_snapshot_catalog_store_test PRIVATE
+                                                                             ${CMAKE_CURRENT_SOURCE_DIR} ${
+                                                                                 MOONCAKE_STORE_HIREDIS_INCLUDE_DIR}) target_link_libraries(redis_snapshot_catalog_store_test PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gflags ibverbs gtest pthread
+                                                                                                                                                PRIVATE
+                                                                                                                                                    ${
+                                                                                                                                                        MOONCAKE_STORE_HIREDIS_LIBRARY}) add_test(NAME
+                                                                                                                                                                                                      redis_snapshot_catalog_store_test
+                                                                                                                                                                                                          COMMAND redis_snapshot_catalog_store_test) endif() target_link_libraries(high_availability_test PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${
+                                    ETCD_WRAPPER_LIB} glog gtest gtest_main pthread) if (STORE_USE_ETCD OR STORE_USE_REDIS) add_test(NAME high_availability_test COMMAND high_availability_test) endif()
 
-add_executable(stress_workload_test stress_workload_test.cpp)
-target_link_libraries(
-  stress_workload_test
-  PUBLIC mooncake_store
-         transfer_engine
-         cachelib_memory_allocator
-         ${ETCD_WRAPPER_LIB}
-         mooncake_common
-         glog
-         gflags
-         pthread)
+                                    add_executable(
+                                        stress_workload_test stress_workload_test
+                                            .cpp) target_link_libraries(stress_workload_test PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${
+                                        ETCD_WRAPPER_LIB} mooncake_common glog gflags pthread)
 
-# HA tests
-add_ha_test(standby_state_machine_test
-            ha/standby/standby_state_machine_test.cpp)
-add_ha_test(ha_metric_manager_test
-            ha/standby/ha_metric_manager_test.cpp)
-add_ha_test(hot_standby_service_test
-            ha/standby/hot_standby_service_test.cpp)
-add_ha_test(hot_standby_snapshot_bootstrap_test
-            ha/standby/hot_standby_snapshot_bootstrap_test.cpp)
-add_ha_test(oplog_applier_test ha/oplog/oplog_applier_test.cpp)
-add_ha_test(oplog_manager_test ha/oplog/oplog_manager_test.cpp)
-add_ha_test(etcd_oplog_store_test ha/oplog/etcd_oplog_store_test.cpp)
-add_ha_test(oplog_replicator_test ha/oplog/oplog_replicator_test.cpp)
-add_ha_test(oplog_serializer_test ha/oplog/oplog_serializer_test.cpp)
-add_ha_test(localfs_oplog_store_test ha/oplog/localfs_oplog_store_test.cpp)
-add_ha_test(ha_recovery_test ha/oplog/ha_recovery_test.cpp)
-add_ha_test(localfs_hot_standby_integration_test
-            ha/oplog/localfs_hot_standby_integration_test.cpp)
-add_ha_test(catalog_backed_snapshot_provider_test
-            ha/snapshot/catalog_backed_snapshot_provider_test.cpp)
-if(STORE_USE_REDIS)
-  foreach(target catalog_backed_snapshot_provider_test
-                 hot_standby_snapshot_bootstrap_test)
-    target_include_directories(${target} PRIVATE
-                               ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
-    target_link_libraries(${target}
-                          PRIVATE ${MOONCAKE_STORE_HIREDIS_LIBRARY})
-  endforeach()
-endif()
+#HA tests
+                                        add_ha_test(
+                                            standby_state_machine_test ha /
+                                            standby /
+                                            standby_state_machine_test.cpp)
+                                            add_ha_test(
+                                                ha_metric_manager_test ha /
+                                                standby /
+                                                ha_metric_manager_test.cpp)
+                                                add_ha_test(
+                                                    hot_standby_service_test
+                                                        ha /
+                                                    standby /
+                                                    hot_standby_service_test
+                                                        .cpp)
+                                                    add_ha_test(
+                                                        hot_standby_snapshot_bootstrap_test
+                                                            ha /
+                                                        standby /
+                                                        hot_standby_snapshot_bootstrap_test
+                                                            .cpp) add_ha_test(oplog_applier_test
+                                                                                  ha /
+                                                                              oplog /
+                                                                              oplog_applier_test
+                                                                                  .cpp)
+                                                        add_ha_test(
+                                                            oplog_manager_test
+                                                                ha /
+                                                            oplog /
+                                                            oplog_manager_test
+                                                                .cpp) add_ha_test(etcd_oplog_store_test ha /
+                                                                                  oplog /
+                                                                                  etcd_oplog_store_test
+                                                                                      .cpp)
+                                                            add_ha_test(
+                                                                oplog_replicator_test
+                                                                    ha /
+                                                                oplog /
+                                                                oplog_replicator_test
+                                                                    .cpp) add_ha_test(oplog_serializer_test ha /
+                                                                                      oplog /
+                                                                                      oplog_serializer_test
+                                                                                          .cpp)
+                                                                add_ha_test(
+                                                                    localfs_oplog_store_test
+                                                                        ha /
+                                                                    oplog /
+                                                                    localfs_oplog_store_test
+                                                                        .cpp) add_ha_test(ha_recovery_test
+                                                                                              ha /
+                                                                                          oplog /
+                                                                                          ha_recovery_test
+                                                                                              .cpp)
+                                                                    add_ha_test(
+                                                                        localfs_hot_standby_integration_test
+                                                                            ha /
+                                                                        oplog /
+                                                                        localfs_hot_standby_integration_test
+                                                                            .cpp) add_ha_test(catalog_backed_snapshot_provider_test
+                                                                                                  ha /
+                                                                                              snapshot /
+                                                                                              catalog_backed_snapshot_provider_test
+                                                                                                  .cpp) if (STORE_USE_REDIS) foreach (target
+                                                                                                                                          catalog_backed_snapshot_provider_test hot_standby_snapshot_bootstrap_test)
+                                                                        target_include_directories(
+                                                                            ${target} PRIVATE
+                                                                                ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
+                                                                            target_link_libraries(
+                                                                                ${target} PRIVATE
+                                                                                    ${MOONCAKE_STORE_HIREDIS_LIBRARY})
+                                                                                endforeach()
+                                                                                    endif()

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ add_store_test(task_executor_test task_executor_test.cpp)
 add_store_test(task_integration_test task_integration_test.cpp)
 add_store_test(dummy_client_get_buffer_test dummy_client_get_buffer_test.cpp)
 add_store_test(health_check_test health_check_test.cpp)
+add_store_test(prefix_index_test prefix_index_test.cpp)
 add_subdirectory(e2e)
 
 add_executable(high_availability_test ha/leadership/high_availability_test.cpp)

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -84,43 +84,28 @@ add_executable(high_availability_test ha/leadership/high_availability_test.cpp)
 target_include_directories(high_availability_test PRIVATE
                            ${CMAKE_CURRENT_SOURCE_DIR})
 if(STORE_USE_REDIS)
-  target_sources(high_availability_test PRIVATE
-                 ha/leadership/backends/redis/high_availability_redis_test.cpp)
-  target_include_directories(high_availability_test PRIVATE
-                             ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
-  target_link_libraries(high_availability_test PRIVATE
-                        ${MOONCAKE_STORE_HIREDIS_LIBRARY})
+    target_sources(high_availability_test PRIVATE
+        ha/leadership/backends/redis/high_availability_redis_test.cpp)
+    target_include_directories(high_availability_test PRIVATE
+        ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
+    target_link_libraries(high_availability_test PRIVATE
+        ${MOONCAKE_STORE_HIREDIS_LIBRARY})
 
-  add_executable(redis_snapshot_catalog_store_test
-                 ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store_test.cpp)
-  target_include_directories(redis_snapshot_catalog_store_test PRIVATE
-                             ${CMAKE_CURRENT_SOURCE_DIR}
-                             ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
-  target_link_libraries(redis_snapshot_catalog_store_test
-                        PUBLIC mooncake_store
-                               transfer_engine
-                               cachelib_memory_allocator
-                               ${ETCD_WRAPPER_LIB}
-                               glog
-                               gflags
-                               ibverbs
-                               gtest
-                               pthread
-                        PRIVATE ${MOONCAKE_STORE_HIREDIS_LIBRARY})
-  add_test(NAME redis_snapshot_catalog_store_test
-           COMMAND redis_snapshot_catalog_store_test)
+    add_executable(redis_snapshot_catalog_store_test
+                   ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store_test.cpp)
+    target_include_directories(redis_snapshot_catalog_store_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
+    target_link_libraries(redis_snapshot_catalog_store_test
+        PUBLIC mooncake_store transfer_engine cachelib_memory_allocator
+               ${ETCD_WRAPPER_LIB} glog gflags ibverbs gtest pthread
+        PRIVATE ${MOONCAKE_STORE_HIREDIS_LIBRARY})
+    add_test(NAME redis_snapshot_catalog_store_test
+             COMMAND redis_snapshot_catalog_store_test)
 endif()
-target_link_libraries(high_availability_test
-                      PUBLIC mooncake_store
-                             transfer_engine
-                             cachelib_memory_allocator
-                             ${ETCD_WRAPPER_LIB}
-                             glog
-                             gtest
-                             gtest_main
-                             pthread)
-if(STORE_USE_ETCD OR STORE_USE_REDIS)
-  add_test(NAME high_availability_test COMMAND high_availability_test)
+target_link_libraries(high_availability_test PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gtest gtest_main pthread)
+if (STORE_USE_ETCD OR STORE_USE_REDIS)
+    add_test(NAME high_availability_test COMMAND high_availability_test)
 endif()
 
 add_executable(stress_workload_test stress_workload_test.cpp)

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -1,205 +1,166 @@
-function(add_store_test name) add_executable(${name} ${
-    ARGN}) target_include_directories(${name} PRIVATE ${
-    CMAKE_CURRENT_SOURCE_DIR}) target_link_libraries(${
-    name} PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${
-    ETCD_WRAPPER_LIB} glog ibverbs gtest gtest_main pthread) add_test(NAME ${
-    name} COMMAND ${name}) endfunction()
+function(add_store_test name)
+  add_executable(${name} ${ARGN})
+  target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  target_link_libraries(
+    ${name}
+    PUBLIC mooncake_store
+           transfer_engine
+           cachelib_memory_allocator
+           ${ETCD_WRAPPER_LIB}
+           glog
+           ibverbs
+           gtest
+           gtest_main
+           pthread)
+  add_test(NAME ${name} COMMAND ${name})
+endfunction()
 
-    function(add_ha_test name) add_executable(${name} ${
-        ARGN}) target_include_directories(${name} PRIVATE ${
-        CMAKE_CURRENT_SOURCE_DIR}) target_link_libraries(${
-        name} PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${
-        ETCD_WRAPPER_LIB} glog gflags ibverbs gtest gtest_main
-                                                             pthread) add_test(NAME ${
-        name} COMMAND ${name}) endfunction()
+function(add_ha_test name)
+  add_executable(${name} ${ARGN})
+  target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  target_link_libraries(
+    ${name}
+    PUBLIC mooncake_store
+           transfer_engine
+           cachelib_memory_allocator
+           ${ETCD_WRAPPER_LIB}
+           glog
+           gflags
+           ibverbs
+           gtest
+           gtest_main
+           pthread)
+  add_test(NAME ${name} COMMAND ${name})
+endfunction()
 
-        add_store_test(buffer_allocator_test buffer_allocator_test.cpp) add_store_test(
-            allocation_strategy_test allocation_strategy_test
-                .cpp) add_store_test(eviction_strategy_test eviction_strategy_test
-                                         .cpp) add_store_test(master_service_test
-                                                                  master_service_test
-                                                                      .cpp)
-            add_store_test(
-                batch_remove_test batch_remove_test
-                    .cpp) add_store_test(master_service_ssd_test
-                                             master_service_ssd_test.cpp)
-                add_store_test(master_service_ssd_test_for_snapshot ha /
-                               snapshot / master_service_ssd_test_for_snapshot.cpp) add_store_test(client_integration_test client_integration_test
-                                                                                                       .cpp) if (USE_CXL) add_store_test(cxl_client_integration_test cxl_client_integration_test
-                                                                                                                                             .cpp) endif() add_store_test(master_metrics_test master_metrics_test
-                                                                                                                                                                              .cpp) add_store_test(posix_file_test
-                                                                                                                                                                                                       posix_file_test
-                                                                                                                                                                                                           .cpp) add_store_test(thread_pool_test
-                                                                                                                                                                                                                                    thread_pool_test
-                                                                                                                                                                                                                                        .cpp) add_store_test(transfer_task_test transfer_task_test
-                                                                                                                                                                                                                                                                 .cpp) add_store_test(segment_test segment_test
-                                                                                                                                                                                                                                                                                          .cpp) add_store_test(offset_allocator_test
-                                                                                                                                                                                                                                                                                                                   offset_allocator_test
-                                                                                                                                                                                                                                                                                                                       .cpp) add_store_test(utils_test utils_test
-                                                                                                                                                                                                                                                                                                                                                .cpp) add_store_test(client_buffer_test
-                                                                                                                                                                                                                                                                                                                                                                         client_buffer_test
-                                                                                                                                                                                                                                                                                                                                                                             .cpp) add_store_test(client_local_hot_cache_test
-                                                                                                                                                                                                                                                                                                                                                                                                      client_local_hot_cache_test
-                                                                                                                                                                                                                                                                                                                                                                                                          .cpp) add_store_test(pybind_client_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                   pybind_client_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                       .cpp) add_store_test(ipv6_client_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                ipv6_client_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                    .cpp) add_store_test(client_metrics_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             client_metrics_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 .cpp) add_store_test(serializer_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          serializer_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              .cpp) add_store_test(embedded_snapshot_catalog_store_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       ha /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   snapshot /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   catalog /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   backends /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   embedded /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   embedded_snapshot_catalog_store_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       .cpp) add_store_test(zstd_util_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                zstd_util_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    .cpp) add_store_test(local_file_snapshot_object_store_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             ha /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         snapshot /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         object /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         backends /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         local /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         local_file_snapshot_object_store_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             .cpp) add_store_test(file_util_test file_util_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      .cpp) add_store_test(snapshot_child_process_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               ha /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           snapshot /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           snapshot_child_process_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               .cpp) add_store_test(master_service_test_for_snapshot
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ha /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    snapshot /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    master_service_test_for_snapshot
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        .cpp) add_store_test(non_ha_reconnect_test non_ha_reconnect_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 .cpp) add_store_test(storage_backend_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          storage_backend_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              .cpp) add_store_test(mutex_test mutex_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       .cpp) add_store_test(file_storage_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                file_storage_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    .cpp) add_store_test(task_manager_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             task_manager_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 .cpp) add_store_test(task_executor_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          task_executor_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              .cpp) add_store_test(task_integration_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       task_integration_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           .cpp) add_store_test(dummy_client_get_buffer_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    dummy_client_get_buffer_test
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        .cpp)
-                    add_store_test(
-                        health_check_test health_check_test
-                            .cpp) add_store_test(prefix_index_test
-                                                     prefix_index_test.cpp) add_subdirectory(e2e)
+add_store_test(buffer_allocator_test buffer_allocator_test.cpp)
+add_store_test(allocation_strategy_test allocation_strategy_test.cpp)
+add_store_test(eviction_strategy_test eviction_strategy_test.cpp)
+add_store_test(master_service_test master_service_test.cpp)
+add_store_test(batch_remove_test batch_remove_test.cpp)
+add_store_test(master_service_ssd_test master_service_ssd_test.cpp)
+add_store_test(master_service_ssd_test_for_snapshot
+               ha/snapshot/master_service_ssd_test_for_snapshot.cpp)
+add_store_test(client_integration_test client_integration_test.cpp)
+if(USE_CXL)
+  add_store_test(cxl_client_integration_test cxl_client_integration_test.cpp)
+endif()
+add_store_test(master_metrics_test master_metrics_test.cpp)
+add_store_test(posix_file_test posix_file_test.cpp)
+add_store_test(thread_pool_test thread_pool_test.cpp)
+add_store_test(transfer_task_test transfer_task_test.cpp)
+add_store_test(segment_test segment_test.cpp)
+add_store_test(offset_allocator_test offset_allocator_test.cpp)
+add_store_test(utils_test utils_test.cpp)
+add_store_test(client_buffer_test client_buffer_test.cpp)
+add_store_test(client_local_hot_cache_test client_local_hot_cache_test.cpp)
+add_store_test(pybind_client_test pybind_client_test.cpp)
+add_store_test(ipv6_client_test ipv6_client_test.cpp)
+add_store_test(client_metrics_test client_metrics_test.cpp)
+add_store_test(serializer_test serializer_test.cpp)
+add_store_test(embedded_snapshot_catalog_store_test
+               ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store_test.cpp)
+add_store_test(zstd_util_test zstd_util_test.cpp)
+add_store_test(local_file_snapshot_object_store_test
+               ha/snapshot/object/backends/local/local_file_snapshot_object_store_test.cpp)
+add_store_test(file_util_test file_util_test.cpp)
+add_store_test(snapshot_child_process_test
+               ha/snapshot/snapshot_child_process_test.cpp)
+add_store_test(master_service_test_for_snapshot
+               ha/snapshot/master_service_test_for_snapshot.cpp)
+add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
+add_store_test(storage_backend_test storage_backend_test.cpp)
+add_store_test(mutex_test mutex_test.cpp)
+add_store_test(file_storage_test file_storage_test.cpp)
+add_store_test(task_manager_test task_manager_test.cpp)
+add_store_test(task_executor_test task_executor_test.cpp)
+add_store_test(task_integration_test task_integration_test.cpp)
+add_store_test(dummy_client_get_buffer_test dummy_client_get_buffer_test.cpp)
+add_store_test(health_check_test health_check_test.cpp)
+add_store_test(prefix_index_test prefix_index_test.cpp)
+add_subdirectory(e2e)
 
-                        add_executable(
-                            high_availability_test
-                                ha /
-                            leadership /
-                            high_availability_test
-                                .cpp) target_include_directories(high_availability_test PRIVATE ${
-                            CMAKE_CURRENT_SOURCE_DIR}) if (STORE_USE_REDIS)
-                            target_sources(
-                                high_availability_test
-                                    PRIVATE
-                                        ha /
-                                leadership / backends /
-                                redis /
-                                high_availability_redis_test
-                                    .cpp) target_include_directories(high_availability_test PRIVATE ${
-                                MOONCAKE_STORE_HIREDIS_INCLUDE_DIR}) target_link_libraries(high_availability_test PRIVATE ${
-                                MOONCAKE_STORE_HIREDIS_LIBRARY})
+add_executable(high_availability_test ha/leadership/high_availability_test.cpp)
+target_include_directories(high_availability_test PRIVATE
+                           ${CMAKE_CURRENT_SOURCE_DIR})
+if(STORE_USE_REDIS)
+  target_sources(high_availability_test PRIVATE
+                 ha/leadership/backends/redis/high_availability_redis_test.cpp)
+  target_include_directories(high_availability_test PRIVATE
+                             ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
+  target_link_libraries(high_availability_test PRIVATE
+                        ${MOONCAKE_STORE_HIREDIS_LIBRARY})
 
-                                add_executable(
-                                    redis_snapshot_catalog_store_test ha /
-                                    snapshot / catalog / backends /
-                                    redis /
-                                    redis_snapshot_catalog_store_test
-                                        .cpp) target_include_directories(redis_snapshot_catalog_store_test PRIVATE
-                                                                             ${CMAKE_CURRENT_SOURCE_DIR} ${
-                                                                                 MOONCAKE_STORE_HIREDIS_INCLUDE_DIR}) target_link_libraries(redis_snapshot_catalog_store_test PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gflags ibverbs gtest pthread
-                                                                                                                                                PRIVATE
-                                                                                                                                                    ${
-                                                                                                                                                        MOONCAKE_STORE_HIREDIS_LIBRARY}) add_test(NAME
-                                                                                                                                                                                                      redis_snapshot_catalog_store_test
-                                                                                                                                                                                                          COMMAND redis_snapshot_catalog_store_test) endif() target_link_libraries(high_availability_test PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${
-                                    ETCD_WRAPPER_LIB} glog gtest gtest_main pthread) if (STORE_USE_ETCD OR STORE_USE_REDIS) add_test(NAME high_availability_test COMMAND high_availability_test) endif()
+  add_executable(redis_snapshot_catalog_store_test
+                 ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store_test.cpp)
+  target_include_directories(redis_snapshot_catalog_store_test PRIVATE
+                             ${CMAKE_CURRENT_SOURCE_DIR}
+                             ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
+  target_link_libraries(redis_snapshot_catalog_store_test
+                        PUBLIC mooncake_store
+                               transfer_engine
+                               cachelib_memory_allocator
+                               ${ETCD_WRAPPER_LIB}
+                               glog
+                               gflags
+                               ibverbs
+                               gtest
+                               pthread
+                        PRIVATE ${MOONCAKE_STORE_HIREDIS_LIBRARY})
+  add_test(NAME redis_snapshot_catalog_store_test
+           COMMAND redis_snapshot_catalog_store_test)
+endif()
+target_link_libraries(high_availability_test
+                      PUBLIC mooncake_store
+                             transfer_engine
+                             cachelib_memory_allocator
+                             ${ETCD_WRAPPER_LIB}
+                             glog
+                             gtest
+                             gtest_main
+                             pthread)
+if(STORE_USE_ETCD OR STORE_USE_REDIS)
+  add_test(NAME high_availability_test COMMAND high_availability_test)
+endif()
 
-                                    add_executable(
-                                        stress_workload_test stress_workload_test
-                                            .cpp) target_link_libraries(stress_workload_test PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${
-                                        ETCD_WRAPPER_LIB} mooncake_common glog gflags pthread)
+add_executable(stress_workload_test stress_workload_test.cpp)
+target_link_libraries(
+  stress_workload_test
+  PUBLIC mooncake_store
+         transfer_engine
+         cachelib_memory_allocator
+         ${ETCD_WRAPPER_LIB}
+         mooncake_common
+         glog
+         gflags
+         pthread)
 
-#HA tests
-                                        add_ha_test(
-                                            standby_state_machine_test ha /
-                                            standby /
-                                            standby_state_machine_test.cpp)
-                                            add_ha_test(
-                                                ha_metric_manager_test ha /
-                                                standby /
-                                                ha_metric_manager_test.cpp)
-                                                add_ha_test(
-                                                    hot_standby_service_test
-                                                        ha /
-                                                    standby /
-                                                    hot_standby_service_test
-                                                        .cpp)
-                                                    add_ha_test(
-                                                        hot_standby_snapshot_bootstrap_test
-                                                            ha /
-                                                        standby /
-                                                        hot_standby_snapshot_bootstrap_test
-                                                            .cpp) add_ha_test(oplog_applier_test
-                                                                                  ha /
-                                                                              oplog /
-                                                                              oplog_applier_test
-                                                                                  .cpp)
-                                                        add_ha_test(
-                                                            oplog_manager_test
-                                                                ha /
-                                                            oplog /
-                                                            oplog_manager_test
-                                                                .cpp) add_ha_test(etcd_oplog_store_test ha /
-                                                                                  oplog /
-                                                                                  etcd_oplog_store_test
-                                                                                      .cpp)
-                                                            add_ha_test(
-                                                                oplog_replicator_test
-                                                                    ha /
-                                                                oplog /
-                                                                oplog_replicator_test
-                                                                    .cpp) add_ha_test(oplog_serializer_test ha /
-                                                                                      oplog /
-                                                                                      oplog_serializer_test
-                                                                                          .cpp)
-                                                                add_ha_test(
-                                                                    localfs_oplog_store_test
-                                                                        ha /
-                                                                    oplog /
-                                                                    localfs_oplog_store_test
-                                                                        .cpp) add_ha_test(ha_recovery_test
-                                                                                              ha /
-                                                                                          oplog /
-                                                                                          ha_recovery_test
-                                                                                              .cpp)
-                                                                    add_ha_test(
-                                                                        localfs_hot_standby_integration_test
-                                                                            ha /
-                                                                        oplog /
-                                                                        localfs_hot_standby_integration_test
-                                                                            .cpp) add_ha_test(catalog_backed_snapshot_provider_test
-                                                                                                  ha /
-                                                                                              snapshot /
-                                                                                              catalog_backed_snapshot_provider_test
-                                                                                                  .cpp) if (STORE_USE_REDIS) foreach (target
-                                                                                                                                          catalog_backed_snapshot_provider_test hot_standby_snapshot_bootstrap_test)
-                                                                        target_include_directories(
-                                                                            ${target} PRIVATE
-                                                                                ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
-                                                                            target_link_libraries(
-                                                                                ${target} PRIVATE
-                                                                                    ${MOONCAKE_STORE_HIREDIS_LIBRARY})
-                                                                                endforeach()
-                                                                                    endif()
+# HA tests
+add_ha_test(standby_state_machine_test
+            ha/standby/standby_state_machine_test.cpp)
+add_ha_test(ha_metric_manager_test
+            ha/standby/ha_metric_manager_test.cpp)
+add_ha_test(hot_standby_service_test
+            ha/standby/hot_standby_service_test.cpp)
+add_ha_test(hot_standby_snapshot_bootstrap_test
+            ha/standby/hot_standby_snapshot_bootstrap_test.cpp)
+add_ha_test(oplog_applier_test ha/oplog/oplog_applier_test.cpp)
+add_ha_test(oplog_manager_test ha/oplog/oplog_manager_test.cpp)
+add_ha_test(etcd_oplog_store_test ha/oplog/etcd_oplog_store_test.cpp)
+add_ha_test(oplog_replicator_test ha/oplog/oplog_replicator_test.cpp)
+add_ha_test(oplog_serializer_test ha/oplog/oplog_serializer_test.cpp)
+add_ha_test(localfs_oplog_store_test ha/oplog/localfs_oplog_store_test.cpp)
+add_ha_test(ha_recovery_test ha/oplog/ha_recovery_test.cpp)
+add_ha_test(localfs_hot_standby_integration_test
+            ha/oplog/localfs_hot_standby_integration_test.cpp)
+add_ha_test(catalog_backed_snapshot_provider_test
+            ha/snapshot/catalog_backed_snapshot_provider_test.cpp)
+if(STORE_USE_REDIS)
+  foreach(target catalog_backed_snapshot_provider_test
+                 hot_standby_snapshot_bootstrap_test)
+    target_include_directories(${target} PRIVATE
+                               ${MOONCAKE_STORE_HIREDIS_INCLUDE_DIR})
+    target_link_libraries(${target}
+                          PRIVATE ${MOONCAKE_STORE_HIREDIS_LIBRARY})
+  endforeach()
+endif()

--- a/mooncake-store/tests/prefix_index_test.cpp
+++ b/mooncake-store/tests/prefix_index_test.cpp
@@ -1,0 +1,1343 @@
+#include "prefix_index.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <thread>
+#include <vector>
+
+namespace mooncake::test {
+
+static const UUID kClient1 = {1, 1};
+static const UUID kClient2 = {2, 2};
+
+// ---------------------------------------------------------------------------
+// Insert: basic
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, InsertSingleKey) {
+    PrefixIndex idx;
+    idx.insert("llama-70b/layer.0/q_proj.weight", 1024, kClient1);
+
+    EXPECT_EQ(idx.size(), 1);
+    EXPECT_EQ(idx.count_by_prefix("llama-70b/"), 1);
+    EXPECT_EQ(idx.bytes_by_prefix("llama-70b/"), 1024);
+}
+
+TEST(PrefixIndexTest, InsertMultipleKeysSharedPrefix) {
+    PrefixIndex idx;
+    idx.insert("llama-70b/layer.0/q_proj.weight", 1024, kClient1);
+    idx.insert("llama-70b/layer.0/k_proj.weight", 2048, kClient1);
+    idx.insert("llama-70b/layer.1/q_proj.weight", 1024, kClient1);
+
+    EXPECT_EQ(idx.size(), 3);
+    EXPECT_EQ(idx.count_by_prefix("llama-70b/"), 3);
+    EXPECT_EQ(idx.count_by_prefix("llama-70b/layer.0/"), 2);
+    EXPECT_EQ(idx.count_by_prefix("llama-70b/layer.1/"), 1);
+    EXPECT_EQ(idx.bytes_by_prefix("llama-70b/"), 1024 + 2048 + 1024);
+    EXPECT_EQ(idx.bytes_by_prefix("llama-70b/layer.0/"), 1024 + 2048);
+}
+
+TEST(PrefixIndexTest, InsertDisjointPrefixes) {
+    PrefixIndex idx;
+    idx.insert("llama-70b/layer.0/q_proj.weight", 1000, kClient1);
+    idx.insert("mistral-7b/layer.0/q_proj.weight", 500, kClient2);
+
+    EXPECT_EQ(idx.size(), 2);
+    EXPECT_EQ(idx.count_by_prefix("llama-70b/"), 1);
+    EXPECT_EQ(idx.count_by_prefix("mistral-7b/"), 1);
+    EXPECT_EQ(idx.bytes_by_prefix("llama-70b/"), 1000);
+    EXPECT_EQ(idx.bytes_by_prefix("mistral-7b/"), 500);
+}
+
+TEST(PrefixIndexTest, InsertDuplicateKeyUpdatesLeafData) {
+    PrefixIndex idx;
+    idx.insert("key1", 100, kClient1);
+    idx.insert("key1", 200, kClient2);
+
+    // Count stays 1 (no new key added).
+    EXPECT_EQ(idx.size(), 1);
+    EXPECT_EQ(idx.count_by_prefix(""), 1);
+    // Bytes reflect the SECOND insert's size (upsert semantics).
+    EXPECT_EQ(idx.bytes_by_prefix(""), 200);
+}
+
+TEST(PrefixIndexTest, InsertDuplicateKeySameSizeNoStatsDrift) {
+    PrefixIndex idx;
+    idx.insert("key1", 100, kClient1);
+    idx.insert("key1", 100, kClient2);
+
+    EXPECT_EQ(idx.size(), 1);
+    EXPECT_EQ(idx.count_by_prefix(""), 1);
+    // Same size — bytes unchanged, no drift.
+    EXPECT_EQ(idx.bytes_by_prefix(""), 100);
+}
+
+TEST(PrefixIndexTest, InsertEmptyKeyIsNoop) {
+    PrefixIndex idx;
+    idx.insert("", 100, kClient1);
+    EXPECT_EQ(idx.size(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Split on insert (partial edge match)
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, SplitOnPartialEdgeMatch) {
+    PrefixIndex idx;
+    idx.insert("abcdef", 100, kClient1);
+    idx.insert("abcxyz", 200, kClient1);
+
+    EXPECT_EQ(idx.size(), 2);
+    EXPECT_EQ(idx.count_by_prefix("abc"), 2);
+    EXPECT_EQ(idx.bytes_by_prefix("abc"), 300);
+    EXPECT_EQ(idx.count_by_prefix("abcd"), 1);
+    EXPECT_EQ(idx.count_by_prefix("abcx"), 1);
+}
+
+TEST(PrefixIndexTest, SplitPreservesExistingSubtreeStats) {
+    PrefixIndex idx;
+    idx.insert("abc/one", 100, kClient1);
+    idx.insert("abc/two", 200, kClient1);
+
+    // Now insert a key that forces a split on "abc/"
+    idx.insert("abd/three", 300, kClient1);
+
+    EXPECT_EQ(idx.size(), 3);
+    EXPECT_EQ(idx.count_by_prefix("abc/"), 2);
+    EXPECT_EQ(idx.bytes_by_prefix("abc/"), 300);
+    EXPECT_EQ(idx.count_by_prefix("abd/"), 1);
+    EXPECT_EQ(idx.count_by_prefix("ab"), 3);
+    EXPECT_EQ(idx.bytes_by_prefix("ab"), 600);
+}
+
+// ---------------------------------------------------------------------------
+// Insert: shorter key after longer key (split where key ends at mid-node)
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, InsertShorterKeyAfterLongerKey) {
+    PrefixIndex idx;
+    idx.insert("abcdef", 200, kClient1);
+    idx.insert("abc", 100, kClient1);
+
+    EXPECT_EQ(idx.size(), 2);
+    EXPECT_EQ(idx.count_by_prefix("abc"), 2);
+    EXPECT_EQ(idx.bytes_by_prefix("abc"), 300);
+
+    auto keys = idx.list_keys_by_prefix("abc");
+    ASSERT_EQ(keys.size(), 2);
+    EXPECT_TRUE(std::find(keys.begin(), keys.end(), "abc") != keys.end());
+    EXPECT_TRUE(std::find(keys.begin(), keys.end(), "abcdef") != keys.end());
+}
+
+// ---------------------------------------------------------------------------
+// Terminal node that is also a prefix of longer keys
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, NodeIsBothTerminalAndInternal) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+    idx.insert("abcdef", 200, kClient1);
+
+    EXPECT_EQ(idx.size(), 2);
+    EXPECT_EQ(idx.count_by_prefix("abc"), 2);
+    EXPECT_EQ(idx.bytes_by_prefix("abc"), 300);
+
+    auto keys = idx.list_keys_by_prefix("abc");
+    EXPECT_EQ(keys.size(), 2);
+    EXPECT_TRUE(std::find(keys.begin(), keys.end(), "abc") != keys.end());
+    EXPECT_TRUE(std::find(keys.begin(), keys.end(), "abcdef") != keys.end());
+}
+
+// ---------------------------------------------------------------------------
+// Remove tests
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, RemoveSingleKey) {
+    PrefixIndex idx;
+    idx.insert("key1", 100, kClient1);
+    idx.remove("key1");
+
+    EXPECT_EQ(idx.size(), 0);
+    EXPECT_EQ(idx.count_by_prefix(""), 0);
+    EXPECT_EQ(idx.bytes_by_prefix(""), 0);
+}
+
+TEST(PrefixIndexTest, RemoveNonexistentKeyIsNoop) {
+    PrefixIndex idx;
+    idx.insert("key1", 100, kClient1);
+    idx.remove("key2");
+
+    EXPECT_EQ(idx.size(), 1);
+}
+
+TEST(PrefixIndexTest, RemoveEmptyKeyIsNoop) {
+    PrefixIndex idx;
+    idx.insert("key1", 100, kClient1);
+    idx.remove("");
+
+    EXPECT_EQ(idx.size(), 1);
+}
+
+TEST(PrefixIndexTest, RemoveTerminalPrefixKeepsLongerKey) {
+    PrefixIndex idx;
+    idx.insert("abcdef", 200, kClient1);
+    idx.insert("abc", 100, kClient1);
+
+    idx.remove("abc");
+
+    EXPECT_EQ(idx.size(), 1);
+    EXPECT_EQ(idx.count_by_prefix("abc"), 1);
+    EXPECT_EQ(idx.bytes_by_prefix("abc"), 200);
+    auto keys = idx.list_keys_by_prefix("");
+    ASSERT_EQ(keys.size(), 1);
+    EXPECT_EQ(keys[0], "abcdef");
+}
+
+TEST(PrefixIndexTest, RemoveLongerKeyKeepsShorterTerminal) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+    idx.insert("abcdef", 200, kClient1);
+
+    idx.remove("abcdef");
+
+    EXPECT_EQ(idx.size(), 1);
+    EXPECT_EQ(idx.count_by_prefix("abc"), 1);
+    EXPECT_EQ(idx.bytes_by_prefix("abc"), 100);
+    auto keys = idx.list_keys_by_prefix("");
+    ASSERT_EQ(keys.size(), 1);
+    EXPECT_EQ(keys[0], "abc");
+}
+
+TEST(PrefixIndexTest, RemoveUpdatesSubtreeStats) {
+    PrefixIndex idx;
+    idx.insert("llama-70b/layer.0/q_proj.weight", 1024, kClient1);
+    idx.insert("llama-70b/layer.0/k_proj.weight", 2048, kClient1);
+    idx.insert("llama-70b/layer.1/q_proj.weight", 512, kClient1);
+
+    idx.remove("llama-70b/layer.0/q_proj.weight");
+
+    EXPECT_EQ(idx.size(), 2);
+    EXPECT_EQ(idx.count_by_prefix("llama-70b/"), 2);
+    EXPECT_EQ(idx.bytes_by_prefix("llama-70b/"), 2048 + 512);
+    EXPECT_EQ(idx.count_by_prefix("llama-70b/layer.0/"), 1);
+    EXPECT_EQ(idx.bytes_by_prefix("llama-70b/layer.0/"), 2048);
+}
+
+// ---------------------------------------------------------------------------
+// Self-cleaning cascade: leaf deletion
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, CascadeDeletesEmptyLeaf) {
+    PrefixIndex idx;
+    idx.insert("abc/one", 100, kClient1);
+    idx.insert("abc/two", 200, kClient1);
+
+    idx.remove("abc/one");
+    idx.remove("abc/two");
+
+    EXPECT_EQ(idx.size(), 0);
+    // After removing all keys, the trie should be clean (no leftover
+    // internal nodes — only root remains).
+    auto keys = idx.list_keys_by_prefix("");
+    EXPECT_TRUE(keys.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Self-cleaning cascade: no merge (delete-only), single-child nodes persist
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, CascadeLeavesInternalSingleChildNode) {
+    PrefixIndex idx;
+    // Creates tree: root -> "ab" -> "c" (terminal) and "d" (terminal)
+    idx.insert("abc", 100, kClient1);
+    idx.insert("abd", 200, kClient1);
+
+    // Remove "abd" — "ab" now has only one child "c", but we do NOT
+    // merge (future-proofing for fine-grained locking). The key "abc"
+    // must still be retrievable.
+    idx.remove("abd");
+
+    EXPECT_EQ(idx.size(), 1);
+    auto keys = idx.list_keys_by_prefix("");
+    ASSERT_EQ(keys.size(), 1);
+    EXPECT_EQ(keys[0], "abc");
+
+    EXPECT_EQ(idx.count_by_prefix("ab"), 1);
+    EXPECT_EQ(idx.bytes_by_prefix("ab"), 100);
+}
+
+TEST(PrefixIndexTest, CascadeDeletesEmptyButKeepsTerminal) {
+    PrefixIndex idx;
+    idx.insert("ab", 100, kClient1);
+    idx.insert("abc", 200, kClient1);
+    idx.insert("abd", 300, kClient1);
+
+    // Remove "abd". The leaf for "abd" is deleted (no children, no
+    // leaf_data). "ab" is still terminal, so it stays.
+    idx.remove("abd");
+
+    EXPECT_EQ(idx.size(), 2);
+    auto keys = idx.list_keys_by_prefix("");
+    ASSERT_EQ(keys.size(), 2);
+    EXPECT_TRUE(std::find(keys.begin(), keys.end(), "ab") != keys.end());
+    EXPECT_TRUE(std::find(keys.begin(), keys.end(), "abc") != keys.end());
+}
+
+// ---------------------------------------------------------------------------
+// list_keys_by_prefix
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ListKeysByPrefixReturnsAllMatches) {
+    PrefixIndex idx;
+    idx.insert("llama-70b/layer.0/q_proj.weight", 1024, kClient1);
+    idx.insert("llama-70b/layer.0/k_proj.weight", 2048, kClient1);
+    idx.insert("llama-70b/layer.1/q_proj.weight", 512, kClient1);
+    idx.insert("mistral-7b/layer.0/q_proj.weight", 100, kClient2);
+
+    auto keys = idx.list_keys_by_prefix("llama-70b/");
+    EXPECT_EQ(keys.size(), 3);
+
+    auto keys2 = idx.list_keys_by_prefix("llama-70b/layer.0/");
+    EXPECT_EQ(keys2.size(), 2);
+
+    auto keys3 = idx.list_keys_by_prefix("mistral");
+    EXPECT_EQ(keys3.size(), 1);
+}
+
+TEST(PrefixIndexTest, ListKeysByEmptyPrefixReturnsAll) {
+    PrefixIndex idx;
+    idx.insert("a", 10, kClient1);
+    idx.insert("b", 20, kClient1);
+    idx.insert("c", 30, kClient1);
+
+    auto keys = idx.list_keys_by_prefix("");
+    EXPECT_EQ(keys.size(), 3);
+}
+
+TEST(PrefixIndexTest, ListKeysByPrefixReturnsSortedOrder) {
+    PrefixIndex idx;
+    idx.insert("c/z", 1, kClient1);
+    idx.insert("a/x", 1, kClient1);
+    idx.insert("b/y", 1, kClient1);
+
+    auto keys = idx.list_keys_by_prefix("");
+    ASSERT_EQ(keys.size(), 3);
+    EXPECT_TRUE(std::is_sorted(keys.begin(), keys.end()));
+}
+
+TEST(PrefixIndexTest, ListKeysByPrefixMidEdgeReturnsFullKeys) {
+    PrefixIndex idx;
+    idx.insert("mistral-7b/layer.0/q_proj.weight", 1024, kClient1);
+
+    // "mistral" ends in the middle of the compressed edge
+    // "mistral-7b/layer.0/q_proj.weight". The returned key must be
+    // the full stored key, NOT the truncated prefix "mistral".
+    auto keys = idx.list_keys_by_prefix("mistral");
+    ASSERT_EQ(keys.size(), 1);
+    EXPECT_EQ(keys[0], "mistral-7b/layer.0/q_proj.weight");
+}
+
+TEST(PrefixIndexTest, ListKeysByPrefixMidEdgeMultipleKeys) {
+    PrefixIndex idx;
+    idx.insert("mistral-7b/layer.0/q_proj.weight", 100, kClient1);
+    idx.insert("mistral-7b/layer.1/q_proj.weight", 200, kClient1);
+
+    // "mistral-7b/layer." ends mid-edge (the split created
+    // "mistral-7b/layer." as an internal node with children "0/..."
+    // and "1/..."). Both full keys must be returned.
+    auto keys = idx.list_keys_by_prefix("mistral-7b/layer.");
+    ASSERT_EQ(keys.size(), 2);
+    EXPECT_TRUE(std::find(keys.begin(), keys.end(),
+                          "mistral-7b/layer.0/q_proj.weight") != keys.end());
+    EXPECT_TRUE(std::find(keys.begin(), keys.end(),
+                          "mistral-7b/layer.1/q_proj.weight") != keys.end());
+}
+
+TEST(PrefixIndexTest, ListKeysByNonexistentPrefixReturnsEmpty) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+
+    auto keys = idx.list_keys_by_prefix("xyz");
+    EXPECT_TRUE(keys.empty());
+}
+
+// ---------------------------------------------------------------------------
+// list_prefix_continuations
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ListPrefixContinuationsReturnsDirectChildrenWithValues) {
+    PrefixIndex idx;
+    idx.insert("llama-70b/layer.0/q_proj.weight", 1024, kClient1);
+    idx.insert("llama-70b/layer.1/q_proj.weight", 2048, kClient1);
+    idx.insert("mistral-7b/layer.0/q_proj.weight", 100, kClient2);
+
+    auto children = idx.list_prefix_continuations("");
+    ASSERT_EQ(children.size(), 2);
+    // Verify actual edge labels, not just count. std::map ordering
+    // guarantees 'l' < 'm'.
+    EXPECT_TRUE(children[0].find("llama") != std::string::npos);
+    EXPECT_TRUE(children[1].find("mistral") != std::string::npos);
+}
+
+TEST(PrefixIndexTest, ListPrefixContinuationsMidEdgePrependsUnmatchedSuffix) {
+    PrefixIndex idx;
+    idx.insert("abc/one", 100, kClient1);
+    idx.insert("abc/two", 200, kClient1);
+
+    // "abc" ends mid-edge on the "abc/" node. The unmatched suffix
+    // "/" is prepended to each child's edge_label, so results are
+    // relative to the user's prefix "abc", not the internal node "abc/".
+    auto children = idx.list_prefix_continuations("abc");
+    ASSERT_EQ(children.size(), 2);
+    EXPECT_TRUE(std::find(children.begin(), children.end(), "/one") !=
+                children.end());
+    EXPECT_TRUE(std::find(children.begin(), children.end(), "/two") !=
+                children.end());
+
+    // Same query at the exact edge boundary gives raw child labels.
+    auto children_exact = idx.list_prefix_continuations("abc/");
+    ASSERT_EQ(children_exact.size(), 2);
+    EXPECT_TRUE(std::find(children_exact.begin(), children_exact.end(),
+                          "one") != children_exact.end());
+    EXPECT_TRUE(std::find(children_exact.begin(), children_exact.end(),
+                          "two") != children_exact.end());
+}
+
+TEST(PrefixIndexTest, ListPrefixContinuationsOfTerminalLeafReturnsEmpty) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+
+    // "abc" is a terminal leaf with no children.
+    auto children = idx.list_prefix_continuations("abc");
+    EXPECT_TRUE(children.empty());
+}
+
+TEST(PrefixIndexTest, ListPrefixContinuationsOfNonexistentPrefixReturnsEmpty) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+
+    auto children = idx.list_prefix_continuations("xyz");
+    EXPECT_TRUE(children.empty());
+}
+
+// ---------------------------------------------------------------------------
+// count_by_prefix
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, CountByPrefixIsO1) {
+    PrefixIndex idx;
+    for (int i = 0; i < 1000; ++i) {
+        idx.insert("prefix/" + std::to_string(i), 10, kClient1);
+    }
+
+    EXPECT_EQ(idx.count_by_prefix("prefix/"), 1000);
+    EXPECT_EQ(idx.count_by_prefix(""), 1000);
+}
+
+TEST(PrefixIndexTest, CountByNonexistentPrefixReturnsZero) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+
+    EXPECT_EQ(idx.count_by_prefix("xyz"), 0);
+}
+
+// ---------------------------------------------------------------------------
+// bytes_by_prefix
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, BytesByPrefixMatchesSumOfInsertedSizes) {
+    PrefixIndex idx;
+    uint64_t total = 0;
+    for (int i = 0; i < 100; ++i) {
+        uint64_t sz = (i + 1) * 100;
+        idx.insert("model/tensor_" + std::to_string(i), sz, kClient1);
+        total += sz;
+    }
+
+    EXPECT_EQ(idx.bytes_by_prefix("model/"), total);
+    EXPECT_EQ(idx.bytes_by_prefix(""), total);
+}
+
+TEST(PrefixIndexTest, BytesByNonexistentPrefixReturnsZero) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+
+    EXPECT_EQ(idx.bytes_by_prefix("xyz"), 0);
+}
+
+// ---------------------------------------------------------------------------
+// clear
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ClearRemovesEverything) {
+    PrefixIndex idx;
+    idx.insert("a", 10, kClient1);
+    idx.insert("b", 20, kClient1);
+    idx.insert("c", 30, kClient1);
+
+    idx.clear();
+
+    EXPECT_EQ(idx.size(), 0);
+    EXPECT_EQ(idx.count_by_prefix(""), 0);
+    EXPECT_EQ(idx.bytes_by_prefix(""), 0);
+    EXPECT_TRUE(idx.list_keys_by_prefix("").empty());
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot rebuild: insert all -> clear -> re-insert -> verify
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, RebuildAfterClear) {
+    PrefixIndex idx;
+    idx.insert("a/1", 100, kClient1);
+    idx.insert("a/2", 200, kClient1);
+    idx.insert("b/1", 300, kClient2);
+
+    idx.clear();
+
+    idx.insert("a/1", 100, kClient1);
+    idx.insert("a/2", 200, kClient1);
+    idx.insert("b/1", 300, kClient2);
+
+    EXPECT_EQ(idx.size(), 3);
+    EXPECT_EQ(idx.count_by_prefix("a/"), 2);
+    EXPECT_EQ(idx.bytes_by_prefix("a/"), 300);
+    EXPECT_EQ(idx.count_by_prefix("b/"), 1);
+    EXPECT_EQ(idx.bytes_by_prefix("b/"), 300);
+}
+
+// ---------------------------------------------------------------------------
+// Churn: repeated insert/remove to catch subtree stats drift
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ChurnSubtreeStatsStayConsistent) {
+    PrefixIndex idx;
+
+    // Round 1: insert overlapping prefixes
+    idx.insert("a/b/c", 100, kClient1);
+    idx.insert("a/b/d", 200, kClient1);
+    idx.insert("a/x/y", 300, kClient2);
+
+    EXPECT_EQ(idx.size(), 3);
+    EXPECT_EQ(idx.count_by_prefix("a/"), 3);
+    EXPECT_EQ(idx.bytes_by_prefix("a/"), 600);
+    EXPECT_EQ(idx.count_by_prefix("a/b/"), 2);
+    EXPECT_EQ(idx.bytes_by_prefix("a/b/"), 300);
+
+    // Round 2: remove and re-insert
+    idx.remove("a/b/c");
+    EXPECT_EQ(idx.count_by_prefix("a/b/"), 1);
+    EXPECT_EQ(idx.bytes_by_prefix("a/b/"), 200);
+
+    idx.insert("a/b/c", 150, kClient1);
+    EXPECT_EQ(idx.count_by_prefix("a/b/"), 2);
+    EXPECT_EQ(idx.bytes_by_prefix("a/b/"), 350);
+
+    // Round 3: remove everything under a/b/ one by one
+    idx.remove("a/b/c");
+    idx.remove("a/b/d");
+    EXPECT_EQ(idx.count_by_prefix("a/b/"), 0);
+    EXPECT_EQ(idx.bytes_by_prefix("a/b/"), 0);
+    EXPECT_EQ(idx.count_by_prefix("a/"), 1);
+    EXPECT_EQ(idx.bytes_by_prefix("a/"), 300);
+
+    // Round 4: remove last key
+    idx.remove("a/x/y");
+    EXPECT_EQ(idx.size(), 0);
+    EXPECT_EQ(idx.count_by_prefix(""), 0);
+    EXPECT_EQ(idx.bytes_by_prefix(""), 0);
+
+    // Round 5: re-insert after full drain
+    idx.insert("a/b/c", 100, kClient1);
+    EXPECT_EQ(idx.size(), 1);
+    EXPECT_EQ(idx.count_by_prefix("a/"), 1);
+    EXPECT_EQ(idx.bytes_by_prefix("a/"), 100);
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent access
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ConcurrentInsertsAndReads) {
+    PrefixIndex idx;
+    constexpr int kNumWriters = 4;
+    constexpr int kKeysPerWriter = 500;
+    constexpr int kNumReaders = 4;
+
+    std::vector<std::thread> threads;
+
+    // Writers
+    for (int w = 0; w < kNumWriters; ++w) {
+        threads.emplace_back([&idx, w]() {
+            for (int i = 0; i < kKeysPerWriter; ++i) {
+                std::string key = "w" + std::to_string(w) + "/key_" +
+                                  std::to_string(i);
+                idx.insert(key, 10, kClient1);
+            }
+        });
+    }
+
+    // Readers (run concurrently with writers)
+    for (int r = 0; r < kNumReaders; ++r) {
+        threads.emplace_back([&idx]() {
+            for (int i = 0; i < 100; ++i) {
+                idx.count_by_prefix("");
+                idx.list_keys_by_prefix("w0/");
+                idx.bytes_by_prefix("w1/");
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(idx.size(), kNumWriters * kKeysPerWriter);
+}
+
+TEST(PrefixIndexTest, ConcurrentInsertsAndRemoves) {
+    PrefixIndex idx;
+    constexpr int kNumKeys = 1000;
+
+    // Pre-populate
+    for (int i = 0; i < kNumKeys; ++i) {
+        idx.insert("key_" + std::to_string(i), 10, kClient1);
+    }
+    EXPECT_EQ(idx.size(), kNumKeys);
+
+    std::vector<std::thread> threads;
+
+    // Remove even keys
+    threads.emplace_back([&idx]() {
+        for (int i = 0; i < kNumKeys; i += 2) {
+            idx.remove("key_" + std::to_string(i));
+        }
+    });
+
+    // Insert new keys concurrently
+    threads.emplace_back([&idx]() {
+        for (int i = kNumKeys; i < kNumKeys + 500; ++i) {
+            idx.insert("key_" + std::to_string(i), 20, kClient2);
+        }
+    });
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(idx.size(), kNumKeys / 2 + 500);
+}
+
+TEST(PrefixIndexTest, ConcurrentReadsAndRemovesSamePrefix) {
+    PrefixIndex idx;
+    constexpr int kNumKeys = 500;
+
+    // Pre-populate under a shared prefix
+    for (int i = 0; i < kNumKeys; ++i) {
+        idx.insert("shared/key_" + std::to_string(i), 10, kClient1);
+    }
+    EXPECT_EQ(idx.count_by_prefix("shared/"), kNumKeys);
+
+    std::vector<std::thread> threads;
+
+    // Remover: deletes all keys under the prefix
+    threads.emplace_back([&idx]() {
+        for (int i = 0; i < kNumKeys; ++i) {
+            idx.remove("shared/key_" + std::to_string(i));
+        }
+    });
+
+    // Readers: query the same prefix being drained
+    for (int r = 0; r < 4; ++r) {
+        threads.emplace_back([&idx]() {
+            for (int i = 0; i < 200; ++i) {
+                auto count = idx.count_by_prefix("shared/");
+                (void)count;  // just exercising thread safety
+                auto keys = idx.list_keys_by_prefix("shared/");
+                (void)keys;
+                auto bytes = idx.bytes_by_prefix("shared/");
+                (void)bytes;
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(idx.count_by_prefix("shared/"), 0);
+    EXPECT_EQ(idx.size(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Mid-edge list_prefix_continuations edge cases
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ListPrefixContinuationsMidEdgeOnLeafReturnsSuffix) {
+    PrefixIndex idx;
+    idx.insert("mistral-7b/layer.0/q_proj.weight", 1024, kClient1);
+
+    // "mistral" ends mid-edge on the terminal leaf. The unmatched
+    // suffix "-7b/layer.0/q_proj.weight" is the continuation.
+    auto children = idx.list_prefix_continuations("mistral");
+    ASSERT_EQ(children.size(), 1);
+    EXPECT_EQ(children[0], "-7b/layer.0/q_proj.weight");
+}
+
+TEST(PrefixIndexTest, ListPrefixContinuationsMidEdgeShortPrefix) {
+    PrefixIndex idx;
+    idx.insert("abc/one", 100, kClient1);
+    idx.insert("abc/two", 200, kClient1);
+
+    // "ab" ends mid-edge on the "abc/" node. Unmatched suffix "c/"
+    // is prepended to children.
+    auto children = idx.list_prefix_continuations("ab");
+    ASSERT_EQ(children.size(), 2);
+    EXPECT_TRUE(std::find(children.begin(), children.end(), "c/one") !=
+                children.end());
+    EXPECT_TRUE(std::find(children.begin(), children.end(), "c/two") !=
+                children.end());
+}
+
+// ---------------------------------------------------------------------------
+// list_prefix_continuations: freeze compressed-edge semantics
+// (returns full trie edges, not delimiter-split segments)
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ListPrefixContinuationsMidEdgeSingleStoredKey) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+
+    // "ab" ends mid-edge on the terminal leaf "abc". The unmatched
+    // suffix "c" is returned as the continuation.
+    auto children = idx.list_prefix_continuations("ab");
+    ASSERT_EQ(children.size(), 1);
+    EXPECT_EQ(children[0], "c");
+}
+
+TEST(PrefixIndexTest, ListPrefixContinuationsExposesCompressedTrieEdges) {
+    PrefixIndex idx;
+    idx.insert("ab/one", 100, kClient1);
+    idx.insert("ac/two", 200, kClient1);
+
+    // Tree: root → "a" (internal) → "b/one" (terminal), "c/two" (terminal)
+    // list_prefix_continuations("a") returns the FULL compressed edges from the "a"
+    // node, not truncated-at-delimiter immediate children. This is the
+    // intended radix tree behavior — edges can span multiple "levels."
+    auto children = idx.list_prefix_continuations("a");
+    ASSERT_EQ(children.size(), 2);
+    EXPECT_EQ(children[0], "b/one");
+    EXPECT_EQ(children[1], "c/two");
+}
+
+TEST(PrefixIndexTest, ListPrefixContinuationsAtExactBranchPoint) {
+    PrefixIndex idx;
+    idx.insert("ab/one", 100, kClient1);
+    idx.insert("ab/two", 200, kClient1);
+    idx.insert("ac/three", 300, kClient1);
+
+    // Tree: root → "a" (internal)
+    //                ├── "b/" (internal) → "one", "two"
+    //                └── "c/three" (terminal)
+    auto children = idx.list_prefix_continuations("a");
+    ASSERT_EQ(children.size(), 2);
+    EXPECT_EQ(children[0], "b/");       // compressed edge to branch node
+    EXPECT_EQ(children[1], "c/three");  // compressed edge to leaf
+
+    // Drilling into "ab/" gives the next level.
+    auto children2 = idx.list_prefix_continuations("ab/");
+    ASSERT_EQ(children2.size(), 2);
+    EXPECT_EQ(children2[0], "one");
+    EXPECT_EQ(children2[1], "two");
+}
+
+TEST(PrefixIndexTest, ListPrefixContinuationsMidEdgeTerminalAndInternal) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+    idx.insert("abc/one", 200, kClient1);
+
+    // Tree: root → "abc" (terminal) → "/one" (terminal)
+    // list_prefix_continuations("ab") lands mid-edge on "abc". Unmatched suffix
+    // is "c". The node is terminal (so "c" is a continuation) AND has
+    // children (so "c/one" is also a continuation).
+    auto children = idx.list_prefix_continuations("ab");
+    ASSERT_EQ(children.size(), 2);
+    EXPECT_EQ(children[0], "c");      // terminal continuation
+    EXPECT_EQ(children[1], "c/one");  // child continuation
+}
+
+// ---------------------------------------------------------------------------
+// Upsert: ownership change on re-insert
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, UpsertChangesClientAndAdjustsBytes) {
+    PrefixIndex idx;
+    idx.insert("tenant-a/obj1", 100, kClient1);
+    idx.insert("tenant-a/obj2", 200, kClient1);
+
+    EXPECT_EQ(idx.bytes_by_prefix("tenant-a/"), 300);
+
+    // Re-register obj1 under a different client with different size.
+    idx.insert("tenant-a/obj1", 150, kClient2);
+
+    // Count unchanged, bytes adjusted.
+    EXPECT_EQ(idx.size(), 2);
+    EXPECT_EQ(idx.count_by_prefix("tenant-a/"), 2);
+    EXPECT_EQ(idx.bytes_by_prefix("tenant-a/"), 350);
+    EXPECT_EQ(idx.bytes_by_prefix(""), 350);
+}
+
+TEST(PrefixIndexTest, UpsertOnNodeThatIsAlsoPrefix) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+    idx.insert("abcdef", 200, kClient1);
+
+    EXPECT_EQ(idx.bytes_by_prefix("abc"), 300);
+
+    // Re-insert "abc" with different size.
+    idx.insert("abc", 50, kClient2);
+
+    EXPECT_EQ(idx.size(), 2);
+    EXPECT_EQ(idx.count_by_prefix("abc"), 2);
+    EXPECT_EQ(idx.bytes_by_prefix("abc"), 250);
+}
+
+// ---------------------------------------------------------------------------
+// Invariant: list_keys_by_prefix results must start with the prefix,
+// and count_by_prefix must equal the number of returned keys.
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, InvariantPrefixConsistency) {
+    PrefixIndex idx;
+    idx.insert("aaa/1", 10, kClient1);
+    idx.insert("aaa/2", 20, kClient1);
+    idx.insert("aab/3", 30, kClient1);
+    idx.insert("bbb/4", 40, kClient2);
+    idx.insert("bbb/5", 50, kClient2);
+
+    std::vector<std::string> prefixes = {"", "a", "aa", "aaa", "aaa/",
+                                         "aab", "b", "bbb", "bbb/", "xyz"};
+
+    for (const auto& p : prefixes) {
+        auto keys = idx.list_keys_by_prefix(p);
+        auto count = idx.count_by_prefix(p);
+
+        // count must match number of returned keys.
+        EXPECT_EQ(count, keys.size())
+            << "Mismatch for prefix \"" << p << "\"";
+
+        // Every returned key must start with the prefix.
+        for (const auto& k : keys) {
+            EXPECT_TRUE(k.substr(0, p.size()) == p)
+                << "Key \"" << k << "\" does not start with prefix \""
+                << p << "\"";
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Upsert: size decrease then remove (exercises negative size_delta)
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, UpsertSizeDecreaseThenRemove) {
+    PrefixIndex idx;
+    idx.insert("obj", 500, kClient1);
+    EXPECT_EQ(idx.bytes_by_prefix(""), 500);
+
+    // Upsert with smaller size (negative size_delta in update_ancestors).
+    idx.insert("obj", 200, kClient2);
+    EXPECT_EQ(idx.size(), 1);
+    EXPECT_EQ(idx.bytes_by_prefix(""), 200);
+
+    // Remove should bring everything to zero without underflow.
+    idx.remove("obj");
+    EXPECT_EQ(idx.size(), 0);
+    EXPECT_EQ(idx.bytes_by_prefix(""), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Repeated upsert churn on same key with varying size/client
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, RepeatedUpsertChurn) {
+    PrefixIndex idx;
+    idx.insert("churn/key", 100, kClient1);
+    idx.insert("churn/other", 50, kClient1);
+
+    // Upsert the same key many times with varying sizes.
+    uint64_t last_size = 100;
+    for (int i = 0; i < 50; ++i) {
+        uint64_t new_size = (i + 1) * 7;
+        UUID client = (i % 2 == 0) ? kClient1 : kClient2;
+        idx.insert("churn/key", new_size, client);
+        last_size = new_size;
+    }
+
+    EXPECT_EQ(idx.size(), 2);
+    EXPECT_EQ(idx.count_by_prefix("churn/"), 2);
+    // "churn/other" is 50, "churn/key" is the last upserted size.
+    EXPECT_EQ(idx.bytes_by_prefix("churn/"), last_size + 50);
+    EXPECT_EQ(idx.bytes_by_prefix(""), last_size + 50);
+
+    // Remove both and verify clean state.
+    idx.remove("churn/key");
+    idx.remove("churn/other");
+    EXPECT_EQ(idx.size(), 0);
+    EXPECT_EQ(idx.bytes_by_prefix(""), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Extended invariant: bytes_by_prefix equals sum of listed key sizes
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, InvariantBytesSumConsistency) {
+    PrefixIndex idx;
+    // Insert keys with known sizes under two prefixes.
+    idx.insert("x/a", 10, kClient1);
+    idx.insert("x/b", 20, kClient1);
+    idx.insert("x/c", 30, kClient1);
+    idx.insert("y/d", 40, kClient2);
+    idx.insert("y/e", 50, kClient2);
+
+    // Upsert a key to change its size.
+    idx.insert("x/a", 15, kClient2);
+
+    // Remove one key.
+    idx.remove("y/d");
+
+    // Verify bytes_by_prefix("") == sum of all remaining sizes.
+    // Remaining: x/a=15, x/b=20, x/c=30, y/e=50
+    EXPECT_EQ(idx.bytes_by_prefix(""), 15 + 20 + 30 + 50);
+    EXPECT_EQ(idx.bytes_by_prefix("x/"), 15 + 20 + 30);
+    EXPECT_EQ(idx.bytes_by_prefix("y/"), 50);
+    EXPECT_EQ(idx.count_by_prefix(""), 4);
+    EXPECT_EQ(idx.count_by_prefix("x/"), 3);
+    EXPECT_EQ(idx.count_by_prefix("y/"), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Stress: churn with periodic clear
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, StressChurnWithPeriodicClear) {
+    PrefixIndex idx;
+    constexpr int kRounds = 5;
+    constexpr int kKeysPerRound = 200;
+
+    for (int round = 0; round < kRounds; ++round) {
+        // Insert keys
+        uint64_t expected_bytes = 0;
+        for (int i = 0; i < kKeysPerRound; ++i) {
+            uint64_t sz = (i + 1) * 10;
+            idx.insert("r" + std::to_string(round) + "/k" +
+                           std::to_string(i),
+                       sz, kClient1);
+            expected_bytes += sz;
+        }
+
+        std::string prefix = "r" + std::to_string(round) + "/";
+        EXPECT_EQ(idx.count_by_prefix(prefix), kKeysPerRound);
+        EXPECT_EQ(idx.bytes_by_prefix(prefix), expected_bytes);
+
+        // Remove half
+        for (int i = 0; i < kKeysPerRound; i += 2) {
+            uint64_t sz = (i + 1) * 10;
+            idx.remove("r" + std::to_string(round) + "/k" +
+                       std::to_string(i));
+            expected_bytes -= sz;
+        }
+
+        EXPECT_EQ(idx.count_by_prefix(prefix), kKeysPerRound / 2);
+        EXPECT_EQ(idx.bytes_by_prefix(prefix), expected_bytes);
+
+        // Periodic clear every other round
+        if (round % 2 == 1) {
+            idx.clear();
+            EXPECT_EQ(idx.size(), 0);
+            EXPECT_EQ(idx.bytes_by_prefix(""), 0);
+        }
+    }
+}
+
+// ===========================================================================
+// list_entries_by_prefix
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Basic functionality
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ListEntriesEmptyTrieReturnsEmpty) {
+    PrefixIndex idx;
+    auto entries = idx.list_entries_by_prefix("anything");
+    EXPECT_TRUE(entries.empty());
+
+    entries = idx.list_entries_by_prefix("");
+    EXPECT_TRUE(entries.empty());
+}
+
+TEST(PrefixIndexTest, ListEntriesSingleKeyExactPrefix) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+
+    auto entries = idx.list_entries_by_prefix("abc");
+    ASSERT_EQ(entries.size(), 1);
+    EXPECT_EQ(entries[0].first, "abc");
+    EXPECT_EQ(entries[0].second.size, 100);
+    EXPECT_EQ(entries[0].second.client_id, kClient1);
+}
+
+TEST(PrefixIndexTest, ListEntriesSingleKeyStrictPrefix) {
+    PrefixIndex idx;
+    idx.insert("abc/def", 256, kClient2);
+
+    auto entries = idx.list_entries_by_prefix("abc/");
+    ASSERT_EQ(entries.size(), 1);
+    EXPECT_EQ(entries[0].first, "abc/def");
+    EXPECT_EQ(entries[0].second.size, 256);
+    EXPECT_EQ(entries[0].second.client_id, kClient2);
+}
+
+TEST(PrefixIndexTest, ListEntriesMultipleKeysSharedPrefix) {
+    PrefixIndex idx;
+    idx.insert("llama-70b/layer.0/q_proj.weight", 1024, kClient1);
+    idx.insert("llama-70b/layer.0/k_proj.weight", 2048, kClient1);
+    idx.insert("llama-70b/layer.1/q_proj.weight", 512, kClient2);
+
+    auto entries = idx.list_entries_by_prefix("llama-70b/");
+    ASSERT_EQ(entries.size(), 3);
+
+    std::map<std::string, TrieLeafData> by_key;
+    for (const auto& [k, v] : entries) by_key[k] = v;
+
+    EXPECT_EQ(by_key["llama-70b/layer.0/q_proj.weight"].size, 1024);
+    EXPECT_EQ(by_key["llama-70b/layer.0/q_proj.weight"].client_id, kClient1);
+    EXPECT_EQ(by_key["llama-70b/layer.0/k_proj.weight"].size, 2048);
+    EXPECT_EQ(by_key["llama-70b/layer.1/q_proj.weight"].size, 512);
+    EXPECT_EQ(by_key["llama-70b/layer.1/q_proj.weight"].client_id, kClient2);
+}
+
+TEST(PrefixIndexTest, ListEntriesEmptyPrefixReturnsAll) {
+    PrefixIndex idx;
+    idx.insert("a/x", 10, kClient1);
+    idx.insert("b/y", 20, kClient2);
+    idx.insert("c/z", 30, kClient1);
+
+    auto entries = idx.list_entries_by_prefix("");
+    ASSERT_EQ(entries.size(), 3);
+}
+
+TEST(PrefixIndexTest, ListEntriesDisjointPrefixReturnsOnlyMatching) {
+    PrefixIndex idx;
+    idx.insert("a/one", 100, kClient1);
+    idx.insert("a/two", 200, kClient1);
+    idx.insert("b/three", 300, kClient2);
+
+    auto entries = idx.list_entries_by_prefix("a/");
+    ASSERT_EQ(entries.size(), 2);
+    for (const auto& [k, v] : entries) {
+        EXPECT_TRUE(k.substr(0, 2) == "a/");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Leaf data correctness
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ListEntriesVerifiesSizeAndClientId) {
+    PrefixIndex idx;
+    idx.insert("tenant-a/obj1", 100, kClient1);
+    idx.insert("tenant-a/obj2", 200, kClient2);
+    idx.insert("tenant-b/obj3", 300, kClient1);
+
+    auto entries = idx.list_entries_by_prefix("tenant-a/");
+    ASSERT_EQ(entries.size(), 2);
+
+    std::map<std::string, TrieLeafData> by_key;
+    for (const auto& [k, v] : entries) by_key[k] = v;
+
+    EXPECT_EQ(by_key["tenant-a/obj1"].size, 100);
+    EXPECT_EQ(by_key["tenant-a/obj1"].client_id, kClient1);
+    EXPECT_EQ(by_key["tenant-a/obj2"].size, 200);
+    EXPECT_EQ(by_key["tenant-a/obj2"].client_id, kClient2);
+}
+
+TEST(PrefixIndexTest, ListEntriesAfterUpsertReflectsLatestData) {
+    PrefixIndex idx;
+    idx.insert("key", 100, kClient1);
+    idx.insert("key", 200, kClient2);
+
+    auto entries = idx.list_entries_by_prefix("key");
+    ASSERT_EQ(entries.size(), 1);
+    EXPECT_EQ(entries[0].second.size, 200);
+    EXPECT_EQ(entries[0].second.client_id, kClient2);
+}
+
+TEST(PrefixIndexTest, ListEntriesMultipleClientsUnderPrefix) {
+    PrefixIndex idx;
+    idx.insert("shared/obj1", 10, kClient1);
+    idx.insert("shared/obj2", 20, kClient2);
+    idx.insert("shared/obj3", 30, kClient1);
+
+    auto entries = idx.list_entries_by_prefix("shared/");
+    ASSERT_EQ(entries.size(), 3);
+
+    std::map<std::string, TrieLeafData> by_key;
+    for (const auto& [k, v] : entries) by_key[k] = v;
+
+    EXPECT_EQ(by_key["shared/obj1"].client_id, kClient1);
+    EXPECT_EQ(by_key["shared/obj2"].client_id, kClient2);
+    EXPECT_EQ(by_key["shared/obj3"].client_id, kClient1);
+}
+
+// ---------------------------------------------------------------------------
+// Mid-edge prefix cases
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ListEntriesMidEdgeSingleKey) {
+    PrefixIndex idx;
+    idx.insert("mistral-7b/layer.0/q_proj.weight", 1024, kClient1);
+
+    auto entries = idx.list_entries_by_prefix("mistral");
+    ASSERT_EQ(entries.size(), 1);
+    EXPECT_EQ(entries[0].first, "mistral-7b/layer.0/q_proj.weight");
+    EXPECT_EQ(entries[0].second.size, 1024);
+    EXPECT_EQ(entries[0].second.client_id, kClient1);
+}
+
+TEST(PrefixIndexTest, ListEntriesMidEdgeMultipleKeys) {
+    PrefixIndex idx;
+    idx.insert("mistral-7b/layer.0/q_proj.weight", 100, kClient1);
+    idx.insert("mistral-7b/layer.1/q_proj.weight", 200, kClient2);
+
+    auto entries = idx.list_entries_by_prefix("mistral-7b/layer.");
+    ASSERT_EQ(entries.size(), 2);
+
+    std::map<std::string, TrieLeafData> by_key;
+    for (const auto& [k, v] : entries) by_key[k] = v;
+
+    EXPECT_EQ(by_key["mistral-7b/layer.0/q_proj.weight"].size, 100);
+    EXPECT_EQ(by_key["mistral-7b/layer.1/q_proj.weight"].size, 200);
+    EXPECT_EQ(by_key["mistral-7b/layer.1/q_proj.weight"].client_id, kClient2);
+}
+
+// ---------------------------------------------------------------------------
+// Structural edge cases
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ListEntriesTerminalAndInternalNode) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+    idx.insert("abc/def", 200, kClient2);
+
+    auto entries = idx.list_entries_by_prefix("abc");
+    ASSERT_EQ(entries.size(), 2);
+
+    std::map<std::string, TrieLeafData> by_key;
+    for (const auto& [k, v] : entries) by_key[k] = v;
+
+    EXPECT_EQ(by_key["abc"].size, 100);
+    EXPECT_EQ(by_key["abc"].client_id, kClient1);
+    EXPECT_EQ(by_key["abc/def"].size, 200);
+    EXPECT_EQ(by_key["abc/def"].client_id, kClient2);
+}
+
+TEST(PrefixIndexTest, ListEntriesAfterRemoveExcludesDeletedKey) {
+    PrefixIndex idx;
+    idx.insert("p/a", 10, kClient1);
+    idx.insert("p/b", 20, kClient1);
+    idx.insert("p/c", 30, kClient2);
+
+    idx.remove("p/b");
+
+    auto entries = idx.list_entries_by_prefix("p/");
+    ASSERT_EQ(entries.size(), 2);
+
+    std::set<std::string> keys;
+    for (const auto& [k, v] : entries) keys.insert(k);
+    EXPECT_TRUE(keys.count("p/a"));
+    EXPECT_FALSE(keys.count("p/b"));
+    EXPECT_TRUE(keys.count("p/c"));
+}
+
+TEST(PrefixIndexTest, ListEntriesAfterClearReturnsEmpty) {
+    PrefixIndex idx;
+    idx.insert("a", 10, kClient1);
+    idx.insert("b", 20, kClient1);
+
+    idx.clear();
+
+    auto entries = idx.list_entries_by_prefix("");
+    EXPECT_TRUE(entries.empty());
+}
+
+TEST(PrefixIndexTest, ListEntriesAfterClearAndRebuild) {
+    PrefixIndex idx;
+    idx.insert("x/1", 100, kClient1);
+    idx.insert("x/2", 200, kClient2);
+
+    idx.clear();
+
+    idx.insert("x/1", 150, kClient2);
+    idx.insert("x/2", 250, kClient1);
+
+    auto entries = idx.list_entries_by_prefix("x/");
+    ASSERT_EQ(entries.size(), 2);
+
+    std::map<std::string, TrieLeafData> by_key;
+    for (const auto& [k, v] : entries) by_key[k] = v;
+
+    EXPECT_EQ(by_key["x/1"].size, 150);
+    EXPECT_EQ(by_key["x/1"].client_id, kClient2);
+    EXPECT_EQ(by_key["x/2"].size, 250);
+    EXPECT_EQ(by_key["x/2"].client_id, kClient1);
+}
+
+// ---------------------------------------------------------------------------
+// Nonexistent / miss cases
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ListEntriesNonexistentPrefixReturnsEmpty) {
+    PrefixIndex idx;
+    idx.insert("abc", 100, kClient1);
+
+    auto entries = idx.list_entries_by_prefix("xyz");
+    EXPECT_TRUE(entries.empty());
+}
+
+TEST(PrefixIndexTest, ListEntriesPrefixDivergesMidEdgeReturnsEmpty) {
+    PrefixIndex idx;
+    idx.insert("abcdef", 100, kClient1);
+
+    auto entries = idx.list_entries_by_prefix("abx");
+    EXPECT_TRUE(entries.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Sorted order
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ListEntriesReturnsSortedByKey) {
+    PrefixIndex idx;
+    idx.insert("c/z", 30, kClient1);
+    idx.insert("a/x", 10, kClient1);
+    idx.insert("b/y", 20, kClient2);
+
+    auto entries = idx.list_entries_by_prefix("");
+    ASSERT_EQ(entries.size(), 3);
+
+    std::vector<std::string> keys;
+    for (const auto& [k, v] : entries) keys.push_back(k);
+    EXPECT_TRUE(std::is_sorted(keys.begin(), keys.end()));
+}
+
+// ---------------------------------------------------------------------------
+// Cross-consistency invariants
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ListEntriesCountMatchesCountByPrefix) {
+    PrefixIndex idx;
+    idx.insert("aaa/1", 10, kClient1);
+    idx.insert("aaa/2", 20, kClient1);
+    idx.insert("aab/3", 30, kClient2);
+    idx.insert("bbb/4", 40, kClient2);
+
+    std::vector<std::string> prefixes = {"", "a", "aa", "aaa", "aaa/",
+                                         "aab", "b", "bbb", "xyz"};
+    for (const auto& p : prefixes) {
+        auto entries = idx.list_entries_by_prefix(p);
+        auto count = idx.count_by_prefix(p);
+        EXPECT_EQ(entries.size(), count)
+            << "Mismatch for prefix \"" << p << "\"";
+    }
+}
+
+TEST(PrefixIndexTest, ListEntriesBytesSumMatchesBytesByPrefix) {
+    PrefixIndex idx;
+    idx.insert("aaa/1", 10, kClient1);
+    idx.insert("aaa/2", 20, kClient1);
+    idx.insert("aab/3", 30, kClient2);
+    idx.insert("bbb/4", 40, kClient2);
+
+    std::vector<std::string> prefixes = {"", "a", "aa", "aaa", "aaa/",
+                                         "aab", "b", "bbb", "xyz"};
+    for (const auto& p : prefixes) {
+        auto entries = idx.list_entries_by_prefix(p);
+        uint64_t sum = 0;
+        for (const auto& [k, v] : entries) sum += v.size;
+        EXPECT_EQ(sum, idx.bytes_by_prefix(p))
+            << "Mismatch for prefix \"" << p << "\"";
+    }
+}
+
+TEST(PrefixIndexTest, ListEntriesKeysMatchListKeysByPrefix) {
+    PrefixIndex idx;
+    idx.insert("aaa/1", 10, kClient1);
+    idx.insert("aaa/2", 20, kClient1);
+    idx.insert("aab/3", 30, kClient2);
+    idx.insert("bbb/4", 40, kClient2);
+
+    std::vector<std::string> prefixes = {"", "a", "aa", "aaa", "aaa/",
+                                         "aab", "b", "bbb", "xyz"};
+    for (const auto& p : prefixes) {
+        auto entries = idx.list_entries_by_prefix(p);
+        auto keys_only = idx.list_keys_by_prefix(p);
+
+        std::vector<std::string> entry_keys;
+        for (const auto& [k, v] : entries) entry_keys.push_back(k);
+
+        EXPECT_EQ(entry_keys, keys_only)
+            << "Key mismatch for prefix \"" << p << "\"";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+TEST(PrefixIndexTest, ConcurrentInsertsAndListEntries) {
+    PrefixIndex idx;
+    constexpr int kNumWriters = 4;
+    constexpr int kKeysPerWriter = 500;
+    constexpr int kNumReaders = 4;
+
+    std::vector<std::thread> threads;
+
+    for (int w = 0; w < kNumWriters; ++w) {
+        threads.emplace_back([&idx, w]() {
+            for (int i = 0; i < kKeysPerWriter; ++i) {
+                std::string key = "w" + std::to_string(w) + "/key_" +
+                                  std::to_string(i);
+                idx.insert(key, 10, kClient1);
+            }
+        });
+    }
+
+    for (int r = 0; r < kNumReaders; ++r) {
+        threads.emplace_back([&idx]() {
+            for (int i = 0; i < 100; ++i) {
+                auto entries = idx.list_entries_by_prefix("w0/");
+                (void)entries;
+                auto all = idx.list_entries_by_prefix("");
+                (void)all;
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    auto all_entries = idx.list_entries_by_prefix("");
+    EXPECT_EQ(all_entries.size(), kNumWriters * kKeysPerWriter);
+
+    for (const auto& [k, v] : all_entries) {
+        EXPECT_EQ(v.size, 10);
+        EXPECT_EQ(v.client_id, kClient1);
+    }
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/prefix_index_test.cpp
+++ b/mooncake-store/tests/prefix_index_test.cpp
@@ -573,8 +573,8 @@ TEST(PrefixIndexTest, ConcurrentInsertsAndReads) {
     for (int w = 0; w < kNumWriters; ++w) {
         threads.emplace_back([&idx, w]() {
             for (int i = 0; i < kKeysPerWriter; ++i) {
-                std::string key = "w" + std::to_string(w) + "/key_" +
-                                  std::to_string(i);
+                std::string key =
+                    "w" + std::to_string(w) + "/key_" + std::to_string(i);
                 idx.insert(key, 10, kClient1);
             }
         });
@@ -724,8 +724,8 @@ TEST(PrefixIndexTest, ListPrefixContinuationsExposesCompressedTrieEdges) {
     idx.insert("ac/two", 200, kClient1);
 
     // Tree: root → "a" (internal) → "b/one" (terminal), "c/two" (terminal)
-    // list_prefix_continuations("a") returns the FULL compressed edges from the "a"
-    // node, not truncated-at-delimiter immediate children. This is the
+    // list_prefix_continuations("a") returns the FULL compressed edges from the
+    // "a" node, not truncated-at-delimiter immediate children. This is the
     // intended radix tree behavior — edges can span multiple "levels."
     auto children = idx.list_prefix_continuations("a");
     ASSERT_EQ(children.size(), 2);
@@ -818,7 +818,7 @@ TEST(PrefixIndexTest, InvariantPrefixConsistency) {
     idx.insert("bbb/4", 40, kClient2);
     idx.insert("bbb/5", 50, kClient2);
 
-    std::vector<std::string> prefixes = {"", "a", "aa", "aaa", "aaa/",
+    std::vector<std::string> prefixes = {"",    "a", "aa",  "aaa",  "aaa/",
                                          "aab", "b", "bbb", "bbb/", "xyz"};
 
     for (const auto& p : prefixes) {
@@ -826,14 +826,13 @@ TEST(PrefixIndexTest, InvariantPrefixConsistency) {
         auto count = idx.count_by_prefix(p);
 
         // count must match number of returned keys.
-        EXPECT_EQ(count, keys.size())
-            << "Mismatch for prefix \"" << p << "\"";
+        EXPECT_EQ(count, keys.size()) << "Mismatch for prefix \"" << p << "\"";
 
         // Every returned key must start with the prefix.
         for (const auto& k : keys) {
             EXPECT_TRUE(k.substr(0, p.size()) == p)
-                << "Key \"" << k << "\" does not start with prefix \""
-                << p << "\"";
+                << "Key \"" << k << "\" does not start with prefix \"" << p
+                << "\"";
         }
     }
 }
@@ -932,8 +931,7 @@ TEST(PrefixIndexTest, StressChurnWithPeriodicClear) {
         uint64_t expected_bytes = 0;
         for (int i = 0; i < kKeysPerRound; ++i) {
             uint64_t sz = (i + 1) * 10;
-            idx.insert("r" + std::to_string(round) + "/k" +
-                           std::to_string(i),
+            idx.insert("r" + std::to_string(round) + "/k" + std::to_string(i),
                        sz, kClient1);
             expected_bytes += sz;
         }
@@ -945,8 +943,7 @@ TEST(PrefixIndexTest, StressChurnWithPeriodicClear) {
         // Remove half
         for (int i = 0; i < kKeysPerRound; i += 2) {
             uint64_t sz = (i + 1) * 10;
-            idx.remove("r" + std::to_string(round) + "/k" +
-                       std::to_string(i));
+            idx.remove("r" + std::to_string(round) + "/k" + std::to_string(i));
             expected_bytes -= sz;
         }
 
@@ -1245,7 +1242,7 @@ TEST(PrefixIndexTest, ListEntriesCountMatchesCountByPrefix) {
     idx.insert("aab/3", 30, kClient2);
     idx.insert("bbb/4", 40, kClient2);
 
-    std::vector<std::string> prefixes = {"", "a", "aa", "aaa", "aaa/",
+    std::vector<std::string> prefixes = {"",    "a", "aa",  "aaa", "aaa/",
                                          "aab", "b", "bbb", "xyz"};
     for (const auto& p : prefixes) {
         auto entries = idx.list_entries_by_prefix(p);
@@ -1262,7 +1259,7 @@ TEST(PrefixIndexTest, ListEntriesBytesSumMatchesBytesByPrefix) {
     idx.insert("aab/3", 30, kClient2);
     idx.insert("bbb/4", 40, kClient2);
 
-    std::vector<std::string> prefixes = {"", "a", "aa", "aaa", "aaa/",
+    std::vector<std::string> prefixes = {"",    "a", "aa",  "aaa", "aaa/",
                                          "aab", "b", "bbb", "xyz"};
     for (const auto& p : prefixes) {
         auto entries = idx.list_entries_by_prefix(p);
@@ -1280,7 +1277,7 @@ TEST(PrefixIndexTest, ListEntriesKeysMatchListKeysByPrefix) {
     idx.insert("aab/3", 30, kClient2);
     idx.insert("bbb/4", 40, kClient2);
 
-    std::vector<std::string> prefixes = {"", "a", "aa", "aaa", "aaa/",
+    std::vector<std::string> prefixes = {"",    "a", "aa",  "aaa", "aaa/",
                                          "aab", "b", "bbb", "xyz"};
     for (const auto& p : prefixes) {
         auto entries = idx.list_entries_by_prefix(p);
@@ -1309,8 +1306,8 @@ TEST(PrefixIndexTest, ConcurrentInsertsAndListEntries) {
     for (int w = 0; w < kNumWriters; ++w) {
         threads.emplace_back([&idx, w]() {
             for (int i = 0; i < kKeysPerWriter; ++i) {
-                std::string key = "w" + std::to_string(w) + "/key_" +
-                                  std::to_string(i);
+                std::string key =
+                    "w" + std::to_string(w) + "/key_" + std::to_string(i);
                 idx.insert(key, 10, kClient1);
             }
         });


### PR DESCRIPTION
## Description

Introduce a compressed Patricia-style radix tree over string keys to support efficient prefix-based enumeration and aggregation.

The trie is implemented as an independent data structure and is not yet integrated with MasterService or the existing hash-sharded metadata index.

Supports:

- insert/remove of full string keys with automatic node cleanup
- listing keys and lightweight leaf data by prefix
- handling prefixes ending mid-edge (compressed trie semantics)
- prefix continuation listing for hierarchical browsing
- subtree aggregation (count, bytes) via maintained statistics

Uses coarse-grained locking to provide thread-safe concurrent reads and writes.

Stores lightweight per-terminal-node summary data (TrieLeafData) to keep scope decoupled from full metadata lifecycle.

Includes unit tests covering:

- insert/remove and prefix query correctness
- edge cases (partial edge splits, prefix-as-key, mid-edge traversal)
- subtree statistic invariants (count/bytes consistency)
- cleanup behavior after deletes
- concurrent access patterns


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [X] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Added a bunch of new UTs.

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [] I have updated the documentation.
- [X] I have added tests to prove my changes are effective.

Ref #1732 
