### PR TITLE
[TENT] Fix static library link group for final targets and reformat related CMake files

### DIFF
--- a/mooncake-transfer-engine/benchmark/CMakeLists.txt
+++ b/mooncake-transfer-engine/benchmark/CMakeLists.txt
@@ -15,5 +15,6 @@ if(USE_CUDA)
 endif()
 
 # Set RPATH for finding libasio.so at runtime
-set_target_properties(tebench PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                         INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/../../mooncake-asio")
+set_target_properties(
+  tebench PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                     INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/../../mooncake-asio")

--- a/mooncake-transfer-engine/benchmark/CMakeLists.txt
+++ b/mooncake-transfer-engine/benchmark/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 file(GLOB TEBENCH_SOURCES "*.cpp")
 add_executable(tebench ${TEBENCH_SOURCES})
-target_link_libraries(tebench PUBLIC transfer_engine tent)
+target_link_libraries(tebench PUBLIC transfer_engine tent_link_group)
 if(USE_CUDA)
   target_link_libraries(tebench PUBLIC CUDA::cudart)
 endif()

--- a/mooncake-transfer-engine/example/CMakeLists.txt
+++ b/mooncake-transfer-engine/example/CMakeLists.txt
@@ -1,47 +1,57 @@
 set(WORKSPACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
-if (USE_HIP)
+if(USE_HIP)
   file(GLOB EXAMPLE_SOURCES "*.cpp")
   hipify_files(EXAMPLE_SOURCES)
 
-  file(RELATIVE_PATH EXAMPLE_REL_PATH "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
+  file(RELATIVE_PATH EXAMPLE_REL_PATH "${CMAKE_SOURCE_DIR}"
+       "${CMAKE_CURRENT_SOURCE_DIR}")
   set(WORKSPACE "${CMAKE_BINARY_DIR}/${EXAMPLE_REL_PATH}")
 endif()
 
 add_executable(transfer_engine_bench ${WORKSPACE}/transfer_engine_bench.cpp)
 target_link_libraries(transfer_engine_bench PUBLIC transfer_engine)
-if (USE_TENT)
-    target_link_libraries(transfer_engine_bench PUBLIC tent_link_group)
-    target_compile_definitions(transfer_engine_bench PRIVATE USE_TENT)
+if(USE_TENT)
+  target_link_libraries(transfer_engine_bench PUBLIC tent_link_group)
+  target_compile_definitions(transfer_engine_bench PRIVATE USE_TENT)
 endif()
 
-add_executable(transfer_engine_validator ${WORKSPACE}/transfer_engine_validator.cpp)
+add_executable(transfer_engine_validator
+               ${WORKSPACE}/transfer_engine_validator.cpp)
 target_link_libraries(transfer_engine_validator PUBLIC transfer_engine)
 
-add_executable(transfer_engine_bench_with_notify ${WORKSPACE}/transfer_engine_bench_with_notify.cpp)
+add_executable(transfer_engine_bench_with_notify
+               ${WORKSPACE}/transfer_engine_bench_with_notify.cpp)
 target_link_libraries(transfer_engine_bench_with_notify PUBLIC transfer_engine)
 
 add_executable(memory_pool ${WORKSPACE}/memory_pool.cpp)
 target_link_libraries(memory_pool PUBLIC transfer_engine)
 
-if (USE_ASCEND)
-    add_executable(transfer_engine_ascend_one_sided ${WORKSPACE}/transfer_engine_ascend_one_sided.cpp)
-    target_link_libraries(transfer_engine_ascend_one_sided PUBLIC transfer_engine)
+if(USE_ASCEND)
+  add_executable(transfer_engine_ascend_one_sided
+                 ${WORKSPACE}/transfer_engine_ascend_one_sided.cpp)
+  target_link_libraries(transfer_engine_ascend_one_sided PUBLIC transfer_engine)
 
-    add_executable(transfer_engine_ascend_perf ${WORKSPACE}/transfer_engine_ascend_perf.cpp)
-    target_link_libraries(transfer_engine_ascend_perf PUBLIC transfer_engine)
+  add_executable(transfer_engine_ascend_perf
+                 ${WORKSPACE}/transfer_engine_ascend_perf.cpp)
+  target_link_libraries(transfer_engine_ascend_perf PUBLIC transfer_engine)
 endif()
 
-if (USE_ASCEND_DIRECT)
-    add_executable(transfer_engine_ascend_direct_perf ${WORKSPACE}/transfer_engine_ascend_direct_perf.cpp)
-    target_link_libraries(transfer_engine_ascend_direct_perf PUBLIC ascendcl transfer_engine)
+if(USE_ASCEND_DIRECT)
+  add_executable(transfer_engine_ascend_direct_perf
+                 ${WORKSPACE}/transfer_engine_ascend_direct_perf.cpp)
+  target_link_libraries(transfer_engine_ascend_direct_perf
+                        PUBLIC ascendcl transfer_engine)
 endif()
 
-if (USE_ASCEND_HETEROGENEOUS)
-    add_executable(transfer_engine_heterogeneous_ascend_perf_initiator ${WORKSPACE}/transfer_engine_heterogeneous_ascend_perf_initiator.cpp)
-    target_link_libraries(transfer_engine_heterogeneous_ascend_perf_initiator PUBLIC transfer_engine)
+if(USE_ASCEND_HETEROGENEOUS)
+  add_executable(
+    transfer_engine_heterogeneous_ascend_perf_initiator
+    ${WORKSPACE}/transfer_engine_heterogeneous_ascend_perf_initiator.cpp)
+  target_link_libraries(transfer_engine_heterogeneous_ascend_perf_initiator
+                        PUBLIC transfer_engine)
 endif()
 
-if (USE_UBSHMEM)
-    target_link_libraries(transfer_engine_bench PUBLIC transfer_engine)
+if(USE_UBSHMEM)
+  target_link_libraries(transfer_engine_bench PUBLIC transfer_engine)
 endif()

--- a/mooncake-transfer-engine/example/CMakeLists.txt
+++ b/mooncake-transfer-engine/example/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 add_executable(transfer_engine_bench ${WORKSPACE}/transfer_engine_bench.cpp)
 target_link_libraries(transfer_engine_bench PUBLIC transfer_engine)
 if (USE_TENT)
-    target_link_libraries(transfer_engine_bench PUBLIC tent)
+    target_link_libraries(transfer_engine_bench PUBLIC tent_link_group)
     target_compile_definitions(transfer_engine_bench PRIVATE USE_TENT)
 endif()
 

--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -91,20 +91,22 @@ if(USE_MLU)
   target_link_libraries(transfer_engine PUBLIC cnrt cndrv)
 endif()
 
-if (USE_ASCEND)
-  target_link_libraries(transfer_engine PUBLIC ascendcl hccl ascend_transport MPI::MPI)
+if(USE_ASCEND)
+  target_link_libraries(transfer_engine PUBLIC ascendcl hccl ascend_transport
+                                               MPI::MPI)
 endif()
 
-if (USE_ASCEND_DIRECT)
+if(USE_ASCEND_DIRECT)
   target_link_libraries(transfer_engine PUBLIC ascend_transport)
 endif()
 
-if (USE_UBSHMEM)
+if(USE_UBSHMEM)
   target_link_libraries(transfer_engine PUBLIC ascend_transport)
 endif()
 
-if (USE_ASCEND_HETEROGENEOUS)
-  file(GLOB ASCEND_TOOLKIT_ROOT "/usr/local/Ascend/ascend-toolkit/latest/*-linux")
+if(USE_ASCEND_HETEROGENEOUS)
+  file(GLOB ASCEND_TOOLKIT_ROOT
+       "/usr/local/Ascend/ascend-toolkit/latest/*-linux")
   set(ASCEND_LIB_DIR "${ASCEND_TOOLKIT_ROOT}/lib64")
   link_directories(${ASCEND_LIB_DIR})
   target_link_libraries(transfer_engine PUBLIC ascendcl ascend_transport)

--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -112,7 +112,7 @@ endif()
 
 if(USE_TENT)
   add_compile_definitions(transfer_engine PUBLIC USE_TENT)
-  target_link_libraries(transfer_engine PUBLIC tent)
+  target_link_libraries(transfer_engine PUBLIC tent_link_group)
 endif()
 
 if(USE_INTRA_NVLINK)

--- a/mooncake-transfer-engine/tent/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/CMakeLists.txt
@@ -1,72 +1,77 @@
-SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 add_library(tent_interface INTERFACE)
-target_include_directories(tent_interface
-    INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-        $<INSTALL_INTERFACE:include>
-)
+target_include_directories(
+  tent_interface
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+            $<INSTALL_INTERFACE:include>)
 target_compile_features(tent_interface INTERFACE cxx_std_20)
 
-if (TARGET asio_shared)
-    target_link_libraries(tent_interface INTERFACE asio_shared)
+if(TARGET asio_shared)
+  target_link_libraries(tent_interface INTERFACE asio_shared)
 endif()
 
 # CUDA
-if (USE_CUDA)
-    find_package(CUDAToolkit REQUIRED)
-    message(STATUS "CUDA: Enabled")
-    target_compile_definitions(tent_interface INTERFACE USE_CUDA)
-    target_include_directories(tent_interface INTERFACE ${CUDAToolkit_INCLUDE_DIRS})
-    target_link_libraries(tent_interface INTERFACE CUDA::cudart)
+if(USE_CUDA)
+  find_package(CUDAToolkit REQUIRED)
+  message(STATUS "CUDA: Enabled")
+  target_compile_definitions(tent_interface INTERFACE USE_CUDA)
+  target_include_directories(tent_interface
+                             INTERFACE ${CUDAToolkit_INCLUDE_DIRS})
+  target_link_libraries(tent_interface INTERFACE CUDA::cudart)
 else()
-    message(STATUS "CUDA: Disabled")
+  message(STATUS "CUDA: Disabled")
 endif()
 
 # GDS
 find_library(CUFILE_LIB cufile PATHS /usr/local/cuda/lib64)
 find_path(CUFILE_INCLUDE cufile.h PATHS /usr/local/cuda/include)
-if (USE_CUDA AND CUDAToolkit_FOUND AND CUFILE_LIB AND CUFILE_INCLUDE)
-    message(STATUS "GDS: Enabled")
-    target_compile_definitions(tent_interface INTERFACE USE_GDS)
-    target_include_directories(tent_interface INTERFACE ${CUFILE_INCLUDE})
-    target_link_libraries(tent_interface INTERFACE ${CUFILE_LIB})
+if(USE_CUDA
+   AND CUDAToolkit_FOUND
+   AND CUFILE_LIB
+   AND CUFILE_INCLUDE)
+  message(STATUS "GDS: Enabled")
+  target_compile_definitions(tent_interface INTERFACE USE_GDS)
+  target_include_directories(tent_interface INTERFACE ${CUFILE_INCLUDE})
+  target_link_libraries(tent_interface INTERFACE ${CUFILE_LIB})
 else()
-    message(STATUS "GDS: Disabled")
+  message(STATUS "GDS: Disabled")
 endif()
 
 # RDMA (ibverbs)
-find_library(IBVERBS_LIB ibverbs PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64)
-find_path(IBVERBS_INCLUDE infiniband/verbs.h PATHS /usr/include /usr/local/include)
-if (IBVERBS_LIB AND IBVERBS_INCLUDE)
-    message(STATUS "RDMA: Enabled")
-    target_compile_definitions(tent_interface INTERFACE USE_RDMA)
-    target_include_directories(tent_interface INTERFACE ${IBVERBS_INCLUDE})
-    target_link_libraries(tent_interface INTERFACE ${IBVERBS_LIB})
+find_library(IBVERBS_LIB ibverbs PATHS /usr/lib /usr/lib64 /usr/local/lib
+                                       /usr/local/lib64)
+find_path(IBVERBS_INCLUDE infiniband/verbs.h PATHS /usr/include
+                                                   /usr/local/include)
+if(IBVERBS_LIB AND IBVERBS_INCLUDE)
+  message(STATUS "RDMA: Enabled")
+  target_compile_definitions(tent_interface INTERFACE USE_RDMA)
+  target_include_directories(tent_interface INTERFACE ${IBVERBS_INCLUDE})
+  target_link_libraries(tent_interface INTERFACE ${IBVERBS_LIB})
 else()
-    message(STATUS "RDMA: Disabled")
+  message(STATUS "RDMA: Disabled")
 endif()
 
 # io_uring
-find_library(URING_LIB uring PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64)
+find_library(URING_LIB uring PATHS /usr/lib /usr/lib64 /usr/local/lib
+                                   /usr/local/lib64)
 find_path(URING_INCLUDE liburing.h PATHS /usr/include /usr/local/include)
-if (URING_LIB AND URING_INCLUDE)
-    message(STATUS "Uring: Enabled")
-    target_compile_definitions(tent_interface INTERFACE USE_URING)
-    target_include_directories(tent_interface INTERFACE ${URING_INCLUDE})
-    target_link_libraries(tent_interface INTERFACE ${URING_LIB})
+if(URING_LIB AND URING_INCLUDE)
+  message(STATUS "Uring: Enabled")
+  target_compile_definitions(tent_interface INTERFACE USE_URING)
+  target_include_directories(tent_interface INTERFACE ${URING_INCLUDE})
+  target_link_libraries(tent_interface INTERFACE ${URING_LIB})
 else()
-    message(STATUS "Uring: Disabled")
+  message(STATUS "Uring: Disabled")
 endif()
 
 set(YALANTING_TARGET yalantinglibs::yalantinglibs)
-if (NOT TARGET ${YALANTING_TARGET})
-    if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-        find_package(yalantinglibs CONFIG REQUIRED)
-    else()
-        message(FATAL_ERROR
-            "yalantinglibs::yalantinglibs target not found")
-    endif()
+if(NOT TARGET ${YALANTING_TARGET})
+  if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    find_package(yalantinglibs CONFIG REQUIRED)
+  else()
+    message(FATAL_ERROR "yalantinglibs::yalantinglibs target not found")
+  endif()
 endif()
 
 add_subdirectory(common)
@@ -81,47 +86,39 @@ add_subdirectory(python)
 file(GLOB TENT_ENGINE_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 
 add_library(tent STATIC ${TENT_ENGINE_SOURCES})
-target_link_libraries(
-    tent
-    PUBLIC
-        tent_runtime
-        tent_interface
-)
+target_link_libraries(tent PUBLIC tent_runtime tent_interface)
 
 add_library(tent_shared SHARED ${TENT_ENGINE_SOURCES})
-target_link_libraries(
-    tent_shared
-    PUBLIC
-        tent_runtime
-        tent_interface
-)
+target_link_libraries(tent_shared PUBLIC tent_runtime tent_interface)
 
 add_library(tent_link_group INTERFACE)
 target_link_libraries(tent_link_group INTERFACE "-Wl,--start-group" tent)
-foreach(tgt
-            metastore_redis
-            metastore_http
-            metastore_etcd
-            tent_platform_all
-            platform_cuda
-            platform_ascend
-            tent_xport_gds
-            tent_xport_uring
-            tent_xport_bufio
-            tent_xport_mnnvl
-            tent_xport_nvlink
-            tent_xport_rdma
-            tent_xport_shm
-            tent_xport_tcp
-            tent_xport_ascend_direct
-            tent_metrics)
-    if (TARGET ${tgt})
-        target_link_libraries(tent_link_group INTERFACE ${tgt})
-    endif()
+foreach(
+  tgt
+  metastore_redis
+  metastore_http
+  metastore_etcd
+  tent_platform_all
+  platform_cuda
+  platform_ascend
+  tent_xport_gds
+  tent_xport_uring
+  tent_xport_bufio
+  tent_xport_mnnvl
+  tent_xport_nvlink
+  tent_xport_rdma
+  tent_xport_shm
+  tent_xport_tcp
+  tent_xport_ascend_direct
+  tent_metrics)
+  if(TARGET ${tgt})
+    target_link_libraries(tent_link_group INTERFACE ${tgt})
+  endif()
 endforeach()
 target_link_libraries(tent_link_group INTERFACE "-Wl,--end-group")
 
-install(TARGETS tent_shared
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin)
+install(
+  TARGETS tent_shared
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/mooncake-transfer-engine/tent/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/CMakeLists.txt
@@ -96,6 +96,31 @@ target_link_libraries(
         tent_interface
 )
 
+add_library(tent_link_group INTERFACE)
+target_link_libraries(tent_link_group INTERFACE "-Wl,--start-group" tent)
+foreach(tgt
+            metastore_redis
+            metastore_http
+            metastore_etcd
+            tent_platform_all
+            platform_cuda
+            platform_ascend
+            tent_xport_gds
+            tent_xport_uring
+            tent_xport_bufio
+            tent_xport_mnnvl
+            tent_xport_nvlink
+            tent_xport_rdma
+            tent_xport_shm
+            tent_xport_tcp
+            tent_xport_ascend_direct
+            tent_metrics)
+    if (TARGET ${tgt})
+        target_link_libraries(tent_link_group INTERFACE ${tgt})
+    endif()
+endforeach()
+target_link_libraries(tent_link_group INTERFACE "-Wl,--end-group")
+
 install(TARGETS tent_shared
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib

--- a/mooncake-transfer-engine/tent/src/python/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/python/CMakeLists.txt
@@ -1,13 +1,13 @@
 file(GLOB SOURCES "*.cpp")
 include(${CMAKE_CURRENT_LIST_DIR}/../../../../mooncake-common/SetupPython.cmake)
 execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import sys; print([s for s in sys.path if 'packages' in s][0])"
-    OUTPUT_VARIABLE PYTHON_SYS_PATH
-)
+  COMMAND ${PYTHON_EXECUTABLE} -c
+          "import sys; print([s for s in sys.path if 'packages' in s][0])"
+  OUTPUT_VARIABLE PYTHON_SYS_PATH)
 string(STRIP ${PYTHON_SYS_PATH} PYTHON_SYS_PATH)
 
 if("${PYTHON_SYS_PATH}" STREQUAL "")
-    message(FATAL_ERROR "Python path is empty! Please check the python env.")
+  message(FATAL_ERROR "Python path is empty! Please check the python env.")
 endif()
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
@@ -18,12 +18,13 @@ message("${PYTHON_SYS_PATH}")
 set(PYTHON_PACKAGE_NAME "tent-core")
 
 pybind11_add_module(tentpy ${SOURCES})
-set_target_properties(tentpy PROPERTIES
-    OUTPUT_NAME "tent"
-    INSTALL_RPATH "$ORIGIN" 
-)
+set_target_properties(tentpy PROPERTIES OUTPUT_NAME "tent" INSTALL_RPATH
+                                                           "$ORIGIN")
 
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+find_package(
+  Python3
+  COMPONENTS Interpreter Development
+  REQUIRED)
 target_link_libraries(tentpy PRIVATE ${Python3_LIBRARIES})
 target_include_directories(tentpy PRIVATE ${Python3_INCLUDE_DIRS})
 target_link_libraries(tentpy PUBLIC tent_link_group)

--- a/mooncake-transfer-engine/tent/src/python/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/python/CMakeLists.txt
@@ -26,4 +26,4 @@ set_target_properties(tentpy PROPERTIES
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 target_link_libraries(tentpy PRIVATE ${Python3_LIBRARIES})
 target_include_directories(tentpy PRIVATE ${Python3_INCLUDE_DIRS})
-target_link_libraries(tentpy PUBLIC tent)
+target_link_libraries(tentpy PUBLIC tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -15,14 +15,13 @@ target_include_directories(metrics_config_loader_test PRIVATE ${CMAKE_CURRENT_SO
 add_test(NAME metrics_config_loader_test COMMAND metrics_config_loader_test)
 
 add_executable(request_merge_test request_merge_test.cpp)
-target_link_libraries(request_merge_test PRIVATE tent gtest gtest_main)
+target_link_libraries(request_merge_test PRIVATE gtest gtest_main tent_link_group)
 target_include_directories(request_merge_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME request_merge_test COMMAND request_merge_test)
 
 add_executable(transfer_engine_config_override_test
                transfer_engine_config_override_test.cpp)
-target_link_libraries(transfer_engine_config_override_test
-                      PRIVATE tent gtest gtest_main)
+target_link_libraries(transfer_engine_config_override_test PRIVATE gtest gtest_main tent_link_group)
 if (TARGET asio_shared)
     target_link_libraries(transfer_engine_config_override_test
                           PRIVATE asio_shared)
@@ -33,13 +32,13 @@ add_test(NAME transfer_engine_config_override_test
          COMMAND transfer_engine_config_override_test)
 
 add_executable(tent_tcp_transport_test tcp_transport_test.cpp)
-target_link_libraries(tent_tcp_transport_test PRIVATE tent gtest gtest_main)
+target_link_libraries(tent_tcp_transport_test PRIVATE gtest gtest_main tent_link_group)
 target_include_directories(tent_tcp_transport_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_tcp_transport_test COMMAND tent_tcp_transport_test)
 
 add_executable(tent_failover_test failover_test.cpp)
-target_link_libraries(tent_failover_test PRIVATE tent gtest gtest_main)
+target_link_libraries(tent_failover_test PRIVATE gtest gtest_main tent_link_group)
 target_include_directories(tent_failover_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_failover_test COMMAND tent_failover_test)

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -2,29 +2,38 @@
 
 # TENT Metrics Example
 add_executable(tent_metrics_example tent_metrics_example.cpp)
-# asio_shared must be linked explicitly for executables: ASIO_SEPARATE_COMPILATION mode requires
-# that any binary using ASIO symbols links against the shared asio implementation directly.
-# Libraries (tent_metrics, tent_interface) get it transitively; executables need it explicit.
-target_link_libraries(tent_metrics_example PRIVATE tent_metrics tent_common asio_shared glog ibverbs)
-target_include_directories(tent_metrics_example PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+# asio_shared must be linked explicitly for executables:
+# ASIO_SEPARATE_COMPILATION mode requires that any binary using ASIO symbols
+# links against the shared asio implementation directly. Libraries
+# (tent_metrics, tent_interface) get it transitively; executables need it
+# explicit.
+target_link_libraries(tent_metrics_example PRIVATE tent_metrics tent_common
+                                                   asio_shared glog ibverbs)
+target_include_directories(tent_metrics_example
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 # TENT Metrics Config Loader Unit Test
 add_executable(metrics_config_loader_test metrics_config_loader_test.cpp)
-target_link_libraries(metrics_config_loader_test PRIVATE tent_metrics tent_common gtest gtest_main glog)
-target_include_directories(metrics_config_loader_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_link_libraries(metrics_config_loader_test
+                      PRIVATE tent_metrics tent_common gtest gtest_main glog)
+target_include_directories(metrics_config_loader_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME metrics_config_loader_test COMMAND metrics_config_loader_test)
 
 add_executable(request_merge_test request_merge_test.cpp)
-target_link_libraries(request_merge_test PRIVATE gtest gtest_main tent_link_group)
-target_include_directories(request_merge_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_link_libraries(request_merge_test PRIVATE gtest gtest_main
+                                                 tent_link_group)
+target_include_directories(request_merge_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME request_merge_test COMMAND request_merge_test)
 
 add_executable(transfer_engine_config_override_test
                transfer_engine_config_override_test.cpp)
-target_link_libraries(transfer_engine_config_override_test PRIVATE gtest gtest_main tent_link_group)
-if (TARGET asio_shared)
-    target_link_libraries(transfer_engine_config_override_test
-                          PRIVATE asio_shared)
+target_link_libraries(transfer_engine_config_override_test
+                      PRIVATE gtest gtest_main tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(transfer_engine_config_override_test
+                        PRIVATE asio_shared)
 endif()
 target_include_directories(transfer_engine_config_override_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
@@ -32,13 +41,15 @@ add_test(NAME transfer_engine_config_override_test
          COMMAND transfer_engine_config_override_test)
 
 add_executable(tent_tcp_transport_test tcp_transport_test.cpp)
-target_link_libraries(tent_tcp_transport_test PRIVATE gtest gtest_main tent_link_group)
+target_link_libraries(tent_tcp_transport_test PRIVATE gtest gtest_main
+                                                      tent_link_group)
 target_include_directories(tent_tcp_transport_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_tcp_transport_test COMMAND tent_tcp_transport_test)
 
 add_executable(tent_failover_test failover_test.cpp)
-target_link_libraries(tent_failover_test PRIVATE gtest gtest_main tent_link_group)
+target_link_libraries(tent_failover_test PRIVATE gtest gtest_main
+                                                 tent_link_group)
 target_include_directories(tent_failover_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_failover_test COMMAND tent_failover_test)


### PR DESCRIPTION
## Description

This PR fixes the static library link-order / circular dependency issue in TENT final link targets.

`libtent.a` and transport-specific static libraries can form a circular dependency during final linking, which caused unresolved symbols in targets such as `tent_failover_test` and `tent_tcp_transport_test`. This change introduces `tent_link_group` and switches the affected final targets to link through that group so the linker can resolve cross-library symbols reliably.

This PR also includes the related CMake formatting cleanup required by pre-commit.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] Refactor
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Compiled using `-DUSE_TENT=ON -DCMAKE_BUILD_TYPE=Debug` and passed

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
