### PR TITLE
[TE] Fix a 1-second stall in RDMA WorkerPool due to store-buffer reordering

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -161,9 +161,8 @@ int WorkerPool::submitPostSend(
         slice_queue_lock_[shard_id].unlock();
     }
 
-    submitted_slice_count_.fetch_add(submitted_slice_count,
-                                     std::memory_order_relaxed);
-    if (suspended_flag_.load(std::memory_order_relaxed)) {
+    submitted_slice_count_.fetch_add(submitted_slice_count);
+    if (suspended_flag_.load()) {
         std::lock_guard<std::mutex> lock(cond_mutex_);
         cond_var_.notify_all();
     }
@@ -398,7 +397,7 @@ void WorkerPool::transferWorker(int thread_id) {
                 // Double-check condition after acquiring lock to avoid lost
                 // wakeup
                 if (processed_slice_count_.load(std::memory_order_relaxed) ==
-                    submitted_slice_count_.load(std::memory_order_relaxed)) {
+                    submitted_slice_count_.load()) {
                     cond_var_.wait_for(lock, std::chrono::seconds(1));
                 }
                 suspended_flag_.fetch_sub(1);


### PR DESCRIPTION
## Description

### Summary                                                                                                                                                                                                
   
Fix a rare 1-second stall caused by store-buffer reordering between `submitPostSend` and `transferWorker`, which leads to a lost wakeup 

### Root Cause 

The submitPostSend (thread S) and transferWorker (thread W) form a classic Dekker pattern, where each thread stores to one atomic variable and then loads the other:                                        

```bash
  Thread S (submitPostSend):                   Thread W (transferWorker):                                                                                                  
  (A) submitted_slice_count_ += n  [relaxed]
                                               (2) suspended_flag_ += 1     [seq_cst]                                                                             
  (B) load suspended_flag_         [relaxed]                                                                                     
                                               (3) load submitted_slice_count_ [relaxed]    
```

With `memory_order_relaxed`, the CPU is free to reorder stores and loads to different variables (store-buffer reordering). On x86 this is the only reordering the TSO model permits, making it extremely rare but still observable under heavy load:                                                                                                                                                            
1. S writes `submitted_slice_count_` into its store buffer, then reads `suspended_flag_` from (stale) cache → sees 0  → skips `notify_all() `
2. W writes `suspended_flag_` into its store buffer, then reads `submitted_slice_count_` from (stale) cache → sees old value → double-check passes → enters `wait_for(1s)`
                                                                                                                                                                                                         
Result: new work is submitted but no worker is woken up until the 1-second timeout expires.

### Fix

Upgrade the four operations involved in the Dekker pattern to `memory_order_seq_cst` (the default). The `seq_cst` total order guarantees that either (A) precedes (2) (so (3) sees the new count and skips the wait) or (2) precedes (A) (so (B) sees `suspended_flag_` ≥ 1 and calls `notify_all()`). The only added cost is a potential fence on the `seq_cst` load, which is negligible.  

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

## Checklist

- [x] I have performed a self-review of my own code.
- [] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
