### PR TITLE
[Store] Fix: KEYS_ULTRA_LIMIT error in eviction-enabled BucketStorageBackend

### DIFF
--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -214,6 +214,11 @@ tl::expected<void, ErrorCode> FileStorage::Init() {
         return init_storage_backend_result;
     }
     auto enable_offloading_result = IsEnableOffloading();
+    if (enable_offloading_result.has_value()) {
+        LOG(INFO) << "IsEnableOffloading result: " << (enable_offloading_result.value() ? "true" : "false");
+    } else {
+        LOG(INFO) << "IsEnableOffloading result: error: " << enable_offloading_result.error();
+    }
     if (!enable_offloading_result) {
         LOG(ERROR) << "Failed to get enable persist result, error : "
                    << enable_offloading_result.error();
@@ -434,6 +439,17 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
         LOG(ERROR) << "client is nullptr";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
+
+    // Re-evaluate enable_offloading_ in case the storage backend now has room
+    // (e.g., eviction freed up space after a previous KEYS_ULTRA_LIMIT error).
+    {
+        auto reeval_result = IsEnableOffloading();
+        if (reeval_result && reeval_result.value()) {
+            MutexLocker locker(&offloading_mutex_);
+            enable_offloading_ = true;
+        }
+    }
+
     std::unordered_map<std::string, int64_t>
         offloading_objects;  // Objects selected for offloading
 
@@ -456,6 +472,8 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
                    << offload_result.error();
         return offload_result;
     }
+    LOG(INFO) << "Successfully completed heartbeat with offloaded objects count: "
+              << offloading_objects.size();
 
     // TODO(eviction): Implement an LRU eviction mechanism to manage local
     // storage capacity.

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -215,9 +215,11 @@ tl::expected<void, ErrorCode> FileStorage::Init() {
     }
     auto enable_offloading_result = IsEnableOffloading();
     if (enable_offloading_result.has_value()) {
-        LOG(INFO) << "IsEnableOffloading result: " << (enable_offloading_result.value() ? "true" : "false");
+        LOG(INFO) << "IsEnableOffloading result: "
+                  << (enable_offloading_result.value() ? "true" : "false");
     } else {
-        LOG(INFO) << "IsEnableOffloading result: error: " << enable_offloading_result.error();
+        LOG(INFO) << "IsEnableOffloading result: error: "
+                  << enable_offloading_result.error();
     }
     if (!enable_offloading_result) {
         LOG(ERROR) << "Failed to get enable persist result, error : "
@@ -472,8 +474,9 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
                    << offload_result.error();
         return offload_result;
     }
-    LOG(INFO) << "Successfully completed heartbeat with offloaded objects count: "
-              << offloading_objects.size();
+    LOG(INFO)
+        << "Successfully completed heartbeat with offloaded objects count: "
+        << offloading_objects.size();
 
     // TODO(eviction): Implement an LRU eviction mechanism to manage local
     // storage capacity.

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -484,18 +484,6 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    // Re-evaluate enable_offloading_ in case the storage backend now has room
-    // (e.g., eviction freed up space after a previous KEYS_ULTRA_LIMIT error).
-    // Synchronize the state directly with IsEnableOffloading() result to be
-    // proactive and consistent.
-    {
-        auto reeval_result = IsEnableOffloading();
-        if (reeval_result) {
-            MutexLocker locker(&offloading_mutex_);
-            enable_offloading_ = reeval_result.value();
-        }
-    }
-
     std::unordered_map<std::string, int64_t>
         offloading_objects;  // Objects selected for offloading
 

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -516,9 +516,6 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
                    << offload_result.error();
         return offload_result;
     }
-    LOG(INFO)
-        << "Successfully completed heartbeat with offloaded objects count: "
-        << offloading_objects.size();
 
     // TODO(eviction): Implement an LRU eviction mechanism to manage local
     // storage capacity.

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -486,11 +486,13 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
 
     // Re-evaluate enable_offloading_ in case the storage backend now has room
     // (e.g., eviction freed up space after a previous KEYS_ULTRA_LIMIT error).
