### PR TITLE
fix(ci): retry ascend submodule update via GitHub mirrors

### DIFF
--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -64,7 +64,6 @@ jobs:
           base="${base#${base%%[![:space:]]*}}"
           base="${base%${base##*[![:space:]]}}"
           [ -n "$base" ] || return 1
-          [ "$base" = "https://github.com" ] && base="https://github.com/"
           [ "$base" != "https://github.com/" ] && base="${base%/}/"
           printf '%s\n' "$base"
         }
@@ -123,7 +122,6 @@ jobs:
             base="${base#${base%%[![:space:]]*}}"
             base="${base%${base##*[![:space:]]}}"
             [ -n "$base" ] || return 1
-            [ "$base" = "https://github.com" ] && base="https://github.com/"
             [ "$base" != "https://github.com/" ] && base="${base%/}/"
             printf '%s\n' "$base"
           }
@@ -144,7 +142,7 @@ jobs:
 
         if [ "$submodule_updated" != true ]; then
           if [ ! -d "extern/pybind11" ] || [ -z "$(ls -A 'extern/pybind11' 2>/dev/null)" ]; then
-            echo "git submodule update failed, try to cp pybind11..."
+            echo "git submodule update failed (mirrors also exhausted), trying to cp pybind11..."
             if [ -d "../pybind11" ]; then
               cp -r ../pybind11 extern/
             else

--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -108,22 +108,54 @@ jobs:
 
     - name: Configure CMake
       shell: bash
+      env:
+        ASCEND_GITHUB_MIRROR_URLS: ${{ vars.ASCEND_GITHUB_MIRROR_URLS }}
       run: |
         source /usr/local/Ascend/cann-9.0.0/set_env.sh
         pwd
-        if ! git submodule update --init --recursive; then
-            if [ ! -d "extern/pybind11" ] || [ -z "$(ls -A 'extern/pybind11' 2>/dev/null)" ]; then
-                echo "git submodule update failed, try to cp pybind11..."
-                if [ -d "../pybind11" ]; then
-                    cp -r ../pybind11 extern/
-                else
-                    echo "Error: ../pybind11 does not exist. Cannot copy pybind11."
-                    exit 1
-                fi
-            else
-                echo "Detected that extern/pybind11 already exists, continuing execution...."
+
+        submodule_updated=false
+        if git submodule update --init --recursive; then
+          submodule_updated=true
+        elif [ -n "${ASCEND_GITHUB_MIRROR_URLS:-}" ]; then
+          normalize_base() {
+            local base="$1"
+            base="${base#${base%%[![:space:]]*}}"
+            base="${base%${base##*[![:space:]]}}"
+            [ -n "$base" ] || return 1
+            [ "$base" = "https://github.com" ] && base="https://github.com/"
+            [ "$base" != "https://github.com/" ] && base="${base%/}/"
+            printf '%s\n' "$base"
+          }
+
+          while IFS= read -r raw; do
+            base="$(normalize_base "$raw" || true)"
+            [ -n "$base" ] || continue
+            [ "$base" = "https://github.com/" ] && continue
+
+            echo "Retrying submodule update with ${base}"
+            if git -c url."${base}https://github.com/".insteadOf=https://github.com/ \
+              submodule update --init --recursive; then
+              submodule_updated=true
+              break
             fi
+          done < <(printf '%s\n' "$ASCEND_GITHUB_MIRROR_URLS" | tr ',;' '\n')
         fi
+
+        if [ "$submodule_updated" != true ]; then
+          if [ ! -d "extern/pybind11" ] || [ -z "$(ls -A 'extern/pybind11' 2>/dev/null)" ]; then
+            echo "git submodule update failed, try to cp pybind11..."
+            if [ -d "../pybind11" ]; then
+              cp -r ../pybind11 extern/
+            else
+              echo "Error: ../pybind11 does not exist. Cannot copy pybind11."
+              exit 1
+            fi
+          else
+            echo "Detected that extern/pybind11 already exists, continuing execution...."
+          fi
+        fi
+
         bash scripts/ascend/dependencies_ascend_installation.sh
         echo "Configuring CMake..."
         rm -rf build


### PR DESCRIPTION
## Description

This PR fixes the remaining GitHub network fragility in the Ascend CI workflow.

ci_ascend.yml already has mirror fallback for the main repository checkout, but git submodule update --init --recursive can still fail when direct access to GitHub is unstable. This PR adds the same fallback idea to the submodule update stage:
1. first try the original git submodule update --init --recursive
2. if it fails and ASCEND_GITHUB_MIRROR_URLS is configured, retry submodule update through the configured GitHub mirror(s)
3. keep the existing extern/pybind11 local copy fallback unchanged as the last safeguard

This makes the Ascend CI path more robust for GitHub-hosted submodules such as extern/yalantinglibs, while preserving the original fast path when direct GitHub access works.

This PR reuses the existing repository variable `ASCEND_GITHUB_MIRROR_URLS` and does not require introducing any new CI secret or variable.


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
