### PR TITLE
[Build] Add memory-aware compile/link parallelism with Ninja support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,17 +70,18 @@ jobs:
     - name: Configure project
       run: |
         sudo apt update -y
+        sudo apt install -y ninja-build
         sudo bash -x dependencies.sh -y
         mkdir build
         cd build
-        cmake .. -DUSE_HTTP=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON -DENABLE_ASAN=ON -DENABLE_SCCACHE=ON
+        cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CXL=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON -DENABLE_ASAN=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Debug
       shell: bash
 
     - name: Build project
       run: |
         cd build
-        make -j
-        sudo make install
+        cmake --build .
+        sudo cmake --install .
       shell: bash
 
     - name: Build nvlink_allocator.so
@@ -103,7 +104,7 @@ jobs:
         cd build
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
         ldconfig -v || echo "always continue"
-        MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 make test -j ARGS="-V"
+        MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 ctest -j --output-on-failure
       shell: bash
 
     - name: Generate Python version tag
@@ -135,18 +136,19 @@ jobs:
     - name: Configure project
       run: |
         apt update -y
+        apt install -y ninja-build
         bash -x dependencies.sh -y
         mkdir build
         cd build
-        cmake .. -DUSE_MUSA=ON -DUSE_MNNVL=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON -DUSE_CXL=ON -DUSE_TCP=ON -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF
+        cmake -G Ninja .. -DUSE_MUSA=ON -DUSE_MNNVL=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON -DUSE_CXL=ON -DUSE_TCP=ON -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF
       shell: bash
 
     - name: Build project
       run: |
         cd build
         source ~/.bashrc
-        make -j
-        make install
+        cmake --build .
+        cmake --install .
       shell: bash
 
   test-wheel-ubuntu:
@@ -364,6 +366,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update -y
+        sudo apt install -y ninja-build
         sudo bash -x dependencies.sh -y
         df -h
       shell: bash
@@ -375,9 +378,9 @@ jobs:
         cd build
         export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH
         export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-        cmake .. -DUSE_ETCD=OFF -DUSE_REDIS=ON -DUSE_HTTP=ON -DWITH_METRICS=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_SCCACHE=ON -DUSE_CUDA=OFF -DUSE_MNNVL=OFF -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs"
-        make -j4
-        sudo make install
+        cmake -G Ninja .. -DUSE_ETCD=OFF -DUSE_CXL=ON -DUSE_REDIS=ON -DUSE_HTTP=ON -DWITH_METRICS=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_SCCACHE=ON -DUSE_CUDA=OFF -DUSE_MNNVL=OFF -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs"
+        cmake --build .
+        sudo cmake --install .
         df -h
       shell: bash
 
@@ -385,7 +388,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -DUSE_ETCD=ON -DUSE_REDIS=ON -DUSE_HTTP=ON -DWITH_STORE=ON -DWITH_P2P_STORE=ON -DWITH_EP=ON -DWITH_METRICS=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_SCCACHE=ON -DUSE_CUDA=ON -DUSE_MNNVL=OFF -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs"
+        cmake -G Ninja .. -DUSE_ETCD=ON -DUSE_CXL=ON -DUSE_REDIS=ON -DUSE_HTTP=ON -DWITH_STORE=ON -DWITH_P2P_STORE=ON -DWITH_METRICS=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_SCCACHE=ON -DUSE_CUDA=ON -DUSE_MNNVL=OFF -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs"
       shell: bash
       # TODO: lack USE_NVMEOF,USE_MNNVL
 
@@ -394,15 +397,15 @@ jobs:
         export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
         export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
         cd build
-        make -j4
-        sudo make install
+        cmake --build .
+        sudo cmake --install .
         df -h
       shell: bash
 
     - name: Configure project with unit tests and examples
       run: |
         cd build
-        cmake .. -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_SCCACHE=ON
+        cmake -G Ninja .. -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_SCCACHE=ON
       shell: bash
       # TODO: lack WITH_RUST_EXAMPLE
 
