### PR TITLE
[Store] Support degraded startup when master is unavailable

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -409,11 +409,14 @@ class ClientService {
     /**
      * @brief Attempts to reconnect to master after heartbeat failures.
      * For HA mode, fetches the latest master address from etcd.
-     * For non-HA mode, reconnects to the same address.
+     * For non-HA mode, reconnects to the current_master_address.
+     * @param is_ha_mode Whether HA mode is enabled.
+     * @param current_master_address Current master address, may be updated
+     * after successful reconnection in HA mode.
      * @return true if reconnect succeeded, false otherwise.
      */
-    bool ReconnectToMaster(bool is_ha_mode, std::string& current_master_address,
-                           const std::string& master_server_entry);
+    bool ReconnectToMaster(bool is_ha_mode,
+                           std::string& current_master_address);
 
     /**
      * @brief Waits for the next heartbeat interval using condition variable.

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -314,7 +314,7 @@ class ClientService {
         return transfer_engine_->getLocalIpAndPort();
     }
     UUID GetClientID() const { return client_id_; }
-    ViewVersionId GetViewVersion() const { return view_version_; }
+    ViewVersionId GetViewVersion() const { return view_version_.load(); }
 
    public:
     /**
@@ -386,7 +386,8 @@ class ClientService {
     void StartHeartbeat(const std::string& master_server_entry);
 
     void HeartbeatThreadMain(bool is_ha_mode,
-                             std::string current_master_address);
+                             std::string current_master_address,
+                             const std::string& master_server_entry);
 
     /**
      * @brief Handles a successful heartbeat response.
@@ -411,8 +412,8 @@ class ClientService {
      * For non-HA mode, reconnects to the same address.
      * @return true if reconnect succeeded, false otherwise.
      */
-    bool ReconnectToMaster(bool is_ha_mode,
-                           std::string& current_master_address);
+    bool ReconnectToMaster(bool is_ha_mode, std::string& current_master_address,
+                           const std::string& master_server_entry);
 
     /**
      * @brief Waits for the next heartbeat interval using condition variable.
@@ -533,7 +534,9 @@ class ClientService {
     std::atomic<bool> heartbeat_running_{false};
     std::condition_variable heartbeat_cv_;
     std::mutex heartbeat_mtx_;
-    ViewVersionId view_version_{0};
+    /// View version from master. Updated by async registration thread,
+    /// read by heartbeat thread.
+    std::atomic<ViewVersionId> view_version_{0};
     /// True after MASTER_UNREACHABLE fires; cleared when MASTER_RECONNECTED
     /// fires. Only accessed from the heartbeat thread — no locking required.
     bool connection_interrupted_ = false;

--- a/mooncake-store/include/ha_recovery_manager.h
+++ b/mooncake-store/include/ha_recovery_manager.h
@@ -40,7 +40,8 @@ class HARecoveryManager {
     HARecoveryManager(const UUID& client_id, P2PMasterClient& master_client,
                       std::optional<DataManager>& data_manager,
                       std::unique_ptr<AsyncMetadataNotifier>& notifier,
-                      std::atomic<ViewVersionId>& view_version);
+                      std::atomic<ViewVersionId>& view_version,
+                      HAClientState initial_state = HAClientState::FULL);
     ~HARecoveryManager();
 
     HARecoveryManager(const HARecoveryManager&) = delete;
@@ -55,15 +56,6 @@ class HARecoveryManager {
 
     HAClientState GetState() const {
         return state_.load(std::memory_order_acquire);
-    }
-
-    /**
-     * @brief Set HA state. Used for degraded startup when master is
-     * unavailable.
-     */
-    void SetState(HAClientState state) {
-        state_.store(state, std::memory_order_release);
-        LOG(INFO) << "HA state set to: " << state;
     }
 
     /**
@@ -97,13 +89,20 @@ class HARecoveryManager {
                           size_t size, bool is_hot,
                           const AbortToken& need_abort);
 
+    /**
+     * @brief Wait for P2PClientService::Init to complete.
+     *        Checks ready_for_recovery_ and data_manager_ availability.
+     * @return true if ready, false if aborted or data_manager not initialized.
+     */
+    bool WaitForReady(const AbortToken& need_abort);
+
     const UUID& client_id_;
     P2PMasterClient& master_client_;
     std::optional<DataManager>& data_manager_;
     std::unique_ptr<AsyncMetadataNotifier>& notifier_;
     std::atomic<ViewVersionId>& view_version_;
 
-    std::atomic<HAClientState> state_{HAClientState::FULL};
+    std::atomic<HAClientState> state_;
     std::atomic<bool> ready_for_recovery_{
         false};         // Set true when P2PClientService::Init completes
     std::mutex mutex_;  // protects transitions + recovery thread lifecycle

--- a/mooncake-store/include/ha_recovery_manager.h
+++ b/mooncake-store/include/ha_recovery_manager.h
@@ -40,7 +40,7 @@ class HARecoveryManager {
     HARecoveryManager(const UUID& client_id, P2PMasterClient& master_client,
                       std::optional<DataManager>& data_manager,
                       std::unique_ptr<AsyncMetadataNotifier>& notifier,
-                      ViewVersionId& view_version);
+                      std::atomic<ViewVersionId>& view_version);
     ~HARecoveryManager();
 
     HARecoveryManager(const HARecoveryManager&) = delete;
@@ -55,6 +55,24 @@ class HARecoveryManager {
 
     HAClientState GetState() const {
         return state_.load(std::memory_order_acquire);
+    }
+
+    /**
+     * @brief Set HA state. Used for degraded startup when master is
+     * unavailable.
+     */
+    void SetState(HAClientState state) {
+        state_.store(state, std::memory_order_release);
+        LOG(INFO) << "HA state set to: " << state;
+    }
+
+    /**
+     * @brief Mark that P2PClientService::Init has completed. Called at the end
+     * of Init(). Recovery thread will wait for this before accessing
+     * data_manager_.
+     */
+    void SetReadyForRecovery() {
+        ready_for_recovery_.store(true, std::memory_order_release);
     }
 
     void HandleEvent(HAEvent event);
@@ -83,9 +101,11 @@ class HARecoveryManager {
     P2PMasterClient& master_client_;
     std::optional<DataManager>& data_manager_;
     std::unique_ptr<AsyncMetadataNotifier>& notifier_;
-    ViewVersionId& view_version_;
+    std::atomic<ViewVersionId>& view_version_;
 
     std::atomic<HAClientState> state_{HAClientState::FULL};
+    std::atomic<bool> ready_for_recovery_{
+        false};         // Set true when P2PClientService::Init completes
     std::mutex mutex_;  // protects transitions + recovery thread lifecycle
     std::thread recovery_thread_;
     AbortToken need_abort_;  // signals recovery thread to exit

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -508,8 +508,7 @@ void ClientService::HeartbeatThreadMain(
                     connection_interrupted_ = true;
                 }
                 // Attempt reconnect
-                if (ReconnectToMaster(is_ha_mode, current_master_address,
-                                      master_server_entry)) {
+                if (ReconnectToMaster(is_ha_mode, current_master_address)) {
                     heartbeat_fail_count = 0;
                     // Do NOT sleep here, immediately loop back to send
                     // heartbeat so the client can discover UNDEFINED status and
@@ -585,8 +584,7 @@ void ClientService::HandleHeartbeatTaskResult(
 }
 
 bool ClientService::ReconnectToMaster(bool is_ha_mode,
-                                      std::string& current_master_address,
-                                      const std::string& master_server_entry) {
+                                      std::string& current_master_address) {
     if (is_ha_mode) {
         LOG(ERROR) << "Heartbeat failure threshold exceeded;"
                    << " fetching latest master view and reconnecting";

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -139,24 +139,28 @@ void ClientService::StartHeartbeat(const std::string& master_server_entry) {
     std::string current_master_address;
 
     if (is_ha_mode) {
-        // For HA mode, resolve the actual address from etcd
+        // For HA mode, try to resolve the actual address from etcd.
+        // If etcd is unavailable, start heartbeat thread anyway - it will
+        // retry and recover when etcd/master becomes available.
         ViewVersionId master_version = 0;
         auto err = master_view_helper_.GetMasterView(current_master_address,
                                                      master_version);
         if (err != ErrorCode::OK) {
-            LOG(ERROR) << "Failed to get master address for heartbeat";
-            return;
+            LOG(WARNING) << "Failed to get master address from etcd, "
+                         << "starting heartbeat thread in degraded mode "
+                         << "(will retry): " << err;
+            // Don't return - Let heartbeat thread handle reconnection
         }
     } else {
         current_master_address = master_server_entry;
     }
 
     heartbeat_running_ = true;
-    heartbeat_thread_ =
-        std::thread([this, is_ha_mode, current_master_address]() mutable {
-            this->HeartbeatThreadMain(is_ha_mode,
-                                      std::move(current_master_address));
-        });
+    heartbeat_thread_ = std::thread([this, is_ha_mode, current_master_address,
+                                     master_server_entry]() mutable {
+        this->HeartbeatThreadMain(is_ha_mode, std::move(current_master_address),
+                                  master_server_entry);
+    });
 }
 
 ErrorCode ClientService::ConnectToMaster(
@@ -445,8 +449,9 @@ tl::expected<void, ErrorCode> ClientService::unregisterLocalMemory(
     return {};
 }
 
-void ClientService::HeartbeatThreadMain(bool is_ha_mode,
-                                        std::string current_master_address) {
+void ClientService::HeartbeatThreadMain(
+    bool is_ha_mode, std::string current_master_address,
+    const std::string& master_server_entry) {
     // How many failed heartbeats before getting latest master view from etcd
     const int max_heartbeat_fail_count = 10;
     // How long to wait for next heartbeat after success
@@ -503,7 +508,8 @@ void ClientService::HeartbeatThreadMain(bool is_ha_mode,
                     connection_interrupted_ = true;
                 }
                 // Attempt reconnect
-                if (ReconnectToMaster(is_ha_mode, current_master_address)) {
+                if (ReconnectToMaster(is_ha_mode, current_master_address,
+                                      master_server_entry)) {
                     heartbeat_fail_count = 0;
                     // Do NOT sleep here, immediately loop back to send
                     // heartbeat so the client can discover UNDEFINED status and
@@ -532,12 +538,12 @@ bool ClientService::HandleHeartbeatResponse(
     const std::string& current_master_address,
     const std::function<void()>& register_client,
     std::future<void>& register_client_future) {
-    if (response.view_version != view_version_) {
+    if (response.view_version != view_version_.load()) {
         LOG(WARNING) << "Master view_version changed"
                      << ", client status in master: " << (int)response.status
                      << ", master address: " << current_master_address
                      << ", Master version: " << response.view_version
-                     << ", Client version: " << view_version_;
+                     << ", Client version: " << view_version_.load();
     }
     for (auto& task_result : response.task_results) {
         HandleHeartbeatTaskResult(task_result);
@@ -579,7 +585,8 @@ void ClientService::HandleHeartbeatTaskResult(
 }
 
 bool ClientService::ReconnectToMaster(bool is_ha_mode,
-                                      std::string& current_master_address) {
+                                      std::string& current_master_address,
+                                      const std::string& master_server_entry) {
     if (is_ha_mode) {
         LOG(ERROR) << "Heartbeat failure threshold exceeded;"
                    << " fetching latest master view and reconnecting";

--- a/mooncake-store/src/ha_recovery_manager.cpp
+++ b/mooncake-store/src/ha_recovery_manager.cpp
@@ -11,12 +11,16 @@ HARecoveryManager::HARecoveryManager(
     const UUID& client_id, P2PMasterClient& master_client,
     std::optional<DataManager>& data_manager,
     std::unique_ptr<AsyncMetadataNotifier>& notifier,
-    std::atomic<ViewVersionId>& view_version)
+    std::atomic<ViewVersionId>& view_version, HAClientState initial_state)
     : client_id_(client_id),
       master_client_(master_client),
       data_manager_(data_manager),
       notifier_(notifier),
-      view_version_(view_version) {}
+      view_version_(view_version),
+      state_(initial_state) {
+    LOG(INFO) << "HA recovery manager initialized with state: "
+              << initial_state;
+}
 
 HARecoveryManager::~HARecoveryManager() { Stop(); }
 
@@ -110,22 +114,17 @@ void HARecoveryManager::StartRecoveryThread() {
         std::thread([this, need_abort]() { RecoveryPipelineMain(need_abort); });
 }
 
-void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
-    LOG(INFO) << "Recovery pipeline started";
-
-    auto aborted = [&]() {
-        return need_abort->load(std::memory_order_acquire);
-    };
-
+bool HARecoveryManager::WaitForReady(const AbortToken& need_abort) {
     // Wait for P2PClientService::Init to complete (InitStorage initializes
     // data_manager_, and Init calls SetReadyForRecovery() at the end).
     // This avoids data race on data_manager_ which is an std::optional.
-    while (!ready_for_recovery_.load(std::memory_order_acquire) && !aborted()) {
+    while (!ready_for_recovery_.load(std::memory_order_acquire) &&
+           !need_abort->load(std::memory_order_acquire)) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
-    if (aborted()) {
+    if (need_abort->load(std::memory_order_acquire)) {
         LOG(INFO) << "Recovery pipeline aborted during wait for ready signal";
-        return;
+        return false;
     }
 
     // After ready_for_recovery_ is set, data_manager_ should be initialized.
@@ -133,10 +132,23 @@ void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
         LOG(ERROR) << "DataManager not initialized, cannot run recovery";
         TransitionState(HAClientState::DEGRADED,
                         "data_manager not initialized");
-        return;
+        return false;
     }
 
     LOG(INFO) << "Recovery pipeline proceeding, service ready";
+    return true;
+}
+
+void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
+    LOG(INFO) << "Recovery pipeline started";
+
+    if (!WaitForReady(need_abort)) {
+        return;
+    }
+
+    auto aborted = [&]() {
+        return need_abort->load(std::memory_order_acquire);
+    };
 
     // Phase 1: Hot key sync — enqueue hot keys first for fastest recovery
     auto hot_stats = data_manager_.value().GetHotKeyStats();

--- a/mooncake-store/src/ha_recovery_manager.cpp
+++ b/mooncake-store/src/ha_recovery_manager.cpp
@@ -11,7 +11,7 @@ HARecoveryManager::HARecoveryManager(
     const UUID& client_id, P2PMasterClient& master_client,
     std::optional<DataManager>& data_manager,
     std::unique_ptr<AsyncMetadataNotifier>& notifier,
-    ViewVersionId& view_version)
+    std::atomic<ViewVersionId>& view_version)
     : client_id_(client_id),
       master_client_(master_client),
       data_manager_(data_manager),
@@ -50,7 +50,8 @@ void HARecoveryManager::TransitionState(HAClientState to,
                                         const std::string& reason) {
     auto from = state_.load(std::memory_order_relaxed);
     LOG(WARNING) << "HA state: " << from << " -> " << to
-                 << ", reason=" << reason << ", view_version=" << view_version_;
+                 << ", reason=" << reason
+                 << ", view_version=" << view_version_.load();
     state_.store(to, std::memory_order_release);
 }
 
@@ -112,14 +113,30 @@ void HARecoveryManager::StartRecoveryThread() {
 void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
     LOG(INFO) << "Recovery pipeline started";
 
-    if (!data_manager_.has_value()) {
-        LOG(ERROR) << "DataManager not initialized, cannot run recovery";
-        return;
-    }
-
     auto aborted = [&]() {
         return need_abort->load(std::memory_order_acquire);
     };
+
+    // Wait for P2PClientService::Init to complete (InitStorage initializes
+    // data_manager_, and Init calls SetReadyForRecovery() at the end).
+    // This avoids data race on data_manager_ which is an std::optional.
+    while (!ready_for_recovery_.load(std::memory_order_acquire) && !aborted()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    if (aborted()) {
+        LOG(INFO) << "Recovery pipeline aborted during wait for ready signal";
+        return;
+    }
+
+    // After ready_for_recovery_ is set, data_manager_ should be initialized.
+    if (!data_manager_.has_value()) {
+        LOG(ERROR) << "DataManager not initialized, cannot run recovery";
+        TransitionState(HAClientState::DEGRADED,
+                        "data_manager not initialized");
+        return;
+    }
+
+    LOG(INFO) << "Recovery pipeline proceeding, service ready";
 
     // Phase 1: Hot key sync — enqueue hot keys first for fastest recovery
     auto hot_stats = data_manager_.value().GetHotKeyStats();

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -400,6 +400,18 @@ SegmentSyncCallback P2PClientService::BuildSegmentSyncCallback() {
                           << segment.id << ", name=" << segment.name;
                 return {};
             }
+            // TODO: There is a race window between the IsDegraded() check above
+            // and the MountSegment() call below. During this window, the system
+            // could transition to degraded mode (e.g., due to master connection
+            // loss), causing the MountSegment RPC to fail. This would result in
+            // segment initialization failure even though the segment could be
+            // registered later during heartbeat recovery.
+            //
+            // Future improvement: Remove BuildSegmentSyncCallback function to
+            // decouple storage layer initialization from master interaction.
+            // The P2PClientService will manage this logic instead, and can
+            // directly convert ha_status to degraded upon RPC failure during
+            // initialization.
             LOG(INFO) << "Mounting segment with Master: id=" << segment.id
                       << ", name=" << segment.name << ", size=" << segment.size;
             auto result = master_client_.MountSegment(segment);

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -93,14 +93,51 @@ P2PClientService::~P2PClientService() {
 ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
     client_rpc_port_ = config.client_rpc_port;
 
-    // 1. Connect to master
+    // 1. Try to connect to master (allow failure for degraded startup)
+    bool master_connected = false;
     ErrorCode err = ConnectToMaster(config.master_server_entry);
-    if (err != ErrorCode::OK) {
-        LOG(ERROR) << "Failed to connect to master in P2P mode";
-        return err;
+    if (err == ErrorCode::OK) {
+        master_connected = true;
+        LOG(INFO) << "Connected to master successfully";
+    } else {
+        LOG(WARNING)
+            << "Failed to connect to master, starting in DEGRADED mode: "
+            << err;
     }
 
-    // 2. Initialize transfer engine
+    // 2. Try to register with master (allow failure for degraded startup)
+    //    Note: RegisterClient before InitStorage sends empty segments.
+    //    Segment info will be updated via MountSegment during InitStorage
+    //    (if connected) or during recovery (if degraded).
+    bool client_registered = false;
+    if (master_connected) {
+        auto reg = RegisterClient();
+        if (reg) {
+            client_registered = true;
+            LOG(INFO) << "Registered with master successfully";
+        } else {
+            LOG(WARNING) << "Failed to register with master: " << reg.error()
+                         << ", starting in DEGRADED mode";
+        }
+    }
+
+    // 3. Initialize HA recovery manager with appropriate initial state.
+    //    FULL: master connected and client registered.
+    //    DEGRADED: connection or registration failed.
+    HAClientState initial_state =
+        client_registered ? HAClientState::FULL : HAClientState::DEGRADED;
+    ha_manager_ = std::make_unique<HARecoveryManager>(
+        client_id_, master_client_, data_manager_, async_route_notifier_,
+        view_version_);
+    ha_manager_->SetState(initial_state);
+    LOG(INFO) << "HA recovery manager initialized with state: "
+              << initial_state;
+
+    // 4. Start heartbeat immediately after registration so master does not
+    //    consider this client disconnected during a lengthy initialization.
+    StartHeartbeat(config.master_server_entry);
+
+    // 5. Initialize transfer engine (local operation, no master dependency)
     if (config.transfer_engine == nullptr) {
         transfer_engine_ = std::make_shared<TransferEngine>();
         err = InitTransferEngine(local_endpoint(), metadata_connstring_,
@@ -116,29 +153,15 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
     }
     initTeEndpoint();
 
-    // 3. Register with master BEFORE InitStorage, because InitStorage
-    //    triggers TieredBackend::MountSegment which requires the client to
-    //    be already registered on the master side.
-    auto reg = RegisterClient();
-    if (!reg) {
-        LOG(ERROR) << "Failed to register P2P client with master";
-        return reg.error();
-    }
-
-    // 3.5. Start heartbeat immediately after registration so master does not
-    //      consider this client disconnected during a lengthy InitStorage.
-    //      build_heartbeat_request() and OnHAEvent() both guard against
-    //      uninitialized data_manager_ / ha_manager_, so this is safe.
-    StartHeartbeat(config.master_server_entry);
-
-    // 4. Initialize TieredBackend + DataManager
+    // 6. Initialize TieredBackend + DataManager.
+    //    SegmentSyncCallback will check degraded state and skip MountSegment.
     err = InitStorage(config);
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "Failed to initialize TieredBackend";
         return err;
     }
 
-    // 4.5. Initialize async route notifier if enabled
+    // 7. Initialize async route notifier if enabled
     if (config.async_sender_thread_count > 0) {
         // When async ADD is rejected by Master, delete the local replica
         // since Master won't track it.
@@ -165,7 +188,7 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
                   << ", queue_size=" << config.async_route_queue_size;
     }
 
-    // 5. Start P2P client RPC service
+    // 8. Start P2P client RPC service
     client_rpc_service_.emplace(*data_manager_);
     client_rpc_server_ = std::make_unique<coro_rpc::coro_rpc_server>(
         config.rpc_thread_num, client_rpc_port_);
@@ -185,12 +208,18 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     LOG(INFO) << "P2P RPC server started on port " << client_rpc_port_;
 
-    // 6. Initialize HA recovery manager
-    ha_manager_ = std::make_unique<HARecoveryManager>(
-        client_id_, master_client_, data_manager_, async_route_notifier_,
-        view_version_);
-    // First-time registration: no keys to sync, clear is_syncing_ on Master
-    ha_manager_->SetSyncCompleted();
+    // 9. If started in FULL state, notify master that sync is complete.
+    //    If in DEGRADED state, heartbeat will recover later.
+    if (!ha_manager_->IsDegraded()) {
+        ha_manager_->SetSyncCompleted();
+    } else {
+        LOG(INFO) << "P2P client started in DEGRADED mode, heartbeat will "
+                  << "establish master connection when available";
+    }
+
+    // 10. Mark service as ready for recovery. HA recovery thread can now
+    // proceed.
+    ha_manager_->SetReadyForRecovery();
 
     return ErrorCode::OK;
 }
@@ -367,6 +396,13 @@ SegmentSyncCallback P2PClientService::BuildSegmentSyncCallback() {
     return [this](const Segment& segment,
                   bool mount) -> tl::expected<void, ErrorCode> {
         if (mount) {
+            // Skip MountSegment in degraded mode (master not connected).
+            // Registration during heartbeat recovery will include segment info.
+            if (ha_manager_ && ha_manager_->IsDegraded()) {
+                LOG(INFO) << "Skipping MountSegment in DEGRADED mode: id="
+                          << segment.id << ", name=" << segment.name;
+                return {};
+            }
             LOG(INFO) << "Mounting segment with Master: id=" << segment.id
                       << ", name=" << segment.name << ", size=" << segment.size;
             auto result = master_client_.MountSegment(segment);

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -128,10 +128,7 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
         client_registered ? HAClientState::FULL : HAClientState::DEGRADED;
     ha_manager_ = std::make_unique<HARecoveryManager>(
         client_id_, master_client_, data_manager_, async_route_notifier_,
-        view_version_);
-    ha_manager_->SetState(initial_state);
-    LOG(INFO) << "HA recovery manager initialized with state: "
-              << initial_state;
+        view_version_, initial_state);
 
     // 4. Start heartbeat immediately after registration so master does not
     //    consider this client disconnected during a lengthy initialization.

--- a/mooncake-store/tests/ha_recovery_manager_test.cpp
+++ b/mooncake-store/tests/ha_recovery_manager_test.cpp
@@ -126,7 +126,7 @@ class HARecoveryManagerTest : public ::testing::Test {
     UUID client_id_{};
     Segment segment_;
     std::unique_ptr<P2PMasterClient> master_client_;
-    ViewVersionId view_version_ = 0;
+    std::atomic<ViewVersionId> view_version_{0};
     std::optional<DataManager> data_manager_;
     std::unique_ptr<AsyncMetadataNotifier> notifier_;
 };
@@ -141,6 +141,7 @@ std::string HARecoveryManagerTest::master_addr_;
 
 TEST_F(HARecoveryManagerTest, BasicStateMachineSmoke) {
     auto mgr = CreateManager();
+    mgr->SetReadyForRecovery();
 
     // Initial state
     EXPECT_EQ(mgr->GetState(), HAClientState::FULL);
@@ -206,6 +207,7 @@ TEST_F(HARecoveryManagerTest, NotifierRestartedOnReachableFromDegraded) {
                                                 /*queue_capacity=*/4000);
     notifier_->Start();
     auto mgr = CreateManager();
+    mgr->SetReadyForRecovery();
 
     // Go to DEGRADED
     mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
@@ -222,6 +224,7 @@ TEST_F(HARecoveryManagerTest, NotifierRestartedOnReachableFromDegraded) {
 
 TEST_F(HARecoveryManagerTest, ConcurrentEvents) {
     auto mgr = CreateManagerWithNotifier();
+    mgr->SetReadyForRecovery();
     std::atomic<bool> stop{false};
 
     // Thread A: rapid UNREACHABLE events


### PR DESCRIPTION
## Description

  Support P2P client degraded startup when master is unavailable. Previously, P2P client
  startup would fail if master was unreachable, blocking the entire application. This PR
  refactors the initialization flow to allow graceful degradation:

  1. Refactor `P2PClientService::Init` to try ConnectToMaster/RegisterClient but allow
  failure, set HA state to FULL or DEGRADED based on connection result
  2. Optimize initialization order: StartHeartbeat before InitTransferEngine to send heartbeat
   faster
  3. Add `HARecoveryManager::SetState()` for setting initial HA state
  4. Make `connection_interrupted_` atomic for thread-safe access
  5. Skip MountSegment in degraded mode; segment info will be synced during recovery

  **Initialization Order (Optimized)**:

  Normal startup:
  1. ConnectToMaster
  2. RegisterClient
  3. HA manager (FULL)
  4. StartHeartbeat
  5. InitTransferEngine
  6. InitStorage
  7. async_route_notifier_
  8. RPC service

  Degraded startup:
  1. ConnectToMaster (fail)
  2. HA manager (DEGRADED)
  3. StartHeartbeat
  4. InitTransferEngine
  5. InitStorage (skip MountSegment)
  6. async_route_notifier_
  7. RPC service
  8. Wait for recovery

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [x] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] PyTorch Backend (`mooncake-pg`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [x] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Other

  ## How Has This Been Tested?

  All existing P2P and HA tests pass:
  - p2p_master_service_test: Passed
  - p2p_client_integration_test: Passed
  - p2p_segment_manager_test: Passed
  - p2p_client_meta_test: Passed
  - p2p_client_manager_test: Passed
  - ha_recovery_manager_test: Passed
  - ha_integration_test: Passed
  - non_ha_reconnect_test: Passed

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [x] I have formatted my own code using `clang-format-20` before submitting.
  - [ ] I have updated the documentation.
  - [x] I have added tests to prove my changes are effective.