### PR TITLE
[Store] Support POSIX shared memory segments for TENT ShmTransport

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -281,7 +281,8 @@ class Client {
      */
     tl::expected<void, ErrorCode> MountSegment(
         const void* buffer, size_t size, const std::string& protocol = "tcp",
-        const std::string& location = kWildcardLocation);
+        const std::string& location = kWildcardLocation,
+        const std::string& shm_path = "");
 
     /**
      * @brief Unregisters a memory segment from master
@@ -299,11 +300,13 @@ class Client {
      * @param location Device location (e.g. "cpu:0")
      * @param remote_accessible Whether the memory can be accessed remotely
      * @param update_metadata Whether to update metadata service
+     * @param shm_path POSIX shared memory name (enables ShmTransport in TENT)
      * @return ErrorCode indicating success/failure
      */
     tl::expected<void, ErrorCode> RegisterLocalMemory(
         void* addr, size_t length, const std::string& location,
-        bool remote_accessible = true, bool update_metadata = true);
+        bool remote_accessible = true, bool update_metadata = true,
+        const std::string& shm_path = "");
 
     /**
      * @brief Unregisters memory buffer from TransferEngine

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <shared_mutex>
 #include <string>
+#include <sys/mman.h>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -689,9 +690,24 @@ class RealClient : public PyClient {
         }
     };
 
+    struct ShmSegmentDeleter {
+        size_t size = 0;
+        std::string shm_name;
+        void operator()(void *ptr) const {
+            if (ptr && size > 0) {
+                munmap(ptr, size);
+            }
+            if (!shm_name.empty()) {
+                shm_unlink(shm_name.c_str());
+            }
+        }
+    };
+
     std::vector<std::unique_ptr<void, HugepageSegmentDeleter>>
         hugepage_segment_ptrs_;
     std::vector<std::unique_ptr<void, SegmentDeleter>> segment_ptrs_;
+    std::vector<std::unique_ptr<void, ShmSegmentDeleter>>
+        shm_segment_ptrs_;
     std::vector<std::unique_ptr<void, AscendSegmentDeleter>>
         ascend_segment_ptrs_;
     std::string protocol;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2077,7 +2077,7 @@ std::vector<int> Client::GetNicNumaNodes() const {
 
 tl::expected<void, ErrorCode> Client::MountSegment(
     const void* buffer, size_t size, const std::string& protocol,
-    const std::string& location) {
+    const std::string& location, const std::string& shm_path) {
     auto check_result = CheckRegisterMemoryParams(buffer, size);
     if (!check_result) {
         return tl::unexpected(check_result.error());
@@ -2102,7 +2102,8 @@ tl::expected<void, ErrorCode> Client::MountSegment(
         }
 
         int rc = transfer_engine_->registerLocalMemory((void*)buffer, size,
-                                                       location, true, true);
+                                                       location, true, true,
+                                                       shm_path);
         if (rc != 0) {
             LOG(ERROR) << "register_local_memory_failed base=" << buffer
                        << " size=" << size << ", error=" << rc;
@@ -2186,13 +2187,15 @@ tl::expected<void, ErrorCode> Client::UnmountSegment(const void* buffer,
 
 tl::expected<void, ErrorCode> Client::RegisterLocalMemory(
     void* addr, size_t length, const std::string& location,
-    bool remote_accessible, bool update_metadata) {
+    bool remote_accessible, bool update_metadata,
+    const std::string& shm_path) {
     auto check_result = CheckRegisterMemoryParams(addr, length);
     if (!check_result) {
         return tl::unexpected(check_result.error());
     }
     if (this->transfer_engine_->registerLocalMemory(
-            addr, length, location, remote_accessible, update_metadata) != 0) {
+            addr, length, location, remote_accessible, update_metadata,
+            shm_path) != 0) {
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
     return {};

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1,4 +1,6 @@
+#include <fcntl.h>
 #include <netinet/in.h>
+#include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -15,6 +17,7 @@
 #include <cctype>
 #include <limits>
 #include <optional>
+#include <random>
 #include <vector>
 
 #include "real_client.h"
@@ -447,6 +450,48 @@ tl::expected<void, ErrorCode> RealClient::setup_ascend_internal(
     return {};
 }
 
+namespace {
+// Generate a random POSIX shared memory name for cross-process segment sharing.
+std::string generate_shm_name() {
+    static thread_local std::mt19937 rng(std::random_device{}());
+    std::string name = "mooncake_seg_";
+    for (int i = 0; i < 8; ++i)
+        name += static_cast<char>('a' + rng() % 26);
+    return name;
+}
+
+// Allocate memory via POSIX shared memory (shm_open + MAP_SHARED).
+void *allocate_shm_segment(size_t size, std::string &shm_name) {
+    shm_name = generate_shm_name();
+    int fd = shm_open(shm_name.c_str(), O_CREAT | O_RDWR, 0644);
+    if (fd < 0) {
+        PLOG(ERROR) << "shm_open failed for " << shm_name;
+        return nullptr;
+    }
+    if (ftruncate64(fd, size) < 0) {
+        PLOG(ERROR) << "ftruncate64 failed for " << shm_name;
+        close(fd);
+        shm_unlink(shm_name.c_str());
+        return nullptr;
+    }
+    void *ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+    if (ptr == MAP_FAILED) {
+        PLOG(ERROR) << "mmap MAP_SHARED failed for " << shm_name;
+        shm_unlink(shm_name.c_str());
+        return nullptr;
+    }
+    return ptr;
+}
+
+bool use_tent_shm() {
+    const char *tent = std::getenv("MC_USE_TENT");
+    const char *tev1 = std::getenv("MC_USE_TEV1");
+    const char *shm = std::getenv("MC_STORE_SHM_SEGMENTS");
+    return (tent || tev1 || (shm && std::string(shm) != "0"));
+}
+}  // namespace
+
 tl::expected<void, ErrorCode> RealClient::setup_internal(
     const std::string &local_hostname, const std::string &metadata_server,
     size_t global_segment_size, size_t local_buffer_size,
@@ -627,9 +672,10 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             size_t mapped_size = segment_size;
             void *ptr = nullptr;
             std::string seg_location = kWildcardLocation;
+            std::string shm_name;
+            const bool want_shm = use_tent_shm();
 
             if (!seg_numa_nodes.empty()) {
-                // NUMA-segmented allocation: contiguous VMA, per-region binding
                 size_t page_sz = should_use_hugepage
                                      ? get_hugepage_size_from_env()
                                      : static_cast<size_t>(getpagesize());
@@ -643,6 +689,12 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                     align_up(segment_size, get_hugepage_size_from_env());
                 ptr = allocate_buffer_mmap_memory(mapped_size,
                                                   get_hugepage_size_from_env());
+            } else if (want_shm) {
+                // POSIX shared memory: enables TENT ShmTransport for
+                // cross-process same-node GPU↔CPU via cudaMemcpy.
+                ptr = allocate_shm_segment(segment_size, shm_name);
+                LOG(INFO) << "Allocated SHM segment: " << shm_name
+                          << " (" << segment_size << " bytes)";
             } else {
                 ptr = allocate_buffer_allocator_memory(segment_size,
                                                        this->protocol);
@@ -656,15 +708,17 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 ascend_segment_ptrs_.emplace_back(
                     ptr, AscendSegmentDeleter{this->protocol});
             } else if (!seg_numa_nodes.empty() || should_use_hugepage) {
-                // NUMA-segmented or hugepage: track as mmap allocation for
-                // munmap cleanup
                 hugepage_segment_ptrs_.emplace_back(
                     ptr, HugepageSegmentDeleter{mapped_size});
+            } else if (!shm_name.empty()) {
+                shm_segment_ptrs_.emplace_back(
+                    ptr, ShmSegmentDeleter{mapped_size, shm_name});
             } else {
                 segment_ptrs_.emplace_back(ptr);
             }
             auto mount_result =
-                client_->MountSegment(ptr, mapped_size, protocol, seg_location);
+                client_->MountSegment(ptr, mapped_size, protocol, seg_location,
+                                      shm_name);
             if (!mount_result.has_value()) {
                 LOG(ERROR) << "Failed to mount segment: "
                            << toString(mount_result.error());

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -93,7 +93,8 @@ class TransferEngine {
     int registerLocalMemory(void* addr, size_t length,
                             const std::string& location = kWildcardLocation,
                             bool remote_accessible = true,
-                            bool update_metadata = true);
+                            bool update_metadata = true,
+                            const std::string& shm_path = "");
 
     int unregisterLocalMemory(void* addr, bool update_metadata = true);
 

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -78,7 +78,8 @@ int TransferEngine::removeLocalSegment(const std::string& segment_name) {
 int TransferEngine::registerLocalMemory(void* addr, size_t length,
                                         const std::string& location,
                                         bool remote_accessible,
-                                        bool update_metadata) {
+                                        bool update_metadata,
+                                        const std::string& /* shm_path */) {
     return impl_->registerLocalMemory(addr, length, location, remote_accessible,
                                       update_metadata);
 }