@@ -411,15 +414,15 @@ jobs:
         export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
         export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
         cd build
-        make -j4
-        sudo make install
+        cmake --build .
+        sudo cmake --install .
       shell: bash
 
     - name: Configure project
       run: |
         cd build
         rm -r */tests
-        cmake .. -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF -DUSE_HTTP=ON -DENABLE_SCCACHE=ON
+        cmake -G Ninja .. -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF -DUSE_HTTP=ON -DENABLE_SCCACHE=ON -DUSE_CXL=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.9.0;2.9.1;2.10.0"
       shell: bash
 
     - name: Build project
@@ -427,8 +430,8 @@ jobs:
         export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
         export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
         cd build
-        make -j4
-        sudo make install
+        cmake --build .
+        sudo cmake --install .
       shell: bash
 
     - name: Build nvlink_allocator.so

--- a/.github/workflows/ci_cu13.yml
+++ b/.github/workflows/ci_cu13.yml
@@ -65,6 +65,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update -y
+        sudo apt install -y ninja-build
         sudo bash -x dependencies.sh -y
         df -h
       shell: bash
@@ -73,7 +74,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. \
+        cmake -G Ninja .. \
           -DUSE_ETCD=ON \
           -DUSE_REDIS=ON \
           -DUSE_HTTP=ON \
@@ -94,8 +95,8 @@ jobs:
         export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
         export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
         cd build
-        make -j4
-        sudo make install
+        cmake --build .
+        sudo cmake --install .
         df -h
       shell: bash
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -102,6 +102,7 @@ echo -e "${YELLOW}This may take a few minutes...${NC}"
 
 SYSTEM_PACKAGES="build-essential \
                   cmake \
+                  ninja-build \
                   git \
                   wget \
                   libibverbs-dev \

--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -40,6 +40,9 @@ add_definitions(-DCONFIG_ERDMA)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Memory-aware build parallelism (compile vs. link job pools)
+include(${CMAKE_CURRENT_LIST_DIR}/limit_jobs.cmake)
+
 option(ENABLE_SCCACHE "Whether to open sccache" OFF)
 if (ENABLE_SCCACHE)
   find_program(SCCACHE sccache REQUIRED)

