### PR TITLE
[TE] rdma: fix use-after-free crash in ibv_post_send caused by concurrent QP destruction

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -43,6 +43,8 @@ class RdmaEndPoint {
         UNCONNECTED,
         CONNECTING,
         CONNECTED,
+        DESTROYING,
+        DESTROYED,
     };
 
    public:
@@ -56,6 +58,7 @@ class RdmaEndPoint {
    private:
     int reconstruct();
     int deconstruct();
+    int deconstructLocked();
 
    public:
     void setPeerNicPath(const std::string &peer_nic_path);
@@ -70,8 +73,6 @@ class RdmaEndPoint {
     using HandShakeDesc = TransferMetadata::HandShakeDesc;
     int setupConnectionsByPassive(const HandShakeDesc &peer_desc,
                                   HandShakeDesc &local_desc);
-
-    bool hasOutstandingSlice() const;
 
     bool active() const { return active_; }
 
@@ -98,6 +99,16 @@ class RdmaEndPoint {
 
     // Destroy QPs before CQs (in RDMA Context)
     int destroyQP();
+
+    // Two-phase QP destruction to avoid use-after-free in concurrent
+    // submitPostSend. Phase 1 (beginDestroy): sets active_=false and
+    // status_=DESTROYING, transitions QPs to ERR state so hardware flushes
+    // inflight WRs to CQ. Does not block. Phase 2 (finishDestroy): called
+    // after all outstanding WRs have been drained (wr_depth_list_ all zero),
+    // actually destroys QPs and frees resources. Returns true if destruction
+    // is complete, false if outstanding WRs remain.
+    void beginDestroy();
+    bool finishDestroy();
 
    private:
     int disconnectUnlocked();
@@ -154,6 +165,16 @@ class RdmaEndPoint {
     static constexpr uint32_t kWaitExistingHandshakeInitialSleepUs = 50;
     static constexpr uint32_t kWaitExistingHandshakeMaxSleepUs = 2000;
 
+    // Maximum time (in seconds) to wait for outstanding WRs to drain in
+    // finishDestroy before forcing QP destruction. This guards against
+    // ibv_modify_qp-to-ERR failures that prevent WR flushing.
+    static constexpr double kFinishDestroyTimeoutSec = 30.0;
+
+    // Maximum number of deconstructLocked retries in finishDestroy before
+    // giving up and marking the endpoint as DESTROYED. Prevents infinite
+    // retry loops and log flooding when ibv_destroy_qp fails permanently.
+    static constexpr int kFinishDestroyMaxRetries = 3;
+
     RdmaContext &context_;
     std::atomic<Status> status_;
 
@@ -171,6 +192,7 @@ class RdmaEndPoint {
     volatile bool active_;
     volatile int *cq_outstanding_;
     volatile uint64_t inactive_time_;
+    int finish_destroy_retries_ = 0;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -78,12 +78,14 @@ std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::insertEndpoint(
 int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     auto iter = endpoint_map_.find(peer_nic_path);
-    // remove endpoint but leaving it status unchanged
-    // in case it is setting up connection or submitting slice
+    // Begin two-phase destruction: mark endpoint as destroying and move QPs
+    // to ERR state so inflight WRs are flushed to CQ. The endpoint is moved
+    // to waiting_list_ and will be fully destroyed by reclaimEndpoint() once
+    // all outstanding WRs have been drained.
     if (iter != endpoint_map_.end()) {
         waiting_list_len_++;
+        iter->second->beginDestroy();
         waiting_list_.insert(iter->second);
-        iter->second->set_active(false);
         endpoint_map_.erase(iter);
         auto fifo_iter = fifo_map_[peer_nic_path];
         fifo_list_.erase(fifo_iter);
@@ -99,7 +101,9 @@ void FIFOEndpointStore::evictEndpoint() {
     fifo_map_.erase(victim);
     LOG(INFO) << victim << " evicted";
     waiting_list_len_++;
-    waiting_list_.insert(endpoint_map_[victim]);
+    auto victim_endpoint = endpoint_map_[victim];
+    victim_endpoint->beginDestroy();
+    waiting_list_.insert(victim_endpoint);
     endpoint_map_.erase(victim);
     return;
 }
@@ -108,8 +112,9 @@ void FIFOEndpointStore::reclaimEndpoint() {
     if (waiting_list_len_.load(std::memory_order_relaxed) == 0) return;
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     std::vector<std::shared_ptr<RdmaEndPoint>> to_delete;
-    for (auto &endpoint : waiting_list_)
-        if (!endpoint->hasOutstandingSlice()) to_delete.push_back(endpoint);
+    for (auto &endpoint : waiting_list_) {
+        if (endpoint->finishDestroy()) to_delete.push_back(endpoint);
+    }
     for (auto &endpoint : to_delete) waiting_list_.erase(endpoint);
     waiting_list_len_ -= to_delete.size();
 }
@@ -203,12 +208,14 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::insertEndpoint(
 int SIEVEEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     auto iter = endpoint_map_.find(peer_nic_path);
-    // remove endpoint but leaving it status unchanged
-    // in case it is setting up connection or submitting slice
+    // Begin two-phase destruction: mark endpoint as destroying and move QPs
+    // to ERR state so inflight WRs are flushed to CQ. The endpoint is moved
+    // to waiting_list_ and will be fully destroyed by reclaimEndpoint() once
+    // all outstanding WRs have been drained.
     if (iter != endpoint_map_.end()) {
+        iter->second.first->beginDestroy();
         waiting_list_len_++;
         waiting_list_.insert(iter->second.first);
-        iter->second.first->set_active(false);
         endpoint_map_.erase(iter);
         auto fifo_iter = fifo_map_[peer_nic_path];
         if (hand_.has_value() && hand_.value() == fifo_iter) {
@@ -242,7 +249,7 @@ void SIEVEEndpointStore::evictEndpoint() {
     fifo_map_.erase(victim);
     LOG(INFO) << victim << " evicted";
     auto victim_instance = endpoint_map_[victim].first;
-    victim_instance->set_active(false);
+    victim_instance->beginDestroy();
     waiting_list_len_++;
     waiting_list_.insert(victim_instance);
     endpoint_map_.erase(victim);
@@ -253,8 +260,9 @@ void SIEVEEndpointStore::reclaimEndpoint() {
     if (waiting_list_len_.load(std::memory_order_relaxed) == 0) return;
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     std::vector<std::shared_ptr<RdmaEndPoint>> to_delete;
-    for (auto &endpoint : waiting_list_)
-        if (!endpoint->hasOutstandingSlice()) to_delete.push_back(endpoint);
+    for (auto &endpoint : waiting_list_) {
+        if (endpoint->finishDestroy()) to_delete.push_back(endpoint);
+    }
     for (auto &endpoint : to_delete) waiting_list_.erase(endpoint);
     waiting_list_len_ -= to_delete.size();
 }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -37,7 +37,13 @@ RdmaEndPoint::RdmaEndPoint(RdmaContext &context)
       cq_outstanding_(nullptr) {}
 
 RdmaEndPoint::~RdmaEndPoint() {
-    if (!qp_list_.empty()) deconstruct();
+    if (!qp_list_.empty()) {
+        // In normal flow, beginDestroy()+finishDestroy() should have been
+        // called already via endpoint_store. This is a fallback for abnormal
+        // shutdown (e.g., process exit).
+        RWSpinlock::WriteGuard guard(lock_);
+        deconstructLocked();
+    }
 }
 
 int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
@@ -91,7 +97,8 @@ int RdmaEndPoint::reconstruct() {
     auto max_inline_bytes = max_inline_bytes_;
 
     // Deconstruct and reconstruct to get fresh QPs (same as delete+create)
-    int ret = deconstruct();
+    // Use deconstructLocked because callers already hold lock_
+    int ret = deconstructLocked();
     if (ret) {
         LOG(ERROR) << "Failed to deconstruct endpoint: " << ret;
         return ret;
@@ -113,13 +120,15 @@ int RdmaEndPoint::reconstruct() {
 }
 
 int RdmaEndPoint::deconstruct() {
+    RWSpinlock::WriteGuard guard(lock_);
+    return deconstructLocked();
+}
+
+int RdmaEndPoint::deconstructLocked() {
+    // Adjust cq_outstanding_ before destroying QPs, so the counter is
+    // always corrected even if ibv_destroy_qp fails and we return early.
+    bool displayed = false;
     for (size_t i = 0; i < qp_list_.size(); ++i) {
-        if (ibv_destroy_qp(qp_list_[i])) {
-            PLOG(ERROR) << "Failed to destroy QP";
-            return ERR_ENDPOINT;
-        }
-        // After destroying QP, the wr_depth_list_ won't change
-        bool displayed = false;
         if (wr_depth_list_[i] != 0) {
             if (!displayed) {
                 LOG(WARNING) << "Outstanding work requests found, CQ will not "
@@ -130,13 +139,111 @@ int RdmaEndPoint::deconstruct() {
             wr_depth_list_[i] = 0;
         }
     }
+
+    int result = 0;
+    for (size_t i = 0; i < qp_list_.size(); ++i) {
+        if (!qp_list_[i]) continue;  // already destroyed in a previous call
+        if (ibv_destroy_qp(qp_list_[i])) {
+            PLOG(ERROR) << "Failed to destroy QP[" << i << "]";
+            result = ERR_ENDPOINT;
+        } else {
+            qp_list_[i] = nullptr;
+        }
+    }
+
+    if (result) return result;
+
     qp_list_.clear();
     peer_qp_num_list_.clear();
     delete[] wr_depth_list_;
+    wr_depth_list_ = nullptr;
     return 0;
 }
 
 int RdmaEndPoint::destroyQP() { return deconstruct(); }
+
+void RdmaEndPoint::beginDestroy() {
+    RWSpinlock::WriteGuard guard(lock_);
+    auto current_status = status_.load(std::memory_order_relaxed);
+    if (current_status == DESTROYING || current_status == DESTROYED) return;
+
+    active_ = false;
+    inactive_time_ = getCurrentTimeInNano();
+    status_.store(DESTROYING, std::memory_order_release);
+
+    // Transition QPs to ERR state so hardware flushes all inflight WRs to CQ.
+    // This allows performPollCq to drain them naturally.
+    ibv_qp_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_ERR;
+    for (size_t i = 0; i < qp_list_.size(); ++i) {
+        if (ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE)) {
+            PLOG(WARNING) << "Failed to modify QP to ERR during beginDestroy";
+        }
+    }
+}
+
+bool RdmaEndPoint::finishDestroy() {
+    RWSpinlock::WriteGuard guard(lock_);
+    auto current_status = status_.load(std::memory_order_relaxed);
+
+    // Gate 1: already done.
+    if (current_status == DESTROYED) return true;
+
+    // Gate 2: non-two-phase path (status != DESTROYING). The endpoint
+    // reached waiting_list_ without going through beginDestroy(). This is
+    // the contract expected by EndpointStore::testOnlyInsertWaiting() and
+    // serves as a safety net for any future non-two-phase path. Mirror the
+    // pre-two-phase predicate (!hasOutstandingSlice == !active_): only
+    // inactive endpoints are eligible for reclaim; active ones must stay.
+    if (current_status != DESTROYING) {
+        if (active_) return false;
+        // Endpoints that never reached construct() own no RDMA resources
+        // and have wr_depth_list_ uninitialized; deconstructLocked() would
+        // delete[] a wild pointer. Drop them directly.
+        if (qp_list_.empty()) {
+            status_.store(DESTROYED, std::memory_order_relaxed);
+            return true;
+        }
+        LOG(WARNING) << "finishDestroy called in unexpected state: "
+                     << current_status
+                     << ", forcing destruction to avoid waiting_list_ leak";
+        // Fall through to the unified destroy path.
+    } else {
+        // Gate 3: two-phase path. Wait for inflight WRs to drain via CQ
+        // polling. If ibv_modify_qp-to-ERR failed in beginDestroy, WRs may
+        // never be flushed; enforce a timeout to avoid leaking forever.
+        bool has_outstanding = false;
+        for (size_t i = 0; i < qp_list_.size(); ++i) {
+            if (wr_depth_list_[i] != 0) {
+                has_outstanding = true;
+                break;
+            }
+        }
+        if (has_outstanding) {
+            double elapsed = (getCurrentTimeInNano() - inactive_time_) / 1e9;
+            if (elapsed < kFinishDestroyTimeoutSec) return false;
+            LOG(WARNING) << "finishDestroy timed out after " << elapsed
+                         << "s with outstanding WRs, forcing destruction";
+        }
+    }
+
+    // Unified destroy: tear down QPs (deconstructLocked handles
+    // cq_outstanding_ adjustment internally) and bound retries to avoid
+    // log flooding when ibv_destroy_qp fails permanently.
+    int ret = deconstructLocked();
+    if (ret) {
+        finish_destroy_retries_++;
+        LOG(ERROR) << "Failed to finish destroying endpoint (attempt "
+                   << finish_destroy_retries_ << "/" << kFinishDestroyMaxRetries
+                   << "): " << ret;
+        if (finish_destroy_retries_ < kFinishDestroyMaxRetries) return false;
+        LOG(ERROR) << "Giving up after " << finish_destroy_retries_
+                   << " retries (possible resource leak)";
+    }
+    status_.store(DESTROYED, std::memory_order_relaxed);
+    return true;
+}
 
 void RdmaEndPoint::setPeerNicPath(const std::string &peer_nic_path) {
     RWSpinlock::WriteGuard guard(lock_);
@@ -459,22 +566,24 @@ const std::string RdmaEndPoint::toString() const {
     if (status == CONNECTED)
         return "EndPoint: local " + context_.nicPath() + ", peer " +
                peer_nic_path_;
+    else if (status == DESTROYING)
+        return "EndPoint: local " + context_.nicPath() + ", peer " +
+               peer_nic_path_ + " (destroying)";
+    else if (status == DESTROYED)
+        return "EndPoint: local " + context_.nicPath() + " (destroyed)";
     else
         return "EndPoint: local " + context_.nicPath() + " (unconnected)";
-}
-
-bool RdmaEndPoint::hasOutstandingSlice() const {
-    if (active_) return true;
-    for (size_t i = 0; i < qp_list_.size(); i++)
-        if (wr_depth_list_[i] != 0) return true;
-    return false;
 }
 
 int RdmaEndPoint::submitPostSend(
     std::vector<Transport::Slice *> &slice_list,
     std::vector<Transport::Slice *> &failed_slice_list) {
     RWSpinlock::WriteGuard guard(lock_);
-    if (!active_) return 0;
+    if (!active_ || status_.load(std::memory_order_relaxed) != CONNECTED) {
+        for (auto &slice : slice_list) failed_slice_list.push_back(slice);
+        slice_list.clear();
+        return 0;
+    }
 
     const size_t num_qp = qp_list_.size();
     if (slice_list.empty()) return 0;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -288,22 +288,32 @@ void WorkerPool::performPollCq(int thread_id) {
                 qp_depth_set[slice->rdma.qp_depth] = 1;
             // __sync_fetch_and_sub(slice->rdma.qp_depth, 1);
             if (wc[i].status != IBV_WC_SUCCESS) {
-                bool show_work_request_flushed_error = globalConfig().trace;
-                // After detect an error, subsequent work requests will result
-                // in work_request_flushed_error, we hide this by default
-                if (wc[i].status != IBV_WC_WR_FLUSH_ERR ||
-                    show_work_request_flushed_error)
-                    LOG(ERROR)
-                        << "Worker: Process failed for slice (opcode: "
-                        << slice->opcode
-                        << ", source_addr: " << slice->source_addr
-                        << ", length: " << slice->length
-                        << ", dest_addr: " << (void *)slice->rdma.dest_addr
-                        << ", local_nic: " << context_.deviceName()
-                        << ", peer_nic: " << slice->peer_nic_path
-                        << ", dest_rkey: " << slice->rdma.dest_rkey
-                        << ", retry_cnt: " << slice->rdma.retry_cnt
-                        << "): " << ibv_wc_status_str(wc[i].status);
+                // Flush errors are generated when QPs transition to ERR
+                // state (e.g., during two-phase endpoint destruction via
+                // beginDestroy). They are not real network errors, so we
+                // directly mark the slice as failed without retry, without
+                // counting toward the RNIC error threshold, and without
+                // triggering endpoint deletion.
+                if (wc[i].status == IBV_WC_WR_FLUSH_ERR) {
+                    if (globalConfig().trace)
+                        LOG(INFO)
+                            << "Worker: WR flush error (peer_nic: "
+                            << slice->peer_nic_path << "), marking failed";
+                    slice->markFailed();
+                    processed_slice_count++;
+                    continue;
+                }
+
+                LOG(ERROR) << "Worker: Process failed for slice (opcode: "
+                           << slice->opcode
+                           << ", source_addr: " << slice->source_addr
+                           << ", length: " << slice->length
+                           << ", dest_addr: " << (void *)slice->rdma.dest_addr
+                           << ", local_nic: " << context_.deviceName()
+                           << ", peer_nic: " << slice->peer_nic_path
+                           << ", dest_rkey: " << slice->rdma.dest_rkey
+                           << ", retry_cnt: " << slice->rdma.retry_cnt
+                           << "): " << ibv_wc_status_str(wc[i].status);
                 failed_nr_polls++;
                 if (context_.active() && failed_nr_polls > 32 &&
                     !success_nr_polls) {
@@ -320,8 +330,6 @@ void WorkerPool::performPollCq(int thread_id) {
                     collective_slice_queue_[thread_id][slice->peer_nic_path]
                         .push_back(slice);
                     redispatch_counter_++;
-                    // std::vector<RdmaTransport::Slice *> slice_list { slice };
-                    // redispatch(slice_list, thread_id);
                 }
             } else {
                 slice->markSuccess();


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

### Problem

When using RDMA transport, a segfault occurs in `ibv_post_send()` inside `RdmaEndPoint::submitPostSend()`, preceded by the warning:

```
Outstanding work requests found, CQ will not be generated
```

**Root cause**: When `deleteEndpoint` or `evictEndpoint` triggers endpoint destruction (via `~RdmaEndPoint()` → `deconstruct()`), `ibv_destroy_qp()` runs concurrently with `submitPostSend()` on another worker thread that still holds a `shared_ptr` to the same endpoint. The destroyed QP pointer becomes dangling, and the subsequent `ibv_post_send()` crashes.

### Solution

Introduce **two-phase asynchronous QP destruction** to eliminate the race condition:

**Phase 1 — `beginDestroy()` (non-blocking)**:
- Sets `active_ = false` and `status_ = DESTROYING` to prevent new work submissions
- Transitions all QPs to `IBV_QPS_ERR` state, causing hardware to flush inflight WRs to CQ as `IBV_WC_WR_FLUSH_ERR`
- Does **not** destroy QPs or free resources

**Phase 2 — `finishDestroy()` (driven by worker loop)**:
- Called periodically by `reclaimEndpoint()` in the worker loop
- Checks if all `wr_depth_list_` entries have been drained to zero (by `performPollCq`)
- Only destroys QPs and frees resources after all outstanding WRs are drained
- Includes a **30-second timeout** to force destruction if `ibv_modify_qp` to ERR failed and WRs were never flushed
- Includes a **retry limit** (`kFinishDestroyMaxRetries = 3`) for `ibv_destroy_qp` failures — if QP destruction fails permanently (e.g., driver bug), the endpoint is force-marked as `DESTROYED` after 3 attempts to prevent infinite retry loops and log flooding

### Additional improvements

- **`submitPostSend` guard**: Rejects submissions unless `status_ == CONNECTED && active_`, moving slices to `failed_slice_list`
- **Lock protection**: `deconstructLocked()` serializes QP destruction with `submitPostSend()` via the same `RWSpinlock`
- **`IBV_WC_WR_FLUSH_ERR` handling**: `performPollCq` now recognizes flush errors as expected during two-phase destruction — marks slices as failed without retry, without counting toward the RNIC error threshold, and without triggering endpoint deletion
- **Best-effort QP destruction**: `deconstructLocked()` continues destroying remaining QPs even if one fails, preventing QP leaks. Successfully destroyed QPs are set to `nullptr` to prevent double-free on retry
- **New `DESTROYING`/`DESTROYED` states**: Clear lifecycle semantics with proper state machine transitions
- **`cq_outstanding_` adjustment before QP destruction**: Moved ahead of `ibv_destroy_qp` loop so the counter is always corrected even if QP destruction fails and returns early

### Files changed

| File | Changes |
|------|---------|
| `rdma_endpoint.h` | Add `DESTROYING`/`DESTROYED` states, `beginDestroy()`/`finishDestroy()`/`deconstructLocked()` declarations, `kFinishDestroyTimeoutSec` and `kFinishDestroyMaxRetries` constants, `finish_destroy_retries_` counter |
| `rdma_endpoint.cpp` | Implement two-phase destruction, add `submitPostSend` guard, lock protection in `deconstruct`, best-effort QP cleanup with retry limit |
| `endpoint_store.cpp` | `deleteEndpoint`/`evictEndpoint` call `beginDestroy()`, `reclaimEndpoint` calls `finishDestroy()` |
| `worker_pool.cpp` | Handle `IBV_WC_WR_FLUSH_ERR` as expected during destruction, remove dead commented-out code |

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
