### PR TITLE
[Store] Fix segfault in disk-replica/offload paths when handling GPU VRAM pointers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,8 @@ jobs:
         export CGO_ENABLED=1
         export CGO_CFLAGS="-I$GITHUB_WORKSPACE/mooncake-store/include -I$GITHUB_WORKSPACE/mooncake-transfer-engine/include"
         export CGO_LDFLAGS="-L$GITHUB_WORKSPACE/build/mooncake-store/src -L$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator -L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src -L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base -L$GITHUB_WORKSPACE/build/mooncake-asio -L$GITHUB_WORKSPACE/build/mooncake-common/etcd -lmooncake_store -lcachelib_memory_allocator -ltransfer_engine -lbase -lasio -letcd_wrapper -lstdc++ -lnuma -lglog -lgflags -libverbs -ljsoncpp -lzstd -lcurl -luring -lasan -lm -lgcov"
+        # Link cudart if CUDA is available (needed for D2H staging in mooncake_store)
+        if [ -d /usr/local/cuda/lib64 ]; then export CGO_LDFLAGS="$CGO_LDFLAGS -L/usr/local/cuda/lib64 -lcudart"; fi
         ASAN_OPTIONS=detect_leaks=0:verify_asan_link_order=0 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata go test -v ./tests/...
         kill $MASTER_PID 2>/dev/null || true
       shell: bash

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -24,6 +24,7 @@
 #include "master_metric_manager.h"
 #include "count_min_sketch.h"
 #include "local_hot_cache.h"