+    // Synchronize the state directly with IsEnableOffloading() result to be
+    // proactive and consistent.
     {
         auto reeval_result = IsEnableOffloading();
-        if (reeval_result && reeval_result.value()) {
+        if (reeval_result) {
             MutexLocker locker(&offloading_mutex_);
-            enable_offloading_ = true;
+            enable_offloading_ = reeval_result.value();
         }
     }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2098,6 +2098,10 @@ auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
     if (enable_offloading) {
         return std::move(local_disk_segment_it->second->offloading_objects);
     }
+    // Even when offloading is disabled, clear the pending queue to prevent
+    // unbounded growth that would trigger KEYS_ULTRA_LIMIT in
+    // PushOffloadingQueue.
+    local_disk_segment_it->second->offloading_objects.clear();
     return {};
 }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2115,15 +2115,41 @@ auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
                    << client_id;
         return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
     }
-    MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
-    local_disk_segment_it->second->enable_offloading = enable_offloading;
-    if (enable_offloading) {
-        return std::move(local_disk_segment_it->second->offloading_objects);
+    std::unordered_map<std::string, int64_t> offloading_objects_copy;
+    {
+        MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
+        local_disk_segment_it->second->enable_offloading = enable_offloading;
+        if (enable_offloading) {
+            return std::move(local_disk_segment_it->second->offloading_objects);
+        }
+        // Offloading is disabled: clear the pending queue to prevent
+        // unbounded growth that would trigger KEYS_ULTRA_LIMIT in
+        // PushOffloadingQueue. We must also clean up corresponding
+        // offloading_tasks and decrement source replica refcounts to avoid
+        // resource leaks and blocked writes (OBJECT_HAS_REPLICATION_TASK).
+        // Copy keys out before releasing the mutex to avoid lock order
+        // violation: the lock order is Shard Lock -> offloading_mutex_, so we
+        // must release offloading_mutex_ before taking shard locks via
+        // MetadataAccessorRW.
+        offloading_objects_copy =
+            std::move(local_disk_segment_it->second->offloading_objects);
     }
-    // Even when offloading is disabled, clear the pending queue to prevent
-    // unbounded growth that would trigger KEYS_ULTRA_LIMIT in
-    // PushOffloadingQueue.
-    local_disk_segment_it->second->offloading_objects.clear();
+
+    for (auto& [key, size] : offloading_objects_copy) {
+        MetadataAccessorRW accessor(this, key);
+        if (accessor.Exists()) {
+            auto& shard = accessor.GetShard();
+            auto task_it = shard->offloading_tasks.find(key);
+            if (task_it != shard->offloading_tasks.end()) {
+                auto source =
+                    accessor.Get().GetReplicaByID(task_it->second.source_id);
+                if (source) {
+                    source->dec_refcnt();
+                }
+                shard->offloading_tasks.erase(task_it);
+            }
+        }
+    }
     return {};
 }
 

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1753,7 +1753,8 @@ tl::expected<bool, ErrorCode> BucketStorageBackend::IsEnableOffloading() {
     if (bucket_backend_config_.eviction_policy != BucketEvictionPolicy::NONE &&
         bucket_backend_config_.max_total_size > 0) {
         return true;
-        
+    }
+
     auto store_metadata_result = GetStoreMetadata();
     if (!store_metadata_result) {
         LOG(ERROR) << "Failed to get store metadata: "

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1748,6 +1748,12 @@ tl::expected<bool, ErrorCode> BucketStorageBackend::IsExist(
 }
 
 tl::expected<bool, ErrorCode> BucketStorageBackend::IsEnableOffloading() {
+    // When eviction is enabled, always allow offloading since PrepareEviction
+    // will manage capacity by evicting old buckets as needed.
+    if (bucket_backend_config_.eviction_policy != BucketEvictionPolicy::NONE &&
+        bucket_backend_config_.max_total_size > 0) {
+        return true;
+        
     auto store_metadata_result = GetStoreMetadata();
     if (!store_metadata_result) {
         LOG(ERROR) << "Failed to get store metadata: "


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
# Fix: KEYS_ULTRA_LIMIT error in eviction-enabled BucketStorageBackend

## Problem Description

When using `BucketStorageBackend` with eviction enabled (`MOONCAKE_BUCKET_MAX_TOTAL_SIZE` > 0 and `MOONCAKE_BUCKET_EVICTION_POLICY=fifo/lru`), the system reports `KEYS_ULTRA_LIMIT` error after running for a while, and then permanently stops accepting new data.

Example error logs:
```
E0414 07:49:57.387607 11908 file_storage.cpp:380] Failed to store objects with error: KEYS_ULTRA_LIMIT
E0414 07:49:57.390941 11908 file_storage.cpp:431] Failed to persist objects with error: KEYS_ULTRA_LIMIT
```

After this error occurs, no new data can be written to the store, even though eviction should have freed up space.

## Root Cause Analysis

Three bugs form a cascading failure chain:

### Bug 1: Missing eviction short-circuit in `BucketStorageBackend::IsEnableOffloading()`

`IsEnableOffloading()` checks `total_keys_limit` (default 10 million) and `total_size_limit` (default 2TB) before allowing offloading. However, when eviction is enabled via `MOONCAKE_BUCKET_MAX_TOTAL_SIZE`, these limits should be bypassed since `PrepareEviction()` will manage capacity by evicting old buckets as needed.

`StorageBackendAdaptor` correctly short-circuits with:
```cpp
if (storage_backend_->enable_eviction_) {
    return true;  // Eviction is on, always allow offloading
}
```

But `BucketStorageBackend` was missing this logic. As a result, when key count reaches `total_keys_limit` even though eviction is configured, `IsEnableOffloading()` returns `false`, triggering `KEYS_ULTRA_LIMIT`.

### Bug 2: `enable_offloading_` is permanently disabled with no recovery mechanism

When `KEYS_ULTRA_LIMIT` is received, `enable_offloading_` is set to `false` in `OffloadObjects()`:
```cpp
if (offload_res.error() == ErrorCode::KEYS_ULTRA_LIMIT) {
    enable_offloading_ = false;  // Permanent!
}
```

`Heartbeat()` never re-evaluates this flag. Even if eviction frees up space, offloading never recovers - the system remains permanently disabled.

### Bug 3: Master's offloading queue grows unbounded when `enable_offloading=false`

When `enable_offloading=false`, master's `OffloadObjectHeartbeat()` returns an empty map without draining the `offloading_objects` queue. Meanwhile, `PutEnd()` keeps adding to this queue via `PushOffloadingQueue()`. The queue grows until it reaches `offloading_queue_limit_` (50,000), at which point `PushOffloadingQueue()` also returns `KEYS_ULTRA_LIMIT`, causing a complete system failure - even new data cannot be accepted.

## Cascading Failure Chain

```
1. Key count reaches ~10 million (total_keys_limit)
2. IsEnableOffloading() returns false (missing eviction short-circuit)
3. BatchOffload() returns KEYS_ULTRA_LIMIT
4. FileStorage sets enable_offloading_ = false (permanent, no recovery)
5. Heartbeat sends enable_offloading=false to master
6. Master returns empty map, does NOT drain queue
7. PutEnd() keeps adding to undrained queue
8. Queue grows to 50,000 entries
9. PushOffloadingQueue() also returns KEYS_ULTRA_LIMIT
10. System can no longer accept new data - complete failure
```

## Solution

### Fix 1: Add eviction short-circuit in `BucketStorageBackend::IsEnableOffloading()`

When eviction is enabled, bypass the `total_keys_limit` and `total_size_limit` checks, since capacity is managed by `PrepareEviction()`.

**File:** `mooncake-store/src/storage_backend.cpp`

```cpp
tl::expected<bool, ErrorCode> BucketStorageBackend::IsEnableOffloading() {
    // When eviction is enabled, always allow offloading since PrepareEviction
    // will manage capacity by evicting old buckets as needed.
    if (bucket_backend_config_.eviction_policy != BucketEvictionPolicy::NONE &&
        bucket_backend_config_.max_total_size > 0) {
        return true;
    }

    auto store_metadata_result = GetStoreMetadata();
    // ... original logic unchanged
}
```

### Fix 2: Re-evaluate `enable_offloading_` in `Heartbeat()`

Re-check `IsEnableOffloading()` at each heartbeat to allow recovery when eviction frees up space. Synchronize the state directly with the result of `IsEnableOffloading()`, so that offloading is also proactively disabled if the backend reports no room, rather than waiting for the next `KEYS_ULTRA_LIMIT` error during an actual offload attempt.

**File:** `mooncake-store/src/file_storage.cpp`

```cpp
tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
    if (client_ == nullptr) {
        LOG(ERROR) << "client is nullptr";
        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
    }

    // Re-evaluate enable_offloading_ in case the storage backend now has room
    // (e.g., eviction freed up space after a previous KEYS_ULTRA_LIMIT error).
    // Synchronize the state directly with IsEnableOffloading() result to be
    // proactive and consistent.
    {
        auto reeval_result = IsEnableOffloading();
        if (reeval_result) {
            MutexLocker locker(&offloading_mutex_);
            enable_offloading_ = reeval_result.value();
        }
    }

    std::unordered_map<std::string, int64_t> offloading_objects;
    // ... rest unchanged
}
```

### Fix 3: Drain pending queue with proper cleanup when offloading is disabled

When `enable_offloading=false`, drain the `offloading_objects` queue and clean up the corresponding `offloading_tasks` entries and source replica refcounts (similar to `NotifyOffloadSuccess`). This prevents:
1. **Resource leak**: Source replicas with dangling refcounts that cannot be evicted.
2. **Blocked writes**: `UpsertStart` rejects writes to keys with pending offloading tasks until they expire (default 10 minutes).
3. **Queue overflow**: Unbounded queue growth causing `PushOffloadingQueue()` to also return `KEYS_ULTRA_LIMIT`.

**File:** `mooncake-store/src/master_service.cpp`

```cpp
std::unordered_map<std::string, int64_t> offloading_objects_copy;
{
    MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
    local_disk_segment_it->second->enable_offloading = enable_offloading;
    if (enable_offloading) {
        return std::move(
            local_disk_segment_it->second->offloading_objects);
    }
    // Offloading is disabled: clear the pending queue to prevent
    // unbounded growth that would trigger KEYS_ULTRA_LIMIT in
    // PushOffloadingQueue. We must also clean up corresponding
    // offloading_tasks and decrement source replica refcounts to avoid
    // resource leaks and blocked writes (OBJECT_HAS_REPLICATION_TASK).
    // Copy keys out before releasing the mutex to avoid lock order
    // violation: the lock order is Shard Lock -> offloading_mutex_, so we
    // must release offloading_mutex_ before taking shard locks via
    // MetadataAccessorRW.
    offloading_objects_copy =
        std::move(local_disk_segment_it->second->offloading_objects);
}

for (auto& [key, size] : offloading_objects_copy) {
    MetadataAccessorRW accessor(this, key);
    if (accessor.Exists()) {
        auto& shard = accessor.GetShard();
        auto task_it = shard->offloading_tasks.find(key);
        if (task_it != shard->offloading_tasks.end()) {
            auto source =
                accessor.Get().GetReplicaByID(task_it->second.source_id);
            if (source) {
                source->dec_refcnt();
            }
            shard->offloading_tasks.erase(task_it);
        }
    }
}
return {};
```

Key design decisions:
- **MutexLocker + nested scope** instead of manual `lock()/unlock()`: RAII guarantees the mutex is released even if an exception is thrown.
- **Copy-then-release pattern**: `offloading_objects_copy` is declared outside the scope so it remains accessible after the lock is released. The queue content is moved out under the lock, then the lock is released at scope exit. Cleanup happens outside the lock.
- **Lock order preserved**: `offloading_mutex_` is released before `MetadataAccessorRW` takes any shard locks, respecting the established order: Shard Lock ? `offloading_mutex_`.

## Files Changed

| File | Change |
|------|--------|
| `mooncake-store/src/storage_backend.cpp` | Add eviction short-circuit in `BucketStorageBackend::IsEnableOffloading()` |
| `mooncake-store/src/file_storage.cpp` | Synchronize `enable_offloading_` with `IsEnableOffloading()` result in `Heartbeat()` |
| `mooncake-store/src/master_service.cpp` | Drain pending queue with offloading_tasks/refcount cleanup when `enable_offloading=false` |

## Testing

Tested with:
- `MOONCAKE_BUCKET_MAX_TOTAL_SIZE=400GB`
- `MOONCAKE_BUCKET_EVICTION_POLICY=fifo`
- Key count exceeding 10 million

After the fix, eviction continues to work correctly without triggering `KEYS_ULTRA_LIMIT`, and the system can accept new data continuously.

## Notes

- `OffsetAllocatorStorageBackend` has no eviction mechanism and its `total_keys_` counter is never decremented - this is a separate design issue, not in scope of this fix.
- Startup behavior is unchanged: Store loads existing data as-is. Eviction only triggers on first write after startup when `total_size_ + required_size > max_total_size`.


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
