### PR TITLE
[store] Bug Fix: Segment fault when transferring data from hbm to 3fs disk file

### DIFF
--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -28,6 +28,10 @@
 #include "rpc_types.h"
 #include "local_hot_cache.h"
 
+#ifdef USE_CUDA
+#include <cuda_runtime.h>
+#endif
+
 namespace mooncake {
 
 [[nodiscard]] size_t CalculateSliceSize(const std::vector<Slice>& slices) {
@@ -2505,7 +2509,35 @@ void Client::PutToLocalFile(const std::string& key,
     std::string value;
     value.reserve(total_size);
     for (const auto& slice : slices) {
+        #if defined(USE_CUDA)
+        cudaPointerAttributes attributes;
+        cudaPointerGetAttributes(&attributes, slice.ptr);
+        if (attributes.type == cudaMemoryTypeDevice) {
+            auto ddr_buffer = std::make_unique<char[]>(slice.size);
+            cudaError_t cuda_ret = cudaMemcpy(
+                ddr_buffer.get(),
+                slice.ptr,
+                slice.size,
+                cudaMemcpyDeviceToHost
+            );
+
+            if (cuda_ret == cudaSuccess) {
+                value.append(ddr_buffer.get(), slice.size);
+            } else {
+                // Fallback: try direct copy
+                LOG(WARNING) << "cudaMemcpy failed for key=" << key
+                             << ", error=" << cudaGetErrorString(cuda_ret)
+                             << ", ptr=" << slice.ptr
+                             << ", size=" << slice.size
+                             << ", attempting direct copy";
+                value.append(static_cast<char*>(slice.ptr), slice.size);
+            }
+        } else {
+            value.append(static_cast<char*>(slice.ptr), slice.size);
+        }
+        #else
         value.append(static_cast<char*>(slice.ptr), slice.size);
+        #endif
     }
 
     write_thread_pool_.enqueue([this, backend = storage_backend_, key,

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2509,17 +2509,14 @@ void Client::PutToLocalFile(const std::string& key,
     std::string value;
     value.reserve(total_size);
     for (const auto& slice : slices) {
-        #if defined(USE_CUDA)
+#if defined(USE_CUDA)
         cudaPointerAttributes attributes;
         cudaPointerGetAttributes(&attributes, slice.ptr);
         if (attributes.type == cudaMemoryTypeDevice) {
             auto ddr_buffer = std::make_unique<char[]>(slice.size);
-            cudaError_t cuda_ret = cudaMemcpy(
-                ddr_buffer.get(),
-                slice.ptr,
-                slice.size,
-                cudaMemcpyDeviceToHost
-            );
+            cudaError_t cuda_ret =
+                cudaMemcpy(ddr_buffer.get(), slice.ptr, slice.size,
+                           cudaMemcpyDeviceToHost);
 
             if (cuda_ret == cudaSuccess) {
                 value.append(ddr_buffer.get(), slice.size);
@@ -2527,17 +2524,16 @@ void Client::PutToLocalFile(const std::string& key,
                 // Fallback: try direct copy
                 LOG(WARNING) << "cudaMemcpy failed for key=" << key
                              << ", error=" << cudaGetErrorString(cuda_ret)
-                             << ", ptr=" << slice.ptr
-                             << ", size=" << slice.size
+                             << ", ptr=" << slice.ptr << ", size=" << slice.size
                              << ", attempting direct copy";
                 value.append(static_cast<char*>(slice.ptr), slice.size);
             }
         } else {
             value.append(static_cast<char*>(slice.ptr), slice.size);
         }
-        #else
+#else
         value.append(static_cast<char*>(slice.ptr), slice.size);
-        #endif
+#endif
     }
 
     write_thread_pool_.enqueue([this, backend = storage_backend_, key,


### PR DESCRIPTION
## Description

When using 3FS as the persistent backend, writing data from HBM to MooncakeStore triggers a segmentation fault. The crash occurs in `PutToLocalFile()` because `std::string::append()` is invoked on a slice residing in HBM rather than DDR. This PR resolves the issue.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

```
import numpy as np
import torch
import math
from mooncake.store import MooncakeDistributedStore

store = MooncakeDistributedStore()

store.setup(
    "xx.xx.xx.xx",
    "P2PHANDSHAKE",
    1*1024*1024 * 1024,
    1*1024*1024,
    "rdma",
    "mlx5_0",
    "xx.xx.xx.xx:50051"
)

original_data = np.random.randn(10, 10).astype(np.float32)
original_data = torch.Tensor(original_data).to('cuda')
buffer_ptr = original_data.data_ptr()
size = original_data.element_size() * math.prod(original_data.shape)

result = store.register_buffer(buffer_ptr, size)
if result != 0:
    raise RuntimeError(f"Failed to register buffer: {result}")

result = store.put_from("large_tensor", buffer_ptr, size)
if result == 0:
    print(f"Successfully stored {size} bytes with zero-copy")
else:
    raise RuntimeError(f"Store failed with code: {result}")
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
