### PR TITLE
[TransferEngine] Add slow log for transfer on cuda operations

### DIFF
--- a/docs/source/python-api-reference/transfer-engine.md
+++ b/docs/source/python-api-reference/transfer-engine.md
@@ -599,6 +599,7 @@ The Transfer Engine respects the following environment variables:
 - `MC_CUSTOM_TOPO_JSON`: Path to custom topology JSON file
 - `MC_TE_METRIC`: Enables metrics reporting (set to "1", "true", "yes", or "on"). **Note:** Not supported when using Transfer Engine TENT.
 - `MC_TE_METRIC_INTERVAL_SECONDS`: Sets metrics reporting interval in seconds
+- `MC_TRANSFER_ON_CUDA_SLOW_BW_GBPS`: Warns (via `LOG(WARNING)`) when the end-to-end effective bandwidth of a CUDA-stream-triggered transfer (the `transfer_*_on_cuda` / `batch_transfer_*_on_cuda` APIs) falls below this many Gb/s. Bandwidth covers the full host-callback span — both `submitTransfer` (CPU enqueue) and the wire wait — so a slow submit stalling the CUDA stream is also surfaced. The log includes `submit_ms` / `wait_ms` breakdown for root-causing. `0` or unset disables the warning (default: unset).
 
 ## Usage Examples
 

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -101,6 +101,14 @@ TransferEnginePy::TransferEnginePy() {
     } else {
         transfer_timeout_nsec_ = 30 * kNanosPerSecond;
     }
+    // MC_TRANSFER_ON_CUDA_SLOW_BW_GBPS: warn when the effective bandwidth of a
+    // CUDA-stream-triggered transfer falls below this many Gb/s. 0 disables.
+    const char* slow_bw_env = getenv("MC_TRANSFER_ON_CUDA_SLOW_BW_GBPS");
+    if (slow_bw_env) {
+        transfer_slow_threshold_gbps_ = std::max(0.0, atof(slow_bw_env));
+    } else {
+        transfer_slow_threshold_gbps_ = 0.0;
+    }
 }
 
 TransferEnginePy::~TransferEnginePy() {
@@ -776,6 +784,9 @@ struct TransferOnCudaContext {
     Transport::BatchID batch_id;
     std::vector<Transport::TransferRequest> requests;
     uint64_t total_bytes;
+    bool is_write;
+    std::string target_hostname;
+    double slow_threshold_gbps;
 };
 
 /**
@@ -790,12 +801,16 @@ struct TransferOnCudaContext {
 void CUDART_CB transfer_on_cuda_callback(void* data) {
     auto* ctx = reinterpret_cast<TransferOnCudaContext*>(data);
 
+    const uint64_t start_ts = getCurrentTimeInNano();
+    uint64_t submit_done_ts = 0;
+
     auto status = ctx->engine->submitTransfer(ctx->batch_id, ctx->requests);
     if (!status.ok()) {
         LOG(ERROR) << "[Mooncake Cuda] Submit failed: " << status.ToString()
                    << " | BatchID: " << ctx->batch_id;
         goto error_exit;
     }
+    submit_done_ts = getCurrentTimeInNano();
 
     Transport::TransferStatus t_status;
     while (true) {
@@ -816,6 +831,29 @@ void CUDART_CB transfer_on_cuda_callback(void* data) {
             LOG(ERROR) << "[Mooncake Cuda] Transfer timeout | BatchID: "
                        << ctx->batch_id;
             goto error_exit;
+        }
+    }
+
+    if (ctx->slow_threshold_gbps > 0.0 && ctx->total_bytes > 0) {
+        const uint64_t end_ts = getCurrentTimeInNano();
+        const uint64_t total_ns = end_ts - start_ts;
+        // End-to-end BW covers both submit (CPU enqueue) and wait (wire):
+        // bytes * 8 bits/byte / (total_ns * 1e-9 s) / 1e9 Gb = bytes * 8 /
+        // total_ns.
+        const double bw_gbps =
+            total_ns > 0 ? (ctx->total_bytes * 8.0) / total_ns : 0.0;
+        if (total_ns > 0 && bw_gbps < ctx->slow_threshold_gbps) {
+            const uint64_t submit_ns = submit_done_ts - start_ts;
+            const uint64_t wait_ns = end_ts - submit_done_ts;
+            LOG(WARNING) << "[Mooncake Cuda] Slow "
+                         << (ctx->is_write ? "write" : "read")
+                         << " | target=" << ctx->target_hostname
+                         << " batch_id=" << ctx->batch_id
+                         << " bytes=" << ctx->total_bytes
+                         << " total_ms=" << total_ns / 1e6
+                         << " submit_ms=" << submit_ns / 1e6
+                         << " wait_ms=" << wait_ns / 1e6
+                         << " bw_gbps=" << bw_gbps;
         }
     }
 
@@ -891,8 +929,13 @@ void TransferEnginePy::batchTransferOnCuda(
     }
 
     auto batch_id = engine_->allocateBatchID(batch_size);
-    auto* ctx = new TransferOnCudaContext{engine_, batch_id, std::move(entries),
-                                          total_bytes};
+    auto* ctx = new TransferOnCudaContext{engine_,
+                                          batch_id,
+                                          std::move(entries),
+                                          total_bytes,
+                                          opcode == TransferOpcode::WRITE,
+                                          target_hostname,
+                                          transfer_slow_threshold_gbps_};
 
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
     cudaError_t err =

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -201,4 +201,5 @@ class TransferEnginePy {
     bool auto_discovery_;
 
     uint64_t transfer_timeout_nsec_;
+    double transfer_slow_threshold_gbps_;
 };


### PR DESCRIPTION
## Description

Add slow log for transfer on cuda operations.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other

## How Has This Been Tested?

Run in training job.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
