### PR TITLE
[transfer_engine] fix: drain endpoint waiting list via periodic reclaim

### DIFF
--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -75,6 +75,8 @@ If a connection fails due to link errors, it is removed from the
 endpoint pools on both sides and re-established during the
 next data transfer attempt.
 
+Evicted and deleted endpoints are moved to an internal `waiting_list_` and reclaimed asynchronously once their outstanding slices drain. Reclaim runs on every new endpoint insertion, and additionally on a ~1 Hz heartbeat from the per-context `monitorWorker`, so the waiting list drains even under failure load where new insertions stall while evictions continue.
+
 ### Fault Handling
 In a multi-NIC environment, one common failure scenario is the temporary unavailability of a specific NIC, while other routes may still connect two nodes.
 Mooncake Store is designed to adeptly manage such temporary

--- a/docs/source/troubleshooting/troubleshooting.md
+++ b/docs/source/troubleshooting/troubleshooting.md
@@ -110,9 +110,10 @@ Errors in this part usually indicate that the error occurred within the `mooncak
      *    hard    memlock    unlimited
      ```
 
-7. If the error `Failed to create QP: Cannot allocate memory` is displayed, it is typically caused by too many QP have been created, reaching the driver limit. You can use `rdma resource` to trace how many QP is created. One possible way to resolve this issue:
+7. If the error `Failed to create QP: Cannot allocate memory` is displayed, it is typically caused by too many QP have been created, reaching the driver limit. You can use `rdma resource` to trace how many QP is created. Possible ways to resolve this issue:
    - Update Mooncake to version v0.3.5 or later
    - Set the environment variable `MC_ENABLE_DEST_DEVICE_AFFINITY=1` before starting the application
+   - If the leak persists under sustained peer failures (many `endpoint evicted` log lines accompanying the QP growth), update to a version that includes the fix for [issue #1845](https://github.com/kvcache-ai/Mooncake/issues/1845). Prior to that fix, the endpoint store's `waiting_list_` only drained when new endpoints were inserted, so evictions under failure load accumulated QPs until the driver limit was hit. The fix adds a periodic reclaim tick to `monitorWorker`.
 
 ## RDMA Transfer Period
 ### Recommended Troubleshooting Directions

--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -86,7 +86,7 @@ class FIFOEndpointStore : public EndpointStore {
     std::list<std::string> fifo_list_;
 
     std::unordered_set<std::shared_ptr<RdmaEndPoint>> waiting_list_;
-    std::atomic<int> waiting_list_len_;
+    std::atomic<size_t> waiting_list_len_;
 
     size_t max_size_;
 };
@@ -129,7 +129,7 @@ class SIEVEEndpointStore : public EndpointStore {
     std::optional<std::list<std::string>::iterator> hand_;
 
     std::unordered_set<std::shared_ptr<RdmaEndPoint>> waiting_list_;
-    std::atomic<int> waiting_list_len_;
+    std::atomic<size_t> waiting_list_len_;
 
     size_t max_size_;
 };

--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -50,6 +50,10 @@ class EndpointStore {
 
     // Get the total number of QPs across all endpoints
     virtual size_t getTotalQPNumber() = 0;
+
+    // Number of endpoints awaiting reclaim (evicted or explicitly deleted but
+    // not yet destructed). Exposed for tests and for operator observability.
+    virtual size_t waitingListSize() const = 0;
 };
 
 // FIFO
@@ -69,6 +73,7 @@ class FIFOEndpointStore : public EndpointStore {
     int disconnectQPs() override;
 
     size_t getTotalQPNumber() override;
+    size_t waitingListSize() const override { return waiting_list_.size(); }
 
    private:
     RWSpinlock endpoint_map_lock_;
@@ -100,6 +105,13 @@ class SIEVEEndpointStore : public EndpointStore {
     int disconnectQPs() override;
 
     size_t getTotalQPNumber() override;
+    size_t waitingListSize() const override {
+        return waiting_list_len_.load(std::memory_order_relaxed);
+    }
+
+    // Test-only: push a pre-constructed endpoint into waiting_list_ so reclaim
+    // logic can be exercised without standing up an RDMA device.
+    void testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> ep);
 
    private:
     RWSpinlock endpoint_map_lock_;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -56,6 +56,10 @@ class EndpointStore {
     // Number of endpoints awaiting reclaim (evicted or explicitly deleted but
     // not yet destructed). Exposed for tests and for operator observability.
     virtual size_t waitingListSize() const = 0;
+
+    // Test-only: push a pre-constructed endpoint into waiting_list_ so reclaim
+    // logic can be exercised without standing up an RDMA device.
+    virtual void testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> ep) = 0;
 };
 
 // FIFO
@@ -79,6 +83,8 @@ class FIFOEndpointStore : public EndpointStore {
     size_t waitingListSize() const override {
         return waiting_list_len_.load(std::memory_order_relaxed);
     }
+
+    void testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> ep) override;
 
    private:
     RWSpinlock endpoint_map_lock_;
@@ -115,9 +121,7 @@ class SIEVEEndpointStore : public EndpointStore {
         return waiting_list_len_.load(std::memory_order_relaxed);
     }
 
-    // Test-only: push a pre-constructed endpoint into waiting_list_ so reclaim
-    // logic can be exercised without standing up an RDMA device.
-    void testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> ep);
+    void testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> ep) override;
 
    private:
     RWSpinlock endpoint_map_lock_;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -42,6 +42,8 @@ class EndpointStore {
         const std::string &peer_nic_path, RdmaContext *context) = 0;
     virtual int deleteEndpoint(const std::string &peer_nic_path) = 0;
     virtual void evictEndpoint() = 0;
