### PR TITLE
[Store ]Implement Master HA recovery based on client

### DIFF
--- a/mooncake-store/include/async_metadata_notifier.h
+++ b/mooncake-store/include/async_metadata_notifier.h
@@ -111,38 +111,12 @@ class AsyncMetadataNotifier {
     };
 
     struct SenderShard {
+       public:
         SenderShard() = default;
         SenderShard(const SenderShard&) = delete;
         SenderShard& operator=(const SenderShard&) = delete;
         SenderShard(SenderShard&&) = delete;
         SenderShard& operator=(SenderShard&&) = delete;
-
-        std::mutex mutex;
-        std::condition_variable sender_cv;    // sender waits when both empty
-        std::condition_variable producer_cv;  // normal producer waits when full
-        std::condition_variable recovery_drain_cv;  // WaitForRecoveryDrain
-
-        // Pre-allocated slot pool — shared by both queues
-        std::vector<Slot> slots;
-        std::vector<size_t> free_stack;
-        size_t capacity = 0;
-        size_t normal_reserved = 0;  // slots reserved for normal ops
-
-        // Normal priority linked list
-        size_t normal_head = InvalidIdx;
-        size_t normal_tail = InvalidIdx;
-        size_t normal_count = 0;
-
-        // Recovery (low priority) linked list
-        size_t recovery_head = InvalidIdx;
-        size_t recovery_tail = InvalidIdx;
-        size_t recovery_count = 0;
-
-        // Shared coalesce index (covers both queues)
-        std::unordered_map<CoalesceKey, CoalesceEntry, CoalesceKeyHash>
-            coalesce_index;
-
-        std::thread sender_thread;
 
         bool IsFull() const { return free_stack.empty(); }
         bool IsFullForRecovery() const {
@@ -202,13 +176,48 @@ class AsyncMetadataNotifier {
             }
             count--;
         }
+
+       public:
+        std::mutex mutex;
+        std::condition_variable sender_cv;    // sender waits when both empty
+        std::condition_variable producer_cv;  // normal producer waits when full
+        std::condition_variable recovery_drain_cv;  // WaitForRecoveryDrain
+
+        // Pre-allocated slot pool — shared by both queues
+        std::vector<Slot> slots;
+        std::vector<size_t> free_stack;
+        size_t capacity = 0;
+        size_t normal_reserved = 0;  // slots reserved for normal ops
+
+        // Normal priority linked list
+        size_t normal_head = InvalidIdx;
+        size_t normal_tail = InvalidIdx;
+        size_t normal_count = 0;
+
+        // Recovery (low priority) linked list
+        size_t recovery_head = InvalidIdx;
+        size_t recovery_tail = InvalidIdx;
+        size_t recovery_count = 0;
+
+        // Shared coalesce index (covers both queues)
+        std::unordered_map<CoalesceKey, CoalesceEntry, CoalesceKeyHash>
+            coalesce_index;
+
+        // Recovery ops that have been dequeued by CollectBatch but whose
+        // SendBatch has not yet completed. WaitForRecoveryDrain waits for
+        // both recovery_count and recovery_in_flight to reach zero.
+        size_t recovery_in_flight = 0;
+
+        std::thread sender_thread;
     };
 
    private:
     tl::expected<void, ErrorCode> DoEnqueue(PendingOp&& op, bool is_recovery);
 
     void SenderLoop(size_t shard_idx);
-    size_t CollectBatch(SenderShard& shard, std::vector<PendingOp>& batch_out);
+    // Returns (total_collected, recovery_collected)
+    std::pair<size_t, size_t> CollectBatch(SenderShard& shard,
+                                           std::vector<PendingOp>& batch_out);
     size_t CollectFromList(SenderShard& shard,
                            std::vector<PendingOp>& batch_out, size_t offset,
                            size_t max_count, bool from_recovery);

