### PR TITLE
[TransferEngine][NVLINK] Replace cudaMemcpy with cudaMemcpyAsync

### DIFF
--- a/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
@@ -173,6 +173,7 @@ Status IntraNodeNvlinkTransport::submitTransfer(
             std::to_string(batch_id));
     }
 
+    std::vector<Slice *> async_submitted_slices;
     size_t task_id = batch_desc.task_list.size();
     batch_desc.task_list.resize(task_id + entries.size());
 
@@ -195,17 +196,36 @@ Status IntraNodeNvlinkTransport::submitTransfer(
         slice->target_id = request.target_id;
         slice->status = Slice::PENDING;
         __sync_fetch_and_add(&task.slice_count, 1);
+
         cudaError_t err;
         if (slice->opcode == TransferRequest::READ)
-            err = cudaMemcpy(slice->source_addr, (void *)slice->local.dest_addr,
-                             slice->length, cudaMemcpyDefault);
+            err = cudaMemcpyAsync(slice->source_addr,
+                                  (void *)slice->local.dest_addr, slice->length,
+                                  cudaMemcpyDefault, 0);
         else
-            err = cudaMemcpy((void *)slice->local.dest_addr, slice->source_addr,
-                             slice->length, cudaMemcpyDefault);
+            err = cudaMemcpyAsync((void *)slice->local.dest_addr,
+                                  slice->source_addr, slice->length,
+                                  cudaMemcpyDefault, 0);
+
         if (err != cudaSuccess)
             slice->markFailed();
         else
-            slice->markSuccess();
+            async_submitted_slices.push_back(slice);
+    }
+
+    if (!async_submitted_slices.empty()) {
+        cudaEvent_t event;
+        cudaError_t event_err =
+            cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+        if (event_err != cudaSuccess) {
+            for (auto *slice : async_submitted_slices) slice->markFailed();
+            return Status::InvalidArgument("cudaEventCreateWithFlags failed");
+        }
+        cudaEventRecord(event, 0);
+        cudaEventSynchronize(event);
+        cudaEventDestroy(event);
+
+        for (auto *slice : async_submitted_slices) slice->markSuccess();
     }
 
     return Status::OK();
