### PR TITLE
[PG] Refactor P2PProxy with shared chunk pools and receiver-driven credit-based flow control

### DIFF
--- a/mooncake-pg/include/connection_poller.h
+++ b/mooncake-pg/include/connection_poller.h
@@ -185,7 +185,7 @@ class ConnectionContext {
                std::to_string(rank);
     }
     static std::string getExtensionStateStoreKey(int backendIndex, int rank) {
-        return "extension_sa" + std::to_string(backendIndex) + "_" +
+        return "extension_state_" + std::to_string(backendIndex) + "_" +
                std::to_string(rank);
     }
 

--- a/mooncake-pg/include/connection_poller.h
+++ b/mooncake-pg/include/connection_poller.h
@@ -184,14 +184,8 @@ class ConnectionContext {
         return "buffer_" + std::to_string(backendIndex) + "_" +
                std::to_string(rank);
     }
-    static std::string getExtensionTaskCountStoreKey(int backendIndex,
-                                                     int rank) {
-        return "extension_task_count_" + std::to_string(backendIndex) + "_" +
-               std::to_string(rank);
-    }
-    static std::string getExtensionActiveRanksStoreKey(int backendIndex,
-                                                       int rank) {
-        return "extension_active_ranks_" + std::to_string(backendIndex) + "_" +
+    static std::string getExtensionStateStoreKey(int backendIndex, int rank) {
+        return "extension_sa" + std::to_string(backendIndex) + "_" +
                std::to_string(rank);
     }
 

--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -208,6 +208,14 @@ class MooncakeBackend final : public ::c10d::Backend {
     bool connectionPollerRegistered_{false};
 };
 
+struct ExtensionState {
+    std::vector<bool> activeRanks;
+    uint32_t p2pGeneration;
+    int taskCount;
+};
+std::vector<uint8_t> serialize(const ExtensionState& state);
+ExtensionState deserialize(const std::vector<uint8_t>& buffer);
+
 }  // namespace mooncake
 
 #endif  // MOONCAKE_BACKEND_H

--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -210,7 +210,7 @@ class MooncakeBackend final : public ::c10d::Backend {
 
 struct ExtensionState {
     std::vector<bool> activeRanks;
-    std::vector<uint32_t> p2pGenerations;
+    std::vector<uint32_t> p2pEpochs;
     int taskCount = -1;
 };
 std::vector<uint8_t> serialize(const ExtensionState& state);

--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -210,8 +210,8 @@ class MooncakeBackend final : public ::c10d::Backend {
 
 struct ExtensionState {
     std::vector<bool> activeRanks;
-    uint32_t p2pGeneration;
-    int taskCount;
+    std::vector<uint32_t> p2pGenerations;
+    int taskCount = -1;
 };
 std::vector<uint8_t> serialize(const ExtensionState& state);
 ExtensionState deserialize(const std::vector<uint8_t>& buffer);

--- a/mooncake-pg/include/mooncake_worker.cuh
+++ b/mooncake-pg/include/mooncake_worker.cuh
@@ -25,8 +25,8 @@ static constexpr size_t kMaxNumRanks = 64;
 struct SegmentInfo {
     uint64_t send_buffer[2], recv_buffer[2], send_sync[2], recv_sync[2],
         warmup_buffer[2];
-    uint64_t p2p_publish_region;
-    uint64_t p2p_completion_region;
+    uint64_t p2p_credit_region;
+    uint64_t p2p_ack_region;
 };
 
 struct TransferGroupMeta {

--- a/mooncake-pg/include/mooncake_worker.cuh
+++ b/mooncake-pg/include/mooncake_worker.cuh
@@ -25,10 +25,8 @@ static constexpr size_t kMaxNumRanks = 64;
 struct SegmentInfo {
     uint64_t send_buffer[2], recv_buffer[2], send_sync[2], recv_sync[2],
         warmup_buffer[2];
-    uint64_t p2p_send_buffer;
-    uint64_t p2p_recv_buffer;
-    uint64_t p2p_ctrl_send;
-    uint64_t p2p_ctrl_recv;
+    uint64_t p2p_publish_region;
+    uint64_t p2p_completion_region;
 };
 
 struct TransferGroupMeta {

--- a/mooncake-pg/include/p2p_proxy.h
+++ b/mooncake-pg/include/p2p_proxy.h
@@ -162,9 +162,12 @@ namespace mooncake {
 //
 // ---------------------------------------------------------------------------
 inline constexpr uint32_t kP2PControlRingSize = 64;
-// default config: pool_size=128M, chunk_size=16M, num_chunks=8
-inline constexpr uint64_t kDefaultPoolSize = 128u * 1024 * 1024;  // 128 M
-inline constexpr uint64_t kDefaultChunkSize = 16u * 1024 * 1024;  // 16 M
+// Pool size and chunk size can be overridden via environment variables:
+//   MOONCAKE_P2P_POOL_SIZE  -- total bytes per direction (default 128 MiB)
+//   MOONCAKE_P2P_CHUNK_SIZE -- granularity of each chunk (default 16 MiB)
+// The chunk count is pool_size / chunk_size (default 8).
+inline constexpr uint64_t kDefaultPoolSize = 128u * 1024 * 1024;  // 128 MiB
+inline constexpr uint64_t kDefaultChunkSize = 16u * 1024 * 1024;  // 16 MiB
 
 // Single-word atomic publication token.
 // Combines generation and sequence to avoid torn reads.
@@ -278,7 +281,6 @@ class P2PProxy {
         int rank = 0;
         int size = 0;
         int cuda_device_index = -1;
-        std::string location;
         std::chrono::milliseconds transfer_timeout_ms{30000};
     };
 
@@ -300,8 +302,6 @@ class P2PProxy {
     P2PProxy(TransferEngine* engine, const Options& options);
     ~P2PProxy();
 
-    void* send_pool_base() const { return resources_.send_pool_base_; }
-    void* recv_pool_base() const { return resources_.recv_pool_base_; }
     PublishSlot* publish_region() const { return resources_.publish_region_; }
     CompletionSlot* completion_region() const {
         return resources_.completion_region_;
@@ -488,7 +488,8 @@ class P2PProxy {
     // For P2PDeviceWorker
     bool stepSend();
     bool stepRecv();
-    void setDeviceWorker(P2PDeviceWorker*);
+    void attachToWorker(P2PDeviceWorker* worker, P2PChunkPool* send,
+                        P2PChunkPool* recv, size_t chunk_size);
     bool hasActiveSendWork() const;
     bool hasActiveRecvWork() const;
 
@@ -510,6 +511,15 @@ class P2PProxy {
     void performSendReset(int peer_rank);
 
     void reportBrokenPeer(int peer_rank);
+
+    // These helpers are used only during reset or shutdown.
+    // In the normal execution path, task and lane resources are released
+    // incrementally as work progresses.
+    void releaseSendTaskResources(SendTransferTask& task) const;
+    void releaseRecvTaskResources(RecvTransferTask& task) const;
+    void resetSendLane(SendPeerLane& lane);
+    void resetRecvLane(RecvPeerLane& lane);
+    void resetPeerControlLanes(int peer_rank);
 
     // Control lane addressing.
     //
@@ -539,8 +549,6 @@ class P2PProxy {
 
    private:
     struct P2PResources {
-        void* send_pool_base_ = nullptr;
-        void* recv_pool_base_ = nullptr;
         PublishSlot* publish_region_ = nullptr;
         CompletionSlot* completion_region_ = nullptr;
         // Serve as RDMA write source address
@@ -556,17 +564,14 @@ class P2PProxy {
     int rank_ = 0;
     int size_ = 0;
     int cuda_device_index_ = -1;
-    std::string location_;
     std::chrono::milliseconds transfer_timeout_ms_{5000};  // 5s
     P2PResources resources_;
     bool resource_abandoned_{false};
 
     size_t chunk_size_ = 0;
-    uint32_t num_chunks_ = 0;
-    size_t pool_bytes_ = 0;
 
-    P2PChunkPool send_pool_;
-    P2PChunkPool recv_pool_;
+    P2PChunkPool* send_pool_ = nullptr;
+    P2PChunkPool* recv_pool_ = nullptr;
 
     std::queue<SendOpContext> send_queue_;
     std::mutex send_queue_mutex_;
@@ -598,13 +603,10 @@ class P2PDeviceWorker {
     void registerProxy(const std::shared_ptr<P2PProxy>&);
     void removeProxy(const std::shared_ptr<P2PProxy>&);
 
-    P2PDeviceWorker(bool is_cpu, int cuda_device_index)
-        : is_cpu_(is_cpu), cuda_device_index_(cuda_device_index) {
-        start();
-    }
+    P2PDeviceWorker(TransferEngine* engine, const std::string& location,
+                    bool is_cpu, int cuda_device_index);
 
-    ~P2PDeviceWorker() { stop(); }
-
+    ~P2PDeviceWorker();
     void wakeUpSend();
     void wakeUpRecv();
 
@@ -633,6 +635,23 @@ class P2PDeviceWorker {
 
     bool is_cpu_;
     int cuda_device_index_;
+
+    // Per-device shared chunk pools
+    //
+    // Memory footprint (with default env values):
+    //   - One direction (send or recv)    : 128 MiB
+    //   - Total per device (send + recv)  : 256 MiB
+    // This stays constant no matter how many backends or peer ranks are active.
+    TransferEngine* engine_ = nullptr;
+    P2PChunkPool send_pool_;
+    P2PChunkPool recv_pool_;
+    void* send_pool_base_ = nullptr;
+    void* recv_pool_base_ = nullptr;
+    size_t pool_bytes_ = 0;
+    size_t chunk_size_ = 0;
+    uint32_t num_chunks_ = 0;
+    void initPools(TransferEngine* engine, const std::string& location);
+    void releasePools();
 };
 
 class P2PDeviceWorkerManager {
@@ -643,8 +662,9 @@ class P2PDeviceWorkerManager {
         return *manager;
     }
 
-    std::shared_ptr<P2PDeviceWorker> getCPUWorker();
-    std::shared_ptr<P2PDeviceWorker> getCUDAWorker(int cuda_device_index);
+    std::shared_ptr<P2PDeviceWorker> getCPUWorker(TransferEngine* engine);
+    std::shared_ptr<P2PDeviceWorker> getCUDAWorker(int cuda_device_index,
+                                                   TransferEngine* engine);
 
    private:
     static constexpr int CPUWorkerID = -1;

--- a/mooncake-pg/include/p2p_proxy.h
+++ b/mooncake-pg/include/p2p_proxy.h
@@ -20,7 +20,7 @@
 
 namespace mooncake {
 
-// Memory layout of one P2PProxy instance (chunk_size=8MiB, num_chunks=32):
+// Memory layout of one P2PProxy (shown for chunk_size=8MiB, num_chunks=32):
 //
 //   +---------------------------------------------------------+
 //   |  SendPool  (32 x 8 MiB = 256 MiB)                       |
@@ -69,7 +69,7 @@ namespace mooncake {
 //     to the receiver's CompletionLane to acknowledge the transfer.
 //
 // Memory model:
-//   - SendPool / RecvPool are fixed-size chunk pools (8 MiB x 32).
+//   - SendPool / RecvPool are fixed-size chunk pools.
 //   - Control lanes are ring buffers.
 //
 // Per-chunk state machines:
@@ -393,7 +393,7 @@ class P2PProxy {
 
     // Active send operation state.  Tasks are created in order and advance
     // through the sender state machine (kCopyIn -> kWriteRemote -> kCompletion
-    // -> kFinished).  A task is erased only after reaching kFinished.
+    // -> kFinished).
     struct SendOpContext {
         SendOpContext() = default;
         SendOpContext(SendOp&& op_in);
@@ -438,8 +438,7 @@ class P2PProxy {
 
     // Active receive operation state.  Tasks are created in order and
     // advance through the receiver state machine (kAdvertise ->
-    // kWaitCompletion -> kCopyOut -> kFinished).  A task is erased after
-    // reaching kFinished.
+    // kWaitCompletion -> kCopyOut -> kFinished).
     struct RecvOpContext {
         RecvOpContext() = default;
         RecvOpContext(RecvOp&& op_in);

--- a/mooncake-pg/include/p2p_proxy.h
+++ b/mooncake-pg/include/p2p_proxy.h
@@ -370,19 +370,22 @@ class P2PProxy {
    public:
     friend class P2PDeviceWorker;
 
+    enum class OpStatus : uint8_t { kPending = 0, kSuccess = 1, kFailed = 2 };
+
     struct Options {
         bool is_cpu = false;
         int rank = 0;
         int size = 0;
         int cuda_device_index = -1;
         std::string location;
+        std::chrono::milliseconds transfer_timeout_ms{30000};
     };
 
     struct SendOp {
         at::Tensor tensor_;
         int peer_rank_ = -1;
         cudaStream_t cuda_stream_ = nullptr;
-        std::shared_ptr<std::atomic<bool>> completed_;
+        std::shared_ptr<std::atomic<OpStatus>> status_;
     };
 
     struct RecvOp {
@@ -390,7 +393,7 @@ class P2PProxy {
         at::Tensor original_tensor_;
         int peer_rank_ = -1;
         cudaStream_t cuda_stream_ = nullptr;
-        std::shared_ptr<std::atomic<bool>> completed_;
+        std::shared_ptr<std::atomic<OpStatus>> status_;
     };
 
     P2PProxy(TransferEngine* engine, const Options& options);
@@ -408,15 +411,6 @@ class P2PProxy {
     void enqueueRecv(RecvOp op);
 
     void resetPeerState(int peer_rank);
-
-    // Generation for fault recovery.  All control slots carry this
-    // value so that stale messages from before a Reset can be detected.
-    uint32_t getGeneration() const {
-        return global_generation_.load(std::memory_order_acquire);
-    }
-    void setGeneration(uint32_t generation) {
-        global_generation_.store(generation, std::memory_order_release);
-    }
 
     /**
      * @brief Waits for all active P2P send and receive tasks to complete.
@@ -438,6 +432,16 @@ class P2PProxy {
      */
     void abandonResources();
 
+    // Generation for fault recovery.  All control slots carry this
+    // value so that stale messages from before a Reset can be detected.
+    uint32_t getGeneration(int peer_rank) const {
+        return peer_generation_[peer_rank].load(std::memory_order_acquire);
+    }
+    void setGeneration(int peer_rank, uint32_t generation) {
+        peer_generation_[peer_rank].store(generation,
+                                          std::memory_order_release);
+    }
+
    private:
     // Sender-side per-chunk state machine.
     enum class SendTaskState {
@@ -447,6 +451,7 @@ class P2PProxy {
         kWriteRemote,  // Write from SendPool -> remote RecvPool.
         kCompletion,   // Writing CompletionSlot back to the receiver.
         kFinished,     // CompletionSlot write done, staging buffer freed.
+        kFailed,       // Transport error or timeout; staging buffer freed.
     };
 
     // Receiver-side per-chunk state machine.
@@ -455,6 +460,7 @@ class P2PProxy {
         kWaitCompletion,  // Waiting for sender's CompletionSlot.
         kCopyOut,         // GPU: cudaMemcpyAsync RecvPool -> tensor in flight.
         kFinished,        // Copy-out done, chunk returned to pool.
+        kFailed,          // Transport error or timeout; chunk returned to pool.
     };
 
     struct SendOpContext;
@@ -480,6 +486,7 @@ class P2PProxy {
         std::optional<BatchID>
             completion_batch_id_;  // CompletionSlot write batch id.
         cudaEvent_t copy_ready_event_ = nullptr;  // Signals Copy-In done (GPU).
+        std::chrono::steady_clock::time_point last_update_time_;
     };
 
     // Active send operation state.  Tasks are created in order and advance
@@ -489,16 +496,19 @@ class P2PProxy {
         SendOpContext() = default;
         SendOpContext(SendOp&& op_in);
 
+        std::deque<SendTransferTask> tasks_;
+        std::shared_ptr<std::atomic<OpStatus>> status_;
+
         at::Tensor tensor_;
         int peer_rank_ = -1;
         cudaStream_t cuda_stream_ = nullptr;
-        std::shared_ptr<std::atomic<bool>> completed_;
         uint64_t total_bytes_ = 0;
         // Number of bytes already pulled from the user tensor into SendPool
         // staging buffers.  When bytes_staged_ == total_bytes_ every chunk
         // has at least entered the Copy-In stage.
         uint64_t bytes_staged_ = 0;
-        std::deque<SendTransferTask> tasks_;
+
+        std::chrono::steady_clock::time_point last_update_time_;
     };
 
     // One chunk of a RecvOp.  The receiver allocates a RecvPool chunk,
@@ -521,6 +531,7 @@ class P2PProxy {
             publish_batch_id_;  // PublishSlot RDMA Write batch id.
         cudaEvent_t copy_ready_event_ =
             nullptr;  // Signals Copy-Out done (GPU).
+        std::chrono::steady_clock::time_point last_update_time_;
     };
 
     // Active receive operation state.  Tasks are created in order and
@@ -531,17 +542,18 @@ class P2PProxy {
         RecvOpContext() = default;
         RecvOpContext(RecvOp&& op_in);
 
+        std::deque<RecvTransferTask> tasks_;
+        std::shared_ptr<std::atomic<OpStatus>> status_;
+
         at::Tensor tensor_;
         at::Tensor original_tensor_;
         int peer_rank_ = -1;
         cudaStream_t cuda_stream_ = nullptr;
-        std::shared_ptr<std::atomic<bool>> completed_;
         uint64_t total_bytes_ = 0;
         // Number of bytes for which a RecvPool chunk has been reserved and a
         // PublishSlot has been sent to the peer.  When bytes_advertised_ ==
         // total_bytes_ the entire tensor has been offered to the sender.
         uint64_t bytes_advertised_ = 0;
-        std::deque<RecvTransferTask> tasks_;
     };
 
     // Per-peer sender state.  The sender consumes PublishSlots that the
@@ -596,6 +608,8 @@ class P2PProxy {
     bool isSendOpCompleted(const SendOpContext& op_ctx) const;
     void performSendReset(int peer_rank);
 
+    void reportBrokenPeer(int peer_rank);
+
     // Control lane addressing.
     //
     // Each rank owns one contiguous Publish region and one Completion region.
@@ -615,6 +629,12 @@ class P2PProxy {
                                            uint32_t sequence) const;
     CompletionSlot* getLocalCompletionStagingBuf(int peer_rank,
                                                  uint32_t sequence) const;
+
+    template <typename T>
+    bool isTimeout(const T& obj) const {
+        return std::chrono::steady_clock::now() - obj.last_update_time_ >
+               transfer_timeout_ms_;
+    }
 
    private:
     struct P2PResources {
@@ -636,6 +656,7 @@ class P2PProxy {
     int size_ = 0;
     int cuda_device_index_ = -1;
     std::string location_;
+    std::chrono::milliseconds transfer_timeout_ms_{5000};  // 5s
     P2PResources resources_;
     bool resource_abandoned_{false};
 
@@ -654,10 +675,10 @@ class P2PProxy {
     std::atomic<int> active_send_tasks_{0};
     std::atomic<int> active_recv_tasks_{0};
 
-    // Global generation for fault recovery.  Incremented once on every Reset
-    // (atomically in resetPeerState) so that all worker threads see the new
-    // epoch immediately and no stale interleaving can occur.
-    std::atomic<uint32_t> global_generation_{1};
+    // Per-peer generation for fault recovery.  Incremented in resetPeerState
+    // and performSend/RecvReset so that stale messages from a previous epoch
+    // can be detected on a per-peer basis.
+    std::array<std::atomic<uint32_t>, kMaxNumRanks> peer_generation_;
 
     std::array<SendPeerLane, kMaxNumRanks> send_peer_lanes_;
     std::array<RecvPeerLane, kMaxNumRanks> recv_peer_lanes_;

--- a/mooncake-pg/include/p2p_proxy.h
+++ b/mooncake-pg/include/p2p_proxy.h
@@ -439,36 +439,22 @@ class P2PProxy {
     void abandonResources();
 
    private:
-    // Per-chunk state machine.  The lifecycle depends on which side owns
-    // the task (Sender task inside SendOpContext, Receiver task inside
-    // RecvOpContext).
-    //
-    // SENDER side lifecycle (SendTransferTask):
-    //   kDataCopy  -- Copy user tensor data into the SendPool staging buffer.
-    //                 On CPU this is synchronous; on GPU we record a
-    //                 cudaEvent on the op's stream and poll it.
-    //   kTransfer  -- Staging buffer is ready.  An RDMA Write to the remote
-    //                 RecvPool has been submitted and we are polling it.
-    //   kDone      -- RDMA Write finished.  We now write a CompletionSlot
-    //                 back to the receiver.  When that control write finishes
-    //                 the task is erased and the staging chunk is freed.
-    //
-    // RECEIVER side lifecycle (RecvTransferTask):
-    //   kTransfer  -- The PublishSlot RDMA Write is in flight.  We poll the
-    //                 local batch status until it completes.
-    //   kDataCopy  -- PublishSlot has reached the sender.  We now poll our
-    //                 local CompletionLane for the sender's ack.  Once the
-    //                 ack arrives we initiate cudaMemcpyAsync (or memcpy on
-    //                 CPU) from RecvPool to the user tensor and record an
-    //                 event (GPU) or finish immediately (CPU).
-    //   kDone      -- (CPU path only) memcpy is finished and the RecvPool
-    //                 chunk has been returned to the pool.  On GPU the
-    //                 transition to kDone happens inside StepRecvDataCopy
-    //                 when the recorded cudaEvent signals completion.
-    enum class TransferState {
-        kDataCopy,
-        kTransfer,
-        kDone,
+    // Sender-side per-chunk state machine.
+    enum class SendTaskState {
+        kCopyIn,  // Copying tensor slice into local SendPool staging buffer.
+                  // On CPU this is synchronous; on GPU we record a
+                  // cudaEvent on the op's stream and poll it.
+        kWriteRemote,  // Write from SendPool -> remote RecvPool.
+        kCompletion,   // Writing CompletionSlot back to the receiver.
+        kFinished,     // CompletionSlot write done, staging buffer freed.
+    };
+
+    // Receiver-side per-chunk state machine.
+    enum class RecvTaskState {
+        kAdvertise,       // PublishSlot Write is in flight.
+        kWaitCompletion,  // Waiting for sender's CompletionSlot.
+        kCopyOut,         // GPU: cudaMemcpyAsync RecvPool -> tensor in flight.
+        kFinished,        // Copy-out done, chunk returned to pool.
     };
 
     struct SendOpContext;
@@ -483,7 +469,7 @@ class P2PProxy {
                          void* staging_addr_in, uint64_t remote_addr_in,
                          uint32_t sequence_in, uint32_t generation_in);
 
-        TransferState state_ = TransferState::kDataCopy;
+        SendTaskState state_ = SendTaskState::kCopyIn;
         uint64_t tensor_offset_ = 0;  // Offset inside the user tensor.
         uint32_t chunk_len_ = 0;      // Bytes in this chunk (<= kP2PChunkSize).
         void* staging_addr_ = nullptr;  // Address inside SendPool.
@@ -497,9 +483,8 @@ class P2PProxy {
     };
 
     // Active send operation state.  Tasks are created in order and advance
-    // through the sender state machine (kDataCopy -> kTransfer -> kDone).
-    // A task is erased only after the CompletionSlot write has finished and
-    // the staging chunk has been returned to SendPool.
+    // through the sender state machine (kCopyIn -> kWriteRemote -> kCompletion
+    // -> kFinished).  A task is erased only after reaching kFinished.
     struct SendOpContext {
         SendOpContext() = default;
         SendOpContext(SendOp&& op_in);
@@ -526,7 +511,7 @@ class P2PProxy {
                          void* local_addr_in, uint32_t sequence_in,
                          uint32_t generation_in);
 
-        TransferState state_ = TransferState::kTransfer;
+        RecvTaskState state_ = RecvTaskState::kAdvertise;
         uint64_t tensor_offset_ = 0;  // Offset inside the user tensor.
         uint32_t chunk_len_ = 0;      // Bytes in this chunk.
         void* local_addr_ = nullptr;  // Address inside local RecvPool.
@@ -539,9 +524,9 @@ class P2PProxy {
     };
 
     // Active receive operation state.  Tasks are created in order and
-    // advance through the receiver state machine (kTransfer -> kDataCopy).
-    // A task is erased after the data has been copied into the user tensor
-    // and the RecvPool chunk has been returned.
+    // advance through the receiver state machine (kAdvertise ->
+    // kWaitCompletion -> kCopyOut -> kFinished).  A task is erased after
+    // reaching kFinished.
     struct RecvOpContext {
         RecvOpContext() = default;
         RecvOpContext(RecvOp&& op_in);
@@ -595,18 +580,19 @@ class P2PProxy {
     bool hasActiveRecvWork() const;
 
     bool tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane);
-    bool stepRecvTransferTask(RecvTransferTask& task);
-    bool stepRecvDataCopy(RecvTransferTask& task);
-    bool stepRecvTransfer(RecvTransferTask& task);
-    bool isRecvDataPathCompleted(const RecvOpContext& op_ctx) const;
+    bool stepRecvTask(RecvTransferTask& task);
+    bool stepRecvCopyOut(RecvTransferTask& task);
+    bool stepRecvAdvertise(RecvTransferTask& task);
+    bool pollRecvCompletionSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
+                                RecvTransferTask& head_task);
+    bool isRecvOpCompleted(const RecvOpContext& op_ctx) const;
     void performRecvReset(int peer_rank);
 
     bool tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane);
-    bool stepSendTransferTask(SendOpContext& op_ctx, SendTransferTask& task);
-    bool stepSendDataCopy(SendTransferTask& task);
-    bool stepSendTransfer(SendOpContext& op_ctx, SendTransferTask& task);
+    bool stepSendTask(SendOpContext& op_ctx, SendTransferTask& task);
+    bool stepSendCopyIn(SendTransferTask& task);
+    bool stepSendWriteRemote(SendOpContext& op_ctx, SendTransferTask& task);
     bool stepSendCompletion(SendOpContext& op_ctx, SendTransferTask& task);
-    bool isSendDataPathCompleted(const SendOpContext& op_ctx) const;
     bool isSendOpCompleted(const SendOpContext& op_ctx) const;
     void performSendReset(int peer_rank);
 

--- a/mooncake-pg/include/p2p_proxy.h
+++ b/mooncake-pg/include/p2p_proxy.h
@@ -1,5 +1,5 @@
-#ifndef MOONCAKE_P2P_PROXY_HH
-#define MOONCAKE_P2P_PROXY_HH
+#ifndef MOONCAKE_P2P_PROXY_H
+#define MOONCAKE_P2P_PROXY_H
 
 #include <mooncake_worker.cuh>
 #include <torch/torch.h>
@@ -9,51 +9,358 @@
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <queue>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 namespace mooncake {
 
-inline constexpr size_t kP2PBufferSize = 1u << 24;
-inline constexpr size_t kP2PNumSlots = 8;
-inline constexpr size_t kP2PSlotSize = kP2PBufferSize / kP2PNumSlots;
+// Memory layout of one P2PProxy instance:
+//
+//   +---------------------------------------------------------+
+//   |  SendPool  (32 x 8 MiB = 256 MiB)                       |
+//   |  +---------+  +---------+        +---------+            |
+//   |  | chunk 0 |  | chunk 1 |  ...   | chunk 31|            |
+//   |  | 8 MiB   |  | 8 MiB   |        | 8 MiB   |            |
+//   |  +---------+  +---------+        +---------+            |
+//   +---------------------------------------------------------+
+//   |  RecvPool (32 x 8 MiB = 256 MiB)                        |
+//   |  +---------+  +---------+        +---------+            |
+//   |  | chunk 0 |  | chunk 1 |  ...   | chunk 31|            |
+//   |  | 8 MiB   |  | 8 MiB   |        | 8 MiB   |            |
+//   |  +---------+  +---------+        +---------+            |
+//   +---------------------------------------------------------+
+//   |  Publish Control Region                                 |
+//   |  [peer 0 lane : 64 slots][peer 1 lane : 64 slots] ...   |
+//   +---------------------------------------------------------+
+//   |  Completion Control Region                              |
+//   |  [peer 0 lane : 64 slots][peer 1 lane : 64 slots] ...   |
+//   +---------------------------------------------------------+
+//
+// Control lane addressing (isolated per sender-receiver pair):
+//
+//      Rank R wants to write a PublishSlot to peer P
+//      -----------------------------------------------------
+//      Target = P's publish base
+//               + (R * kP2PControlRingSize + seq % 64) * sizeof(PublishSlot)
+//
+//      Rank R wants to write a CompletionSlot to peer P
+//      -----------------------------------------------------
+//      Target = P's completion base
+//               + (R * kP2PControlRingSize + seq % 64) * sizeof(CompletionSlot)
+//
+//
+// P2PProxy implements a credit-based RDMA pull protocol.
+//
+// Protocol overview:
+//   - The RECEIVER drives the flow. It allocates chunks from its RecvPool and
+//     writes PublishSlots into the sender's PublishLane to invite the sender
+//     to write data into the designated RecvPool offset.
+//   - The SENDER is passive. It polls its local PublishLane (written by the
+//     receiver via RDMA). Only after receiving an invitation does it allocate
+//     a staging buffer from SendPool, copy user tensor data into it, and
+//     perform the RDMA Write to the remote RecvPool.
+//   - After the RDMA Write finishes, the sender writes a CompletionSlot back
+//     to the receiver's CompletionLane to acknowledge the transfer.
+//
+// Memory model:
+//   - SendPool / RecvPool are fixed-size chunk pools (8 MiB x 32).
+//   - Control lanes are ring buffers.
+//
+// Per-chunk state machines:
+//   Sender:  Fetch Invite -> Copy-In (staging) -> RDMA Write -> Acknowledge
+//   Receiver: Advertise -> Poll Completion -> Copy-Out -> Free Chunk
+//
+// Concurrency rules:
+//   - All pool allocations are non-blocking (TryAlloc). If a pool is exhausted
+//     the step function returns false immediately and retries on the next
+//     polling iteration. This prevents deadlocks.
+//   - SendPool and RecvPool are strictly separated so that a deadlock where
+//     "all chunks are reserved for receiving and none are left for sending"
+//     can never happen.
+//
+// Data flow example -- Rank 0 sends a 24 MiB tensor to Rank 1.
+// The five steps below are separated between Sender (Rank 0) and
+// Receiver (Rank 1) to make the protocol explicit.
+//
+//   Step 1 -- Rank 1 advertises free RecvPool chunks to Rank 0
+//   ------------------------------------------------------------------------
+//   Rank 1 (Receiver)                RDMA Write
+//   +-----------------------+              +-------------------------------+
+//   | RecvPool              |              | Rank 0's PublishLane[1]       |
+//   | chunk 7 : free        | -----------> | slot 0 : {seq=0,off=7,len=8M} |
+//   | chunk 2 : free        | -----------> | slot 1 : {seq=1,off=2,len=8M} |
+//   | chunk 1 : free        | -----------> | slot 2 : {seq=2,off=1,len=8M} |
+//   +-----------------------+              +-------------------------------+
+//
+//   Step 2 -- Rank 0 stages user tensor into SendPool
+//   ------------------------------------------------------------------------
+//   Rank 0 (Sender)
+//   +-----------------------+
+//   | User tensor           |
+//   |[0..8M)[8..16M)[16..24)|
+//   +-----------------------+
+//            |
+//            | cudaMemcpyAsync (device-to-device)
+//            v
+//   +----------------------------+
+//   | SendPool                   |
+//   | chunk 3 : bytes [0..8M)    |
+//   | chunk 0 : bytes [8..16M)   |
+//   | chunk 5 : bytes [16..24M)  |
+//   +----------------------------+
+//
+//   Step 3 -- Rank 0 RDMA-writes SendPool -> Rank 1's RecvPool
+//   ------------------------------------------------------------------------
+//   Rank 0's SendPool                    RDMA Write       Rank 1's RecvPool
+//   +---------------------+                           +---------------------+
+//   | chunk 3 : [0..8M)   | ------------------------> | chunk 7 : [0..8M)   |
+//   | chunk 0 : [8..16M)  | -------------------- ---> | chunk 2 : [8..16M)  |
+//   | chunk 5 : [16..24M) | ------------------------> | chunk 1 : [16..24M) |
+//   +---------------------+                           +---------------------+
+//
+//   Step 4 -- Rank 0 acknowledges with CompletionSlots
+//   ------------------------------------------------------------------------
+//   Rank 0 (Sender)                      RDMA Write       Rank 1 (Receiver)
+//   +-----------------------+               +-------------------------------+
+//   | CompletionLane[0]     |               | Rank 1's CompletionLane[0]    |
+//   | (local cache only)    | ------------> | slot 0 : {seq=0,len=8M,gen=G} |
+//   +-----------------------+               | slot 1 : {seq=1,len=8M,gen=G} |
+//                                           | slot 2 : {seq=2,len=8M,gen=G} |
+//                                           +-------------------------------+
+//
+//   Step 5 -- Rank 1 copies out and recycles chunks
+//   ------------------------------------------------------------------------
+//   Rank 1 (Receiver)
+//   +-----------------------+
+//   | RecvPool              |
+//   | chunk 7 : [0..8M)     |
+//   | chunk 2 : [8..16M)    |
+//   | chunk 1 : [16..24M)   |
+//   +-----------------------+
+//            |
+//            | cudaMemcpyAsync (RecvPool -> user tensor)
+//            v
+//   +-----------------------+
+//   | User tensor (ready)   |
+//   |[0..8M)[8..16M)[16..24)|
+//   +-----------------------+
+//            |
+//            | Free chunks back to pool
+//            v
+//   +-----------------------+
+//   | RecvPool              |
+//   | chunk 7 : free        |
+//   | chunk 2 : free        |
+//   | chunk 1 : free        |
+//   +-----------------------+
+//
+// ---------------------------------------------------------------------------
+inline constexpr size_t kP2PChunkSize = 8u * 1024 * 1024;  // 8 MB
+inline constexpr uint32_t kP2PPoolNumChunks = 32;
+inline constexpr uint32_t kP2PControlRingSize = 64;
 
-struct alignas(64) AtomicHeadTail {
-    uint32_t load(
-        std::memory_order order = std::memory_order_seq_cst) const noexcept {
-        return std::atomic_ref<uint32_t>(value).load(order);
+// Single-word atomic publication token.
+// Combines generation and sequence to avoid torn reads.
+// kInvalidControlToken (all 1s) means "slot empty / not yet published".
+using ControlToken = uint64_t;
+inline constexpr ControlToken kInvalidControlToken =
+    std::numeric_limits<uint64_t>::max();
+
+inline ControlToken makeControlToken(uint32_t generation, uint32_t sequence) {
+    return (static_cast<ControlToken>(generation) << 32) |
+           static_cast<ControlToken>(sequence & 0xFFFFFFFFu);
+}
+
+// PublishSlot
+//
+// Header-Footer double-token guard:
+//   We store the same token at both ends of the 64-byte block.
+//     - Producer: write payload -> write footer -> write header (release).
+//     - Consumer: read header -> read payload -> read footer -> accept only
+//                 when header == footer.
+// If the NIC has only partially written the slot, header and footer will
+// mismatch (or one of them will still be kInvalidControlToken) and the
+// consumer safely retries on the next poll iteration.
+//
+// Layout:
+//   [0..7]   header_token  (generation << 32 | sequence)
+//   [8..15]  recv_addr     (payload)
+//   [16..19] chunk_len     (payload)
+//   [20..55] padding       (kept zero, reserved for future use)
+//   [56..63] footer_token  (identical to header_token)
+struct alignas(64) PublishSlot {
+   private:
+    uint64_t header_token = kInvalidControlToken;
+    uint64_t recv_addr = 0;
+    uint32_t chunk_len = 0;
+    uint32_t _reserved = 0;
+    uint8_t _padding[32]{};
+    uint64_t footer_token = kInvalidControlToken;
+
+   public:
+    // Consumer-side reliable read.
+    //
+    // 1. Load header_token with acquire semantics.
+    // 2. If it is kInvalidControlToken the slot is empty -> fail.
+    // 3. Optimistically copy the payload (these plain loads may be torn).
+    // 4. Issue an acquire fence so the payload reads cannot be reordered past
+    //    the footer load that follows.
+    // 5. Load footer_token.
+    // 6. Accept the payload only when header == footer.
+    bool tryLoad(uint64_t& out_recv_addr, uint32_t& out_chunk_len,
+                 uint32_t& out_generation, uint32_t& out_sequence) const {
+        uint64_t h =
+            std::atomic_ref(header_token).load(std::memory_order_acquire);
+        if (h == kInvalidControlToken) return false;
+
+        // Optimistic payload copy – may be torn if the NIC is still writing.
+        uint64_t addr = recv_addr;
+        uint32_t len = chunk_len;
+
+        // Avoid moving payload reads below the footer check.
+        std::atomic_thread_fence(std::memory_order_acquire);
+
+        uint64_t f =
+            std::atomic_ref(footer_token).load(std::memory_order_relaxed);
+
+        if (h == f) {
+            out_recv_addr = addr;
+            out_chunk_len = len;
+            out_generation = static_cast<uint32_t>(h >> 32);
+            out_sequence = static_cast<uint32_t>(h);
+            return true;
+        }
+        // Torn write – caller retries next poll.
+        return false;
     }
 
-    void store(uint32_t new_value,
-               std::memory_order order = std::memory_order_seq_cst) noexcept {
-        std::atomic_ref<uint32_t>(value).store(new_value, order);
+    // Producer-side reliable publish.
+    //
+    // On the local CPU the store order matters:
+    //   payload -> footer (relaxed) -> header (release).
+    // The release store to header_token guarantees that every prior store is
+    // visible to any consumer that sees the new header value.
+    void publish(uint32_t gen, uint32_t seq, uint64_t addr, uint32_t len) {
+        uint64_t new_token = makeControlToken(gen, seq);
+
+        recv_addr = addr;
+        chunk_len = len;
+
+        // Write footer first so it is never ahead of the header.
+        std::atomic_ref(footer_token)
+            .store(new_token, std::memory_order_relaxed);
+        // Release the header last
+        std::atomic_ref(header_token)
+            .store(new_token, std::memory_order_release);
     }
 
-    mutable uint32_t value{0};
+    void reset() {
+        recv_addr = 0;
+        chunk_len = 0;
+        uint64_t inv = kInvalidControlToken;
+        std::atomic_ref(footer_token).store(inv, std::memory_order_relaxed);
+        std::atomic_ref(header_token).store(inv, std::memory_order_release);
+    }
 };
 
-// Ring-control metadata for one peer lane.
-//
-//   slot index:   0 -> 1 -> 2 -> ... -> N-1 -> 0   (N = kP2PNumSlots)
-//                   ^h (producer publish cursor)
-//                   ^t (consumer reclaim cursor)
-//
-// State by (head, tail), modulo N:
-// - empty: head == tail
-// - full : (head + 1) % N == tail   (one slot reserved to distinguish
-// full/empty)
-// - ready: head != tail
-//
-// Protocol:
-// - producer writes slot[head], then advances head (publish)
-// - consumer reads slot[tail], then advances tail (reclaim)
-struct P2PControlSlot {
-    AtomicHeadTail head;
-    AtomicHeadTail tail;
+// CompletionSlot Layout:
+//   [0..7]   header_token  (generation << 32 | sequence)
+//   [8..11]  chunk_len     (payload)
+//   [12..55] padding       (kept zero, reserved for future use)
+//   [56..63] footer_token  (identical to header_token)
+struct alignas(64) CompletionSlot {
+   private:
+    uint64_t header_token = kInvalidControlToken;
+    uint32_t chunk_len = 0;
+    uint32_t _reserved = 0;
+    uint8_t _padding[40]{};
+    uint64_t footer_token = kInvalidControlToken;
+
+   public:
+    // See PublishSlot::tryLoad() for the detailed description.
+    bool tryLoad(uint32_t& out_chunk_len, uint32_t& out_generation,
+                 uint32_t& out_sequence) const {
+        uint64_t h =
+            std::atomic_ref(header_token).load(std::memory_order_acquire);
+        if (h == kInvalidControlToken) return false;
+
+        uint32_t len = chunk_len;
+
+        std::atomic_thread_fence(std::memory_order_acquire);
+
+        uint64_t f =
+            std::atomic_ref(footer_token).load(std::memory_order_relaxed);
+
+        if (h == f) {
+            out_chunk_len = len;
+            out_generation = static_cast<uint32_t>(h >> 32);
+            out_sequence = static_cast<uint32_t>(h);
+            return true;
+        }
+        return false;
+    }
+
+    // See PublishSlot::publish() for the detailed description.
+    void publish(uint32_t gen, uint32_t seq, uint32_t len) {
+        uint64_t new_token = makeControlToken(gen, seq);
+
+        chunk_len = len;
+
+        std::atomic_ref(footer_token)
+            .store(new_token, std::memory_order_relaxed);
+        std::atomic_ref(header_token)
+            .store(new_token, std::memory_order_release);
+    }
+
+    void reset() {
+        chunk_len = 0;
+        uint64_t inv = kInvalidControlToken;
+        std::atomic_ref(footer_token).store(inv, std::memory_order_relaxed);
+        std::atomic_ref(header_token).store(inv, std::memory_order_release);
+    }
+};
+
+class P2PChunkPool {
+   public:
+    P2PChunkPool() = default;
+
+    void init(void* base_addr, size_t chunk_size, uint32_t num_chunks) {
+        base_addr_ = base_addr;
+        chunk_size_ = chunk_size;
+        free_stack_.clear();
+        free_stack_.reserve(num_chunks);
+        for (uint32_t idx = 0; idx < num_chunks; ++idx) {
+            free_stack_.push_back(static_cast<uint8_t*>(base_addr_) +
+                                  (num_chunks - 1 - idx) * chunk_size_);
+        }
+    }
+
+    void* acquire() {
+        std::lock_guard<std::mutex> l(lock_);
+        if (free_stack_.empty()) {
+            return nullptr;
+        }
+        void* ptr = free_stack_.back();
+        free_stack_.pop_back();
+        return ptr;
+    }
+
+    void release(void* ptr) {
+        std::lock_guard<std::mutex> l(lock_);
+        free_stack_.push_back(ptr);
+    }
+
+   private:
+    void* base_addr_ = nullptr;
+    size_t chunk_size_ = 0;
+    std::vector<void*> free_stack_;
+    std::mutex lock_;
 };
 
 class P2PDeviceWorker;
@@ -89,20 +396,27 @@ class P2PProxy {
     P2PProxy(TransferEngine* engine, const Options& options);
     ~P2PProxy();
 
-    void BindMeta(const std::shared_ptr<TransferGroupMeta>& meta);
-    void* send_buffer() const { return resources_.send_buffer_; }
-    void* recv_buffer() const { return resources_.recv_buffer_; }
-    P2PControlSlot* ctrl_send_region() const {
-        return resources_.ctrl_send_region_;
+    void* send_pool_base() const { return resources_.send_pool_base_; }
+    void* recv_pool_base() const { return resources_.recv_pool_base_; }
+    PublishSlot* publish_region() const { return resources_.publish_region_; }
+    CompletionSlot* completion_region() const {
+        return resources_.completion_region_;
     }
-    P2PControlSlot* ctrl_recv_region() const {
-        return resources_.ctrl_recv_region_;
+    void bindMeta(const std::shared_ptr<TransferGroupMeta>& meta);
+
+    void enqueueSend(SendOp op);
+    void enqueueRecv(RecvOp op);
+
+    void resetPeerState(int peer_rank);
+
+    // Generation for fault recovery.  All control slots carry this
+    // value so that stale messages from before a Reset can be detected.
+    uint32_t getGeneration() const {
+        return global_generation_.load(std::memory_order_acquire);
     }
-
-    void EnqueueSend(SendOp op);
-    void EnqueueRecv(RecvOp op);
-
-    void ResetPeerState(int peer_rank);
+    void setGeneration(uint32_t generation) {
+        global_generation_.store(generation, std::memory_order_release);
+    }
 
     /**
      * @brief Waits for all active P2P send and receive tasks to complete.
@@ -114,7 +428,7 @@ class P2PProxy {
      * @return True if all tasks completed within the timeout; false if timed
      * out.
      */
-    bool DrainTasks() const;
+    bool drainTasks() const;
 
     /**
      * @brief Abandons resources instead of releasing them properly.
@@ -122,9 +436,35 @@ class P2PProxy {
      * When a hung operation prevents clean shutdown, this method marks
      * resources as abandoned to prevent crashes during destructor.
      */
-    void AbandonResources();
+    void abandonResources();
 
    private:
+    // Per-chunk state machine.  The lifecycle depends on which side owns
+    // the task (Sender task inside SendOpContext, Receiver task inside
+    // RecvOpContext).
+    //
+    // SENDER side lifecycle (SendTransferTask):
+    //   kDataCopy  -- Copy user tensor data into the SendPool staging buffer.
+    //                 On CPU this is synchronous; on GPU we record a
+    //                 cudaEvent on the op's stream and poll it.
+    //   kTransfer  -- Staging buffer is ready.  An RDMA Write to the remote
+    //                 RecvPool has been submitted and we are polling it.
+    //   kDone      -- RDMA Write finished.  We now write a CompletionSlot
+    //                 back to the receiver.  When that control write finishes
+    //                 the task is erased and the staging chunk is freed.
+    //
+    // RECEIVER side lifecycle (RecvTransferTask):
+    //   kTransfer  -- The PublishSlot RDMA Write is in flight.  We poll the
+    //                 local batch status until it completes.
+    //   kDataCopy  -- PublishSlot has reached the sender.  We now poll our
+    //                 local CompletionLane for the sender's ack.  Once the
+    //                 ack arrives we initiate cudaMemcpyAsync (or memcpy on
+    //                 CPU) from RecvPool to the user tensor and record an
+    //                 event (GPU) or finish immediately (CPU).
+    //   kDone      -- (CPU path only) memcpy is finished and the RecvPool
+    //                 chunk has been returned to the pool.  On GPU the
+    //                 transition to kDone happens inside StepRecvDataCopy
+    //                 when the recorded cudaEvent signals completion.
     enum class TransferState {
         kDataCopy,
         kTransfer,
@@ -134,20 +474,32 @@ class P2PProxy {
     struct SendOpContext;
     struct RecvOpContext;
 
+    // One chunk of a SendOp.  The sender copies data from the user tensor
+    // into a SendPool staging buffer and then RDMA-writes it to the remote
+    // RecvPool offset that the receiver advertised in the PublishSlot.
     struct SendTransferTask {
         SendTransferTask() = default;
-        SendTransferTask(uint64_t chunk_offset_in, uint64_t chunk_bytes_in,
-                         void* source_in, uint64_t target_offset_in);
+        SendTransferTask(uint64_t tensor_offset_in, uint32_t chunk_len_in,
+                         void* staging_addr_in, uint64_t remote_addr_in,
+                         uint32_t sequence_in, uint32_t generation_in);
 
         TransferState state_ = TransferState::kDataCopy;
-        uint64_t chunk_offset_ = 0;
-        uint64_t chunk_bytes_ = 0;
-        void* source_ = nullptr;
-        uint64_t target_offset_ = 0;
-        std::optional<BatchID> transfer_batch_id_;
-        cudaEvent_t copy_ready_event_ = nullptr;
+        uint64_t tensor_offset_ = 0;  // Offset inside the user tensor.
+        uint32_t chunk_len_ = 0;      // Bytes in this chunk (<= kP2PChunkSize).
+        void* staging_addr_ = nullptr;  // Address inside SendPool.
+        uint64_t remote_addr_ = 0;      // Address inside REMOTE RecvPool.
+        uint32_t sequence_ = 0;         // Sequence number in the control ring.
+        uint32_t generation_ = 0;       // Generation for Reset detection.
+        std::optional<BatchID> transfer_batch_id_;  // RDMA Write batch id.
+        std::optional<BatchID>
+            completion_batch_id_;  // CompletionSlot write batch id.
+        cudaEvent_t copy_ready_event_ = nullptr;  // Signals Copy-In done (GPU).
     };
 
+    // Active send operation state.  Tasks are created in order and advance
+    // through the sender state machine (kDataCopy -> kTransfer -> kDone).
+    // A task is erased only after the CompletionSlot write has finished and
+    // the staging chunk has been returned to SendPool.
     struct SendOpContext {
         SendOpContext() = default;
         SendOpContext(SendOp&& op_in);
@@ -157,24 +509,39 @@ class P2PProxy {
         cudaStream_t cuda_stream_ = nullptr;
         std::shared_ptr<std::atomic<bool>> completed_;
         uint64_t total_bytes_ = 0;
-        uint64_t bytes_issued_ = 0;
-        std::optional<BatchID> head_update_batch_id_;
+        // Number of bytes already pulled from the user tensor into SendPool
+        // staging buffers.  When bytes_staged_ == total_bytes_ every chunk
+        // has at least entered the Copy-In stage.
+        uint64_t bytes_staged_ = 0;
         std::deque<SendTransferTask> tasks_;
     };
 
+    // One chunk of a RecvOp.  The receiver allocates a RecvPool chunk,
+    // advertises it to the sender via a PublishSlot, waits for the sender
+    // to RDMA-write data into it, and finally copies the data into the user
+    // tensor before returning the chunk to RecvPool.
     struct RecvTransferTask {
         RecvTransferTask() = default;
-        RecvTransferTask(uint64_t chunk_offset_in, uint64_t chunk_bytes_in,
-                         void* source_in, void* target_in);
+        RecvTransferTask(uint64_t tensor_offset_in, uint32_t chunk_len_in,
+                         void* local_addr_in, uint32_t sequence_in,
+                         uint32_t generation_in);
 
-        TransferState state_ = TransferState::kDataCopy;
-        uint64_t chunk_offset_ = 0;
-        uint64_t chunk_bytes_ = 0;
-        void* source_ = nullptr;
-        void* target_ = nullptr;
-        cudaEvent_t copy_ready_event_ = nullptr;
+        TransferState state_ = TransferState::kTransfer;
+        uint64_t tensor_offset_ = 0;  // Offset inside the user tensor.
+        uint32_t chunk_len_ = 0;      // Bytes in this chunk.
+        void* local_addr_ = nullptr;  // Address inside local RecvPool.
+        uint32_t sequence_ = 0;       // Sequence number in the control ring.
+        uint32_t generation_ = 0;     // Generation for Reset detection.
+        std::optional<BatchID>
+            publish_batch_id_;  // PublishSlot RDMA Write batch id.
+        cudaEvent_t copy_ready_event_ =
+            nullptr;  // Signals Copy-Out done (GPU).
     };
 
+    // Active receive operation state.  Tasks are created in order and
+    // advance through the receiver state machine (kTransfer -> kDataCopy).
+    // A task is erased after the data has been copied into the user tensor
+    // and the RecvPool chunk has been returned.
     struct RecvOpContext {
         RecvOpContext() = default;
         RecvOpContext(RecvOp&& op_in);
@@ -185,65 +552,93 @@ class P2PProxy {
         cudaStream_t cuda_stream_ = nullptr;
         std::shared_ptr<std::atomic<bool>> completed_;
         uint64_t total_bytes_ = 0;
-        uint64_t bytes_issued_ = 0;
-        std::optional<BatchID> tail_update_batch_id_;
+        // Number of bytes for which a RecvPool chunk has been reserved and a
+        // PublishSlot has been sent to the peer.  When bytes_advertised_ ==
+        // total_bytes_ the entire tensor has been offered to the sender.
+        uint64_t bytes_advertised_ = 0;
         std::deque<RecvTransferTask> tasks_;
     };
 
+    // Per-peer sender state.  The sender consumes PublishSlots that the
+    // receiver writes into our local PublishLane for this peer.
     struct SendPeerLane {
         std::deque<SendOpContext> pending_send_ops_;
         std::optional<SendOpContext> active_send_op_;
-        uint32_t local_head_ = 0;
-        std::array<cudaEvent_t, kP2PNumSlots> copy_ready_events_;
+        // Sequence number of the next PublishSlot to consume from this peer.
+        // Monotonically increases; wraps around the ring via modulo.
+        uint64_t publish_consume_seq_ = 0;
+        std::array<cudaEvent_t, kP2PControlRingSize> copy_ready_events_;
     };
 
+    // Per-peer receiver state.  The receiver issues PublishSlots to invite
+    // the peer to write data, and consumes CompletionSlots that the peer
+    // writes back to acknowledge finished transfers.
     struct RecvPeerLane {
         std::deque<RecvOp> pending_recv_ops_;
         std::optional<RecvOpContext> active_recv_op_;
-        uint32_t local_tail_ = 0;
-        std::array<cudaEvent_t, kP2PNumSlots> copy_ready_events_;
+        // Sequence number of the next PublishSlot to issue to this peer.
+        uint64_t publish_issue_seq_ = 0;
+        // Sequence number of the next CompletionSlot to consume from this peer.
+        uint64_t completion_consume_seq_ = 0;
+        std::array<cudaEvent_t, kP2PControlRingSize> copy_ready_events_;
     };
 
     // Resources are allocated and released by constructor/destructor
-    void AllocateResources();
-    void ReleaseResources();
+    void allocateResources();
+    void releaseResources();
 
     // For P2PDeviceWorker
-    bool StepSend();
-    bool StepRecv();
-    void SetDeviceWorker(P2PDeviceWorker*);
-    bool HasActiveSendWork() const;
-    bool HasActiveRecvWork() const;
+    bool stepSend();
+    bool stepRecv();
+    void setDeviceWorker(P2PDeviceWorker*);
+    bool hasActiveSendWork() const;
+    bool hasActiveRecvWork() const;
 
-    // Internal Steps
-    bool TryIssueSendTask(SendOpContext& op_ctx, uint32_t capacity);
-    bool StepSendTransferTask(SendOpContext& op_ctx, SendTransferTask& task);
-    bool StepSendDataCopy(SendTransferTask& task);
-    bool StepSendTransfer(SendOpContext& op_ctx, SendTransferTask& task);
-    bool StepSendHeadCommit(SendOpContext& op_ctx, uint32_t capacity);
-    bool IsSendDataPathCompleted(const SendOpContext& op_ctx) const;
-    bool IsSendOpCompleted(const SendOpContext& op_ctx) const;
-    void PerformSendReset(int peer_rank);
+    bool tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane);
+    bool stepRecvTransferTask(RecvTransferTask& task);
+    bool stepRecvDataCopy(RecvTransferTask& task);
+    bool stepRecvTransfer(RecvTransferTask& task);
+    bool isRecvDataPathCompleted(const RecvOpContext& op_ctx) const;
+    void performRecvReset(int peer_rank);
 
-    bool TryIssueRecvTask(RecvOpContext& op_ctx, uint32_t capacity);
-    bool StepRecvTransferTask(RecvTransferTask& task);
-    bool StepRecvDataCopy(RecvTransferTask& task);
-    bool StepRecvTailCommit(RecvOpContext& op_ctx, uint32_t capacity);
-    bool IsRecvDataPathCompleted(const RecvOpContext& op_ctx) const;
-    void PerformRecvReset(int peer_rank);
+    bool tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane);
+    bool stepSendTransferTask(SendOpContext& op_ctx, SendTransferTask& task);
+    bool stepSendDataCopy(SendTransferTask& task);
+    bool stepSendTransfer(SendOpContext& op_ctx, SendTransferTask& task);
+    bool stepSendCompletion(SendOpContext& op_ctx, SendTransferTask& task);
+    bool isSendDataPathCompleted(const SendOpContext& op_ctx) const;
+    bool isSendOpCompleted(const SendOpContext& op_ctx) const;
+    void performSendReset(int peer_rank);
 
-    uint64_t GetLocalSendSlotAddress(int peer_rank, uint32_t slot_index) const;
-    uint64_t GetLocalRecvSlotAddress(int peer_rank, uint32_t slot_index) const;
-    uint64_t GetRemoteRecvSlotAddress(int peer_rank, uint32_t slot_index) const;
-    uint64_t GetRemoteCtrlRecvHeadOffset(int peer_rank) const;
-    uint64_t GetRemoteCtrlSendTailOffset(int peer_rank) const;
+    // Control lane addressing.
+    //
+    // Each rank owns one contiguous Publish region and one Completion region.
+    // Within each region there are kMaxNumRanks lanes, one per peer.
+    // Lane index == peer rank.  Each lane has kP2PControlRingSize slots.
+    //
+    // Example: rank R wants to write a PublishSlot to peer P.
+    //   target = P's publish base + (R * kRingSize + seq % kRingSize) * sizeof
+    //
+    // This isolates control traffic per (sender, receiver) pair.
+    PublishSlot* getLocalPublishLane(int peer_rank) const;
+    CompletionSlot* getLocalCompletionLane(int peer_rank) const;
+    uint64_t getRemotePublishSlot(int peer_rank, uint32_t sequence) const;
+    uint64_t getRemoteCompletionSlot(int peer_rank, uint32_t sequence) const;
+
+    PublishSlot* getLocalPublishStagingBuf(int peer_rank,
+                                           uint32_t sequence) const;
+    CompletionSlot* getLocalCompletionStagingBuf(int peer_rank,
+                                                 uint32_t sequence) const;
 
    private:
     struct P2PResources {
-        void* send_buffer_ = nullptr;
-        void* recv_buffer_ = nullptr;
-        P2PControlSlot* ctrl_send_region_ = nullptr;
-        P2PControlSlot* ctrl_recv_region_ = nullptr;
+        void* send_pool_base_ = nullptr;
+        void* recv_pool_base_ = nullptr;
+        PublishSlot* publish_region_ = nullptr;
+        CompletionSlot* completion_region_ = nullptr;
+        // Serve as RDMA write source address
+        PublishSlot* publish_staging_buf_ = nullptr;
+        CompletionSlot* completion_staging_buf_ = nullptr;
     };
 
     P2PDeviceWorker* device_worker_ = nullptr;
@@ -258,6 +653,9 @@ class P2PProxy {
     P2PResources resources_;
     bool resource_abandoned_{false};
 
+    P2PChunkPool send_pool_;
+    P2PChunkPool recv_pool_;
+
     std::queue<SendOpContext> send_queue_;
     std::mutex send_queue_mutex_;
 
@@ -269,6 +667,11 @@ class P2PProxy {
 
     std::atomic<int> active_send_tasks_{0};
     std::atomic<int> active_recv_tasks_{0};
+
+    // Global generation for fault recovery.  Incremented once on every Reset
+    // (atomically in resetPeerState) so that all worker threads see the new
+    // epoch immediately and no stale interleaving can occur.
+    std::atomic<uint32_t> global_generation_{1};
 
     std::array<SendPeerLane, kMaxNumRanks> send_peer_lanes_;
     std::array<RecvPeerLane, kMaxNumRanks> recv_peer_lanes_;
@@ -285,20 +688,20 @@ class P2PDeviceWorker {
 
     P2PDeviceWorker(bool is_cpu, int cuda_device_index)
         : is_cpu_(is_cpu), cuda_device_index_(cuda_device_index) {
-        Start();
+        start();
     }
 
-    ~P2PDeviceWorker() { Stop(); }
+    ~P2PDeviceWorker() { stop(); }
 
-    void WakeUpSend();
-    void WakeUpRecv();
+    void wakeUpSend();
+    void wakeUpRecv();
 
    private:
-    void Start();
-    void Stop();
+    void start();
+    void stop();
 
-    void SendWorkerThread();
-    void RecvWorkerThread();
+    void sendWorkerMainloop();
+    void recvWorkerMainloop();
 
     std::mutex send_wakeup_mutex_;
     std::condition_variable send_wakeup_cv_;
@@ -322,14 +725,14 @@ class P2PDeviceWorker {
 
 class P2PDeviceWorkerManager {
    public:
-    static P2PDeviceWorkerManager& GetInstance() {
+    static P2PDeviceWorkerManager& getInstance() {
         // leaky singleton to avoid destructor fiasco problem
         static P2PDeviceWorkerManager* manager = new P2PDeviceWorkerManager;
         return *manager;
     }
 
-    std::shared_ptr<P2PDeviceWorker> GetCPUWorker();
-    std::shared_ptr<P2PDeviceWorker> GetCUDAWorker(int cuda_device_index);
+    std::shared_ptr<P2PDeviceWorker> getCPUWorker();
+    std::shared_ptr<P2PDeviceWorker> getCUDAWorker(int cuda_device_index);
 
    private:
     static constexpr int CPUWorkerID = -1;

--- a/mooncake-pg/include/p2p_proxy.h
+++ b/mooncake-pg/include/p2p_proxy.h
@@ -35,46 +35,46 @@ namespace mooncake {
 //   |  | 8 MiB   |  | 8 MiB   |        | 8 MiB   |            |
 //   |  +---------+  +---------+        +---------+            |
 //   +---------------------------------------------------------+
-//   |  Publish Control Region                                 |
+//   |  Credit Control Region                                  |
 //   |  [peer 0 lane : 64 slots][peer 1 lane : 64 slots] ...   |
 //   +---------------------------------------------------------+
-//   |  Completion Control Region                              |
+//   |  Ack Control Region                                     |
 //   |  [peer 0 lane : 64 slots][peer 1 lane : 64 slots] ...   |
 //   +---------------------------------------------------------+
 //
 // Control lane addressing (isolated per sender-receiver pair):
 //
-//      Rank R wants to write a PublishSlot to peer P
+//      Rank R wants to write a CreditSlot to peer P
 //      -----------------------------------------------------
-//      Target = P's publish base
-//               + (R * kP2PControlRingSize + seq % 64) * sizeof(PublishSlot)
+//      Target = P's credit base
+//               + (R * kP2PControlRingSize + seq % 64) * sizeof(CreditSlot)
 //
-//      Rank R wants to write a CompletionSlot to peer P
+//      Rank R wants to write an AckSlot to peer P
 //      -----------------------------------------------------
-//      Target = P's completion base
-//               + (R * kP2PControlRingSize + seq % 64) * sizeof(CompletionSlot)
+//      Target = P's ack base
+//               + (R * kP2PControlRingSize + seq % 64) * sizeof(AckSlot)
 //
 //
 // P2PProxy implements a credit-based RDMA pull protocol.
 //
 // Protocol overview:
 //   - The RECEIVER drives the flow. It allocates chunks from its RecvPool and
-//     writes PublishSlots into the sender's PublishLane to invite the sender
-//     to write data into the designated RecvPool offset.
-//   - The SENDER is passive. It polls its local PublishLane (written by the
-//     receiver via RDMA). Only after receiving an invitation does it allocate
+//     writes CreditSlots into the sender's CreditLane to grant credit to the
+//     sender to write data into the designated RecvPool offset.
+//   - The SENDER is passive. It polls its local CreditLane (written by the
+//     receiver via RDMA). Only after receiving a credit does it allocate
 //     a staging buffer from SendPool, copy user tensor data into it, and
 //     perform the RDMA Write to the remote RecvPool.
-//   - After the RDMA Write finishes, the sender writes a CompletionSlot back
-//     to the receiver's CompletionLane to acknowledge the transfer.
+//   - After the RDMA Write finishes, the sender writes an AckSlot back
+//     to the receiver's AckLane to acknowledge the transfer.
 //
 // Memory model:
 //   - SendPool / RecvPool are fixed-size chunk pools.
 //   - Control lanes are ring buffers.
 //
 // Per-chunk state machines:
-//   Sender:  Fetch Invite -> Copy-In (staging) -> RDMA Write -> Acknowledge
-//   Receiver: Advertise -> Poll Completion -> Copy-Out -> Free Chunk
+//   Sender:  Fetch Credit -> Copy-In (staging) -> RDMA Write -> Acknowledge
+//   Receiver: IssueCredit -> Poll Ack -> Copy-Out -> Free Chunk
 //
 // Concurrency rules:
 //   - All pool allocations are non-blocking. If a pool is exhausted the step
@@ -88,11 +88,11 @@ namespace mooncake {
 // The five steps below are separated between Sender (Rank 0) and
 // Receiver (Rank 1) to make the protocol explicit.
 //
-//   Step 1 -- Rank 1 advertises free RecvPool chunks to Rank 0
+//   Step 1 -- Rank 1 issues credits for free RecvPool chunks to Rank 0
 //   ------------------------------------------------------------------------
 //   Rank 1 (Receiver)                RDMA Write
 //   +-----------------------+              +-------------------------------+
-//   | RecvPool              |              | Rank 0's PublishLane[1]       |
+//   | RecvPool              |              | Rank 0's CreditLane[1]        |
 //   | chunk 7 : free        | -----------> | slot 0 : {seq=0,off=7,len=8M} |
 //   | chunk 2 : free        | -----------> | slot 1 : {seq=1,off=2,len=8M} |
 //   | chunk 1 : free        | -----------> | slot 2 : {seq=2,off=1,len=8M} |
@@ -124,15 +124,15 @@ namespace mooncake {
 //   | chunk 5 : [16..24M) | ------------------------> | chunk 1 : [16..24M) |
 //   +---------------------+                           +---------------------+
 //
-//   Step 4 -- Rank 0 acknowledges with CompletionSlots
+//   Step 4 -- Rank 0 acknowledges with AckSlots
 //   ------------------------------------------------------------------------
 //   Rank 0 (Sender)                      RDMA Write       Rank 1 (Receiver)
-//   +-----------------------+               +-------------------------------+
-//   | CompletionLane[0]     |               | Rank 1's CompletionLane[0]    |
-//   | (local cache only)    | ------------> | slot 0 : {seq=0,len=8M,gen=G} |
-//   +-----------------------+               | slot 1 : {seq=1,len=8M,gen=G} |
-//                                           | slot 2 : {seq=2,len=8M,gen=G} |
-//                                           +-------------------------------+
+//   +-----------------------+             +---------------------------------+
+//   | AckLane[0]            |             | Rank 1's AckLane[0]             |
+//   | (local cache only)    | ----------> | slot 0 : {seq=0,len=8M,epoch=G} |
+//   +-----------------------+             | slot 1 : {seq=1,len=8M,epoch=G} |
+//                                         | slot 2 : {seq=2,len=8M,epoch=G} |
+//                                         +---------------------------------+
 //
 //   Step 5 -- Rank 1 copies out and recycles chunks
 //   ------------------------------------------------------------------------
@@ -170,18 +170,18 @@ inline constexpr uint64_t kDefaultPoolSize = 128u * 1024 * 1024;  // 128 MiB
 inline constexpr uint64_t kDefaultChunkSize = 16u * 1024 * 1024;  // 16 MiB
 
 // Single-word atomic publication token.
-// Combines generation and sequence to avoid torn reads.
+// Combines epoch and sequence to avoid torn reads.
 // kInvalidControlToken (all 1s) means "slot empty / not yet published".
 using ControlToken = uint64_t;
 inline constexpr ControlToken kInvalidControlToken =
     std::numeric_limits<uint64_t>::max();
 
-inline ControlToken makeControlToken(uint32_t generation, uint32_t sequence) {
-    return (static_cast<ControlToken>(generation) << 32) |
+inline ControlToken makeControlToken(uint32_t epoch, uint32_t sequence) {
+    return (static_cast<ControlToken>(epoch) << 32) |
            static_cast<ControlToken>(sequence & 0xFFFFFFFFu);
 }
 
-// PublishSlot
+// CreditSlot
 //
 // Header-Footer double-token guard:
 //   We store the same token at both ends of the 64-byte block.
@@ -193,12 +193,12 @@ inline ControlToken makeControlToken(uint32_t generation, uint32_t sequence) {
 // consumer safely retries on the next poll iteration.
 //
 // Layout:
-//   [0..7]   header_token  (generation << 32 | sequence)
+//   [0..7]   header_token  (epoch << 32 | sequence)
 //   [8..15]  recv_addr     (payload)
 //   [16..19] chunk_len     (payload)
 //   [20..55] padding       (kept zero, reserved for future use)
 //   [56..63] footer_token  (identical to header_token)
-struct alignas(64) PublishSlot {
+struct alignas(64) CreditSlot {
    private:
     uint64_t header_token = kInvalidControlToken;
     uint64_t recv_addr = 0;
@@ -211,22 +211,22 @@ struct alignas(64) PublishSlot {
     // Consumer-side reliable read.  Returns true when a consistent slot is
     // observed (header == footer != kInvalidControlToken).
     bool tryLoad(uint64_t& out_recv_addr, uint32_t& out_chunk_len,
-                 uint32_t& out_generation, uint32_t& out_sequence) const;
+                 uint32_t& out_epoch, uint32_t& out_sequence) const;
 
     // Producer-side reliable publish.  Writes payload and footer first,
     // then releases header so consumers see a consistent slot.
-    void publish(uint32_t gen, uint32_t seq, uint64_t addr, uint32_t len);
+    void publish(uint32_t epoch, uint32_t seq, uint64_t addr, uint32_t len);
 
     // Reset both tokens to kInvalidControlToken.
     void reset();
 };
 
-// CompletionSlot Layout:
-//   [0..7]   header_token  (generation << 32 | sequence)
+// AckSlot Layout:
+//   [0..7]   header_token  (epoch << 32 | sequence)
 //   [8..11]  chunk_len     (payload)
 //   [12..55] padding       (kept zero, reserved for future use)
 //   [56..63] footer_token  (identical to header_token)
-struct alignas(64) CompletionSlot {
+struct alignas(64) AckSlot {
    private:
     uint64_t header_token = kInvalidControlToken;
     uint32_t chunk_len = 0;
@@ -235,12 +235,12 @@ struct alignas(64) CompletionSlot {
     uint64_t footer_token = kInvalidControlToken;
 
    public:
-    // See PublishSlot::tryLoad().
-    bool tryLoad(uint32_t& out_chunk_len, uint32_t& out_generation,
+    // See CreditSlot::tryLoad().
+    bool tryLoad(uint32_t& out_chunk_len, uint32_t& out_epoch,
                  uint32_t& out_sequence) const;
 
-    // See PublishSlot::publish().
-    void publish(uint32_t gen, uint32_t seq, uint32_t len);
+    // See CreditSlot::publish().
+    void publish(uint32_t epoch, uint32_t seq, uint32_t len);
 
     // Reset both tokens to kInvalidControlToken.
     void reset();
@@ -302,10 +302,8 @@ class P2PProxy {
     P2PProxy(TransferEngine* engine, const Options& options);
     ~P2PProxy();
 
-    PublishSlot* publish_region() const { return resources_.publish_region_; }
-    CompletionSlot* completion_region() const {
-        return resources_.completion_region_;
-    }
+    CreditSlot* credit_region() const { return resources_.credit_region_; }
+    AckSlot* ack_region() const { return resources_.ack_region_; }
     void bindMeta(const std::shared_ptr<TransferGroupMeta>& meta);
     void extendGroupSizeTo(int new_size);
 
@@ -334,14 +332,13 @@ class P2PProxy {
      */
     void abandonResources();
 
-    // Generation for fault recovery.  All control slots carry this
+    // Epoch for fault recovery.  All control slots carry this
     // value so that stale messages from before a Reset can be detected.
-    uint32_t getGeneration(int peer_rank) const {
-        return peer_generation_[peer_rank].load(std::memory_order_acquire);
+    uint32_t getEpoch(int peer_rank) const {
+        return peer_epoch_[peer_rank].load(std::memory_order_acquire);
     }
-    void setGeneration(int peer_rank, uint32_t generation) {
-        peer_generation_[peer_rank].store(generation,
-                                          std::memory_order_release);
+    void setEpoch(int peer_rank, uint32_t epoch) {
+        peer_epoch_[peer_rank].store(epoch, std::memory_order_release);
     }
 
    private:
@@ -351,18 +348,18 @@ class P2PProxy {
                   // On CPU this is synchronous; on GPU we record a
                   // cudaEvent on the op's stream and poll it.
         kWriteRemote,  // Write from SendPool -> remote RecvPool.
-        kCompletion,   // Writing CompletionSlot back to the receiver.
-        kFinished,     // CompletionSlot write done, staging buffer freed.
+        kAck,          // Writing AckSlot back to the receiver.
+        kFinished,     // AckSlot write done, staging buffer freed.
         kFailed,       // Transport error or timeout; staging buffer freed.
     };
 
     // Receiver-side per-chunk state machine.
     enum class RecvTaskState {
-        kAdvertise,       // PublishSlot Write is in flight.
-        kWaitCompletion,  // Waiting for sender's CompletionSlot.
-        kCopyOut,         // GPU: cudaMemcpyAsync RecvPool -> tensor in flight.
-        kFinished,        // Copy-out done, chunk returned to pool.
-        kFailed,          // Transport error or timeout; chunk returned to pool.
+        kIssueCredit,  // CreditSlot Write is in flight.
+        kWaitAck,      // Waiting for sender's AckSlot.
+        kCopyOut,      // GPU: cudaMemcpyAsync RecvPool -> tensor in flight.
+        kFinished,     // Copy-out done, chunk returned to pool.
+        kFailed,       // Transport error or timeout; chunk returned to pool.
     };
 
     struct SendOpContext;
@@ -370,12 +367,12 @@ class P2PProxy {
 
     // One chunk of a SendOp.  The sender copies data from the user tensor
     // into a SendPool staging buffer and then RDMA-writes it to the remote
-    // RecvPool offset that the receiver advertised in the PublishSlot.
+    // RecvPool offset that the receiver issued in the CreditSlot.
     struct SendTransferTask {
         SendTransferTask() = default;
         SendTransferTask(uint64_t tensor_offset_in, uint32_t chunk_len_in,
                          void* staging_addr_in, uint64_t remote_addr_in,
-                         uint32_t sequence_in, uint32_t generation_in);
+                         uint32_t sequence_in, uint32_t epoch_in);
 
         SendTaskState state_ = SendTaskState::kCopyIn;
         uint64_t tensor_offset_ = 0;  // Offset inside the user tensor.
@@ -383,16 +380,15 @@ class P2PProxy {
         void* staging_addr_ = nullptr;  // Address inside SendPool.
         uint64_t remote_addr_ = 0;      // Address inside REMOTE RecvPool.
         uint32_t sequence_ = 0;         // Sequence number in the control ring.
-        uint32_t generation_ = 0;       // Generation for Reset detection.
+        uint32_t epoch_ = 0;            // Epoch for Reset detection.
         std::optional<BatchID> transfer_batch_id_;  // RDMA Write batch id.
-        std::optional<BatchID>
-            completion_batch_id_;  // CompletionSlot write batch id.
+        std::optional<BatchID> ack_batch_id_;       // AckSlot write batch id.
         cudaEvent_t copy_ready_event_ = nullptr;  // Signals Copy-In done (GPU).
         std::chrono::steady_clock::time_point last_update_time_;
     };
 
     // Active send operation state.  Tasks are created in order and advance
-    // through the sender state machine (kCopyIn -> kWriteRemote -> kCompletion
+    // through the sender state machine (kCopyIn -> kWriteRemote -> kAck
     // -> kFinished).
     struct SendOpContext {
         SendOpContext() = default;
@@ -414,31 +410,31 @@ class P2PProxy {
     };
 
     // One chunk of a RecvOp.  The receiver allocates a RecvPool chunk,
-    // advertises it to the sender via a PublishSlot, waits for the sender
+    // issues it to the sender via a CreditSlot, waits for the sender
     // to RDMA-write data into it, and finally copies the data into the user
     // tensor before returning the chunk to RecvPool.
     struct RecvTransferTask {
         RecvTransferTask() = default;
         RecvTransferTask(uint64_t tensor_offset_in, uint32_t chunk_len_in,
                          void* local_addr_in, uint32_t sequence_in,
-                         uint32_t generation_in);
+                         uint32_t epoch_in);
 
-        RecvTaskState state_ = RecvTaskState::kAdvertise;
+        RecvTaskState state_ = RecvTaskState::kIssueCredit;
         uint64_t tensor_offset_ = 0;  // Offset inside the user tensor.
         uint32_t chunk_len_ = 0;      // Bytes in this chunk.
         void* local_addr_ = nullptr;  // Address inside local RecvPool.
         uint32_t sequence_ = 0;       // Sequence number in the control ring.
-        uint32_t generation_ = 0;     // Generation for Reset detection.
+        uint32_t epoch_ = 0;          // Epoch for Reset detection.
         std::optional<BatchID>
-            publish_batch_id_;  // PublishSlot RDMA Write batch id.
+            credit_batch_id_;  // CreditSlot RDMA Write batch id.
         cudaEvent_t copy_ready_event_ =
             nullptr;  // Signals Copy-Out done (GPU).
         std::chrono::steady_clock::time_point last_update_time_;
     };
 
     // Active receive operation state.  Tasks are created in order and
-    // advance through the receiver state machine (kAdvertise ->
-    // kWaitCompletion -> kCopyOut -> kFinished).
+    // advance through the receiver state machine (kIssueCredit ->
+    // kWaitAck -> kCopyOut -> kFinished).
     struct RecvOpContext {
         RecvOpContext() = default;
         RecvOpContext(RecvOp&& op_in);
@@ -452,32 +448,32 @@ class P2PProxy {
         cudaStream_t cuda_stream_ = nullptr;
         uint64_t total_bytes_ = 0;
         // Number of bytes for which a RecvPool chunk has been reserved and a
-        // PublishSlot has been sent to the peer.  When bytes_advertised_ ==
+        // CreditSlot has been sent to the peer.  When bytes_credited_ ==
         // total_bytes_ the entire tensor has been offered to the sender.
-        uint64_t bytes_advertised_ = 0;
+        uint64_t bytes_credited_ = 0;
     };
 
-    // Per-peer sender state.  The sender consumes PublishSlots that the
-    // receiver writes into our local PublishLane for this peer.
+    // Per-peer sender state.  The sender consumes CreditSlots that the
+    // receiver writes into our local CreditLane for this peer.
     struct SendPeerLane {
         std::deque<SendOpContext> pending_send_ops_;
         std::optional<SendOpContext> active_send_op_;
-        // Sequence number of the next PublishSlot to consume from this peer.
+        // Sequence number of the next CreditSlot to consume from this peer.
         // Monotonically increases; wraps around the ring via modulo.
-        uint64_t publish_consume_seq_ = 0;
+        uint64_t credit_consume_seq_ = 0;
         std::array<cudaEvent_t, kP2PControlRingSize> copy_ready_events_;
     };
 
-    // Per-peer receiver state.  The receiver issues PublishSlots to invite
-    // the peer to write data, and consumes CompletionSlots that the peer
-    // writes back to acknowledge finished transfers.
+    // Per-peer receiver state.  The receiver issues CreditSlots to grant credit
+    // to the peer to write data, and consumes AckSlots that the peer writes
+    // back to acknowledge finished transfers.
     struct RecvPeerLane {
         std::deque<RecvOp> pending_recv_ops_;
         std::optional<RecvOpContext> active_recv_op_;
-        // Sequence number of the next PublishSlot to issue to this peer.
-        uint64_t publish_issue_seq_ = 0;
-        // Sequence number of the next CompletionSlot to consume from this peer.
-        uint64_t completion_consume_seq_ = 0;
+        // Sequence number of the next CreditSlot to issue to this peer.
+        uint64_t credit_issue_seq_ = 0;
+        // Sequence number of the next AckSlot to consume from this peer.
+        uint64_t ack_consume_seq_ = 0;
         std::array<cudaEvent_t, kP2PControlRingSize> copy_ready_events_;
     };
 
@@ -496,9 +492,9 @@ class P2PProxy {
     bool tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane);
     bool stepRecvTask(RecvTransferTask& task);
     bool stepRecvCopyOut(RecvTransferTask& task);
-    bool stepRecvAdvertise(RecvTransferTask& task);
-    bool pollRecvCompletionSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
-                                RecvTransferTask& head_task);
+    bool stepRecvIssueCredit(RecvTransferTask& task);
+    bool pollRecvAckSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
+                         RecvTransferTask& head_task);
     bool isRecvOpCompleted(const RecvOpContext& op_ctx) const;
     void performRecvReset(int peer_rank);
 
@@ -506,7 +502,7 @@ class P2PProxy {
     bool stepSendTask(SendOpContext& op_ctx, SendTransferTask& task);
     bool stepSendCopyIn(SendTransferTask& task);
     bool stepSendWriteRemote(SendOpContext& op_ctx, SendTransferTask& task);
-    bool stepSendCompletion(SendOpContext& op_ctx, SendTransferTask& task);
+    bool stepSendAck(SendOpContext& op_ctx, SendTransferTask& task);
     bool isSendOpCompleted(const SendOpContext& op_ctx) const;
     void performSendReset(int peer_rank);
 
@@ -523,23 +519,22 @@ class P2PProxy {
 
     // Control lane addressing.
     //
-    // Each rank owns one contiguous Publish region and one Completion region.
+    // Each rank owns one contiguous Credit region and one Ack region.
     // Within each region there are kMaxNumRanks lanes, one per peer.
     // Lane index == peer rank.  Each lane has kP2PControlRingSize slots.
     //
-    // Example: rank R wants to write a PublishSlot to peer P.
-    //   target = P's publish base + (R * kRingSize + seq % kRingSize) * sizeof
+    // Example: rank R wants to write a CreditSlot to peer P.
+    //   target = P's credit base + (R * kRingSize + seq % kRingSize) * sizeof
     //
     // This isolates control traffic per (sender, receiver) pair.
-    PublishSlot* getLocalPublishLane(int peer_rank) const;
-    CompletionSlot* getLocalCompletionLane(int peer_rank) const;
-    uint64_t getRemotePublishSlot(int peer_rank, uint32_t sequence) const;
-    uint64_t getRemoteCompletionSlot(int peer_rank, uint32_t sequence) const;
+    CreditSlot* getLocalCreditLane(int peer_rank) const;
+    AckSlot* getLocalAckLane(int peer_rank) const;
+    uint64_t getRemoteCreditSlot(int peer_rank, uint32_t sequence) const;
+    uint64_t getRemoteAckSlot(int peer_rank, uint32_t sequence) const;
 
-    PublishSlot* getLocalPublishStagingBuf(int peer_rank,
-                                           uint32_t sequence) const;
-    CompletionSlot* getLocalCompletionStagingBuf(int peer_rank,
-                                                 uint32_t sequence) const;
+    CreditSlot* getLocalCreditStagingBuf(int peer_rank,
+                                         uint32_t sequence) const;
+    AckSlot* getLocalAckStagingBuf(int peer_rank, uint32_t sequence) const;
 
     template <typename T>
     bool isTimeout(const T& obj) const {
@@ -549,11 +544,11 @@ class P2PProxy {
 
    private:
     struct P2PResources {
-        PublishSlot* publish_region_ = nullptr;
-        CompletionSlot* completion_region_ = nullptr;
+        CreditSlot* credit_region_ = nullptr;
+        AckSlot* ack_region_ = nullptr;
         // Serve as RDMA write source address
-        PublishSlot* publish_staging_buf_ = nullptr;
-        CompletionSlot* completion_staging_buf_ = nullptr;
+        CreditSlot* credit_staging_buf_ = nullptr;
+        AckSlot* ack_staging_buf_ = nullptr;
     };
 
     P2PDeviceWorker* device_worker_ = nullptr;
@@ -585,10 +580,10 @@ class P2PProxy {
     std::atomic<int> active_send_tasks_{0};
     std::atomic<int> active_recv_tasks_{0};
 
-    // Per-peer generation for fault recovery.  Incremented in resetPeerState
+    // Per-peer epoch for fault recovery.  Incremented in resetPeerState
     // and performSend/RecvReset so that stale messages from a previous epoch
     // can be detected on a per-peer basis.
-    std::array<std::atomic<uint32_t>, kMaxNumRanks> peer_generation_;
+    std::array<std::atomic<uint32_t>, kMaxNumRanks> peer_epoch_;
 
     std::array<SendPeerLane, kMaxNumRanks> send_peer_lanes_;
     std::array<RecvPeerLane, kMaxNumRanks> recv_peer_lanes_;

--- a/mooncake-pg/include/p2p_proxy.h
+++ b/mooncake-pg/include/p2p_proxy.h
@@ -20,7 +20,7 @@
 
 namespace mooncake {
 
-// Memory layout of one P2PProxy instance:
+// Memory layout of one P2PProxy instance (chunk_size=8MiB, num_chunks=32):
 //
 //   +---------------------------------------------------------+
 //   |  SendPool  (32 x 8 MiB = 256 MiB)                       |
@@ -77,9 +77,9 @@ namespace mooncake {
 //   Receiver: Advertise -> Poll Completion -> Copy-Out -> Free Chunk
 //
 // Concurrency rules:
-//   - All pool allocations are non-blocking (TryAlloc). If a pool is exhausted
-//     the step function returns false immediately and retries on the next
-//     polling iteration. This prevents deadlocks.
+//   - All pool allocations are non-blocking. If a pool is exhausted the step
+//     function returns false immediately and retries on the next polling
+//     iteration. This prevents deadlocks.
 //   - SendPool and RecvPool are strictly separated so that a deadlock where
 //     "all chunks are reserved for receiving and none are left for sending"
 //     can never happen.
@@ -161,9 +161,10 @@ namespace mooncake {
 //   +-----------------------+
 //
 // ---------------------------------------------------------------------------
-inline constexpr size_t kP2PChunkSize = 8u * 1024 * 1024;  // 8 MB
-inline constexpr uint32_t kP2PPoolNumChunks = 32;
 inline constexpr uint32_t kP2PControlRingSize = 64;
+// default config: pool_size=128M, chunk_size=16M, num_chunks=8
+inline constexpr uint64_t kDefaultPoolSize = 128u * 1024 * 1024;  // 128 M
+inline constexpr uint64_t kDefaultChunkSize = 16u * 1024 * 1024;  // 16 M
 
 // Single-word atomic publication token.
 // Combines generation and sequence to avoid torn reads.
@@ -204,69 +205,17 @@ struct alignas(64) PublishSlot {
     uint64_t footer_token = kInvalidControlToken;
 
    public:
-    // Consumer-side reliable read.
-    //
-    // 1. Load header_token with acquire semantics.
-    // 2. If it is kInvalidControlToken the slot is empty -> fail.
-    // 3. Optimistically copy the payload (these plain loads may be torn).
-    // 4. Issue an acquire fence so the payload reads cannot be reordered past
-    //    the footer load that follows.
-    // 5. Load footer_token.
-    // 6. Accept the payload only when header == footer.
+    // Consumer-side reliable read.  Returns true when a consistent slot is
+    // observed (header == footer != kInvalidControlToken).
     bool tryLoad(uint64_t& out_recv_addr, uint32_t& out_chunk_len,
-                 uint32_t& out_generation, uint32_t& out_sequence) const {
-        uint64_t h =
-            std::atomic_ref(header_token).load(std::memory_order_acquire);
-        if (h == kInvalidControlToken) return false;
+                 uint32_t& out_generation, uint32_t& out_sequence) const;
 
-        // Optimistic payload copy – may be torn if the NIC is still writing.
-        uint64_t addr = recv_addr;
-        uint32_t len = chunk_len;
+    // Producer-side reliable publish.  Writes payload and footer first,
+    // then releases header so consumers see a consistent slot.
+    void publish(uint32_t gen, uint32_t seq, uint64_t addr, uint32_t len);
 
-        // Avoid moving payload reads below the footer check.
-        std::atomic_thread_fence(std::memory_order_acquire);
-
-        uint64_t f =
-            std::atomic_ref(footer_token).load(std::memory_order_relaxed);
-
-        if (h == f) {
-            out_recv_addr = addr;
-            out_chunk_len = len;
-            out_generation = static_cast<uint32_t>(h >> 32);
-            out_sequence = static_cast<uint32_t>(h);
-            return true;
-        }
-        // Torn write – caller retries next poll.
-        return false;
-    }
-
-    // Producer-side reliable publish.
-    //
-    // On the local CPU the store order matters:
-    //   payload -> footer (relaxed) -> header (release).
-    // The release store to header_token guarantees that every prior store is
-    // visible to any consumer that sees the new header value.
-    void publish(uint32_t gen, uint32_t seq, uint64_t addr, uint32_t len) {
-        uint64_t new_token = makeControlToken(gen, seq);
-
-        recv_addr = addr;
-        chunk_len = len;
-
-        // Write footer first so it is never ahead of the header.
-        std::atomic_ref(footer_token)
-            .store(new_token, std::memory_order_relaxed);
-        // Release the header last
-        std::atomic_ref(header_token)
-            .store(new_token, std::memory_order_release);
-    }
-
-    void reset() {
-        recv_addr = 0;
-        chunk_len = 0;
-        uint64_t inv = kInvalidControlToken;
-        std::atomic_ref(footer_token).store(inv, std::memory_order_relaxed);
-        std::atomic_ref(header_token).store(inv, std::memory_order_release);
-    }
+    // Reset both tokens to kInvalidControlToken.
+    void reset();
 };
 
 // CompletionSlot Layout:
@@ -283,84 +232,36 @@ struct alignas(64) CompletionSlot {
     uint64_t footer_token = kInvalidControlToken;
 
    public:
-    // See PublishSlot::tryLoad() for the detailed description.
+    // See PublishSlot::tryLoad().
     bool tryLoad(uint32_t& out_chunk_len, uint32_t& out_generation,
-                 uint32_t& out_sequence) const {
-        uint64_t h =
-            std::atomic_ref(header_token).load(std::memory_order_acquire);
-        if (h == kInvalidControlToken) return false;
+                 uint32_t& out_sequence) const;
 
-        uint32_t len = chunk_len;
+    // See PublishSlot::publish().
+    void publish(uint32_t gen, uint32_t seq, uint32_t len);
 
-        std::atomic_thread_fence(std::memory_order_acquire);
-
-        uint64_t f =
-            std::atomic_ref(footer_token).load(std::memory_order_relaxed);
-
-        if (h == f) {
-            out_chunk_len = len;
-            out_generation = static_cast<uint32_t>(h >> 32);
-            out_sequence = static_cast<uint32_t>(h);
-            return true;
-        }
-        return false;
-    }
-
-    // See PublishSlot::publish() for the detailed description.
-    void publish(uint32_t gen, uint32_t seq, uint32_t len) {
-        uint64_t new_token = makeControlToken(gen, seq);
-
-        chunk_len = len;
-
-        std::atomic_ref(footer_token)
-            .store(new_token, std::memory_order_relaxed);
-        std::atomic_ref(header_token)
-            .store(new_token, std::memory_order_release);
-    }
-
-    void reset() {
-        chunk_len = 0;
-        uint64_t inv = kInvalidControlToken;
-        std::atomic_ref(footer_token).store(inv, std::memory_order_relaxed);
-        std::atomic_ref(header_token).store(inv, std::memory_order_release);
-    }
+    // Reset both tokens to kInvalidControlToken.
+    void reset();
 };
 
+// P2PChunkPool
+// No lock needed because it is only accessed by one worker thread.
 class P2PChunkPool {
    public:
     P2PChunkPool() = default;
 
-    void init(void* base_addr, size_t chunk_size, uint32_t num_chunks) {
-        base_addr_ = base_addr;
-        chunk_size_ = chunk_size;
-        free_stack_.clear();
-        free_stack_.reserve(num_chunks);
-        for (uint32_t idx = 0; idx < num_chunks; ++idx) {
-            free_stack_.push_back(static_cast<uint8_t*>(base_addr_) +
-                                  (num_chunks - 1 - idx) * chunk_size_);
-        }
-    }
+    // Initialize pool with given base address, chunk size and number of chunks.
+    void init(void* base_addr, size_t chunk_size, uint32_t num_chunks);
 
-    void* acquire() {
-        std::lock_guard<std::mutex> l(lock_);
-        if (free_stack_.empty()) {
-            return nullptr;
-        }
-        void* ptr = free_stack_.back();
-        free_stack_.pop_back();
-        return ptr;
-    }
+    // Acquire a free chunk. Returns nullptr if the pool is exhausted.
+    void* acquire();
 
-    void release(void* ptr) {
-        std::lock_guard<std::mutex> l(lock_);
-        free_stack_.push_back(ptr);
-    }
+    // Release a chunk back to the pool.
+    void release(void* ptr);
 
    private:
     void* base_addr_ = nullptr;
     size_t chunk_size_ = 0;
     std::vector<void*> free_stack_;
-    std::mutex lock_;
 };
 
 class P2PDeviceWorker;
@@ -406,6 +307,7 @@ class P2PProxy {
         return resources_.completion_region_;
     }
     void bindMeta(const std::shared_ptr<TransferGroupMeta>& meta);
+    void extendGroupSizeTo(int new_size);
 
     void enqueueSend(SendOp op);
     void enqueueRecv(RecvOp op);
@@ -659,6 +561,10 @@ class P2PProxy {
     std::chrono::milliseconds transfer_timeout_ms_{5000};  // 5s
     P2PResources resources_;
     bool resource_abandoned_{false};
+
+    size_t chunk_size_ = 0;
+    uint32_t num_chunks_ = 0;
+    size_t pool_bytes_ = 0;
 
     P2PChunkPool send_pool_;
     P2PChunkPool recv_pool_;

--- a/mooncake-pg/src/connection_poller.cpp
+++ b/mooncake-pg/src/connection_poller.cpp
@@ -400,9 +400,7 @@ bool ConnectionContext::pollPeer(int pollingRank) {
                 store_->deleteKey(
                     getBufferStoreKey(backendIndex_, pollingRank));
                 store_->deleteKey(
-                    getExtensionTaskCountStoreKey(backendIndex_, pollingRank));
-                store_->deleteKey(getExtensionActiveRanksStoreKey(backendIndex_,
-                                                                  pollingRank));
+                    getExtensionStateStoreKey(backendIndex_, pollingRank));
             } catch (const std::exception& e) {
                 LOG(WARNING) << "Rank " << rank_
                              << " got an exception when deleteKey for peer "
@@ -414,7 +412,7 @@ bool ConnectionContext::pollPeer(int pollingRank) {
                 &warmup_recv_region_[pollingRank]) = 0;
 
             // Reset P2PProxy states
-            p2p_proxy_->ResetPeerState(pollingRank);
+            p2p_proxy_->resetPeerState(pollingRank);
 
             // Back to WAITING_STORE to reconnect it.
             peerState.state = PeerConnectionState::WAITING_STORE;

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -40,9 +40,9 @@ std::vector<uint8_t> serialize(const ExtensionState& state) {
     // nearest byte
     size_t bitmapSize = (rankCount + 7) / 8;
 
-    // Total size = count field + bitmap + p2pGeneration + taskCount
-    size_t totalSize =
-        sizeof(uint32_t) + bitmapSize + sizeof(uint32_t) + sizeof(int);
+    // Total size = count field + bitmap + p2pGenerations[] + taskCount
+    size_t totalSize = sizeof(uint32_t) + bitmapSize +
+                       sizeof(uint32_t) * rankCount + sizeof(int);
 
     std::vector<uint8_t> buffer(totalSize, 0);
     uint8_t* ptr = buffer.data();
@@ -60,9 +60,12 @@ std::vector<uint8_t> serialize(const ExtensionState& state) {
     }
     ptr += bitmapSize;
 
-    // 3. Store p2pGeneration
-    std::memcpy(ptr, &state.p2pGeneration, sizeof(uint32_t));
-    ptr += sizeof(uint32_t);
+    // 3. Store per-peer p2pGenerations
+    for (size_t i = 0; i < rankCount; ++i) {
+        std::memcpy(ptr + i * sizeof(uint32_t), &state.p2pGenerations[i],
+                    sizeof(uint32_t));
+    }
+    ptr += sizeof(uint32_t) * rankCount;
 
     // 4. Store taskCount
     std::memcpy(ptr, &state.taskCount, sizeof(int));
@@ -91,10 +94,13 @@ ExtensionState deserialize(const std::vector<uint8_t>& buffer) {
     }
     ptr += bitmapSize;
 
-    // 3. Read p2pGeneration
-    if (ptr + sizeof(uint32_t) <= buffer.data() + buffer.size()) {
-        std::memcpy(&state.p2pGeneration, ptr, sizeof(uint32_t));
-        ptr += sizeof(uint32_t);
+    // 3. Read per-peer p2pGenerations
+    state.p2pGenerations.resize(rankCount);
+    for (size_t i = 0; i < rankCount; ++i) {
+        if (ptr + sizeof(uint32_t) <= buffer.data() + buffer.size()) {
+            std::memcpy(&state.p2pGenerations[i], ptr, sizeof(uint32_t));
+            ptr += sizeof(uint32_t);
+        }
     }
 
     // 4. Read taskCount
@@ -108,35 +114,52 @@ ExtensionState deserialize(const std::vector<uint8_t>& buffer) {
 // Async Work implementation for P2P operations processed by worker threads.
 class MooncakeP2PWork : public ::c10d::Work {
    public:
-    explicit MooncakeP2PWork(std::shared_ptr<std::atomic<bool>> completed)
-        : Work(-1, c10d::OpType::UNKNOWN), completed_(completed) {}
+    explicit MooncakeP2PWork(
+        std::shared_ptr<std::atomic<P2PProxy::OpStatus>> status)
+        : Work(-1, c10d::OpType::UNKNOWN), status_(status) {}
 
     bool isCompleted() override {
-        return completed_->load(std::memory_order_acquire);
+        return status_->load(std::memory_order_acquire) !=
+               P2PProxy::OpStatus::kPending;
+    }
+
+    bool isSuccess() const override {
+        return status_->load(std::memory_order_acquire) ==
+               P2PProxy::OpStatus::kSuccess;
     }
 
     bool wait(std::chrono::milliseconds timeout) override {
-        if (completed_->load(std::memory_order_acquire)) {
-            return true;
-        }
-
         BackoffWaiterConfig cfg{};
         cfg.max_sleep = std::chrono::microseconds(10);
         BackoffWaiter waiter(cfg);
 
+        bool done = false;
         if (timeout.count() > 0) {
-            return waiter.wait_for(timeout, [this] {
-                return completed_->load(std::memory_order_acquire);
+            done = waiter.wait_for(timeout, [this] {
+                return status_->load(std::memory_order_acquire) !=
+                       P2PProxy::OpStatus::kPending;
             });
+        } else {
+            waiter.wait([this] {
+                return status_->load(std::memory_order_acquire) !=
+                       P2PProxy::OpStatus::kPending;
+            });
+            done = true;
         }
 
-        waiter.wait(
-            [this] { return completed_->load(std::memory_order_acquire); });
+        if (!done) {
+            return false;
+        }
+
+        if (status_->load(std::memory_order_acquire) ==
+            P2PProxy::OpStatus::kFailed) {
+            TORCH_CHECK(false, "Mooncake P2P operation failed.");
+        }
         return true;
     }
 
    private:
-    std::shared_ptr<std::atomic<bool>> completed_;
+    std::shared_ptr<std::atomic<P2PProxy::OpStatus>> status_;
 };
 
 /**
@@ -364,7 +387,8 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::send(
                 "P2P send: dstRank out of range.");
 
     auto contiguous = tensor.contiguous();
-    auto completed = std::make_shared<std::atomic<bool>>(false);
+    auto status = std::make_shared<std::atomic<P2PProxy::OpStatus>>(
+        P2PProxy::OpStatus::kPending);
     cudaStream_t stream = nullptr;
     if (!isCpu_) {
         auto current_stream =
@@ -377,10 +401,10 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::send(
         .tensor_ = std::move(contiguous),
         .peer_rank_ = dstRank,
         .cuda_stream_ = stream,
-        .completed_ = completed,
+        .status_ = status,
     });
 
-    return c10::make_intrusive<MooncakeP2PWork>(completed);
+    return c10::make_intrusive<MooncakeP2PWork>(status);
 }
 
 c10::intrusive_ptr<c10d::Work> MooncakeBackend::recv(
@@ -396,7 +420,8 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::recv(
                 "P2P recv: srcRank out of range.");
 
     auto target = tensor.is_contiguous() ? tensor : tensor.contiguous();
-    auto completed = std::make_shared<std::atomic<bool>>(false);
+    auto status = std::make_shared<std::atomic<P2PProxy::OpStatus>>(
+        P2PProxy::OpStatus::kPending);
     cudaStream_t stream = nullptr;
     if (!isCpu_) {
         auto current_stream =
@@ -410,10 +435,10 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::recv(
         .original_tensor_ = tensor,
         .peer_rank_ = srcRank,
         .cuda_stream_ = stream,
-        .completed_ = completed,
+        .status_ = status,
     });
 
-    return c10::make_intrusive<MooncakeP2PWork>(completed);
+    return c10::make_intrusive<MooncakeP2PWork>(status);
 }
 
 c10::intrusive_ptr<c10d::Work> MooncakeBackend::broadcast(
@@ -959,8 +984,12 @@ void MooncakeBackend::waitForExtensionState() {
     // taskCount
     meta_->taskCount = state.taskCount;
 
-    // p2pGeneration
-    p2p_proxy_->setGeneration(state.p2pGeneration);
+    // p2pGenerations
+    TORCH_CHECK(static_cast<size_t>(meta_->size) == state.p2pGenerations.size(),
+                "Invalid p2pGenerations size");
+    for (int i = 0; i < meta_->size; ++i) {
+        p2p_proxy_->setGeneration(i, state.p2pGenerations[i]);
+    }
 
     // activeRanks
     TORCH_CHECK(static_cast<size_t>(meta_->size) == state.activeRanks.size(),
@@ -1075,10 +1104,14 @@ void MooncakeBackend::recoverRanks(const std::vector<int>& ranks) {
     }
 
     syncActiveRanksTensor();
+    std::vector<uint32_t> generations(meta_->size);
+    for (int i = 0; i < meta_->size; ++i) {
+        generations[i] = p2p_proxy_->getGeneration(i);
+    }
     ExtensionState state{
         .activeRanks =
             std::vector(meta_->activeRanks, meta_->activeRanks + meta_->size),
-        .p2pGeneration = p2p_proxy_->getGeneration(),
+        .p2pGenerations = std::move(generations),
         .taskCount = meta_->taskCount};
     auto state_data = serialize(state);
     for (const int rank : ranks) {

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -40,9 +40,9 @@ std::vector<uint8_t> serialize(const ExtensionState& state) {
     // nearest byte
     size_t bitmapSize = (rankCount + 7) / 8;
 
-    // Total size = count field + bitmap + p2pGenerations[] + taskCount
+    // Total size = count field + bitmap + p2pEpochs[] + taskCount
     size_t totalSize = sizeof(uint32_t) + bitmapSize +
-                       sizeof(uint32_t) * rankCount + sizeof(int);
+                       sizeof(uint32_t) * rankCount + sizeof(int32_t);
 
     std::vector<uint8_t> buffer(totalSize, 0);
     uint8_t* ptr = buffer.data();
@@ -60,15 +60,16 @@ std::vector<uint8_t> serialize(const ExtensionState& state) {
     }
     ptr += bitmapSize;
 
-    // 3. Store per-peer p2pGenerations
+    // 3. Store per-peer p2pEpochs
     for (size_t i = 0; i < rankCount; ++i) {
-        std::memcpy(ptr + i * sizeof(uint32_t), &state.p2pGenerations[i],
+        std::memcpy(ptr + i * sizeof(uint32_t), &state.p2pEpochs[i],
                     sizeof(uint32_t));
     }
     ptr += sizeof(uint32_t) * rankCount;
 
     // 4. Store taskCount
-    std::memcpy(ptr, &state.taskCount, sizeof(int));
+    int32_t taskCount = static_cast<int32_t>(state.taskCount);
+    std::memcpy(ptr, &taskCount, sizeof(int32_t));
 
     return buffer;
 }
@@ -88,7 +89,7 @@ ExtensionState deserialize(const std::vector<uint8_t>& buffer) {
     // proceeding with further reads.
     size_t bitmapSize = (rankCount + 7) / 8;
     size_t expectedSize = sizeof(uint32_t) + bitmapSize +
-                          sizeof(uint32_t) * rankCount + sizeof(int);
+                          sizeof(uint32_t) * rankCount + sizeof(int32_t);
     if (buffer.size() < expectedSize) return state;
 
     // 2. Read the bitmap and reconstruct the activeRanks vector
@@ -100,15 +101,17 @@ ExtensionState deserialize(const std::vector<uint8_t>& buffer) {
     }
     ptr += bitmapSize;
 
-    // 3. Read per-peer p2pGenerations
-    state.p2pGenerations.resize(rankCount);
+    // 3. Read per-peer p2pEpochs
+    state.p2pEpochs.resize(rankCount);
     for (size_t i = 0; i < rankCount; ++i) {
-        std::memcpy(&state.p2pGenerations[i], ptr, sizeof(uint32_t));
+        std::memcpy(&state.p2pEpochs[i], ptr, sizeof(uint32_t));
         ptr += sizeof(uint32_t);
     }
 
     // 4. Read taskCount
-    std::memcpy(&state.taskCount, ptr, sizeof(int));
+    int32_t taskCount = 0;
+    std::memcpy(&taskCount, ptr, sizeof(int32_t));
+    state.taskCount = static_cast<int>(taskCount);
 
     return state;
 }
@@ -316,8 +319,8 @@ MooncakeBackend::MooncakeBackend(
         (uint64_t)connection_ctx_->warmup_send_region();
     rank_info.warmup_buffer[1] =
         (uint64_t)connection_ctx_->warmup_recv_region();
-    rank_info.p2p_publish_region = (uint64_t)p2p_proxy_->publish_region();
-    rank_info.p2p_completion_region = (uint64_t)p2p_proxy_->completion_region();
+    rank_info.p2p_credit_region = (uint64_t)p2p_proxy_->credit_region();
+    rank_info.p2p_ack_region = (uint64_t)p2p_proxy_->ack_region();
 
     // Sync metadata
     std::vector<uint8_t> rank_info_bytes(sizeof(SegmentInfo));
@@ -986,11 +989,11 @@ void MooncakeBackend::waitForExtensionState() {
     // taskCount
     meta_->taskCount = state.taskCount;
 
-    // p2pGenerations
-    TORCH_CHECK(static_cast<size_t>(meta_->size) == state.p2pGenerations.size(),
-                "Invalid p2pGenerations size");
+    // p2pEpochs
+    TORCH_CHECK(static_cast<size_t>(meta_->size) == state.p2pEpochs.size(),
+                "Invalid p2pEpochs size");
     for (int i = 0; i < meta_->size; ++i) {
-        p2p_proxy_->setGeneration(i, state.p2pGenerations[i]);
+        p2p_proxy_->setEpoch(i, state.p2pEpochs[i]);
     }
 
     // activeRanks
@@ -1107,14 +1110,14 @@ void MooncakeBackend::recoverRanks(const std::vector<int>& ranks) {
     }
 
     syncActiveRanksTensor();
-    std::vector<uint32_t> generations(meta_->size);
+    std::vector<uint32_t> epochs(meta_->size);
     for (int i = 0; i < meta_->size; ++i) {
-        generations[i] = p2p_proxy_->getGeneration(i);
+        epochs[i] = p2p_proxy_->getEpoch(i);
     }
     ExtensionState state{
         .activeRanks =
             std::vector(meta_->activeRanks, meta_->activeRanks + meta_->size),
-        .p2pGenerations = std::move(generations),
+        .p2pEpochs = std::move(epochs),
         .taskCount = meta_->taskCount};
     auto state_data = serialize(state);
     for (const int rank : ranks) {

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -84,9 +84,15 @@ ExtensionState deserialize(const std::vector<uint8_t>& buffer) {
     std::memcpy(&rankCount, ptr, sizeof(uint32_t));
     ptr += sizeof(uint32_t);
 
+    // Calculate expected total size and verify buffer is sufficient before
+    // proceeding with further reads.
+    size_t bitmapSize = (rankCount + 7) / 8;
+    size_t expectedSize = sizeof(uint32_t) + bitmapSize +
+                          sizeof(uint32_t) * rankCount + sizeof(int);
+    if (buffer.size() < expectedSize) return state;
+
     // 2. Read the bitmap and reconstruct the activeRanks vector
     state.activeRanks.resize(rankCount);
-    size_t bitmapSize = (rankCount + 7) / 8;
     for (size_t i = 0; i < rankCount; ++i) {
         // Check if the i-th bit is set
         bool isActive = ptr[i / 8] & (1 << (i % 8));
@@ -97,16 +103,12 @@ ExtensionState deserialize(const std::vector<uint8_t>& buffer) {
     // 3. Read per-peer p2pGenerations
     state.p2pGenerations.resize(rankCount);
     for (size_t i = 0; i < rankCount; ++i) {
-        if (ptr + sizeof(uint32_t) <= buffer.data() + buffer.size()) {
-            std::memcpy(&state.p2pGenerations[i], ptr, sizeof(uint32_t));
-            ptr += sizeof(uint32_t);
-        }
+        std::memcpy(&state.p2pGenerations[i], ptr, sizeof(uint32_t));
+        ptr += sizeof(uint32_t);
     }
 
     // 4. Read taskCount
-    if (ptr + sizeof(int) <= buffer.data() + buffer.size()) {
-        std::memcpy(&state.taskCount, ptr, sizeof(int));
-    }
+    std::memcpy(&state.taskCount, ptr, sizeof(int));
 
     return state;
 }

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -275,9 +275,10 @@ MooncakeBackend::MooncakeBackend(
     int cuda_device_index = isCpu_ ? -1 : at::cuda::current_device();
 
     if (isCpu_)
-        p2p_device_worker_ = dev_worker_mgr.getCPUWorker();
+        p2p_device_worker_ = dev_worker_mgr.getCPUWorker(engine_);
     else
-        p2p_device_worker_ = dev_worker_mgr.getCUDAWorker(cuda_device_index);
+        p2p_device_worker_ =
+            dev_worker_mgr.getCUDAWorker(cuda_device_index, engine_);
 
     auto& worker_mgr = MooncakeWorkerManager::GetInstance();
     if (isCpu_)
@@ -295,7 +296,6 @@ MooncakeBackend::MooncakeBackend(
                      .rank = rank_,
                      .size = size_,
                      .cuda_device_index = cuda_device_index,
-                     .location = location,
                  });
     p2p_device_worker_->registerProxy(p2p_proxy_);
 

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -33,26 +33,77 @@ TransferEngine* MooncakeBackend::engine_ = new TransferEngine(true);
 bool MooncakeBackend::engineInitialized_ = false;
 int MooncakeBackend::backendIndex_ = 0;
 
-namespace {
+std::vector<uint8_t> serialize(const ExtensionState& state) {
+    uint32_t rankCount = static_cast<uint32_t>(state.activeRanks.size());
 
-std::vector<uint8_t> serializeActiveRanks(const bool* activeRanks, int size) {
-    std::vector<uint8_t> bytes(size);
-    for (int i = 0; i < size; ++i) {
-        bytes[i] = activeRanks[i] ? 1 : 0;
+    // Calculate bytes needed for the bitmap: 1 bit per rank, rounded up to
+    // nearest byte
+    size_t bitmapSize = (rankCount + 7) / 8;
+
+    // Total size = count field + bitmap + p2pGeneration + taskCount
+    size_t totalSize =
+        sizeof(uint32_t) + bitmapSize + sizeof(uint32_t) + sizeof(int);
+
+    std::vector<uint8_t> buffer(totalSize, 0);
+    uint8_t* ptr = buffer.data();
+
+    // 1. Store the number of ranks
+    std::memcpy(ptr, &rankCount, sizeof(uint32_t));
+    ptr += sizeof(uint32_t);
+
+    // 2. Store activeRanks as a bitset
+    for (size_t i = 0; i < rankCount; ++i) {
+        if (state.activeRanks[i]) {
+            // Set the i-th bit to 1 if the rank is active
+            ptr[i / 8] |= (1 << (i % 8));
+        }
     }
-    return bytes;
+    ptr += bitmapSize;
+
+    // 3. Store p2pGeneration
+    std::memcpy(ptr, &state.p2pGeneration, sizeof(uint32_t));
+    ptr += sizeof(uint32_t);
+
+    // 4. Store taskCount
+    std::memcpy(ptr, &state.taskCount, sizeof(int));
+
+    return buffer;
 }
 
-void deserializeActiveRanks(const std::vector<uint8_t>& bytes,
-                            bool* activeRanks, int size) {
-    TORCH_CHECK(static_cast<int>(bytes.size()) == size,
-                "Unexpected active-ranks snapshot size.");
-    for (int i = 0; i < size; ++i) {
-        activeRanks[i] = (bytes[i] != 0);
-    }
-}
+ExtensionState deserialize(const std::vector<uint8_t>& buffer) {
+    ExtensionState state;
+    if (buffer.size() < sizeof(uint32_t)) return state;
 
-}  // namespace
+    const uint8_t* ptr = buffer.data();
+
+    // 1. Read the number of ranks
+    uint32_t rankCount = 0;
+    std::memcpy(&rankCount, ptr, sizeof(uint32_t));
+    ptr += sizeof(uint32_t);
+
+    // 2. Read the bitmap and reconstruct the activeRanks vector
+    state.activeRanks.resize(rankCount);
+    size_t bitmapSize = (rankCount + 7) / 8;
+    for (size_t i = 0; i < rankCount; ++i) {
+        // Check if the i-th bit is set
+        bool isActive = ptr[i / 8] & (1 << (i % 8));
+        state.activeRanks[i] = isActive;
+    }
+    ptr += bitmapSize;
+
+    // 3. Read p2pGeneration
+    if (ptr + sizeof(uint32_t) <= buffer.data() + buffer.size()) {
+        std::memcpy(&state.p2pGeneration, ptr, sizeof(uint32_t));
+        ptr += sizeof(uint32_t);
+    }
+
+    // 4. Read taskCount
+    if (ptr + sizeof(int) <= buffer.data() + buffer.size()) {
+        std::memcpy(&state.taskCount, ptr, sizeof(int));
+    }
+
+    return state;
+}
 
 // Async Work implementation for P2P operations processed by worker threads.
 class MooncakeP2PWork : public ::c10d::Work {
@@ -195,13 +246,13 @@ MooncakeBackend::MooncakeBackend(
         TORCH_CHECK(!rc, REGISTER_BUFFER_ERROR_MSG);
     }
 
-    auto& dev_worker_mgr = P2PDeviceWorkerManager::GetInstance();
+    auto& dev_worker_mgr = P2PDeviceWorkerManager::getInstance();
     int cuda_device_index = isCpu_ ? -1 : at::cuda::current_device();
 
     if (isCpu_)
-        p2p_device_worker_ = dev_worker_mgr.GetCPUWorker();
+        p2p_device_worker_ = dev_worker_mgr.getCPUWorker();
     else
-        p2p_device_worker_ = dev_worker_mgr.GetCUDAWorker(cuda_device_index);
+        p2p_device_worker_ = dev_worker_mgr.getCUDAWorker(cuda_device_index);
 
     auto& worker_mgr = MooncakeWorkerManager::GetInstance();
     if (isCpu_)
@@ -240,10 +291,8 @@ MooncakeBackend::MooncakeBackend(
         (uint64_t)connection_ctx_->warmup_send_region();
     rank_info.warmup_buffer[1] =
         (uint64_t)connection_ctx_->warmup_recv_region();
-    rank_info.p2p_send_buffer = (uint64_t)p2p_proxy_->send_buffer();
-    rank_info.p2p_recv_buffer = (uint64_t)p2p_proxy_->recv_buffer();
-    rank_info.p2p_ctrl_send = (uint64_t)p2p_proxy_->ctrl_send_region();
-    rank_info.p2p_ctrl_recv = (uint64_t)p2p_proxy_->ctrl_recv_region();
+    rank_info.p2p_publish_region = (uint64_t)p2p_proxy_->publish_region();
+    rank_info.p2p_completion_region = (uint64_t)p2p_proxy_->completion_region();
 
     // Sync metadata
     std::vector<uint8_t> rank_info_bytes(sizeof(SegmentInfo));
@@ -282,7 +331,7 @@ MooncakeBackend::MooncakeBackend(
     meta_->store = store;
     meta_->backendIndex = backendIndex_;
     meta_->bufferBaseIndex = backendIndex_ * 10;
-    p2p_proxy_->BindMeta(meta_);
+    p2p_proxy_->bindMeta(meta_);
 
     connection_ctx_->bootstrapLocalPeer(localServerName_, rank_info);
     if (options_ && options_->isExtension_) {
@@ -324,7 +373,7 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::send(
     }
 
     TORCH_CHECK(p2p_proxy_, "P2P send proxy is not initialized.");
-    p2p_proxy_->EnqueueSend(P2PProxy::SendOp{
+    p2p_proxy_->enqueueSend(P2PProxy::SendOp{
         .tensor_ = std::move(contiguous),
         .peer_rank_ = dstRank,
         .cuda_stream_ = stream,
@@ -356,7 +405,7 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::recv(
     }
 
     TORCH_CHECK(p2p_proxy_, "P2P recv proxy is not initialized.");
-    p2p_proxy_->EnqueueRecv(P2PProxy::RecvOp{
+    p2p_proxy_->enqueueRecv(P2PProxy::RecvOp{
         .tensor_ = target,
         .original_tensor_ = tensor,
         .peer_rank_ = srcRank,
@@ -805,7 +854,7 @@ void MooncakeBackend::shutdown() {
 
     // Phase 1: Drain P2P tasks
     p2p_device_worker_->removeProxy(p2p_proxy_);
-    has_hung_operation |= !p2p_proxy_->DrainTasks();
+    has_hung_operation |= !p2p_proxy_->drainTasks();
 
     // Phase 2: Drain collective tasks for this backend
     has_hung_operation |= !worker_->drainTasks(meta_.get());
@@ -825,7 +874,7 @@ void MooncakeBackend::shutdown() {
 
     // Phase 5: Release resources if no hung operations
     if (has_hung_operation) {
-        p2p_proxy_->AbandonResources();
+        p2p_proxy_->abandonResources();
         connection_ctx_->abandonResources();
     }
 
@@ -896,24 +945,29 @@ void MooncakeBackend::setLocalOnlyActiveRanks() {
 void MooncakeBackend::waitForExtensionState() {
     TORCH_CHECK(meta_->store, "Recovery join requires a valid Store.");
 
-    auto task_count_key = ConnectionContext::getExtensionTaskCountStoreKey(
-        meta_->backendIndex, rank_);
-    auto active_ranks_key = ConnectionContext::getExtensionActiveRanksStoreKey(
+    auto state_key = ConnectionContext::getExtensionStateStoreKey(
         meta_->backendIndex, rank_);
 
     BackoffWaiter waiter(
         BackoffWaiterConfig::constantSleep(std::chrono::milliseconds(50)));
 
-    waiter.wait([&] {
-        return meta_->store->check({task_count_key, active_ranks_key});
-    });
+    waiter.wait([&] { return meta_->store->check({state_key}); });
 
-    auto task_count_data = meta_->store->get(task_count_key);
-    std::string task_count(task_count_data.begin(), task_count_data.end());
-    meta_->taskCount = std::stoi(task_count);
+    auto state_data = meta_->store->get(state_key);
+    auto state = deserialize(state_data);
 
-    auto active_ranks = meta_->store->get(active_ranks_key);
-    deserializeActiveRanks(active_ranks, meta_->activeRanks, meta_->size);
+    // taskCount
+    meta_->taskCount = state.taskCount;
+
+    // p2pGeneration
+    p2p_proxy_->setGeneration(state.p2pGeneration);
+
+    // activeRanks
+    TORCH_CHECK(static_cast<size_t>(meta_->size) == state.activeRanks.size(),
+                "Invalid activeRanks");
+    for (int i = 0; i < meta_->size; ++i) {
+        meta_->activeRanks[i] = state.activeRanks[i];
+    }
     syncActiveRanksTensor();
 }
 
@@ -1021,15 +1075,16 @@ void MooncakeBackend::recoverRanks(const std::vector<int>& ranks) {
     }
 
     syncActiveRanksTensor();
-    auto active_ranks_snapshot =
-        serializeActiveRanks(meta_->activeRanks, meta_->size);
+    ExtensionState state{
+        .activeRanks =
+            std::vector(meta_->activeRanks, meta_->activeRanks + meta_->size),
+        .p2pGeneration = p2p_proxy_->getGeneration(),
+        .taskCount = meta_->taskCount};
+    auto state_data = serialize(state);
     for (const int rank : ranks) {
-        meta_->store->set(ConnectionContext::getExtensionTaskCountStoreKey(
-                              meta_->backendIndex, rank),
-                          std::to_string(meta_->taskCount));
-        meta_->store->set(ConnectionContext::getExtensionActiveRanksStoreKey(
-                              meta_->backendIndex, rank),
-                          active_ranks_snapshot);
+        auto key = ConnectionContext::getExtensionStateStoreKey(
+            meta_->backendIndex, rank);
+        meta_->store->set(key, state_data);
     }
 }
 

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -1043,6 +1043,7 @@ void MooncakeBackend::extendGroupSizeTo(int newSize) {
     tensor.slice(0, oldSize, newSize).fill_(1);
 
     connection_ctx_->extendGroupSizeTo(newSize);
+    p2p_proxy_->extendGroupSizeTo(newSize);
     // After extendGroupSizeTo, we don't `waitUntilNewRanksConnected` here
     // but do it in the first task. This enables client code to overlap
     // execution between `extendGroupSizeTo` and the first communication call.

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -821,9 +821,7 @@ bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
     }
 
     // Step 2 -- Stale packet: the slot carries data from a previous epoch
-    // (before a Reset).  Clear it so the fresh invitation can land safely,
-    // but DO NOT advance the consume cursor -- the peer will re-send the
-    // same sequence after the Reset.
+    // (before a Reset).  Clear it so the fresh invitation can land safely.
     const uint32_t current_gen =
         peer_generation_[op_ctx.peer_rank_].load(std::memory_order_acquire);
     if (slot_gen != current_gen) {
@@ -1181,10 +1179,7 @@ bool P2PProxy::pollRecvCompletionSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
         peer_generation_[op_ctx.peer_rank_].load(std::memory_order_acquire);
 
     // Step 2 -- Stale packet: data from a previous epoch (before Reset).
-    // Clear the slot so the fresh completion can land safely.  Do NOT pop
-    // the task, do NOT free the chunk, and do NOT advance
-    // completion_consume_seq_ -- the current task is still waiting for valid
-    // completion.
+    // Clear the slot so the fresh completion can land safely.
     if (slot_gen != current_gen) {
         LOG(WARNING) << "[P2PProxy][Recv] pollRecvCompletionSlot peer="
                      << op_ctx.peer_rank_

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -68,9 +68,8 @@ void P2PChunkPool::release(void* ptr) { free_stack_.push_back(ptr); }
 //    the footer load that follows.
 // 5. Load footer_token.
 // 6. Accept the payload only when header == footer.
-bool PublishSlot::tryLoad(uint64_t& out_recv_addr, uint32_t& out_chunk_len,
-                          uint32_t& out_generation,
-                          uint32_t& out_sequence) const {
+bool CreditSlot::tryLoad(uint64_t& out_recv_addr, uint32_t& out_chunk_len,
+                         uint32_t& out_epoch, uint32_t& out_sequence) const {
     uint64_t h = std::atomic_ref(header_token).load(std::memory_order_acquire);
     if (h == kInvalidControlToken) return false;
 
@@ -86,7 +85,7 @@ bool PublishSlot::tryLoad(uint64_t& out_recv_addr, uint32_t& out_chunk_len,
     if (h == f) {
         out_recv_addr = addr;
         out_chunk_len = len;
-        out_generation = static_cast<uint32_t>(h >> 32);
+        out_epoch = static_cast<uint32_t>(h >> 32);
         out_sequence = static_cast<uint32_t>(h);
         return true;
     }
@@ -100,9 +99,9 @@ bool PublishSlot::tryLoad(uint64_t& out_recv_addr, uint32_t& out_chunk_len,
 //   payload -> footer (relaxed) -> header (release).
 // The release store to header_token guarantees that every prior store is
 // visible to any consumer that sees the new header value.
-void PublishSlot::publish(uint32_t gen, uint32_t seq, uint64_t addr,
-                          uint32_t len) {
-    uint64_t new_token = makeControlToken(gen, seq);
+void CreditSlot::publish(uint32_t epoch, uint32_t seq, uint64_t addr,
+                         uint32_t len) {
+    uint64_t new_token = makeControlToken(epoch, seq);
 
     recv_addr = addr;
     chunk_len = len;
@@ -113,7 +112,7 @@ void PublishSlot::publish(uint32_t gen, uint32_t seq, uint64_t addr,
     std::atomic_ref(header_token).store(new_token, std::memory_order_release);
 }
 
-void PublishSlot::reset() {
+void CreditSlot::reset() {
     recv_addr = 0;
     chunk_len = 0;
     uint64_t inv = kInvalidControlToken;
@@ -121,9 +120,9 @@ void PublishSlot::reset() {
     std::atomic_ref(header_token).store(inv, std::memory_order_release);
 }
 
-// See PublishSlot::tryLoad() for the detailed description.
-bool CompletionSlot::tryLoad(uint32_t& out_chunk_len, uint32_t& out_generation,
-                             uint32_t& out_sequence) const {
+// See CreditSlot::tryLoad() for the detailed description.
+bool AckSlot::tryLoad(uint32_t& out_chunk_len, uint32_t& out_epoch,
+                      uint32_t& out_sequence) const {
     uint64_t h = std::atomic_ref(header_token).load(std::memory_order_acquire);
     if (h == kInvalidControlToken) return false;
 
@@ -135,16 +134,16 @@ bool CompletionSlot::tryLoad(uint32_t& out_chunk_len, uint32_t& out_generation,
 
     if (h == f) {
         out_chunk_len = len;
-        out_generation = static_cast<uint32_t>(h >> 32);
+        out_epoch = static_cast<uint32_t>(h >> 32);
         out_sequence = static_cast<uint32_t>(h);
         return true;
     }
     return false;
 }
 
-// See PublishSlot::publish() for the detailed description.
-void CompletionSlot::publish(uint32_t gen, uint32_t seq, uint32_t len) {
-    uint64_t new_token = makeControlToken(gen, seq);
+// See CreditSlot::publish() for the detailed description.
+void AckSlot::publish(uint32_t epoch, uint32_t seq, uint32_t len) {
+    uint64_t new_token = makeControlToken(epoch, seq);
 
     chunk_len = len;
 
@@ -152,7 +151,7 @@ void CompletionSlot::publish(uint32_t gen, uint32_t seq, uint32_t len) {
     std::atomic_ref(header_token).store(new_token, std::memory_order_release);
 }
 
-void CompletionSlot::reset() {
+void AckSlot::reset() {
     chunk_len = 0;
     uint64_t inv = kInvalidControlToken;
     std::atomic_ref(footer_token).store(inv, std::memory_order_relaxed);
@@ -201,8 +200,8 @@ void P2PProxy::extendGroupSizeTo(int new_size) {
 // multiple P2PProxy instances on the same device.
 void P2PProxy::allocateResources() {
     TORCH_CHECK(engine_, "P2PProxy engine is null.");
-    if (resources_.publish_region_ != nullptr ||
-        resources_.completion_region_ != nullptr) {
+    if (resources_.credit_region_ != nullptr ||
+        resources_.ack_region_ != nullptr) {
         return;
     }
 
@@ -212,28 +211,28 @@ void P2PProxy::allocateResources() {
 
     const size_t ctrl_slots =
         kMaxNumRanks * static_cast<size_t>(kP2PControlRingSize);
-    resources_.publish_region_ = new PublishSlot[ctrl_slots]{};
-    resources_.completion_region_ = new CompletionSlot[ctrl_slots]{};
+    resources_.credit_region_ = new CreditSlot[ctrl_slots]{};
+    resources_.ack_region_ = new AckSlot[ctrl_slots]{};
 
     for (size_t i = 0; i < ctrl_slots; ++i) {
-        resources_.publish_region_[i].reset();
-        resources_.completion_region_[i].reset();
+        resources_.credit_region_[i].reset();
+        resources_.ack_region_[i].reset();
     }
 
     for (size_t i = 0; i < kMaxNumRanks; ++i) {
-        peer_generation_[i].store(1, std::memory_order_release);
+        peer_epoch_[i].store(1, std::memory_order_release);
     }
 
     for (size_t i = 0; i < kMaxNumRanks; ++i) {
         send_peer_lanes_[i].pending_send_ops_.clear();
         send_peer_lanes_[i].active_send_op_.reset();
-        send_peer_lanes_[i].publish_consume_seq_ = 0;
+        send_peer_lanes_[i].credit_consume_seq_ = 0;
         send_peer_lanes_[i].copy_ready_events_.fill(nullptr);
 
         recv_peer_lanes_[i].pending_recv_ops_.clear();
         recv_peer_lanes_[i].active_recv_op_.reset();
-        recv_peer_lanes_[i].publish_issue_seq_ = 0;
-        recv_peer_lanes_[i].completion_consume_seq_ = 0;
+        recv_peer_lanes_[i].credit_issue_seq_ = 0;
+        recv_peer_lanes_[i].ack_consume_seq_ = 0;
         recv_peer_lanes_[i].copy_ready_events_.fill(nullptr);
     }
 
@@ -259,29 +258,29 @@ void P2PProxy::allocateResources() {
         }
     }
 
-    int rc = engine_->registerLocalMemory(resources_.publish_region_,
-                                          ctrl_slots * sizeof(PublishSlot),
+    int rc = engine_->registerLocalMemory(resources_.credit_region_,
+                                          ctrl_slots * sizeof(CreditSlot),
                                           kWildcardLocation);
-    TORCH_CHECK(rc == 0, "Failed to register P2P publish region");
+    TORCH_CHECK(rc == 0, "Failed to register P2P credit region");
 
-    rc = engine_->registerLocalMemory(resources_.completion_region_,
-                                      ctrl_slots * sizeof(CompletionSlot),
+    rc = engine_->registerLocalMemory(resources_.ack_region_,
+                                      ctrl_slots * sizeof(AckSlot),
                                       kWildcardLocation);
-    TORCH_CHECK(rc == 0, "Failed to register P2P completion region");
+    TORCH_CHECK(rc == 0, "Failed to register P2P ack region");
 
     // Staging buffers for control messages.  RDMA requires every
     // transfer source to live in a registered MR.
-    resources_.publish_staging_buf_ = new PublishSlot[ctrl_slots]{};
-    rc = engine_->registerLocalMemory(resources_.publish_staging_buf_,
-                                      ctrl_slots * sizeof(PublishSlot),
+    resources_.credit_staging_buf_ = new CreditSlot[ctrl_slots]{};
+    rc = engine_->registerLocalMemory(resources_.credit_staging_buf_,
+                                      ctrl_slots * sizeof(CreditSlot),
                                       kWildcardLocation);
-    TORCH_CHECK(rc == 0, "Failed to register P2P publish staging region");
+    TORCH_CHECK(rc == 0, "Failed to register P2P credit staging region");
 
-    resources_.completion_staging_buf_ = new CompletionSlot[ctrl_slots]{};
-    rc = engine_->registerLocalMemory(resources_.completion_staging_buf_,
-                                      ctrl_slots * sizeof(CompletionSlot),
+    resources_.ack_staging_buf_ = new AckSlot[ctrl_slots]{};
+    rc = engine_->registerLocalMemory(resources_.ack_staging_buf_,
+                                      ctrl_slots * sizeof(AckSlot),
                                       kWildcardLocation);
-    TORCH_CHECK(rc == 0, "Failed to register P2P completion staging region");
+    TORCH_CHECK(rc == 0, "Failed to register P2P ack staging region");
 }
 
 void P2PProxy::resetPeerState(int peer_rank) {
@@ -289,11 +288,11 @@ void P2PProxy::resetPeerState(int peer_rank) {
                 "ResetPeerState: peer_rank out of range: ", peer_rank,
                 " size: ", size_);
 
-    // Generation update:
-    //   We bump generation_ so that any slots still in flight from the
+    // Epoch update:
+    //   We bump epoch_ so that any slots still in flight from the
     //   old session (written by the sender/receiver before it learned about
     //   the Reset) are recognized as stale and skipped.
-    peer_generation_[peer_rank].fetch_add(1, std::memory_order_acq_rel);
+    peer_epoch_[peer_rank].fetch_add(1, std::memory_order_acq_rel);
 
     // Request reset
     reset_send_req_[peer_rank].store(true, std::memory_order_release);
@@ -337,9 +336,9 @@ void P2PProxy::releaseSendTaskResources(SendTransferTask& task) const {
         if (engine_) engine_->freeBatchID(task.transfer_batch_id_.value());
         task.transfer_batch_id_.reset();
     }
-    if (task.completion_batch_id_.has_value()) {
-        if (engine_) engine_->freeBatchID(task.completion_batch_id_.value());
-        task.completion_batch_id_.reset();
+    if (task.ack_batch_id_.has_value()) {
+        if (engine_) engine_->freeBatchID(task.ack_batch_id_.value());
+        task.ack_batch_id_.reset();
     }
 }
 
@@ -348,9 +347,9 @@ void P2PProxy::releaseRecvTaskResources(RecvTransferTask& task) const {
         if (recv_pool_) recv_pool_->release(task.local_addr_);
         task.local_addr_ = nullptr;
     }
-    if (task.publish_batch_id_.has_value()) {
-        if (engine_) engine_->freeBatchID(task.publish_batch_id_.value());
-        task.publish_batch_id_.reset();
+    if (task.credit_batch_id_.has_value()) {
+        if (engine_) engine_->freeBatchID(task.credit_batch_id_.value());
+        task.credit_batch_id_.reset();
     }
 }
 
@@ -371,7 +370,7 @@ void P2PProxy::resetSendLane(SendPeerLane& lane) {
         active_send_tasks_.fetch_sub(1, std::memory_order_release);
         lane.active_send_op_.reset();
     }
-    lane.publish_consume_seq_ = 0;
+    lane.credit_consume_seq_ = 0;
 }
 
 void P2PProxy::resetRecvLane(RecvPeerLane& lane) {
@@ -391,16 +390,16 @@ void P2PProxy::resetRecvLane(RecvPeerLane& lane) {
         active_recv_tasks_.fetch_sub(1, std::memory_order_release);
         lane.active_recv_op_.reset();
     }
-    lane.publish_issue_seq_ = 0;
-    lane.completion_consume_seq_ = 0;
+    lane.credit_issue_seq_ = 0;
+    lane.ack_consume_seq_ = 0;
 }
 
 void P2PProxy::resetPeerControlLanes(int peer_rank) {
-    auto* publish_lane = getLocalPublishLane(peer_rank);
-    auto* completion_lane = getLocalCompletionLane(peer_rank);
+    auto* credit_lane = getLocalCreditLane(peer_rank);
+    auto* ack_lane = getLocalAckLane(peer_rank);
     for (uint32_t i = 0; i < kP2PControlRingSize; ++i) {
-        publish_lane[i].reset();
-        completion_lane[i].reset();
+        credit_lane[i].reset();
+        ack_lane[i].reset();
     }
 }
 
@@ -433,31 +432,30 @@ void P2PProxy::releaseResources() {
         destroyEvents(recv_lane.copy_ready_events_);
     }
 
-    if (resources_.publish_staging_buf_ != nullptr) {
+    if (resources_.credit_staging_buf_ != nullptr) {
         if (engine_)
-            engine_->unregisterLocalMemory(resources_.publish_staging_buf_);
-        delete[] resources_.publish_staging_buf_;
-        resources_.publish_staging_buf_ = nullptr;
+            engine_->unregisterLocalMemory(resources_.credit_staging_buf_);
+        delete[] resources_.credit_staging_buf_;
+        resources_.credit_staging_buf_ = nullptr;
     }
 
-    if (resources_.completion_staging_buf_ != nullptr) {
+    if (resources_.ack_staging_buf_ != nullptr) {
         if (engine_)
-            engine_->unregisterLocalMemory(resources_.completion_staging_buf_);
-        delete[] resources_.completion_staging_buf_;
-        resources_.completion_staging_buf_ = nullptr;
+            engine_->unregisterLocalMemory(resources_.ack_staging_buf_);
+        delete[] resources_.ack_staging_buf_;
+        resources_.ack_staging_buf_ = nullptr;
     }
 
-    if (resources_.publish_region_ != nullptr) {
-        if (engine_) engine_->unregisterLocalMemory(resources_.publish_region_);
-        delete[] resources_.publish_region_;
-        resources_.publish_region_ = nullptr;
+    if (resources_.credit_region_ != nullptr) {
+        if (engine_) engine_->unregisterLocalMemory(resources_.credit_region_);
+        delete[] resources_.credit_region_;
+        resources_.credit_region_ = nullptr;
     }
 
-    if (resources_.completion_region_ != nullptr) {
-        if (engine_)
-            engine_->unregisterLocalMemory(resources_.completion_region_);
-        delete[] resources_.completion_region_;
-        resources_.completion_region_ = nullptr;
+    if (resources_.ack_region_ != nullptr) {
+        if (engine_) engine_->unregisterLocalMemory(resources_.ack_region_);
+        delete[] resources_.ack_region_;
+        resources_.ack_region_ = nullptr;
     }
 }
 
@@ -486,13 +484,13 @@ void P2PProxy::enqueueRecv(RecvOp op) {
 
 P2PProxy::SendTransferTask::SendTransferTask(
     uint64_t tensor_offset_in, uint32_t chunk_len_in, void* staging_addr_in,
-    uint64_t remote_addr_in, uint32_t sequence_in, uint32_t generation_in)
+    uint64_t remote_addr_in, uint32_t sequence_in, uint32_t epoch_in)
     : tensor_offset_(tensor_offset_in),
       chunk_len_(chunk_len_in),
       staging_addr_(staging_addr_in),
       remote_addr_(remote_addr_in),
       sequence_(sequence_in),
-      generation_(generation_in) {
+      epoch_(epoch_in) {
     last_update_time_ = std::chrono::steady_clock::now();
 }
 
@@ -510,12 +508,12 @@ P2PProxy::RecvTransferTask::RecvTransferTask(uint64_t tensor_offset_in,
                                              uint32_t chunk_len_in,
                                              void* local_addr_in,
                                              uint32_t sequence_in,
-                                             uint32_t generation_in)
+                                             uint32_t epoch_in)
     : tensor_offset_(tensor_offset_in),
       chunk_len_(chunk_len_in),
       local_addr_(local_addr_in),
       sequence_(sequence_in),
-      generation_(generation_in) {
+      epoch_(epoch_in) {
     last_update_time_ = std::chrono::steady_clock::now();
 }
 
@@ -529,59 +527,56 @@ P2PProxy::RecvOpContext::RecvOpContext(RecvOp&& op_in)
         tensor_.numel() * static_cast<uint64_t>(tensor_.element_size());
 }
 
-PublishSlot* P2PProxy::getLocalPublishLane(int peer_rank) const {
-    return resources_.publish_region_ +
+CreditSlot* P2PProxy::getLocalCreditLane(int peer_rank) const {
+    return resources_.credit_region_ +
            static_cast<size_t>(peer_rank) * kP2PControlRingSize;
 }
 
-CompletionSlot* P2PProxy::getLocalCompletionLane(int peer_rank) const {
-    return resources_.completion_region_ +
+AckSlot* P2PProxy::getLocalAckLane(int peer_rank) const {
+    return resources_.ack_region_ +
            static_cast<size_t>(peer_rank) * kP2PControlRingSize;
 }
 
-uint64_t P2PProxy::getRemotePublishSlot(int peer_rank,
-                                        uint32_t sequence) const {
+uint64_t P2PProxy::getRemoteCreditSlot(int peer_rank, uint32_t sequence) const {
     const uint64_t slot_index = sequence % kP2PControlRingSize;
-    return meta_->segmentInfos[peer_rank].p2p_publish_region +
+    return meta_->segmentInfos[peer_rank].p2p_credit_region +
            (static_cast<uint64_t>(rank_) * kP2PControlRingSize + slot_index) *
-               sizeof(PublishSlot);
+               sizeof(CreditSlot);
 }
 
-uint64_t P2PProxy::getRemoteCompletionSlot(int peer_rank,
-                                           uint32_t sequence) const {
+uint64_t P2PProxy::getRemoteAckSlot(int peer_rank, uint32_t sequence) const {
     const uint64_t slot_index = sequence % kP2PControlRingSize;
-    return meta_->segmentInfos[peer_rank].p2p_completion_region +
+    return meta_->segmentInfos[peer_rank].p2p_ack_region +
            (static_cast<uint64_t>(rank_) * kP2PControlRingSize + slot_index) *
-               sizeof(CompletionSlot);
+               sizeof(AckSlot);
 }
 
-PublishSlot* P2PProxy::getLocalPublishStagingBuf(int peer_rank,
-                                                 uint32_t sequence) const {
+CreditSlot* P2PProxy::getLocalCreditStagingBuf(int peer_rank,
+                                               uint32_t sequence) const {
     const size_t staging_idx =
         static_cast<size_t>(peer_rank) * kP2PControlRingSize +
         sequence % kP2PControlRingSize;
-    return resources_.publish_staging_buf_ + staging_idx;
+    return resources_.credit_staging_buf_ + staging_idx;
 }
-CompletionSlot* P2PProxy::getLocalCompletionStagingBuf(
-    int peer_rank, uint32_t sequence) const {
+AckSlot* P2PProxy::getLocalAckStagingBuf(int peer_rank,
+                                         uint32_t sequence) const {
     const size_t staging_idx =
         static_cast<size_t>(peer_rank) * kP2PControlRingSize +
         static_cast<size_t>(sequence % kP2PControlRingSize);
-    return resources_.completion_staging_buf_ + staging_idx;
+    return resources_.ack_staging_buf_ + staging_idx;
 }
 
-// Receiver advertise.
+// Receiver issues credit.
 //
-// Grab a free chunk from RecvPool and invite the sender to write into it.
-// We (RDMA) write a PublishSlot into the sender's PublishLane so the sender
-// knows:
+// Grab a free chunk from RecvPool and grant the sender credit to write into it.
+// We write a CreditSlot into the sender's CreditLane so the sender knows:
 //   (a) which sequence this is,
 //   (b) the RecvPool offset to write to,
 //   (c) how many bytes we expect.
 // If the pool is exhausted we return false and retry on the next polling
 // iteration (non-blocking).
 bool P2PProxy::tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane) {
-    if (op_ctx.bytes_advertised_ >= op_ctx.total_bytes_) {
+    if (op_ctx.bytes_credited_ >= op_ctx.total_bytes_) {
         return false;
     }
 
@@ -597,47 +592,47 @@ bool P2PProxy::tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane) {
     }
 
     const uint32_t chunk_len = static_cast<uint32_t>(std::min<uint64_t>(
-        chunk_size_, op_ctx.total_bytes_ - op_ctx.bytes_advertised_));
-    const uint64_t seq = lane.publish_issue_seq_;
-    const uint64_t remote_publish_offset =
-        getRemotePublishSlot(op_ctx.peer_rank_, seq);
+        chunk_size_, op_ctx.total_bytes_ - op_ctx.bytes_credited_));
+    const uint64_t seq = lane.credit_issue_seq_;
+    const uint64_t remote_credit_offset =
+        getRemoteCreditSlot(op_ctx.peer_rank_, seq);
 
-    const uint32_t current_gen =
-        peer_generation_[op_ctx.peer_rank_].load(std::memory_order_acquire);
-    op_ctx.tasks_.emplace_back(op_ctx.bytes_advertised_, chunk_len, local_addr,
-                               seq, current_gen);
+    const uint32_t curr_epoch =
+        peer_epoch_[op_ctx.peer_rank_].load(std::memory_order_acquire);
+    op_ctx.tasks_.emplace_back(op_ctx.bytes_credited_, chunk_len, local_addr,
+                               seq, curr_epoch);
     auto& task = op_ctx.tasks_.back();
 
-    auto* publish_buf = getLocalPublishStagingBuf(op_ctx.peer_rank_, seq);
-    publish_buf->publish(current_gen, seq,
-                         reinterpret_cast<uint64_t>(local_addr), chunk_len);
+    auto* credit_staging_buf = getLocalCreditStagingBuf(op_ctx.peer_rank_, seq);
+    credit_staging_buf->publish(
+        curr_epoch, seq, reinterpret_cast<uint64_t>(local_addr), chunk_len);
     const BatchID batch_id = engine_->allocateBatchID(1);
     engine_->submitTransfer(
         batch_id, {TransferRequest{
                       .opcode = TransferRequest::WRITE,
-                      .source = static_cast<void*>(publish_buf),
+                      .source = static_cast<void*>(credit_staging_buf),
                       .target_id = meta_->segmentIDs[op_ctx.peer_rank_],
-                      .target_offset = remote_publish_offset,
-                      .length = sizeof(PublishSlot),
+                      .target_offset = remote_credit_offset,
+                      .length = sizeof(CreditSlot),
                   }});
-    task.publish_batch_id_ = batch_id;
+    task.credit_batch_id_ = batch_id;
     task.last_update_time_ = std::chrono::steady_clock::now();
 
-    ++lane.publish_issue_seq_;
-    op_ctx.bytes_advertised_ += chunk_len;
+    ++lane.credit_issue_seq_;
+    op_ctx.bytes_credited_ += chunk_len;
     return true;
 }
 
 // Drive a single receiver chunk through its state machine.
 //
-// kAdvertise -> kWaitCompletion -> kCopyOut -> kFinished -> erase.
+// kIssueCredit -> kWaitAck -> kCopyOut -> kFinished -> erase.
 bool P2PProxy::stepRecvTask(RecvTransferTask& task) {
     switch (task.state_) {
-        case RecvTaskState::kAdvertise:
-            return stepRecvAdvertise(task);
+        case RecvTaskState::kIssueCredit:
+            return stepRecvIssueCredit(task);
 
-        case RecvTaskState::kWaitCompletion:
-            // kWaitCompletion is polled in stepRecv
+        case RecvTaskState::kWaitAck:
+            // kWaitAck is polled in stepRecv
             return false;
 
         case RecvTaskState::kCopyOut:
@@ -650,27 +645,26 @@ bool P2PProxy::stepRecvTask(RecvTransferTask& task) {
     return false;
 }
 
-bool P2PProxy::stepRecvAdvertise(RecvTransferTask& task) {
-    TORCH_CHECK(task.publish_batch_id_.has_value(),
-                "Expected a publish_batch_id in tryIssueRecvTask");
+bool P2PProxy::stepRecvIssueCredit(RecvTransferTask& task) {
+    TORCH_CHECK(task.credit_batch_id_.has_value(),
+                "Expected a credit_batch_id in tryIssueRecvTask");
 
-    TransferStatus publish_status;
-    engine_->getTransferStatus(task.publish_batch_id_.value(), 0,
-                               publish_status);
+    TransferStatus credit_status;
+    engine_->getTransferStatus(task.credit_batch_id_.value(), 0, credit_status);
 
-    if (publish_status.s == TransferStatusEnum::COMPLETED) {
-        engine_->freeBatchID(task.publish_batch_id_.value());
-        task.publish_batch_id_.reset();
-        task.state_ = RecvTaskState::kWaitCompletion;
+    if (credit_status.s == TransferStatusEnum::COMPLETED) {
+        engine_->freeBatchID(task.credit_batch_id_.value());
+        task.credit_batch_id_.reset();
+        task.state_ = RecvTaskState::kWaitAck;
         task.last_update_time_ = std::chrono::steady_clock::now();
         return true;
     }
 
-    if (publish_status.s == TransferStatusEnum::FAILED || isTimeout(task)) {
-        LOG(ERROR) << "P2P publish transfer failed/timeout, seq="
+    if (credit_status.s == TransferStatusEnum::FAILED || isTimeout(task)) {
+        LOG(ERROR) << "P2P credit transfer failed/timeout, seq="
                    << task.sequence_;
-        engine_->freeBatchID(task.publish_batch_id_.value());
-        task.publish_batch_id_.reset();
+        engine_->freeBatchID(task.credit_batch_id_.value());
+        task.credit_batch_id_.reset();
         task.state_ = RecvTaskState::kFailed;
         return true;
     }
@@ -679,7 +673,7 @@ bool P2PProxy::stepRecvAdvertise(RecvTransferTask& task) {
 
 // Poll the GPU Copy-Out event.
 //
-// After the CompletionSlot arrives we initiate cudaMemcpyAsync from the
+// After the AckSlot arrives we initiate cudaMemcpyAsync from the
 // RecvPool chunk to the user tensor and record an event.  This function
 // waits for that event and returns the chunk to RecvPool.
 bool P2PProxy::stepRecvCopyOut(RecvTransferTask& task) {
@@ -703,17 +697,17 @@ bool P2PProxy::stepRecvCopyOut(RecvTransferTask& task) {
     return false;
 }
 
-// Sender fetch invitation
+// Sender fetches credits.
 //
-// Poll the local PublishLane for the next expected sequence.  If the slot
-// matches our consume cursor we accept the invitation: allocate a staging
+// Poll the local CreditLane for the next expected sequence.  If the slot
+// matches our consume cursor we accept the credit: allocate a staging
 // chunk from SendPool, copy the corresponding slice of the user tensor into
-// it, and advance the cursor.  If the pool is full or no invitation has
+// it, and advance the cursor.  If the pool is full or no credit has
 // arrived we return false immediately (non-blocking).
 bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
-    // Check for timeout while waiting for the peer's PublishSlot.
+    // Check for timeout while waiting for the peer's CreditSlot.
     if (isTimeout(op_ctx)) {
-        LOG(ERROR) << "P2P wait invitation timeout peer=" << op_ctx.peer_rank_;
+        LOG(ERROR) << "P2P wait-for-credit timeout, peer=" << op_ctx.peer_rank_;
         op_ctx.status_->store(OpStatus::kFailed, std::memory_order_release);
         return false;
     }
@@ -726,29 +720,29 @@ bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
         return false;
     }
 
-    PublishSlot* local_publish = getLocalPublishLane(op_ctx.peer_rank_);
-    const uint64_t seq = lane.publish_consume_seq_;
-    auto& slot = local_publish[static_cast<size_t>(seq % kP2PControlRingSize)];
+    CreditSlot* local_credit = getLocalCreditLane(op_ctx.peer_rank_);
+    const uint64_t seq = lane.credit_consume_seq_;
+    auto& slot = local_credit[static_cast<size_t>(seq % kP2PControlRingSize)];
 
     // Step 1 -- Try load the slot
     uint64_t recv_addr = 0;
     uint32_t chunk_len = 0;
-    uint32_t slot_gen = 0;
+    uint32_t slot_epoch = 0;
     uint32_t slot_seq = 0;
-    if (!slot.tryLoad(recv_addr, chunk_len, slot_gen, slot_seq)) {
+    if (!slot.tryLoad(recv_addr, chunk_len, slot_epoch, slot_seq)) {
         // Slot is either empty or torn (partial RDMA write). Retry next poll.
         return false;
     }
 
     // Step 2 -- Stale packet: the slot carries data from a previous epoch
-    // (before a Reset).  Clear it so the fresh invitation can land safely.
-    const uint32_t current_gen =
-        peer_generation_[op_ctx.peer_rank_].load(std::memory_order_acquire);
-    if (slot_gen != current_gen) {
+    // (before a Reset).  Clear it so the fresh credit can land safely.
+    const uint32_t curr_epoch =
+        peer_epoch_[op_ctx.peer_rank_].load(std::memory_order_acquire);
+    if (slot_epoch != curr_epoch) {
         LOG(WARNING) << "[P2PProxy][Send] tryIssueSendTask peer="
-                     << op_ctx.peer_rank_ << " STALE_GEN seq=" << seq
-                     << " slot.gen=" << slot_gen
-                     << " current_gen=" << current_gen;
+                     << op_ctx.peer_rank_ << " STALE_EPOCH seq=" << seq
+                     << " slot.epoch=" << slot_epoch
+                     << " curr_epoch=" << curr_epoch;
         slot.reset();
         return true;
     }
@@ -767,10 +761,10 @@ bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
         static_cast<uint32_t>(std::min<uint64_t>(
             chunk_size_, op_ctx.total_bytes_ - op_ctx.bytes_staged_));
     TORCH_CHECK(chunk_len <= expected_chunk_len,
-                "P2P send got invalid chunk_len in publish slot.");
+                "P2P send got invalid chunk_len in credit slot.");
 
     op_ctx.tasks_.emplace_back(op_ctx.bytes_staged_, chunk_len, staging_addr,
-                               recv_addr, seq, slot_gen);
+                               recv_addr, seq, slot_epoch);
     auto& task = op_ctx.tasks_.back();
 
     slot.reset();
@@ -803,7 +797,7 @@ bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
         }
     }
 
-    ++lane.publish_consume_seq_;
+    ++lane.credit_consume_seq_;
     op_ctx.bytes_staged_ += task.chunk_len_;
     task.last_update_time_ = std::chrono::steady_clock::now();
     return true;
@@ -811,7 +805,7 @@ bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
 
 // Drive a single sender chunk through its state machine.
 //
-// kCopyIn -> kWriteRemote -> kCompletion -> kFinished -> erase.
+// kCopyIn -> kWriteRemote -> kAck -> kFinished -> erase.
 bool P2PProxy::stepSendTask(SendOpContext& op_ctx, SendTransferTask& task) {
     switch (task.state_) {
         case SendTaskState::kCopyIn:
@@ -820,8 +814,8 @@ bool P2PProxy::stepSendTask(SendOpContext& op_ctx, SendTransferTask& task) {
         case SendTaskState::kWriteRemote:
             return stepSendWriteRemote(op_ctx, task);
 
-        case SendTaskState::kCompletion:
-            return stepSendCompletion(op_ctx, task);
+        case SendTaskState::kAck:
+            return stepSendAck(op_ctx, task);
 
         case SendTaskState::kFinished:
         case SendTaskState::kFailed:
@@ -886,7 +880,7 @@ bool P2PProxy::stepSendWriteRemote(SendOpContext& op_ctx,
     if (transfer_status.s == TransferStatusEnum::COMPLETED) {
         engine_->freeBatchID(task.transfer_batch_id_.value());
         task.transfer_batch_id_.reset();
-        task.state_ = SendTaskState::kCompletion;
+        task.state_ = SendTaskState::kAck;
         task.last_update_time_ = std::chrono::steady_clock::now();
         did_work = true;
     } else if (transfer_status.s == TransferStatusEnum::FAILED ||
@@ -902,51 +896,47 @@ bool P2PProxy::stepSendWriteRemote(SendOpContext& op_ctx,
     return did_work;
 }
 
-// Write the CompletionSlot back to the receiver.
+// Write the AckSlot back to the receiver.
 //
 // This tells the receiver that the data is present in its RecvPool and it
-// may begin the Copy-Out.  When the CompletionSlot write finishes we free
+// may begin the Copy-Out.  When the AckSlot write finishes we free
 // the staging chunk and transition to kFinished.
-bool P2PProxy::stepSendCompletion(SendOpContext& op_ctx,
-                                  SendTransferTask& task) {
+bool P2PProxy::stepSendAck(SendOpContext& op_ctx, SendTransferTask& task) {
     bool did_work = false;
-    if (!task.completion_batch_id_.has_value()) {
-        auto* completion_buf =
-            getLocalCompletionStagingBuf(op_ctx.peer_rank_, task.sequence_);
-        completion_buf->publish(task.generation_, task.sequence_,
-                                task.chunk_len_);
+    if (!task.ack_batch_id_.has_value()) {
+        auto* ack_staging_buf =
+            getLocalAckStagingBuf(op_ctx.peer_rank_, task.sequence_);
+        ack_staging_buf->publish(task.epoch_, task.sequence_, task.chunk_len_);
 
         const BatchID batch_id = engine_->allocateBatchID(1);
         engine_->submitTransfer(
             batch_id, {TransferRequest{
                           .opcode = TransferRequest::WRITE,
-                          .source = static_cast<void*>(completion_buf),
+                          .source = static_cast<void*>(ack_staging_buf),
                           .target_id = meta_->segmentIDs[op_ctx.peer_rank_],
-                          .target_offset = getRemoteCompletionSlot(
-                              op_ctx.peer_rank_, task.sequence_),
-                          .length = sizeof(CompletionSlot),
+                          .target_offset = getRemoteAckSlot(op_ctx.peer_rank_,
+                                                            task.sequence_),
+                          .length = sizeof(AckSlot),
                       }});
-        task.completion_batch_id_ = batch_id;
+        task.ack_batch_id_ = batch_id;
         task.last_update_time_ = std::chrono::steady_clock::now();
         did_work = true;
     }
 
-    TransferStatus completion_status;
-    engine_->getTransferStatus(task.completion_batch_id_.value(), 0,
-                               completion_status);
-    if (completion_status.s == TransferStatusEnum::COMPLETED) {
-        engine_->freeBatchID(task.completion_batch_id_.value());
-        task.completion_batch_id_.reset();
+    TransferStatus ack_status;
+    engine_->getTransferStatus(task.ack_batch_id_.value(), 0, ack_status);
+    if (ack_status.s == TransferStatusEnum::COMPLETED) {
+        engine_->freeBatchID(task.ack_batch_id_.value());
+        task.ack_batch_id_.reset();
         send_pool_->release(task.staging_addr_);
         task.staging_addr_ = nullptr;
         task.state_ = SendTaskState::kFinished;
         did_work = true;
-    } else if (completion_status.s == TransferStatusEnum::FAILED ||
-               isTimeout(task)) {
-        LOG(ERROR) << "P2P completion transfer failed/timeout, peer="
+    } else if (ack_status.s == TransferStatusEnum::FAILED || isTimeout(task)) {
+        LOG(ERROR) << "P2P ack transfer failed/timeout, peer="
                    << op_ctx.peer_rank_ << ", seq=" << task.sequence_;
-        engine_->freeBatchID(task.completion_batch_id_.value());
-        task.completion_batch_id_.reset();
+        engine_->freeBatchID(task.ack_batch_id_.value());
+        task.ack_batch_id_.reset();
         task.state_ = SendTaskState::kFailed;
         did_work = true;
     }
@@ -959,7 +949,7 @@ bool P2PProxy::isSendOpCompleted(const SendOpContext& op_ctx) const {
 }
 
 bool P2PProxy::isRecvOpCompleted(const RecvOpContext& op_ctx) const {
-    return op_ctx.bytes_advertised_ == op_ctx.total_bytes_ &&
+    return op_ctx.bytes_credited_ == op_ctx.total_bytes_ &&
            op_ctx.tasks_.empty();
 }
 
@@ -968,10 +958,10 @@ bool P2PProxy::isRecvOpCompleted(const RecvOpContext& op_ctx) const {
 // Pipeline per peer:
 //   1. Drain the shared send_queue_ into the peer's pending_send_ops_.
 //   2. Promote the first pending op to active_send_op_.
-//   3. While we have invitations (PublishSlots) and staging buffers,
+//   3. While we have credits (CreditSlots) and staging buffers,
 //      pull more tensor slices into SendPool (TryIssueSendTask).
 //   4. Advance every active chunk through its state machine
-//      (Copy-In -> Write Remote -> Completion write).
+//      (Copy-In -> Write Remote -> Ack write).
 //   5. Erase fully-acknowledged chunks.  When the op is empty and all
 //      bytes have been staged, mark it complete.
 bool P2PProxy::stepSend() {
@@ -1026,13 +1016,13 @@ bool P2PProxy::stepSend() {
         }
         auto& op_ctx = lane.active_send_op_.value();
 
-        // Pull as many invitations as we have free chunks
+        // Pull as many credits as we have free chunks
         while (tryIssueSendTask(op_ctx, lane)) {
             did_work = true;
         }
 
         // Advance every chunk through the sender state machine.
-        // send op may fail due to wait invitation timeout in tryIssueSendTask.
+        // send op may fail due to credit-wait timeout in tryIssueSendTask.
         auto op_status = op_ctx.status_->load(std::memory_order_acquire);
         bool op_failed = op_status == OpStatus::kFailed;
         if (!op_failed) {
@@ -1070,47 +1060,47 @@ bool P2PProxy::stepSend() {
     return did_work;
 }
 
-// Poll the local CompletionLane for the head task and initiate Copy-Out.
+// Poll the local AckLane for the head task and initiate Copy-Out.
 //
-// Returns true if a completion was processed (including stale-slot clearing).
-bool P2PProxy::pollRecvCompletionSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
-                                      RecvTransferTask& head_task) {
-    // Check for timeout while waiting for the peer's CompletionSlot.
+// Returns true if an ack was processed (including stale-slot clearing).
+bool P2PProxy::pollRecvAckSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
+                               RecvTransferTask& head_task) {
+    // Check for timeout while waiting for the peer's AckSlot.
     if (isTimeout(head_task)) {
-        LOG(ERROR) << "P2P recv completion timeout peer=" << op_ctx.peer_rank_
+        LOG(ERROR) << "P2P wait-for-ack timeout, peer=" << op_ctx.peer_rank_
                    << " seq=" << head_task.sequence_;
         head_task.state_ = RecvTaskState::kFailed;
         return true;
     }
 
-    auto* completion_lane = getLocalCompletionLane(op_ctx.peer_rank_);
-    auto& slot = completion_lane[head_task.sequence_ % kP2PControlRingSize];
+    auto* ack_lane = getLocalAckLane(op_ctx.peer_rank_);
+    auto& slot = ack_lane[head_task.sequence_ % kP2PControlRingSize];
 
     // Step 1 -- Try load the slot
-    uint32_t completed_len = 0;
-    uint32_t slot_gen = 0;
+    uint32_t ack_len = 0;
+    uint32_t slot_epoch = 0;
     uint32_t slot_seq = 0;
-    if (!slot.tryLoad(completed_len, slot_gen, slot_seq)) {
+    if (!slot.tryLoad(ack_len, slot_epoch, slot_seq)) {
         // Slot is either empty or torn. Retry next poll.
         return false;
     }
 
-    const uint32_t current_gen =
-        peer_generation_[op_ctx.peer_rank_].load(std::memory_order_acquire);
+    const uint32_t curr_epoch =
+        peer_epoch_[op_ctx.peer_rank_].load(std::memory_order_acquire);
 
     // Step 2 -- Stale packet: data from a previous epoch (before Reset).
-    // Clear the slot so the fresh completion can land safely.
-    if (slot_gen != current_gen) {
-        LOG(WARNING) << "[P2PProxy][Recv] pollRecvCompletionSlot peer="
+    // Clear the slot so the fresh ack can land safely.
+    if (slot_epoch != curr_epoch) {
+        LOG(WARNING) << "[P2PProxy][Recv] pollRecvAckSlot peer="
                      << op_ctx.peer_rank_
                      << " front-seq=" << head_task.sequence_
-                     << " GEN_MISMATCH slot.gen=" << slot_gen
-                     << " current_gen=" << current_gen;
+                     << " EPOCH_MISMATCH slot.epoch=" << slot_epoch
+                     << " curr_epoch=" << curr_epoch;
         slot.reset();
         return true;
     }
 
-    // Step 3 -- Sequence check: make sure this is the exact completion
+    // Step 3 -- Sequence check: make sure this is the exact ack
     // we are waiting for.
     if (slot_seq != head_task.sequence_) {
         return false;
@@ -1149,7 +1139,7 @@ bool P2PProxy::pollRecvCompletionSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
 
     head_task.last_update_time_ = std::chrono::steady_clock::now();
     slot.reset();
-    ++lane.completion_consume_seq_;
+    ++lane.ack_consume_seq_;
     return true;
 }
 
@@ -1158,12 +1148,12 @@ bool P2PProxy::pollRecvCompletionSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
 // Pipeline per peer:
 //   1. Drain the shared recv_queue_ into the peer's pending_recv_ops_.
 //   2. Promote the first pending op to active_recv_op_.
-//   3. While we have free RecvPool chunks, issue PublishSlots to the sender
+//   3. While we have free RecvPool chunks, issue CreditSlots to the sender
 //      (TryIssueRecvTask).
-//   4. Poll the local CompletionLane in order.  When a CompletionSlot
+//   4. Poll the local AckLane in order.  When an AckSlot
 //      arrives, initiate Copy-Out from RecvPool to the user tensor.
 //   5. Advance every active chunk through its state machine
-//      (Advertise -> Copy-Out -> erase).
+//      (IssueCredit -> Copy-Out -> erase).
 //   6. When all chunks are copied out, mark the op complete.
 bool P2PProxy::stepRecv() {
     bool did_work = false;
@@ -1218,13 +1208,13 @@ bool P2PProxy::stepRecv() {
             did_work = true;
         }
 
-        // In-order completion polling: we only look at the head of the queue
+        // In-order ack polling: we only look at the head of the queue
         // because the sender acknowledges chunks in the same order it
-        // consumes invitations.
+        // consumes credits.
         if (!op_ctx.tasks_.empty()) {
             auto& head = op_ctx.tasks_.front();
-            if (head.state_ == RecvTaskState::kWaitCompletion) {
-                if (pollRecvCompletionSlot(op_ctx, lane, head)) {
+            if (head.state_ == RecvTaskState::kWaitAck) {
+                if (pollRecvAckSlot(op_ctx, lane, head)) {
                     did_work = true;
                 }
             }

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -16,14 +16,10 @@ namespace mooncake {
 
 namespace {
 
-constexpr size_t kP2PBytesPerRank = kP2PBufferSize;
-constexpr size_t kP2PNumSlotsPerRank = kP2PNumSlots;
+constexpr size_t kP2PPoolBytes =
+    static_cast<size_t>(kP2PPoolNumChunks) * kP2PChunkSize;
 
-static_assert(kP2PBufferSize % kP2PNumSlots == 0,
-              "kP2PBufferSize must be divisible by kP2PNumSlots");
-static_assert(kP2PNumSlots > 1, "P2P ring requires at least 2 slots per rank");
-
-void SetCudaDeviceIfNeeded(bool is_cpu, int cuda_device_index,
+void setCudaDeviceIfNeeded(bool is_cpu, int cuda_device_index,
                            const char* context) {
     if (is_cpu) {
         return;
@@ -52,7 +48,7 @@ P2PProxy::P2PProxy(TransferEngine* engine, const Options& options)
                     cudaGetErrorString(get_device_error));
         cuda_device_index_ = current_device;
     }
-    AllocateResources();
+    allocateResources();
 }
 
 P2PProxy::~P2PProxy() {
@@ -62,85 +58,93 @@ P2PProxy::~P2PProxy() {
         return;
     }
 
-    ReleaseResources();
+    releaseResources();
 }
 
-void P2PProxy::BindMeta(const std::shared_ptr<TransferGroupMeta>& meta) {
+void P2PProxy::bindMeta(const std::shared_ptr<TransferGroupMeta>& meta) {
     meta_ = meta;
 }
 
-void P2PProxy::AllocateResources() {
+// Allocate fixed-size SendPool, RecvPool and control regions.
+// Both pools are registered as a single MR each, eliminating per-rank MR
+// proliferation.  Control regions are sized for kMaxNumRanks peers with
+// kP2PControlRingSize slots per peer.
+void P2PProxy::allocateResources() {
     TORCH_CHECK(engine_, "P2PProxy engine is null.");
-    if (resources_.send_buffer_ != nullptr ||
-        resources_.recv_buffer_ != nullptr ||
-        resources_.ctrl_send_region_ != nullptr ||
-        resources_.ctrl_recv_region_ != nullptr) {
+    if (resources_.send_pool_base_ != nullptr ||
+        resources_.recv_pool_base_ != nullptr ||
+        resources_.publish_region_ != nullptr ||
+        resources_.completion_region_ != nullptr) {
         return;
     }
 
-    TORCH_CHECK(size_ >= 0, "P2PProxy invalid size_: ", size_);
+    TORCH_CHECK(size_ > 0, "P2PProxy invalid group size: ", size_);
     TORCH_CHECK(static_cast<size_t>(size_) <= kMaxNumRanks,
-                "P2PProxy size_ exceeds kMaxNumRanks: ", size_);
-
-    if (size_ == 0) {
-        return;
-    }
-
-    const size_t p2p_total_buffer_size =
-        kP2PBufferSize * static_cast<size_t>(size_);
+                "P2PProxy group size exceeds kMaxNumRanks: ", size_);
 
     if (is_cpu_) {
-        resources_.send_buffer_ = std::malloc(p2p_total_buffer_size);
-        TORCH_CHECK(resources_.send_buffer_ != nullptr,
-                    "Failed to allocate CPU P2P send buffer");
-        int rc = engine_->registerLocalMemory(resources_.send_buffer_,
-                                              p2p_total_buffer_size, location_);
-        TORCH_CHECK(rc == 0, "Failed to register CPU P2P send buffer");
+        resources_.send_pool_base_ = std::malloc(kP2PPoolBytes);
+        TORCH_CHECK(resources_.send_pool_base_ != nullptr,
+                    "Failed to allocate CPU P2P send pool");
+        int rc = engine_->registerLocalMemory(resources_.send_pool_base_,
+                                              kP2PPoolBytes, location_);
+        TORCH_CHECK(rc == 0, "Failed to register CPU P2P send pool");
 
-        resources_.recv_buffer_ = std::malloc(p2p_total_buffer_size);
-        TORCH_CHECK(resources_.recv_buffer_ != nullptr,
-                    "Failed to allocate CPU P2P recv buffer");
-        rc = engine_->registerLocalMemory(resources_.recv_buffer_,
-                                          p2p_total_buffer_size, location_);
-        TORCH_CHECK(rc == 0, "Failed to register CPU P2P recv buffer");
+        resources_.recv_pool_base_ = std::malloc(kP2PPoolBytes);
+        TORCH_CHECK(resources_.recv_pool_base_ != nullptr,
+                    "Failed to allocate CPU P2P recv pool");
+        rc = engine_->registerLocalMemory(resources_.recv_pool_base_,
+                                          kP2PPoolBytes, location_);
+        TORCH_CHECK(rc == 0, "Failed to register CPU P2P recv pool");
     } else {
-        SetCudaDeviceIfNeeded(
+        setCudaDeviceIfNeeded(
             is_cpu_, cuda_device_index_,
             "P2PProxy AllocateResources cudaSetDevice failed");
         cudaError_t err =
-            cudaMalloc(&resources_.send_buffer_, p2p_total_buffer_size);
-        TORCH_CHECK(err == cudaSuccess,
-                    "Failed to allocate CUDA P2P send buffer");
-        int rc = engine_->registerLocalMemory(resources_.send_buffer_,
-                                              p2p_total_buffer_size, location_);
-        TORCH_CHECK(rc == 0, "Failed to register CUDA P2P send buffer");
+            cudaMalloc(&resources_.send_pool_base_, kP2PPoolBytes);
+        TORCH_CHECK(
+            err == cudaSuccess,
+            "Failed to allocate CUDA P2P send pool: ", cudaGetErrorString(err));
+        int rc = engine_->registerLocalMemory(resources_.send_pool_base_,
+                                              kP2PPoolBytes, location_);
+        TORCH_CHECK(rc == 0, "Failed to register CUDA P2P send pool");
 
-        err = cudaMalloc(&resources_.recv_buffer_, p2p_total_buffer_size);
-        TORCH_CHECK(err == cudaSuccess,
-                    "Failed to allocate CUDA P2P recv buffer");
-        rc = engine_->registerLocalMemory(resources_.recv_buffer_,
-                                          p2p_total_buffer_size, location_);
-        TORCH_CHECK(rc == 0, "Failed to register CUDA P2P recv buffer");
+        err = cudaMalloc(&resources_.recv_pool_base_, kP2PPoolBytes);
+        TORCH_CHECK(
+            err == cudaSuccess,
+            "Failed to allocate CUDA P2P recv pool: ", cudaGetErrorString(err));
+        rc = engine_->registerLocalMemory(resources_.recv_pool_base_,
+                                          kP2PPoolBytes, location_);
+        TORCH_CHECK(rc == 0, "Failed to register CUDA P2P recv pool");
     }
 
-    resources_.ctrl_send_region_ = new P2PControlSlot[kMaxNumRanks]{};
-    resources_.ctrl_recv_region_ = new P2PControlSlot[kMaxNumRanks]{};
+    send_pool_.init(resources_.send_pool_base_, kP2PChunkSize,
+                    kP2PPoolNumChunks);
+    recv_pool_.init(resources_.recv_pool_base_, kP2PChunkSize,
+                    kP2PPoolNumChunks);
+
+    const size_t ctrl_slots =
+        kMaxNumRanks * static_cast<size_t>(kP2PControlRingSize);
+    resources_.publish_region_ = new PublishSlot[ctrl_slots]{};
+    resources_.completion_region_ = new CompletionSlot[ctrl_slots]{};
+
+    for (size_t i = 0; i < ctrl_slots; ++i) {
+        resources_.publish_region_[i].reset();
+        resources_.completion_region_[i].reset();
+    }
+
+    global_generation_.store(1, std::memory_order_release);
+
     for (size_t i = 0; i < kMaxNumRanks; ++i) {
-        resources_.ctrl_send_region_[i].head.store(0,
-                                                   std::memory_order_relaxed);
-        resources_.ctrl_send_region_[i].tail.store(0,
-                                                   std::memory_order_relaxed);
-        resources_.ctrl_recv_region_[i].head.store(0,
-                                                   std::memory_order_relaxed);
-        resources_.ctrl_recv_region_[i].tail.store(0,
-                                                   std::memory_order_relaxed);
-        send_peer_lanes_[i].local_head_ = 0;
         send_peer_lanes_[i].pending_send_ops_.clear();
         send_peer_lanes_[i].active_send_op_.reset();
+        send_peer_lanes_[i].publish_consume_seq_ = 0;
         send_peer_lanes_[i].copy_ready_events_.fill(nullptr);
-        recv_peer_lanes_[i].local_tail_ = 0;
+
         recv_peer_lanes_[i].pending_recv_ops_.clear();
         recv_peer_lanes_[i].active_recv_op_.reset();
+        recv_peer_lanes_[i].publish_issue_seq_ = 0;
+        recv_peer_lanes_[i].completion_consume_seq_ = 0;
         recv_peer_lanes_[i].copy_ready_events_.fill(nullptr);
     }
 
@@ -148,9 +152,6 @@ void P2PProxy::AllocateResources() {
         for (int peer_rank = 0; peer_rank < size_; ++peer_rank) {
             for (auto& copy_ready_event :
                  send_peer_lanes_[peer_rank].copy_ready_events_) {
-                if (copy_ready_event != nullptr) {
-                    continue;
-                }
                 const cudaError_t create_error = cudaEventCreateWithFlags(
                     &copy_ready_event, cudaEventDisableTiming);
                 TORCH_CHECK(create_error == cudaSuccess,
@@ -160,9 +161,6 @@ void P2PProxy::AllocateResources() {
 
             for (auto& copy_ready_event :
                  recv_peer_lanes_[peer_rank].copy_ready_events_) {
-                if (copy_ready_event != nullptr) {
-                    continue;
-                }
                 const cudaError_t create_error = cudaEventCreateWithFlags(
                     &copy_ready_event, cudaEventDisableTiming);
                 TORCH_CHECK(create_error == cudaSuccess,
@@ -171,62 +169,113 @@ void P2PProxy::AllocateResources() {
             }
         }
     }
-    int rc = engine_->registerLocalMemory(resources_.ctrl_send_region_,
-                                          kMaxNumRanks * sizeof(P2PControlSlot),
-                                          kWildcardLocation);
-    TORCH_CHECK(rc == 0, "Failed to register P2P ctrl send region");
 
-    rc = engine_->registerLocalMemory(resources_.ctrl_recv_region_,
-                                      kMaxNumRanks * sizeof(P2PControlSlot),
+    int rc = engine_->registerLocalMemory(resources_.publish_region_,
+                                          ctrl_slots * sizeof(PublishSlot),
+                                          kWildcardLocation);
+    TORCH_CHECK(rc == 0, "Failed to register P2P publish region");
+
+    rc = engine_->registerLocalMemory(resources_.completion_region_,
+                                      ctrl_slots * sizeof(CompletionSlot),
                                       kWildcardLocation);
-    TORCH_CHECK(rc == 0, "Failed to register P2P ctrl recv region");
+    TORCH_CHECK(rc == 0, "Failed to register P2P completion region");
+
+    // Staging buffers for control messages.  RDMA requires every
+    // transfer source to live in a registered MR.
+    resources_.publish_staging_buf_ = new PublishSlot[ctrl_slots]{};
+    rc = engine_->registerLocalMemory(resources_.publish_staging_buf_,
+                                      ctrl_slots * sizeof(PublishSlot),
+                                      kWildcardLocation);
+    TORCH_CHECK(rc == 0, "Failed to register P2P publish staging region");
+
+    resources_.completion_staging_buf_ = new CompletionSlot[ctrl_slots]{};
+    rc = engine_->registerLocalMemory(resources_.completion_staging_buf_,
+                                      ctrl_slots * sizeof(CompletionSlot),
+                                      kWildcardLocation);
+    TORCH_CHECK(rc == 0, "Failed to register P2P completion staging region");
 }
 
-void P2PProxy::ResetPeerState(int peer_rank) {
+void P2PProxy::resetPeerState(int peer_rank) {
     TORCH_CHECK(peer_rank >= 0 && peer_rank < size_,
                 "ResetPeerState: peer_rank out of range: ", peer_rank,
                 " size: ", size_);
+
+    // Bump the generation once per peer Reset.
+    global_generation_.fetch_add(1, std::memory_order_acq_rel);
     reset_send_req_[peer_rank].store(true, std::memory_order_release);
     reset_recv_req_[peer_rank].store(true, std::memory_order_release);
     if (device_worker_) {
-        device_worker_->WakeUpSend();
-        device_worker_->WakeUpRecv();
+        device_worker_->wakeUpSend();
+        device_worker_->wakeUpRecv();
     }
 }
 
-void P2PProxy::PerformSendReset(int peer_rank) {
+// Reset sender state for peer_rank.
+// Generation update:
+//   We bump generation_ so that any PublishSlots still in flight from the
+//   old session (written by the receiver before it learned about the Reset)
+//   are recognized as stale and skipped.  We also reinitialize the local
+//   control lanes with the new generation so that our own CompletionSlot
+//   writes (if any are still in flight) can be identified as stale by the
+//   receiver.
+void P2PProxy::performSendReset(int peer_rank) {
     auto& lane = send_peer_lanes_[peer_rank];
     lane.pending_send_ops_.clear();
-    lane.active_send_op_.reset();
-    lane.local_head_ = 0;
 
-    if (resources_.ctrl_send_region_) {
-        resources_.ctrl_send_region_[peer_rank].head.store(
-            0, std::memory_order_relaxed);
-        resources_.ctrl_send_region_[peer_rank].tail.store(
-            0, std::memory_order_relaxed);
+    if (lane.active_send_op_.has_value()) {
+        auto& op_ctx = lane.active_send_op_.value();
+        for (auto& task : op_ctx.tasks_) {
+            if (task.staging_addr_ != nullptr) {
+                send_pool_.release(task.staging_addr_);
+                task.staging_addr_ = nullptr;
+            }
+        }
+        active_send_tasks_.fetch_sub(1, std::memory_order_release);
+    }
+
+    lane.active_send_op_.reset();
+    lane.publish_consume_seq_ = 0;
+
+    auto* publish_lane = getLocalPublishLane(peer_rank);
+    auto* completion_lane = getLocalCompletionLane(peer_rank);
+    for (uint32_t i = 0; i < kP2PControlRingSize; ++i) {
+        publish_lane[i].reset();
+        completion_lane[i].reset();
     }
 }
 
-void P2PProxy::PerformRecvReset(int peer_rank) {
+// Reset receiver state for peer_rank.
+void P2PProxy::performRecvReset(int peer_rank) {
     auto& lane = recv_peer_lanes_[peer_rank];
     lane.pending_recv_ops_.clear();
-    lane.active_recv_op_.reset();
-    lane.local_tail_ = 0;
 
-    if (resources_.ctrl_recv_region_) {
-        resources_.ctrl_recv_region_[peer_rank].head.store(
-            0, std::memory_order_relaxed);
-        resources_.ctrl_recv_region_[peer_rank].tail.store(
-            0, std::memory_order_relaxed);
+    if (lane.active_recv_op_.has_value()) {
+        auto& op_ctx = lane.active_recv_op_.value();
+        for (auto& task : op_ctx.tasks_) {
+            if (task.local_addr_ != nullptr) {
+                recv_pool_.release(task.local_addr_);
+            }
+        }
+        active_recv_tasks_.fetch_sub(1, std::memory_order_release);
+    }
+
+    lane.active_recv_op_.reset();
+    lane.publish_issue_seq_ = 0;
+    lane.completion_consume_seq_ = 0;
+
+    auto* publish_lane = getLocalPublishLane(peer_rank);
+    auto* completion_lane = getLocalCompletionLane(peer_rank);
+    for (uint32_t i = 0; i < kP2PControlRingSize; ++i) {
+        publish_lane[i].reset();
+        completion_lane[i].reset();
     }
 }
 
-void P2PProxy::ReleaseResources() {
+void P2PProxy::releaseResources() {
     TORCH_CHECK(!resource_abandoned_,
                 "Should not release abandoned resources.");
 
-    SetCudaDeviceIfNeeded(is_cpu_, cuda_device_index_,
+    setCudaDeviceIfNeeded(is_cpu_, cuda_device_index_,
                           "P2PProxy ReleaseResources cudaSetDevice failed");
 
     for (size_t i = 0; i < kMaxNumRanks; ++i) {
@@ -243,8 +292,17 @@ void P2PProxy::ReleaseResources() {
             copy_ready_event = nullptr;
         }
         send_lane.pending_send_ops_.clear();
+
+        if (send_lane.active_send_op_.has_value()) {
+            auto& op_ctx = send_lane.active_send_op_.value();
+            for (auto& task : op_ctx.tasks_) {
+                if (task.staging_addr_ != nullptr) {
+                    send_pool_.release(task.staging_addr_);
+                    task.staging_addr_ = nullptr;
+                }
+            }
+        }
         send_lane.active_send_op_.reset();
-        send_lane.local_head_ = 0;
 
         auto& recv_lane = recv_peer_lanes_[i];
         for (auto& copy_ready_event : recv_lane.copy_ready_events_) {
@@ -266,42 +324,54 @@ void P2PProxy::ReleaseResources() {
         return;
     }
 
-    if (resources_.ctrl_send_region_ != nullptr) {
-        engine_->unregisterLocalMemory(resources_.ctrl_send_region_);
-        delete[] resources_.ctrl_send_region_;
-        resources_.ctrl_send_region_ = nullptr;
+    if (resources_.publish_staging_buf_ != nullptr) {
+        engine_->unregisterLocalMemory(resources_.publish_staging_buf_);
+        delete[] resources_.publish_staging_buf_;
+        resources_.publish_staging_buf_ = nullptr;
     }
 
-    if (resources_.ctrl_recv_region_ != nullptr) {
-        engine_->unregisterLocalMemory(resources_.ctrl_recv_region_);
-        delete[] resources_.ctrl_recv_region_;
-        resources_.ctrl_recv_region_ = nullptr;
+    if (resources_.completion_staging_buf_ != nullptr) {
+        engine_->unregisterLocalMemory(resources_.completion_staging_buf_);
+        delete[] resources_.completion_staging_buf_;
+        resources_.completion_staging_buf_ = nullptr;
     }
 
-    if (resources_.send_buffer_ != nullptr) {
-        engine_->unregisterLocalMemory(resources_.send_buffer_);
+    if (resources_.publish_region_ != nullptr) {
+        engine_->unregisterLocalMemory(resources_.publish_region_);
+        delete[] resources_.publish_region_;
+        resources_.publish_region_ = nullptr;
+    }
+
+    if (resources_.completion_region_ != nullptr) {
+        engine_->unregisterLocalMemory(resources_.completion_region_);
+        delete[] resources_.completion_region_;
+        resources_.completion_region_ = nullptr;
+    }
+
+    if (resources_.send_pool_base_ != nullptr) {
+        engine_->unregisterLocalMemory(resources_.send_pool_base_);
         if (is_cpu_) {
-            std::free(resources_.send_buffer_);
+            std::free(resources_.send_pool_base_);
         } else {
-            cudaFree(resources_.send_buffer_);
+            cudaFree(resources_.send_pool_base_);
         }
-        resources_.send_buffer_ = nullptr;
+        resources_.send_pool_base_ = nullptr;
     }
 
-    if (resources_.recv_buffer_ != nullptr) {
-        engine_->unregisterLocalMemory(resources_.recv_buffer_);
+    if (resources_.recv_pool_base_ != nullptr) {
+        engine_->unregisterLocalMemory(resources_.recv_pool_base_);
         if (is_cpu_) {
-            std::free(resources_.recv_buffer_);
+            std::free(resources_.recv_pool_base_);
         } else {
-            cudaFree(resources_.recv_buffer_);
+            cudaFree(resources_.recv_pool_base_);
         }
-        resources_.recv_buffer_ = nullptr;
+        resources_.recv_pool_base_ = nullptr;
     }
 }
 
-void P2PProxy::AbandonResources() { resource_abandoned_ = true; }
+void P2PProxy::abandonResources() { resource_abandoned_ = true; }
 
-void P2PProxy::EnqueueSend(SendOp op) {
+void P2PProxy::enqueueSend(SendOp op) {
     op.tensor_ =
         op.tensor_.is_contiguous() ? op.tensor_ : op.tensor_.contiguous();
 
@@ -310,26 +380,27 @@ void P2PProxy::EnqueueSend(SendOp op) {
         send_queue_.emplace(std::move(op));
     }
     active_send_tasks_.fetch_add(1, std::memory_order_release);
-    if (device_worker_) device_worker_->WakeUpSend();
+    if (device_worker_) device_worker_->wakeUpSend();
 }
 
-void P2PProxy::EnqueueRecv(RecvOp op) {
+void P2PProxy::enqueueRecv(RecvOp op) {
     {
         std::lock_guard<std::mutex> lock(recv_queue_mutex_);
         recv_queue_.push(std::move(op));
     }
     active_recv_tasks_.fetch_add(1, std::memory_order_release);
-    if (device_worker_) device_worker_->WakeUpRecv();
+    if (device_worker_) device_worker_->wakeUpRecv();
 }
 
-P2PProxy::SendTransferTask::SendTransferTask(uint64_t chunk_offset_in,
-                                             uint64_t chunk_bytes_in,
-                                             void* source_in,
-                                             uint64_t target_offset_in)
-    : chunk_offset_(chunk_offset_in),
-      chunk_bytes_(chunk_bytes_in),
-      source_(source_in),
-      target_offset_(target_offset_in) {}
+P2PProxy::SendTransferTask::SendTransferTask(
+    uint64_t tensor_offset_in, uint32_t chunk_len_in, void* staging_addr_in,
+    uint64_t remote_addr_in, uint32_t sequence_in, uint32_t generation_in)
+    : tensor_offset_(tensor_offset_in),
+      chunk_len_(chunk_len_in),
+      staging_addr_(staging_addr_in),
+      remote_addr_(remote_addr_in),
+      sequence_(sequence_in),
+      generation_(generation_in) {}
 
 P2PProxy::SendOpContext::SendOpContext(SendOp&& op_in)
     : tensor_(std::move(op_in.tensor_)),
@@ -340,13 +411,16 @@ P2PProxy::SendOpContext::SendOpContext(SendOp&& op_in)
         tensor_.numel() * static_cast<uint64_t>(tensor_.element_size());
 }
 
-P2PProxy::RecvTransferTask::RecvTransferTask(uint64_t chunk_offset_in,
-                                             uint64_t chunk_bytes_in,
-                                             void* source_in, void* target_in)
-    : chunk_offset_(chunk_offset_in),
-      chunk_bytes_(chunk_bytes_in),
-      source_(source_in),
-      target_(target_in) {}
+P2PProxy::RecvTransferTask::RecvTransferTask(uint64_t tensor_offset_in,
+                                             uint32_t chunk_len_in,
+                                             void* local_addr_in,
+                                             uint32_t sequence_in,
+                                             uint32_t generation_in)
+    : tensor_offset_(tensor_offset_in),
+      chunk_len_(chunk_len_in),
+      local_addr_(local_addr_in),
+      sequence_(sequence_in),
+      generation_(generation_in) {}
 
 P2PProxy::RecvOpContext::RecvOpContext(RecvOp&& op_in)
     : tensor_(std::move(op_in.tensor_)),
@@ -358,81 +432,263 @@ P2PProxy::RecvOpContext::RecvOpContext(RecvOp&& op_in)
         tensor_.numel() * static_cast<uint64_t>(tensor_.element_size());
 }
 
-uint64_t P2PProxy::GetLocalSendSlotAddress(int peer_rank,
-                                           uint32_t slot_index) const {
-    const uint64_t send_addr_base =
-        meta_->segmentInfos[rank_].p2p_send_buffer +
-        static_cast<uint64_t>(peer_rank) * kP2PBytesPerRank;
-    return send_addr_base + static_cast<uint64_t>(slot_index) * kP2PSlotSize;
+PublishSlot* P2PProxy::getLocalPublishLane(int peer_rank) const {
+    return resources_.publish_region_ +
+           static_cast<size_t>(peer_rank) * kP2PControlRingSize;
 }
 
-uint64_t P2PProxy::GetLocalRecvSlotAddress(int peer_rank,
-                                           uint32_t slot_index) const {
-    const uint64_t recv_addr_base =
-        meta_->segmentInfos[rank_].p2p_recv_buffer +
-        static_cast<uint64_t>(peer_rank) * kP2PBytesPerRank;
-    return recv_addr_base + static_cast<uint64_t>(slot_index) * kP2PSlotSize;
+CompletionSlot* P2PProxy::getLocalCompletionLane(int peer_rank) const {
+    return resources_.completion_region_ +
+           static_cast<size_t>(peer_rank) * kP2PControlRingSize;
 }
 
-uint64_t P2PProxy::GetRemoteRecvSlotAddress(int peer_rank,
-                                            uint32_t slot_index) const {
-    const uint64_t remote_recv_addr_base =
-        meta_->segmentInfos[peer_rank].p2p_recv_buffer +
-        static_cast<uint64_t>(rank_) * kP2PBytesPerRank;
-    return remote_recv_addr_base +
-           static_cast<uint64_t>(slot_index) * kP2PSlotSize;
+uint64_t P2PProxy::getRemotePublishSlot(int peer_rank,
+                                        uint32_t sequence) const {
+    const uint64_t slot_index = sequence % kP2PControlRingSize;
+    return meta_->segmentInfos[peer_rank].p2p_publish_region +
+           (static_cast<uint64_t>(rank_) * kP2PControlRingSize + slot_index) *
+               sizeof(PublishSlot);
 }
 
-uint64_t P2PProxy::GetRemoteCtrlRecvHeadOffset(int peer_rank) const {
-    return meta_->segmentInfos[peer_rank].p2p_ctrl_recv +
-           rank_ * sizeof(P2PControlSlot) + offsetof(P2PControlSlot, head);
+uint64_t P2PProxy::getRemoteCompletionSlot(int peer_rank,
+                                           uint32_t sequence) const {
+    const uint64_t slot_index = sequence % kP2PControlRingSize;
+    return meta_->segmentInfos[peer_rank].p2p_completion_region +
+           (static_cast<uint64_t>(rank_) * kP2PControlRingSize + slot_index) *
+               sizeof(CompletionSlot);
 }
 
-uint64_t P2PProxy::GetRemoteCtrlSendTailOffset(int peer_rank) const {
-    return meta_->segmentInfos[peer_rank].p2p_ctrl_send +
-           rank_ * sizeof(P2PControlSlot) + offsetof(P2PControlSlot, tail);
+PublishSlot* P2PProxy::getLocalPublishStagingBuf(int peer_rank,
+                                                 uint32_t sequence) const {
+    const size_t staging_idx =
+        static_cast<size_t>(peer_rank) * kP2PControlRingSize +
+        sequence % kP2PControlRingSize;
+    return resources_.publish_staging_buf_ + staging_idx;
+}
+CompletionSlot* P2PProxy::getLocalCompletionStagingBuf(
+    int peer_rank, uint32_t sequence) const {
+    const size_t staging_idx =
+        static_cast<size_t>(peer_rank) * kP2PControlRingSize +
+        static_cast<size_t>(sequence % kP2PControlRingSize);
+    return resources_.completion_staging_buf_ + staging_idx;
 }
 
-bool P2PProxy::TryIssueSendTask(SendOpContext& op_ctx, uint32_t capacity) {
-    if (op_ctx.bytes_issued_ >= op_ctx.total_bytes_) {
+// Receiver advertise.
+//
+// Grab a free chunk from RecvPool and invite the sender to write into it.
+// We RDMA-write a PublishSlot into the sender's PublishLane so the sender
+// knows:
+//   (a) which sequence this is,
+//   (b) the RecvPool offset to write to,
+//   (c) how many bytes we expect.
+// If the pool is exhausted we return false and retry on the next polling
+// iteration (non-blocking).
+bool P2PProxy::tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane) {
+    if (op_ctx.bytes_advertised_ >= op_ctx.total_bytes_) {
         return false;
     }
 
-    const int peer_rank = op_ctx.peer_rank_;
-    auto& lane = send_peer_lanes_[peer_rank];
-    const uint32_t head = lane.local_head_;
-    const uint32_t slot_index = head;
-    const uint32_t remote_tail =
-        resources_.ctrl_send_region_[peer_rank].tail.load(
-            std::memory_order_acquire);
-    if (((head + 1) % capacity) == remote_tail) {
+    if (op_ctx.tasks_.size() >= kP2PControlRingSize) {
+        // No free control slot, retry on the next iteration
         return false;
     }
 
-    const uint64_t chunk_bytes =
-        std::min(static_cast<uint64_t>(kP2PSlotSize),
-                 op_ctx.total_bytes_ - op_ctx.bytes_issued_);
-    const uint64_t send_addr = GetLocalSendSlotAddress(peer_rank, head);
-    const uint64_t target_offset = GetRemoteRecvSlotAddress(peer_rank, head);
-    op_ctx.tasks_.emplace_back(op_ctx.bytes_issued_, chunk_bytes,
-                               reinterpret_cast<void*>(send_addr),
-                               target_offset);
+    void* local_addr = recv_pool_.acquire();
+    if (local_addr == nullptr) {
+        // No free recv chunk, retry on the next iteration
+        return false;
+    }
+
+    const uint32_t chunk_len = static_cast<uint32_t>(std::min<uint64_t>(
+        kP2PChunkSize, op_ctx.total_bytes_ - op_ctx.bytes_advertised_));
+    const uint64_t seq = lane.publish_issue_seq_;
+    const uint64_t remote_publish_offset =
+        getRemotePublishSlot(op_ctx.peer_rank_, seq);
+
+    const uint32_t current_gen =
+        global_generation_.load(std::memory_order_acquire);
+    op_ctx.tasks_.emplace_back(op_ctx.bytes_advertised_, chunk_len, local_addr,
+                               seq, current_gen);
     auto& task = op_ctx.tasks_.back();
+
+    auto* publish_buf = getLocalPublishStagingBuf(op_ctx.peer_rank_, seq);
+    publish_buf->publish(current_gen, seq,
+                         reinterpret_cast<uint64_t>(local_addr), chunk_len);
+    const BatchID batch_id = engine_->allocateBatchID(1);
+    engine_->submitTransfer(
+        batch_id, {TransferRequest{
+                      .opcode = TransferRequest::WRITE,
+                      .source = static_cast<void*>(publish_buf),
+                      .target_id = meta_->segmentIDs[op_ctx.peer_rank_],
+                      .target_offset = remote_publish_offset,
+                      .length = sizeof(PublishSlot),
+                  }});
+    task.publish_batch_id_ = batch_id;
+
+    ++lane.publish_issue_seq_;
+    op_ctx.bytes_advertised_ += chunk_len;
+    return true;
+}
+
+// Poll the PublishSlot RDMA Write batch.
+//
+// Before we can consider a chunk "advertised" we must know that the
+// PublishSlot write has reached the sender.  Once the batch completes we
+// clear the batch id and transition to kDataCopy, where we wait for the
+// sender's CompletionSlot.
+bool P2PProxy::stepRecvTransferTask(RecvTransferTask& task) {
+    switch (task.state_) {
+        case TransferState::kTransfer:
+            return stepRecvTransfer(task);
+        case TransferState::kDataCopy:
+            return stepRecvDataCopy(task);
+        default:
+            return false;
+    }
+    return false;
+}
+
+bool P2PProxy::stepRecvTransfer(RecvTransferTask& task) {
+    if (!task.publish_batch_id_.has_value()) {
+        task.state_ = TransferState::kDataCopy;
+        return true;
+    }
+
+    TransferStatus publish_status;
+    engine_->getTransferStatus(task.publish_batch_id_.value(), 0,
+                               publish_status);
+
+    if (publish_status.s == TransferStatusEnum::COMPLETED) {
+        engine_->freeBatchID(task.publish_batch_id_.value());
+        task.publish_batch_id_.reset();
+        task.state_ = TransferState::kDataCopy;
+        return true;
+    }
+
+    if (publish_status.s == TransferStatusEnum::FAILED) {
+        engine_->freeBatchID(task.publish_batch_id_.value());
+        task.publish_batch_id_.reset();
+        TORCH_CHECK(false, "P2P publish transfer failed.");
+    }
+    return false;
+}
+
+// Poll the GPU Copy-Out event.
+//
+// After the CompletionSlot arrives we initiate cudaMemcpyAsync from the
+// RecvPool chunk to the user tensor and record an event.  This function
+// waits for that event and returns the chunk to RecvPool.
+bool P2PProxy::stepRecvDataCopy(RecvTransferTask& task) {
+    if (task.copy_ready_event_ != nullptr) {
+        cudaError_t query_error = cudaEventQuery(task.copy_ready_event_);
+        if (query_error == cudaSuccess) {
+            task.copy_ready_event_ = nullptr;
+            recv_pool_.release(task.local_addr_);
+            task.local_addr_ = nullptr;
+            task.state_ = TransferState::kDone;
+            return true;
+        }
+        if (query_error == cudaErrorNotReady) {
+            return false;
+        }
+
+        task.copy_ready_event_ = nullptr;
+        TORCH_CHECK(false, "P2P recv cudaEventQuery failed: ",
+                    cudaGetErrorString(query_error));
+        return false;
+    }
+
+    return false;
+}
+
+bool P2PProxy::isRecvDataPathCompleted(const RecvOpContext& op_ctx) const {
+    return op_ctx.bytes_advertised_ == op_ctx.total_bytes_ &&
+           op_ctx.tasks_.empty();
+}
+
+// Sender fetch invitation
+//
+// Poll the local PublishLane for the next expected sequence.  If the slot
+// matches our consume cursor we accept the invitation: allocate a staging
+// chunk from SendPool, copy the corresponding slice of the user tensor into
+// it, and advance the cursor.  If the pool is full or no invitation has
+// arrived we return false immediately (non-blocking).
+bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
+    if (op_ctx.bytes_staged_ >= op_ctx.total_bytes_) {
+        return false;
+    }
+
+    if (op_ctx.tasks_.size() >= kP2PControlRingSize) {
+        return false;
+    }
+
+    PublishSlot* local_publish = getLocalPublishLane(op_ctx.peer_rank_);
+    const uint64_t seq = lane.publish_consume_seq_;
+    auto& slot = local_publish[static_cast<size_t>(seq % kP2PControlRingSize)];
+
+    // Step 1 -- Try load the slot
+    uint64_t recv_addr = 0;
+    uint32_t chunk_len = 0;
+    uint32_t slot_gen = 0;
+    uint32_t slot_seq = 0;
+    if (!slot.tryLoad(recv_addr, chunk_len, slot_gen, slot_seq)) {
+        // Slot is either empty or torn (partial RDMA write). Retry next poll.
+        return false;
+    }
+
+    // Step 2 -- Stale packet: the slot carries data from a previous epoch
+    // (before a Reset).  Clear it so the fresh invitation can land safely,
+    // but DO NOT advance the consume cursor -- the peer will re-send the
+    // same sequence after the Reset.
+    const uint32_t current_gen =
+        global_generation_.load(std::memory_order_acquire);
+    if (slot_gen != current_gen) {
+        LOG(WARNING) << "[P2PProxy][Send] tryIssueSendTask peer="
+                     << op_ctx.peer_rank_ << " STALE_GEN seq=" << seq
+                     << " slot.gen=" << slot_gen
+                     << " current_gen=" << current_gen;
+        slot.reset();
+        return true;
+    }
+
+    // Step 3 -- Sequence check: make sure this is exactly the slot we expect.
+    if (slot_seq != static_cast<uint32_t>(seq)) {
+        return false;
+    }
+
+    void* staging_addr = send_pool_.acquire();
+    if (staging_addr == nullptr) {
+        return false;
+    }
+
+    const uint32_t expected_chunk_len =
+        static_cast<uint32_t>(std::min<uint64_t>(
+            kP2PChunkSize, op_ctx.total_bytes_ - op_ctx.bytes_staged_));
+    TORCH_CHECK(chunk_len <= expected_chunk_len,
+                "P2P send got invalid chunk_len in publish slot.");
+
+    op_ctx.tasks_.emplace_back(op_ctx.bytes_staged_, chunk_len, staging_addr,
+                               recv_addr, seq, slot_gen);
+    auto& task = op_ctx.tasks_.back();
+
+    slot.reset();
+
     const auto* tensor_ptr =
         static_cast<const uint8_t*>(op_ctx.tensor_.data_ptr());
-
     if (is_cpu_) {
-        std::memcpy(task.source_, tensor_ptr + task.chunk_offset_,
-                    task.chunk_bytes_);
+        std::memcpy(staging_addr, tensor_ptr + task.tensor_offset_,
+                    task.chunk_len_);
         task.state_ = TransferState::kTransfer;
     } else {
         cudaError_t copy_error = cudaMemcpyAsync(
-            task.source_, tensor_ptr + task.chunk_offset_, task.chunk_bytes_,
+            staging_addr, tensor_ptr + task.tensor_offset_, task.chunk_len_,
             cudaMemcpyDeviceToDevice, op_ctx.cuda_stream_);
         TORCH_CHECK(!copy_error, "P2P send cudaMemcpyAsync failed: ",
                     cudaGetErrorString(copy_error));
+
         const cudaEvent_t pooled_copy_ready_event =
-            lane.copy_ready_events_[slot_index];
+            lane.copy_ready_events_[static_cast<size_t>(seq %
+                                                        kP2PControlRingSize)];
         TORCH_CHECK(pooled_copy_ready_event != nullptr,
                     "P2P send pooled copy-ready event is not initialized.");
         task.copy_ready_event_ = pooled_copy_ready_event;
@@ -445,61 +701,69 @@ bool P2PProxy::TryIssueSendTask(SendOpContext& op_ctx, uint32_t capacity) {
         }
     }
 
-    op_ctx.bytes_issued_ += task.chunk_bytes_;
-    lane.local_head_ = (head + 1) % capacity;
+    ++lane.publish_consume_seq_;
+    op_ctx.bytes_staged_ += task.chunk_len_;
     return true;
 }
 
-bool P2PProxy::StepSendTransferTask(SendOpContext& op_ctx,
+// Drive a single sender chunk through its state machine.
+//
+// DataCopy -> Transfer -> Done -> Completion write -> erase.
+bool P2PProxy::stepSendTransferTask(SendOpContext& op_ctx,
                                     SendTransferTask& task) {
-    bool did_work = false;
+    switch (task.state_) {
+        case TransferState::kDataCopy:
+            return stepSendDataCopy(task);
 
-    if (task.state_ == TransferState::kDataCopy && StepSendDataCopy(task)) {
-        did_work = true;
-    }
-    if (task.state_ == TransferState::kTransfer &&
-        StepSendTransfer(op_ctx, task)) {
-        did_work = true;
-    }
+        case TransferState::kTransfer:
+            return stepSendTransfer(op_ctx, task);
 
-    return did_work;
+        case TransferState::kDone:
+            return stepSendCompletion(op_ctx, task);
+    }
+    return false;
 }
 
-bool P2PProxy::StepSendDataCopy(SendTransferTask& task) {
+// Poll the GPU Copy-In event (or skip on CPU).
+//
+// When the event signals we transition from kDataCopy to kTransfer so the
+// RDMA Write can be submitted.
+bool P2PProxy::stepSendDataCopy(SendTransferTask& task) {
     if (task.copy_ready_event_ == nullptr) {
         task.state_ = TransferState::kTransfer;
         return true;
     }
 
-    cudaError_t query_error = cudaSuccess;
-    query_error = cudaEventQuery(task.copy_ready_event_);
-
-    if (query_error == cudaSuccess) {
-        task.copy_ready_event_ = nullptr;
-        task.state_ = TransferState::kTransfer;
-        return true;
-    }
+    cudaError_t query_error = cudaEventQuery(task.copy_ready_event_);
     if (query_error == cudaErrorNotReady) {
         return false;
     }
 
     task.copy_ready_event_ = nullptr;
+
+    if (query_error == cudaSuccess) {
+        task.state_ = TransferState::kTransfer;
+        return true;
+    }
+
     TORCH_CHECK(false, "P2P send cudaEventQuery failed: ",
                 cudaGetErrorString(query_error));
     return false;
 }
 
-bool P2PProxy::StepSendTransfer(SendOpContext& op_ctx, SendTransferTask& task) {
+// Submit the RDMA Write from SendPool staging to remote RecvPool, then
+// poll for its completion.
+bool P2PProxy::stepSendTransfer(SendOpContext& op_ctx, SendTransferTask& task) {
     bool did_work = false;
     if (!task.transfer_batch_id_.has_value()) {
         const BatchID batch_id = engine_->allocateBatchID(1);
         engine_->submitTransfer(
             batch_id, {TransferRequest{
                           .opcode = TransferRequest::WRITE,
-                          .source = task.source_,
+                          .source = task.staging_addr_,
                           .target_id = meta_->segmentIDs[op_ctx.peer_rank_],
-                          .target_offset = task.target_offset_,
-                          .length = task.chunk_bytes_,
+                          .target_offset = task.remote_addr_,
+                          .length = task.chunk_len_,
                       }});
         task.transfer_batch_id_ = batch_id;
         did_work = true;
@@ -512,9 +776,8 @@ bool P2PProxy::StepSendTransfer(SendOpContext& op_ctx, SendTransferTask& task) {
         engine_->freeBatchID(task.transfer_batch_id_.value());
         task.transfer_batch_id_.reset();
         task.state_ = TransferState::kDone;
-        return true;
-    }
-    if (transfer_status.s == TransferStatusEnum::FAILED) {
+        did_work = true;
+    } else if (transfer_status.s == TransferStatusEnum::FAILED) {
         engine_->freeBatchID(task.transfer_batch_id_.value());
         task.transfer_batch_id_.reset();
         TORCH_CHECK(false, "P2P send transfer failed.");
@@ -524,234 +787,80 @@ bool P2PProxy::StepSendTransfer(SendOpContext& op_ctx, SendTransferTask& task) {
     return did_work;
 }
 
-bool P2PProxy::StepSendHeadCommit(SendOpContext& op_ctx, uint32_t capacity) {
+// Write the CompletionSlot back to the receiver.
+//
+// This tells the receiver that the data is present in its RecvPool and it
+// may begin the Copy-Out.  When the CompletionSlot write finishes we free
+// the staging chunk.
+bool P2PProxy::stepSendCompletion(SendOpContext& op_ctx,
+                                  SendTransferTask& task) {
     bool did_work = false;
-    if (op_ctx.head_update_batch_id_.has_value()) {
-        TransferStatus head_status;
-        engine_->getTransferStatus(op_ctx.head_update_batch_id_.value(), 0,
-                                   head_status);
-        if (head_status.s == TransferStatusEnum::COMPLETED) {
-            engine_->freeBatchID(op_ctx.head_update_batch_id_.value());
-            op_ctx.head_update_batch_id_.reset();
-            did_work = true;
-        } else if (head_status.s == TransferStatusEnum::FAILED) {
-            engine_->freeBatchID(op_ctx.head_update_batch_id_.value());
-            op_ctx.head_update_batch_id_.reset();
-            TORCH_CHECK(false, "P2P ctrl head update failed.");
-            return false;
-        }
-    }
+    if (!task.completion_batch_id_.has_value()) {
+        auto* completion_buf =
+            getLocalCompletionStagingBuf(op_ctx.peer_rank_, task.sequence_);
+        completion_buf->publish(task.generation_, task.sequence_,
+                                task.chunk_len_);
 
-    if (op_ctx.head_update_batch_id_.has_value()) {
-        return did_work;
-    }
-
-    uint32_t committed_tasks = 0;
-    while (!op_ctx.tasks_.empty() &&
-           op_ctx.tasks_.front().state_ == TransferState::kDone) {
-        op_ctx.tasks_.pop_front();
-        ++committed_tasks;
+        const BatchID batch_id = engine_->allocateBatchID(1);
+        engine_->submitTransfer(
+            batch_id, {TransferRequest{
+                          .opcode = TransferRequest::WRITE,
+                          .source = static_cast<void*>(completion_buf),
+                          .target_id = meta_->segmentIDs[op_ctx.peer_rank_],
+                          .target_offset = getRemoteCompletionSlot(
+                              op_ctx.peer_rank_, task.sequence_),
+                          .length = sizeof(CompletionSlot),
+                      }});
+        task.completion_batch_id_ = batch_id;
         did_work = true;
     }
 
-    if (committed_tasks == 0) {
-        return did_work;
-    }
-
-    const uint32_t current_head =
-        resources_.ctrl_send_region_[op_ctx.peer_rank_].head.load(
-            std::memory_order_relaxed);
-    const uint32_t next_head = (current_head + committed_tasks) % capacity;
-    resources_.ctrl_send_region_[op_ctx.peer_rank_].head.store(
-        next_head, std::memory_order_release);
-    void* head_source = static_cast<void*>(
-        &resources_.ctrl_send_region_[op_ctx.peer_rank_].head.value);
-    const uint64_t remote_head_offset =
-        GetRemoteCtrlRecvHeadOffset(op_ctx.peer_rank_);
-
-    const BatchID batch_id = engine_->allocateBatchID(1);
-    engine_->submitTransfer(
-        batch_id, {TransferRequest{
-                      .opcode = TransferRequest::WRITE,
-                      .source = head_source,
-                      .target_id = meta_->segmentIDs[op_ctx.peer_rank_],
-                      .target_offset = remote_head_offset,
-                      .length = sizeof(uint32_t),
-                  }});
-    op_ctx.head_update_batch_id_ = batch_id;
-    did_work = true;
-
-    return did_work;
-}
-
-bool P2PProxy::IsSendDataPathCompleted(const SendOpContext& op_ctx) const {
-    return op_ctx.bytes_issued_ == op_ctx.total_bytes_ && op_ctx.tasks_.empty();
-}
-
-bool P2PProxy::IsSendOpCompleted(const SendOpContext& op_ctx) const {
-    return IsSendDataPathCompleted(op_ctx) &&
-           !op_ctx.head_update_batch_id_.has_value();
-}
-
-bool P2PProxy::TryIssueRecvTask(RecvOpContext& op_ctx, uint32_t capacity) {
-    if (op_ctx.bytes_issued_ >= op_ctx.total_bytes_) {
-        return false;
-    }
-
-    auto* local_ctrl = &resources_.ctrl_recv_region_[op_ctx.peer_rank_];
-    auto& lane = recv_peer_lanes_[op_ctx.peer_rank_];
-    const uint32_t head = local_ctrl->head.load(std::memory_order_acquire);
-    const uint32_t tail = lane.local_tail_;
-    const uint32_t slot_index = tail;
-    if (head == tail) {
-        return false;
-    }
-
-    const uint64_t chunk_bytes =
-        std::min(static_cast<uint64_t>(kP2PSlotSize),
-                 op_ctx.total_bytes_ - op_ctx.bytes_issued_);
-    const uint64_t recv_addr = GetLocalRecvSlotAddress(op_ctx.peer_rank_, tail);
-    auto* tensor_ptr = static_cast<uint8_t*>(op_ctx.tensor_.data_ptr());
-    void* target_ptr = static_cast<void*>(tensor_ptr + op_ctx.bytes_issued_);
-
-    op_ctx.tasks_.emplace_back(op_ctx.bytes_issued_, chunk_bytes,
-                               reinterpret_cast<void*>(recv_addr), target_ptr);
-    auto& task = op_ctx.tasks_.back();
-
-    if (is_cpu_) {
-        std::memcpy(task.target_, task.source_, task.chunk_bytes_);
-        task.state_ = TransferState::kDone;
-    } else {
-        cudaError_t copy_error =
-            cudaMemcpyAsync(task.target_, task.source_, task.chunk_bytes_,
-                            cudaMemcpyDeviceToDevice, op_ctx.cuda_stream_);
-        TORCH_CHECK(!copy_error, "P2P recv cudaMemcpyAsync failed: ",
-                    cudaGetErrorString(copy_error));
-        const cudaEvent_t pooled_copy_ready_event =
-            lane.copy_ready_events_[slot_index];
-        TORCH_CHECK(pooled_copy_ready_event != nullptr,
-                    "P2P recv pooled copy-ready event is not initialized.");
-        task.copy_ready_event_ = pooled_copy_ready_event;
-        copy_error =
-            cudaEventRecord(task.copy_ready_event_, op_ctx.cuda_stream_);
-        if (copy_error != cudaSuccess) {
-            task.copy_ready_event_ = nullptr;
-            TORCH_CHECK(false, "P2P recv cudaEventRecord failed: ",
-                        cudaGetErrorString(copy_error));
-        }
-    }
-
-    op_ctx.bytes_issued_ += task.chunk_bytes_;
-    lane.local_tail_ = (tail + 1) % capacity;
-    return true;
-}
-
-bool P2PProxy::StepRecvTransferTask(RecvTransferTask& task) {
-    bool did_work = false;
-
-    if (task.state_ == TransferState::kDataCopy && StepRecvDataCopy(task)) {
-        did_work = true;
-    }
-
-    return did_work;
-}
-
-bool P2PProxy::StepRecvDataCopy(RecvTransferTask& task) {
-    if (task.copy_ready_event_ == nullptr) {
-        task.state_ = TransferState::kDone;
+    TransferStatus completion_status;
+    engine_->getTransferStatus(task.completion_batch_id_.value(), 0,
+                               completion_status);
+    if (completion_status.s == TransferStatusEnum::COMPLETED) {
+        engine_->freeBatchID(task.completion_batch_id_.value());
+        task.completion_batch_id_.reset();
+        send_pool_.release(task.staging_addr_);
+        task.staging_addr_ = nullptr;
         return true;
     }
-
-    cudaError_t query_error = cudaSuccess;
-    query_error = cudaEventQuery(task.copy_ready_event_);
-
-    if (query_error == cudaSuccess) {
-        task.copy_ready_event_ = nullptr;
-        task.state_ = TransferState::kDone;
-        return true;
-    }
-    if (query_error == cudaErrorNotReady) {
+    if (completion_status.s == TransferStatusEnum::FAILED) {
+        engine_->freeBatchID(task.completion_batch_id_.value());
+        task.completion_batch_id_.reset();
+        TORCH_CHECK(false, "P2P completion transfer failed.");
         return false;
     }
-
-    task.copy_ready_event_ = nullptr;
-    TORCH_CHECK(false, "P2P recv cudaEventQuery failed: ",
-                cudaGetErrorString(query_error));
-    return false;
-}
-
-bool P2PProxy::StepRecvTailCommit(RecvOpContext& op_ctx, uint32_t capacity) {
-    bool did_work = false;
-    if (op_ctx.tail_update_batch_id_.has_value()) {
-        TransferStatus tail_status;
-        engine_->getTransferStatus(op_ctx.tail_update_batch_id_.value(), 0,
-                                   tail_status);
-        if (tail_status.s == TransferStatusEnum::COMPLETED) {
-            engine_->freeBatchID(op_ctx.tail_update_batch_id_.value());
-            op_ctx.tail_update_batch_id_.reset();
-            did_work = true;
-        } else if (tail_status.s == TransferStatusEnum::FAILED) {
-            engine_->freeBatchID(op_ctx.tail_update_batch_id_.value());
-            op_ctx.tail_update_batch_id_.reset();
-            TORCH_CHECK(false, "P2P ctrl tail update failed.");
-            return false;
-        }
-    }
-
-    if (op_ctx.tail_update_batch_id_.has_value()) {
-        return did_work;
-    }
-
-    uint32_t committed_tasks = 0;
-    while (!op_ctx.tasks_.empty() &&
-           op_ctx.tasks_.front().state_ == TransferState::kDone) {
-        op_ctx.tasks_.pop_front();
-        ++committed_tasks;
-        did_work = true;
-    }
-
-    if (committed_tasks == 0) {
-        return did_work;
-    }
-
-    auto* local_ctrl = &resources_.ctrl_recv_region_[op_ctx.peer_rank_];
-    const uint32_t current_tail =
-        local_ctrl->tail.load(std::memory_order_relaxed);
-    const uint32_t next_tail = (current_tail + committed_tasks) % capacity;
-    local_ctrl->tail.store(next_tail, std::memory_order_release);
-
-    const uint64_t remote_tail_offset =
-        GetRemoteCtrlSendTailOffset(op_ctx.peer_rank_);
-    void* tail_source = static_cast<void*>(&local_ctrl->tail.value);
-
-    const BatchID batch_id = engine_->allocateBatchID(1);
-    engine_->submitTransfer(
-        batch_id, {TransferRequest{
-                      .opcode = TransferRequest::WRITE,
-                      .source = tail_source,
-                      .target_id = meta_->segmentIDs[op_ctx.peer_rank_],
-                      .target_offset = remote_tail_offset,
-                      .length = sizeof(uint32_t),
-                  }});
-    op_ctx.tail_update_batch_id_ = batch_id;
-    did_work = true;
 
     return did_work;
 }
 
-bool P2PProxy::IsRecvDataPathCompleted(const RecvOpContext& op_ctx) const {
-    return op_ctx.bytes_issued_ == op_ctx.total_bytes_ &&
-           op_ctx.tasks_.empty() && !op_ctx.tail_update_batch_id_.has_value();
+bool P2PProxy::isSendDataPathCompleted(const SendOpContext& op_ctx) const {
+    return op_ctx.bytes_staged_ == op_ctx.total_bytes_ && op_ctx.tasks_.empty();
 }
 
-bool P2PProxy::StepSend() {
-    const uint32_t capacity = static_cast<uint32_t>(kP2PNumSlotsPerRank);
+bool P2PProxy::isSendOpCompleted(const SendOpContext& op_ctx) const {
+    return isSendDataPathCompleted(op_ctx);
+}
+
+// Sender state machine
+//
+// Pipeline per peer:
+//   1. Drain the shared send_queue_ into the peer's pending_send_ops_.
+//   2. Promote the first pending op to active_send_op_.
+//   3. While we have invitations (PublishSlots) and staging buffers,
+//      pull more tensor slices into SendPool (TryIssueSendTask).
+//   4. Advance every active chunk through its state machine
+//      (Copy-In -> RDMA Write -> Completion write).
+//   5. Erase fully-acknowledged chunks.  When the op is empty and all
+//      bytes have been staged, mark it complete.
+bool P2PProxy::stepSend() {
     bool did_work = false;
 
     for (int peer_rank = 0; peer_rank < size_; ++peer_rank) {
         if (reset_send_req_[peer_rank].exchange(false,
                                                 std::memory_order_acquire)) {
-            PerformSendReset(peer_rank);
+            performSendReset(peer_rank);
             did_work = true;
         }
     }
@@ -791,21 +900,30 @@ bool P2PProxy::StepSend() {
             continue;
         }
         auto& op_ctx = lane.active_send_op_.value();
-        while (TryIssueSendTask(op_ctx, capacity)) {
+        // Pull as many invitations as we have free chunks
+        while (tryIssueSendTask(op_ctx, lane)) {
             did_work = true;
         }
-        for (auto& task : op_ctx.tasks_) {
-            if (task.state_ == TransferState::kDone) {
-                continue;
-            }
-            if (StepSendTransferTask(op_ctx, task)) {
+
+        // Advance every chunk through the sender state machine.
+        for (auto it = op_ctx.tasks_.begin(); it != op_ctx.tasks_.end();) {
+            if (stepSendTransferTask(op_ctx, *it)) {
                 did_work = true;
             }
+
+            // A task is fully retired only after the CompletionSlot write
+            // has finished and the staging buffer has been freed.
+            if (it->state_ == TransferState::kDone &&
+                !it->completion_batch_id_.has_value() &&
+                it->staging_addr_ == nullptr) {
+                it = op_ctx.tasks_.erase(it);
+                did_work = true;
+            } else {
+                ++it;
+            }
         }
-        if (StepSendHeadCommit(op_ctx, capacity)) {
-            did_work = true;
-        }
-        if (IsSendOpCompleted(op_ctx)) {
+
+        if (isSendOpCompleted(op_ctx)) {
             op_ctx.completed_->store(true, std::memory_order_release);
             lane.active_send_op_.reset();
             active_send_tasks_.fetch_sub(1, std::memory_order_release);
@@ -816,14 +934,25 @@ bool P2PProxy::StepSend() {
     return did_work;
 }
 
-bool P2PProxy::StepRecv() {
-    const uint32_t capacity = static_cast<uint32_t>(kP2PNumSlotsPerRank);
+// Receiver state machine
+//
+// Pipeline per peer:
+//   1. Drain the shared recv_queue_ into the peer's pending_recv_ops_.
+//   2. Promote the first pending op to active_recv_op_.
+//   3. While we have free RecvPool chunks, issue PublishSlots to the sender
+//      (TryIssueRecvTask).
+//   4. Poll the local CompletionLane in order.  When a CompletionSlot
+//      arrives, initiate Copy-Out from RecvPool to the user tensor.
+//   5. Advance every active chunk through its state machine
+//      (Publish done -> Copy-Out done -> erase).
+//   6. When all chunks are copied out, mark the op complete.
+bool P2PProxy::stepRecv() {
     bool did_work = false;
 
     for (int peer_rank = 0; peer_rank < size_; ++peer_rank) {
         if (reset_recv_req_[peer_rank].exchange(false,
                                                 std::memory_order_acquire)) {
-            PerformRecvReset(peer_rank);
+            performRecvReset(peer_rank);
             did_work = true;
         }
     }
@@ -847,8 +976,6 @@ bool P2PProxy::StepRecv() {
         }
         RecvOp recv_op = std::move(lane.pending_recv_ops_.front());
         lane.pending_recv_ops_.pop_front();
-        lane.local_tail_ = resources_.ctrl_recv_region_[peer_rank].tail.load(
-            std::memory_order_acquire);
         RecvOpContext op_ctx(std::move(recv_op));
         lane.active_recv_op_ = std::move(op_ctx);
         did_work = true;
@@ -859,24 +986,107 @@ bool P2PProxy::StepRecv() {
         if (!lane.active_recv_op_.has_value()) {
             continue;
         }
+
         auto& op_ctx = lane.active_recv_op_.value();
-        while (TryIssueRecvTask(op_ctx, capacity)) {
+
+        // Offer as many RecvPool chunks as we have free buffers and tensor
+        // bytes remaining.
+        while (tryIssueRecvTask(op_ctx, lane)) {
             did_work = true;
         }
-        for (auto& task : op_ctx.tasks_) {
-            if (task.state_ == TransferState::kDone) {
+
+        // In-order completion polling: we only look at the head of the queue
+        // because the sender acknowledges chunks in the same order it
+        // consumes invitations.
+        auto* completion_lane = getLocalCompletionLane(peer_rank);
+        while (!op_ctx.tasks_.empty()) {
+            auto& task = op_ctx.tasks_.front();
+            auto& slot = completion_lane[task.sequence_ % kP2PControlRingSize];
+
+            // Step 1 -- Try load the slot
+            uint32_t completed_len = 0;
+            uint32_t slot_gen = 0;
+            uint32_t slot_seq = 0;
+            if (!slot.tryLoad(completed_len, slot_gen, slot_seq)) {
+                // Slot is either empty or torn. Retry next poll.
+                break;
+            }
+
+            const uint32_t current_gen =
+                global_generation_.load(std::memory_order_acquire);
+
+            // Step 2 -- Stale packet: data from a previous epoch (before
+            // Reset). Clear the slot so the fresh completion can land safely.
+            // Do NOT pop the task, do NOT free the chunk, and do NOT advance
+            // completion_consume_seq_ -- the current task is still waiting.
+            if (slot_gen != current_gen) {
+                LOG(WARNING) << "[P2PProxy][Recv] stepRecv peer=" << peer_rank
+                             << " front-seq=" << task.sequence_
+                             << " GEN_MISMATCH slot.gen=" << slot_gen
+                             << " current_gen=" << current_gen;
+                slot.reset();
+                did_work = true;
+                break;
+            }
+
+            // Step 3 -- Sequence check: make sure this is the exact completion
+            // we are waiting for.
+            if (slot_seq != task.sequence_) {
+                break;
+            }
+
+            void* src_ptr = task.local_addr_;
+            auto* tensor_ptr = static_cast<uint8_t*>(op_ctx.tensor_.data_ptr());
+            void* dst_ptr = tensor_ptr + task.tensor_offset_;
+
+            if (is_cpu_) {
+                std::memcpy(dst_ptr, src_ptr, task.chunk_len_);
+                recv_pool_.release(task.local_addr_);
+                task.local_addr_ = nullptr;
+                task.state_ = TransferState::kDone;
+            } else {
+                cudaError_t copy_error = cudaMemcpyAsync(
+                    dst_ptr, src_ptr, task.chunk_len_, cudaMemcpyDeviceToDevice,
+                    op_ctx.cuda_stream_);
+                TORCH_CHECK(!copy_error, "P2P recv cudaMemcpyAsync failed: ",
+                            cudaGetErrorString(copy_error));
+                const cudaEvent_t pooled_copy_ready_event =
+                    lane.copy_ready_events_[static_cast<size_t>(
+                        task.sequence_ % kP2PControlRingSize)];
+                TORCH_CHECK(
+                    pooled_copy_ready_event != nullptr,
+                    "P2P recv pooled copy-ready event is not initialized.");
+                task.copy_ready_event_ = pooled_copy_ready_event;
+                copy_error = cudaEventRecord(task.copy_ready_event_,
+                                             op_ctx.cuda_stream_);
+                if (copy_error != cudaSuccess) {
+                    task.copy_ready_event_ = nullptr;
+                    TORCH_CHECK(false, "P2P recv cudaEventRecord failed: ",
+                                cudaGetErrorString(copy_error));
+                }
+            }
+
+            slot.reset();
+            ++lane.completion_consume_seq_;
+            did_work = true;
+            break;
+        }
+
+        for (auto it = op_ctx.tasks_.begin(); it != op_ctx.tasks_.end();) {
+            if (it->state_ == TransferState::kDone) {
+                it = op_ctx.tasks_.erase(it);
+                did_work = true;
                 continue;
             }
-            if (StepRecvTransferTask(task)) {
+            if (stepRecvTransferTask(*it)) {
                 did_work = true;
             }
+            ++it;
         }
-        if (StepRecvTailCommit(op_ctx, capacity)) {
-            did_work = true;
-        }
-        if (IsRecvDataPathCompleted(op_ctx)) {
+
+        if (isRecvDataPathCompleted(op_ctx)) {
             if (!op_ctx.original_tensor_.is_contiguous()) {
-                op_ctx.original_tensor_.copy_(op_ctx.tensor_);
+                (void)op_ctx.original_tensor_.copy_(op_ctx.tensor_);
                 if (!is_cpu_) {
                     const cudaError_t sync_error = cudaDeviceSynchronize();
                     TORCH_CHECK(sync_error == cudaSuccess,
@@ -895,46 +1105,46 @@ bool P2PProxy::StepRecv() {
     return did_work;
 }
 
-void P2PProxy::SetDeviceWorker(P2PDeviceWorker* worker) {
+void P2PProxy::setDeviceWorker(P2PDeviceWorker* worker) {
     device_worker_ = worker;
 }
 
-bool P2PProxy::HasActiveSendWork() const {
+bool P2PProxy::hasActiveSendWork() const {
     for (int i = 0; i < size_; ++i) {
         if (reset_send_req_[i].load(std::memory_order_acquire)) return true;
     }
     return active_send_tasks_.load(std::memory_order_acquire) > 0;
 }
 
-bool P2PProxy::HasActiveRecvWork() const {
+bool P2PProxy::hasActiveRecvWork() const {
     for (int i = 0; i < size_; ++i) {
         if (reset_recv_req_[i].load(std::memory_order_acquire)) return true;
     }
     return active_recv_tasks_.load(std::memory_order_acquire) > 0;
 }
 
-bool P2PProxy::DrainTasks() const {
+bool P2PProxy::drainTasks() const {
     BackoffWaiter waiter;
     return waiter.wait_for(
         std::chrono::milliseconds(kDrainTasksTimeoutMs),
-        [this] { return !HasActiveSendWork() && !HasActiveRecvWork(); });
+        [this] { return !hasActiveSendWork() && !hasActiveRecvWork(); });
 }
 
-void P2PDeviceWorker::Start() {
+void P2PDeviceWorker::start() {
     bool expected_send = false;
     if (send_worker_running_.compare_exchange_strong(expected_send, true)) {
         send_worker_thread_ =
-            std::thread(&P2PDeviceWorker::SendWorkerThread, this);
+            std::thread(&P2PDeviceWorker::sendWorkerMainloop, this);
     }
 
     bool expected_recv = false;
     if (recv_worker_running_.compare_exchange_strong(expected_recv, true)) {
         recv_worker_thread_ =
-            std::thread(&P2PDeviceWorker::RecvWorkerThread, this);
+            std::thread(&P2PDeviceWorker::recvWorkerMainloop, this);
     }
 }
 
-void P2PDeviceWorker::Stop() {
+void P2PDeviceWorker::stop() {
     bool expected_send = true;
     std::unique_lock<std::mutex> s_lock(send_wakeup_mutex_);
     if (send_worker_running_.compare_exchange_strong(expected_send, false)) {
@@ -957,7 +1167,7 @@ void P2PDeviceWorker::Stop() {
 }
 
 void P2PDeviceWorker::registerProxy(const std::shared_ptr<P2PProxy>& proxy) {
-    proxy->SetDeviceWorker(this);
+    proxy->setDeviceWorker(this);
     {
         std::lock_guard<std::mutex> lock(proxies_mutex_);
         proxies_.emplace_back(proxy);
@@ -981,13 +1191,13 @@ void P2PDeviceWorker::removeProxy(const std::shared_ptr<P2PProxy>& proxy) {
         std::lock_guard<std::mutex> r_lock(recv_wakeup_mutex_);
         proxies_version_.fetch_add(1, std::memory_order_release);
     }
-    proxy->SetDeviceWorker(nullptr);
+    proxy->setDeviceWorker(nullptr);
     send_wakeup_cv_.notify_one();
     recv_wakeup_cv_.notify_one();
 }
 
 template <typename HasWorkFn, typename StepWorkFn>
-void WorkerThreadLoop(bool is_cpu, int cuda_device_index,
+void workerThreadLoop(bool is_cpu, int cuda_device_index,
                       std::atomic<bool>& worker_running,
                       std::atomic<uint64_t>& proxies_version,
                       std::mutex& proxies_mutex,
@@ -995,7 +1205,7 @@ void WorkerThreadLoop(bool is_cpu, int cuda_device_index,
                       std::mutex& wakeup_mutex,
                       std::condition_variable& wakeup_cv, HasWorkFn has_work,
                       StepWorkFn step_work) {
-    SetCudaDeviceIfNeeded(is_cpu, cuda_device_index,
+    setCudaDeviceIfNeeded(is_cpu, cuda_device_index,
                           "P2PDeviceWorker::WorkerThread cudaSetDevice failed");
 
     // A thread-local cache for proxies to avoid locking too frequently.
@@ -1091,20 +1301,20 @@ void WorkerThreadLoop(bool is_cpu, int cuda_device_index,
     }
 }
 
-void P2PDeviceWorker::SendWorkerThread() {
-    WorkerThreadLoop(
+void P2PDeviceWorker::sendWorkerMainloop() {
+    workerThreadLoop(
         is_cpu_, cuda_device_index_, send_worker_running_, proxies_version_,
         proxies_mutex_, proxies_, send_wakeup_mutex_, send_wakeup_cv_,
-        [](P2PProxy& p) { return p.HasActiveSendWork(); },
-        [](P2PProxy& p) { return p.StepSend(); });
+        [](P2PProxy& p) { return p.hasActiveSendWork(); },
+        [](P2PProxy& p) { return p.stepSend(); });
 }
 
-void P2PDeviceWorker::RecvWorkerThread() {
-    WorkerThreadLoop(
+void P2PDeviceWorker::recvWorkerMainloop() {
+    workerThreadLoop(
         is_cpu_, cuda_device_index_, recv_worker_running_, proxies_version_,
         proxies_mutex_, proxies_, recv_wakeup_mutex_, recv_wakeup_cv_,
-        [](P2PProxy& p) { return p.HasActiveRecvWork(); },
-        [](P2PProxy& p) { return p.StepRecv(); });
+        [](P2PProxy& p) { return p.hasActiveRecvWork(); },
+        [](P2PProxy& p) { return p.stepRecv(); });
 }
 
 // Standard practice is to update states shared with condition_variables under
@@ -1114,16 +1324,16 @@ void P2PDeviceWorker::RecvWorkerThread() {
 //  acquired in WakeUpSend/Recv)
 //
 // Ref: https://stackoverflow.com/a/21439617
-void P2PDeviceWorker::WakeUpSend() {
+void P2PDeviceWorker::wakeUpSend() {
     std::lock_guard<std::mutex> lock(send_wakeup_mutex_);
     send_wakeup_cv_.notify_one();
 }
-void P2PDeviceWorker::WakeUpRecv() {
+void P2PDeviceWorker::wakeUpRecv() {
     std::lock_guard<std::mutex> lock(recv_wakeup_mutex_);
     recv_wakeup_cv_.notify_one();
 }
 
-std::shared_ptr<P2PDeviceWorker> P2PDeviceWorkerManager::GetCPUWorker() {
+std::shared_ptr<P2PDeviceWorker> P2PDeviceWorkerManager::getCPUWorker() {
     std::lock_guard<std::mutex> lock(manager_mutex_);
 
     auto it = workers_.find(CPUWorkerID);
@@ -1137,7 +1347,7 @@ std::shared_ptr<P2PDeviceWorker> P2PDeviceWorkerManager::GetCPUWorker() {
     return worker;
 }
 
-std::shared_ptr<P2PDeviceWorker> P2PDeviceWorkerManager::GetCUDAWorker(
+std::shared_ptr<P2PDeviceWorker> P2PDeviceWorkerManager::getCUDAWorker(
     int cuda_device_index) {
     std::lock_guard<std::mutex> lock(manager_mutex_);
 
@@ -1151,4 +1361,5 @@ std::shared_ptr<P2PDeviceWorker> P2PDeviceWorkerManager::GetCUDAWorker(
     workers_[cuda_device_index] = worker;
     return worker;
 }
+
 }  // namespace mooncake

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -62,7 +62,7 @@ void P2PChunkPool::release(void* ptr) { free_stack_.push_back(ptr); }
 //
 // 1. Load header_token with acquire semantics.
 // 2. If it is kInvalidControlToken the slot is empty -> fail.
-// 3. Optimistically copy the payload (these plain loads may be torn).
+// 3. Optimistically copy the payload.
 // 4. Issue an acquire fence so the payload reads cannot be reordered past
 //    the footer load that follows.
 // 5. Load footer_token.
@@ -74,8 +74,8 @@ bool PublishSlot::tryLoad(uint64_t& out_recv_addr, uint32_t& out_chunk_len,
     if (h == kInvalidControlToken) return false;
 
     // Optimistic payload copy – may be torn if the NIC is still writing.
-    uint64_t addr = recv_addr;
-    uint32_t len = chunk_len;
+    uint64_t addr = std::atomic_ref(recv_addr).load(std::memory_order_relaxed);
+    uint32_t len = std::atomic_ref(chunk_len).load(std::memory_order_relaxed);
 
     // Avoid moving payload reads below the footer check.
     std::atomic_thread_fence(std::memory_order_acquire);
@@ -126,7 +126,7 @@ bool CompletionSlot::tryLoad(uint32_t& out_chunk_len, uint32_t& out_generation,
     uint64_t h = std::atomic_ref(header_token).load(std::memory_order_acquire);
     if (h == kInvalidControlToken) return false;
 
-    uint32_t len = chunk_len;
+    uint32_t len = std::atomic_ref(chunk_len).load(std::memory_order_relaxed);
 
     std::atomic_thread_fence(std::memory_order_acquire);
 
@@ -213,10 +213,19 @@ void P2PProxy::allocateResources() {
     // Parse pool configuration from environment.
     pool_bytes_ = getEnv_size_t("MOONCAKE_P2P_POOL_SIZE", kDefaultPoolSize);
     chunk_size_ = getEnv_size_t("MOONCAKE_P2P_CHUNK_SIZE", kDefaultChunkSize);
+
+    // chunk_len is uint32_t fields in control slots
     TORCH_CHECK(
-        pool_bytes_ % chunk_size_ == 0,
-        "Invalid pool size and chunk size (pool_bytes_ % chunk_size_ != 0)");
-    num_chunks_ = pool_bytes_ / chunk_size_;
+        chunk_size_ > 0 && chunk_size_ <= std::numeric_limits<uint32_t>::max(),
+        "Invalid MOONCAKE_P2P_CHUNK_SIZE: must be > 0 and <= 4GB");
+
+    TORCH_CHECK(
+        pool_bytes_ > 0 && pool_bytes_ % chunk_size_ == 0,
+        "Invalid pool size and chunk size (must hold 'pool_bytes_ > 0 && "
+        "pool_bytes_ % chunk_size_ == 0')");
+
+    num_chunks_ = static_cast<uint32_t>(pool_bytes_ / chunk_size_);
+    TORCH_CHECK(num_chunks_ > 0, "P2PProxy: num_chunks_ must be > 0");
 
     if (is_cpu_) {
         resources_.send_pool_base_ = std::malloc(pool_bytes_);

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -476,7 +476,7 @@ CompletionSlot* P2PProxy::getLocalCompletionStagingBuf(
 // Receiver advertise.
 //
 // Grab a free chunk from RecvPool and invite the sender to write into it.
-// We RDMA-write a PublishSlot into the sender's PublishLane so the sender
+// We (RDMA) write a PublishSlot into the sender's PublishLane so the sender
 // knows:
 //   (a) which sequence this is,
 //   (b) the RecvPool offset to write to,
@@ -530,29 +530,30 @@ bool P2PProxy::tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane) {
     return true;
 }
 
-// Poll the PublishSlot RDMA Write batch.
+// Drive a single receiver chunk through its state machine.
 //
-// Before we can consider a chunk "advertised" we must know that the
-// PublishSlot write has reached the sender.  Once the batch completes we
-// clear the batch id and transition to kDataCopy, where we wait for the
-// sender's CompletionSlot.
-bool P2PProxy::stepRecvTransferTask(RecvTransferTask& task) {
+// kAdvertise -> kWaitCompletion -> kCopyOut -> kFinished -> erase.
+bool P2PProxy::stepRecvTask(RecvTransferTask& task) {
     switch (task.state_) {
-        case TransferState::kTransfer:
-            return stepRecvTransfer(task);
-        case TransferState::kDataCopy:
-            return stepRecvDataCopy(task);
-        default:
+        case RecvTaskState::kAdvertise:
+            return stepRecvAdvertise(task);
+
+        case RecvTaskState::kWaitCompletion:
+            // kWaitCompletion is polled in stepRecv
+            return false;
+
+        case RecvTaskState::kCopyOut:
+            return stepRecvCopyOut(task);
+
+        case RecvTaskState::kFinished:
             return false;
     }
     return false;
 }
 
-bool P2PProxy::stepRecvTransfer(RecvTransferTask& task) {
-    if (!task.publish_batch_id_.has_value()) {
-        task.state_ = TransferState::kDataCopy;
-        return true;
-    }
+bool P2PProxy::stepRecvAdvertise(RecvTransferTask& task) {
+    TORCH_CHECK(task.publish_batch_id_.has_value(),
+                "Expected a publish_batch_id in tryIssueRecvTask");
 
     TransferStatus publish_status;
     engine_->getTransferStatus(task.publish_batch_id_.value(), 0,
@@ -561,7 +562,7 @@ bool P2PProxy::stepRecvTransfer(RecvTransferTask& task) {
     if (publish_status.s == TransferStatusEnum::COMPLETED) {
         engine_->freeBatchID(task.publish_batch_id_.value());
         task.publish_batch_id_.reset();
-        task.state_ = TransferState::kDataCopy;
+        task.state_ = RecvTaskState::kWaitCompletion;
         return true;
     }
 
@@ -578,32 +579,25 @@ bool P2PProxy::stepRecvTransfer(RecvTransferTask& task) {
 // After the CompletionSlot arrives we initiate cudaMemcpyAsync from the
 // RecvPool chunk to the user tensor and record an event.  This function
 // waits for that event and returns the chunk to RecvPool.
-bool P2PProxy::stepRecvDataCopy(RecvTransferTask& task) {
-    if (task.copy_ready_event_ != nullptr) {
-        cudaError_t query_error = cudaEventQuery(task.copy_ready_event_);
-        if (query_error == cudaSuccess) {
-            task.copy_ready_event_ = nullptr;
-            recv_pool_.release(task.local_addr_);
-            task.local_addr_ = nullptr;
-            task.state_ = TransferState::kDone;
-            return true;
-        }
-        if (query_error == cudaErrorNotReady) {
-            return false;
-        }
-
+bool P2PProxy::stepRecvCopyOut(RecvTransferTask& task) {
+    TORCH_CHECK(task.copy_ready_event_ != nullptr,
+                "Expected a copy_ready_event");
+    cudaError_t query_error = cudaEventQuery(task.copy_ready_event_);
+    if (query_error == cudaSuccess) {
         task.copy_ready_event_ = nullptr;
-        TORCH_CHECK(false, "P2P recv cudaEventQuery failed: ",
-                    cudaGetErrorString(query_error));
+        recv_pool_.release(task.local_addr_);
+        task.local_addr_ = nullptr;
+        task.state_ = RecvTaskState::kFinished;
+        return true;
+    }
+    if (query_error == cudaErrorNotReady) {
         return false;
     }
 
+    task.copy_ready_event_ = nullptr;
+    TORCH_CHECK(false, "P2P recv cudaEventQuery failed: ",
+                cudaGetErrorString(query_error));
     return false;
-}
-
-bool P2PProxy::isRecvDataPathCompleted(const RecvOpContext& op_ctx) const {
-    return op_ctx.bytes_advertised_ == op_ctx.total_bytes_ &&
-           op_ctx.tasks_.empty();
 }
 
 // Sender fetch invitation
@@ -678,7 +672,7 @@ bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
     if (is_cpu_) {
         std::memcpy(staging_addr, tensor_ptr + task.tensor_offset_,
                     task.chunk_len_);
-        task.state_ = TransferState::kTransfer;
+        task.state_ = SendTaskState::kWriteRemote;
     } else {
         cudaError_t copy_error = cudaMemcpyAsync(
             staging_addr, tensor_ptr + task.tensor_offset_, task.chunk_len_,
@@ -708,29 +702,32 @@ bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
 
 // Drive a single sender chunk through its state machine.
 //
-// DataCopy -> Transfer -> Done -> Completion write -> erase.
-bool P2PProxy::stepSendTransferTask(SendOpContext& op_ctx,
-                                    SendTransferTask& task) {
+// kCopyIn -> kWriteRemote -> kCompletion -> kFinished -> erase.
+bool P2PProxy::stepSendTask(SendOpContext& op_ctx, SendTransferTask& task) {
     switch (task.state_) {
-        case TransferState::kDataCopy:
-            return stepSendDataCopy(task);
+        case SendTaskState::kCopyIn:
+            return stepSendCopyIn(task);
 
-        case TransferState::kTransfer:
-            return stepSendTransfer(op_ctx, task);
+        case SendTaskState::kWriteRemote:
+            return stepSendWriteRemote(op_ctx, task);
 
-        case TransferState::kDone:
+        case SendTaskState::kCompletion:
             return stepSendCompletion(op_ctx, task);
+
+        case SendTaskState::kFinished:
+            return false;
     }
     return false;
 }
 
 // Poll the GPU Copy-In event (or skip on CPU).
 //
-// When the event signals we transition from kDataCopy to kTransfer so the
-// RDMA Write can be submitted.
-bool P2PProxy::stepSendDataCopy(SendTransferTask& task) {
+// When the event signals we transition from kCopyIn to kWriteRemote so the
+// (RDMA) Write can be submitted.
+bool P2PProxy::stepSendCopyIn(SendTransferTask& task) {
     if (task.copy_ready_event_ == nullptr) {
-        task.state_ = TransferState::kTransfer;
+        // CPU case
+        task.state_ = SendTaskState::kWriteRemote;
         return true;
     }
 
@@ -742,7 +739,7 @@ bool P2PProxy::stepSendDataCopy(SendTransferTask& task) {
     task.copy_ready_event_ = nullptr;
 
     if (query_error == cudaSuccess) {
-        task.state_ = TransferState::kTransfer;
+        task.state_ = SendTaskState::kWriteRemote;
         return true;
     }
 
@@ -751,9 +748,10 @@ bool P2PProxy::stepSendDataCopy(SendTransferTask& task) {
     return false;
 }
 
-// Submit the RDMA Write from SendPool staging to remote RecvPool, then
+// Submit the Write from SendPool staging to remote RecvPool, then
 // poll for its completion.
-bool P2PProxy::stepSendTransfer(SendOpContext& op_ctx, SendTransferTask& task) {
+bool P2PProxy::stepSendWriteRemote(SendOpContext& op_ctx,
+                                   SendTransferTask& task) {
     bool did_work = false;
     if (!task.transfer_batch_id_.has_value()) {
         const BatchID batch_id = engine_->allocateBatchID(1);
@@ -775,7 +773,7 @@ bool P2PProxy::stepSendTransfer(SendOpContext& op_ctx, SendTransferTask& task) {
     if (transfer_status.s == TransferStatusEnum::COMPLETED) {
         engine_->freeBatchID(task.transfer_batch_id_.value());
         task.transfer_batch_id_.reset();
-        task.state_ = TransferState::kDone;
+        task.state_ = SendTaskState::kCompletion;
         did_work = true;
     } else if (transfer_status.s == TransferStatusEnum::FAILED) {
         engine_->freeBatchID(task.transfer_batch_id_.value());
@@ -791,7 +789,7 @@ bool P2PProxy::stepSendTransfer(SendOpContext& op_ctx, SendTransferTask& task) {
 //
 // This tells the receiver that the data is present in its RecvPool and it
 // may begin the Copy-Out.  When the CompletionSlot write finishes we free
-// the staging chunk.
+// the staging chunk and transition to kFinished.
 bool P2PProxy::stepSendCompletion(SendOpContext& op_ctx,
                                   SendTransferTask& task) {
     bool did_work = false;
@@ -823,6 +821,7 @@ bool P2PProxy::stepSendCompletion(SendOpContext& op_ctx,
         task.completion_batch_id_.reset();
         send_pool_.release(task.staging_addr_);
         task.staging_addr_ = nullptr;
+        task.state_ = SendTaskState::kFinished;
         return true;
     }
     if (completion_status.s == TransferStatusEnum::FAILED) {
@@ -835,12 +834,13 @@ bool P2PProxy::stepSendCompletion(SendOpContext& op_ctx,
     return did_work;
 }
 
-bool P2PProxy::isSendDataPathCompleted(const SendOpContext& op_ctx) const {
+bool P2PProxy::isSendOpCompleted(const SendOpContext& op_ctx) const {
     return op_ctx.bytes_staged_ == op_ctx.total_bytes_ && op_ctx.tasks_.empty();
 }
 
-bool P2PProxy::isSendOpCompleted(const SendOpContext& op_ctx) const {
-    return isSendDataPathCompleted(op_ctx);
+bool P2PProxy::isRecvOpCompleted(const RecvOpContext& op_ctx) const {
+    return op_ctx.bytes_advertised_ == op_ctx.total_bytes_ &&
+           op_ctx.tasks_.empty();
 }
 
 // Sender state machine
@@ -851,12 +851,13 @@ bool P2PProxy::isSendOpCompleted(const SendOpContext& op_ctx) const {
 //   3. While we have invitations (PublishSlots) and staging buffers,
 //      pull more tensor slices into SendPool (TryIssueSendTask).
 //   4. Advance every active chunk through its state machine
-//      (Copy-In -> RDMA Write -> Completion write).
+//      (Copy-In -> Write Remote -> Completion write).
 //   5. Erase fully-acknowledged chunks.  When the op is empty and all
 //      bytes have been staged, mark it complete.
 bool P2PProxy::stepSend() {
     bool did_work = false;
 
+    // Handle reset first
     for (int peer_rank = 0; peer_rank < size_; ++peer_rank) {
         if (reset_send_req_[peer_rank].exchange(false,
                                                 std::memory_order_acquire)) {
@@ -865,6 +866,7 @@ bool P2PProxy::stepSend() {
         }
     }
 
+    // Drain send_queue_
     {
         std::lock_guard<std::mutex> lock(send_queue_mutex_);
         while (!send_queue_.empty()) {
@@ -876,6 +878,7 @@ bool P2PProxy::stepSend() {
         }
     }
 
+    // Promote active op
     for (int peer_rank = 0; peer_rank < size_; ++peer_rank) {
         auto& lane = send_peer_lanes_[peer_rank];
         if (lane.active_send_op_.has_value() ||
@@ -894,12 +897,14 @@ bool P2PProxy::stepSend() {
         did_work = true;
     }
 
+    // Advance state machine
     for (int peer_rank = 0; peer_rank < size_; ++peer_rank) {
         auto& lane = send_peer_lanes_[peer_rank];
         if (!lane.active_send_op_.has_value()) {
             continue;
         }
         auto& op_ctx = lane.active_send_op_.value();
+
         // Pull as many invitations as we have free chunks
         while (tryIssueSendTask(op_ctx, lane)) {
             did_work = true;
@@ -907,15 +912,10 @@ bool P2PProxy::stepSend() {
 
         // Advance every chunk through the sender state machine.
         for (auto it = op_ctx.tasks_.begin(); it != op_ctx.tasks_.end();) {
-            if (stepSendTransferTask(op_ctx, *it)) {
+            if (stepSendTask(op_ctx, *it)) {
                 did_work = true;
             }
-
-            // A task is fully retired only after the CompletionSlot write
-            // has finished and the staging buffer has been freed.
-            if (it->state_ == TransferState::kDone &&
-                !it->completion_batch_id_.has_value() &&
-                it->staging_addr_ == nullptr) {
+            if (it->state_ == SendTaskState::kFinished) {
                 it = op_ctx.tasks_.erase(it);
                 did_work = true;
             } else {
@@ -934,6 +934,82 @@ bool P2PProxy::stepSend() {
     return did_work;
 }
 
+// Poll the local CompletionLane for the head task and initiate Copy-Out.
+//
+// Returns true if a completion was processed (including stale-slot clearing).
+bool P2PProxy::pollRecvCompletionSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
+                                      RecvTransferTask& head_task) {
+    auto* completion_lane = getLocalCompletionLane(op_ctx.peer_rank_);
+    auto& slot = completion_lane[head_task.sequence_ % kP2PControlRingSize];
+
+    // Step 1 -- Try load the slot
+    uint32_t completed_len = 0;
+    uint32_t slot_gen = 0;
+    uint32_t slot_seq = 0;
+    if (!slot.tryLoad(completed_len, slot_gen, slot_seq)) {
+        // Slot is either empty or torn. Retry next poll.
+        return false;
+    }
+
+    const uint32_t current_gen =
+        global_generation_.load(std::memory_order_acquire);
+
+    // Step 2 -- Stale packet: data from a previous epoch (before Reset).
+    // Clear the slot so the fresh completion can land safely.  Do NOT pop
+    // the task, do NOT free the chunk, and do NOT advance
+    // completion_consume_seq_ -- the current task is still waiting.
+    if (slot_gen != current_gen) {
+        LOG(WARNING) << "[P2PProxy][Recv] pollRecvCompletionSlot peer="
+                     << op_ctx.peer_rank_
+                     << " front-seq=" << head_task.sequence_
+                     << " GEN_MISMATCH slot.gen=" << slot_gen
+                     << " current_gen=" << current_gen;
+        slot.reset();
+        return true;
+    }
+
+    // Step 3 -- Sequence check: make sure this is the exact completion
+    // we are waiting for.
+    if (slot_seq != head_task.sequence_) {
+        return false;
+    }
+
+    void* src_ptr = head_task.local_addr_;
+    auto* tensor_ptr = static_cast<uint8_t*>(op_ctx.tensor_.data_ptr());
+    void* dst_ptr = tensor_ptr + head_task.tensor_offset_;
+
+    if (is_cpu_) {
+        std::memcpy(dst_ptr, src_ptr, head_task.chunk_len_);
+        recv_pool_.release(head_task.local_addr_);
+        head_task.local_addr_ = nullptr;
+        head_task.state_ = RecvTaskState::kFinished;
+    } else {
+        cudaError_t copy_error =
+            cudaMemcpyAsync(dst_ptr, src_ptr, head_task.chunk_len_,
+                            cudaMemcpyDeviceToDevice, op_ctx.cuda_stream_);
+        TORCH_CHECK(!copy_error, "P2P recv cudaMemcpyAsync failed: ",
+                    cudaGetErrorString(copy_error));
+        const cudaEvent_t pooled_copy_ready_event =
+            lane.copy_ready_events_[static_cast<size_t>(head_task.sequence_ %
+                                                        kP2PControlRingSize)];
+        TORCH_CHECK(pooled_copy_ready_event != nullptr,
+                    "P2P recv pooled copy-ready event is not initialized.");
+        head_task.copy_ready_event_ = pooled_copy_ready_event;
+        copy_error =
+            cudaEventRecord(head_task.copy_ready_event_, op_ctx.cuda_stream_);
+        if (copy_error != cudaSuccess) {
+            head_task.copy_ready_event_ = nullptr;
+            TORCH_CHECK(false, "P2P recv cudaEventRecord failed: ",
+                        cudaGetErrorString(copy_error));
+        }
+        head_task.state_ = RecvTaskState::kCopyOut;
+    }
+
+    slot.reset();
+    ++lane.completion_consume_seq_;
+    return true;
+}
+
 // Receiver state machine
 //
 // Pipeline per peer:
@@ -944,11 +1020,12 @@ bool P2PProxy::stepSend() {
 //   4. Poll the local CompletionLane in order.  When a CompletionSlot
 //      arrives, initiate Copy-Out from RecvPool to the user tensor.
 //   5. Advance every active chunk through its state machine
-//      (Publish done -> Copy-Out done -> erase).
+//      (Advertise -> Copy-Out -> erase).
 //   6. When all chunks are copied out, mark the op complete.
 bool P2PProxy::stepRecv() {
     bool did_work = false;
 
+    // Handle reset first
     for (int peer_rank = 0; peer_rank < size_; ++peer_rank) {
         if (reset_recv_req_[peer_rank].exchange(false,
                                                 std::memory_order_acquire)) {
@@ -957,6 +1034,7 @@ bool P2PProxy::stepRecv() {
         }
     }
 
+    // Drain recv_queue_
     {
         std::lock_guard<std::mutex> lock(recv_queue_mutex_);
         while (!recv_queue_.empty()) {
@@ -968,6 +1046,7 @@ bool P2PProxy::stepRecv() {
         }
     }
 
+    // Promote active op
     for (int peer_rank = 0; peer_rank < size_; ++peer_rank) {
         auto& lane = recv_peer_lanes_[peer_rank];
         if (lane.active_recv_op_.has_value() ||
@@ -981,6 +1060,7 @@ bool P2PProxy::stepRecv() {
         did_work = true;
     }
 
+    // Advance state machine
     for (int peer_rank = 0; peer_rank < size_; ++peer_rank) {
         auto& lane = recv_peer_lanes_[peer_rank];
         if (!lane.active_recv_op_.has_value()) {
@@ -998,93 +1078,27 @@ bool P2PProxy::stepRecv() {
         // In-order completion polling: we only look at the head of the queue
         // because the sender acknowledges chunks in the same order it
         // consumes invitations.
-        auto* completion_lane = getLocalCompletionLane(peer_rank);
-        while (!op_ctx.tasks_.empty()) {
-            auto& task = op_ctx.tasks_.front();
-            auto& slot = completion_lane[task.sequence_ % kP2PControlRingSize];
-
-            // Step 1 -- Try load the slot
-            uint32_t completed_len = 0;
-            uint32_t slot_gen = 0;
-            uint32_t slot_seq = 0;
-            if (!slot.tryLoad(completed_len, slot_gen, slot_seq)) {
-                // Slot is either empty or torn. Retry next poll.
-                break;
-            }
-
-            const uint32_t current_gen =
-                global_generation_.load(std::memory_order_acquire);
-
-            // Step 2 -- Stale packet: data from a previous epoch (before
-            // Reset). Clear the slot so the fresh completion can land safely.
-            // Do NOT pop the task, do NOT free the chunk, and do NOT advance
-            // completion_consume_seq_ -- the current task is still waiting.
-            if (slot_gen != current_gen) {
-                LOG(WARNING) << "[P2PProxy][Recv] stepRecv peer=" << peer_rank
-                             << " front-seq=" << task.sequence_
-                             << " GEN_MISMATCH slot.gen=" << slot_gen
-                             << " current_gen=" << current_gen;
-                slot.reset();
-                did_work = true;
-                break;
-            }
-
-            // Step 3 -- Sequence check: make sure this is the exact completion
-            // we are waiting for.
-            if (slot_seq != task.sequence_) {
-                break;
-            }
-
-            void* src_ptr = task.local_addr_;
-            auto* tensor_ptr = static_cast<uint8_t*>(op_ctx.tensor_.data_ptr());
-            void* dst_ptr = tensor_ptr + task.tensor_offset_;
-
-            if (is_cpu_) {
-                std::memcpy(dst_ptr, src_ptr, task.chunk_len_);
-                recv_pool_.release(task.local_addr_);
-                task.local_addr_ = nullptr;
-                task.state_ = TransferState::kDone;
-            } else {
-                cudaError_t copy_error = cudaMemcpyAsync(
-                    dst_ptr, src_ptr, task.chunk_len_, cudaMemcpyDeviceToDevice,
-                    op_ctx.cuda_stream_);
-                TORCH_CHECK(!copy_error, "P2P recv cudaMemcpyAsync failed: ",
-                            cudaGetErrorString(copy_error));
-                const cudaEvent_t pooled_copy_ready_event =
-                    lane.copy_ready_events_[static_cast<size_t>(
-                        task.sequence_ % kP2PControlRingSize)];
-                TORCH_CHECK(
-                    pooled_copy_ready_event != nullptr,
-                    "P2P recv pooled copy-ready event is not initialized.");
-                task.copy_ready_event_ = pooled_copy_ready_event;
-                copy_error = cudaEventRecord(task.copy_ready_event_,
-                                             op_ctx.cuda_stream_);
-                if (copy_error != cudaSuccess) {
-                    task.copy_ready_event_ = nullptr;
-                    TORCH_CHECK(false, "P2P recv cudaEventRecord failed: ",
-                                cudaGetErrorString(copy_error));
+        if (!op_ctx.tasks_.empty()) {
+            auto& head = op_ctx.tasks_.front();
+            if (head.state_ == RecvTaskState::kWaitCompletion) {
+                if (pollRecvCompletionSlot(op_ctx, lane, head)) {
+                    did_work = true;
                 }
             }
-
-            slot.reset();
-            ++lane.completion_consume_seq_;
-            did_work = true;
-            break;
         }
 
+        // Advance every chunk through the receiver state machine.
         for (auto it = op_ctx.tasks_.begin(); it != op_ctx.tasks_.end();) {
-            if (it->state_ == TransferState::kDone) {
+            did_work |= stepRecvTask(*it);
+            if (it->state_ == RecvTaskState::kFinished) {
                 it = op_ctx.tasks_.erase(it);
                 did_work = true;
-                continue;
+            } else {
+                ++it;
             }
-            if (stepRecvTransferTask(*it)) {
-                did_work = true;
-            }
-            ++it;
         }
 
-        if (isRecvDataPathCompleted(op_ctx)) {
+        if (isRecvOpCompleted(op_ctx)) {
             if (!op_ctx.original_tensor_.is_contiguous()) {
                 (void)op_ctx.original_tensor_.copy_(op_ctx.tensor_);
                 if (!is_cpu_) {

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <limits>
 #include <thread>
+#include "cuda_alike.h"
 #include "memory_location.h"
 #include "pg_utils.h"
 
@@ -164,7 +165,6 @@ P2PProxy::P2PProxy(TransferEngine* engine, const Options& options)
       rank_(options.rank),
       size_(options.size),
       cuda_device_index_(options.cuda_device_index),
-      location_(options.location),
       transfer_timeout_ms_(options.transfer_timeout_ms) {
     if (!is_cpu_ && cuda_device_index_ < 0) {
         int current_device = -1;
@@ -196,12 +196,12 @@ void P2PProxy::extendGroupSizeTo(int new_size) {
     size_ = new_size;
 }
 
-// Allocate fixed-size SendPool, RecvPool and control regions.
+// Allocate control regions only.
+// Send/Recv chunk pools are owned by P2PDeviceWorker and shared across
+// multiple P2PProxy instances on the same device.
 void P2PProxy::allocateResources() {
     TORCH_CHECK(engine_, "P2PProxy engine is null.");
-    if (resources_.send_pool_base_ != nullptr ||
-        resources_.recv_pool_base_ != nullptr ||
-        resources_.publish_region_ != nullptr ||
+    if (resources_.publish_region_ != nullptr ||
         resources_.completion_region_ != nullptr) {
         return;
     }
@@ -209,61 +209,6 @@ void P2PProxy::allocateResources() {
     TORCH_CHECK(size_ > 0, "P2PProxy invalid group size: ", size_);
     TORCH_CHECK(static_cast<size_t>(size_) <= kMaxNumRanks,
                 "P2PProxy group size exceeds kMaxNumRanks: ", size_);
-
-    // Parse pool configuration from environment.
-    pool_bytes_ = getEnv_size_t("MOONCAKE_P2P_POOL_SIZE", kDefaultPoolSize);
-    chunk_size_ = getEnv_size_t("MOONCAKE_P2P_CHUNK_SIZE", kDefaultChunkSize);
-
-    // chunk_len is uint32_t fields in control slots
-    TORCH_CHECK(
-        chunk_size_ > 0 && chunk_size_ <= std::numeric_limits<uint32_t>::max(),
-        "Invalid MOONCAKE_P2P_CHUNK_SIZE: must be > 0 and <= 4GB");
-
-    TORCH_CHECK(
-        pool_bytes_ > 0 && pool_bytes_ % chunk_size_ == 0,
-        "Invalid pool size and chunk size (must hold 'pool_bytes_ > 0 && "
-        "pool_bytes_ % chunk_size_ == 0')");
-
-    num_chunks_ = static_cast<uint32_t>(pool_bytes_ / chunk_size_);
-    TORCH_CHECK(num_chunks_ > 0, "P2PProxy: num_chunks_ must be > 0");
-
-    if (is_cpu_) {
-        resources_.send_pool_base_ = std::malloc(pool_bytes_);
-        TORCH_CHECK(resources_.send_pool_base_ != nullptr,
-                    "Failed to allocate CPU P2P send pool");
-        int rc = engine_->registerLocalMemory(resources_.send_pool_base_,
-                                              pool_bytes_, location_);
-        TORCH_CHECK(rc == 0, "Failed to register CPU P2P send pool");
-
-        resources_.recv_pool_base_ = std::malloc(pool_bytes_);
-        TORCH_CHECK(resources_.recv_pool_base_ != nullptr,
-                    "Failed to allocate CPU P2P recv pool");
-        rc = engine_->registerLocalMemory(resources_.recv_pool_base_,
-                                          pool_bytes_, location_);
-        TORCH_CHECK(rc == 0, "Failed to register CPU P2P recv pool");
-    } else {
-        setCudaDeviceIfNeeded(
-            is_cpu_, cuda_device_index_,
-            "P2PProxy AllocateResources cudaSetDevice failed");
-        cudaError_t err = cudaMalloc(&resources_.send_pool_base_, pool_bytes_);
-        TORCH_CHECK(
-            err == cudaSuccess,
-            "Failed to allocate CUDA P2P send pool: ", cudaGetErrorString(err));
-        int rc = engine_->registerLocalMemory(resources_.send_pool_base_,
-                                              pool_bytes_, location_);
-        TORCH_CHECK(rc == 0, "Failed to register CUDA P2P send pool");
-
-        err = cudaMalloc(&resources_.recv_pool_base_, pool_bytes_);
-        TORCH_CHECK(
-            err == cudaSuccess,
-            "Failed to allocate CUDA P2P recv pool: ", cudaGetErrorString(err));
-        rc = engine_->registerLocalMemory(resources_.recv_pool_base_,
-                                          pool_bytes_, location_);
-        TORCH_CHECK(rc == 0, "Failed to register CUDA P2P recv pool");
-    }
-
-    send_pool_.init(resources_.send_pool_base_, chunk_size_, num_chunks_);
-    recv_pool_.init(resources_.recv_pool_base_, chunk_size_, num_chunks_);
 
     const size_t ctrl_slots =
         kMaxNumRanks * static_cast<size_t>(kP2PControlRingSize);
@@ -363,83 +308,14 @@ void P2PProxy::resetPeerState(int peer_rank) {
 
 // Reset sender state for peer_rank.
 void P2PProxy::performSendReset(int peer_rank) {
-    auto& lane = send_peer_lanes_[peer_rank];
-
-    // Mark all pending ops as failed and clear them.
-    for (auto& pending : lane.pending_send_ops_) {
-        pending.status_->store(OpStatus::kFailed, std::memory_order_release);
-        active_send_tasks_.fetch_sub(1, std::memory_order_release);
-    }
-    lane.pending_send_ops_.clear();
-
-    if (lane.active_send_op_.has_value()) {
-        auto& op_ctx = lane.active_send_op_.value();
-        // Free all remaining batch IDs and staging buffers.
-        for (auto& task : op_ctx.tasks_) {
-            if (task.staging_addr_ != nullptr) {
-                send_pool_.release(task.staging_addr_);
-                task.staging_addr_ = nullptr;
-            }
-            if (task.transfer_batch_id_.has_value()) {
-                engine_->freeBatchID(task.transfer_batch_id_.value());
-            }
-            if (task.completion_batch_id_.has_value()) {
-                engine_->freeBatchID(task.completion_batch_id_.value());
-            }
-        }
-        op_ctx.tasks_.clear();
-        op_ctx.status_->store(OpStatus::kFailed, std::memory_order_release);
-        active_send_tasks_.fetch_sub(1, std::memory_order_release);
-    }
-
-    lane.active_send_op_.reset();
-    lane.publish_consume_seq_ = 0;
-
-    auto* publish_lane = getLocalPublishLane(peer_rank);
-    auto* completion_lane = getLocalCompletionLane(peer_rank);
-    for (uint32_t i = 0; i < kP2PControlRingSize; ++i) {
-        publish_lane[i].reset();
-        completion_lane[i].reset();
-    }
+    resetSendLane(send_peer_lanes_[peer_rank]);
+    resetPeerControlLanes(peer_rank);
 }
 
 // Reset receiver state for peer_rank.
 void P2PProxy::performRecvReset(int peer_rank) {
-    auto& lane = recv_peer_lanes_[peer_rank];
-
-    // Mark all pending ops as failed and clear them.
-    for (auto& pending : lane.pending_recv_ops_) {
-        pending.status_->store(OpStatus::kFailed, std::memory_order_release);
-        active_recv_tasks_.fetch_sub(1, std::memory_order_release);
-    }
-    lane.pending_recv_ops_.clear();
-
-    if (lane.active_recv_op_.has_value()) {
-        auto& op_ctx = lane.active_recv_op_.value();
-        // Free all remaining batch IDs and recv pool chunks.
-        for (auto& task : op_ctx.tasks_) {
-            if (task.local_addr_ != nullptr) {
-                recv_pool_.release(task.local_addr_);
-            }
-            if (task.publish_batch_id_.has_value()) {
-                engine_->freeBatchID(task.publish_batch_id_.value());
-            }
-        }
-        op_ctx.tasks_.clear();
-        op_ctx.status_->store(OpStatus::kFailed, std::memory_order_release);
-        active_recv_tasks_.fetch_sub(1, std::memory_order_release);
-    }
-
-    lane.active_recv_op_.reset();
-    lane.publish_issue_seq_ = 0;
-    lane.completion_consume_seq_ = 0;
-
-    auto* publish_lane = getLocalPublishLane(peer_rank);
-    auto* completion_lane = getLocalCompletionLane(peer_rank);
-    for (uint32_t i = 0; i < kP2PControlRingSize; ++i) {
-        publish_lane[i].reset();
-        completion_lane[i].reset();
-    }
+    resetRecvLane(recv_peer_lanes_[peer_rank]);
+    resetPeerControlLanes(peer_rank);
 }
 
 void P2PProxy::reportBrokenPeer(int peer_rank) {
@@ -452,6 +328,82 @@ void P2PProxy::reportBrokenPeer(int peer_rank) {
                << " as broken during P2P transfer.";
 }
 
+void P2PProxy::releaseSendTaskResources(SendTransferTask& task) const {
+    if (task.staging_addr_ != nullptr) {
+        if (send_pool_) send_pool_->release(task.staging_addr_);
+        task.staging_addr_ = nullptr;
+    }
+    if (task.transfer_batch_id_.has_value()) {
+        if (engine_) engine_->freeBatchID(task.transfer_batch_id_.value());
+        task.transfer_batch_id_.reset();
+    }
+    if (task.completion_batch_id_.has_value()) {
+        if (engine_) engine_->freeBatchID(task.completion_batch_id_.value());
+        task.completion_batch_id_.reset();
+    }
+}
+
+void P2PProxy::releaseRecvTaskResources(RecvTransferTask& task) const {
+    if (task.local_addr_ != nullptr) {
+        if (recv_pool_) recv_pool_->release(task.local_addr_);
+        task.local_addr_ = nullptr;
+    }
+    if (task.publish_batch_id_.has_value()) {
+        if (engine_) engine_->freeBatchID(task.publish_batch_id_.value());
+        task.publish_batch_id_.reset();
+    }
+}
+
+void P2PProxy::resetSendLane(SendPeerLane& lane) {
+    for (auto& pending : lane.pending_send_ops_) {
+        pending.status_->store(OpStatus::kFailed, std::memory_order_release);
+        active_send_tasks_.fetch_sub(1, std::memory_order_release);
+    }
+    lane.pending_send_ops_.clear();
+
+    if (lane.active_send_op_.has_value()) {
+        auto& op_ctx = lane.active_send_op_.value();
+        for (auto& task : op_ctx.tasks_) {
+            releaseSendTaskResources(task);
+        }
+        op_ctx.tasks_.clear();
+        op_ctx.status_->store(OpStatus::kFailed, std::memory_order_release);
+        active_send_tasks_.fetch_sub(1, std::memory_order_release);
+        lane.active_send_op_.reset();
+    }
+    lane.publish_consume_seq_ = 0;
+}
+
+void P2PProxy::resetRecvLane(RecvPeerLane& lane) {
+    for (auto& pending : lane.pending_recv_ops_) {
+        pending.status_->store(OpStatus::kFailed, std::memory_order_release);
+        active_recv_tasks_.fetch_sub(1, std::memory_order_release);
+    }
+    lane.pending_recv_ops_.clear();
+
+    if (lane.active_recv_op_.has_value()) {
+        auto& op_ctx = lane.active_recv_op_.value();
+        for (auto& task : op_ctx.tasks_) {
+            releaseRecvTaskResources(task);
+        }
+        op_ctx.tasks_.clear();
+        op_ctx.status_->store(OpStatus::kFailed, std::memory_order_release);
+        active_recv_tasks_.fetch_sub(1, std::memory_order_release);
+        lane.active_recv_op_.reset();
+    }
+    lane.publish_issue_seq_ = 0;
+    lane.completion_consume_seq_ = 0;
+}
+
+void P2PProxy::resetPeerControlLanes(int peer_rank) {
+    auto* publish_lane = getLocalPublishLane(peer_rank);
+    auto* completion_lane = getLocalCompletionLane(peer_rank);
+    for (uint32_t i = 0; i < kP2PControlRingSize; ++i) {
+        publish_lane[i].reset();
+        completion_lane[i].reset();
+    }
+}
+
 void P2PProxy::releaseResources() {
     TORCH_CHECK(!resource_abandoned_,
                 "Should not release abandoned resources.");
@@ -460,93 +412,52 @@ void P2PProxy::releaseResources() {
                           "P2PProxy ReleaseResources cudaSetDevice failed");
 
     for (size_t i = 0; i < kMaxNumRanks; ++i) {
+        // Reset lane
         auto& send_lane = send_peer_lanes_[i];
-        for (auto& copy_ready_event : send_lane.copy_ready_events_) {
-            if (copy_ready_event == nullptr) {
-                continue;
-            }
-            const cudaError_t destroy_error =
-                cudaEventDestroy(copy_ready_event);
-            TORCH_CHECK(destroy_error == cudaSuccess,
-                        "Failed to destroy pooled send copy-ready event: ",
-                        cudaGetErrorString(destroy_error));
-            copy_ready_event = nullptr;
-        }
-        send_lane.pending_send_ops_.clear();
-
-        if (send_lane.active_send_op_.has_value()) {
-            auto& op_ctx = send_lane.active_send_op_.value();
-            for (auto& task : op_ctx.tasks_) {
-                if (task.staging_addr_ != nullptr) {
-                    send_pool_.release(task.staging_addr_);
-                    task.staging_addr_ = nullptr;
-                }
-            }
-        }
-        send_lane.active_send_op_.reset();
-
         auto& recv_lane = recv_peer_lanes_[i];
-        for (auto& copy_ready_event : recv_lane.copy_ready_events_) {
-            if (copy_ready_event == nullptr) {
-                continue;
-            }
-            const cudaError_t destroy_error =
-                cudaEventDestroy(copy_ready_event);
-            TORCH_CHECK(destroy_error == cudaSuccess,
-                        "Failed to destroy pooled recv copy-ready event: ",
-                        cudaGetErrorString(destroy_error));
-            copy_ready_event = nullptr;
-        }
-        recv_lane.pending_recv_ops_.clear();
-        recv_lane.active_recv_op_.reset();
-    }
+        resetSendLane(send_lane);
+        resetRecvLane(recv_lane);
 
-    if (!engine_) {
-        return;
+        // Destroy cuda events
+        auto destroyEvents = [](auto& events) {
+            for (auto& ev : events) {
+                if (ev == nullptr) continue;
+                const cudaError_t err = cudaEventDestroy(ev);
+                TORCH_CHECK(err == cudaSuccess,
+                            "Failed to destroy pooled copy-ready event: ",
+                            cudaGetErrorString(err));
+                ev = nullptr;
+            }
+        };
+        destroyEvents(send_lane.copy_ready_events_);
+        destroyEvents(recv_lane.copy_ready_events_);
     }
 
     if (resources_.publish_staging_buf_ != nullptr) {
-        engine_->unregisterLocalMemory(resources_.publish_staging_buf_);
+        if (engine_)
+            engine_->unregisterLocalMemory(resources_.publish_staging_buf_);
         delete[] resources_.publish_staging_buf_;
         resources_.publish_staging_buf_ = nullptr;
     }
 
     if (resources_.completion_staging_buf_ != nullptr) {
-        engine_->unregisterLocalMemory(resources_.completion_staging_buf_);
+        if (engine_)
+            engine_->unregisterLocalMemory(resources_.completion_staging_buf_);
         delete[] resources_.completion_staging_buf_;
         resources_.completion_staging_buf_ = nullptr;
     }
 
     if (resources_.publish_region_ != nullptr) {
-        engine_->unregisterLocalMemory(resources_.publish_region_);
+        if (engine_) engine_->unregisterLocalMemory(resources_.publish_region_);
         delete[] resources_.publish_region_;
         resources_.publish_region_ = nullptr;
     }
 
     if (resources_.completion_region_ != nullptr) {
-        engine_->unregisterLocalMemory(resources_.completion_region_);
+        if (engine_)
+            engine_->unregisterLocalMemory(resources_.completion_region_);
         delete[] resources_.completion_region_;
         resources_.completion_region_ = nullptr;
-    }
-
-    if (resources_.send_pool_base_ != nullptr) {
-        engine_->unregisterLocalMemory(resources_.send_pool_base_);
-        if (is_cpu_) {
-            std::free(resources_.send_pool_base_);
-        } else {
-            cudaFree(resources_.send_pool_base_);
-        }
-        resources_.send_pool_base_ = nullptr;
-    }
-
-    if (resources_.recv_pool_base_ != nullptr) {
-        engine_->unregisterLocalMemory(resources_.recv_pool_base_);
-        if (is_cpu_) {
-            std::free(resources_.recv_pool_base_);
-        } else {
-            cudaFree(resources_.recv_pool_base_);
-        }
-        resources_.recv_pool_base_ = nullptr;
     }
 }
 
@@ -679,7 +590,7 @@ bool P2PProxy::tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane) {
         return false;
     }
 
-    void* local_addr = recv_pool_.acquire();
+    void* local_addr = recv_pool_->acquire();
     if (local_addr == nullptr) {
         // No free recv chunk, retry on the next iteration
         return false;
@@ -777,7 +688,7 @@ bool P2PProxy::stepRecvCopyOut(RecvTransferTask& task) {
     cudaError_t query_error = cudaEventQuery(task.copy_ready_event_);
     if (query_error == cudaSuccess) {
         task.copy_ready_event_ = nullptr;
-        recv_pool_.release(task.local_addr_);
+        recv_pool_->release(task.local_addr_);
         task.local_addr_ = nullptr;
         task.state_ = RecvTaskState::kFinished;
         return true;
@@ -847,7 +758,7 @@ bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
         return false;
     }
 
-    void* staging_addr = send_pool_.acquire();
+    void* staging_addr = send_pool_->acquire();
     if (staging_addr == nullptr) {
         return false;
     }
@@ -1026,7 +937,7 @@ bool P2PProxy::stepSendCompletion(SendOpContext& op_ctx,
     if (completion_status.s == TransferStatusEnum::COMPLETED) {
         engine_->freeBatchID(task.completion_batch_id_.value());
         task.completion_batch_id_.reset();
-        send_pool_.release(task.staging_addr_);
+        send_pool_->release(task.staging_addr_);
         task.staging_addr_ = nullptr;
         task.state_ = SendTaskState::kFinished;
         did_work = true;
@@ -1211,7 +1122,7 @@ bool P2PProxy::pollRecvCompletionSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
 
     if (is_cpu_) {
         std::memcpy(dst_ptr, src_ptr, head_task.chunk_len_);
-        recv_pool_.release(head_task.local_addr_);
+        recv_pool_->release(head_task.local_addr_);
         head_task.local_addr_ = nullptr;
         head_task.state_ = RecvTaskState::kFinished;
     } else {
@@ -1362,8 +1273,12 @@ bool P2PProxy::stepRecv() {
     return did_work;
 }
 
-void P2PProxy::setDeviceWorker(P2PDeviceWorker* worker) {
+void P2PProxy::attachToWorker(P2PDeviceWorker* worker, P2PChunkPool* send,
+                              P2PChunkPool* recv, size_t chunk_size) {
     device_worker_ = worker;
+    send_pool_ = send;
+    recv_pool_ = recv;
+    chunk_size_ = chunk_size;
 }
 
 bool P2PProxy::hasActiveSendWork() const {
@@ -1423,8 +1338,21 @@ void P2PDeviceWorker::stop() {
     }
 }
 
+P2PDeviceWorker::P2PDeviceWorker(TransferEngine* engine,
+                                 const std::string& location, bool is_cpu,
+                                 int cuda_device_index)
+    : is_cpu_(is_cpu), cuda_device_index_(cuda_device_index) {
+    initPools(engine, location);
+    start();
+}
+
+P2PDeviceWorker::~P2PDeviceWorker() {
+    stop();
+    releasePools();
+}
+
 void P2PDeviceWorker::registerProxy(const std::shared_ptr<P2PProxy>& proxy) {
-    proxy->setDeviceWorker(this);
+    proxy->attachToWorker(this, &send_pool_, &recv_pool_, chunk_size_);
     {
         std::lock_guard<std::mutex> lock(proxies_mutex_);
         proxies_.emplace_back(proxy);
@@ -1448,9 +1376,92 @@ void P2PDeviceWorker::removeProxy(const std::shared_ptr<P2PProxy>& proxy) {
         std::lock_guard<std::mutex> r_lock(recv_wakeup_mutex_);
         proxies_version_.fetch_add(1, std::memory_order_release);
     }
-    proxy->setDeviceWorker(nullptr);
     send_wakeup_cv_.notify_one();
     recv_wakeup_cv_.notify_one();
+}
+
+void P2PDeviceWorker::initPools(TransferEngine* engine,
+                                const std::string& location) {
+    engine_ = engine;
+
+    // Parse from environment variables
+    pool_bytes_ = getEnv_size_t("MOONCAKE_P2P_POOL_SIZE", kDefaultPoolSize);
+    chunk_size_ = getEnv_size_t("MOONCAKE_P2P_CHUNK_SIZE", kDefaultChunkSize);
+
+    // chunk_len is uint32_t fields in control slots
+    TORCH_CHECK(
+        chunk_size_ > 0 && chunk_size_ <= std::numeric_limits<uint32_t>::max(),
+        "Invalid MOONCAKE_P2P_CHUNK_SIZE: must be > 0 and <= 4GB");
+
+    TORCH_CHECK(
+        pool_bytes_ > 0 && pool_bytes_ % chunk_size_ == 0,
+        "Invalid pool size and chunk size (must hold 'pool_bytes_ > 0 && "
+        "pool_bytes_ % chunk_size_ == 0')");
+
+    num_chunks_ = static_cast<uint32_t>(pool_bytes_ / chunk_size_);
+    TORCH_CHECK(num_chunks_ > 0, "P2PDeviceWorker: num_chunks_ must be > 0");
+
+    if (is_cpu_) {
+        send_pool_base_ = std::malloc(pool_bytes_);
+        TORCH_CHECK(send_pool_base_ != nullptr,
+                    "Failed to allocate CPU P2P send pool");
+        int rc =
+            engine->registerLocalMemory(send_pool_base_, pool_bytes_, location);
+        TORCH_CHECK(rc == 0, "Failed to register CPU P2P send pool");
+
+        recv_pool_base_ = std::malloc(pool_bytes_);
+        TORCH_CHECK(recv_pool_base_ != nullptr,
+                    "Failed to allocate CPU P2P recv pool");
+        rc =
+            engine->registerLocalMemory(recv_pool_base_, pool_bytes_, location);
+        TORCH_CHECK(rc == 0, "Failed to register CPU P2P recv pool");
+    } else {
+        setCudaDeviceIfNeeded(is_cpu_, cuda_device_index_,
+                              "P2PDeviceWorker initPools cudaSetDevice failed");
+        cudaError_t err = cudaMalloc(&send_pool_base_, pool_bytes_);
+        TORCH_CHECK(
+            err == cudaSuccess,
+            "Failed to allocate CUDA P2P send pool: ", cudaGetErrorString(err));
+        int rc =
+            engine->registerLocalMemory(send_pool_base_, pool_bytes_, location);
+        TORCH_CHECK(rc == 0, "Failed to register CUDA P2P send pool");
+
+        err = cudaMalloc(&recv_pool_base_, pool_bytes_);
+        TORCH_CHECK(
+            err == cudaSuccess,
+            "Failed to allocate CUDA P2P recv pool: ", cudaGetErrorString(err));
+        rc =
+            engine->registerLocalMemory(recv_pool_base_, pool_bytes_, location);
+        TORCH_CHECK(rc == 0, "Failed to register CUDA P2P recv pool");
+    }
+
+    send_pool_.init(send_pool_base_, chunk_size_, num_chunks_);
+    recv_pool_.init(recv_pool_base_, chunk_size_, num_chunks_);
+}
+
+void P2PDeviceWorker::releasePools() {
+    setCudaDeviceIfNeeded(is_cpu_, cuda_device_index_,
+                          "P2PDeviceWorker releasePools cudaSetDevice failed");
+
+    if (send_pool_base_ != nullptr) {
+        if (engine_) engine_->unregisterLocalMemory(send_pool_base_);
+        if (is_cpu_) {
+            std::free(send_pool_base_);
+        } else {
+            cudaFree(send_pool_base_);
+        }
+        send_pool_base_ = nullptr;
+    }
+
+    if (recv_pool_base_ != nullptr) {
+        if (engine_) engine_->unregisterLocalMemory(recv_pool_base_);
+        if (is_cpu_) {
+            std::free(recv_pool_base_);
+        } else {
+            cudaFree(recv_pool_base_);
+        }
+        recv_pool_base_ = nullptr;
+    }
 }
 
 template <typename HasWorkFn, typename StepWorkFn>
@@ -1590,7 +1601,8 @@ void P2PDeviceWorker::wakeUpRecv() {
     recv_wakeup_cv_.notify_one();
 }
 
-std::shared_ptr<P2PDeviceWorker> P2PDeviceWorkerManager::getCPUWorker() {
+std::shared_ptr<P2PDeviceWorker> P2PDeviceWorkerManager::getCPUWorker(
+    TransferEngine* engine) {
     std::lock_guard<std::mutex> lock(manager_mutex_);
 
     auto it = workers_.find(CPUWorkerID);
@@ -1598,14 +1610,14 @@ std::shared_ptr<P2PDeviceWorker> P2PDeviceWorkerManager::getCPUWorker() {
         if (auto ptr = it->second.lock()) return ptr;
     }
 
-    auto worker =
-        std::make_shared<P2PDeviceWorker>(/* is_cpu */ true, CPUWorkerID);
+    auto worker = std::make_shared<P2PDeviceWorker>(
+        engine, kWildcardLocation, /* is_cpu */ true, CPUWorkerID);
     workers_[CPUWorkerID] = worker;
     return worker;
 }
 
 std::shared_ptr<P2PDeviceWorker> P2PDeviceWorkerManager::getCUDAWorker(
-    int cuda_device_index) {
+    int cuda_device_index, TransferEngine* engine) {
     std::lock_guard<std::mutex> lock(manager_mutex_);
 
     auto it = workers_.find(cuda_device_index);
@@ -1613,8 +1625,9 @@ std::shared_ptr<P2PDeviceWorker> P2PDeviceWorkerManager::getCUDAWorker(
         if (auto ptr = it->second.lock()) return ptr;
     }
 
-    auto worker = std::make_shared<P2PDeviceWorker>(/* is_cpu */ false,
-                                                    cuda_device_index);
+    auto worker = std::make_shared<P2PDeviceWorker>(
+        engine, GPU_PREFIX + std::to_string(cuda_device_index),
+        /* is_cpu */ false, cuda_device_index);
     workers_[cuda_device_index] = worker;
     return worker;
 }

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -39,7 +39,8 @@ P2PProxy::P2PProxy(TransferEngine* engine, const Options& options)
       rank_(options.rank),
       size_(options.size),
       cuda_device_index_(options.cuda_device_index),
-      location_(options.location) {
+      location_(options.location),
+      transfer_timeout_ms_(options.transfer_timeout_ms) {
     if (!is_cpu_ && cuda_device_index_ < 0) {
         int current_device = -1;
         const cudaError_t get_device_error = cudaGetDevice(&current_device);
@@ -66,9 +67,6 @@ void P2PProxy::bindMeta(const std::shared_ptr<TransferGroupMeta>& meta) {
 }
 
 // Allocate fixed-size SendPool, RecvPool and control regions.
-// Both pools are registered as a single MR each, eliminating per-rank MR
-// proliferation.  Control regions are sized for kMaxNumRanks peers with
-// kP2PControlRingSize slots per peer.
 void P2PProxy::allocateResources() {
     TORCH_CHECK(engine_, "P2PProxy engine is null.");
     if (resources_.send_pool_base_ != nullptr ||
@@ -133,7 +131,9 @@ void P2PProxy::allocateResources() {
         resources_.completion_region_[i].reset();
     }
 
-    global_generation_.store(1, std::memory_order_release);
+    for (size_t i = 0; i < kMaxNumRanks; ++i) {
+        peer_generation_[i].store(1, std::memory_order_release);
+    }
 
     for (size_t i = 0; i < kMaxNumRanks; ++i) {
         send_peer_lanes_[i].pending_send_ops_.clear();
@@ -200,10 +200,17 @@ void P2PProxy::resetPeerState(int peer_rank) {
                 "ResetPeerState: peer_rank out of range: ", peer_rank,
                 " size: ", size_);
 
-    // Bump the generation once per peer Reset.
-    global_generation_.fetch_add(1, std::memory_order_acq_rel);
+    // Generation update:
+    //   We bump generation_ so that any slots still in flight from the
+    //   old session (written by the sender/receiver before it learned about
+    //   the Reset) are recognized as stale and skipped.
+    peer_generation_[peer_rank].fetch_add(1, std::memory_order_acq_rel);
+
+    // Request reset
     reset_send_req_[peer_rank].store(true, std::memory_order_release);
     reset_recv_req_[peer_rank].store(true, std::memory_order_release);
+
+    // Wake up worker
     if (device_worker_) {
         device_worker_->wakeUpSend();
         device_worker_->wakeUpRecv();
@@ -211,25 +218,33 @@ void P2PProxy::resetPeerState(int peer_rank) {
 }
 
 // Reset sender state for peer_rank.
-// Generation update:
-//   We bump generation_ so that any PublishSlots still in flight from the
-//   old session (written by the receiver before it learned about the Reset)
-//   are recognized as stale and skipped.  We also reinitialize the local
-//   control lanes with the new generation so that our own CompletionSlot
-//   writes (if any are still in flight) can be identified as stale by the
-//   receiver.
 void P2PProxy::performSendReset(int peer_rank) {
     auto& lane = send_peer_lanes_[peer_rank];
+
+    // Mark all pending ops as failed and clear them.
+    for (auto& pending : lane.pending_send_ops_) {
+        pending.status_->store(OpStatus::kFailed, std::memory_order_release);
+        active_send_tasks_.fetch_sub(1, std::memory_order_release);
+    }
     lane.pending_send_ops_.clear();
 
     if (lane.active_send_op_.has_value()) {
         auto& op_ctx = lane.active_send_op_.value();
+        // Free all remaining batch IDs and staging buffers.
         for (auto& task : op_ctx.tasks_) {
             if (task.staging_addr_ != nullptr) {
                 send_pool_.release(task.staging_addr_);
                 task.staging_addr_ = nullptr;
             }
+            if (task.transfer_batch_id_.has_value()) {
+                engine_->freeBatchID(task.transfer_batch_id_.value());
+            }
+            if (task.completion_batch_id_.has_value()) {
+                engine_->freeBatchID(task.completion_batch_id_.value());
+            }
         }
+        op_ctx.tasks_.clear();
+        op_ctx.status_->store(OpStatus::kFailed, std::memory_order_release);
         active_send_tasks_.fetch_sub(1, std::memory_order_release);
     }
 
@@ -247,15 +262,27 @@ void P2PProxy::performSendReset(int peer_rank) {
 // Reset receiver state for peer_rank.
 void P2PProxy::performRecvReset(int peer_rank) {
     auto& lane = recv_peer_lanes_[peer_rank];
+
+    // Mark all pending ops as failed and clear them.
+    for (auto& pending : lane.pending_recv_ops_) {
+        pending.status_->store(OpStatus::kFailed, std::memory_order_release);
+        active_recv_tasks_.fetch_sub(1, std::memory_order_release);
+    }
     lane.pending_recv_ops_.clear();
 
     if (lane.active_recv_op_.has_value()) {
         auto& op_ctx = lane.active_recv_op_.value();
+        // Free all remaining batch IDs and recv pool chunks.
         for (auto& task : op_ctx.tasks_) {
             if (task.local_addr_ != nullptr) {
                 recv_pool_.release(task.local_addr_);
             }
+            if (task.publish_batch_id_.has_value()) {
+                engine_->freeBatchID(task.publish_batch_id_.value());
+            }
         }
+        op_ctx.tasks_.clear();
+        op_ctx.status_->store(OpStatus::kFailed, std::memory_order_release);
         active_recv_tasks_.fetch_sub(1, std::memory_order_release);
     }
 
@@ -269,6 +296,16 @@ void P2PProxy::performRecvReset(int peer_rank) {
         publish_lane[i].reset();
         completion_lane[i].reset();
     }
+}
+
+void P2PProxy::reportBrokenPeer(int peer_rank) {
+    resetPeerState(peer_rank);
+    // Set peerConnected to notify the connection poller to reconnect it.
+    meta_->peerConnected[peer_rank] = false;
+    meta_->activeRanks[peer_rank] = false;
+    meta_->activeRanksTensor[peer_rank] = 0;
+    LOG(ERROR) << "Rank " << meta_->rank << " marking peer " << peer_rank
+               << " as broken during P2P transfer.";
 }
 
 void P2PProxy::releaseResources() {
@@ -400,15 +437,18 @@ P2PProxy::SendTransferTask::SendTransferTask(
       staging_addr_(staging_addr_in),
       remote_addr_(remote_addr_in),
       sequence_(sequence_in),
-      generation_(generation_in) {}
+      generation_(generation_in) {
+    last_update_time_ = std::chrono::steady_clock::now();
+}
 
 P2PProxy::SendOpContext::SendOpContext(SendOp&& op_in)
-    : tensor_(std::move(op_in.tensor_)),
+    : status_(std::move(op_in.status_)),
+      tensor_(std::move(op_in.tensor_)),
       peer_rank_(op_in.peer_rank_),
-      cuda_stream_(op_in.cuda_stream_),
-      completed_(std::move(op_in.completed_)) {
+      cuda_stream_(op_in.cuda_stream_) {
     total_bytes_ =
         tensor_.numel() * static_cast<uint64_t>(tensor_.element_size());
+    last_update_time_ = std::chrono::steady_clock::now();
 }
 
 P2PProxy::RecvTransferTask::RecvTransferTask(uint64_t tensor_offset_in,
@@ -420,14 +460,16 @@ P2PProxy::RecvTransferTask::RecvTransferTask(uint64_t tensor_offset_in,
       chunk_len_(chunk_len_in),
       local_addr_(local_addr_in),
       sequence_(sequence_in),
-      generation_(generation_in) {}
+      generation_(generation_in) {
+    last_update_time_ = std::chrono::steady_clock::now();
+}
 
 P2PProxy::RecvOpContext::RecvOpContext(RecvOp&& op_in)
-    : tensor_(std::move(op_in.tensor_)),
+    : status_(std::move(op_in.status_)),
+      tensor_(std::move(op_in.tensor_)),
       original_tensor_(std::move(op_in.original_tensor_)),
       peer_rank_(op_in.peer_rank_),
-      cuda_stream_(op_in.cuda_stream_),
-      completed_(std::move(op_in.completed_)) {
+      cuda_stream_(op_in.cuda_stream_) {
     total_bytes_ =
         tensor_.numel() * static_cast<uint64_t>(tensor_.element_size());
 }
@@ -506,7 +548,7 @@ bool P2PProxy::tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane) {
         getRemotePublishSlot(op_ctx.peer_rank_, seq);
 
     const uint32_t current_gen =
-        global_generation_.load(std::memory_order_acquire);
+        peer_generation_[op_ctx.peer_rank_].load(std::memory_order_acquire);
     op_ctx.tasks_.emplace_back(op_ctx.bytes_advertised_, chunk_len, local_addr,
                                seq, current_gen);
     auto& task = op_ctx.tasks_.back();
@@ -524,6 +566,7 @@ bool P2PProxy::tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane) {
                       .length = sizeof(PublishSlot),
                   }});
     task.publish_batch_id_ = batch_id;
+    task.last_update_time_ = std::chrono::steady_clock::now();
 
     ++lane.publish_issue_seq_;
     op_ctx.bytes_advertised_ += chunk_len;
@@ -546,6 +589,7 @@ bool P2PProxy::stepRecvTask(RecvTransferTask& task) {
             return stepRecvCopyOut(task);
 
         case RecvTaskState::kFinished:
+        case RecvTaskState::kFailed:
             return false;
     }
     return false;
@@ -563,13 +607,17 @@ bool P2PProxy::stepRecvAdvertise(RecvTransferTask& task) {
         engine_->freeBatchID(task.publish_batch_id_.value());
         task.publish_batch_id_.reset();
         task.state_ = RecvTaskState::kWaitCompletion;
+        task.last_update_time_ = std::chrono::steady_clock::now();
         return true;
     }
 
-    if (publish_status.s == TransferStatusEnum::FAILED) {
+    if (publish_status.s == TransferStatusEnum::FAILED || isTimeout(task)) {
+        LOG(ERROR) << "P2P publish transfer failed/timeout, seq="
+                   << task.sequence_;
         engine_->freeBatchID(task.publish_batch_id_.value());
         task.publish_batch_id_.reset();
-        TORCH_CHECK(false, "P2P publish transfer failed.");
+        task.state_ = RecvTaskState::kFailed;
+        return true;
     }
     return false;
 }
@@ -608,6 +656,13 @@ bool P2PProxy::stepRecvCopyOut(RecvTransferTask& task) {
 // it, and advance the cursor.  If the pool is full or no invitation has
 // arrived we return false immediately (non-blocking).
 bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
+    // Check for timeout while waiting for the peer's PublishSlot.
+    if (isTimeout(op_ctx)) {
+        LOG(ERROR) << "P2P wait invitation timeout peer=" << op_ctx.peer_rank_;
+        op_ctx.status_->store(OpStatus::kFailed, std::memory_order_release);
+        return false;
+    }
+
     if (op_ctx.bytes_staged_ >= op_ctx.total_bytes_) {
         return false;
     }
@@ -635,7 +690,7 @@ bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
     // but DO NOT advance the consume cursor -- the peer will re-send the
     // same sequence after the Reset.
     const uint32_t current_gen =
-        global_generation_.load(std::memory_order_acquire);
+        peer_generation_[op_ctx.peer_rank_].load(std::memory_order_acquire);
     if (slot_gen != current_gen) {
         LOG(WARNING) << "[P2PProxy][Send] tryIssueSendTask peer="
                      << op_ctx.peer_rank_ << " STALE_GEN seq=" << seq
@@ -697,6 +752,7 @@ bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
 
     ++lane.publish_consume_seq_;
     op_ctx.bytes_staged_ += task.chunk_len_;
+    task.last_update_time_ = std::chrono::steady_clock::now();
     return true;
 }
 
@@ -715,6 +771,7 @@ bool P2PProxy::stepSendTask(SendOpContext& op_ctx, SendTransferTask& task) {
             return stepSendCompletion(op_ctx, task);
 
         case SendTaskState::kFinished:
+        case SendTaskState::kFailed:
             return false;
     }
     return false;
@@ -728,6 +785,7 @@ bool P2PProxy::stepSendCopyIn(SendTransferTask& task) {
     if (task.copy_ready_event_ == nullptr) {
         // CPU case
         task.state_ = SendTaskState::kWriteRemote;
+        task.last_update_time_ = std::chrono::steady_clock::now();
         return true;
     }
 
@@ -740,6 +798,7 @@ bool P2PProxy::stepSendCopyIn(SendTransferTask& task) {
 
     if (query_error == cudaSuccess) {
         task.state_ = SendTaskState::kWriteRemote;
+        task.last_update_time_ = std::chrono::steady_clock::now();
         return true;
     }
 
@@ -764,6 +823,7 @@ bool P2PProxy::stepSendWriteRemote(SendOpContext& op_ctx,
                           .length = task.chunk_len_,
                       }});
         task.transfer_batch_id_ = batch_id;
+        task.last_update_time_ = std::chrono::steady_clock::now();
         did_work = true;
     }
 
@@ -774,12 +834,16 @@ bool P2PProxy::stepSendWriteRemote(SendOpContext& op_ctx,
         engine_->freeBatchID(task.transfer_batch_id_.value());
         task.transfer_batch_id_.reset();
         task.state_ = SendTaskState::kCompletion;
+        task.last_update_time_ = std::chrono::steady_clock::now();
         did_work = true;
-    } else if (transfer_status.s == TransferStatusEnum::FAILED) {
+    } else if (transfer_status.s == TransferStatusEnum::FAILED ||
+               isTimeout(task)) {
+        LOG(ERROR) << "P2P send transfer failed/timeout, peer="
+                   << op_ctx.peer_rank_ << ", seq=" << task.sequence_;
         engine_->freeBatchID(task.transfer_batch_id_.value());
         task.transfer_batch_id_.reset();
-        TORCH_CHECK(false, "P2P send transfer failed.");
-        return false;
+        task.state_ = SendTaskState::kFailed;
+        did_work = true;
     }
 
     return did_work;
@@ -810,6 +874,7 @@ bool P2PProxy::stepSendCompletion(SendOpContext& op_ctx,
                           .length = sizeof(CompletionSlot),
                       }});
         task.completion_batch_id_ = batch_id;
+        task.last_update_time_ = std::chrono::steady_clock::now();
         did_work = true;
     }
 
@@ -822,13 +887,15 @@ bool P2PProxy::stepSendCompletion(SendOpContext& op_ctx,
         send_pool_.release(task.staging_addr_);
         task.staging_addr_ = nullptr;
         task.state_ = SendTaskState::kFinished;
-        return true;
-    }
-    if (completion_status.s == TransferStatusEnum::FAILED) {
+        did_work = true;
+    } else if (completion_status.s == TransferStatusEnum::FAILED ||
+               isTimeout(task)) {
+        LOG(ERROR) << "P2P completion transfer failed/timeout, peer="
+                   << op_ctx.peer_rank_ << ", seq=" << task.sequence_;
         engine_->freeBatchID(task.completion_batch_id_.value());
         task.completion_batch_id_.reset();
-        TORCH_CHECK(false, "P2P completion transfer failed.");
-        return false;
+        task.state_ = SendTaskState::kFailed;
+        did_work = true;
     }
 
     return did_work;
@@ -888,7 +955,8 @@ bool P2PProxy::stepSend() {
         SendOpContext op_ctx = std::move(lane.pending_send_ops_.front());
         lane.pending_send_ops_.pop_front();
         if (op_ctx.total_bytes_ == 0) {
-            op_ctx.completed_->store(true, std::memory_order_release);
+            op_ctx.status_->store(OpStatus::kSuccess,
+                                  std::memory_order_release);
             active_send_tasks_.fetch_sub(1, std::memory_order_release);
             did_work = true;
             continue;
@@ -911,20 +979,35 @@ bool P2PProxy::stepSend() {
         }
 
         // Advance every chunk through the sender state machine.
-        for (auto it = op_ctx.tasks_.begin(); it != op_ctx.tasks_.end();) {
-            if (stepSendTask(op_ctx, *it)) {
-                did_work = true;
-            }
-            if (it->state_ == SendTaskState::kFinished) {
-                it = op_ctx.tasks_.erase(it);
-                did_work = true;
-            } else {
-                ++it;
+        // send op may fail due to wait invitation timeout in tryIssueSendTask.
+        auto op_status = op_ctx.status_->load(std::memory_order_acquire);
+        bool op_failed = op_status == OpStatus::kFailed;
+        if (!op_failed) {
+            for (auto it = op_ctx.tasks_.begin(); it != op_ctx.tasks_.end();) {
+                if (stepSendTask(op_ctx, *it)) {
+                    did_work = true;
+                }
+                if (it->state_ == SendTaskState::kFinished) {
+                    it = op_ctx.tasks_.erase(it);
+                    did_work = true;
+                } else if (it->state_ == SendTaskState::kFailed) {
+                    op_failed = true;
+                    break;
+                } else {
+                    ++it;
+                }
             }
         }
 
+        if (op_failed) {
+            reportBrokenPeer(peer_rank);
+            did_work = true;
+            continue;
+        }
+
         if (isSendOpCompleted(op_ctx)) {
-            op_ctx.completed_->store(true, std::memory_order_release);
+            op_ctx.status_->store(OpStatus::kSuccess,
+                                  std::memory_order_release);
             lane.active_send_op_.reset();
             active_send_tasks_.fetch_sub(1, std::memory_order_release);
             did_work = true;
@@ -939,6 +1022,14 @@ bool P2PProxy::stepSend() {
 // Returns true if a completion was processed (including stale-slot clearing).
 bool P2PProxy::pollRecvCompletionSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
                                       RecvTransferTask& head_task) {
+    // Check for timeout while waiting for the peer's CompletionSlot.
+    if (isTimeout(head_task)) {
+        LOG(ERROR) << "P2P recv completion timeout peer=" << op_ctx.peer_rank_
+                   << " seq=" << head_task.sequence_;
+        head_task.state_ = RecvTaskState::kFailed;
+        return true;
+    }
+
     auto* completion_lane = getLocalCompletionLane(op_ctx.peer_rank_);
     auto& slot = completion_lane[head_task.sequence_ % kP2PControlRingSize];
 
@@ -952,12 +1043,13 @@ bool P2PProxy::pollRecvCompletionSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
     }
 
     const uint32_t current_gen =
-        global_generation_.load(std::memory_order_acquire);
+        peer_generation_[op_ctx.peer_rank_].load(std::memory_order_acquire);
 
     // Step 2 -- Stale packet: data from a previous epoch (before Reset).
     // Clear the slot so the fresh completion can land safely.  Do NOT pop
     // the task, do NOT free the chunk, and do NOT advance
-    // completion_consume_seq_ -- the current task is still waiting.
+    // completion_consume_seq_ -- the current task is still waiting for valid
+    // completion.
     if (slot_gen != current_gen) {
         LOG(WARNING) << "[P2PProxy][Recv] pollRecvCompletionSlot peer="
                      << op_ctx.peer_rank_
@@ -1005,6 +1097,7 @@ bool P2PProxy::pollRecvCompletionSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
         head_task.state_ = RecvTaskState::kCopyOut;
     }
 
+    head_task.last_update_time_ = std::chrono::steady_clock::now();
     slot.reset();
     ++lane.completion_consume_seq_;
     return true;
@@ -1088,14 +1181,24 @@ bool P2PProxy::stepRecv() {
         }
 
         // Advance every chunk through the receiver state machine.
+        bool op_failed = false;
         for (auto it = op_ctx.tasks_.begin(); it != op_ctx.tasks_.end();) {
             did_work |= stepRecvTask(*it);
             if (it->state_ == RecvTaskState::kFinished) {
                 it = op_ctx.tasks_.erase(it);
                 did_work = true;
+            } else if (it->state_ == RecvTaskState::kFailed) {
+                op_failed = true;
+                break;
             } else {
                 ++it;
             }
+        }
+
+        if (op_failed) {
+            reportBrokenPeer(peer_rank);
+            did_work = true;
+            continue;
         }
 
         if (isRecvOpCompleted(op_ctx)) {
@@ -1109,7 +1212,8 @@ bool P2PProxy::stepRecv() {
                                 cudaGetErrorString(sync_error));
                 }
             }
-            op_ctx.completed_->store(true, std::memory_order_release);
+            op_ctx.status_->store(OpStatus::kSuccess,
+                                  std::memory_order_release);
             lane.active_recv_op_.reset();
             active_recv_tasks_.fetch_sub(1, std::memory_order_release);
             did_work = true;

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -16,8 +16,10 @@ namespace mooncake {
 
 namespace {
 
-constexpr size_t kP2PPoolBytes =
-    static_cast<size_t>(kP2PPoolNumChunks) * kP2PChunkSize;
+size_t getEnv_size_t(const char* name, size_t default_val) {
+    const char* val = std::getenv(name);
+    return val ? std::strtoull(val, nullptr, 10) : default_val;
+}
 
 void setCudaDeviceIfNeeded(bool is_cpu, int cuda_device_index,
                            const char* context) {
@@ -32,6 +34,129 @@ void setCudaDeviceIfNeeded(bool is_cpu, int cuda_device_index,
 }
 
 }  // namespace
+
+void P2PChunkPool::init(void* base_addr, size_t chunk_size,
+                        uint32_t num_chunks) {
+    base_addr_ = base_addr;
+    chunk_size_ = chunk_size;
+    free_stack_.clear();
+    free_stack_.reserve(num_chunks);
+    for (uint32_t idx = 0; idx < num_chunks; ++idx) {
+        free_stack_.push_back(static_cast<uint8_t*>(base_addr_) +
+                              (num_chunks - 1 - idx) * chunk_size_);
+    }
+}
+
+void* P2PChunkPool::acquire() {
+    if (free_stack_.empty()) {
+        return nullptr;
+    }
+    void* ptr = free_stack_.back();
+    free_stack_.pop_back();
+    return ptr;
+}
+
+void P2PChunkPool::release(void* ptr) { free_stack_.push_back(ptr); }
+
+// Consumer-side reliable read.
+//
+// 1. Load header_token with acquire semantics.
+// 2. If it is kInvalidControlToken the slot is empty -> fail.
+// 3. Optimistically copy the payload (these plain loads may be torn).
+// 4. Issue an acquire fence so the payload reads cannot be reordered past
+//    the footer load that follows.
+// 5. Load footer_token.
+// 6. Accept the payload only when header == footer.
+bool PublishSlot::tryLoad(uint64_t& out_recv_addr, uint32_t& out_chunk_len,
+                          uint32_t& out_generation,
+                          uint32_t& out_sequence) const {
+    uint64_t h = std::atomic_ref(header_token).load(std::memory_order_acquire);
+    if (h == kInvalidControlToken) return false;
+
+    // Optimistic payload copy – may be torn if the NIC is still writing.
+    uint64_t addr = recv_addr;
+    uint32_t len = chunk_len;
+
+    // Avoid moving payload reads below the footer check.
+    std::atomic_thread_fence(std::memory_order_acquire);
+
+    uint64_t f = std::atomic_ref(footer_token).load(std::memory_order_relaxed);
+
+    if (h == f) {
+        out_recv_addr = addr;
+        out_chunk_len = len;
+        out_generation = static_cast<uint32_t>(h >> 32);
+        out_sequence = static_cast<uint32_t>(h);
+        return true;
+    }
+    // Torn write – caller retries next poll.
+    return false;
+}
+
+// Producer-side reliable publish.
+//
+// On the local CPU the store order matters:
+//   payload -> footer (relaxed) -> header (release).
+// The release store to header_token guarantees that every prior store is
+// visible to any consumer that sees the new header value.
+void PublishSlot::publish(uint32_t gen, uint32_t seq, uint64_t addr,
+                          uint32_t len) {
+    uint64_t new_token = makeControlToken(gen, seq);
+
+    recv_addr = addr;
+    chunk_len = len;
+
+    // Write footer first so it is never ahead of the header.
+    std::atomic_ref(footer_token).store(new_token, std::memory_order_relaxed);
+    // Release the header last
+    std::atomic_ref(header_token).store(new_token, std::memory_order_release);
+}
+
+void PublishSlot::reset() {
+    recv_addr = 0;
+    chunk_len = 0;
+    uint64_t inv = kInvalidControlToken;
+    std::atomic_ref(footer_token).store(inv, std::memory_order_relaxed);
+    std::atomic_ref(header_token).store(inv, std::memory_order_release);
+}
+
+// See PublishSlot::tryLoad() for the detailed description.
+bool CompletionSlot::tryLoad(uint32_t& out_chunk_len, uint32_t& out_generation,
+                             uint32_t& out_sequence) const {
+    uint64_t h = std::atomic_ref(header_token).load(std::memory_order_acquire);
+    if (h == kInvalidControlToken) return false;
+
+    uint32_t len = chunk_len;
+
+    std::atomic_thread_fence(std::memory_order_acquire);
+
+    uint64_t f = std::atomic_ref(footer_token).load(std::memory_order_relaxed);
+
+    if (h == f) {
+        out_chunk_len = len;
+        out_generation = static_cast<uint32_t>(h >> 32);
+        out_sequence = static_cast<uint32_t>(h);
+        return true;
+    }
+    return false;
+}
+
+// See PublishSlot::publish() for the detailed description.
+void CompletionSlot::publish(uint32_t gen, uint32_t seq, uint32_t len) {
+    uint64_t new_token = makeControlToken(gen, seq);
+
+    chunk_len = len;
+
+    std::atomic_ref(footer_token).store(new_token, std::memory_order_relaxed);
+    std::atomic_ref(header_token).store(new_token, std::memory_order_release);
+}
+
+void CompletionSlot::reset() {
+    chunk_len = 0;
+    uint64_t inv = kInvalidControlToken;
+    std::atomic_ref(footer_token).store(inv, std::memory_order_relaxed);
+    std::atomic_ref(header_token).store(inv, std::memory_order_release);
+}
 
 P2PProxy::P2PProxy(TransferEngine* engine, const Options& options)
     : engine_(engine),
@@ -66,6 +191,11 @@ void P2PProxy::bindMeta(const std::shared_ptr<TransferGroupMeta>& meta) {
     meta_ = meta;
 }
 
+void P2PProxy::extendGroupSizeTo(int new_size) {
+    TORCH_CHECK(new_size >= size_, "extendGroupSizeTo: new_size < size_");
+    size_ = new_size;
+}
+
 // Allocate fixed-size SendPool, RecvPool and control regions.
 void P2PProxy::allocateResources() {
     TORCH_CHECK(engine_, "P2PProxy engine is null.");
@@ -80,46 +210,51 @@ void P2PProxy::allocateResources() {
     TORCH_CHECK(static_cast<size_t>(size_) <= kMaxNumRanks,
                 "P2PProxy group size exceeds kMaxNumRanks: ", size_);
 
+    // Parse pool configuration from environment.
+    pool_bytes_ = getEnv_size_t("MOONCAKE_P2P_POOL_SIZE", kDefaultPoolSize);
+    chunk_size_ = getEnv_size_t("MOONCAKE_P2P_CHUNK_SIZE", kDefaultChunkSize);
+    TORCH_CHECK(
+        pool_bytes_ % chunk_size_ == 0,
+        "Invalid pool size and chunk size (pool_bytes_ % chunk_size_ != 0)");
+    num_chunks_ = pool_bytes_ / chunk_size_;
+
     if (is_cpu_) {
-        resources_.send_pool_base_ = std::malloc(kP2PPoolBytes);
+        resources_.send_pool_base_ = std::malloc(pool_bytes_);
         TORCH_CHECK(resources_.send_pool_base_ != nullptr,
                     "Failed to allocate CPU P2P send pool");
         int rc = engine_->registerLocalMemory(resources_.send_pool_base_,
-                                              kP2PPoolBytes, location_);
+                                              pool_bytes_, location_);
         TORCH_CHECK(rc == 0, "Failed to register CPU P2P send pool");
 
-        resources_.recv_pool_base_ = std::malloc(kP2PPoolBytes);
+        resources_.recv_pool_base_ = std::malloc(pool_bytes_);
         TORCH_CHECK(resources_.recv_pool_base_ != nullptr,
                     "Failed to allocate CPU P2P recv pool");
         rc = engine_->registerLocalMemory(resources_.recv_pool_base_,
-                                          kP2PPoolBytes, location_);
+                                          pool_bytes_, location_);
         TORCH_CHECK(rc == 0, "Failed to register CPU P2P recv pool");
     } else {
         setCudaDeviceIfNeeded(
             is_cpu_, cuda_device_index_,
             "P2PProxy AllocateResources cudaSetDevice failed");
-        cudaError_t err =
-            cudaMalloc(&resources_.send_pool_base_, kP2PPoolBytes);
+        cudaError_t err = cudaMalloc(&resources_.send_pool_base_, pool_bytes_);
         TORCH_CHECK(
             err == cudaSuccess,
             "Failed to allocate CUDA P2P send pool: ", cudaGetErrorString(err));
         int rc = engine_->registerLocalMemory(resources_.send_pool_base_,
-                                              kP2PPoolBytes, location_);
+                                              pool_bytes_, location_);
         TORCH_CHECK(rc == 0, "Failed to register CUDA P2P send pool");
 
-        err = cudaMalloc(&resources_.recv_pool_base_, kP2PPoolBytes);
+        err = cudaMalloc(&resources_.recv_pool_base_, pool_bytes_);
         TORCH_CHECK(
             err == cudaSuccess,
             "Failed to allocate CUDA P2P recv pool: ", cudaGetErrorString(err));
         rc = engine_->registerLocalMemory(resources_.recv_pool_base_,
-                                          kP2PPoolBytes, location_);
+                                          pool_bytes_, location_);
         TORCH_CHECK(rc == 0, "Failed to register CUDA P2P recv pool");
     }
 
-    send_pool_.init(resources_.send_pool_base_, kP2PChunkSize,
-                    kP2PPoolNumChunks);
-    recv_pool_.init(resources_.recv_pool_base_, kP2PChunkSize,
-                    kP2PPoolNumChunks);
+    send_pool_.init(resources_.send_pool_base_, chunk_size_, num_chunks_);
+    recv_pool_.init(resources_.recv_pool_base_, chunk_size_, num_chunks_);
 
     const size_t ctrl_slots =
         kMaxNumRanks * static_cast<size_t>(kP2PControlRingSize);
@@ -542,7 +677,7 @@ bool P2PProxy::tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane) {
     }
 
     const uint32_t chunk_len = static_cast<uint32_t>(std::min<uint64_t>(
-        kP2PChunkSize, op_ctx.total_bytes_ - op_ctx.bytes_advertised_));
+        chunk_size_, op_ctx.total_bytes_ - op_ctx.bytes_advertised_));
     const uint64_t seq = lane.publish_issue_seq_;
     const uint64_t remote_publish_offset =
         getRemotePublishSlot(op_ctx.peer_rank_, seq);
@@ -712,7 +847,7 @@ bool P2PProxy::tryIssueSendTask(SendOpContext& op_ctx, SendPeerLane& lane) {
 
     const uint32_t expected_chunk_len =
         static_cast<uint32_t>(std::min<uint64_t>(
-            kP2PChunkSize, op_ctx.total_bytes_ - op_ctx.bytes_staged_));
+            chunk_size_, op_ctx.total_bytes_ - op_ctx.bytes_staged_));
     TORCH_CHECK(chunk_len <= expected_chunk_len,
                 "P2P send got invalid chunk_len in publish slot.");
 


### PR DESCRIPTION
## Description

This PR refactors P2PProxy in Mooncake-PG by introducing a **receiver-driven, credit-based RDMA pull protocol**. It replaces the legacy sender-driven ring-buffer design with fixed-size shared chunk pools, per-peer generation tracking, configurable memory pools, and more robust failure handling.

The primary objective of this PR is to improve P2P performance **without incurring additional memory overhead**.

## Key Changes

### 1. P2P Protocol & Memory Layout

* **Receiver-driven credit-based protocol**: The receiver now drives the flow by advertising free `RecvPool` chunks to the sender via `PublishSlot`s. The sender remains passive and only performs RDMA Writes after receiving an invitation.
* **Chunk pools**: Replaced monolithic per-rank ring buffers with shared `SendPool` and `RecvPool`, each managed by a `P2PChunkPool`. (Separating send and receive memory can prevent deadlocks where all memory could be reserved for receiving with none left for sending.)
* **Control regions**: Restructured control memory into `publish_region` (receivers invite senders) and `completion_region` (senders acknowledge finished transfers).
* **Header-footer double-token guard**: `PublishSlot` and `CompletionSlot` use a 64-byte aligned header/footer token pattern to detect torn RDMA writes, ensuring consumers never observe partially written control data.

### 2. State Machine & Concurrency

* **Per-chunk state machines**:
  * Sender: Fetch Invite -> Copy-In (staging) -> RDMA Write -> Acknowledge
  * Receiver: Advertise -> Poll Completion -> Copy-Out
* **Non-blocking allocations**: All pool acquisitions are strictly non-blocking. If a pool is exhausted the step function returns `false` immediately and retries on the next polling iteration.
* **Credit-based flow control**: The receiver issues up to `kP2PControlRingSize` (64) outstanding invitations per peer, and the sender stages data only when credits are available.

### 3. Reliability & Failure Handling

* **Per-peer generation tracking**: Added `p2pGenerations` to `ExtensionState` so that each peer pair maintains an independent protocol generation, enabling safe recovery and reconnections.
* **Tri-state operation status**: Replaced `std::atomic<bool> completed` with `OpStatus` (`kPending` / `kSuccess` / `kFailed`) in `MooncakeP2PWork`. `wait()` now correctly distinguishes timeout from actual failure and throws on `kFailed`.
* **Unified ExtensionState serialization**: Merged separate store keys (`extension_task_count_*`, `extension_active_ranks_*`) into a single binary blob (`extension_state_*`), reducing metadata store keys and making the state atomically observable.

### 4. Backend Integration & Configuration

* **Environment-variable tuning**: Added `MOONCAKE_P2P_POOL_SIZE` (default 128 MB) and `MOONCAKE_P2P_CHUNK_SIZE` (default 16 MB) to allow runtime tuning of P2P memory usage without recompilation.
* **API style unification**: Renamed public methods for consistency. (e.g., `GetInstance` -> `getInstance`, `BindMeta` -> `bindMeta`)
* **Simplified metadata**: `SegmentInfo` shrank from 4 P2P fields (`p2p_send_buffer`, `p2p_recv_buffer`, `p2p_ctrl_send`, `p2p_ctrl_recv`) down to 2 (`p2p_publish_region`, `p2p_completion_region`).

## Why Performance Improved

The significant performance gains are directly attributed to two core changes in this refactor:

1. **Maximized RDMA Bandwidth Utilization via Larger Chunks**
   * *Old:* The fixed buffer layout forced an inefficient `2 MB` chunk size.
   * *New:* By utilizing shared pools, the default chunk size was increased to `16 MB` (an 8x increase), without requiring extra memory.

2. **Fine-Grained Pipelining (Eliminating Batch-Commit Serialization)**
   * *Old:* The legacy design relied on a single global head pointer to notify the receiver. Because only one head RDMA update could be in-flight at a time, if Chunk 1 finished transferring while Chunk 0's head update was still traversing the network, Chunk 1's completion notification was forcefully stalled. This single-point bottleneck could frequently interrupt the pipeline.
   * *New:* By transitioning to independent, per-chunk `CompletionSlot`s, the sender emits completion notifications immediately as each chunk finishes, with zero serialization dependency on previous control signals. This enables true concurrent pipelining, allowing the receiver to start pulling Chunk 1 into the GPU (`cudaMemcpyAsync`) while the NIC is simultaneously transmitting Chunk 0's completion.

## Memory Footprint Analysis

*Note: The following analysis compares data-buffer (send/recv pool) memory only; control slot memory is negligible.*

###  Single-Group: Achieving the Same Transfer Unit

The legacy design pre-allocated an independent send/recv lane for *every* peer. Those lanes could not be borrowed by others. The new design uses a **global shared pool** where all peers dynamically compete for chunks, decoupling total memory from `world_size`.

To achieve the same minimal transfer unit (**16 MB**) across 8 peers:

|Architecture|Send Buffer|Recv Buffer|Total Memory Used|
|:-----------|:----------|:----------|:----------------|
|**Old Design** (to achieve 16MB slot)|128 MB × 8 = 1 GB|128 MB × 8 = 1 GB|**2 GB**|
|**New Design** |128 MB |128 MB|**256 MB**|

### Multi‑Group Scaling

In real-world applications, frameworks like SGLang initialize multiple process groups with varying sizes. This exposes another critical limitation of the legacy architecture:

*   **Old design:** Each process group instantiated a dedicated `P2PProxy` with its own buffers. Because of this 1:1 mapping between backend, proxy, and buffer, memory consumption scaled linearly with the sum of participants across all groups. Even if we compromised on performance by using the old default configuration (which yielded a suboptimal **2 MB** transfer unit by allocating 16 MB send + 16 MB recv = 32 MB per peer), the total memory would still multiply across groups:  
    $\sum (\text{group size} \times 32 \text{ MB})$
*   **New design:** The memory pools are hoisted from the `P2PProxy` level to the `P2PDeviceWorker` level. In a typical setup where one process runs on a single device, all groups' `P2PProxy` instances within the process run on the same `P2PDeviceWorker`. Consequently, they all share a single global `P2PChunkPool`. This results in a constant total memory footprint of **256 MB** per process/device -- completely independent of the number of groups or their individual world sizes.

| Architecture | Total Memory Used | Transfer Unit |
|:---|:---|:---|
| **Old design** (Default buffers) | $\sum (\text{group size} \times 32 \text{ MB})$ | 2 MB |
| **New design** | **256 MB** (Constant) | **16 MB** |

> **Example:** With three groups of sizes 2, 4, and 8, the old design would allocate $(2+4+8) \times 32 \text{ MB} = 448 \text{ MB}$ just to provide a tiny 2 MB transfer unit. The new design stays at **256 MB** globally, while simultaneously delivering a 16 MB minimal transfer unit (8× larger) to all groups.

## Benchmarks

### Setup & Configurations

Tests were conducted on a single node equipped with 8 × H20-3e.

|Config| Total (Send + Recv) Memory|Minimal transfer unit|Note|
|:-----|:----------------------------|:--------------------|:---|
|**Original (256 MB)**|16 MB × 8 × 2 = **256 MB**|**2 MB**|Default (`kP2PBufferSize` = `1 << 24`)|
|**Original (2048 MB)**|128 MB × 8 × 2 = **2 GB**|**16 MB**|Modified (`kP2PBufferSize` = `1 << 27`)|
|**New (This PR)**|128 MB × 2 = **256 MB** (Shared)|**16 MB**|Default|
|**NCCL**|-|-|Default|



 > Note: In practice, the new implementation's performance scales even better with larger chunk sizes. However, those results are omitted because the primary goal is achieving better performance **without** incurring additional memory overhead.

### Result

#### PGBench

<img width="1200" height="720" alt="p2p_pool_pr" src="https://github.com/user-attachments/assets/8b172e4f-a5d3-489a-a8f6-788e8b1dfc66" />


 > **Note:** The chart above is plotted with out-of-place bandwidth. PGBench with send/recv can be conceptually viewed as a k=1 regular-k benchmark. Under this condition (low-concurrency), the bandwidth improvements are even more pronounced -- reaching approximately **5x** higher peak throughput compared to the original 256 MB baseline.

#### P2P Regular K (K=4)

#### Overview

* **Bandwidth:**  
  * Increased by **~2.4x** compared to the original default (121 GB/s -> 297 GB/s).
  * Increased by **~1.85x** compared to the larger-memory original (2048 MB) configuration (160 GB/s -> 297 GB/s).

* **Iteration Latency:**
  * Reduced by **\>50%** compared to the original default (17.6 ms -> 7.2 ms).
  * Reduced by **~46%** compared to the larger-memory original (2048 MB) configuration (13.4 ms -> 7.2 ms).

#### Details

* Original (256 MB)

````
# p2p regular-k benchmark  
# backend=mooncake device=cuda world_size=8 k=4 dtype=float  
# tensor_bytes=268435456 element_count=67108864 warmup=5 iters=100  
lat_mean_us=17610.078 lat_p50_us=15606.874 lat_p95_us=17250.967 lat_p99_us=26650.512 rank_bidir_GBps=121.946 cluster_bidir_GBps=975.570 wrong=0
````

* Original (2048 MB)

````
# p2p regular-k benchmark  
# backend=mooncake device=cuda world_size=8 k=4 dtype=float  
# tensor_bytes=268435456 element_count=67108864 warmup=5 iters=100  
lat_mean_us=13375.125 lat_p50_us=11736.808 lat_p95_us=13831.891 lat_p99_us=16987.017 rank_bidir_GBps=160.558 cluster_bidir_GBps=1284.464 wrong=0
````

* New

````
# p2p regular-k benchmark  
# backend=mooncake device=cuda world_size=8 k=4 dtype=float  
# tensor_bytes=268435456 element_count=67108864 warmup=5 iters=100  
lat_mean_us=7227.835 lat_p50_us=5587.480 lat_p95_us=6221.791 lat_p99_us=8897.243 rank_bidir_GBps=297.113 cluster_bidir_GBps=2376.904 wrong=0
````

* NCCL

````
# p2p regular-k benchmark  
# backend=nccl device=cuda world_size=8 k=4 dtype=float  
# tensor_bytes=268435456 element_count=67108864 warmup=5 iters=100  
lat_mean_us=3844.538 lat_p50_us=3823.407 lat_p95_us=4018.876 lat_p99_us=4099.451 rank_bidir_GBps=558.580 cluster_bidir_GBps=4468.644 wrong=0
````

### Reproduction commands

#### PGBench

##### Mooncake-PG + TENT

````
sudo env PATH="$PATH" MC_USE_TENT=1 MC_TENT_CONF='{"topology": {"rdma_blacklist": ["mlx5_0"]}}' python mooncake-pg/benchmark/pgbench.py --collective sendrecv --backe  
nd mooncake  --device cuda  -b 128K -e 1G -f 2 -g 8 -n 100 -w 5
````

##### NCCL

````
sudo env PATH="$PATH" python mooncake-pg/benchmark/pgbench.py --collective sendrecv --backend nccl --device cuda  -b 128K -e 1G -f 2 -g 8 -n 100 -w 5
````

#### P2P Regular K

##### Mooncake-PG + TENT

````
sudo env PATH="$PATH" MC_USE_TENT=1 MC_TENT_CONF='{"topology": {"rdma_blacklist": ["mlx5_0"]}}' python mooncake-pg/benchmark/p2p_regular_k_bench.py --backend mooncak  
e --device cuda -g 8 --tensor-bytes 256M -w 5 -n 100 -k 4
````

##### NCCL

````
sudo env PATH="$PATH" python mooncake-pg/benchmark/p2p_regular_k_bench.py --backend nccl --device cuda -g 8 --tensor-bytes 256M -w 5 -n 100 -k 4
````

## Future Optimizations

* **Topology-Aware Chunk Sizing:** Currently, chunk size is fixed after initialization. In heterogeneous interconnect environments, optimal chunk size depends on link efficiency. Since `chunk_len_` is already determined at runtime within `PublishSlot`/`CompletionSlot`, migrating to a per-peer (or even per-op) configuration is a natural next step.
* **Finer-Grained Failure Detection:** Current fault tolerance relies on a static `transfer_timeout_ms_` (default 5s). While effective for hard crashes, a slow NIC or temporarily congested switch might trigger false positives. Future iterations will introduce granular, per-batch retries before initiating a full `reportBrokenPeer()` teardown, mitigating disruptions caused by transient network fluctuations.
* **Node-local control plane over ShmTransport:** Currently, intra-node control updates (writes to `PublishSlot` / `CompletionSlot`)  go through `RdmaTransport`. Switching these writes to TENT's `ShmTransport` would further reduce control-path latency.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- Unit tests in `mooncake-pg/tests` passed.
- End-to-end integration test with DeepSeekV3 passed.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
