### PR TITLE
[CI] add configurable GitHub mirror fallback for Ascend checkout

### DIFF
--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -15,8 +15,8 @@ jobs:
 
     container:
       image: localhost:5000/mooncake-hixl-ci:v5
-      options: --privileged --user 0:0 --device /dev/davinci0 --device /dev/davinci1 --device /dev/davinci2 --device /dev/davinci3 
-                    --device /dev/davinci4 --device /dev/davinci5 --device /dev/davinci6 --device /dev/davinci7 
+      options: --privileged --user 0:0 --device /dev/davinci0 --device /dev/davinci1 --device /dev/davinci2 --device /dev/davinci3
+                    --device /dev/davinci4 --device /dev/davinci5 --device /dev/davinci6 --device /dev/davinci7
                     --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc --ulimit nproc=65535:65535
       env:
         GITHUB_ACTIONS: "true"
@@ -28,6 +28,63 @@ jobs:
         - /etc/hccn.conf:/etc/hccn.conf
 
     steps:
+    - name: Configure GitHub fetch fallback
+      shell: bash
+      env:
+        ASCEND_GITHUB_MIRROR_URLS: ${{ vars.ASCEND_GITHUB_MIRROR_URLS }}
+      run: |
+        set -euo pipefail
+
+        git config --global protocol.version 2
+        git config --global http.version HTTP/1.1
+        git config --global http.lowSpeedLimit 1024
+        git config --global http.lowSpeedTime 30
+
+        if [ -z "${ASCEND_GITHUB_MIRROR_URLS:-}" ]; then
+          echo "ASCEND_GITHUB_MIRROR_URLS is not set, using direct GitHub"
+          exit 0
+        fi
+
+        normalize_base() {
+          local base="$1"
+          base="${base#${base%%[![:space:]]*}}"
+          base="${base%${base##*[![:space:]]}}"
+          [ -n "$base" ] || return 1
+          [ "$base" = "https://github.com" ] && base="https://github.com/"
+          [ "$base" != "https://github.com/" ] && base="${base%/}/"
+          printf '%s\n' "$base"
+        }
+
+        candidates=()
+        while IFS= read -r raw; do
+          base="$(normalize_base "$raw" || true)"
+          [ -n "$base" ] && candidates+=("$base")
+        done < <(printf '%s\n' "$ASCEND_GITHUB_MIRROR_URLS" | tr ',;' '\n')
+        candidates+=("https://github.com/")
+
+        for base in "${candidates[@]}"; do
+          if [ "$base" = "https://github.com/" ]; then
+            test_url="https://github.com/${GITHUB_REPOSITORY}.git"
+          else
+            test_url="${base}https://github.com/${GITHUB_REPOSITORY}.git"
+          fi
+
+          echo "Probing ${test_url}"
+          if git ls-remote --exit-code "$test_url" HEAD >/dev/null 2>&1; then
+            if [ "$base" = "https://github.com/" ]; then
+              echo "Using direct GitHub"
+            else
+              git config --global url."${base}https://github.com/".insteadOf https://github.com/
+              echo "Using GitHub mirror prefix: ${base}"
+            fi
+            exit 0
+          fi
+
+          echo "Probe failed for ${base}, trying next candidate"
+        done
+
+        echo "No reachable GitHub mirror found, using direct GitHub"
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
@@ -120,7 +177,7 @@ jobs:
           # Check if master is running
           if ! kill -0 $MASTER_PID 2>/dev/null; then
               echo "Error: Mooncake Master failed to start"
-              cat /tmp/mooncake_master.log 
+              cat /tmp/mooncake_master.log
               exit 1
           fi
 
@@ -244,7 +301,7 @@ jobs:
 
           echo ""
           echo "All Hixl Mooncake Store tests completed successfully!"
-          
+
 
     - name: Test Summary
       if: always()

--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -28,21 +28,35 @@ jobs:
         - /etc/hccn.conf:/etc/hccn.conf
 
     steps:
-    - name: Configure GitHub fetch fallback
+    - name: Configure GitHub fetch defaults
       shell: bash
-      env:
-        ASCEND_GITHUB_MIRROR_URLS: ${{ vars.ASCEND_GITHUB_MIRROR_URLS }}
       run: |
-        set -euo pipefail
-
         git config --global protocol.version 2
         git config --global http.version HTTP/1.1
         git config --global http.lowSpeedLimit 1024
         git config --global http.lowSpeedTime 30
 
+    - name: Checkout code
+      id: checkout_code
+      continue-on-error: true
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.checkout_ref || github.sha }}
+        fetch-depth: 1
+        persist-credentials: false
+
+    - name: Retry checkout via GitHub mirror
+      if: steps.checkout_code.outcome == 'failure'
+      shell: bash
+      env:
+        ASCEND_GITHUB_MIRROR_URLS: ${{ vars.ASCEND_GITHUB_MIRROR_URLS }}
+        CHECKOUT_REF: ${{ inputs.checkout_ref || github.sha }}
+      run: |
+        set -euo pipefail
+
         if [ -z "${ASCEND_GITHUB_MIRROR_URLS:-}" ]; then
