### PR TITLE
[Integration] connector_v1: subclass SupportsHMA so PD-disagg works for hybrid models

### DIFF
--- a/mooncake-wheel/mooncake/mooncake_connector_v1.py
+++ b/mooncake-wheel/mooncake/mooncake_connector_v1.py
@@ -28,6 +28,21 @@ from vllm.attention.selector import get_attn_backend
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1, KVConnectorMetadata, KVConnectorRole)
+
+# SupportsHMA was introduced in vllm-project/vllm PR #25712 and is enforced
+# for KV connectors by PR #27592. It is the marker the Hybrid Memory
+# Allocator uses to allow PD-disaggregation with hybrid (e.g. attention +
+# Mamba2) models. We import it conditionally so this connector keeps
+# working on older vLLM releases that pre-date the interface; on those
+# releases the marker is a no-op object base and the
+# `request_finished_all_groups` shim below is dead code.
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+        SupportsHMA)
+    _HAS_SUPPORTS_HMA = True
+except ImportError:  # pragma: no cover - older vLLM
+    SupportsHMA = object  # type: ignore[assignment, misc]
+    _HAS_SUPPORTS_HMA = False
 from vllm.distributed.parallel_state import (get_tensor_model_parallel_rank,
                                              get_tp_group)
 from vllm.forward_context import ForwardContext
@@ -104,7 +119,12 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
             self.reqs_to_send[request_id] = local_block_ids
 
 
-class MooncakeConnector(KVConnectorBase_V1):
+class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
+    # Subclassing SupportsHMA gates this connector through vLLM's Hybrid
+    # Memory Allocator path, which is required to PD-disaggregate hybrid
+    # attention + Mamba2 models (e.g. nvidia/NVIDIA-Nemotron-Nano-9B-v2).
+    # On vLLM versions that pre-date PR #25712 the marker resolves to
+    # `object` and this is identical to the previous single-base class.
 
     def __init__(self, vllm_config: VllmConfig, role: KVConnectorRole):
         assert vllm_config.kv_transfer_config is not None
@@ -153,6 +173,28 @@ class MooncakeConnector(KVConnectorBase_V1):
     ) -> tuple[bool, Optional[dict[str, Any]]]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished(request, block_ids)
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, Optional[dict[str, Any]]]:
+        """SupportsHMA hook for hybrid (multi-group) KV cache layouts.
+
+        Hybrid models (e.g. attention + Mamba2) expose one block-id list
+        per KV cache group instead of a single flat list. The Mooncake
+        transport itself does not yet distinguish groups on the wire, so
+        we flatten the per-group lists and delegate to the existing
+        single-group `request_finished`. This is the minimum-viable shim
+        that satisfies the `SupportsHMA` contract and unblocks the
+        Hybrid Memory Allocator gate so the engine can start up; cross-
+        node fidelity for non-attention SSM/Mamba state is not asserted
+        by this method and remains a follow-up (the Mamba2 backend in
+        vLLM still raises NotImplementedError from
+        `get_kv_cache_shape()`).
+        """
+        flat: list[int] = [b for group in block_ids for b in group]
+        return self.request_finished(request, flat)
 
     ############################################################
     # Worker Side Methods

--- a/mooncake-wheel/mooncake/mooncake_connector_v1.py
+++ b/mooncake-wheel/mooncake/mooncake_connector_v1.py
@@ -39,10 +39,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 try:
     from vllm.distributed.kv_transfer.kv_connector.v1.base import (
         SupportsHMA)
-    _HAS_SUPPORTS_HMA = True
 except ImportError:  # pragma: no cover - older vLLM
     SupportsHMA = object  # type: ignore[assignment, misc]
-    _HAS_SUPPORTS_HMA = False
 from vllm.distributed.parallel_state import (get_tensor_model_parallel_rank,
                                              get_tp_group)
 from vllm.forward_context import ForwardContext


### PR DESCRIPTION
## Description

