### PR TITLE
[TENT] Enhance memory registration with transport type support

### DIFF
--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -131,7 +131,12 @@ int TENTBenchRunner::allocateBuffers() {
     // Register
     auto allocated_ts = getCurrentTimeInNano();
     std::vector<size_t> buffers_size(num_buffers, total_buffer_size);
-    CHECK_FAIL(engine_->registerLocalMemory(pinned_buffer_list_, buffers_size));
+    MemoryOptions options;
+    if (!xport_type.empty()) {
+        options.type = getTransportType(xport_type);
+    }
+    CHECK_FAIL(engine_->registerLocalMemory(pinned_buffer_list_, buffers_size,
+                                            options));
     auto registered_ts = getCurrentTimeInNano();
 
     LOG(INFO) << "Allocated " << total_buffer_size * num_buffers << " bytes "

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -808,10 +808,9 @@ TransportType TransferEngineImpl::getTransportType(const Request& request,
         bool same_machine = (request.target_id == LOCAL_SEGMENT_ID);
         if (!same_machine) {
             auto local_desc = metadata_->segmentManager().getLocal();
-            same_machine =
-                local_desc && !desc->machine_id.empty() &&
-                !local_desc->machine_id.empty() &&
-                desc->machine_id == local_desc->machine_id;
+            same_machine = local_desc && !desc->machine_id.empty() &&
+                           !local_desc->machine_id.empty() &&
+                           desc->machine_id == local_desc->machine_id;
         }
         auto remote_mtype = getTypeEnum(LocationParser(entry->location).type());
         for (auto type : entry->transports) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -805,11 +805,14 @@ TransportType TransferEngineImpl::getTransportType(const Request& request,
     } else {
         auto entry = desc->findBuffer(request.target_offset, request.length);
         if (!entry) return UNSPEC;
-        auto* local_desc = metadata_->segmentManager().getLocal().get();
-        bool same_machine =
-            request.target_id == LOCAL_SEGMENT_ID ||
-            (!desc->machine_id.empty() && !local_desc->machine_id.empty() &&
-             desc->machine_id == local_desc->machine_id);
+        bool same_machine = (request.target_id == LOCAL_SEGMENT_ID);
+        if (!same_machine) {
+            auto local_desc = metadata_->segmentManager().getLocal();
+            same_machine =
+                local_desc && !desc->machine_id.empty() &&
+                !local_desc->machine_id.empty() &&
+                desc->machine_id == local_desc->machine_id;
+        }
         auto remote_mtype = getTypeEnum(LocationParser(entry->location).type());
         for (auto type : entry->transports) {
             if ((type == NVLINK || type == SHM) && !same_machine) continue;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -593,6 +593,13 @@ Status TransferEngineImpl::registerLocalMemory(std::vector<void*> addr_list,
 std::vector<TransportType> TransferEngineImpl::getSupportedTransports(
     TransportType request_type) {
     std::vector<TransportType> result;
+    if (request_type != UNSPEC) {
+        if (request_type >= 0 && request_type < kSupportedTransportTypes &&
+            transport_list_[request_type]) {
+            result.push_back(request_type);
+        }
+        return result;
+    }
     if (transport_list_[MNNVL]) result.push_back(MNNVL);
     if (transport_list_[NVLINK]) result.push_back(NVLINK);
     if (transport_list_[RDMA]) result.push_back(RDMA);
@@ -611,6 +618,10 @@ Status TransferEngineImpl::registerLocalMemory(std::vector<void*> addr_list,
             "Mismatched addresses and sizes in registerLocalMemory" LOC_MARK);
     }
     auto transports = getSupportedTransports(options.type);
+    if (transports.empty()) {
+        return Status::InvalidArgument(
+            "No available transport for registerLocalMemory" LOC_MARK);
+    }
 
     // Build BufferDescs: warm-up → NUMA probe → fill location
     std::vector<BufferDesc> desc_list;
@@ -794,9 +805,11 @@ TransportType TransferEngineImpl::getTransportType(const Request& request,
     } else {
         auto entry = desc->findBuffer(request.target_offset, request.length);
         if (!entry) return UNSPEC;
+        auto* local_desc = metadata_->segmentManager().getLocal().get();
         bool same_machine =
-            (desc->machine_id ==
-             metadata_->segmentManager().getLocal()->machine_id);
+            request.target_id == LOCAL_SEGMENT_ID ||
+            (!desc->machine_id.empty() && !local_desc->machine_id.empty() &&
+             desc->machine_id == local_desc->machine_id);
         auto remote_mtype = getTypeEnum(LocationParser(entry->location).type());
         for (auto type : entry->transports) {
             if ((type == NVLINK || type == SHM) && !same_machine) continue;


### PR DESCRIPTION
## Description

This PR fixes a transport selection bug in TENT that affected cross-node VRAM transfers.

Before this change, we observed that **once `NVLINK` was enabled, VRAM transfers in `tebench` could no longer proceed successfully**, even when `RDMA` was the intended transport. The failure was caused by two issues working together:

1. When `/etc/machine-id` is empty on both hosts, remote peers may be incorrectly treated as being on the same machine, which leaves `NVLINK`/`SHM` as unexpected candidates during transport selection.
2. In `tebench`, `--xport_type` was only honored during buffer allocation, but not during memory registration, so registered metadata could still include extra transports such as `NVLINK`.

This PR fixes both issues by:
- requiring non-empty matching `machine_id` values for same-machine detection,
- making `registerLocalMemory()` respect explicit `MemoryOptions::type`,
- returning an error when the requested transport is unavailable, and
- forwarding benchmark `xport_type` into the registration path so the exported metadata matches the requested transport.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- Built `tebench` successfully with `USE_TENT=ON` and `USE_CUDA=ON`.
- Ran `tebench` with `--seg_type=VRAM --backend=tent`

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
