### PR TITLE
[DEBUG] compare port 50052 state in passing CI run (do not merge)

### DIFF
--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -113,10 +113,10 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    coro_rpc::coro_rpc_server server(FLAGS_threads, FLAGS_port, "127.0.0.1");
+    coro_rpc::coro_rpc_server server(FLAGS_threads, FLAGS_port, FLAGS_host);
     RegisterClientRpcService(server, *client_inst);
 
-    LOG(INFO) << "Starting real client service on 127.0.0.1:" << FLAGS_port;
+    LOG(INFO) << "Starting real client service on " << FLAGS_host << ":" << FLAGS_port;
 
     return server.start();
 }

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -116,7 +116,8 @@ int main(int argc, char *argv[]) {
     coro_rpc::coro_rpc_server server(FLAGS_threads, FLAGS_port, FLAGS_host);
     RegisterClientRpcService(server, *client_inst);
 
-    LOG(INFO) << "Starting real client service on " << FLAGS_host << ":" << FLAGS_port;
+    LOG(INFO) << "Starting real client service on " << FLAGS_host << ":"
+              << FLAGS_port;
 
     return server.start();
 }

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    coro_rpc::coro_rpc_server server(FLAGS_threads, FLAGS_port, FLAGS_host);
+    coro_rpc::coro_rpc_server server(FLAGS_threads, FLAGS_port, "127.0.0.1");
     RegisterClientRpcService(server, *client_inst);
 
     LOG(INFO) << "Starting real client service on " << FLAGS_host << ":"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -29,6 +29,16 @@ sleep 1
 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_distributed_object_store.py
 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_replicated_distributed_object_store.py
 sleep 1
+# DEBUG: who holds port 50052 right before mooncake_client starts?
+echo "=== port 50052 diagnostic ==="
+ss -tlnp 2>&1 | head -30 || true
+echo "--- specifically port 50052 ---"
+ss -tlnp 2>&1 | grep -E ":(50051|50052|9300|9003)" || echo "(nothing on 50051/50052/9300/9003)"
+lsof -iTCP:50052 2>&1 || echo "(no lsof for 50052)"
+echo "--- sysctl ip_local_port_range ---"
+sysctl net.ipv4.ip_local_port_range || true
+echo "=== end port 50052 diagnostic ==="
+
 mooncake_client &
 CLIENT_PID=$!
 sleep 1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -31,12 +31,19 @@ MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 pytho
 sleep 1
 # DEBUG: who holds port 50052 right before mooncake_client starts?
 echo "=== port 50052 diagnostic ==="
+echo "--- all LISTEN sockets ---"
 ss -tlnp 2>&1 | head -30 || true
-echo "--- specifically port 50052 ---"
-ss -tlnp 2>&1 | grep -E ":(50051|50052|9300|9003)" || echo "(nothing on 50051/50052/9300/9003)"
+echo "--- 50051/50052/9300/9003 (LISTEN only) ---"
+ss -tlnp 2>&1 | grep -E ":(50051|50052|9300|9003)" || echo "(nothing LISTEN on these ports)"
+echo "--- ANY state on port 50052 ---"
+ss -tanp 2>&1 | grep -E ":50052" || echo "(no 50052 in any state)"
+echo "--- lsof ---"
 lsof -iTCP:50052 2>&1 || echo "(no lsof for 50052)"
 echo "--- sysctl ip_local_port_range ---"
 sysctl net.ipv4.ip_local_port_range || true
+echo "--- tcp_tw_reuse / tcp_tw_recycle ---"
+sysctl net.ipv4.tcp_tw_reuse 2>&1 || true
+sysctl net.ipv4.tcp_tw_recycle 2>&1 || true
 echo "=== end port 50052 diagnostic ==="
 
 mooncake_client &


### PR DESCRIPTION
Temporary debug PR to observe port 50052 state with bind=127.0.0.1 (which succeeds) to confirm hypothesis about TIME_WAIT interaction. Will be closed after analysis.

See #1900 for the actual fix.