@@ -241,6 +261,8 @@ Status IntraNodeNvlinkTransport::getTransferStatus(BatchID batch_id,
 
 Status IntraNodeNvlinkTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
+    std::vector<Slice *> async_submitted_slices;
+
     for (size_t index = 0; index < task_list.size(); ++index) {
         assert(task_list[index]);
         auto &task = *task_list[index];
@@ -263,18 +285,38 @@ Status IntraNodeNvlinkTransport::submitTransferTask(
         slice->status = Slice::PENDING;
         task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
+
         cudaError_t err;
         if (slice->opcode == TransferRequest::READ)
-            err = cudaMemcpy(slice->source_addr, (void *)slice->local.dest_addr,
-                             slice->length, cudaMemcpyDefault);
+            err = cudaMemcpyAsync(slice->source_addr,
+                                  (void *)slice->local.dest_addr, slice->length,
+                                  cudaMemcpyDefault, 0);
         else
-            err = cudaMemcpy((void *)slice->local.dest_addr, slice->source_addr,
-                             slice->length, cudaMemcpyDefault);
+            err = cudaMemcpyAsync((void *)slice->local.dest_addr,
+                                  slice->source_addr, slice->length,
+                                  cudaMemcpyDefault, 0);
+
         if (err != cudaSuccess)
             slice->markFailed();
         else
-            slice->markSuccess();
+            async_submitted_slices.push_back(slice);
     }
+
+    if (!async_submitted_slices.empty()) {
+        cudaEvent_t event;
+        cudaError_t event_err =
+            cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+        if (event_err != cudaSuccess) {
+            for (auto *slice : async_submitted_slices) slice->markFailed();
+            return Status::InvalidArgument("cudaEventCreateWithFlags failed");
+        }
+        cudaEventRecord(event, 0);
+        cudaEventSynchronize(event);
+        cudaEventDestroy(event);
+
+        for (auto *slice : async_submitted_slices) slice->markSuccess();
+    }
+
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
@@ -200,6 +200,7 @@ Status NvlinkTransport::submitTransfer(
             std::to_string(batch_id));
     }
 
+    std::vector<Slice *> async_submitted_slices;
     size_t task_id = batch_desc.task_list.size();
     batch_desc.task_list.resize(task_id + entries.size());
 
@@ -222,17 +223,36 @@ Status NvlinkTransport::submitTransfer(
         slice->target_id = request.target_id;
         slice->status = Slice::PENDING;
         __sync_fetch_and_add(&task.slice_count, 1);
+
         cudaError_t err;
         if (slice->opcode == TransferRequest::READ)
-            err = cudaMemcpy(slice->source_addr, (void *)slice->local.dest_addr,
-                             slice->length, cudaMemcpyDefault);
+            err = cudaMemcpyAsync(slice->source_addr,
+                                  (void *)slice->local.dest_addr, slice->length,
+                                  cudaMemcpyDefault, 0);
         else
-            err = cudaMemcpy((void *)slice->local.dest_addr, slice->source_addr,
-                             slice->length, cudaMemcpyDefault);
+            err = cudaMemcpyAsync((void *)slice->local.dest_addr,
+                                  slice->source_addr, slice->length,
+                                  cudaMemcpyDefault, 0);
+
         if (err != cudaSuccess)
             slice->markFailed();
         else
-            slice->markSuccess();
+            async_submitted_slices.push_back(slice);
+    }
+
+    if (!async_submitted_slices.empty()) {
+        cudaEvent_t event;
+        cudaError_t event_err =
+            cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+        if (event_err != cudaSuccess) {
+            for (auto *slice : async_submitted_slices) slice->markFailed();
+            return Status::InvalidArgument("cudaEventCreateWithFlags failed");
+        }
+        cudaEventRecord(event, 0);
+        cudaEventSynchronize(event);
+        cudaEventDestroy(event);
+
+        for (auto *slice : async_submitted_slices) slice->markSuccess();
     }
 
     return Status::OK();
@@ -266,6 +286,8 @@ Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
 
 Status NvlinkTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
+    std::vector<Slice *> async_submitted_slices;
+
     for (size_t index = 0; index < task_list.size(); ++index) {
         assert(task_list[index]);
         auto &task = *task_list[index];
@@ -288,18 +310,38 @@ Status NvlinkTransport::submitTransferTask(
         slice->status = Slice::PENDING;
         task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
+
         cudaError_t err;
         if (slice->opcode == TransferRequest::READ)
-            err = cudaMemcpy(slice->source_addr, (void *)slice->local.dest_addr,
-                             slice->length, cudaMemcpyDefault);
+            err = cudaMemcpyAsync(slice->source_addr,
+                                  (void *)slice->local.dest_addr, slice->length,
+                                  cudaMemcpyDefault, 0);
         else
-            err = cudaMemcpy((void *)slice->local.dest_addr, slice->source_addr,
-                             slice->length, cudaMemcpyDefault);
+            err = cudaMemcpyAsync((void *)slice->local.dest_addr,
+                                  slice->source_addr, slice->length,
+                                  cudaMemcpyDefault, 0);
+
         if (err != cudaSuccess)
             slice->markFailed();
         else
-            slice->markSuccess();
+            async_submitted_slices.push_back(slice);
     }
+
+    if (!async_submitted_slices.empty()) {
+        cudaEvent_t event;
+        cudaError_t event_err =
+            cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+        if (event_err != cudaSuccess) {
+            for (auto *slice : async_submitted_slices) slice->markFailed();
+            return Status::InvalidArgument("cudaEventCreateWithFlags failed");
+        }
+        cudaEventRecord(event, 0);
+        cudaEventSynchronize(event);
+        cudaEventDestroy(event);
+
+        for (auto *slice : async_submitted_slices) slice->markSuccess();
+    }
+
     return Status::OK();
 }
 


### PR DESCRIPTION
## Description

### Background
cudaMemcpy for D2D data transfer does not synchronize the host.

According to [CUDA Runtime API](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1gc263dbe6574220cc776b45438fc351e8):

> This function exhibits [synchronous](https://docs.nvidia.com/cuda/cuda-runtime-api/api-sync-behavior.html#api-sync-behavior__memcpy-sync) behavior for most use cases.

and in the link above:

> For transfers from device memory to device memory, no host-side synchronization is performed.

### Problem
Currently, the SGLang prefill node relies on batch_transfer_sync to signal transfer completion to the decode node. However, since cudaMemcpy is asynchronous with respect to the host under the hood, there is a risk that the decode phase may start before the data is actually ready.

### Verify
Add profiling for cudaMemcpy:
```
Status NvlinkTransport::submitTransferTask(
    const std::vector<TransferTask *> &task_list) {
    for (size_t index = 0; index < task_list.size(); ++index) {
        assert(task_list[index]);
        auto &task = *task_list[index];
        assert(task.request);
        auto &request = *task.request;
        uint64_t dest_addr = request.target_offset;
        if (request.target_id != LOCAL_SEGMENT_ID) {
            int rc = relocateSharedMemoryAddress(dest_addr, request.length,
                                                 request.target_id);
            if (rc) return Status::Memory("device memory not registered");
        }
        task.total_bytes = request.length;
        Slice *slice = getSliceCache().allocate();
        slice->source_addr = (char *)request.source;
        slice->local.dest_addr = (char *)dest_addr;
        slice->length = request.length;
        slice->opcode = request.opcode;
        slice->task = &task;
        slice->target_id = request.target_id;
        slice->status = Slice::PENDING;
        task.slice_list.push_back(slice);
        __sync_fetch_and_add(&task.slice_count, 1);
        cudaError_t err;

        auto t_start = std::chrono::high_resolution_clock::now();

        if (slice->opcode == TransferRequest::READ)
            err = cudaMemcpy(slice->source_addr, (void *)slice->local.dest_addr,
                             slice->length, cudaMemcpyDefault);
        else
            err = cudaMemcpy((void *)slice->local.dest_addr, slice->source_addr,
                             slice->length, cudaMemcpyDefault);

        auto t_end = std::chrono::high_resolution_clock::now();
        double elapsed_us = std::chrono::duration<double, std::micro>(t_end - t_start).count();
        LOG(INFO) << "[NvlinkTransport] cudaMemcpy index=" << index
                  << " length=" << slice->length
                  << " elapsed=" << elapsed_us << " us"
                  << " bandwidth=" << (slice->length / elapsed_us) << " MB/s";

        if (err != cudaSuccess)
            slice->markFailed();
        else
            slice->markSuccess();
    }
    return Status::OK();
}
```
It returns immediately with abnormal transfer speed.
```
I20260417 13:39:41.180181 1666868 nvlink_transport.cpp:306] [NvlinkTransport] cudaMemcpy index=80 length=4194304 elapsed=1.984 us bandwidth=2.11406e+06 MB/s
I20260417 13:39:41.180190 1666868 nvlink_transport.cpp:306] [NvlinkTransport] cudaMemcpy index=81 length=4194304 elapsed=2.336 us bandwidth=1.79551e+06 MB/s
I20260417 13:39:41.180202 1666868 nvlink_transport.cpp:306] [NvlinkTransport] cudaMemcpy index=82 length=4194304 elapsed=2.176 us bandwidth=1.92753e+06 MB/s
I20260417 13:39:41.180210 1666868 nvlink_transport.cpp:306] [NvlinkTransport] cudaMemcpy index=83 length=4194304 elapsed=2.08 us bandwidth=2.01649e+06 MB/s
I20260417 13:39:41.180218 1666868 nvlink_transport.cpp:306] [NvlinkTransport] cudaMemcpy index=84 length=4194304 elapsed=2.08 us bandwidth=2.01649e+06 MB/s
I20260417 13:39:41.180228 1666868 nvlink_transport.cpp:306] [NvlinkTransport] cudaMemcpy index=85 length=4194304 elapsed=2.208 us bandwidth=1.89959e+06 MB/s
I20260417 13:39:41.180238 1666868 nvlink_transport.cpp:306] [NvlinkTransport] cudaMemcpy index=86 length=4194304 elapsed=2.304 us bandwidth=1.82044e+06 MB/s
I20260417 13:39:41.180249 1666868 nvlink_transport.cpp:306] [NvlinkTransport] cudaMemcpy index=87 length=4194304 elapsed=2.208 us bandwidth=1.89959e+06 MB/s
I20260417 13:39:41.180259 1666868 nvlink_transport.cpp:306] [NvlinkTransport] cudaMemcpy index=88 length=4194304 elapsed=2.208 us bandwidth=1.89959e+06 MB/s
I20260417 13:39:41.180270 1666868 nvlink_transport.cpp:306] [NvlinkTransport] cudaMemcpy index=89 length=4194304 elapsed=2.08 us bandwidth=2.01649e+06 MB/s
```
Also verified with standalone cuda test.

###Modification
Replace cudaMemcpy with cudaMemcpyAsync and cudaEventSynchronize.

Another possible solution is to retain cudaMemcpy and call cudaStreamSynchronize before submitTransferTask returns. However, this will block until the entire stream is empty, which is problematic if other commands continue to be queued on the default stream.

###Test
Unfortunately, there would be extra synchronization cost.

Tested with `python3 -m sglang.bench_serving --max-concurrency 256 --dataset-name random --random-input-len=2000 --random-output-len=10  --random-range-ratio 0 --num-prompts 5120   --port 30030  --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json`

cudaMemcpy:

============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 256
Successful requests:                     5120
Benchmark duration (s):                  102.39
Total input tokens:                      5112534
Total input text tokens:                 5112534
Total generated tokens:                  28257
Total generated tokens (retokenized):    27703
Request throughput (req/s):              50.00
Input token throughput (tok/s):          49930.03
Output token throughput (tok/s):         275.96
Peak output token throughput (tok/s):    373.00
Peak concurrent requests:                324
Total token throughput (tok/s):          50205.99
Concurrency:                             246.41
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   4927.84
Median E2E Latency (ms):                 4745.54
P90 E2E Latency (ms):                    7056.63
P99 E2E Latency (ms):                    7839.55
---------------Time to First Token----------------
Mean TTFT (ms):                          4815.80
Median TTFT (ms):                        4614.60
P99 TTFT (ms):                           7742.88
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          22.57
Median TPOT (ms):                        21.54
P99 TPOT (ms):                           43.66
---------------Inter-Token Latency----------------
Mean ITL (ms):                           21.88
Median ITL (ms):                         20.66
P95 ITL (ms):                            38.49
P99 ITL (ms):                            53.81
Max ITL (ms):                            587.35

with the patch:

============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 256
Successful requests:                     5120
Benchmark duration (s):                  106.90
Total input tokens:                      5112534
Total input text tokens:                 5112534
Total generated tokens:                  28257
Total generated tokens (retokenized):    27728
Request throughput (req/s):              47.90
Input token throughput (tok/s):          47827.52
Output token throughput (tok/s):         264.34
Peak output token throughput (tok/s):    420.00
Peak concurrent requests:                325
Total token throughput (tok/s):          48091.86
Concurrency:                             241.29
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   5037.58
Median E2E Latency (ms):                 5163.21
P90 E2E Latency (ms):                    7646.48
P99 E2E Latency (ms):                    9760.61
---------------Time to First Token----------------
Mean TTFT (ms):                          4935.51
Median TTFT (ms):                        5075.37
P99 TTFT (ms):                           9678.05
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          22.07
Median TPOT (ms):                        21.29
P99 TPOT (ms):                           42.92
---------------Inter-Token Latency----------------
Mean ITL (ms):                           21.60
Median ITL (ms):                         20.27
P95 ITL (ms):                            39.13
P99 ITL (ms):                            55.85
Max ITL (ms):                            91.32

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
