### PR TITLE
[Bugfix]: route cache allocator capacity adapt

### DIFF
--- a/mooncake-store/src/route_cache.cpp
+++ b/mooncake-store/src/route_cache.cpp
@@ -72,7 +72,8 @@ RouteCache::RouteCache(size_t max_memory_bytes, uint64_t ttl_ms)
         auto& shard = *shards_[i];
         shard.base_addr_ = static_cast<char*>(base_all_) + i * per_shard_bytes;
         shard.allocator_ = offset_allocator::OffsetAllocator::create(
-            reinterpret_cast<uintptr_t>(shard.base_addr_), per_shard_bytes);
+            reinterpret_cast<uintptr_t>(shard.base_addr_), per_shard_bytes,
+            nodes_per_shard_, 2 * nodes_per_shard_);
 
         shard.buckets_ =
             std::make_unique<std::atomic<Node*>[]>(buckets_per_shard_);

--- a/mooncake-store/src/route_cache.cpp
+++ b/mooncake-store/src/route_cache.cpp
@@ -73,7 +73,8 @@ RouteCache::RouteCache(size_t max_memory_bytes, uint64_t ttl_ms)
         shard.base_addr_ = static_cast<char*>(base_all_) + i * per_shard_bytes;
         shard.allocator_ = offset_allocator::OffsetAllocator::create(
             reinterpret_cast<uintptr_t>(shard.base_addr_), per_shard_bytes,
-            nodes_per_shard_, 2 * nodes_per_shard_);
+            static_cast<uint32_t>(nodes_per_shard_),
+            static_cast<uint32_t>(2 * nodes_per_shard_));
 
         shard.buckets_ =
             std::make_unique<std::atomic<Node*>[]>(buckets_per_shard_);


### PR DESCRIPTION
## Description
adapt route cache allocator capacity to actual nodes num
<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
