### PR TITLE
[Store] fix(master-metrics): track local SSD storage in Master metrics

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -388,6 +388,9 @@ class Client {
         bool enable_offloading,
         std::unordered_map<std::string, int64_t>& offloading_objects);
 
+    tl::expected<void, ErrorCode> ReportSsdCapacity(
+        int64_t ssd_total_capacity_bytes);
+
     /**
      * @brief Performs a batched read of multiple objects using a
      * high-throughput Transfer Engine.

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -349,6 +349,9 @@ class MasterClient {
                                ErrorCode>
     OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading);
 
+    [[nodiscard]] tl::expected<void, ErrorCode> ReportSsdCapacity(
+        const UUID& client_id, int64_t ssd_total_capacity_bytes);
+
     /**
      * @brief Adds multiple new objects to a specified client in batch.
      * @param keys         A list of object keys (names) that were successfully

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -439,6 +439,10 @@ class MasterService {
     auto OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading)
         -> tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>;
 
+    auto ReportSsdCapacity(const UUID& client_id,
+                           int64_t ssd_total_capacity_bytes)
+        -> tl::expected<void, ErrorCode>;
+
     /**
      * @brief Notifies the master that offloading of specified objects has
      * succeeded.

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -169,17 +169,25 @@ class Replica {
         MasterMetricManager::instance().inc_allocated_file_size(object_size);
     }
 
+    // local disk replica constructor
     Replica(UUID client_id, uint64_t object_size,
             std::string transport_endpoint, ReplicaStatus status)
-        : data_(LocalDiskReplicaData{client_id, object_size,
+        : id_(next_id_.fetch_add(1)),
+          data_(LocalDiskReplicaData{client_id, object_size,
                                      std::move(transport_endpoint)}),
-          status_(status) {}
+          status_(status),
+          refcnt_(0) {
+        MasterMetricManager::instance().inc_allocated_file_size(object_size);
+    }
 
     ~Replica() {
-        if (status_ != ReplicaStatus::UNDEFINED && is_disk_replica()) {
-            const auto& disk_data = std::get<DiskReplicaData>(data_);
+        if (status_ == ReplicaStatus::UNDEFINED) return;
+        if (is_disk_replica()) {
             MasterMetricManager::instance().dec_allocated_file_size(
-                disk_data.object_size);
+                std::get<DiskReplicaData>(data_).object_size);
+        } else if (is_local_disk_replica()) {
+            MasterMetricManager::instance().dec_allocated_file_size(
+                std::get<LocalDiskReplicaData>(data_).object_size);
         }
     }
 
@@ -205,10 +213,14 @@ class Replica {
         }
 
         // Decrement metric for the current object before overwriting.
-        if (status_ != ReplicaStatus::UNDEFINED && is_disk_replica()) {
-            const auto& disk_data = std::get<DiskReplicaData>(data_);
-            MasterMetricManager::instance().dec_allocated_file_size(
-                disk_data.object_size);
+        if (status_ != ReplicaStatus::UNDEFINED) {
+            if (is_disk_replica()) {
+                MasterMetricManager::instance().dec_allocated_file_size(
+                    std::get<DiskReplicaData>(data_).object_size);
+            } else if (is_local_disk_replica()) {
+                MasterMetricManager::instance().dec_allocated_file_size(
+                    std::get<LocalDiskReplicaData>(data_).object_size);
+            }
         }
 
         id_ = src.id_;

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -145,6 +145,9 @@ class WrappedMasterService {
     tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>
     OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading);
 
+    tl::expected<void, ErrorCode> ReportSsdCapacity(
+        const UUID& client_id, int64_t ssd_total_capacity_bytes);
+
     tl::expected<void, ErrorCode> NotifyOffloadSuccess(
         const UUID& client_id, const std::vector<std::string>& keys,
         const std::vector<StorageObjectMetadata>& metadatas);

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -50,6 +50,7 @@ struct MountedSegment {
 struct LocalDiskSegment {
     mutable Mutex offloading_mutex_;
     bool enable_offloading;
+    int64_t ssd_total_capacity_bytes = 0;  // last reported by client heartbeat
     std::unordered_map<std::string, int64_t> GUARDED_BY(offloading_mutex_)
         offloading_objects;
     explicit LocalDiskSegment(bool enable_offloading)

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2271,6 +2271,18 @@ tl::expected<void, ErrorCode> Client::OffloadObjectHeartbeat(
     return {};
 }
 
+tl::expected<void, ErrorCode> Client::ReportSsdCapacity(
+    int64_t ssd_total_capacity_bytes) {
+    auto response =
+        master_client_.ReportSsdCapacity(client_id_, ssd_total_capacity_bytes);
+    if (!response) {
+        LOG(ERROR) << "ReportSsdCapacity failed, error code is "
+                   << response.error();
+        return tl::make_unexpected(response.error());
+    }
+    return {};
+}
+
 tl::expected<void, ErrorCode> Client::BatchGetOffloadObject(
     const std::string& transfer_engine_addr,
     const std::vector<std::string>& keys,

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -239,6 +239,17 @@ tl::expected<void, ErrorCode> FileStorage::Init() {
             return mount_file_storage_result;
         }
     }
+    // Report configured SSD capacity to Master so it can populate
+    // file_total_capacity_ (the denominator in "SSD Storage: X / Y").
+    // Called once at init; old Masters that lack this RPC will log an error
+    // but FileStorage continues normally.
+    if (config_.total_size_limit > 0) {
+        auto cap_result = client_->ReportSsdCapacity(config_.total_size_limit);
+        if (!cap_result) {
+            LOG(WARNING) << "ReportSsdCapacity failed (old Master?): "
+                         << cap_result.error();
+        }
+    }
 
     auto scan_meta_result = storage_backend_->ScanMeta(
         [this](const std::vector<std::string>& keys,

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -188,6 +188,11 @@ struct RpcNameTraits<&WrappedMasterService::OffloadObjectHeartbeat> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::ReportSsdCapacity> {
+    static constexpr const char* value = "ReportSsdCapacity";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::NotifyOffloadSuccess> {
     static constexpr const char* value = "NotifyOffloadSuccess";
 };
@@ -806,6 +811,15 @@ MasterClient::OffloadObjectHeartbeat(const UUID& client_id,
                              std::unordered_map<std::string, int64_t>>(
         client_id, enable_offloading);
     return result;
+}
+
+tl::expected<void, ErrorCode> MasterClient::ReportSsdCapacity(
+    const UUID& client_id, int64_t ssd_total_capacity_bytes) {
+    ScopedVLogTimer timer(1, "MasterClient::ReportSsdCapacity");
+    timer.LogRequest("client_id=", client_id,
+                     ", ssd_total_capacity_bytes=", ssd_total_capacity_bytes);
+    return invoke_rpc<&WrappedMasterService::ReportSsdCapacity, void>(
+        client_id, ssd_total_capacity_bytes);
 }
 
 tl::expected<void, ErrorCode> MasterClient::NotifyOffloadSuccess(

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2143,6 +2143,38 @@ auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
     return {};
 }
 
+auto MasterService::ReportSsdCapacity(const UUID& client_id,
+                                      int64_t ssd_total_capacity_bytes)
+    -> tl::expected<void, ErrorCode> {
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    ScopedLocalDiskSegmentAccess local_disk_segment_access =
+        segment_manager_.getLocalDiskSegmentAccess();
+    auto& client_local_disk_segment =
+        local_disk_segment_access.getClientLocalDiskSegment();
+    auto local_disk_segment_it = client_local_disk_segment.find(client_id);
+    if (local_disk_segment_it == client_local_disk_segment.end()) {
+        LOG(ERROR) << "Local disk segment not found with client id = "
+                   << client_id;
+        return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
+    }
+    MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
+    int64_t old_capacity =
+        local_disk_segment_it->second->ssd_total_capacity_bytes;
+    if (ssd_total_capacity_bytes != old_capacity) {
+        local_disk_segment_it->second->ssd_total_capacity_bytes =
+            ssd_total_capacity_bytes;
+        if (old_capacity > 0) {
+            MasterMetricManager::instance().dec_total_file_capacity(
+                old_capacity);
+        }
+        if (ssd_total_capacity_bytes > 0) {
+            MasterMetricManager::instance().inc_total_file_capacity(
+                ssd_total_capacity_bytes);
+        }
+    }
+    return {};
+}
+
 auto MasterService::NotifyOffloadSuccess(
     const UUID& client_id, const std::vector<std::string>& keys,
     const std::vector<StorageObjectMetadata>& metadatas)

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2146,6 +2146,9 @@ auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
 auto MasterService::ReportSsdCapacity(const UUID& client_id,
                                       int64_t ssd_total_capacity_bytes)
     -> tl::expected<void, ErrorCode> {
+    if (ssd_total_capacity_bytes < 0) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     ScopedLocalDiskSegmentAccess local_disk_segment_access =
         segment_manager_.getLocalDiskSegmentAccess();

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1651,6 +1651,15 @@ WrappedMasterService::OffloadObjectHeartbeat(const UUID& client_id,
     return result;
 }
 
+tl::expected<void, ErrorCode> WrappedMasterService::ReportSsdCapacity(
+    const UUID& client_id, int64_t ssd_total_capacity_bytes) {
+    ScopedVLogTimer timer(1, "ReportSsdCapacity");
+    timer.LogRequest("client_id=", client_id,
+                     ", ssd_total_capacity_bytes=", ssd_total_capacity_bytes);
+    return master_service_.ReportSsdCapacity(client_id,
+                                             ssd_total_capacity_bytes);
+}
+
 tl::expected<void, ErrorCode> WrappedMasterService::NotifyOffloadSuccess(
     const UUID& client_id, const std::vector<std::string>& keys,
     const std::vector<StorageObjectMetadata>& metadatas) {
@@ -1753,6 +1762,8 @@ void RegisterRpcService(
         &wrapped_master_service);
     server.register_handler<
         &mooncake::WrappedMasterService::OffloadObjectHeartbeat>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::ReportSsdCapacity>(
         &wrapped_master_service);
     server.register_handler<
         &mooncake::WrappedMasterService::NotifyOffloadSuccess>(

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -276,6 +276,20 @@ ErrorCode ScopedSegmentAccess::GetClientSegments(
 void ScopedSegmentAccess::UnmountLocalDiskSegment(const UUID& client_id) {
     auto it = segment_manager_->client_local_disk_segment_.find(client_id);
     if (it != segment_manager_->client_local_disk_segment_.end()) {
+        // Hold offloading_mutex_ while reading ssd_total_capacity_bytes to
+        // avoid a data race with OffloadObjectHeartbeat, which writes the
+        // field under the same lock.  Release the lock before erase() so we
+        // don't unlock an already-destroyed mutex (erase destroys the
+        // LocalDiskSegment, including its mutex).
+        int64_t reported_capacity = 0;
+        {
+            MutexLocker locker(&it->second->offloading_mutex_);
+            reported_capacity = it->second->ssd_total_capacity_bytes;
+        }
+        if (reported_capacity > 0) {
+            MasterMetricManager::instance().dec_total_file_capacity(
+                reported_capacity);
+        }
         segment_manager_->client_local_disk_segment_.erase(it);
         LOG(INFO) << "client_id=" << client_id
                   << ", action=unmount_local_disk_segment";

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -8,6 +8,7 @@
 #include <ylt/coro_http/coro_http_client.hpp>
 
 #include "utils.h"
+#include "master_service.h"
 #include "rpc_service.h"
 #include "types.h"
 #include "master_config.h"
@@ -509,6 +510,105 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
     ASSERT_EQ(metrics.get_batch_put_start_failures(), 0);
     ASSERT_EQ(metrics.get_batch_put_start_items(), 7);
     ASSERT_EQ(metrics.get_batch_put_start_failed_items(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Tests for local SSD metrics (Bug 1 fix)
+// ---------------------------------------------------------------------------
+
+// Helper: put a key into a mem segment and immediately notify offload success,
+// simulating the client-side SSD write completing.
+static std::string PutKeyAndOffload(MasterService& svc, const UUID& client_id,
+                                    const std::string& segment_name,
+                                    uint64_t value_size,
+                                    const std::string& key) {
+    ReplicateConfig cfg;
+    cfg.replica_num = 1;
+    auto put_start = svc.PutStart(client_id, key, value_size, cfg);
+    if (!put_start) return "";
+    svc.PutEnd(client_id, key, ReplicaType::MEMORY);
+
+    StorageObjectMetadata meta;
+    meta.data_size = static_cast<int64_t>(value_size);
+    meta.transport_endpoint = "127.0.0.1:9999";
+    svc.NotifyOffloadSuccess(client_id, {key}, {meta});
+    return key;
+}
+
+// Verify that creating a LocalDiskReplica (via NotifyOffloadSuccess) increments
+// file_allocated_size, and that removing the key decrements it back to zero.
+TEST_F(MasterMetricsTest, LocalDiskReplicaAllocatedSize) {
+    auto& metrics = MasterMetricManager::instance();
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    MasterService svc(config);
+
+    constexpr size_t kBuf = 0x400000000;
+    constexpr size_t kSegSize = 64 * 1024 * 1024;
+    constexpr uint64_t kValueSize = 4096;
+
+    UUID client_id = generate_uuid();
+    Segment seg;
+    seg.id = generate_uuid();
+    seg.name = "ssd_alloc_test_segment";
+    seg.base = kBuf;
+    seg.size = kSegSize;
+    seg.te_endpoint = seg.name;
+
+    ASSERT_TRUE(svc.MountSegment(seg, client_id).has_value());
+    ASSERT_TRUE(svc.MountLocalDiskSegment(client_id, true).has_value());
+
+    const int64_t baseline = metrics.get_allocated_file_size();
+
+    // After NotifyOffloadSuccess, a LocalDiskReplica is created.
+    std::string key = PutKeyAndOffload(svc, client_id, seg.name, kValueSize,
+                                       "ssd_alloc_test_key");
+    ASSERT_FALSE(key.empty());
+    EXPECT_EQ(metrics.get_allocated_file_size(), baseline + kValueSize);
+
+    // After removing the key the LocalDiskReplica is destroyed; gauge resets.
+    ASSERT_TRUE(svc.Remove(key).has_value());
+    EXPECT_EQ(metrics.get_allocated_file_size(), baseline);
+}
+
+// Verify that OffloadObjectHeartbeat updates total_file_capacity correctly,
+// including when a client reports a changed capacity on a subsequent heartbeat.
+TEST_F(MasterMetricsTest, LocalDiskSegmentCapacityHeartbeat) {
+    auto& metrics = MasterMetricManager::instance();
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    MasterService svc(config);
+
+    constexpr size_t kBuf = 0x500000000;
+    constexpr size_t kSegSize = 64 * 1024 * 1024;
+    constexpr int64_t kCap1 = 800LL * 1024 * 1024 * 1024;  // 800 GB
+    constexpr int64_t kCap2 = 400LL * 1024 * 1024 * 1024;  // 400 GB
+
+    UUID client_id = generate_uuid();
+    Segment seg;
+    seg.id = generate_uuid();
+    seg.name = "ssd_capacity_test_segment";
+    seg.base = kBuf;
+    seg.size = kSegSize;
+    seg.te_endpoint = seg.name;
+
+    ASSERT_TRUE(svc.MountSegment(seg, client_id).has_value());
+    ASSERT_TRUE(svc.MountLocalDiskSegment(client_id, true).has_value());
+
+    const int64_t baseline = metrics.get_total_file_capacity();
+
+    // ReportSsdCapacity: client reports 800 GB.
+    ASSERT_TRUE(svc.ReportSsdCapacity(client_id, kCap1).has_value());
+    EXPECT_EQ(metrics.get_total_file_capacity(), baseline + kCap1);
+
+    // Client reports 400 GB (e.g. config changed).
+    // Gauge must be updated to reflect the new value, not double-counted.
+    ASSERT_TRUE(svc.ReportSsdCapacity(client_id, kCap2).has_value());
+    EXPECT_EQ(metrics.get_total_file_capacity(), baseline + kCap2);
+
+    // Idempotent: same capacity reported again — gauge must not change.
+    ASSERT_TRUE(svc.ReportSsdCapacity(client_id, kCap2).has_value());
+    EXPECT_EQ(metrics.get_total_file_capacity(), baseline + kCap2);
 }
 
 }  // namespace mooncake::test


### PR DESCRIPTION
## Description

Fix `SSD Storage: 0 B / 0 B` always shown in Master metrics even when local SSD offloading is active.

Three root causes were identified and fixed:

**Bug 1 — Allocated size not tracked for `LocalDiskReplica`**

`MasterMetricManager::file_allocated_size_` (the numerator) was only incremented/decremented for `DiskReplicaData` (3FS/NFS shared storage). The `LocalDiskReplicaData` constructor never called `inc_allocated_file_size()`, so successful SSD offloads were invisible to the metric. The destructor and move-assignment operator had the same omission.

Also fixed a pre-existing bug in the same constructor: `id_` and `refcnt_` were uninitialized.

**Bug 2 — Total SSD capacity unknown to Master**

`MasterMetricManager::file_total_capacity_` (the denominator) was only set when `root_fs_dir_` (3FS path) was configured. For local SSD offloading the total capacity is a client-side configuration (`MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES`) that Master has no direct visibility into, so the denominator was permanently 0.

Fix: a new dedicated RPC `ReportSsdCapacity(client_id, ssd_total_capacity_bytes)` is added. `FileStorage::Init()` calls it once after `MountLocalDiskSegment` succeeds. Master stores the value per-client in `LocalDiskSegment::ssd_total_capacity_bytes` and updates the gauge via inc/dec on change. Capacity is returned to the gauge in `UnmountLocalDiskSegment` to prevent leaks on client disconnect.

`OffloadObjectHeartbeat` signature is **unchanged** — old clients that predate this fix continue to work normally; the denominator simply shows 0 for those clients rather than failing the RPC.

**Bug 3 — Data race in `UnmountLocalDiskSegment`**

`ssd_total_capacity_bytes` was read in `UnmountLocalDiskSegment` without holding `offloading_mutex_`, while `OffloadObjectHeartbeat` (and the new `ReportSsdCapacity`) write it under that lock — a data race (UB per C++ standard). Fixed by reading inside a scoped lock block, then releasing the lock *before* `erase()` to avoid unlocking an already-destroyed mutex.

Related issue: users reported `SSD Storage: 0 B / 0 B` in Master logs despite confirmed SSD writes (meta and bucket data visible on disk).

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

**Unit tests** (`mooncake-store/tests/master_metrics_test.cpp`):

Two new test cases were added and verified to fail on the unfixed code and pass on the fixed code:

- `LocalDiskReplicaAllocatedSize`: calls `NotifyOffloadSuccess` to create a `LocalDiskReplica`, asserts `master_allocated_file_size_bytes` increases by the object size, then calls `Remove()` and asserts the gauge returns to zero.

- `LocalDiskSegmentCapacityHeartbeat`: calls `ReportSsdCapacity` directly, asserts `master_total_file_capacity_bytes` is updated correctly. Also verifies no double-counting on repeated calls and idempotency when the same value is reported twice.

**Integration test** (real `mooncake_master` + `mooncake_client`):

Started a master with `--enable_offload=true` and a client with `MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES=10737418240`. After `FileStorage::Init()` called `ReportSsdCapacity`, queried the Prometheus metrics endpoint and confirmed:

```
master_total_file_capacity_bytes 10737418240   # was 0 before fix
master_allocated_file_size_bytes 0             # non-zero with real SGLang writes
```

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
