### PR TITLE
[Store] Add standalone HTTP mount_shm/unmount_shm API with reconfiguration support

### DIFF
--- a/docs/source/http-api-reference/http-service.md
+++ b/docs/source/http-api-reference/http-service.md
@@ -10,6 +10,10 @@ The HTTP service serves multiple purposes:
 - **Data Inspection**: Examine stored objects and their replicas
 - **Health Checks**: Service availability and status verification
 
+The Python `mooncake.mooncake_store_service` module also provides a lightweight
+Store REST API for data operations and standalone segment mount/unmount
+workflows. Unless configured otherwise, it listens on port `8080`.
+
 ## HTTP Endpoints
 
 ### Metrics Endpoints
@@ -159,3 +163,100 @@ Basic health check endpoint for service availability verification.
 curl http://localhost:8080/health
 ```
 
+## Store REST API Endpoints
+
+The following endpoints are served by the Python store REST service, which wraps
+`MooncakeDistributedStore` with an aiohttp service. The HTTP handlers live in
+Python, while mount and unmount operations are delegated to the underlying store
+binding. Start the service with:
+
+```bash
+python -m mooncake.mooncake_store_service \
+  --config /path/to/mooncake_config.json \
+  --port 8080
+```
+
+If the wheel console scripts are installed, the equivalent command is:
+
+```bash
+mc_store_rest_server --config /path/to/mooncake_config.json --port 8080
+```
+
+### `/api/mount_shm`
+Mount a named shared memory object as one or more Mooncake store segments. If
+the requested size exceeds the maximum registration size, the service may split
+the region and return multiple segment ids.
+
+**Method**: `POST`
+**Content-Type**: `application/json`
+
+**Request Body**:
+```json
+{
+  "name": "mooncake_segment",
+  "size": 16777216,
+  "offset": 0,
+  "protocol": "tcp",
+  "location": ""
+}
+```
+
+**Fields**:
+- `name` (string, required): Named shared memory object name. A leading `/` is
+  accepted, but path separators are not.
+- `size` (integer, required): Number of bytes to mount.
+- `offset` (integer, optional): File offset in bytes. Defaults to `0`.
+- `protocol` (string, optional): Transfer protocol. Defaults to the service
+  configuration protocol.
+- `location` (string, optional): Device or locality hint. Defaults to an empty
+  string.
+
+**Success Response**:
+```json
+{
+  "status": "success",
+  "segment_ids": ["00000000-0000-0000-0000-000000000001"]
+}
+```
+
+**Example**:
+```bash
+curl -X POST http://localhost:8080/api/mount_shm \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "mooncake_segment",
+        "size": 16777216,
+        "offset": 0,
+        "protocol": "tcp",
+        "location": ""
+      }'
+```
+
+### `/api/unmount_shm`
+Unmount one or more segment ids previously returned by `/api/mount_shm`.
+
+**Method**: `POST`
+**Content-Type**: `application/json`
+
+**Request Body**:
+```json
+{
+  "segment_ids": ["00000000-0000-0000-0000-000000000001"]
+}
+```
+
+`segment_ids` may also be provided as a single string for one segment.
+
+**Success Response**:
+```json
+{
+  "status": "success"
+}
+```
+
+**Example**:
+```bash
+curl -X POST http://localhost:8080/api/unmount_shm \
+  -H "Content-Type: application/json" \
+  -d '{"segment_ids": ["00000000-0000-0000-0000-000000000001"]}'
+```

--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -1429,6 +1429,79 @@ def init_all(self, protocol: str, device_name: str, mount_segment_size: int = 16
 
 ---
 
+#### mount_segment()
+Mount a local file or shared-memory region as one or more Mooncake store
+segments.
+
+```python
+def mount_segment(
+    self,
+    path: str,
+    size: int,
+    offset: int = 0,
+    protocol: str = "tcp",
+    location: str = "",
+) -> dict
+```
+
+**Parameters:**
+- `path` (str): File path to map and mount.
+- `size` (int): Number of bytes to mount.
+- `offset` (int, optional): File offset in bytes. Defaults to `0`.
+- `protocol` (str, optional): Transfer protocol. Defaults to `"tcp"`.
+- `location` (str, optional): Device or locality hint. Defaults to an empty
+  string.
+
+**Returns:**
+- `dict`: A result dictionary with:
+  - `ret` (int): Status code (0 = success, non-zero = error code)
+  - `segment_ids` (List[str]): Segment ids created by the mount operation
+
+**Example:**
+```python
+result = store.mount_segment(
+    "/dev/shm/mooncake_segment",
+    16 * 1024 * 1024,
+    offset=0,
+    protocol="tcp",
+    location="",
+)
+
+if result["ret"] == 0:
+    segment_ids = list(result["segment_ids"])
+    print("Mounted segments:", segment_ids)
+else:
+    print("Mount failed:", result["ret"])
+```
+
+The corresponding HTTP endpoints are `/api/mount_shm` and
+`/api/unmount_shm`, but the HTTP API is intentionally narrower: it accepts a
+named shared memory object name instead of an arbitrary path.
+
+---
+
+#### unmount_segment()
+Unmount one or more file or shared-memory segments by segment id.
+
+```python
+def unmount_segment(self, segment_ids: List[str]) -> int
+```
+
+**Parameters:**
+- `segment_ids` (List[str]): Segment ids returned by `mount_segment()`.
+
+**Returns:**
+- `int`: Status code (0 = success, non-zero = error code)
+
+**Example:**
+```python
+ret = store.unmount_segment(segment_ids)
+if ret != 0:
+    print("Unmount failed:", ret)
+```
+
+---
+
 #### get_hostname()
 Get the hostname of the current store instance.
 

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -276,6 +276,39 @@ class MooncakeStorePyWrapper {
         return store_->health_check();
     }
 
+    py::dict mount_segment(const std::string &path, size_t offset, size_t size,
+                           const std::string &protocol,
+                           const std::string &location) {
+        py::dict result;
+        result["ret"] = -1;
+        result["segment_ids"] = py::list();
+
+        auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
+        if (!real_client) {
+            LOG(ERROR) << "mount_segment requires RealClient";
+            return result;
+        }
+        std::vector<std::string> segment_ids;
+        int ret = real_client->mountSegment(path, offset, size, protocol,
+                                            location, segment_ids);
+        result["ret"] = ret;
+        py::list ids;
+        for (const auto &id : segment_ids) {
+            ids.append(id);
+        }
+        result["segment_ids"] = ids;
+        return result;
+    }
+
+    int unmount_segment(const std::vector<std::string> &segment_ids) {
+        auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
+        if (!real_client) {
+            LOG(ERROR) << "unmount_segment requires RealClient";
+            return -1;
+        }
+        return real_client->unmountSegment(segment_ids);
+    }
+
     std::string get_tp_key_name(const std::string &base_key, int rank) {
         return base_key + "_tp_" + std::to_string(rank);
     }
@@ -1638,6 +1671,11 @@ PYBIND11_MODULE(store, m) {
                  return self.store_->initAll(protocol, device_name,
                                              mount_segment_size);
              })
+        .def("mount_segment", &MooncakeStorePyWrapper::mount_segment,
+             py::arg("path"), py::arg("offset") = 0, py::arg("size"),
+             py::arg("protocol") = "tcp", py::arg("location") = "")
+        .def("unmount_segment", &MooncakeStorePyWrapper::unmount_segment,
+             py::arg("segment_id"))
         .def("alloc_from_mem_pool",
              [](MooncakeStorePyWrapper &self, size_t size) {
                  py::gil_scoped_release release;

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -302,6 +302,44 @@ class MooncakeStorePyWrapper {
         return store_->health_check();
     }
 
+    py::dict mount_segment(const std::string &path, size_t size, size_t offset,
+                           const std::string &protocol,
+                           const std::string &location) {
+        py::dict result;
+        result["ret"] = -1;
+        result["segment_ids"] = py::list();
+
+        auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
+        if (!real_client) {
+            LOG(ERROR) << "mount_segment requires RealClient";
+            return result;
+        }
+        std::vector<std::string> segment_ids;
+        int ret;
+        {
+            py::gil_scoped_release release;
+            ret = real_client->mountSegment(path, offset, size, protocol,
+                                            location, segment_ids);
+        }
+        result["ret"] = ret;
+        py::list ids;
+        for (const auto &id : segment_ids) {
+            ids.append(id);
+        }
+        result["segment_ids"] = ids;
+        return result;
+    }
+
+    int unmount_segment(const std::vector<std::string> &segment_ids) {
+        auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
+        if (!real_client) {
+            LOG(ERROR) << "unmount_segment requires RealClient";
+            return -1;
+        }
+        py::gil_scoped_release release;
+        return real_client->unmountSegment(segment_ids);
+    }
+
     std::string get_tp_key_name(const std::string &base_key, int rank) const {
         return base_key + "_tp_" + std::to_string(rank);
     }
@@ -1772,6 +1810,11 @@ PYBIND11_MODULE(store, m) {
                  return self.store_->initAll(protocol, device_name,
                                              mount_segment_size);
              })
+        .def("mount_segment", &MooncakeStorePyWrapper::mount_segment,
+             py::arg("path"), py::arg("size"), py::arg("offset") = 0,
+             py::arg("protocol") = "tcp", py::arg("location") = "")
+        .def("unmount_segment", &MooncakeStorePyWrapper::unmount_segment,
+             py::arg("segment_ids"))
         .def("alloc_from_mem_pool",
              [](MooncakeStorePyWrapper &self, size_t size) {
                  py::gil_scoped_release release;

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -296,6 +296,20 @@ class Client {
                                                  size_t size);
 
     /**
+     * @brief Mounts a memory segment and returns its generated Segment UUID.
+     *        Logic is identical to MountSegment, but returns the segment id.
+     */
+    tl::expected<UUID, ErrorCode> MountSegmentAndGetId(
+        const void* buffer, size_t size, const std::string& protocol = "tcp",
+        const std::string& location = kWildcardLocation);
+
+    /**
+     * @brief Unmounts a segment by its UUID.
+     *        Logic is identical to UnmountSegment, but looks up by id.
+     */
+    tl::expected<void, ErrorCode> UnmountSegmentById(const UUID& segment_id);
+
+    /**
      * @brief Registers memory buffer with TransferEngine for data transfer
      * @param addr Memory address to register
      * @param length Size of the memory region
@@ -665,6 +679,13 @@ class Client {
     // Mutex to protect mounted_segments_
     std::mutex mounted_segments_mutex_;
     std::unordered_map<UUID, Segment, boost::hash<UUID>> mounted_segments_;
+
+    /**
+     * @brief Internal helper to unmount a segment by iterator.
+     *        Caller must hold mounted_segments_mutex_.
+     */
+    tl::expected<void, ErrorCode> UnmountSegmentImpl(
+        std::unordered_map<UUID, Segment, boost::hash<UUID>>::iterator it);
 
     // Configuration
     const std::string local_hostname_;

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -670,6 +670,13 @@ class Client {
     std::mutex mounted_segments_mutex_;
     std::unordered_map<UUID, Segment, boost::hash<UUID>> mounted_segments_;
 
+    /**
+     * @brief Internal helper to unmount a segment by iterator.
+     *        Caller must hold mounted_segments_mutex_.
+     */
+    tl::expected<void, ErrorCode> UnmountSegmentImpl(
+        std::unordered_map<UUID, Segment, boost::hash<UUID>>::iterator it);
+
     // Configuration
     const std::string local_hostname_;
     const std::string metadata_connstring_;

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -295,6 +295,20 @@ class Client {
                                                  size_t size);
 
     /**
+     * @brief Mounts a memory segment and returns its generated Segment UUID.
+     *        Logic is identical to MountSegment, but returns the segment id.
+     */
+    tl::expected<UUID, ErrorCode> MountSegmentAndGetId(
+        const void* buffer, size_t size, const std::string& protocol = "tcp",
+        const std::string& location = kWildcardLocation);
+
+    /**
+     * @brief Unmounts a segment by its UUID.
+     *        Logic is identical to UnmountSegment, but looks up by id.
+     */
+    tl::expected<void, ErrorCode> UnmountSegmentById(const UUID& segment_id);
+
+    /**
      * @brief Registers memory buffer with TransferEngine for data transfer
      * @param addr Memory address to register
      * @param length Size of the memory region

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -667,6 +667,31 @@ class RealClient : public PyClient {
         const std::string &target_rpc_service_addr,
         std::unordered_map<std::string, Slice> &objects);
 
+    /**
+     * @brief Mount a shared memory file region and return segment ids.
+     *        If size > max_mr_size, it will be split into multiple chunks
+     *        and mounted separately. RealClient will open(path) + mmap
+     *        internally for each chunk.
+     */
+    int mountSegment(const std::string &path, size_t offset, size_t size,
+                     const std::string &protocol, const std::string &location,
+                     std::vector<std::string> &out_segment_ids);
+
+    /**
+     * @brief Unmount segments by their ids and clean up local mmap/fd.
+     */
+    int unmountSegment(const std::vector<std::string> &segment_ids);
+
+   private:
+    struct MountedSegmentRecord {
+        int fd = -1;
+        void *mmap_base = nullptr;
+        size_t size = 0;
+        std::string path;
+    };
+    std::unordered_map<std::string, MountedSegmentRecord>
+        mounted_segment_records_;
+
     std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
 
     struct SegmentDeleter {

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -682,16 +682,11 @@ class RealClient : public PyClient {
      */
     int unmountSegment(const std::vector<std::string> &segment_ids);
 
-   private:
     struct MountedSegmentRecord {
-        int fd = -1;
         void *mmap_base = nullptr;
         size_t size = 0;
         std::string path;
     };
-    std::unordered_map<std::string, MountedSegmentRecord>
-        mounted_segment_records_;
-    std::mutex mounted_segment_records_mutex_;
 
     std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
 
@@ -829,6 +824,11 @@ class RealClient : public PyClient {
     void teardown_ascend_shm_buffer(MappedShm &shm);
     tl::expected<void, ErrorCode> setup_ascend_internal(
         size_t local_buffer_size);
+
+   private:
+    std::unordered_map<std::string, MountedSegmentRecord>
+        mounted_segment_records_;
+    std::mutex mounted_segment_records_mutex_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -676,6 +676,27 @@ class RealClient : public PyClient {
         const std::string &target_rpc_service_addr,
         std::unordered_map<std::string, Slice> &objects);
 
+    /**
+     * @brief Mount a shared memory file region and return segment ids.
+     *        If size > max_mr_size, it will be split into multiple chunks
+     *        and mounted separately. RealClient will open(path) + mmap
+     *        internally for each chunk.
+     */
+    int mountSegment(const std::string &path, size_t offset, size_t size,
+                     const std::string &protocol, const std::string &location,
+                     std::vector<std::string> &out_segment_ids);
+
+    /**
+     * @brief Unmount segments by their ids and clean up local mmap/fd.
+     */
+    int unmountSegment(const std::vector<std::string> &segment_ids);
+
+    struct MountedSegmentRecord {
+        void *mmap_base = nullptr;
+        size_t size = 0;
+        std::string path;
+    };
+
     std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
 
     struct SegmentDeleter {
@@ -812,6 +833,11 @@ class RealClient : public PyClient {
     void teardown_ascend_shm_buffer(MappedShm &shm);
     tl::expected<void, ErrorCode> setup_ascend_internal(
         size_t local_buffer_size);
+
+   private:
+    std::unordered_map<std::string, MountedSegmentRecord>
+        mounted_segment_records_;
+    std::mutex mounted_segment_records_mutex_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -691,6 +691,7 @@ class RealClient : public PyClient {
     };
     std::unordered_map<std::string, MountedSegmentRecord>
         mounted_segment_records_;
+    std::mutex mounted_segment_records_mutex_;
 
     std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2078,66 +2078,37 @@ std::vector<int> Client::GetNicNumaNodes() const {
 tl::expected<void, ErrorCode> Client::MountSegment(
     const void* buffer, size_t size, const std::string& protocol,
     const std::string& location) {
-    auto check_result = CheckRegisterMemoryParams(buffer, size);
-    if (!check_result) {
-        return tl::unexpected(check_result.error());
+    auto result = MountSegmentAndGetId(buffer, size, protocol, location);
+    if (!result) {
+        return tl::unexpected(result.error());
+    }
+    return {};
+}
+
+tl::expected<void, ErrorCode> Client::UnmountSegmentImpl(
+    std::unordered_map<UUID, Segment, boost::hash<UUID>>::iterator it) {
+    auto unmount_result = master_client_.UnmountSegment(it->second.id);
+    if (!unmount_result) {
+        ErrorCode err = unmount_result.error();
+        LOG(ERROR) << "Failed to unmount segment from master: "
+                   << toString(err);
+        return tl::unexpected(err);
     }
 
-    {
-        std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
-
-        // Check if the segment overlaps with any existing segment
-        for (auto& it : mounted_segments_) {
-            auto& mtseg = it.second;
-            uintptr_t l1 = reinterpret_cast<uintptr_t>(mtseg.base);
-            uintptr_t r1 = reinterpret_cast<uintptr_t>(mtseg.size) + l1;
-            uintptr_t l2 = reinterpret_cast<uintptr_t>(buffer);
-            uintptr_t r2 = reinterpret_cast<uintptr_t>(size) + l2;
-            if (std::max(l1, l2) < std::min(r1, r2)) {
-                LOG(ERROR) << "segment_overlaps base1=" << mtseg.base
-                           << " size1=" << mtseg.size << " base2=" << buffer
-                           << " size2=" << size;
-                return tl::unexpected(ErrorCode::INVALID_PARAMS);
-            }
+    int rc = transfer_engine_->unregisterLocalMemory(
+        reinterpret_cast<void*>(it->second.base));
+    if (rc != 0) {
+        LOG(ERROR) << "Failed to unregister transfer buffer with transfer "
+                      "engine ret is "
+                   << rc;
+        if (rc != ERR_ADDRESS_NOT_REGISTERED) {
+            return tl::unexpected(ErrorCode::INTERNAL_ERROR);
         }
-
-        int rc = transfer_engine_->registerLocalMemory((void*)buffer, size,
-                                                       location, true, true);
-        if (rc != 0) {
-            LOG(ERROR) << "register_local_memory_failed base=" << buffer
-                       << " size=" << size << ", error=" << rc;
-            return tl::unexpected(ErrorCode::INVALID_PARAMS);
-        }
-
-        // Build segment with logical name; attach TE endpoint for transport
-        Segment segment;
-        segment.id = generate_uuid();
-        segment.name = local_hostname_;
-        segment.base = reinterpret_cast<uintptr_t>(buffer);
-        segment.size = size;
-        segment.protocol = protocol;
-        // For P2P handshake mode, publish the actual transport endpoint that
-        // was negotiated by the transfer engine. Otherwise, keep the logical
-        // hostname so metadata backends (HTTP/etcd/redis) can resolve the
-        // segment by name.
-        if (metadata_connstring_ == P2PHANDSHAKE) {
-            segment.te_endpoint = transfer_engine_->getLocalIpAndPort();
-        } else {
-            segment.te_endpoint = local_hostname_;
-        }
-
-        auto mount_result = master_client_.MountSegment(segment);
-        if (!mount_result) {
-            ErrorCode err = mount_result.error();
-            LOG(ERROR) << "mount_segment_to_master_failed base=" << buffer
-                       << " size=" << size << ", error=" << err;
-            return tl::unexpected(err);
-        }
-
-        mounted_segments_[segment.id] = segment;
+        // Otherwise, the segment is already unregistered from transfer
+        // engine, we can continue
     }
 
-    EnsureStorageControlPlaneStarted();
+    mounted_segments_.erase(it);
     return {};
 }
 
@@ -2159,29 +2130,7 @@ tl::expected<void, ErrorCode> Client::UnmountSegment(const void* buffer,
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    auto unmount_result = master_client_.UnmountSegment(segment->second.id);
-    if (!unmount_result) {
-        ErrorCode err = unmount_result.error();
-        LOG(ERROR) << "Failed to unmount segment from master: "
-                   << toString(err);
-        return tl::unexpected(err);
-    }
-
-    int rc = transfer_engine_->unregisterLocalMemory(
-        reinterpret_cast<void*>(segment->second.base));
-    if (rc != 0) {
-        LOG(ERROR) << "Failed to unregister transfer buffer with transfer "
-                      "engine ret is "
-                   << rc;
-        if (rc != ERR_ADDRESS_NOT_REGISTERED) {
-            return tl::unexpected(ErrorCode::INTERNAL_ERROR);
-        }
-        // Otherwise, the segment is already unregistered from transfer
-        // engine, we can continue
-    }
-
-    mounted_segments_.erase(segment);
-    return {};
+    return UnmountSegmentImpl(segment);
 }
 
 tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
@@ -2256,27 +2205,7 @@ tl::expected<void, ErrorCode> Client::UnmountSegmentById(
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    auto unmount_result = master_client_.UnmountSegment(segment->second.id);
-    if (!unmount_result) {
-        ErrorCode err = unmount_result.error();
-        LOG(ERROR) << "Failed to unmount segment from master: "
-                   << toString(err);
-        return tl::unexpected(err);
-    }
-
-    int rc = transfer_engine_->unregisterLocalMemory(
-        reinterpret_cast<void*>(segment->second.base));
-    if (rc != 0) {
-        LOG(ERROR) << "Failed to unregister transfer buffer with transfer "
-                      "engine ret is "
-                   << rc;
-        if (rc != ERR_ADDRESS_NOT_REGISTERED) {
-            return tl::unexpected(ErrorCode::INTERNAL_ERROR);
-        }
-    }
-
-    mounted_segments_.erase(segment);
-    return {};
+    return UnmountSegmentImpl(segment);
 }
 
 tl::expected<void, ErrorCode> Client::RegisterLocalMemory(

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2184,6 +2184,101 @@ tl::expected<void, ErrorCode> Client::UnmountSegment(const void* buffer,
     return {};
 }
 
+tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
+    const void* buffer, size_t size, const std::string& protocol,
+    const std::string& location) {
+    auto check_result = CheckRegisterMemoryParams(buffer, size);
+    if (!check_result) {
+        return tl::unexpected(check_result.error());
+    }
+
+    UUID segment_id;
+    {
+        std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+
+        // Check if the segment overlaps with any existing segment
+        for (auto& it : mounted_segments_) {
+            auto& mtseg = it.second;
+            uintptr_t l1 = reinterpret_cast<uintptr_t>(mtseg.base);
+            uintptr_t r1 = reinterpret_cast<uintptr_t>(mtseg.size) + l1;
+            uintptr_t l2 = reinterpret_cast<uintptr_t>(buffer);
+            uintptr_t r2 = reinterpret_cast<uintptr_t>(size) + l2;
+            if (std::max(l1, l2) < std::min(r1, r2)) {
+                LOG(ERROR) << "segment_overlaps base1=" << mtseg.base
+                           << " size1=" << mtseg.size << " base2=" << buffer
+                           << " size2=" << size;
+                return tl::unexpected(ErrorCode::INVALID_PARAMS);
+            }
+        }
+
+        int rc = transfer_engine_->registerLocalMemory((void*)buffer, size,
+                                                       location, true, true);
+        if (rc != 0) {
+            LOG(ERROR) << "register_local_memory_failed base=" << buffer
+                       << " size=" << size << ", error=" << rc;
+            return tl::unexpected(ErrorCode::INVALID_PARAMS);
+        }
+
+        Segment segment;
+        segment.id = generate_uuid();
+        segment.name = local_hostname_;
+        segment.base = reinterpret_cast<uintptr_t>(buffer);
+        segment.size = size;
+        segment.protocol = protocol;
+        if (metadata_connstring_ == P2PHANDSHAKE) {
+            segment.te_endpoint = transfer_engine_->getLocalIpAndPort();
+        } else {
+            segment.te_endpoint = local_hostname_;
+        }
+
+        auto mount_result = master_client_.MountSegment(segment);
+        if (!mount_result) {
+            ErrorCode err = mount_result.error();
+            LOG(ERROR) << "mount_segment_to_master_failed base=" << buffer
+                       << " size=" << size << ", error=" << err;
+            return tl::unexpected(err);
+        }
+
+        segment_id = segment.id;
+        mounted_segments_[segment_id] = segment;
+    }
+
+    EnsureStorageControlPlaneStarted();
+    return segment_id;
+}
+
+tl::expected<void, ErrorCode> Client::UnmountSegmentById(
+    const UUID& segment_id) {
+    std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+    auto segment = mounted_segments_.find(segment_id);
+    if (segment == mounted_segments_.end()) {
+        LOG(ERROR) << "segment_not_found id=" << UuidToString(segment_id);
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    auto unmount_result = master_client_.UnmountSegment(segment->second.id);
+    if (!unmount_result) {
+        ErrorCode err = unmount_result.error();
+        LOG(ERROR) << "Failed to unmount segment from master: "
+                   << toString(err);
+        return tl::unexpected(err);
+    }
+
+    int rc = transfer_engine_->unregisterLocalMemory(
+        reinterpret_cast<void*>(segment->second.base));
+    if (rc != 0) {
+        LOG(ERROR) << "Failed to unregister transfer buffer with transfer "
+                      "engine ret is "
+                   << rc;
+        if (rc != ERR_ADDRESS_NOT_REGISTERED) {
+            return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+    }
+
+    mounted_segments_.erase(segment);
+    return {};
+}
+
 tl::expected<void, ErrorCode> Client::RegisterLocalMemory(
     void* addr, size_t length, const std::string& location,
     bool remote_accessible, bool update_metadata) {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2084,11 +2084,70 @@ std::vector<int> Client::GetNicNumaNodes() const {
 tl::expected<void, ErrorCode> Client::MountSegment(
     const void* buffer, size_t size, const std::string& protocol,
     const std::string& location) {
+    auto result = MountSegmentAndGetId(buffer, size, protocol, location);
+    if (!result) {
+        return tl::unexpected(result.error());
+    }
+    return {};
+}
+
+tl::expected<void, ErrorCode> Client::UnmountSegmentImpl(
+    std::unordered_map<UUID, Segment, boost::hash<UUID>>::iterator it) {
+    auto unmount_result = master_client_.UnmountSegment(it->second.id);
+    if (!unmount_result) {
+        ErrorCode err = unmount_result.error();
+        LOG(ERROR) << "Failed to unmount segment from master: "
+                   << toString(err);
+        return tl::unexpected(err);
+    }
+
+    int rc = transfer_engine_->unregisterLocalMemory(
+        reinterpret_cast<void*>(it->second.base));
+    if (rc != 0) {
+        LOG(ERROR) << "Failed to unregister transfer buffer with transfer "
+                      "engine ret is "
+                   << rc;
+        if (rc != ERR_ADDRESS_NOT_REGISTERED) {
+            return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+        // Otherwise, the segment is already unregistered from transfer
+        // engine, we can continue
+    }
+
+    mounted_segments_.erase(it);
+    return {};
+}
+
+tl::expected<void, ErrorCode> Client::UnmountSegment(const void* buffer,
+                                                     size_t size) {
+    std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+    auto segment = mounted_segments_.end();
+
+    for (auto it = mounted_segments_.begin(); it != mounted_segments_.end();
+         ++it) {
+        if (it->second.base == reinterpret_cast<uintptr_t>(buffer) &&
+            it->second.size == size) {
+            segment = it;
+            break;
+        }
+    }
+    if (segment == mounted_segments_.end()) {
+        LOG(ERROR) << "segment_not_found base=" << buffer << " size=" << size;
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    return UnmountSegmentImpl(segment);
+}
+
+tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
+    const void* buffer, size_t size, const std::string& protocol,
+    const std::string& location) {
     auto check_result = CheckRegisterMemoryParams(buffer, size);
     if (!check_result) {
         return tl::unexpected(check_result.error());
     }
 
+    UUID segment_id;
     {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
 
@@ -2115,17 +2174,12 @@ tl::expected<void, ErrorCode> Client::MountSegment(
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
 
-        // Build segment with logical name; attach TE endpoint for transport
         Segment segment;
         segment.id = generate_uuid();
         segment.name = local_hostname_;
         segment.base = reinterpret_cast<uintptr_t>(buffer);
         segment.size = size;
         segment.protocol = protocol;
-        // For P2P handshake mode, publish the actual transport endpoint that
-        // was negotiated by the transfer engine. Otherwise, keep the logical
-        // hostname so metadata backends (HTTP/etcd/redis) can resolve the
-        // segment by name.
         if (metadata_connstring_ == P2PHANDSHAKE) {
             segment.te_endpoint = transfer_engine_->getLocalIpAndPort();
         } else {
@@ -2140,54 +2194,24 @@ tl::expected<void, ErrorCode> Client::MountSegment(
             return tl::unexpected(err);
         }
 
-        mounted_segments_[segment.id] = segment;
+        segment_id = segment.id;
+        mounted_segments_[segment_id] = segment;
     }
 
     EnsureStorageControlPlaneStarted();
-    return {};
+    return segment_id;
 }
 
-tl::expected<void, ErrorCode> Client::UnmountSegment(const void* buffer,
-                                                     size_t size) {
+tl::expected<void, ErrorCode> Client::UnmountSegmentById(
+    const UUID& segment_id) {
     std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
-    auto segment = mounted_segments_.end();
-
-    for (auto it = mounted_segments_.begin(); it != mounted_segments_.end();
-         ++it) {
-        if (it->second.base == reinterpret_cast<uintptr_t>(buffer) &&
-            it->second.size == size) {
-            segment = it;
-            break;
-        }
-    }
+    auto segment = mounted_segments_.find(segment_id);
     if (segment == mounted_segments_.end()) {
-        LOG(ERROR) << "segment_not_found base=" << buffer << " size=" << size;
+        LOG(ERROR) << "segment_not_found id=" << UuidToString(segment_id);
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    auto unmount_result = master_client_.UnmountSegment(segment->second.id);
-    if (!unmount_result) {
-        ErrorCode err = unmount_result.error();
-        LOG(ERROR) << "Failed to unmount segment from master: "
-                   << toString(err);
-        return tl::unexpected(err);
-    }
-
-    int rc = transfer_engine_->unregisterLocalMemory(
-        reinterpret_cast<void*>(segment->second.base));
-    if (rc != 0) {
-        LOG(ERROR) << "Failed to unregister transfer buffer with transfer "
-                      "engine ret is "
-                   << rc;
-        if (rc != ERR_ADDRESS_NOT_REGISTERED) {
-            return tl::unexpected(ErrorCode::INTERNAL_ERROR);
-        }
-        // Otherwise, the segment is already unregistered from transfer
-        // engine, we can continue
-    }
-
-    mounted_segments_.erase(segment);
-    return {};
+    return UnmountSegmentImpl(segment);
 }
 
 tl::expected<void, ErrorCode> Client::RegisterLocalMemory(

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2,6 +2,8 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
 #include <numa.h>
 #include <numaif.h>
 #include <pthread.h>
@@ -1020,6 +1022,159 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
 }
 
 int RealClient::tearDownAll() { return to_py_ret(tearDownAll_internal()); }
+
+int RealClient::mountSegment(const std::string &path, size_t offset,
+                             size_t size, const std::string &protocol,
+                             const std::string &location,
+                             std::vector<std::string> &out_segment_ids) {
+    if (!client_) {
+        LOG(ERROR) << "Client not initialized";
+        return -1;
+    }
+
+    size_t max_mr_size = globalConfig().max_mr_size;
+    if (max_mr_size == 0) {
+        LOG(ERROR) << "Invalid max_mr_size: 0";
+        return -1;
+    }
+
+    size_t page_size = sysconf(_SC_PAGESIZE);
+    if (max_mr_size < page_size) {
+        LOG(ERROR) << "max_mr_size " << max_mr_size
+                   << " is smaller than page_size " << page_size;
+        return -1;
+    }
+
+    int fd = open(path.c_str(), O_RDWR);
+    if (fd < 0) {
+        LOG(ERROR) << "open failed for " << path << ": " << strerror(errno);
+        return -1;
+    }
+
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        LOG(ERROR) << "fstat failed for " << path << ": " << strerror(errno);
+        close(fd);
+        return -1;
+    }
+
+    if (offset > (size_t)st.st_size || size > (size_t)st.st_size - offset) {
+        LOG(ERROR) << "requested range [offset=" << offset << ", size=" << size
+                   << "] exceeds file size " << st.st_size;
+        close(fd);
+        return -1;
+    }
+
+    if (offset % page_size != 0) {
+        LOG(ERROR) << "offset " << offset
+                   << " is not page-aligned (page_size=" << page_size << ")";
+        close(fd);
+        return -1;
+    }
+
+    size_t aligned_max_chunk = (max_mr_size / page_size) * page_size;
+    size_t remaining = size;
+    size_t current_offset = offset;
+    std::vector<std::string> mounted_ids;
+    std::vector<MountedSegmentRecord> mounted_records;
+
+    while (remaining > 0) {
+        size_t chunk_size = std::min(remaining, aligned_max_chunk);
+        if (chunk_size == 0) break;
+
+        void *ptr = mmap(nullptr, chunk_size, PROT_READ | PROT_WRITE,
+                         MAP_SHARED, fd, current_offset);
+        if (ptr == MAP_FAILED) {
+            LOG(ERROR) << "mmap failed for " << path << ": " << strerror(errno);
+            break;
+        }
+
+        auto result =
+            client_->MountSegmentAndGetId(ptr, chunk_size, protocol, location);
+        if (!result.has_value()) {
+            LOG(ERROR) << "MountSegmentAndGetId failed";
+            munmap(ptr, chunk_size);
+            break;
+        }
+
+        std::string segment_id = UuidToString(result.value());
+        mounted_ids.push_back(segment_id);
+        mounted_records.push_back({ptr, chunk_size, path});
+
+        remaining -= chunk_size;
+        current_offset += chunk_size;
+    }
+
+    close(fd);
+
+    // If not all chunks were mounted, roll back successfully mounted ones
+    if (remaining > 0) {
+        for (size_t i = 0; i < mounted_ids.size(); ++i) {
+            UUID id;
+            if (StringToUuid(mounted_ids[i], id)) {
+                client_->UnmountSegmentById(id);
+            }
+            if (mounted_records[i].mmap_base) {
+                munmap(mounted_records[i].mmap_base, mounted_records[i].size);
+            }
+        }
+        out_segment_ids.clear();
+        return -1;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mounted_segment_records_mutex_);
+        for (size_t i = 0; i < mounted_ids.size(); ++i) {
+            mounted_segment_records_[mounted_ids[i]] = mounted_records[i];
+        }
+    }
+    out_segment_ids = std::move(mounted_ids);
+    return 0;
+}
+
+int RealClient::unmountSegment(const std::vector<std::string> &segment_ids) {
+    if (!client_) {
+        LOG(ERROR) << "Client not initialized";
+        return -1;
+    }
+
+    int first_error = 0;
+    std::vector<std::pair<std::string, MountedSegmentRecord>> to_cleanup;
+    {
+        std::lock_guard<std::mutex> lock(mounted_segment_records_mutex_);
+        for (const auto &segment_id : segment_ids) {
+            UUID id;
+            if (!StringToUuid(segment_id, id)) {
+                LOG(ERROR) << "Invalid segment_id: " << segment_id;
+                if (first_error == 0) first_error = -1;
+                continue;
+            }
+
+            auto result = client_->UnmountSegmentById(id);
+            if (!result.has_value()) {
+                LOG(ERROR) << "UnmountSegmentById failed for " << segment_id;
+                if (first_error == 0) {
+                    first_error = static_cast<int>(result.error());
+                }
+                continue;  // Don't release local resources on failure
+            }
+
+            auto it = mounted_segment_records_.find(segment_id);
+            if (it != mounted_segment_records_.end()) {
+                to_cleanup.emplace_back(segment_id, it->second);
+                mounted_segment_records_.erase(it);
+            }
+        }
+    }
+
+    for (auto &p : to_cleanup) {
+        if (p.second.mmap_base) {
+            munmap(p.second.mmap_base, p.second.size);
+        }
+    }
+
+    return first_error;
+}
 
 int RealClient::health_check() {
     if (closed_.load()) return HC_NOT_INITIALIZED;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2,6 +2,8 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
 #include <numa.h>
 #include <numaif.h>
 #include <pthread.h>
@@ -939,6 +941,117 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
 }
 
 int RealClient::tearDownAll() { return to_py_ret(tearDownAll_internal()); }
+
+int RealClient::mountSegment(const std::string &path, size_t offset,
+                             size_t size, const std::string &protocol,
+                             const std::string &location,
+                             std::vector<std::string> &out_segment_ids) {
+    if (!client_) {
+        LOG(ERROR) << "Client not initialized";
+        return -1;
+    }
+
+    size_t max_mr_size = globalConfig().max_mr_size;
+    size_t remaining = size;
+    size_t current_offset = offset;
+    std::vector<std::string> mounted_ids;
+    std::vector<MountedSegmentRecord> mounted_records;
+
+    while (remaining > 0) {
+        size_t chunk_size = std::min(remaining, max_mr_size);
+
+        int fd = open(path.c_str(), O_RDWR);
+        if (fd < 0) {
+            LOG(ERROR) << "open failed for " << path << ": " << strerror(errno);
+            break;
+        }
+
+        void *ptr = mmap(nullptr, chunk_size, PROT_READ | PROT_WRITE,
+                         MAP_SHARED, fd, current_offset);
+        if (ptr == MAP_FAILED) {
+            LOG(ERROR) << "mmap failed for " << path << ": " << strerror(errno);
+            close(fd);
+            break;
+        }
+
+        auto result =
+            client_->MountSegmentAndGetId(ptr, chunk_size, protocol, location);
+        if (!result.has_value()) {
+            LOG(ERROR) << "MountSegmentAndGetId failed";
+            munmap(ptr, chunk_size);
+            close(fd);
+            break;
+        }
+
+        std::string segment_id = UuidToString(result.value());
+        mounted_ids.push_back(segment_id);
+        mounted_records.push_back({fd, ptr, chunk_size, path});
+
+        remaining -= chunk_size;
+        current_offset += chunk_size;
+    }
+
+    // If not all chunks were mounted, roll back successfully mounted ones
+    if (remaining > 0) {
+        for (size_t i = 0; i < mounted_ids.size(); ++i) {
+            UUID id;
+            if (StringToUuid(mounted_ids[i], id)) {
+                client_->UnmountSegmentById(id);
+            }
+            if (mounted_records[i].mmap_base) {
+                munmap(mounted_records[i].mmap_base, mounted_records[i].size);
+            }
+            if (mounted_records[i].fd >= 0) {
+                close(mounted_records[i].fd);
+            }
+        }
+        out_segment_ids.clear();
+        return -1;
+    }
+
+    for (size_t i = 0; i < mounted_ids.size(); ++i) {
+        mounted_segment_records_[mounted_ids[i]] = mounted_records[i];
+    }
+    out_segment_ids = std::move(mounted_ids);
+    return 0;
+}
+
+int RealClient::unmountSegment(const std::vector<std::string> &segment_ids) {
+    if (!client_) {
+        LOG(ERROR) << "Client not initialized";
+        return -1;
+    }
+
+    int first_error = 0;
+    for (const auto &segment_id : segment_ids) {
+        UUID id;
+        if (!StringToUuid(segment_id, id)) {
+            LOG(ERROR) << "Invalid segment_id: " << segment_id;
+            if (first_error == 0) first_error = -1;
+            continue;
+        }
+
+        auto result = client_->UnmountSegmentById(id);
+        if (!result.has_value()) {
+            LOG(ERROR) << "UnmountSegmentById failed for " << segment_id;
+            if (first_error == 0) {
+                first_error = static_cast<int>(result.error());
+            }
+        }
+
+        auto it = mounted_segment_records_.find(segment_id);
+        if (it != mounted_segment_records_.end()) {
+            if (it->second.mmap_base) {
+                munmap(it->second.mmap_base, it->second.size);
+            }
+            if (it->second.fd >= 0) {
+                close(it->second.fd);
+            }
+            mounted_segment_records_.erase(it);
+        }
+    }
+    return first_error;
+}
 
 int RealClient::health_check() {
     if (closed_.load()) return HC_NOT_INITIALIZED;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -957,20 +957,19 @@ int RealClient::mountSegment(const std::string &path, size_t offset,
     std::vector<std::string> mounted_ids;
     std::vector<MountedSegmentRecord> mounted_records;
 
+    int fd = open(path.c_str(), O_RDWR);
+    if (fd < 0) {
+        LOG(ERROR) << "open failed for " << path << ": " << strerror(errno);
+        return -1;
+    }
+
     while (remaining > 0) {
         size_t chunk_size = std::min(remaining, max_mr_size);
-
-        int fd = open(path.c_str(), O_RDWR);
-        if (fd < 0) {
-            LOG(ERROR) << "open failed for " << path << ": " << strerror(errno);
-            break;
-        }
 
         void *ptr = mmap(nullptr, chunk_size, PROT_READ | PROT_WRITE,
                          MAP_SHARED, fd, current_offset);
         if (ptr == MAP_FAILED) {
             LOG(ERROR) << "mmap failed for " << path << ": " << strerror(errno);
-            close(fd);
             break;
         }
 
@@ -979,17 +978,18 @@ int RealClient::mountSegment(const std::string &path, size_t offset,
         if (!result.has_value()) {
             LOG(ERROR) << "MountSegmentAndGetId failed";
             munmap(ptr, chunk_size);
-            close(fd);
             break;
         }
 
         std::string segment_id = UuidToString(result.value());
         mounted_ids.push_back(segment_id);
-        mounted_records.push_back({fd, ptr, chunk_size, path});
+        mounted_records.push_back({ptr, chunk_size, path});
 
         remaining -= chunk_size;
         current_offset += chunk_size;
     }
+
+    close(fd);
 
     // If not all chunks were mounted, roll back successfully mounted ones
     if (remaining > 0) {
@@ -1000,9 +1000,6 @@ int RealClient::mountSegment(const std::string &path, size_t offset,
             }
             if (mounted_records[i].mmap_base) {
                 munmap(mounted_records[i].mmap_base, mounted_records[i].size);
-            }
-            if (mounted_records[i].fd >= 0) {
-                close(mounted_records[i].fd);
             }
         }
         out_segment_ids.clear();
@@ -1048,9 +1045,6 @@ int RealClient::unmountSegment(const std::vector<std::string> &segment_ids) {
             if (it != mounted_segment_records_.end()) {
                 if (it->second.mmap_base) {
                     munmap(it->second.mmap_base, it->second.size);
-                }
-                if (it->second.fd >= 0) {
-                    close(it->second.fd);
                 }
                 mounted_segment_records_.erase(it);
             }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1009,8 +1009,11 @@ int RealClient::mountSegment(const std::string &path, size_t offset,
         return -1;
     }
 
-    for (size_t i = 0; i < mounted_ids.size(); ++i) {
-        mounted_segment_records_[mounted_ids[i]] = mounted_records[i];
+    {
+        std::lock_guard<std::mutex> lock(mounted_segment_records_mutex_);
+        for (size_t i = 0; i < mounted_ids.size(); ++i) {
+            mounted_segment_records_[mounted_ids[i]] = mounted_records[i];
+        }
     }
     out_segment_ids = std::move(mounted_ids);
     return 0;
@@ -1023,31 +1026,34 @@ int RealClient::unmountSegment(const std::vector<std::string> &segment_ids) {
     }
 
     int first_error = 0;
-    for (const auto &segment_id : segment_ids) {
-        UUID id;
-        if (!StringToUuid(segment_id, id)) {
-            LOG(ERROR) << "Invalid segment_id: " << segment_id;
-            if (first_error == 0) first_error = -1;
-            continue;
-        }
+    {
+        std::lock_guard<std::mutex> lock(mounted_segment_records_mutex_);
+        for (const auto &segment_id : segment_ids) {
+            UUID id;
+            if (!StringToUuid(segment_id, id)) {
+                LOG(ERROR) << "Invalid segment_id: " << segment_id;
+                if (first_error == 0) first_error = -1;
+                continue;
+            }
 
-        auto result = client_->UnmountSegmentById(id);
-        if (!result.has_value()) {
-            LOG(ERROR) << "UnmountSegmentById failed for " << segment_id;
-            if (first_error == 0) {
-                first_error = static_cast<int>(result.error());
+            auto result = client_->UnmountSegmentById(id);
+            if (!result.has_value()) {
+                LOG(ERROR) << "UnmountSegmentById failed for " << segment_id;
+                if (first_error == 0) {
+                    first_error = static_cast<int>(result.error());
+                }
             }
-        }
 
-        auto it = mounted_segment_records_.find(segment_id);
-        if (it != mounted_segment_records_.end()) {
-            if (it->second.mmap_base) {
-                munmap(it->second.mmap_base, it->second.size);
+            auto it = mounted_segment_records_.find(segment_id);
+            if (it != mounted_segment_records_.end()) {
+                if (it->second.mmap_base) {
+                    munmap(it->second.mmap_base, it->second.size);
+                }
+                if (it->second.fd >= 0) {
+                    close(it->second.fd);
+                }
+                mounted_segment_records_.erase(it);
             }
-            if (it->second.fd >= 0) {
-                close(it->second.fd);
-            }
-            mounted_segment_records_.erase(it);
         }
     }
     return first_error;

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -1734,6 +1734,40 @@ TEST_F(ClientIntegrationTest, BatchUpsertMixed) {
     }
 }
 
+TEST_F(ClientIntegrationTest, MountSegmentAndGetIdAndUnmountSegmentById) {
+    // Allocate a small buffer for this test
+    size_t test_size = 16 * 1024 * 1024;  // 16 MB
+    void* test_buffer = allocate_buffer_allocator_memory(test_size);
+    ASSERT_NE(test_buffer, nullptr);
+
+    // Test MountSegmentAndGetId returns a valid UUID
+    auto mount_result = test_client_->MountSegmentAndGetId(
+        test_buffer, test_size, FLAGS_protocol);
+    ASSERT_TRUE(mount_result.has_value())
+        << "MountSegmentAndGetId failed: " << toString(mount_result.error());
+    UUID segment_id = mount_result.value();
+    EXPECT_NE(segment_id.first, 0u);
+    EXPECT_NE(segment_id.second, 0u);
+
+    // Test UnmountSegmentById succeeds
+    auto unmount_result = test_client_->UnmountSegmentById(segment_id);
+    EXPECT_TRUE(unmount_result.has_value())
+        << "UnmountSegmentById failed: " << toString(unmount_result.error());
+
+    // Test MountSegment delegates to MountSegmentAndGetId (equivalent behavior)
+    auto mount2 =
+        test_client_->MountSegment(test_buffer, test_size, FLAGS_protocol);
+    EXPECT_TRUE(mount2.has_value())
+        << "MountSegment failed: " << toString(mount2.error());
+
+    // Test UnmountSegment delegates to UnmountSegmentImpl (equivalent behavior)
+    auto unmount2 = test_client_->UnmountSegment(test_buffer, test_size);
+    EXPECT_TRUE(unmount2.has_value())
+        << "UnmountSegment failed: " << toString(unmount2.error());
+
+    free(test_buffer);
+}
+
 }  // namespace testing
 
 }  // namespace mooncake

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -23,6 +23,15 @@ def _timed_handler(operation_name, handler):
     return wrapper
 
 
+def _shm_name_to_path(name):
+    if not isinstance(name, str) or not name:
+        return None
+    normalized = name[1:] if name.startswith("/") else name
+    if not normalized or "/" in normalized or normalized in {".", ".."}:
+        return None
+    return f"/dev/shm/{normalized}"
+
+
 class MooncakeStoreService:
     """
     Mooncake Store Service with REST API.
@@ -52,6 +61,12 @@ class MooncakeStoreService:
         self.store = None
         self.config = None
         self._setup_logging()
+
+        # State for /api/reconfigure (Prefill/Decode mode switch)
+        self.current_mode = "prefill"          # "prefill" or "decode"
+        self.mounted_segment_ids = []          # persisted segment_ids from last decode mount
+        self.last_mount_info = {}              # last mount parameters for debugging
+        self._state_lock = asyncio.Lock()      # serialize reconfigure/mount/unmount state changes
 
         try:
             if config_path:
@@ -143,6 +158,9 @@ class MooncakeStoreService:
     async def start_http_service(self, port: int = 8080):
         app = web.Application(client_max_size=1024 * 1024 * 100)  # 100MB limit
         app.add_routes([
+            web.post('/api/reconfigure', _timed_handler("RECONFIGURE", self.handle_reconfigure)),
+            web.post('/api/mount_shm', _timed_handler("MOUNT_SHM", self.handle_mount_shm)),
+            web.post('/api/unmount_shm', _timed_handler("UNMOUNT_SHM", self.handle_unmount_shm)),
             web.put('/api/put', _timed_handler("PUT", self.handle_put)),
             web.get('/api/get/{key}', _timed_handler("GET", self.handle_get)),
             web.get('/api/exist/{key}', _timed_handler("EXIST", self.handle_exist)),
@@ -157,6 +175,184 @@ class MooncakeStoreService:
         return True
 
     # REST API handlers
+    async def handle_reconfigure(self, request):
+        try:
+            data = await request.json()
+            mode = data.get("mode", "").lower()
+
+            if mode == "decode":
+                path = data.get("path")
+                size = data.get("size")
+                offset = data.get("offset", 0)
+                protocol = data.get("protocol", self.config.protocol)
+                location = data.get("location", "")
+
+                if not path or size is None:
+                    return web.Response(
+                        status=400,
+                        text=json.dumps({"error": "Missing path or size for decode mode"}),
+                        content_type="application/json"
+                    )
+
+                async with self._state_lock:
+                    # If already in decode mode with mounted segments, unmount them first
+                    if self.mounted_segment_ids:
+                        logging.info("Reconfigure decode: unmounting previous segments before remount")
+                        ret = self.store.unmount_segment(self.mounted_segment_ids)
+                        if ret != 0:
+                            return web.Response(
+                                status=500,
+                                text=json.dumps({"error": f"Unmount of previous segments failed, ret={ret}"}),
+                                content_type="application/json"
+                            )
+                        self.mounted_segment_ids.clear()
+
+                    result = self.store.mount_segment(path, size, offset, protocol, location)
+                    if result["ret"] != 0:
+                        return web.Response(
+                            status=500,
+                            text=json.dumps({"error": f"Mount failed, ret={result['ret']}"}),
+                            content_type="application/json"
+                        )
+
+                    self.mounted_segment_ids = list(result["segment_ids"])
+                    self.current_mode = "decode"
+                    self.last_mount_info = {
+                        "path": path, "offset": offset, "size": size,
+                        "protocol": protocol, "location": location
+                    }
+
+                return web.Response(
+                    status=200,
+                    text=json.dumps({
+                        "status": "success",
+                        "mode": self.current_mode,
+                        "segment_ids": self.mounted_segment_ids,
+                    }),
+                    content_type="application/json"
+                )
+
+            elif mode == "prefill":
+                async with self._state_lock:
+                    if self.mounted_segment_ids:
+                        ret = self.store.unmount_segment(self.mounted_segment_ids)
+                        if ret != 0:
+                            return web.Response(
+                                status=500,
+                                text=json.dumps({"error": f"Unmount failed, ret={ret}"}),
+                                content_type="application/json"
+                            )
+                        self.mounted_segment_ids.clear()
+
+                    self.current_mode = "prefill"
+                    self.last_mount_info.clear()
+
+                return web.Response(
+                    status=200,
+                    text=json.dumps({"status": "success", "mode": self.current_mode}),
+                    content_type="application/json"
+                )
+
+            else:
+                return web.Response(
+                    status=400,
+                    text=json.dumps({"error": "Invalid mode. Use 'decode' or 'prefill'"}),
+                    content_type="application/json"
+                )
+        except Exception as e:
+            logging.error("RECONFIGURE error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json"
+            )
+
+    async def handle_mount_shm(self, request):
+        try:
+            data = await request.json()
+            name = data.get("name")
+            path = _shm_name_to_path(name)
+            offset = data.get("offset", 0)
+            size = data.get("size")
+            protocol = data.get("protocol", self.config.protocol)
+            location = data.get("location", "")
+
+            if not path or size is None:
+                return web.Response(
+                    status=400,
+                    text=json.dumps({"error": "Missing or invalid name or size"}),
+                    content_type="application/json"
+                )
+
+            result = self.store.mount_segment(path, size, offset, protocol, location)
+            if result["ret"] != 0:
+                return web.Response(
+                    status=500,
+                    text=json.dumps({"error": f"Mount failed, ret={result['ret']}"}),
+                    content_type="application/json"
+                )
+
+            return web.Response(
+                status=200,
+                text=json.dumps(
+                    {
+                        "status": "success",
+                        "segment_ids": list(result["segment_ids"]),
+                    }
+                ),
+                content_type="application/json",
+            )
+        except Exception as e:
+            logging.error("MOUNT_SHM error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json"
+            )
+
+    async def handle_unmount_shm(self, request):
+        try:
+            data = await request.json()
+            segment_ids = data.get("segment_ids", [])
+            if isinstance(segment_ids, str):
+                segment_ids = [segment_ids]
+            if not segment_ids:
+                return web.Response(
+                    status=400,
+                    text=json.dumps({"error": "Missing segment_ids"}),
+                    content_type="application/json",
+                )
+
+            ret = self.store.unmount_segment(segment_ids)
+            if ret != 0:
+                return web.Response(
+                    status=500,
+                    text=json.dumps(
+                        {"error": f"Unmount failed, ret={ret}"}
+                    ),
+                    content_type="application/json",
+                )
+
+            async with self._state_lock:
+                for sid in segment_ids:
+                    if sid in self.mounted_segment_ids:
+                        self.mounted_segment_ids.remove(sid)
+                if not self.mounted_segment_ids:
+                    self.current_mode = "prefill"
+
+            return web.Response(
+                status=200,
+                text=json.dumps({"status": "success"}),
+                content_type="application/json",
+            )
+        except Exception as e:
+            logging.error("UNMOUNT_SHM error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json"
+            )
+
     async def handle_put(self, request):
         try:
             data = await request.json()

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -53,6 +53,11 @@ class MooncakeStoreService:
         self.config = None
         self._setup_logging()
 
+        # State for /api/reconfigure (Prefill/Decode mode switch)
+        self.current_mode = "prefill"          # "prefill" or "decode"
+        self.mounted_segment_ids = []          # persisted segment_ids from last decode mount
+        self.last_mount_info = {}              # last mount parameters for debugging
+
         try:
             if config_path:
                 self.config = MooncakeConfig.from_file(config_path)
@@ -143,6 +148,7 @@ class MooncakeStoreService:
     async def start_http_service(self, port: int = 8080):
         app = web.Application(client_max_size=1024 * 1024 * 100)  # 100MB limit
         app.add_routes([
+            web.post('/api/reconfigure', _timed_handler("RECONFIGURE", self.handle_reconfigure)),
             web.post('/api/mount', _timed_handler("MOUNT", self.handle_mount)),
             web.post('/api/unmount', _timed_handler("UNMOUNT", self.handle_unmount)),
             web.put('/api/put', _timed_handler("PUT", self.handle_put)),
@@ -159,6 +165,89 @@ class MooncakeStoreService:
         return True
 
     # REST API handlers
+    async def handle_reconfigure(self, request):
+        try:
+            data = await request.json()
+            mode = data.get("mode", "").lower()
+
+            if mode == "decode":
+                path = data.get("path")
+                size = data.get("size")
+                offset = data.get("offset", 0)
+                protocol = data.get("protocol", self.config.protocol)
+                location = data.get("location", "")
+
+                if not path or size is None:
+                    return web.Response(
+                        status=400,
+                        text=json.dumps({"error": "Missing path or size for decode mode"}),
+                        content_type="application/json"
+                    )
+
+                # If already in decode mode with mounted segments, unmount them first
+                if self.mounted_segment_ids:
+                    logging.info("Reconfigure decode: unmounting previous segments before remount")
+                    self.store.unmount_segment(self.mounted_segment_ids)
+                    self.mounted_segment_ids.clear()
+
+                result = self.store.mount_segment(path, offset, size, protocol, location)
+                if result["ret"] != 0:
+                    return web.Response(
+                        status=500,
+                        text=json.dumps({"error": f"Mount failed, ret={result['ret']}"}),
+                        content_type="application/json"
+                    )
+
+                self.mounted_segment_ids = list(result["segment_ids"])
+                self.current_mode = "decode"
+                self.last_mount_info = {
+                    "path": path, "offset": offset, "size": size,
+                    "protocol": protocol, "location": location
+                }
+
+                return web.Response(
+                    status=200,
+                    text=json.dumps({
+                        "status": "success",
+                        "mode": self.current_mode,
+                        "segment_ids": self.mounted_segment_ids,
+                    }),
+                    content_type="application/json"
+                )
+
+            elif mode == "prefill":
+                if self.mounted_segment_ids:
+                    ret = self.store.unmount_segment(self.mounted_segment_ids)
+                    if ret != 0:
+                        return web.Response(
+                            status=500,
+                            text=json.dumps({"error": f"Unmount failed, ret={ret}"}),
+                            content_type="application/json"
+                        )
+                    self.mounted_segment_ids.clear()
+
+                self.current_mode = "prefill"
+                self.last_mount_info.clear()
+                return web.Response(
+                    status=200,
+                    text=json.dumps({"status": "success", "mode": self.current_mode}),
+                    content_type="application/json"
+                )
+
+            else:
+                return web.Response(
+                    status=400,
+                    text=json.dumps({"error": "Invalid mode. Use 'decode' or 'prefill'"}),
+                    content_type="application/json"
+                )
+        except Exception as e:
+            logging.error("RECONFIGURE error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json"
+            )
+
     async def handle_mount(self, request):
         try:
             data = await request.json()

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -187,7 +187,13 @@ class MooncakeStoreService:
                 # If already in decode mode with mounted segments, unmount them first
                 if self.mounted_segment_ids:
                     logging.info("Reconfigure decode: unmounting previous segments before remount")
-                    self.store.unmount_segment(self.mounted_segment_ids)
+                    ret = self.store.unmount_segment(self.mounted_segment_ids)
+                    if ret != 0:
+                        return web.Response(
+                            status=500,
+                            text=json.dumps({"error": f"Unmount of previous segments failed, ret={ret}"}),
+                            content_type="application/json"
+                        )
                     self.mounted_segment_ids.clear()
 
                 result = self.store.mount_segment(path, offset, size, protocol, location)

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -209,9 +209,20 @@ class MooncakeStoreService:
 
                     result = self.store.mount_segment(path, size, offset, protocol, location)
                     if result["ret"] != 0:
+                        self.current_mode = "prefill"
+                        self.mounted_segment_ids.clear()
+                        self.last_mount_info.clear()
                         return web.Response(
                             status=500,
-                            text=json.dumps({"error": f"Mount failed, ret={result['ret']}"}),
+                            text=json.dumps(
+                                {
+                                    "error": (
+                                        f"Mount failed, ret={result['ret']}; "
+                                        "rolled back to prefill"
+                                    ),
+                                    "mode": self.current_mode,
+                                }
+                            ),
                             content_type="application/json"
                         )
 
@@ -323,22 +334,29 @@ class MooncakeStoreService:
                     content_type="application/json",
                 )
 
-            ret = self.store.unmount_segment(segment_ids)
-            if ret != 0:
-                return web.Response(
-                    status=500,
-                    text=json.dumps(
-                        {"error": f"Unmount failed, ret={ret}"}
-                    ),
-                    content_type="application/json",
-                )
-
+            failed_segment_ids = []
             async with self._state_lock:
                 for sid in segment_ids:
+                    ret = self.store.unmount_segment([sid])
+                    if ret != 0:
+                        failed_segment_ids.append(sid)
+                        continue
                     if sid in self.mounted_segment_ids:
                         self.mounted_segment_ids.remove(sid)
                 if not self.mounted_segment_ids:
                     self.current_mode = "prefill"
+
+            if failed_segment_ids:
+                return web.Response(
+                    status=500,
+                    text=json.dumps(
+                        {
+                            "error": "Unmount failed for one or more segments",
+                            "failed_segment_ids": failed_segment_ids,
+                        }
+                    ),
+                    content_type="application/json",
+                )
 
             return web.Response(
                 status=200,

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -143,6 +143,8 @@ class MooncakeStoreService:
     async def start_http_service(self, port: int = 8080):
         app = web.Application(client_max_size=1024 * 1024 * 100)  # 100MB limit
         app.add_routes([
+            web.post('/api/mount', _timed_handler("MOUNT", self.handle_mount)),
+            web.post('/api/unmount', _timed_handler("UNMOUNT", self.handle_unmount)),
             web.put('/api/put', _timed_handler("PUT", self.handle_put)),
             web.get('/api/get/{key}', _timed_handler("GET", self.handle_get)),
             web.get('/api/exist/{key}', _timed_handler("EXIST", self.handle_exist)),
@@ -157,6 +159,84 @@ class MooncakeStoreService:
         return True
 
     # REST API handlers
+    async def handle_mount(self, request):
+        try:
+            data = await request.json()
+            path = data.get("path")
+            offset = data.get("offset", 0)
+            size = data.get("size")
+            protocol = data.get("protocol", self.config.protocol)
+            location = data.get("location", "")
+
+            if not path or size is None:
+                return web.Response(
+                    status=400,
+                    text=json.dumps({"error": "Missing path or size"}),
+                    content_type="application/json"
+                )
+
+            result = self.store.mount_segment(path, offset, size, protocol, location)
+            if result["ret"] != 0:
+                return web.Response(
+                    status=500,
+                    text=json.dumps({"error": f"Mount failed, ret={result['ret']}"}),
+                    content_type="application/json"
+                )
+
+            return web.Response(
+                status=200,
+                text=json.dumps(
+                    {
+                        "status": "success",
+                        "segment_ids": list(result["segment_ids"]),
+                    }
+                ),
+                content_type="application/json",
+            )
+        except Exception as e:
+            logging.error("MOUNT error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json"
+            )
+
+    async def handle_unmount(self, request):
+        try:
+            data = await request.json()
+            segment_ids = data.get("segment_ids", [])
+            if isinstance(segment_ids, str):
+                segment_ids = [segment_ids]
+            if not segment_ids:
+                return web.Response(
+                    status=400,
+                    text=json.dumps({"error": "Missing segment_ids"}),
+                    content_type="application/json",
+                )
+
+            ret = self.store.unmount_segment(segment_ids)
+            if ret != 0:
+                return web.Response(
+                    status=500,
+                    text=json.dumps(
+                        {"error": f"Unmount failed, ret={ret}"}
+                    ),
+                    content_type="application/json",
+                )
+
+            return web.Response(
+                status=200,
+                text=json.dumps({"status": "success"}),
+                content_type="application/json",
+            )
+        except Exception as e:
+            logging.error("UNMOUNT error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json"
+            )
+
     async def handle_put(self, request):
         try:
             data = await request.json()

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -45,9 +45,13 @@ class FakeStore:
         self.mounted = {}
         self.mount_calls = []
         self.unmount_calls = []
+        self.fail_mount = False
+        self.unmount_failures = set()
 
     def mount_segment(self, path, size, offset, protocol, location):
         self.mount_calls.append((path, size, offset, protocol, location))
+        if self.fail_mount:
+            return {"ret": -1, "segment_ids": []}
         segment_id = "00000000-0000-0000-0000-000000000001"
         self.mounted[segment_id] = {
             "path": path,
@@ -60,6 +64,9 @@ class FakeStore:
 
     def unmount_segment(self, segment_ids):
         self.unmount_calls.append(list(segment_ids))
+        for segment_id in segment_ids:
+            if segment_id in self.unmount_failures:
+                return -1
         for segment_id in segment_ids:
             self.mounted.pop(segment_id, None)
         return 0
@@ -119,6 +126,53 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
             [["00000000-0000-0000-0000-000000000001"]],
         )
         self.assertEqual(self.service.current_mode, "prefill")
+
+    async def test_unmount_shm_updates_state_for_partial_success(self):
+        succeeded_id = "00000000-0000-0000-0000-000000000001"
+        failed_id = "00000000-0000-0000-0000-000000000002"
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = [succeeded_id, failed_id]
+        self.fake_store.unmount_failures = {failed_id}
+
+        resp = await self.service.handle_unmount_shm(
+            FakeRequest({"segment_ids": [succeeded_id, failed_id]})
+        )
+
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertEqual(body["failed_segment_ids"], [failed_id])
+        self.assertEqual(
+            self.fake_store.unmount_calls,
+            [[succeeded_id], [failed_id]],
+        )
+        self.assertEqual(self.service.mounted_segment_ids, [failed_id])
+        self.assertEqual(self.service.current_mode, "decode")
+
+    async def test_reconfigure_decode_mount_failure_rolls_back_to_prefill(self):
+        old_id = "00000000-0000-0000-0000-000000000001"
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = [old_id]
+        self.service.last_mount_info = {
+            "path": "/dev/shm/old",
+            "offset": 0,
+            "size": 4096,
+            "protocol": "tcp",
+            "location": "",
+        }
+        self.fake_store.fail_mount = True
+
+        resp = await self.service.handle_reconfigure(
+            FakeRequest({"mode": "decode", "path": "/dev/shm/new", "size": 4096})
+        )
+
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertEqual(body["mode"], "prefill")
+        self.assertIn("rolled back to prefill", body["error"])
+        self.assertEqual(self.fake_store.unmount_calls, [[old_id]])
+        self.assertEqual(self.service.mounted_segment_ids, [])
+        self.assertEqual(self.service.current_mode, "prefill")
+        self.assertEqual(self.service.last_mount_info, {})
 
     async def test_mount_shm_requires_name_and_size(self):
         resp = await self.service.handle_mount_shm(

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+try:
+    from aiohttp import web as _unused_web
+except ModuleNotFoundError:
+    aiohttp_module = types.ModuleType("aiohttp")
+    web_module = types.ModuleType("aiohttp.web")
+
+    class Response:
+        def __init__(self, status=200, text="", content_type=None):
+            self.status = status
+            self.text = text
+            self.content_type = content_type
+
+    web_module.Response = Response
+    aiohttp_module.web = web_module
+    sys.modules["aiohttp"] = aiohttp_module
+    sys.modules["aiohttp.web"] = web_module
+
+try:
+    from mooncake.store import MooncakeDistributedStore as _unused_store
+except ModuleNotFoundError:
+    store_module = types.ModuleType("mooncake.store")
+
+    class MooncakeDistributedStore:
+        pass
+
+    store_module.MooncakeDistributedStore = MooncakeDistributedStore
+    sys.modules["mooncake.store"] = store_module
+
+from mooncake.mooncake_store_service import MooncakeStoreService
+
+
+class FakeStore:
+    def __init__(self):
+        self.mounted = {}
+        self.mount_calls = []
+        self.unmount_calls = []
+
+    def mount_segment(self, path, size, offset, protocol, location):
+        self.mount_calls.append((path, size, offset, protocol, location))
+        segment_id = "00000000-0000-0000-0000-000000000001"
+        self.mounted[segment_id] = {
+            "path": path,
+            "size": size,
+            "offset": offset,
+            "protocol": protocol,
+            "location": location,
+        }
+        return {"ret": 0, "segment_ids": [segment_id]}
+
+    def unmount_segment(self, segment_ids):
+        self.unmount_calls.append(list(segment_ids))
+        for segment_id in segment_ids:
+            self.mounted.pop(segment_id, None)
+        return 0
+
+
+class FakeRequest:
+    def __init__(self, body):
+        self.body = body
+
+    async def json(self):
+        return self.body
+
+
+class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.fake_store = FakeStore()
+        self.service = MooncakeStoreService.__new__(MooncakeStoreService)
+        self.service.store = self.fake_store
+        self.service.config = SimpleNamespace(protocol="tcp")
+        self.service.current_mode = "prefill"
+        self.service.mounted_segment_ids = []
+        self.service.last_mount_info = {}
+        self.service._state_lock = asyncio.Lock()
+
+    async def test_mount_shm_then_unmount_shm_api(self):
+        mount_resp = await self.service.handle_mount_shm(
+            FakeRequest(
+                {
+                    "name": "mooncake-segment",
+                    "size": 4096,
+                    "offset": 128,
+                    "protocol": "tcp",
+                    "location": "cpu:0",
+                }
+            )
+        )
+        self.assertEqual(mount_resp.status, 200)
+        mount_body = json.loads(mount_resp.text)
+        self.assertEqual(mount_body["status"], "success")
+        self.assertEqual(
+            mount_body["segment_ids"],
+            ["00000000-0000-0000-0000-000000000001"],
+        )
+        self.assertEqual(
+            self.fake_store.mount_calls,
+            [("/dev/shm/mooncake-segment", 4096, 128, "tcp", "cpu:0")],
+        )
+
+        unmount_resp = await self.service.handle_unmount_shm(
+            FakeRequest({"segment_ids": mount_body["segment_ids"]})
+        )
+        self.assertEqual(unmount_resp.status, 200)
+        unmount_body = json.loads(unmount_resp.text)
+        self.assertEqual(unmount_body["status"], "success")
+        self.assertEqual(
+            self.fake_store.unmount_calls,
+            [["00000000-0000-0000-0000-000000000001"]],
+        )
+        self.assertEqual(self.service.current_mode, "prefill")
+
+    async def test_mount_shm_requires_name_and_size(self):
+        resp = await self.service.handle_mount_shm(
+            FakeRequest({"name": "mooncake-segment"})
+        )
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("name or size", body["error"])
+
+    async def test_mount_shm_rejects_path_like_name(self):
+        resp = await self.service.handle_mount_shm(
+            FakeRequest({"name": "../foo", "size": 4096})
+        )
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("name or size", body["error"])
+
+    async def test_unmount_shm_requires_segment_ids(self):
+        resp = await self.service.handle_unmount_shm(FakeRequest({}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Missing segment_ids", body["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This PR introduces standalone HTTP APIs for dynamic memory segment management and Prefill/Decode mode switching in Mooncake Store.

The core design principle is **decoupling memory allocation from segment management**: external systems, such as a scheduler or memory daemon, are responsible for creating named shared memory objects, while Mooncake Store acts as a mount agent that performs standard `MountSegment` / `UnmountSegment` operations upon HTTP requests.

### Key Changes

1. **HTTP Reconfigure API (`POST /api/reconfigure`)**
    - Unified entry point for Prefill/Decode mode switching.
    - `mode=decode`: mounts an external memory region and internally persists returned `segment_ids`.
    - `mode=prefill`: unmounts currently persisted `segment_ids` and switches back to Prefill state.
    - Service maintains state (`current_mode`, `mounted_segment_ids`, `last_mount_info`) and serializes reconfigure/mount/unmount state changes with an async lock.

2. **Standalone Named Shared Memory Mount/Unmount APIs**
    - `POST /api/mount_shm`: mounts a named shared memory object as one or more Mooncake Store segments.
    - Request uses `name`, not arbitrary `path`. The service maps the name to `/dev/shm/<name>` and rejects path-like names.
    - `POST /api/unmount_shm`: batch-unmounts segments by `segment_ids`, unregisters TE MR, and cleans up local `mmap` resources.
    - If `size > max_mr_size`, auto-chunking splits the shared memory region into multiple mounted segments.

3. **C++ Core Enhancements**
    - Added `Client::MountSegmentAndGetId()` / `UnmountSegmentById()` for UUID-based segment lifecycle management.
    - Refactored `MountSegment` and unmount paths to share internal implementations and reduce duplicated logic.
    - Added thread-safe mounted segment record tracking in `RealClient`.
    - Added validation for mount parameters and robust rollback on partial mount failure.

4. **Python Bindings & Service Layer**
    - Exposed `mount_segment(path, offset, size, protocol, location)` and `unmount_segment(segment_ids)` via pybind11.
    - Added REST service handlers for `reconfigure`, `mount_shm`, and `unmount_shm`.
    - Added focused unit tests for the REST service handler behavior.

5. **Documentation**
    - Updated HTTP API docs for `/api/reconfigure`, `/api/mount_shm`, and `/api/unmount_shm`.
    - Updated Python API docs for `mount_segment()` / `unmount_segment()`.
    - Clarified that the Python binding accepts a path, while the HTTP `mount_shm` API intentionally accepts only a named shared memory object name.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

- [x] `./scripts/code_format.sh --check -b upstream/main`
- [x] `python3 -m unittest mooncake-wheel/tests/test_mooncake_store_service_api.py`
- [x] `git diff --check upstream/main...HEAD`
- [x] `python3 -m py_compile mooncake-wheel/mooncake/mooncake_store_service.py mooncake-wheel/tests/test_mooncake_store_service_api.py`
- [x] Verified no stale `/api/mount` / `/api/unmount` standalone REST routes remain in service/docs.
- [x] Verified `/api/mount_shm` rejects path-like names and maps valid names to `/dev/shm/<name>`.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.