### PR TITLE
[Store] Fix `with_hard_pin` failure in python API

### DIFF
--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -446,6 +446,16 @@ config = ReplicateConfig()
 config.with_soft_pin = True  # Keep this object in memory longer
 ```
 
+#### with_hard_pin
+**Type:** `bool`
+**Default:** `False`
+**Description:** Enables hard pinning for the stored object. Hard pinned objects will not be evicted. This grants user to manually control the life time of stored objects.
+
+```python
+config = ReplicateConfig()
+config.with_hard_pin = True  # Keep this object in memory that will not be evicted
+```
+
 #### preferred_segment
 **Type:** `str`
 **Default:** `""` (empty string)

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1397,6 +1397,7 @@ PYBIND11_MODULE(store, m) {
         .def(py::init<>())
         .def_readwrite("replica_num", &ReplicateConfig::replica_num)
         .def_readwrite("with_soft_pin", &ReplicateConfig::with_soft_pin)
+        .def_readwrite("with_hard_pin", &ReplicateConfig::with_hard_pin)
         .def_readwrite("preferred_segments",
                        &ReplicateConfig::preferred_segments)
         .def_readwrite("preferred_segment", &ReplicateConfig::preferred_segment)

--- a/mooncake-store/go/mooncakestore/config.go
+++ b/mooncake-store/go/mooncakestore/config.go
@@ -18,6 +18,7 @@ package mooncakestore
 type ReplicateConfig struct {
 	ReplicaNum        int
 	WithSoftPin       bool
+	WithHardPin       bool
 	PreferredSegments []string
 }
 
@@ -26,5 +27,6 @@ func DefaultReplicateConfig() ReplicateConfig {
 	return ReplicateConfig{
 		ReplicaNum:  1,
 		WithSoftPin: false,
+		WithHardPin: false,
 	}
 }

--- a/mooncake-store/go/mooncakestore/store.go
+++ b/mooncake-store/go/mooncakestore/store.go
@@ -140,6 +140,9 @@ func (s *Store) toCConfig(cfg *ReplicateConfig) (C.mooncake_replicate_config_t, 
 	if cfg.WithSoftPin {
 		cc.with_soft_pin = 1
 	}
+	if cfg.WithHardPin {
+		cc.with_hard_pin = 1
+	}
 
 	if len(cfg.PreferredSegments) > 0 {
 		cSegs = make([]*C.char, len(cfg.PreferredSegments))

--- a/mooncake-store/include/store_c.h
+++ b/mooncake-store/include/store_c.h
@@ -27,6 +27,7 @@ typedef void *mooncake_store_t;
 struct mooncake_replicate_config {
     size_t replica_num;
     int with_soft_pin;
+    int with_hard_pin;
     const char **preferred_segments;
     size_t preferred_segments_count;
 };

--- a/mooncake-store/rust/examples/basic_usage.rs
+++ b/mooncake-store/rust/examples/basic_usage.rs
@@ -126,13 +126,14 @@ fn main() {
     let config = ReplicateConfig {
         replica_num: 2,
         with_soft_pin: true,
+        with_hard_pin: false,
         preferred_segments: vec!["seg-0".to_string()],
     };
 
     if let Err(e) = store.put("replicated-key", b"replicated value", Some(&config)) {
         eprintln!("[FAIL] put() with ReplicateConfig failed: {e}");
     } else {
-        println!("[OK] put(\"replicated-key\") with replica_num=2, soft_pin=true");
+        println!("[OK] put(\"replicated-key\") with replica_num=2, soft_pin=true, hard_pin=false");
     }
 
     // Step 8: Remove the keys.

--- a/mooncake-store/rust/src/store.rs
+++ b/mooncake-store/rust/src/store.rs
@@ -42,6 +42,8 @@ pub struct ReplicateConfig {
     pub replica_num: usize,
     /// Prefer a replica on the same NUMA node / host ("soft pin").
     pub with_soft_pin: bool,
+    /// Declare whether the object will never be evicted.
+    pub with_hard_pin: bool,
     /// Whitelist of segment names that should host a replica.
     pub preferred_segments: Vec<String>,
 }
@@ -69,6 +71,7 @@ impl ReplicateConfig {
         let c_config = ffi::mooncake_replicate_config_t {
             replica_num: self.replica_num,
             with_soft_pin: i32::from(self.with_soft_pin),
+            with_hard_pin: i32::from(self.with_hard_pin),
             preferred_segments: if ptrs.is_empty() {
                 std::ptr::null_mut()
             } else {
@@ -465,12 +468,14 @@ mod tests {
         let config = ReplicateConfig {
             replica_num: 2,
             with_soft_pin: true,
+            with_hard_pin: false,
             preferred_segments: Vec::new(),
         };
 
         let (ffi_cfg, strings, ptrs) = config.to_ffi().expect("to_ffi should succeed");
         assert_eq!(ffi_cfg.replica_num, 2);
         assert_eq!(ffi_cfg.with_soft_pin, 1);
+        assert_eq!(ffi_cfg.with_hard_pin, 0);
         assert!(ffi_cfg.preferred_segments.is_null());
         assert_eq!(ffi_cfg.preferred_segments_count, 0);
         assert!(strings.is_empty());
@@ -482,12 +487,14 @@ mod tests {
         let config = ReplicateConfig {
             replica_num: 3,
             with_soft_pin: false,
+            with_hard_pin: false,
             preferred_segments: vec!["seg-a".to_string(), "seg-b".to_string()],
         };
 
         let (ffi_cfg, strings, ptrs) = config.to_ffi().expect("to_ffi should succeed");
         assert_eq!(ffi_cfg.replica_num, 3);
         assert_eq!(ffi_cfg.with_soft_pin, 0);
+        assert_eq!(ffi_cfg.with_hard_pin, 0);
         assert!(!ffi_cfg.preferred_segments.is_null());
         assert_eq!(ffi_cfg.preferred_segments_count, 2);
         assert_eq!(strings.len(), 2);
@@ -504,6 +511,7 @@ mod tests {
         let config = ReplicateConfig {
             replica_num: 1,
             with_soft_pin: false,
+            with_hard_pin: false,
             preferred_segments: vec!["bad\0segment".to_string()],
         };
 
@@ -534,6 +542,7 @@ mod tests {
         let cfg_ref = c_cfg.as_ref().expect("expected Some config");
         assert_eq!(cfg_ref.replica_num, 4);
         assert_eq!(cfg_ref.with_soft_pin, 1);
+        assert_eq!(cfg_ref.with_hard_pin, 0);
         assert_eq!(cfg_ref.preferred_segments_count, 2);
         assert_eq!(strings.len(), 2);
         assert_eq!(ptrs.len(), 2);

--- a/mooncake-store/rust/src/store.rs
+++ b/mooncake-store/rust/src/store.rs
@@ -534,6 +534,7 @@ mod tests {
         let config = ReplicateConfig {
             replica_num: 4,
             with_soft_pin: true,
+            with_hard_pin: false,
             preferred_segments: vec!["x".to_string(), "y".to_string()],
         };
 

--- a/mooncake-store/src/store_c.cpp
+++ b/mooncake-store/src/store_c.cpp
@@ -45,6 +45,7 @@ mooncake::ReplicateConfig to_replicate_config(
 
     config.replica_num = c_config->replica_num;
     config.with_soft_pin = c_config->with_soft_pin != 0;
+    config.with_hard_pin = c_config->with_hard_pin != 0;
     if (c_config->preferred_segments &&
         c_config->preferred_segments_count > 0) {
         for (size_t i = 0; i < c_config->preferred_segments_count; ++i) {

--- a/mooncake-wheel/tests/test_replicated_distributed_object_store.py
+++ b/mooncake-wheel/tests/test_replicated_distributed_object_store.py
@@ -174,6 +174,7 @@ class TestDistributedObjectStoreReplication(unittest.TestCase):
         config = ReplicateConfig()
         config.replica_num = self.max_replicate_num
         config.with_soft_pin = False
+        config.with_hard_pin = False
         
         key2 = "test_put_from_config_key2"
         result = self.store.put_from(key=key2, buffer_ptr=buffer_ptr, size=len(test_data), config=config)
@@ -244,6 +245,7 @@ class TestDistributedObjectStoreReplication(unittest.TestCase):
         config = ReplicateConfig()
         config.replica_num = self.max_replicate_num
         config.with_soft_pin = False
+        config.with_hard_pin = False
 
         keys2 = ["test_batch_put_from_config_key4", "test_batch_put_from_config_key5", "test_batch_put_from_config_key6"]
         results = self.store.batch_put_from(keys=keys2, buffer_ptrs=buffer_ptrs, sizes=buffer_sizes, config=config)


### PR DESCRIPTION
## Description

While PR #1728 introduced the `with_hard_pin` capability to the C++ core, the corresponding Python interface was missing. 

Currently, attempting to configure `with_hard_pin` via the Python API results in the following error:

```python
from mooncake.store import ReplicateConfig
config = ReplicateConfig()
config.with_hard_pin = True
```

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'mooncake.store.ReplicateConfig' object has no attribute 'with_hard_pin'
```

### Root Cause & Solution:

The `with_hard_pin` attribute was not registered in the pybind11 module (`store_py.cpp`). This PR fixes the issue by explicitly exposing `with_hard_pin` via pybind11, aligning the Python API with the underlying C++ `ReplicateConfig` struct.


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
