### PR TITLE
[Store] Optimize batch_put with BatchGetWriteRoute RPC

### DIFF
--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -143,6 +143,9 @@ class MasterMetricManager {
     void inc_batch_remove_replica_requests(int64_t items);
     void inc_batch_remove_replica_failures(int64_t failed_items);
     void inc_batch_remove_replica_partial_success(int64_t failed_items);
+    void inc_batch_get_write_route_requests(int64_t items);
+    void inc_batch_get_write_route_failures(int64_t failed_items);
+    void inc_batch_get_write_route_partial_success(int64_t failed_items);
 
     // Operation Statistics Getters
     int64_t get_put_start_requests();
@@ -219,6 +222,9 @@ class MasterMetricManager {
     int64_t get_batch_remove_replica_partial_successes();
     int64_t get_batch_remove_replica_items();
     int64_t get_batch_remove_replica_failed_items();
+    int64_t get_batch_get_write_route_requests();
+    int64_t get_batch_get_write_route_failures();
+    int64_t get_batch_get_write_route_partial_successes();
 
     // Eviction Metrics
     void inc_eviction_success(int64_t key_count, int64_t size);
@@ -361,6 +367,9 @@ class MasterMetricManager {
     ylt::metric::counter_t batch_remove_replica_partial_successes_;
     ylt::metric::counter_t batch_remove_replica_items_;
     ylt::metric::counter_t batch_remove_replica_failed_items_;
+    ylt::metric::counter_t batch_get_write_route_requests_;
+    ylt::metric::counter_t batch_get_write_route_failures_;
+    ylt::metric::counter_t batch_get_write_route_partial_successes_;
 
     // cache hit Statistics
     ylt::metric::counter_t mem_cache_hit_nums_;

--- a/mooncake-store/include/p2p_client_service.h
+++ b/mooncake-store/include/p2p_client_service.h
@@ -280,9 +280,23 @@ class P2PClientService final : public ClientService {
         std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise);
 
    private:
+    // Fetch write routes for all keys in one master RPC.
+    tl::expected<BatchGetWriteRouteResponse, ErrorCode> BatchFetchWriteRoutes(
+        const std::vector<ObjectKey>& keys,
+        const std::vector<std::vector<Slice>>& batched_slices,
+        const WriteRouteRequestConfig& config);
+
     tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode> CreatePutHandle(
         const std::string& key, std::vector<Slice>& slices,
         const WriteRouteRequestConfig& config);
+
+    tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
+    CreateLocalPutHandle(const std::string& key, std::vector<Slice>& slices);
+
+    tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
+    InnerCreatePutHandle(const std::string& key, std::vector<Slice>& slices,
+                         const WriteRouteRequestConfig& config,
+                         std::vector<WriteCandidate> candidates);
 
     tl::expected<ReadTaskHandle, ErrorCode> CreateGetHandle(
         const std::string& key,

--- a/mooncake-store/include/p2p_master_client.h
+++ b/mooncake-store/include/p2p_master_client.h
@@ -24,6 +24,12 @@ class P2PMasterClient final : public MasterClient {
         const WriteRouteRequest& req);
 
     /**
+     * @brief Batch gets write candidate routes for multiple keys in one RPC
+     */
+    [[nodiscard]] tl::expected<BatchGetWriteRouteResponse, ErrorCode>
+    BatchGetWriteRoute(const BatchGetWriteRouteRequest& req);
+
+    /**
      * @brief Adds a replica to master
      */
     [[nodiscard]] tl::expected<void, ErrorCode> AddReplica(

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -23,6 +23,13 @@ class P2PMasterService : public MasterService {
         -> tl::expected<WriteRouteResponse, ErrorCode>;
 
     /**
+     * @brief Batch get write routes for multiple keys.
+     *        Reuses GetWriteRoute logic per key.
+     */
+    auto BatchGetWriteRoute(const BatchGetWriteRouteRequest& req)
+        -> BatchGetWriteRouteResponse;
+
+    /**
      * @brief Add a route replica to master
      */
     auto AddReplica(const AddReplicaRequest& req)

--- a/mooncake-store/include/p2p_rpc_service.h
+++ b/mooncake-store/include/p2p_rpc_service.h
@@ -18,6 +18,9 @@ class WrappedP2PMasterService final : public WrappedMasterService {
     tl::expected<WriteRouteResponse, ErrorCode> GetWriteRoute(
         const WriteRouteRequest& req);
 
+    BatchGetWriteRouteResponse BatchGetWriteRoute(
+        const BatchGetWriteRouteRequest& req);
+
     tl::expected<void, ErrorCode> AddReplica(const AddReplicaRequest& req);
 
     tl::expected<void, ErrorCode> RemoveReplica(

--- a/mooncake-store/include/p2p_rpc_types.h
+++ b/mooncake-store/include/p2p_rpc_types.h
@@ -72,6 +72,27 @@ struct WriteRouteResponse {
 YLT_REFL(WriteRouteResponse, candidates);
 
 /**
+ * @brief Request for batch write route lookup.
+ */
+struct BatchGetWriteRouteRequest {
+    UUID client_id;
+    std::vector<std::string> keys;
+    std::vector<size_t> sizes;
+    WriteRouteRequestConfig config;  // shared config for all keys
+};
+YLT_REFL(BatchGetWriteRouteRequest, client_id, keys, sizes, config);
+
+/**
+ * @brief Response for batch write route lookup.
+ *        responses[i] and error_codes[i] correspond to keys[i] in the request.
+ */
+struct BatchGetWriteRouteResponse {
+    std::vector<WriteRouteResponse> responses;  // valid when error_codes[i]==OK
+    std::vector<ErrorCode> error_codes;
+};
+YLT_REFL(BatchGetWriteRouteResponse, responses, error_codes);
+
+/**
  * @brief Request to add a replica.
  *        Master resolves ip_address/rpc_port from registered client info.
  */

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -1007,7 +1007,7 @@ tl::expected<void, ErrorCode> DataManager::WaitTransferBatch(
 // poll until all tasks reach a terminal state before calling freeBatchID.
 void DataManager::CancelBatchTETask(Transport::BatchID batch_id,
                                     size_t num_tasks) {
-    constexpr int64_t kDrainTimeoutSeconds = 30;
+    constexpr int64_t kDrainTimeoutSeconds = 10;
     auto start = std::chrono::steady_clock::now();
     while (true) {
         bool all_finished = true;

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -247,6 +247,15 @@ MasterMetricManager::MasterMetricManager()
       batch_remove_replica_failed_items_(
           "master_batch_remove_replica_failed_items_total",
           "Total number of failed items in BatchRemoveReplica requests"),
+      batch_get_write_route_requests_(
+          "master_batch_get_write_route_requests_total",
+          "Total number of BatchGetWriteRoute requests received"),
+      batch_get_write_route_failures_(
+          "master_batch_get_write_route_failures_total",
+          "Total number of failed BatchGetWriteRoute requests"),
+      batch_get_write_route_partial_successes_(
+          "master_batch_get_write_route_partial_successes_total",
+          "Total number of partially successful BatchGetWriteRoute requests"),
 
       // Initialize cache hit rate metrics
       mem_cache_hit_nums_("mem_cache_hit_nums_",
@@ -378,6 +387,9 @@ void MasterMetricManager::update_metrics_for_zero_output() {
     batch_remove_replica_partial_successes_.inc(0);
     batch_remove_replica_items_.inc(0);
     batch_remove_replica_failed_items_.inc(0);
+    batch_get_write_route_requests_.inc(0);
+    batch_get_write_route_failures_.inc(0);
+    batch_get_write_route_partial_successes_.inc(0);
 
     // Update cache hit rate metrics
     mem_cache_hit_nums_.inc(0);
@@ -772,6 +784,20 @@ void MasterMetricManager::inc_batch_remove_replica_partial_success(
     batch_remove_replica_partial_successes_.inc(1);
     batch_remove_replica_failed_items_.inc(failed_items);
 }
+void MasterMetricManager::inc_batch_get_write_route_requests(int64_t items) {
+    batch_get_write_route_requests_.inc(1);
+    (void)items;
+}
+void MasterMetricManager::inc_batch_get_write_route_failures(
+    int64_t failed_items) {
+    batch_get_write_route_failures_.inc(1);
+    (void)failed_items;
+}
+void MasterMetricManager::inc_batch_get_write_route_partial_success(
+    int64_t failed_items) {
+    batch_get_write_route_partial_successes_.inc(1);
+    (void)failed_items;
+}
 
 // PutStart Discard Metrics
 void MasterMetricManager::inc_put_start_discard_cnt(int64_t count,
@@ -1069,6 +1095,18 @@ int64_t MasterMetricManager::get_batch_remove_replica_failed_items() {
     return batch_remove_replica_failed_items_.value();
 }
 
+int64_t MasterMetricManager::get_batch_get_write_route_requests() {
+    return batch_get_write_route_requests_.value();
+}
+
+int64_t MasterMetricManager::get_batch_get_write_route_failures() {
+    return batch_get_write_route_failures_.value();
+}
+
+int64_t MasterMetricManager::get_batch_get_write_route_partial_successes() {
+    return batch_get_write_route_partial_successes_.value();
+}
+
 // Eviction Metrics
 void MasterMetricManager::inc_eviction_success(int64_t key_count,
                                                int64_t size) {
@@ -1194,6 +1232,9 @@ std::string MasterMetricManager::serialize_metrics() {
     serialize_metric(batch_remove_replica_partial_successes_);
     serialize_metric(batch_remove_replica_items_);
     serialize_metric(batch_remove_replica_failed_items_);
+    serialize_metric(batch_get_write_route_requests_);
+    serialize_metric(batch_get_write_route_failures_);
+    serialize_metric(batch_get_write_route_partial_successes_);
 
     // Serialize Eviction Counters
     serialize_metric(eviction_success_);

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -1508,12 +1508,15 @@ std::string MasterMetricManager::get_summary_string() {
        << batch_remove_replica_items << "), ";
 
     // Eviction summary
-    ss << " | Eviction: " << "Success/Attempts=" << eviction_success << "/"
-       << eviction_attempts << ", " << "keys=" << evicted_key_count << ", "
+    ss << " | Eviction: "
+       << "Success/Attempts=" << eviction_success << "/" << eviction_attempts
+       << ", "
+       << "keys=" << evicted_key_count << ", "
        << "size=" << byte_size_to_string(evicted_size);
 
     // Discard summary
-    ss << " | Discard: " << "Released/Total=" << put_start_release_cnt << "/"
+    ss << " | Discard: "
+       << "Released/Total=" << put_start_release_cnt << "/"
        << put_start_discard_cnt << ", StagingSize="
        << byte_size_to_string(put_start_discarded_staging_size);
 

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -667,18 +667,26 @@ P2PClientService::CreatePutHandle(const std::string& key,
         return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
     }
 
-    // 2. Try all local candidates synchronously
+    // 2. Generate a retry list based on the recommended order of master.
+    // If there is a local candidate among them, generate a local task handle.
     std::vector<P2PProxyDescriptor> remote_proxies;
     for (size_t i = 0; i < candidates.size(); ++i) {
         auto& proxy = candidates[i].replica;
 
         if (proxy.client_id == client_id_) {
+            // Defensive check: master should not return local candidates when
+            // allow_local=false, but if it does, just skip it.
+            if (!config.allow_local) {
+                LOG(WARNING) << "Master returned local candidate but "
+                                "allow_local=false, skipping";
+                continue;
+            }
             if (data_manager_.has_value()) {
                 auto local_handle = data_manager_->Put(key, slices);
                 if (local_handle) {
                     return std::move(local_handle.value());
                 } else if (IsAlreadyExistsError(local_handle.error())) {
-                    // The key is already exists. Currently, we think this is a
+                    // The key already exists. Currently, we think this is a
                     // normal case, just ignore the error and return success.
                     return ImmediateHandle<void>::Create();
                 } else {

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -545,16 +545,43 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::BatchPut(
         return results;
     }
 
-    // Phase 1: create handles for all keys (remote writes are in-flight).
     std::vector<tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>>
         handles;
     handles.reserve(keys.size());
-    for (size_t i = 0; i < keys.size(); ++i) {
-        handles.push_back(
-            CreatePutHandle(keys[i], batched_slices[i], *route_config));
+
+    if (ha_manager_ && ha_manager_->IsDegraded()) {
+        // DEGRADED: skip master RPC, write locally for each key.
+        for (size_t i = 0; i < keys.size(); ++i) {
+            handles.push_back(CreateLocalPutHandle(keys[i], batched_slices[i]));
+        }
+    } else {
+        // Phase 1: single RPC to fetch all routes.
+        auto batch_route_result =
+            BatchFetchWriteRoutes(keys, batched_slices, *route_config);
+        if (!batch_route_result) {
+            LOG(ERROR) << "BatchGetWriteRoute RPC failed: "
+                       << batch_route_result.error();
+            std::fill(results.begin(), results.end(),
+                      tl::unexpected(batch_route_result.error()));
+            timer.LogResponse("success=0 fail=", keys.size(),
+                              " error_code=", batch_route_result.error());
+            return results;
+        }
+
+        // Phase 2: per-key handle creation using pre-fetched candidates.
+        auto& batch_resp = batch_route_result.value();
+        for (size_t i = 0; i < keys.size(); ++i) {
+            if (batch_resp.error_codes[i] != ErrorCode::OK) {
+                handles.push_back(tl::unexpected(batch_resp.error_codes[i]));
+                continue;
+            }
+            handles.push_back(InnerCreatePutHandle(
+                keys[i], batched_slices[i], *route_config,
+                std::move(batch_resp.responses[i].candidates)));
+        }
     }
 
-    // Phase 2: collect results.
+    // Phase 3: collect results.
     for (size_t i = 0; i < keys.size(); ++i) {
         if (!handles[i]) {
             LOG(ERROR) << "Failed to create put handle for key: " << keys[i]
@@ -630,28 +657,43 @@ static async_simple::coro::Lazy<void> RunWriteRetry(
     }
 }
 
+tl::expected<BatchGetWriteRouteResponse, ErrorCode>
+P2PClientService::BatchFetchWriteRoutes(
+    const std::vector<ObjectKey>& keys,
+    const std::vector<std::vector<Slice>>& batched_slices,
+    const WriteRouteRequestConfig& config) {
+    BatchGetWriteRouteRequest req;
+    req.client_id = client_id_;
+    req.config = config;
+    req.keys.reserve(keys.size());
+    req.sizes.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        req.keys.push_back(keys[i]);
+        req.sizes.push_back(
+            ClientService::CalculateSliceSize(batched_slices[i]));
+    }
+    auto batch_route_result = master_client_.BatchGetWriteRoute(req);
+    if (!batch_route_result) {
+        LOG(ERROR) << "BatchGetWriteRoute RPC failed: "
+                   << batch_route_result.error();
+        return batch_route_result;
+    }
+    return batch_route_result;
+}
+
 tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
 P2PClientService::CreatePutHandle(const std::string& key,
                                   std::vector<Slice>& slices,
                                   const WriteRouteRequestConfig& config) {
     // DEGRADED: Master unreachable, only allow local writes
     if (ha_manager_ && ha_manager_->IsDegraded()) {
-        auto local_handle = data_manager_->Put(key, slices);
-        if (local_handle) {
-            return std::move(local_handle.value());
-        }
-        LOG(ERROR) << "Local write failed for key: " << key
-                   << ", error: " << local_handle.error();
-        return tl::unexpected(local_handle.error());
+        return CreateLocalPutHandle(key, slices);
     }
 
-    size_t total_size = ClientService::CalculateSliceSize(slices);
-
-    // 1. Get write route from master
     WriteRouteRequest route_req;
     route_req.key = key;
     route_req.client_id = client_id_;
-    route_req.size = total_size;
+    route_req.size = ClientService::CalculateSliceSize(slices);
     route_req.config = config;
 
     auto route_result = master_client_.GetWriteRoute(route_req);
@@ -661,13 +703,33 @@ P2PClientService::CreatePutHandle(const std::string& key,
         return tl::unexpected(route_result.error());
     }
 
-    auto& candidates = route_result.value().candidates;
+    return InnerCreatePutHandle(key, slices, config,
+                                std::move(route_result.value().candidates));
+}
+
+tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
+P2PClientService::CreateLocalPutHandle(const std::string& key,
+                                       std::vector<Slice>& slices) {
+    auto local_handle = data_manager_->Put(key, slices);
+    if (local_handle) {
+        return std::move(local_handle.value());
+    }
+    LOG(ERROR) << "Local write failed for key: " << key
+               << ", error: " << local_handle.error();
+    return tl::unexpected(local_handle.error());
+}
+
+tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
+P2PClientService::InnerCreatePutHandle(const std::string& key,
+                                       std::vector<Slice>& slices,
+                                       const WriteRouteRequestConfig& config,
+                                       std::vector<WriteCandidate> candidates) {
     if (candidates.empty()) {
         LOG(ERROR) << "No write candidates for key: " << key;
         return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
     }
 
-    // 2. Generate a retry list based on the recommended order of master.
+    // 1. Generate a retry list based on the recommended order of master.
     // If there is a local candidate among them, generate a local task handle.
     std::vector<P2PProxyDescriptor> remote_proxies;
     for (size_t i = 0; i < candidates.size(); ++i) {
@@ -700,7 +762,7 @@ P2PClientService::CreatePutHandle(const std::string& key,
         }
     }
 
-    // 3. Chain async RPCs over remote candidates via continuation
+    // 2. Chain async RPCs over remote candidates via continuation
     if (remote_proxies.empty()) {
         LOG(ERROR) << "No remote candidates for key: " << key;
         return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);

--- a/mooncake-store/src/p2p_master_client.cpp
+++ b/mooncake-store/src/p2p_master_client.cpp
@@ -11,6 +11,11 @@ struct RpcNameTraits<&WrappedP2PMasterService::GetWriteRoute> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedP2PMasterService::BatchGetWriteRoute> {
+    static constexpr const char* value = "BatchGetWriteRoute";
+};
+
+template <>
 struct RpcNameTraits<&WrappedP2PMasterService::AddReplica> {
     static constexpr const char* value = "AddReplica";
 };
@@ -43,6 +48,18 @@ tl::expected<WriteRouteResponse, ErrorCode> P2PMasterClient::GetWriteRoute(
     auto result =
         invoke_rpc<&WrappedP2PMasterService::GetWriteRoute, WriteRouteResponse>(
             req);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<BatchGetWriteRouteResponse, ErrorCode>
+P2PMasterClient::BatchGetWriteRoute(const BatchGetWriteRouteRequest& req) {
+    ScopedVLogTimer timer(1, "P2PMasterClient::BatchGetWriteRoute");
+    timer.LogRequest("key_count=", req.keys.size());
+
+    auto result =
+        invoke_rpc<&WrappedP2PMasterService::BatchGetWriteRoute,
+                   BatchGetWriteRouteResponse>(req);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/p2p_master_client.cpp
+++ b/mooncake-store/src/p2p_master_client.cpp
@@ -57,9 +57,8 @@ P2PMasterClient::BatchGetWriteRoute(const BatchGetWriteRouteRequest& req) {
     ScopedVLogTimer timer(1, "P2PMasterClient::BatchGetWriteRoute");
     timer.LogRequest("key_count=", req.keys.size());
 
-    auto result =
-        invoke_rpc<&WrappedP2PMasterService::BatchGetWriteRoute,
-                   BatchGetWriteRouteResponse>(req);
+    auto result = invoke_rpc<&WrappedP2PMasterService::BatchGetWriteRoute,
+                             BatchGetWriteRouteResponse>(req);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -142,6 +142,35 @@ auto P2PMasterService::GetWriteRoute(const WriteRouteRequest& req)
     return response;
 }
 
+auto P2PMasterService::BatchGetWriteRoute(const BatchGetWriteRouteRequest& req)
+    -> BatchGetWriteRouteResponse {
+    const size_t n = req.keys.size();
+    BatchGetWriteRouteResponse response;
+    response.responses.resize(n);
+    response.error_codes.resize(n, ErrorCode::OK);
+
+    if (req.keys.size() != req.sizes.size()) {
+        std::fill(response.error_codes.begin(), response.error_codes.end(),
+                  ErrorCode::INVALID_PARAMS);
+        return response;
+    }
+
+    WriteRouteRequest single_req;
+    single_req.client_id = req.client_id;
+    single_req.config    = req.config;
+    for (size_t i = 0; i < n; ++i) {
+        single_req.key  = req.keys[i];
+        single_req.size = req.sizes[i];
+        auto result = GetWriteRoute(single_req);
+        if (result.has_value()) {
+            response.responses[i] = std::move(*result);
+        } else {
+            response.error_codes[i] = result.error();
+        }
+    }
+    return response;
+}
+
 auto P2PMasterService::AddReplica(const AddReplicaRequest& req)
     -> tl::expected<void, ErrorCode> {
     auto accessor = GetMetadataAccessor(req.key);

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -54,7 +54,8 @@ std::vector<Replica::Descriptor> P2PMasterService::FilterReplicas(
         // 1.2 priority filter
         auto priority_opt = replica.get_p2p_priority();
         if (!priority_opt) {
-            LOG(ERROR) << "invalid priority" << ", replica: " << replica;
+            LOG(ERROR) << "invalid priority"
+                       << ", replica: " << replica;
             continue;
         }
         if (*priority_opt < p2p_config.priority_limit) continue;
@@ -98,8 +99,8 @@ auto P2PMasterService::GetWriteRoute(const WriteRouteRequest& req)
             auto& metadata = accessor->Get();
             if (metadata.replicas_.size() >= max_replicas_per_key_) {
                 LOG(WARNING)
-                    << "replica num exceeded" << ", key: " << req.key
-                    << ", client_id: " << req.client_id
+                    << "replica num exceeded"
+                    << ", key: " << req.key << ", client_id: " << req.client_id
                     << ", current replica num:" << metadata.replicas_.size()
                     << ", max replica num: " << max_replicas_per_key_;
                 return tl::make_unexpected(ErrorCode::REPLICA_NUM_EXCEEDED);
@@ -157,9 +158,9 @@ auto P2PMasterService::BatchGetWriteRoute(const BatchGetWriteRouteRequest& req)
 
     WriteRouteRequest single_req;
     single_req.client_id = req.client_id;
-    single_req.config    = req.config;
+    single_req.config = req.config;
     for (size_t i = 0; i < n; ++i) {
-        single_req.key  = req.keys[i];
+        single_req.key = req.keys[i];
         single_req.size = req.sizes[i];
         auto result = GetWriteRoute(single_req);
         if (result.has_value()) {
@@ -205,15 +206,16 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
         auto& metadata = *it->second;
         if (max_replicas_per_key_ > 0 &&
             metadata.replicas_.size() >= max_replicas_per_key_) {
-            LOG(WARNING) << "replica num exceeded" << ", key: " << key
-                         << ", client_id: " << client_id
+            LOG(WARNING) << "replica num exceeded"
+                         << ", key: " << key << ", client_id: " << client_id
                          << ", segment_id: " << segment_id
                          << ", current replica num:" << max_replicas_per_key_;
             return tl::make_unexpected(ErrorCode::REPLICA_NUM_EXCEEDED);
         }
         for (const auto& replica : metadata.replicas_) {
             if (!replica.is_p2p_proxy_replica()) {
-                LOG(ERROR) << "unexpected replica type" << ", key: " << key
+                LOG(ERROR) << "unexpected replica type"
+                           << ", key: " << key
                            << ", request client_id: " << client_id
                            << ", request segment_id: " << segment_id
                            << ", replica:" << replica;
@@ -223,8 +225,8 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
             auto cli_id = replica.get_p2p_client_id();
             if (cli_id && seg_id && cli_id == client_id &&
                 *seg_id == segment_id) {
-                LOG(WARNING) << "replica has existed" << ", key: " << key
-                             << ", client_id: " << client_id
+                LOG(WARNING) << "replica has existed"
+                             << ", key: " << key << ", client_id: " << client_id
                              << ", segment_id: " << segment_id;
                 return tl::make_unexpected(ErrorCode::REPLICA_ALREADY_EXISTS);
             }
@@ -258,8 +260,8 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerRemoveReplica(
     const UUID& segment_id) {
     auto it = shard.metadata.find(key);
     if (it == shard.metadata.end()) {
-        LOG(WARNING) << "object not found" << ", key: " << key
-                     << ", client_id: " << client_id
+        LOG(WARNING) << "object not found"
+                     << ", key: " << key << ", client_id: " << client_id
                      << ", segment_id: " << segment_id;
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -268,8 +270,8 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerRemoveReplica(
     for (auto rit = metadata.replicas_.begin(); rit != metadata.replicas_.end();
          ++rit) {
         if (!rit->is_p2p_proxy_replica()) {
-            LOG(ERROR) << "unexpected replica type" << ", key: " << key
-                       << ", client_id: " << client_id
+            LOG(ERROR) << "unexpected replica type"
+                       << ", key: " << key << ", client_id: " << client_id
                        << ", segment_id: " << segment_id
                        << ", replica: " << *rit;
             return tl::make_unexpected(ErrorCode::INVALID_REPLICA);
@@ -288,8 +290,8 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerRemoveReplica(
         }
     }
 
-    LOG(WARNING) << "replica not found" << ", key: " << key
-                 << ", client_id: " << client_id
+    LOG(WARNING) << "replica not found"
+                 << ", key: " << key << ", client_id: " << client_id
                  << ", segment_id: " << segment_id;
     return tl::make_unexpected(ErrorCode::REPLICA_NOT_FOUND);
 }
@@ -321,7 +323,8 @@ auto P2PMasterService::BatchRemoveReplica(const BatchRemoveReplicaRequest& req)
                           << ", segment_id: " << segment_id;
                 results.push_back({});
             } else {
-                LOG(ERROR) << "failed to remove replica" << ", key: " << req.key
+                LOG(ERROR) << "failed to remove replica"
+                           << ", key: " << req.key
                            << ", client_id: " << req.client_id
                            << ", segment_id: " << segment_id
                            << ", error: " << toString(result.error());

--- a/mooncake-store/src/p2p_rpc_service.cpp
+++ b/mooncake-store/src/p2p_rpc_service.cpp
@@ -53,8 +53,7 @@ BatchGetWriteRouteResponse WrappedP2PMasterService::BatchGetWriteRoute(
     for (size_t i = 0; i < response.error_codes.size(); ++i) {
         if (response.error_codes[i] != ErrorCode::OK) {
             failure_count++;
-            LOG(ERROR) << "BatchGetWriteRoute failed for key '"
-                       << req.keys[i]
+            LOG(ERROR) << "BatchGetWriteRoute failed for key '" << req.keys[i]
                        << "': " << toString(response.error_codes[i]);
         }
     }

--- a/mooncake-store/src/p2p_rpc_service.cpp
+++ b/mooncake-store/src/p2p_rpc_service.cpp
@@ -13,6 +13,9 @@ void RegisterP2PRpcService(
     RegisterRpcService(server, wrapped_master_service);
     server.register_handler<&mooncake::WrappedP2PMasterService::GetWriteRoute>(
         &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedP2PMasterService::BatchGetWriteRoute>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedP2PMasterService::AddReplica>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedP2PMasterService::RemoveReplica>(
@@ -35,6 +38,36 @@ WrappedP2PMasterService::GetWriteRoute(const WriteRouteRequest& req) {
         [&](auto& timer) { timer.LogRequest("key=", req.key); },
         [] { MasterMetricManager::instance().inc_get_write_route_requests(); },
         [] { MasterMetricManager::instance().inc_get_write_route_failures(); });
+}
+
+BatchGetWriteRouteResponse WrappedP2PMasterService::BatchGetWriteRoute(
+    const BatchGetWriteRouteRequest& req) {
+    ScopedVLogTimer timer(1, "BatchGetWriteRoute");
+    const size_t total = req.keys.size();
+    timer.LogRequest("client_id=", req.client_id, ", key_count=", total);
+    MasterMetricManager::instance().inc_batch_get_write_route_requests(total);
+
+    auto response = master_service_.BatchGetWriteRoute(req);
+
+    size_t failure_count = 0;
+    for (size_t i = 0; i < response.error_codes.size(); ++i) {
+        if (response.error_codes[i] != ErrorCode::OK) {
+            failure_count++;
+            LOG(ERROR) << "BatchGetWriteRoute failed for key '"
+                       << req.keys[i]
+                       << "': " << toString(response.error_codes[i]);
+        }
+    }
+    if (failure_count == total && total > 0) {
+        MasterMetricManager::instance().inc_batch_get_write_route_failures(
+            failure_count);
+    } else if (failure_count != 0) {
+        MasterMetricManager::instance()
+            .inc_batch_get_write_route_partial_success(failure_count);
+    }
+    timer.LogResponse("total=", total, ", success=", total - failure_count,
+                      ", failures=", failure_count);
+    return response;
 }
 
 tl::expected<void, ErrorCode> WrappedP2PMasterService::AddReplica(


### PR DESCRIPTION
## Description
1. Fix local write route bug. In the past code, when write candidates includes local route, the client will directly choose this route to write. However, this might not match to the write config.
2. aggregate write route requests in a batch rpc rather than multiply call single rpc

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
