### PR TITLE
[Store] auto-enable MC_STORE_MEMCPY in TCP-only environments

### DIFF
--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -416,10 +416,17 @@ TransferSubmitter::TransferSubmitter(TransferEngine& engine,
       memcpy_pool_(std::make_unique<MemcpyWorkerPool>()),
       fileread_pool_(std::make_unique<FilereadWorkerPool>(backend)),
       transfer_metric_(transfer_metric) {
-    // Read MC_STORE_MEMCPY environment variable, default to false (disabled)
+    // Read MC_STORE_MEMCPY environment variable.
+    // When not set, auto-detect based on transport type:
+    //   - TCP-only environment: enable memcpy (avoids TCP loopback overhead)
+    //   - RDMA/other transports: disable memcpy (RDMA is more efficient)
     const char* env_value = std::getenv("MC_STORE_MEMCPY");
     if (env_value == nullptr) {
-        memcpy_enabled_ = false;  // Default: disabled
+        memcpy_enabled_ = engine_.isTcpOnly();
+        LOG(INFO) << "MC_STORE_MEMCPY not set, auto-detected: "
+                  << (memcpy_enabled_ ? "TCP-only environment, memcpy enabled"
+                                      : "non-TCP transport available, memcpy "
+                                        "disabled");
     } else {
         std::string env_str(env_value);
         // Convert to lowercase for case-insensitive comparison

--- a/mooncake-transfer-engine/include/multi_transport.h
+++ b/mooncake-transfer-engine/include/multi_transport.h
@@ -55,6 +55,14 @@ class MultiTransport {
 
     Transport *getTransport(const std::string &proto);
 
+    /**
+     * @brief Check if TCP is the only installed transport.
+     *
+     * When only TCP transport is available (no RDMA, NVLink, etc.),
+     * local memcpy is preferred over TCP loopback for same-host transfers.
+     */
+    bool isTcpOnly() const;
+
     std::vector<Transport *> listTransports();
 
     void *getBaseAddr();

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -150,6 +150,14 @@ class TransferEngine {
 
     Transport* getTransport(const std::string& proto);
 
+    /**
+     * @brief Check if TCP is the only installed transport.
+     *
+     * When only TCP transport is available (no RDMA, NVLink, etc.),
+     * local memcpy is preferred over TCP loopback for same-host transfers.
+     */
+    bool isTcpOnly() const;
+
     int syncSegmentCache(const std::string& segment_name = "");
 
     std::shared_ptr<TransferMetadata> getMetadata();

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -334,6 +334,8 @@ class TransferEngineImpl {
         return multi_transports_->getTransport(proto);
     }
 
+    bool isTcpOnly() const { return multi_transports_->isTcpOnly(); }
+
     int syncSegmentCache(const std::string& segment_name = "") {
         return metadata_->syncSegmentCache(segment_name);
     }

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -461,6 +461,10 @@ Transport* MultiTransport::getTransport(const std::string& proto) {
     return transport_map_[proto].get();
 }
 
+bool MultiTransport::isTcpOnly() const {
+    return transport_map_.size() == 1 && transport_map_.count("tcp") == 1;
+}
+
 std::vector<Transport*> MultiTransport::listTransports() {
     std::vector<Transport*> transport_list;
     for (auto& entry : transport_map_)

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -179,6 +179,8 @@ Transport* TransferEngine::getTransport(const std::string& proto) {
     return impl_->getTransport(proto);
 }
 
+bool TransferEngine::isTcpOnly() const { return impl_->isTcpOnly(); }
+
 int TransferEngine::syncSegmentCache(const std::string& segment_name) {
     return impl_->syncSegmentCache(segment_name);
 }
@@ -576,6 +578,15 @@ Transport* TransferEngine::getTransport(const std::string& proto) {
         return nullptr;
     else
         return impl_->getTransport(proto);
+}
+
+bool TransferEngine::isTcpOnly() const {
+    if (use_tent_)
+        // TENT already rejects TCP loopback transfers when MC_STORE_MEMCPY
+        // is disabled, so auto-enabling memcpy is unnecessary in TENT mode.
+        return false;
+    else
+        return impl_->isTcpOnly();
 }
 
 int TransferEngine::syncSegmentCache(const std::string& segment_name) {


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

### Background

#577 disabled `MC_STORE_MEMCPY` by default (`false`) for better RDMA performance stability — RDMA transfers are more stable and resource-efficient than memcpy operations. This was the correct decision for RDMA deployments.

However, in **TCP-only environments** (where no RDMA hardware is available), disabling memcpy forces same-host transfers to go through TCP loopback, which is significantly less efficient than a direct `memcpy`.

### What this PR does

This PR makes the `MC_STORE_MEMCPY` default **transport-aware** without conflicting with #577's intent:

- When `MC_STORE_MEMCPY` is **not explicitly set**, the system auto-detects installed transports via the new `TransferEngine::isTcpOnly()` API and enables memcpy **only when TCP is the sole transport**.
- When `MC_STORE_MEMCPY` is **explicitly set** by the user (to `0` or `1`), the user's choice is always respected.
- **RDMA environments are completely unaffected** — the default remains `false`, exactly as #577 intended.

| Scenario | Before | After |
|----------|--------|-------|
| Not set, RDMA available | `false` | `false` (unchanged, per #577) |
| Not set, TCP-only | `false` | **`true`** (auto-enabled) |
| `MC_STORE_MEMCPY=0` (explicit) | `false` | `false` (user respected) |
| `MC_STORE_MEMCPY=1` (explicit) | `true` | `true` (user respected) |

### Implementation

Added `TransferEngine::isTcpOnly()` that queries `MultiTransport::transport_map_` to check whether TCP is the only installed transport (`size() == 1 && count("tcp") == 1`). This is **future-proof**: any new transport protocol registered via `installTransport()` is automatically accounted for — no protocol whitelist/blacklist to maintain.

The TENT path returns `false` unconditionally since TENT already rejects TCP loopback transfers when `MC_STORE_MEMCPY` is disabled.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