--- a/mooncake-common/limit_jobs.cmake
+++ b/mooncake-common/limit_jobs.cmake
@@ -1,0 +1,86 @@
+# limit_jobs.cmake — Memory-aware build parallelism
+#
+# Auto-detects available memory and CPU count, calculates safe parallel job
+# limits for compilation and linking separately. With Ninja, creates job pools
+# so compilation uses many cores while memory-heavy linking is restricted.
+#
+# User overrides (cmake -D...):
+#   PARALLEL_COMPILE_JOBS  — override compile parallelism
+#   PARALLEL_LINK_JOBS     — override link parallelism
+#   MAX_COMPILER_MEMORY_MB — per-compile-job memory estimate (default: 1500)
+#   MAX_LINKER_MEMORY_MB   — per-link-job memory estimate (default: 4000)
+
+set(MAX_COMPILER_MEMORY_MB "1500" CACHE STRING
+    "Estimated peak memory per compile job in MB")
+set(MAX_LINKER_MEMORY_MB "4000" CACHE STRING
+    "Estimated peak memory per link job in MB")
+
+# Guard against invalid user input (division by zero)
+if(MAX_COMPILER_MEMORY_MB LESS_EQUAL 0)
+    message(WARNING "[limit_jobs] MAX_COMPILER_MEMORY_MB=${MAX_COMPILER_MEMORY_MB} "
+        "invalid, falling back to 1500")
+    set(MAX_COMPILER_MEMORY_MB 1500 CACHE STRING
+        "Estimated peak memory per compile job in MB" FORCE)
+endif()
+if(MAX_LINKER_MEMORY_MB LESS_EQUAL 0)
+    message(WARNING "[limit_jobs] MAX_LINKER_MEMORY_MB=${MAX_LINKER_MEMORY_MB} "
+        "invalid, falling back to 4000")
+    set(MAX_LINKER_MEMORY_MB 4000 CACHE STRING
+        "Estimated peak memory per link job in MB" FORCE)
+endif()
+
+# Detect system resources
+cmake_host_system_information(RESULT _available_mem_mb
+    QUERY AVAILABLE_PHYSICAL_MEMORY)
+cmake_host_system_information(RESULT _nproc
+    QUERY NUMBER_OF_LOGICAL_CORES)
+
+message(STATUS "[limit_jobs] Available memory: ${_available_mem_mb} MB, "
+    "CPU cores: ${_nproc}")
+
+# Calculate safe parallel jobs from memory
+math(EXPR _compile_jobs "${_available_mem_mb} / ${MAX_COMPILER_MEMORY_MB}")
+math(EXPR _link_jobs "${_available_mem_mb} / ${MAX_LINKER_MEMORY_MB}")
+
+# Clamp: [1, nproc]
+if(_compile_jobs LESS 1)
+    set(_compile_jobs 1)
+endif()
+if(_compile_jobs GREATER _nproc)
+    set(_compile_jobs ${_nproc})
+endif()
+if(_link_jobs LESS 1)
+    set(_link_jobs 1)
+endif()
+if(_link_jobs GREATER _nproc)
+    set(_link_jobs ${_nproc})
+endif()
+
+# Use auto-detected values unless user explicitly overrides with -D
+if(NOT DEFINED PARALLEL_COMPILE_JOBS)
+    set(PARALLEL_COMPILE_JOBS "${_compile_jobs}")
+endif()
+if(NOT DEFINED PARALLEL_LINK_JOBS)
+    set(PARALLEL_LINK_JOBS "${_link_jobs}")
+endif()
+
+message(STATUS "[limit_jobs] Compile jobs: ${PARALLEL_COMPILE_JOBS} "
+    "(${MAX_COMPILER_MEMORY_MB} MB/job), "
+    "Link jobs: ${PARALLEL_LINK_JOBS} (${MAX_LINKER_MEMORY_MB} MB/job)")
+
+# Apply to build system
+if(CMAKE_GENERATOR MATCHES "Ninja")
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS
+        compile_pool=${PARALLEL_COMPILE_JOBS}
+        link_pool=${PARALLEL_LINK_JOBS}
+    )
+    set(CMAKE_JOB_POOL_COMPILE "compile_pool" CACHE STRING "" FORCE)
+    set(CMAKE_JOB_POOL_LINK "link_pool" CACHE STRING "" FORCE)
+    message(STATUS "[limit_jobs] Ninja job pools: "
+        "compile=${PARALLEL_COMPILE_JOBS}, link=${PARALLEL_LINK_JOBS}")
+else()
+    message(STATUS "[limit_jobs] Hint: use -G Ninja for automatic "
+        "compile/link parallelism separation")
+    message(STATUS "[limit_jobs] With Make, recommend: "
+        "cmake --build . -j${PARALLEL_LINK_JOBS}")
+endif()


### PR DESCRIPTION
  ## Description

  Cherry-picked from main branch commit 79266ffb4dbdd3814199dd26c2cfab70148dfc91. Due to significant branch divergence, not all changes were
  cherry-picked:
  - CI workflow files (ci.yml, ci_cu13.yml) were manually adapted
  - Dockerfile and ci_ascend.yml were skipped (not present in this branch)

  - Add limit_jobs.cmake module for memory-aware build parallelism
  - Auto-detect available memory and CPU cores to calculate safe job limits
  - With Ninja, create separate job pools for compilation (~1.5GB/job) and linking (~4GB/job)
  - Switch CI workflows to use Ninja generator
  - Add ninja-build to dependencies.sh

  This helps prevent OOM during linking on high-core machines.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [x] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] PyTorch Backend (`mooncake-pg`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [x] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [x] Other

  ## How Has This Been Tested?

  - Local container test with Ninja passed
  - CI build verification pending

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
  - [ ] I have updated the documentation.
  - [ ] I have added tests to prove my changes are effective.