### PR TITLE
[Bugfix][Store]fix: local route will also follow the order sorted by master

### DIFF
--- a/mooncake-store/include/async_memcpy_executor.h
+++ b/mooncake-store/include/async_memcpy_executor.h
@@ -4,7 +4,6 @@
 #include <condition_variable>
 #include <exception>
 #include <functional>
-#include <future>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -13,6 +12,8 @@
 #include <type_traits>
 #include <vector>
 
+#include <async_simple/Future.h>
+#include <async_simple/Promise.h>
 #include <glog/logging.h>
 
 #include "tiered_cache/tiered_backend.h"
@@ -78,7 +79,7 @@ class AsyncMemcpyExecutor {
                                              ErrorFn&& on_error);
 
     template <typename ResultType, typename Fn>
-    std::future<ResultType> SubmitSingleTask(Fn&& fn);
+    async_simple::Future<ResultType> SubmitSingleTask(Fn&& fn);
 
     void Shutdown();
 
@@ -182,9 +183,10 @@ AsyncMemcpyExecutor::SubmitBatchTasks(const std::vector<size_t>& indices,
 }
 
 template <typename ResultType, typename Fn>
-std::future<ResultType> AsyncMemcpyExecutor::SubmitSingleTask(Fn&& fn) {
-    auto promise = std::make_shared<std::promise<ResultType>>();
-    auto future = promise->get_future();
+async_simple::Future<ResultType> AsyncMemcpyExecutor::SubmitSingleTask(
+    Fn&& fn) {
+    auto promise = std::make_shared<async_simple::Promise<ResultType>>();
+    auto future = promise->getFuture();
 
     using FnType = typename std::decay<Fn>::type;
     auto fn_ptr = std::make_shared<FnType>(std::forward<Fn>(fn));
@@ -192,14 +194,14 @@ std::future<ResultType> AsyncMemcpyExecutor::SubmitSingleTask(Fn&& fn) {
     QueueTask task;
     task.run = [promise, fn_ptr]() {
         try {
-            promise->set_value((*fn_ptr)());
+            promise->setValue((*fn_ptr)());
         } catch (...) {
-            promise->set_exception(std::current_exception());
+            promise->setException(std::current_exception());
         }
     };
     task.cancel = [promise]() {
         try {
-            promise->set_exception(
+            promise->setException(
                 std::make_exception_ptr(std::runtime_error("task cancelled")));
         } catch (...) {
         }

--- a/mooncake-store/include/p2p_client_service.h
+++ b/mooncake-store/include/p2p_client_service.h
@@ -8,6 +8,8 @@
 #include <thread>
 #include <utility>
 #include <coroutine>
+#include <async_simple/Future.h>
+#include <async_simple/Promise.h>
 #include <async_simple/Try.h>
 #include <async_simple/coro/Lazy.h>
 
@@ -245,45 +247,84 @@ class P2PClientService final : public ClientService {
         std::vector<std::vector<Slice>>& batched_slices,
         const WriteRouteRequestConfig& route_config);
 
-    tl::expected<BatchGetWriteRouteResponse, ErrorCode> BatchFetchWriteRoutes(
+    std::vector<tl::expected<void, ErrorCode>> InnerBatchPutDegraded(
         const std::vector<ObjectKey>& keys,
-        const std::vector<std::vector<Slice>>& batched_slices,
-        const WriteRouteRequestConfig& config);
+        std::vector<std::vector<Slice>>& batched_slices);
+
+    std::vector<tl::expected<void, ErrorCode>> InnerBatchPutNormal(
+        const std::vector<ObjectKey>& keys,
+        std::vector<std::vector<Slice>>& batched_slices,
+        const WriteRouteRequestConfig& route_config);
+
+    std::vector<tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>>
+    CreatePutHandlesFromRoute(const std::vector<ObjectKey>& keys,
+                              std::vector<std::vector<Slice>>& batched_slices,
+                              const WriteRouteRequestConfig& route_config,
+                              BatchGetWriteRouteResponse& batch_resp);
 
     tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
     CreatePutHandleFromLocal(const std::string& key,
                              std::vector<Slice>& slices);
 
-    tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
-    CreatePutHandleViaRoute(const std::string& key, std::vector<Slice>& slices,
-                            const WriteRouteRequestConfig& config,
-                            std::vector<WriteCandidate> candidates);
+    std::vector<tl::expected<void, ErrorCode>> CollectResults(
+        std::vector<tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>>&
+            handles,
+        const std::vector<ObjectKey>& keys);
 
-    struct LocalWriteOp {
+    tl::expected<BatchGetWriteRouteResponse, ErrorCode> BatchFetchWriteRoutes(
+        const std::vector<ObjectKey>& keys,
+        const std::vector<std::vector<Slice>>& batched_slices,
+        const WriteRouteRequestConfig& config);
+
+    struct WriteOp {
+        virtual ~WriteOp() = default;
+        virtual std::string_view route() const = 0;
+        // starts an async write task, then generate a wait task handle
+        virtual std::unique_ptr<TaskHandle<void>> Dispatch() = 0;
+    };
+
+    struct LocalWriteOp : WriteOp {
         DataManager* data_manager;
         std::string key;
         std::vector<Slice>* slices;
 
-        std::string_view route() const { return "local"; }
-        async_simple::coro::Lazy<tl::expected<void, ErrorCode>> operator()();
+        LocalWriteOp(DataManager* dm, std::string k, std::vector<Slice>* s)
+            : data_manager(dm), key(std::move(k)), slices(s) {}
+
+        std::string_view route() const override { return "local"; }
+        std::unique_ptr<TaskHandle<void>> Dispatch() override;
     };
 
-    struct RemoteWriteOp {
+    struct RemoteWriteOp : WriteOp {
         PeerClient* peer_ptr;
         std::shared_ptr<RemoteWriteRequest> write_req;
         P2PProxyDescriptor proxy;
         RouteCache* route_cache;
         std::string endpoint;
 
-        std::string_view route() const { return endpoint; }
-        async_simple::coro::Lazy<tl::expected<void, ErrorCode>> operator()();
+        RemoteWriteOp(PeerClient* p, std::shared_ptr<RemoteWriteRequest> wr,
+                      P2PProxyDescriptor px, RouteCache* rc, std::string ep)
+            : peer_ptr(p),
+              write_req(std::move(wr)),
+              proxy(std::move(px)),
+              route_cache(rc),
+              endpoint(std::move(ep)) {}
+
+        std::string_view route() const override { return endpoint; }
+        std::unique_ptr<TaskHandle<void>> Dispatch() override;
     };
 
-    using WriteOp = std::variant<LocalWriteOp, RemoteWriteOp>;
+    tl::expected<std::vector<std::unique_ptr<WriteOp>>, ErrorCode>
+    BuildWriteOps(const std::string& key, std::vector<Slice>& slices,
+                  const WriteRouteRequestConfig& config,
+                  std::vector<WriteCandidate> candidates);
 
-    async_simple::coro::Lazy<void> RunWriteRetry(
-        std::vector<WriteOp> write_ops, const std::string& key,
-        std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise);
+    async_simple::coro::Lazy<void> RunWriteWithRetry(
+        std::shared_ptr<async_simple::Promise<tl::expected<void, ErrorCode>>>
+            promise,
+        std::unique_ptr<TaskHandle<void>> current_task,
+        std::string current_route,
+        std::vector<std::unique_ptr<WriteOp>> retry_op_list, std::string key);
 
    private:
     struct ResolvedRoute {
@@ -379,9 +420,10 @@ class P2PClientService final : public ClientService {
     tl::expected<ReadTaskHandle, ErrorCode> InnerGetViaRoute(
         const std::string& key, std::vector<Slice>& slices, RouteIterator iter);
 
-    async_simple::coro::Lazy<void> RunReadRetry(
+    async_simple::coro::Lazy<void> RunReadWithRetry(
         RouteIterator iter, std::shared_ptr<RemoteReadRequest> req,
-        std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise);
+        std::shared_ptr<async_simple::Promise<tl::expected<void, ErrorCode>>>
+            promise);
 
     async_simple::coro::Lazy<std::vector<ResolvedRoute>>
     AsyncResolveRoutesFromMaster(const std::string& key,

--- a/mooncake-store/include/p2p_client_service.h
+++ b/mooncake-store/include/p2p_client_service.h
@@ -240,6 +240,48 @@ class P2PClientService final : public ClientService {
     HeartbeatRequest build_heartbeat_request() override;
 
    private:
+    std::vector<tl::expected<void, ErrorCode>> InnerBatchPut(
+        const std::vector<ObjectKey>& keys,
+        std::vector<std::vector<Slice>>& batched_slices,
+        const WriteRouteRequestConfig& route_config);
+
+    tl::expected<BatchGetWriteRouteResponse, ErrorCode> BatchFetchWriteRoutes(
+        const std::vector<ObjectKey>& keys,
+        const std::vector<std::vector<Slice>>& batched_slices,
+        const WriteRouteRequestConfig& config);
+
+    tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
+    CreatePutHandleFromLocal(const std::string& key,
+                             std::vector<Slice>& slices);
+
+    tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
+    CreatePutHandleViaRoute(const std::string& key, std::vector<Slice>& slices,
+                            const WriteRouteRequestConfig& config,
+                            std::vector<WriteCandidate> candidates);
+
+    class WriteOp {
+       public:
+        template <typename F>
+        explicit WriteOp(F&& f) : fn_(std::forward<F>(f)) {}
+        async_simple::coro::Lazy<tl::expected<void, ErrorCode>> operator()() {
+            return fn_();
+        }
+
+       private:
+        std::function<async_simple::coro::Lazy<tl::expected<void, ErrorCode>>()>
+            fn_;
+    };
+
+    WriteOp MakeLocalWriteOp(const std::string& key,
+                             std::vector<Slice>* slices);
+    WriteOp MakeRemoteWriteOp(PeerClient& peer,
+                              std::shared_ptr<RemoteWriteRequest> write_req,
+                              P2PProxyDescriptor proxy);
+    async_simple::coro::Lazy<void> RunWriteRetry(
+        std::vector<WriteOp> write_ops,
+        std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise);
+
+   private:
     struct ResolvedRoute {
         PeerClient* peer = nullptr;
         uint64_t object_size = 0;
@@ -289,46 +331,7 @@ class P2PClientService final : public ClientService {
         const std::string& key, const ReadRouteConfig& config,
         std::vector<ResolvedRoute> pre_fetched);
 
-    std::vector<tl::expected<std::vector<ResolvedRoute>, ErrorCode>>
-    BatchFetchReadRoutes(const std::vector<std::string_view>& keys,
-                         const ReadRouteConfig& config);
-
-    async_simple::coro::Lazy<std::vector<ResolvedRoute>>
-    AsyncResolveRoutesFromMaster(const std::string& key,
-                                 const ReadRouteConfig& config);
-
-    async_simple::coro::Lazy<void> RunReadRetry(
-        RouteIterator iter, std::shared_ptr<RemoteReadRequest> req,
-        std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise);
-
    private:
-    std::vector<tl::expected<void, ErrorCode>> InnerBatchPut(
-        const std::vector<ObjectKey>& keys,
-        std::vector<std::vector<Slice>>& batched_slices,
-        const WriteRouteRequestConfig& route_config);
-
-    tl::expected<BatchGetWriteRouteResponse, ErrorCode> BatchFetchWriteRoutes(
-        const std::vector<ObjectKey>& keys,
-        const std::vector<std::vector<Slice>>& batched_slices,
-        const WriteRouteRequestConfig& config);
-
-    tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode> CreatePutHandle(
-        const std::string& key, std::vector<Slice>& slices,
-        const WriteRouteRequestConfig& config);
-
-    tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
-    CreateLocalPutHandle(const std::string& key, std::vector<Slice>& slices);
-
-    tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
-    InnerCreatePutHandle(const std::string& key, std::vector<Slice>& slices,
-                         const WriteRouteRequestConfig& config,
-                         std::vector<WriteCandidate> candidates);
-    async_simple::coro::Lazy<void> RunWriteRetry(
-        std::vector<std::pair<PeerClient*, P2PProxyDescriptor>> peers,
-        std::shared_ptr<RemoteWriteRequest> write_req,
-        std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise,
-        RouteCache* route_cache, std::string key);
-
     template <typename ResultT, typename CreateHandlesFn, typename ExtractFn>
     std::vector<tl::expected<ResultT, ErrorCode>> BatchGetImpl(
         const std::vector<std::string>& keys, CreateHandlesFn&& create_handles,
@@ -350,6 +353,10 @@ class P2PClientService final : public ClientService {
                               const ReadRouteConfig& config,
                               LocalGetFn&& local_get, RemoteGetFn&& remote_get);
 
+    std::vector<tl::expected<std::vector<ResolvedRoute>, ErrorCode>>
+    BatchFetchReadRoutes(const std::vector<std::string_view>& keys,
+                         const ReadRouteConfig& config);
+
     tl::expected<ReadTaskHandle, ErrorCode> CreateRemoteGetHandle(
         const std::string& key,
         std::shared_ptr<ClientBufferAllocator> allocator,
@@ -367,6 +374,14 @@ class P2PClientService final : public ClientService {
      */
     tl::expected<ReadTaskHandle, ErrorCode> InnerGetViaRoute(
         const std::string& key, std::vector<Slice>& slices, RouteIterator iter);
+
+    async_simple::coro::Lazy<void> RunReadRetry(
+        RouteIterator iter, std::shared_ptr<RemoteReadRequest> req,
+        std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise);
+
+    async_simple::coro::Lazy<std::vector<ResolvedRoute>>
+    AsyncResolveRoutesFromMaster(const std::string& key,
+                                 const ReadRouteConfig& config);
 
     /**
      * @brief Get or create a PeerClient for the given endpoint.

--- a/mooncake-store/include/p2p_client_service.h
+++ b/mooncake-store/include/p2p_client_service.h
@@ -259,26 +259,30 @@ class P2PClientService final : public ClientService {
                             const WriteRouteRequestConfig& config,
                             std::vector<WriteCandidate> candidates);
 
-    class WriteOp {
-       public:
-        template <typename F>
-        explicit WriteOp(F&& f) : fn_(std::forward<F>(f)) {}
-        async_simple::coro::Lazy<tl::expected<void, ErrorCode>> operator()() {
-            return fn_();
-        }
+    struct LocalWriteOp {
+        DataManager* data_manager;
+        std::string key;
+        std::vector<Slice>* slices;
 
-       private:
-        std::function<async_simple::coro::Lazy<tl::expected<void, ErrorCode>>()>
-            fn_;
+        std::string_view route() const { return "local"; }
+        async_simple::coro::Lazy<tl::expected<void, ErrorCode>> operator()();
     };
 
-    WriteOp MakeLocalWriteOp(const std::string& key,
-                             std::vector<Slice>* slices);
-    WriteOp MakeRemoteWriteOp(PeerClient& peer,
-                              std::shared_ptr<RemoteWriteRequest> write_req,
-                              P2PProxyDescriptor proxy);
+    struct RemoteWriteOp {
+        PeerClient* peer_ptr;
+        std::shared_ptr<RemoteWriteRequest> write_req;
+        P2PProxyDescriptor proxy;
+        RouteCache* route_cache;
+        std::string endpoint;
+
+        std::string_view route() const { return endpoint; }
+        async_simple::coro::Lazy<tl::expected<void, ErrorCode>> operator()();
+    };
+
+    using WriteOp = std::variant<LocalWriteOp, RemoteWriteOp>;
+
     async_simple::coro::Lazy<void> RunWriteRetry(
-        std::vector<WriteOp> write_ops,
+        std::vector<WriteOp> write_ops, const std::string& key,
         std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise);
 
    private:

--- a/mooncake-store/include/task_handle.h
+++ b/mooncake-store/include/task_handle.h
@@ -1,8 +1,12 @@
 #pragma once
 
-#include <future>
 #include <memory>
 
+#include <async_simple/Future.h>
+#include <async_simple/Promise.h>
+#include <async_simple/coro/FutureAwaiter.h>
+#include <async_simple/coro/Lazy.h>
+#include <async_simple/coro/SyncAwait.h>
 #include <ylt/util/tl/expected.hpp>
 
 #include "types.h"
@@ -13,6 +17,10 @@ namespace mooncake {
 // TaskHandle<V> — abstract base for pending operations.
 // Wait() returns tl::expected<V, ErrorCode>, where ErrorCode is the error type
 // and V is the value type on success.
+// WaitAsync() is the coroutine-friendly entry; default falls back to Wait()
+// (sync block on the coroutine's current thread). Subclasses backed by an
+// asynchronously-completed future (see FutureHandle) override it for true
+// suspension.
 // ============================================================================
 
 template <typename V>
@@ -20,6 +28,9 @@ class TaskHandle {
    public:
     virtual ~TaskHandle() = default;
     virtual tl::expected<V, ErrorCode> Wait() = 0;
+    virtual async_simple::coro::Lazy<tl::expected<V, ErrorCode>> WaitAsync() {
+        co_return Wait();
+    }
 };
 
 template <typename V>
@@ -69,23 +80,29 @@ template <typename V>
 class FutureHandle : public TaskHandle<V> {
    public:
     FutureHandle(std::shared_ptr<void> request_storage,
-                 std::future<tl::expected<V, ErrorCode>> future)
+                 async_simple::Future<tl::expected<V, ErrorCode>> future)
         : request_storage_(std::move(request_storage)),
           future_(std::move(future)) {}
 
-    tl::expected<V, ErrorCode> Wait() override { return future_.get(); }
+    tl::expected<V, ErrorCode> Wait() override {
+        return async_simple::coro::syncAwait(WaitAsync());
+    }
+
+    async_simple::coro::Lazy<tl::expected<V, ErrorCode>> WaitAsync() override {
+        co_return co_await std::move(future_);
+    }
 
     template <typename T>
     static std::unique_ptr<FutureHandle<V>> Create(
         std::shared_ptr<T> request_storage,
-        std::future<tl::expected<V, ErrorCode>> future) {
+        async_simple::Future<tl::expected<V, ErrorCode>> future) {
         return std::make_unique<FutureHandle<V>>(std::move(request_storage),
                                                  std::move(future));
     }
 
    private:
     std::shared_ptr<void> request_storage_;
-    std::future<tl::expected<V, ErrorCode>> future_;
+    async_simple::Future<tl::expected<V, ErrorCode>> future_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/task_handle.h
+++ b/mooncake-store/include/task_handle.h
@@ -66,21 +66,21 @@ class CallableTaskHandle : public TaskHandle<V> {
 };
 
 template <typename V>
-class RemoteRpcHandle : public TaskHandle<V> {
+class FutureHandle : public TaskHandle<V> {
    public:
-    RemoteRpcHandle(std::shared_ptr<void> request_storage,
-                    std::future<tl::expected<V, ErrorCode>> future)
+    FutureHandle(std::shared_ptr<void> request_storage,
+                 std::future<tl::expected<V, ErrorCode>> future)
         : request_storage_(std::move(request_storage)),
           future_(std::move(future)) {}
 
     tl::expected<V, ErrorCode> Wait() override { return future_.get(); }
 
     template <typename T>
-    static std::unique_ptr<RemoteRpcHandle<V>> Create(
+    static std::unique_ptr<FutureHandle<V>> Create(
         std::shared_ptr<T> request_storage,
         std::future<tl::expected<V, ErrorCode>> future) {
-        return std::make_unique<RemoteRpcHandle<V>>(std::move(request_storage),
-                                                    std::move(future));
+        return std::make_unique<FutureHandle<V>>(std::move(request_storage),
+                                                 std::move(future));
     }
 
    private:

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -77,6 +77,16 @@ tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode> DataManager::Put(
     return tl::unexpected(ErrorCode::INTERNAL_ERROR);
 }
 
+// TODO: The returned CallableTaskHandle's WaitAsync() falls back to a
+// synchronous Wait() on the coroutine's current thread, because the
+// WaitAllTransferBatches() is a loop with no async completion notification.
+// Possible optimizations:
+//   (1) run a polling coroutine on yalantinglibs coro_io's io_context (via
+//       co_await coro_io::sleep_for(100us) + getTransferStatus), no new thread;
+//   (2) introduce a lightweight timer service to bridge cv-poll to
+//       async_simple::Promise;
+//   (3) introduce a completion callback from transfer_engine itself.
+// Once any of these lands, switch the return type to FutureHandle.
 tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
 DataManager::PutViaTe(const std::string& key, std::vector<Slice>& slices) {
     // using Te, treat local memory as remote memory
@@ -85,7 +95,7 @@ DataManager::PutViaTe(const std::string& key, std::vector<Slice>& slices) {
     auto src_buffers = SlicesToRemoteBufferDescs(slices);
     auto validate_result = ValidateRemoteBuffers(src_buffers);
     if (!validate_result) {
-        LOG(ERROR) << "PutViaTe: Buffer validation failed"
+        LOG(ERROR) << "Buffer validation failed"
                    << ", error: " << toString(validate_result.error());
         return tl::unexpected(validate_result.error());
     }
@@ -95,7 +105,7 @@ DataManager::PutViaTe(const std::string& key, std::vector<Slice>& slices) {
         std::unique_lock<std::shared_mutex> lock(GetKeyLock(key));
 
         if (tiered_backend_->Exist(key)) {
-            LOG(WARNING) << "PutViaTe: key already exists: " << key;
+            LOG(WARNING) << "key already exists: " << key;
             return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
         }
 
@@ -105,9 +115,8 @@ DataManager::PutViaTe(const std::string& key, std::vector<Slice>& slices) {
             if (err == ErrorCode::REPLICA_NUM_EXCEEDED ||
                 err == ErrorCode::OBJECT_ALREADY_EXISTS ||
                 err == ErrorCode::REPLICA_ALREADY_EXISTS) {
-                LOG(WARNING)
-                    << "PutViaTe: object already exists for key: " << key
-                    << ", error code: " << err;
+                LOG(WARNING) << "object already exists for key: " << key
+                             << ", error code: " << err;
             }
             return tl::unexpected(err);
         }
@@ -117,7 +126,7 @@ DataManager::PutViaTe(const std::string& key, std::vector<Slice>& slices) {
     auto submit_result = SubmitTeTransferInternal(
         alloc_handle, src_buffers, Transport::TransferRequest::READ);
     if (!submit_result) {
-        LOG(ERROR) << "PutViaTe: SubmitTeTransferInternal failed"
+        LOG(ERROR) << "SubmitTeTransferInternal failed"
                    << ", key=" << key
                    << ", error_code=" << toString(submit_result.error());
         return tl::unexpected(submit_result.error());
@@ -131,7 +140,7 @@ DataManager::PutViaTe(const std::string& key, std::vector<Slice>& slices) {
 
             auto wait_result = WaitAllTransferBatches(ctx.transfer_batches);
             if (!wait_result) {
-                LOG(ERROR) << "PutViaTe: WaitAllTransferBatches failed"
+                LOG(ERROR) << "WaitAllTransferBatches failed"
                            << ", key=" << key
                            << ", error_code=" << toString(wait_result.error());
                 return tl::unexpected(wait_result.error());
@@ -147,7 +156,7 @@ DataManager::PutViaTe(const std::string& key, std::vector<Slice>& slices) {
                     ctx.handle->backend);
                 if (!copy_result) {
                     LOG(ERROR)
-                        << "PutViaTe: CopyFromDRAMBuffer failed"
+                        << "CopyFromDRAMBuffer failed"
                         << ", key=" << key
                         << ", error_code=" << toString(copy_result.error());
                     return tl::unexpected(copy_result.error());
@@ -157,7 +166,7 @@ DataManager::PutViaTe(const std::string& key, std::vector<Slice>& slices) {
             std::unique_lock<std::shared_mutex> lock(GetKeyLock(key));
             auto commit_result = tiered_backend_->Commit(key, alloc_handle);
             if (!commit_result) {
-                LOG(WARNING) << "PutViaTe: commit race for key: " << key;
+                LOG(WARNING) << "commit race for key: " << key;
             }
             timer.LogResponse("error_code=", ErrorCode::OK);
             return {};
@@ -222,54 +231,36 @@ DataManager::PutViaMemcpy(const std::string& key, std::vector<Slice>& slices) {
         return {};
     };
 
+    auto write_and_commit = [write_fn = std::move(write_fn),
+                             commit_fn = std::move(commit_fn),
+                             key]() mutable -> tl::expected<void, ErrorCode> {
+        ScopedVLogTimer timer(1, "DataManager::PutViaMemcpy");
+        timer.LogRequest("key=", key);
+        auto write_result = write_fn();
+        if (!write_result) {
+            LOG(ERROR) << "Failed to write data, error: "
+                       << write_result.error();
+            return tl::make_unexpected(write_result.error());
+        }
+        auto commit_result = commit_fn();
+        if (!commit_result) {
+            LOG(ERROR) << "Failed to commit data, error: "
+                       << commit_result.error();
+            return tl::make_unexpected(commit_result.error());
+        }
+        timer.LogResponse("error_code=", ErrorCode::OK);
+        return {};
+    };
+
     if (async_memcpy_executor_) {
-        // async write + sync commit
         auto future = async_memcpy_executor_
                           ->SubmitSingleTask<tl::expected<void, ErrorCode>>(
-                              std::move(write_fn));
-        return CallableTaskHandle<void>::Create(
-            [f = std::move(future), commit_fn = std::move(commit_fn),
-             key]() mutable -> tl::expected<void, ErrorCode> {
-                ScopedVLogTimer timer(1, "DataManager::PutViaMemcpy");
-                timer.LogRequest("key=", key);
-                auto write_result = f.get();
-                if (!write_result) {
-                    LOG(ERROR) << "Failed to write data, error: "
-                               << write_result.error();
-                    return tl::make_unexpected(write_result.error());
-                }
-                auto commit_result = commit_fn();
-                if (!commit_result) {
-                    LOG(ERROR) << "Failed to commit data, error: "
-                               << commit_result.error();
-                    return tl::make_unexpected(commit_result.error());
-                }
-                timer.LogResponse("error_code=", ErrorCode::OK);
-                return {};
-            });
-    } else {
-        // sync write + sync commit
-        return CallableTaskHandle<void>::Create(
-            [write_fn = std::move(write_fn), commit_fn = std::move(commit_fn),
-             key]() mutable -> tl::expected<void, ErrorCode> {
-                ScopedVLogTimer timer(1, "DataManager::PutViaMemcpy");
-                timer.LogRequest("key=", key);
-                auto write_result = write_fn();
-                if (!write_result) {
-                    LOG(ERROR) << "Failed to write data, error: "
-                               << write_result.error();
-                    return tl::make_unexpected(write_result.error());
-                }
-                auto commit_result = commit_fn();
-                if (!commit_result) {
-                    LOG(ERROR) << "Failed to commit data, error: "
-                               << commit_result.error();
-                    return tl::make_unexpected(commit_result.error());
-                }
-                timer.LogResponse("error_code=", ErrorCode::OK);
-                return {};
-            });
+                              std::move(write_and_commit));
+        return FutureHandle<void>::Create(std::shared_ptr<void>{},
+                                          std::move(future));
     }
+    // No async executor: run synchronously when Wait() is called.
+    return CallableTaskHandle<void>::Create(std::move(write_and_commit));
 }
 
 // ================================================================
@@ -396,25 +387,26 @@ tl::expected<ReadTaskHandle, ErrorCode> DataManager::BuildDataCopierViaMemcpy(
     res.data_size = static_cast<int64_t>(plan_result.value().source_size);
 
     if (async_memcpy_executor_) {
-        auto future = async_memcpy_executor_->SubmitSingleTask<ErrorCode>(
-            [plan = plan_result.value()]() {
-                return ExecuteLocalCopyPlan(plan);
-            });
-        res.task_handle = CallableTaskHandle<void>::Create(
-            [f = std::move(future),
-             key]() mutable -> tl::expected<void, ErrorCode> {
-                ScopedVLogTimer timer(1,
-                                      "DataManager::BuildDataCopierViaMemcpy");
-                timer.LogRequest("key=", key);
-                ErrorCode ec = f.get();
-                if (ec != ErrorCode::OK) {
-                    LOG(ERROR) << "Failed to execute local copy plan"
-                               << ", key=" << key << ", error_code=" << ec;
-                    return tl::unexpected(ec);
-                }
-                timer.LogResponse("error_code=", ErrorCode::OK);
-                return {};
-            });
+        auto future =
+            async_memcpy_executor_
+                ->SubmitSingleTask<tl::expected<void, ErrorCode>>(
+                    [plan = plan_result.value(),
+                     key]() -> tl::expected<void, ErrorCode> {
+                        ScopedVLogTimer timer(
+                            1, "DataManager::BuildDataCopierViaMemcpy");
+                        timer.LogRequest("key=", key);
+                        ErrorCode ec = ExecuteLocalCopyPlan(plan);
+                        if (ec != ErrorCode::OK) {
+                            LOG(ERROR)
+                                << "Failed to execute local copy plan"
+                                << ", key=" << key << ", error_code=" << ec;
+                            return tl::unexpected(ec);
+                        }
+                        timer.LogResponse("error_code=", ErrorCode::OK);
+                        return {};
+                    });
+        res.task_handle = FutureHandle<void>::Create(std::shared_ptr<void>{},
+                                                     std::move(future));
     } else {
         res.task_handle = CallableTaskHandle<void>::Create(
             [plan = std::move(plan_result.value()),

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -11,6 +11,7 @@
 
 #include <async_simple/Try.h>
 #include <async_simple/coro/Lazy.h>
+#include <async_simple/coro/SyncAwait.h>
 
 #include "utils/scoped_vlog_timer.h"
 
@@ -523,6 +524,12 @@ std::string P2PClientService::GetHealthStatus() const {
 // Put Operations
 // ============================================================================
 
+inline bool IsAlreadyExistsError(ErrorCode err) {
+    return err == ErrorCode::REPLICA_NUM_EXCEEDED ||
+           err == ErrorCode::REPLICA_ALREADY_EXISTS ||
+           err == ErrorCode::OBJECT_ALREADY_EXISTS;
+}
+
 tl::expected<void, ErrorCode> P2PClientService::Put(const ObjectKey& key,
                                                     std::vector<Slice>& slices,
                                                     const WriteConfig& config) {
@@ -610,7 +617,8 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::InnerBatchPut(
     if (ha_manager_ && ha_manager_->IsDegraded()) {
         // DEGRADED: skip master RPC, write locally for each key.
         for (size_t i = 0; i < keys.size(); ++i) {
-            handles.push_back(CreateLocalPutHandle(keys[i], batched_slices[i]));
+            handles.push_back(
+                CreatePutHandleFromLocal(keys[i], batched_slices[i]));
         }
     } else {
         // NORMAL: fetch routes from master, write based on routes.
@@ -629,7 +637,7 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::InnerBatchPut(
             if (batch_resp.error_codes[i] != ErrorCode::OK) {
                 handles.push_back(tl::unexpected(batch_resp.error_codes[i]));
             } else {
-                handles.push_back(InnerCreatePutHandle(
+                handles.push_back(CreatePutHandleViaRoute(
                     keys[i], batched_slices[i], route_config,
                     std::move(batch_resp.responses[i].candidates)));
             }
@@ -647,24 +655,41 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::InnerBatchPut(
                        << ", error: " << handles[i].error();
             results[i] = tl::unexpected(handles[i].error());
         } else if (!handles[i].value()) {
-            LOG(ERROR) << "put task handle is null for key: " << keys[i];
-            results[i] = tl::unexpected(ErrorCode::INTERNAL_ERROR);
+            if (!IsAlreadyExistsError(handles[i].error())) {
+                LOG(ERROR) << "put task handle is null for key: " << keys[i];
+                results[i] = tl::unexpected(handles[i].error());
+            } else {
+                results[i] = {};
+            }
         } else {
             auto wait_result = handles[i].value()->Wait();
-            if (!wait_result) {
-                LOG(ERROR) << "Failed to put key: " << keys[i]
-                           << ", error: " << wait_result.error();
+            if (wait_result || !IsAlreadyExistsError(wait_result.error())) {
+                if (!wait_result) {
+                    LOG(ERROR) << "Failed to put key: " << keys[i]
+                               << ", error: " << wait_result.error();
+                }
+                results[i] = wait_result;
+            } else {
+                results[i] = {};
             }
-            results[i] = wait_result;
         }
     }
     return results;
 }
 
-inline bool IsAlreadyExistsError(ErrorCode err) {
-    return err == ErrorCode::REPLICA_NUM_EXCEEDED ||
-           err == ErrorCode::REPLICA_ALREADY_EXISTS ||
-           err == ErrorCode::OBJECT_ALREADY_EXISTS;
+tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
+P2PClientService::CreatePutHandleFromLocal(const std::string& key,
+                                           std::vector<Slice>& slices) {
+    auto local_handle = data_manager_->Put(key, slices);
+
+    if (local_handle) {
+        return std::move(local_handle.value());
+    } else if (!IsAlreadyExistsError(local_handle.error())) {
+        LOG(ERROR) << "Local write failed for key: " << key
+                   << ", error: " << local_handle.error();
+    }
+
+    return tl::unexpected(local_handle.error());
 }
 
 tl::expected<BatchGetWriteRouteResponse, ErrorCode>
@@ -692,93 +717,12 @@ P2PClientService::BatchFetchWriteRoutes(
 }
 
 tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
-P2PClientService::CreatePutHandle(const std::string& key,
-                                  std::vector<Slice>& slices,
-                                  const WriteRouteRequestConfig& config) {
-    // DEGRADED: Master unreachable, only allow local writes
-    if (ha_manager_ && ha_manager_->IsDegraded()) {
-        return CreateLocalPutHandle(key, slices);
-    }
-
-    WriteRouteRequest route_req;
-    route_req.key = key;
-    route_req.client_id = client_id_;
-    route_req.size = ClientService::CalculateSliceSize(slices);
-    route_req.config = config;
-
-    auto route_result = master_client_.GetWriteRoute(route_req);
-    if (!route_result) {
-        LOG(WARNING) << "Failed to get write route for key: " << key
-                     << " error: " << route_result.error();
-        return tl::unexpected(route_result.error());
-    }
-
-    return InnerCreatePutHandle(key, slices, config,
-                                std::move(route_result.value().candidates));
-}
-
-tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
-P2PClientService::CreateLocalPutHandle(const std::string& key,
-                                       std::vector<Slice>& slices) {
-    auto local_handle = data_manager_->Put(key, slices);
-
-    if (local_handle) {
-        return std::move(local_handle.value());
-    }
-
-    LOG(ERROR) << "Local write failed for key: " << key
-               << ", error: " << local_handle.error();
-    return tl::unexpected(local_handle.error());
-}
-
-tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
-P2PClientService::InnerCreatePutHandle(const std::string& key,
-                                       std::vector<Slice>& slices,
-                                       const WriteRouteRequestConfig& config,
-                                       std::vector<WriteCandidate> candidates) {
+P2PClientService::CreatePutHandleViaRoute(
+    const std::string& key, std::vector<Slice>& slices,
+    const WriteRouteRequestConfig& config,
+    std::vector<WriteCandidate> candidates) {
     if (candidates.empty()) {
         LOG(ERROR) << "No write candidates for key: " << key;
-        return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
-    }
-
-    // 1. Generate a retry list based on the recommended order of master.
-    // If there is a local candidate among them, generate a local task handle.
-    std::vector<P2PProxyDescriptor> remote_proxies;
-    for (size_t i = 0; i < candidates.size(); ++i) {
-        auto& proxy = candidates[i].replica;
-
-        if (proxy.client_id == client_id_) {
-            // Defensive check: master should not return local candidates when
-            // allow_local=false, but if it does, just skip it.
-            if (!config.allow_local) {
-                LOG(WARNING) << "Master returned local candidate but "
-                                "allow_local=false, skipping";
-                continue;
-            }
-            if (data_manager_.has_value()) {
-                auto local_handle = data_manager_->Put(key, slices);
-
-                if (local_handle) {
-                    return std::move(local_handle.value());
-                } else if (IsAlreadyExistsError(local_handle.error())) {
-                    // The key already exists. Currently, we think this is a
-                    // normal case, just ignore the error and return success.
-                    return ImmediateHandle<void>::Create();
-                } else {
-                    // Local put failure, try next candidate
-                    LOG(WARNING) << "Local write failed, trying next candidate"
-                                 << ", error: " << local_handle.error();
-                    continue;
-                }
-            }
-        } else {
-            remote_proxies.push_back(proxy);
-        }
-    }
-
-    // 2. Chain async RPCs over remote candidates via continuation
-    if (remote_proxies.empty()) {
-        LOG(ERROR) << "No remote candidates for key: " << key;
         return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
     }
 
@@ -792,59 +736,101 @@ P2PClientService::InnerCreatePutHandle(const std::string& key,
         write_req->src_buffers.push_back(buf);
     }
 
-    // Resolve proxies to PeerClient* before entering the coroutine so that
-    // RunWriteRetry needs no back-reference to the service (mirrors how
-    // RunReadRetry receives already-resolved PeerClient* via RouteIterator).
-    std::vector<std::pair<PeerClient*, P2PProxyDescriptor>> peers;
-    peers.reserve(remote_proxies.size());
-    for (auto& proxy : remote_proxies) {
-        std::string ep =
-            proxy.ip_address + ":" + std::to_string(proxy.rpc_port);
-        peers.emplace_back(&GetOrCreatePeerClient(ep), std::move(proxy));
+    std::vector<WriteOp> write_ops;
+    for (auto& candidate : candidates) {
+        auto& proxy = candidate.replica;
+        if (proxy.client_id == client_id_) {
+            // Defensive check: master should not return local candidates when
+            // allow_local=false, but if it does, just skip it.
+            if (!config.allow_local) {
+                LOG(WARNING) << "Master returned local candidate but "
+                                "allow_local=false, skipping";
+                continue;
+            } else if (!data_manager_.has_value()) {
+                LOG(ERROR) << "Data manager not initialized";
+                continue;
+            }
+            write_ops.push_back(MakeLocalWriteOp(key, &slices));
+        } else {
+            std::string endpoint =
+                proxy.ip_address + ":" + std::to_string(proxy.rpc_port);
+            write_ops.push_back(MakeRemoteWriteOp(
+                GetOrCreatePeerClient(endpoint), write_req, proxy));
+        }
+    }
+
+    if (write_ops.empty()) {
+        LOG(ERROR) << "No valid candidates for key: " << key;
+        return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
     }
 
     auto promise =
         std::make_shared<std::promise<tl::expected<void, ErrorCode>>>();
     auto future = promise->get_future();
 
-    RunWriteRetry(std::move(peers), write_req, promise,
-                  route_cache_ ? &(*route_cache_) : nullptr, key)
-        .start([](auto&&) {});
+    RunWriteRetry(std::move(write_ops), promise).start([](auto&&) {});
 
-    return RemoteRpcHandle<void>::Create(std::move(write_req),
-                                         std::move(future));
+    return FutureHandle<void>::Create(std::move(write_req), std::move(future));
+}
+
+P2PClientService::WriteOp P2PClientService::MakeLocalWriteOp(
+    const std::string& key, std::vector<Slice>* slices) {
+    return WriteOp(
+        [this, key,
+         slices]() -> async_simple::coro::Lazy<tl::expected<void, ErrorCode>> {
+            auto handle = data_manager_->Put(key, *slices);
+            if (!handle) {
+                if (!IsAlreadyExistsError(handle.error())) {
+                    LOG(ERROR) << "Local write failed, key: " << key
+                               << ", error: " << handle.error();
+                }
+                co_return tl::unexpected(handle.error());
+            }
+            co_return handle.value()->Wait();
+        });
+}
+
+P2PClientService::WriteOp P2PClientService::MakeRemoteWriteOp(
+    PeerClient& peer, std::shared_ptr<RemoteWriteRequest> write_req,
+    P2PProxyDescriptor proxy) {
+    RouteCache* route_cache = route_cache_ ? &(*route_cache_) : nullptr;
+    return WriteOp(
+        [peer_ptr = &peer, write_req = std::move(write_req), proxy,
+         route_cache]()
+            -> async_simple::coro::Lazy<tl::expected<void, ErrorCode>> {
+            auto result = co_await peer_ptr->AsyncWriteRemoteData(*write_req);
+            if (result.has_value()) {
+                if (route_cache) {
+                    P2PProxyDescriptor np = proxy;
+                    np.segment_id = result.value();
+                    route_cache->Upsert(write_req->key, {np});
+                }
+                co_return tl::expected<void, ErrorCode>{};
+            }
+            if (!IsAlreadyExistsError(result.error())) {
+                LOG(ERROR) << "Failed to write to remote, key: "
+                           << write_req->key << ", error: " << result.error();
+            }
+            co_return tl::unexpected(result.error());
+        });
 }
 
 async_simple::coro::Lazy<void> P2PClientService::RunWriteRetry(
-    std::vector<std::pair<PeerClient*, P2PProxyDescriptor>> peers,
-    std::shared_ptr<RemoteWriteRequest> write_req,
-    std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise,
-    RouteCache* route_cache, std::string key) {
+    std::vector<WriteOp> write_ops,
+    std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise) {
     try {
-        for (auto& [peer, proxy] : peers) {
+        for (auto& op : write_ops) {
             try {
-                auto result = co_await peer->AsyncWriteRemoteData(*write_req);
-                if (result.has_value()) {
-                    if (route_cache) {
-                        P2PProxyDescriptor np = proxy;
-                        np.segment_id = result.value();
-                        route_cache->Upsert(key, {np});
-                    }
+                auto result = co_await op();
+                if (result.has_value() ||
+                    IsAlreadyExistsError(result.error())) {
                     promise->set_value({});
                     co_return;
-                } else if (IsAlreadyExistsError(result.error())) {
-                    promise->set_value({});
-                    co_return;
-                } else {
-                    LOG(ERROR) << "Failed to write to remote, key: " << key
-                               << ", error: " << result.error();
                 }
             } catch (const std::exception& e) {
-                LOG(ERROR) << "Failed to write to remote, key: " << key
-                           << ", exception: " << e.what();
+                LOG(ERROR) << "Write candidate failed, exception: " << e.what();
             } catch (...) {
-                LOG(ERROR) << "Failed to write to remote, key: " << key
-                           << ", unknown exception";
+                LOG(ERROR) << "Write candidate failed, unknown exception";
             }
         }
         promise->set_value(tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE));
@@ -1275,7 +1261,7 @@ tl::expected<ReadTaskHandle, ErrorCode> P2PClientService::InnerGetViaRoute(
     ReadTaskHandle res;
     res.data_size = object_size;
     res.task_handle =
-        RemoteRpcHandle<void>::Create(std::move(req), std::move(future));
+        FutureHandle<void>::Create(std::move(req), std::move(future));
     return res;
 }
 

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -606,71 +606,26 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::InnerBatchPut(
     const std::vector<ObjectKey>& keys,
     std::vector<std::vector<Slice>>& batched_slices,
     const WriteRouteRequestConfig& route_config) {
-    std::vector<tl::expected<void, ErrorCode>> results(
-        keys.size(), tl::unexpected(ErrorCode::INTERNAL_ERROR));
+    if (ha_manager_ && ha_manager_->IsDegraded()) {
+        return InnerBatchPutDegraded(keys, batched_slices);
+    }
+    return InnerBatchPutNormal(keys, batched_slices, route_config);
+}
 
-    // Phase 1: create task handles for each key.
+std::vector<tl::expected<void, ErrorCode>>
+P2PClientService::InnerBatchPutDegraded(
+    const std::vector<ObjectKey>& keys,
+    std::vector<std::vector<Slice>>& batched_slices) {
+    // Phase 1: dispatch all local writes.
     std::vector<tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>>
         handles;
     handles.reserve(keys.size());
-
-    if (ha_manager_ && ha_manager_->IsDegraded()) {
-        // DEGRADED: skip master RPC, write locally for each key.
-        for (size_t i = 0; i < keys.size(); ++i) {
-            handles.push_back(
-                CreatePutHandleFromLocal(keys[i], batched_slices[i]));
-        }
-    } else {
-        // NORMAL: fetch routes from master, write based on routes.
-        auto batch_route_result =
-            BatchFetchWriteRoutes(keys, batched_slices, route_config);
-        if (!batch_route_result) {
-            LOG(ERROR) << "BatchGetWriteRoute RPC failed: "
-                       << batch_route_result.error();
-            std::fill(results.begin(), results.end(),
-                      tl::unexpected(batch_route_result.error()));
-            return results;
-        }
-
-        auto& batch_resp = batch_route_result.value();
-        for (size_t i = 0; i < keys.size(); ++i) {
-            if (batch_resp.error_codes[i] != ErrorCode::OK) {
-                handles.push_back(tl::unexpected(batch_resp.error_codes[i]));
-            } else {
-                handles.push_back(CreatePutHandleViaRoute(
-                    keys[i], batched_slices[i], route_config,
-                    std::move(batch_resp.responses[i].candidates)));
-            }
-        }
+    for (size_t i = 0; i < keys.size(); ++i) {
+        handles.push_back(CreatePutHandleFromLocal(keys[i], batched_slices[i]));
     }
 
-    // Phase 2: wait every handle and collect results.
-    if (handles.size() != keys.size()) {
-        LOG(ERROR) << "handles size mismatch";
-        return results;
-    }
-    for (size_t i = 0; i < handles.size(); ++i) {
-        if (!handles[i]) {
-            if (!IsAlreadyExistsError(handles[i].error())) {
-                LOG(ERROR) << "Failed to create put handle for key: " << keys[i]
-                           << ", error: " << handles[i].error();
-                results[i] = tl::unexpected(handles[i].error());
-            } else {
-                results[i] = {};
-            }
-        } else if (!handles[i].value()) {
-            LOG(ERROR) << "put task handle is null for key: " << keys[i];
-            results[i] = tl::unexpected(ErrorCode::INTERNAL_ERROR);
-        } else {
-            auto wait_result = handles[i].value()->Wait();
-            if (!wait_result) {
-                LOG(ERROR) << "Failed to put key: " << keys[i]
-                           << ", error: " << wait_result.error();
-            }
-            results[i] = wait_result;
-        }
-    }
-    return results;
+    // Phase 2: wait each handle and collect results.
+    return CollectResults(handles, keys);
 }
 
 tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
@@ -690,6 +645,63 @@ P2PClientService::CreatePutHandleFromLocal(const std::string& key,
     }
 
     return tl::unexpected(local_handle.error());
+}
+
+std::vector<tl::expected<void, ErrorCode>> P2PClientService::CollectResults(
+    std::vector<tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>>&
+        handles,
+    const std::vector<ObjectKey>& keys) {
+    std::vector<tl::expected<void, ErrorCode>> results(
+        keys.size(), tl::unexpected(ErrorCode::INTERNAL_ERROR));
+    for (size_t i = 0; i < handles.size(); ++i) {
+        if (!handles[i]) {
+            if (!IsAlreadyExistsError(handles[i].error())) {
+                LOG(ERROR) << "Failed to put key: " << keys[i]
+                           << ", error: " << handles[i].error();
+                results[i] = tl::unexpected(handles[i].error());
+            } else {
+                results[i] = {};
+            }
+        } else if (!handles[i].value()) {
+            LOG(ERROR) << "put task handle is null for key: " << keys[i];
+            results[i] = tl::unexpected(ErrorCode::INTERNAL_ERROR);
+        } else {
+            auto wait_result = handles[i].value()->Wait();
+
+            if (wait_result || IsAlreadyExistsError(wait_result.error())) {
+                results[i] = {};
+            } else {
+                LOG(ERROR) << "Failed to put key: " << keys[i]
+                           << ", error: " << wait_result.error();
+                results[i] = tl::unexpected(wait_result.error());
+            }
+        }
+    }
+    return results;
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+P2PClientService::InnerBatchPutNormal(
+    const std::vector<ObjectKey>& keys,
+    std::vector<std::vector<Slice>>& batched_slices,
+    const WriteRouteRequestConfig& route_config) {
+    // Phase 1: fetch write routes from master.
+    auto batch_routes =
+        BatchFetchWriteRoutes(keys, batched_slices, route_config);
+    if (!batch_routes) {
+        LOG(ERROR) << "BatchGetWriteRoute RPC failed: " << batch_routes.error();
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(batch_routes.error()));
+    }
+
+    // Phase 2:
+    // 2.1: async dispatch first-candidate writes for each key
+    // 2.2: wrap each key in a retry chain based on rotute
+    auto handles = CreatePutHandlesFromRoute(keys, batched_slices, route_config,
+                                             batch_routes.value());
+
+    // Phase 3: wait every retry chain and collect results.
+    return CollectResults(handles, keys);
 }
 
 tl::expected<BatchGetWriteRouteResponse, ErrorCode>
@@ -716,11 +728,85 @@ P2PClientService::BatchFetchWriteRoutes(
     return batch_route_result;
 }
 
-tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
-P2PClientService::CreatePutHandleViaRoute(
-    const std::string& key, std::vector<Slice>& slices,
-    const WriteRouteRequestConfig& config,
-    std::vector<WriteCandidate> candidates) {
+std::vector<tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>>
+P2PClientService::CreatePutHandlesFromRoute(
+    const std::vector<ObjectKey>& keys,
+    std::vector<std::vector<Slice>>& batched_slices,
+    const WriteRouteRequestConfig& route_config,
+    BatchGetWriteRouteResponse& batch_resp) {
+    struct WriteTask {
+        std::unique_ptr<TaskHandle<void>> first_task;
+        std::string first_route;
+        std::vector<std::unique_ptr<WriteOp>> retry_op_list;
+    };
+
+    // Step 1: dispatch first candidate for each key so all writes are
+    // in-flight before we build retry chain.
+    std::vector<tl::expected<WriteTask, ErrorCode>> tasks;
+    tasks.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (batch_resp.error_codes[i] != ErrorCode::OK) {
+            tasks.push_back(tl::unexpected(batch_resp.error_codes[i]));
+            continue;
+        }
+        auto ops = BuildWriteOps(keys[i], batched_slices[i], route_config,
+                                 std::move(batch_resp.responses[i].candidates));
+        if (!ops) {
+            LOG(ERROR) << "fail to build write ops"
+                       << ", key=" << keys[i] << ", error=" << ops.error();
+            tasks.push_back(tl::unexpected(ops.error()));
+            continue;
+        }
+        std::string first_route(ops->front()->route());
+        std::unique_ptr<TaskHandle<void>> first_task;
+        try {
+            // start a async write task and generate a wait handle
+            first_task = ops->front()->Dispatch();
+        } catch (const std::exception& e) {
+            LOG(ERROR) << "First-candidate dispatch threw, key: " << keys[i]
+                       << ", route: " << first_route << ", what: " << e.what();
+            tasks.push_back(tl::unexpected(ErrorCode::INTERNAL_ERROR));
+            continue;
+        } catch (...) {
+            LOG(ERROR) << "First-candidate dispatch threw unknown, key: "
+                       << keys[i] << ", route: " << first_route;
+            tasks.push_back(tl::unexpected(ErrorCode::INTERNAL_ERROR));
+            continue;
+        }
+        tasks.push_back(WriteTask{std::move(first_task),
+                                  std::move(first_route),
+                                  {std::make_move_iterator(ops->begin() + 1),
+                                   std::make_move_iterator(ops->end())}});
+    }
+
+    // Step 2: build a retry chain for each key and wrap it in task_handle
+    using Handle = tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>;
+    std::vector<Handle> handles;
+    handles.reserve(keys.size());
+    for (size_t i = 0; i < tasks.size(); ++i) {
+        if (!tasks[i]) {
+            handles.push_back(tl::unexpected(tasks[i].error()));
+            continue;
+        }
+        auto& t = *tasks[i];
+        auto promise = std::make_shared<
+            async_simple::Promise<tl::expected<void, ErrorCode>>>();
+        auto future = promise->getFuture();
+        RunWriteWithRetry(std::move(promise), std::move(t.first_task),
+                          std::move(t.first_route), std::move(t.retry_op_list),
+                          keys[i])
+            .start([](auto&&) {});
+        handles.push_back(FutureHandle<void>::Create(std::shared_ptr<void>{},
+                                                     std::move(future)));
+    }
+    return handles;
+}
+
+auto P2PClientService::BuildWriteOps(const std::string& key,
+                                     std::vector<Slice>& slices,
+                                     const WriteRouteRequestConfig& config,
+                                     std::vector<WriteCandidate> candidates)
+    -> tl::expected<std::vector<std::unique_ptr<WriteOp>>, ErrorCode> {
     if (candidates.empty()) {
         LOG(ERROR) << "No write candidates for key: " << key;
         return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
@@ -736,7 +822,7 @@ P2PClientService::CreatePutHandleViaRoute(
         write_req->src_buffers.push_back(buf);
     }
 
-    std::vector<WriteOp> write_ops;
+    std::vector<std::unique_ptr<WriteOp>> write_ops;
     for (auto& candidate : candidates) {
         auto& proxy = candidate.replica;
         if (proxy.client_id == client_id_) {
@@ -750,14 +836,14 @@ P2PClientService::CreatePutHandleViaRoute(
                 LOG(ERROR) << "Data manager not initialized";
                 continue;
             }
-            write_ops.push_back(LocalWriteOp{
-                data_manager_ ? &*data_manager_ : nullptr, key, &slices});
+            write_ops.push_back(
+                std::make_unique<LocalWriteOp>(&*data_manager_, key, &slices));
         } else {
             std::string endpoint =
                 proxy.ip_address + ":" + std::to_string(proxy.rpc_port);
-            write_ops.push_back(RemoteWriteOp{
+            write_ops.push_back(std::make_unique<RemoteWriteOp>(
                 &GetOrCreatePeerClient(endpoint), write_req, std::move(proxy),
-                route_cache_ ? &*route_cache_ : nullptr, endpoint});
+                route_cache_ ? &*route_cache_ : nullptr, endpoint));
         }
     }
 
@@ -766,83 +852,135 @@ P2PClientService::CreatePutHandleViaRoute(
         return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
     }
 
-    auto promise =
-        std::make_shared<std::promise<tl::expected<void, ErrorCode>>>();
-    auto future = promise->get_future();
-
-    RunWriteRetry(std::move(write_ops), key, promise).start([](auto&&) {});
-
-    return FutureHandle<void>::Create(std::move(write_req), std::move(future));
+    return write_ops;
 }
 
-async_simple::coro::Lazy<tl::expected<void, ErrorCode>>
-P2PClientService::LocalWriteOp::operator()() {
+// TODO (TE mode blocking):
+// When local_transfer_mode == TE, data_manager->Put() returns a
+// CallableTaskHandle whose WaitAsync() falls back to the base class synchronous
+// Wait() — there is no true coroutine suspension point.
+// As a result, co_await current_task->WaitAsync() inside RunWriteWithRetry will
+// block the coroutine worker thread for the full duration of the TE transfer
+// instead of yielding it.
+// The retry chain can only advance after that blocking wait returns.
+// See the TODO in DataManager::PutViaTe for planned async improvements.
+std::unique_ptr<TaskHandle<void>> P2PClientService::LocalWriteOp::Dispatch() {
     if (!data_manager) {
         LOG(ERROR) << "Data manager not initialized";
-        co_return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+        return CallableTaskHandle<void>::Create(
+            []() -> tl::expected<void, ErrorCode> {
+                return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+            });
     }
     auto handle = data_manager->Put(key, *slices);
     if (!handle) {
         if (!IsAlreadyExistsError(handle.error())) {
-            LOG(ERROR) << "Local write failed, key: " << key
+            LOG(ERROR) << "Local write failed (dispatch), key: " << key
                        << ", error: " << handle.error();
         }
-        co_return tl::unexpected(handle.error());
+        return CallableTaskHandle<void>::Create(
+            [e = handle.error()]() -> tl::expected<void, ErrorCode> {
+                return tl::make_unexpected(e);
+            });
     }
-    co_return handle.value()->Wait();
+    return std::move(handle.value());
 }
 
-async_simple::coro::Lazy<tl::expected<void, ErrorCode>>
-P2PClientService::RemoteWriteOp::operator()() {
-    auto result = co_await peer_ptr->AsyncWriteRemoteData(*write_req);
-    if (result.has_value()) {
-        if (route_cache) {
-            P2PProxyDescriptor np = proxy;
-            np.segment_id = result.value();
-            route_cache->Upsert(write_req->key, {np});
-        }
-        co_return tl::expected<void, ErrorCode>{};
-    }
-    if (!IsAlreadyExistsError(result.error())) {
-        LOG(ERROR) << "Failed to write to remote, key: " << write_req->key
-                   << ", error: " << result.error();
-    }
-    co_return tl::unexpected(result.error());
-}
+std::unique_ptr<TaskHandle<void>> P2PClientService::RemoteWriteOp::Dispatch() {
+    auto promise = std::make_shared<
+        async_simple::Promise<tl::expected<void, ErrorCode>>>();
+    auto future = promise->getFuture();
 
-async_simple::coro::Lazy<void> P2PClientService::RunWriteRetry(
-    std::vector<WriteOp> write_ops, const std::string& key,
-    std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise) {
-    auto get_route = [](const WriteOp& op) {
-        return std::visit([](const auto& o) { return o.route(); }, op);
-    };
-    try {
-        for (auto& op : write_ops) {
+    auto req = write_req;
+    auto cached_proxy = proxy;
+    auto* cache = route_cache;
+
+    peer_ptr->AsyncWriteRemoteData(*write_req)
+        .start([promise, req, cached_proxy,
+                cache](async_simple::Try<tl::expected<UUID, ErrorCode>>&&
+                           remote_res) mutable {
+            tl::expected<void, ErrorCode> out;
             try {
-                auto result =
-                    co_await std::visit([](auto& o) { return o(); }, op);
-                if (result.has_value() ||
-                    IsAlreadyExistsError(result.error())) {
-                    promise->set_value({});
-                    co_return;
+                auto& result = remote_res.value();
+                if (result.has_value()) {
+                    if (cache) {
+                        P2PProxyDescriptor desc = cached_proxy;
+                        desc.segment_id = result.value();
+                        cache->Upsert(req->key, {desc});
+                    }
+                } else {
+                    if (!IsAlreadyExistsError(result.error())) {
+                        LOG(ERROR)
+                            << "Failed to write to remote, key: " << req->key
+                            << ", error: " << result.error();
+                    }
+                    out = tl::make_unexpected(result.error());
                 }
-                LOG(ERROR) << "Write candidate failed, key: " << key
-                           << ", route: " << get_route(op)
-                           << ", error: " << result.error();
             } catch (const std::exception& e) {
-                LOG(ERROR) << "Write candidate failed, key: " << key
-                           << ", route: " << get_route(op)
-                           << ", exception: " << e.what();
+                LOG(ERROR) << "Remote write threw, key: " << req->key
+                           << ", what: " << e.what();
+                out = tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
             } catch (...) {
-                LOG(ERROR) << "Write candidate failed, key: " << key
-                           << ", route: " << get_route(op)
-                           << ", unknown exception";
+                LOG(ERROR) << "Remote write threw unknown, key: " << req->key;
+                out = tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
             }
+            promise->setValue(std::move(out));
+        });
+
+    return FutureHandle<void>::Create(req, std::move(future));
+}
+
+async_simple::coro::Lazy<void> P2PClientService::RunWriteWithRetry(
+    std::shared_ptr<async_simple::Promise<tl::expected<void, ErrorCode>>>
+        promise,
+    std::unique_ptr<TaskHandle<void>> current_task, std::string current_route,
+    std::vector<std::unique_ptr<WriteOp>> retry_op_list, std::string key) {
+    size_t retry_cnt = 0;
+    while (current_task) {
+        tl::expected<void, ErrorCode> result;
+        try {
+            result = co_await current_task->WaitAsync();
+        } catch (const std::exception& e) {
+            LOG(ERROR) << "Wait threw, key: " << key
+                       << ", route: " << current_route
+                       << ", what: " << e.what();
+            result = tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        } catch (...) {
+            LOG(ERROR) << "Wait threw unknown, key: " << key
+                       << ", route: " << current_route;
+            result = tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
         }
-        promise->set_value(tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE));
-    } catch (...) {
-        promise->set_value(tl::unexpected(ErrorCode::INTERNAL_ERROR));
+        if (result.has_value() || IsAlreadyExistsError(result.error())) {
+            promise->setValue(std::move(result));
+            co_return;
+        }
+        LOG(ERROR) << "Write candidate failed, key: " << key
+                   << ", route: " << current_route
+                   << ", retry_cnt: " << retry_cnt
+                   << ", error: " << result.error();
+        current_task.reset();
+        while (retry_cnt < retry_op_list.size() && !current_task) {
+            auto& op = retry_op_list[retry_cnt];
+            current_route = std::string(op->route());
+            try {
+                current_task = op->Dispatch();
+            } catch (const std::exception& e) {
+                LOG(ERROR) << "Dispatch threw, key: " << key
+                           << ", route: " << current_route
+                           << ", retry_cnt: " << retry_cnt
+                           << ", what: " << e.what();
+            } catch (...) {
+                LOG(ERROR) << "Dispatch threw unknown, key: " << key
+                           << ", retry_cnt: " << retry_cnt
+                           << ", route: " << current_route;
+            }
+            retry_cnt++;
+        }
     }
+    LOG(ERROR) << "write failed with all retry list, key:" << key;
+    tl::expected<void, ErrorCode> exhausted =
+        tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+    promise->setValue(std::move(exhausted));
 }
 
 // ============================================================================
@@ -1257,12 +1395,12 @@ tl::expected<ReadTaskHandle, ErrorCode> P2PClientService::InnerGetViaRoute(
         req->dest_buffers.push_back(buf);
     }
 
-    auto promise =
-        std::make_shared<std::promise<tl::expected<void, ErrorCode>>>();
-    auto future = promise->get_future();
+    auto promise = std::make_shared<
+        async_simple::Promise<tl::expected<void, ErrorCode>>>();
+    auto future = promise->getFuture();
 
     const uint64_t object_size = iter.object_size();
-    RunReadRetry(std::move(iter), req, promise).start([](auto&&) {});
+    RunReadWithRetry(std::move(iter), req, promise).start([](auto&&) {});
 
     ReadTaskHandle res;
     res.data_size = object_size;
@@ -1272,16 +1410,18 @@ tl::expected<ReadTaskHandle, ErrorCode> P2PClientService::InnerGetViaRoute(
 }
 
 // Coroutine iterates route candidates and retries on failure.
-async_simple::coro::Lazy<void> P2PClientService::RunReadRetry(
+async_simple::coro::Lazy<void> P2PClientService::RunReadWithRetry(
     RouteIterator iter, std::shared_ptr<RemoteReadRequest> req,
-    std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise) {
+    std::shared_ptr<async_simple::Promise<tl::expected<void, ErrorCode>>>
+        promise) {
     ErrorCode final_result = ErrorCode::OBJECT_NOT_FOUND;
     try {
         while (auto route = co_await iter.AsyncNext()) {
             try {
                 auto result = co_await route->peer->AsyncReadRemoteData(*req);
                 if (result.has_value()) {
-                    promise->set_value({});
+                    tl::expected<void, ErrorCode> ok;
+                    promise->setValue(std::move(ok));
                     co_return;
                 } else if (result.error() != ErrorCode::OBJECT_NOT_FOUND) {
                     LOG(ERROR) << "Failed to get from remote, key: " << req->key
@@ -1298,9 +1438,12 @@ async_simple::coro::Lazy<void> P2PClientService::RunReadRetry(
             }
             iter.Evict(*route);
         }
-        promise->set_value(tl::unexpected(final_result));
+        tl::expected<void, ErrorCode> err = tl::make_unexpected(final_result);
+        promise->setValue(std::move(err));
     } catch (...) {
-        promise->set_value(tl::unexpected(ErrorCode::INTERNAL_ERROR));
+        tl::expected<void, ErrorCode> internal_err =
+            tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        promise->setValue(std::move(internal_err));
     }
 }
 

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -651,27 +651,23 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::InnerBatchPut(
     }
     for (size_t i = 0; i < handles.size(); ++i) {
         if (!handles[i]) {
-            LOG(ERROR) << "Failed to create put handle for key: " << keys[i]
-                       << ", error: " << handles[i].error();
-            results[i] = tl::unexpected(handles[i].error());
-        } else if (!handles[i].value()) {
             if (!IsAlreadyExistsError(handles[i].error())) {
-                LOG(ERROR) << "put task handle is null for key: " << keys[i];
+                LOG(ERROR) << "Failed to create put handle for key: " << keys[i]
+                           << ", error: " << handles[i].error();
                 results[i] = tl::unexpected(handles[i].error());
             } else {
                 results[i] = {};
             }
+        } else if (!handles[i].value()) {
+            LOG(ERROR) << "put task handle is null for key: " << keys[i];
+            results[i] = tl::unexpected(ErrorCode::INTERNAL_ERROR);
         } else {
             auto wait_result = handles[i].value()->Wait();
-            if (wait_result || !IsAlreadyExistsError(wait_result.error())) {
-                if (!wait_result) {
-                    LOG(ERROR) << "Failed to put key: " << keys[i]
-                               << ", error: " << wait_result.error();
-                }
-                results[i] = wait_result;
-            } else {
-                results[i] = {};
+            if (!wait_result) {
+                LOG(ERROR) << "Failed to put key: " << keys[i]
+                           << ", error: " << wait_result.error();
             }
+            results[i] = wait_result;
         }
     }
     return results;
@@ -680,6 +676,10 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::InnerBatchPut(
 tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
 P2PClientService::CreatePutHandleFromLocal(const std::string& key,
                                            std::vector<Slice>& slices) {
+    if (!data_manager_.has_value()) {
+        LOG(ERROR) << "Data manager not initialized";
+        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
     auto local_handle = data_manager_->Put(key, slices);
 
     if (local_handle) {
@@ -750,12 +750,14 @@ P2PClientService::CreatePutHandleViaRoute(
                 LOG(ERROR) << "Data manager not initialized";
                 continue;
             }
-            write_ops.push_back(MakeLocalWriteOp(key, &slices));
+            write_ops.push_back(LocalWriteOp{
+                data_manager_ ? &*data_manager_ : nullptr, key, &slices});
         } else {
             std::string endpoint =
                 proxy.ip_address + ":" + std::to_string(proxy.rpc_port);
-            write_ops.push_back(MakeRemoteWriteOp(
-                GetOrCreatePeerClient(endpoint), write_req, proxy));
+            write_ops.push_back(RemoteWriteOp{
+                &GetOrCreatePeerClient(endpoint), write_req, std::move(proxy),
+                route_cache_ ? &*route_cache_ : nullptr, endpoint});
         }
     }
 
@@ -768,69 +770,73 @@ P2PClientService::CreatePutHandleViaRoute(
         std::make_shared<std::promise<tl::expected<void, ErrorCode>>>();
     auto future = promise->get_future();
 
-    RunWriteRetry(std::move(write_ops), promise).start([](auto&&) {});
+    RunWriteRetry(std::move(write_ops), key, promise).start([](auto&&) {});
 
     return FutureHandle<void>::Create(std::move(write_req), std::move(future));
 }
 
-P2PClientService::WriteOp P2PClientService::MakeLocalWriteOp(
-    const std::string& key, std::vector<Slice>* slices) {
-    return WriteOp(
-        [this, key,
-         slices]() -> async_simple::coro::Lazy<tl::expected<void, ErrorCode>> {
-            auto handle = data_manager_->Put(key, *slices);
-            if (!handle) {
-                if (!IsAlreadyExistsError(handle.error())) {
-                    LOG(ERROR) << "Local write failed, key: " << key
-                               << ", error: " << handle.error();
-                }
-                co_return tl::unexpected(handle.error());
-            }
-            co_return handle.value()->Wait();
-        });
+async_simple::coro::Lazy<tl::expected<void, ErrorCode>>
+P2PClientService::LocalWriteOp::operator()() {
+    if (!data_manager) {
+        LOG(ERROR) << "Data manager not initialized";
+        co_return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    auto handle = data_manager->Put(key, *slices);
+    if (!handle) {
+        if (!IsAlreadyExistsError(handle.error())) {
+            LOG(ERROR) << "Local write failed, key: " << key
+                       << ", error: " << handle.error();
+        }
+        co_return tl::unexpected(handle.error());
+    }
+    co_return handle.value()->Wait();
 }
 
-P2PClientService::WriteOp P2PClientService::MakeRemoteWriteOp(
-    PeerClient& peer, std::shared_ptr<RemoteWriteRequest> write_req,
-    P2PProxyDescriptor proxy) {
-    RouteCache* route_cache = route_cache_ ? &(*route_cache_) : nullptr;
-    return WriteOp(
-        [peer_ptr = &peer, write_req = std::move(write_req), proxy,
-         route_cache]()
-            -> async_simple::coro::Lazy<tl::expected<void, ErrorCode>> {
-            auto result = co_await peer_ptr->AsyncWriteRemoteData(*write_req);
-            if (result.has_value()) {
-                if (route_cache) {
-                    P2PProxyDescriptor np = proxy;
-                    np.segment_id = result.value();
-                    route_cache->Upsert(write_req->key, {np});
-                }
-                co_return tl::expected<void, ErrorCode>{};
-            }
-            if (!IsAlreadyExistsError(result.error())) {
-                LOG(ERROR) << "Failed to write to remote, key: "
-                           << write_req->key << ", error: " << result.error();
-            }
-            co_return tl::unexpected(result.error());
-        });
+async_simple::coro::Lazy<tl::expected<void, ErrorCode>>
+P2PClientService::RemoteWriteOp::operator()() {
+    auto result = co_await peer_ptr->AsyncWriteRemoteData(*write_req);
+    if (result.has_value()) {
+        if (route_cache) {
+            P2PProxyDescriptor np = proxy;
+            np.segment_id = result.value();
+            route_cache->Upsert(write_req->key, {np});
+        }
+        co_return tl::expected<void, ErrorCode>{};
+    }
+    if (!IsAlreadyExistsError(result.error())) {
+        LOG(ERROR) << "Failed to write to remote, key: " << write_req->key
+                   << ", error: " << result.error();
+    }
+    co_return tl::unexpected(result.error());
 }
 
 async_simple::coro::Lazy<void> P2PClientService::RunWriteRetry(
-    std::vector<WriteOp> write_ops,
+    std::vector<WriteOp> write_ops, const std::string& key,
     std::shared_ptr<std::promise<tl::expected<void, ErrorCode>>> promise) {
+    auto get_route = [](const WriteOp& op) {
+        return std::visit([](const auto& o) { return o.route(); }, op);
+    };
     try {
         for (auto& op : write_ops) {
             try {
-                auto result = co_await op();
+                auto result =
+                    co_await std::visit([](auto& o) { return o(); }, op);
                 if (result.has_value() ||
                     IsAlreadyExistsError(result.error())) {
                     promise->set_value({});
                     co_return;
                 }
+                LOG(ERROR) << "Write candidate failed, key: " << key
+                           << ", route: " << get_route(op)
+                           << ", error: " << result.error();
             } catch (const std::exception& e) {
-                LOG(ERROR) << "Write candidate failed, exception: " << e.what();
+                LOG(ERROR) << "Write candidate failed, key: " << key
+                           << ", route: " << get_route(op)
+                           << ", exception: " << e.what();
             } catch (...) {
-                LOG(ERROR) << "Write candidate failed, unknown exception";
+                LOG(ERROR) << "Write candidate failed, key: " << key
+                           << ", route: " << get_route(op)
+                           << ", unknown exception";
             }
         }
         promise->set_value(tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE));


### PR DESCRIPTION
## Description

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
