### PR TITLE
[Test] Fix HA integration test flakiness

### DIFF
--- a/mooncake-store/tests/ha_integration_test.cpp
+++ b/mooncake-store/tests/ha_integration_test.cpp
@@ -107,6 +107,21 @@ class HAIntegrationTest : public ::testing::Test {
                std::chrono::steady_clock::now() < deadline) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
+
+        // If recovery failed (still SYNCING), try re-registering and retry.
+        // This can happen if master restarted and lost client registration.
+        if (client->ha_manager_->GetState() != HAClientState::FULL) {
+            auto reg = client->RegisterClient();
+            if (reg.has_value()) {
+                client->ha_manager_->HandleEvent(HAEvent::MASTER_RECONNECTED);
+                deadline =
+                    std::chrono::steady_clock::now() + std::chrono::seconds(10);
+                while (client->ha_manager_->GetState() != HAClientState::FULL &&
+                       std::chrono::steady_clock::now() < deadline) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                }
+            }
+        }
         ASSERT_EQ(client->ha_manager_->GetState(), HAClientState::FULL)
             << "Client did not recover to FULL within 10s";
     }
@@ -436,15 +451,19 @@ TEST_F(HAIntegrationTest, MasterRestartRecovery) {
     // Reconnect RPC clients to the restarted master (old connections are
     // stale). Retry with backoff since the restarted RPC server may not
     // be fully accepting connections immediately.
+    // Each client has its own connection pool, so both need to clear stale
+    // connections independently.
     for (int attempt = 0; attempt < 10; ++attempt) {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         auto err = client1_->GetMasterClient().Connect(master_address_);
         if (err == ErrorCode::OK) break;
         if (attempt == 9) FAIL() << "Reconnect client1 failed after retries";
     }
-    {
+    for (int attempt = 0; attempt < 10; ++attempt) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
         auto err = client2_->GetMasterClient().Connect(master_address_);
-        ASSERT_EQ(err, ErrorCode::OK) << "Reconnect client2 failed";
+        if (err == ErrorCode::OK) break;
+        if (attempt == 9) FAIL() << "Reconnect client2 failed after retries";
     }
 
     // Re-register clients with the restarted master.


### PR DESCRIPTION
 ## Description

  Fix two flaky HA integration tests that fail intermittently in CI.

  ### 1. MasterRestartRecovery: Add retry logic for client2 reconnection

  Each `MasterClient` has its own connection pool. After master restarts, both client1 and client2 have stale connections in their pools. The
  `Connect` function only retries once internally, which may not be enough to clear all stale connections.

  - Previously: client1 had 10 retries, client2 only tried once
  - Fix: client2 also gets 10 retries to clear stale connections

  ### 2. ForceRecover: Add re-registration on recovery failure

  When `SetUp()` detects clients not in FULL state (e.g., after previous test), it calls `ForceRecover()`. If the master restarted and lost
  client registration, recovery would fail with `CLIENT_NOT_FOUND` and get stuck in SYNCING state.

  - Fix: If recovery fails, try re-registering with the master and retry recovery

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [x] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] PyTorch Backend (`mooncake-pg`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Other

  ## How Has This Been Tested?

  - Local container tests pass for both `MasterRestartRecovery` and `ClientDisconnectAndRecover`
  - Both tests run together without interference

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
  - [ ] I have updated the documentation.
  - [ ] I have added tests to prove my changes are effective.