@@ -366,11 +367,14 @@ int TransferEngine::removeLocalSegment(const std::string& segment_name) {
 int TransferEngine::registerLocalMemory(void* addr, size_t length,
                                         const std::string& location,
                                         bool remote_accessible,
-                                        bool update_metadata) {
+                                        bool update_metadata,
+                                        const std::string& shm_path) {
     if (use_tent_) {
         mooncake::tent::MemoryOptions option;
         if (!location.empty() && location != kWildcardLocation)
             option.location = location;
+        if (!shm_path.empty())
+            option.shm_path = shm_path;
         auto status = impl_tent_->registerLocalMemory(addr, length, option);
         return (int)status.code();
     } else


### PR DESCRIPTION
## Problem

In the owner/requester architecture, same-node GPU↔CPU transfers go through **RDMA NIC loopback** even when both processes are on the same machine:

```
Current: GPU →(PCIe)→ NIC →(loopback)→ NIC →(PCIe)→ CPU   [2 PCIe hops, wastes NIC bandwidth]
```

TENT already has `ShmTransport` that can do cross-process same-node transfers via POSIX shared memory + `cudaMemcpy`, but it requires the Owner's CPU segments to be allocated with `shm_open` (not `malloc`/`mmap(MAP_PRIVATE)`), and the `shm_path` must be passed through to `ShmTransport::addMemoryBuffer` during `registerLocalMemory`.

## Solution

When `MC_USE_TENT` (or `MC_STORE_SHM_SEGMENTS`) is set, allocate global segments via `shm_open + mmap(MAP_SHARED)` and pass the `shm_path` through the registration chain:

```
real_client.cpp (shm_open) → MountSegment(shm_path)
  → registerLocalMemory(shm_path)
    → TENT MemoryOptions{shm_path}
      → ShmTransport::addMemoryBuffer registers the buffer
        → Requester can cross-process mmap the same /dev/shm file
          → cudaMemcpy(shm_addr, gpu_addr) — 1 PCIe hop, no NIC
```

## Changes

| File | Change |
|------|--------|
| `transfer_engine.h` | Add `shm_path` param to `registerLocalMemory` (default `""`) |
| `transfer_engine.cpp` | Pass `shm_path` to TENT `MemoryOptions`; ignored in non-TENT path |
| `client_service.h` | Add `shm_path` to `MountSegment` and `RegisterLocalMemory` |
| `client_service.cpp` | Pass `shm_path` through to `registerLocalMemory` |
| `real_client.h` | Add `ShmSegmentDeleter` (munmap + shm_unlink) |
| `real_client.cpp` | Add `allocate_shm_segment()` helper; use it when `MC_USE_TENT` is set |

All new parameters have default values — **fully backward compatible**.

## Activation

```bash
# Owner process
export MC_USE_TENT=1
# or explicitly:
export MC_STORE_SHM_SEGMENTS=1
```

Segments will appear in `/dev/shm/mooncake_seg_*`. TENT's ShmTransport (with `transports/shm/enable: true`) will automatically route same-node transfers through these shared memory regions.

## Verification

- [x] Builds successfully with `cmake -DWITH_STORE=ON -DUSE_CUDA=ON`
- [x] All new params have defaults — no API breakage
- [ ] End-to-end: owner with SHM + requester on same node → verify `ShmTransport` used (via GLOG)
- [ ] Cross-node: segments still accessible via RDMA (SHM is a local optimization only)

## Related

- Issue #162: "[WIP] Refactoring Mooncake Transfer Engine" — mentions SHM transport for same-node
- Issue #68 comment: "We will support shared memory transport for P/D in the same node"
- Issue #1163: "Decouple TransferTask from TE" — ITransferEngine interface
- TENT roadmap #1058: "Runtime integration with Mooncake Store"