### PR TITLE
[Store]Fix SSD offload in Metadata Server mode: sync ClientBuffer to metadata server

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -465,6 +465,17 @@ class Client {
         return transfer_engine_->getLocalIpAndPort();
     }
 
+    /**
+     * @brief Get the endpoint address for segment operations.
+     * @return For P2PHANDSHAKE mode, returns the actual RPC endpoint (IP:Port).
+     *         For other modes, returns the logical local hostname used for segment registration.
+     */
+    [[nodiscard]] std::string GetSegmentEndpoint() {
+        return (metadata_connstring_ == P2PHANDSHAKE)
+               ? GetTransportEndpoint()
+               : local_hostname_;
+    }
+
     // Return sorted NUMA node IDs that have at least one RDMA NIC.
     [[nodiscard]] std::vector<int> GetNicNumaNodes() const;
 

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -468,12 +468,12 @@ class Client {
     /**
      * @brief Get the endpoint address for segment operations.
      * @return For P2PHANDSHAKE mode, returns the actual RPC endpoint (IP:Port).
-     *         For other modes, returns the logical local hostname used for segment registration.
+     *         For other modes, returns the logical local hostname used for
+     * segment registration.
      */
     [[nodiscard]] std::string GetSegmentEndpoint() {
-        return (metadata_connstring_ == P2PHANDSHAKE)
-               ? GetTransportEndpoint()
-               : local_hostname_;
+        return (metadata_connstring_ == P2PHANDSHAKE) ? GetTransportEndpoint()
+                                                      : local_hostname_;
     }
 
     // Return sorted NUMA node IDs that have at least one RDMA NIC.

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -570,7 +570,7 @@ tl::expected<void, ErrorCode> FileStorage::BatchQuerySegmentSlices(
 tl::expected<void, ErrorCode> FileStorage::RegisterLocalMemory() {
     auto error_code = client_->RegisterLocalMemory(
         client_buffer_allocator_->getBase(), config_.local_buffer_size,
-        kWildcardLocation, false, false);
+        kWildcardLocation, false, true);
     if (!error_code) {
         LOG(ERROR) << "Failed to register local memory: " << error_code.error();
         return error_code;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3940,7 +3940,7 @@ RealClient::batch_get_offload_object(const std::vector<std::string> &keys,
     }
     return BatchGetOffloadObjectResponse(
         result.value().batch_id, std::move(result.value().pointers),
-        client_->GetTransportEndpoint(),
+        client_->GetSegmentEndpoint(),
         file_storage_->config_.client_buffer_gc_ttl_ms);
 }
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
### Problem
When using SSD offload with Metadata Server mode (non-P2PHANDSHAKE), the transfer operation fails with the following error:
```
W20260420 09:09:28.022851 555139 transfer_metadata.cpp:880] Failed to retrieve segment descriptor, name IP:Host
E20260420 09:09:28.022857 555139 transfer_task.cpp:535] Failed to open segment IP:Host
E20260420 09:09:28.022862 555139 client_service.cpp:2276] Failed to submit transfer operation
E20260420 09:09:28.022912 555139 real_client.cpp:3973] Batch get into offload object failed with error: TRANSFER_FAIL
```
```
E20260420 08:25:14.973784 transfer_metadata_dump.cpp:51] Failed to get segment descriptor for segment IP:Host address 0x7f0c9bfff500--0x7f0c9c007500
E20260420 08:25:14.961825 transfer_task.cpp:249] Transfer failed for batch ... task ... with status 6
```
This issue **does not occur** when:

- Using P2PHANDSHAKE mode, or
- SSD offload is disabled

### Related Issue
This issue was previously reported in https://github.com/kvcache-ai/Mooncake/issues/1729, but the fix was incomplete and the problem still persists. The initial fix addressed the `GetSegmentEndpoint()` issue but missed the ClientBuffer metadata synchronization problem.

### Root Cause Analysis
There were **two separate issues** causing the SSD offload failure in Metadata Server mode:
#### Issue 1: Incorrect segment name in response (fixed in previous PR)
The code pattern for distinguishing between P2PHANDSHAKE and Metadata Server modes already exists in other parts of the codebase (e.g., `client_service.cpp` lines 1165-2267, 3124-3126). These places correctly handle the difference between RPC endpoint and segment name based on the metadata connection mode. However, in `batch_get_offload_object` response, it was directly using `GetTransportEndpoint()` without following this pattern:
```
// Previous code - didn't follow the established pattern
return BatchGetOffloadObjectResponse(
    result.value().batch_id, std::move(result.value().pointers),
    client_->GetTransportEndpoint(),  // Wrong: always returns RPC endpoint
    file_storage_->config_.client_buffer_gc_ttl_ms);
```
`GetTransportEndpoint()` always returns the RPC endpoint (e.g., `10.154.0.13:15130`), which is correct for P2PHANDSHAKE mode but wrong for Metadata Server mode. The fix introduced `GetSegmentEndpoint()` to follow the established pattern and correctly distinguish between modes:
```
[[nodiscard]] std::string GetSegmentEndpoint() {
    return (metadata_connstring_ == P2PHANDSHAKE)
           ? GetTransportEndpoint()  // P2PHANDSHAKE: RPC endpoint
           : local_hostname_;         // Metadata Server: segment name
}
```

- P2PHANDSHAKE mode: Returns RPC endpoint (e.g., IP1:15130)
- Metadata Server mode: Returns logical segment name (e.g., IP2:13510)

#### Issue 2: ClientBuffer not synced to metadata server (this PR)
Even after fixing Issue 1, transfers still failed because the ClientBuffer's address range was not available in the segment descriptor. When FileStorage registers the ClientBuffer via `client_->RegisterLocalMemory()`, it was called with `update_metadata=false`:
```
auto error_code = client_->RegisterLocalMemory(
    client_buffer_allocator_->getBase(), config_.local_buffer_size,
    kWildcardLocation, false, false);  // Last param: update_metadata=false
```
This caused:

1. The ClientBuffer was added to the local segment descriptor in memory
2. **But the segment descriptor was not synchronized to the metadata server**
3. When a requesting client fetched the segment descriptor from metadata server, it did not contain the ClientBuffer's address range
4. The RDMA transport failed because the requested address was not in any registered buffer range

### Solution
Change update_metadata from `false` to `true` when registering ClientBuffer:
```
auto error_code = client_->RegisterLocalMemory(
    client_buffer_allocator_->getBase(), config_.local_buffer_size,
    kWildcardLocation, false, true);  // Changed: update_metadata=true
```
### Testing
Tested with the following configuration:

- Metadata Server mode (non-P2PHANDSHAKE)
- SSD offload enabled
- RDMA transport with 2x ConnectX-6 NICs
- Batch get operations from offloaded objects
The transfer operations now succeed without errors.

This PR completes the fix for issue #1729 by addressing the remaining ClientBuffer metadata synchronization problem:

1. Introduced GetSegmentEndpoint() following the established pattern elsewhere in the codebase to correctly distinguish between P2PHANDSHAKE and Metadata Server modes
2. Fixed ClientBuffer registration to sync segment descriptor to metadata server

Both fixes are necessary for SSD offload to work correctly in Metadata Server mode.


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