--- a/mooncake-store/include/async_metadata_notifier.h
+++ b/mooncake-store/include/async_metadata_notifier.h
@@ -34,9 +34,12 @@ class AsyncMetadataNotifier {
     AsyncMetadataNotifier(const AsyncMetadataNotifier&) = delete;
     AsyncMetadataNotifier& operator=(const AsyncMetadataNotifier&) = delete;
 
-    // Start/Stop can be called alternately. Stop drains + clears queue.
+    // Start/Stop can be called alternately.
+    // drop_pending=false (default): sender drains remaining ops before exiting.
+    // drop_pending=true: queued ops are discarded immediately without invoking
+    // failure_cb.
     void Start();
-    void Stop();
+    void Stop(bool drop_pending = false);
 
     // --- Normal priority ---
     tl::expected<void, ErrorCode> EnqueueAdd(const std::string& key,
@@ -234,6 +237,11 @@ class AsyncMetadataNotifier {
     std::vector<std::unique_ptr<SenderShard>> shards_;
     std::vector<std::vector<PendingOp>> batch_buffers_;
     SyncFailureCallback failure_cb_;
+
+    // Set to true by Stop(drop_pending=true) before waking senders.
+    // Tells CollectBatch to return 0 immediately so senders exit after their
+    // current in-flight SendBatch without processing any further queued ops.
+    std::atomic<bool> drop_on_stop_{false};
 
     // Circuit breaker via consecutive failure count:
     //   >=0 : active, value = consecutive failures so far

--- a/mooncake-store/include/async_metadata_notifier.h
+++ b/mooncake-store/include/async_metadata_notifier.h
@@ -38,12 +38,26 @@ class AsyncMetadataNotifier {
     void Start();
     void Stop();
 
+    // --- Normal priority ---
     tl::expected<void, ErrorCode> EnqueueAdd(const std::string& key,
                                              const UUID& segment_id,
                                              size_t size);
 
     tl::expected<void, ErrorCode> EnqueueRemove(const std::string& key,
                                                 const UUID& segment_id);
+
+    // --- Recovery priority (lower send priority) ---
+    tl::expected<void, ErrorCode> EnqueueRecoveryAdd(const std::string& key,
+                                                     const UUID& segment_id,
+                                                     size_t size);
+
+    /**
+     * @brief Wait until all recovery ops have been sent.
+     * Only valid after the caller has finished enqueueing all recovery ops.
+     * @return true if drained, false if aborted or timed out.
+     */
+    bool WaitForRecoveryDrain(const std::function<bool()>& abort_fn,
+                              std::chrono::milliseconds timeout);
 
     bool IsPaused() const {
         return consecutive_rpc_failures_.load(std::memory_order_acquire) < 0;
@@ -90,6 +104,7 @@ class AsyncMetadataNotifier {
         PendingOp op;
         size_t prev = InvalidIdx;
         size_t next = InvalidIdx;
+        bool is_recovery = false;  // which list this slot belongs to
     };
 
     struct SenderShard {
@@ -100,76 +115,100 @@ class AsyncMetadataNotifier {
         SenderShard& operator=(SenderShard&&) = delete;
 
         std::mutex mutex;
-        std::condition_variable sender_cv;    // sender waits when empty
-        std::condition_variable producer_cv;  // producer waits when full
+        std::condition_variable sender_cv;    // sender waits when both empty
+        std::condition_variable producer_cv;  // normal producer waits when full
+        std::condition_variable recovery_drain_cv;  // WaitForRecoveryDrain
 
-        // Pre-allocated slot pool — no dynamic alloc on enqueue/dequeue
+        // Pre-allocated slot pool — shared by both queues
         std::vector<Slot> slots;
         std::vector<size_t> free_stack;
-
-        // Index-based intrusive doubly-linked list for FIFO ordering
-        size_t list_head = InvalidIdx;
-        size_t list_tail = InvalidIdx;
-        size_t count = 0;
         size_t capacity = 0;
+        size_t normal_reserved = 0;  // slots reserved for normal ops
 
+        // Normal priority linked list
+        size_t normal_head = InvalidIdx;
+        size_t normal_tail = InvalidIdx;
+        size_t normal_count = 0;
+
+        // Recovery (low priority) linked list
+        size_t recovery_head = InvalidIdx;
+        size_t recovery_tail = InvalidIdx;
+        size_t recovery_count = 0;
+
+        // Shared coalesce index (covers both queues)
         std::unordered_map<CoalesceKey, CoalesceEntry, CoalesceKeyHash>
             coalesce_index;
 
         std::thread sender_thread;
 
         bool IsFull() const { return free_stack.empty(); }
-        bool IsEmpty() const { return count == 0; }
+        bool IsFullForRecovery() const {
+            return free_stack.size() <= normal_reserved;
+        }
+        bool IsEmpty() const {
+            return normal_count == 0 && recovery_count == 0;
+        }
 
-        // Allocate a slot from the free stack. Caller must check !IsFull().
         size_t AllocSlot() {
             size_t idx = free_stack.back();
             free_stack.pop_back();
             return idx;
         }
 
-        // Return a slot to the free stack.
         void FreeSlot(size_t idx) {
             slots[idx].prev = InvalidIdx;
             slots[idx].next = InvalidIdx;
+            slots[idx].is_recovery = false;
             free_stack.push_back(idx);
         }
 
-        // Append slot idx to the tail of the ordered list.
-        void LinkTail(size_t idx) {
-            slots[idx].prev = list_tail;
+        // Link to the tail of the appropriate list based on is_recovery flag.
+        void LinkTail(size_t idx, bool is_recovery) {
+            auto& head = is_recovery ? recovery_head : normal_head;
+            auto& tail = is_recovery ? recovery_tail : normal_tail;
+            auto& count = is_recovery ? recovery_count : normal_count;
+
+            slots[idx].prev = tail;
             slots[idx].next = InvalidIdx;
-            if (list_tail != InvalidIdx) {
-                slots[list_tail].next = idx;
+            slots[idx].is_recovery = is_recovery;
+            if (tail != InvalidIdx) {
+                slots[tail].next = idx;
             } else {
-                list_head = idx;
+                head = idx;
             }
-            list_tail = idx;
+            tail = idx;
             count++;
         }
 
-        // Remove slot idx from the ordered list.
+        // Unlink from whichever list the slot belongs to.
         void Unlink(size_t idx) {
             auto& slot = slots[idx];
+            auto& head = slot.is_recovery ? recovery_head : normal_head;
+            auto& tail = slot.is_recovery ? recovery_tail : normal_tail;
+            auto& count = slot.is_recovery ? recovery_count : normal_count;
+
             if (slot.prev != InvalidIdx) {
                 slots[slot.prev].next = slot.next;
             } else {
-                list_head = slot.next;
+                head = slot.next;
             }
             if (slot.next != InvalidIdx) {
                 slots[slot.next].prev = slot.prev;
             } else {
-                list_tail = slot.prev;
+                tail = slot.prev;
             }
             count--;
         }
     };
 
    private:
-    tl::expected<void, ErrorCode> DoEnqueue(PendingOp&& op);
+    tl::expected<void, ErrorCode> DoEnqueue(PendingOp&& op, bool is_recovery);
 
     void SenderLoop(size_t shard_idx);
     size_t CollectBatch(SenderShard& shard, std::vector<PendingOp>& batch_out);
+    size_t CollectFromList(SenderShard& shard,
+                           std::vector<PendingOp>& batch_out, size_t offset,
+                           size_t max_count, bool from_recovery);
     void SendBatch(std::vector<PendingOp>& batch, size_t count);
     void RecordSuccess();
     void RecordFailure();

--- a/mooncake-store/include/client_manager.h
+++ b/mooncake-store/include/client_manager.h
@@ -164,6 +164,14 @@ class ClientManager {
         const RegisterClientRequest& req) = 0;
 
     /**
+     * @brief Hook called after a client is registered.
+     * Subclasses can override to perform post-registration logic
+     * (e.g., setting is_syncing flag for HA recovery).
+     */
+    virtual void OnClientRegistered(
+        const std::shared_ptr<ClientMeta>& /*meta*/) {}
+
+    /**
      * @brief Get the deployment mode of this ClientManager.
      * Used for architecture validation during client registration.
      */

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -391,13 +391,13 @@ class ClientService {
     /**
      * @brief Handles a successful heartbeat response.
      * Triggers async RegisterClient if master reports UNDEFINED status.
+     * Fires MASTER_RECONNECTED if connection_interrupted_ was set.
      * @return true if heartbeat was successfully processed.
      */
     bool HandleHeartbeatResponse(const HeartbeatResponse& response,
                                  const std::string& current_master_address,
                                  const std::function<void()>& register_client,
-                                 std::future<void>& register_client_future,
-                                 bool& master_reachable);
+                                 std::future<void>& register_client_future);
 
     /**
      * @brief Handles the result of a task received in a heartbeat response.
@@ -534,6 +534,9 @@ class ClientService {
     std::condition_variable heartbeat_cv_;
     std::mutex heartbeat_mtx_;
     ViewVersionId view_version_{0};
+    /// True after MASTER_UNREACHABLE fires; cleared when MASTER_RECONNECTED fires.
+    /// Only accessed from the heartbeat thread — no locking required.
+    bool connection_interrupted_ = false;
 
     // Shutdown protection
     SharedMutex running_rw_mtx_;

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -534,8 +534,8 @@ class ClientService {
     std::condition_variable heartbeat_cv_;
     std::mutex heartbeat_mtx_;
     ViewVersionId view_version_{0};
-    /// True after MASTER_UNREACHABLE fires; cleared when MASTER_RECONNECTED fires.
-    /// Only accessed from the heartbeat thread — no locking required.
+    /// True after MASTER_UNREACHABLE fires; cleared when MASTER_RECONNECTED
+    /// fires. Only accessed from the heartbeat thread — no locking required.
     bool connection_interrupted_ = false;
 
     // Shutdown protection

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -396,7 +396,8 @@ class ClientService {
     bool HandleHeartbeatResponse(const HeartbeatResponse& response,
                                  const std::string& current_master_address,
                                  const std::function<void()>& register_client,
-                                 std::future<void>& register_client_future);
+                                 std::future<void>& register_client_future,
+                                 bool& master_reachable);
 
     /**
      * @brief Handles the result of a task received in a heartbeat response.
@@ -426,6 +427,12 @@ class ClientService {
      */
     virtual tl::expected<RegisterClientResponse, ErrorCode>
     RegisterClient() = 0;
+
+    /**
+     * @brief Single hook for all HA-related events from the heartbeat loop.
+     * Subclasses override to handle state transitions.
+     */
+    virtual void OnHAEvent(HAEvent event) { (void)event; }
 
    protected:
     /**

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -94,6 +94,24 @@ class DataManager {
     std::vector<TierView> GetTierViews() const;
 
     /**
+     * @brief Iterate all keys in batches.
+     * Delegates to TieredBackend::ForEachKeyBatch().
+     */
+    void ForEachKeyBatch(
+        const std::function<bool(std::vector<ReplicaLocation>&&)>& callback)
+        const;
+
+    /**
+     * @brief Get hot key statistics
+     */
+    AccessStats GetHotKeyStats() const;
+
+    /**
+     * @brief Get all tier IDs where a key has replicas.
+     */
+    std::vector<UUID> GetReplicaTierIds(const std::string& key) const;
+
+    /**
      * @brief Read data and transfer to remote destination buffers
      *
      * This is the core method for remote data access:

--- a/mooncake-store/include/ha_recovery_manager.h
+++ b/mooncake-store/include/ha_recovery_manager.h
@@ -68,9 +68,16 @@ class HARecoveryManager {
     void StartRecoveryThread();
     void RecoveryPipelineMain(AbortToken need_abort);
 
-    /** @brief TryEnqueue with back-off, yielding priority to normal writes. */
-    bool RecoveryEnqueueAdd(const std::string& key, const UUID& tier_id,
-                            size_t size, const AbortToken& need_abort);
+    /**
+     * @brief Retry enqueue until success or abort is signalled.
+     *        Hot keys use the normal (high-priority) queue; recovery keys use
+     *        the recovery queue. Sleeps 10 ms between attempts so normal
+     *        writes keep priority.
+     * @return true on success, false if aborted.
+     */
+    bool EnqueueWithRetry(const std::string& key, const UUID& tier_id,
+                          size_t size, bool is_hot,
+                          const AbortToken& need_abort);
 
     const UUID& client_id_;
     P2PMasterClient& master_client_;

--- a/mooncake-store/include/ha_recovery_manager.h
+++ b/mooncake-store/include/ha_recovery_manager.h
@@ -82,6 +82,11 @@ class HARecoveryManager {
     std::mutex mutex_;  // protects transitions + recovery thread lifecycle
     std::thread recovery_thread_;
     AbortToken need_abort_;  // signals recovery thread to exit
+
+    // Separate mutex/CV for interruptible sleeps inside the recovery thread.
+    // Must NOT be mutex_ (HandleEvent holds mutex_ while joining the thread).
+    std::mutex abort_mutex_;
+    std::condition_variable abort_cv_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha_recovery_manager.h
+++ b/mooncake-store/include/ha_recovery_manager.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+
+#include <boost/functional/hash.hpp>
+
+#include "async_metadata_notifier.h"
+#include "data_manager.h"
+#include "p2p_master_client.h"
+#include "types.h"
+
+namespace mooncake {
+
+/**
+ * @class HARecoveryManager
+ * @brief Manages client-side HA state machine and multi-phase recovery pipeline
+ *        for Master crash recovery.
+ *
+ * State machine (2 events: MASTER_UNREACHABLE, MASTER_REACHABLE):
+ *   FULL ──MASTER_UNREACHABLE─────> DEGRADED
+ *   FULL ──MASTER_REACHABLE───────> SYNCING  (Master restarted)
+ *   DEGRADED ──MASTER_REACHABLE───> SYNCING  (always full re-sync)
+ *   SYNCING ──recovery complete───> FULL
+ *   SYNCING ──MASTER_UNREACHABLE──> DEGRADED
+ *   SYNCING ──MASTER_REACHABLE────> SYNCING  (restart pipeline)
+ *
+ * Thread safety:
+ *   state_ is atomic for lock-free reads on data-path hot path.
+ *   mutex_ protects transitions and recovery thread lifecycle.
+ *   need_abort_ (shared atomic bool) signals the recovery thread to stop
+ *   without requiring mutex_, enabling safe join from HandleEvent.
+ */
+class HARecoveryManager {
+   public:
+    HARecoveryManager(const UUID& client_id, P2PMasterClient& master_client,
+                      std::optional<DataManager>& data_manager,
+                      std::unique_ptr<AsyncMetadataNotifier>& notifier,
+                      ViewVersionId& view_version);
+    ~HARecoveryManager();
+
+    HARecoveryManager(const HARecoveryManager&) = delete;
+    HARecoveryManager& operator=(const HARecoveryManager&) = delete;
+
+    void Stop();
+
+    bool IsDegraded() const {
+        return state_.load(std::memory_order_acquire) ==
+               HAClientState::DEGRADED;
+    }
+
+    HAClientState GetState() const {
+        return state_.load(std::memory_order_acquire);
+    }
+
+    void HandleEvent(HAEvent event);
+
+    tl::expected<void, ErrorCode> SetSyncCompleted();
+
+   private:
+    using AbortToken = std::shared_ptr<std::atomic<bool>>;
+
+    void TransitionState(HAClientState to, const std::string& reason);
+    void StartRecoveryThread();
+    void RecoveryPipelineMain(AbortToken need_abort);
+
+    /** @brief TryEnqueue with back-off, yielding priority to normal writes. */
+    bool RecoveryEnqueueAdd(const std::string& key, const UUID& tier_id,
+                            size_t size, const AbortToken& need_abort);
+
+    const UUID& client_id_;
+    P2PMasterClient& master_client_;
+    std::optional<DataManager>& data_manager_;
+    std::unique_ptr<AsyncMetadataNotifier>& notifier_;
+    ViewVersionId& view_version_;
+
+    std::atomic<HAClientState> state_{HAClientState::FULL};
+    std::mutex mutex_;  // protects transitions + recovery thread lifecycle
+    std::thread recovery_thread_;
+    AbortToken need_abort_;  // signals recovery thread to exit
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/p2p_client_manager.h
+++ b/mooncake-store/include/p2p_client_manager.h
@@ -20,8 +20,7 @@ class P2PClientManager final : public ClientManager {
     std::shared_ptr<ClientMeta> CreateClientMeta(
         const RegisterClientRequest& req) override;
 
-    void OnClientRegistered(
-        const std::shared_ptr<ClientMeta>& meta) override {
+    void OnClientRegistered(const std::shared_ptr<ClientMeta>& meta) override {
         auto p2p_meta = std::dynamic_pointer_cast<P2PClientMeta>(meta);
         if (p2p_meta) {
             p2p_meta->SetSyncing(true);

--- a/mooncake-store/include/p2p_client_manager.h
+++ b/mooncake-store/include/p2p_client_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "client_manager.h"
+#include "p2p_client_meta.h"
 
 namespace mooncake {
 class P2PClientManager final : public ClientManager {
@@ -18,6 +19,14 @@ class P2PClientManager final : public ClientManager {
         ObjectIterateStrategy strategy) override;
     std::shared_ptr<ClientMeta> CreateClientMeta(
         const RegisterClientRequest& req) override;
+
+    void OnClientRegistered(
+        const std::shared_ptr<ClientMeta>& meta) override {
+        auto p2p_meta = std::dynamic_pointer_cast<P2PClientMeta>(meta);
+        if (p2p_meta) {
+            p2p_meta->SetSyncing(true);
+        }
+    }
 
     HeartbeatTaskResult ProcessTask(const UUID& client_id,
                                     const HeartbeatTask& task) override;

--- a/mooncake-store/include/p2p_client_meta.h
+++ b/mooncake-store/include/p2p_client_meta.h
@@ -41,6 +41,14 @@ class P2PClientMeta final : public ClientMeta {
     void DoOnDisconnected() override {}
     void DoOnRecovered() override {}
 
+    // HA sync tracking
+    void SetSyncing(bool syncing) {
+        is_syncing_.store(syncing, std::memory_order_release);
+    }
+    bool IsSyncing() const {
+        return is_syncing_.load(std::memory_order_acquire);
+    }
+
    private:
     static constexpr size_t INF_PRIORITY = 10000;
 
@@ -51,6 +59,8 @@ class P2PClientMeta final : public ClientMeta {
     mutable SpinRWLock capacity_mutex_;
     size_t client_capacity_ GUARDED_BY(capacity_mutex_) = 0;
     size_t client_usage_ GUARDED_BY(capacity_mutex_) = 0;
+
+    std::atomic<bool> is_syncing_{false};
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/p2p_client_service.h
+++ b/mooncake-store/include/p2p_client_service.h
@@ -9,6 +9,7 @@
 #include "client_service.h"
 #include "data_manager.h"
 #include "client_rpc_service.h"
+#include "ha_recovery_manager.h"
 #include "peer_client.h"
 #include "p2p_master_client.h"
 #include "route_cache.h"
@@ -269,6 +270,9 @@ class P2PClientService final : public ClientService {
     PeerClient& GetOrCreatePeerClient(const std::string& endpoint);
 
    private:
+    void OnHAEvent(HAEvent event) override;
+
+   private:
     P2PMasterClient master_client_;
     uint16_t client_rpc_port_ = 12345;
 
@@ -286,6 +290,9 @@ class P2PClientService final : public ClientService {
 
     // Async route notifier (nullptr when disabled)
     std::unique_ptr<AsyncMetadataNotifier> async_route_notifier_;
+
+    // HA recovery manager
+    std::unique_ptr<HARecoveryManager> ha_manager_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/p2p_master_client.h
+++ b/mooncake-store/include/p2p_master_client.h
@@ -46,6 +46,12 @@ class P2PMasterClient final : public MasterClient {
      */
     [[nodiscard]] tl::expected<BatchSyncReplicaResponse, ErrorCode>
     BatchSyncReplica(const BatchSyncReplicaRequest& req);
+
+    /**
+     * @brief Notify Master that this client has finished syncing metadata
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> SetSyncCompleted(
+        UUID client_id);
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -46,6 +46,11 @@ class P2PMasterService : public MasterService {
     auto BatchSyncReplica(const BatchSyncReplicaRequest& req)
         -> BatchSyncReplicaResponse;
 
+    /**
+     * @brief Client notifies Master that metadata sync is complete
+     */
+    auto SetSyncCompleted(UUID client_id) -> tl::expected<void, ErrorCode>;
+
     std::vector<Replica::Descriptor> FilterReplicas(
         const GetReplicaListRequestConfig& config,
         const ObjectMetadata& metadata) override;

--- a/mooncake-store/include/p2p_rpc_service.h
+++ b/mooncake-store/include/p2p_rpc_service.h
@@ -29,6 +29,8 @@ class WrappedP2PMasterService final : public WrappedMasterService {
     BatchSyncReplicaResponse BatchSyncReplica(
         const BatchSyncReplicaRequest& req);
 
+    tl::expected<void, ErrorCode> SetSyncCompleted(UUID client_id);
+
    private:
     P2PMasterService master_service_;
 };

--- a/mooncake-store/include/tiered_cache/scheduler/client_scheduler.h
+++ b/mooncake-store/include/tiered_cache/scheduler/client_scheduler.h
@@ -43,6 +43,11 @@ class ClientScheduler {
     // Incoming event hook (thread-safe)
     void OnAccess(const std::string& key);
 
+    /**
+     * @brief Get current hot key statistics for HA recovery prioritization.
+     */
+    AccessStats GetHotKeyStats() const;
+
     // Called when a replica is committed or updated
     void OnCommit(const std::string& key, UUID tier_id, size_t size_bytes);
 

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <string>
 #include <vector>
@@ -12,6 +13,7 @@
 
 #include "tiered_cache/tiers/cache_tier.h"
 #include "tiered_cache/data_copier.h"
+#include "tiered_cache/scheduler/stats_collector.h"
 #include "rpc_types.h"
 
 namespace mooncake {
@@ -213,6 +215,21 @@ class TieredBackend {
     const CacheTier* GetTier(UUID tier_id) const;
     const DataCopier& GetDataCopier() const;
 
+    /**
+     * @brief Iterate all keys in batches.
+     * Iterates per-shard to minimize lock hold time.
+     * @param callback Receives each batch; return false to stop iteration.
+     * @param batch_size Max entries per batch before releasing lock.
+     */
+    void ForEachKeyBatch(
+        const std::function<bool(std::vector<ReplicaLocation>&&)>& callback)
+        const;
+
+    /**
+     * @brief Get hot key statistics from the scheduler's StatsCollector.
+     */
+    AccessStats GetHotKeyStats() const;
+
    private:
     tl::expected<void, ErrorCode> MountSegment(
         UUID id, size_t capacity, int priority,
@@ -250,12 +267,24 @@ class TieredBackend {
     // Map from tier ID to static config info
     std::unordered_map<UUID, TierInfo> tier_info_;
 
-    // Global Metadata Index: Key -> Entry
-    // map_mutex_ only protects the structure of this map (insertions/deletions
-    // of keys). Accessing existing keys is highly concurrent.
-    std::unordered_map<std::string, std::shared_ptr<MetadataEntry>>
-        metadata_index_;
-    mutable std::shared_mutex map_mutex_;
+    // Sharded Metadata Index: Key -> Entry
+    // Each shard has its own mutex for fine-grained locking.
+    struct MetadataShard {
+        mutable std::shared_mutex mutex;
+        std::unordered_map<std::string, std::shared_ptr<MetadataEntry>> index;
+    };
+
+    static constexpr size_t kMetadataShardCount = 64;
+    std::array<MetadataShard, kMetadataShardCount> metadata_shards_;
+
+    MetadataShard& GetMetadataShard(const std::string& key) {
+        return metadata_shards_[std::hash<std::string>{}(key) %
+                                kMetadataShardCount];
+    }
+    const MetadataShard& GetMetadataShard(const std::string& key) const {
+        return metadata_shards_[std::hash<std::string>{}(key) %
+                                kMetadataShardCount];
+    }
 
     std::unique_ptr<DataCopier> data_copier_;
     // Callbacks for metadata synchronization with Master

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -219,7 +219,6 @@ class TieredBackend {
      * @brief Iterate all keys in batches.
      * Iterates per-shard to minimize lock hold time.
      * @param callback Receives each batch; return false to stop iteration.
-     * @param batch_size Max entries per batch before releasing lock.
      */
     void ForEachKeyBatch(
         const std::function<bool(std::vector<ReplicaLocation>&&)>& callback)

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -380,11 +380,12 @@ inline std::ostream& operator<<(std::ostream& os,
  * @brief Events that drive client-side HA state transitions.
  */
 enum class HAEvent {
-    MASTER_UNREACHABLE,  // Consecutive heartbeat failures exceeded threshold
-    MASTER_REACHABLE,    // Master is reachable. Triggered on:
-                         // 1. RegisterClient succeeded (Master restarted)
-                         // 2. Heartbeat recovered with HEALTH status
-                         //    (short-term network disconnection)
+    MASTER_UNREACHABLE,   // Consecutive heartbeat failures exceeded threshold
+    MASTER_RECONNECTED,   // Master connection restored. Triggered on:
+                          // 1. RegisterClient succeeded (Master restarted or
+                          //    client re-registered after reconnection)
+                          // 2. Heartbeat recovered with HEALTH status after
+                          //    a prior MASTER_UNREACHABLE event
 };
 
 /**

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -380,12 +380,12 @@ inline std::ostream& operator<<(std::ostream& os,
  * @brief Events that drive client-side HA state transitions.
  */
 enum class HAEvent {
-    MASTER_UNREACHABLE,   // Consecutive heartbeat failures exceeded threshold
-    MASTER_RECONNECTED,   // Master connection restored. Triggered on:
-                          // 1. RegisterClient succeeded (Master restarted or
-                          //    client re-registered after reconnection)
-                          // 2. Heartbeat recovered with HEALTH status after
-                          //    a prior MASTER_UNREACHABLE event
+    MASTER_UNREACHABLE,  // Consecutive heartbeat failures exceeded threshold
+    MASTER_RECONNECTED,  // Master connection restored. Triggered on:
+                         // 1. RegisterClient succeeded (Master restarted or
+                         //    client re-registered after reconnection)
+                         // 2. Heartbeat recovered with HEALTH status after
+                         //    a prior MASTER_UNREACHABLE event
 };
 
 /**

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -177,8 +177,9 @@ enum class ErrorCode : int32_t {
 
     // Store errors (Range: -1500 to -1599)
     SHUTTING_DOWN = -1500,  ///< Store is shutting down, rejecting new requests.
-    ASYNC_ENQUEUE_FAILED =
-        -1501,  ///< Async metadata notifier enqueue failed (queue full/stopped).
+    ASYNC_ENQUEUE_FAILED = -1501,  ///< Async metadata notifier enqueue failed
+                                   ///< (queue full/stopped).
+    INACCESSIBLE_MASTER = -1502
 };
 
 int32_t toInt(ErrorCode errorCode) noexcept;
@@ -341,6 +342,60 @@ inline std::ostream& operator<<(std::ostream& os,
                                         : "UNKNOWN");
     return os;
 }
+
+/**
+ * @enum HAClientState
+ * @brief Client-side HA state for Master crash recovery.
+ *        FULL: normal operation
+ *        DEGRADED: Master unreachable, local-only mode
+ *        SYNCING: re-syncing metadata to restarted Master
+ */
+enum class HAClientState : int32_t {
+    FULL = 0,
+    DEGRADED = 1,
+    SYNCING = 2,
+};
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const HAClientState& state) noexcept {
+    switch (state) {
+        case HAClientState::FULL:
+            os << "FULL";
+            break;
+        case HAClientState::DEGRADED:
+            os << "DEGRADED";
+            break;
+        case HAClientState::SYNCING:
+            os << "SYNCING";
+            break;
+        default:
+            os << "UNKNOWN";
+            break;
+    }
+    return os;
+}
+
+/**
+ * @enum HAEvent
+ * @brief Events that drive client-side HA state transitions.
+ */
+enum class HAEvent {
+    MASTER_UNREACHABLE,  // Consecutive heartbeat failures exceeded threshold
+    MASTER_REACHABLE,    // Master is reachable. Triggered on:
+                         // 1. RegisterClient succeeded (Master restarted)
+                         // 2. Heartbeat recovered with HEALTH status
+                         //    (short-term network disconnection)
+};
+
+/**
+ * @struct ReplicaLocation
+ * @brief Describes a single replica's key, tier and size.
+ */
+struct ReplicaLocation {
+    std::string key;
+    UUID tier_id;
+    size_t size;
+};
 
 enum class BufferAllocatorType {
     CACHELIB = 0,  // CachelibBufferAllocator

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -49,6 +49,7 @@ set(MOONCAKE_STORE_SOURCES
     data_manager.cpp
     route_cache.cpp
     async_metadata_notifier.cpp
+    ha_recovery_manager.cpp
     client_rpc_service.cpp
     peer_client.cpp
     tiered_cache/tiers/dram_tier.cpp

--- a/mooncake-store/src/async_metadata_notifier.cpp
+++ b/mooncake-store/src/async_metadata_notifier.cpp
@@ -103,6 +103,7 @@ void AsyncMetadataNotifier::ResetShard(SenderShard& shard) {
     shard.normal_count = 0;
     shard.recovery_head = shard.recovery_tail = InvalidIdx;
     shard.recovery_count = 0;
+    shard.recovery_in_flight = 0;
     shard.free_stack.clear();
     for (size_t i = 0; i < shard.capacity; ++i) {
         shard.slots[i] = Slot{};
@@ -249,7 +250,7 @@ void AsyncMetadataNotifier::SenderLoop(size_t shard_idx) {
             });
         }
 
-        size_t n = CollectBatch(shard, batch);
+        auto [n, recovery_n] = CollectBatch(shard, batch);
 
         if (n == 0) {
             if (!running_.load(std::memory_order_acquire)) break;
@@ -257,11 +258,21 @@ void AsyncMetadataNotifier::SenderLoop(size_t shard_idx) {
         }
 
         SendBatch(batch, n);
+
+        // Decrement recovery_in_flight after the batch is actually sent.
+        // Notify WaitForRecoveryDrain when all recovery ops are drained.
+        if (recovery_n > 0) {
+            std::lock_guard<std::mutex> lk(shard.mutex);
+            shard.recovery_in_flight -= recovery_n;
+            if (shard.recovery_in_flight == 0 && shard.recovery_count == 0) {
+                shard.recovery_drain_cv.notify_all();
+            }
+        }
     }
 }
 
-size_t AsyncMetadataNotifier::CollectBatch(SenderShard& shard,
-                                           std::vector<PendingOp>& batch_out) {
+std::pair<size_t, size_t> AsyncMetadataNotifier::CollectBatch(
+    SenderShard& shard, std::vector<PendingOp>& batch_out) {
     std::unique_lock<std::mutex> lock(shard.mutex);
 
     shard.sender_cv.wait_for(lock, BatchTimeout, [&] {
@@ -270,7 +281,7 @@ size_t AsyncMetadataNotifier::CollectBatch(SenderShard& shard,
 
     // drop mode: don't collect any more batches — let the sender exit cleanly
     if (drop_on_stop_.load(std::memory_order_relaxed)) {
-        return 0;
+        return {0, 0};
     }
 
     // Phase 1: collect from normal queue (high priority)
@@ -286,14 +297,14 @@ size_t AsyncMetadataNotifier::CollectBatch(SenderShard& shard,
     }
 
     if (collected > 0) {
+        if (recovery_collected > 0) {
+            shard.recovery_in_flight += recovery_collected;
+        }
         lock.unlock();
         shard.producer_cv.notify_all();
-        if (recovery_collected > 0) {
-            shard.recovery_drain_cv.notify_all();
-        }
     }
 
-    return collected;
+    return {collected, recovery_collected};
 }
 
 size_t AsyncMetadataNotifier::CollectFromList(SenderShard& shard,
@@ -445,7 +456,7 @@ bool AsyncMetadataNotifier::WaitForRecoveryDrain(
     for (size_t i = 0; i < sender_thread_count_; ++i) {
         auto& shard = *shards_[i];
         std::unique_lock<std::mutex> lock(shard.mutex);
-        while (shard.recovery_count > 0) {
+        while (shard.recovery_count > 0 || shard.recovery_in_flight > 0) {
             if (abort_fn && abort_fn()) return false;
 
             auto remaining = deadline - std::chrono::steady_clock::now();

--- a/mooncake-store/src/async_metadata_notifier.cpp
+++ b/mooncake-store/src/async_metadata_notifier.cpp
@@ -57,10 +57,14 @@ void AsyncMetadataNotifier::Start() {
     }
 }
 
-void AsyncMetadataNotifier::Stop() {
+void AsyncMetadataNotifier::Stop(bool drop_pending) {
     bool expected = true;
     if (!running_.compare_exchange_strong(expected, false)) {
         return;  // not running
+    }
+
+    if (drop_pending) {
+        drop_on_stop_.store(true, std::memory_order_release);
     }
 
     // Wake all sender threads (both shard CVs and stop CV for retry sleeps)
@@ -82,7 +86,7 @@ void AsyncMetadataNotifier::Stop() {
     for (auto& shard : shards_) {
         ResetShard(*shard);
     }
-    // Reset circuit breaker for next Start cycle
+    drop_on_stop_.store(false, std::memory_order_release);
     consecutive_rpc_failures_.store(0, std::memory_order_release);
 
     LOG(INFO) << "AsyncMetadataNotifier stopped";
@@ -248,12 +252,7 @@ void AsyncMetadataNotifier::SenderLoop(size_t shard_idx) {
         size_t n = CollectBatch(shard, batch);
 
         if (n == 0) {
-            if (!running_.load(std::memory_order_acquire)) {
-                std::lock_guard<std::mutex> lock(shard.mutex);
-                if (shard.IsEmpty()) {
-                    break;
-                }
-            }
+            if (!running_.load(std::memory_order_acquire)) break;
             continue;
         }
 
@@ -268,6 +267,11 @@ size_t AsyncMetadataNotifier::CollectBatch(SenderShard& shard,
     shard.sender_cv.wait_for(lock, BatchTimeout, [&] {
         return !shard.IsEmpty() || !running_.load(std::memory_order_relaxed);
     });
+
+    // drop mode: don't collect any more batches — let the sender exit cleanly
+    if (drop_on_stop_.load(std::memory_order_relaxed)) {
+        return 0;
+    }
 
     // Phase 1: collect from normal queue (high priority)
     size_t collected =
@@ -452,9 +456,9 @@ bool AsyncMetadataNotifier::WaitForRecoveryDrain(
             }
 
             auto wait_time = std::min(
-                remaining, std::chrono::duration_cast<
-                               std::chrono::steady_clock::duration>(
-                               std::chrono::milliseconds(100)));
+                remaining,
+                std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                    std::chrono::milliseconds(100)));
             shard.recovery_drain_cv.wait_for(lock, wait_time);
         }
     }

--- a/mooncake-store/src/async_metadata_notifier.cpp
+++ b/mooncake-store/src/async_metadata_notifier.cpp
@@ -26,6 +26,7 @@ AsyncMetadataNotifier::AsyncMetadataNotifier(P2PMasterClient& master_client,
     for (size_t i = 0; i < sender_thread_count_; ++i) {
         auto shard = std::make_unique<SenderShard>();
         shard->capacity = per_shard;
+        shard->normal_reserved = per_shard / 4;
         shard->slots.resize(per_shard);
         shard->free_stack.reserve(per_shard);
         for (size_t j = 0; j < per_shard; ++j) {
@@ -89,13 +90,15 @@ void AsyncMetadataNotifier::Stop() {
 
 void AsyncMetadataNotifier::ResetShard(SenderShard& shard) {
     std::lock_guard<std::mutex> lock(shard.mutex);
-    if (shard.count > 0) {
-        LOG(WARNING) << "AsyncMetadataNotifier: discarding " << shard.count
-                     << " pending ops on reset";
+    if (!shard.IsEmpty()) {
+        LOG(WARNING) << "AsyncMetadataNotifier: discarding "
+                     << shard.normal_count << " normal + "
+                     << shard.recovery_count << " recovery pending ops";
     }
-    shard.list_head = InvalidIdx;
-    shard.list_tail = InvalidIdx;
-    shard.count = 0;
+    shard.normal_head = shard.normal_tail = InvalidIdx;
+    shard.normal_count = 0;
+    shard.recovery_head = shard.recovery_tail = InvalidIdx;
+    shard.recovery_count = 0;
     shard.free_stack.clear();
     for (size_t i = 0; i < shard.capacity; ++i) {
         shard.slots[i] = Slot{};
@@ -104,6 +107,10 @@ void AsyncMetadataNotifier::ResetShard(SenderShard& shard) {
     shard.coalesce_index.clear();
 }
 
+// ============================================================================
+// Enqueue
+// ============================================================================
+
 tl::expected<void, ErrorCode> AsyncMetadataNotifier::EnqueueAdd(
     const std::string& key, const UUID& segment_id, size_t size) {
     PendingOp op;
@@ -111,7 +118,7 @@ tl::expected<void, ErrorCode> AsyncMetadataNotifier::EnqueueAdd(
     op.key = key;
     op.segment_id = segment_id;
     op.size = size;
-    return DoEnqueue(std::move(op));
+    return DoEnqueue(std::move(op), /*is_recovery=*/false);
 }
 
 tl::expected<void, ErrorCode> AsyncMetadataNotifier::EnqueueRemove(
@@ -120,10 +127,21 @@ tl::expected<void, ErrorCode> AsyncMetadataNotifier::EnqueueRemove(
     op.type = PendingOp::REMOVE;
     op.key = key;
     op.segment_id = segment_id;
-    return DoEnqueue(std::move(op));
+    return DoEnqueue(std::move(op), /*is_recovery=*/false);
 }
 
-tl::expected<void, ErrorCode> AsyncMetadataNotifier::DoEnqueue(PendingOp&& op) {
+tl::expected<void, ErrorCode> AsyncMetadataNotifier::EnqueueRecoveryAdd(
+    const std::string& key, const UUID& segment_id, size_t size) {
+    PendingOp op;
+    op.type = PendingOp::ADD;
+    op.key = key;
+    op.segment_id = segment_id;
+    op.size = size;
+    return DoEnqueue(std::move(op), /*is_recovery=*/true);
+}
+
+tl::expected<void, ErrorCode> AsyncMetadataNotifier::DoEnqueue(
+    PendingOp&& op, bool is_recovery) {
     if (!running_.load(std::memory_order_acquire)) {
         LOG(WARNING)
             << "AsyncMetadataNotifier has stopped, fail to enqueue key="
@@ -137,8 +155,13 @@ tl::expected<void, ErrorCode> AsyncMetadataNotifier::DoEnqueue(PendingOp&& op) {
 
     std::unique_lock<std::mutex> lock(shard.mutex);
 
-    // 1. Wait if pool is full
-    if (shard.IsFull()) {
+    // 1. Handle full pool
+    if (is_recovery ? shard.IsFullForRecovery() : shard.IsFull()) {
+        if (is_recovery) {
+            // Recovery: non-blocking, caller retries with sleep
+            return tl::unexpected(ErrorCode::ASYNC_ENQUEUE_FAILED);
+        }
+        // Normal: block until space available
         bool ok = shard.producer_cv.wait_for(lock, EnqueueTimeout, [&] {
             return !shard.IsFull() || !running_.load(std::memory_order_relaxed);
         });
@@ -165,29 +188,35 @@ tl::expected<void, ErrorCode> AsyncMetadataNotifier::DoEnqueue(PendingOp&& op) {
     // 2b. Opposite-type op pending — cancel it
     if (op.type == PendingOp::ADD && entry.remove_idx != InvalidIdx) {
         // Cancel the pending REMOVE, don't insert this ADD
-        shard.Unlink(entry.remove_idx);
-        shard.FreeSlot(entry.remove_idx);
+        size_t cancel_idx = entry.remove_idx;
+        bool was_recovery = shard.slots[cancel_idx].is_recovery;
+        shard.Unlink(cancel_idx);
+        shard.FreeSlot(cancel_idx);
         entry.remove_idx = InvalidIdx;
         shard.coalesce_index.erase(ci);
         lock.unlock();
         shard.producer_cv.notify_one();
+        if (was_recovery) shard.recovery_drain_cv.notify_all();
         return {};
     }
     if (op.type == PendingOp::REMOVE && entry.add_idx != InvalidIdx) {
         // Cancel the pending ADD, don't insert this REMOVE
-        shard.Unlink(entry.add_idx);
-        shard.FreeSlot(entry.add_idx);
+        size_t cancel_idx = entry.add_idx;
+        bool was_recovery = shard.slots[cancel_idx].is_recovery;
+        shard.Unlink(cancel_idx);
+        shard.FreeSlot(cancel_idx);
         entry.add_idx = InvalidIdx;
         shard.coalesce_index.erase(ci);
         lock.unlock();
         shard.producer_cv.notify_one();
+        if (was_recovery) shard.recovery_drain_cv.notify_all();
         return {};
     }
 
     // 3. No coalescing: alloc slot, write data, link to tail
     size_t idx = shard.AllocSlot();
     shard.slots[idx].op = std::move(op);
-    shard.LinkTail(idx);
+    shard.LinkTail(idx, is_recovery);
 
     if (shard.slots[idx].op.type == PendingOp::ADD) {
         entry.add_idx = idx;
@@ -200,14 +229,15 @@ tl::expected<void, ErrorCode> AsyncMetadataNotifier::DoEnqueue(PendingOp&& op) {
     return {};
 }
 
+// ============================================================================
+// Sender
+// ============================================================================
+
 void AsyncMetadataNotifier::SenderLoop(size_t shard_idx) {
     auto& shard = *shards_[shard_idx];
     auto& batch = batch_buffers_[shard_idx];
 
     while (true) {
-        // Circuit breaker: cool down then fall through to attempt send.
-        // Must NOT continue — at least one thread must attempt SendBatch
-        // so that RecordSuccess() can close the breaker.
         if (running_.load(std::memory_order_acquire) && IsPaused()) {
             std::unique_lock<std::mutex> lock(shard.mutex);
             shard.sender_cv.wait_for(lock, CircuitBreakerCooldown, [&] {
@@ -219,7 +249,6 @@ void AsyncMetadataNotifier::SenderLoop(size_t shard_idx) {
 
         if (n == 0) {
             if (!running_.load(std::memory_order_acquire)) {
-                // Draining: exit if queue is empty
                 std::lock_guard<std::mutex> lock(shard.mutex);
                 if (shard.IsEmpty()) {
                     break;
@@ -240,9 +269,39 @@ size_t AsyncMetadataNotifier::CollectBatch(SenderShard& shard,
         return !shard.IsEmpty() || !running_.load(std::memory_order_relaxed);
     });
 
+    // Phase 1: collect from normal queue (high priority)
+    size_t collected =
+        CollectFromList(shard, batch_out, 0, max_batch_size_, false);
+    // Phase 2: fill remaining from recovery queue (low priority)
+    size_t remaining = max_batch_size_ - collected;
+    size_t recovery_collected = 0;
+    if (remaining > 0) {
+        recovery_collected =
+            CollectFromList(shard, batch_out, collected, remaining, true);
+        collected += recovery_collected;
+    }
+
+    if (collected > 0) {
+        lock.unlock();
+        shard.producer_cv.notify_all();
+        if (recovery_collected > 0) {
+            shard.recovery_drain_cv.notify_all();
+        }
+    }
+
+    return collected;
+}
+
+size_t AsyncMetadataNotifier::CollectFromList(SenderShard& shard,
+                                              std::vector<PendingOp>& batch_out,
+                                              size_t offset, size_t max_count,
+                                              bool from_recovery) {
+    auto& head = from_recovery ? shard.recovery_head : shard.normal_head;
+    auto& count = from_recovery ? shard.recovery_count : shard.normal_count;
+
     size_t collected = 0;
-    while (!shard.IsEmpty() && collected < max_batch_size_) {
-        size_t idx = shard.list_head;
+    while (count > 0 && collected < max_count) {
+        size_t idx = head;
         auto& slot = shard.slots[idx];
 
         // Remove from coalesce index
@@ -260,16 +319,11 @@ size_t AsyncMetadataNotifier::CollectBatch(SenderShard& shard,
             }
         }
 
-        batch_out[collected++] = std::move(slot.op);
+        batch_out[offset + collected] = std::move(slot.op);
         shard.Unlink(idx);
         shard.FreeSlot(idx);
+        collected++;
     }
-
-    if (collected > 0) {
-        lock.unlock();
-        shard.producer_cv.notify_all();
-    }
-
     return collected;
 }
 
@@ -377,6 +431,34 @@ void AsyncMetadataNotifier::RecordFailure() {
         }
         // old_val updated by CAS, retry
     }
+}
+
+bool AsyncMetadataNotifier::WaitForRecoveryDrain(
+    const std::function<bool()>& abort_fn, std::chrono::milliseconds timeout) {
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+
+    // Wait for each shard's recovery queue to drain independently.
+    for (size_t i = 0; i < sender_thread_count_; ++i) {
+        auto& shard = *shards_[i];
+        std::unique_lock<std::mutex> lock(shard.mutex);
+        while (shard.recovery_count > 0) {
+            if (abort_fn && abort_fn()) return false;
+
+            auto remaining = deadline - std::chrono::steady_clock::now();
+            if (remaining <= std::chrono::milliseconds::zero()) {
+                LOG(WARNING) << "WaitForRecoveryDrain timed out, shard=" << i
+                             << ", remaining_count=" << shard.recovery_count;
+                return false;
+            }
+
+            auto wait_time = std::min(
+                remaining, std::chrono::duration_cast<
+                               std::chrono::steady_clock::duration>(
+                               std::chrono::milliseconds(100)));
+            shard.recovery_drain_cv.wait_for(lock, wait_time);
+        }
+    }
+    return true;
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/client_manager.cpp
+++ b/mooncake-store/src/client_manager.cpp
@@ -218,6 +218,8 @@ auto ClientManager::RegisterClient(const RegisterClientRequest& req)
         }
     }
 
+    OnClientRegistered(meta);
+
     SharedMutexLocker lock(&clients_mutex_);
     // Write to client_metas_ (overwrites if re-registering after crash)
     client_metas_[client_id] = std::move(meta);

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -455,7 +455,6 @@ void ClientService::HeartbeatThreadMain(bool is_ha_mode,
     const int fail_heartbeat_interval_ms = 1000;
     // Increment after a heartbeat failure, reset after a heartbeat success
     int heartbeat_fail_count = 0;
-    bool master_reachable = true;
 
     auto register_client = [this]() {
         LOG(INFO) << "Sending RegisterClientRequest"
@@ -469,7 +468,7 @@ void ClientService::HeartbeatThreadMain(bool is_ha_mode,
             LOG(INFO) << "Client registered successfully"
                       << ", client_id=" << client_id_
                       << ", view_version=" << res.value().view_version;
-            OnHAEvent(HAEvent::MASTER_REACHABLE);
+            OnHAEvent(HAEvent::MASTER_RECONNECTED);
         }
     };
     // Use another thread to register client to avoid blocking the heartbeat
@@ -491,7 +490,7 @@ void ClientService::HeartbeatThreadMain(bool is_ha_mode,
             heartbeat_fail_count = 0;
             HandleHeartbeatResponse(heartbeat_result.value(),
                                     current_master_address, register_client,
-                                    register_client_future, master_reachable);
+                                    register_client_future);
             WaitForNextHeartbeat(success_heartbeat_interval_ms);
         } else {  // Heartbeat failed
             heartbeat_fail_count++;
@@ -499,9 +498,9 @@ void ClientService::HeartbeatThreadMain(bool is_ha_mode,
                 // just retry
                 LOG(ERROR) << "Failed to send heartbeat to master";
             } else {
-                if (master_reachable) {
+                if (!connection_interrupted_) {
                     OnHAEvent(HAEvent::MASTER_UNREACHABLE);
-                    master_reachable = false;
+                    connection_interrupted_ = true;
                 }
                 // Attempt reconnect
                 if (ReconnectToMaster(is_ha_mode, current_master_address)) {
@@ -532,7 +531,7 @@ bool ClientService::HandleHeartbeatResponse(
     const HeartbeatResponse& response,
     const std::string& current_master_address,
     const std::function<void()>& register_client,
-    std::future<void>& register_client_future, bool& master_reachable) {
+    std::future<void>& register_client_future) {
     if (response.view_version != view_version_) {
         LOG(WARNING) << "Master view_version changed"
                      << ", client status in master: " << (int)response.status
@@ -544,11 +543,11 @@ bool ClientService::HandleHeartbeatResponse(
         HandleHeartbeatTaskResult(task_result);
     }
     if (response.status == ClientStatus::HEALTH) {
-        // Heartbeat recovered after degraded: Master still knows this client.
-        // Enter SYNCING to re-sync any keys whose callbacks failed.
-        if (!master_reachable) {
-            OnHAEvent(HAEvent::MASTER_REACHABLE);
-            master_reachable = true;
+        // Heartbeat recovered after a connection interruption: master still
+        // knows this client. Fire MASTER_RECONNECTED once to trigger re-sync.
+        if (connection_interrupted_) {
+            OnHAEvent(HAEvent::MASTER_RECONNECTED);
+            connection_interrupted_ = false;
         }
     } else if (response.status == ClientStatus::UNDEFINED &&
                !register_client_future.valid()) {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -448,13 +448,14 @@ tl::expected<void, ErrorCode> ClientService::unregisterLocalMemory(
 void ClientService::HeartbeatThreadMain(bool is_ha_mode,
                                         std::string current_master_address) {
     // How many failed heartbeats before getting latest master view from etcd
-    const int max_heartbeat_fail_count = 3;
+    const int max_heartbeat_fail_count = 10;
     // How long to wait for next heartbeat after success
     const int success_heartbeat_interval_ms = 1000;
     // How long to wait for next heartbeat after failure
     const int fail_heartbeat_interval_ms = 1000;
     // Increment after a heartbeat failure, reset after a heartbeat success
     int heartbeat_fail_count = 0;
+    bool master_reachable = true;
 
     auto register_client = [this]() {
         LOG(INFO) << "Sending RegisterClientRequest"
@@ -468,6 +469,7 @@ void ClientService::HeartbeatThreadMain(bool is_ha_mode,
             LOG(INFO) << "Client registered successfully"
                       << ", client_id=" << client_id_
                       << ", view_version=" << res.value().view_version;
+            OnHAEvent(HAEvent::MASTER_REACHABLE);
         }
     };
     // Use another thread to register client to avoid blocking the heartbeat
@@ -489,7 +491,7 @@ void ClientService::HeartbeatThreadMain(bool is_ha_mode,
             heartbeat_fail_count = 0;
             HandleHeartbeatResponse(heartbeat_result.value(),
                                     current_master_address, register_client,
-                                    register_client_future);
+                                    register_client_future, master_reachable);
             WaitForNextHeartbeat(success_heartbeat_interval_ms);
         } else {  // Heartbeat failed
             heartbeat_fail_count++;
@@ -497,7 +499,11 @@ void ClientService::HeartbeatThreadMain(bool is_ha_mode,
                 // just retry
                 LOG(ERROR) << "Failed to send heartbeat to master";
             } else {
-                // Exceeded failure threshold, attempt reconnect
+                if (master_reachable) {
+                    OnHAEvent(HAEvent::MASTER_UNREACHABLE);
+                    master_reachable = false;
+                }
+                // Attempt reconnect
                 if (ReconnectToMaster(is_ha_mode, current_master_address)) {
                     heartbeat_fail_count = 0;
                     // Do NOT sleep here, immediately loop back to send
@@ -526,7 +532,7 @@ bool ClientService::HandleHeartbeatResponse(
     const HeartbeatResponse& response,
     const std::string& current_master_address,
     const std::function<void()>& register_client,
-    std::future<void>& register_client_future) {
+    std::future<void>& register_client_future, bool& master_reachable) {
     if (response.view_version != view_version_) {
         LOG(WARNING) << "Master view_version changed"
                      << ", client status in master: " << (int)response.status
@@ -537,8 +543,15 @@ bool ClientService::HandleHeartbeatResponse(
     for (auto& task_result : response.task_results) {
         HandleHeartbeatTaskResult(task_result);
     }
-    if (response.status == ClientStatus::UNDEFINED &&
-        !register_client_future.valid()) {
+    if (response.status == ClientStatus::HEALTH) {
+        // Heartbeat recovered after degraded: Master still knows this client.
+        // Enter SYNCING to re-sync any keys whose callbacks failed.
+        if (!master_reachable) {
+            OnHAEvent(HAEvent::MASTER_REACHABLE);
+            master_reachable = true;
+        }
+    } else if (response.status == ClientStatus::UNDEFINED &&
+               !register_client_future.valid()) {
         // Ensure at most one register client thread is running
         register_client_future =
             std::async(std::launch::async, register_client);

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -129,6 +129,25 @@ std::vector<TierView> DataManager::GetTierViews() const {
     return tiered_backend_->GetTierViews();
 }
 
+void DataManager::ForEachKeyBatch(
+    const std::function<bool(std::vector<ReplicaLocation>&&)>& callback)
+    const {
+    if (tiered_backend_) {
+        tiered_backend_->ForEachKeyBatch(callback);
+    }
+}
+
+AccessStats DataManager::GetHotKeyStats() const {
+    if (!tiered_backend_) return {};
+    return tiered_backend_->GetHotKeyStats();
+}
+
+std::vector<UUID> DataManager::GetReplicaTierIds(
+    const std::string& key) const {
+    if (!tiered_backend_) return {};
+    return tiered_backend_->GetReplicaTierIds(key);
+}
+
 // Attention!!!
 // This method run without key lock.
 // It works based on two assumptions:

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -130,8 +130,7 @@ std::vector<TierView> DataManager::GetTierViews() const {
 }
 
 void DataManager::ForEachKeyBatch(
-    const std::function<bool(std::vector<ReplicaLocation>&&)>& callback)
-    const {
+    const std::function<bool(std::vector<ReplicaLocation>&&)>& callback) const {
     if (tiered_backend_) {
         tiered_backend_->ForEachKeyBatch(callback);
     }
@@ -142,8 +141,7 @@ AccessStats DataManager::GetHotKeyStats() const {
     return tiered_backend_->GetHotKeyStats();
 }
 
-std::vector<UUID> DataManager::GetReplicaTierIds(
-    const std::string& key) const {
+std::vector<UUID> DataManager::GetReplicaTierIds(const std::string& key) const {
     if (!tiered_backend_) return {};
     return tiered_backend_->GetReplicaTierIds(key);
 }

--- a/mooncake-store/src/ha_recovery_manager.cpp
+++ b/mooncake-store/src/ha_recovery_manager.cpp
@@ -83,7 +83,7 @@ void HARecoveryManager::HandleEvent(HAEvent event) {
             }
             break;
 
-        case HAEvent::MASTER_REACHABLE:
+        case HAEvent::MASTER_RECONNECTED:
             if (current == HAClientState::DEGRADED) {
                 if (notifier_) notifier_->Start();
             }

--- a/mooncake-store/src/ha_recovery_manager.cpp
+++ b/mooncake-store/src/ha_recovery_manager.cpp
@@ -137,7 +137,10 @@ void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
                               : 0;
             if (notifier_ && size > 0) {
                 // Hot keys go through normal (high-priority) queue
-                notifier_->EnqueueAdd(entry.key, tier_id, size);
+                if (!EnqueueWithRetry(entry.key, tier_id, size,
+                                      /*is_hot=*/true, need_abort)) {
+                    return;  // aborted
+                }
                 hot_count++;
             }
         }
@@ -168,14 +171,14 @@ void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
                 return false;
             }
 
-            std::vector<ReplicaLocation> storage_batch;
-            for (auto& e : batch) {
+            // Pass 1: DRAM entries first for fastest recovery
+            for (const auto& e : batch) {
                 if (synced_keys.count(e.key)) continue;
                 if (dram_tiers.count(e.tier_id)) {
                     if (e.size == 0) continue;
                     if (notifier_) {
-                        if (!RecoveryEnqueueAdd(e.key, e.tier_id, e.size,
-                                                need_abort)) {
+                        if (!EnqueueWithRetry(e.key, e.tier_id, e.size,
+                                              /*is_hot=*/false, need_abort)) {
                             was_aborted = true;
                             LOG(WARNING)
                                 << "fail to enqueue route recovery list";
@@ -183,15 +186,16 @@ void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
                         }
                         dram_count++;
                     }
-                } else {
-                    storage_batch.push_back(std::move(e));
                 }
             }
-            for (auto& e : storage_batch) {
+            // Pass 2: Storage entries
+            for (const auto& e : batch) {
+                if (synced_keys.count(e.key)) continue;
+                if (dram_tiers.count(e.tier_id)) continue;
                 if (e.size == 0) continue;
                 if (notifier_) {
-                    if (!RecoveryEnqueueAdd(e.key, e.tier_id, e.size,
-                                            need_abort)) {
+                    if (!EnqueueWithRetry(e.key, e.tier_id, e.size,
+                                          /*is_hot=*/false, need_abort)) {
                         was_aborted = true;
                         LOG(WARNING) << "fail to enqueue route recovery list";
                         return false;
@@ -253,12 +257,14 @@ void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
 }
 
 // return false when abort
-bool HARecoveryManager::RecoveryEnqueueAdd(const std::string& key,
-                                           const UUID& tier_id, size_t size,
-                                           const AbortToken& need_abort) {
+bool HARecoveryManager::EnqueueWithRetry(const std::string& key,
+                                         const UUID& tier_id, size_t size,
+                                         bool is_hot,
+                                         const AbortToken& need_abort) {
     while (true) {
         if (need_abort->load(std::memory_order_acquire)) return false;
-        auto r = notifier_->EnqueueRecoveryAdd(key, tier_id, size);
+        auto r = is_hot ? notifier_->EnqueueAdd(key, tier_id, size)
+                        : notifier_->EnqueueRecoveryAdd(key, tier_id, size);
         if (r) return true;
         // Queue full — yield to normal writes then retry
         std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/mooncake-store/src/ha_recovery_manager.cpp
+++ b/mooncake-store/src/ha_recovery_manager.cpp
@@ -1,0 +1,262 @@
+#include "ha_recovery_manager.h"
+
+#include <glog/logging.h>
+
+#include <thread>
+#include <unordered_set>
+
+namespace mooncake {
+
+HARecoveryManager::HARecoveryManager(
+    const UUID& client_id, P2PMasterClient& master_client,
+    std::optional<DataManager>& data_manager,
+    std::unique_ptr<AsyncMetadataNotifier>& notifier,
+    ViewVersionId& view_version)
+    : client_id_(client_id),
+      master_client_(master_client),
+      data_manager_(data_manager),
+      notifier_(notifier),
+      view_version_(view_version) {}
+
+HARecoveryManager::~HARecoveryManager() { Stop(); }
+
+void HARecoveryManager::Stop() {
+    std::lock_guard<std::mutex> lk(mutex_);
+    if (need_abort_) need_abort_->store(true, std::memory_order_release);
+    if (recovery_thread_.joinable()) {
+        recovery_thread_.join();
+    }
+    if (state_.load(std::memory_order_relaxed) == HAClientState::SYNCING) {
+        TransitionState(HAClientState::DEGRADED, "shutdown");
+    }
+}
+
+tl::expected<void, ErrorCode> HARecoveryManager::SetSyncCompleted() {
+    auto result = master_client_.SetSyncCompleted(client_id_);
+    if (!result) {
+        LOG(ERROR) << "SetSyncCompleted RPC failed: " << result.error();
+    }
+    return result;
+}
+
+// ============================================================================
+// State Machine
+// ============================================================================
+
+void HARecoveryManager::TransitionState(HAClientState to,
+                                        const std::string& reason) {
+    auto from = state_.load(std::memory_order_relaxed);
+    LOG(WARNING) << "HA state: " << from << " -> " << to
+                 << ", reason=" << reason << ", view_version=" << view_version_;
+    state_.store(to, std::memory_order_release);
+}
+
+void HARecoveryManager::HandleEvent(HAEvent event) {
+    std::lock_guard<std::mutex> lk(mutex_);
+    if (event == HAEvent::MASTER_UNREACHABLE &&
+        state_.load(std::memory_order_acquire) == HAClientState::DEGRADED) {
+        return;
+    }
+
+    // Abort + join under mutex_. Safe because recovery thread's exit path
+    // uses lock-free CAS (no mutex_ needed), so no deadlock.
+    if (need_abort_) {
+        need_abort_->store(true, std::memory_order_release);
+    }
+    if (recovery_thread_.joinable()) {
+        recovery_thread_.join();
+    }
+
+    auto current = state_.load(std::memory_order_relaxed);
+
+    switch (event) {
+        case HAEvent::MASTER_UNREACHABLE:
+            if (current == HAClientState::FULL ||
+                current == HAClientState::SYNCING) {
+                TransitionState(HAClientState::DEGRADED,
+                                "heartbeat failure threshold exceeded");
+                if (notifier_) notifier_->Stop();
+            }
+            break;
+
+        case HAEvent::MASTER_REACHABLE:
+            if (current == HAClientState::DEGRADED) {
+                if (notifier_) notifier_->Start();
+            }
+            if (current != HAClientState::SYNCING) {
+                TransitionState(HAClientState::SYNCING,
+                                "master connection ready, starting recovery");
+            }
+            StartRecoveryThread();
+            break;
+    }
+}
+
+// ============================================================================
+// Recovery Thread Management
+// ============================================================================
+
+void HARecoveryManager::StartRecoveryThread() {
+    // Old thread already joined by HandleEvent before acquiring mutex_.
+    // Create fresh abort token and start new thread.
+    need_abort_ = std::make_shared<std::atomic<bool>>(false);
+    auto need_abort = need_abort_;
+    recovery_thread_ =
+        std::thread([this, need_abort]() { RecoveryPipelineMain(need_abort); });
+}
+
+void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
+    LOG(INFO) << "Recovery pipeline started";
+
+    if (!data_manager_.has_value()) {
+        LOG(ERROR) << "DataManager not initialized, cannot run recovery";
+        return;
+    }
+
+    auto aborted = [&]() {
+        return need_abort->load(std::memory_order_acquire);
+    };
+
+    // Phase 1: Hot key sync — enqueue hot keys first for fastest recovery
+    auto hot_stats = data_manager_.value().GetHotKeyStats();
+    std::unordered_set<std::string> synced_keys;
+    size_t hot_count = 0;
+
+    for (const auto& entry : hot_stats.hot_keys) {
+        if (aborted()) return;
+        auto tier_ids = data_manager_.value().GetReplicaTierIds(entry.key);
+        for (const auto& tier_id : tier_ids) {
+            auto handle = data_manager_.value().Get(entry.key, tier_id);
+            if (!handle) continue;
+            size_t size = handle.value()->loc.data.buffer
+                              ? handle.value()->loc.data.buffer->size()
+                              : 0;
+            if (notifier_ && size > 0) {
+                // Hot keys go through normal (high-priority) queue
+                notifier_->EnqueueAdd(entry.key, tier_id, size);
+                hot_count++;
+            }
+        }
+        synced_keys.insert(entry.key);
+    }
+    LOG(INFO) << "Recovery Phase 1: enqueued " << hot_count
+              << " hot key entries";
+
+    if (aborted()) return;
+
+    // Phase 2+3: Iterate all keys in batches.
+    // DRAM entries enqueued before storage entries within each batch.
+    auto tier_views = data_manager_.value().GetTierViews();
+    std::unordered_set<UUID, boost::hash<UUID>> dram_tiers;
+    for (const auto& tv : tier_views) {
+        if (tv.type == MemoryType::DRAM) {
+            dram_tiers.insert(tv.id);
+        }
+    }
+
+    size_t dram_count = 0, storage_count = 0;
+    bool was_aborted = false;
+
+    data_manager_.value().ForEachKeyBatch(
+        [&](std::vector<ReplicaLocation>&& batch) -> bool {
+            if (aborted()) {
+                was_aborted = true;
+                return false;
+            }
+
+            std::vector<ReplicaLocation> storage_batch;
+            for (auto& e : batch) {
+                if (synced_keys.count(e.key)) continue;
+                if (dram_tiers.count(e.tier_id)) {
+                    if (e.size == 0) continue;
+                    if (notifier_) {
+                        if (!RecoveryEnqueueAdd(e.key, e.tier_id, e.size,
+                                                need_abort)) {
+                            was_aborted = true;
+                            LOG(WARNING)
+                                << "fail to enqueue route recovery list";
+                            return false;
+                        }
+                        dram_count++;
+                    }
+                } else {
+                    storage_batch.push_back(std::move(e));
+                }
+            }
+            for (auto& e : storage_batch) {
+                if (e.size == 0) continue;
+                if (notifier_) {
+                    if (!RecoveryEnqueueAdd(e.key, e.tier_id, e.size,
+                                            need_abort)) {
+                        was_aborted = true;
+                        LOG(WARNING) << "fail to enqueue route recovery list";
+                        return false;
+                    }
+                    storage_count++;
+                }
+            }
+            return true;
+        });
+
+    if (was_aborted) {
+        LOG(INFO) << "Recovery aborted during key iteration";
+        return;
+    }
+
+    LOG(INFO) << "Recovery enqueue complete: hot=" << hot_count
+              << ", dram=" << dram_count << ", storage=" << storage_count;
+
+    // Wait for recovery queue to drain (all ops sent to Master).
+    static constexpr auto kRecoveryDrainTimeout = std::chrono::minutes(10);
+    if (notifier_) {
+        bool drained = notifier_->WaitForRecoveryDrain(
+            [&]() { return aborted(); }, kRecoveryDrainTimeout);
+        if (!drained) {
+            if (aborted()) {
+                LOG(INFO) << "Recovery aborted during drain wait";
+                return;
+            }
+            LOG(WARNING) << "Recovery drain timed out, transitioning to FULL"
+                         << " with incomplete route sync";
+        }
+    }
+
+    // All recovery routes delivered. Notify Master.
+    // Retry indefinitely until success or abort — if Master restarts again,
+    // HandleEvent(MASTER_UNREACHABLE) will set need_abort and this thread
+    // exits.
+    while (true) {
+        if (aborted()) return;
+        auto sync_result = SetSyncCompleted();
+        if (sync_result) break;
+        LOG(WARNING) << "SetSyncCompleted failed: " << sync_result.error()
+                     << ", retrying in 500ms";
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    // Transition SYNCING→FULL if not aborted.
+    if (!need_abort->load(std::memory_order_acquire)) {
+        HAClientState expected = HAClientState::SYNCING;
+        if (state_.compare_exchange_strong(expected, HAClientState::FULL,
+                                           std::memory_order_acq_rel)) {
+            LOG(WARNING) << "HA state: SYNCING -> FULL"
+                         << ", reason=recovery complete";
+        }
+    }
+    LOG(INFO) << "Recovery pipeline completed";
+}
+
+// return false when abort
+bool HARecoveryManager::RecoveryEnqueueAdd(const std::string& key,
+                                           const UUID& tier_id, size_t size,
+                                           const AbortToken& need_abort) {
+    while (true) {
+        if (need_abort->load(std::memory_order_acquire)) return false;
+        auto r = notifier_->EnqueueRecoveryAdd(key, tier_id, size);
+        if (r) return true;
+        // Queue full — yield to normal writes then retry
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha_recovery_manager.cpp
+++ b/mooncake-store/src/ha_recovery_manager.cpp
@@ -22,7 +22,10 @@ HARecoveryManager::~HARecoveryManager() { Stop(); }
 
 void HARecoveryManager::Stop() {
     std::lock_guard<std::mutex> lk(mutex_);
-    if (need_abort_) need_abort_->store(true, std::memory_order_release);
+    if (need_abort_) {
+        need_abort_->store(true, std::memory_order_release);
+        abort_cv_.notify_all();
+    }
     if (recovery_thread_.joinable()) {
         recovery_thread_.join();
     }
@@ -62,6 +65,7 @@ void HARecoveryManager::HandleEvent(HAEvent event) {
     // uses lock-free CAS (no mutex_ needed), so no deadlock.
     if (need_abort_) {
         need_abort_->store(true, std::memory_order_release);
+        abort_cv_.notify_all();
     }
     if (recovery_thread_.joinable()) {
         recovery_thread_.join();
@@ -75,7 +79,7 @@ void HARecoveryManager::HandleEvent(HAEvent event) {
                 current == HAClientState::SYNCING) {
                 TransitionState(HAClientState::DEGRADED,
                                 "heartbeat failure threshold exceeded");
-                if (notifier_) notifier_->Stop();
+                if (notifier_) notifier_->Stop(/*drop_pending=*/true);
             }
             break;
 
@@ -231,7 +235,9 @@ void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
         if (sync_result) break;
         LOG(WARNING) << "SetSyncCompleted failed: " << sync_result.error()
                      << ", retrying in 500ms";
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        std::unique_lock<std::mutex> lk(abort_mutex_);
+        abort_cv_.wait_for(lk, std::chrono::milliseconds(500),
+                           [&] { return aborted(); });
     }
 
     // Transition SYNCING→FULL if not aborted.

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -253,6 +253,12 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
 AddReplicaCallback P2PClientService::BuildAddReplicaCallback() {
     return [this](const std::string& key, const UUID& tier_id,
                   size_t size) -> tl::expected<void, ErrorCode> {
+        // In degraded mode, skip metadata notification to Master.
+        // The data is stored locally; the recovery pipeline will re-sync
+        // all local metadata to Master when the connection is restored.
+        if (ha_manager_ && ha_manager_->IsDegraded()) {
+            return {};
+        }
         if (async_route_notifier_) {
             return async_route_notifier_->EnqueueAdd(key, tier_id, size);
         }
@@ -265,6 +271,13 @@ RemoveReplicaCallback P2PClientService::BuildRemoveReplicaCallback() {
         [this](
             const std::string& key, const UUID& tier_id,
             enum REMOVE_CALLBACK_TYPE type) -> tl::expected<void, ErrorCode> {
+            // In degraded mode, skip metadata notification to Master.
+            // The recovery pipeline will re-sync all local metadata,
+            // and Master will discard routes for keys that no longer
+            // exist locally.
+            if (ha_manager_ && ha_manager_->IsDegraded()) {
+                return {};
+            }
             if (type == REMOVE_CALLBACK_TYPE::DELETE) {
                 if (async_route_notifier_) {
                     return async_route_notifier_->EnqueueRemove(key, tier_id);

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -112,6 +112,12 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
         return reg.error();
     }
 
+    // 3.5. Start heartbeat immediately after registration so master does not
+    //      consider this client disconnected during a lengthy InitStorage.
+    //      build_heartbeat_request() and OnHAEvent() both guard against
+    //      uninitialized data_manager_ / ha_manager_, so this is safe.
+    StartHeartbeat(config.master_server_entry);
+
     // 4. Initialize TieredBackend + DataManager
     err = InitStorage(config);
     if (err != ErrorCode::OK) {
@@ -165,9 +171,6 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
     // Give RPC server a moment to start
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     LOG(INFO) << "P2P RPC server started on port " << client_rpc_port_;
-
-    // 6. Start heartbeat AFTER everything is fully initialized
-    StartHeartbeat(config.master_server_entry);
 
     return ErrorCode::OK;
 }

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -28,6 +28,11 @@ void P2PClientService::Stop() {
 
     LOG(INFO) << "P2PClientService::Stop() — begin";
 
+    // Stop HA recovery thread first
+    if (ha_manager_) {
+        ha_manager_->Stop();
+    }
+
     // Stop RPC server so no new requests arrive.
     if (client_rpc_server_) {
         client_rpc_server_->stop();
@@ -61,6 +66,7 @@ void P2PClientService::Destroy() {
     }
 
     client_rpc_service_.reset();
+    ha_manager_.reset();
     async_route_notifier_.reset();
     if (data_manager_.has_value()) {
         data_manager_->Destroy();
@@ -171,6 +177,13 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
     // Give RPC server a moment to start
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     LOG(INFO) << "P2P RPC server started on port " << client_rpc_port_;
+
+    // 6. Initialize HA recovery manager
+    ha_manager_ = std::make_unique<HARecoveryManager>(
+        client_id_, master_client_, data_manager_, async_route_notifier_,
+        view_version_);
+    // First-time registration: no keys to sync, clear is_syncing_ on Master
+    ha_manager_->SetSyncCompleted();
 
     return ErrorCode::OK;
 }
@@ -416,6 +429,14 @@ P2PClientService::RegisterClient() {
 }
 
 // ============================================================================
+// HA Recovery — delegate to HARecoveryManager
+// ============================================================================
+
+void P2PClientService::OnHAEvent(HAEvent event) {
+    if (ha_manager_) ha_manager_->HandleEvent(event);
+}
+
+// ============================================================================
 // Put Operations
 // ============================================================================
 
@@ -446,6 +467,11 @@ tl::expected<void, ErrorCode> P2PClientService::PutLocal(
 tl::expected<void, ErrorCode> P2PClientService::PutViaRoute(
     const std::string& key, std::vector<Slice>& slices,
     const WriteRouteRequestConfig& config) {
+    // DEGRADED: Master unreachable, only allow local writes
+    if (ha_manager_ && ha_manager_->IsDegraded()) {
+        return PutLocal(key, slices);
+    }
+
     size_t total_size = ClientService::CalculateSliceSize(slices);
 
     // 1. Get write route from master
@@ -717,6 +743,11 @@ tl::expected<std::shared_ptr<BufferHandle>, ErrorCode> P2PClientService::Get(
         }
     }
 
+    // DEGRADED: local + cache both missed, cannot query Master
+    if (ha_manager_ && ha_manager_->IsDegraded()) {
+        return tl::unexpected(ErrorCode::INACCESSIBLE_MASTER);
+    }
+
     // Local miss and Cache miss/fail — query Master for replicas and size
     auto size_result = QueryReplicaSize(key, config);
     if (!size_result) {
@@ -827,6 +858,11 @@ tl::expected<int64_t, ErrorCode> P2PClientService::Get(
                 return static_cast<int64_t>(total_size);
             }
         }
+    }
+
+    // DEGRADED: local + cache both missed, cannot query Master
+    if (ha_manager_ && ha_manager_->IsDegraded()) {
+        return tl::unexpected(ErrorCode::INACCESSIBLE_MASTER);
     }
 
     // Step 2: Local miss and cache miss — query Master for replicas and size
@@ -1009,6 +1045,11 @@ tl::expected<bool, ErrorCode> P2PClientService::IsExist(
         }
     }
 
+    // DEGRADED: skip Master fallback, return local-only result
+    if (ha_manager_ && ha_manager_->IsDegraded()) {
+        return false;
+    }
+
     // Fallback to master
     return master_client_.ExistKey(key);
 }
@@ -1065,9 +1106,19 @@ tl::expected<std::unique_ptr<QueryResult>, ErrorCode> P2PClientService::Query(
         LOG(ERROR) << "client is shutting down";
         return tl::make_unexpected(ErrorCode::SHUTTING_DOWN);
     }
+
+    // DEGRADED: return empty result (local-only, no Master query)
+    if (ha_manager_ && ha_manager_->IsDegraded()) {
+        LOG(WARNING) << "fail to access master"
+                     << ", key=" << object_key;
+        return tl::make_unexpected(ErrorCode::INACCESSIBLE_MASTER);
+    }
+
     // Query master for replica list
     auto result = master_client_.GetReplicaList(object_key, config);
     if (!result) {
+        LOG(WARNING) << "fail to get replica list"
+                     << ", key=" << object_key << ", error=" << result.error();
         return tl::unexpected(result.error());
     }
 

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -605,9 +605,9 @@ tl::expected<void, ErrorCode> P2PClientService::Put(const ObjectKey& key,
             LOG(ERROR) << "Failed to put key: " << key
                        << " error: " << result.error();
             return result;
+        } else {
+            // the key exists, just ignore the error
         }
-        // REPLICA_NUM_EXCEEDED / REPLICA_ALREADY_EXISTS: object already
-        // stored, treat as success so callers don't retry needlessly.
     }
 
     return {};

--- a/mooncake-store/src/p2p_master_client.cpp
+++ b/mooncake-store/src/p2p_master_client.cpp
@@ -30,6 +30,11 @@ struct RpcNameTraits<&WrappedP2PMasterService::BatchSyncReplica> {
     static constexpr const char* value = "BatchSyncReplica";
 };
 
+template <>
+struct RpcNameTraits<&WrappedP2PMasterService::SetSyncCompleted> {
+    static constexpr const char* value = "SetSyncCompleted";
+};
+
 tl::expected<WriteRouteResponse, ErrorCode> P2PMasterClient::GetWriteRoute(
     const WriteRouteRequest& req) {
     ScopedVLogTimer timer(1, "P2PMasterClient::GetWriteRoute");
@@ -92,6 +97,17 @@ P2PMasterClient::BatchSyncReplica(const BatchSyncReplicaRequest& req) {
     auto result =
         invoke_rpc<&WrappedP2PMasterService::BatchSyncReplica,
                     BatchSyncReplicaResponse>(req);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<void, ErrorCode> P2PMasterClient::SetSyncCompleted(
+    UUID client_id) {
+    ScopedVLogTimer timer(1, "P2PMasterClient::SetSyncCompleted");
+    timer.LogRequest("client_id=", client_id);
+
+    auto result =
+        invoke_rpc<&WrappedP2PMasterService::SetSyncCompleted, void>(client_id);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/p2p_master_client.cpp
+++ b/mooncake-store/src/p2p_master_client.cpp
@@ -94,9 +94,8 @@ P2PMasterClient::BatchSyncReplica(const BatchSyncReplicaRequest& req) {
     timer.LogRequest("adds=", req.add_keys.size(),
                      ", removes=", req.remove_keys.size());
 
-    auto result =
-        invoke_rpc<&WrappedP2PMasterService::BatchSyncReplica,
-                    BatchSyncReplicaResponse>(req);
+    auto result = invoke_rpc<&WrappedP2PMasterService::BatchSyncReplica,
+                             BatchSyncReplicaResponse>(req);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -387,6 +387,25 @@ auto P2PMasterService::BatchSyncReplica(const BatchSyncReplicaRequest& req)
     return response;
 }
 
+auto P2PMasterService::SetSyncCompleted(UUID client_id)
+    -> tl::expected<void, ErrorCode> {
+    auto client = client_manager_->GetClient(client_id);
+    if (!client) {
+        LOG(WARNING) << "SetSyncCompleted: client not found"
+                     << ", client_id=" << client_id;
+        return tl::make_unexpected(ErrorCode::CLIENT_NOT_FOUND);
+    }
+    auto p2p_client = std::dynamic_pointer_cast<P2PClientMeta>(client);
+    if (!p2p_client) {
+        LOG(ERROR) << "SetSyncCompleted: client is not P2PClientMeta"
+                   << ", client_id=" << client_id;
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    p2p_client->SetSyncing(false);
+    LOG(INFO) << "SetSyncCompleted: client_id=" << client_id;
+    return {};
+}
+
 void P2PMasterService::OnObjectAccessed(ObjectMetadata& metadata) {
     // do nothing
 }

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -127,18 +127,16 @@ auto P2PMasterService::GetWriteRoute(const WriteRouteRequest& req)
                    << ", client_id: " << req.client_id
                    << ", size: " << req.size;
         return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
-    } else if (req.config.max_candidates ==
-                   WriteRouteRequestConfig::RETURN_ALL_CANDIDATES ||
-               candidates.size() <= req.config.max_candidates) {
-        // return all candidates
-        response.candidates = std::move(candidates);
     } else {
-        // return top max_candidates candidates
         std::sort(candidates.begin(), candidates.end(),
                   [](const auto& a, const auto& b) {
                       return a.priority > b.priority;
                   });
-        candidates.resize(req.config.max_candidates);
+        if (req.config.max_candidates !=
+                WriteRouteRequestConfig::RETURN_ALL_CANDIDATES &&
+            candidates.size() > req.config.max_candidates) {
+            candidates.resize(req.config.max_candidates);
+        }
         response.candidates = std::move(candidates);
     }
     return response;

--- a/mooncake-store/src/p2p_rpc_service.cpp
+++ b/mooncake-store/src/p2p_rpc_service.cpp
@@ -23,6 +23,9 @@ void RegisterP2PRpcService(
     server.register_handler<
         &mooncake::WrappedP2PMasterService::BatchSyncReplica>(
         &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedP2PMasterService::SetSyncCompleted>(
+            &wrapped_master_service);
 }
 
 tl::expected<WriteRouteResponse, ErrorCode>
@@ -109,6 +112,18 @@ BatchSyncReplicaResponse WrappedP2PMasterService::BatchSyncReplica(
     timer.LogResponse("add_failures=", add_failures,
                       ", remove_failures=", remove_failures);
     return response;
+}
+
+tl::expected<void, ErrorCode> WrappedP2PMasterService::SetSyncCompleted(
+    UUID client_id) {
+    ScopedVLogTimer timer(1, "SetSyncCompleted");
+    timer.LogRequest("client_id=", client_id);
+
+    auto result = master_service_.SetSyncCompleted(client_id);
+    if (!result) {
+        LOG(ERROR) << "SetSyncCompleted failed: " << toString(result.error());
+    }
+    return result;
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/p2p_rpc_service.cpp
+++ b/mooncake-store/src/p2p_rpc_service.cpp
@@ -20,9 +20,9 @@ void RegisterP2PRpcService(
     server.register_handler<
         &mooncake::WrappedP2PMasterService::BatchRemoveReplica>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedP2PMasterService::BatchSyncReplica>(
-        &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedP2PMasterService::BatchSyncReplica>(
+            &wrapped_master_service);
     server
         .register_handler<&mooncake::WrappedP2PMasterService::SetSyncCompleted>(
             &wrapped_master_service);

--- a/mooncake-store/src/tiered_cache/scheduler/client_scheduler.cpp
+++ b/mooncake-store/src/tiered_cache/scheduler/client_scheduler.cpp
@@ -128,6 +128,13 @@ void ClientScheduler::OnAccess(const std::string& key) {
     }
 }
 
+AccessStats ClientScheduler::GetHotKeyStats() const {
+    if (stats_collector_) {
+        return stats_collector_->GetSnapshot();
+    }
+    return {};
+}
+
 void ClientScheduler::OnCommit(const std::string& key, UUID tier_id,
                                size_t size_bytes) {
     auto& shard = GetKeyCacheShard(key);

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -456,29 +456,30 @@ tl::expected<void, ErrorCode> TieredBackend::Commit(
     if (!handle) return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
 
     std::shared_ptr<MetadataEntry> entry = nullptr;
+    auto& shard = GetMetadataShard(key);
 
-    // Try to find existing entry (Global Read Lock)
+    // Try to find existing entry (Shard Read Lock)
     {
-        std::shared_lock<std::shared_mutex> read_lock(map_mutex_);
-        auto it = metadata_index_.find(key);
-        if (it != metadata_index_.end()) {
+        std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
+        auto it = shard.index.find(key);
+        if (it != shard.index.end()) {
             entry = it->second;
         }
     }
 
-    // Create if not exists (Global Write Lock)
+    // Create if not exists (Shard Write Lock)
     if (!entry) {
         if (expected_version.has_value()) {
             return tl::make_unexpected(ErrorCode::CAS_FAILED);
         }
 
-        std::unique_lock<std::shared_mutex> write_lock(map_mutex_);
-        auto it = metadata_index_.find(key);
-        if (it != metadata_index_.end()) {
+        std::unique_lock<std::shared_mutex> write_lock(shard.mutex);
+        auto it = shard.index.find(key);
+        if (it != shard.index.end()) {
             entry = it->second;
         } else {
             entry = std::make_shared<MetadataEntry>();
-            metadata_index_[key] = entry;
+            shard.index[key] = entry;
         }
     }
 
@@ -572,11 +573,12 @@ tl::expected<AllocationHandle, ErrorCode> TieredBackend::Get(
     }
     std::shared_ptr<MetadataEntry> entry = nullptr;
 
-    // Find Entry (Global Read Lock)
+    // Find Entry (Shard Read Lock)
     {
-        std::shared_lock<std::shared_mutex> read_lock(map_mutex_);
-        auto it = metadata_index_.find(key);
-        if (it == metadata_index_.end()) {
+        auto& shard = GetMetadataShard(key);
+        std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
+        auto it = shard.index.find(key);
+        if (it == shard.index.end()) {
             LOG(ERROR) << "Key not found: " << key;
             return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
         }
@@ -616,9 +618,10 @@ tl::expected<AllocationHandle, ErrorCode> TieredBackend::Get(
 
 bool TieredBackend::Exist(const std::string& key,
                           std::optional<UUID> tier_id) const {
-    std::shared_lock<std::shared_mutex> read_lock(map_mutex_);
-    auto it = metadata_index_.find(key);
-    if (it == metadata_index_.end()) {
+    auto& shard = GetMetadataShard(key);
+    std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
+    auto it = shard.index.find(key);
+    if (it == shard.index.end()) {
         return false;  // Key not found
     }
     if (!tier_id.has_value()) {
@@ -652,12 +655,12 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
         bool need_cleanup = false;
         bool found_tier = false;
 
-        // Optimistic Delete (Global Read Lock + Entry Write Lock)
-        // This is fast and allows high concurrency.
+        auto& shard = GetMetadataShard(key);
+        // Optimistic Delete (Shard Read Lock + Entry Write Lock)
         {
-            std::shared_lock<std::shared_mutex> read_lock(map_mutex_);
-            auto it = metadata_index_.find(key);
-            if (it == metadata_index_.end()) {
+            std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
+            auto it = shard.index.find(key);
+            if (it == shard.index.end()) {
                 LOG(ERROR) << "Key not found: " << key;
                 return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
             }
@@ -703,10 +706,10 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
         // remove it. This prevents memory leaks from empty "zombie"
         // entries.
         if (need_cleanup) {
-            std::unique_lock<std::shared_mutex> write_lock(map_mutex_);
+            std::unique_lock<std::shared_mutex> write_lock(shard.mutex);
 
-            auto it = metadata_index_.find(key);
-            if (it != metadata_index_.end()) {
+            auto it = shard.index.find(key);
+            if (it != shard.index.end()) {
                 auto entry = it->second;
 
                 // Double-Check Locking:
@@ -714,8 +717,7 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
                 std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
 
                 if (entry->replicas.empty()) {
-                    // Confirmed empty, safe to remove from global index
-                    metadata_index_.erase(it);
+                    shard.index.erase(it);
                 }
             }
         }
@@ -731,11 +733,10 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
         }
     } else {
         // Delete All Replicas (Full Key Deletion)
-        // Requires Global Write Lock since we are modifying the map
-        // structure.
-        std::unique_lock<std::shared_mutex> global_write_lock(map_mutex_);
-        auto it = metadata_index_.find(key);
-        if (it == metadata_index_.end()) {
+        auto& shard = GetMetadataShard(key);
+        std::unique_lock<std::shared_mutex> shard_write_lock(shard.mutex);
+        auto it = shard.index.find(key);
+        if (it == shard.index.end()) {
             LOG(ERROR) << "Key not found: " << key;
             return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
         }
@@ -760,8 +761,7 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
             entry->replicas.clear();
         }
 
-        // Remove the entry from the global index
-        metadata_index_.erase(it);
+        shard.index.erase(it);
     }
 
     // Handles go out of scope here.
@@ -867,9 +867,10 @@ std::vector<TierView> TieredBackend::GetTierViews() const {
 
 std::vector<UUID> TieredBackend::GetReplicaTierIds(
     const std::string& key) const {
-    std::shared_lock map_lock(map_mutex_);
-    auto it = metadata_index_.find(key);
-    if (it == metadata_index_.end()) {
+    auto& shard = GetMetadataShard(key);
+    std::shared_lock map_lock(shard.mutex);
+    auto it = shard.index.find(key);
+    if (it == shard.index.end()) {
         return {};
     }
 
@@ -890,6 +891,48 @@ const CacheTier* TieredBackend::GetTier(UUID tier_id) const {
 const DataCopier& TieredBackend::GetDataCopier() const {
     CHECK(data_copier_) << "TieredBackend not initialized";
     return *data_copier_;
+}
+
+void TieredBackend::ForEachKeyBatch(
+    const std::function<bool(std::vector<ReplicaLocation>&&)>& callback) const {
+    // Iterate per-shard. Each shard is locked independently.
+    for (size_t s = 0; s < kMetadataShardCount; ++s) {
+        auto& shard = metadata_shards_[s];
+
+        // Copy entry pointers under shard shared lock
+        std::vector<std::pair<std::string, std::shared_ptr<MetadataEntry>>>
+            shard_entries;
+        {
+            std::shared_lock<std::shared_mutex> lock(shard.mutex);
+            shard_entries.reserve(shard.index.size());
+            for (const auto& [key, entry] : shard.index) {
+                shard_entries.emplace_back(key, entry);
+            }
+        }
+
+        // Read per-entry data outside shard lock
+        std::vector<ReplicaLocation> result;
+        result.reserve(shard_entries.size());
+        for (auto& [key, entry] : shard_entries) {
+            std::shared_lock<std::shared_mutex> entry_lock(entry->mutex);
+            for (const auto& [tier_id, handle] : entry->replicas) {
+                size_t size = 0;
+                if (handle && handle->loc.data.buffer) {
+                    size = handle->loc.data.buffer->size();
+                }
+                result.push_back({key, tier_id, size});
+            }
+        }
+
+        if (!result.empty() && !callback(std::move(result))) return;
+    }
+}
+
+AccessStats TieredBackend::GetHotKeyStats() const {
+    if (scheduler_) {
+        return scheduler_->GetHotKeyStats();
+    }
+    return {};
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/types.cpp
+++ b/mooncake-store/src/types.cpp
@@ -57,7 +57,8 @@ const std::string& toString(ErrorCode errorCode) noexcept {
         {ErrorCode::UNABLE_OFFLOAD, "UNABLE_OFFLOAD"},
         {ErrorCode::UNABLE_OFFLOADING, "UNABLE_OFFLOADING"},
         {ErrorCode::SHUTTING_DOWN, "SHUTTING_DOWN"},
-        {ErrorCode::ASYNC_ENQUEUE_FAILED, "ASYNC_ENQUEUE_FAILED"}};
+        {ErrorCode::ASYNC_ENQUEUE_FAILED, "ASYNC_ENQUEUE_FAILED"},
+        {ErrorCode::INACCESSIBLE_MASTER, "INACCESSIBLE_MASTER"}};
 
     auto it = errorCodeMap.find(errorCode);
     static const std::string unknownError = "UNKNOWN_ERROR";

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -55,6 +55,8 @@ add_store_test(p2p_client_manager_test p2p_client_manager_test.cpp)
 add_store_test(centralized_client_manager_test centralized_client_manager_test.cpp)
 add_store_test(route_cache_test route_cache_test.cpp)
 add_store_test(async_metadata_notifier_test async_metadata_notifier_test.cpp)
+add_store_test(ha_recovery_manager_test ha_recovery_manager_test.cpp)
+add_store_test(ha_integration_test ha_integration_test.cpp)
 add_subdirectory(e2e)
 
 add_executable(high_availability_test high_availability_test.cpp)

--- a/mooncake-store/tests/async_metadata_notifier_test.cpp
+++ b/mooncake-store/tests/async_metadata_notifier_test.cpp
@@ -216,21 +216,17 @@ TEST_F(AsyncMetadataNotifierTest, StopDrainsQueue) {
                                    /*queue_capacity=*/4000);
     notifier.Start();
 
-    // Enqueue several ops then immediately stop — they should be drained
+    // Enqueue all ops before Stop() — sender drains until queue is empty before
+    // exiting, so all ops are guaranteed to be sent.
     for (int i = 0; i < 10; ++i) {
         notifier.EnqueueAdd("drain_key_" + std::to_string(i), segment_.id, 64);
     }
     notifier.Stop();
 
-    // Verify at least some were flushed (drain is best-effort during stop)
-    int found = 0;
     for (int i = 0; i < 10; ++i) {
-        if (CountReplicas("drain_key_" + std::to_string(i)) == 1) {
-            ++found;
-        }
+        EXPECT_EQ(CountReplicas("drain_key_" + std::to_string(i)), 1u)
+            << "drain_key_" << i << " was not sent before Stop()";
     }
-    // With drain logic, all should be flushed
-    EXPECT_EQ(found, 10) << "Only " << found << "/10 drained before stop";
 }
 
 TEST_F(AsyncMetadataNotifierTest, FailureCallbackInvoked) {
@@ -257,7 +253,8 @@ TEST_F(AsyncMetadataNotifierTest, FailureCallbackInvoked) {
     auto r = notifier.EnqueueAdd("fail_key", segment_.id, 100);
     ASSERT_TRUE(r.has_value());
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    // MaxRetryCount=3 with backoffs 100ms+200ms; add margin for RPC overhead.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     EXPECT_GE(failure_count.load(), 1)
         << "Expected failure callback to be invoked";
 
@@ -310,7 +307,7 @@ TEST_F(AsyncMetadataNotifierTest, ConfigurableMaxBatchSize) {
 }
 
 TEST_F(AsyncMetadataNotifierTest, DuplicateAddIsIdempotent) {
-    // Test that a duplicate same-type op is silently dropped (no double-send).
+    // Duplicate same-type ops are silently dropped (no double-send).
     AsyncMetadataNotifier notifier(*master_client_, client_id_,
                                    /*sender_thread_count=*/1,
                                    /*max_batch_size=*/2000,
@@ -321,10 +318,19 @@ TEST_F(AsyncMetadataNotifierTest, DuplicateAddIsIdempotent) {
     ASSERT_TRUE(r1.has_value());
     EXPECT_EQ(notifier.shards_[0]->normal_count, 1u);
 
-    // Second ADD for same key+segment — should be silently skipped
+    // Second ADD for same key+segment — silently skipped
     auto r2 = notifier.EnqueueAdd("dup_key", segment_.id, 256);
     ASSERT_TRUE(r2.has_value());
     EXPECT_EQ(notifier.shards_[0]->normal_count, 1u);  // still 1, not 2
+
+    // Second REMOVE for same key+segment — also silently skipped
+    auto r3 = notifier.EnqueueRemove("dup_key", segment_.id);
+    ASSERT_TRUE(r3.has_value());
+    // ADD cancelled by REMOVE → count drops to 0
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 0u);
+    auto r4 = notifier.EnqueueRemove("dup_key", segment_.id);
+    ASSERT_TRUE(r4.has_value());
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 0u);  // still 0, not 1
 
     notifier.running_.store(false, std::memory_order_release);
 }
@@ -350,23 +356,6 @@ TEST_F(AsyncMetadataNotifierTest, RecoveryAddEnqueueAndFlush) {
     notifier.Stop();
 }
 
-TEST_F(AsyncMetadataNotifierTest, RecoveryEnqueueGoesToRecoveryList) {
-    AsyncMetadataNotifier notifier(*master_client_, client_id_,
-                                   /*sender_thread_count=*/1,
-                                   /*max_batch_size=*/2000,
-                                   /*queue_capacity=*/4000);
-    notifier.running_.store(true, std::memory_order_release);
-
-    auto r = notifier.EnqueueRecoveryAdd("rec_list_key", segment_.id, 512);
-    ASSERT_TRUE(r.has_value());
-
-    // Should be in recovery list, not normal list
-    EXPECT_EQ(notifier.shards_[0]->recovery_count, 1u);
-    EXPECT_EQ(notifier.shards_[0]->normal_count, 0u);
-
-    notifier.running_.store(false, std::memory_order_release);
-}
-
 TEST_F(AsyncMetadataNotifierTest, NormalAndRecoveryCoexist) {
     AsyncMetadataNotifier notifier(*master_client_, client_id_,
                                    /*sender_thread_count=*/1,
@@ -387,14 +376,15 @@ TEST_F(AsyncMetadataNotifierTest, NormalAndRecoveryCoexist) {
 TEST_F(AsyncMetadataNotifierTest, RecoveryQueueReservesSlots) {
     // Use tiny capacity to test reservation logic
     // normal_reserved = capacity / 4 = 1
+    uint64_t queue_capacity = 4;
+    uint64_t normal_reserved = queue_capacity / 4;
     AsyncMetadataNotifier notifier(*master_client_, client_id_,
                                    /*sender_thread_count=*/1,
-                                   /*max_batch_size=*/1,
-                                   /*queue_capacity=*/4);
+                                   /*max_batch_size=*/1, queue_capacity);
     notifier.running_.store(true, std::memory_order_release);
 
     auto& shard = *notifier.shards_[0];
-    EXPECT_EQ(shard.normal_reserved, 1u);  // capacity/4
+    EXPECT_EQ(shard.normal_reserved, normal_reserved);
 
     // Fill recovery slots up to the limit (capacity - normal_reserved = 3)
     auto r1 = notifier.EnqueueRecoveryAdd("rr_key1", segment_.id, 100);
@@ -417,58 +407,76 @@ TEST_F(AsyncMetadataNotifierTest, RecoveryQueueReservesSlots) {
 }
 
 TEST_F(AsyncMetadataNotifierTest, NormalPriorityOverRecovery) {
-    // Verify that normal ops are sent before recovery ops
+    // Verify that CollectBatch drains normal ops before recovery ops.
+    // Use max_batch_size=5 and no sender thread so we can call CollectBatch
+    // directly and observe which list is dequeued first.
     AsyncMetadataNotifier notifier(*master_client_, client_id_,
                                    /*sender_thread_count=*/1,
-                                   /*max_batch_size=*/2000,
+                                   /*max_batch_size=*/5,
                                    /*queue_capacity=*/4000);
-    notifier.Start();
+    notifier.running_.store(true, std::memory_order_release);
 
-    // Enqueue recovery first, then normal
-    for (int i = 0; i < 10; ++i) {
+    // Enqueue recovery ops first — they should be sent LAST
+    for (int i = 0; i < 5; ++i) {
         notifier.EnqueueRecoveryAdd("rec_prio_" + std::to_string(i),
                                     segment_.id, 64);
     }
-    for (int i = 0; i < 10; ++i) {
+    // Enqueue normal ops second — they should be sent FIRST
+    for (int i = 0; i < 5; ++i) {
         notifier.EnqueueAdd("norm_prio_" + std::to_string(i), segment_.id, 64);
     }
 
-    // Wait for flush
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    ASSERT_EQ(notifier.shards_[0]->normal_count, 5u);
+    ASSERT_EQ(notifier.shards_[0]->recovery_count, 5u);
 
-    // All should be flushed
-    for (int i = 0; i < 10; ++i) {
-        EXPECT_EQ(CountReplicas("rec_prio_" + std::to_string(i)), 1u);
-        EXPECT_EQ(CountReplicas("norm_prio_" + std::to_string(i)), 1u);
+    // CollectBatch with max_batch_size=5 must return only normal ops
+    size_t n =
+        notifier.CollectBatch(*notifier.shards_[0], notifier.batch_buffers_[0]);
+    ASSERT_EQ(n, 5u);
+
+    // Normal queue must now be empty; recovery queue must still hold all 5 ops
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 0u);
+    EXPECT_EQ(notifier.shards_[0]->recovery_count, 5u);
+
+    // Every collected op must belong to the normal list (key prefix
+    // "norm_prio_")
+    for (size_t i = 0; i < n; ++i) {
+        EXPECT_NE(notifier.batch_buffers_[0][i].key.find("norm_prio_"),
+                  std::string::npos)
+            << "Expected normal op at batch index " << i
+            << " but got key: " << notifier.batch_buffers_[0][i].key;
     }
 
-    notifier.Stop();
+    notifier.running_.store(false, std::memory_order_release);
 }
 
 TEST_F(AsyncMetadataNotifierTest, WaitForRecoveryDrainSuccess) {
+    // Use a small batch size so the sender needs multiple cycles to drain all
+    // ops, making it necessary for WaitForRecoveryDrain to actually block.
     AsyncMetadataNotifier notifier(*master_client_, client_id_,
                                    /*sender_thread_count=*/1,
-                                   /*max_batch_size=*/2000,
+                                   /*max_batch_size=*/3,
                                    /*queue_capacity=*/4000);
     notifier.Start();
 
-    // Enqueue some recovery ops
-    for (int i = 0; i < 5; ++i) {
-        notifier.EnqueueRecoveryAdd("wfd_key_" + std::to_string(i),
-                                    segment_.id, 64);
+    constexpr int kNumKeys = 15;
+    for (int i = 0; i < kNumKeys; ++i) {
+        notifier.EnqueueRecoveryAdd("wfd_key_" + std::to_string(i), segment_.id,
+                                    64);
     }
 
-    // Wait for drain with generous timeout
-    bool drained = notifier.WaitForRecoveryDrain(
-        nullptr, std::chrono::milliseconds(5000));
+    bool drained =
+        notifier.WaitForRecoveryDrain(nullptr, std::chrono::milliseconds(5000));
     EXPECT_TRUE(drained);
 
-    notifier.Stop();
-
-    // All should be flushed
-    for (int i = 0; i < 5; ++i) {
+    // Verify BEFORE Stop(): Stop() also drains the queue, which would mask a
+    // buggy WaitForRecoveryDrain that returned before all ops were actually
+    // sent.
+    for (int i = 0; i < kNumKeys; ++i) {
         EXPECT_EQ(CountReplicas("wfd_key_" + std::to_string(i)), 1u);
     }
+
+    notifier.Stop();
 }
 
 TEST_F(AsyncMetadataNotifierTest, WaitForRecoveryDrainAbort) {
@@ -500,8 +508,8 @@ TEST_F(AsyncMetadataNotifierTest, WaitForRecoveryDrainTimeout) {
     // Enqueue but don't start sender — will never drain
     notifier.EnqueueRecoveryAdd("timeout_key", segment_.id, 64);
 
-    bool drained = notifier.WaitForRecoveryDrain(
-        nullptr, std::chrono::milliseconds(200));
+    bool drained =
+        notifier.WaitForRecoveryDrain(nullptr, std::chrono::milliseconds(200));
     EXPECT_FALSE(drained);
 
     notifier.running_.store(false, std::memory_order_release);
@@ -515,8 +523,8 @@ TEST_F(AsyncMetadataNotifierTest, WaitForRecoveryDrainEmptyImmediate) {
     notifier.Start();
 
     // No recovery ops — should return immediately
-    bool drained = notifier.WaitForRecoveryDrain(
-        nullptr, std::chrono::milliseconds(100));
+    bool drained =
+        notifier.WaitForRecoveryDrain(nullptr, std::chrono::milliseconds(100));
     EXPECT_TRUE(drained);
 
     notifier.Stop();
@@ -552,22 +560,22 @@ TEST_F(AsyncMetadataNotifierTest, RecoveryBatchMultipleKeys) {
 
     constexpr int kNumKeys = 50;
     for (int i = 0; i < kNumKeys; ++i) {
-        auto r = notifier.EnqueueRecoveryAdd(
-            "rec_batch_" + std::to_string(i), segment_.id, 128);
+        auto r = notifier.EnqueueRecoveryAdd("rec_batch_" + std::to_string(i),
+                                             segment_.id, 128);
         ASSERT_TRUE(r.has_value());
     }
 
     // Wait for drain
-    bool drained = notifier.WaitForRecoveryDrain(
-        nullptr, std::chrono::milliseconds(5000));
+    bool drained =
+        notifier.WaitForRecoveryDrain(nullptr, std::chrono::milliseconds(5000));
     EXPECT_TRUE(drained);
-
-    notifier.Stop();
 
     for (int i = 0; i < kNumKeys; ++i) {
         EXPECT_EQ(CountReplicas("rec_batch_" + std::to_string(i)), 1u)
             << "Missing replica for rec_batch_" << i;
     }
+
+    notifier.Stop();
 }
 
 TEST_F(AsyncMetadataNotifierTest, StopDrainsRecoveryQueue) {
@@ -583,13 +591,56 @@ TEST_F(AsyncMetadataNotifierTest, StopDrainsRecoveryQueue) {
     }
     notifier.Stop();
 
-    int found = 0;
     for (int i = 0; i < 10; ++i) {
-        if (CountReplicas("rec_drain_stop_" + std::to_string(i)) == 1) {
-            ++found;
-        }
+        EXPECT_EQ(CountReplicas("rec_drain_stop_" + std::to_string(i)), 1u)
+            << "rec_drain_stop_" << i << " was not sent before Stop()";
     }
-    EXPECT_EQ(found, 10) << "Only " << found << "/10 recovery ops drained";
+}
+
+TEST_F(AsyncMetadataNotifierTest, StopDropsPendingOps) {
+    // Compare Stop(drop_pending=true) vs Stop(drop_pending=false):
+    //   true  — sender exits after current batch; queued ops are dropped.
+    //   false — sender drains the full queue before exiting.
+    //
+    // max_batch_size=1 limits throughput so the sender cannot process all
+    // kNumKeys ops in the time it takes the enqueue loop + Stop() to run.
+    constexpr int kNumKeys = 200;
+
+    // --- Part 1: Stop(drop_pending=true) ---
+    {
+        AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                       /*sender_thread_count=*/1,
+                                       /*max_batch_size=*/1,
+                                       /*queue_capacity=*/4000);
+        notifier.Start();
+        for (int i = 0; i < kNumKeys; ++i)
+            notifier.EnqueueAdd("drop_" + std::to_string(i), segment_.id, 64);
+        notifier.Stop(/*drop_pending=*/true);
+
+        int sent = 0;
+        for (int i = 0; i < kNumKeys; ++i)
+            sent += (CountReplicas("drop_" + std::to_string(i)) == 1u) ? 1 : 0;
+        // With max_batch_size=1 the sender processes one RPC at a time; 200 ops
+        // cannot all be sent in the time the enqueue loop + Stop() take to run.
+        EXPECT_LT(sent, kNumKeys)
+            << "Stop(drop_pending=true) should leave some ops unsent";
+    }
+
+    // --- Part 2: Stop(drop_pending=false) ---
+    {
+        AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                       /*sender_thread_count=*/1,
+                                       /*max_batch_size=*/1,
+                                       /*queue_capacity=*/4000);
+        notifier.Start();
+        for (int i = 0; i < kNumKeys; ++i)
+            notifier.EnqueueAdd("drain_" + std::to_string(i), segment_.id, 64);
+        notifier.Stop(/*drop_pending=*/false);
+
+        for (int i = 0; i < kNumKeys; ++i)
+            EXPECT_EQ(CountReplicas("drain_" + std::to_string(i)), 1u)
+                << "Stop(drop_pending=false) should drain all ops";
+    }
 }
 
 }  // namespace test

--- a/mooncake-store/tests/async_metadata_notifier_test.cpp
+++ b/mooncake-store/tests/async_metadata_notifier_test.cpp
@@ -323,14 +323,14 @@ TEST_F(AsyncMetadataNotifierTest, DuplicateAddIsIdempotent) {
     ASSERT_TRUE(r2.has_value());
     EXPECT_EQ(notifier.shards_[0]->normal_count, 1u);  // still 1, not 2
 
-    // Second REMOVE for same key+segment — also silently skipped
-    auto r3 = notifier.EnqueueRemove("dup_key", segment_.id);
+    auto r3 = notifier.EnqueueRemove("dup_remove_key", segment_.id);
     ASSERT_TRUE(r3.has_value());
-    // ADD cancelled by REMOVE → count drops to 0
-    EXPECT_EQ(notifier.shards_[0]->normal_count, 0u);
-    auto r4 = notifier.EnqueueRemove("dup_key", segment_.id);
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 2u);
+
+    // Second REMOVE for same key — silently skipped (pending REMOVE exists)
+    auto r4 = notifier.EnqueueRemove("dup_remove_key", segment_.id);
     ASSERT_TRUE(r4.has_value());
-    EXPECT_EQ(notifier.shards_[0]->normal_count, 0u);  // still 0, not 1
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 2u);  // still 2, not 3
 
     notifier.running_.store(false, std::memory_order_release);
 }
@@ -430,9 +430,10 @@ TEST_F(AsyncMetadataNotifierTest, NormalPriorityOverRecovery) {
     ASSERT_EQ(notifier.shards_[0]->recovery_count, 5u);
 
     // CollectBatch with max_batch_size=5 must return only normal ops
-    size_t n =
+    auto [n, recovery_n] =
         notifier.CollectBatch(*notifier.shards_[0], notifier.batch_buffers_[0]);
     ASSERT_EQ(n, 5u);
+    ASSERT_EQ(recovery_n, 0u);
 
     // Normal queue must now be empty; recovery queue must still hold all 5 ops
     EXPECT_EQ(notifier.shards_[0]->normal_count, 0u);

--- a/mooncake-store/tests/async_metadata_notifier_test.cpp
+++ b/mooncake-store/tests/async_metadata_notifier_test.cpp
@@ -139,12 +139,12 @@ TEST_F(AsyncMetadataNotifierTest, CoalesceAddThenRemove) {
 
     auto r1 = notifier.EnqueueAdd("coalesce_key", segment_.id, 512);
     ASSERT_TRUE(r1.has_value());
-    EXPECT_EQ(notifier.shards_[0]->count, 1u);
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 1u);
 
     // REMOVE should cancel the pending ADD — queue becomes empty
     auto r2 = notifier.EnqueueRemove("coalesce_key", segment_.id);
     ASSERT_TRUE(r2.has_value());
-    EXPECT_EQ(notifier.shards_[0]->count, 0u);
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 0u);
     EXPECT_TRUE(notifier.shards_[0]->coalesce_index.empty());
 
     notifier.running_.store(false, std::memory_order_release);
@@ -161,11 +161,11 @@ TEST_F(AsyncMetadataNotifierTest, CoalesceRemoveThenAdd) {
     // REMOVE then ADD for same key — ADD should cancel the pending REMOVE
     auto r1 = notifier.EnqueueRemove("coalesce_ra_key", segment_.id);
     ASSERT_TRUE(r1.has_value());
-    EXPECT_EQ(notifier.shards_[0]->count, 1u);
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 1u);
 
     auto r2 = notifier.EnqueueAdd("coalesce_ra_key", segment_.id, 512);
     ASSERT_TRUE(r2.has_value());
-    EXPECT_EQ(notifier.shards_[0]->count, 0u);
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 0u);
     EXPECT_TRUE(notifier.shards_[0]->coalesce_index.empty());
 
     notifier.running_.store(false, std::memory_order_release);
@@ -319,14 +319,277 @@ TEST_F(AsyncMetadataNotifierTest, DuplicateAddIsIdempotent) {
 
     auto r1 = notifier.EnqueueAdd("dup_key", segment_.id, 256);
     ASSERT_TRUE(r1.has_value());
-    EXPECT_EQ(notifier.shards_[0]->count, 1u);
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 1u);
 
     // Second ADD for same key+segment — should be silently skipped
     auto r2 = notifier.EnqueueAdd("dup_key", segment_.id, 256);
     ASSERT_TRUE(r2.has_value());
-    EXPECT_EQ(notifier.shards_[0]->count, 1u);  // still 1, not 2
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 1u);  // still 1, not 2
 
     notifier.running_.store(false, std::memory_order_release);
+}
+
+// ============================================================================
+// Recovery Queue Tests
+// ============================================================================
+
+TEST_F(AsyncMetadataNotifierTest, RecoveryAddEnqueueAndFlush) {
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/4000);
+    notifier.Start();
+
+    auto r = notifier.EnqueueRecoveryAdd("recovery_key1", segment_.id, 1024);
+    ASSERT_TRUE(r.has_value());
+
+    // Give sender time to flush
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    EXPECT_EQ(CountReplicas("recovery_key1"), 1u);
+
+    notifier.Stop();
+}
+
+TEST_F(AsyncMetadataNotifierTest, RecoveryEnqueueGoesToRecoveryList) {
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/4000);
+    notifier.running_.store(true, std::memory_order_release);
+
+    auto r = notifier.EnqueueRecoveryAdd("rec_list_key", segment_.id, 512);
+    ASSERT_TRUE(r.has_value());
+
+    // Should be in recovery list, not normal list
+    EXPECT_EQ(notifier.shards_[0]->recovery_count, 1u);
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 0u);
+
+    notifier.running_.store(false, std::memory_order_release);
+}
+
+TEST_F(AsyncMetadataNotifierTest, NormalAndRecoveryCoexist) {
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/4000);
+    notifier.running_.store(true, std::memory_order_release);
+
+    // Enqueue normal + recovery ops for different keys
+    notifier.EnqueueAdd("normal_key", segment_.id, 256);
+    notifier.EnqueueRecoveryAdd("recovery_key", segment_.id, 512);
+
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 1u);
+    EXPECT_EQ(notifier.shards_[0]->recovery_count, 1u);
+
+    notifier.running_.store(false, std::memory_order_release);
+}
+
+TEST_F(AsyncMetadataNotifierTest, RecoveryQueueReservesSlots) {
+    // Use tiny capacity to test reservation logic
+    // normal_reserved = capacity / 4 = 1
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/1,
+                                   /*queue_capacity=*/4);
+    notifier.running_.store(true, std::memory_order_release);
+
+    auto& shard = *notifier.shards_[0];
+    EXPECT_EQ(shard.normal_reserved, 1u);  // capacity/4
+
+    // Fill recovery slots up to the limit (capacity - normal_reserved = 3)
+    auto r1 = notifier.EnqueueRecoveryAdd("rr_key1", segment_.id, 100);
+    auto r2 = notifier.EnqueueRecoveryAdd("rr_key2", segment_.id, 200);
+    auto r3 = notifier.EnqueueRecoveryAdd("rr_key3", segment_.id, 300);
+    EXPECT_TRUE(r1.has_value());
+    EXPECT_TRUE(r2.has_value());
+    EXPECT_TRUE(r3.has_value());
+
+    // Next recovery enqueue should fail (non-blocking)
+    auto r4 = notifier.EnqueueRecoveryAdd("rr_key4", segment_.id, 400);
+    EXPECT_FALSE(r4.has_value());
+    EXPECT_EQ(r4.error(), ErrorCode::ASYNC_ENQUEUE_FAILED);
+
+    // But normal enqueue should still work (reserved slot)
+    auto r5 = notifier.EnqueueAdd("normal_reserved_key", segment_.id, 500);
+    EXPECT_TRUE(r5.has_value());
+
+    notifier.running_.store(false, std::memory_order_release);
+}
+
+TEST_F(AsyncMetadataNotifierTest, NormalPriorityOverRecovery) {
+    // Verify that normal ops are sent before recovery ops
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/4000);
+    notifier.Start();
+
+    // Enqueue recovery first, then normal
+    for (int i = 0; i < 10; ++i) {
+        notifier.EnqueueRecoveryAdd("rec_prio_" + std::to_string(i),
+                                    segment_.id, 64);
+    }
+    for (int i = 0; i < 10; ++i) {
+        notifier.EnqueueAdd("norm_prio_" + std::to_string(i), segment_.id, 64);
+    }
+
+    // Wait for flush
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // All should be flushed
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_EQ(CountReplicas("rec_prio_" + std::to_string(i)), 1u);
+        EXPECT_EQ(CountReplicas("norm_prio_" + std::to_string(i)), 1u);
+    }
+
+    notifier.Stop();
+}
+
+TEST_F(AsyncMetadataNotifierTest, WaitForRecoveryDrainSuccess) {
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/4000);
+    notifier.Start();
+
+    // Enqueue some recovery ops
+    for (int i = 0; i < 5; ++i) {
+        notifier.EnqueueRecoveryAdd("wfd_key_" + std::to_string(i),
+                                    segment_.id, 64);
+    }
+
+    // Wait for drain with generous timeout
+    bool drained = notifier.WaitForRecoveryDrain(
+        nullptr, std::chrono::milliseconds(5000));
+    EXPECT_TRUE(drained);
+
+    notifier.Stop();
+
+    // All should be flushed
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(CountReplicas("wfd_key_" + std::to_string(i)), 1u);
+    }
+}
+
+TEST_F(AsyncMetadataNotifierTest, WaitForRecoveryDrainAbort) {
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/4000);
+    notifier.running_.store(true, std::memory_order_release);
+
+    // Enqueue a recovery op but don't start sender
+    notifier.EnqueueRecoveryAdd("abort_drain_key", segment_.id, 64);
+
+    // Abort immediately
+    std::atomic<bool> abort{true};
+    bool drained = notifier.WaitForRecoveryDrain(
+        [&]() { return abort.load(); }, std::chrono::milliseconds(1000));
+    EXPECT_FALSE(drained);
+
+    notifier.running_.store(false, std::memory_order_release);
+}
+
+TEST_F(AsyncMetadataNotifierTest, WaitForRecoveryDrainTimeout) {
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/4000);
+    notifier.running_.store(true, std::memory_order_release);
+
+    // Enqueue but don't start sender — will never drain
+    notifier.EnqueueRecoveryAdd("timeout_key", segment_.id, 64);
+
+    bool drained = notifier.WaitForRecoveryDrain(
+        nullptr, std::chrono::milliseconds(200));
+    EXPECT_FALSE(drained);
+
+    notifier.running_.store(false, std::memory_order_release);
+}
+
+TEST_F(AsyncMetadataNotifierTest, WaitForRecoveryDrainEmptyImmediate) {
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/4000);
+    notifier.Start();
+
+    // No recovery ops — should return immediately
+    bool drained = notifier.WaitForRecoveryDrain(
+        nullptr, std::chrono::milliseconds(100));
+    EXPECT_TRUE(drained);
+
+    notifier.Stop();
+}
+
+TEST_F(AsyncMetadataNotifierTest, RecoveryCoalesceWithNormalRemove) {
+    // A normal REMOVE should cancel a pending recovery ADD for the same key
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/4000);
+    notifier.running_.store(true, std::memory_order_release);
+
+    auto r1 = notifier.EnqueueRecoveryAdd("cross_coalesce", segment_.id, 256);
+    ASSERT_TRUE(r1.has_value());
+    EXPECT_EQ(notifier.shards_[0]->recovery_count, 1u);
+
+    // Normal REMOVE for the same key should cancel the recovery ADD
+    auto r2 = notifier.EnqueueRemove("cross_coalesce", segment_.id);
+    ASSERT_TRUE(r2.has_value());
+    EXPECT_EQ(notifier.shards_[0]->recovery_count, 0u);
+    EXPECT_EQ(notifier.shards_[0]->normal_count, 0u);
+
+    notifier.running_.store(false, std::memory_order_release);
+}
+
+TEST_F(AsyncMetadataNotifierTest, RecoveryBatchMultipleKeys) {
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/2,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/8000);
+    notifier.Start();
+
+    constexpr int kNumKeys = 50;
+    for (int i = 0; i < kNumKeys; ++i) {
+        auto r = notifier.EnqueueRecoveryAdd(
+            "rec_batch_" + std::to_string(i), segment_.id, 128);
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // Wait for drain
+    bool drained = notifier.WaitForRecoveryDrain(
+        nullptr, std::chrono::milliseconds(5000));
+    EXPECT_TRUE(drained);
+
+    notifier.Stop();
+
+    for (int i = 0; i < kNumKeys; ++i) {
+        EXPECT_EQ(CountReplicas("rec_batch_" + std::to_string(i)), 1u)
+            << "Missing replica for rec_batch_" << i;
+    }
+}
+
+TEST_F(AsyncMetadataNotifierTest, StopDrainsRecoveryQueue) {
+    AsyncMetadataNotifier notifier(*master_client_, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/4000);
+    notifier.Start();
+
+    for (int i = 0; i < 10; ++i) {
+        notifier.EnqueueRecoveryAdd("rec_drain_stop_" + std::to_string(i),
+                                    segment_.id, 64);
+    }
+    notifier.Stop();
+
+    int found = 0;
+    for (int i = 0; i < 10; ++i) {
+        if (CountReplicas("rec_drain_stop_" + std::to_string(i)) == 1) {
+            ++found;
+        }
+    }
+    EXPECT_EQ(found, 10) << "Only " << found << "/10 recovery ops drained";
 }
 
 }  // namespace test

--- a/mooncake-store/tests/ha_integration_test.cpp
+++ b/mooncake-store/tests/ha_integration_test.cpp
@@ -1,0 +1,308 @@
+/**
+ * @file ha_integration_test.cpp
+ * @brief Integration tests for HA recovery: master restart, degraded mode,
+ *        and full recovery pipeline through P2PClientService.
+ *
+ * Launches an in-process P2P master and one P2PClientService, exercises
+ * degraded mode behavior and master-restart recovery flow.
+ */
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#define private public
+#define protected public
+#include "p2p_client_service.h"
+#include "p2p_master_service.h"
+#include "master_service.h"
+#undef protected
+#undef private
+
+#include "p2p_client_meta.h"
+#include "test_p2p_server_helpers.h"
+#include "types.h"
+
+namespace mooncake {
+namespace testing {
+
+// ============================================================================
+// Test fixture
+// ============================================================================
+
+class HAIntegrationTest : public ::testing::Test {
+   protected:
+    static std::shared_ptr<P2PClientService> CreateP2PClient(
+        const std::string& host_name, uint32_t rpc_port = 0) {
+        if (rpc_port == 0) rpc_port = getFreeTcpPort();
+
+        auto config = ClientConfigBuilder::build_p2p_real_client(
+            host_name, "P2PHANDSHAKE", "tcp", std::nullopt, master_address_,
+            R"({"tiers": [{"type": "DRAM", "capacity": 67108864, "priority": 100}]})",
+            /*local_buffer_size=*/0, nullptr, "", rpc_port);
+
+        auto client = std::make_shared<P2PClientService>(
+            config.local_ip, config.te_port, config.metadata_connstring,
+            config.labels);
+
+        auto err = client->Init(config);
+        EXPECT_EQ(err, ErrorCode::OK)
+            << "Init failed: " << static_cast<int>(err);
+
+        return client;
+    }
+
+    static void SetUpTestSuite() {
+        google::InitGoogleLogging("HAIntegrationTest");
+        FLAGS_logtostderr = 1;
+
+        ASSERT_TRUE(master_.Start()) << "Failed to start P2P master";
+        master_address_ = master_.master_address();
+        LOG(INFO) << "P2P master started at " << master_address_;
+
+        client_ = CreateP2PClient("localhost:18901");
+        ASSERT_NE(client_, nullptr);
+
+        // Wait for heartbeat to stabilize
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    static void TearDownTestSuite() {
+        if (client_) {
+            client_->Stop();
+            client_->Destroy();
+            client_.reset();
+        }
+        master_.Stop();
+        google::ShutdownGoogleLogging();
+    }
+
+    static InProcP2PMaster master_;
+    static std::string master_address_;
+    static std::shared_ptr<P2PClientService> client_;
+};
+
+InProcP2PMaster HAIntegrationTest::master_;
+std::string HAIntegrationTest::master_address_;
+std::shared_ptr<P2PClientService> HAIntegrationTest::client_ = nullptr;
+
+// ============================================================================
+// Baseline: normal operations work before any HA events
+// ============================================================================
+
+TEST_F(HAIntegrationTest, BaselinePutAndGet) {
+    const std::string key = "ha_baseline";
+    const std::string data = "baseline_data";
+
+    std::vector<Slice> slices;
+    slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
+    auto put = client_->Put(key, slices, WriteRouteRequestConfig{});
+    ASSERT_TRUE(put.has_value())
+        << "Put failed: " << static_cast<int>(put.error());
+
+    std::vector<char> buf(data.size(), 0);
+    auto get = client_->Get(key, {(void*)buf.data()}, {buf.size()});
+    ASSERT_TRUE(get.has_value())
+        << "Get failed: " << static_cast<int>(get.error());
+    EXPECT_EQ(std::string(buf.data(), buf.size()), data);
+}
+
+// ============================================================================
+// HARecoveryManager state via P2PClientService
+// ============================================================================
+
+TEST_F(HAIntegrationTest, InitialStateIsFull) {
+    ASSERT_NE(client_->ha_manager_, nullptr);
+    EXPECT_EQ(client_->ha_manager_->GetState(), HAClientState::FULL);
+}
+
+// ============================================================================
+// Degraded mode: MASTER_UNREACHABLE -> local-only operations
+// ============================================================================
+
+TEST_F(HAIntegrationTest, DegradedModePutLocal) {
+    // Put some data first in FULL mode
+    const std::string key = "ha_degraded_put";
+    const std::string data = "degraded_data";
+
+    std::vector<Slice> slices;
+    slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
+    auto put = client_->Put(key, slices, WriteRouteRequestConfig{});
+    ASSERT_TRUE(put.has_value());
+
+    // Simulate MASTER_UNREACHABLE
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_TRUE(client_->ha_manager_->IsDegraded());
+
+    // PutViaRoute should fall back to PutLocal in degraded mode
+    const std::string key2 = "ha_degraded_put2";
+    const std::string data2 = "degraded_data2";
+    std::vector<Slice> slices2;
+    slices2.emplace_back(Slice{const_cast<char*>(data2.data()), data2.size()});
+    auto put2 = client_->Put(key2, slices2, WriteRouteRequestConfig{});
+    ASSERT_TRUE(put2.has_value())
+        << "Degraded PutLocal failed: " << static_cast<int>(put2.error());
+
+    // Local Get should still work for locally stored data
+    std::vector<char> buf(data2.size(), 0);
+    auto get = client_->Get(key2, {(void*)buf.data()}, {buf.size()});
+    ASSERT_TRUE(get.has_value())
+        << "Degraded local Get failed: " << static_cast<int>(get.error());
+    EXPECT_EQ(std::string(buf.data(), buf.size()), data2);
+
+    // Restore state for subsequent tests
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+TEST_F(HAIntegrationTest, DegradedModeIsExistLocalOnly) {
+    // Put a key in FULL mode
+    const std::string key = "ha_degraded_exist";
+    const std::string data = "exist_data";
+    std::vector<Slice> slices;
+    slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
+    auto put = client_->Put(key, slices, WriteRouteRequestConfig{});
+    ASSERT_TRUE(put.has_value());
+
+    // Go degraded
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_TRUE(client_->ha_manager_->IsDegraded());
+
+    // IsExist for locally stored key should still work (local hit)
+    auto exist = client_->IsExist(key);
+    ASSERT_TRUE(exist.has_value());
+    EXPECT_TRUE(exist.value());
+
+    // IsExist for unknown key should return false (no Master fallback)
+    auto not_exist = client_->IsExist("ha_nonexistent_key_xyz");
+    ASSERT_TRUE(not_exist.has_value());
+    EXPECT_FALSE(not_exist.value());
+
+    // Restore
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+TEST_F(HAIntegrationTest, DegradedModeQueryFails) {
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_TRUE(client_->ha_manager_->IsDegraded());
+
+    // Query requires Master — should fail with INACCESSIBLE_MASTER
+    auto query = client_->Query("any_key");
+    EXPECT_FALSE(query.has_value());
+    EXPECT_EQ(query.error(), ErrorCode::INACCESSIBLE_MASTER);
+
+    // Restore
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+TEST_F(HAIntegrationTest, DegradedModeGetRemoteKeyFails) {
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_TRUE(client_->ha_manager_->IsDegraded());
+
+    // Get for a key that doesn't exist locally should fail
+    std::vector<char> buf(100, 0);
+    auto get = client_->Get("ha_remote_only_key", {(void*)buf.data()},
+                            {buf.size()});
+    EXPECT_FALSE(get.has_value());
+    EXPECT_EQ(get.error(), ErrorCode::INACCESSIBLE_MASTER);
+
+    // Restore
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+// ============================================================================
+// Recovery: DEGRADED -> MASTER_REACHABLE -> SYNCING -> FULL
+// ============================================================================
+
+TEST_F(HAIntegrationTest, RecoverFromDegraded) {
+    // Write some data first
+    const std::string key = "ha_recovery_key";
+    const std::string data = "recovery_data";
+    std::vector<Slice> slices;
+    slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
+    auto put = client_->Put(key, slices, WriteRouteRequestConfig{});
+    ASSERT_TRUE(put.has_value());
+
+    // Go degraded
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_EQ(client_->ha_manager_->GetState(), HAClientState::DEGRADED);
+
+    // Come back
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+
+    // Wait for recovery pipeline to complete
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (client_->ha_manager_->GetState() != HAClientState::FULL &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    EXPECT_EQ(client_->ha_manager_->GetState(), HAClientState::FULL);
+
+    // After recovery, normal operations should work
+    auto exist = client_->IsExist(key);
+    ASSERT_TRUE(exist.has_value());
+    EXPECT_TRUE(exist.value());
+}
+
+// ============================================================================
+// State transitions are consistent under rapid events
+// ============================================================================
+
+TEST_F(HAIntegrationTest, RapidDegradedRecoveredCycle) {
+    for (int i = 0; i < 5; ++i) {
+        client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+        EXPECT_TRUE(client_->ha_manager_->IsDegraded());
+
+        client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+        // Should be SYNCING or FULL
+        auto state = client_->ha_manager_->GetState();
+        EXPECT_TRUE(state == HAClientState::SYNCING ||
+                    state == HAClientState::FULL);
+
+        // Wait briefly for recovery
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    // Final recovery wait
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (client_->ha_manager_->GetState() != HAClientState::FULL &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    EXPECT_EQ(client_->ha_manager_->GetState(), HAClientState::FULL);
+}
+
+// ============================================================================
+// SetSyncCompleted via RPC round-trip
+// ============================================================================
+
+TEST_F(HAIntegrationTest, SetSyncCompletedRPC) {
+    ASSERT_NE(client_->ha_manager_, nullptr);
+    auto result = client_->ha_manager_->SetSyncCompleted();
+    EXPECT_TRUE(result.has_value());
+}
+
+// ============================================================================
+// OnClientRegistered sets is_syncing on Master side
+// ============================================================================
+
+TEST_F(HAIntegrationTest, ClientRegistrationSetsSyncing) {
+    auto& svc = master_.GetWrapped().GetMasterService();
+    auto client_meta = svc.GetClientManager().GetClient(client_->GetClientID());
+    ASSERT_NE(client_meta, nullptr);
+
+    auto p2p_meta = std::dynamic_pointer_cast<P2PClientMeta>(client_meta);
+    ASSERT_NE(p2p_meta, nullptr);
+    // After Init() calls SetSyncCompleted(), is_syncing should be false
+    EXPECT_FALSE(p2p_meta->IsSyncing());
+}
+
+}  // namespace testing
+}  // namespace mooncake

--- a/mooncake-store/tests/ha_integration_test.cpp
+++ b/mooncake-store/tests/ha_integration_test.cpp
@@ -91,40 +91,13 @@ std::string HAIntegrationTest::master_address_;
 std::shared_ptr<P2PClientService> HAIntegrationTest::client_ = nullptr;
 
 // ============================================================================
-// Baseline: normal operations work before any HA events
-// ============================================================================
-
-TEST_F(HAIntegrationTest, BaselinePutAndGet) {
-    const std::string key = "ha_baseline";
-    const std::string data = "baseline_data";
-
-    std::vector<Slice> slices;
-    slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
-    auto put = client_->Put(key, slices, WriteRouteRequestConfig{});
-    ASSERT_TRUE(put.has_value())
-        << "Put failed: " << static_cast<int>(put.error());
-
-    std::vector<char> buf(data.size(), 0);
-    auto get = client_->Get(key, {(void*)buf.data()}, {buf.size()});
-    ASSERT_TRUE(get.has_value())
-        << "Get failed: " << static_cast<int>(get.error());
-    EXPECT_EQ(std::string(buf.data(), buf.size()), data);
-}
-
-// ============================================================================
-// HARecoveryManager state via P2PClientService
-// ============================================================================
-
-TEST_F(HAIntegrationTest, InitialStateIsFull) {
-    ASSERT_NE(client_->ha_manager_, nullptr);
-    EXPECT_EQ(client_->ha_manager_->GetState(), HAClientState::FULL);
-}
-
-// ============================================================================
 // Degraded mode: MASTER_UNREACHABLE -> local-only operations
 // ============================================================================
 
 TEST_F(HAIntegrationTest, DegradedModePutLocal) {
+    ASSERT_NE(client_->ha_manager_, nullptr);
+    EXPECT_EQ(client_->ha_manager_->GetState(), HAClientState::FULL);
+
     // Put some data first in FULL mode
     const std::string key = "ha_degraded_put";
     const std::string data = "degraded_data";
@@ -155,7 +128,7 @@ TEST_F(HAIntegrationTest, DegradedModePutLocal) {
     EXPECT_EQ(std::string(buf.data(), buf.size()), data2);
 
     // Restore state for subsequent tests
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
@@ -183,7 +156,7 @@ TEST_F(HAIntegrationTest, DegradedModeIsExistLocalOnly) {
     EXPECT_FALSE(not_exist.value());
 
     // Restore
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
@@ -197,7 +170,7 @@ TEST_F(HAIntegrationTest, DegradedModeQueryFails) {
     EXPECT_EQ(query.error(), ErrorCode::INACCESSIBLE_MASTER);
 
     // Restore
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
@@ -213,12 +186,12 @@ TEST_F(HAIntegrationTest, DegradedModeGetRemoteKeyFails) {
     EXPECT_EQ(get.error(), ErrorCode::INACCESSIBLE_MASTER);
 
     // Restore
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
 // ============================================================================
-// Recovery: DEGRADED -> MASTER_REACHABLE -> SYNCING -> FULL
+// Recovery: DEGRADED -> MASTER_RECONNECTED -> SYNCING -> FULL
 // ============================================================================
 
 TEST_F(HAIntegrationTest, RecoverFromDegraded) {
@@ -235,7 +208,7 @@ TEST_F(HAIntegrationTest, RecoverFromDegraded) {
     EXPECT_EQ(client_->ha_manager_->GetState(), HAClientState::DEGRADED);
 
     // Come back
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+    client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
 
     // Wait for recovery pipeline to complete
     auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
@@ -260,7 +233,7 @@ TEST_F(HAIntegrationTest, RapidDegradedRecoveredCycle) {
         client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
         EXPECT_TRUE(client_->ha_manager_->IsDegraded());
 
-        client_->ha_manager_->HandleEvent(HAEvent::MASTER_REACHABLE);
+        client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
         // Should be SYNCING or FULL
         auto state = client_->ha_manager_->GetState();
         EXPECT_TRUE(state == HAClientState::SYNCING ||

--- a/mooncake-store/tests/ha_integration_test.cpp
+++ b/mooncake-store/tests/ha_integration_test.cpp
@@ -72,11 +72,9 @@ class HAIntegrationTest : public ::testing::Test {
 
     static tl::expected<void, ErrorCode> PutData(
         std::shared_ptr<P2PClientService>& client, const std::string& key,
-        const std::string& data,
-        const WriteRouteRequestConfig& config = {}) {
+        const std::string& data, const WriteRouteRequestConfig& config = {}) {
         std::vector<Slice> slices;
-        slices.emplace_back(
-            Slice{const_cast<char*>(data.data()), data.size()});
+        slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
         return client->Put(key, slices, config);
     }
 
@@ -84,8 +82,7 @@ class HAIntegrationTest : public ::testing::Test {
         std::shared_ptr<P2PClientService>& client, const std::string& key,
         size_t buf_size) {
         std::vector<char> buf(buf_size, 0);
-        auto result =
-            client->Get(key, {(void*)buf.data()}, {buf.size()});
+        auto result = client->Get(key, {(void*)buf.data()}, {buf.size()});
         if (!result.has_value()) {
             return tl::unexpected(result.error());
         }
@@ -114,8 +111,7 @@ class HAIntegrationTest : public ::testing::Test {
             << "Client did not recover to FULL within 10s";
     }
 
-    static void SendManualHeartbeat(
-        std::shared_ptr<P2PClientService>& client) {
+    static void SendManualHeartbeat(std::shared_ptr<P2PClientService>& client) {
         HeartbeatRequest req;
         req.client_id = client->GetClientID();
         auto result = client->GetMasterClient().Heartbeat(req);
@@ -170,8 +166,7 @@ class HAIntegrationTest : public ::testing::Test {
 
     // Per-test setup: ensure both clients are in FULL state.
     void SetUp() override {
-        for (auto* client :
-             {&client1_, &client2_}) {
+        for (auto* client : {&client1_, &client2_}) {
             if ((*client)->ha_manager_ &&
                 (*client)->ha_manager_->GetState() != HAClientState::FULL) {
                 ForceRecover(*client);
@@ -273,8 +268,8 @@ TEST_F(HAIntegrationTest, DegradedModeRemoteOpsFail) {
 
     // Get: local miss → cache miss → degraded check → INACCESSIBLE_MASTER
     std::vector<char> buf(100, 0);
-    auto get = client1_->Get("a3_client2_key", {(void*)buf.data()},
-                             {buf.size()});
+    auto get =
+        client1_->Get("a3_client2_key", {(void*)buf.data()}, {buf.size()});
     EXPECT_FALSE(get.has_value());
     EXPECT_EQ(get.error(), ErrorCode::INACCESSIBLE_MASTER);
 
@@ -295,8 +290,8 @@ TEST_F(HAIntegrationTest, RecoverFromDegradedRemoteGet) {
 
     // Verify Get fails during degradation
     std::vector<char> buf(11, 0);
-    auto get_fail = client1_->Get("a4_client2_key", {(void*)buf.data()},
-                                  {buf.size()});
+    auto get_fail =
+        client1_->Get("a4_client2_key", {(void*)buf.data()}, {buf.size()});
     EXPECT_FALSE(get_fail.has_value());
     EXPECT_EQ(get_fail.error(), ErrorCode::INACCESSIBLE_MASTER);
 
@@ -406,8 +401,7 @@ TEST_F(HAIntegrationTest, MasterSideState) {
             svc.GetClientManager().GetClient((*client)->GetClientID());
         ASSERT_NE(client_meta, nullptr);
 
-        auto p2p_meta =
-            std::dynamic_pointer_cast<P2PClientMeta>(client_meta);
+        auto p2p_meta = std::dynamic_pointer_cast<P2PClientMeta>(client_meta);
         ASSERT_NE(p2p_meta, nullptr);
         EXPECT_FALSE(p2p_meta->IsSyncing());
     }
@@ -437,8 +431,7 @@ TEST_F(HAIntegrationTest, MasterRestartRecovery) {
     builder.set_rpc_port(port);
     builder.set_client_live_ttl_sec(3600);
     builder.set_client_crashed_ttl_sec(7200);
-    ASSERT_TRUE(master_.Start(builder.build()))
-        << "Failed to restart master";
+    ASSERT_TRUE(master_.Start(builder.build())) << "Failed to restart master";
 
     // Reconnect RPC clients to the restarted master (old connections are
     // stale). Retry with backoff since the restarted RPC server may not
@@ -447,8 +440,7 @@ TEST_F(HAIntegrationTest, MasterRestartRecovery) {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         auto err = client1_->GetMasterClient().Connect(master_address_);
         if (err == ErrorCode::OK) break;
-        if (attempt == 9)
-            FAIL() << "Reconnect client1 failed after retries";
+        if (attempt == 9) FAIL() << "Reconnect client1 failed after retries";
     }
     {
         auto err = client2_->GetMasterClient().Connect(master_address_);
@@ -458,12 +450,10 @@ TEST_F(HAIntegrationTest, MasterRestartRecovery) {
     // Re-register clients with the restarted master.
     auto reg1 = client1_->RegisterClient();
     ASSERT_TRUE(reg1.has_value())
-        << "Re-register client1 failed: "
-        << static_cast<int>(reg1.error());
+        << "Re-register client1 failed: " << static_cast<int>(reg1.error());
     auto reg2 = client2_->RegisterClient();
     ASSERT_TRUE(reg2.has_value())
-        << "Re-register client2 failed: "
-        << static_cast<int>(reg2.error());
+        << "Re-register client2 failed: " << static_cast<int>(reg2.error());
 
     // Recovery: DEGRADED → SYNCING → FULL
     ForceRecover(client1_);
@@ -503,9 +493,9 @@ TEST_F(HAIntegrationTest, ClientDisconnectAndRecover) {
     {
         QueryClientStatusRequest req;
         req.client_id = tmp1->GetClientID();
-        auto res = short_ttl_master.GetWrapped()
-                       .GetMasterService()
-                       .QueryClientStatus(req);
+        auto res =
+            short_ttl_master.GetWrapped().GetMasterService().QueryClientStatus(
+                req);
         ASSERT_TRUE(res.has_value());
         ASSERT_EQ(res.value().status, ClientStatus::HEALTH);
     }
@@ -520,9 +510,9 @@ TEST_F(HAIntegrationTest, ClientDisconnectAndRecover) {
     {
         QueryClientStatusRequest req;
         req.client_id = tmp1->GetClientID();
-        auto res = short_ttl_master.GetWrapped()
-                       .GetMasterService()
-                       .QueryClientStatus(req);
+        auto res =
+            short_ttl_master.GetWrapped().GetMasterService().QueryClientStatus(
+                req);
         ASSERT_TRUE(res.has_value());
         EXPECT_EQ(res.value().status, ClientStatus::DISCONNECTION)
             << "Master should have marked disconnected client";
@@ -532,9 +522,9 @@ TEST_F(HAIntegrationTest, ClientDisconnectAndRecover) {
     {
         QueryClientStatusRequest req;
         req.client_id = tmp2->GetClientID();
-        auto res = short_ttl_master.GetWrapped()
-                       .GetMasterService()
-                       .QueryClientStatus(req);
+        auto res =
+            short_ttl_master.GetWrapped().GetMasterService().QueryClientStatus(
+                req);
         ASSERT_TRUE(res.has_value());
         EXPECT_EQ(res.value().status, ClientStatus::HEALTH);
     }
@@ -553,9 +543,9 @@ TEST_F(HAIntegrationTest, ClientDisconnectAndRecover) {
     {
         QueryClientStatusRequest req;
         req.client_id = tmp1->GetClientID();
-        auto res = short_ttl_master.GetWrapped()
-                       .GetMasterService()
-                       .QueryClientStatus(req);
+        auto res =
+            short_ttl_master.GetWrapped().GetMasterService().QueryClientStatus(
+                req);
         ASSERT_TRUE(res.has_value());
         EXPECT_EQ(res.value().status, ClientStatus::HEALTH)
             << "Client should be HEALTH after recovery heartbeat";

--- a/mooncake-store/tests/ha_integration_test.cpp
+++ b/mooncake-store/tests/ha_integration_test.cpp
@@ -1,10 +1,14 @@
 /**
  * @file ha_integration_test.cpp
- * @brief Integration tests for HA recovery: master restart, degraded mode,
- *        and full recovery pipeline through P2PClientService.
+ * @brief Integration tests for HA recovery with two P2PClientService instances.
  *
- * Launches an in-process P2P master and one P2PClientService, exercises
- * degraded mode behavior and master-restart recovery flow.
+ * Group A: Client-side HA logic (long TTL master, stopped heartbeat,
+ *          manual HandleEvent for deterministic state control).
+ * Group B: End-to-end failure scenarios (master restart, client disconnect).
+ *
+ * Two clients (client1_, client2_) connect to the same InProcP2PMaster.
+ * Heartbeat threads are stopped after Init(); tests manually control HA
+ * state via HandleEvent() and manual heartbeat RPCs.
  */
 #include <glog/logging.h>
 #include <gtest/gtest.h>
@@ -36,14 +40,22 @@ namespace testing {
 
 class HAIntegrationTest : public ::testing::Test {
    protected:
+    // Create a P2PClient and connect to the given master address.
+    // async_sender_thread_count > 0 enables the async notifier for recovery
+    // metadata sync.
     static std::shared_ptr<P2PClientService> CreateP2PClient(
-        const std::string& host_name, uint32_t rpc_port = 0) {
+        const std::string& host_name, const std::string& master_addr,
+        uint32_t rpc_port = 0, size_t async_sender_thread_count = 1) {
         if (rpc_port == 0) rpc_port = getFreeTcpPort();
 
         auto config = ClientConfigBuilder::build_p2p_real_client(
-            host_name, "P2PHANDSHAKE", "tcp", std::nullopt, master_address_,
+            host_name, "P2PHANDSHAKE", "tcp", std::nullopt, master_addr,
             R"({"tiers": [{"type": "DRAM", "capacity": 67108864, "priority": 100}]})",
-            /*local_buffer_size=*/0, nullptr, "", rpc_port);
+            /*local_buffer_size=*/0, nullptr, "", rpc_port,
+            /*rpc_thread_num=*/2, /*lock_shard_count=*/1024,
+            /*route_cache_max_memory_bytes=*/300 * 1024 * 1024,
+            /*route_cache_ttl_ms=*/5 * 60 * 1000,
+            /*labels=*/{}, async_sender_thread_count);
 
         auto client = std::make_shared<P2PClientService>(
             config.local_ip, config.te_port, config.metadata_connstring,
@@ -56,225 +68,505 @@ class HAIntegrationTest : public ::testing::Test {
         return client;
     }
 
+    // ---- Helpers ----
+
+    static tl::expected<void, ErrorCode> PutData(
+        std::shared_ptr<P2PClientService>& client, const std::string& key,
+        const std::string& data,
+        const WriteRouteRequestConfig& config = {}) {
+        std::vector<Slice> slices;
+        slices.emplace_back(
+            Slice{const_cast<char*>(data.data()), data.size()});
+        return client->Put(key, slices, config);
+    }
+
+    static tl::expected<std::string, ErrorCode> GetData(
+        std::shared_ptr<P2PClientService>& client, const std::string& key,
+        size_t buf_size) {
+        std::vector<char> buf(buf_size, 0);
+        auto result =
+            client->Get(key, {(void*)buf.data()}, {buf.size()});
+        if (!result.has_value()) {
+            return tl::unexpected(result.error());
+        }
+        size_t actual_size = static_cast<size_t>(result.value());
+        return std::string(buf.data(), actual_size);
+    }
+
+    static void ForceDegraded(std::shared_ptr<P2PClientService>& client) {
+        ASSERT_NE(client->ha_manager_, nullptr);
+        client->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+        ASSERT_TRUE(client->ha_manager_->IsDegraded())
+            << "Expected DEGRADED state after MASTER_UNREACHABLE";
+    }
+
+    static void ForceRecover(std::shared_ptr<P2PClientService>& client) {
+        ASSERT_NE(client->ha_manager_, nullptr);
+        client->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
+
+        auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(10);
+        while (client->ha_manager_->GetState() != HAClientState::FULL &&
+               std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+        ASSERT_EQ(client->ha_manager_->GetState(), HAClientState::FULL)
+            << "Client did not recover to FULL within 10s";
+    }
+
+    static void SendManualHeartbeat(
+        std::shared_ptr<P2PClientService>& client) {
+        HeartbeatRequest req;
+        req.client_id = client->GetClientID();
+        auto result = client->GetMasterClient().Heartbeat(req);
+        ASSERT_TRUE(result.has_value()) << "Manual heartbeat failed";
+    }
+
+    // ---- Suite setup / teardown ----
+
     static void SetUpTestSuite() {
         google::InitGoogleLogging("HAIntegrationTest");
         FLAGS_logtostderr = 1;
 
-        ASSERT_TRUE(master_.Start()) << "Failed to start P2P master";
+        // Start master with long TTL so it won't mark clients as
+        // DISCONNECTION when heartbeat is stopped.
+        InProcMasterConfigBuilder builder;
+        builder.set_client_live_ttl_sec(3600);
+        builder.set_client_crashed_ttl_sec(7200);
+        auto master_config = builder.build();
+
+        ASSERT_TRUE(master_.Start(master_config))
+            << "Failed to start P2P master";
         master_address_ = master_.master_address();
         LOG(INFO) << "P2P master started at " << master_address_;
 
-        client_ = CreateP2PClient("localhost:18901");
-        ASSERT_NE(client_, nullptr);
+        client1_ = CreateP2PClient("localhost:18901", master_address_);
+        ASSERT_NE(client1_, nullptr);
+        client2_ = CreateP2PClient("localhost:18902", master_address_);
+        ASSERT_NE(client2_, nullptr);
 
-        // Wait for heartbeat to stabilize
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        // Stop heartbeat threads to prevent race conditions.
+        client1_->StopHeartbeat();
+        client2_->StopHeartbeat();
+
+        // Brief wait to let any in-flight heartbeat RPC complete.
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
     static void TearDownTestSuite() {
-        if (client_) {
-            client_->Stop();
-            client_->Destroy();
-            client_.reset();
+        if (client1_) {
+            client1_->Stop();
+            client1_->Destroy();
+            client1_.reset();
+        }
+        if (client2_) {
+            client2_->Stop();
+            client2_->Destroy();
+            client2_.reset();
         }
         master_.Stop();
         google::ShutdownGoogleLogging();
     }
 
+    // Per-test setup: ensure both clients are in FULL state.
+    void SetUp() override {
+        for (auto* client :
+             {&client1_, &client2_}) {
+            if ((*client)->ha_manager_ &&
+                (*client)->ha_manager_->GetState() != HAClientState::FULL) {
+                ForceRecover(*client);
+            }
+        }
+    }
+
     static InProcP2PMaster master_;
     static std::string master_address_;
-    static std::shared_ptr<P2PClientService> client_;
+    static std::shared_ptr<P2PClientService> client1_;
+    static std::shared_ptr<P2PClientService> client2_;
 };
 
 InProcP2PMaster HAIntegrationTest::master_;
 std::string HAIntegrationTest::master_address_;
-std::shared_ptr<P2PClientService> HAIntegrationTest::client_ = nullptr;
+std::shared_ptr<P2PClientService> HAIntegrationTest::client1_ = nullptr;
+std::shared_ptr<P2PClientService> HAIntegrationTest::client2_ = nullptr;
 
 // ============================================================================
-// Degraded mode: MASTER_UNREACHABLE -> local-only operations
+// Group A: Client-side HA logic tests
+// (long TTL master, stopped heartbeat, manual HandleEvent)
 // ============================================================================
 
-TEST_F(HAIntegrationTest, DegradedModePutLocal) {
-    ASSERT_NE(client_->ha_manager_, nullptr);
-    EXPECT_EQ(client_->ha_manager_->GetState(), HAClientState::FULL);
+// A1: Baseline — put from client1 routed to client2, then read back.
+TEST_F(HAIntegrationTest, RemotePutAndGet) {
+    // Put with allow_local=false: master routes to client2
+    WriteRouteRequestConfig config;
+    config.allow_local = false;
 
-    // Put some data first in FULL mode
-    const std::string key = "ha_degraded_put";
-    const std::string data = "degraded_data";
+    auto put = PutData(client1_, "a1_client1_remote_baseline", "hello", config);
+    ASSERT_TRUE(put.has_value())
+        << "Remote put failed: " << static_cast<int>(put.error());
 
-    std::vector<Slice> slices;
-    slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
-    auto put = client_->Put(key, slices, WriteRouteRequestConfig{});
-    ASSERT_TRUE(put.has_value());
-
-    // Simulate MASTER_UNREACHABLE
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
-    EXPECT_TRUE(client_->ha_manager_->IsDegraded());
-
-    // PutViaRoute should fall back to PutLocal in degraded mode
-    const std::string key2 = "ha_degraded_put2";
-    const std::string data2 = "degraded_data2";
-    std::vector<Slice> slices2;
-    slices2.emplace_back(Slice{const_cast<char*>(data2.data()), data2.size()});
-    auto put2 = client_->Put(key2, slices2, WriteRouteRequestConfig{});
-    ASSERT_TRUE(put2.has_value())
-        << "Degraded PutLocal failed: " << static_cast<int>(put2.error());
-
-    // Local Get should still work for locally stored data
-    std::vector<char> buf(data2.size(), 0);
-    auto get = client_->Get(key2, {(void*)buf.data()}, {buf.size()});
+    // client1 Get: local miss → queries master → reads from client2
+    auto get = GetData(client1_, "a1_client1_remote_baseline", 5);
     ASSERT_TRUE(get.has_value())
-        << "Degraded local Get failed: " << static_cast<int>(get.error());
-    EXPECT_EQ(std::string(buf.data(), buf.size()), data2);
+        << "Remote get failed: " << static_cast<int>(get.error());
+    EXPECT_EQ(get.value(), "hello");
 
-    // Restore state for subsequent tests
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-}
-
-TEST_F(HAIntegrationTest, DegradedModeIsExistLocalOnly) {
-    // Put a key in FULL mode
-    const std::string key = "ha_degraded_exist";
-    const std::string data = "exist_data";
-    std::vector<Slice> slices;
-    slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
-    auto put = client_->Put(key, slices, WriteRouteRequestConfig{});
-    ASSERT_TRUE(put.has_value());
-
-    // Go degraded
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
-    EXPECT_TRUE(client_->ha_manager_->IsDegraded());
-
-    // IsExist for locally stored key should still work (local hit)
-    auto exist = client_->IsExist(key);
+    // Verify data physically resides on client2
+    auto exist = client2_->IsExist("a1_client1_remote_baseline");
     ASSERT_TRUE(exist.has_value());
     EXPECT_TRUE(exist.value());
-
-    // IsExist for unknown key should return false (no Master fallback)
-    auto not_exist = client_->IsExist("ha_nonexistent_key_xyz");
-    ASSERT_TRUE(not_exist.has_value());
-    EXPECT_FALSE(not_exist.value());
-
-    // Restore
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
-TEST_F(HAIntegrationTest, DegradedModeQueryFails) {
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
-    EXPECT_TRUE(client_->ha_manager_->IsDegraded());
+// A2: Degraded mode — local Put/Get/IsExist all work; remote-only keys
+//     and nonexistent keys return false for IsExist.
+TEST_F(HAIntegrationTest, DegradedModeLocalOps) {
+    // Write locally on client1 (default config: prefer_local=true, master
+    // now sorts candidates by priority so local segment wins).
+    auto put_a = PutData(client1_, "a2_client1_local", "local_data");
+    ASSERT_TRUE(put_a.has_value());
 
-    // Query requires Master — should fail with INACCESSIBLE_MASTER
-    auto query = client_->Query("any_key");
-    EXPECT_FALSE(query.has_value());
-    EXPECT_EQ(query.error(), ErrorCode::INACCESSIBLE_MASTER);
+    // Write locally on client2 (client1's cache never populated)
+    auto put_b = PutData(client2_, "a2_client2_remote_only", "remote_data");
+    ASSERT_TRUE(put_b.has_value());
 
-    // Restore
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    ForceDegraded(client1_);
+
+    // Degraded Put falls back to PutLocal
+    auto put_c = PutData(client1_, "a2_client1_degraded_put", "degraded_data");
+    ASSERT_TRUE(put_c.has_value())
+        << "Degraded PutLocal failed: " << static_cast<int>(put_c.error());
+
+    // Local Get works for pre-existing and degraded-mode keys
+    auto get_a = GetData(client1_, "a2_client1_local", 10);
+    ASSERT_TRUE(get_a.has_value());
+    EXPECT_EQ(get_a.value(), "local_data");
+
+    auto get_c = GetData(client1_, "a2_client1_degraded_put", 13);
+    ASSERT_TRUE(get_c.has_value());
+    EXPECT_EQ(get_c.value(), "degraded_data");
+
+    // IsExist: local key → true
+    auto exist_local = client1_->IsExist("a2_client1_local");
+    ASSERT_TRUE(exist_local.has_value());
+    EXPECT_TRUE(exist_local.value());
+
+    // IsExist: key only on client2 → false (local miss, degraded skip)
+    auto exist_remote = client1_->IsExist("a2_client2_remote_only");
+    ASSERT_TRUE(exist_remote.has_value());
+    EXPECT_FALSE(exist_remote.value());
+
+    // IsExist: nonexistent key → false
+    auto exist_none = client1_->IsExist("a2_nonexistent_key");
+    ASSERT_TRUE(exist_none.has_value());
+    EXPECT_FALSE(exist_none.value());
+
+    ForceRecover(client1_);
 }
 
-TEST_F(HAIntegrationTest, DegradedModeGetRemoteKeyFails) {
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
-    EXPECT_TRUE(client_->ha_manager_->IsDegraded());
+// A3: Degraded mode — remote Get and Query fail with INACCESSIBLE_MASTER.
+TEST_F(HAIntegrationTest, DegradedModeRemoteOpsFail) {
+    // Write on client2 — client1's route cache not populated
+    auto put = PutData(client2_, "a3_client2_key", "remote_val");
+    ASSERT_TRUE(put.has_value());
 
-    // Get for a key that doesn't exist locally should fail
+    ForceDegraded(client1_);
+
+    // Get: local miss → cache miss → degraded check → INACCESSIBLE_MASTER
     std::vector<char> buf(100, 0);
-    auto get = client_->Get("ha_remote_only_key", {(void*)buf.data()},
-                            {buf.size()});
+    auto get = client1_->Get("a3_client2_key", {(void*)buf.data()},
+                             {buf.size()});
     EXPECT_FALSE(get.has_value());
     EXPECT_EQ(get.error(), ErrorCode::INACCESSIBLE_MASTER);
 
-    // Restore
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    // Query: requires master → fails
+    auto query = client1_->Query("a3_client1_query_key");
+    EXPECT_FALSE(query.has_value());
+    EXPECT_EQ(query.error(), ErrorCode::INACCESSIBLE_MASTER);
+
+    ForceRecover(client1_);
 }
 
-// ============================================================================
-// Recovery: DEGRADED -> MASTER_RECONNECTED -> SYNCING -> FULL
-// ============================================================================
-
-TEST_F(HAIntegrationTest, RecoverFromDegraded) {
-    // Write some data first
-    const std::string key = "ha_recovery_key";
-    const std::string data = "recovery_data";
-    std::vector<Slice> slices;
-    slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
-    auto put = client_->Put(key, slices, WriteRouteRequestConfig{});
+// A4: Recovery — after degraded, remote data on client2 becomes accessible.
+TEST_F(HAIntegrationTest, RecoverFromDegradedRemoteGet) {
+    auto put = PutData(client2_, "a4_client2_key", "recoverable");
     ASSERT_TRUE(put.has_value());
 
-    // Go degraded
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
-    EXPECT_EQ(client_->ha_manager_->GetState(), HAClientState::DEGRADED);
+    ForceDegraded(client1_);
 
-    // Come back
-    client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
+    // Verify Get fails during degradation
+    std::vector<char> buf(11, 0);
+    auto get_fail = client1_->Get("a4_client2_key", {(void*)buf.data()},
+                                  {buf.size()});
+    EXPECT_FALSE(get_fail.has_value());
+    EXPECT_EQ(get_fail.error(), ErrorCode::INACCESSIBLE_MASTER);
 
-    // Wait for recovery pipeline to complete
-    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
-    while (client_->ha_manager_->GetState() != HAClientState::FULL &&
-           std::chrono::steady_clock::now() < deadline) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-    EXPECT_EQ(client_->ha_manager_->GetState(), HAClientState::FULL);
+    ForceRecover(client1_);
 
-    // After recovery, normal operations should work
-    auto exist = client_->IsExist(key);
-    ASSERT_TRUE(exist.has_value());
-    EXPECT_TRUE(exist.value());
+    // After recovery, Get succeeds via master routing to client2
+    auto get_ok = GetData(client1_, "a4_client2_key", 11);
+    ASSERT_TRUE(get_ok.has_value())
+        << "Post-recovery get failed: " << static_cast<int>(get_ok.error());
+    EXPECT_EQ(get_ok.value(), "recoverable");
 }
 
-// ============================================================================
-// State transitions are consistent under rapid events
-// ============================================================================
+// A5: Degraded writes are synced to master after recovery,
+//     allowing the other client to read them.
+TEST_F(HAIntegrationTest, RecoverDegradedWritesSyncToMaster) {
+    ForceDegraded(client1_);
 
-TEST_F(HAIntegrationTest, RapidDegradedRecoveredCycle) {
+    // Write during degraded mode → PutLocal with metadata skip.
+    // The add_replica_callback detects degraded mode and skips notifier
+    // enqueue, so the local write succeeds without master involvement.
+    auto put = PutData(client1_, "a5_client1_degraded_write", "synced_data");
+    ASSERT_TRUE(put.has_value())
+        << "Degraded PutLocal failed: " << static_cast<int>(put.error());
+
+    // Recovery: notifier syncs all local metadata to master
+    ForceRecover(client1_);
+
+    // client2 reads data written by client1 during degradation.
+    // master now has the route (synced by recovery pipeline).
+    auto get = GetData(client2_, "a5_client1_degraded_write", 11);
+    ASSERT_TRUE(get.has_value())
+        << "Cross-client get after recovery sync failed: "
+        << static_cast<int>(get.error());
+    EXPECT_EQ(get.value(), "synced_data");
+}
+
+// A6: Eviction (Delete) during degraded mode succeeds locally without
+//     failing on master notification.
+TEST_F(HAIntegrationTest, DegradedModeEvictionSkipsMasterSync) {
+    // Write a key locally on client1 in FULL mode
+    auto put = PutData(client1_, "a6_client1_evict_key", "evict_data");
+    ASSERT_TRUE(put.has_value());
+
+    // Verify key exists before degradation
+    auto exist_before = client1_->IsExist("a6_client1_evict_key");
+    ASSERT_TRUE(exist_before.has_value());
+    EXPECT_TRUE(exist_before.value());
+
+    ForceDegraded(client1_);
+
+    // Simulate eviction: delete the key via data_manager while degraded.
+    // Without the degraded skip fix in remove_replica_callback, this would
+    // fail with ASYNC_ENQUEUE_FAILED because the notifier is stopped.
+    auto del = client1_->data_manager_->Delete("a6_client1_evict_key");
+    ASSERT_TRUE(del.has_value())
+        << "Degraded Delete failed: " << static_cast<int>(del.error());
+
+    // Verify key is gone locally
+    auto exist_after = client1_->IsExist("a6_client1_evict_key");
+    ASSERT_TRUE(exist_after.has_value());
+    EXPECT_FALSE(exist_after.value());
+
+    // Recover and verify master-side consistency:
+    // After recovery, master should NOT have a stale route for the deleted key.
+    ForceRecover(client1_);
+
+    // client2 tries to read the deleted key — should fail (key doesn't exist)
+    std::vector<char> buf(100, 0);
+    auto get = client2_->Get("a6_client1_evict_key", {(void*)buf.data()},
+                             {buf.size()});
+    EXPECT_FALSE(get.has_value());
+}
+
+// A7: Rapid degraded/recovery cycles are consistent.
+TEST_F(HAIntegrationTest, RapidDegradedRecoveryCycle) {
     for (int i = 0; i < 5; ++i) {
-        client_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
-        EXPECT_TRUE(client_->ha_manager_->IsDegraded());
+        client1_->ha_manager_->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+        EXPECT_TRUE(client1_->ha_manager_->IsDegraded());
 
-        client_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
-        // Should be SYNCING or FULL
-        auto state = client_->ha_manager_->GetState();
+        client1_->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
+        auto state = client1_->ha_manager_->GetState();
         EXPECT_TRUE(state == HAClientState::SYNCING ||
                     state == HAClientState::FULL);
 
-        // Wait briefly for recovery
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        // Wait for recovery pipeline to complete
+        auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(10);
+        while (client1_->ha_manager_->GetState() != HAClientState::FULL &&
+               std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
     }
-
-    // Final recovery wait
-    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
-    while (client_->ha_manager_->GetState() != HAClientState::FULL &&
-           std::chrono::steady_clock::now() < deadline) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-    EXPECT_EQ(client_->ha_manager_->GetState(), HAClientState::FULL);
+    EXPECT_EQ(client1_->ha_manager_->GetState(), HAClientState::FULL);
 }
 
-// ============================================================================
-// SetSyncCompleted via RPC round-trip
-// ============================================================================
-
-TEST_F(HAIntegrationTest, SetSyncCompletedRPC) {
-    ASSERT_NE(client_->ha_manager_, nullptr);
-    auto result = client_->ha_manager_->SetSyncCompleted();
+// A7: Master-side state verification.
+TEST_F(HAIntegrationTest, MasterSideState) {
+    // SetSyncCompleted RPC round-trip
+    ASSERT_NE(client1_->ha_manager_, nullptr);
+    auto result = client1_->ha_manager_->SetSyncCompleted();
     EXPECT_TRUE(result.has_value());
+
+    // Both clients should have is_syncing=false on master side
+    auto& svc = master_.GetWrapped().GetMasterService();
+    for (auto* client : {&client1_, &client2_}) {
+        auto client_meta =
+            svc.GetClientManager().GetClient((*client)->GetClientID());
+        ASSERT_NE(client_meta, nullptr);
+
+        auto p2p_meta =
+            std::dynamic_pointer_cast<P2PClientMeta>(client_meta);
+        ASSERT_NE(p2p_meta, nullptr);
+        EXPECT_FALSE(p2p_meta->IsSyncing());
+    }
 }
 
 // ============================================================================
-// OnClientRegistered sets is_syncing on Master side
+// Group B: End-to-end failure scenario tests
 // ============================================================================
 
-TEST_F(HAIntegrationTest, ClientRegistrationSetsSyncing) {
-    auto& svc = master_.GetWrapped().GetMasterService();
-    auto client_meta = svc.GetClientManager().GetClient(client_->GetClientID());
-    ASSERT_NE(client_meta, nullptr);
+// B1: Master crashes and restarts — both clients recover.
+TEST_F(HAIntegrationTest, MasterRestartRecovery) {
+    // Write data locally on client1 before master crash
+    auto put = PutData(client1_, "b1_client1_before_crash", "persistent");
+    ASSERT_TRUE(put.has_value());
 
-    auto p2p_meta = std::dynamic_pointer_cast<P2PClientMeta>(client_meta);
-    ASSERT_NE(p2p_meta, nullptr);
-    // After Init() calls SetSyncCompleted(), is_syncing should be false
-    EXPECT_FALSE(p2p_meta->IsSyncing());
+    int port = master_.rpc_port();
+
+    // Stop master (simulates crash)
+    master_.Stop();
+
+    // Both clients detect master down → DEGRADED
+    ForceDegraded(client1_);
+    ForceDegraded(client2_);
+
+    // Restart master on the same port
+    InProcMasterConfigBuilder builder;
+    builder.set_rpc_port(port);
+    builder.set_client_live_ttl_sec(3600);
+    builder.set_client_crashed_ttl_sec(7200);
+    ASSERT_TRUE(master_.Start(builder.build()))
+        << "Failed to restart master";
+
+    // Reconnect RPC clients to the restarted master (old connections are
+    // stale). Retry with backoff since the restarted RPC server may not
+    // be fully accepting connections immediately.
+    for (int attempt = 0; attempt < 10; ++attempt) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        auto err = client1_->GetMasterClient().Connect(master_address_);
+        if (err == ErrorCode::OK) break;
+        if (attempt == 9)
+            FAIL() << "Reconnect client1 failed after retries";
+    }
+    {
+        auto err = client2_->GetMasterClient().Connect(master_address_);
+        ASSERT_EQ(err, ErrorCode::OK) << "Reconnect client2 failed";
+    }
+
+    // Re-register clients with the restarted master.
+    auto reg1 = client1_->RegisterClient();
+    ASSERT_TRUE(reg1.has_value())
+        << "Re-register client1 failed: "
+        << static_cast<int>(reg1.error());
+    auto reg2 = client2_->RegisterClient();
+    ASSERT_TRUE(reg2.has_value())
+        << "Re-register client2 failed: "
+        << static_cast<int>(reg2.error());
+
+    // Recovery: DEGRADED → SYNCING → FULL
+    ForceRecover(client1_);
+    ForceRecover(client2_);
+
+    // After recovery, verify the system is functional:
+    // new Put + Get should work through the restarted master.
+    auto put2 = PutData(client1_, "b1_client1_after_restart", "works");
+    ASSERT_TRUE(put2.has_value())
+        << "Post-restart put failed: " << static_cast<int>(put2.error());
+    auto get = GetData(client1_, "b1_client1_after_restart", 5);
+    ASSERT_TRUE(get.has_value())
+        << "Post-restart get failed: " << static_cast<int>(get.error());
+    EXPECT_EQ(get.value(), "works");
+}
+
+// B2: Single client disconnects (network failure), master marks it
+//     DISCONNECTION, then client recovers via heartbeat.
+//     Uses independent short-TTL master to avoid affecting other tests.
+TEST_F(HAIntegrationTest, ClientDisconnectAndRecover) {
+    // Start an independent master with short TTL
+    InProcP2PMaster short_ttl_master;
+    InProcMasterConfigBuilder builder;
+    builder.set_client_live_ttl_sec(2);
+    builder.set_client_crashed_ttl_sec(20);
+    ASSERT_TRUE(short_ttl_master.Start(builder.build()));
+
+    std::string short_master_addr = short_ttl_master.master_address();
+
+    // Create two temporary clients on the short-TTL master
+    auto tmp1 = CreateP2PClient("localhost:19001", short_master_addr);
+    ASSERT_NE(tmp1, nullptr);
+    auto tmp2 = CreateP2PClient("localhost:19002", short_master_addr);
+    ASSERT_NE(tmp2, nullptr);
+
+    // Verify both are HEALTH initially
+    {
+        QueryClientStatusRequest req;
+        req.client_id = tmp1->GetClientID();
+        auto res = short_ttl_master.GetWrapped()
+                       .GetMasterService()
+                       .QueryClientStatus(req);
+        ASSERT_TRUE(res.has_value());
+        ASSERT_EQ(res.value().status, ClientStatus::HEALTH);
+    }
+
+    // Simulate client1 network failure: stop its heartbeat
+    tmp1->StopHeartbeat();
+
+    // Wait for master to mark tmp1 as DISCONNECTION (TTL=2s)
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+
+    // Verify master side: tmp1 is DISCONNECTION
+    {
+        QueryClientStatusRequest req;
+        req.client_id = tmp1->GetClientID();
+        auto res = short_ttl_master.GetWrapped()
+                       .GetMasterService()
+                       .QueryClientStatus(req);
+        ASSERT_TRUE(res.has_value());
+        EXPECT_EQ(res.value().status, ClientStatus::DISCONNECTION)
+            << "Master should have marked disconnected client";
+    }
+
+    // Verify tmp2 is still HEALTH
+    {
+        QueryClientStatusRequest req;
+        req.client_id = tmp2->GetClientID();
+        auto res = short_ttl_master.GetWrapped()
+                       .GetMasterService()
+                       .QueryClientStatus(req);
+        ASSERT_TRUE(res.has_value());
+        EXPECT_EQ(res.value().status, ClientStatus::HEALTH);
+    }
+
+    // Recover: manually send heartbeat from tmp1
+    {
+        HeartbeatRequest req;
+        req.client_id = tmp1->GetClientID();
+        auto hb_res = tmp1->GetMasterClient().Heartbeat(req);
+        ASSERT_TRUE(hb_res.has_value()) << "Recovery heartbeat failed";
+        EXPECT_EQ(hb_res.value().status, ClientStatus::HEALTH)
+            << "Client should recover to HEALTH after heartbeat";
+    }
+
+    // Verify master side: tmp1 is HEALTH again
+    {
+        QueryClientStatusRequest req;
+        req.client_id = tmp1->GetClientID();
+        auto res = short_ttl_master.GetWrapped()
+                       .GetMasterService()
+                       .QueryClientStatus(req);
+        ASSERT_TRUE(res.has_value());
+        EXPECT_EQ(res.value().status, ClientStatus::HEALTH)
+            << "Client should be HEALTH after recovery heartbeat";
+    }
+
+    // Cleanup
+    tmp1->Stop();
+    tmp1->Destroy();
+    tmp2->Stop();
+    tmp2->Destroy();
+    short_ttl_master.Stop();
 }
 
 }  // namespace testing

--- a/mooncake-store/tests/ha_recovery_manager_test.cpp
+++ b/mooncake-store/tests/ha_recovery_manager_test.cpp
@@ -132,24 +132,20 @@ std::string HARecoveryManagerTest::master_addr_;
 // State Machine Tests
 // ============================================================================
 
-TEST_F(HARecoveryManagerTest, InitialStateIsFull) {
+TEST_F(HARecoveryManagerTest, FullToDegragedOnUnreachable) {
     auto mgr = CreateManager();
     EXPECT_EQ(mgr->GetState(), HAClientState::FULL);
     EXPECT_FALSE(mgr->IsDegraded());
-}
-
-TEST_F(HARecoveryManagerTest, FullToDegragedOnUnreachable) {
-    auto mgr = CreateManager();
     mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
     EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
     EXPECT_TRUE(mgr->IsDegraded());
 }
 
 TEST_F(HARecoveryManagerTest, FullToSyncingOnReachable) {
-    // FULL -> MASTER_REACHABLE -> SYNCING (Master restarted scenario)
+    // FULL -> MASTER_RECONNECTED -> SYNCING (Master restarted scenario)
     // Without DataManager, recovery thread exits quickly
     auto mgr = CreateManager();
-    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
     // Should transition to SYNCING (recovery thread will run but no data_manager)
     // Give it a moment to start
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -165,7 +161,7 @@ TEST_F(HARecoveryManagerTest, DegradedToSyncingOnReachable) {
     mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
     EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
 
-    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
     // Should attempt SYNCING
     auto state = mgr->GetState();
     EXPECT_TRUE(state == HAClientState::SYNCING || state == HAClientState::FULL);
@@ -184,8 +180,8 @@ TEST_F(HARecoveryManagerTest, DuplicateUnreachableIsNoop) {
 TEST_F(HARecoveryManagerTest, SyncingToDegragedOnUnreachable) {
     auto mgr = CreateManagerWithNotifier();
 
-    // First go to SYNCING via MASTER_REACHABLE
-    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    // First go to SYNCING via MASTER_RECONNECTED
+    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
     // Allow transition to start
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
@@ -198,18 +194,18 @@ TEST_F(HARecoveryManagerTest, ReachableDuringSyncingRestartsPipeline) {
     auto mgr = CreateManagerWithNotifier();
 
     // Start recovery
-    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-    // Another MASTER_REACHABLE should abort old thread and restart
-    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    // Another MASTER_RECONNECTED should abort old thread and restart
+    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
     // Should still be SYNCING
     EXPECT_EQ(mgr->GetState(), HAClientState::SYNCING);
 }
 
 TEST_F(HARecoveryManagerTest, StopFromSyncingGoesToDegraded) {
     auto mgr = CreateManagerWithNotifier();
-    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
     mgr->Stop();
@@ -226,7 +222,7 @@ TEST_F(HARecoveryManagerTest, StopIdempotent) {
 TEST_F(HARecoveryManagerTest, DestructorCallsStop) {
     {
         auto mgr = CreateManagerWithNotifier();
-        mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+        mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
         // Destructor should cleanly join recovery thread
     }
@@ -276,8 +272,8 @@ TEST_F(HARecoveryManagerTest, NotifierRestartedOnReachableFromDegraded) {
     mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
     EXPECT_FALSE(notifier_->running_.load());
 
-    // MASTER_REACHABLE from DEGRADED should restart notifier
-    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    // MASTER_RECONNECTED from DEGRADED should restart notifier
+    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
     EXPECT_TRUE(notifier_->running_.load());
 }
 
@@ -300,7 +296,7 @@ TEST_F(HARecoveryManagerTest, ConcurrentEvents) {
     // Thread B: rapid REACHABLE events
     std::thread t2([&]() {
         while (!stop.load(std::memory_order_relaxed)) {
-            mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+            mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
         }
     });
@@ -331,7 +327,7 @@ TEST_F(HARecoveryManagerTest, FullCycle_FullDegradedSyncingFull) {
     EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
 
     // DEGRADED -> SYNCING (no data_manager, recovery will fail fast)
-    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     // Without data_manager, stays SYNCING
     EXPECT_EQ(mgr->GetState(), HAClientState::SYNCING);

--- a/mooncake-store/tests/ha_recovery_manager_test.cpp
+++ b/mooncake-store/tests/ha_recovery_manager_test.cpp
@@ -1,0 +1,344 @@
+/**
+ * @file ha_recovery_manager_test.cpp
+ * @brief Unit tests for HARecoveryManager state machine and recovery pipeline.
+ *
+ * Uses an in-process P2P master so that RPCs are real but require no network
+ * setup. The DataManager is left as std::nullopt for state-machine-only tests;
+ * a populated DataManager is used for recovery pipeline tests.
+ */
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+#define private public
+#define protected public
+#include "ha_recovery_manager.h"
+#undef protected
+#undef private
+
+#include "async_metadata_notifier.h"
+#include "p2p_master_client.h"
+#include "test_p2p_server_helpers.h"
+#include "types.h"
+
+namespace mooncake {
+namespace test {
+
+// ============================================================================
+// Test fixture
+// ============================================================================
+
+class HARecoveryManagerTest : public ::testing::Test {
+   protected:
+    static void SetUpTestSuite() {
+        google::InitGoogleLogging("HARecoveryManagerTest");
+        FLAGS_logtostderr = 1;
+
+        ASSERT_TRUE(master_.Start()) << "Failed to start in-proc P2P master";
+        master_addr_ = master_.master_address();
+    }
+
+    static void TearDownTestSuite() {
+        master_.Stop();
+        google::ShutdownGoogleLogging();
+    }
+
+    void SetUp() override {
+        client_id_ = generate_uuid();
+        segment_ = MakeSegment();
+
+        // Register client + segment with master
+        RegisterClientRequest reg;
+        reg.client_id = client_id_;
+        reg.ip_address = "127.0.0.1";
+        reg.rpc_port = 50099;
+        reg.segments.push_back(segment_);
+        reg.deployment_mode = DeploymentMode::P2P;
+        auto& svc = master_.GetWrapped().GetMasterService();
+        auto res = svc.RegisterClient(reg);
+        ASSERT_TRUE(res.has_value())
+            << "RegisterClient failed: " << res.error();
+
+        // Connect P2PMasterClient to in-proc master
+        master_client_ = std::make_unique<P2PMasterClient>(client_id_);
+        auto ec = master_client_->Connect(master_addr_);
+        ASSERT_EQ(ec, ErrorCode::OK) << "Connect failed";
+
+        view_version_ = 0;
+        data_manager_ = std::nullopt;
+        notifier_.reset();
+    }
+
+    void TearDown() override {
+        notifier_.reset();
+        master_client_.reset();
+    }
+
+    static Segment MakeSegment(size_t size = 16 * 1024 * 1024) {
+        Segment seg;
+        seg.id = generate_uuid();
+        seg.name = "test_segment";
+        seg.size = size;
+        seg.extra = P2PSegmentExtraData{
+            .priority = 0,
+            .tags = {},
+            .memory_type = MemoryType::DRAM,
+        };
+        return seg;
+    }
+
+    std::unique_ptr<HARecoveryManager> CreateManager() {
+        return std::make_unique<HARecoveryManager>(
+            client_id_, *master_client_, data_manager_, notifier_,
+            view_version_);
+    }
+
+    std::unique_ptr<HARecoveryManager> CreateManagerWithNotifier() {
+        notifier_ = std::make_unique<AsyncMetadataNotifier>(
+            *master_client_, client_id_,
+            /*sender_thread_count=*/1,
+            /*max_batch_size=*/2000,
+            /*queue_capacity=*/4000);
+        notifier_->Start();
+        return CreateManager();
+    }
+
+    size_t CountReplicas(const std::string& key) {
+        auto& svc = master_.GetWrapped().GetMasterService();
+        auto res = svc.GetReplicaList(key);
+        if (!res.has_value()) return 0;
+        return res->replicas.size();
+    }
+
+    static testing::InProcP2PMaster master_;
+    static std::string master_addr_;
+
+    UUID client_id_{};
+    Segment segment_;
+    std::unique_ptr<P2PMasterClient> master_client_;
+    ViewVersionId view_version_ = 0;
+    std::optional<DataManager> data_manager_;
+    std::unique_ptr<AsyncMetadataNotifier> notifier_;
+};
+
+testing::InProcP2PMaster HARecoveryManagerTest::master_;
+std::string HARecoveryManagerTest::master_addr_;
+
+// ============================================================================
+// State Machine Tests
+// ============================================================================
+
+TEST_F(HARecoveryManagerTest, InitialStateIsFull) {
+    auto mgr = CreateManager();
+    EXPECT_EQ(mgr->GetState(), HAClientState::FULL);
+    EXPECT_FALSE(mgr->IsDegraded());
+}
+
+TEST_F(HARecoveryManagerTest, FullToDegragedOnUnreachable) {
+    auto mgr = CreateManager();
+    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
+    EXPECT_TRUE(mgr->IsDegraded());
+}
+
+TEST_F(HARecoveryManagerTest, FullToSyncingOnReachable) {
+    // FULL -> MASTER_REACHABLE -> SYNCING (Master restarted scenario)
+    // Without DataManager, recovery thread exits quickly
+    auto mgr = CreateManager();
+    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    // Should transition to SYNCING (recovery thread will run but no data_manager)
+    // Give it a moment to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Recovery thread exits because data_manager_ is nullopt,
+    // but state doesn't automatically go to FULL without successful pipeline
+    auto state = mgr->GetState();
+    // Without data_manager, pipeline logs error and returns without transitioning
+    EXPECT_TRUE(state == HAClientState::SYNCING || state == HAClientState::FULL);
+}
+
+TEST_F(HARecoveryManagerTest, DegradedToSyncingOnReachable) {
+    auto mgr = CreateManager();
+    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
+
+    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    // Should attempt SYNCING
+    auto state = mgr->GetState();
+    EXPECT_TRUE(state == HAClientState::SYNCING || state == HAClientState::FULL);
+}
+
+TEST_F(HARecoveryManagerTest, DuplicateUnreachableIsNoop) {
+    auto mgr = CreateManager();
+    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
+
+    // Second UNREACHABLE should be a no-op (early return in HandleEvent)
+    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
+}
+
+TEST_F(HARecoveryManagerTest, SyncingToDegragedOnUnreachable) {
+    auto mgr = CreateManagerWithNotifier();
+
+    // First go to SYNCING via MASTER_REACHABLE
+    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    // Allow transition to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Now UNREACHABLE should transition to DEGRADED
+    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
+}
+
+TEST_F(HARecoveryManagerTest, ReachableDuringSyncingRestartsPipeline) {
+    auto mgr = CreateManagerWithNotifier();
+
+    // Start recovery
+    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Another MASTER_REACHABLE should abort old thread and restart
+    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    // Should still be SYNCING
+    EXPECT_EQ(mgr->GetState(), HAClientState::SYNCING);
+}
+
+TEST_F(HARecoveryManagerTest, StopFromSyncingGoesToDegraded) {
+    auto mgr = CreateManagerWithNotifier();
+    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    mgr->Stop();
+    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
+}
+
+TEST_F(HARecoveryManagerTest, StopIdempotent) {
+    auto mgr = CreateManager();
+    mgr->Stop();
+    mgr->Stop();  // Should not crash
+    EXPECT_EQ(mgr->GetState(), HAClientState::FULL);
+}
+
+TEST_F(HARecoveryManagerTest, DestructorCallsStop) {
+    {
+        auto mgr = CreateManagerWithNotifier();
+        mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        // Destructor should cleanly join recovery thread
+    }
+    // If we get here without hanging, the test passes
+    SUCCEED();
+}
+
+// ============================================================================
+// SetSyncCompleted RPC
+// ============================================================================
+
+TEST_F(HARecoveryManagerTest, SetSyncCompletedSuccess) {
+    auto mgr = CreateManager();
+    auto result = mgr->SetSyncCompleted();
+    EXPECT_TRUE(result.has_value());
+}
+
+// ============================================================================
+// Notifier Start/Stop on transitions
+// ============================================================================
+
+TEST_F(HARecoveryManagerTest, NotifierStoppedOnUnreachable) {
+    notifier_ = std::make_unique<AsyncMetadataNotifier>(
+        *master_client_, client_id_,
+        /*sender_thread_count=*/1,
+        /*max_batch_size=*/2000,
+        /*queue_capacity=*/4000);
+    notifier_->Start();
+    auto mgr = CreateManager();
+
+    EXPECT_TRUE(notifier_->running_.load());
+    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    // Notifier should be stopped
+    EXPECT_FALSE(notifier_->running_.load());
+}
+
+TEST_F(HARecoveryManagerTest, NotifierRestartedOnReachableFromDegraded) {
+    notifier_ = std::make_unique<AsyncMetadataNotifier>(
+        *master_client_, client_id_,
+        /*sender_thread_count=*/1,
+        /*max_batch_size=*/2000,
+        /*queue_capacity=*/4000);
+    notifier_->Start();
+    auto mgr = CreateManager();
+
+    // Go to DEGRADED
+    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_FALSE(notifier_->running_.load());
+
+    // MASTER_REACHABLE from DEGRADED should restart notifier
+    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    EXPECT_TRUE(notifier_->running_.load());
+}
+
+// ============================================================================
+// Concurrent event handling
+// ============================================================================
+
+TEST_F(HARecoveryManagerTest, ConcurrentEvents) {
+    auto mgr = CreateManagerWithNotifier();
+    std::atomic<bool> stop{false};
+
+    // Thread A: rapid UNREACHABLE events
+    std::thread t1([&]() {
+        while (!stop.load(std::memory_order_relaxed)) {
+            mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    });
+
+    // Thread B: rapid REACHABLE events
+    std::thread t2([&]() {
+        while (!stop.load(std::memory_order_relaxed)) {
+            mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    });
+
+    // Run for a short duration
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    stop.store(true);
+    t1.join();
+    t2.join();
+
+    // Final state should be valid
+    auto state = mgr->GetState();
+    EXPECT_TRUE(state == HAClientState::FULL ||
+                state == HAClientState::DEGRADED ||
+                state == HAClientState::SYNCING);
+}
+
+// ============================================================================
+// Full state machine cycle
+// ============================================================================
+
+TEST_F(HARecoveryManagerTest, FullCycle_FullDegradedSyncingFull) {
+    auto mgr = CreateManagerWithNotifier();
+
+    // FULL -> DEGRADED
+    EXPECT_EQ(mgr->GetState(), HAClientState::FULL);
+    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
+
+    // DEGRADED -> SYNCING (no data_manager, recovery will fail fast)
+    mgr->HandleEvent(HAEvent::MASTER_REACHABLE);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    // Without data_manager, stays SYNCING
+    EXPECT_EQ(mgr->GetState(), HAClientState::SYNCING);
+
+    // Cleanup
+    mgr->Stop();
+}
+
+}  // namespace test
+}  // namespace mooncake

--- a/mooncake-store/tests/ha_recovery_manager_test.cpp
+++ b/mooncake-store/tests/ha_recovery_manager_test.cpp
@@ -3,8 +3,17 @@
  * @brief Unit tests for HARecoveryManager state machine and recovery pipeline.
  *
  * Uses an in-process P2P master so that RPCs are real but require no network
- * setup. The DataManager is left as std::nullopt for state-machine-only tests;
- * a populated DataManager is used for recovery pipeline tests.
+ * setup. DataManager is initialised with an empty TieredBackend (no tiers,
+ * no keys) so the recovery pipeline runs and exits cleanly without special-
+ * casing the nullopt scenario in production code.
+ *
+ * Note: basic state-machine transitions (FULL→DEGRADED→SYNCING) are covered
+ * end-to-end by ha_integration_test. This file focuses on behaviours that are
+ * not observable through the full P2PClientService stack:
+ *   - duplicate / idempotent events
+ *   - AsyncMetadataNotifier start/stop lifecycle
+ *   - Stop() idempotency and destructor safety
+ *   - concurrent event handling
  */
 #include <glog/logging.h>
 #include <gtest/gtest.h>
@@ -69,7 +78,11 @@ class HARecoveryManagerTest : public ::testing::Test {
         ASSERT_EQ(ec, ErrorCode::OK) << "Connect failed";
 
         view_version_ = 0;
-        data_manager_ = std::nullopt;
+        // Initialise with an empty TieredBackend (no tiers, no keys) and a
+        // default TransferEngine (not init()'d — only RDMA ops need it, and
+        // the recovery pipeline only iterates metadata which is empty here).
+        data_manager_.emplace(std::make_unique<TieredBackend>(),
+                              std::make_shared<TransferEngine>());
         notifier_.reset();
     }
 
@@ -92,26 +105,19 @@ class HARecoveryManagerTest : public ::testing::Test {
     }
 
     std::unique_ptr<HARecoveryManager> CreateManager() {
-        return std::make_unique<HARecoveryManager>(
-            client_id_, *master_client_, data_manager_, notifier_,
-            view_version_);
+        return std::make_unique<HARecoveryManager>(client_id_, *master_client_,
+                                                   data_manager_, notifier_,
+                                                   view_version_);
     }
 
     std::unique_ptr<HARecoveryManager> CreateManagerWithNotifier() {
-        notifier_ = std::make_unique<AsyncMetadataNotifier>(
-            *master_client_, client_id_,
-            /*sender_thread_count=*/1,
-            /*max_batch_size=*/2000,
-            /*queue_capacity=*/4000);
+        notifier_ =
+            std::make_unique<AsyncMetadataNotifier>(*master_client_, client_id_,
+                                                    /*sender_thread_count=*/1,
+                                                    /*max_batch_size=*/2000,
+                                                    /*queue_capacity=*/4000);
         notifier_->Start();
         return CreateManager();
-    }
-
-    size_t CountReplicas(const std::string& key) {
-        auto& svc = master_.GetWrapped().GetMasterService();
-        auto res = svc.GetReplicaList(key);
-        if (!res.has_value()) return 0;
-        return res->replicas.size();
     }
 
     static testing::InProcP2PMaster master_;
@@ -129,42 +135,33 @@ testing::InProcP2PMaster HARecoveryManagerTest::master_;
 std::string HARecoveryManagerTest::master_addr_;
 
 // ============================================================================
-// State Machine Tests
+// State Machine – smoke test
+// (detailed transition coverage lives in ha_integration_test)
 // ============================================================================
 
-TEST_F(HARecoveryManagerTest, FullToDegragedOnUnreachable) {
+TEST_F(HARecoveryManagerTest, BasicStateMachineSmoke) {
     auto mgr = CreateManager();
+
+    // Initial state
     EXPECT_EQ(mgr->GetState(), HAClientState::FULL);
     EXPECT_FALSE(mgr->IsDegraded());
+
+    // FULL -> DEGRADED
     mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
     EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
     EXPECT_TRUE(mgr->IsDegraded());
-}
 
-TEST_F(HARecoveryManagerTest, FullToSyncingOnReachable) {
-    // FULL -> MASTER_RECONNECTED -> SYNCING (Master restarted scenario)
-    // Without DataManager, recovery thread exits quickly
-    auto mgr = CreateManager();
+    // DEGRADED -> SYNCING (no data_manager: pipeline exits fast)
     mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
-    // Should transition to SYNCING (recovery thread will run but no data_manager)
-    // Give it a moment to start
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    // Recovery thread exits because data_manager_ is nullopt,
-    // but state doesn't automatically go to FULL without successful pipeline
     auto state = mgr->GetState();
-    // Without data_manager, pipeline logs error and returns without transitioning
-    EXPECT_TRUE(state == HAClientState::SYNCING || state == HAClientState::FULL);
-}
-
-TEST_F(HARecoveryManagerTest, DegradedToSyncingOnReachable) {
-    auto mgr = CreateManager();
-    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
-    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
+    EXPECT_TRUE(state == HAClientState::SYNCING);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    state = mgr->GetState();
+    EXPECT_TRUE(state == HAClientState::FULL);
 
     mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
-    // Should attempt SYNCING
-    auto state = mgr->GetState();
-    EXPECT_TRUE(state == HAClientState::SYNCING || state == HAClientState::FULL);
+    state = mgr->GetState();
+    EXPECT_TRUE(state == HAClientState::SYNCING);
 }
 
 TEST_F(HARecoveryManagerTest, DuplicateUnreachableIsNoop) {
@@ -172,67 +169,10 @@ TEST_F(HARecoveryManagerTest, DuplicateUnreachableIsNoop) {
     mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
     EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
 
-    // Second UNREACHABLE should be a no-op (early return in HandleEvent)
+    // Second UNREACHABLE should be a no-op
     mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
     EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
 }
-
-TEST_F(HARecoveryManagerTest, SyncingToDegragedOnUnreachable) {
-    auto mgr = CreateManagerWithNotifier();
-
-    // First go to SYNCING via MASTER_RECONNECTED
-    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
-    // Allow transition to start
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    // Now UNREACHABLE should transition to DEGRADED
-    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
-    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
-}
-
-TEST_F(HARecoveryManagerTest, ReachableDuringSyncingRestartsPipeline) {
-    auto mgr = CreateManagerWithNotifier();
-
-    // Start recovery
-    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    // Another MASTER_RECONNECTED should abort old thread and restart
-    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
-    // Should still be SYNCING
-    EXPECT_EQ(mgr->GetState(), HAClientState::SYNCING);
-}
-
-TEST_F(HARecoveryManagerTest, StopFromSyncingGoesToDegraded) {
-    auto mgr = CreateManagerWithNotifier();
-    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    mgr->Stop();
-    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
-}
-
-TEST_F(HARecoveryManagerTest, StopIdempotent) {
-    auto mgr = CreateManager();
-    mgr->Stop();
-    mgr->Stop();  // Should not crash
-    EXPECT_EQ(mgr->GetState(), HAClientState::FULL);
-}
-
-TEST_F(HARecoveryManagerTest, DestructorCallsStop) {
-    {
-        auto mgr = CreateManagerWithNotifier();
-        mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        // Destructor should cleanly join recovery thread
-    }
-    // If we get here without hanging, the test passes
-    SUCCEED();
-}
-
-// ============================================================================
-// SetSyncCompleted RPC
-// ============================================================================
 
 TEST_F(HARecoveryManagerTest, SetSyncCompletedSuccess) {
     auto mgr = CreateManager();
@@ -245,26 +185,25 @@ TEST_F(HARecoveryManagerTest, SetSyncCompletedSuccess) {
 // ============================================================================
 
 TEST_F(HARecoveryManagerTest, NotifierStoppedOnUnreachable) {
-    notifier_ = std::make_unique<AsyncMetadataNotifier>(
-        *master_client_, client_id_,
-        /*sender_thread_count=*/1,
-        /*max_batch_size=*/2000,
-        /*queue_capacity=*/4000);
+    notifier_ =
+        std::make_unique<AsyncMetadataNotifier>(*master_client_, client_id_,
+                                                /*sender_thread_count=*/1,
+                                                /*max_batch_size=*/2000,
+                                                /*queue_capacity=*/4000);
     notifier_->Start();
     auto mgr = CreateManager();
 
     EXPECT_TRUE(notifier_->running_.load());
     mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
-    // Notifier should be stopped
     EXPECT_FALSE(notifier_->running_.load());
 }
 
 TEST_F(HARecoveryManagerTest, NotifierRestartedOnReachableFromDegraded) {
-    notifier_ = std::make_unique<AsyncMetadataNotifier>(
-        *master_client_, client_id_,
-        /*sender_thread_count=*/1,
-        /*max_batch_size=*/2000,
-        /*queue_capacity=*/4000);
+    notifier_ =
+        std::make_unique<AsyncMetadataNotifier>(*master_client_, client_id_,
+                                                /*sender_thread_count=*/1,
+                                                /*max_batch_size=*/2000,
+                                                /*queue_capacity=*/4000);
     notifier_->Start();
     auto mgr = CreateManager();
 
@@ -301,39 +240,16 @@ TEST_F(HARecoveryManagerTest, ConcurrentEvents) {
         }
     });
 
-    // Run for a short duration
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     stop.store(true);
     t1.join();
     t2.join();
 
-    // Final state should be valid
+    // Final state should be a valid state
     auto state = mgr->GetState();
     EXPECT_TRUE(state == HAClientState::FULL ||
                 state == HAClientState::DEGRADED ||
                 state == HAClientState::SYNCING);
-}
-
-// ============================================================================
-// Full state machine cycle
-// ============================================================================
-
-TEST_F(HARecoveryManagerTest, FullCycle_FullDegradedSyncingFull) {
-    auto mgr = CreateManagerWithNotifier();
-
-    // FULL -> DEGRADED
-    EXPECT_EQ(mgr->GetState(), HAClientState::FULL);
-    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
-    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
-
-    // DEGRADED -> SYNCING (no data_manager, recovery will fail fast)
-    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    // Without data_manager, stays SYNCING
-    EXPECT_EQ(mgr->GetState(), HAClientState::SYNCING);
-
-    // Cleanup
-    mgr->Stop();
 }
 
 }  // namespace test

--- a/mooncake-store/tests/p2p_master_service_test.cpp
+++ b/mooncake-store/tests/p2p_master_service_test.cpp
@@ -1,5 +1,3 @@
-#include "p2p_master_service.h"
-
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
@@ -7,7 +5,14 @@
 #include <string>
 #include <vector>
 
+#define private public
+#define protected public
+#include "p2p_master_service.h"
+#undef protected
+#undef private
+
 #include "master_config.h"
+#include "p2p_client_meta.h"
 #include "p2p_rpc_types.h"
 #include "rpc_types.h"
 #include "types.h"
@@ -684,6 +689,51 @@ TEST_F(P2PMasterServiceTest, FullWriteReadCycle) {
     auto r_res2 = service->GetReplicaList("data_001");
     EXPECT_FALSE(r_res2.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, r_res2.error());
+}
+
+// ============================================================
+// SetSyncCompleted Tests
+// ============================================================
+
+TEST_F(P2PMasterServiceTest, SetSyncCompletedSuccess) {
+    auto service = CreateService();
+    auto seg = MakeP2PSegment();
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
+
+    // After registration, OnClientRegistered sets is_syncing = true
+    auto client = service->client_manager_->GetClient(client_id);
+    ASSERT_NE(client, nullptr);
+    auto p2p_client = std::dynamic_pointer_cast<P2PClientMeta>(client);
+    ASSERT_NE(p2p_client, nullptr);
+    EXPECT_TRUE(p2p_client->IsSyncing());
+
+    // SetSyncCompleted should clear is_syncing
+    auto result = service->SetSyncCompleted(client_id);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(p2p_client->IsSyncing());
+}
+
+TEST_F(P2PMasterServiceTest, SetSyncCompletedClientNotFound) {
+    auto service = CreateService();
+    auto result = service->SetSyncCompleted(generate_uuid());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::CLIENT_NOT_FOUND);
+}
+
+TEST_F(P2PMasterServiceTest, SetSyncCompletedIdempotent) {
+    auto service = CreateService();
+    auto seg = MakeP2PSegment();
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
+
+    // Call twice — should succeed both times
+    EXPECT_TRUE(service->SetSyncCompleted(client_id).has_value());
+    EXPECT_TRUE(service->SetSyncCompleted(client_id).has_value());
+
+    auto client = service->client_manager_->GetClient(client_id);
+    auto p2p_client = std::dynamic_pointer_cast<P2PClientMeta>(client);
+    EXPECT_FALSE(p2p_client->IsSyncing());
 }
 
 }  // namespace mooncake::test


### PR DESCRIPTION
## Description

When the Master node crashes or restarts, there is no mechanism for clients to re-synchronize their metadata back to Master. Upon restart, Master loses all route information previously reported by clients, so clients must re-report it before normal operation can resume.

## Changes

### 1. New `HARecoveryManager`

Manages the client-side HA state machine and multi-phase recovery pipeline.

**State machine (3 states):**

```
FULL ──MASTER_UNREACHABLE──> DEGRADED
FULL / DEGRADED ──MASTER_RECONNECTED──> SYNCING
SYNCING ──recovery complete──> FULL
SYNCING ──MASTER_UNREACHABLE──> DEGRADED
```

**Recovery pipeline (3 phases):**

- **Phase 1 — Hot keys:** Fetches the hot key list from `StatsCollector` and enqueues them via the normal async queue (high-priority) first for fastest recovery.
- **Phase 2 — DRAM entries:** Iterates all keys in per-shard batches and enqueues DRAM-tier entries into the recovery queue.
- **Phase 3 — Storage entries:** Enqueues storage-tier entries from the same batch iteration.
- **Drain & notify:** Once the queue is fully flushed, calls `SetSyncCompleted` RPC to notify Master and transitions `SYNCING → FULL`.

If Master crashes again during recovery, `HandleEvent(MASTER_UNREACHABLE)` immediately aborts the recovery thread via an abort token. To avoid deadlock between `HandleEvent` (which holds `mutex_` while joining the thread) and the recovery thread (which sleeps during retry), a separate `abort_mutex_`/`abort_cv_` pair is used for interruptible sleeps inside the recovery thread.

---

### 2. `AsyncMetadataNotifier` — Dual-priority queue

|                        | Normal queue                         | Recovery queue                                                        |
|------------------------|--------------------------------------|-----------------------------------------------------------------------|
| Priority               | High (drained first)                 | Low (fills remaining batch slots)                                     |
| Behavior when full     | Blocking wait                        | Returns `ASYNC_ENQUEUE_FAILED` immediately; caller retries with backoff |
| Slot reservation       | Full pool available                  | Capped at `capacity - normal_reserved`                                |

New APIs:
- `EnqueueRecoveryAdd()` — enqueues a recovery op at low priority.
- `Stop(drop_pending=true)` — discards all queued ops and exits immediately without draining, used when Master becomes unreachable.
- `WaitForRecoveryDrain(abort_fn, timeout)` — blocks until all recovery ops have been sent.

Internally, `SenderShard` maintains two independent intrusive linked lists: `normal_head/tail` and `recovery_head/tail`. `CollectBatch` drains the normal queue first, then fills remaining batch slots from the recovery queue. A `recovery_in_flight` counter tracks in-flight recovery ops so that drain completion can be detected accurately.

---

### 3. `TieredBackend` — Sharded metadata index

Replaces the single `metadata_index_` + `map_mutex_` with **64 independent shards**:

```cpp
static constexpr size_t kMetadataShardCount = 64;
std::array<MetadataShard, kMetadataShardCount> metadata_shards_;
// shard = hash(key) % 64
```

`Commit`, `Get`, `Exist`, and `Delete` each lock only the shard corresponding to the key's hash. Concurrent writes to different keys no longer contend on a global lock, significantly reducing interference with normal writes during high-load recovery iteration.

`ForEachKeyBatch()` acquires a shard shared lock briefly to copy entry pointers, then reads per-entry data outside the shard lock, minimizing lock hold time during iteration.


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
