### PR TITLE
[TENT] Fix crashes caused by negative numa_node and incorrect config type inference

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/config.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config.h
@@ -124,6 +124,41 @@ class Config {
         *node = value;
     }
 
+    // Set a config value from a string with automatic type inference.
+    // Recognizes "true"/"false" (case-insensitive) as booleans and
+    // pure-integer strings as long long, falling back to std::string.
+    void setFromString(const std::string& key, const std::string& value) {
+        // Boolean detection (case-insensitive)
+        {
+            std::string lower = value;
+            std::transform(lower.begin(), lower.end(), lower.begin(),
+                           ::tolower);
+            if (lower == "true") {
+                set(key, true);
+                return;
+            }
+            if (lower == "false") {
+                set(key, false);
+                return;
+            }
+        }
+        // Integer detection
+        if (!value.empty()) {
+            try {
+                size_t pos = 0;
+                long long int_val = std::stoll(value, &pos);
+                if (pos == value.size()) {
+                    set(key, int_val);
+                    return;
+                }
+            } catch (const std::exception&) {
+                // Not an integer, fall through
+            }
+        }
+        // Fallback: store as string
+        set(key, value);
+    }
+
     Status load(const std::string& content);
 
     Status loadFile(const std::string& file_path);

--- a/mooncake-transfer-engine/tent/include/tent/common/config.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config.h
@@ -132,7 +132,7 @@ class Config {
         {
             std::string lower = value;
             std::transform(lower.begin(), lower.end(), lower.begin(),
-                           ::tolower);
+                           [](unsigned char c) { return std::tolower(c); });
             if (lower == "true") {
                 set(key, true);
                 return;

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -50,23 +50,7 @@ std::string Config::dump(int indent) const {
 static inline void setConfig(Config& config, const std::string& env_key,
                              const std::string& config_key) {
     const char* val = std::getenv(env_key.c_str());
-    if (val) {
-        std::string str_val(val);
-        // Try to parse as integer first
-        try {
-            size_t pos;
-            int int_val = std::stoi(str_val, &pos);
-            if (pos == str_val.length()) {
-                // Fully numeric, store as int
-                config.set(config_key, int_val);
-                return;
-            }
-        } catch (const std::exception& e) {
-            // Not an integer, continue to store as string
-        }
-        // Store as string
-        config.set(config_key, str_val);
-    }
+    if (val) config.setFromString(config_key, std::string(val));
 }
 
 Status ConfigHelper::loadFromEnv(Config& config) {

--- a/mooncake-transfer-engine/tent/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/tent/src/transfer_engine_c.cpp
@@ -47,7 +47,8 @@ tent_engine_t tent_create_engine() {
                          << ", fallback to default config";
         }
     }
-    for (auto& attr : tl_settings.attrs) config->set(attr.first, attr.second);
+    for (auto& attr : tl_settings.attrs)
+        config->setFromString(attr.first, attr.second);
     auto engine = new mooncake::tent::TransferEngineImpl(config);
     return (tent_engine_t)engine;
 }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
@@ -226,7 +226,10 @@ Status RailMonitor::loadDefault() {
                 best_nic = cand;
             }
         }
-        if (best_nic < 0) continue;
+        if (best_nic < 0) {
+            direct_rails_[local_nic] = -1;
+            continue;
+        }
         remote_load[best_nic]++;
         direct_rails_[local_nic] = best_nic;
     }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
@@ -226,6 +226,7 @@ Status RailMonitor::loadDefault() {
                 best_nic = cand;
             }
         }
+        if (best_nic < 0) continue;
         remote_load[best_nic]++;
         direct_rails_[local_nic] = best_nic;
     }
