### PR TITLE
Minor bug fixes and improvments for Mooncake Store and Transfer Engine

### DIFF
--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -174,7 +174,10 @@ class TransferEngineOperationState : public OperationState {
    public:
     TransferEngineOperationState(TransferEngine& engine, BatchID batch_id,
                                  size_t batch_size)
-        : engine_(engine), batch_id_(batch_id), batch_size_(batch_size) {}
+        : engine_(engine),
+          batch_id_(batch_id),
+          batch_size_(batch_size),
+          start_ts_(getCurrentTimeInMilli()) {}
 
     ~TransferEngineOperationState() { engine_.freeBatchID(batch_id_); }
 
@@ -199,6 +202,7 @@ class TransferEngineOperationState : public OperationState {
     TransferEngine& engine_;
     BatchID batch_id_;
     size_t batch_size_;
+    const int64_t start_ts_;
 };
 
 /**

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -202,15 +202,19 @@ if(STORE_USE_ETCD)
   add_dependencies(mooncake_master build_etcd_wrapper)
 endif()
 
-target_compile_options(mooncake_master PRIVATE -Os)
-target_link_options(mooncake_master PRIVATE -Os -s)
-
 # Client server binary
 add_executable(mooncake_client real_client_main.cpp)
 # Client needs transfer_engine for data transfer operations
 target_link_libraries(mooncake_client PRIVATE mooncake_store transfer_engine
                                               asio_shared)
-target_compile_options(mooncake_client PRIVATE -Os)
-target_link_options(mooncake_client PRIVATE -Os -s)
+
+# Optimize binary sizes only in Release mode
+string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
+if (CMAKE_BUILD_TYPE_UPPER STREQUAL "RELEASE")
+  target_compile_options(mooncake_master PRIVATE -Os)
+  target_link_options(mooncake_master PRIVATE -Os -s)
+  target_compile_options(mooncake_client PRIVATE -Os)
+  target_link_options(mooncake_client PRIVATE -Os -s)
+endif()
 
 install(TARGETS mooncake_master mooncake_client DESTINATION bin)

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3598,6 +3598,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 auto it = shard->metadata.begin();
                 while (it != shard->metadata.end() && target_evict_num > 0) {
                     if (!it->second.IsHardPinned() &&
+                        it->second.IsLeaseExpired(now) &&
                         it->second.lease_timeout <= target_timeout &&
                         !it->second.IsSoftPinned(now) &&
                         can_evict_replicas(it->second)) {

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -294,7 +294,8 @@ void TransferEngineOperationState::wait_for_completion() {
         return;
     }
 
-    constexpr int64_t timeout_seconds = 60;
+    // 60 seconds
+    constexpr int64_t timeout_milliseconds = 60 * 1000;
 
 #ifdef USE_EVENT_DRIVEN_COMPLETION
     VLOG(1) << "Waiting for transfer engine completion for batch " << batch_id_;
@@ -314,10 +315,18 @@ void TransferEngineOperationState::wait_for_completion() {
         // lock. Under the mutex, relaxed is sufficient; the mutex acquire
         // orders prior writes.
         std::unique_lock<std::mutex> lock(batch_desc.completion_mutex);
-        completed = batch_desc.completion_cv.wait_for(
-            lock, std::chrono::seconds(timeout_seconds), [&batch_desc] {
-                return batch_desc.is_finished.load(std::memory_order_relaxed);
-            });
+        const int64_t elapsed_milliseconds =
+            getCurrentTimeInMilli() - start_ts_;
+        if (elapsed_milliseconds < timeout_milliseconds) {
+            completed = batch_desc.completion_cv.wait_for(
+                lock,
+                std::chrono::milliseconds(timeout_milliseconds -
+                                          elapsed_milliseconds),
+                [&batch_desc] {
+                    return batch_desc.is_finished.load(
+                        std::memory_order_relaxed);
+                });
+        }
     }  // Explicitly release completion_mutex before acquiring mutex_
 
     // Once completion is observed, read failure flag.
@@ -338,20 +347,18 @@ void TransferEngineOperationState::wait_for_completion() {
         VLOG(1) << "Transfer engine operation completed for batch " << batch_id_
                 << " with result: " << static_cast<int>(error_code);
     } else {
-        LOG(ERROR) << "Failed to complete transfers after " << timeout_seconds
-                   << " seconds for batch " << batch_id_;
+        LOG(ERROR) << "Failed to complete transfers after "
+                   << timeout_milliseconds << " milliseconds for batch "
+                   << batch_id_;
     }
 #else
     VLOG(1) << "Starting transfer engine polling for batch " << batch_id_;
 
-    constexpr int64_t kOneSecondInNano = 1000 * 1000 * 1000;
-    const int64_t start_ts = getCurrentTimeInNano();
-
     while (true) {
-        if (getCurrentTimeInNano() - start_ts >
-            timeout_seconds * kOneSecondInNano) {
+        if (getCurrentTimeInMilli() - start_ts_ > timeout_milliseconds) {
             LOG(ERROR) << "Failed to complete transfers after "
-                       << timeout_seconds << " seconds for batch " << batch_id_;
+                       << timeout_milliseconds << " milliseconds for batch "
+                       << batch_id_;
             set_result_internal(ErrorCode::TRANSFER_FAIL);
             return;
         }

--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -113,6 +113,10 @@ static inline int64_t getCurrentTimeInNano() {
     return (int64_t{ts.tv_sec} * kNanosPerSecond + int64_t{ts.tv_nsec});
 }
 
+static inline int64_t getCurrentTimeInMilli() {
+    return getCurrentTimeInNano() / 1000 / 1000;
+}
+
 static inline std::string getCurrentDateTime() {
     auto now = std::chrono::system_clock::now();
     auto time_t_now = std::chrono::system_clock::to_time_t(now);

--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -331,9 +331,13 @@ static inline ssize_t writeFully(int fd, const void *buf, size_t len) {
 }
 
 static inline ssize_t readFully(int fd, void *buf, size_t len) {
+    // Set a timeout for read to avoid hanging forever.
+    constexpr std::chrono::seconds kReadTimeout = std::chrono::seconds(300);
+    const std::chrono::steady_clock::time_point deadline =
+        std::chrono::steady_clock::now() + kReadTimeout;
     char *pos = (char *)buf;
     size_t nbytes = len;
-    while (nbytes) {
+    while (nbytes && std::chrono::steady_clock::now() < deadline) {
         ssize_t rc = read(fd, pos, nbytes);
         if (rc < 0 && (errno == EAGAIN || errno == EINTR))
             continue;
@@ -348,7 +352,14 @@ static inline ssize_t readFully(int fd, void *buf, size_t len) {
         pos += rc;
         nbytes -= rc;
     }
-    return len;
+    if (nbytes != 0) {
+        LOG(WARNING) << "Socket read timed out, timeout: "
+                     << kReadTimeout.count()
+                     << ", deadline: " << deadline.time_since_epoch().count()
+                     << ", read " << len - nbytes << " out of " << len
+                     << " bytes";
+    }
+    return len - nbytes;
 }
 
 static inline int writeString(int fd, const HandShakeRequestType type,

--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -38,6 +38,8 @@ class EndpointStore {
    public:
     virtual std::shared_ptr<RdmaEndPoint> getEndpoint(
         const std::string &peer_nic_path) = 0;
+    virtual std::shared_ptr<RdmaEndPoint> getEndpointByPtr(
+        const RdmaEndPoint *endpoint_ptr) = 0;
     virtual std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) = 0;
     virtual int deleteEndpoint(const std::string &peer_nic_path) = 0;
@@ -58,6 +60,8 @@ class FIFOEndpointStore : public EndpointStore {
     FIFOEndpointStore(size_t max_size) : max_size_(max_size) {}
     std::shared_ptr<RdmaEndPoint> getEndpoint(
         const std::string &peer_nic_path) override;
+    std::shared_ptr<RdmaEndPoint> getEndpointByPtr(
+        const RdmaEndPoint *endpoint_ptr) override;
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) override;
     int deleteEndpoint(const std::string &peer_nic_path) override;
@@ -89,6 +93,8 @@ class SIEVEEndpointStore : public EndpointStore {
         : waiting_list_len_(0), max_size_(max_size) {}
     std::shared_ptr<RdmaEndPoint> getEndpoint(
         const std::string &peer_nic_path) override;
+    std::shared_ptr<RdmaEndPoint> getEndpointByPtr(
+        const RdmaEndPoint *endpoint_ptr) override;
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) override;
     int deleteEndpoint(const std::string &peer_nic_path) override;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -99,6 +99,9 @@ class RdmaContext {
     // EndPoint Management
     std::shared_ptr<RdmaEndPoint> endpoint(const std::string &peer_nic_path);
 
+    std::shared_ptr<RdmaEndPoint> getEndpointByPtr(
+        const RdmaEndPoint *endpoint_ptr);
+
     int deleteEndpoint(const std::string &peer_nic_path);
 
     int disconnectAllEndpoints();

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -29,7 +29,9 @@
 
 #include "transfer_metadata_plugin.h"
 #include "transport/transport.h"
+#ifdef USE_BAREX
 #include "transport/barex_transport/barex_transport.h"
+#endif
 
 namespace mooncake {
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -35,6 +35,17 @@ std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::getEndpoint(
     return nullptr;
 }
 
+std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::getEndpointByPtr(
+    const RdmaEndPoint *endpoint_ptr) {
+    RWSpinlock::ReadGuard guard(endpoint_map_lock_);
+    for (auto &kv : endpoint_map_) {
+        if (kv.second.get() == endpoint_ptr) return kv.second;
+    }
+    for (auto &endpoint : waiting_list_)
+        if (endpoint.get() == endpoint_ptr) return endpoint;
+    return nullptr;
+}
+
 std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::insertEndpoint(
     const std::string &peer_nic_path, RdmaContext *context) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
@@ -136,6 +147,17 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::getEndpoint(
     }
     // LOG(INFO) << "Endpoint " << peer_nic_path << " not found in
     // SIEVEEndpointStore";
+    return nullptr;
+}
+
+std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::getEndpointByPtr(
+    const RdmaEndPoint *endpoint_ptr) {
+    RWSpinlock::ReadGuard guard(endpoint_map_lock_);
+    for (auto &kv : endpoint_map_) {
+        if (kv.second.first.get() == endpoint_ptr) return kv.second.first;
+    }
+    for (auto &endpoint : waiting_list_)
+        if (endpoint.get() == endpoint_ptr) return endpoint;
     return nullptr;
 }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -357,6 +357,11 @@ std::shared_ptr<RdmaEndPoint> RdmaContext::endpoint(
     return endpoint;
 }
 
+std::shared_ptr<RdmaEndPoint> RdmaContext::getEndpointByPtr(
+    const RdmaEndPoint *endpoint_ptr) {
+    return endpoint_store_->getEndpointByPtr(endpoint_ptr);
+}
+
 int RdmaContext::disconnectAllEndpoints() {
     return endpoint_store_->disconnectQPs();
 }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -415,19 +415,62 @@ void WorkerPool::transferWorker(int thread_id) {
 
 int WorkerPool::doProcessContextEvents() {
     ibv_async_event event;
+    bool event_acked = false;
     if (ibv_get_async_event(context_.context(), &event) < 0) return ERR_CONTEXT;
     LOG(WARNING) << "Worker: Received context async event "
                  << ibv_event_type_str(event.event_type) << " for context "
                  << context_.deviceName();
     if (event.event_type == IBV_EVENT_QP_FATAL) {
-        auto endpoint = (RdmaEndPoint *)event.element.qp->qp_context;
-        endpoint->set_active(false);
+        auto endpoint_ptr = (RdmaEndPoint *)event.element.qp->qp_context;
+
+        /**
+         * There might be a deadlock if we call endpoint->set_active(false)
+         * before ack the event:
+         *
+         * Thread A:
+         *     Holding endpoint->lock_ and calling ibv_destroy_qp (if using
+         * eRDMA), ibv_destroy_qp will block until the event is acked.
+         *
+         * Thread B (this thread):
+         *     Calling endpoint->set_active(false), which blocks as
+         * endpoint->lock_ is held by Thread A.
+         */
+        ibv_ack_async_event(&event);
+        event_acked = true;
+
+        /**
+         * After ack the event, the endpoint might be destroyed if it happened
+         * to be destroying event.element.qp. Therefore, we cannot just
+         * dereference endpoint_ptr. Instead, we need to get the shared_ptr of
+         * the endpoint from context_ and use that shared_ptr to access the
+         * endpoint.
+         */
+        auto endpoint = context_.getEndpointByPtr(endpoint_ptr);
+        if (endpoint) {
+            endpoint->set_active(false);
+        }
     } else if (event.event_type == IBV_EVENT_DEVICE_FATAL ||
                event.event_type == IBV_EVENT_CQ_ERR ||
                event.event_type == IBV_EVENT_WQ_FATAL ||
                event.event_type == IBV_EVENT_PORT_ERR ||
                event.event_type == IBV_EVENT_LID_CHANGE) {
         context_.set_active(false);
+
+        /**
+         * Similar deadlock might happen if we call
+         * context_.disconnectAllEndpoints() before ack the event:
+         *
+         * Thread A:
+         *     Holding endpoint->lock_ and calling ibv_destroy_qp (if using
+         * eRDMA), ibv_destroy_qp will block until the event is acked.
+         *
+         * Thread B (this thread):
+         *     Calling endpoint->disconnect(), which blocks as endpoint->lock_
+         * is held by Thread A.
+         */
+        ibv_ack_async_event(&event);
+        event_acked = true;
+
         context_.disconnectAllEndpoints();
         LOG(INFO) << "Worker: Context " << context_.deviceName()
                   << " is now inactive";
@@ -436,7 +479,11 @@ int WorkerPool::doProcessContextEvents() {
         LOG(INFO) << "Worker: Context " << context_.deviceName()
                   << " is now active";
     }
-    ibv_ack_async_event(&event);
+
+    if (!event_acked) {
+        ibv_ack_async_event(&event);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Description

This PR includes several bug fixes and improvments we revealed in production deployment.

* [54a85e34]: Fix timeout check in transfer_task
  Currently, the timeout check for a batch with size N takes up to N * 60 seconds, which is totally unacceptable. Use the correct start_ts of tasks to fix this.
* [d02d5631]: Do not include barex_transport.h when USE_BAREX is off
* [610b5b07]: Fix possible hang in TE
  Add timeout to readFully to avoid hanging when peer hangs.
* [af9abf9f]: Fix a possible deadlock when handling IB async events
* [2ee833bf]: Fix master evicting leased objects unexpectedly
  Add the missing lease check in second pass A of the eviction.
* [33753d4a]: Only optimize binary sizes in Release build
  Debug symbols is critical for debugging, don't remove them in non-release builds.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