+#include "pinned_buffer_pool.h"
 
 namespace mooncake {
 
@@ -660,6 +661,9 @@ class Client {
     const std::string protocol_;
 
     // Client persistent thread pool for async operations
+    // Pinned host memory pool for GPU D2H staging (must outlive
+    // write_thread_pool_)
+    std::unique_ptr<PinnedBufferPool> pinned_buffer_pool_;
     ThreadPool write_thread_pool_;
     std::shared_ptr<StorageBackend> storage_backend_;
 

--- a/mooncake-store/include/file_storage.h
+++ b/mooncake-store/include/file_storage.h
@@ -3,6 +3,7 @@
 #include "client_service.h"
 #include "client_buffer.hpp"
 #include "storage_backend.h"
+#include "pinned_buffer_pool.h"
 
 namespace mooncake {
 
@@ -105,6 +106,8 @@ class FileStorage {
     std::shared_ptr<Client> client_;
     SsdMetric* ssd_metric_{nullptr};
     std::string local_rpc_addr_;
+    // Pinned host memory pool for GPU D2H staging in OffloadObjects
+    std::unique_ptr<PinnedBufferPool> pinned_buffer_pool_;
     std::shared_ptr<StorageBackendInterface> storage_backend_;
     std::shared_ptr<ClientBufferAllocator> client_buffer_allocator_;
     mutable Mutex client_buffer_mutex_;

--- a/mooncake-store/include/gpu_staging_utils.h
+++ b/mooncake-store/include/gpu_staging_utils.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "cuda_alike.h"
+
+#if defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+#include <acl/acl_rt.h>
+#endif
+
+#include <cstddef>
+#include <glog/logging.h>
+
+namespace mooncake {
+namespace gpu_staging {
+
+// Detect whether ptr resides in accelerator device memory.
+// If so, writes the device ID to *out_device_id for subsequent SetDevice.
+inline bool IsDevicePointer(const void* ptr, int* out_device_id) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    cudaPointerAttributes attr{};
+    if (cudaPointerGetAttributes(&attr, ptr) == cudaSuccess &&
+        attr.type == cudaMemoryTypeDevice) {
+        if (out_device_id) *out_device_id = attr.device;
+        return true;
+    }
+#elif defined(USE_HIP)
+    hipPointerAttribute_t attr{};
+    if (hipPointerGetAttributes(&attr, ptr) == hipSuccess &&
+        attr.type == hipMemoryTypeDevice) {
+        if (out_device_id) *out_device_id = attr.device;
+        return true;
+    }
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    aclrtPtrAttributes attr{};
+    if (aclrtPointerGetAttributes(const_cast<void*>(ptr), &attr) ==
+            ACL_SUCCESS &&
+        attr.location.type == ACL_MEM_LOCATION_TYPE_DEVICE) {
+        if (out_device_id) *out_device_id = static_cast<int>(attr.location.id);
+        return true;
+    }
+#endif
+    (void)ptr;
+    (void)out_device_id;
+    return false;
+}
+
+// Copy device memory to host. Caller must have called SetDevice first.
+inline bool CopyDeviceToHost(void* dst, const void* src, size_t size) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    return cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost) == cudaSuccess;
+#elif defined(USE_HIP)
+    return hipMemcpy(dst, src, size, hipMemcpyDeviceToHost) == hipSuccess;
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    return aclrtMemcpy(dst, size, src, size, ACL_MEMCPY_DEVICE_TO_HOST) ==
+           ACL_SUCCESS;
+#else
+    (void)dst;
+    (void)src;
+    (void)size;
+    return false;
+#endif
+}
+
+// Bind the calling thread to the given device context.
+inline void SetDevice(int device_id) {
+    if (device_id < 0) return;
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    cudaSetDevice(device_id);
+#elif defined(USE_HIP)
+    hipSetDevice(device_id);
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    aclrtSetDevice(device_id);
+#endif
+}
+
+}  // namespace gpu_staging
+}  // namespace mooncake

--- a/mooncake-store/include/pinned_buffer_pool.h
+++ b/mooncake-store/include/pinned_buffer_pool.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <mutex>
+#include <vector>
+#include <cstdlib>
+#include "cuda_alike.h"
+
+// Ascend CANN is not covered by cuda_alike.h
+#if defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+#include <acl/acl_rt.h>
+#endif
+
+namespace mooncake {
+
+/**
+ * PinnedBufferPool: Thread-safe pool of reusable pinned host memory buffers.
+ *
+ * Platform pinned alloc APIs:
+ *   CUDA / MUSA / MACA : cudaMallocHost   (mapped via cuda_alike.h)
+ *   HIP                : hipHostMalloc     (not mapped in hip.h, native API)
+ *   Ascend             : aclrtMallocHost
+ *   Other              : new char[]        (pageable fallback)
+ *
+ * Pinned memory provides 10x~100x higher D2H bandwidth than pageable memory.
+ * Falls back to new char[] if pinned allocation fails.
+ *
+ * The pool enforces a maximum number of cached buffers (kDefaultMaxPoolSize).
+ * When the pool is full, Release() frees the buffer immediately instead of
+ * caching it, preventing unbounded pinned memory growth.
+ */
+class PinnedBufferPool {
+   public:
+    static constexpr size_t kDefaultMaxPoolSize = 32;
+
+    struct Buffer {
+        char* data = nullptr;
+        size_t capacity = 0;
+        bool is_pinned = false;  // Selects correct free API in FreeBuffer
+    };
+
+    explicit PinnedBufferPool(size_t max_pool_size = kDefaultMaxPoolSize)
+        : max_pool_size_(max_pool_size) {}
+
+    ~PinnedBufferPool() { Clear(); }
+
+    Buffer Acquire(size_t size) {
+        {
+            std::lock_guard<std::mutex> lk(mutex_);
+            for (size_t i = 0; i < pool_.size(); ++i) {
+                if (pool_[i].capacity >= size) {
+                    Buffer buf = pool_[i];
+                    // O(1) erase: swap with back then pop
+                    pool_[i] = pool_.back();
+                    pool_.pop_back();
+                    return buf;
+                }
+            }
+        }
+        return AllocNew(size);
+    }
+
+    void Release(Buffer buf) {
+        std::lock_guard<std::mutex> lk(mutex_);
+        if (pool_.size() < max_pool_size_) {
+            pool_.push_back(buf);
+        } else {
+            // Pool full — free immediately to bound pinned memory usage
+            FreeBuffer(buf);
+        }
+    }
+
+    void Clear() {
+        std::lock_guard<std::mutex> lk(mutex_);
+        for (auto& buf : pool_) {
+            FreeBuffer(buf);
+        }
+        pool_.clear();
+    }
+
+   private:
+    static Buffer AllocNew(size_t size) {
+        Buffer buf;
+        buf.capacity = size;
+        buf.is_pinned = false;
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+        if (cudaMallocHost(reinterpret_cast<void**>(&buf.data), size) ==
+            cudaSuccess) {
+            buf.is_pinned = true;
+        } else {
+            buf.data = new char[size];
+        }
+
+#elif defined(USE_HIP)
+        if (hipHostMalloc(reinterpret_cast<void**>(&buf.data), size, 0) ==
+            hipSuccess) {
+            buf.is_pinned = true;
+        } else {
+            buf.data = new char[size];
+        }
+
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+        if (aclrtMallocHost(reinterpret_cast<void**>(&buf.data), size) ==
+            ACL_SUCCESS) {
+            buf.is_pinned = true;
+        } else {
+            buf.data = new char[size];
+        }
+
+#else
+        buf.data = new char[size];
+#endif
+        return buf;
+    }
+
+    static void FreeBuffer(Buffer& buf) {
+        if (!buf.data) return;
+        if (!buf.is_pinned) {
+            delete[] buf.data;
+            return;
+        }
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+        cudaFreeHost(buf.data);
+#elif defined(USE_HIP)
+        hipHostFree(buf.data);
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+        aclrtFreeHost(buf.data);
+#else
+        delete[] buf.data;
+#endif
+    }
+
+    const size_t max_pool_size_;
+    std::mutex mutex_;
+    std::vector<Buffer> pool_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -213,4 +213,47 @@ target_link_libraries(mooncake_client PRIVATE mooncake_store transfer_engine
 target_compile_options(mooncake_client PRIVATE -Os)
 target_link_options(mooncake_client PRIVATE -Os -s)
 
+
+# GPU runtime library for D2H staging in PutToLocalFile / OffloadObjects.
+# transfer_engine is PRIVATE-linked, so its CUDA/HIP/Ascend dependencies
+# are not propagated; we must detect and link them independently.
+#
+# Auto-detect each toolkit regardless of global USE_CUDA/USE_HIP flags,
+# because USE_CUDA may be OFF even when GPU pointers are present
+# (e.g. WITH_NVIDIA_PEERMEM=ON uses nvidia-peermem for RDMA without cudart).
+# Each detected toolkit gets both link libraries AND compile definitions,
+# so that gpu_staging_utils.h / pinned_buffer_pool.h pick the correct backend.
+#
+# NOTE: mooncake_store is a static library (.a). External consumers (Go CGo,
+# Python pybind) that link it must also link the GPU runtime (e.g. -lcudart).
+# Go's build.sh already does this; CI workflows must do the same.
+
+find_package(CUDAToolkit QUIET)
+if(CUDAToolkit_FOUND)
+    message(STATUS "mooncake_store: CUDAToolkit detected, enabling D2H staging")
+    target_compile_definitions(mooncake_store PRIVATE USE_CUDA)
+    target_compile_definitions(mooncake_client PRIVATE USE_CUDA)
+    target_include_directories(mooncake_store PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_include_directories(mooncake_client PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_link_libraries(mooncake_store PRIVATE CUDA::cudart)
+    target_link_libraries(mooncake_client PRIVATE CUDA::cudart)
+endif()
+
+if(NOT CUDAToolkit_FOUND)
+    find_package(hip QUIET)
+    if(hip_FOUND)
+        message(STATUS "mooncake_store: HIP detected, enabling D2H staging")
+        target_compile_definitions(mooncake_store PRIVATE USE_HIP)
+        target_compile_definitions(mooncake_client PRIVATE USE_HIP)
+        target_link_libraries(mooncake_store PRIVATE hip::host)
+        target_link_libraries(mooncake_client PRIVATE hip::host)
+    endif()
+endif()
+
+if(USE_ASCEND OR USE_ASCEND_DIRECT OR USE_UBSHMEM)
+    target_include_directories(mooncake_store PRIVATE $ENV{ASCEND_PATH}/include)
+    target_link_libraries(mooncake_store PRIVATE ascendcl)
+    target_include_directories(mooncake_client PRIVATE $ENV{ASCEND_PATH}/include)
+    target_link_libraries(mooncake_client PRIVATE ascendcl)
+endif()
 install(TARGETS mooncake_master mooncake_client DESTINATION bin)

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -27,8 +27,13 @@
 #include "utils.h"
 #include "rpc_types.h"
 #include "local_hot_cache.h"
+#include "gpu_staging_utils.h"
 
 namespace mooncake {
+
+using gpu_staging::CopyDeviceToHost;
+using gpu_staging::IsDevicePointer;
+using gpu_staging::SetDevice;
 
 [[nodiscard]] size_t CalculateSliceSize(const std::vector<Slice>& slices) {
     size_t slice_size = 0;
@@ -57,6 +62,7 @@ Client::Client(const std::string& local_hostname,
       local_hostname_(local_hostname),
       metadata_connstring_(metadata_connstring),
       protocol_(protocol),
+      pinned_buffer_pool_(std::make_unique<PinnedBufferPool>()),
       write_thread_pool_(2),
       task_thread_pool_(4) {
     LOG(INFO) << "client_id=" << client_id_;
@@ -2495,19 +2501,34 @@ void Client::PutToLocalFile(const std::string& key,
     }
 
     std::string path = disk_descriptor.file_path;
-    // Currently, persistence is achieved through asynchronous writes, but
-    // before asynchronous writing in 3FS, significant performance degradation
-    // may occur due to data copying. Profiling reveals that the number of page
-    // faults triggered in this scenario is nearly double the normal count.
-    // Future plans include introducing a reuse buffer list to address this
-    // performance degradation issue.
 
+    // Synchronous D2H staging + copy into std::string.
+    // Done on the calling thread to guarantee GPU buffers are still valid
+    // (BatchPut has not yet returned to Python, so blocks are not reused).
     std::string value;
     value.reserve(total_size);
+
     for (const auto& slice : slices) {
-        value.append(static_cast<char*>(slice.ptr), slice.size);
+        int device_id = -1;
+        if (IsDevicePointer(slice.ptr, &device_id)) {
+            SetDevice(device_id);
+            auto buf = pinned_buffer_pool_->Acquire(slice.size);
+            if (!CopyDeviceToHost(buf.data, slice.ptr, slice.size)) {
+                LOG(ERROR) << "D2H copy failed for key: " << key
+                           << ", triggering PutRevoke for disk replica";
+                pinned_buffer_pool_->Release(buf);
+                // Must revoke to avoid phantom replica in master
+                master_client_.PutRevoke(key, ReplicaType::DISK);
+                return;
+            }
+            value.append(buf.data, slice.size);
+            pinned_buffer_pool_->Release(buf);
+        } else {
+            value.append(static_cast<char*>(slice.ptr), slice.size);
+        }
     }
 
+    // Async StoreObject + PutEnd (unchanged from original)
     write_thread_pool_.enqueue([this, backend = storage_backend_, key,
                                 value = std::move(value), path] {
         // Store the object

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -7,11 +7,16 @@
 #include "storage_backend.h"
 #include "client_metric.h"
 #include "utils.h"
+#include "gpu_staging_utils.h"
 #ifdef USE_URING
 #include "file_interface.h"
 #endif
 
 namespace mooncake {
+
+using gpu_staging::CopyDeviceToHost;
+using gpu_staging::IsDevicePointer;
+using gpu_staging::SetDevice;
 
 FileStorageConfig FileStorageConfig::FromEnvironment() {
     FileStorageConfig config;
@@ -152,6 +157,7 @@ FileStorage::FileStorage(const FileStorageConfig& config,
       client_(client),
       ssd_metric_(ssd_metric),
       local_rpc_addr_(local_rpc_addr),
+      pinned_buffer_pool_(std::make_unique<PinnedBufferPool>()),
       client_buffer_allocator_(
           AlignedClientBufferAllocator::create(config.local_buffer_size, "")) {
     if (!config.Validate()) {
@@ -372,6 +378,37 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
             }
         };
 
+        // D2H staging: replace device slices with host memory slices
+        // so that storage_backend (ConcatSlicesToString / BuildBucket /
+        // WriteBucket) always receives host pointers.
+        std::unordered_map<std::string, std::vector<Slice>> host_batch_object;
+        std::vector<PinnedBufferPool::Buffer> staging_bufs;
+
+        for (auto& [obj_key, slices] : batch_object) {
+            std::vector<Slice> host_slices;
+            bool obj_success = true;
+            for (const auto& slice : slices) {
+                int device_id = -1;
+                if (IsDevicePointer(slice.ptr, &device_id)) {
+                    SetDevice(device_id);
+                    auto buf = pinned_buffer_pool_->Acquire(slice.size);
+                    if (!CopyDeviceToHost(buf.data, slice.ptr, slice.size)) {
+                        LOG(ERROR) << "D2H staging failed for key: " << obj_key;
+                        pinned_buffer_pool_->Release(buf);
+                        obj_success = false;
+                        break;
+                    }
+                    host_slices.emplace_back(Slice{buf.data, slice.size});
+                    staging_bufs.push_back(buf);
+                } else {
+                    host_slices.push_back(slice);
+                }
+            }
+            if (obj_success) {
+                host_batch_object[obj_key] = std::move(host_slices);
+            }
+        }
+
         auto offload_start = std::chrono::steady_clock::now();
         auto bucket_complete_handler =
             [this, offload_start, complete_handler](
@@ -399,7 +436,12 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
             return res;
         };
         auto offload_res = storage_backend_->BatchOffload(
-            batch_object, bucket_complete_handler, eviction_handler);
+            host_batch_object, bucket_complete_handler, eviction_handler);
+
+        // Release staging buffers back to pool (Buffer is POD, no destructor)
+        for (auto& buf : staging_bufs) {
+            pinned_buffer_pool_->Release(buf);
+        }
         if (!offload_res) {
             LOG(ERROR) << "Failed to store objects with error: "
                        << offload_res.error();


### PR DESCRIPTION
## Description

Fix segfault in the upcoming [vLLM](https://github.com/ivanium/vllm/tree/feat/mooncake-store-int) `MooncakeStoreConnector` integration when disk-replica / SSD-offload paths dereference GPU device pointers via CPU `memcpy`.

`MooncakeStoreConnector` is a new KV-transfer connector currently being integrated with an **unreleased [vLLM V1](https://github.com/ivanium/vllm/tree/feat/mooncake-store-int)** branch. In this integration, KV cache tensors live in GPU device memory, and their raw `data_ptr()` addresses are passed through `batch_put_from_multi_buffers` into the Mooncake C++ layer. The RDMA memory-replica path handles these correctly via GPUDirect / `nvidia_peermem`, but all "CPU thread writes to disk" paths crash with `SIGSEGV` inside `__memcpy_avx_unaligned` because they attempt to read GPU virtual addresses from a CPU thread.

### Root Cause

Four code paths in `mooncake-store` assume `slice.ptr` is host memory, which is incorrect when the caller (e.g., the upcoming `MooncakeStoreConnector` in vLLM) passes GPU device pointers:

| Path | Location | Operation |
|------|----------|-----------|
| Sync Disk Replica | `client_service.cpp` `PutToLocalFile` | `value.append(slice.ptr, ...)` |

The segmentation fault in this path is reproducible. Although the following _three paths_ appear to have similar issues to `Sync Disk Replica`, the transfer engine eliminates this potential risk at the underlying layer. （Thanks to @zhangzuo21  for identifying this issue.）

| Path | Location | Operation |
|------|----------|-----------|
| Async Adaptor Offload | `storage_backend.cpp` `ConcatSlicesToString` | `out.append(s.ptr, ...)` |
| Async BuildBucket | `storage_backend.cpp` `BuildBucket` | `iovs.emplace_back(iovec{slice.ptr, ...})` |
| Async WriteBucket | `storage_backend.cpp` `WriteBucket` | `memcpy(dst, iov.iov_base, ...)` |

**Notes:** As Sync Disk Replica is slated for removal from mooncake-store in the future, this PR merely achieves two objectives: (i) addressing existing issues in the Sync Disk Replica code path, and (ii) acting as defensive programming that may provide protection for potential future GPU VRAM mounting operations.

### Fix

Introduce **synchronous Device-to-Host (D2H) staging** before the data reaches these paths:

1. **`PutToLocalFile`**: Detect GPU pointers via `cudaPointerGetAttributes` (or platform equivalent), stage to pinned host memory via `cudaMemcpy(DeviceToHost)`, then proceed with the existing async `StoreObject` flow. D2H is done synchronously on the calling thread to guarantee GPU buffers are still valid (`BatchPut` has not yet returned to the caller). On D2H failure, `PutRevoke` is called to prevent phantom replicas in the master.

2. **`FileStorage::OffloadObjects`**: Insert D2H staging between `BatchQuerySegmentSlices` and `storage_backend_->BatchOffload`, so that `ConcatSlicesToString` / `BuildBucket` / `WriteBucket` in `storage_backend.cpp` always receive host pointers — **zero changes to StorageBackend internals**. If any slice fails D2H, the entire object is skipped to prevent partial/corrupt data.

### New components

**`gpu_staging_utils.h`**: Shared `IsDevicePointer` / `CopyDeviceToHost` / `SetDevice` inline helpers, eliminating code duplication between `client_service.cpp` and `file_storage.cpp`.

**`PinnedBufferPool`**: Thread-safe, reusable pool of pinned host memory buffers (`cudaMallocHost` / `hipHostMalloc` / `aclrtMallocHost`). Pinned memory provides significantly higher D2H bandwidth than pageable memory. Features max pool capacity (default 32) to bound pinned memory growth, O(1) swap-pop acquire, and fallback to `new char[]` if pinned allocation fails.

### Cross-platform support

All helpers and `PinnedBufferPool` support:
- **NVIDIA CUDA** (`USE_CUDA`) — via `cuda_alike.h`
- **AMD HIP** (`USE_HIP`) — native `hipPointerGetAttributes` / `hipHostMalloc` (not mapped in `hip.h`)
- **Moore Threads MUSA** (`USE_MUSA`) — via `cuda_alike.h` mappings
- **MetaX MACA** (`USE_MACA`) — via `cuda_alike.h` mappings
- **Ascend CANN** (`USE_ASCEND` / `USE_ASCEND_DIRECT` / `USE_UBSHMEM`) — native `aclrt*` API
- **CPU-only builds** — all guards compile out, zero overhead

### CMake: auto-detect GPU toolkit

`mooncake_store` auto-detects CUDAToolkit / HIP independently of the global `USE_CUDA` flag via `find_package(...QUIET)`. This is necessary because `WITH_NVIDIA_PEERMEM=ON` (default) uses `nvidia_peermem` for RDMA and does **not** set `USE_CUDA`, even though GPU pointers are present. Each detected toolkit gets explicit `PRIVATE` compile definitions (`USE_CUDA` / `USE_HIP`) and link libraries (`CUDA::cudart` / `hip::host`), so `gpu_staging_utils.h` guards activate correctly regardless of global CMake flags.

### CI: add `-lcudart` to Go test link flags

`mooncake_store` is a static library (`.a`). When it contains `cudaMallocHost` / `cudaMemcpy` symbol references (due to auto-detected CUDA), all consumers must also link `-lcudart`. The Go `build.sh` already handles this (`if [ -d "/usr/local/cuda/lib64" ]`), but the CI workflow's inline `CGO_LDFLAGS` for `go test` did not. Added the same conditional `-lcudart` link. **This change is a no-op on CI runners without CUDA and does not affect any other CI jobs.**

### Files changed

| File | Change |
|------|--------|
| `mooncake-store/include/gpu_staging_utils.h` | **New** — shared GPU D2H helpers |
| `mooncake-store/include/pinned_buffer_pool.h` | **New** — pinned buffer pool |
| `mooncake-store/include/client_service.h` | Add `pinned_buffer_pool_` member (declared before `write_thread_pool_` for correct destruction order) |
| `mooncake-store/src/client_service.cpp` | Rewrite `PutToLocalFile` with sync D2H staging |
| `mooncake-store/include/file_storage.h` | Add `pinned_buffer_pool_` member |
| `mooncake-store/src/file_storage.cpp` | Insert D2H staging in `OffloadObjects` before `BatchOffload` |
| `mooncake-store/src/CMakeLists.txt` | Auto-detect CUDAToolkit/HIP with `PRIVATE` compile definitions and link libraries |
| `.github/workflows/ci.yml` | Add conditional `-lcudart` to Go test `CGO_LDFLAGS` |

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] CI/CD

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

### Integration test environment
- **vLLM**: unreleased `main` branch (`620e8924d`), Python 3.12, with the upcoming `MooncakeStoreConnector`
- **Mooncake**: `ssd-gpu-pointer` branch
- **Model**: `/mnt/data/models/Qwen3-8B` (loaded locally)
- **GPU**: single A100 / H100 (tests run with `--tensor-parallel-size 1`)
- **IB**: `ibp12s0` (forced via `device_name` to avoid intra-node dual-NIC loopback retry issues)

### Reproduction before fix
With `global_segment_size=512MB` and 10 prompts × 2048 tokens, the memory segment filled up and Mooncake Master appended a disk replica. `Client::PutToLocalFile` then dereferenced the GPU pointer with `value.append(slice.ptr, slice.size)`, triggering a **reproducible segfault**:
```text
__memcpy_avx_unaligned
mooncake::Client::PutToLocalFile(...)
mooncake::Client::SubmitTransfers(...)
...
```

### Verification after fix
1. **Sync disk-replica path (`PutToLocalFile`)**
   ```bash
   python benchmarks/benchmark_prefix_caching.py \
     --model /mnt/data/models/Qwen3-8B \
     --tensor-parallel-size 1 \
     --enable-prefix-caching \
     --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both"}' \
     --num-prompts 3 \
     --repeat-count 1 \
     --input-length-range 2048:2048 \
     --output-len 1
   ```
   - **Result**: benchmark completed successfully (`cost time ~0.67s`), no segfault, process exited cleanly.
   - Previously this command would crash within seconds with `__memcpy_avx_unaligned`.

2. **Larger prompt batch (10 prompts)**
   - Same command with `--num-prompts 10` also completed prefill successfully; the only errors observed were unrelated RDMA `transport retry counter exceeded` caused by dual-IB loopback in our testbed (resolved by pinning `device_name` to a single NIC).

3. **Compile-definition propagation**
   - Verified that `mooncake_store` receives `USE_CUDA` via auto-detected `target_compile_definitions(PRIVATE)`, ensuring `gpu_staging_utils.h` guards activate correctly even when global `USE_CUDA=OFF`.

4. **Async offload path (`FileStorage::OffloadObjects`)**
   - D2H staging was inserted before `storage_backend_->BatchOffload`. No changes were required inside `StorageBackendAdaptor::ConcatSlicesToString`, `BucketStorageBackend::BuildBucket`, or `WriteBucket`. This path is exercised whenever the heartbeat thread decides to evict blocks to SSD.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