@@ -241,16 +242,24 @@ void RailMonitor::updateBestMapping() {
     std::unordered_set<int> remote_nic_set;
     const int local_nic_count = (int)local_->getNicCount();
     const int remote_nic_count = (int)remote_->getNicCount();
+
+    // Helper: clamp negative numa_node (e.g. -1 for eRDMA devices that lack
+    // NUMA affinity) to 0 so it can be used safely as an array index.
+    auto safeNuma = [](int numa) -> size_t {
+        return (numa >= 0 && numa < (int)kMaxNuma) ? (size_t)numa : 0;
+    };
+
     for (int local_nic = 0; local_nic < local_nic_count; ++local_nic) {
         auto local_entry = local_->getNicEntry(local_nic);
         if (!local_entry || local_entry->type != Topology::NIC_RDMA) continue;
-        local_devices[local_entry->numa_node].push_back(local_nic);
+        local_devices[safeNuma(local_entry->numa_node)].push_back(local_nic);
         auto remote_nic = direct_rails_[local_nic];
         if (!remote_nic_set.count(remote_nic)) {
             auto remote_entry = remote_->getNicEntry(remote_nic);
             if (!remote_entry || remote_entry->type != Topology::NIC_RDMA)
                 continue;
-            remote_devices[remote_entry->numa_node].push_back(remote_nic);
+            remote_devices[safeNuma(remote_entry->numa_node)].push_back(
+                remote_nic);
             remote_nic_set.insert(remote_nic);
         }
     }
@@ -259,7 +268,8 @@ void RailMonitor::updateBestMapping() {
             auto remote_entry = remote_->getNicEntry(remote_nic);
             if (!remote_entry || remote_entry->type != Topology::NIC_RDMA)
                 continue;
-            remote_devices[remote_entry->numa_node].push_back(remote_nic);
+            remote_devices[safeNuma(remote_entry->numa_node)].push_back(
+                remote_nic);
         }
     }
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

**Summary**

This PR fixes two crash issues encountered when using TENT with eRDMA devices:

1. **Config type inference for C API (`tent_set_config`)**: The `tent_set_config` C API accepts all values as strings, but downstream code retrieves them via `Config::get<bool>()` / `Config::get<int>()`. Without proper type inference, `nlohmann::json::get<bool>()` throws on a string value like `"true"`, causing a crash during TCP transport initialization.

2. **Negative `numa_node` in RDMA rail monitor**: eRDMA devices report `numa_node = -1` (no NUMA affinity). `RailMonitor::updateBestMapping()` uses `numa_node` directly as an array index into a stack-allocated `std::vector<int>[kMaxNuma]`, causing out-of-bounds access and a segfault. Additionally, `loadDefault()` could use `best_nic = -1` as a vector index when no matching remote NIC is found.

**Changes**

### Commit 1: Fix config type inference (`config.cpp`, `transfer_engine_c.cpp`)

- **`transfer_engine_c.cpp`**: Add `setConfigWithTypeInference()` helper that parses string values passed through `tent_set_config` into their proper types (bool for `"true"`/`"false"`, integer for numeric strings) before storing in `Config`. This ensures `Config::get<bool>()` and `Config::get<int>()` work correctly.
- **`config.cpp`**: Apply the same boolean-first parsing order to environment variable config loading (`setConfig`), ensuring consistency between env-var and C API config paths.

### Commit 2: Fix RDMA rail monitor crashes (`rail_monitor.cpp`)

- **`updateBestMapping()`**: Introduce a `safeNuma()` lambda that clamps negative `numa_node` values (e.g. `-1` from eRDMA devices) to `0`, preventing out-of-bounds array access on `local_devices[]` and `remote_devices[]`.
- **`loadDefault()`**: Add a guard (`if (best_nic < 0) continue`) after the second-pass NIC search to skip the assignment when no suitable remote NIC is found, preventing `remote_load[-1]` out-of-bounds access.

**Root Cause**

- eRDMA (Elastic RDMA) devices on Alibaba Cloud ECS instances expose `numa_node = -1` via sysfs, indicating no specific NUMA affinity. The existing code assumed `numa_node` is always non-negative and used it directly as an array index.
- The `tent_set_config` C API stores all values as `std::string` in a JSON object, but `nlohmann::json` strictly distinguishes types — calling `get<bool>()` on a string value throws `nlohmann::json::type_error`.

**Testing**

- Verified on two Alibaba Cloud ECS instances with eRDMA devices (`erdma_0`, `erdma_1`, `numa_node = -1`).
- Confirmed both TCP and RDMA transport modes no longer crash.
- End-to-end test: client1 put + client2 get completes successfully.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
