### PR TITLE
[Store] Support storage hierarchy with offload-on-evict mode

### DIFF
--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -81,6 +81,10 @@ struct MasterConfig {
     std::string cxl_path;
     size_t cxl_size;
     bool enable_cxl = false;
+
+    // Offload-on-evict: defer LOCAL_DISK offload to eviction time
+    bool offload_on_evict = false;
+    bool offload_force_evict = false;
 };
 
 class MasterServiceSupervisorConfig {
@@ -140,6 +144,8 @@ class MasterServiceSupervisorConfig {
     std::string cxl_path = DEFAULT_CXL_PATH;
     size_t cxl_size = DEFAULT_CXL_SIZE;
     bool enable_cxl = false;
+    bool offload_on_evict = false;
+    bool offload_force_evict = false;
     MasterServiceSupervisorConfig() = default;
 
     // From MasterConfig
@@ -155,6 +161,8 @@ class MasterServiceSupervisorConfig {
         eviction_high_watermark_ratio = config.eviction_high_watermark_ratio;
         client_live_ttl_sec = config.client_live_ttl_sec;
         enable_offload = config.enable_offload;
+        offload_on_evict = config.offload_on_evict;
+        offload_force_evict = config.offload_force_evict;
         rpc_port = static_cast<int>(config.rpc_port);
         rpc_thread_num = static_cast<size_t>(config.rpc_thread_num);
 
@@ -267,6 +275,8 @@ class WrappedMasterServiceConfig {
     int64_t client_live_ttl_sec = DEFAULT_CLIENT_LIVE_TTL_SEC;
     bool enable_ha = false;
     bool enable_offload = false;
+    bool offload_on_evict = false;
+    bool offload_force_evict = false;
     std::string ha_backend_type = "etcd";
     std::string ha_backend_connstring;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
@@ -322,6 +332,8 @@ class WrappedMasterServiceConfig {
         client_live_ttl_sec = config.client_live_ttl_sec;
         enable_ha = config.enable_ha;
         enable_offload = config.enable_offload;
+        offload_on_evict = config.offload_on_evict;
+        offload_force_evict = config.offload_force_evict;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = config.ha_backend_connstring;
         if (ha_backend_connstring.empty()) {
@@ -400,6 +412,8 @@ class WrappedMasterServiceConfig {
         enable_ha =
             true;  // This is used in HA mode, so enable_ha should be true
         enable_offload = config.enable_offload;
+        offload_on_evict = config.offload_on_evict;
+        offload_force_evict = config.offload_force_evict;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = config.ha_backend_connstring;
         if (ha_backend_connstring.empty()) {
@@ -736,6 +750,8 @@ class MasterServiceConfig {
     int64_t client_live_ttl_sec = DEFAULT_CLIENT_LIVE_TTL_SEC;
     bool enable_ha = false;
     bool enable_offload = false;
+    bool offload_on_evict = false;
+    bool offload_force_evict = false;
     std::string ha_backend_type = "etcd";
     std::string ha_backend_connstring;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
@@ -787,6 +803,8 @@ class MasterServiceConfig {
         client_live_ttl_sec = config.client_live_ttl_sec;
         enable_ha = config.enable_ha;
         enable_offload = config.enable_offload;
+        offload_on_evict = config.offload_on_evict;
+        offload_force_evict = config.offload_force_evict;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = config.ha_backend_connstring;
         cluster_id = config.cluster_id;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1168,11 +1168,11 @@ class MasterService {
 
     const bool enable_offload_;
 
-    // Offload-on-evict: defer disk offload to eviction time (env:
-    // MOONCAKE_OFFLOAD_ON_EVICT)
+    // Offload-on-evict: defer disk offload to eviction time
+    // (config: offload_on_evict)
     bool offload_on_evict_{false};
     // Force-evict: allow evicting MEMORY replicas without disk offload when cap
-    // exceeded (env: MOONCAKE_OFFLOAD_FORCE_EVICT, only effective when
+    // exceeded (config: offload_force_evict, only effective when
     // offload_on_evict_=true)
     bool offload_force_evict_{false};
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1168,6 +1168,14 @@ class MasterService {
 
     const bool enable_offload_;
 
+    // Offload-on-evict: defer disk offload to eviction time (env:
+    // MOONCAKE_OFFLOAD_ON_EVICT)
+    bool offload_on_evict_{false};
+    // Force-evict: allow evicting MEMORY replicas without disk offload when cap
+    // exceeded (env: MOONCAKE_OFFLOAD_FORCE_EVICT, only effective when
+    // offload_on_evict_=true)
+    bool offload_force_evict_{false};
+
     const std::string ha_backend_type_;
 
     const std::string ha_backend_connstring_;

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -109,6 +109,10 @@ DEFINE_validator(eviction_ratio, [](const char* flagname, double value) {
 DEFINE_bool(enable_ha, false,
             "Enable high availability, which depends on etcd");
 DEFINE_bool(enable_offload, false, "Enable offload availability");
+DEFINE_bool(offload_on_evict, false,
+            "Defer LOCAL_DISK offload to eviction time instead of PutEnd");
+DEFINE_bool(offload_force_evict, false,
+            "Force-evict objects exceeding offload cap without disk offload");
 DEFINE_string(ha_backend_type, "etcd",
               "HA backend type, e.g. etcd | redis | k8s");
 DEFINE_string(ha_backend_connstring, "",
@@ -293,6 +297,11 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                            FLAGS_enable_ha);
     default_config.GetBool("enable_offload", &master_config.enable_offload,
                            FLAGS_enable_offload);
+    default_config.GetBool("offload_on_evict", &master_config.offload_on_evict,
+                           FLAGS_offload_on_evict);
+    default_config.GetBool("offload_force_evict",
+                           &master_config.offload_force_evict,
+                           FLAGS_offload_force_evict);
     default_config.GetString("ha_backend_type", &master_config.ha_backend_type,
                              FLAGS_ha_backend_type);
     default_config.GetString("ha_backend_connstring",
@@ -867,6 +876,8 @@ int main(int argc, char* argv[]) {
         << master_config.eviction_high_watermark_ratio
         << ", enable_ha=" << master_config.enable_ha
         << ", enable_offload=" << master_config.enable_offload
+        << ", offload_on_evict=" << master_config.offload_on_evict
+        << ", offload_force_evict=" << master_config.offload_force_evict
         << ", ha_backend_type=" << master_config.ha_backend_type
         << ", ha_backend_connstring=" << ha_backend_connstring
         << ", etcd_endpoints=" << master_config.etcd_endpoints

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -159,6 +159,23 @@ MasterService::MasterService(const MasterServiceConfig& config)
             "put_start_discard_timeout_sec");
     }
 
+    // Offload-on-evict: defer LOCAL_DISK offload to eviction time
+    {
+        const char* env = std::getenv("MOONCAKE_OFFLOAD_ON_EVICT");
+        offload_on_evict_ = enable_offload_ && env && std::string(env) == "1";
+        if (offload_on_evict_) {
+            LOG(INFO) << "Offload-on-evict mode enabled: DRAM offload to "
+                         "LOCAL_DISK will occur at eviction time instead of "
+                         "PutEnd";
+            const char* force_env = std::getenv("MOONCAKE_OFFLOAD_FORCE_EVICT");
+            offload_force_evict_ = force_env && std::string(force_env) == "1";
+            if (offload_force_evict_) {
+                LOG(INFO) << "Force-evict enabled: objects exceeding offload "
+                             "cap will be evicted without disk offload";
+            }
+        }
+    }
+
     eviction_running_ = true;
     eviction_thread_ = std::thread(&MasterService::EvictionThreadFunc, this);
     VLOG(1) << "action=start_eviction_thread";
@@ -910,7 +927,7 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
         },
         [](Replica& replica) { replica.mark_complete(); });
 
-    if (enable_offload_) {
+    if (enable_offload_ && !offload_on_evict_) {
         auto& shard = accessor.GetShard();
         metadata.VisitReplicas(
             &Replica::fn_is_completed, [this, &key, &shard](Replica& replica) {
@@ -3491,6 +3508,66 @@ void MasterService::BatchEvict(double evict_ratio_target,
         });
     };
 
+    // --- Offload-on-evict support ---
+    long offload_queued_this_cycle = 0;
+    long offload_deferred_count = 0;
+    const long offload_cap =
+        offload_on_evict_ ? static_cast<long>(offloading_queue_limit_ * 0.5)
+                          : 0;
+
+    auto has_local_disk_replica = [](const ObjectMetadata& metadata) {
+        return metadata.HasReplica(&Replica::fn_is_local_disk_replica);
+    };
+
+    // Returns freed bytes. Returns 0 if offload-queued (no memory freed yet).
+    auto try_evict_or_offload =
+        [&](const std::string& key, ObjectMetadata& metadata,
+            MetadataShardAccessorRW& shard) -> uint64_t {
+        if (!offload_on_evict_) {
+            // Original behavior
+            return metadata.size * evict_replicas(metadata);
+        }
+
+        // LOCAL_DISK replica already exists — safe to delete MEMORY immediately
+        if (has_local_disk_replica(metadata)) {
+            return metadata.size * evict_replicas(metadata);
+        }
+
+        // Force-evict cap: if force_evict enabled and cap reached, force delete
+        if (offload_force_evict_ && offload_queued_this_cycle >= offload_cap) {
+            LOG(WARNING) << "[EVICT] Offload cap reached, force-evicting key="
+                         << key << " without disk offload";
+            return metadata.size * evict_replicas(metadata);
+        }
+
+        // Queue for offload: push to offloading queue + inc_refcnt
+        bool queued = false;
+        metadata.VisitReplicas(
+            [](const Replica& r) {
+                return r.is_memory_replica() && r.is_completed() &&
+                       r.get_refcnt() == 0;
+            },
+            [this, &key, &shard, &queued](Replica& replica) {
+                auto result = PushOffloadingQueue(key, replica);
+                if (result) {
+                    replica.inc_refcnt();
+                    shard->offloading_tasks.emplace(
+                        key, OffloadingTask{replica.id(),
+                                            std::chrono::system_clock::now()});
+                    queued = true;
+                }
+            });
+
+        if (queued) {
+            offload_queued_this_cycle++;
+            offload_deferred_count++;
+            return 0;  // No memory freed yet
+        }
+
+        // PushOffloadingQueue failed — force-evict as fallback
+        return metadata.size * evict_replicas(metadata);
+    };
+
     // Randomly select a starting shard to avoid imbalance eviction between
     // shards. No need to use expensive random_device here.
     size_t start_idx = rand() % kNumShards;
@@ -3563,16 +3640,18 @@ void MasterService::BatchEvict(double evict_ratio_target,
                     continue;
                 }
                 if (it->second.lease_timeout <= target_timeout) {
-                    // Evict this object
-                    total_freed_size +=
-                        it->second.size *
-                        evict_replicas(it->second);  // Erase memory replicas
+                    // Evict this object (or defer for offload)
+                    uint64_t freed =
+                        try_evict_or_offload(it->first, it->second, shard);
+                    total_freed_size += freed;
                     if (it->second.IsValid() == false) {
                         it = shard->metadata.erase(it);
                     } else {
                         ++it;
                     }
-                    shard_evicted_count++;
+                    if (freed > 0) {
+                        shard_evicted_count++;
+                    }
                 } else {
                     // second pass candidates
                     no_pin_objects.push_back(it->second.lease_timeout);
@@ -3624,17 +3703,18 @@ void MasterService::BatchEvict(double evict_ratio_target,
                         it->second.lease_timeout <= target_timeout &&
                         !it->second.IsSoftPinned(now) &&
                         can_evict_replicas(it->second)) {
-                        // Evict this object
-                        total_freed_size +=
-                            it->second.size *
-                            evict_replicas(
-                                it->second);  // Erase memory replicas
+                        // Evict this object (or defer for offload)
+                        uint64_t freed =
+                            try_evict_or_offload(it->first, it->second, shard);
+                        total_freed_size += freed;
                         if (it->second.IsValid() == false) {
                             it = shard->metadata.erase(it);
                         } else {
                             ++it;
                         }
-                        evicted_count++;
+                        if (freed > 0) {
+                            evicted_count++;
+                        }
                         target_evict_num--;
                     } else {
                         ++it;
@@ -3674,16 +3754,18 @@ void MasterService::BatchEvict(double evict_ratio_target,
                     // and lease timeout less than or equal to target.
                     if (!it->second.IsSoftPinned(now) ||
                         it->second.lease_timeout <= soft_target_timeout) {
-                        total_freed_size +=
-                            it->second.size *
-                            evict_replicas(
-                                it->second);  // Erase memory replicas
+                        // Evict this object (or defer for offload)
+                        uint64_t freed =
+                            try_evict_or_offload(it->first, it->second, shard);
+                        total_freed_size += freed;
                         if (it->second.IsValid() == false) {
                             it = shard->metadata.erase(it);
                         } else {
                             ++it;
                         }
-                        evicted_count++;
+                        if (freed > 0) {
+                            evicted_count++;
+                        }
                         target_evict_num--;
                     } else {
                         ++it;
@@ -3704,7 +3786,11 @@ void MasterService::BatchEvict(double evict_ratio_target,
         }
     }
 
-    if (evicted_count > 0 || released_discarded_cnt > 0) {
+    if (evicted_count > 0 || released_discarded_cnt > 0 ||
+        offload_deferred_count > 0) {
+        // Offload-deferred counts as partial success: work was done (objects
+        // queued for disk offload), so suppress re-triggering until the next
+        // watermark breach or explicit need_eviction_ signal.
         need_eviction_ = false;
         MasterMetricManager::instance().inc_eviction_success(evicted_count,
                                                              total_freed_size);
@@ -3716,7 +3802,14 @@ void MasterService::BatchEvict(double evict_ratio_target,
         MasterMetricManager::instance().inc_eviction_fail();
     }
     VLOG(1) << "action=evict_objects" << ", evicted_count=" << evicted_count
+            << ", offload_deferred=" << offload_deferred_count
             << ", total_freed_size=" << total_freed_size;
+    if (offload_on_evict_ && evicted_count == 0 && offload_deferred_count > 0) {
+        LOG(WARNING) << "[EVICT] No memory freed this cycle; "
+                     << offload_deferred_count
+                     << " objects deferred for disk offload. "
+                        "Consider lowering eviction_high_watermark_ratio.";
+    }
 }
 
 void MasterService::ClientMonitorFunc() {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -48,6 +48,13 @@ namespace {
 
 constexpr size_t kUnlimitedSnapshotList = 0;
 
+// Per-cycle offload cap as a fraction of `offloading_queue_limit_`. Used only
+// when offload-on-evict mode is active. Defers memory eviction for at most
+// this fraction of the queue limit per BatchEvict cycle; beyond that, eviction
+// falls back according to `offload_force_evict_`. A future change may expose
+// this as a configurable parameter if workloads demand tuning.
+constexpr double kOffloadCapRatio = 0.5;
+
 enum class SnapshotCatalogBackendKind {
     kEmbedded,
     kRedis,
@@ -3511,18 +3518,22 @@ void MasterService::BatchEvict(double evict_ratio_target,
     // --- Offload-on-evict support ---
     long offload_queued_this_cycle = 0;
     long offload_deferred_count = 0;
+    long offload_cap_forced_count = 0;    // #keys force-evicted due to cap
+    long offload_push_failed_forced = 0;  // #keys force-evicted on push fail
     const long offload_cap =
-        offload_on_evict_ ? static_cast<long>(offloading_queue_limit_ * 0.5)
-                          : 0;
+        offload_on_evict_
+            ? static_cast<long>(offloading_queue_limit_ * kOffloadCapRatio)
+            : 0;
 
     auto has_local_disk_replica = [](const ObjectMetadata& metadata) {
         return metadata.HasReplica(&Replica::fn_is_local_disk_replica);
     };
 
-    // Returns freed bytes. Returns 0 if offload-queued (no memory freed yet).
+    // Returns freed bytes. Returns 0 if offload-queued and no additional
+    // replicas were evicted (all MEMORY replicas of the key are now pinned).
     auto try_evict_or_offload =
-        [&](const std::string& key, ObjectMetadata& metadata,
-            MetadataShardAccessorRW& shard) -> uint64_t {
+        [&, this](const std::string& key, ObjectMetadata& metadata,
+                  MetadataShardAccessorRW& shard) -> uint64_t {
         if (!offload_on_evict_) {
             // Original behavior
             return metadata.size * evict_replicas(metadata);
@@ -3533,27 +3544,28 @@ void MasterService::BatchEvict(double evict_ratio_target,
             return metadata.size * evict_replicas(metadata);
         }
 
-        // Force-evict cap: if force_evict enabled and cap reached, force delete
+        // Force-evict cap: if force_evict enabled and cap reached, force
+        // delete. Warning is aggregated at the end of the cycle to avoid log
+        // flooding.
         if (offload_force_evict_ && offload_queued_this_cycle >= offload_cap) {
-            LOG(WARNING) << "[EVICT] Offload cap reached, force-evicting key="
-                         << key << " without disk offload";
+            offload_cap_forced_count++;
             return metadata.size * evict_replicas(metadata);
         }
 
-        // Queue for offload: push to offloading queue + inc_refcnt
+        // Queue one MEMORY replica for offload; others will be evicted below.
         bool queued = false;
         metadata.VisitReplicas(
             [](const Replica& r) {
                 return r.is_memory_replica() && r.is_completed() &&
                        r.get_refcnt() == 0;
             },
-            [this, &key, &shard, &queued](Replica& replica) {
+            [this, &key, &shard, &queued, &now](Replica& replica) {
+                if (queued) return;  // only need to pin one replica for offload
                 auto result = PushOffloadingQueue(key, replica);
                 if (result) {
                     replica.inc_refcnt();
                     shard->offloading_tasks.emplace(
-                        key, OffloadingTask{replica.id(),
-                                            std::chrono::system_clock::now()});
+                        key, OffloadingTask{replica.id(), now});
                     queued = true;
                 }
             });
@@ -3561,11 +3573,21 @@ void MasterService::BatchEvict(double evict_ratio_target,
         if (queued) {
             offload_queued_this_cycle++;
             offload_deferred_count++;
-            return 0;  // No memory freed yet
+            // Any remaining MEMORY replicas with refcnt==0 are redundant copies
+            // (data survives via the pinned replica → disk). Evict them now to
+            // reclaim memory immediately rather than waiting another cycle.
+            return metadata.size * evict_replicas(metadata);
         }
 
-        // PushOffloadingQueue failed — force-evict as fallback
-        return metadata.size * evict_replicas(metadata);
+        // PushOffloadingQueue failed. Default (data-preserving) behavior is to
+        // skip this cycle — the outer eviction loop will retry after the
+        // offload queue drains. Only force-evict when explicitly opted in, to
+        // prevent silent data loss when the queue is unavailable.
+        if (offload_force_evict_) {
+            offload_push_failed_forced++;
+            return metadata.size * evict_replicas(metadata);
+        }
+        return 0;
     };
 
     // Randomly select a starting shard to avoid imbalance eviction between
@@ -3803,12 +3825,25 @@ void MasterService::BatchEvict(double evict_ratio_target,
     }
     VLOG(1) << "action=evict_objects" << ", evicted_count=" << evicted_count
             << ", offload_deferred=" << offload_deferred_count
+            << ", offload_cap_forced=" << offload_cap_forced_count
+            << ", offload_push_failed_forced=" << offload_push_failed_forced
             << ", total_freed_size=" << total_freed_size;
     if (offload_on_evict_ && evicted_count == 0 && offload_deferred_count > 0) {
         LOG(WARNING) << "[EVICT] No memory freed this cycle; "
                      << offload_deferred_count
                      << " objects deferred for disk offload. "
                         "Consider lowering eviction_high_watermark_ratio.";
+    }
+    if (offload_cap_forced_count > 0) {
+        LOG(WARNING) << "[EVICT] Offload cap (" << offload_cap
+                     << ") reached; force-evicted " << offload_cap_forced_count
+                     << " object(s) without disk offload this cycle.";
+    }
+    if (offload_push_failed_forced > 0) {
+        LOG(WARNING) << "[EVICT] PushOffloadingQueue failed for "
+                     << offload_push_failed_forced
+                     << " object(s); force-evicted without disk offload "
+                        "(MOONCAKE_OFFLOAD_FORCE_EVICT=1).";
     }
 }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -167,19 +167,15 @@ MasterService::MasterService(const MasterServiceConfig& config)
     }
 
     // Offload-on-evict: defer LOCAL_DISK offload to eviction time
-    {
-        const char* env = std::getenv("MOONCAKE_OFFLOAD_ON_EVICT");
-        offload_on_evict_ = enable_offload_ && env && std::string(env) == "1";
-        if (offload_on_evict_) {
-            LOG(INFO) << "Offload-on-evict mode enabled: DRAM offload to "
-                         "LOCAL_DISK will occur at eviction time instead of "
-                         "PutEnd";
-            const char* force_env = std::getenv("MOONCAKE_OFFLOAD_FORCE_EVICT");
-            offload_force_evict_ = force_env && std::string(force_env) == "1";
-            if (offload_force_evict_) {
-                LOG(INFO) << "Force-evict enabled: objects exceeding offload "
-                             "cap will be evicted without disk offload";
-            }
+    offload_on_evict_ = enable_offload_ && config.offload_on_evict;
+    if (offload_on_evict_) {
+        LOG(INFO) << "Offload-on-evict mode enabled: DRAM offload to "
+                     "LOCAL_DISK will occur at eviction time instead of "
+                     "PutEnd";
+        offload_force_evict_ = config.offload_force_evict;
+        if (offload_force_evict_) {
+            LOG(INFO) << "Force-evict enabled: objects exceeding offload "
+                         "cap will be evicted without disk offload";
         }
     }
 
@@ -3843,7 +3839,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
         LOG(WARNING) << "[EVICT] PushOffloadingQueue failed for "
                      << offload_push_failed_forced
                      << " object(s); force-evicted without disk offload "
-                        "(MOONCAKE_OFFLOAD_FORCE_EVICT=1).";
+                        "(offload_force_evict=true).";
     }
 }
 

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_store_test(eviction_strategy_test eviction_strategy_test.cpp)
 add_store_test(master_service_test master_service_test.cpp)
 add_store_test(batch_remove_test batch_remove_test.cpp)
 add_store_test(master_service_ssd_test master_service_ssd_test.cpp)
+add_store_test(offload_on_evict_test offload_on_evict_test.cpp)
 add_store_test(master_service_ssd_test_for_snapshot
                ha/snapshot/master_service_ssd_test_for_snapshot.cpp)
 add_store_test(client_integration_test client_integration_test.cpp)

--- a/mooncake-store/tests/offload_on_evict_test.cpp
+++ b/mooncake-store/tests/offload_on_evict_test.cpp
@@ -5,7 +5,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <cstdlib>
 #include <memory>
 #include <string>
 #include <thread>
@@ -15,37 +14,14 @@
 
 namespace mooncake::test {
 
-// RAII helper to set/unset environment variables per test
-class ScopedEnv {
-   public:
-    ScopedEnv(const char* name, const char* value) : name_(name) {
-        if (value) {
-            setenv(name, value, /*overwrite=*/1);
-        } else {
-            unsetenv(name);
-        }
-    }
-    ~ScopedEnv() { unsetenv(name_); }
-
-   private:
-    const char* name_;
-};
-
 class OffloadOnEvictTest : public ::testing::Test {
    protected:
     void SetUp() override {
         google::InitGoogleLogging("OffloadOnEvictTest");
         FLAGS_logtostderr = true;
-        // Clean env vars before each test
-        unsetenv("MOONCAKE_OFFLOAD_ON_EVICT");
-        unsetenv("MOONCAKE_OFFLOAD_FORCE_EVICT");
     }
 
-    void TearDown() override {
-        unsetenv("MOONCAKE_OFFLOAD_ON_EVICT");
-        unsetenv("MOONCAKE_OFFLOAD_FORCE_EVICT");
-        google::ShutdownGoogleLogging();
-    }
+    void TearDown() override { google::ShutdownGoogleLogging(); }
 
     static constexpr size_t kDefaultSegmentBase = 0x300000000;
 
@@ -136,11 +112,10 @@ class OffloadOnEvictTest : public ::testing::Test {
 };
 
 // =============================================================================
-// Combo A: No env vars (default — offload at PutEnd)
+// Combo A: Default config (offload at PutEnd)
 // =============================================================================
 
 TEST_F(OffloadOnEvictTest, ComboA_OffloadAtPutEnd) {
-    // No env vars set — default behavior
     MasterServiceConfig config;
     config.enable_offload = true;
     config.default_kv_lease_ttl = 2000;
@@ -195,14 +170,13 @@ TEST_F(OffloadOnEvictTest, ComboA_EvictionWorks) {
 }
 
 // =============================================================================
-// Combo B: MOONCAKE_OFFLOAD_ON_EVICT=1 (offload on evict, no force-evict)
+// Combo B: offload_on_evict=true (offload on evict, no force-evict)
 // =============================================================================
 
 TEST_F(OffloadOnEvictTest, ComboB_PutEndSkipsOffloadQueue) {
-    ScopedEnv env("MOONCAKE_OFFLOAD_ON_EVICT", "1");
-
     MasterServiceConfig config;
     config.enable_offload = true;
+    config.offload_on_evict = true;
     config.default_kv_lease_ttl = 2000;
     auto service = std::make_unique<MasterService>(config);
 
@@ -225,11 +199,10 @@ TEST_F(OffloadOnEvictTest, ComboB_PutEndSkipsOffloadQueue) {
 }
 
 TEST_F(OffloadOnEvictTest, ComboB_EvictionTriggersOffload) {
-    ScopedEnv env("MOONCAKE_OFFLOAD_ON_EVICT", "1");
-
     const uint64_t kv_lease_ttl = 2000;
     MasterServiceConfig config;
     config.enable_offload = true;
+    config.offload_on_evict = true;
     config.default_kv_lease_ttl = kv_lease_ttl;
     auto service = std::make_unique<MasterService>(config);
 
@@ -275,11 +248,10 @@ TEST_F(OffloadOnEvictTest, ComboB_NoFallbackWithoutForceEvict) {
     // Without force_evict AND without a LocalDiskSegment, offload queue push
     // fails and eviction does NOT force-delete MEMORY (data-preserving).
     // The segment fills and subsequent puts fail — this is the safe default.
-    ScopedEnv env("MOONCAKE_OFFLOAD_ON_EVICT", "1");
-
     const uint64_t kv_lease_ttl = 2000;
     MasterServiceConfig config;
     config.enable_offload = true;
+    config.offload_on_evict = true;
     config.default_kv_lease_ttl = kv_lease_ttl;
     auto service = std::make_unique<MasterService>(config);
 
@@ -301,15 +273,14 @@ TEST_F(OffloadOnEvictTest, ComboB_NoFallbackWithoutForceEvict) {
 }
 
 // =============================================================================
-// Combo C: MOONCAKE_OFFLOAD_ON_EVICT=1 + MOONCAKE_OFFLOAD_FORCE_EVICT=1
+// Combo C: offload_on_evict=true + offload_force_evict=true
 // =============================================================================
 
 TEST_F(OffloadOnEvictTest, ComboC_PutEndSkipsOffloadQueue) {
-    ScopedEnv env1("MOONCAKE_OFFLOAD_ON_EVICT", "1");
-    ScopedEnv env2("MOONCAKE_OFFLOAD_FORCE_EVICT", "1");
-
     MasterServiceConfig config;
     config.enable_offload = true;
+    config.offload_on_evict = true;
+    config.offload_force_evict = true;
     config.default_kv_lease_ttl = 2000;
     auto service = std::make_unique<MasterService>(config);
 
@@ -331,12 +302,11 @@ TEST_F(OffloadOnEvictTest, ComboC_PutEndSkipsOffloadQueue) {
 }
 
 TEST_F(OffloadOnEvictTest, ComboC_EvictionWithForceEvict) {
-    ScopedEnv env1("MOONCAKE_OFFLOAD_ON_EVICT", "1");
-    ScopedEnv env2("MOONCAKE_OFFLOAD_FORCE_EVICT", "1");
-
     const uint64_t kv_lease_ttl = 2000;
     MasterServiceConfig config;
     config.enable_offload = true;
+    config.offload_on_evict = true;
+    config.offload_force_evict = true;
     config.default_kv_lease_ttl = kv_lease_ttl;
     auto service = std::make_unique<MasterService>(config);
 
@@ -361,14 +331,13 @@ TEST_F(OffloadOnEvictTest, ComboC_EvictionWithForceEvict) {
 }
 
 // =============================================================================
-// Combo D: MOONCAKE_OFFLOAD_FORCE_EVICT=1 only (should be no-op)
+// Combo D: offload_force_evict=true only (should be no-op without on_evict)
 // =============================================================================
 
 TEST_F(OffloadOnEvictTest, ComboD_ForceEvictAloneIsIgnored) {
-    ScopedEnv env("MOONCAKE_OFFLOAD_FORCE_EVICT", "1");
-
     MasterServiceConfig config;
     config.enable_offload = true;
+    config.offload_force_evict = true;  // on_evict is false → force is ignored
     config.default_kv_lease_ttl = 2000;
     auto service = std::make_unique<MasterService>(config);
 
@@ -390,11 +359,10 @@ TEST_F(OffloadOnEvictTest, ComboD_ForceEvictAloneIsIgnored) {
 }
 
 TEST_F(OffloadOnEvictTest, ComboD_EvictionWorks) {
-    ScopedEnv env("MOONCAKE_OFFLOAD_FORCE_EVICT", "1");
-
     const uint64_t kv_lease_ttl = 2000;
     MasterServiceConfig config;
     config.enable_offload = true;
+    config.offload_force_evict = true;  // on_evict is false → force is ignored
     config.default_kv_lease_ttl = kv_lease_ttl;
     auto service = std::make_unique<MasterService>(config);
 

--- a/mooncake-store/tests/offload_on_evict_test.cpp
+++ b/mooncake-store/tests/offload_on_evict_test.cpp
@@ -271,7 +271,10 @@ TEST_F(OffloadOnEvictTest, ComboB_EvictionTriggersOffload) {
     service->RemoveAll();
 }
 
-TEST_F(OffloadOnEvictTest, ComboB_FallbackWhenNoLocalDiskSegment) {
+TEST_F(OffloadOnEvictTest, ComboB_NoFallbackWithoutForceEvict) {
+    // Without force_evict AND without a LocalDiskSegment, offload queue push
+    // fails and eviction does NOT force-delete MEMORY (data-preserving).
+    // The segment fills and subsequent puts fail — this is the safe default.
     ScopedEnv env("MOONCAKE_OFFLOAD_ON_EVICT", "1");
 
     const uint64_t kv_lease_ttl = 2000;
@@ -286,11 +289,12 @@ TEST_F(OffloadOnEvictTest, ComboB_FallbackWhenNoLocalDiskSegment) {
     auto ctx =
         PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
 
-    // Should still work via force-evict fallback (PushOffloadingQueue fails)
+    // Without force_evict, push failures mean DRAM cannot be freed,
+    // so we can only put up to segment capacity (no overflow).
     int success_puts = FillSegmentUntilEviction(
         *service, ctx.client_id, "evict_b2_", object_size, 1024 * 16 + 50);
-    EXPECT_GT(success_puts, 1024 * 16)
-        << "Offload-on-evict: fallback eviction should work without local disk";
+    EXPECT_LE(success_puts, 1024 * 16)
+        << "Without force_evict, segment should fill and stay full";
 
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
     service->RemoveAll();

--- a/mooncake-store/tests/offload_on_evict_test.cpp
+++ b/mooncake-store/tests/offload_on_evict_test.cpp
@@ -1,0 +1,416 @@
+#include "master_service.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "types.h"
+
+namespace mooncake::test {
+
+// RAII helper to set/unset environment variables per test
+class ScopedEnv {
+   public:
+    ScopedEnv(const char* name, const char* value) : name_(name) {
+        if (value) {
+            setenv(name, value, /*overwrite=*/1);
+        } else {
+            unsetenv(name);
+        }
+    }
+    ~ScopedEnv() { unsetenv(name_); }
+
+   private:
+    const char* name_;
+};
+
+class OffloadOnEvictTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("OffloadOnEvictTest");
+        FLAGS_logtostderr = true;
+        // Clean env vars before each test
+        unsetenv("MOONCAKE_OFFLOAD_ON_EVICT");
+        unsetenv("MOONCAKE_OFFLOAD_FORCE_EVICT");
+    }
+
+    void TearDown() override {
+        unsetenv("MOONCAKE_OFFLOAD_ON_EVICT");
+        unsetenv("MOONCAKE_OFFLOAD_FORCE_EVICT");
+        google::ShutdownGoogleLogging();
+    }
+
+    static constexpr size_t kDefaultSegmentBase = 0x300000000;
+
+    Segment MakeSegment(std::string name, size_t base, size_t size) const {
+        Segment segment;
+        segment.id = generate_uuid();
+        segment.name = std::move(name);
+        segment.base = base;
+        segment.size = size;
+        segment.te_endpoint = segment.name;
+        return segment;
+    }
+
+    struct MountedSegmentContext {
+        UUID segment_id;
+        UUID client_id;
+    };
+
+    MountedSegmentContext PrepareSegment(MasterService& service,
+                                         std::string name, size_t base,
+                                         size_t size) const {
+        Segment segment = MakeSegment(std::move(name), base, size);
+        UUID client_id = generate_uuid();
+        auto mount_result = service.MountSegment(segment, client_id);
+        EXPECT_TRUE(mount_result.has_value());
+        return {.segment_id = segment.id, .client_id = client_id};
+    }
+
+    // Put an object and complete it.
+    void PutObject(MasterService& service, const UUID& client_id,
+                   const std::string& key, size_t size = 1024) {
+        ReplicateConfig config;
+        config.replica_num = 1;
+        auto put_start = service.PutStart(client_id, key, size, config);
+        ASSERT_TRUE(put_start.has_value()) << "PutStart failed for key=" << key;
+        auto put_end = service.PutEnd(client_id, key, ReplicaType::MEMORY);
+        ASSERT_TRUE(put_end.has_value()) << "PutEnd failed for key=" << key;
+    }
+
+    // Drain the offload queue via OffloadObjectHeartbeat.
+    std::unordered_map<std::string, int64_t> DrainOffloadQueue(
+        MasterService& service, const UUID& client_id) {
+        auto res = service.OffloadObjectHeartbeat(client_id, true);
+        if (!res) {
+            return {};
+        }
+        return std::move(res.value());
+    }
+
+    template <typename Predicate>
+    void WaitUntil(
+        Predicate&& predicate,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds(4000),
+        std::chrono::milliseconds interval =
+            std::chrono::milliseconds(50)) const {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (predicate()) {
+                return;
+            }
+            std::this_thread::sleep_for(interval);
+        }
+        EXPECT_TRUE(predicate());
+    }
+
+    // Fill a segment until PutStart fails, triggering eviction.
+    // Returns the number of successful puts.
+    int FillSegmentUntilEviction(MasterService& service, const UUID& client_id,
+                                 const std::string& key_prefix,
+                                 size_t object_size, int max_puts) {
+        int success_puts = 0;
+        for (int i = 0; i < max_puts; ++i) {
+            std::string key = key_prefix + std::to_string(i);
+            ReplicateConfig config;
+            config.replica_num = 1;
+            auto result = service.PutStart(client_id, key, object_size, config);
+            if (result.has_value()) {
+                auto end = service.PutEnd(client_id, key, ReplicaType::MEMORY);
+                EXPECT_TRUE(end.has_value());
+                success_puts++;
+            } else {
+                // Wait for eviction to process
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+        }
+        return success_puts;
+    }
+};
+
+// =============================================================================
+// Combo A: No env vars (default — offload at PutEnd)
+// =============================================================================
+
+TEST_F(OffloadOnEvictTest, ComboA_OffloadAtPutEnd) {
+    // No env vars set — default behavior
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+
+    // Mount local disk segment with offloading ENABLED
+    auto mount_ld = service->MountLocalDiskSegment(ctx.client_id, true);
+    ASSERT_TRUE(mount_ld.has_value());
+
+    // Put objects
+    PutObject(*service, ctx.client_id, "key_a1");
+    PutObject(*service, ctx.client_id, "key_a2");
+    PutObject(*service, ctx.client_id, "key_a3");
+
+    // Default mode: PutEnd pushes to offload queue immediately
+    auto queued = DrainOffloadQueue(*service, ctx.client_id);
+    EXPECT_EQ(queued.size(), 3u)
+        << "Default: all 3 objects should be in offload queue after PutEnd";
+    EXPECT_TRUE(queued.count("key_a1"));
+    EXPECT_TRUE(queued.count("key_a2"));
+    EXPECT_TRUE(queued.count("key_a3"));
+
+    service->RemoveAll();
+}
+
+TEST_F(OffloadOnEvictTest, ComboA_EvictionWorks) {
+    // Regression: eviction still works in default mode
+    const uint64_t kv_lease_ttl = 2000;
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = kv_lease_ttl;
+    auto service = std::make_unique<MasterService>(config);
+
+    // Large segment: can hold ~16K objects of 15KB
+    constexpr size_t seg_size = 1024 * 1024 * 16 * 15;
+    constexpr size_t object_size = 1024 * 15;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+
+    // Put more objects than the segment can hold
+    int success_puts = FillSegmentUntilEviction(
+        *service, ctx.client_id, "evict_a_", object_size, 1024 * 16 + 50);
+    EXPECT_GT(success_puts, 1024 * 16)
+        << "Default: eviction should allow more puts than capacity";
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
+    service->RemoveAll();
+}
+
+// =============================================================================
+// Combo B: MOONCAKE_OFFLOAD_ON_EVICT=1 (offload on evict, no force-evict)
+// =============================================================================
+
+TEST_F(OffloadOnEvictTest, ComboB_PutEndSkipsOffloadQueue) {
+    ScopedEnv env("MOONCAKE_OFFLOAD_ON_EVICT", "1");
+
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+    auto mount_ld = service->MountLocalDiskSegment(ctx.client_id, true);
+    ASSERT_TRUE(mount_ld.has_value());
+
+    PutObject(*service, ctx.client_id, "key_b1");
+    PutObject(*service, ctx.client_id, "key_b2");
+    PutObject(*service, ctx.client_id, "key_b3");
+
+    // Offload-on-evict: PutEnd should NOT push to offload queue
+    auto queued = DrainOffloadQueue(*service, ctx.client_id);
+    EXPECT_EQ(queued.size(), 0u)
+        << "Offload-on-evict: queue should be empty after PutEnd";
+
+    service->RemoveAll();
+}
+
+TEST_F(OffloadOnEvictTest, ComboB_EvictionTriggersOffload) {
+    ScopedEnv env("MOONCAKE_OFFLOAD_ON_EVICT", "1");
+
+    const uint64_t kv_lease_ttl = 2000;
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = kv_lease_ttl;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16 * 15;
+    constexpr size_t object_size = 1024 * 15;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+    auto mount_ld = service->MountLocalDiskSegment(ctx.client_id, true);
+    ASSERT_TRUE(mount_ld.has_value());
+
+    // Fill segment to trigger eviction
+    bool eviction_triggered = false;
+    int success_puts = 0;
+    for (int i = 0; i < 1024 * 16 + 50; ++i) {
+        std::string key = "evict_b_" + std::to_string(i);
+        ReplicateConfig config;
+        config.replica_num = 1;
+        auto result =
+            service->PutStart(ctx.client_id, key, object_size, config);
+        if (result.has_value()) {
+            auto end = service->PutEnd(ctx.client_id, key, ReplicaType::MEMORY);
+            ASSERT_TRUE(end.has_value());
+            success_puts++;
+        } else {
+            eviction_triggered = true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+    }
+
+    EXPECT_TRUE(eviction_triggered)
+        << "Eviction should trigger when segment fills up";
+
+    // Offload-on-evict: eviction should push objects to offload queue
+    auto queued = DrainOffloadQueue(*service, ctx.client_id);
+    EXPECT_GT(queued.size(), 0u)
+        << "Offload-on-evict: eviction should push to offload queue";
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
+    service->RemoveAll();
+}
+
+TEST_F(OffloadOnEvictTest, ComboB_FallbackWhenNoLocalDiskSegment) {
+    ScopedEnv env("MOONCAKE_OFFLOAD_ON_EVICT", "1");
+
+    const uint64_t kv_lease_ttl = 2000;
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = kv_lease_ttl;
+    auto service = std::make_unique<MasterService>(config);
+
+    // NO local disk segment mounted — PushOffloadingQueue will fail
+    constexpr size_t seg_size = 1024 * 1024 * 16 * 15;
+    constexpr size_t object_size = 1024 * 15;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+
+    // Should still work via force-evict fallback (PushOffloadingQueue fails)
+    int success_puts = FillSegmentUntilEviction(
+        *service, ctx.client_id, "evict_b2_", object_size, 1024 * 16 + 50);
+    EXPECT_GT(success_puts, 1024 * 16)
+        << "Offload-on-evict: fallback eviction should work without local disk";
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
+    service->RemoveAll();
+}
+
+// =============================================================================
+// Combo C: MOONCAKE_OFFLOAD_ON_EVICT=1 + MOONCAKE_OFFLOAD_FORCE_EVICT=1
+// =============================================================================
+
+TEST_F(OffloadOnEvictTest, ComboC_PutEndSkipsOffloadQueue) {
+    ScopedEnv env1("MOONCAKE_OFFLOAD_ON_EVICT", "1");
+    ScopedEnv env2("MOONCAKE_OFFLOAD_FORCE_EVICT", "1");
+
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+    auto mount_ld = service->MountLocalDiskSegment(ctx.client_id, true);
+    ASSERT_TRUE(mount_ld.has_value());
+
+    PutObject(*service, ctx.client_id, "key_c1");
+    PutObject(*service, ctx.client_id, "key_c2");
+
+    // Same as Combo B: PutEnd should skip offload queue
+    auto queued = DrainOffloadQueue(*service, ctx.client_id);
+    EXPECT_EQ(queued.size(), 0u)
+        << "Combo C: offload queue should be empty after PutEnd";
+
+    service->RemoveAll();
+}
+
+TEST_F(OffloadOnEvictTest, ComboC_EvictionWithForceEvict) {
+    ScopedEnv env1("MOONCAKE_OFFLOAD_ON_EVICT", "1");
+    ScopedEnv env2("MOONCAKE_OFFLOAD_FORCE_EVICT", "1");
+
+    const uint64_t kv_lease_ttl = 2000;
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = kv_lease_ttl;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16 * 15;
+    constexpr size_t object_size = 1024 * 15;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+    auto mount_ld = service->MountLocalDiskSegment(ctx.client_id, true);
+    ASSERT_TRUE(mount_ld.has_value());
+
+    // With force-evict, eviction should work effectively.
+    // Note: without a real FileStorage heartbeat, offloaded objects' refcnt
+    // never decreases, so DRAM isn't fully freed beyond what direct eviction
+    // allows. We verify eviction doesn't deadlock (can fill to capacity).
+    int success_puts = FillSegmentUntilEviction(
+        *service, ctx.client_id, "evict_c_", object_size, 1024 * 16 + 50);
+    EXPECT_GE(success_puts, 1024 * 16)
+        << "Combo C: eviction should work with force-evict enabled";
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
+    service->RemoveAll();
+}
+
+// =============================================================================
+// Combo D: MOONCAKE_OFFLOAD_FORCE_EVICT=1 only (should be no-op)
+// =============================================================================
+
+TEST_F(OffloadOnEvictTest, ComboD_ForceEvictAloneIsIgnored) {
+    ScopedEnv env("MOONCAKE_OFFLOAD_FORCE_EVICT", "1");
+
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+    auto mount_ld = service->MountLocalDiskSegment(ctx.client_id, true);
+    ASSERT_TRUE(mount_ld.has_value());
+
+    // Should behave like Combo A (default: offload at PutEnd)
+    PutObject(*service, ctx.client_id, "key_d1");
+    PutObject(*service, ctx.client_id, "key_d2");
+
+    auto queued = DrainOffloadQueue(*service, ctx.client_id);
+    EXPECT_EQ(queued.size(), 2u)
+        << "Combo D: FORCE_EVICT alone should not change default behavior";
+
+    service->RemoveAll();
+}
+
+TEST_F(OffloadOnEvictTest, ComboD_EvictionWorks) {
+    ScopedEnv env("MOONCAKE_OFFLOAD_FORCE_EVICT", "1");
+
+    const uint64_t kv_lease_ttl = 2000;
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = kv_lease_ttl;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16 * 15;
+    constexpr size_t object_size = 1024 * 15;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+
+    int success_puts = FillSegmentUntilEviction(
+        *service, ctx.client_id, "evict_d_", object_size, 1024 * 16 + 50);
+    EXPECT_GT(success_puts, 1024 * 16)
+        << "Combo D: eviction should work normally";
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
+    service->RemoveAll();
+}
+
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-wheel/tests/test_offload_on_eviction.py
+++ b/mooncake-wheel/tests/test_offload_on_eviction.py
@@ -13,12 +13,11 @@ project, both of which exercise the same storage backend code paths as
 this feature.
 
 Prerequisites:
-  - mooncake_master running with:
-      ``MOONCAKE_OFFLOAD_ON_EVICT=1``
-      ``MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=/tmp/...``
-      ``enable_offload=true`` in master.json
-  - The same ``MOONCAKE_OFFLOAD_*`` env vars set on the pytest side so the
-    client's FileStorage uses the matching backend / path.
+  - mooncake_master running with master.json containing:
+      ``"enable_offload": true``
+      ``"offload_on_evict": true``
+  - ``MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=/tmp/...`` env var set on the
+    client side so FileStorage uses the matching backend / path.
 """
 
 import unittest
@@ -78,7 +77,7 @@ class TestOffloadOnEviction(unittest.TestCase):
         is for — avoiding redundant disk I/O for hot data.
 
         A zero disk-replica count thus doubles as a guard that the
-        master is actually running with ``MOONCAKE_OFFLOAD_ON_EVICT=1``.
+        master is actually running with ``offload_on_evict: true`` in config.
         """
         VALUE_SIZE = 1024  # 1 KB
         NUM_KEYS = 16  # 16 KB total, several orders of magnitude below
@@ -122,7 +121,7 @@ class TestOffloadOnEviction(unittest.TestCase):
                 0,
                 f"Offload-on-evict should keep small workloads in DRAM "
                 f"only, but found {disk_replicas} LOCAL_DISK replicas. "
-                f"Is MOONCAKE_OFFLOAD_ON_EVICT=1 set on the master?",
+                f"Is offload_on_evict=true set in master config?",
             )
 
             # Sanity: every key is readable and bit-exact (served from DRAM).

--- a/mooncake-wheel/tests/test_offload_on_eviction.py
+++ b/mooncake-wheel/tests/test_offload_on_eviction.py
@@ -1,0 +1,145 @@
+"""Python-binding test for the offload-on-evict feature.
+
+Unlike the default ``enable_ssd_offload`` path where PutEnd synchronously
+queues objects for offload, the offload-on-evict mode defers offload until
+DRAM eviction triggers. This test asserts the core behavioral difference:
+small workloads below the eviction watermark stay in DRAM only and do not
+produce LOCAL_DISK replicas.
+
+The end-to-end overflow → evict → offload → read contract is covered by
+``test_ssd_offload_in_evict.py`` (legacy sync-offload mode) and the
+``verify_offload_on_eviction`` scenario in the kv-cache-offload-benchmark
+project, both of which exercise the same storage backend code paths as
+this feature.
+
+Prerequisites:
+  - mooncake_master running with:
+      ``MOONCAKE_OFFLOAD_ON_EVICT=1``
+      ``MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=/tmp/...``
+      ``enable_offload=true`` in master.json
+  - The same ``MOONCAKE_OFFLOAD_*`` env vars set on the pytest side so the
+    client's FileStorage uses the matching backend / path.
+"""
+
+import unittest
+import os
+import time
+from mooncake.store import MooncakeDistributedStore
+
+# Align with the master's default_kv_lease_ttl (override via env).
+DEFAULT_DEFAULT_KV_LEASE_TTL = 5000  # ms
+default_kv_lease_ttl = int(
+    os.getenv("DEFAULT_KV_LEASE_TTL", DEFAULT_DEFAULT_KV_LEASE_TTL)
+)
+
+SEGMENT_SIZE = int(os.getenv("SEGMENT_SIZE_BYTES", str(128 * 1024 * 1024)))
+LOCAL_BUFFER_SIZE = int(os.getenv("LOCAL_BUFFER_SIZE_BYTES", str(128 * 1024 * 1024)))
+
+
+def get_client(store):
+    """Initialize and setup the distributed store client."""
+    protocol = os.getenv("PROTOCOL", "tcp")
+    device_name = os.getenv("DEVICE_NAME", "")
+    local_hostname = os.getenv("LOCAL_HOSTNAME", "localhost")
+    metadata_server = os.getenv("MC_METADATA_SERVER", "P2PHANDSHAKE")
+    master_server_address = os.getenv("MASTER_SERVER", "127.0.0.1:50051")
+
+    retcode = store.setup(
+        local_hostname,
+        metadata_server,
+        SEGMENT_SIZE,
+        LOCAL_BUFFER_SIZE,
+        protocol,
+        device_name,
+        master_server_address,
+        None,  # engine
+        True,  # enable_ssd_offload — required for FileStorage / LOCAL_DISK
+    )
+    if retcode:
+        raise RuntimeError(f"Failed to setup store client. Return code: {retcode}")
+
+
+class TestOffloadOnEviction(unittest.TestCase):
+    """Python-binding test for offload-on-evict behavioral difference."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.store = MooncakeDistributedStore()
+        get_client(cls.store)
+
+    def test_small_workload_no_disk_replica(self):
+        """Workload well below the eviction watermark must NOT produce
+        LOCAL_DISK replicas.
+
+        Under the default ``enable_ssd_offload=true`` path, every PutEnd
+        would queue the key for offload (heartbeat → disk). Under
+        offload-on-evict, the offload queue stays empty until DRAM
+        pressure triggers eviction. This asymmetry is what the feature
+        is for — avoiding redundant disk I/O for hot data.
+
+        A zero disk-replica count thus doubles as a guard that the
+        master is actually running with ``MOONCAKE_OFFLOAD_ON_EVICT=1``.
+        """
+        VALUE_SIZE = 1024  # 1 KB
+        NUM_KEYS = 16  # 16 KB total, several orders of magnitude below
+        # the 128 MB segment — eviction cannot trigger.
+
+        timestamp = int(time.time())
+        keys = [f"ooe_small_{i}_{timestamp}" for i in range(NUM_KEYS)]
+        reference = {}
+
+        try:
+            for key in keys:
+                value = os.urandom(VALUE_SIZE)
+                retcode = self.store.put(key, value)
+                self.assertEqual(
+                    retcode,
+                    0,
+                    f"Put failed for {key}: retcode={retcode}",
+                )
+                reference[key] = value
+
+            # Wait past one heartbeat interval so any async offload would
+            # have had a chance to complete.
+            time.sleep(3)
+
+            # Query replicas — they must all be MEMORY only.
+            descs = self.store.batch_get_replica_desc(keys)
+            disk_replicas = 0
+            for key in keys:
+                infos = descs.get(key) if isinstance(descs, dict) else None
+                if infos is None:
+                    continue
+                if not isinstance(infos, (list, tuple)):
+                    infos = [infos]
+                for info in infos:
+                    type_str = str(getattr(info, "type", ""))
+                    if type_str and "MEMORY" not in type_str:
+                        disk_replicas += 1
+
+            self.assertEqual(
+                disk_replicas,
+                0,
+                f"Offload-on-evict should keep small workloads in DRAM "
+                f"only, but found {disk_replicas} LOCAL_DISK replicas. "
+                f"Is MOONCAKE_OFFLOAD_ON_EVICT=1 set on the master?",
+            )
+
+            # Sanity: every key is readable and bit-exact (served from DRAM).
+            for key, expected in reference.items():
+                self.assertEqual(
+                    self.store.get(key), expected, f"Bit-exact mismatch for {key}"
+                )
+        finally:
+            # Cleanup — remove all keys written by this test regardless of
+            # success or failure so subsequent tests start with clean DRAM.
+            for key in keys:
+                try:
+                    self.store.remove(key)
+                except Exception:
+                    pass
+            time.sleep(default_kv_lease_ttl / 1000 + 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add opt-in **offload-on-evict** mode to Mooncake Store, which defers LOCAL_DISK offload from `PutEnd` time to `BatchEvict` time, forming a proper DRAM→LOCAL_DISK storage hierarchy.

**Today** (`enable_ssd_offload=true`): every `PutEnd` synchronously queues the key for offload, so the FileStorage heartbeat writes every put to disk — even hot keys that never leave DRAM. Disk I/O is incurred up front regardless of access pattern.

**With this change** (`MOONCAKE_OFFLOAD_ON_EVICT=1`): keys stay in DRAM only until watermark pressure causes `BatchEvict` to select them. `BatchEvict` queues the selected MEMORY replicas for offload (pinning them via refcnt), the heartbeat completes the disk write, and the next eviction cycle frees the MEMORY replica via the existing `has_local_disk_replica` shortcut. Hot keys that are never evicted never touch disk.

Semantics summary:

| env var | effect |
|---------|--------|
| `MOONCAKE_OFFLOAD_ON_EVICT=1` | defer offload from `PutEnd` to `BatchEvict`; requires `enable_offload=true` in master config |
| `MOONCAKE_OFFLOAD_FORCE_EVICT=1` | allow data-lossy force-eviction when the per-cycle offload cap is exceeded; requires `MOONCAKE_OFFLOAD_ON_EVICT=1`; default OFF (data-preserving mode) |

Neither env var is read through the JSON config schema — they are read once in the `MasterService` constructor via `std::getenv`. This keeps the surface area minimal for an experimental flag. If the feature is adopted as the default, promoting it to a proper config field is straightforward.

**Backward compatibility**: when neither env var is set, behavior is unchanged — the `PutEnd` offload block and the `BatchEvict` eviction paths both take their original fast path. All 16 existing eviction / offload tests pass unchanged.

**Scope**: LOCAL_DISK replicas (FileStorage-based) only. DISK replicas (`root_fs_dir` path, created by `Client::PutToLocalFile` at `PutEnd`) are written client-side, outside the Master's offload queue, and are not affected by this change. Deferring them is possible but requires client-side changes and is left as future work.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

### New tests in this PR

- **C++ unit tests** — `mooncake-store/tests/offload_on_evict_test.cpp`, 9 cases across all four env-var combinations:
  - A (neither set): `PutEnd` still queues offload; existing eviction works.
  - B (`ON_EVICT=1`): `PutEnd` skips the queue; eviction queues offload; `PushOffloadingQueue` failure falls back to direct eviction.
  - C (`ON_EVICT=1` + `FORCE_EVICT=1`): `PutEnd` skips; eviction still makes progress under the force-evict cap.
  - D (`FORCE_EVICT=1` only): treated as if unset — requires `ON_EVICT=1` to take effect.
- **Python-binding integration test** — `mooncake-wheel/tests/test_offload_on_eviction.py`, `test_small_workload_no_disk_replica`: asserts that a workload below the eviction watermark produces **zero** LOCAL_DISK replicas. This is the behavioral difference from the default `enable_ssd_offload` path (which would produce disk replicas for every put).

### Existing tests (regression)

Run on `hnts03/support-storage-hierarchy` after the changes:

- `eviction_strategy_test`: 4/4 PASS
- `master_service_test --gtest_filter='*Evict*'`: 8/8 PASS
- `master_service_ssd_test --gtest_filter='*Evict*'`: 4/4 PASS

No behavioral change when the new env vars are unset.

### End-to-end empirical verification

Validated against a running `mooncake_master` with the Python client binding (`enable_ssd_offload=true`, `MOONCAKE_OFFLOAD_ON_EVICT=1`):

- Workload: 50 MB DRAM segment, 100 keys × 1 MB (2x overflow), heartbeat interval = 1 s.
- Result: 96 / 100 keys offloaded to LOCAL_DISK via the eviction path; 100 / 100 keys readable bit-exact afterwards.
- Master log confirmed feature activation (`Offload-on-evict mode enabled`) and our new diagnostic (`[EVICT] N objects deferred for disk offload`).

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