vLLM PR [#25712](https://github.com/vllm-project/vllm/pull/25712) (and [#27592](https://github.com/vllm-project/vllm/pull/27592) which enforces it for KV connectors) added the `SupportsHMA` marker that the Hybrid Memory Allocator uses to gate PD-disaggregation for models with **mixed KV cache layouts** — e.g. attention + Mamba2 hybrids such as `nvidia/NVIDIA-Nemotron-Nano-9B-v2`.

Without it, vLLM auto-disables the hybrid KV cache manager whenever `--kv-transfer-config` is set and the engine crashes during startup with:

```
ValueError: Hybrid KV cache manager is disabled but failed to convert
the KV cache specs to one unified type.
```

This change makes `MooncakeConnector` opt in to the HMA path so a `mooncake.mooncake_connector_v1` user can run hybrid models with `--no-disable-hybrid-kv-cache-manager` and `--kv-transfer-config '{"kv_connector":"MooncakeConnector",...}'` together.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## What changes

`mooncake-wheel/mooncake/mooncake_connector_v1.py` only — **+43 / −1 lines**, no other files touched:

1. **Conditional `SupportsHMA` import.** Wrapped in `try/except ImportError` so the connector still loads on older vLLM releases that pre-date PR #25712. On those releases the marker collapses to `object` and the new method is dead code, so behaviour for current users is unchanged.
2. **Add `SupportsHMA` to the class bases.** `class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):`.
3. **Implement `request_finished_all_groups`** as the minimum-viable shim required by the contract: flatten the per-group block-id tuple and delegate to the existing single-group `request_finished`. The Mooncake transport itself does not yet distinguish KV groups on the wire, so flattening is semantically correct for getting the engine past the HMA gate.

## Known limitation (called out in the docstring)

Subclassing `SupportsHMA` unblocks the **engine-startup gate**. End-to-end hybrid PD-disagg over Mooncake will additionally need a fix on the vLLM side: `TpKVTopology.__post_init__` calls `attn_backend.get_kv_cache_shape(...)` on every layer, and vLLM's Mamba2 backend currently raises `NotImplementedError` from that method (Mamba SSM state is not a traditional `(block, kv_heads, head_dim)` cube). That is out of scope for this PR — this PR is the necessary-but-not-sufficient connector-side change.

The docstring on `request_finished_all_groups` documents this explicitly so future readers don't expect cross-node SSM-state fidelity from this commit alone.

## How Has This Been Tested?

Verified locally on `vllm/vllm-openai:v0.19.1` with `mooncake-transfer-engine==0.3.10.post1` running 1P1D over Mooncake on a single H100×8 node:

| Model | Layout | With this change |
|---|---|---|
| `Qwen/Qwen2.5-7B-Instruct` (TP=4 each side) | Dense attention | Pass — engine starts, smoke `curl` to the proxy returns HTTP 200 with the expected token, KV transfer path exercised. Confirms the change is **fully no-op for dense models**. |
| `nvidia/NVIDIA-Nemotron-Nano-9B-v2` (TP=4 each side) | Attention + Mamba2 hybrid | Past the `Hybrid KV cache manager is disabled` ValueError that previously crashed startup. Hits the separate, vLLM-side `NotImplementedError` in `TpKVTopology` → `Mamba2Backend.get_kv_cache_shape()` (documented above as the necessary follow-up; not addressed by this PR). |

Both runs were done by applying this exact diff as an in-place patch to the connector source via an `initContainer` so the change is byte-for-byte what reviewers see here.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.  
  *Note: this PR is intentionally a minimal targeted diff (+43/−1). Running `pre-commit run --files mooncake-wheel/mooncake/mooncake_connector_v1.py` locally triggers ruff-format / trailing-whitespace fixes on ~200 unrelated pre-existing lines in the same file (auto-rewrap of long lines, `from queue import Queue` flagged as unused, etc.). I deliberately did **not** include those style-only changes so the PR stays scoped to the SupportsHMA work — happy to either land them as a separate cleanup PR or include them here if maintainers prefer.*
- [x] I have updated the documentation. (Inline docstring on `request_finished_all_groups`; user-facing behaviour unchanged for current callers.)
- [ ] I have added tests to prove my changes are effective.  
  *Suggestions for what a test should look like welcome — happy to add a unit test that asserts `issubclass(MooncakeConnector, SupportsHMA)` (when available) and that `request_finished_all_groups` correctly flattens a multi-group `block_ids` tuple, if that style matches what `mooncake-wheel/tests/` expects.*

Made with [Cursor](https://cursor.com)