+    // Takes endpoint_map_lock_; caller must not hold it (RWSpinlock is
+    // non-reentrant, so recursive acquisition deadlocks).
     virtual void reclaimEndpoint() = 0;
     virtual size_t getSize() = 0;
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -59,7 +59,8 @@ class EndpointStore {
 // FIFO
 class FIFOEndpointStore : public EndpointStore {
    public:
-    FIFOEndpointStore(size_t max_size) : max_size_(max_size) {}
+    FIFOEndpointStore(size_t max_size)
+        : waiting_list_len_(0), max_size_(max_size) {}
     std::shared_ptr<RdmaEndPoint> getEndpoint(
         const std::string &peer_nic_path) override;
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
@@ -73,7 +74,9 @@ class FIFOEndpointStore : public EndpointStore {
     int disconnectQPs() override;
 
     size_t getTotalQPNumber() override;
-    size_t waitingListSize() const override { return waiting_list_.size(); }
+    size_t waitingListSize() const override {
+        return waiting_list_len_.load(std::memory_order_relaxed);
+    }
 
    private:
     RWSpinlock endpoint_map_lock_;
@@ -83,6 +86,7 @@ class FIFOEndpointStore : public EndpointStore {
     std::list<std::string> fifo_list_;
 
     std::unordered_set<std::shared_ptr<RdmaEndPoint>> waiting_list_;
+    std::atomic<int> waiting_list_len_;
 
     size_t max_size_;
 };

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -101,6 +101,12 @@ class RdmaContext {
 
     int deleteEndpoint(const std::string &peer_nic_path);
 
+    // Drain the endpoint store's waiting list. Safe to call on any thread;
+    // intended to be invoked periodically from monitorWorker so reclaim is
+    // not gated on new endpoint insertions (which can stall under failure
+    // load while evictions/deletions continue). See issue #1845.
+    void reclaimEndpoints();
+
     int disconnectAllEndpoints();
 
     // Get the total number of QPs across all endpoints in this context

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -107,9 +107,14 @@ class RdmaContext {
     // load while evictions/deletions continue). See issue #1845.
     void reclaimEndpoints();
 
-    // Raw accessor for the endpoint cache. Null before construct() runs.
-    // Used by integration tests that need to observe waiting_list_ directly.
-    EndpointStore *endpointStore() const { return endpoint_store_.get(); }
+    // Number of endpoints awaiting reclaim. For tests and operator
+    // observability.
+    size_t waitingListSize() const;
+
+    // Test-only: push a pre-constructed endpoint into the store's
+    // waiting_list_ so the reclaim path can be exercised without standing up
+    // a real RDMA QP.
+    void testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> ep);
 
     int disconnectAllEndpoints();
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -107,6 +107,10 @@ class RdmaContext {
     // load while evictions/deletions continue). See issue #1845.
     void reclaimEndpoints();
 
+    // Raw accessor for the endpoint cache. Null before construct() runs.
+    // Used by integration tests that need to observe waiting_list_ directly.
+    EndpointStore *endpointStore() const { return endpoint_store_.get(); }
+
     int disconnectAllEndpoints();
 
     // Get the total number of QPs across all endpoints in this context

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -70,6 +70,7 @@ int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     // remove endpoint but leaving it status unchanged
     // in case it is setting up connection or submitting slice
     if (iter != endpoint_map_.end()) {
+        waiting_list_len_++;
         waiting_list_.insert(iter->second);
         iter->second->set_active(false);
         endpoint_map_.erase(iter);
@@ -86,6 +87,7 @@ void FIFOEndpointStore::evictEndpoint() {
     fifo_list_.pop_front();
     fifo_map_.erase(victim);
     LOG(INFO) << victim << " evicted";
+    waiting_list_len_++;
     waiting_list_.insert(endpoint_map_[victim]);
     endpoint_map_.erase(victim);
     return;
@@ -97,6 +99,7 @@ void FIFOEndpointStore::reclaimEndpoint() {
     for (auto &endpoint : waiting_list_)
         if (!endpoint->hasOutstandingSlice()) to_delete.push_back(endpoint);
     for (auto &endpoint : to_delete) waiting_list_.erase(endpoint);
+    waiting_list_len_ -= to_delete.size();
 }
 
 size_t FIFOEndpointStore::getSize() { return endpoint_map_.size(); }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -240,6 +240,13 @@ int SIEVEEndpointStore::disconnectQPs() {
 
 size_t SIEVEEndpointStore::getSize() { return endpoint_map_.size(); }
 
+void SIEVEEndpointStore::testOnlyInsertWaiting(
+    std::shared_ptr<RdmaEndPoint> ep) {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    waiting_list_.insert(ep);
+    waiting_list_len_++;
+}
+
 size_t SIEVEEndpointStore::getTotalQPNumber() {
     RWSpinlock::ReadGuard guard(endpoint_map_lock_);
     size_t total_qps = 0;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -94,6 +94,7 @@ void FIFOEndpointStore::evictEndpoint() {
 }
 
 void FIFOEndpointStore::reclaimEndpoint() {
+    if (waiting_list_len_.load(std::memory_order_relaxed) == 0) return;
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     std::vector<std::shared_ptr<RdmaEndPoint>> to_delete;
     for (auto &endpoint : waiting_list_)

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -127,6 +127,13 @@ size_t FIFOEndpointStore::getTotalQPNumber() {
     return total_qps;
 }
 
+void FIFOEndpointStore::testOnlyInsertWaiting(
+    std::shared_ptr<RdmaEndPoint> ep) {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    waiting_list_.insert(ep);
+    waiting_list_len_++;
+}
+
 std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::getEndpoint(
     const std::string &peer_nic_path) {
     RWSpinlock::ReadGuard guard(endpoint_map_lock_);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -367,6 +367,14 @@ int RdmaContext::deleteEndpoint(const std::string &peer_nic_path) {
 
 void RdmaContext::reclaimEndpoints() { endpoint_store_->reclaimEndpoint(); }
 
+size_t RdmaContext::waitingListSize() const {
+    return endpoint_store_->waitingListSize();
+}
+
+void RdmaContext::testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> ep) {
+    endpoint_store_->testOnlyInsertWaiting(std::move(ep));
+}
+
 size_t RdmaContext::getTotalQPNumber() const {
     return endpoint_store_->getTotalQPNumber();
 }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -365,6 +365,8 @@ int RdmaContext::deleteEndpoint(const std::string &peer_nic_path) {
     return endpoint_store_->deleteEndpoint(peer_nic_path);
 }
 
+void RdmaContext::reclaimEndpoints() { endpoint_store_->reclaimEndpoint(); }
+
 size_t RdmaContext::getTotalQPNumber() const {
     return endpoint_store_->getTotalQPNumber();
 }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -447,6 +447,11 @@ void WorkerPool::monitorWorker() {
         auto current_ts = getCurrentTimeInNano();
         if (current_ts - last_reset_ts > 1000000000ll) {
             context_.set_active(true);
+            // Drain endpoint_store_->waiting_list_ even when no new
+            // insertions are happening. Without this, reclaim only runs
+            // from RdmaContext::endpoint() and the waiting list grows
+            // unboundedly under failure load. See issue #1845.
+            context_.reclaimEndpoints();
             last_reset_ts = current_ts;
         }
         struct epoll_event event;

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -21,10 +21,11 @@ target_link_libraries(endpoint_store_test PUBLIC transfer_engine gtest gtest_mai
 add_test(NAME endpoint_store_test COMMAND endpoint_store_test)
 
 # Integration test for the monitorWorker reclaim tick (issue #1845).
-# Requires an RDMA device (rxe0, mlx5, etc.) — invoked manually, not via ctest.
+# Self-skips when no RDMA device is present, so safe to register with ctest.
 add_executable(endpoint_store_integration_test ${WORKSPACE}/endpoint_store_integration_test.cpp)
 target_link_libraries(endpoint_store_integration_test PUBLIC transfer_engine gtest gtest_main)
-# add_test(NAME endpoint_store_integration_test COMMAND endpoint_store_integration_test)
+add_test(NAME endpoint_store_integration_test COMMAND endpoint_store_integration_test)
+set_tests_properties(endpoint_store_integration_test PROPERTIES LABELS "rdma")
 
 add_executable(rdma_transport_test2 ${WORKSPACE}/rdma_transport_test2.cpp)
 target_link_libraries(rdma_transport_test2 PUBLIC transfer_engine gtest gtest_main )

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -16,6 +16,16 @@ add_executable(transport_uint_test ${WORKSPACE}/transport_uint_test.cpp)
 target_link_libraries(transport_uint_test PUBLIC transfer_engine gtest gtest_main )
 add_test(NAME transport_uint_test COMMAND transport_uint_test)
 
+add_executable(endpoint_store_test ${WORKSPACE}/endpoint_store_test.cpp)
+target_link_libraries(endpoint_store_test PUBLIC transfer_engine gtest gtest_main)
+add_test(NAME endpoint_store_test COMMAND endpoint_store_test)
+
+# Integration test for the monitorWorker reclaim tick (issue #1845).
+# Requires an RDMA device (rxe0, mlx5, etc.) — invoked manually, not via ctest.
+add_executable(endpoint_store_integration_test ${WORKSPACE}/endpoint_store_integration_test.cpp)
+target_link_libraries(endpoint_store_integration_test PUBLIC transfer_engine gtest gtest_main)
+# add_test(NAME endpoint_store_integration_test COMMAND endpoint_store_integration_test)
+
 add_executable(rdma_transport_test2 ${WORKSPACE}/rdma_transport_test2.cpp)
 target_link_libraries(rdma_transport_test2 PUBLIC transfer_engine gtest gtest_main )
 # add_test(NAME rdma_transport_test2 COMMAND rdma_transport_test2)

--- a/mooncake-transfer-engine/tests/endpoint_store_integration_test.cpp
+++ b/mooncake-transfer-engine/tests/endpoint_store_integration_test.cpp
@@ -99,7 +99,12 @@ TEST(EndpointStoreIntegration, MonitorWorkerTickDrainsWaitingList) {
                                 config.num_comp_channels_per_ctx, config.port,
                                 config.gid_index, config.max_cqe,
                                 /*max_endpoints=*/4);
-    ASSERT_EQ(rc, 0) << "RdmaContext::construct failed on device " << device;
+    if (rc != 0) {
+        GTEST_SKIP() << "RdmaContext::construct failed on device " << device
+                     << " (rc=" << rc << "); no usable RDMA device on this "
+                     << "host (e.g., CI runners may enumerate a phantom "
+                     << "mlx5_0 without a working port).";
+    }
 
     context->testOnlyInsertWaiting(makeQuiescentEndpoint(*context));
     context->testOnlyInsertWaiting(makeQuiescentEndpoint(*context));

--- a/mooncake-transfer-engine/tests/endpoint_store_integration_test.cpp
+++ b/mooncake-transfer-engine/tests/endpoint_store_integration_test.cpp
@@ -101,22 +101,16 @@ TEST(EndpointStoreIntegration, MonitorWorkerTickDrainsWaitingList) {
                                 /*max_endpoints=*/4);
     ASSERT_EQ(rc, 0) << "RdmaContext::construct failed on device " << device;
 
-    auto *raw_store = context->endpointStore();
-    ASSERT_NE(raw_store, nullptr);
-    auto *sieve = dynamic_cast<SIEVEEndpointStore *>(raw_store);
-    ASSERT_NE(sieve, nullptr) << "default endpoint store should be SIEVE; "
-                                 "integration test assumes it";
-
-    sieve->testOnlyInsertWaiting(makeQuiescentEndpoint(*context));
-    sieve->testOnlyInsertWaiting(makeQuiescentEndpoint(*context));
-    sieve->testOnlyInsertWaiting(makeQuiescentEndpoint(*context));
-    ASSERT_EQ(sieve->waitingListSize(), 3u);
+    context->testOnlyInsertWaiting(makeQuiescentEndpoint(*context));
+    context->testOnlyInsertWaiting(makeQuiescentEndpoint(*context));
+    context->testOnlyInsertWaiting(makeQuiescentEndpoint(*context));
+    ASSERT_EQ(context->waitingListSize(), 3u);
 
     // monitorWorker's reclaim tick fires every ~1 s. Give it enough margin
     // for scheduling jitter but keep the test fast.
     std::this_thread::sleep_for(std::chrono::milliseconds(1500));
 
-    EXPECT_EQ(sieve->waitingListSize(), 0u)
+    EXPECT_EQ(context->waitingListSize(), 0u)
         << "monitorWorker must call reclaimEndpoints within ~1 s. If this "
            "fails, either the periodic tick in worker_pool.cpp was removed or "
            "reclaim is failing on quiescent entries.";

--- a/mooncake-transfer-engine/tests/endpoint_store_integration_test.cpp
+++ b/mooncake-transfer-engine/tests/endpoint_store_integration_test.cpp
@@ -1,0 +1,111 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Integration test for #1845. Verifies the end-to-end wiring of the fix:
+// WorkerPool::monitorWorker actually calls RdmaContext::reclaimEndpoints at
+// ~1 Hz, causing quiescent entries in the endpoint store's waiting_list_ to
+// drain without any further insertion traffic. The unit tests in
+// endpoint_store_test.cpp verify the reclaim method itself; this file
+// verifies that the scheduler invokes it.
+//
+// Requires an RDMA device. Passes on soft-RoCE (`rdma_rxe`) as well as real
+// NICs. Not registered with ctest by default because CI runners don't have
+// devices; invoke manually:
+//
+//     ./build/mooncake-transfer-engine/tests/endpoint_store_integration_test
+//
+// Environment override: set MC_TEST_DEVICE_NAME to force a specific device;
+// otherwise the first device returned by ibv_get_device_list is used.
+
+#include <gtest/gtest.h>
+#include <infiniband/verbs.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "config.h"
+#include "transport/rdma_transport/endpoint_store.h"
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_transport/rdma_endpoint.h"
+#include "transport/rdma_transport/rdma_transport.h"
+
+using namespace mooncake;
+
+namespace {
+
+std::string pickRdmaDevice() {
+    const char *override_name = std::getenv("MC_TEST_DEVICE_NAME");
+    if (override_name && *override_name) return override_name;
+    int num_devices = 0;
+    ibv_device **list = ibv_get_device_list(&num_devices);
+    if (!list || num_devices == 0) return "";
+    std::string name = ibv_get_device_name(list[0]);
+    ibv_free_device_list(list);
+    return name;
+}
+
+// Build an RdmaEndPoint with no QPs and active_=false. The store's reclaim
+// path only inspects hasOutstandingSlice(), which for an endpoint with empty
+// qp_list_ reduces to !active_. Safe to destruct because qp_list_ is empty.
+std::shared_ptr<RdmaEndPoint> makeQuiescentEndpoint(RdmaContext &ctx) {
+    auto ep = std::make_shared<RdmaEndPoint>(ctx);
+    ep->set_active(false);
+    return ep;
+}
+
+// Verifies the full fix wiring: after construct() spawns monitorWorker, a
+// quiescent entry injected into the store's waiting_list_ is drained by the
+// scheduler within ~1.5 s with no further insertion traffic.
+TEST(EndpointStoreIntegration, MonitorWorkerTickDrainsWaitingList) {
+    const std::string device = pickRdmaDevice();
+    ASSERT_FALSE(device.empty())
+        << "no RDMA device available — integration test requires rxe0, mlx5, "
+           "or similar. Set MC_TEST_DEVICE_NAME to override.";
+
+    // RdmaTransport's destructor dereferences metadata_ which is null until
+    // init(); leak the engine to avoid touching that path.
+    auto *transport = new RdmaTransport();
+    auto context = std::make_shared<RdmaContext>(*transport, device);
+    auto &config = globalConfig();
+    int rc = context->construct(config.num_cq_per_ctx,
+                                config.num_comp_channels_per_ctx, config.port,
+                                config.gid_index, config.max_cqe,
+                                /*max_endpoints=*/4);
+    ASSERT_EQ(rc, 0) << "RdmaContext::construct failed on device " << device;
+
+    auto *raw_store = context->endpointStore();
+    ASSERT_NE(raw_store, nullptr);
+    auto *sieve = dynamic_cast<SIEVEEndpointStore *>(raw_store);
+    ASSERT_NE(sieve, nullptr) << "default endpoint store should be SIEVE; "
+                                 "integration test assumes it";
+
+    sieve->testOnlyInsertWaiting(makeQuiescentEndpoint(*context));
+    sieve->testOnlyInsertWaiting(makeQuiescentEndpoint(*context));
+    sieve->testOnlyInsertWaiting(makeQuiescentEndpoint(*context));
+    ASSERT_EQ(sieve->waitingListSize(), 3u);
+
+    // monitorWorker's reclaim tick fires every ~1 s. Give it enough margin
+    // for scheduling jitter but keep the test fast.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+    EXPECT_EQ(sieve->waitingListSize(), 0u)
+        << "monitorWorker must call reclaimEndpoints within ~1 s. If this "
+           "fails, either the periodic tick in worker_pool.cpp was removed or "
+           "reclaim is failing on quiescent entries.";
+}
+
+}  // namespace

--- a/mooncake-transfer-engine/tests/endpoint_store_integration_test.cpp
+++ b/mooncake-transfer-engine/tests/endpoint_store_integration_test.cpp
@@ -20,10 +20,8 @@
 // verifies that the scheduler invokes it.
 //
 // Requires an RDMA device. Passes on soft-RoCE (`rdma_rxe`) as well as real
-// NICs. Not registered with ctest by default because CI runners don't have
-// devices; invoke manually:
-//
-//     ./build/mooncake-transfer-engine/tests/endpoint_store_integration_test
+// NICs. Self-skips (GTEST_SKIP) when no device is present, so it is safe to
+// register with ctest on CI runners without RDMA.
 //
 // Environment override: set MC_TEST_DEVICE_NAME to force a specific device;
 // otherwise the first device returned by ibv_get_device_list is used.
@@ -84,9 +82,11 @@ std::shared_ptr<RdmaEndPoint> makeQuiescentEndpoint(RdmaContext &ctx) {
 // scheduler within ~1.5 s with no further insertion traffic.
 TEST(EndpointStoreIntegration, MonitorWorkerTickDrainsWaitingList) {
     const std::string device = pickRdmaDevice();
-    ASSERT_FALSE(device.empty())
-        << "no RDMA device available — integration test requires rxe0, mlx5, "
-           "or similar. Set MC_TEST_DEVICE_NAME to override.";
+    if (device.empty()) {
+        GTEST_SKIP() << "no RDMA device available — integration test requires "
+                        "rxe0, mlx5, or similar. Set MC_TEST_DEVICE_NAME to "
+                        "override.";
+    }
 
     // RdmaTransport's destructor dereferences metadata_ which is null until
     // init(); leak the engine to avoid touching that path. Marked ignored so

--- a/mooncake-transfer-engine/tests/endpoint_store_integration_test.cpp
+++ b/mooncake-transfer-engine/tests/endpoint_store_integration_test.cpp
@@ -43,6 +43,18 @@
 #include "transport/rdma_transport/rdma_endpoint.h"
 #include "transport/rdma_transport/rdma_transport.h"
 
+#if defined(__has_feature)
+#define MC_HAS_FEATURE(x) __has_feature(x)
+#else
+#define MC_HAS_FEATURE(x) 0
+#endif
+#if defined(__SANITIZE_ADDRESS__) || MC_HAS_FEATURE(address_sanitizer)
+#include <sanitizer/lsan_interface.h>
+#define MC_LSAN_IGNORE_OBJECT(p) __lsan_ignore_object(p)
+#else
+#define MC_LSAN_IGNORE_OBJECT(p) ((void)(p))
+#endif
+
 using namespace mooncake;
 
 namespace {
@@ -77,8 +89,10 @@ TEST(EndpointStoreIntegration, MonitorWorkerTickDrainsWaitingList) {
            "or similar. Set MC_TEST_DEVICE_NAME to override.";
 
     // RdmaTransport's destructor dereferences metadata_ which is null until
-    // init(); leak the engine to avoid touching that path.
+    // init(); leak the engine to avoid touching that path. Marked ignored so
+    // LSAN under ASAN builds doesn't flag this intentional leak.
     auto *transport = new RdmaTransport();
+    MC_LSAN_IGNORE_OBJECT(transport);
     auto context = std::make_shared<RdmaContext>(*transport, device);
     auto &config = globalConfig();
     int rc = context->construct(config.num_cq_per_ctx,

--- a/mooncake-transfer-engine/tests/endpoint_store_test.cpp
+++ b/mooncake-transfer-engine/tests/endpoint_store_test.cpp
@@ -1,0 +1,161 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression coverage for #1845. Asserts that
+// SIEVEEndpointStore::reclaimEndpoint drains quiescent entries from
+// waiting_list_ without requiring a subsequent insertEndpoint call. This is the
+// invariant the periodic-reclaim tick in monitorWorker depends on.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "transport/rdma_transport/endpoint_store.h"
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_transport/rdma_endpoint.h"
+#include "transport/rdma_transport/rdma_transport.h"
+
+using namespace mooncake;
+
+namespace {
+
+// Build an RdmaEndPoint that owns zero QPs and has active_=false. construct()
+// is deliberately not called — the store's reclaim logic only inspects
+// hasOutstandingSlice(), which for an endpoint with empty qp_list_ returns
+// whatever active_ is.
+std::shared_ptr<RdmaEndPoint> makeQuiescentEndpoint(RdmaContext& ctx) {
+    auto ep = std::make_shared<RdmaEndPoint>(ctx);
+    ep->set_active(false);
+    return ep;
+}
+
+std::shared_ptr<RdmaEndPoint> makeActiveEndpoint(RdmaContext& ctx) {
+    // Default ctor leaves active_=true.
+    return std::make_shared<RdmaEndPoint>(ctx);
+}
+
+class EndpointStoreTest : public ::testing::Test {
+   protected:
+    // Leaked on purpose: RdmaTransport's destructor dereferences metadata_,
+    // which is null when the engine was never init()ed. We only need a live
+    // reference for RdmaContext's constructor; the engine object is otherwise
+    // unused by the reclaim logic under test.
+    RdmaTransport* transport_ = nullptr;
+    std::unique_ptr<RdmaContext> ctx_;
+
+    void SetUp() override {
+        transport_ = new RdmaTransport();
+        ctx_ = std::make_unique<RdmaContext>(*transport_, "unused");
+    }
+};
+
+// The core invariant behind #1845's fix: reclaimEndpoint must drain quiescent
+// entries on its own, without needing a subsequent insertEndpoint to trigger
+// it. Before the fix, reclaim ran only on insertion, so if insertions stopped
+// (e.g., all peers died), waiting_list_ grew unboundedly. The periodic tick
+// from monitorWorker calls this method every second; this test asserts its
+// contract in isolation.
+TEST_F(EndpointStoreTest, ReclaimDrainsQuiescentEntries) {
+    SIEVEEndpointStore store(/*max_size=*/4);
+
+    constexpr size_t kN = 10;
+    for (size_t i = 0; i < kN; ++i) {
+        store.testOnlyInsertWaiting(makeQuiescentEndpoint(*ctx_));
+    }
+    EXPECT_EQ(store.waitingListSize(), kN);
+
+    store.reclaimEndpoint();
+    EXPECT_EQ(store.waitingListSize(), 0u)
+        << "reclaimEndpoint must drain quiescent entries with no insertion "
+           "prerequisite";
+}
+
+// Negative control: reclaim must leave entries in place if they still report
+// outstanding slices. Ensures we didn't break the hasOutstandingSlice gate.
+TEST_F(EndpointStoreTest, ReclaimLeavesActiveEntries) {
+    SIEVEEndpointStore store(4);
+
+    store.testOnlyInsertWaiting(makeActiveEndpoint(*ctx_));
+    store.testOnlyInsertWaiting(makeActiveEndpoint(*ctx_));
+    store.testOnlyInsertWaiting(makeQuiescentEndpoint(*ctx_));
+    EXPECT_EQ(store.waitingListSize(), 3u);
+
+    store.reclaimEndpoint();
+    EXPECT_EQ(store.waitingListSize(), 2u)
+        << "reclaim should drop only the quiescent endpoint, keep the two "
+           "active ones";
+}
+
+TEST_F(EndpointStoreTest, ReclaimIsIdempotentWhenEmpty) {
+    SIEVEEndpointStore store(4);
+
+    store.reclaimEndpoint();
+    EXPECT_EQ(store.waitingListSize(), 0u);
+
+    store.testOnlyInsertWaiting(makeQuiescentEndpoint(*ctx_));
+    store.reclaimEndpoint();
+    EXPECT_EQ(store.waitingListSize(), 0u);
+
+    store.reclaimEndpoint();  // second call is a no-op
+    EXPECT_EQ(store.waitingListSize(), 0u);
+}
+
+// Demonstrates the #1845 failure mode: once insertions stop but evictions
+// keep landing in the waiting list, nothing drains them without an explicit
+// reclaim call. Before this fix, reclaimEndpoint ran only from insertEndpoint,
+// so "many evictions, no new peers to connect to" meant waiting_list_ grew
+// without bound. This test simulates that workload without any RDMA or
+// scheduler; the assertion is a strict "zero reclaim calls leaves the leak
+// at its peak."
+TEST_F(EndpointStoreTest, LeakManifestsWithoutReclaimCall) {
+    SIEVEEndpointStore store(/*max_size=*/4);
+
+    constexpr size_t kEvictions = 1118;  // match reporter's eviction count
+    for (size_t i = 0; i < kEvictions; ++i) {
+        store.testOnlyInsertWaiting(makeQuiescentEndpoint(*ctx_));
+    }
+
+    // Without a reclaim call the leak is at its peak.
+    EXPECT_EQ(store.waitingListSize(), kEvictions)
+        << "baseline confirmation: waiting_list_ accumulates as expected";
+
+    // The fix is a 1 Hz invocation of this single method from monitorWorker.
+    // One call is enough to drain the entire backlog (because the entries are
+    // quiescent by the time the peer-death path finishes). This is the
+    // invariant the PR relies on.
+    store.reclaimEndpoint();
+    EXPECT_EQ(store.waitingListSize(), 0u)
+        << "a single reclaim call drains the full backlog once insertions "
+           "stop; this is what the periodic tick in monitorWorker provides";
+}
+
+// Guards against a future regression that re-breaks the reclaim contract —
+// e.g., someone changing reclaimEndpoint to no-op when endpoint_map_ is
+// empty, on the incorrect assumption that reclaim only runs from
+// insertEndpoint. Walking 1000 quiescent entries should still drain them.
+TEST_F(EndpointStoreTest, ReclaimDoesNotRequireActiveMap) {
+    SIEVEEndpointStore store(4);
+    EXPECT_EQ(store.getSize(), 0u);  // endpoint_map_ empty
+
+    for (size_t i = 0; i < 1000; ++i) {
+        store.testOnlyInsertWaiting(makeQuiescentEndpoint(*ctx_));
+    }
+    EXPECT_EQ(store.getSize(), 0u);  // still empty
+    EXPECT_EQ(store.waitingListSize(), 1000u);
+
+    store.reclaimEndpoint();
+    EXPECT_EQ(store.waitingListSize(), 0u);
+}
+
+}  // namespace

--- a/mooncake-transfer-engine/tests/endpoint_store_test.cpp
+++ b/mooncake-transfer-engine/tests/endpoint_store_test.cpp
@@ -26,6 +26,18 @@
 #include "transport/rdma_transport/rdma_endpoint.h"
 #include "transport/rdma_transport/rdma_transport.h"
 
+#if defined(__has_feature)
+#define MC_HAS_FEATURE(x) __has_feature(x)
+#else
+#define MC_HAS_FEATURE(x) 0
+#endif
+#if defined(__SANITIZE_ADDRESS__) || MC_HAS_FEATURE(address_sanitizer)
+#include <sanitizer/lsan_interface.h>
+#define MC_LSAN_IGNORE_OBJECT(p) __lsan_ignore_object(p)
+#else
+#define MC_LSAN_IGNORE_OBJECT(p) ((void)(p))
+#endif
+
 using namespace mooncake;
 
 namespace {
@@ -56,6 +68,11 @@ class EndpointStoreTest : public ::testing::Test {
 
     void SetUp() override {
         transport_ = new RdmaTransport();
+        // Intentional leak: ~RdmaTransport dereferences metadata_, which is
+        // null until install(). Marking it ignored keeps LSAN under ASAN
+        // builds from flagging this one allocation while still catching
+        // real leaks elsewhere.
+        MC_LSAN_IGNORE_OBJECT(transport_);
         ctx_ = std::make_unique<RdmaContext>(*transport_, "unused");
     }
 };


### PR DESCRIPTION
## Description

This closes #1845. Under SGLang PD-disaggregated prefill, `ibv_create_qp` eventually fails with `Cannot allocate memory` and `rdma resource show` reports >20K QPs per NIC, preceded by 1118 endpoint-evicted events.

`SIEVEEndpointStore::reclaimEndpoint` drains `waiting_list_` of quiescent (a.k.a. evicted and deleted) endpoints so their `shared_ptrs` drop, and destructors run `ibv_destroy_qp`. The only production caller was `RdmaContext::endpoint()`. The reclaim piggybacked on new endpoint insertions. Under healthy load, insertions and evictions are coupled, so the list drains in step. Under failure load, such as peers dying or when retries are exhausted, evictions and deletions continue while insertions stop. This causes reclaims to stop firing and `waiting_list_` grows unboundedly. Each accumulated endpoint pins `num_qp_per_ep` QPs against the NIC's pool (1118 x 2..4 ~= enough to exhaust). The reporter's 4x QP asymmetry across NIC groups (22k on `mlx5_00-03` vs. 6k on `mlx5_04-07`) is consistent with this. Eviction load concentrated on the NICs routing to the failing peer.

To fix this, I added a `context_.reclaimEndpoints()` call inside `WorkerPool::monitorWorker`. This is included on the existing `last_reset_ts` heartbeat. The result is that reclaim no longer depends on insertion traffic. The change is minimal. There is one line of behavior change in `worker_pool.cpp` and a thin wrapper method `RdmaContext::reclaimEndpoints()` to delegate to the store.

I also tried adding eager `disconnect()` to `deleteEndpoint`/`evictEndpoint` initially, but it crashes on `rxe` within ~5s with `malloc(): unaligned tcache chunk detected`. I think the `slice->rdma.qp_depth` raw pointer into `wr_depth_list_` becomes dangling when reclaim destroys the endpoint while an in-flight slice still holds it. Fixing that properly requires a shared-ownership refactor of `wr_depth_list_`, which I could do as a follow-up so eager disconnect can be re-added safely.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

There are 5 new unit tests:
1. `ReclaimDrainsQuiescentEntries` is the base method contract.
2. `ReclaimLeavesActiveEntries` tests that the `hasOutstandingSlice` gate is preserved.
3. `ReclaimIsIdempotentWhenEmpty` tests cadence safety.
4. `LeakManifestsWithoutReclaimCall` reproduces the reporter's 1118-eviction shape and asserts a single reclaim call drains the full backlog.
5. `ReclaimDoesNotRequireActiveMap` guards against a regression that conflates reclaim with insert.

There is 1 new integration test:
1. `endpoint_store_integration_test` constructs a real `RdmaContext`, spawns `monitorWorker`, injects quiescent entries into `waiting_list_`, sleeps, and asserts drainage. I used this bisection to validate the fix. If you remove the new `reclaimEndpoints()` call then this test will fail with the right error message, if you add it back it will pass again.

I ran the full ctest suite. There is one existing failure: `hot_standby_service_test`. I think this is simply due to `etcd` not being available on my system. It's also failing on main, and the code doesn't seem related at all, so I'm flagging this as environmental. Please let me know if you'd like me to take a closer look.

I don't have the hardware to match the original SGLang mlx5 cluster conditions, unfortunately. If you are aware of on-demand spot instances for mlx5, please let me know and I can run this patch there.

This is the test script I used to manually reproduce:
```
sudo apt install -y linux-modules-extra-$(uname -r) rdma-core
sudo modprobe rdma_rxe
sudo rdma link add rxe0 type rxe netdev <your_iface>

mkdir build && cd build
cmake .. -DBUILD_UNIT_TESTS=ON
make -j8
ctest -R endpoint_store_test --output-on-failure
./mooncake-transfer-engine/tests/endpoint_store_integration_test
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.