### PR TITLE
[Store] Add GPU IPC for same-node GPU<->CPU transfer optimization

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -21,6 +21,7 @@
 #include "transfer_task.h"
 #include "types.h"
 #include "replica.h"
+#include "gpu_staging_utils.h"
 #include "master_metric_manager.h"
 #include "count_min_sketch.h"
 #include "local_hot_cache.h"
@@ -29,6 +30,7 @@
 namespace mooncake {
 
 class PutOperation;
+class ClientRequester;
 
 /**
  * @brief Result of a query operation containing replica information and lease
@@ -570,7 +572,47 @@ class Client {
         return admission_sketch_->increment(key) >= admission_threshold_;
     }
 
+    struct GpuBufferInfo {
+        std::string ipc_handle;
+        uint64_t base_addr = 0;
+        uint64_t length = 0;
+        int device_id = -1;
+    };
+    std::optional<GpuBufferInfo> FindLocalGpuBufferInfo(
+        const void* gpu_ptr) const;
+
+    std::shared_ptr<TransferEngine> GetTransferEngine() const {
+        return transfer_engine_;
+    }
+
+    // GPU IPC support
+    void setClientRequester(std::shared_ptr<ClientRequester> requester) {
+        client_requester_ = std::move(requester);
+    }
+    void setLocalRpcAddr(const std::string& addr) { local_rpc_addr_ = addr; }
+    const std::string& getLocalRpcAddr() const { return local_rpc_addr_; }
+    void enableGpuIpcPull() { gpu_ipc_pull_enabled_ = true; }
+    std::unordered_set<std::string> getGpuIpcPullPeers(
+        const std::string& ipc_handle) const;
+    void clearGpuIpcPullPeers(const std::string& ipc_handle);
+    void invalidateGpuBufferCache(void* buffer);
+
+    bool IsAddressInMountedSegment(uint64_t addr, uint64_t size);
     bool IsReplicaOnLocalMemory(const Replica::Descriptor& replica);
+
+    std::optional<TransferFuture> SubmitGpuIpcPull(
+        const std::string& owner_rpc_endpoint,
+        const std::string& gpu_ipc_handle, int gpu_device_id,
+        const std::vector<uint64_t>& gpu_offsets,
+        const std::vector<uint64_t>& cpu_addrs,
+        const std::vector<size_t>& sizes);
+
+    std::optional<TransferFuture> SubmitGpuIpcPush(
+        const std::string& owner_rpc_endpoint,
+        const std::string& gpu_ipc_handle, int gpu_device_id,
+        const std::vector<uint64_t>& gpu_offsets,
+        const std::vector<uint64_t>& cpu_addrs,
+        const std::vector<size_t>& sizes, const std::string& key);
 
    private:
     /**
@@ -702,6 +744,18 @@ class Client {
     std::shared_ptr<TransferEngine> transfer_engine_;
     MasterClient master_client_;
     std::unique_ptr<TransferSubmitter> transfer_submitter_;
+
+    // GPU IPC pull support
+    bool gpu_ipc_pull_enabled_ = false;
+    std::shared_ptr<ClientRequester> client_requester_;
+    std::string local_rpc_addr_;
+    // Maps IPC handle -> set of peer RPC addrs that have cached it
+    std::unordered_map<std::string, std::unordered_set<std::string>>
+        gpu_ipc_pull_peer_map_;
+    mutable std::mutex gpu_ipc_pull_peers_mutex_;
+    // GpuBufferInfo cache (B13)
+    mutable std::mutex gpu_buffer_cache_mutex_;
+    mutable std::unordered_map<uintptr_t, GpuBufferInfo> gpu_buffer_cache_;
 
     // Mutex to protect mounted_segments_
     mutable std::mutex mounted_segments_mutex_;

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -29,7 +29,8 @@ class DummyClient : public PyClient {
                    const std::shared_ptr<TransferEngine> &transfer_engine,
                    const std::string &ipc_socket_path,
                    bool enable_ssd_offload = false,
-                   const std::string &ssd_offload_path = "") {
+                   const std::string &ssd_offload_path = "",
+                   bool enable_gpu_ipc_pull = false) {
         // Dummy client does not support real setup
         return -1;
     };

--- a/mooncake-store/include/gpu_ipc_utils.h
+++ b/mooncake-store/include/gpu_ipc_utils.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "cuda_alike.h"
+
+#if defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+#include <acl/acl_rt.h>
+#endif
+
+#include <cstddef>
+#include <cstring>
+#include <glog/logging.h>
+
+namespace mooncake {
+namespace gpu_ipc {
+
+// IPC handle size for each platform, used for deserialization validation.
+inline size_t IpcHandleSize() {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    return sizeof(cudaIpcMemHandle_t);  // 64
+#elif defined(USE_HIP)
+    return sizeof(hipIpcMemHandle_t);  // 64
+#elif defined(USE_ASCEND) || defined(USE_UBSHMEM)
+    return 65;  // kIPCHandleKeyLength, consistent with ubshmem_transport.cpp
+#else
+    return 0;
+#endif
+}
+
+// Open a remote accelerator memory IPC handle in the current process.
+// handle_data: deserialized raw bytes
+// handle_size: byte count (must match IpcHandleSize())
+// device_ptr [out]: device virtual address accessible in this process
+inline bool OpenIpcHandle(const void* handle_data, size_t handle_size,
+                          void** device_ptr) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    if (handle_size != sizeof(cudaIpcMemHandle_t)) return false;
+    cudaIpcMemHandle_t handle;
+    std::memcpy(&handle, handle_data, sizeof(handle));
+    return cudaIpcOpenMemHandle(device_ptr, handle,
+                                cudaIpcMemLazyEnablePeerAccess) == cudaSuccess;
+#elif defined(USE_HIP)
+    if (handle_size != sizeof(hipIpcMemHandle_t)) return false;
+    hipIpcMemHandle_t handle;
+    std::memcpy(&handle, handle_data, sizeof(handle));
+    return hipIpcOpenMemHandle(device_ptr, handle,
+                               hipIpcMemLazyEnablePeerAccess) == hipSuccess;
+#elif defined(USE_ASCEND) || defined(USE_UBSHMEM)
+    if (handle_size != 65) return false;
+    char ipc_key[65] = {0};
+    std::memcpy(ipc_key, handle_data, 65);
+    return aclrtIpcMemImportByKey(
+               device_ptr, ipc_key,
+               ACL_RT_IPC_MEM_IMPORT_FLAG_ENABLE_PEER_ACCESS) == ACL_SUCCESS;
+#else
+    (void)handle_data;
+    (void)handle_size;
+    (void)device_ptr;
+    return false;
+#endif
+}
+
+// Close an opened IPC handle.
+inline void CloseIpcHandle(void* device_ptr) {
+    if (!device_ptr) return;
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    cudaIpcCloseMemHandle(device_ptr);
+#elif defined(USE_HIP)
+    hipIpcCloseMemHandle(device_ptr);
+#elif defined(USE_ASCEND) || defined(USE_UBSHMEM)
+    aclrtIpcMemClose(device_ptr);
+#else
+    (void)device_ptr;
+#endif
+}
+
+}  // namespace gpu_ipc
+}  // namespace mooncake

--- a/mooncake-store/include/gpu_staging_utils.h
+++ b/mooncake-store/include/gpu_staging_utils.h
@@ -14,7 +14,7 @@ namespace gpu_staging {
 
 // Detect whether ptr resides in accelerator device memory.
 // If so, writes the device ID to *out_device_id for subsequent SetDevice.
-inline bool IsDevicePointer(const void* ptr, int* out_device_id) {
+inline bool IsDevicePointer(const void* ptr, int* out_device_id = nullptr) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
     cudaPointerAttributes attr{};
     if (cudaPointerGetAttributes(&attr, ptr) == cudaSuccess &&
@@ -92,14 +92,16 @@ inline bool CopyAuto(void* dst, const void* src, size_t size) {
 }
 
 // Bind the calling thread to the given device context.
-inline void SetDevice(int device_id) {
-    if (device_id < 0) return;
+inline bool SetDevice(int device_id) {
+    if (device_id < 0) return false;
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
-    cudaSetDevice(device_id);
+    return cudaSetDevice(device_id) == cudaSuccess;
 #elif defined(USE_HIP)
-    hipSetDevice(device_id);
+    return hipSetDevice(device_id) == hipSuccess;
 #elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
-    aclrtSetDevice(device_id);
+    return aclrtSetDevice(device_id) == ACL_SUCCESS;
+#else
+    return false;
 #endif
 }
 
@@ -156,5 +158,179 @@ inline bool IsHostPointer(const void* ptr) {
     return true;  // CPU-only build: all pointers are host
 #endif
 }
+
+// --- Stream types and async copy ---
+
+using GpuStream =
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    cudaStream_t;
+#elif defined(USE_HIP)
+    hipStream_t;
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    aclrtStream;
+#else
+    void*;
+#endif
+
+inline bool CreateStream(GpuStream* stream) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    return cudaStreamCreate(stream) == cudaSuccess;
+#elif defined(USE_HIP)
+    return hipStreamCreate(stream) == hipSuccess;
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    return aclrtCreateStream(stream) == ACL_SUCCESS;
+#else
+    (void)stream;
+    return false;
+#endif
+}
+
+inline void DestroyStream(GpuStream stream) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    cudaStreamDestroy(stream);
+#elif defined(USE_HIP)
+    hipStreamDestroy(stream);
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    aclrtDestroyStream(stream);
+#endif
+}
+
+inline bool SyncStream(GpuStream stream) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    return cudaStreamSynchronize(stream) == cudaSuccess;
+#elif defined(USE_HIP)
+    return hipStreamSynchronize(stream) == hipSuccess;
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    return aclrtSynchronizeStream(stream) == ACL_SUCCESS;
+#else
+    (void)stream;
+    return false;
+#endif
+}
+
+inline bool CopyDeviceToHostAsync(void* dst, const void* src, size_t size,
+                                  GpuStream stream) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    return cudaMemcpyAsync(dst, src, size, cudaMemcpyDeviceToHost, stream) ==
+           cudaSuccess;
+#elif defined(USE_HIP)
+    return hipMemcpyAsync(dst, src, size, hipMemcpyDeviceToHost, stream) ==
+           hipSuccess;
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    return aclrtMemcpyAsync(dst, size, src, size, ACL_MEMCPY_DEVICE_TO_HOST,
+                            stream) == ACL_SUCCESS;
+#else
+    (void)dst;
+    (void)src;
+    (void)size;
+    (void)stream;
+    return false;
+#endif
+}
+
+inline bool CopyHostToDeviceAsync(void* dst, const void* src, size_t size,
+                                  GpuStream stream) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    return cudaMemcpyAsync(dst, src, size, cudaMemcpyHostToDevice, stream) ==
+           cudaSuccess;
+#elif defined(USE_HIP)
+    return hipMemcpyAsync(dst, src, size, hipMemcpyHostToDevice, stream) ==
+           hipSuccess;
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    return aclrtMemcpyAsync(dst, size, src, size, ACL_MEMCPY_HOST_TO_DEVICE,
+                            stream) == ACL_SUCCESS;
+#else
+    (void)dst;
+    (void)src;
+    (void)size;
+    (void)stream;
+    return false;
+#endif
+}
+
+// Single-stream RAII wrapper.
+// Same-GPU same-direction transfers share one Copy Engine, so multiple
+// streams provide no bandwidth benefit. A single stream is sufficient
+// to achieve CPU-GPU overlap (submit all slices, then sync once).
+class ScopedGpuStream {
+   public:
+    explicit ScopedGpuStream(int device_id) : device_id_(device_id) {
+        if (!SetDevice(device_id_)) {
+            LOG(ERROR) << "Failed to set GPU device " << device_id;
+            valid_ = false;
+            return;
+        }
+        valid_ = CreateStream(&stream_);
+        if (!valid_) {
+            LOG(ERROR) << "Failed to create GPU stream for device "
+                       << device_id;
+        }
+    }
+
+    ~ScopedGpuStream() {
+        if (!valid_) return;
+        SetDevice(device_id_);
+        if (!synced_) {
+            if (!SyncStream(stream_)) {
+                LOG(WARNING)
+                    << "ScopedGpuStream: implicit sync failed in destructor"
+                    << " for device " << device_id_
+                    << ", data may be incomplete";
+            }
+        }
+        DestroyStream(stream_);
+    }
+
+    ScopedGpuStream(const ScopedGpuStream&) = delete;
+    ScopedGpuStream& operator=(const ScopedGpuStream&) = delete;
+    ScopedGpuStream(ScopedGpuStream&& other) noexcept
+        : device_id_(other.device_id_),
+          stream_(other.stream_),
+          valid_(other.valid_),
+          synced_(other.synced_) {
+        other.stream_ = GpuStream{};
+        other.valid_ = false;
+    }
+    ScopedGpuStream& operator=(ScopedGpuStream&& other) noexcept {
+        if (this != &other) {
+            // Clean up current stream (inline destructor logic)
+            if (valid_) {
+                if (!SetDevice(device_id_)) {
+                    LOG(ERROR) << "ScopedGpuStream: SetDevice failed in"
+                               << " move-assignment for device " << device_id_
+                               << ", skipping sync";
+                } else if (!synced_) {
+                    SyncStream(stream_);
+                }
+                DestroyStream(stream_);
+            }
+            device_id_ = other.device_id_;
+            stream_ = other.stream_;
+            valid_ = other.valid_;
+            synced_ = other.synced_;
+            other.stream_ = GpuStream{};
+            other.valid_ = false;
+        }
+        return *this;
+    }
+
+    GpuStream get() const { return stream_; }
+    bool valid() const { return valid_; }
+
+    bool sync() {
+        if (!valid_) return false;
+        SetDevice(device_id_);
+        bool ok = SyncStream(stream_);
+        synced_ = true;
+        return ok;
+    }
+
+   private:
+    int device_id_;
+    GpuStream stream_{};
+    bool valid_ = false;
+    bool synced_ = false;
+};
+
 }  // namespace gpu_staging
 }  // namespace mooncake

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -160,6 +160,17 @@ class ClientRequester {
     void release_offload_buffer(const std::string &client_addr,
                                 uint64_t batch_id);
 
+    // Unified GPU IPC transfer (sync + async)
+    tl::expected<GpuIpcTransferResponse, ErrorCode> gpu_ipc_transfer(
+        const std::string &owner_rpc_addr, const GpuIpcTransferRequest &req);
+
+    async_simple::coro::Lazy<tl::expected<GpuIpcTransferResponse, ErrorCode>>
+    gpu_ipc_transfer_async(const std::string &owner_rpc_addr,
+                           const GpuIpcTransferRequest &req);
+
+    void release_gpu_ipc_handle(const std::string &client_addr,
+                                const std::string &gpu_ipc_handle);
+
    private:
     /**
      * @brief A batch of allocated memory buffers, tracking both handles and
@@ -215,7 +226,8 @@ class PyClient {
         const std::string &master_server_addr,
         const std::shared_ptr<TransferEngine> &transfer_engine,
         const std::string &ipc_socket_path, bool enable_ssd_offload = false,
-        const std::string &ssd_offload_path = "") = 0;
+        const std::string &ssd_offload_path = "",
+        bool enable_gpu_ipc_pull = false) = 0;
 
     virtual int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                             const std::string &server_address,

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_map>
+
 #include <atomic>
 #include <boost/lockfree/queue.hpp>
 #include <csignal>
@@ -82,7 +84,8 @@ class RealClient : public PyClient {
         const std::shared_ptr<TransferEngine> &transfer_engine = nullptr,
         const std::string &ipc_socket_path = "",
         bool enable_ssd_offload = false,
-        const std::string &ssd_offload_path = "");
+        const std::string &ssd_offload_path = "",
+        bool enable_gpu_ipc_pull = false);
 
     int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                     const std::string &server_address,
@@ -500,7 +503,8 @@ class RealClient : public PyClient {
         const std::shared_ptr<TransferEngine> &transfer_engine = nullptr,
         const std::string &ipc_socket_path = "", int local_rpc_port = 50052,
         bool enable_ssd_offload = false, bool start_offload_rpc_server = false,
-        const std::string &ssd_offload_path = "");
+        const std::string &ssd_offload_path = "",
+        bool enable_gpu_ipc_pull = false);
 
     // Overload that accepts a configuration dictionary
     tl::expected<void, ErrorCode> setup_internal(const ConfigDict &config);
@@ -764,6 +768,17 @@ class RealClient : public PyClient {
     std::string device_name;
     std::string local_hostname;
     std::string local_rpc_addr;
+    // GPU IPC pull support
+    bool enable_gpu_ipc_pull_ = false;
+    std::unordered_map<std::string, void *> ipc_handle_cache_;
+    std::mutex ipc_cache_mutex_;
+
+    // Unified GPU IPC transfer handler (D2H + H2D)
+    tl::expected<GpuIpcTransferResponse, ErrorCode> gpu_ipc_transfer(
+        const GpuIpcTransferRequest &req);
+
+    bool release_gpu_ipc_handle(const std::string &gpu_ipc_handle);
+
     std::unique_ptr<coro_rpc::coro_rpc_server> offload_rpc_server_;
     int offload_rpc_port_ = 0;
     bool use_hugepage_ = false;

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -239,4 +239,31 @@ struct BatchGetOffloadObjectResponse {
 YLT_REFL(BatchGetOffloadObjectResponse, batch_id, pointers,
          transfer_engine_addr, gc_ttl_ms);
 
+// --- GPU IPC Transfer Types ---
+
+enum class GpuIpcDirection : int32_t {
+    DEVICE_TO_HOST = 0,  // PUT path: GPU(requester) -> CPU(owner)
+    HOST_TO_DEVICE = 1,  // GET path: CPU(owner) -> GPU(requester)
+};
+
+struct GpuIpcTransferRequest {
+    GpuIpcDirection direction;
+    std::string gpu_ipc_handle;  // Requester GPU IPC handle (base64)
+    int gpu_device_id = 0;
+    std::vector<std::string> keys;  // For logging/metrics only
+    std::vector<uint64_t>
+        gpu_offsets;  // GPU-side offsets (relative to handle base)
+    std::vector<uint64_t>
+        cpu_addrs;  // CPU-side virtual addresses (in owner process)
+    std::vector<uint64_t> sizes;
+};
+YLT_REFL(GpuIpcTransferRequest, direction, gpu_ipc_handle, gpu_device_id, keys,
+         gpu_offsets, cpu_addrs, sizes);
+
+struct GpuIpcTransferResponse {
+    int32_t overall_status = 0;
+    std::vector<int32_t> per_slice_status;
+};
+YLT_REFL(GpuIpcTransferResponse, overall_status, per_slice_status);
+
 }  // namespace mooncake

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <cstring>
@@ -13,6 +14,12 @@
 #include <thread>
 #include <vector>
 
+#include <functional>
+#include <async_simple/coro/Lazy.h>
+#include <async_simple/coro/SyncAwait.h>
+#include <ylt/util/tl/expected.hpp>
+
+#include "rpc_types.h"
 #include "transfer_engine.h"
 #include "types.h"
 #include "replica.h"
@@ -28,7 +35,8 @@ enum class TransferStrategy {
     LOCAL_MEMCPY = 0,     // Local memory copy using memcpy
     TRANSFER_ENGINE = 1,  // Remote transfer using transfer engine
     FILE_READ = 2,        // File read operation
-    EMPTY = 3
+    EMPTY = 3,
+    GPU_IPC = 4
 };
 
 /**
@@ -43,6 +51,10 @@ inline std::ostream& operator<<(std::ostream& os,
             return os << "TRANSFER_ENGINE";
         case TransferStrategy::FILE_READ:
             return os << "FILE_READ";
+        case TransferStrategy::GPU_IPC:
+            return os << "GPU_IPC";
+        case TransferStrategy::EMPTY:
+            return os << "EMPTY";
         default:
             return os << "UNKNOWN";
     }
@@ -96,6 +108,82 @@ class OperationState {
     std::optional<ErrorCode> result_ = std::nullopt;
     mutable std::mutex mutex_;
     std::condition_variable cv_;
+};
+
+/**
+ * @brief Operation state for GPU IPC transfers (same-node GPU<->CPU)
+ *
+ * Uses async_simple::coro::Lazy to achieve true async: the RPC is submitted
+ * without blocking, and syncAwait happens only in wait_for_completion().
+ *
+ * B3 fix: awaiter extraction is mutex-protected to prevent race condition.
+ */
+class GpuIpcOperationState : public OperationState {
+   public:
+    // Lazy is move-only with no default ctor; wrap in optional.
+    std::optional<async_simple::coro::Lazy<
+        tl::expected<GpuIpcTransferResponse, ErrorCode>>>
+        awaiter;
+
+    void set_awaiter(async_simple::coro::Lazy<
+                     tl::expected<GpuIpcTransferResponse, ErrorCode>>
+                         a) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        awaiter.emplace(std::move(a));
+    }
+
+    bool is_completed() override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return result_.has_value();
+    }
+
+    void set_completed(ErrorCode error_code) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (result_.has_value()) {
+                LOG(ERROR) << "GpuIpcOperationState::set_completed called twice"
+                           << ", ignoring duplicate with code "
+                           << static_cast<int>(error_code);
+                return;
+            }
+            result_.emplace(error_code);
+        }
+        cv_.notify_all();
+    }
+
+    void wait_for_completion() override {
+        // B3 fix: extract awaiter under lock, then await outside lock
+        std::optional<async_simple::coro::Lazy<
+            tl::expected<GpuIpcTransferResponse, ErrorCode>>>
+            lazy;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (awaiter.has_value()) {
+                lazy.emplace(std::move(*awaiter));
+                awaiter.reset();
+            }
+        }
+        if (lazy) {
+            auto result = async_simple::coro::syncAwait(std::move(*lazy));
+            ErrorCode ec = (!result || result->overall_status != 0)
+                               ? ErrorCode::TRANSFER_FAIL
+                               : ErrorCode::OK;
+            set_completed(ec);
+        } else {
+            // Fallback: already completed synchronously (with timeout)
+            std::unique_lock<std::mutex> lock(mutex_);
+            if (!cv_.wait_for(lock, std::chrono::seconds(60),
+                              [this] { return result_.has_value(); })) {
+                LOG(ERROR) << "GpuIpcOperationState::wait_for_completion"
+                           << " timed out after 60s";
+                result_.emplace(ErrorCode::TRANSFER_FAIL);
+            }
+        }
+    }
+
+    TransferStrategy get_strategy() const override {
+        return TransferStrategy::GPU_IPC;
+    }
 };
 
 /**

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1,4 +1,5 @@
 #include "client_service.h"
+#include "pyclient.h"
 
 #include <glog/logging.h>
 
@@ -10,6 +11,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <iomanip>
+#include <limits>
 #include <optional>
 #include <ranges>
 #include <thread>
@@ -1556,6 +1558,19 @@ void Client::SubmitTransfers(std::vector<PutOperation>& ops) {
             continue;
         }
 
+        // Detect GPU source once for all replicas.
+        // Only checking the first slice is sufficient because the subsequent
+        // boundary check (slice_addr in gpu_info range) will catch any
+        // non-GPU slices and trigger RDMA fallback. Using std::all_of would
+        // add a cudaPointerGetAttributes call per slice with no correctness
+        // benefit, since mixed GPU/CPU slices within a single PutOperation
+        // should never occur.
+        bool gpu_source = false;
+        if (gpu_ipc_pull_enabled_ && client_requester_ && !op.slices.empty()) {
+            gpu_source =
+                gpu_staging::IsDevicePointer(op.slices[0].ptr, nullptr);
+        }
+
         bool all_transfers_submitted = true;
         std::string failure_context;
 
@@ -1577,6 +1592,77 @@ void Client::SubmitTransfers(std::vector<PutOperation>& ops) {
              ++replica_idx) {
             const auto& replica = op.replicas[replica_idx];
             if (replica.is_memory_replica()) {
+                // GPU IPC pull: same-node GPU->CPU bypass RDMA
+                if (gpu_source && IsReplicaOnLocalMemory(replica)) {
+                    // B1 fix: use local_rpc_addr_ instead of
+                    // handle.rpc_endpoint_
+                    auto gpu_info = FindLocalGpuBufferInfo(op.slices[0].ptr);
+                    if (gpu_info) {
+                        // Build GPU IPC request
+                        GpuIpcTransferRequest req;
+                        req.direction = GpuIpcDirection::DEVICE_TO_HOST;
+                        req.gpu_ipc_handle = gpu_info->ipc_handle;
+                        req.gpu_device_id = gpu_info->device_id;
+                        req.keys.push_back(op.key);
+
+                        // Get replica's buffer base address (absolute addr in
+                        // owner)
+                        auto& buf_desc =
+                            replica.get_memory_descriptor().buffer_descriptor;
+                        uint64_t owner_base = buf_desc.buffer_address_;
+
+                        uint64_t dst_offset = 0;
+                        bool slices_valid = true;
+                        for (const auto& slice : op.slices) {
+                            uint64_t slice_addr =
+                                reinterpret_cast<uint64_t>(slice.ptr);
+                            if (slice_addr < gpu_info->base_addr ||
+                                slice_addr + slice.size >
+                                    gpu_info->base_addr + gpu_info->length) {
+                                slices_valid = false;
+                                break;
+                            }
+                            req.gpu_offsets.push_back(slice_addr -
+                                                      gpu_info->base_addr);
+                            req.cpu_addrs.push_back(owner_base + dst_offset);
+                            req.sizes.push_back(slice.size);
+                            dst_offset += slice.size;
+                        }
+                        if (slices_valid) {
+                            // GPU IPC handler is on offload RPC server.
+                            // Use 127.0.0.1:<port> so the connection goes
+                            // through loopback, matching IsCallerLocalhost().
+                            auto colon = local_rpc_addr_.rfind(":");
+                            if (colon == std::string::npos) {
+                                LOG(ERROR) << "Invalid local_rpc_addr format: "
+                                           << local_rpc_addr_;
+                                // Fall through to RDMA
+                            } else {
+                                std::string gpu_ipc_ep =
+                                    "127.0.0.1" + local_rpc_addr_.substr(colon);
+                                auto state =
+                                    std::make_shared<GpuIpcOperationState>();
+                                state->set_awaiter(
+                                    client_requester_->gpu_ipc_transfer_async(
+                                        gpu_ipc_ep, req));
+                                // B10 fix: record peer immediately on RPC
+                                // submission
+                                auto ipc_handle = gpu_info->ipc_handle;
+                                {
+                                    std::lock_guard<std::mutex> lock(
+                                        gpu_ipc_pull_peers_mutex_);
+                                    gpu_ipc_pull_peer_map_[ipc_handle].insert(
+                                        gpu_ipc_ep);
+                                }
+                                op.pending_transfers.emplace_back(
+                                    TransferFuture(state));
+                                continue;  // skip RDMA for this replica
+                            }
+                        }
+                    }
+                    // fallthrough to RDMA if IPC pull failed
+                }
+
                 auto submit_result = transfer_submitter_->submit(
                     replica, op.slices, TransferRequest::WRITE);
 
@@ -3151,6 +3237,21 @@ void Client::ProcessSlicesAsync(const std::string& key,
     }
 }
 
+bool Client::IsAddressInMountedSegment(uint64_t addr, uint64_t size) {
+    std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+    // Overflow check: addr + size must not wrap around
+    if (size > UINT64_MAX - addr) return false;
+    uint64_t end = addr + size;
+    for (const auto& [_, seg] : mounted_segments_) {
+        // Overflow check: seg.base + seg.size must not wrap around
+        if (seg.size > UINT64_MAX - seg.base) continue;
+        if (addr >= seg.base && end <= seg.base + seg.size) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool Client::IsReplicaOnLocalMemory(const Replica::Descriptor& replica) {
     if (!replica.is_memory_replica()) {
         return false;
@@ -3160,7 +3261,155 @@ bool Client::IsReplicaOnLocalMemory(const Replica::Descriptor& replica) {
     if (metadata_connstring_ == P2PHANDSHAKE) {
         return replica_transfer_endpoint == GetTransportEndpoint();
     }
-    return local_hostname_ == replica_transfer_endpoint;
+    // Strip port for same-node comparison (handles different ports on same
+    // host)
+    auto strip_port = [](const std::string& addr) -> std::string {
+        auto pos = addr.rfind(':');
+        return (pos != std::string::npos) ? addr.substr(0, pos) : addr;
+    };
+    return strip_port(local_hostname_) == strip_port(replica_transfer_endpoint);
+}
+
+// ============== GPU IPC Support ==============
+
+std::unordered_set<std::string> Client::getGpuIpcPullPeers(
+    const std::string& ipc_handle) const {
+    std::lock_guard<std::mutex> lock(gpu_ipc_pull_peers_mutex_);
+    auto it = gpu_ipc_pull_peer_map_.find(ipc_handle);
+    if (it != gpu_ipc_pull_peer_map_.end()) return it->second;
+    return {};
+}
+
+void Client::clearGpuIpcPullPeers(const std::string& ipc_handle) {
+    std::lock_guard<std::mutex> lock(gpu_ipc_pull_peers_mutex_);
+    gpu_ipc_pull_peer_map_.erase(ipc_handle);
+}
+
+void Client::invalidateGpuBufferCache(void* buffer) {
+    uint64_t addr = reinterpret_cast<uint64_t>(buffer);
+    std::lock_guard<std::mutex> lock(gpu_buffer_cache_mutex_);
+    for (auto it = gpu_buffer_cache_.begin(); it != gpu_buffer_cache_.end();) {
+        if (addr >= it->second.base_addr &&
+            addr < it->second.base_addr + it->second.length) {
+            it = gpu_buffer_cache_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+std::optional<Client::GpuBufferInfo> Client::FindLocalGpuBufferInfo(
+    const void* gpu_ptr) const {
+    uint64_t addr = reinterpret_cast<uint64_t>(gpu_ptr);
+
+    // B13: Check cache first
+    {
+        std::lock_guard<std::mutex> lock(gpu_buffer_cache_mutex_);
+        for (const auto& [base, info] : gpu_buffer_cache_) {
+            if (addr >= info.base_addr && addr < info.base_addr + info.length) {
+                return info;
+            }
+        }
+    }
+
+    // Cache miss: query TENT
+    auto result = transfer_engine_->findLocalGpuBuffer(addr);
+    if (!result) return std::nullopt;
+
+    // Get device_id via cudaPointerGetAttributes
+    int dev_id = -1;
+    gpu_staging::IsDevicePointer(gpu_ptr, &dev_id);
+
+    GpuBufferInfo info;
+    info.ipc_handle = result->ipc_handle;
+    info.base_addr = result->base_addr;
+    info.length = result->length;
+    info.device_id = dev_id;
+
+    // Write to cache
+    {
+        std::lock_guard<std::mutex> lock(gpu_buffer_cache_mutex_);
+        gpu_buffer_cache_[info.base_addr] = info;
+    }
+    return info;
+}
+
+std::optional<TransferFuture> Client::SubmitGpuIpcPull(
+    const std::string& owner_rpc_endpoint, const std::string& gpu_ipc_handle,
+    int gpu_device_id, const std::vector<uint64_t>& gpu_offsets,
+    const std::vector<uint64_t>& cpu_addrs, const std::vector<size_t>& sizes) {
+    // §5.7: null protection
+    if (!client_requester_ || local_rpc_addr_.empty()) {
+        LOG(WARNING) << "GPU IPC not initialized";
+        return std::nullopt;
+    }
+
+    GpuIpcTransferRequest req;
+    req.direction = GpuIpcDirection::DEVICE_TO_HOST;
+    req.gpu_ipc_handle = gpu_ipc_handle;
+    req.gpu_device_id = gpu_device_id;
+    req.gpu_offsets = gpu_offsets;
+    req.cpu_addrs = cpu_addrs;
+    req.sizes = sizes;
+
+    // Use 127.0.0.1:<port> so the connection goes through loopback,
+    // matching IsCallerLocalhost() on the owner side.
+    auto colon = owner_rpc_endpoint.rfind(":");
+    if (colon == std::string::npos) {
+        LOG(ERROR) << "Invalid owner_rpc_endpoint format: "
+                   << owner_rpc_endpoint;
+        return std::nullopt;
+    }
+    std::string gpu_ipc_ep = "127.0.0.1" + owner_rpc_endpoint.substr(colon);
+    auto state = std::make_shared<GpuIpcOperationState>();
+    state->set_awaiter(
+        client_requester_->gpu_ipc_transfer_async(gpu_ipc_ep, req));
+    // B10 fix: record peer immediately
+    {
+        std::lock_guard<std::mutex> lock(gpu_ipc_pull_peers_mutex_);
+        gpu_ipc_pull_peer_map_[gpu_ipc_handle].insert(gpu_ipc_ep);
+    }
+    return TransferFuture(state);
+}
+
+std::optional<TransferFuture> Client::SubmitGpuIpcPush(
+    const std::string& owner_rpc_endpoint, const std::string& gpu_ipc_handle,
+    int gpu_device_id, const std::vector<uint64_t>& gpu_offsets,
+    const std::vector<uint64_t>& cpu_addrs, const std::vector<size_t>& sizes,
+    const std::string& key) {
+    // §5.7: null protection
+    if (!client_requester_ || local_rpc_addr_.empty()) {
+        LOG(WARNING) << "GPU IPC not initialized";
+        return std::nullopt;
+    }
+
+    GpuIpcTransferRequest req;
+    req.direction = GpuIpcDirection::HOST_TO_DEVICE;
+    req.gpu_ipc_handle = gpu_ipc_handle;
+    req.gpu_device_id = gpu_device_id;
+    req.keys = {key};
+    req.gpu_offsets = gpu_offsets;
+    req.cpu_addrs = cpu_addrs;
+    req.sizes = sizes;
+
+    // Use 127.0.0.1:<port> so the connection goes through loopback,
+    // matching IsCallerLocalhost() on the owner side.
+    auto colon = owner_rpc_endpoint.rfind(":");
+    if (colon == std::string::npos) {
+        LOG(ERROR) << "Invalid owner_rpc_endpoint format: "
+                   << owner_rpc_endpoint;
+        return std::nullopt;
+    }
+    std::string gpu_ipc_ep = "127.0.0.1" + owner_rpc_endpoint.substr(colon);
+    auto state = std::make_shared<GpuIpcOperationState>();
+    state->set_awaiter(
+        client_requester_->gpu_ipc_transfer_async(gpu_ipc_ep, req));
+    // B10 fix: record peer immediately
+    {
+        std::lock_guard<std::mutex> lock(gpu_ipc_pull_peers_mutex_);
+        gpu_ipc_pull_peer_map_[gpu_ipc_handle].insert(gpu_ipc_ep);
+    }
+    return TransferFuture(state);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -7,6 +7,12 @@
 #include <numa.h>
 #include <numaif.h>
 #include <pthread.h>
+// <csignal> is needed by coro_io.hpp (std::signal); <signal.h> alone is
+// insufficient.
+#include <csignal>
+// get_context() is only declared in this internal header, not in any public
+// ylt/coro_rpc/ header.  Revisit if yalantinglibs is upgraded.
+#include <ylt/coro_rpc/impl/protocol/coro_rpc_protocol.hpp>
 #include <signal.h>
 #include <thread>
 #include <stop_token>
@@ -20,6 +26,9 @@
 #include <vector>
 
 #include "real_client.h"
+#include "gpu_ipc_utils.h"
+#include "common/serialization.h"
+#include "gpu_staging_utils.h"
 #include "client_buffer.hpp"
 #include "config.h"
 #include "mutex.h"
@@ -27,7 +36,6 @@
 #include "utils.h"
 #include "rpc_types.h"
 #include "file_storage.h"
-#include "gpu_staging_utils.h"
 #include "default_config.h"
 #include "shm_helper.h"
 #include "memory_location.h"
@@ -619,8 +627,9 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     const std::shared_ptr<TransferEngine> &transfer_engine,
     const std::string &ipc_socket_path, int local_rpc_port,
     bool enable_ssd_offload, bool start_offload_rpc_server,
-    const std::string &ssd_offload_path) {
+    const std::string &ssd_offload_path, bool enable_gpu_ipc_pull) {
     this->protocol = protocol;
+    this->enable_gpu_ipc_pull_ = enable_gpu_ipc_pull;
     this->ipc_socket_path_ = ipc_socket_path;
     const bool should_use_hugepage =
         use_hugepage_ && this->protocol != "ubshmem";
@@ -854,8 +863,10 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         }
         LOG(INFO) << "Starting IPC server at " << ipc_socket_path_;
     }
-    if (enable_ssd_offload && start_offload_rpc_server) {
-        // Start RPC server for offload operations (batch_get / release_buffer).
+    bool need_rpc_server = (enable_ssd_offload && start_offload_rpc_server) ||
+                           enable_gpu_ipc_pull_;
+    if (need_rpc_server) {
+        // Start RPC server for offload / GPU IPC pull operations.
         // Use port 0 to let the OS auto-allocate an available port.
         offload_rpc_server_ =
             std::make_unique<coro_rpc::coro_rpc_server>(1, 0, "0.0.0.0");
@@ -863,6 +874,12 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             ->register_handler<&RealClient::batch_get_offload_object>(this);
         offload_rpc_server_
             ->register_handler<&RealClient::release_offload_buffer>(this);
+        if (enable_gpu_ipc_pull_) {
+            offload_rpc_server_
+                ->register_handler<&RealClient::gpu_ipc_transfer>(this);
+            offload_rpc_server_
+                ->register_handler<&RealClient::release_gpu_ipc_handle>(this);
+        }
         offload_rpc_server_->async_start();
         auto err = offload_rpc_server_->get_errc();
         if (err) {
@@ -882,6 +899,12 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         }
         this->local_rpc_addr =
             rpc_host + ":" + std::to_string(offload_rpc_port_);
+    }
+    // Inject GPU IPC pull into Client layer
+    if (enable_gpu_ipc_pull_ && client_) {
+        client_->setClientRequester(client_requester_);
+        client_->setLocalRpcAddr(this->local_rpc_addr);
+        client_->enableGpuIpcPull();
     }
     if (enable_ssd_offload) {
         auto file_storage_config = FileStorageConfig::FromEnvironment();
@@ -916,11 +939,12 @@ int RealClient::setup_real(
     const std::string &master_server_addr,
     const std::shared_ptr<TransferEngine> &transfer_engine,
     const std::string &ipc_socket_path, bool enable_ssd_offload,
-    const std::string &ssd_offload_path) {
+    const std::string &ssd_offload_path, bool enable_gpu_ipc_pull) {
     return to_py_ret(setup_internal(
         local_hostname, metadata_server, global_segment_size, local_buffer_size,
         protocol, rdma_devices, master_server_addr, transfer_engine,
-        ipc_socket_path, 50052, enable_ssd_offload, true, ssd_offload_path));
+        ipc_socket_path, 50052, enable_ssd_offload, true, ssd_offload_path,
+        enable_gpu_ipc_pull));
 }
 
 namespace {
@@ -989,13 +1013,15 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         get_config(config, CONFIG_KEY_IPC_SOCKET_PATH);
 
     // Validate size parameters are within acceptable ranges
-    if (global_segment_size < MIN_SEGMENT_SIZE ||
-        global_segment_size > MAX_SEGMENT_SIZE) {
+    // global_segment_size == 0 means requester mode (skip segment mount)
+    if (global_segment_size != 0 && (global_segment_size < MIN_SEGMENT_SIZE ||
+                                     global_segment_size > MAX_SEGMENT_SIZE)) {
         LOG(ERROR) << "Invalid " << CONFIG_KEY_GLOBAL_SEGMENT_SIZE << ": "
-                   << global_segment_size << ", must be between "
+                   << global_segment_size << ", must be 0 or between "
                    << MIN_SEGMENT_SIZE << " and " << MAX_SEGMENT_SIZE;
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
+
     if (local_buffer_size < MIN_SEGMENT_SIZE ||
         local_buffer_size > MAX_SEGMENT_SIZE) {
         LOG(ERROR) << "Invalid " << CONFIG_KEY_LOCAL_BUFFER_SIZE << ": "
@@ -1021,10 +1047,29 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     bool enable_ssd_offload =
         (enable_ssd_offload_str == "true" || enable_ssd_offload_str == "1");
 
-    return setup_internal(local_hostname, metadata_server, global_segment_size,
-                          local_buffer_size, protocol, rdma_devices,
-                          master_server_addr, nullptr, ipc_socket_path, 50052,
-                          enable_ssd_offload, true, ssd_offload_path);
+    std::string enable_gpu_ipc_pull_str =
+        get_config(config, "enable_gpu_ipc_pull", "");
+    // B9: env var fallback
+    if (enable_gpu_ipc_pull_str.empty()) {
+        const char *env_val = std::getenv("MOONCAKE_ENABLE_GPU_IPC_PULL");
+        if (env_val) {
+            enable_gpu_ipc_pull_str = env_val;
+        }
+    }
+    if (enable_gpu_ipc_pull_str.empty()) {
+        enable_gpu_ipc_pull_str = "false";
+    }
+    std::transform(enable_gpu_ipc_pull_str.begin(),
+                   enable_gpu_ipc_pull_str.end(),
+                   enable_gpu_ipc_pull_str.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    bool enable_gpu_ipc_pull =
+        (enable_gpu_ipc_pull_str == "true" || enable_gpu_ipc_pull_str == "1");
+
+    return setup_internal(
+        local_hostname, metadata_server, global_segment_size, local_buffer_size,
+        protocol, rdma_devices, master_server_addr, nullptr, ipc_socket_path,
+        50052, enable_ssd_offload, true, ssd_offload_path, enable_gpu_ipc_pull);
 }
 
 tl::expected<void, ErrorCode> RealClient::initAll_internal(
@@ -1082,6 +1127,17 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
         if (entry.second.base) {
             free_memory(entry.second.protocol, entry.second.base);
         }
+    }
+
+    // Clean up GPU IPC handle cache before resetting client.
+    // ipc_handle_cache_ holds CUDA IPC mappings that must be closed
+    // while the GPU context is still valid.
+    {
+        std::lock_guard<std::mutex> lock(ipc_cache_mutex_);
+        for (auto &[handle, gpu_va] : ipc_handle_cache_) {
+            gpu_ipc::CloseIpcHandle(gpu_va);
+        }
+        ipc_handle_cache_.clear();
     }
 
     // Reset all resources
@@ -2901,6 +2957,20 @@ tl::expected<void, ErrorCode> RealClient::unregister_buffer_internal(
                    << toString(unregister_result.error());
         return tl::unexpected(unregister_result.error());
     }
+    // GPU IPC pull: notify peers to close cached IPC handles
+    if (enable_gpu_ipc_pull_ && client_requester_ && client_) {
+        auto buf_info = client_->FindLocalGpuBufferInfo(buffer);
+        if (buf_info) {
+            auto peers = client_->getGpuIpcPullPeers(buf_info->ipc_handle);
+            for (const auto &peer_rpc : peers) {
+                client_requester_->release_gpu_ipc_handle(peer_rpc,
+                                                          buf_info->ipc_handle);
+            }
+            client_->clearGpuIpcPullPeers(buf_info->ipc_handle);
+        }
+        // B13: invalidate gpu_buffer_cache_ for this buffer
+        client_->invalidateGpuBufferCache(buffer);
+    }
     {
         std::unique_lock<std::shared_mutex> lock(registered_buffer_mutex_);
         registered_buffer_sizes_.erase(buffer);
@@ -4184,6 +4254,12 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
     std::vector<ValidKeyInfo> valid_operations;
     std::unordered_map<std::string, ValidKeyInfo> valid_local_disk_operations;
     std::vector<DiskKeyInfo> disk_operations;
+    struct GpuIpcPushInfo {
+        size_t original_index;
+        std::string key;
+        TransferFuture future;
+    };
+    std::vector<GpuIpcPushInfo> gpu_ipc_futures;
     valid_operations.reserve(num_keys);
 
     auto local_endpoints = client_->GetLocalEndpoints();
@@ -4258,6 +4334,53 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
             results[i] = static_cast<int64_t>(total_size);
             continue;
         }
+        // GPU IPC Push: same-node CPU->GPU bypass RDMA
+        if (enable_gpu_ipc_pull_ && client_ && replica.is_memory_replica()) {
+            // buffers[i] is void* (single GPU buffer for this key)
+            if (gpu_staging::IsDevicePointer(buffers[i]) &&
+                client_->IsReplicaOnLocalMemory(replica)) {
+                auto gpu_info = client_->FindLocalGpuBufferInfo(buffers[i]);
+                if (gpu_info) {
+                    // Boundary check: ensure copy fits within GPU buffer
+                    uint64_t target_addr =
+                        reinterpret_cast<uint64_t>(buffers[i]);
+                    uint64_t initial_offset = target_addr - gpu_info->base_addr;
+                    if (initial_offset + total_size > gpu_info->length) {
+                        LOG(WARNING)
+                            << "GPU IPC Push: key " << key << " size "
+                            << total_size << " exceeds GPU buffer remaining "
+                            << (gpu_info->length - initial_offset)
+                            << ", falling back to BatchGet";
+                    } else {
+                        auto &mem_desc = replica.get_memory_descriptor();
+                        auto &buf_desc = mem_desc.buffer_descriptor;
+                        std::string owner_endpoint = client_->getLocalRpcAddr();
+                        uint64_t owner_base = buf_desc.buffer_address_;
+
+                        std::vector<uint64_t> gpu_offsets;
+                        std::vector<uint64_t> cpu_addrs;
+                        std::vector<size_t> slice_sizes;
+                        gpu_offsets.push_back(initial_offset);
+                        cpu_addrs.push_back(owner_base);
+                        slice_sizes.push_back(total_size);
+
+                        auto future = client_->SubmitGpuIpcPush(
+                            owner_endpoint, gpu_info->ipc_handle,
+                            gpu_info->device_id, gpu_offsets, cpu_addrs,
+                            slice_sizes, key);
+                        if (future) {
+                            gpu_ipc_futures.push_back(
+                                {i, key, std::move(*future)});
+                            results[i] = static_cast<int64_t>(total_size);
+                            continue;
+                        }
+                        LOG(WARNING) << "GPU IPC Push failed for key " << key
+                                     << ", falling back to BatchGet";
+                    }
+                }
+            }
+        }
+
         // MEMORY: RDMA directly to user buffer.
         std::vector<Slice> key_slices;
         allocateSlices(key_slices, replica, buffers[i]);
@@ -4270,6 +4393,16 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
 
         // Set success result (actual bytes transferred)
         results[i] = static_cast<int64_t>(total_size);
+    }
+
+    // Wait for all GPU IPC Push futures to complete
+    for (auto &info : gpu_ipc_futures) {
+        auto err = info.future.wait();
+        if (err != ErrorCode::OK) {
+            LOG(ERROR) << "GPU IPC Push failed for key '" << info.key
+                       << "': " << toString(err);
+            results[info.original_index] = tl::unexpected(err);
+        }
     }
 
     // Early return if no valid operations
@@ -5455,4 +5588,197 @@ tl::expected<ReturnType, ErrorCode> ClientRequester::invoke_rpc(
             co_return result->result();
         }());
 }
+
+// ============== GPU IPC Transfer Handler ==============
+
+// B11: NOTE: GPU IPC handler assumes segments remain mounted during execution.
+// Unmounting a segment during active GPU IPC transfer is undefined behavior.
+// This is acceptable because unmount only happens at shutdown and handler
+// execution time is < 1ms.
+// Check that the RPC caller is on localhost (127.0.0.1 or ::1).
+// GPU IPC handlers execute cudaMemcpy on addresses provided by the requester;
+// only same-node processes should be allowed to invoke them.
+static bool IsCallerLocalhost() {
+    auto *ctx = coro_rpc::get_context();
+    if (!ctx) {
+        LOG(WARNING) << "GPU IPC: cannot determine caller identity, rejecting";
+        return false;
+    }
+    auto remote_ep = ctx->get_remote_endpoint();
+    auto addr = remote_ep.address;
+    if (addr.is_loopback()) {
+        return true;
+    }
+    LOG(WARNING) << "GPU IPC: rejected non-localhost caller "
+                 << addr.to_string();
+    return false;
+}
+
+tl::expected<GpuIpcTransferResponse, ErrorCode> RealClient::gpu_ipc_transfer(
+    const GpuIpcTransferRequest &req) {
+    // Precondition: client must be initialized for address validation
+    if (!client_) {
+        LOG(ERROR) << "gpu_ipc_transfer: client not initialized, rejecting";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    // Security: only accept calls from localhost
+    if (!IsCallerLocalhost()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    gpu_staging::SetDevice(req.gpu_device_id);
+
+    // 1. Open/cache IPC handle
+    void *gpu_va = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(ipc_cache_mutex_);
+        auto it = ipc_handle_cache_.find(req.gpu_ipc_handle);
+        if (it != ipc_handle_cache_.end()) {
+            gpu_va = it->second;
+        } else {
+            std::vector<uint8_t> buf;
+            deserializeBinaryData(req.gpu_ipc_handle, buf);
+            if (buf.size() != gpu_ipc::IpcHandleSize()) {
+                LOG(ERROR) << "gpu_ipc_transfer: handle size mismatch, got "
+                           << buf.size() << ", expected "
+                           << gpu_ipc::IpcHandleSize();
+                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+            }
+            if (!gpu_ipc::OpenIpcHandle(buf.data(), buf.size(), &gpu_va)) {
+                LOG(ERROR) << "gpu_ipc_transfer: OpenIpcHandle failed";
+                return tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
+            }
+            ipc_handle_cache_[req.gpu_ipc_handle] = gpu_va;
+        }
+    }
+
+    // 1b. Validate vector size consistency
+    if (req.gpu_offsets.size() != req.sizes.size() ||
+        req.cpu_addrs.size() != req.sizes.size()) {
+        LOG(ERROR) << "gpu_ipc_transfer: vector size mismatch ("
+                   << req.gpu_offsets.size() << ", " << req.cpu_addrs.size()
+                   << ", " << req.sizes.size() << ")";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    // 2. Security check: cpu_addrs must be within mounted segments
+    {
+        for (size_t i = 0; i < req.cpu_addrs.size(); ++i) {
+            if (!client_->IsAddressInMountedSegment(req.cpu_addrs[i],
+                                                    req.sizes[i])) {
+                LOG(ERROR) << "gpu_ipc_transfer: cpu_addr 0x" << std::hex
+                           << req.cpu_addrs[i] << std::dec
+                           << " not in any mounted segment";
+                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+            }
+        }
+    }
+
+    // 3. Execute async copy with single stream
+    gpu_staging::SetDevice(req.gpu_device_id);
+    gpu_staging::ScopedGpuStream stream(req.gpu_device_id);
+
+    GpuIpcTransferResponse resp;
+    resp.per_slice_status.reserve(req.sizes.size());
+    for (size_t i = 0; i < req.sizes.size(); ++i) {
+        void *gpu_ptr = static_cast<char *>(gpu_va) + req.gpu_offsets[i];
+        void *cpu_ptr = reinterpret_cast<void *>(req.cpu_addrs[i]);
+        bool ok = false;
+
+        if (stream.valid()) {
+            if (req.direction == GpuIpcDirection::DEVICE_TO_HOST) {
+                ok = gpu_staging::CopyDeviceToHostAsync(
+                    cpu_ptr, gpu_ptr, req.sizes[i], stream.get());
+            } else {
+                ok = gpu_staging::CopyHostToDeviceAsync(
+                    gpu_ptr, cpu_ptr, req.sizes[i], stream.get());
+            }
+        } else {
+            // Stream creation failed: fallback to sync copy
+            if (req.direction == GpuIpcDirection::DEVICE_TO_HOST) {
+                ok = gpu_staging::CopyDeviceToHost(cpu_ptr, gpu_ptr,
+                                                   req.sizes[i]);
+            } else {
+                ok = gpu_staging::CopyHostToDevice(gpu_ptr, cpu_ptr,
+                                                   req.sizes[i]);
+            }
+        }
+
+        resp.per_slice_status.push_back(ok ? 0 : -1);
+        if (!ok) {
+            LOG(ERROR) << "gpu_ipc_transfer: copy submit failed for slice "
+                       << i;
+            resp.overall_status = -1;
+        }
+    }
+
+    // Sync once for all async copies
+    if (stream.valid()) {
+        if (!stream.sync()) {
+            // B4 fix: mark all per_slice_status as failed on sync failure
+            LOG(ERROR) << "gpu_ipc_transfer: stream sync failed";
+            resp.overall_status = -1;
+            for (auto &s : resp.per_slice_status) s = -1;
+        }
+    }
+
+    return resp;
+}
+
+bool RealClient::release_gpu_ipc_handle(const std::string &gpu_ipc_handle) {
+    // Security: only accept calls from localhost
+    if (!IsCallerLocalhost()) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(ipc_cache_mutex_);
+    auto it = ipc_handle_cache_.find(gpu_ipc_handle);
+    if (it != ipc_handle_cache_.end()) {
+        gpu_ipc::CloseIpcHandle(it->second);
+        ipc_handle_cache_.erase(it);
+        return true;
+    }
+    return false;
+}
+
+// ============== ClientRequester GPU IPC methods ==============
+
+tl::expected<GpuIpcTransferResponse, ErrorCode>
+ClientRequester::gpu_ipc_transfer(const std::string &owner_rpc_addr,
+                                  const GpuIpcTransferRequest &req) {
+    return invoke_rpc<&RealClient::gpu_ipc_transfer, GpuIpcTransferResponse>(
+        owner_rpc_addr, req);
+}
+
+async_simple::coro::Lazy<tl::expected<GpuIpcTransferResponse, ErrorCode>>
+ClientRequester::gpu_ipc_transfer_async(const std::string &owner_rpc_addr,
+                                        const GpuIpcTransferRequest &req) {
+    auto client_pool = client_pools_->at(owner_rpc_addr);
+    auto ret = co_await client_pool->send_request(
+        [&](coro_io::client_reuse_hint, coro_rpc::coro_rpc_client &client) {
+            return client.send_request<&RealClient::gpu_ipc_transfer>(req);
+        });
+    if (!ret.has_value()) {
+        LOG(ERROR) << "gpu_ipc_transfer_async: connection failed to "
+                   << owner_rpc_addr;
+        co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
+    }
+    auto result = co_await std::move(ret.value());
+    if (!result) {
+        LOG(ERROR) << "gpu_ipc_transfer_async RPC failed: "
+                   << result.error().msg;
+        co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
+    }
+    co_return result->result();
+}
+
+void ClientRequester::release_gpu_ipc_handle(
+    const std::string &client_addr, const std::string &gpu_ipc_handle) {
+    auto result = invoke_rpc<&RealClient::release_gpu_ipc_handle, bool>(
+        client_addr, gpu_ipc_handle);
+    if (!result) {
+        VLOG(1) << "Failed to release_gpu_ipc_handle at " << client_addr
+                << " (will be cleaned on process exit): " << result.error();
+    }
+}
+
 }  // namespace mooncake

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -147,6 +147,15 @@ target_link_libraries(
          gflags
          pthread)
 
+
+add_store_test(gpu_ipc_pull_test gpu_ipc_pull_test.cpp)
+find_package(CUDAToolkit QUIET)
+if(CUDAToolkit_FOUND)
+    target_compile_definitions(gpu_ipc_pull_test PRIVATE USE_CUDA)
+    target_include_directories(gpu_ipc_pull_test PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_link_libraries(gpu_ipc_pull_test PRIVATE CUDA::cudart)
+endif()
+
 # HA tests
 add_ha_test(standby_state_machine_test
             ha/standby/standby_state_machine_test.cpp)

--- a/mooncake-store/tests/gpu_ipc_pull_test.cpp
+++ b/mooncake-store/tests/gpu_ipc_pull_test.cpp
@@ -1,0 +1,446 @@
+// gpu_ipc_pull_test.cpp
+// Unit tests for GPU IPC pull feature (same-node GPU->CPU optimization)
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "transfer_task.h"
+#include "rpc_types.h"
+#include "allocator.h"
+#include "gpu_ipc_utils.h"
+#include "gpu_staging_utils.h"
+
+#ifdef USE_CUDA
+#include <cuda_runtime.h>
+#include "common/serialization.h"
+#endif
+
+namespace mooncake {
+
+class GpuIpcPullTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("GpuIpcPullTest");
+        FLAGS_logtostderr = 1;
+    }
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+};
+
+// ============================================================
+// 1. GpuIpcOperationState (no GPU required)
+// ============================================================
+
+TEST_F(GpuIpcPullTest, OperationStateBasic) {
+    auto state = std::make_shared<GpuIpcOperationState>();
+
+    // Initially not completed
+    EXPECT_FALSE(state->is_completed());
+    EXPECT_EQ(state->get_strategy(), TransferStrategy::GPU_IPC);
+
+    // Set completed with success
+    state->set_completed(ErrorCode::OK);
+    EXPECT_TRUE(state->is_completed());
+    EXPECT_EQ(state->get_result(), ErrorCode::OK);
+}
+
+TEST_F(GpuIpcPullTest, OperationStateError) {
+    auto state = std::make_shared<GpuIpcOperationState>();
+
+    state->set_completed(ErrorCode::TRANSFER_FAIL);
+    EXPECT_TRUE(state->is_completed());
+    EXPECT_EQ(state->get_result(), ErrorCode::TRANSFER_FAIL);
+}
+
+TEST_F(GpuIpcPullTest, OperationStateWaitCompletion) {
+    auto state = std::make_shared<GpuIpcOperationState>();
+
+    // Complete from another thread
+    std::thread t([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        state->set_completed(ErrorCode::OK);
+    });
+
+    state->wait_for_completion();
+    EXPECT_TRUE(state->is_completed());
+    EXPECT_EQ(state->get_result(), ErrorCode::OK);
+    t.join();
+}
+
+TEST_F(GpuIpcPullTest, TransferFutureWithGpuIpcPull) {
+    auto state = std::make_shared<GpuIpcOperationState>();
+    state->set_completed(ErrorCode::OK);
+
+    TransferFuture future(state);
+    EXPECT_EQ(future.strategy(), TransferStrategy::GPU_IPC);
+    EXPECT_EQ(future.wait(), ErrorCode::OK);
+}
+
+// ============================================================
+// 2. TransferStrategy enum
+// ============================================================
+
+TEST_F(GpuIpcPullTest, TransferStrategyEnum) {
+    // Verify enum values don't collide
+    EXPECT_EQ(static_cast<int>(TransferStrategy::LOCAL_MEMCPY), 0);
+    EXPECT_EQ(static_cast<int>(TransferStrategy::TRANSFER_ENGINE), 1);
+    EXPECT_EQ(static_cast<int>(TransferStrategy::FILE_READ), 2);
+    EXPECT_EQ(static_cast<int>(TransferStrategy::GPU_IPC), 4);
+    EXPECT_EQ(static_cast<int>(TransferStrategy::EMPTY), 3);
+
+    // Verify operator<< works
+    std::ostringstream oss;
+    oss << TransferStrategy::GPU_IPC;
+    EXPECT_EQ(oss.str(), "GPU_IPC");
+
+    std::ostringstream oss2;
+    oss2 << TransferStrategy::EMPTY;
+    EXPECT_EQ(oss2.str(), "EMPTY");
+}
+
+// ============================================================
+// 3. RPC message structs
+// ============================================================
+
+TEST_F(GpuIpcPullTest, GpuIpcTransferRequestD2H) {
+    GpuIpcTransferRequest req;
+    req.direction = GpuIpcDirection::DEVICE_TO_HOST;
+    req.gpu_ipc_handle = "test_handle_data";
+    req.gpu_device_id = 0;
+    req.gpu_offsets = {0, 4096};
+    req.cpu_addrs = {0x1000, 0x2000};
+    req.sizes = {4096, 4096};
+
+    EXPECT_EQ(req.direction, GpuIpcDirection::DEVICE_TO_HOST);
+    EXPECT_EQ(req.gpu_ipc_handle, "test_handle_data");
+    EXPECT_EQ(req.gpu_device_id, 0);
+    EXPECT_EQ(req.gpu_offsets.size(), 2u);
+    EXPECT_EQ(req.cpu_addrs.size(), 2u);
+    EXPECT_EQ(req.sizes.size(), 2u);
+}
+
+TEST_F(GpuIpcPullTest, GpuIpcTransferResponseDefault) {
+    GpuIpcTransferResponse resp;
+    EXPECT_EQ(resp.overall_status, 0);
+    EXPECT_TRUE(resp.per_slice_status.empty());
+}
+
+// ============================================================
+// 4. AllocatedBuffer::Descriptor transport_endpoint_
+// ============================================================
+
+TEST_F(GpuIpcPullTest, DescriptorRpcEndpoint) {
+    AllocatedBuffer::Descriptor desc;
+    desc.size_ = 4096;
+    desc.buffer_address_ = 0x7f000000;
+    desc.protocol_ = "tcp";
+    desc.transport_endpoint_ = "192.168.1.1:12345";
+    // rpc_endpoint_ field removed — not part of current API
+
+    EXPECT_EQ(desc.transport_endpoint_, "192.168.1.1:12345");
+
+    // Empty transport_endpoint_ is the default
+    AllocatedBuffer::Descriptor desc2;
+    EXPECT_TRUE(desc2.transport_endpoint_.empty());
+}
+
+// ============================================================
+// 5. gpu_ipc_utils.h (compile-time checks + GPU runtime tests)
+// ============================================================
+
+TEST_F(GpuIpcPullTest, IpcHandleSize) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    EXPECT_EQ(gpu_ipc::IpcHandleSize(), sizeof(cudaIpcMemHandle_t));
+    EXPECT_EQ(gpu_ipc::IpcHandleSize(), 64u);
+#elif defined(USE_HIP)
+    EXPECT_EQ(gpu_ipc::IpcHandleSize(), sizeof(hipIpcMemHandle_t));
+#elif defined(USE_ASCEND) || defined(USE_UBSHMEM)
+    EXPECT_EQ(gpu_ipc::IpcHandleSize(), 65u);
+#else
+    EXPECT_EQ(gpu_ipc::IpcHandleSize(), 0u);
+#endif
+}
+
+TEST_F(GpuIpcPullTest, OpenIpcHandleInvalidSize) {
+    // Wrong size should fail gracefully
+    char dummy[4] = {0};
+    void* ptr = nullptr;
+    EXPECT_FALSE(gpu_ipc::OpenIpcHandle(dummy, sizeof(dummy), &ptr));
+    EXPECT_EQ(ptr, nullptr);
+}
+
+TEST_F(GpuIpcPullTest, CloseIpcHandleNull) {
+    // Should not crash on nullptr
+    gpu_ipc::CloseIpcHandle(nullptr);
+}
+
+// ============================================================
+// 6. GPU-dependent tests (only run if CUDA is available)
+// ============================================================
+
+#ifdef USE_CUDA
+
+TEST_F(GpuIpcPullTest, IsDevicePointerDetectsGpu) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+    void* gpu_ptr = nullptr;
+    cudaError_t err = cudaMalloc(&gpu_ptr, 4096);
+    ASSERT_EQ(err, cudaSuccess);
+    ASSERT_NE(gpu_ptr, nullptr);
+
+    int dev_id = -1;
+    EXPECT_TRUE(gpu_staging::IsDevicePointer(gpu_ptr, &dev_id));
+    EXPECT_GE(dev_id, 0);
+
+    // CPU pointer should return false
+    char cpu_buf[64];
+    EXPECT_FALSE(gpu_staging::IsDevicePointer(cpu_buf, nullptr));
+
+    cudaFree(gpu_ptr);
+}
+
+TEST_F(GpuIpcPullTest, IpcHandleRoundTrip) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+    // Allocate GPU memory
+    void* gpu_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&gpu_ptr, 4096), cudaSuccess);
+
+    // Write known pattern
+    std::vector<char> src(4096, 0x42);
+    ASSERT_EQ(cudaMemcpy(gpu_ptr, src.data(), 4096, cudaMemcpyHostToDevice),
+              cudaSuccess);
+
+    // Get IPC handle
+    cudaIpcMemHandle_t handle;
+    ASSERT_EQ(cudaIpcGetMemHandle(&handle, gpu_ptr), cudaSuccess);
+
+    // Serialize
+    std::string serialized =
+        serializeBinaryData(&handle, sizeof(cudaIpcMemHandle_t));
+
+    // Deserialize
+    std::vector<uint8_t> buf;
+    deserializeBinaryData(serialized, buf);
+    ASSERT_EQ(buf.size(), sizeof(cudaIpcMemHandle_t));
+
+    // Open via cross-platform API (same process — this is for unit test only,
+    // in production IPC handles are opened in a different process)
+    // Note: cudaIpcOpenMemHandle in same process returns cudaErrorInvalidValue
+    // on most drivers. We test the serialization round-trip instead.
+    cudaIpcMemHandle_t handle2;
+    std::memcpy(&handle2, buf.data(), sizeof(handle2));
+    EXPECT_EQ(std::memcmp(&handle, &handle2, sizeof(handle)), 0);
+
+    cudaFree(gpu_ptr);
+}
+
+TEST_F(GpuIpcPullTest, CopyDeviceToHostWorks) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+    void* gpu_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&gpu_ptr, 4096), cudaSuccess);
+
+    // Write pattern to GPU
+    std::vector<char> src(4096, 0xAB);
+    ASSERT_EQ(cudaMemcpy(gpu_ptr, src.data(), 4096, cudaMemcpyHostToDevice),
+              cudaSuccess);
+
+    // Read back via cross-platform API
+    std::vector<char> dst(4096, 0);
+    EXPECT_TRUE(gpu_staging::CopyDeviceToHost(dst.data(), gpu_ptr, 4096));
+
+    // Verify
+    EXPECT_EQ(dst, src);
+
+    cudaFree(gpu_ptr);
+}
+
+TEST_F(GpuIpcPullTest, SetDeviceWorks) {
+    int device_count = 0;
+    cudaGetDeviceCount(&device_count);
+    if (device_count == 0) {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+
+    // Should not crash
+    gpu_staging::SetDevice(0);
+
+    int current_device = -1;
+    cudaGetDevice(&current_device);
+    EXPECT_EQ(current_device, 0);
+}
+
+#endif  // USE_CUDA
+
+// ============================================================
+// 7. New unified GPU IPC Transfer types (no GPU required)
+// ============================================================
+
+TEST_F(GpuIpcPullTest, GpuIpcTransferRequestFields) {
+    GpuIpcTransferRequest req;
+    req.direction = GpuIpcDirection::DEVICE_TO_HOST;
+    req.gpu_ipc_handle = "test_handle";
+    req.gpu_device_id = 1;
+    req.keys = {"key0", "key1"};
+    req.gpu_offsets = {0, 4096};
+    req.cpu_addrs = {0x1000, 0x2000};
+    req.sizes = {4096, 4096};
+
+    EXPECT_EQ(req.direction, GpuIpcDirection::DEVICE_TO_HOST);
+    EXPECT_EQ(req.gpu_device_id, 1);
+    EXPECT_EQ(req.keys.size(), 2u);
+    EXPECT_EQ(req.gpu_offsets.size(), 2u);
+    EXPECT_EQ(req.cpu_addrs.size(), 2u);
+    EXPECT_EQ(req.sizes.size(), 2u);
+
+    req.direction = GpuIpcDirection::HOST_TO_DEVICE;
+    EXPECT_EQ(req.direction, GpuIpcDirection::HOST_TO_DEVICE);
+}
+
+TEST_F(GpuIpcPullTest, GpuIpcTransferResponsePerSlice) {
+    GpuIpcTransferResponse resp;
+    EXPECT_EQ(resp.overall_status, 0);
+    EXPECT_TRUE(resp.per_slice_status.empty());
+
+    resp.per_slice_status = {0, 0, -1, 0};
+    resp.overall_status = -1;
+    EXPECT_EQ(resp.per_slice_status.size(), 4u);
+    EXPECT_EQ(resp.per_slice_status[2], -1);
+}
+
+TEST_F(GpuIpcPullTest, GpuIpcOperationStateSyncFallback) {
+    // Test the synchronous (non-coro) fallback path — no awaiter set
+    auto state = std::make_shared<GpuIpcOperationState>();
+
+    EXPECT_FALSE(state->is_completed());
+    EXPECT_EQ(state->get_strategy(), TransferStrategy::GPU_IPC);
+
+    std::thread t([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));
+        state->set_completed(ErrorCode::OK);
+    });
+
+    state->wait_for_completion();
+    EXPECT_TRUE(state->is_completed());
+    EXPECT_EQ(state->get_result(), ErrorCode::OK);
+    t.join();
+}
+
+// ============================================================
+// 8. GPU-dependent: CopyHostToDevice + async + NUMA tests
+// ============================================================
+
+#ifdef USE_CUDA
+
+TEST_F(GpuIpcPullTest, CopyHostToDeviceWorks) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+    void* gpu_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&gpu_ptr, 4096), cudaSuccess);
+
+    std::vector<char> src(4096, 0xCD);
+    EXPECT_TRUE(gpu_staging::CopyHostToDevice(gpu_ptr, src.data(), 4096));
+
+    std::vector<char> dst(4096, 0);
+    ASSERT_EQ(cudaMemcpy(dst.data(), gpu_ptr, 4096, cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    EXPECT_EQ(dst, src);
+    cudaFree(gpu_ptr);
+}
+
+TEST_F(GpuIpcPullTest, ScopedGpuStreamBasic) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+    gpu_staging::SetDevice(0);
+    {
+        gpu_staging::ScopedGpuStream stream(0);
+        EXPECT_TRUE(stream.valid());
+        EXPECT_TRUE(stream.sync());
+    }
+}
+
+TEST_F(GpuIpcPullTest, AsyncCopyD2HRoundTrip) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+    void* gpu_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&gpu_ptr, 4096), cudaSuccess);
+
+    std::vector<char> src(4096, 0xEF);
+    ASSERT_EQ(cudaMemcpy(gpu_ptr, src.data(), 4096, cudaMemcpyHostToDevice),
+              cudaSuccess);
+
+    std::vector<char> dst(4096, 0);
+    {
+        gpu_staging::ScopedGpuStream stream(0);
+        ASSERT_TRUE(stream.valid());
+        EXPECT_TRUE(gpu_staging::CopyDeviceToHostAsync(dst.data(), gpu_ptr,
+                                                       4096, stream.get()));
+        EXPECT_TRUE(stream.sync());
+    }
+    EXPECT_EQ(dst, src);
+    cudaFree(gpu_ptr);
+}
+
+TEST_F(GpuIpcPullTest, AsyncCopyH2DRoundTrip) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+    void* gpu_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&gpu_ptr, 4096), cudaSuccess);
+
+    std::vector<char> src(4096, 0xBB);
+    {
+        gpu_staging::ScopedGpuStream stream(0);
+        ASSERT_TRUE(stream.valid());
+        EXPECT_TRUE(gpu_staging::CopyHostToDeviceAsync(gpu_ptr, src.data(),
+                                                       4096, stream.get()));
+        EXPECT_TRUE(stream.sync());
+    }
+
+    std::vector<char> dst(4096, 0);
+    ASSERT_EQ(cudaMemcpy(dst.data(), gpu_ptr, 4096, cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    EXPECT_EQ(dst, src);
+    cudaFree(gpu_ptr);
+}
+
+// GetDeviceNumaNode test removed — function not in gpu_staging API
+
+TEST_F(GpuIpcPullTest, IsDevicePointerDefaultParam) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+    void* gpu_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&gpu_ptr, 4096), cudaSuccess);
+
+    // Default param (no out_device_id)
+    EXPECT_TRUE(gpu_staging::IsDevicePointer(gpu_ptr));
+
+    char cpu_buf[64];
+    EXPECT_FALSE(gpu_staging::IsDevicePointer(cpu_buf));
+    cudaFree(gpu_ptr);
+}
+
+#endif  // USE_CUDA
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -162,6 +162,20 @@ class TransferEngine {
 
     std::shared_ptr<TransferMetadata> getMetadata();
 
+    // GPU IPC: find local buffer containing addr, return IPC handle info.
+    // Works in both TENT and non-TENT modes.
+    struct LocalGpuBufferInfo {
+        std::string
+            ipc_handle;  // serialized cudaIpcMemHandle (shm_name/shm_path)
+        uint64_t base_addr;
+        uint64_t length;
+    };
+    std::optional<LocalGpuBufferInfo> findLocalGpuBuffer(uint64_t addr);
+
+    // Register GPU memory with NVLink transport only (skip RDMA).
+    // Returns 0 on success.
+    int registerLocalMemoryNvlinkOnly(void* addr, size_t length);
+
     bool checkOverlap(void* addr, uint64_t length);
 
     void setAutoDiscover(bool auto_discover);

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -209,6 +209,22 @@ std::shared_ptr<Topology> TransferEngine::getLocalTopology() {
     return impl_->getLocalTopology();
 }
 
+std::optional<TransferEngine::LocalGpuBufferInfo>
+TransferEngine::findLocalGpuBuffer(uint64_t addr) {
+    // Non-TENT: use legacy TransferMetadata
+    auto metadata = impl_->getMetadata();
+    if (!metadata) return std::nullopt;
+    auto seg_desc = metadata->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    if (!seg_desc) return std::nullopt;
+    for (const auto& buf : seg_desc->buffers) {
+        if (addr >= buf.addr && addr < buf.addr + buf.length) {
+            if (buf.shm_name.empty()) return std::nullopt;
+            return LocalGpuBufferInfo{buf.shm_name, buf.addr, buf.length};
+        }
+    }
+    return std::nullopt;
+}
+
 }  // namespace mooncake
 #else
 #include "transfer_engine.h"
@@ -602,6 +618,42 @@ std::shared_ptr<TransferMetadata> TransferEngine::getMetadata() {
         return nullptr;
     } else
         return impl_->getMetadata();
+}
+
+std::optional<TransferEngine::LocalGpuBufferInfo>
+TransferEngine::findLocalGpuBuffer(uint64_t addr) {
+    if (use_tent_) {
+        auto result = impl_tent_->findLocalBuffer(addr);
+        if (!result) return std::nullopt;
+        return LocalGpuBufferInfo{result->shm_path, result->base_addr,
+                                  result->length};
+    } else {
+        // Non-TENT: use legacy TransferMetadata
+        auto metadata = impl_->getMetadata();
+        if (!metadata) return std::nullopt;
+        auto seg_desc = metadata->getSegmentDescByID(LOCAL_SEGMENT_ID);
+        if (!seg_desc) return std::nullopt;
+        for (const auto& buf : seg_desc->buffers) {
+            if (addr >= buf.addr && addr < buf.addr + buf.length) {
+                if (buf.shm_name.empty()) return std::nullopt;
+                return LocalGpuBufferInfo{buf.shm_name, buf.addr, buf.length};
+            }
+        }
+        return std::nullopt;
+    }
+}
+
+int TransferEngine::registerLocalMemoryNvlinkOnly(void* addr, size_t length) {
+    if (use_tent_) {
+        mooncake::tent::MemoryOptions option;
+        option.type = mooncake::tent::NVLINK;
+        auto status = impl_tent_->registerLocalMemory(addr, length, option);
+        return (int)status.code();
+    } else {
+        // Non-TENT: no NVLink transport available, fall through to regular
+        return registerLocalMemory(addr, length, kWildcardLocation, false,
+                                   true);
+    }
 }
 
 bool TransferEngine::checkOverlap(void* addr, uint64_t length) {

--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment_tracker.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment_tracker.h
@@ -56,10 +56,11 @@ class SegmentTracker {
                   std::function<Status(BufferDesc&)> callback);
 
     Status forEach(std::function<Status(BufferDesc&)> callback);
+    Status forEach(std::function<Status(const BufferDesc&)> callback) const;
 
    private:
     SegmentDescRef local_desc_;
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <optional>
 #include <vector>
 
 #include "tent/common/config.h"
@@ -158,16 +159,10 @@ class TransferEngineImpl {
 
     Status unlockStageBuffer(uint64_t addr);
 
-    // Test-only hook: replace the transport in a given slot after construct().
-    // Production code never calls this. Used by failover integration tests to
-    // inject a FaultProxyTransport without bypassing resubmitTransferTask,
-    // resolveTransport, or any other engine state. Not thread-safe with any
-    // in-flight transfer on that slot.
+    // Test-only: swap a transport in the transport_list_ array.
     void swapTransportForTest(TransportType type,
-                              std::shared_ptr<Transport> xport) {
-        if (type >= 0 && type < (TransportType)kSupportedTransportTypes) {
-            transport_list_[type] = std::move(xport);
-        }
+                              std::shared_ptr<Transport> t) {
+        transport_list_[static_cast<int>(type)] = std::move(t);
     }
 
    private:
@@ -222,6 +217,16 @@ class TransferEngineImpl {
     std::array<std::shared_ptr<Transport>, kSupportedTransportTypes>
         transport_list_;
     std::unique_ptr<SegmentTracker> local_segment_tracker_;
+
+   public:
+    // Find local buffer containing addr; returns (shm_path, base_addr, length)
+    // Used by GPU IPC to locate cudaIpcMemHandle for a GPU pointer.
+    struct LocalBufferResult {
+        std::string shm_path;
+        uint64_t base_addr;
+        uint64_t length;
+    };
+    std::optional<LocalBufferResult> findLocalBuffer(uint64_t addr) const;
 
     ThreadLocalStorage<BatchSet> batch_set_;
 

--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -205,6 +205,7 @@ int tent_task_status_list(tent_engine_t engine, tent_batch_id_t batch_id,
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -306,6 +307,14 @@ class TransferEngine {
                              std::vector<TransferStatus>& status_list);
 
     Status getTransferStatus(BatchID batch_id, TransferStatus& overall_status);
+
+   public:
+    struct LocalBufferResult {
+        std::string shm_path;
+        uint64_t base_addr;
+        uint64_t length;
+    };
+    std::optional<LocalBufferResult> findLocalBuffer(uint64_t addr) const;
 
    private:
     std::unique_ptr<TransferEngineImpl> impl_;

--- a/mooncake-transfer-engine/tent/src/runtime/segment_tracker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/segment_tracker.cpp
@@ -158,5 +158,17 @@ Status SegmentTracker::forEach(std::function<Status(BufferDesc&)> callback) {
     return Status::OK();
 }
 
+Status SegmentTracker::forEach(
+    std::function<Status(const BufferDesc&)> callback) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    assert(local_desc_->type == SegmentType::Memory);
+    const auto& detail = std::get<MemorySegmentDesc>(local_desc_->detail);
+    for (const auto& buf : detail.buffers) {
+        auto status = callback(buf);
+        if (!status.ok()) return status;
+    }
+    return Status::OK();
+}
+
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -279,12 +279,6 @@ Status TransferEngineImpl::construct() {
         redis_password = env_password;
     }
 
-    std::string redis_username;
-    const char* env_username = std::getenv("MC_REDIS_USERNAME");
-    if (env_username && *env_username) {
-        redis_username = env_username;
-    }
-
     // Get Redis DB index from environment variable or config
     int redis_db_index_config = conf_->get("redis_db_index", 0);
     const char* env_db_index = std::getenv("MC_REDIS_DB_INDEX");
@@ -325,8 +319,7 @@ Status TransferEngineImpl::construct() {
     }
 
     metadata_ = std::make_shared<ControlService>(
-        metadata_type, metadata_servers, redis_username, redis_password,
-        db_index, this);
+        metadata_type, metadata_servers, redis_password, db_index, this);
 
     CHECK_STATUS(metadata_->start(port_, ipv6_));
 
@@ -729,6 +722,22 @@ Status TransferEngineImpl::unregisterLocalMemory(
     }
     if (!removed_any) return Status::OK();
     return metadata_->segmentManager().synchronizeLocal();
+}
+
+std::optional<TransferEngineImpl::LocalBufferResult>
+TransferEngineImpl::findLocalBuffer(uint64_t addr) const {
+    if (!local_segment_tracker_) return std::nullopt;
+    // Iterate all local buffers directly (avoid SegmentTracker::query
+    // which has early-break logic that skips non-contiguous buffers).
+    std::optional<LocalBufferResult> found;
+    local_segment_tracker_->forEach([&](const BufferDesc& buf) -> Status {
+        if (addr >= buf.addr && addr < buf.addr + buf.length &&
+            !buf.shm_path.empty()) {
+            found = LocalBufferResult{buf.shm_path, buf.addr, buf.length};
+        }
+        return Status::OK();
+    });
+    return found;
 }
 
 BatchID TransferEngineImpl::allocateBatch(size_t batch_size) {

--- a/mooncake-transfer-engine/tent/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/tent/src/transfer_engine.cpp
@@ -169,5 +169,13 @@ Status TransferEngine::getTransferStatus(BatchID batch_id,
     return impl_->getTransferStatus(batch_id, overall_status);
 }
 
+std::optional<TransferEngine::LocalBufferResult>
+TransferEngine::findLocalBuffer(uint64_t addr) const {
+    auto result = impl_->findLocalBuffer(addr);
+    if (!result) return std::nullopt;
+    return LocalBufferResult{result->shm_path, result->base_addr,
+                             result->length};
+}
+
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -475,9 +475,9 @@ RdmaContext::MemReg RdmaContext::registerMemReg(void* addr, size_t length,
     }
     ibv_mr* entry = verbs_.ibv_reg_mr_default(native_pd_, addr, length, access);
     if (!entry) {
-        const void* end = static_cast<const char*>(addr) + length;
         PLOG(ERROR) << "Failed to register memory from " << addr << " to "
-                    << end << " in RDMA device " << device_name_;
+                    << static_cast<const char*>(addr) + length
+                    << " in RDMA device " << device_name_;
         return nullptr;
     }
     mr_set_mutex_.lock();
@@ -519,9 +519,9 @@ int RdmaContext::unregisterMemReg(MemReg id) {
     mr_set_mutex_.unlock();
 
     if (verbs_.ibv_dereg_mr(entry)) {
-        const void* end = static_cast<const char*>(entry->addr) + entry->length;
         LOG(ERROR) << "Failed to unregister memory from " << entry->addr
-                   << " to " << end << " in RDMA device " << device_name_;
+                   << " to " << (char*)entry->addr + entry->length
+                   << " in RDMA device " << device_name_;
     }
 
     return 0;


### PR DESCRIPTION
## Description

**[vLLM Test Repo]:** https://github.com/LujhCoconut/vllm/tree/feat/mooncake-int-intranode .

```
┌─────────────────────────────────────────────────────────┐                                                                                                                              
  │ Node                                                    │                                                                                                                              
  │                                                         │                                                                                                                              
  │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐   │                                                                                                                               
  │  │ vLLM     │ │ vLLM     │ │ vLLM     │ │ vLLM     │   │                                                                                                                               
  │  │ Worker 0 │ │ Worker 1 │ │ Worker 2 │ │ Worker 3 │   │                                                                                                                               
  │  │ (GPU 0)  │ │ (GPU 1)  │ │ (GPU 2)  │ │ (GPU 3)  │   │                                                                                                                               
  │  └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘   │                                                                                                                               
  │       │             │             │             │        │                                                                                                                             
  │       └──────┬──────┴──────┬──────┴──────┬──────┘        │                                                                                                                             
  │              │             │             │               │                                                                                                                             
  │         ┌────▼─────────────▼─────────────▼────┐          │                                                                                                                             
  │         │          Owner (mooncake_client)     │          │                                                                                                                            
  │         │          CPU Memory Pool (80GB)      │          │                                                                                                                            
  │         │          + optional SSD offload      │          │                                                                                                                            
  │         └─────────────────────────────────────┘          │                                                                                                                             
  │                                                         │                                                                                                                              
  └─────────────────────────────────────────────────────────┘                                                                                                                              
           │                                                                                                                                                                               
           │ RDMA / TCP                                                                                                                                                                    
           ▼                                                                                                                                                                               
  ┌─────────────────┐                                                                                                                                                                      
  │ Master Server   │                                                                                                                                           
  └─────────────────┘     
```


This PR introduces GPU IPC same-node transfer optimization for Mooncake Store, solving the problem that GPU↔CPU data transfers between co-located processes incur unnecessary latency and bandwidth penalties when routed through RDMA NIC loopback — when source and destination reside on the same physical node, data that would otherwise traverse a round-trip through the RDMA network card can instead perform a single-hop DMA via `cudaIpcMemHandle` over PCIe, significantly reducing latency and improving throughput.

To achieve this, the PR makes changes at three layers: the TENT transfer engine layer, the Store client service layer, and the RPC type layer. At the TENT layer, a new `findLocalGpuBuffer` API is added, supporting lookup of locally registered GPU buffer IPC handles, base addresses, and lengths via `SegmentTracker` (TENT mode) or `TransferMetadata` (non-TENT mode); metadata key prefix migration is handled with a default of `mooncake/ram/` and fallback to legacy `mooncake/tent/`, overridable via the `MC_METADATA_KEY_PREFIX` environment variable. At the Store layer, the PUT path (`SubmitTransfers`) detects GPU sources with local replicas and constructs a `GpuIpcTransferRequest`, sending each slice's GPU offset, CPU destination address, and size via async RPC to the process's own offload RPC server; the GET path (`batch_get_into_internal`) similarly detects device-pointer destinations with local replicas and initiates a reverse H2D transfer via `SubmitGpuIpcPush`. Both paths share a single `gpu_ipc_transfer` RPC handler that maintains an IPC handle cache (avoiding repeated `cudaIpcOpenMemHandle` calls), uses `ScopedGpuStream` to serialize all slices onto a single stream with `cudaMemcpyAsync`, performs a unified `stream.sync()` at the end, and marks all slices as failed upon sync failure.

The implementation relies on two new RPC structs, `GpuIpcTransferRequest` and `GpuIpcTransferResponse`, serialized via `YLT_REFL`; `GpuIpcOperationState` (inheriting from `OperationState`) wraps `async_simple::coro::Lazy` to achieve truly asynchronous waiting — RPC submission is non-blocking, with synchronous completion deferred to `TransferFuture::wait()` via `syncAwait`. GPU buffer information is queried through `FindLocalGpuBufferInfo` and cached (keyed by `base_addr`) to reduce redundant CUDA driver API calls; on buffer unregistration, `invalidateGpuBufferCache` clears local cache entries and `notifyReleaseGpuIpcHandle` notifies all peers to release their cached IPC handles. Additionally, the PR introduces the `MOONCAKE_ENABLE_GPU_IPC_PULL` environment variable as a configuration fallback, and performs port stripping in `IsReplicaOnLocalMemory` to correctly match service instances on the same machine with different ports.

```
═══════════════════════════════════════════════════════════════════════                                                                                                                  
    PUT Path  (GPU KV Cache → Owner CPU Memory,  DEVICE_TO_HOST)                          
  ═══════════════════════════════════════════════════════════════════════                                                                                                                  
                                                                                                                                                                                           
    Same Node                                                                                                                                                                              
    ┌──────────────────────────────────────────────────────────────────┐                                                                                                                   
    │                                                                  │                                                                                                                   
    │  vLLM Worker Process              Owner Process                  │
    │  ┌────────────────────┐          ┌────────────────────────┐     │                                                                                                                    
    │  │ GPU 0              │          │ CPU Memory             │     │                                                                                                                    
    │  │ ┌────────────────┐ │          │ ┌────────────────────┐ │     │                                                                                                                    
    │  │ │  KV Cache      │ │          │ │                    │ │     │                                                                                                                    
    │  │ │  (cudaMalloc)  │ │          │ │   (owned by        │ │     │                                                                                                                    
    │  │ └───────┬────────┘ │          │ │    Owner)          │ │     │                                                                                                                    
    │  │         │          │          │ └────────────────────┘ │     │                                                                                                                    
    │  │  cudaIpcGet        │          │                        │     │                                                                                                                    
    │  │  MemHandle()       │          │                        │     │                                                                                                                    
    │  │         │          │          │                        │     │                                                                                                                    
    │  │    ┌────▼────┐     │          │                        │     │                                                                                                                    
    │  │    │ handle  │     │          │                        │     │                                                                                                                    
    │  │    │ (64 B)  │     │          │                        │     │                                                                                                                    
    │  │    └────┬────┘     │          │                        │     │                                                                                                                    
    │  └─────────┼──────────┘          └────────────────────────┘     │                                                                                                                    
    │            │                                                    │                                                                                                                    
    │            │  ① RPC (async, via 127.0.0.1)                     │                                                                                                                     
    │            │  handle + gpu_offset + cpu_addr + size             │                                                                                                                    
    │            ├───────────────────────────────────────────────────→ │                                                                                                                   
    │            │                                                    │                                                                                                                    
    │            │          ┌─────────────────────────────────────┐   │                                                                                                                    
    │            │          │ cudaIpcOpenMemHandle(handle)        │   │                                                                                                                    
    │            │          │ → gpu_va (cross-process GPU ptr)    │   │                                                                                                                    
    │            │          └──────────────┬──────────────────────┘   │                                                                                                                    
    │            │                         │                          │                                                                                                                    
    │            │          ┌──────────────▼──────────────────────┐   │                                                                                                                    
    │            │          │ cudaMemcpyAsync(                    │   │                                                                                                                    
    │            │          │   dst = cpu_addr,                   │   │                                                                                                                    
    │            │          │   src = gpu_va + offset,            │   │                                                                                                                    
    │            │          │   kind = DeviceToHost,              │   │                                                                                                                    
    │            │          │   stream = scoped_stream            │   │                                                                                                                    
    │            │          │ )                                   │   │                                                                                                                    
    │            │          └──────────────┬──────────────────────┘   │                                                                                                                    
    │            │                         │                          │                                                                                                                    
    │  ┌─────────▼──────────┐             │                          │                                                                                                                     
    │  │ GPU 0              │  ② DMA      │                          │
    │  │ ┌────────────────┐ │ ───────────→│                          │                                                                                                                     
    │  │ │  KV Cache      │ │  PCIe       │                          │                                                                                                                     
    │  │ └────────────────┘ │  transfer   ▼                          │                                                                                                                     
    │  └────────────────────┘         ┌────────────────────────┐     │                                                                                                                     
    │                                 │ CPU Memory             │     │
    │                                 │ ┌────────────────────┐ │     │
    │                                 │ │  KV Cache (copy)   │ │     │                                                                                                                     
    │                                 │ └────────────────────┘ │     │
    │                                 └────────────────────────┘     │                                                                                                                     
    │            │                         │                          │                                                                                                                    
    │            │          ┌──────────────▼──────────────────────┐   │                                                                                                                    
    │            │          │ cudaStreamSynchronize(stream)       │   │                                                                                                                    
    │            │          └──────────────┬──────────────────────┘   │                                                                                                                    
    │            │                         │                          │                                                                                                                    
    │            │  ③ RPC Response         │                          │                                                                                                                    
    │            │←────────────────────────┤                          │                                                                                                                    
    │            │  (status: OK / FAIL)    │                          │                                                                                                                    
    │                                                                  │
    └──────────────────────────────────────────────────────────────────┘


 ═══════════════════════════════════════════════════════════════════════                                                                                                                  
    GET Path  (Owner CPU Memory → GPU KV Cache,  HOST_TO_DEVICE)                                                                                                                           
  ═══════════════════════════════════════════════════════════════════════                                                                                                                  
                                                                                                                                                                                           
    Same Node                                                                                                                                                                              
    ┌──────────────────────────────────────────────────────────────────┐                                                                                                                   
    │                                                                  │
    │  vLLM Worker Process              Owner Process                  │
    │  ┌────────────────────┐          ┌────────────────────────┐     │                                                                                                                    
    │  │ GPU 0              │          │ CPU Memory             │     │                                                                                                                    
    │  │ ┌────────────────┐ │          │ ┌────────────────────┐ │     │                                                                                                                    
    │  │ │  KV Cache      │ │          │ │  KV Cache (saved)  │ │     │                                                                                                                    
    │  │ │  (cudaMalloc)  │ │          │ │                    │ │     │                                                                                                                    
    │  │ └───────┬────────┘ │          │ └────────────────────┘ │     │
    │  │         │          │          │                        │     │
    │  │  cudaIpcGet        │          │                        │     │                                                                                                                    
    │  │  MemHandle()       │          │                        │     │                                                                                                                    
    │  │         │          │          │                        │     │                                                                                                                    
    │  │    ┌────▼────┐     │          │                        │     │                                                                                                                    
    │  │    │ handle  │     │          │                        │     │                                                                                                                    
    │  │    │ (64 B)  │     │          │                        │     │                                                                                                                    
    │  │    └────┬────┘     │          │                        │     │                                                                                                                    
    │  └─────────┼──────────┘          └────────────────────────┘     │                                                                                                                    
    │            │                                                    │                                                                                                                    
    │            │  ① RPC (async, via 127.0.0.1)                     │                                                                                                                     
    │            │  handle + gpu_offset + cpu_addr + size + key       │                                                                                                                    
    │            ├───────────────────────────────────────────────────→ │                                                                                                                   
    │            │                                                    │                                                                                                                    
    │            │          ┌─────────────────────────────────────┐   │                                                                                                                    
    │            │          │ cudaIpcOpenMemHandle(handle)        │   │                                                                                                                    
    │            │          │ → gpu_va (cross-process GPU ptr)    │   │                                                                                                                    
    │            │          └──────────────┬──────────────────────┘   │                                                                                                                    
    │            │                         │                          │                                                                                                                    
    │            │          ┌──────────────▼──────────────────────┐   │                                                                                                                    
    │            │          │ cudaMemcpyAsync(                    │   │                                                                                                                    
    │            │          │   dst = gpu_va + offset,            │   │                                                                                                                    
    │            │          │   src = cpu_addr,                   │   │                                                                                                                    
    │            │          │   kind = HostToDevice,              │   │                                                                                                                    
    │            │          │   stream = scoped_stream            │   │                                                                                                                    
    │            │          │ )                                   │   │                                                                                                                    
    │            │          └──────────────┬──────────────────────┘   │                                                                                                                    
    │            │                         │                          │                                                                                                                    
    │  ┌─────────▼──────────┐             │                          │                                                                                                                     
    │  │ GPU 0              │  ② DMA      │                          │                                                                                                                     
    │  │ ┌────────────────┐ │ ←───────────│                          │                                                                                                                     
    │  │ │  KV Cache      │ │  PCIe       │                          │                                                                                                                     
    │  │ │  (restored)    │ │  transfer   │                          │                                                                                                                     
    │  │ └────────────────┘ │             │                          │                                                                                                                     
    │  └────────────────────┘         ┌────────────────────────┐     │                                                                                                                     
    │                                 │ CPU Memory             │     │                                                                                                                     
    │                                 │ ┌────────────────────┐ │     │                                                                                                                     
    │                                 │ │  KV Cache (source) │ │     │                                                                                                                     
    │                                 │ └────────────────────┘ │     │                                                                                                                     
    │                                 └────────────────────────┘     │                                                                                                                     
    │            │                         │                          │                                                                                                                    
    │            │          ┌──────────────▼──────────────────────┐   │                                                                                                                    
    │            │          │ cudaStreamSynchronize(stream)       │   │                                                                                                                    
    │            │          └──────────────┬──────────────────────┘   │                                                                                                                    
    │            │                         │                          │                                                                                                                    
    │            │  ③ RPC Response         │                          │                                                                                                                    
    │            │←────────────────────────┤                          │                                                                                                                    
    │            │  (status: OK / FAIL)    │                          │                                                                                                                    
    │                                                                  │                                                                                                                   
    └──────────────────────────────────────────────────────────────────┘     
                              
```

### Usage

1. Mooncake Build
```shell
cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_TENT=ON -DUSE_CUDA=ON
```

2. Env
```shell
export MOONCAKE_ENABLE_GPU_IPC_PULL=true
```


**How It Works (Automatic):**

Once enabled, GPU IPC is **transparent to the application** — no API changes needed.

```
PUT path (GPU→CPU, D2H):
  vLLM calls batch_put_from_multi_buffers(gpu_ptr, ...)
    → mooncake detects: source is GPU pointer + replica is local
    → routes through gpu_ipc_transfer (D2H) via cudaMemcpyAsync
    → falls back to RDMA automatically if IPC fails

GET path (CPU→GPU, H2D):
  vLLM calls batch_get_into(gpu_ptr, ...)
    → mooncake detects: destination is GPU pointer + replica is local
    → routes through gpu_ipc_transfer (H2D) via cudaMemcpyAsync
    → falls back to RDMA automatically if IPC fails
```

**Troubleshooting:**

| Symptom | Cause | Fix |
|---------|-------|-----|
| GPU IPC not activating (still using RDMA) | `MC_USE_TENT=1` not set | Set environment variable |
| GPU IPC not activating | NVLink transport not installed | Ensure compile-time macro + `MC_INTRANODE_NVLINK=1` |
| GPU IPC not activating | `enable_gpu_ipc_pull` not in config | Add to JSON config or set `MOONCAKE_ENABLE_GPU_IPC_PULL=1` |
| GPU IPC not activating | Cross-node transfer | Expected — GPU IPC is same-node only |
| `FindLocalGpuBufferInfo` returns empty | No GPU buffer registered or no IPC handle | Verify `register_buffer` was called with a GPU pointer |
| Handler `stream sync failed` | GPU error during async copy | Check `nvidia-smi` for GPU health; fallback to sync copy is automatic |
| `cudaMemcpyAsync` no faster than sync | CPU segment not CUDA-pinned | Expected with `ibv_reg_mr`; no harm, just no async benefit |
