### PR TITLE
[Refactor] Extract RequestMetric from P2PClientMetric

### DIFF
--- a/mooncake-store/include/client_metric.h
+++ b/mooncake-store/include/client_metric.h
@@ -324,7 +324,7 @@ struct ClientMetric {
      *   (default: 0, 0 = collect but don't report)
      */
     static std::unique_ptr<ClientMetric> Create(
-        std::map<std::string, std::string> labels = {}) {
+        const std::map<std::string, std::string>& labels = {}) {
         return CreatePtr<ClientMetric>(labels);
     }
 
@@ -333,8 +333,9 @@ struct ClientMetric {
 
     uint64_t GetReportingInterval() const { return metrics_interval_seconds_; }
 
-    explicit ClientMetric(uint64_t interval_seconds = 0,
-                          std::map<std::string, std::string> labels = {});
+    explicit ClientMetric(
+        uint64_t interval_seconds = 0,
+        const std::map<std::string, std::string>& labels = {});
     virtual ~ClientMetric();
 
    protected:
@@ -344,7 +345,7 @@ struct ClientMetric {
      */
     template <typename T>
     static std::unique_ptr<T> CreatePtr(
-        std::map<std::string, std::string> labels) {
+        const std::map<std::string, std::string>& labels) {
         if (!IsEnabled()) {
             LOG(INFO) << "Client metrics disabled (set "
                          "MC_STORE_CLIENT_METRIC=1 to enable)";

--- a/mooncake-store/include/p2p_client_metric.h
+++ b/mooncake-store/include/p2p_client_metric.h
@@ -4,21 +4,34 @@
 
 namespace mooncake {
 
+// Request metrics for Get/Put operations
+struct RequestMetric {
+    // Get metrics
+    ylt::metric::counter_t get_requests;
+    ylt::metric::counter_t get_hits;
+    ylt::metric::counter_t get_misses;
+    ylt::metric::counter_t get_failures;
+    ylt::metric::counter_t get_bytes;
+    ylt::metric::histogram_t get_latency;
+
+    // Put metrics
+    ylt::metric::counter_t put_requests;
+    ylt::metric::counter_t put_failures;
+    ylt::metric::counter_t put_bytes;
+    ylt::metric::histogram_t put_latency;
+
+    explicit RequestMetric(
+        const std::string& prefix,
+        const std::map<std::string, std::string>& labels = {});
+
+    void serialize(std::string& str);
+    std::string summary_metrics();
+};
+
 // P2P client metrics for local storage operations
 struct P2PClientMetric : public ClientMetric {
-    // Local Get metrics
-    ylt::metric::counter_t local_get_requests;
-    ylt::metric::counter_t local_get_hits;
-    ylt::metric::counter_t local_get_misses;
-    ylt::metric::counter_t local_get_failures;
-    ylt::metric::counter_t local_get_bytes;
-    ylt::metric::histogram_t local_get_latency;
-
-    // Local Put metrics
-    ylt::metric::counter_t local_put_requests;
-    ylt::metric::counter_t local_put_failures;
-    ylt::metric::counter_t local_put_bytes;
-    ylt::metric::histogram_t local_put_latency;
+    // Local request metrics (Get/Put)
+    RequestMetric local_request;
 
     /**
      * @brief Creates a P2PClientMetric instance based on environment variables
@@ -26,12 +39,13 @@ struct P2PClientMetric : public ClientMetric {
      * enabled, nullptr if disabled
      */
     static std::unique_ptr<P2PClientMetric> Create(
-        std::map<std::string, std::string> labels) {
+        const std::map<std::string, std::string>& labels = {}) {
         return CreatePtr<P2PClientMetric>(labels);
     }
 
-    explicit P2PClientMetric(uint64_t interval_seconds = 0,
-                             std::map<std::string, std::string> labels = {});
+    explicit P2PClientMetric(
+        uint64_t interval_seconds = 0,
+        const std::map<std::string, std::string>& labels = {});
 
     void serialize(std::string& str) override;
     std::string summary_metrics() override;

--- a/mooncake-store/src/client_metric.cpp
+++ b/mooncake-store/src/client_metric.cpp
@@ -55,7 +55,7 @@ uint64_t parseMetricsInterval() {
 }  // anonymous namespace
 
 ClientMetric::ClientMetric(uint64_t interval_seconds,
-                           std::map<std::string, std::string> labels)
+                           const std::map<std::string, std::string>& labels)
     : transfer_metric(labels),
       master_client_metric(labels),
       should_stop_metrics_thread_(false),

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -2,47 +2,65 @@
 
 namespace mooncake {
 
-P2PClientMetric::P2PClientMetric(uint64_t interval_seconds,
-                                 std::map<std::string, std::string> labels)
+RequestMetric::RequestMetric(const std::string& prefix,
+                             const std::map<std::string, std::string>& labels)
+    : get_requests(prefix + "_get_requests_total",
+                   "Total number of Get requests", labels),
+      get_hits(prefix + "_get_hits_total", "Total number of Get hits (found)",
+               labels),
+      get_misses(prefix + "_get_misses_total",
+                 "Total number of Get misses (not found)", labels),
+      get_failures(prefix + "_get_failures_total",
+                   "Total number of failed Get requests", labels),
+      get_bytes(prefix + "_get_bytes_total", "Total bytes read by Get", labels),
+      get_latency(prefix + "_get_latency_us", "Get latency (us)",
+                  kLatencyBucket, labels),
+      put_requests(prefix + "_put_requests_total",
+                   "Total number of Put requests", labels),
+      put_failures(prefix + "_put_failures_total",
+                   "Total number of failed Put requests", labels),
+      put_bytes(prefix + "_put_bytes_total", "Total bytes written by Put",
+                labels),
+      put_latency(prefix + "_put_latency_us", "Put latency (us)",
+                  kLatencyBucket, labels) {}
+
+void RequestMetric::serialize(std::string& str) {
+    get_requests.serialize(str);
+    get_hits.serialize(str);
+    get_misses.serialize(str);
+    get_failures.serialize(str);
+    get_bytes.serialize(str);
+    get_latency.serialize(str);
+    put_requests.serialize(str);
+    put_failures.serialize(str);
+    put_bytes.serialize(str);
+    put_latency.serialize(str);
+}
+
+std::string RequestMetric::summary_metrics() {
+    std::stringstream ss;
+    ss << "Get: " << get_requests.value() << " requests, " << get_hits.value()
+       << " hits, " << get_misses.value() << " misses, " << get_failures.value()
+       << " failures, " << byte_size_to_string(get_bytes.value()) << " read\n";
+
+    ss << "Put: " << put_requests.value() << " requests, "
+       << put_failures.value() << " failures, "
+       << byte_size_to_string(put_bytes.value()) << " written\n";
+
+    return ss.str();
+}
+
+P2PClientMetric::P2PClientMetric(
+    uint64_t interval_seconds, const std::map<std::string, std::string>& labels)
     : ClientMetric(interval_seconds, labels),
-      local_get_requests("mooncake_p2p_local_get_requests_total",
-                         "Total number of local Get requests", labels),
-      local_get_hits("mooncake_p2p_local_get_hits_total",
-                     "Total number of local Get hits (found in local storage)",
-                     labels),
-      local_get_misses("mooncake_p2p_local_get_misses_total",
-                       "Total number of local Get misses (not found locally)",
-                       labels),
-      local_get_failures("mooncake_p2p_local_get_failures_total",
-                         "Total number of failed local Get requests", labels),
-      local_get_bytes("mooncake_p2p_local_get_bytes_total",
-                      "Total bytes read by local Get", labels),
-      local_get_latency("mooncake_p2p_local_get_latency_us",
-                        "Local Get latency (us)", kLatencyBucket, labels),
-      local_put_requests("mooncake_p2p_local_put_requests_total",
-                         "Total number of local Put requests", labels),
-      local_put_failures("mooncake_p2p_local_put_failures_total",
-                         "Total number of failed local Put requests", labels),
-      local_put_bytes("mooncake_p2p_local_put_bytes_total",
-                      "Total bytes written by local Put", labels),
-      local_put_latency("mooncake_p2p_local_put_latency_us",
-                        "Local Put latency (us)", kLatencyBucket, labels) {}
+      local_request("mooncake_p2p_local", labels) {}
 
 void P2PClientMetric::serialize(std::string& str) {
     // Call base class serialize first
     ClientMetric::serialize(str);
 
     // Then serialize P2P-specific metrics
-    local_get_requests.serialize(str);
-    local_get_hits.serialize(str);
-    local_get_misses.serialize(str);
-    local_get_failures.serialize(str);
-    local_get_bytes.serialize(str);
-    local_get_latency.serialize(str);
-    local_put_requests.serialize(str);
-    local_put_failures.serialize(str);
-    local_put_bytes.serialize(str);
-    local_put_latency.serialize(str);
+    local_request.serialize(str);
 }
 
 std::string P2PClientMetric::summary_metrics() {
@@ -51,16 +69,8 @@ std::string P2PClientMetric::summary_metrics() {
     ss << ClientMetric::summary_metrics();
 
     // Then add P2P-specific metrics
-    ss << "=== P2P Local Storage Metrics ===\n";
-
-    ss << "Local Get: " << local_get_requests.value() << " requests, "
-       << local_get_hits.value() << " hits, " << local_get_misses.value()
-       << " misses, " << local_get_failures.value() << " failures, "
-       << byte_size_to_string(local_get_bytes.value()) << " read\n";
-
-    ss << "Local Put: " << local_put_requests.value() << " requests, "
-       << local_put_failures.value() << " failures, "
-       << byte_size_to_string(local_put_bytes.value()) << " written\n";
+    ss << "=== P2P Local Request Metrics ===\n";
+    ss << local_request.summary_metrics();
 
     return ss.str();
 }

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -547,7 +547,7 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::BatchPut(
 
     Stopwatch stopwatch;
     if (metrics_) {
-        metrics_->local_put_requests.inc(keys.size());
+        metrics_->local_request.put_requests.inc(keys.size());
     }
 
     auto guard = AcquireInflightGuard();
@@ -574,7 +574,7 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::BatchPut(
         if (results[i].has_value()) {
             success_count++;
             if (metrics_) {
-                metrics_->local_put_bytes.inc(
+                metrics_->local_request.put_bytes.inc(
                     ClientService::CalculateSliceSize(batched_slices[i]));
             }
         }
@@ -582,11 +582,15 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::BatchPut(
     if (metrics_) {
         size_t failure_count = keys.size() - success_count;
         if (failure_count > 0) {
-            metrics_->local_put_failures.inc(failure_count);
+            metrics_->local_request.put_failures.inc(failure_count);
         }
         const auto elapsed = stopwatch.elapsed_us();
-        for (size_t i = 0; i < keys.size(); ++i) {
-            metrics_->local_put_latency.observe(elapsed);
+        if (!keys.empty()) {
+            const double avg_latency =
+                static_cast<double>(elapsed) / keys.size();
+            for (size_t i = 0; i < keys.size(); ++i) {
+                metrics_->local_request.put_latency.observe(avg_latency);
+            }
         }
     }
 
@@ -925,7 +929,7 @@ std::vector<tl::expected<ResultT, ErrorCode>> P2PClientService::BatchGetImpl(
     timer.LogRequest("batch_size=", keys.size());
 
     if (metrics_) {
-        metrics_->local_get_requests.inc(keys.size());
+        metrics_->local_request.get_requests.inc(keys.size());
     }
 
     std::vector<tl::expected<ResultT, ErrorCode>> results(
@@ -972,18 +976,22 @@ std::vector<tl::expected<ResultT, ErrorCode>> P2PClientService::BatchGetImpl(
         if (results[i].has_value()) {
             success_count++;
             if (metrics_) {
-                metrics_->local_get_bytes.inc(handles[i]->data_size);
+                metrics_->local_request.get_bytes.inc(handles[i]->data_size);
             }
         }
     }
     if (metrics_) {
         size_t failure_count = keys.size() - success_count;
         if (failure_count > 0) {
-            metrics_->local_get_failures.inc(failure_count);
+            metrics_->local_request.get_failures.inc(failure_count);
         }
         const auto elapsed = stopwatch.elapsed_us();
-        for (size_t i = 0; i < keys.size(); ++i) {
-            metrics_->local_get_latency.observe(elapsed);
+        if (!keys.empty()) {
+            const double avg_latency =
+                static_cast<double>(elapsed) / keys.size();
+            for (size_t i = 0; i < keys.size(); ++i) {
+                metrics_->local_request.get_latency.observe(avg_latency);
+            }
         }
     }
 
@@ -1052,7 +1060,7 @@ P2PClientService::BatchCreateGetHandlesImpl(
             handles[i] = std::move(local.value());
             // Count local cache hits
             if (metrics_) {
-                metrics_->local_get_hits.inc();
+                metrics_->local_request.get_hits.inc();
             }
         } else if (local.error() != ErrorCode::OBJECT_NOT_FOUND) {
             LOG(ERROR) << "Failed to get from local, key: " << keys[i]
@@ -1062,7 +1070,7 @@ P2PClientService::BatchCreateGetHandlesImpl(
             miss_indices.push_back(i);
             // Count local cache misses
             if (metrics_) {
-                metrics_->local_get_misses.inc();
+                metrics_->local_request.get_misses.inc();
             }
         }
     }

--- a/mooncake-store/tests/client_http_metrics_test.cpp
+++ b/mooncake-store/tests/client_http_metrics_test.cpp
@@ -219,19 +219,19 @@ TEST_F(ClientHttpMetricsTest, P2PClientMetricsHttpEndpointsTest) {
 
     // Add test data to P2P metrics
     // Local Put metrics
-    p2p_metrics->local_put_requests.inc(10);
-    p2p_metrics->local_put_bytes.inc(5 * 1024 * 1024);  // 5 MB
-    p2p_metrics->local_put_latency.observe(200);
-    p2p_metrics->local_put_latency.observe(300);
+    p2p_metrics->local_request.put_requests.inc(10);
+    p2p_metrics->local_request.put_bytes.inc(5 * 1024 * 1024);  // 5 MB
+    p2p_metrics->local_request.put_latency.observe(200);
+    p2p_metrics->local_request.put_latency.observe(300);
 
     // Local Get metrics
-    p2p_metrics->local_get_requests.inc(100);
-    p2p_metrics->local_get_hits.inc(80);
-    p2p_metrics->local_get_misses.inc(15);
-    p2p_metrics->local_get_failures.inc(5);
-    p2p_metrics->local_get_bytes.inc(20 * 1024 * 1024);  // 20 MB
-    p2p_metrics->local_get_latency.observe(100);
-    p2p_metrics->local_get_latency.observe(150);
+    p2p_metrics->local_request.get_requests.inc(100);
+    p2p_metrics->local_request.get_hits.inc(80);
+    p2p_metrics->local_request.get_misses.inc(15);
+    p2p_metrics->local_request.get_failures.inc(5);
+    p2p_metrics->local_request.get_bytes.inc(20 * 1024 * 1024);  // 20 MB
+    p2p_metrics->local_request.get_latency.observe(100);
+    p2p_metrics->local_request.get_latency.observe(150);
 
     // Create and start HTTP server
     coro_http::coro_http_server server(1, test_port);
@@ -337,13 +337,13 @@ TEST_F(ClientHttpMetricsTest, P2PClientMetricsHttpEndpointsTest) {
             << "P2P metrics summary endpoint returned wrong status";
 
         // Check summary contains expected P2P metrics
-        EXPECT_TRUE(resp.resp_body.find("P2P Local Storage Metrics") !=
+        EXPECT_TRUE(resp.resp_body.find("P2P Local Request Metrics") !=
                     std::string::npos)
             << "Summary should contain P2P metrics header";
-        EXPECT_TRUE(resp.resp_body.find("Local Put:") != std::string::npos)
-            << "Summary should contain local put section";
-        EXPECT_TRUE(resp.resp_body.find("Local Get:") != std::string::npos)
-            << "Summary should contain local get section";
+        EXPECT_TRUE(resp.resp_body.find("Put:") != std::string::npos)
+            << "Summary should contain put section";
+        EXPECT_TRUE(resp.resp_body.find("Get:") != std::string::npos)
+            << "Summary should contain get section";
         EXPECT_TRUE(resp.resp_body.find("10 requests") != std::string::npos)
             << "Summary should show 10 put requests";
         EXPECT_TRUE(resp.resp_body.find("100 requests") != std::string::npos)
@@ -376,11 +376,11 @@ TEST_F(ClientHttpMetricsTest, CombinedMetricsHttpEndpointsTest) {
     metrics->transfer_metric.total_read_bytes.inc(1024 * 1024);
     metrics->transfer_metric.total_write_bytes.inc(2 * 1024 * 1024);
 
-    p2p_metrics->local_get_requests.inc(50);
-    p2p_metrics->local_get_hits.inc(40);
-    p2p_metrics->local_get_bytes.inc(10 * 1024 * 1024);
-    p2p_metrics->local_put_requests.inc(20);
-    p2p_metrics->local_put_bytes.inc(5 * 1024 * 1024);
+    p2p_metrics->local_request.get_requests.inc(50);
+    p2p_metrics->local_request.get_hits.inc(40);
+    p2p_metrics->local_request.get_bytes.inc(10 * 1024 * 1024);
+    p2p_metrics->local_request.put_requests.inc(20);
+    p2p_metrics->local_request.put_bytes.inc(5 * 1024 * 1024);
 
     // Create and start HTTP server
     coro_http::coro_http_server server(1, test_port);
@@ -446,15 +446,15 @@ TEST_F(ClientHttpMetricsTest, CombinedMetricsHttpEndpointsTest) {
         EXPECT_TRUE(resp.resp_body.find("Transfer Metrics Summary") !=
                     std::string::npos)
             << "Should contain transfer metrics summary";
-        EXPECT_TRUE(resp.resp_body.find("P2P Local Storage Metrics") !=
+        EXPECT_TRUE(resp.resp_body.find("P2P Local Request Metrics") !=
                     std::string::npos)
             << "Should contain P2P metrics summary";
         EXPECT_TRUE(resp.resp_body.find("Total Read") != std::string::npos)
             << "Should contain transfer total read";
-        EXPECT_TRUE(resp.resp_body.find("Local Get:") != std::string::npos)
-            << "Should contain local get section";
-        EXPECT_TRUE(resp.resp_body.find("Local Put:") != std::string::npos)
-            << "Should contain local put section";
+        EXPECT_TRUE(resp.resp_body.find("Get:") != std::string::npos)
+            << "Should contain get section";
+        EXPECT_TRUE(resp.resp_body.find("Put:") != std::string::npos)
+            << "Should contain put section";
     }
 
     server.stop();

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -273,32 +273,32 @@ TEST_F(ClientMetricsTest, P2PClientMetricBasicTest) {
 
     // Test empty metrics
     std::string summary = metrics.summary_metrics();
-    EXPECT_TRUE(summary.find("Local Get: 0 requests") != std::string::npos);
-    EXPECT_TRUE(summary.find("Local Put: 0 requests") != std::string::npos);
+    EXPECT_TRUE(summary.find("Get: 0 requests") != std::string::npos);
+    EXPECT_TRUE(summary.find("Put: 0 requests") != std::string::npos);
 
     // Add put data
-    metrics.local_put_requests.inc();
-    metrics.local_put_requests.inc();
-    metrics.local_put_failures.inc();
-    metrics.local_put_bytes.inc(1024 * 1024);  // 1 MB
-    metrics.local_put_latency.observe(200);
-    metrics.local_put_latency.observe(300);
+    metrics.local_request.put_requests.inc();
+    metrics.local_request.put_requests.inc();
+    metrics.local_request.put_failures.inc();
+    metrics.local_request.put_bytes.inc(1024 * 1024);  // 1 MB
+    metrics.local_request.put_latency.observe(200);
+    metrics.local_request.put_latency.observe(300);
 
     // Add get data
-    metrics.local_get_requests.inc();
-    metrics.local_get_requests.inc();
-    metrics.local_get_requests.inc();
-    metrics.local_get_failures.inc();
-    metrics.local_get_misses.inc();
-    metrics.local_get_hits.inc();
-    metrics.local_get_bytes.inc(2 * 1024 * 1024);  // 2 MB
-    metrics.local_get_latency.observe(100);
-    metrics.local_get_latency.observe(150);
+    metrics.local_request.get_requests.inc();
+    metrics.local_request.get_requests.inc();
+    metrics.local_request.get_requests.inc();
+    metrics.local_request.get_failures.inc();
+    metrics.local_request.get_misses.inc();
+    metrics.local_request.get_hits.inc();
+    metrics.local_request.get_bytes.inc(2 * 1024 * 1024);  // 2 MB
+    metrics.local_request.get_latency.observe(100);
+    metrics.local_request.get_latency.observe(150);
 
     summary = metrics.summary_metrics();
-    EXPECT_TRUE(summary.find("Local Put: 2 requests") != std::string::npos);
+    EXPECT_TRUE(summary.find("Put: 2 requests") != std::string::npos);
     EXPECT_TRUE(summary.find("1.00 MB written") != std::string::npos);
-    EXPECT_TRUE(summary.find("Local Get: 3 requests") != std::string::npos);
+    EXPECT_TRUE(summary.find("Get: 3 requests") != std::string::npos);
     EXPECT_TRUE(summary.find("2.00 MB read") != std::string::npos);
     EXPECT_TRUE(summary.find("1 misses") != std::string::npos);
     EXPECT_TRUE(summary.find("1 hits") != std::string::npos);
@@ -310,17 +310,17 @@ TEST_F(ClientMetricsTest, P2PClientMetricSerializeTest) {
     P2PClientMetric metrics;
 
     // Add some data
-    metrics.local_put_requests.inc(100);
-    metrics.local_put_bytes.inc(50 * 1024 * 1024);  // 50 MB
-    metrics.local_get_requests.inc(500);
-    metrics.local_get_misses.inc(20);
-    metrics.local_get_hits.inc(480);
-    metrics.local_get_bytes.inc(100 * 1024 * 1024);  // 100 MB
+    metrics.local_request.put_requests.inc(100);
+    metrics.local_request.put_bytes.inc(50 * 1024 * 1024);  // 50 MB
+    metrics.local_request.get_requests.inc(500);
+    metrics.local_request.get_misses.inc(20);
+    metrics.local_request.get_hits.inc(480);
+    metrics.local_request.get_bytes.inc(100 * 1024 * 1024);  // 100 MB
 
     // Add latency data to test histogram output
-    metrics.local_put_latency.observe(200);
-    metrics.local_put_latency.observe(300);
-    metrics.local_get_latency.observe(100);
+    metrics.local_request.put_latency.observe(200);
+    metrics.local_request.put_latency.observe(300);
+    metrics.local_request.get_latency.observe(100);
 
     std::string serialized;
     metrics.serialize(serialized);
@@ -356,8 +356,8 @@ TEST_F(ClientMetricsTest, P2PClientMetricWithLabelsTest) {
 
     auto metrics = P2PClientMetric::Create(labels);
     ASSERT_NE(metrics, nullptr);
-    metrics->local_put_requests.inc();
-    metrics->local_get_requests.inc();
+    metrics->local_request.put_requests.inc();
+    metrics->local_request.get_requests.inc();
 
     std::string serialized;
     metrics->serialize(serialized);
@@ -378,8 +378,8 @@ TEST_F(ClientMetricsTest, P2PClientMetricInheritanceTest) {
     p2p_metrics->transfer_metric.total_read_bytes.inc(1024 * 1024);  // 1 MB
     p2p_metrics->transfer_metric.total_write_bytes.inc(2 * 1024 *
                                                        1024);  // 2 MB
-    p2p_metrics->local_get_requests.inc(100);
-    p2p_metrics->local_put_requests.inc(50);
+    p2p_metrics->local_request.get_requests.inc(100);
+    p2p_metrics->local_request.put_requests.inc(50);
 
     // Test serialize includes both base and P2P metrics
     std::string serialized;
@@ -399,10 +399,10 @@ TEST_F(ClientMetricsTest, P2PClientMetricInheritanceTest) {
                 std::string::npos);  // Base class summary
     EXPECT_TRUE(summary.find("RPC Metrics Summary") !=
                 std::string::npos);  // Base class summary
-    EXPECT_TRUE(summary.find("P2P Local Storage Metrics") !=
+    EXPECT_TRUE(summary.find("P2P Local Request Metrics") !=
                 std::string::npos);  // P2P-specific summary
-    EXPECT_TRUE(summary.find("Local Get: 100 requests") != std::string::npos);
-    EXPECT_TRUE(summary.find("Local Put: 50 requests") != std::string::npos);
+    EXPECT_TRUE(summary.find("Get: 100 requests") != std::string::npos);
+    EXPECT_TRUE(summary.find("Put: 50 requests") != std::string::npos);
 }
 
 // Test ClientMetric::Create returns nullptr when disabled


### PR DESCRIPTION
  ## Summary

  - Add RequestMetric struct to encapsulate Get/Put metrics
  - Rename member from local_get_*/local_put_* to local_request.get_*/put_*
  - Keep Prometheus metric names unchanged (mooncake_p2p_local_*)
  - Prepare for future remote_request metrics
  - Fix labels parameter to use const reference instead of value copy

  ## Description

  This PR refactors the P2P client metrics to better organize Get/Put metrics into a reusable `RequestMetric` struct. This change:

  1. Creates a new `RequestMetric` struct that encapsulates all Get/Put related metrics
  2. Replaces individual metric members (`local_get_*`, `local_put_*`) with a single `local_request` member
  3. Maintains backward compatibility by keeping Prometheus metric names unchanged
  4. Prepares the codebase for future `remote_request` metrics (following the same pattern)
  5. Optimizes performance by changing `labels` parameter from value copy to const reference

  The refactoring improves code organization and makes it easier to add similar metric structures in the future.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [x] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] PyTorch Backend (`mooncake-pg`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [ ] New feature
  - [x] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Other

  ## How Has This Been Tested?

  - [x] Clean build passed
  - [x] All unit tests passed:
    - `client_metrics_test`: 14 tests passed
    - `client_http_metrics_test`: 6 tests passed
  - [x] Code formatted with clang-format

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
  - [ ] I have updated the documentation.
  - [ ] I have added tests to prove my changes are effective.