### PR TITLE
[docs] Document TCP port exhaustion and pool limitations

### DIFF
--- a/docs/source/troubleshooting/troubleshooting.md
+++ b/docs/source/troubleshooting/troubleshooting.md
@@ -123,6 +123,34 @@ Note: In most cases, the errors output, except for the first occurrence, are `wo
 
 In addition, if the error `Failed to get description of XXX` is displayed, it indicates that the Segment name input by the user when calling the `openSegment` interface cannot be found in the etcd database. For memory read/write scenarios, the Segment name needs to strictly match the `local_hostname` field filled in by the other node during initialization.
 
+## TCP Transport
+### Recommended Troubleshooting Directions
+
+1. If sustained, high-concurrency TCP traffic (for example, PD-disaggregated KV transfers over the TCP transport) fails with `connect: Cannot assign requested address`, the initiator side has exhausted its ephemeral port range. Each transfer opens a fresh short-lived socket, and ports held in `TIME_WAIT` accumulate faster than the kernel can reclaim them.
+
+   **Diagnostic Commands:**
+   ```bash
+   # Confirm large numbers of TIME_WAIT sockets to the peer
+   ss -tan state time-wait | wc -l
+
+   # Check the local ephemeral port range
+   sysctl net.ipv4.ip_local_port_range
+   ```
+
+   **Solutions:**
+   - Enable the TCP connection pool so that long-lived sockets are reused across transfers instead of being opened per transfer:
+     ```bash
+     export MC_TCP_ENABLE_CONNECTION_POOL=1
+     ```
+   - Widen the ephemeral port range if the workload genuinely needs many distinct connections:
+     ```bash
+     sysctl -w net.ipv4.ip_local_port_range="1024 65535"
+     ```
+   - As a last resort, enable `TIME_WAIT` reuse on the initiator. `tcp_tw_reuse` only affects outbound connections and requires TCP timestamps to be enabled on both sides:
+     ```bash
+     sysctl -w net.ipv4.tcp_tw_reuse=1
+     ```
+
 ## SGLang Common Questions
 
 ### Do I need RDMA to run SGLang and Mooncake?

--- a/docs/source/troubleshooting/troubleshooting.md
+++ b/docs/source/troubleshooting/troubleshooting.md
@@ -151,6 +151,21 @@ In addition, if the error `Failed to get description of XXX` is displayed, it in
      sysctl -w net.ipv4.tcp_tw_reuse=1
      ```
 
+2. The TCP connection pool (`MC_TCP_ENABLE_CONNECTION_POOL=1`) has two known limitations in the current implementation. The pool is functional for most workloads, but operators running long-lived services should be aware of them:
+
+   * **Idle-expired connections are not always reclaimed.** `cleanupIdleConnections()` only inspects the tail of each endpoint's deque. When a newer `in_use` entry has been pushed behind an older idle-expired entry, the loop terminates at the tail and the idle entry is never removed. The pool's reported state diverges from reality: it still lists the connection as idle while the socket has been sitting past `kConnectionIdleTimeout`, may have been half-closed by the peer, and will fail on the next `getConnection()` that tries to reuse it. In long-running services this also leaks sockets and file descriptors until the process is restarted.
+
+     **Diagnostic Commands:**
+     ```bash
+     # Watch for unbounded growth of open sockets from the process
+     ls /proc/$PID/fd | wc -l
+     ss -tan | awk '$1=="ESTAB"' | wc -l
+     ```
+
+     **Workaround:** restart the process periodically if fd usage climbs without bound.
+
+   * **`asio::socket::close()` runs under `pool_mutex_`.** `close()` cancels outstanding async operations and posts completion handlers to the io_context. Handlers such as `returnConnection()` also acquire `pool_mutex_`, so the current code is one scheduling step away from a circular wait. No deadlock has been observed in practice, but if the transfer engine hangs with all worker threads stuck waiting on `pool_mutex_`, this is the first place to look.
+
 ## SGLang Common Questions
 
 ### Do I need RDMA to run SGLang and Mooncake?


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [✅ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [✅ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [✅ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.

## Description                                                                                                                                                      
   
  Add a **TCP Transport** section to `docs/source/troubleshooting/troubleshooting.md` covering two related failure modes that users have hit in practice. This        
  replaces the code-change approach in earlier revisions of this PR: since the SGLang TCP fallback CI has stabilized on `0.3.10.post2`, landing code changes to the
  TCP transport right now carries more risk than benefit, so the issue is documented for operators while the fix is deferred.                                         
                                                            
  ### What the new entry covers                                                                                                                                       
   
  1. **Ephemeral-port exhaustion under sustained high-concurrency TCP transfers.** When the connection pool is off (the current default), every transfer opens a      
  short-lived socket and `TIME_WAIT` accumulation exhausts the local port range, surfacing as `connect: Cannot assign requested address`. Gives `ss` / `sysctl`
  diagnostics and three mitigations: enable the pool (`MC_TCP_ENABLE_CONNECTION_POOL=1`), widen `net.ipv4.ip_local_port_range`, or enable `tcp_tw_reuse`.             
                                                            
  2. **Known limitations of the current pool implementation**, so operators who enable it as a workaround know what to watch for:                                     
     - `cleanupIdleConnections()` only inspects the tail of each endpoint's deque — idle-expired entries stuck behind `in_use` entries are never reclaimed, so pool
  state can diverge from real socket state and fds leak slowly in long-running services.                                                                              
     - `asio::socket::close()` runs under `pool_mutex_`; since asio completion handlers (e.g. `returnConnection`) also take `pool_mutex_`, this is one scheduling step
   away from a circular wait. Not observed in production, but documented as a hang hypothesis.                                                                                                                                                                                
                                                                                                                                                                                          
                                                                                      
                                                                                             
 