### PR TITLE
[TENT] Batch transfer requests using cudaMemcpyBatchAsync

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
@@ -37,6 +37,7 @@ struct MnnvlTask {
     volatile size_t transferred_bytes;
     uint64_t target_addr = 0;
     int cuda_id = 0;
+    cudaEvent_t completion_event = nullptr;
 };
 
 struct MnnvlSubBatch : public Transport::SubBatch {
@@ -83,7 +84,7 @@ class MnnvlTransport : public Transport {
     virtual Status freeLocalMemory(void *addr, size_t size);
 
    private:
-    void startTransfer(MnnvlTask *task, MnnvlSubBatch *batch);
+    void startTransfer(std::vector<MnnvlTask *> &tasks, MnnvlSubBatch *batch);
 
     void *createSharedMemory(const std::string &path, size_t size);
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
@@ -40,6 +40,7 @@ struct NVLinkTask {
     uint64_t target_addr = 0;
     bool is_cuda_ipc;
     int cuda_id = 0;
+    cudaEvent_t completion_event = nullptr;
 };
 
 struct NVLinkSubBatch : public Transport::SubBatch {
@@ -81,7 +82,7 @@ class NVLinkTransport : public Transport {
     virtual const char *getName() const { return "nvlink"; }
 
    private:
-    void startTransfer(NVLinkTask *task, NVLinkSubBatch *batch);
+    void startTransfer(std::vector<NVLinkTask *> &tasks, NVLinkSubBatch *batch);
 
     void *createSharedMemory(const std::string &path, size_t size);
 

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -168,6 +168,7 @@ Status MnnvlTransport::submitTransferTasks(
     if (request_list.size() + mnnvl_batch->task_list.size() >
         mnnvl_batch->max_size)
         return Status::TooManyRequests("Exceed batch capacity" LOC_MARK);
+    std::vector<MnnvlTask *> new_tasks;
     for (auto &request : request_list) {
         mnnvl_batch->task_list.push_back(MnnvlTask{});
         auto &task = mnnvl_batch->task_list[mnnvl_batch->task_list.size() - 1];
@@ -184,72 +185,84 @@ Status MnnvlTransport::submitTransferTasks(
         task.target_addr = target_addr;
         task.request = request;
         task.status_word = TransferStatusEnum::PENDING;
-        startTransfer(&task, mnnvl_batch);
+        new_tasks.push_back(&task);
     }
+    startTransfer(new_tasks, mnnvl_batch);
     return Status::OK();
 }
 
-void MnnvlTransport::startTransfer(MnnvlTask *task, MnnvlSubBatch *batch) {
+void MnnvlTransport::startTransfer(std::vector<MnnvlTask *> &tasks,
+                                   MnnvlSubBatch *batch) {
+    if (tasks.empty()) return;
+
+    std::vector<void *> srcs;
+    std::vector<void *> dsts;
+    std::vector<size_t> sizes;
+    for (auto *task : tasks) {
+        void *src = nullptr, *dst = nullptr;
+        if (task->request.opcode == Request::READ) {
+            dst = task->request.source;       // read into source buffer
+            src = (void *)task->target_addr;  // from remote
+        } else {
+            src = task->request.source;       // write from source buffer
+            dst = (void *)task->target_addr;  // to remote
+        }
+        srcs.push_back(src);
+        dsts.push_back(dst);
+        sizes.push_back(task->request.length);
+    }
+
     cudaError_t err;
-    void *src = nullptr, *dst = nullptr;
 
-    // Determine direction and addresses
-    if (task->request.opcode == Request::READ) {
-        dst = task->request.source;       // read into source buffer
-        src = (void *)task->target_addr;  // from remote
-    } else {
-        src = task->request.source;       // write from source buffer
-        dst = (void *)task->target_addr;  // to remote
+#if CUDART_VERSION >= 13000
+    cudaMemcpyAttributes attr{};
+    attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+    size_t attrs_idx = 0;
+    err = cudaMemcpyBatchAsync(const_cast<const void **>(dsts.data()),
+                               const_cast<const void **>(srcs.data()),
+                               sizes.data(), srcs.size(), &attr, &attrs_idx, 1,
+                               batch->async_stream.get());
+#elif CUDART_VERSION >= 12080
+    cudaMemcpyAttributes attr{};
+    attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+    size_t attrs_idx = 0;
+    size_t fail_idx = tasks.size();
+    err = cudaMemcpyBatchAsync(dsts.data(), srcs.data(), sizes.data(),
+                               srcs.size(), &attr, &attrs_idx, 1, &fail_idx,
+                               batch->async_stream.get());
+    if (err != cudaSuccess && fail_idx < tasks.size()) {
+        LOG(ERROR) << "MnnvlTransport::startTransfer internal error: "
+                   << "cudaMemcpyBatchAsync failed at task index " << fail_idx
+                   << " (src=" << srcs[fail_idx] << ", dst=" << dsts[fail_idx]
+                   << ", size=" << sizes[fail_idx]
+                   << "): " << cudaGetErrorString(err);
+        tasks[fail_idx]->status_word = TransferStatusEnum::FAILED;
     }
-
-    bool is_async = (task->request.length >= async_memcpy_threshold_);
-
-    cudaPointerAttributes src_attr_info, dst_attr_info;
-    cudaMemoryType src_type = cudaMemoryTypeHost, dst_type = cudaMemoryTypeHost;
-    if (cudaPointerGetAttributes(&src_attr_info, src) == cudaSuccess) {
-        src_type = src_attr_info.type;
-    }
-    if (cudaPointerGetAttributes(&dst_attr_info, dst) == cudaSuccess) {
-        dst_type = dst_attr_info.type;
-    }
-
-    cudaMemcpyKind kind = cudaMemcpyDefault;
-    if (src_type == cudaMemoryTypeDevice && dst_type == cudaMemoryTypeHost) {
-        kind = cudaMemcpyDeviceToHost;
-    } else if (src_type == cudaMemoryTypeHost &&
-               dst_type == cudaMemoryTypeDevice) {
-        kind = cudaMemcpyHostToDevice;
-    } else if (src_type == cudaMemoryTypeDevice &&
-               dst_type == cudaMemoryTypeDevice) {
-        kind = cudaMemcpyDeviceToDevice;
-    } else if (src_type == cudaMemoryTypeHost &&
-               dst_type == cudaMemoryTypeHost) {
-        kind = cudaMemcpyHostToHost;
-    }
-
-    if (!is_async) {
-        err = cudaMemcpyAsync(dst, src, task->request.length, kind,
-                              batch->sync_stream.get());
-        if (err != cudaSuccess) {
-            task->status_word = TransferStatusEnum::FAILED;
-            return;
+#else
+    err = cudaSuccess;
+    for (size_t i = 0; i < tasks.size(); ++i) {
+        auto single_err =
+            cudaMemcpyAsync(dsts[i], srcs[i], sizes[i], cudaMemcpyDefault,
+                            batch->async_stream.get());
+        if (single_err != cudaSuccess) {
+            tasks[i]->status_word = TransferStatusEnum::FAILED;
+            err = single_err;
         }
+    }
+#endif
 
-        err = cudaStreamSynchronize(batch->sync_stream.get());
-        if (err != cudaSuccess) {
-            task->status_word = TransferStatusEnum::FAILED;
-            return;
+    if (err != cudaSuccess) {
+        for (auto *task : tasks) {
+            if (task->status_word == TransferStatusEnum::PENDING)
+                task->status_word = TransferStatusEnum::FAILED;
         }
-
-        task->transferred_bytes = task->request.length;
-        task->status_word = TransferStatusEnum::COMPLETED;
         return;
     }
 
-    err = cudaMemcpyAsync(dst, src, task->request.length, kind,
-                          batch->async_stream.get());
-
-    if (err != cudaSuccess) task->status_word = TransferStatusEnum::FAILED;
+    cudaEvent_t event;
+    cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+    cudaEventRecord(event, batch->async_stream.get());
+    for (auto *task : tasks) task->completion_event = event;
 }
 
 Status MnnvlTransport::getTransferStatus(SubBatchRef batch, int task_id,
@@ -261,9 +274,8 @@ Status MnnvlTransport::getTransferStatus(SubBatchRef batch, int task_id,
     auto &task = mnnvl_batch->task_list[task_id];
     status = TransferStatus{task.status_word, task.transferred_bytes};
     if (task.status_word == TransferStatusEnum::PENDING) {
-        auto err = cudaStreamQuery(mnnvl_batch->async_stream.get());
+        auto err = cudaEventQuery(task.completion_event);
         if (err == cudaSuccess) {
-            cudaStreamSynchronize(mnnvl_batch->async_stream.get());
             task.transferred_bytes = task.request.length;
             task.status_word = TransferStatusEnum::COMPLETED;
         } else if (err != cudaErrorNotReady) {

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -106,6 +106,7 @@ Status NVLinkTransport::submitTransferTasks(
         return Status::InvalidArgument("Invalid NVLink sub-batch" LOC_MARK);
     if (request_list.size() + shm_batch->task_list.size() > shm_batch->max_size)
         return Status::TooManyRequests("Exceed batch capacity" LOC_MARK);
+    std::vector<NVLinkTask*> new_tasks;
     for (auto& request : request_list) {
         shm_batch->task_list.push_back(NVLinkTask{});
         auto& task = shm_batch->task_list[shm_batch->task_list.size() - 1];
@@ -118,72 +119,83 @@ Status NVLinkTransport::submitTransferTasks(
         task.target_addr = target_addr;
         task.request = request;
         task.status_word = TransferStatusEnum::PENDING;
-        startTransfer(&task, shm_batch);
+        new_tasks.push_back(&task);
     }
+    startTransfer(new_tasks, shm_batch);
     return Status::OK();
 }
 
-void NVLinkTransport::startTransfer(NVLinkTask* task, NVLinkSubBatch* batch) {
+void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
+                                    NVLinkSubBatch* batch) {
+    if (tasks.empty()) return;
+
+    std::vector<void*> srcs;
+    std::vector<void*> dsts;
+    std::vector<size_t> sizes;
+    for (auto* task : tasks) {
+        void *src = nullptr, *dst = nullptr;
+        if (task->request.opcode == Request::READ) {
+            dst = task->request.source;      // read into source buffer
+            src = (void*)task->target_addr;  // from remote
+        } else {
+            src = task->request.source;      // write from source buffer
+            dst = (void*)task->target_addr;  // to remote
+        }
+        srcs.push_back(src);
+        dsts.push_back(dst);
+        sizes.push_back(task->request.length);
+    }
+
     cudaError_t err;
-    void *src = nullptr, *dst = nullptr;
 
-    // Determine direction and addresses
-    if (task->request.opcode == Request::READ) {
-        dst = task->request.source;      // read into source buffer
-        src = (void*)task->target_addr;  // from remote
-    } else {
-        src = task->request.source;      // write from source buffer
-        dst = (void*)task->target_addr;  // to remote
+#if CUDART_VERSION >= 13000
+    cudaMemcpyAttributes attr{};
+    attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+    size_t attrs_idx = 0;
+    err = cudaMemcpyBatchAsync(const_cast<const void**>(dsts.data()),
+                               const_cast<const void**>(srcs.data()),
+                               sizes.data(), srcs.size(), &attr, &attrs_idx, 1,
+                               batch->async_stream.get());
+#elif CUDART_VERSION >= 12080
+    cudaMemcpyAttributes attr{};
+    attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+    size_t attrs_idx = 0;
+    size_t fail_idx = tasks.size();
+    err = cudaMemcpyBatchAsync(dsts.data(), srcs.data(), sizes.data(),
+                               srcs.size(), &attr, &attrs_idx, 1, &fail_idx,
+                               batch->async_stream.get());
+    if (err != cudaSuccess && fail_idx < tasks.size()) {
+        LOG(ERROR) << "NVLinkTransport::startTransfer internal error: "
+                   << "cudaMemcpyBatchAsync failed at task index " << fail_idx
+                   << " (src=" << srcs[fail_idx] << ", dst=" << dsts[fail_idx]
+                   << ", size=" << sizes[fail_idx]
+                   << "): " << cudaGetErrorString(err);
+        tasks[fail_idx]->status_word = TransferStatusEnum::FAILED;
     }
-
-    bool is_async = (task->request.length >= async_memcpy_threshold_);
-
-    cudaPointerAttributes src_attr_info, dst_attr_info;
-    cudaMemoryType src_type = cudaMemoryTypeHost, dst_type = cudaMemoryTypeHost;
-    if (cudaPointerGetAttributes(&src_attr_info, src) == cudaSuccess) {
-        src_type = src_attr_info.type;
-    }
-    if (cudaPointerGetAttributes(&dst_attr_info, dst) == cudaSuccess) {
-        dst_type = dst_attr_info.type;
-    }
-
-    cudaMemcpyKind kind = cudaMemcpyDefault;
-    if (src_type == cudaMemoryTypeDevice && dst_type == cudaMemoryTypeHost) {
-        kind = cudaMemcpyDeviceToHost;
-    } else if (src_type == cudaMemoryTypeHost &&
-               dst_type == cudaMemoryTypeDevice) {
-        kind = cudaMemcpyHostToDevice;
-    } else if (src_type == cudaMemoryTypeDevice &&
-               dst_type == cudaMemoryTypeDevice) {
-        kind = cudaMemcpyDeviceToDevice;
-    } else if (src_type == cudaMemoryTypeHost &&
-               dst_type == cudaMemoryTypeHost) {
-        kind = cudaMemcpyHostToHost;
-    }
-
-    if (!is_async) {
-        err = cudaMemcpyAsync(dst, src, task->request.length, kind,
-                              batch->sync_stream.get());
-        if (err != cudaSuccess) {
-            task->status_word = TransferStatusEnum::FAILED;
-            return;
+#else
+    err = cudaSuccess;
+    for (size_t i = 0; i < tasks.size(); ++i) {
+        auto single_err =
+            cudaMemcpyAsync(dsts[i], srcs[i], sizes[i], cudaMemcpyDefault,
+                            batch->async_stream.get());
+        if (single_err != cudaSuccess) {
+            tasks[i]->status_word = TransferStatusEnum::FAILED;
+            err = single_err;
         }
+    }
+#endif
 
-        err = cudaStreamSynchronize(batch->sync_stream.get());
-        if (err != cudaSuccess) {
-            task->status_word = TransferStatusEnum::FAILED;
-            return;
+    if (err != cudaSuccess) {
+        for (auto* task : tasks) {
+            if (task->status_word == TransferStatusEnum::PENDING)
+                task->status_word = TransferStatusEnum::FAILED;
         }
-
-        task->transferred_bytes = task->request.length;
-        task->status_word = TransferStatusEnum::COMPLETED;
-        return;
     }
 
-    err = cudaMemcpyAsync(dst, src, task->request.length, kind,
-                          batch->async_stream.get());
-
-    if (err != cudaSuccess) task->status_word = TransferStatusEnum::FAILED;
+    cudaEvent_t event;
+    cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+    cudaEventRecord(event, batch->async_stream.get());
+    for (auto* task : tasks) task->completion_event = event;
 }
 
 Status NVLinkTransport::getTransferStatus(SubBatchRef batch, int task_id,
@@ -195,9 +207,8 @@ Status NVLinkTransport::getTransferStatus(SubBatchRef batch, int task_id,
     auto& task = shm_batch->task_list[task_id];
     status = TransferStatus{task.status_word, task.transferred_bytes};
     if (task.status_word == TransferStatusEnum::PENDING) {
-        auto err = cudaStreamQuery(shm_batch->async_stream.get());
+        auto err = cudaEventQuery(task.completion_event);
         if (err == cudaSuccess) {
-            cudaStreamSynchronize(shm_batch->async_stream.get());
             task.transferred_bytes = task.request.length;
             task.status_word = TransferStatusEnum::COMPLETED;
         } else if (err != cudaErrorNotReady) {


### PR DESCRIPTION
## Description

### Motivation 
When prefill and decode use different TP layouts in disaggregated serving, SGLang issues a large number of transfer requests, each equal to the token size. With the MNNVL transport backend, performance can suffer significantly due to runtime overhead.

A recently merged PR in SGLang addressed this issue by gathering the KV cache into staging buffers, which requires a memory pool:
https://github.com/sgl-project/sglang/pull/19890

### Modification
1. CUDA 12.8.0 introduced cudaMemcpyBatchAsync, so requests can now be batched and issued in a single call.
2. Use CUDA events to query transfer status instead of querying completion of the entire stream.

### Discussion
I also remove `async_memcpy_threshold` because I believe it is no longer needed, unless there are cases where cudaMemcpy is faster than cudaMemcpyAsync. Please let me know. Otherwise, I shall remove it completely from these two files.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
