### PR TITLE
[TENT] Batch transfer requests using cudaMemcpyBatchAsync

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
@@ -81,7 +81,7 @@ class MnnvlTransport : public Transport {
     virtual Status freeLocalMemory(void *addr, size_t size);
 
    private:
-    void startTransfer(MnnvlTask *task, MnnvlSubBatch *batch);
+    void startTransfer(MnnvlSubBatch *batch);
 
     void *createSharedMemory(const std::string &path, size_t size);
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
@@ -79,7 +79,7 @@ class NVLinkTransport : public Transport {
     virtual const char *getName() const { return "nvlink"; }
 
    private:
-    void startTransfer(NVLinkTask *task, NVLinkSubBatch *batch);
+    void startTransfer(NVLinkSubBatch *batch);
 
     void *createSharedMemory(const std::string &path, size_t size);
 

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -194,63 +194,45 @@ Status MnnvlTransport::submitTransferTasks(
         task.target_addr = target_addr;
         task.request = request;
         task.status_word = TransferStatusEnum::PENDING;
-        startTransfer(&task, mnnvl_batch);
     }
+    startTransfer(mnnvl_batch);
     return Status::OK();
 }
 
-void MnnvlTransport::startTransfer(MnnvlTask *task, MnnvlSubBatch *batch) {
-    cudaError_t err;
-    void *src = nullptr, *dst = nullptr;
+void MnnvlTransport::startTransfer(MnnvlSubBatch *batch) {
+    std::vector<const void *> srcs;
+    std::vector<const void *> dsts;
+    std::vector<size_t> sizes;
 
-    // Determine direction and addresses
-    if (task->request.opcode == Request::READ) {
-        dst = task->request.source;       // read into source buffer
-        src = (void *)task->target_addr;  // from remote
-    } else {
-        src = task->request.source;       // write from source buffer
-        dst = (void *)task->target_addr;  // to remote
-    }
-
-    bool is_async = (task->request.length >= async_memcpy_threshold_);
-
-    cudaPointerAttributes src_attr_info, dst_attr_info;
-    cudaMemoryType src_type = cudaMemoryTypeHost, dst_type = cudaMemoryTypeHost;
-    if (cudaPointerGetAttributes(&src_attr_info, src) == cudaSuccess) {
-        src_type = src_attr_info.type;
-    }
-    if (cudaPointerGetAttributes(&dst_attr_info, dst) == cudaSuccess) {
-        dst_type = dst_attr_info.type;
-    }
-
-    cudaMemcpyKind kind = cudaMemcpyDefault;
-    if (src_type == cudaMemoryTypeDevice && dst_type == cudaMemoryTypeHost) {
-        kind = cudaMemcpyDeviceToHost;
-    } else if (src_type == cudaMemoryTypeHost &&
-               dst_type == cudaMemoryTypeDevice) {
-        kind = cudaMemcpyHostToDevice;
-    } else if (src_type == cudaMemoryTypeDevice &&
-               dst_type == cudaMemoryTypeDevice) {
-        kind = cudaMemcpyDeviceToDevice;
-    } else if (src_type == cudaMemoryTypeHost &&
-               dst_type == cudaMemoryTypeHost) {
-        kind = cudaMemcpyHostToHost;
-    }
-
-    if (!is_async) {
-        err = cudaMemcpy(dst, src, task->request.length, kind);
-        if (err != cudaSuccess) {
-            task->status_word = TransferStatusEnum::FAILED;
+    for (auto &task : batch->task_list) {
+        if (task.status_word != TransferStatusEnum::PENDING) continue;
+        void *src = nullptr, *dst = nullptr;
+        if (task.request.opcode == Request::READ) {
+            dst = task.request.source;       // read into source buffer
+            src = (void *)task.target_addr;  // from remote
         } else {
-            task->transferred_bytes = task->request.length;
-            task->status_word = TransferStatusEnum::COMPLETED;
+            src = task.request.source;       // write from source buffer
+            dst = (void *)task.target_addr;  // to remote
         }
-        return;
+        srcs.push_back(src);
+        dsts.push_back(dst);
+        sizes.push_back(task.request.length);
     }
 
-    err = cudaMemcpyAsync(dst, src, task->request.length, kind, batch->stream);
+    if (srcs.empty()) return;
 
-    if (err != cudaSuccess) task->status_word = TransferStatusEnum::FAILED;
+    cudaMemcpyAttributes attr{};
+    attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+    size_t attrs_idx = 0;
+    auto err =
+        cudaMemcpyBatchAsync(dsts.data(), srcs.data(), sizes.data(),
+                             srcs.size(), &attr, &attrs_idx, 1, batch->stream);
+    if (err != cudaSuccess) {
+        for (auto &task : batch->task_list) {
+            if (task.status_word == TransferStatusEnum::PENDING)
+                task.status_word = TransferStatusEnum::FAILED;
+        }
+    }
 }
 
 Status MnnvlTransport::getTransferStatus(SubBatchRef batch, int task_id,
@@ -265,10 +247,17 @@ Status MnnvlTransport::getTransferStatus(SubBatchRef batch, int task_id,
         auto err = cudaStreamQuery(mnnvl_batch->stream);
         if (err == cudaSuccess) {
             cudaStreamSynchronize(mnnvl_batch->stream);
-            task.transferred_bytes = task.request.length;
-            task.status_word = TransferStatusEnum::COMPLETED;
+            for (auto &t : mnnvl_batch->task_list) {
+                if (t.status_word == TransferStatusEnum::PENDING) {
+                    t.transferred_bytes = t.request.length;
+                    t.status_word = TransferStatusEnum::COMPLETED;
+                }
+            }
         } else if (err != cudaErrorNotReady) {
-            task.status_word = TransferStatusEnum::FAILED;
+            for (auto &t : mnnvl_batch->task_list) {
+                if (t.status_word == TransferStatusEnum::PENDING)
+                    t.status_word = TransferStatusEnum::FAILED;
+            }
         }
     }
     return Status::OK();

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -128,63 +128,45 @@ Status NVLinkTransport::submitTransferTasks(
         task.target_addr = target_addr;
         task.request = request;
         task.status_word = TransferStatusEnum::PENDING;
-        startTransfer(&task, shm_batch);
     }
+    startTransfer(shm_batch);
     return Status::OK();
 }
 
-void NVLinkTransport::startTransfer(NVLinkTask* task, NVLinkSubBatch* batch) {
-    cudaError_t err;
-    void *src = nullptr, *dst = nullptr;
+void NVLinkTransport::startTransfer(NVLinkSubBatch* batch) {
+    std::vector<const void*> srcs;
+    std::vector<const void*> dsts;
+    std::vector<size_t> sizes;
 
-    // Determine direction and addresses
-    if (task->request.opcode == Request::READ) {
-        dst = task->request.source;      // read into source buffer
-        src = (void*)task->target_addr;  // from remote
-    } else {
-        src = task->request.source;      // write from source buffer
-        dst = (void*)task->target_addr;  // to remote
-    }
-
-    bool is_async = (task->request.length >= async_memcpy_threshold_);
-
-    cudaPointerAttributes src_attr_info, dst_attr_info;
-    cudaMemoryType src_type = cudaMemoryTypeHost, dst_type = cudaMemoryTypeHost;
-    if (cudaPointerGetAttributes(&src_attr_info, src) == cudaSuccess) {
-        src_type = src_attr_info.type;
-    }
-    if (cudaPointerGetAttributes(&dst_attr_info, dst) == cudaSuccess) {
-        dst_type = dst_attr_info.type;
-    }
-
-    cudaMemcpyKind kind = cudaMemcpyDefault;
-    if (src_type == cudaMemoryTypeDevice && dst_type == cudaMemoryTypeHost) {
-        kind = cudaMemcpyDeviceToHost;
-    } else if (src_type == cudaMemoryTypeHost &&
-               dst_type == cudaMemoryTypeDevice) {
-        kind = cudaMemcpyHostToDevice;
-    } else if (src_type == cudaMemoryTypeDevice &&
-               dst_type == cudaMemoryTypeDevice) {
-        kind = cudaMemcpyDeviceToDevice;
-    } else if (src_type == cudaMemoryTypeHost &&
-               dst_type == cudaMemoryTypeHost) {
-        kind = cudaMemcpyHostToHost;
-    }
-
-    if (!is_async) {
-        err = cudaMemcpy(dst, src, task->request.length, kind);
-        if (err != cudaSuccess) {
-            task->status_word = TransferStatusEnum::FAILED;
+    for (auto& task : batch->task_list) {
+        if (task.status_word != TransferStatusEnum::PENDING) continue;
+        void *src = nullptr, *dst = nullptr;
+        if (task.request.opcode == Request::READ) {
+            dst = task.request.source;      // read into source buffer
+            src = (void*)task.target_addr;  // from remote
         } else {
-            task->transferred_bytes = task->request.length;
-            task->status_word = TransferStatusEnum::COMPLETED;
+            src = task.request.source;      // write from source buffer
+            dst = (void*)task.target_addr;  // to remote
         }
-        return;
+        srcs.push_back(src);
+        dsts.push_back(dst);
+        sizes.push_back(task.request.length);
     }
 
-    err = cudaMemcpyAsync(dst, src, task->request.length, kind, batch->stream);
+    if (srcs.empty()) return;
 
-    if (err != cudaSuccess) task->status_word = TransferStatusEnum::FAILED;
+    cudaMemcpyAttributes attr{};
+    attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+    size_t attrs_idx = 0;
+    auto err =
+        cudaMemcpyBatchAsync(dsts.data(), srcs.data(), sizes.data(),
+                             srcs.size(), &attr, &attrs_idx, 1, batch->stream);
+    if (err != cudaSuccess) {
+        for (auto& task : batch->task_list) {
+            if (task.status_word == TransferStatusEnum::PENDING)
+                task.status_word = TransferStatusEnum::FAILED;
+        }
+    }
 }
 
 Status NVLinkTransport::getTransferStatus(SubBatchRef batch, int task_id,
@@ -199,10 +181,20 @@ Status NVLinkTransport::getTransferStatus(SubBatchRef batch, int task_id,
         auto err = cudaStreamQuery(shm_batch->stream);
         if (err == cudaSuccess) {
             cudaStreamSynchronize(shm_batch->stream);
-            task.transferred_bytes = task.request.length;
-            task.status_word = TransferStatusEnum::COMPLETED;
+            // All tasks in the batch complete together since
+            // cudaMemcpyBatchAsync submits them as a single unit on the same
+            // stream
+            for (auto& t : shm_batch->task_list) {
+                if (t.status_word == TransferStatusEnum::PENDING) {
+                    t.transferred_bytes = t.request.length;
+                    t.status_word = TransferStatusEnum::COMPLETED;
+                }
+            }
         } else if (err != cudaErrorNotReady) {
-            task.status_word = TransferStatusEnum::FAILED;
+            for (auto& t : shm_batch->task_list) {
+                if (t.status_word == TransferStatusEnum::PENDING)
+                    t.status_word = TransferStatusEnum::FAILED;
+            }
         }
     }
     return Status::OK();


### PR DESCRIPTION
## Description

### Motivation 
When prefill and decode use different TP layouts in disaggregated serving, SGLang issues a large number of transfer requests, each equal to the token size. With the MNNVL transport backend, performance can suffer significantly due to runtime overhead.

A recently merged PR in SGLang addressed this issue by gathering the KV cache into staging buffers, which requires a memory pool:
https://github.com/sgl-project/sglang/pull/19890

### Modification
CUDA 12.8.0 introduced cudaMemcpyBatchAsync, so requests can now be batched and issued in a single call.

### Tests
Tested with SGLang, P (--tp 4), D (--tp 4 --moe-dense-tp-size 1 --enable-dp-lm-head --enable-dp-attention --dp-size 4), on Blackwell machines.

`python3 -m sglang.bench_serving --max-concurrency 8 --dataset-name random --random-input-len=2000 --random-output-len=10  --random-range-ratio 0 --num-prompts 64   --port 30030  --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json`

Before:
<img width="712" height="276" alt="image" src="https://github.com/user-attachments/assets/6c2a91f1-86eb-4d57-bb13-2004a1b0d447" />

After:
<img width="720" height="276" alt="image" src="https://github.com/user-attachments/assets/b8e499a5-f2c0-429d-80eb-ff01ed79ec87" />

### Discussion
I also removed `async_memcpy_threshold` because I believe it is no longer needed, and the code is cleaner this way — unless there are cases where cudaMemcpy is faster than cudaMemcpyAsync. Please let me know. Otherwise, I will remove it completely from these two files.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
