### PR TITLE
[store] Bug Fix: Local Disk Replica Metadata Not Cleaned Up After Store Node Offline

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -562,8 +562,13 @@ class MasterService {
     // fulfill evict ratio lowerbound.
     void BatchEvict(double evict_ratio_target, double evict_ratio_lowerbound);
 
+    // Helper to get a snapshot of alive clients (under client_mutex_ shared lock)
+    std::unordered_set<UUID, boost::hash<UUID>> getAliveClientsSnapshot() const;
+
     // Clear invalid handles in all shards
     void ClearInvalidHandles();
+    void ClearInvalidHandles(
+        const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients);
 
     std::string FormatTimestamp(
         const std::chrono::system_clock::time_point& tp);
@@ -891,7 +896,10 @@ class MasterService {
     }
 
     // Helper to clean up stale handles pointing to unmounted segments
-    bool CleanupStaleHandles(ObjectMetadata& metadata);
+    // or local_disk replicas whose owner client is no longer alive.
+    bool CleanupStaleHandles(
+        ObjectMetadata& metadata,
+        const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients);
 
     // Helper: allocate replicas, create ObjectMetadata, insert into shard,
     // and return descriptor list.  Shared by PutStart and UpsertStart.
@@ -964,7 +972,8 @@ class MasterService {
               replication_task_it_(shard_guard_->replication_tasks.find(key)) {
             // Automatically clean up invalid handles
             if (it_ != shard_guard_->metadata.end()) {
-                if (service_->CleanupStaleHandles(it_->second)) {
+                if (service_->CleanupStaleHandles(
+                        it_->second, service_->getAliveClientsSnapshot())) {
                     this->Erase();
 
                     if (processing_it_ != shard_guard_->processing_keys.end()) {

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -562,7 +562,8 @@ class MasterService {
     // fulfill evict ratio lowerbound.
     void BatchEvict(double evict_ratio_target, double evict_ratio_lowerbound);
 
-    // Helper to get a snapshot of alive clients (under client_mutex_ shared lock)
+    // Helper to get a snapshot of alive clients (under client_mutex_ shared
+    // lock)
     std::unordered_set<UUID, boost::hash<UUID>> getAliveClientsSnapshot() const;
 
     // Clear invalid handles in all shards
@@ -977,12 +978,13 @@ class MasterService {
             // ClientMonitorFunc.
             if (it_ != shard_guard_->metadata.end()) {
                 bool all_invalid = true;
-                it_->second.VisitReplicas([&all_invalid](const Replica& replica) {
-                    if (!replica.is_memory_replica() ||
-                        !replica.has_invalid_mem_handle()) {
-                        all_invalid = false;
-                    }
-                });
+                it_->second.VisitReplicas(
+                    [&all_invalid](const Replica& replica) {
+                        if (!replica.is_memory_replica() ||
+                            !replica.has_invalid_mem_handle()) {
+                            all_invalid = false;
+                        }
+                    });
                 if (all_invalid && it_->second.HasReplica()) {
                     this->Erase();
                     if (processing_it_ != shard_guard_->processing_keys.end()) {

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -977,15 +977,14 @@ class MasterService {
             // local_disk replicas are cleaned up by ClearInvalidHandles() in
             // ClientMonitorFunc.
             if (it_ != shard_guard_->metadata.end()) {
-                bool all_invalid = true;
-                it_->second.VisitReplicas(
-                    [&all_invalid](const Replica& replica) {
-                        if (!replica.is_memory_replica() ||
-                            !replica.has_invalid_mem_handle()) {
-                            all_invalid = false;
-                        }
-                    });
-                if (all_invalid && it_->second.HasReplica()) {
+                // Erase invalid memory replicas (those with unmounted
+                // segments). No client_mutex_ needed since we only check memory
+                // replicas.
+                it_->second.EraseReplicas([](const Replica& replica) {
+                    return replica.has_invalid_mem_handle();
+                });
+                // If no valid replicas remain, delete the whole object.
+                if (!it_->second.IsValid()) {
                     this->Erase();
                     if (processing_it_ != shard_guard_->processing_keys.end()) {
                         this->EraseFromProcessing();

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -970,12 +970,21 @@ class MasterService {
               it_(shard_guard_->metadata.find(key)),
               processing_it_(shard_guard_->processing_keys.find(key)),
               replication_task_it_(shard_guard_->replication_tasks.find(key)) {
-            // Automatically clean up invalid handles
+            // Automatically clean up invalid handles (memory replicas only).
+            // Note: We only check memory replicas here to avoid lock order
+            // violation (client_mutex_ must be acquired before metadata shard).
+            // local_disk replicas are cleaned up by ClearInvalidHandles() in
+            // ClientMonitorFunc.
             if (it_ != shard_guard_->metadata.end()) {
-                if (service_->CleanupStaleHandles(
-                        it_->second, service_->getAliveClientsSnapshot())) {
+                bool all_invalid = true;
+                it_->second.VisitReplicas([&all_invalid](const Replica& replica) {
+                    if (!replica.is_memory_replica() ||
+                        !replica.has_invalid_mem_handle()) {
+                        all_invalid = false;
+                    }
+                });
+                if (all_invalid && it_->second.HasReplica()) {
                     this->Erase();
-
                     if (processing_it_ != shard_guard_->processing_keys.end()) {
                         this->EraseFromProcessing();
                     }

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -295,10 +295,9 @@ class Replica {
     [[nodiscard]] bool has_stale_local_disk_client(
         const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients)
         const {
-        if (is_local_disk_replica()) {
-            const auto& disk_data = std::get<LocalDiskReplicaData>(data_);
-            return alive_clients.find(disk_data.client_id) ==
-                   alive_clients.end();
+        auto client_id = get_local_disk_client_id();
+        if (client_id.has_value()) {
+            return alive_clients.find(client_id.value()) == alive_clients.end();
         }
         return false;
     }

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -2,9 +2,12 @@
 
 #include <glog/logging.h>
 
+#include <boost/functional/hash.hpp>
+
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 #include <unordered_map>
@@ -280,6 +283,37 @@ class Replica {
             return !mem_data.buffer->isAllocatorValid();
         }
         return false;  // DiskReplicaData does not have handles
+    }
+
+    /**
+     * @brief Check if a local_disk replica's owner client is still alive.
+     * Used by CleanupStaleHandles to remove replicas belonging to expired
+     * clients. For non-local_disk replicas, always returns false.
+     * @param alive_clients Set of currently alive client IDs.
+     * @return true if this is a local_disk replica whose client is not alive.
+     */
+    [[nodiscard]] bool has_stale_local_disk_client(
+        const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients)
+        const {
+        if (is_local_disk_replica()) {
+            const auto& disk_data = std::get<LocalDiskReplicaData>(data_);
+            return alive_clients.find(disk_data.client_id) ==
+                   alive_clients.end();
+        }
+        return false;
+    }
+
+    /**
+     * @brief Get the client_id for local_disk replicas.
+     * @return The client_id if this is a local_disk replica, std::nullopt
+     * otherwise.
+     */
+    [[nodiscard]] std::optional<UUID> get_local_disk_client_id() const {
+        if (is_local_disk_replica()) {
+            const auto& disk_data = std::get<LocalDiskReplicaData>(data_);
+            return disk_data.client_id;
+        }
+        return std::nullopt;
     }
 
     [[nodiscard]] size_t get_memory_buffer_size() const {

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -170,6 +170,12 @@ class ScopedSegmentAccess {
     ErrorCode SetSegmentStatusByName(const std::string& segment_name,
                                      SegmentStatus status);
 
+    /**
+     * @brief Remove the local disk segment entry for a client.
+     * Called when a client expires to clean up its local disk segment.
+     */
+    void UnmountLocalDiskSegment(const UUID& client_id);
+
    private:
     SegmentManager* segment_manager_;
     std::unique_lock<std::shared_mutex> lock_;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -351,12 +351,23 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
     return {};
 }
 
+std::unordered_set<UUID, boost::hash<UUID>>
+MasterService::getAliveClientsSnapshot() const {
+    std::shared_lock<std::shared_mutex> lock(client_mutex_);
+    return ok_client_;
+}
+
 void MasterService::ClearInvalidHandles() {
+    ClearInvalidHandles(getAliveClientsSnapshot());
+}
+
+void MasterService::ClearInvalidHandles(
+    const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients) {
     for (size_t i = 0; i < kNumShards; i++) {
         MetadataShardAccessorRW shard(this, i);
         auto it = shard->metadata.begin();
         while (it != shard->metadata.end()) {
-            if (CleanupStaleHandles(it->second)) {
+            if (CleanupStaleHandles(it->second, alive_clients)) {
                 // If the object is empty, we need to erase the iterator and
                 // also erase the key from processing_keys,
                 // replication_tasks, and offloading_tasks.
@@ -842,13 +853,15 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
     VLOG(1) << "key=" << key << ", value_length=" << slice_length
             << ", config=" << config << ", action=put_start_begin";
 
+    auto alive_clients = getAliveClientsSnapshot();
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     // Lock the shard and check if object already exists
     MetadataShardAccessorRW shard(this, getShardIndex(key));
 
     const auto now = std::chrono::system_clock::now();
     auto it = shard->metadata.find(key);
-    if (it != shard->metadata.end() && !CleanupStaleHandles(it->second)) {
+    if (it != shard->metadata.end() &&
+        !CleanupStaleHandles(it->second, alive_clients)) {
         auto& metadata = it->second;
         // If the object's PutStart expired and has not completed any
         // replicas, we can discard it and allow the new PutStart to
@@ -1085,6 +1098,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     //   during full metadata snapshots.
     // shard lock (exclusive via MetadataShardAccessorRW): serializes all
     //   operations on keys that hash to the same shard.
+    auto alive_clients = getAliveClientsSnapshot();
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataShardAccessorRW shard(this, getShardIndex(key));
 
@@ -1094,7 +1108,9 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     // --- Step 0: stale handle cleanup ---
     // If all memory replicas point to unmounted segments (node crashed and
     // restarted), the metadata is useless — erase it and treat as new key.
-    if (it != shard->metadata.end() && CleanupStaleHandles(it->second)) {
+    // Also clean up local_disk replicas whose owner client has expired.
+    if (it != shard->metadata.end() &&
+        CleanupStaleHandles(it->second, alive_clients)) {
         shard->processing_keys.erase(key);
         shard->metadata.erase(it);
         it = shard->metadata.end();
@@ -1931,6 +1947,8 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
 
     std::shared_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
 
+    auto alive_clients = getAliveClientsSnapshot();
+
     // Process each shard once, acquiring lock per shard
     for (auto& [shard_idx, key_group] : keys_by_shard) {
         MetadataShardAccessorRW shard(this, shard_idx);
@@ -1948,7 +1966,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
             }
 
             // Clean up stale replica handles (consistent with single Remove)
-            if (CleanupStaleHandles(it->second)) {
+            if (CleanupStaleHandles(it->second, alive_clients)) {
                 shard->processing_keys.erase(key);
                 shard->replication_tasks.erase(key);
                 shard->offloading_tasks.erase(key);
@@ -1996,10 +2014,14 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
     return results;
 }
 
-bool MasterService::CleanupStaleHandles(ObjectMetadata& metadata) {
-    // Remove those with invalid allocators
-    metadata.EraseReplicas([](const Replica& replica) {
-        return replica.has_invalid_mem_handle();
+bool MasterService::CleanupStaleHandles(
+    ObjectMetadata& metadata,
+    const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients) {
+    // Remove those with invalid allocators (memory replicas on unmounted
+    // segments) and local_disk replicas whose owner client is no longer alive.
+    metadata.EraseReplicas([&alive_clients](const Replica& replica) {
+        return replica.has_invalid_mem_handle() ||
+               replica.has_stale_local_disk_client(alive_clients);
     });
 
     // Return true if no valid replicas remain after cleanup
@@ -3770,9 +3792,15 @@ void MasterService::ClientMonitorFunc() {
             }  // Release the mutex before long-running ClearInvalidHandles and
                // avoid deadlocks
 
-            if (!unmount_segments.empty()) {
-                ClearInvalidHandles();
+            // Always clean up invalid handles when there are expired clients,
+            // even if no memory segments were unmounted. This is necessary
+            // to clean up local_disk replicas whose owner client has expired.
+            ClearInvalidHandles();
 
+            // Commit unmount of memory segments and clean up local_disk
+            // segments for expired clients. Both require the exclusive
+            // segment lock.
+            {
                 ScopedSegmentAccess segment_access =
                     segment_manager_.getSegmentAccess();
                 for (size_t i = 0; i < unmount_segments.size(); i++) {
@@ -3781,6 +3809,9 @@ void MasterService::ClientMonitorFunc() {
                     LOG(INFO) << "client_id=" << client_ids[i]
                               << ", segment_name=" << segment_names[i]
                               << ", action=unmount_expired_segment";
+                }
+                for (auto& client_id : expired_clients) {
+                    segment_access.UnmountLocalDiskSegment(client_id);
                 }
             }
         }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3987,6 +3987,18 @@ ClientRequester::ClientRequester() {
         pool_conf.client_config.socket_config =
             coro_io::ib_socket_t::config_t{};
     }
+    // Configure reasonable retry limits for SSD offload RPC connections.
+    // - connect_retry_count: Maximum connection retry attempts (default: 3)
+    // - reconnect_wait_time: Wait time between retries (default: 1000ms)
+    // - host_alive_detect_duration: Duration for background alive detection.
+    //   Set to 0 to disable infinite background reconnection attempts when
+    //   a Store node goes down. This prevents continuous "Connection refused"
+    //   logs. When Master cleans up stale local_disk replicas (via
+    //   CleanupStaleHandles), new requests won't route to dead nodes anyway.
+    pool_conf.connect_retry_count = 3;
+    pool_conf.reconnect_wait_time = std::chrono::milliseconds{1000};
+    pool_conf.host_alive_detect_duration = std::chrono::milliseconds{0};
+
     client_pools_ =
         std::make_shared<coro_io::client_pools<coro_rpc::coro_rpc_client>>(
             pool_conf);

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -273,6 +273,15 @@ ErrorCode ScopedSegmentAccess::GetClientSegments(
     return ErrorCode::OK;
 }
 
+void ScopedSegmentAccess::UnmountLocalDiskSegment(const UUID& client_id) {
+    auto it = segment_manager_->client_local_disk_segment_.find(client_id);
+    if (it != segment_manager_->client_local_disk_segment_.end()) {
+        segment_manager_->client_local_disk_segment_.erase(it);
+        LOG(INFO) << "client_id=" << client_id
+                  << ", action=unmount_local_disk_segment";
+    }
+}
+
 ErrorCode ScopedSegmentAccess::GetAllSegments(
     std::vector<std::string>& all_segments) {
     all_segments.clear();


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

### Problem Description
When a Store node with SSD offload enabled goes offline, the following issues occur:
#### Issue 1: BatchQuery Still Returns Dead Node Addresses
After a Store node is taken offline, the Master service detects the client expiration and logs segment unmount operations. However, client applications continue to receive replica information pointing to the dead node through BatchQuery, resulting in repeated failed RPC connection attempts. Example logs showing the issue:
```# Repeated connection failures to dead node
2026-04-14 09:18:36.632720 WARNING [420934] [coro_rpc_client.hpp:989] client_id 8 failed:Connection refused
2026-04-14 09:18:37.101003 WARNING [421439] [coro_rpc_client.hpp:989] client_id 8 failed:Connection refused

# RPC call fails
2026-04-14 09:18:40.841515 WARNING  [421742] [client_pool.hpp:207] reconnect client{0x7f8e8a3a9100},host:{10.15.56.55:50052} out of max limit, stop retry. connect failed
2026-04-14 09:18:40.841530 WARNING  [421742] [client_pool.hpp:445] send request to 10.xx.xx.xx:50052 failed. connection refused.
E20260414 09:18:40.841552 421742 real_client.cpp:2857] Dummy Client not available
E20260414 09:18:40.841598 421964 real_client.cpp:2820] Failed to invoke batch_get_offload_object, client_addr = 10.xx.xx.xx:50052, error is: RPC_FAIL
E20260414 09:18:40.841625 421964 real_client.cpp:2765] Batch get offload object failed with error: RPC_FAIL
E20260414 09:18:40.841634 421964 real_client.cpp:2115] Batch get store object failed with error: RPC_FAIL
```
The errors persist for an **indefinite period** (observed over 10 minutes after node shutdown in production). Each new request triggers a new cycle of connection attempts to the dead node.

#### Issue 2: Background Reconnection Loop
When a connection pool has cached connections to a Store node that goes offline, the `coro_io` library's `alive_detect` background coroutine attempts infinite reconnection every 30 seconds (default `host_alive_detect_duration`), generating continuous warning logs.
Memory replicas are cleaned up properly because `has_invalid_mem_handle()` detects when the segment's allocator becomes invalid after unmount. Additionally, memory replicas use Transfer Engine (RDMA/TCP) which returns errors immediately without persistent RPC reconnection attempts.

### Root Cause Analysis
#### Cause 1: CleanupStaleHandles Does Not Check local_disk Replica Client Liveness
The `CleanupStaleHandles` function only removes memory replicas with invalid handles:
```
// replica.h:277-282
[[nodiscard]] bool has_invalid_mem_handle() const {
    if (is_memory_replica()) {
        const auto& mem_data = std::get<MemoryReplicaData>(data_);
        return !mem_data.buffer->isAllocatorValid();
    }
    return false;  // local_disk replicas always return false
}
```
`LocalDiskReplicaData` contains a client_id field identifying the owning Store node, but `has_invalid_mem_handle()` does not check whether this client is still alive.

#### Cause 2: client_local_disk_segment_ Not Cleaned Up
The `client_local_disk_segment_ ` map tracks local disk segments per client but is not cleaned up in `ClientMonitorFunc` when a client expires.
#### Cause 3: Infinite Background Reconnection
The `coro_io::client_pool` starts an `alive_detect` coroutine after connection failures that loops infinitely with 30-second intervals, controlled by `host_alive_detect_duration` (default 30000ms).

### Solution Design
#### Fix 1: Add Client Liveness Check for local_disk Replicas
Add `has_stale_local_disk_client()` method to Replica class:
```
[[nodiscard]] bool has_stale_local_disk_client(
    const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients) const {
    if (is_local_disk_replica()) {
        const auto& disk_data = std::get<LocalDiskReplicaData>(data_);
        return alive_clients.find(disk_data.client_id) == alive_clients.end();
    }
    return false;
}
```
#### Fix 2: Update CleanupStaleHandles to Accept alive_clients Parameter
Modify signature and implementation:
```
bool CleanupStaleHandles(
    ObjectMetadata& metadata,
    const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients);
```
Add helper method `getAliveClientsSnapshot()` to obtain a snapshot of currently alive clients.
#### Fix 3: Clean Up client_local_disk_segment_ in ClientMonitorFunc
Add `UnmountLocalDiskSegment()` method to ScopedSegmentAccess and call it in `ClientMonitorFunc` when processing expired clients:
```
for (auto& client_id : expired_clients) {
    segment_access.UnmountLocalDiskSegment(client_id);
}
```
#### Fix 4: Disable Infinite Background Reconnection
Configure `ClientRequester` connection pool:
```
pool_conf.host_alive_detect_duration = std::chrono::milliseconds{0};
```
After Master properly cleans up `local_disk` replicas, new requests won't route to dead nodes, making infinite reconnection unnecessary. 
Additionally, even if a Store node is temporarily unreachable (e.g., during initialization), with `host_alive_detect_duration = 0`, the connection pool will attempt up to `connect_retry_count` retries per request rather than infinite background reconnection. If the node becomes available later, new requests will successfully establish connections; if the node is permanently offline, the metadata cleanup ensures no further requests will be routed to it.

### Testing
The fix ensures:

1. When a Store node goes offline, BatchQuery stops returning its address after cleanup
2. client_local_disk_segment_ entries are properly cleaned up
3. Connection warning logs stop after retry limit (not infinite)
4. Store node restart scenarios work correctly (new connections established on demand)


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [X] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
