### PR TITLE
[Store] Fix hardcoded 127.0.0.1 bind address in standalone client RPC…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,14 @@ jobs:
 
     - name: Run tests with ssd
       run: |
+        # Reserve port 50052 (mooncake_client RPC port) so the kernel never
+        # auto-allocates it as ephemeral source port for other outbound
+        # connections in the test suite. Without this, a random Python test
+        # connection can pick src_port=50052, leave a TIME_WAIT on
+        # <eth0_ip>:50052 for 60s, and block mooncake_client's bind to
+        # 0.0.0.0:50052 even with SO_REUSEADDR (Linux only relaxes
+        # TIME_WAIT+bind conflict for same-IP or loopback).
+        sudo sysctl -w net.ipv4.ip_local_reserved_ports=50052
         source test_env/bin/activate
         MC_STORE_MEMCPY=false TEST_SSD_OFFLOAD_IN_EVICT=true ./scripts/run_tests.sh
         rm -rf /tmp/mooncake_test_ssd

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -113,10 +113,10 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    coro_rpc::coro_rpc_server server(FLAGS_threads, FLAGS_port, "127.0.0.1");
+    coro_rpc::coro_rpc_server server(FLAGS_threads, FLAGS_port, FLAGS_host);
     RegisterClientRpcService(server, *client_inst);
 
-    LOG(INFO) << "Starting real client service on 127.0.0.1:" << FLAGS_port;
+    LOG(INFO) << "Starting real client service on " << FLAGS_host << ":" << FLAGS_port;
 
     return server.start();
 }

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -116,7 +116,8 @@ int main(int argc, char *argv[]) {
     coro_rpc::coro_rpc_server server(FLAGS_threads, FLAGS_port, FLAGS_host);
     RegisterClientRpcService(server, *client_inst);
 
-    LOG(INFO) << "Starting real client service on " << FLAGS_host << ":" << FLAGS_port;
+    LOG(INFO) << "Starting real client service on " << FLAGS_host << ":"
+              << FLAGS_port;
 
     return server.start();
 }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -31,19 +31,12 @@ MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 pytho
 sleep 1
 # DEBUG: who holds port 50052 right before mooncake_client starts?
 echo "=== port 50052 diagnostic ==="
-echo "--- all LISTEN sockets ---"
 ss -tlnp 2>&1 | head -30 || true
-echo "--- 50051/50052/9300/9003 (LISTEN only) ---"
-ss -tlnp 2>&1 | grep -E ":(50051|50052|9300|9003)" || echo "(nothing LISTEN on these ports)"
-echo "--- ANY state on port 50052 ---"
-ss -tanp 2>&1 | grep -E ":50052" || echo "(no 50052 in any state)"
-echo "--- lsof ---"
+echo "--- specifically port 50052 ---"
+ss -tlnp 2>&1 | grep -E ":(50051|50052|9300|9003)" || echo "(nothing on 50051/50052/9300/9003)"
 lsof -iTCP:50052 2>&1 || echo "(no lsof for 50052)"
 echo "--- sysctl ip_local_port_range ---"
 sysctl net.ipv4.ip_local_port_range || true
-echo "--- tcp_tw_reuse / tcp_tw_recycle ---"
-sysctl net.ipv4.tcp_tw_reuse 2>&1 || true
-sysctl net.ipv4.tcp_tw_recycle 2>&1 || true
 echo "=== end port 50052 diagnostic ==="
 
 mooncake_client &

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -29,16 +29,6 @@ sleep 1
 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_distributed_object_store.py
 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_replicated_distributed_object_store.py
 sleep 1
-# DEBUG: who holds port 50052 right before mooncake_client starts?
-echo "=== port 50052 diagnostic ==="
-ss -tlnp 2>&1 | head -30 || true
-echo "--- specifically port 50052 ---"
-ss -tlnp 2>&1 | grep -E ":(50051|50052|9300|9003)" || echo "(nothing on 50051/50052/9300/9003)"
-lsof -iTCP:50052 2>&1 || echo "(no lsof for 50052)"
-echo "--- sysctl ip_local_port_range ---"
-sysctl net.ipv4.ip_local_port_range || true
-echo "=== end port 50052 diagnostic ==="
-
 mooncake_client &
 CLIENT_PID=$!
 sleep 1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -29,6 +29,16 @@ sleep 1
 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_distributed_object_store.py
 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_replicated_distributed_object_store.py
 sleep 1
+# DEBUG: who holds port 50052 right before mooncake_client starts?
+echo "=== port 50052 diagnostic ==="
+ss -tlnp 2>&1 | head -30 || true
+echo "--- specifically port 50052 ---"
+ss -tlnp 2>&1 | grep -E ":(50051|50052|9300|9003)" || echo "(nothing on 50051/50052/9300/9003)"
+lsof -iTCP:50052 2>&1 || echo "(no lsof for 50052)"
+echo "--- sysctl ip_local_port_range ---"
+sysctl net.ipv4.ip_local_port_range || true
+echo "=== end port 50052 diagnostic ==="
+
 mooncake_client &
 CLIENT_PID=$!
 sleep 1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -31,12 +31,19 @@ MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 pytho
 sleep 1
 # DEBUG: who holds port 50052 right before mooncake_client starts?
 echo "=== port 50052 diagnostic ==="
+echo "--- all LISTEN sockets ---"
 ss -tlnp 2>&1 | head -30 || true
-echo "--- specifically port 50052 ---"
-ss -tlnp 2>&1 | grep -E ":(50051|50052|9300|9003)" || echo "(nothing on 50051/50052/9300/9003)"
+echo "--- 50051/50052/9300/9003 (LISTEN only) ---"
+ss -tlnp 2>&1 | grep -E ":(50051|50052|9300|9003)" || echo "(nothing LISTEN on these ports)"
+echo "--- ANY state on port 50052 ---"
+ss -tanp 2>&1 | grep -E ":50052" || echo "(no 50052 in any state)"
+echo "--- lsof ---"
 lsof -iTCP:50052 2>&1 || echo "(no lsof for 50052)"
 echo "--- sysctl ip_local_port_range ---"
 sysctl net.ipv4.ip_local_port_range || true
+echo "--- tcp_tw_reuse / tcp_tw_recycle ---"
+sysctl net.ipv4.tcp_tw_reuse 2>&1 || true
+sysctl net.ipv4.tcp_tw_recycle 2>&1 || true
 echo "=== end port 50052 diagnostic ==="
 
 mooncake_client &


### PR DESCRIPTION
… server

The coro_rpc server in real_client_main.cpp was hardcoded to bind to 127.0.0.1, preventing cross-machine SSD offload deployment. Remote clients could reach the advertised transport_endpoint (FLAGS_host:FLAGS_port) metadata from master but got ECONNREFUSED at the TCP layer because the server only accepted connections with destination IP == 127.0.0.1.

Change the bind address to FLAGS_host (default 0.0.0.0, consistent with master.cpf rpc_address default). Users can still pin to a specific NIC by setting --host=<internal-ip> to avoid exposing the unauthenticated offload RPC on public interfaces.

Fixes #1891

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [✅ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [✅ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