-          echo "ASCEND_GITHUB_MIRROR_URLS is not set, using direct GitHub"
-          exit 0
+          echo "Checkout from GitHub failed and ASCEND_GITHUB_MIRROR_URLS is not set"
+          exit 1
         fi
 
         normalize_base() {
@@ -58,39 +72,39 @@ jobs:
         candidates=()
         while IFS= read -r raw; do
           base="$(normalize_base "$raw" || true)"
-          [ -n "$base" ] && candidates+=("$base")
+          [ -n "$base" ] || continue
+          [ "$base" = "https://github.com/" ] && continue
+          candidates+=("$base")
         done < <(printf '%s\n' "$ASCEND_GITHUB_MIRROR_URLS" | tr ',;' '\n')
-        candidates+=("https://github.com/")
+
+        if [ ${#candidates[@]} -eq 0 ]; then
+          echo "Checkout from GitHub failed and no valid mirror candidates were configured"
+          exit 1
+        fi
+
+        workdir="${GITHUB_WORKSPACE}"
+        git config --global --add safe.directory "$workdir"
 
         for base in "${candidates[@]}"; do
-          if [ "$base" = "https://github.com/" ]; then
-            test_url="https://github.com/${GITHUB_REPOSITORY}.git"
-          else
-            test_url="${base}https://github.com/${GITHUB_REPOSITORY}.git"
-          fi
+          mirror_url="${base}https://github.com/${GITHUB_REPOSITORY}.git"
+          echo "Retrying checkout with ${mirror_url}"
 
-          echo "Probing ${test_url}"
-          if git ls-remote --exit-code "$test_url" HEAD >/dev/null 2>&1; then
-            if [ "$base" = "https://github.com/" ]; then
-              echo "Using direct GitHub"
-            else
-              git config --global url."${base}https://github.com/".insteadOf https://github.com/
-              echo "Using GitHub mirror prefix: ${base}"
-            fi
+          find "$workdir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          git init "$workdir"
+          git -C "$workdir" remote add origin "$mirror_url"
+
+          if git -C "$workdir" fetch --depth=1 origin "$CHECKOUT_REF" && \
+             git -C "$workdir" checkout --force --detach FETCH_HEAD; then
+            echo "Mirror checkout succeeded via ${base}"
             exit 0
           fi
 
-          echo "Probe failed for ${base}, trying next candidate"
+          echo "Mirror checkout failed via ${base}"
+          rm -rf "$workdir/.git"
         done
 
-        echo "No reachable GitHub mirror found, using direct GitHub"
-
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.checkout_ref || github.sha }}
-        fetch-depth: 1
-        persist-credentials: false
+        echo "Direct GitHub checkout failed and all mirror retries failed"
+        exit 1
 
     - name: Configure CMake
       shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     hooks:
       - id: codespell
         exclude: '^(extern/|FAST25-release/)'
-        args: ['--ignore-words-list=te,mooncake,KVCache']
+        args: ['--ignore-words-list=te,mooncake,KVCache,cann']
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v20.1.8


### PR DESCRIPTION
## Description

This PR makes the Ascend E2E checkout flow more resilient on the self-hosted runner.

The recent `ascend-test / build-and-test` failure happened before CMake started, during `actions/checkout` fetching from GitHub. Instead of changing the default path, this PR keeps the original direct GitHub checkout behavior and only adds a mirror-based retry when that checkout fails.

Specifically, this change:

- keeps the original `actions/checkout@v4` path as the first attempt
- adds a fallback step that runs only when the direct checkout fails
- retries checkout with candidate GitHub mirror prefixes from the repository variable `ASCEND_GITHUB_MIRROR_URLS`
- performs a real shallow fetch of the target ref during retry, instead of using a lightweight connectivity probe
- keeps direct GitHub as the default behavior when the initial checkout succeeds

This keeps the workflow behavior simple and conservative: no mirror is used unless the original checkout path actually fails.

After this PR is merged, we should configure the repository Actions variable below in `kvcache-ai/Mooncake`:

- `ASCEND_GITHUB_MIRROR_URLS`

The value should be a comma- or semicolon-separated list of candidate mirror prefixes, for example:

- `https://ghproxy.com/`

If the variable is not configured, the workflow will still behave as before; the only difference is that a failed direct checkout will not have mirror candidates available for retry.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Full end-to-end validation requires the workflow change to be merged to `main`, because the current Ascend E2E job is triggered from the workflow definition on `main`.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
