### PR TITLE
[Store] support host mem in ascend dummy-real mode

### DIFF
--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -2,6 +2,8 @@
 
 #include <atomic>
 #include <csignal>
+#include <mutex>
+#include <unordered_map>
 #include <ylt/coro_rpc/coro_rpc_client.hpp>
 
 #include "pyclient.h"
@@ -178,6 +180,15 @@ class DummyClient : public PyClient {
     int register_shm_via_ipc(const ShmHelper::ShmSegment *shm,
                              bool is_local = false);
 
+#if defined(USE_ASCEND_DIRECT)
+    int register_device_buffer_for_reconnect(void *buffer, size_t size);
+
+    int unregister_device_buffer_for_reconnect(void *buffer);
+
+    [[nodiscard]] std::vector<ShmHelper::ShmSegment>
+    get_registered_device_buffers() const;
+#endif
+
     /**
      * @brief Generic RPC invocation helper for single-result operations
      * @tparam ServiceMethod Pointer to WrappedMasterService member function
@@ -258,6 +269,11 @@ class DummyClient : public PyClient {
     std::atomic<bool> last_ping_healthy_{false};
     void ping_thread_main();
     std::atomic<bool> connected_{false};
+
+#if defined(USE_ASCEND_DIRECT)
+    mutable std::mutex registered_device_buffers_mutex_;
+    std::unordered_map<uint64_t, size_t> registered_device_buffers_;
+#endif
 
     // Ascend physical device id for dummy-real RPC to real, set in setup_dummy
     int32_t device_id_ = 0;

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -28,6 +28,8 @@ enum ShmSegmentType : uint32_t {
     SHM_SEG_HOT_CACHE = 0,  // local hot cache backing memory
 };
 
+constexpr int32_t kInvalidPhysicalDeviceId = -1;
+
 // Return codes for health_check()
 enum HealthCheckStatus : int {
     HC_HEALTHY = 0,          // Fully connected, all links up
@@ -116,6 +118,7 @@ struct ShmRegisterRequest {
     uint64_t client_id_second;
     uint64_t dummy_base_addr;
     uint64_t shm_size;
+    int32_t device_id = kInvalidPhysicalDeviceId;
     bool is_local_buffer;
 };
 

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -453,6 +453,9 @@ class RealClient : public PyClient {
                                                    size_t shm_size,
                                                    bool is_local_buffer,
                                                    const UUID &client_id);
+    tl::expected<void, ErrorCode> map_shm_internal_with_device(
+        int fd, uint64_t shm_base_addr, size_t shm_size, bool is_local_buffer,
+        int32_t physical_device_id, const UUID &client_id);
 
     tl::expected<void, ErrorCode> unmap_shm_internal(const UUID &client_id);
 
@@ -718,7 +721,7 @@ class RealClient : public PyClient {
         bool is_ascend = false;
         bool is_ipc = false;
         // Ascend physical device id from dummy (dummy-real RPC).
-        int32_t device_id = -1;
+        int32_t device_id = kInvalidPhysicalDeviceId;
         uint64_t vmm_handle = 0;
         std::string ipc_key_data;
     };

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -202,8 +202,15 @@ int DummyClient::register_ascend_shm(const ShmHelper::ShmSegment* shm,
         return 0;
     }
     if (!globalConfig().ascend_use_fabric_mem) {
-        LOG(ERROR) << "Host mem is only supported in fabric mem mode.";
-        return -1;
+        // Host: memfd + mmap (ShmHelper); register with Real like non-agent GPU
+        // path.
+        if (shm->fd < 0) {
+            LOG(ERROR)
+                << "Host POSIX shared memory requires memfd-backed allocation "
+                   "(use ShmHelper::allocate / alloc_from_mem_pool)";
+            return -1;
+        }
+        return register_shm_via_ipc(shm, is_local);
     }
 
     // Fabric host mem shared by vmm
@@ -288,6 +295,8 @@ int DummyClient::register_shm_via_ipc(const ShmHelper::ShmSegment* shm,
     req.client_id_second = client_id_.second;
     req.dummy_base_addr = reinterpret_cast<uintptr_t>(shm->base_addr);
     req.shm_size = shm->size;
+    req.device_id = globalConfig().ascend_agent_mode ? device_id_
+                                                     : kInvalidPhysicalDeviceId;
     req.is_local_buffer = is_local;
 
     if (ipc_send_fd(sock_fd, shm->fd, &req, sizeof(req)) < 0) {
@@ -385,16 +394,16 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
         }
         local_buffer_shm->registered = true;
         local_buffer_shm->is_local = true;
+
+        // Best-effort: request hot cache shm from real client
+        if (request_hot_cache_fd() != 0) {
+            LOG(INFO)
+                << "Hot cache shm not available (real client may not have it)";
+        }
     }
 
     ping_running_ = true;
     ping_thread_ = std::thread([this]() mutable { this->ping_thread_main(); });
-
-    // Best-effort: request hot cache shm from real client
-    if (request_hot_cache_fd() != 0) {
-        LOG(INFO)
-            << "Hot cache shm not available (real client may not have it)";
-    }
     return 0;
 }
 
@@ -420,6 +429,12 @@ int DummyClient::tearDownAll() {
     }
     connected_.store(false);
     last_ping_healthy_.store(false);
+#if defined(USE_ASCEND_DIRECT)
+    {
+        std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
+        registered_device_buffers_.clear();
+    }
+#endif
     return 0;
 }
 
@@ -436,22 +451,103 @@ int64_t DummyClient::unregister_shm() {
         invoke_rpc<&RealClient::unmap_shm_internal, void>(client_id_));
 }
 
+#if defined(USE_ASCEND_DIRECT)
+int DummyClient::register_device_buffer_for_reconnect(void* buffer,
+                                                      size_t size) {
+    const auto buffer_addr = reinterpret_cast<uint64_t>(buffer);
+    {
+        std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
+        auto it = registered_device_buffers_.find(buffer_addr);
+        if (it != registered_device_buffers_.end() && it->second != size) {
+            LOG(ERROR) << "Device buffer size mismatch for tracked buffer, "
+                       << "buffer=" << buffer << ", size=" << size
+                       << ", tracked_size=" << it->second;
+            return -1;
+        }
+    }
+
+    ShmHelper::ShmSegment shm{};
+    shm.base_addr = buffer;
+    shm.size = size;
+    if (register_ascend_shm(&shm, false) != 0) {
+        LOG(ERROR) << "Failed to register device buffer, buffer=" << buffer
+                   << ", size=" << size;
+        return -1;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
+        registered_device_buffers_[buffer_addr] = size;
+    }
+    return 0;
+}
+
+int DummyClient::unregister_device_buffer_for_reconnect(void* buffer) {
+    const auto buffer_addr = reinterpret_cast<uint64_t>(buffer);
+    {
+        std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
+        if (registered_device_buffers_.find(buffer_addr) ==
+            registered_device_buffers_.end()) {
+            LOG(ERROR) << "Device buffer is not registered with RealClient";
+            return -1;
+        }
+    }
+
+    auto ret = invoke_rpc<&RealClient::unregister_shm_buffer_internal, void>(
+        buffer_addr, client_id_);
+    if (ret.has_value()) {
+        std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
+        registered_device_buffers_.erase(buffer_addr);
+    }
+    return to_py_ret(ret);
+}
+
+std::vector<ShmHelper::ShmSegment> DummyClient::get_registered_device_buffers()
+    const {
+    std::vector<ShmHelper::ShmSegment> device_buffers;
+    std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
+    device_buffers.reserve(registered_device_buffers_.size());
+    for (const auto& [buffer_addr, size] : registered_device_buffers_) {
+        ShmHelper::ShmSegment shm{};
+        shm.base_addr = reinterpret_cast<void*>(buffer_addr);
+        shm.size = size;
+        device_buffers.push_back(std::move(shm));
+    }
+    return device_buffers;
+}
+#endif
+
 // Dummy only register buffer within the shared memory region
 int DummyClient::register_buffer(void* buffer, size_t size) {
     if (buffer == nullptr) {
         LOG(ERROR) << "Invalid buffer pointer";
         return -1;
     }
+#if defined(USE_ASCEND_DIRECT)
     if (globalConfig().ascend_agent_mode) {
-        auto shm = std::make_shared<ShmHelper::ShmSegment>();
-        shm->base_addr = buffer;
-        shm->size = size;
-        if (register_ascend_shm(shm.get(), false) != 0) {
-            LOG(ERROR) << "Failed to implicitly register new ascend shm.";
+        aclrtPtrAttributes attributes{};
+        auto acl_ret = aclrtPointerGetAttributes(buffer, &attributes);
+        if (acl_ret != ACL_ERROR_NONE) {
+            LOG(ERROR) << "Failed to get pointer attributes, ret=" << acl_ret;
             return -1;
         }
-        return 0;
+        if (attributes.location.type == ACL_MEM_LOCATION_TYPE_DEVICE) {
+            return register_device_buffer_for_reconnect(buffer, size);
+        }
+        if (globalConfig().ascend_use_fabric_mem) {
+            auto shm = std::make_shared<ShmHelper::ShmSegment>();
+            shm->base_addr = buffer;
+            shm->size = size;
+            if (register_ascend_shm(shm.get(), false) != 0) {
+                LOG(ERROR) << "Failed to register buffer, buffer=" << buffer
+                           << ", size=" << size;
+                return -1;
+            }
+            return 0;
+        }
+        // non-Fabric Host: same rules as shm
     }
+#endif
     // Find which shm this buffer belongs to
     auto shm = shm_helper_->get_shm(buffer);
     if (!shm) {
@@ -489,6 +585,17 @@ int DummyClient::unregister_buffer(void* buffer) {
         LOG(ERROR) << "Invalid buffer pointer";
         return -1;
     }
+
+#if defined(USE_ASCEND_DIRECT)
+    if (globalConfig().ascend_agent_mode) {
+        aclrtPtrAttributes attributes{};
+        auto acl_ret = aclrtPointerGetAttributes(buffer, &attributes);
+        if (acl_ret == ACL_ERROR_NONE &&
+            attributes.location.type == ACL_MEM_LOCATION_TYPE_DEVICE) {
+            return unregister_device_buffer_for_reconnect(buffer);
+        }
+    }
+#endif
 
     auto shm = shm_helper_->get_shm(buffer);
     if (!shm) {
@@ -970,23 +1077,39 @@ void DummyClient::ping_thread_main() {
                         if (globalConfig().ascend_agent_mode) {
                             if (register_ascend_shm(shm_ptr.get(),
                                                     shm_ptr->is_local) != 0) {
-                                LOG(WARNING) << "Failed to re-register VMM "
-                                                "during reconnection";
-                                all_registered = false;
-                                break;
-                            }
-                        } else {
-                            if (register_shm_via_ipc(shm_ptr.get(),
-                                                     shm_ptr->is_local) != 0) {
                                 LOG(WARNING)
-                                    << "Failed to re-register shared memory "
-                                       "during reconnection";
+                                    << "Failed to re-register Ascend shared "
+                                       "memory during reconnection";
                                 all_registered = false;
                                 break;
                             }
+                        } else if (register_shm_via_ipc(
+                                       shm_ptr.get(), shm_ptr->is_local) != 0) {
+                            LOG(WARNING)
+                                << "Failed to re-register shared memory "
+                                   "during reconnection";
+                            all_registered = false;
+                            break;
                         }
                     }
                 }
+
+#if defined(USE_ASCEND_DIRECT)
+                if (all_registered && globalConfig().ascend_agent_mode) {
+                    auto device_buffers = get_registered_device_buffers();
+                    for (const auto& device_buffer : device_buffers) {
+                        if (register_ascend_shm(&device_buffer, false) != 0) {
+                            LOG(WARNING)
+                                << "Failed to re-register device buffer "
+                                   "during reconnection, buffer="
+                                << device_buffer.base_addr
+                                << ", size=" << device_buffer.size;
+                            all_registered = false;
+                            break;
+                        }
+                    }
+                }
+#endif
 
                 if (all_registered) {
                     LOG(INFO)

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -51,6 +51,25 @@ bool checkAcl(aclError result, const char *message) {
     }
     return true;
 }
+
+tl::expected<void, ErrorCode> set_context_if_needed(const std::string &protocol,
+                                                    int32_t physical_device_id,
+                                                    const char *action) {
+    if (protocol != "ascend" || !globalConfig().ascend_agent_mode) {
+        return {};
+    }
+    if (physical_device_id == kInvalidPhysicalDeviceId) {
+        LOG(ERROR) << "Missing physical device id for " << action;
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    if (!ContextManager::getInstance().setCurrentContextByPhysicalId(
+            physical_device_id)) {
+        LOG(ERROR) << "Failed to set current context for physical device "
+                   << physical_device_id << " during " << action;
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    return {};
+}
 #endif
 
 struct PreparedRangedReadRequest {
@@ -458,9 +477,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     const std::string &ssd_offload_path) {
     this->protocol = protocol;
     this->ipc_socket_path_ = ipc_socket_path;
-    const bool should_use_hugepage = use_hugepage_ &&
-                                     this->protocol != "ascend" &&
-                                     this->protocol != "ubshmem";
+    const bool should_use_hugepage =
+        use_hugepage_ && this->protocol != "ubshmem";
 #ifdef USE_ASCEND_DIRECT
     if (protocol == "ascend" && globalConfig().ascend_agent_mode) {
         auto ascend_setup = setup_ascend_internal(local_buffer_size);
@@ -1400,6 +1418,14 @@ int64_t RealClient::getSize(const std::string &key) {
 tl::expected<void, ErrorCode> RealClient::map_shm_internal(
     int fd, uint64_t dummy_base_addr, size_t shm_size, bool is_local_buffer,
     const UUID &client_id) {
+    return map_shm_internal_with_device(fd, dummy_base_addr, shm_size,
+                                        is_local_buffer,
+                                        kInvalidPhysicalDeviceId, client_id);
+}
+
+tl::expected<void, ErrorCode> RealClient::map_shm_internal_with_device(
+    int fd, uint64_t dummy_base_addr, size_t shm_size, bool is_local_buffer,
+    int32_t physical_device_id, const UUID &client_id) {
     std::stringstream addr_stream;
     addr_stream << "0x" << std::hex << dummy_base_addr;
 
@@ -1408,15 +1434,16 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal(
         "_" + std::to_string(client_id.second) + "_" + addr_stream.str();
     std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);
 
-    // Check if client context exists, create if not
-    auto &context = shm_contexts_[client_id];
-
     // Check if this shm is already mapped
-    for (const auto &shm : context.mapped_shms) {
-        if (shm.dummy_base_addr == static_cast<uintptr_t>(dummy_base_addr)) {
-            LOG(INFO) << "Segment already mapped: " << shm_name;
-            if (fd >= 0) close(fd);
-            return {};
+    auto context_it = shm_contexts_.find(client_id);
+    if (context_it != shm_contexts_.end()) {
+        for (const auto &shm : context_it->second.mapped_shms) {
+            if (shm.dummy_base_addr ==
+                static_cast<uintptr_t>(dummy_base_addr)) {
+                LOG(INFO) << "Segment already mapped: " << shm_name;
+                if (fd >= 0) close(fd);
+                return {};
+            }
         }
     }
 
@@ -1424,6 +1451,15 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal(
         LOG(ERROR) << "Invalid file descriptor: " << fd;
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
+
+#ifdef USE_ASCEND_DIRECT
+    auto context_result = set_context_if_needed(protocol, physical_device_id,
+                                                "POSIX shm registration");
+    if (!context_result) {
+        close(fd);
+        return context_result;
+    }
+#endif
 
     // Map shared memory from FD
     void *shm_buffer =
@@ -1444,6 +1480,11 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal(
     shm.dummy_base_addr = static_cast<uintptr_t>(dummy_base_addr);
     shm.shm_addr_offset = reinterpret_cast<uintptr_t>(shm_buffer) -
                           reinterpret_cast<uintptr_t>(dummy_base_addr);
+    shm.is_ascend =
+        false;  // memfd/POSIX path; teardown differs from Ascend VMM/IPC
+    shm.device_id = physical_device_id;
+
+    auto &context = shm_contexts_[client_id];
 
     if (shm_size > 0) {
         auto result = client_->RegisterLocalMemory(
@@ -1719,7 +1760,38 @@ tl::expected<void, ErrorCode> RealClient::ascend_unmap_shm_internal(
         if (!shm.shm_buffer) {
             continue;
         }
-        teardown_ascend_shm_buffer(shm);
+        if (shm.is_ascend) {
+            teardown_ascend_shm_buffer(shm);
+        } else {
+#ifdef USE_ASCEND_DIRECT
+            auto context_result = set_context_if_needed(protocol, shm.device_id,
+                                                        "POSIX shm cleanup");
+            if (!context_result) {
+                LOG(WARNING) << "Skip unregisterLocalMemory for POSIX shm: "
+                             << shm.shm_name
+                             << ", error: " << toString(context_result.error());
+            } else
+#endif
+                // Host POSIX shm mapped via map_shm_internal (memfd); not
+                // Ascend VMM/IPC.
+                if (shm.shm_size > 0 && client_) {
+                    auto res =
+                        client_->unregisterLocalMemory(shm.shm_buffer, true);
+                    if (!res) {
+                        LOG(WARNING) << "Failed to unregister local memory for "
+                                        "POSIX shm: "
+                                     << shm.shm_name
+                                     << ", error: " << toString(res.error());
+                    }
+                }
+            if (munmap(shm.shm_buffer, shm.shm_size) != 0) {
+                LOG(ERROR) << "Failed to munmap POSIX shared memory: "
+                           << shm.shm_name << ", error: " << strerror(errno);
+            } else {
+                LOG(INFO) << "Unmapped POSIX shared memory: " << shm.shm_name
+                          << ", size: " << shm.shm_size;
+            }
+        }
     }
     shm_contexts_.erase(it);
     return {};
@@ -1758,6 +1830,13 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
         if (shm_it->is_ascend) {
             teardown_ascend_shm_buffer(*shm_it);
         } else {
+#ifdef USE_ASCEND_DIRECT
+            auto context_result = set_context_if_needed(
+                protocol, shm_it->device_id, "POSIX shm unregister");
+            if (!context_result) {
+                return context_result;
+            }
+#endif
             auto rc = client_->unregisterLocalMemory(shm_it->shm_buffer, true);
             if (!rc) {
                 LOG(ERROR) << "Failed to unregister memory: "
@@ -3796,8 +3875,9 @@ void RealClient::handle_ipc_shm_register(int client_sock) {
     }
 
     UUID client_id{req.client_id_first, req.client_id_second};
-    auto result = map_shm_internal(fd, req.dummy_base_addr, req.shm_size,
-                                   req.is_local_buffer, client_id);
+    auto result = map_shm_internal_with_device(
+        fd, req.dummy_base_addr, req.shm_size, req.is_local_buffer,
+        req.device_id, client_id);
 
     int status = result.has_value() ? 0 : -1;
     ::send(client_sock, &status, sizeof(status), 0);

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -54,7 +54,8 @@ bool ShmHelper::cleanup() {
         }
         if (shm->base_addr) {
 #if defined(USE_ASCEND_DIRECT)
-            if (globalConfig().ascend_agent_mode) {
+            if (globalConfig().ascend_agent_mode &&
+                globalConfig().ascend_use_fabric_mem) {
                 free_memory("ascend", shm->base_addr);
                 continue;
             }
@@ -73,22 +74,28 @@ bool ShmHelper::cleanup() {
 
 void* ShmHelper::allocate(size_t size) {
     std::lock_guard<std::mutex> lock(shm_mutex_);
+    // Dummy-real: FabricMem host uses VMM; non-Fabric host uses memfd+mmap like
+    // non-agent / GPU shm path.
 #ifdef USE_ASCEND_DIRECT
     if (globalConfig().ascend_agent_mode) {
-        void* base_addr = nullptr;
-        size_t alloc_size = size;
-        base_addr = ascend_allocate_vmm_memory_direct(alloc_size);
-        if (base_addr == nullptr) {
-            throw std::runtime_error("Failed to allocate VMM shared memory");
+        if (globalConfig().ascend_use_fabric_mem) {
+            void* base_addr = nullptr;
+            size_t alloc_size = size;
+            base_addr = ascend_allocate_vmm_memory_direct(alloc_size);
+            if (base_addr == nullptr) {
+                throw std::runtime_error(
+                    "Failed to allocate VMM shared memory");
+            }
+            auto shm = std::make_shared<ShmSegment>();
+            shm->fd = -1;
+            shm->base_addr = base_addr;
+            shm->size = alloc_size;
+            shm->name = MOONCAKE_SHM_NAME;
+            shm->registered = false;
+            shms_.push_back(shm);
+            return base_addr;
         }
-        auto shm = std::make_shared<ShmSegment>();
-        shm->fd = -1;
-        shm->base_addr = base_addr;
-        shm->size = alloc_size;
-        shm->name = MOONCAKE_SHM_NAME;
-        shm->registered = false;
-        shms_.push_back(shm);
-        return base_addr;
+        // ascend_agent_mode && !ascend_use_fabric_mem: fall through to memfd
     }
 #endif
 
@@ -142,7 +149,8 @@ int ShmHelper::free(void* addr) {
             }
             if ((*it)->base_addr) {
 #if defined(USE_ASCEND_DIRECT)
-                if (globalConfig().ascend_agent_mode) {
+                if (globalConfig().ascend_agent_mode &&
+                    globalConfig().ascend_use_fabric_mem) {
                     free_memory("ascend", (*it)->base_addr);
                 } else
 #endif


### PR DESCRIPTION
## Description

On the Ascend platform, in dummy-real mode, we previously supported device memory as local memory. We now reuse the Linux shared memory (shm) mechanism to support host memory as local memory.
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

test dummy-real mode in ascend platform

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
