### PR TITLE
[Bugfix]: abort ascend unified pointer

### DIFF
--- a/mooncake-store/include/tiered_cache/tiers/ascend_tier.h
+++ b/mooncake-store/include/tiered_cache/tiers/ascend_tier.h
@@ -12,19 +12,6 @@
 namespace mooncake {
 
 /**
- * @struct AscendUnifiedPointer
- * @brief Encapsulates Ascend device pointer information.
- *
- * Contains the device pointer along with device ID and size,
- * enabling proper device context management for multi-device scenarios.
- */
-struct AscendUnifiedPointer {
-    void* device_ptr;  // The actual device memory pointer
-    int device_id;     // The device ID this pointer belongs to
-    size_t size;       // Size of the allocated memory in bytes
-};
-
-/**
  * @class AscendBuffer
  * @brief Ascend NPU memory buffer wrapper inheriting from BufferBase.
  *
@@ -35,10 +22,8 @@ class AscendBuffer : public BufferBase {
    public:
     /**
      * @brief Constructs an AscendBuffer taking ownership of device memory.
-     * @param unified_ptr unique_ptr to AscendUnifiedPointer containing device
-     * memory info.
      */
-    explicit AscendBuffer(std::unique_ptr<AscendUnifiedPointer> unified_ptr);
+    explicit AscendBuffer(void* device_ptr, size_t size);
 
     /**
      * @brief Destructor that automatically releases device memory.
@@ -56,8 +41,7 @@ class AscendBuffer : public BufferBase {
     /**
      * @brief Returns the device pointer address as uint64_t.
      *
-     * Returns the raw device memory pointer. For accessing device context
-     * information (device_id), use GetUnifiedPointer() or GetDeviceId().
+     * Returns the raw device memory pointer.
      */
     uint64_t data() const override;
 
@@ -67,25 +51,14 @@ class AscendBuffer : public BufferBase {
     std::size_t size() const override;
 
     /**
-     * @brief Gets the device ID for this buffer.
-     * @return Device ID, or -1 if buffer is invalid.
-     */
-    int GetDeviceId() const;
-
-    /**
      * @brief Gets the actual device pointer.
      * @return Device pointer, or nullptr if buffer is invalid.
      */
     void* GetDevicePtr() const;
 
-    /**
-     * @brief Gets the complete AscendUnifiedPointer structure.
-     * @return Pointer to AscendUnifiedPointer, or nullptr if invalid.
-     */
-    const AscendUnifiedPointer* GetUnifiedPointer() const;
-
    private:
-    std::unique_ptr<AscendUnifiedPointer> unified_ptr_;
+    void* device_ptr_{nullptr};
+    size_t size_{0};
 
     // Internal function to release device memory
     void ReleaseMemory();
@@ -152,7 +125,7 @@ class AscendCacheTier : public CacheTier {
     mutable std::mutex init_mutex_;
 
     // Internal device memory allocation
-    std::unique_ptr<AscendUnifiedPointer> AllocateDeviceMemory(size_t size);
+    void* AllocateDeviceMemory(size_t size);
 
     // Check if sufficient space is available
     bool HasSpace(size_t size) const;

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -109,6 +109,10 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
+#ifdef USE_ASCEND_CACHE_TIER
+    bool ascend_tier_initialized = false;
+#endif
+
     for (const auto& tier_config : root["tiers"]) {
         // Parse required fields
         if (!tier_config.isMember("type")) {
@@ -195,6 +199,11 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
         }
 #ifdef USE_ASCEND_CACHE_TIER
         else if (type == "ASCEND_NPU" || type == "ASCEND") {
+            if (ascend_tier_initialized) {
+                LOG(ERROR) << "Multiple Ascend tiers are not allowed, skipping "
+                              "this tier";
+                continue;
+            }
             // Parse device_id
             int device_id = 0;
             if (tier_config.isMember("device_id")) {
@@ -218,6 +227,7 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
             tier_info_[id] = {priority, tags};
             memory_type = MemoryType::ASCEND_NPU;
             LOG(INFO) << "Successfully initialized ASCEND_NPU tier: id=" << id;
+            ascend_tier_initialized = true;
         }
 #endif
         else if (type == "STORAGE" || type == "DISK") {

--- a/mooncake-store/src/tiered_cache/tiers/ascend_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/ascend_tier.cpp
@@ -2,6 +2,7 @@
 
 #include <glog/logging.h>
 
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 
@@ -19,6 +20,30 @@ namespace mooncake {
 // ============================================================================
 
 #ifdef USE_ASCEND_CACHE_TIER
+
+namespace {
+constexpr const char* kAscendDeviceIdEnv = "MOONCAKE_ASCEND_DEVICE_ID";
+
+inline int GetSingleAscendDeviceId() {
+    const char* value = std::getenv(kAscendDeviceIdEnv);
+    if (!value || std::string(value).empty()) {
+        return 0;
+    }
+    try {
+        return std::stoi(value);
+    } catch (...) {
+        return 0;
+    }
+}
+
+inline void SetSingleAscendDeviceId(int device_id) {
+#ifdef _WIN32
+    _putenv_s(kAscendDeviceIdEnv, std::to_string(device_id).c_str());
+#else
+    setenv(kAscendDeviceIdEnv, std::to_string(device_id).c_str(), 1);
+#endif
+}
+}  // namespace
 
 // Helper function to set device context
 inline bool AclSetDevice(int device_id, const char* operation_name) {
@@ -85,56 +110,50 @@ inline bool AclMemcpyWithDevice(int device_id, void* dst, size_t dst_size,
 // AscendBuffer Implementation
 // ============================================================================
 
-AscendBuffer::AscendBuffer(std::unique_ptr<AscendUnifiedPointer> unified_ptr)
-    : unified_ptr_(std::move(unified_ptr)) {}
+AscendBuffer::AscendBuffer(void* device_ptr, size_t size)
+    : device_ptr_(device_ptr), size_(size) {}
 
 AscendBuffer::~AscendBuffer() { ReleaseMemory(); }
 
 AscendBuffer::AscendBuffer(AscendBuffer&& other) noexcept
-    : unified_ptr_(std::move(other.unified_ptr_)) {}
+    : device_ptr_(other.device_ptr_), size_(other.size_) {
+    other.device_ptr_ = nullptr;
+    other.size_ = 0;
+}
 
 AscendBuffer& AscendBuffer::operator=(AscendBuffer&& other) noexcept {
     if (this != &other) {
         ReleaseMemory();
-        unified_ptr_ = std::move(other.unified_ptr_);
+        device_ptr_ = other.device_ptr_;
+        size_ = other.size_;
+        other.device_ptr_ = nullptr;
+        other.size_ = 0;
     }
     return *this;
 }
 
 void AscendBuffer::ReleaseMemory() {
-    if (unified_ptr_) {
+    if (device_ptr_) {
 #ifdef USE_ASCEND_CACHE_TIER
-        AclFreeWithDevice(unified_ptr_->device_id, unified_ptr_->device_ptr,
+        AclFreeWithDevice(GetSingleAscendDeviceId(), device_ptr_,
                           "AscendBuffer::ReleaseMemory");
 #else
         // This should not happen as Init fails without USE_ASCEND_CACHE_TIER
         LOG(ERROR) << "AscendBuffer::ReleaseMemory called but "
                       "USE_ASCEND_CACHE_TIER is not enabled";
 #endif
-        unified_ptr_.reset();
+        device_ptr_ = nullptr;
+        size_ = 0;
     }
 }
 
 uint64_t AscendBuffer::data() const {
-    return unified_ptr_ ? reinterpret_cast<uint64_t>(unified_ptr_->device_ptr)
-                        : 0;
+    return reinterpret_cast<uint64_t>(device_ptr_);
 }
 
-std::size_t AscendBuffer::size() const {
-    return unified_ptr_ ? unified_ptr_->size : 0;
-}
+std::size_t AscendBuffer::size() const { return size_; }
 
-int AscendBuffer::GetDeviceId() const {
-    return unified_ptr_ ? unified_ptr_->device_id : -1;
-}
-
-void* AscendBuffer::GetDevicePtr() const {
-    return unified_ptr_ ? unified_ptr_->device_ptr : nullptr;
-}
-
-const AscendUnifiedPointer* AscendBuffer::GetUnifiedPointer() const {
-    return unified_ptr_.get();
-}
+void* AscendBuffer::GetDevicePtr() const { return device_ptr_; }
 
 // ============================================================================
 // AscendCacheTier Implementation
@@ -224,6 +243,7 @@ tl::expected<void, ErrorCode> AscendCacheTier::Init(TieredBackend* backend,
     if (!AclSetDevice(device_id_, "AscendCacheTier::Init")) {
         return tl::unexpected(ErrorCode::INTERNAL_ERROR);
     }
+    SetSingleAscendDeviceId(device_id_);
 
     LOG(INFO) << "AscendCacheTier initialized: tier_id=" << tier_id_
               << ", capacity=" << capacity_ << " bytes"
@@ -265,8 +285,8 @@ tl::expected<void, ErrorCode> AscendCacheTier::Allocate(size_t size,
                                                    std::memory_order_acquire));
 
     // Space reserved, now allocate device memory
-    auto unified_ptr = AllocateDeviceMemory(size);
-    if (!unified_ptr) {
+    void* device_ptr = AllocateDeviceMemory(size);
+    if (!device_ptr) {
         // Allocation failed, rollback the reserved space
         current_usage_.fetch_sub(size, std::memory_order_release);
         LOG(ERROR) << "Failed to allocate device memory for tier " << tier_id_;
@@ -274,7 +294,7 @@ tl::expected<void, ErrorCode> AscendCacheTier::Allocate(size_t size,
     }
 
     // Create AscendBuffer and wrap in DataSource
-    auto ascend_buffer = std::make_unique<AscendBuffer>(std::move(unified_ptr));
+    auto ascend_buffer = std::make_unique<AscendBuffer>(device_ptr, size);
     data.buffer = std::move(ascend_buffer);
     data.type = MemoryType::ASCEND_NPU;
 
@@ -312,8 +332,7 @@ size_t AscendCacheTier::GetUsage() const {
     return current_usage_.load(std::memory_order_acquire);
 }
 
-std::unique_ptr<AscendUnifiedPointer> AscendCacheTier::AllocateDeviceMemory(
-    size_t size) {
+void* AscendCacheTier::AllocateDeviceMemory(size_t size) {
     if (size == 0) {
         LOG(ERROR) << "AllocateDeviceMemory called with size 0";
         return nullptr;
@@ -322,19 +341,7 @@ std::unique_ptr<AscendUnifiedPointer> AscendCacheTier::AllocateDeviceMemory(
 #ifdef USE_ASCEND_CACHE_TIER
     void* device_ptr =
         AclMallocWithDevice(device_id_, size, "AllocateDeviceMemory");
-    if (!device_ptr) {
-        return nullptr;
-    }
-
-    try {
-        return std::make_unique<AscendUnifiedPointer>(
-            AscendUnifiedPointer{device_ptr, device_id_, size});
-    } catch (const std::bad_alloc& e) {
-        LOG(ERROR) << "Failed to allocate AscendUnifiedPointer: " << e.what();
-        AclFreeWithDevice(device_id_, device_ptr,
-                          "AllocateDeviceMemory cleanup");
-        return nullptr;
-    }
+    return device_ptr;
 #else
     // USE_ASCEND_CACHE_TIER not defined - Init should have failed already
     LOG(ERROR)
@@ -355,8 +362,7 @@ bool AscendCacheTier::HasSpace(size_t size) const {
 /**
  * @brief Copy data from Ascend NPU to DRAM.
  *
- * Extracts AscendUnifiedPointer from source buffer to get device context,
- * then performs device-to-host memory copy.
+ * Uses the active Ascend device context to perform device-to-host copy.
  */
 tl::expected<void, ErrorCode> CopyAscendToDram(const DataSource& src,
                                                const DataSource& dst) {
@@ -372,23 +378,12 @@ tl::expected<void, ErrorCode> CopyAscendToDram(const DataSource& src,
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    // Get AscendUnifiedPointer from source using type-safe cast
-    const AscendBuffer* ascend_src_buffer =
-        static_cast<const AscendBuffer*>(src.buffer.get());
-    if (!ascend_src_buffer) {
-        LOG(ERROR) << "CopyAscendToDram: source buffer is not an AscendBuffer";
-        return tl::unexpected(ErrorCode::INVALID_PARAMS);
-    }
-    const AscendUnifiedPointer* ascend_ptr =
-        ascend_src_buffer->GetUnifiedPointer();
-
-    if (!ascend_ptr || !ascend_ptr->device_ptr) {
-        LOG(ERROR) << "CopyAscendToDram: invalid Ascend pointer";
-        return tl::unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    // Get destination DRAM address
     size_t copy_size = src.buffer->size();
+    void* src_ptr = reinterpret_cast<void*>(src.buffer->data());
+    if (!src_ptr) {
+        LOG(ERROR) << "CopyAscendToDram: source pointer is null";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
 
     // Validate destination buffer size
     if (dst.buffer->size() < copy_size) {
@@ -399,16 +394,20 @@ tl::expected<void, ErrorCode> CopyAscendToDram(const DataSource& src,
 
 #ifdef USE_ASCEND_CACHE_TIER
     void* dest_ptr = reinterpret_cast<void*>(dst.buffer->data());
+    if (!dest_ptr) {
+        LOG(ERROR) << "CopyAscendToDram: destination pointer is null";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
     // Perform copy with device context management
-    if (!AclMemcpyWithDevice(ascend_ptr->device_id, dest_ptr,
-                             dst.buffer->size(), ascend_ptr->device_ptr,
+    int device_id = GetSingleAscendDeviceId();
+    if (!AclMemcpyWithDevice(device_id, dest_ptr, dst.buffer->size(), src_ptr,
                              copy_size, ACL_MEMCPY_DEVICE_TO_HOST,
                              "CopyAscendToDram")) {
         return tl::unexpected(ErrorCode::DATA_COPY_FAILED);
     }
 
     VLOG(1) << "CopyAscendToDram: copied " << copy_size << " bytes from device "
-            << ascend_ptr->device_id;
+            << device_id;
     return tl::expected<void, ErrorCode>{};
 #else
     LOG(ERROR)
@@ -420,8 +419,7 @@ tl::expected<void, ErrorCode> CopyAscendToDram(const DataSource& src,
 /**
  * @brief Copy data from DRAM to Ascend NPU.
  *
- * Extracts AscendUnifiedPointer from destination buffer to get device context,
- * then performs host-to-device memory copy.
+ * Uses the active Ascend device context to perform host-to-device copy.
  */
 tl::expected<void, ErrorCode> CopyDramToAscend(const DataSource& src,
                                                const DataSource& dst) {
@@ -439,41 +437,36 @@ tl::expected<void, ErrorCode> CopyDramToAscend(const DataSource& src,
 
     // Get source DRAM address
     size_t copy_size = src.buffer->size();
-
-    // Get AscendUnifiedPointer from destination using type-safe cast
-    const AscendBuffer* ascend_dst_buffer =
-        static_cast<const AscendBuffer*>(dst.buffer.get());
-    if (!ascend_dst_buffer) {
-        LOG(ERROR)
-            << "CopyDramToAscend: destination buffer is not an AscendBuffer";
+    const void* src_ptr = reinterpret_cast<const void*>(src.buffer->data());
+    if (!src_ptr) {
+        LOG(ERROR) << "CopyDramToAscend: source pointer is null";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
-    const AscendUnifiedPointer* ascend_ptr =
-        ascend_dst_buffer->GetUnifiedPointer();
 
-    if (!ascend_ptr || !ascend_ptr->device_ptr) {
-        LOG(ERROR) << "CopyDramToAscend: invalid Ascend pointer";
+    void* dst_ptr = reinterpret_cast<void*>(dst.buffer->data());
+    if (!dst_ptr) {
+        LOG(ERROR) << "CopyDramToAscend: destination pointer is null";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
     // Validate destination buffer size
-    if (ascend_ptr->size < copy_size) {
+    if (dst.buffer->size() < copy_size) {
         LOG(ERROR) << "CopyDramToAscend: destination buffer too small ("
-                   << ascend_ptr->size << " < " << copy_size << ")";
+                   << dst.buffer->size() << " < " << copy_size << ")";
         return tl::unexpected(ErrorCode::BUFFER_OVERFLOW);
     }
 
 #ifdef USE_ASCEND_CACHE_TIER
-    const void* src_ptr = reinterpret_cast<const void*>(src.buffer->data());
     // Perform copy with device context management
-    if (!AclMemcpyWithDevice(ascend_ptr->device_id, ascend_ptr->device_ptr,
-                             ascend_ptr->size, src_ptr, copy_size,
-                             ACL_MEMCPY_HOST_TO_DEVICE, "CopyDramToAscend")) {
+    int device_id = GetSingleAscendDeviceId();
+    if (!AclMemcpyWithDevice(device_id, dst_ptr, dst.buffer->size(), src_ptr,
+                             copy_size, ACL_MEMCPY_HOST_TO_DEVICE,
+                             "CopyDramToAscend")) {
         return tl::unexpected(ErrorCode::DATA_COPY_FAILED);
     }
 
     VLOG(1) << "CopyDramToAscend: copied " << copy_size << " bytes to device "
-            << ascend_ptr->device_id;
+            << device_id;
     return tl::expected<void, ErrorCode>{};
 #else
     LOG(ERROR)

--- a/mooncake-store/src/tiered_cache/tiers/ascend_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/ascend_tier.cpp
@@ -47,7 +47,16 @@ inline void SetSingleAscendDeviceId(int device_id) {
 
 // Helper function to set device context
 inline bool AclSetDevice(int device_id, const char* operation_name) {
-    auto ret = aclrtSetDevice(device_id);
+    // Stub: Reuse the existing device context of the process, skip
+    // configuration if already set
+    int current_device = -1;
+    auto ret = aclrtGetDevice(&current_device);
+    if (ret == ACL_SUCCESS) {
+        // Device context already configured for this process, skip
+        return true;
+    }
+
+    ret = aclrtSetDevice(device_id);
     if (ret != ACL_SUCCESS) {
         LOG(ERROR) << operation_name
                    << ": aclrtSetDevice failed, device: " << device_id

--- a/mooncake-store/tests/ascend_tier_test.cpp
+++ b/mooncake-store/tests/ascend_tier_test.cpp
@@ -659,9 +659,9 @@ TEST_F(AscendTierTest, AscendCacheTierInitWithInvalidDeviceId) {
     // Verify basic properties are set correctly
     EXPECT_EQ(tier.GetTierId(), tier_id);
     EXPECT_EQ(tier.GetCapacity(), BASIC_CAPACITY);
+    EXPECT_EQ(tier.GetDeviceId(), INVALID_DEVICE_ID);
     EXPECT_EQ(tier.GetUsage(), 0);
     EXPECT_EQ(tier.GetMemoryType(), MemoryType::ASCEND_NPU);
-    EXPECT_EQ(tier.GetDeviceId(), INVALID_DEVICE_ID);
 
     TieredBackend backend;
 
@@ -840,13 +840,15 @@ TEST_F(AscendTierTest, CopyBetweenAscendTiersSameDevice) {
 TEST_F(AscendTierTest, AscendCacheTierAccessors) {
     UUID tier_id = generate_uuid();
     std::vector<std::string> tags = {"tag1", "tag2", "tag3"};
-    AscendCacheTier tier(tier_id, BASIC_CAPACITY, tags, 1);
+    const int device_id = 1;
+
+    AscendCacheTier tier(tier_id, BASIC_CAPACITY, tags, device_id);
 
     EXPECT_EQ(tier.GetTierId(), tier_id);
     EXPECT_EQ(tier.GetCapacity(), BASIC_CAPACITY);
     EXPECT_EQ(tier.GetUsage(), 0);
     EXPECT_EQ(tier.GetMemoryType(), MemoryType::ASCEND_NPU);
-    EXPECT_EQ(tier.GetDeviceId(), 1);
+    EXPECT_EQ(tier.GetDeviceId(), device_id);
     EXPECT_EQ(tier.GetTags().size(), 3);
     EXPECT_EQ(tier.GetTags()[0], "tag1");
     EXPECT_EQ(tier.GetTags()[1], "tag2");
@@ -864,8 +866,8 @@ TEST_F(AscendTierTest, AscendCacheTierConstructorWithDefaults) {
     EXPECT_EQ(tier.GetCapacity(), BASIC_CAPACITY);
     EXPECT_EQ(tier.GetUsage(), 0);
     EXPECT_EQ(tier.GetMemoryType(), MemoryType::ASCEND_NPU);
-    EXPECT_EQ(tier.GetDeviceId(), 0);
     EXPECT_EQ(tier.GetTags().size(), 0);  // Default empty tags
+    EXPECT_EQ(tier.GetDeviceId(), 0);
 }
 
 // ============================================================================

--- a/mooncake-store/tests/ascend_tier_test.cpp
+++ b/mooncake-store/tests/ascend_tier_test.cpp
@@ -50,52 +50,6 @@ class BufferRef : public BufferBase {
     const BufferBase* ref_;
 };
 
-#ifdef USE_ASCEND_CACHE_TIER
-/**
- * @class AscendBufferRef
- * @brief Non-owning reference to an AscendBuffer for testing.
- * Extends AscendBuffer but does not own the memory - destructor is a no-op.
- */
-class AscendBufferRef : public AscendBuffer {
-   public:
-    // Create a non-owning reference by passing a "dummy" unique_ptr that we
-    // will immediately release and replace with our reference
-    explicit AscendBufferRef(const AscendBuffer* ref)
-        : AscendBuffer(CreateDummyPtr(ref)), ref_(ref) {
-        // The base class now holds the dummy ptr. We override all methods
-        // to delegate to ref_ instead.
-    }
-
-    // Override to prevent memory release (we don't own the memory)
-    ~AscendBufferRef() override = default;
-
-    uint64_t data() const override { return ref_ ? ref_->data() : 0; }
-    std::size_t size() const override { return ref_ ? ref_->size() : 0; }
-    int GetDeviceId() const { return ref_ ? ref_->GetDeviceId() : -1; }
-    void* GetDevicePtr() const { return ref_ ? ref_->GetDevicePtr() : nullptr; }
-    const AscendUnifiedPointer* GetUnifiedPointer() const {
-        return ref_ ? ref_->GetUnifiedPointer() : nullptr;
-    }
-
-   private:
-    const AscendBuffer* ref_;
-
-    // Create a minimal AscendUnifiedPointer for base class construction
-    static std::unique_ptr<AscendUnifiedPointer> CreateDummyPtr(
-        const AscendBuffer* ref) {
-        auto ptr = std::make_unique<AscendUnifiedPointer>();
-        if (ref && ref->GetUnifiedPointer()) {
-            *ptr = *ref->GetUnifiedPointer();  // Copy the data
-        } else {
-            ptr->device_ptr = nullptr;
-            ptr->device_id = -1;
-            ptr->size = 0;
-        }
-        return ptr;
-    }
-};
-#endif
-
 // Test data size constants
 static constexpr size_t SMALL_DATA_SIZE = 4 * 1024;    // 4KB
 static constexpr size_t MEDIUM_DATA_SIZE = 64 * 1024;  // 64KB
@@ -159,21 +113,14 @@ TEST_F(AscendTierTest, MemoryTypeToStringAllTypes) {
 
 // Test AscendBuffer basic lifecycle
 TEST_F(AscendTierTest, AscendBufferLifecycle) {
-    // Create a mock AscendUnifiedPointer with fallback (host memory)
     void* mock_ptr = std::malloc(1024);
     ASSERT_NE(mock_ptr, nullptr);
 
-    auto unified_ptr = std::make_unique<AscendUnifiedPointer>(
-        AscendUnifiedPointer{mock_ptr, -1, 1024});
-    auto* raw_ptr = unified_ptr.get();
-
     {
-        AscendBuffer buffer(std::move(unified_ptr));
+        AscendBuffer buffer(mock_ptr, 1024);
         EXPECT_EQ(buffer.size(), 1024);
-        EXPECT_EQ(buffer.GetDeviceId(), -1);
         EXPECT_NE(buffer.data(), 0);
         EXPECT_EQ(buffer.GetDevicePtr(), mock_ptr);
-        EXPECT_EQ(buffer.GetUnifiedPointer(), raw_ptr);
     }
     // Buffer should be released when going out of scope
 }
@@ -183,9 +130,7 @@ TEST_F(AscendTierTest, AscendBufferMoveConstructor) {
     void* mock_ptr = std::malloc(2048);
     ASSERT_NE(mock_ptr, nullptr);
 
-    auto unified_ptr = std::make_unique<AscendUnifiedPointer>(
-        AscendUnifiedPointer{mock_ptr, 0, 2048});
-    AscendBuffer original(std::move(unified_ptr));
+    AscendBuffer original(mock_ptr, 2048);
 
     EXPECT_EQ(original.size(), 2048);
 
@@ -206,13 +151,8 @@ TEST_F(AscendTierTest, AscendBufferMoveAssignment) {
     ASSERT_NE(mock_ptr1, nullptr);
     ASSERT_NE(mock_ptr2, nullptr);
 
-    auto unified_ptr1 = std::make_unique<AscendUnifiedPointer>(
-        AscendUnifiedPointer{mock_ptr1, 0, 1024});
-    auto unified_ptr2 = std::make_unique<AscendUnifiedPointer>(
-        AscendUnifiedPointer{mock_ptr2, 1, 2048});
-
-    AscendBuffer buffer1(std::move(unified_ptr1));
-    AscendBuffer buffer2(std::move(unified_ptr2));
+    AscendBuffer buffer1(mock_ptr1, 1024);
+    AscendBuffer buffer2(mock_ptr2, 2048);
 
     EXPECT_EQ(buffer1.size(), 1024);
     EXPECT_EQ(buffer2.size(), 2048);
@@ -220,7 +160,6 @@ TEST_F(AscendTierTest, AscendBufferMoveAssignment) {
     // Move assign
     buffer1 = std::move(buffer2);
     EXPECT_EQ(buffer1.size(), 2048);
-    EXPECT_EQ(buffer1.GetDeviceId(), 1);
     EXPECT_EQ(buffer2.size(), 0);
 }
 
@@ -630,12 +569,9 @@ TEST_F(AscendTierTest, CopyAscendToDramWithVerification) {
 
     // 4. Copy from Ascend to DRAM using DataCopier (this should invoke
     // CopyAscendToDram)
-    const AscendBuffer* ascend_buf = static_pointer_cast<const AscendBuffer*>(
-        ascend_handle->loc.data.buffer.get());
-    ASSERT_NE(ascend_buf, nullptr) << "Buffer should be AscendBuffer";
-
     DataSource ascend_source;
-    ascend_source.buffer = std::make_unique<AscendBufferRef>(ascend_buf);
+    ascend_source.buffer =
+        std::make_unique<BufferRef>(ascend_handle->loc.data.buffer.get());
     ascend_source.type = MemoryType::ASCEND_NPU;
 
     auto copy_result = backend.GetDataCopier().Copy(ascend_source, dram_dest);
@@ -723,9 +659,9 @@ TEST_F(AscendTierTest, AscendCacheTierInitWithInvalidDeviceId) {
     // Verify basic properties are set correctly
     EXPECT_EQ(tier.GetTierId(), tier_id);
     EXPECT_EQ(tier.GetCapacity(), BASIC_CAPACITY);
-    EXPECT_EQ(tier.GetDeviceId(), INVALID_DEVICE_ID);
     EXPECT_EQ(tier.GetUsage(), 0);
     EXPECT_EQ(tier.GetMemoryType(), MemoryType::ASCEND_NPU);
+    EXPECT_EQ(tier.GetDeviceId(), INVALID_DEVICE_ID);
 
     TieredBackend backend;
 
@@ -904,15 +840,13 @@ TEST_F(AscendTierTest, CopyBetweenAscendTiersSameDevice) {
 TEST_F(AscendTierTest, AscendCacheTierAccessors) {
     UUID tier_id = generate_uuid();
     std::vector<std::string> tags = {"tag1", "tag2", "tag3"};
-    const int device_id = 1;
-
-    AscendCacheTier tier(tier_id, BASIC_CAPACITY, tags, device_id);
+    AscendCacheTier tier(tier_id, BASIC_CAPACITY, tags, 1);
 
     EXPECT_EQ(tier.GetTierId(), tier_id);
     EXPECT_EQ(tier.GetCapacity(), BASIC_CAPACITY);
     EXPECT_EQ(tier.GetUsage(), 0);
     EXPECT_EQ(tier.GetMemoryType(), MemoryType::ASCEND_NPU);
-    EXPECT_EQ(tier.GetDeviceId(), device_id);
+    EXPECT_EQ(tier.GetDeviceId(), 1);
     EXPECT_EQ(tier.GetTags().size(), 3);
     EXPECT_EQ(tier.GetTags()[0], "tag1");
     EXPECT_EQ(tier.GetTags()[1], "tag2");
@@ -930,8 +864,8 @@ TEST_F(AscendTierTest, AscendCacheTierConstructorWithDefaults) {
     EXPECT_EQ(tier.GetCapacity(), BASIC_CAPACITY);
     EXPECT_EQ(tier.GetUsage(), 0);
     EXPECT_EQ(tier.GetMemoryType(), MemoryType::ASCEND_NPU);
-    EXPECT_EQ(tier.GetTags().size(), 0);  // Default empty tags
     EXPECT_EQ(tier.GetDeviceId(), 0);
+    EXPECT_EQ(tier.GetTags().size(), 0);  // Default empty tags
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description
limit num of ascend tier to 1
use env value `MOONCAKE_ASCEND_DEVICE_ID` to get device context instead of `ascend_ptr.device_id`
<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
