### PR TITLE
[TransferEngine] Bandwidth-aware NIC selection + DMA-BUF and IPv6 binding fixes

### DIFF
--- a/mooncake-transfer-engine/include/pci_topology.h
+++ b/mooncake-transfer-engine/include/pci_topology.h
@@ -1,0 +1,186 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PCI_TOPOLOGY_H
+#define PCI_TOPOLOGY_H
+
+#include <cctype>
+#include <climits>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace mooncake {
+
+enum class PciPathType {
+    PIX = 0,   // Same PCI switch
+    PXB = 1,   // Crossing PCI bridges
+    PHB = 2,   // Crossing PCH/host bridge
+    NODE = 3,  // Same NUMA node, no common PCI ancestor
+    SYS = 4,   // Cross-NUMA
+    DIS = 5,   // Disconnected
+};
+
+struct InfinibandDevice {
+    std::string name;
+    std::string pci_bus_id;
+    int numa_node;
+    double
+        pci_bw_gbps;  // PCIe bandwidth in GT/s * width (e.g. 1024 for Gen5 x16)
+};
+
+constexpr size_t kMaxPciDepth = 32;
+
+// Normalize a PCI bus ID: lowercase and strip leading zeros from the domain
+// so that CUDA's 8-digit format (e.g. "00000008:06:00.0") matches sysfs's
+// 4-digit format (e.g. "0008:06:00.0").
+inline std::string normalizePciBusId(const std::string &pci_bus_id) {
+    std::string normalized = pci_bus_id;
+    for (char &ch : normalized) {
+        ch = std::tolower(static_cast<unsigned char>(ch));
+    }
+    auto first_colon = normalized.find(':');
+    if (first_colon != std::string::npos && first_colon > 4) {
+        size_t leading = first_colon - 4;
+        if (normalized.substr(0, leading) == std::string(leading, '0')) {
+            normalized.erase(0, leading);
+        }
+    }
+    return normalized;
+}
+
+// Classify the PCI path between a GPU and a NIC given their pre-built
+// ancestor chains and NUMA node information.  This is the pure-logic core
+// that can be unit-tested without sysfs access.
+inline std::pair<PciPathType, int> classifyGpuNicPath(
+    const std::vector<std::string> &gpu_ancestor_chain,
+    const std::unordered_set<std::string> &gpu_ancestors, int gpu_numa_node,
+    int nic_numa_node, const std::vector<std::string> &nic_ancestor_chain) {
+    if (gpu_numa_node >= 0 && nic_numa_node >= 0 &&
+        gpu_numa_node != nic_numa_node) {
+        return {PciPathType::SYS, -1};
+    }
+
+    int nic_hops = 0;
+    for (const auto &ancestor : nic_ancestor_chain) {
+        if (gpu_ancestors.count(ancestor)) {
+            int gpu_hops = 0;
+            for (const auto &gpu_ancestor : gpu_ancestor_chain) {
+                if (gpu_ancestor == ancestor) {
+                    break;
+                }
+                gpu_hops++;
+            }
+
+            int total_hops = gpu_hops + nic_hops;
+            if (total_hops <= 2) {
+                return {PciPathType::PIX, total_hops};
+            }
+            if (total_hops <= 4) {
+                return {PciPathType::PXB, total_hops};
+            }
+            return {PciPathType::PHB, total_hops};
+        }
+        nic_hops++;
+    }
+
+    if (gpu_numa_node >= 0 && gpu_numa_node == nic_numa_node) {
+        // All same-NUMA NICs with no common PCI ancestor are equally close;
+        // chain length is not a meaningful proximity metric here.  Return a
+        // fixed hop count so the selection logic treats them identically.
+        return {PciPathType::NODE, 0};
+    }
+    return {PciPathType::SYS, -1};
+}
+
+struct HcaPartition {
+    std::vector<std::string> preferred_hca;
+    std::vector<std::string> avail_hca;
+};
+
+// Partition a GPU's HCAs into preferred vs avail using a 3-level hierarchy:
+//   1. Best (lowest) PciPathType wins.
+//   2. Fewest hops within the same path type.
+//   3. Highest PCIe bandwidth among NICs that tie on the above.
+// HCA ancestor chains must be supplied in parallel to all_hca and are
+// expected to be pre-computed once by the caller (sysfs lookups are
+// expensive).  Insertion order from all_hca is preserved in the output.
+inline HcaPartition selectPreferredHcas(
+    const std::vector<std::string> &gpu_ancestor_chain, int gpu_numa_node,
+    const std::vector<InfinibandDevice> &all_hca,
+    const std::vector<std::vector<std::string>> &nic_ancestor_chains) {
+    std::unordered_set<std::string> gpu_ancestors(gpu_ancestor_chain.begin(),
+                                                  gpu_ancestor_chain.end());
+
+    struct HcaPathInfo {
+        const InfinibandDevice *hca;
+        PciPathType path_type;
+        int hops;
+        double pci_bw;
+    };
+
+    std::vector<HcaPathInfo> hca_paths;
+    hca_paths.reserve(all_hca.size());
+    PciPathType best_path_type = PciPathType::DIS;
+    int best_hops = INT_MAX;
+    double best_bw = 0.0;
+
+    for (size_t j = 0; j < all_hca.size(); ++j) {
+        const auto &hca = all_hca[j];
+        const auto &nic_ancestor_chain = nic_ancestor_chains[j];
+        auto [path_type, hops] =
+            classifyGpuNicPath(gpu_ancestor_chain, gpu_ancestors, gpu_numa_node,
+                               hca.numa_node, nic_ancestor_chain);
+        hca_paths.push_back(HcaPathInfo{.hca = &hca,
+                                        .path_type = path_type,
+                                        .hops = hops,
+                                        .pci_bw = hca.pci_bw_gbps});
+
+        int hop_rank = hops >= 0 ? hops : INT_MAX;
+        if (static_cast<int>(path_type) < static_cast<int>(best_path_type) ||
+            (path_type == best_path_type && hop_rank < best_hops)) {
+            best_path_type = path_type;
+            best_hops = hop_rank;
+            best_bw = hca.pci_bw_gbps;
+        } else if (path_type == best_path_type && hop_rank == best_hops &&
+                   hca.pci_bw_gbps > best_bw) {
+            best_bw = hca.pci_bw_gbps;
+        }
+    }
+
+    HcaPartition result;
+    for (const auto &path_info : hca_paths) {
+        bool is_preferred = path_info.path_type == best_path_type;
+        if (is_preferred && best_hops != INT_MAX) {
+            is_preferred = path_info.hops == best_hops;
+        }
+        // Among NICs with same path type and hops, prefer those with the
+        // highest PCIe bandwidth.  This filters out lower-bandwidth
+        // front-end/management NICs automatically.
+        if (is_preferred && best_bw > 0.0) {
+            is_preferred = path_info.pci_bw >= best_bw;
+        }
+        if (is_preferred) {
+            result.preferred_hca.push_back(path_info.hca->name);
+        } else {
+            result.avail_hca.push_back(path_info.hca->name);
+        }
+    }
+    return result;
+}
+
+}  // namespace mooncake
+
+#endif  // PCI_TOPOLOGY_H

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -14,14 +14,17 @@
 
 #include <glog/logging.h>
 
+#include <cctype>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <set>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
-#include <ctype.h>
+
+#include "pci_topology.h"
 #include <dirent.h>
 #include <infiniband/verbs.h>
 #include <limits.h>
@@ -136,11 +139,7 @@ static bool isIbDeviceAvailable(struct ibv_device *device) {
     return has_active_port;
 }
 
-struct InfinibandDevice {
-    std::string name;
-    std::string pci_bus_id;
-    int numa_node;
-};
+// InfinibandDevice is defined in pci_topology.h
 
 static std::vector<InfinibandDevice> listInfiniBandDevices(
     const std::vector<std::string> &filter) {
@@ -188,9 +187,28 @@ static std::vector<InfinibandDevice> listInfiniBandDevices(
         snprintf(path, sizeof(path), "%s/numa_node", resolved_path);
         std::ifstream(path) >> numa_node;
 
+        // Read PCIe link speed and width to compute bandwidth.
+        // Used to distinguish high-bandwidth backend NICs from
+        // lower-bandwidth front-end/management NICs.
+        double pci_bw_gbps = 0.0;
+        {
+            double speed_gts = 0.0;
+            int width = 0;
+            snprintf(path, sizeof(path), "%s/current_link_speed",
+                     resolved_path);
+            std::ifstream speed_file(path);
+            if (speed_file.is_open()) speed_file >> speed_gts;
+            snprintf(path, sizeof(path), "%s/current_link_width",
+                     resolved_path);
+            std::ifstream width_file(path);
+            if (width_file.is_open()) width_file >> width;
+            pci_bw_gbps = speed_gts * width;
+        }
+
         devices.push_back(InfinibandDevice{.name = std::move(device_name),
                                            .pci_bus_id = std::move(pci_bus_id),
-                                           .numa_node = numa_node});
+                                           .numa_node = numa_node,
+                                           .pci_bw_gbps = pci_bw_gbps});
     }
     ibv_free_device_list(device_list);
     return devices;
@@ -320,9 +338,18 @@ static std::vector<TopologyEntry> discoverCpuTopology(
         int node_id = atoi(entry->d_name + strlen(prefix));
         std::vector<std::string> preferred_hca;
         std::vector<std::string> avail_hca;
-        // an HCA connected to the same cpu NUMA node is preferred
+        // An HCA connected to the same cpu NUMA node is preferred.
+        // Among same-NUMA HCAs, only keep those with the highest PCIe
+        // bandwidth to filter out lower-bandwidth management NICs.
+        double best_bw = 0.0;
         for (const auto &hca : all_hca) {
-            if (hca.numa_node == node_id) {
+            if (hca.numa_node == node_id && hca.pci_bw_gbps > best_bw) {
+                best_bw = hca.pci_bw_gbps;
+            }
+        }
+        for (const auto &hca : all_hca) {
+            if (hca.numa_node == node_id &&
+                (best_bw <= 0.0 || hca.pci_bw_gbps >= best_bw)) {
                 preferred_hca.push_back(hca.name);
             } else {
                 avail_hca.push_back(hca.name);
@@ -340,104 +367,95 @@ static std::vector<TopologyEntry> discoverCpuTopology(
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
     defined(USE_MLU) || defined(USE_MACA)
 
-static int getPciDistance(const char *bus1, const char *bus2) {
-    char buf[PATH_MAX];
-    char path1[PATH_MAX];
-    char path2[PATH_MAX];
-    snprintf(buf, sizeof(buf), "/sys/bus/pci/devices/%s", bus1);
-    if (realpath(buf, path1) == NULL) {
-        return -1;
-    }
-    snprintf(buf, sizeof(buf), "/sys/bus/pci/devices/%s", bus2);
-    if (realpath(buf, path2) == NULL) {
-        return -1;
+// PciPathType, InfinibandDevice, kMaxPciDepth, normalizePciBusId,
+// classifyGpuNicPath, and selectPreferredHcas are defined in pci_topology.h.
+using mooncake::InfinibandDevice;
+using mooncake::normalizePciBusId;
+using mooncake::selectPreferredHcas;
+
+static std::string getPciParent(const std::string &normalized_pci_bus_id) {
+    std::string path = "/sys/bus/pci/devices/" + normalized_pci_bus_id + "/..";
+    char resolved[PATH_MAX];
+    if (realpath(path.c_str(), resolved) == nullptr) {
+        return "";
     }
 
-    char *ptr1 = path1;
-    char *ptr2 = path2;
-    while (*ptr1 && *ptr1 == *ptr2) {
-        ptr1++;
-        ptr2++;
-    }
-    int distance = 0;
-    for (; *ptr1; ptr1++) {
-        distance += (*ptr1 == '/');
-    }
-    for (; *ptr2; ptr2++) {
-        distance += (*ptr2 == '/');
+    std::string full_path(resolved);
+    auto pos = full_path.rfind('/');
+    if (pos == std::string::npos) {
+        return "";
     }
 
-    return distance;
+    std::string parent = full_path.substr(pos + 1);
+    if (parent.find(':') != std::string::npos &&
+        std::isxdigit(static_cast<unsigned char>(parent[0]))) {
+        return parent;
+    }
+    // Include the PCI root bus (e.g. "pci0008:00") so that devices behind
+    // different root ports on the same root complex share a common ancestor.
+    if (parent.rfind("pci", 0) == 0 && parent.find(':') != std::string::npos) {
+        return parent;
+    }
+    return "";
 }
 
-static bool isSameNumaNode(const char *bus1, const char *bus2) {
-    char path[PATH_MAX];
-    int numa1 = -1;
-    int numa2 = -1;
-    snprintf(path, sizeof(path), "/sys/bus/pci/devices/%s/numa_node", bus1);
-    std::ifstream(path) >> numa1;
-    snprintf(path, sizeof(path), "/sys/bus/pci/devices/%s/numa_node", bus2);
-    std::ifstream(path) >> numa2;
-    return (numa1 != -1 && numa1 == numa2);
+static std::vector<std::string> buildPciAncestorChain(
+    const std::string &pci_bus_id) {
+    std::vector<std::string> chain;
+    std::string current = normalizePciBusId(pci_bus_id);
+    while (!current.empty() && chain.size() < kMaxPciDepth) {
+        chain.push_back(current);
+        current = getPciParent(current);
+    }
+    return chain;
+}
+
+static int getPciNumaNode(const std::string &pci_bus_id) {
+    std::string path =
+        "/sys/bus/pci/devices/" + normalizePciBusId(pci_bus_id) + "/numa_node";
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return -1;
+    }
+
+    int numa_node = -1;
+    file >> numa_node;
+    return numa_node;
 }
 
 static std::vector<TopologyEntry> discoverCudaTopology(
     const std::vector<InfinibandDevice> &all_hca) {
     std::vector<TopologyEntry> topology;
-    int device_count;
+    int device_count = 0;
     if (cudaGetDeviceCount(&device_count) != cudaSuccess) {
         device_count = 0;
     }
+
+    // sysfs lookups are expensive; build each HCA's ancestor chain once.
+    std::vector<std::vector<std::string>> nic_ancestor_chains;
+    nic_ancestor_chains.reserve(all_hca.size());
+    for (const auto &hca : all_hca) {
+        nic_ancestor_chains.push_back(buildPciAncestorChain(hca.pci_bus_id));
+    }
+
     for (int i = 0; i < device_count; i++) {
         char pci_bus_id[20];
         if (cudaDeviceGetPCIBusId(pci_bus_id, sizeof(pci_bus_id), i) !=
             cudaSuccess) {
             continue;
         }
-        for (char *ch = pci_bus_id; (*ch = tolower(*ch)); ch++);
 
-        std::vector<std::string> preferred_hca;
-        std::vector<std::string> avail_hca;
+        std::string gpu_pci_bus_id = normalizePciBusId(pci_bus_id);
+        int gpu_numa_node = getPciNumaNode(gpu_pci_bus_id);
+        auto gpu_ancestor_chain = buildPciAncestorChain(gpu_pci_bus_id);
 
-        // Find HCAs with minimum distance in one pass.
-        int min_distance = INT_MAX;
-        std::vector<std::string> min_distance_hcas;
+        auto partition = selectPreferredHcas(gpu_ancestor_chain, gpu_numa_node,
+                                             all_hca, nic_ancestor_chains);
 
-        std::vector<InfinibandDevice> same_numa_hca;
-        for (const auto &hca : all_hca) {
-            if (isSameNumaNode(hca.pci_bus_id.c_str(), pci_bus_id)) {
-                same_numa_hca.push_back(hca);
-            }
-        }
-        const auto &candidate_preferred_hca =
-            same_numa_hca.empty() ? all_hca : same_numa_hca;
-
-        for (const auto &hca : candidate_preferred_hca) {
-            int distance = getPciDistance(hca.pci_bus_id.c_str(), pci_bus_id);
-            if (distance >= 0) {
-                if (distance < min_distance) {
-                    min_distance = distance;
-                    min_distance_hcas.clear();
-                    min_distance_hcas.push_back(hca.name);
-                } else if (distance == min_distance) {
-                    min_distance_hcas.push_back(hca.name);
-                }
-            }
-        }
-
-        // Add HCAs with minimum distance to preferred_hca, others to avail_hca
-        for (const auto &hca : all_hca) {
-            if (std::find(min_distance_hcas.begin(), min_distance_hcas.end(),
-                          hca.name) != min_distance_hcas.end()) {
-                preferred_hca.push_back(hca.name);
-            } else {
-                avail_hca.push_back(hca.name);
-            }
-        }
         topology.push_back(
             TopologyEntry{.name = GPU_PREFIX + std::to_string(i),
-                          .preferred_hca = std::move(preferred_hca),
-                          .avail_hca = std::move(avail_hca)});
+                          .preferred_hca = std::move(partition.preferred_hca),
+                          .avail_hca = std::move(partition.avail_hca)});
     }
     return topology;
 }

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -91,6 +91,10 @@ add_executable(topology_test ${WORKSPACE}/topology_test.cpp)
 target_link_libraries(topology_test PUBLIC transfer_engine gtest gtest_main)
 add_test(NAME topology_test COMMAND topology_test)
 
+add_executable(pci_topology_test ${WORKSPACE}/pci_topology_test.cpp)
+target_link_libraries(pci_topology_test PUBLIC transfer_engine gtest gtest_main)
+add_test(NAME pci_topology_test COMMAND pci_topology_test)
+
 add_executable(memory_location_test ${WORKSPACE}/memory_location_test.cpp)
 target_link_libraries(memory_location_test PUBLIC transfer_engine gtest gtest_main)
 add_test(NAME memory_location_test COMMAND memory_location_test)

--- a/mooncake-transfer-engine/tests/pci_topology_test.cpp
+++ b/mooncake-transfer-engine/tests/pci_topology_test.cpp
@@ -1,0 +1,499 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pci_topology.h"
+#include "topology.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+using mooncake::classifyGpuNicPath;
+using mooncake::HcaPartition;
+using mooncake::InfinibandDevice;
+using mooncake::normalizePciBusId;
+using mooncake::PciPathType;
+using mooncake::selectPreferredHcas;
+
+// ---------------------------------------------------------------------------
+// normalizePciBusId tests
+// ---------------------------------------------------------------------------
+
+TEST(NormalizePciBusIdTest, LowercaseConversion) {
+    EXPECT_EQ(normalizePciBusId("0000:03:00.0"), "0000:03:00.0");
+    EXPECT_EQ(normalizePciBusId("0000:03:00.0"), "0000:03:00.0");
+    EXPECT_EQ(normalizePciBusId("0000:AB:CD.0"), "0000:ab:cd.0");
+}
+
+TEST(NormalizePciBusIdTest, StripLeadingZerosFrom8DigitDomain) {
+    // CUDA returns 8-digit domain, sysfs uses 4-digit
+    EXPECT_EQ(normalizePciBusId("00000008:06:00.0"), "0008:06:00.0");
+    EXPECT_EQ(normalizePciBusId("00000000:03:00.0"), "0000:03:00.0");
+    EXPECT_EQ(normalizePciBusId("00000018:06:00.0"), "0018:06:00.0");
+}
+
+TEST(NormalizePciBusIdTest, AlreadyNormalized4Digit) {
+    // 4-digit domain should pass through unchanged
+    EXPECT_EQ(normalizePciBusId("0008:06:00.0"), "0008:06:00.0");
+    EXPECT_EQ(normalizePciBusId("0000:03:00.1"), "0000:03:00.1");
+}
+
+TEST(NormalizePciBusIdTest, NonZeroLeadingDigitsPreserved) {
+    // If leading digits are non-zero, they should not be stripped
+    EXPECT_EQ(normalizePciBusId("10000008:06:00.0"), "10000008:06:00.0");
+}
+
+TEST(NormalizePciBusIdTest, MixedCaseWithDomainStrip) {
+    EXPECT_EQ(normalizePciBusId("00000008:AB:CD.0"), "0008:ab:cd.0");
+}
+
+// ---------------------------------------------------------------------------
+// classifyGpuNicPath tests
+// ---------------------------------------------------------------------------
+
+// Helper: build an unordered_set from a vector for the gpu_ancestors param.
+static std::unordered_set<std::string> toSet(
+    const std::vector<std::string> &v) {
+    return {v.begin(), v.end()};
+}
+
+// Scenario: GPU and NIC on different NUMA nodes -> SYS
+TEST(ClassifyGpuNicPathTest, DifferentNuma) {
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:00:00.0"};
+    std::vector<std::string> nic_chain = {"0010:03:00.0", "0010:00:00.0"};
+    auto [path_type, hops] =
+        classifyGpuNicPath(gpu_chain, toSet(gpu_chain), /*gpu_numa=*/0,
+                           /*nic_numa=*/1, nic_chain);
+    EXPECT_EQ(path_type, PciPathType::SYS);
+    EXPECT_EQ(hops, -1);
+}
+
+// Scenario: Same PCI switch (total hops <= 2) -> PIX
+TEST(ClassifyGpuNicPathTest, SamePciSwitch_PIX) {
+    // GPU: switch -> gpu
+    // NIC: switch -> nic
+    // Common ancestor is "0008:01:00.0" (the switch)
+    std::vector<std::string> gpu_chain = {"0008:02:00.0", "0008:01:00.0"};
+    std::vector<std::string> nic_chain = {"0008:03:00.0", "0008:01:00.0"};
+    auto [path_type, hops] =
+        classifyGpuNicPath(gpu_chain, toSet(gpu_chain), /*gpu_numa=*/0,
+                           /*nic_numa=*/0, nic_chain);
+    EXPECT_EQ(path_type, PciPathType::PIX);
+    EXPECT_EQ(hops, 2);  // 1 gpu hop + 1 nic hop
+}
+
+// Scenario: Crossing PCI bridges (total hops 3-4) -> PXB
+TEST(ClassifyGpuNicPathTest, CrossingBridges_PXB) {
+    // Common ancestor is "0008:00:00.0", gpu is 2 hops away, nic is 2 hops
+    std::vector<std::string> gpu_chain = {"0008:04:00.0", "0008:02:00.0",
+                                          "0008:00:00.0"};
+    std::vector<std::string> nic_chain = {"0008:05:00.0", "0008:03:00.0",
+                                          "0008:00:00.0"};
+    auto [path_type, hops] =
+        classifyGpuNicPath(gpu_chain, toSet(gpu_chain), /*gpu_numa=*/0,
+                           /*nic_numa=*/0, nic_chain);
+    EXPECT_EQ(path_type, PciPathType::PXB);
+    EXPECT_EQ(hops, 4);  // 2 + 2
+}
+
+// Scenario: Crossing host bridge (total hops > 4) -> PHB
+TEST(ClassifyGpuNicPathTest, HostBridge_PHB) {
+    // Deep chains with common ancestor far up
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:05:00.0",
+                                          "0008:04:00.0", "0008:00:00.0"};
+    std::vector<std::string> nic_chain = {"0008:09:00.0", "0008:08:00.0",
+                                          "0008:07:00.0", "0008:00:00.0"};
+    auto [path_type, hops] =
+        classifyGpuNicPath(gpu_chain, toSet(gpu_chain), /*gpu_numa=*/0,
+                           /*nic_numa=*/0, nic_chain);
+    EXPECT_EQ(path_type, PciPathType::PHB);
+    EXPECT_EQ(hops, 6);  // 3 + 3
+}
+
+// Scenario: Same NUMA but no common PCI ancestor -> NODE
+TEST(ClassifyGpuNicPathTest, SameNuma_NoCommonAncestor_NODE) {
+    // GPU and NIC on completely separate PCI domains (like GB200)
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:00:00.0"};
+    std::vector<std::string> nic_chain = {"0006:01:00.0", "0006:00:00.0"};
+    auto [path_type, hops] =
+        classifyGpuNicPath(gpu_chain, toSet(gpu_chain), /*gpu_numa=*/0,
+                           /*nic_numa=*/0, nic_chain);
+    EXPECT_EQ(path_type, PciPathType::NODE);
+    // All NODE NICs use a fixed hop count (0) so chain length doesn't matter
+    EXPECT_EQ(hops, 0);
+}
+
+// Scenario: GPU and NIC behind different root ports on the same root bus.
+// The root bus (e.g. "pci0008:00") is the common ancestor -> PHB.
+TEST(ClassifyGpuNicPathTest, SameRootBus_DifferentRootPorts_PHB) {
+    // GPU behind root port 0008:00:00.0
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:01:00.0",
+                                          "0008:00:00.0", "pci0008:00"};
+    // NIC behind root port 0008:00:01.0 on the same root bus
+    std::vector<std::string> nic_chain = {"0008:04:00.0", "0008:03:00.0",
+                                          "0008:00:01.0", "pci0008:00"};
+    auto [path_type, hops] =
+        classifyGpuNicPath(gpu_chain, toSet(gpu_chain), /*gpu_numa=*/0,
+                           /*nic_numa=*/0, nic_chain);
+    // Common ancestor is pci0008:00 at gpu_hops=3, nic_hops=3 -> total 6 -> PHB
+    EXPECT_EQ(path_type, PciPathType::PHB);
+    EXPECT_EQ(hops, 6);
+}
+
+// Scenario: GPU and NIC on different root buses (different PCI domains),
+// root bus included in chain but no match -> still NODE.
+TEST(ClassifyGpuNicPathTest, DifferentRootBuses_StillNODE) {
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:00:00.0",
+                                          "pci0008:00"};
+    std::vector<std::string> nic_chain = {"0006:01:00.0", "0006:00:00.0",
+                                          "pci0006:00"};
+    auto [path_type, hops] =
+        classifyGpuNicPath(gpu_chain, toSet(gpu_chain), /*gpu_numa=*/0,
+                           /*nic_numa=*/0, nic_chain);
+    EXPECT_EQ(path_type, PciPathType::NODE);
+    EXPECT_EQ(hops, 0);
+}
+
+// Scenario: Different NUMA, no common ancestor -> SYS (not NODE)
+TEST(ClassifyGpuNicPathTest, DifferentNuma_NoCommonAncestor_SYS) {
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:00:00.0"};
+    std::vector<std::string> nic_chain = {"0016:01:00.0", "0016:00:00.0"};
+    auto [path_type, hops] =
+        classifyGpuNicPath(gpu_chain, toSet(gpu_chain), /*gpu_numa=*/0,
+                           /*nic_numa=*/1, nic_chain);
+    EXPECT_EQ(path_type, PciPathType::SYS);
+    EXPECT_EQ(hops, -1);
+}
+
+// Scenario: GPU NUMA unknown (-1) should not short-circuit to SYS
+TEST(ClassifyGpuNicPathTest, UnknownGpuNuma_FallsThrough) {
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:00:00.0"};
+    std::vector<std::string> nic_chain = {"0008:03:00.0", "0008:00:00.0"};
+    auto [path_type, hops] =
+        classifyGpuNicPath(gpu_chain, toSet(gpu_chain), /*gpu_numa=*/-1,
+                           /*nic_numa=*/0, nic_chain);
+    // Should still find common ancestor and classify by hops
+    EXPECT_EQ(path_type, PciPathType::PIX);
+    EXPECT_EQ(hops, 2);
+}
+
+// Scenario: Both NUMA unknown, no common ancestor -> SYS (not NODE)
+TEST(ClassifyGpuNicPathTest, BothNumaUnknown_NoCommonAncestor_SYS) {
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:00:00.0"};
+    std::vector<std::string> nic_chain = {"0006:01:00.0", "0006:00:00.0"};
+    auto [path_type, hops] =
+        classifyGpuNicPath(gpu_chain, toSet(gpu_chain), /*gpu_numa=*/-1,
+                           /*nic_numa=*/-1, nic_chain);
+    // Can't confirm same NUMA, so falls to SYS
+    EXPECT_EQ(path_type, PciPathType::SYS);
+    EXPECT_EQ(hops, -1);
+}
+
+// ---------------------------------------------------------------------------
+// Selection logic tests — verify that the preferred/avail partition works
+// correctly for multi-NIC topologies like GB200.
+// ---------------------------------------------------------------------------
+
+// Thin adapter that unpacks the (hca, chain) pair-list used by these tests
+// into the parallel-vector form expected by selectPreferredHcas, so the
+// tests exercise the production selection logic directly.
+struct NicSelection {
+    std::vector<std::string> preferred;
+    std::vector<std::string> avail;
+};
+
+static NicSelection selectPreferredNics(
+    const std::vector<std::string> &gpu_ancestor_chain, int gpu_numa_node,
+    const std::vector<std::pair<InfinibandDevice, std::vector<std::string>>>
+        &hcas_with_chains) {
+    std::vector<InfinibandDevice> all_hca;
+    std::vector<std::vector<std::string>> nic_chains;
+    all_hca.reserve(hcas_with_chains.size());
+    nic_chains.reserve(hcas_with_chains.size());
+    for (const auto &[hca, chain] : hcas_with_chains) {
+        all_hca.push_back(hca);
+        nic_chains.push_back(chain);
+    }
+
+    HcaPartition partition = selectPreferredHcas(
+        gpu_ancestor_chain, gpu_numa_node, all_hca, nic_chains);
+    return NicSelection{.preferred = std::move(partition.preferred_hca),
+                        .avail = std::move(partition.avail_hca)};
+}
+
+// GB200-like topology: GPUs and NICs on separate PCI domains, same NUMA.
+// All same-NUMA NICs with equal chain length should be preferred together.
+TEST(NicSelectionTest, GB200_AllSameNumaNicsPreferred) {
+    // GPU 0: domain 0008, NUMA 0, chain length 3
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:01:00.0",
+                                          "0008:00:00.0"};
+
+    // 4 NICs on NUMA 0 with equal chain lengths (domain 0000, 0002)
+    // 4 NICs on NUMA 1 (should be SYS)
+    using HcaWithChain =
+        std::pair<mooncake::InfinibandDevice, std::vector<std::string>>;
+    std::vector<HcaWithChain> hcas = {
+        {{"mlx5_0", "0000:03:00.0", 0, 1024.0},
+         {"0000:03:00.0", "0000:02:00.0", "0000:00:00.0"}},
+        {{"mlx5_1", "0000:03:00.1", 0, 1024.0},
+         {"0000:03:00.1", "0000:02:00.0", "0000:00:00.0"}},
+        {{"mlx5_2", "0002:03:00.0", 0, 1024.0},
+         {"0002:03:00.0", "0002:02:00.0", "0002:00:00.0"}},
+        {{"mlx5_3", "0002:03:00.1", 0, 1024.0},
+         {"0002:03:00.1", "0002:02:00.0", "0002:00:00.0"}},
+        {{"mlx5_5", "0010:03:00.0", 1, 1024.0},
+         {"0010:03:00.0", "0010:02:00.0", "0010:00:00.0"}},
+        {{"mlx5_6", "0010:03:00.1", 1, 1024.0},
+         {"0010:03:00.1", "0010:02:00.0", "0010:00:00.0"}},
+        {{"mlx5_7", "0012:03:00.0", 1, 1024.0},
+         {"0012:03:00.0", "0012:02:00.0", "0012:00:00.0"}},
+        {{"mlx5_8", "0012:03:00.1", 1, 1024.0},
+         {"0012:03:00.1", "0012:02:00.0", "0012:00:00.0"}},
+    };
+
+    auto result = selectPreferredNics(gpu_chain, /*gpu_numa=*/0, hcas);
+
+    // All 4 NUMA-0 NICs should be preferred (equal chain length = equal hops)
+    std::sort(result.preferred.begin(), result.preferred.end());
+    ASSERT_EQ(result.preferred.size(), 4u);
+    EXPECT_EQ(result.preferred[0], "mlx5_0");
+    EXPECT_EQ(result.preferred[1], "mlx5_1");
+    EXPECT_EQ(result.preferred[2], "mlx5_2");
+    EXPECT_EQ(result.preferred[3], "mlx5_3");
+
+    // All 4 NUMA-1 NICs should be avail (SYS)
+    std::sort(result.avail.begin(), result.avail.end());
+    ASSERT_EQ(result.avail.size(), 4u);
+    EXPECT_EQ(result.avail[0], "mlx5_5");
+    EXPECT_EQ(result.avail[1], "mlx5_6");
+    EXPECT_EQ(result.avail[2], "mlx5_7");
+    EXPECT_EQ(result.avail[3], "mlx5_8");
+}
+
+// GB200-like topology: front-end NIC (Gen4, 512 GT/s*width) vs backend NICs
+// (Gen5, 1024 GT/s*width).  All are NODE on the same NUMA, but the bandwidth
+// tiebreaker should filter out the slower front-end NIC.
+TEST(NicSelectionTest, GB200_BandwidthFiltersOutFrontEndNic) {
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:01:00.0",
+                                          "0008:00:00.0"};
+
+    using HcaWithChain =
+        std::pair<mooncake::InfinibandDevice, std::vector<std::string>>;
+    std::vector<HcaWithChain> hcas = {
+        // Front-end NIC: Gen4 x16 = 512 on NUMA 0
+        {{"mlx5_4", "0006:01:00.0", 0, 512.0},
+         {"0006:01:00.0", "0006:00:00.0"}},
+        // Backend NICs: Gen5 x16 = 1024 on NUMA 0
+        {{"mlx5_0", "0000:03:00.0", 0, 1024.0},
+         {"0000:03:00.0", "0000:02:00.0", "0000:00:00.0"}},
+        {{"mlx5_1", "0000:03:00.1", 0, 1024.0},
+         {"0000:03:00.1", "0000:02:00.0", "0000:00:00.0"}},
+    };
+
+    auto result = selectPreferredNics(gpu_chain, /*gpu_numa=*/0, hcas);
+
+    // mlx5_0 and mlx5_1 (1024) are preferred; mlx5_4 (512) goes to avail
+    std::sort(result.preferred.begin(), result.preferred.end());
+    ASSERT_EQ(result.preferred.size(), 2u);
+    EXPECT_EQ(result.preferred[0], "mlx5_0");
+    EXPECT_EQ(result.preferred[1], "mlx5_1");
+    ASSERT_EQ(result.avail.size(), 1u);
+    EXPECT_EQ(result.avail[0], "mlx5_4");
+}
+
+// When all NICs have the same bandwidth, all same-NUMA NODE NICs should
+// still be preferred together (no bandwidth differentiation).
+TEST(NicSelectionTest, GB200_EqualBandwidth_AllPreferred) {
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:01:00.0",
+                                          "0008:00:00.0"};
+
+    using HcaWithChain =
+        std::pair<mooncake::InfinibandDevice, std::vector<std::string>>;
+    std::vector<HcaWithChain> hcas = {
+        {{"mlx5_4", "0006:01:00.0", 0, 1024.0},
+         {"0006:01:00.0", "0006:00:00.0"}},
+        {{"mlx5_0", "0000:03:00.0", 0, 1024.0},
+         {"0000:03:00.0", "0000:02:00.0", "0000:00:00.0"}},
+        {{"mlx5_1", "0000:03:00.1", 0, 1024.0},
+         {"0000:03:00.1", "0000:02:00.0", "0000:00:00.0"}},
+    };
+
+    auto result = selectPreferredNics(gpu_chain, /*gpu_numa=*/0, hcas);
+
+    std::sort(result.preferred.begin(), result.preferred.end());
+    ASSERT_EQ(result.preferred.size(), 3u);
+    EXPECT_EQ(result.preferred[0], "mlx5_0");
+    EXPECT_EQ(result.preferred[1], "mlx5_1");
+    EXPECT_EQ(result.preferred[2], "mlx5_4");
+    EXPECT_TRUE(result.avail.empty());
+}
+
+// Shared PCI ancestor: all NICs under same switch should be PIX together
+TEST(NicSelectionTest, AllNicsUnderSameSwitch) {
+    std::vector<std::string> gpu_chain = {"0008:03:00.0", "0008:01:00.0"};
+
+    using HcaWithChain =
+        std::pair<mooncake::InfinibandDevice, std::vector<std::string>>;
+    std::vector<HcaWithChain> hcas = {
+        {{"mlx5_0", "0008:04:00.0", 0, 1024.0},
+         {"0008:04:00.0", "0008:01:00.0"}},
+        {{"mlx5_1", "0008:05:00.0", 0, 1024.0},
+         {"0008:05:00.0", "0008:01:00.0"}},
+        {{"mlx5_2", "0008:06:00.0", 0, 1024.0},
+         {"0008:06:00.0", "0008:01:00.0"}},
+    };
+
+    auto result = selectPreferredNics(gpu_chain, /*gpu_numa=*/0, hcas);
+
+    // All NICs are PIX with 2 hops -> all preferred
+    ASSERT_EQ(result.preferred.size(), 3u);
+    EXPECT_TRUE(result.avail.empty());
+}
+
+// Mixed path types: PIX NIC preferred over NODE NICs
+TEST(NicSelectionTest, PIX_PreferredOverNODE) {
+    std::vector<std::string> gpu_chain = {"0008:03:00.0", "0008:01:00.0"};
+
+    using HcaWithChain =
+        std::pair<mooncake::InfinibandDevice, std::vector<std::string>>;
+    std::vector<HcaWithChain> hcas = {
+        // PIX: same switch as GPU
+        {{"mlx5_0", "0008:04:00.0", 0, 1024.0},
+         {"0008:04:00.0", "0008:01:00.0"}},
+        // NODE: same NUMA, different PCI domain
+        {{"mlx5_1", "0006:01:00.0", 0, 1024.0},
+         {"0006:01:00.0", "0006:00:00.0"}},
+        // SYS: different NUMA
+        {{"mlx5_2", "0010:01:00.0", 1, 1024.0},
+         {"0010:01:00.0", "0010:00:00.0"}},
+    };
+
+    auto result = selectPreferredNics(gpu_chain, /*gpu_numa=*/0, hcas);
+
+    ASSERT_EQ(result.preferred.size(), 1u);
+    EXPECT_EQ(result.preferred[0], "mlx5_0");
+    ASSERT_EQ(result.avail.size(), 2u);
+}
+
+// H100-like topology: GPU and some NICs share the same root bus (different
+// root ports -> PHB), while other NICs are on a separate root bus (NODE).
+// PHB NICs must be preferred over NODE NICs.
+TEST(NicSelectionTest, PHB_PreferredOverNODE_SharedRootBus) {
+    // GPU behind root port 0008:00:00.0 on root bus pci0008:00
+    std::vector<std::string> gpu_chain = {"0008:06:00.0", "0008:01:00.0",
+                                          "0008:00:00.0", "pci0008:00"};
+
+    using HcaWithChain =
+        std::pair<mooncake::InfinibandDevice, std::vector<std::string>>;
+    std::vector<HcaWithChain> hcas = {
+        // PHB: same root bus, different root port
+        {{"mlx5_0", "0008:04:00.0", 0, 1024.0},
+         {"0008:04:00.0", "0008:03:00.0", "0008:00:01.0", "pci0008:00"}},
+        // NODE: different root bus, same NUMA
+        {{"mlx5_1", "0006:01:00.0", 0, 1024.0},
+         {"0006:01:00.0", "0006:00:00.0", "pci0006:00"}},
+        // NODE: different root bus, same NUMA
+        {{"mlx5_2", "0002:03:00.0", 0, 1024.0},
+         {"0002:03:00.0", "0002:00:00.0", "pci0002:00"}},
+    };
+
+    auto result = selectPreferredNics(gpu_chain, /*gpu_numa=*/0, hcas);
+
+    // mlx5_0 is PHB (shares root bus), mlx5_1/2 are NODE -> PHB wins
+    ASSERT_EQ(result.preferred.size(), 1u);
+    EXPECT_EQ(result.preferred[0], "mlx5_0");
+    ASSERT_EQ(result.avail.size(), 2u);
+}
+
+// ---------------------------------------------------------------------------
+// Fallback path tests — verify that after disabling a preferred NIC,
+// avail_hca NICs are still reachable and would have passed DMA-BUF
+// validation (i.e., they appear in the topology for that GPU).
+// ---------------------------------------------------------------------------
+
+// Simulate the fallback scenario: preferred NIC is disabled, selection
+// falls back to avail_hca.  The avail NIC must appear in the GPU's
+// topology entry so that DMA-BUF validation (which now checks both
+// preferred and avail lists) covers it.
+TEST(FallbackPathTest, DisabledPreferredFallsBackToAvail) {
+    // Build a topology via Topology::parse with known preferred/avail.
+    mooncake::Topology topology;
+    std::string json = R"({
+        "cuda:0": [["mlx5_0"], ["mlx5_1", "mlx5_2"]],
+        "cpu:0":  [["mlx5_0", "mlx5_1", "mlx5_2"], []]
+    })";
+    topology.parse(json);
+
+    // Before disable: cuda:0 preferred = [mlx5_0], avail = [mlx5_1, mlx5_2]
+    auto matrix = topology.getMatrix();
+    ASSERT_EQ(matrix["cuda:0"].preferred_hca.size(), 1u);
+    EXPECT_EQ(matrix["cuda:0"].preferred_hca[0], "mlx5_0");
+    ASSERT_EQ(matrix["cuda:0"].avail_hca.size(), 2u);
+
+    // Disable the preferred NIC (simulating a runtime failure)
+    topology.disableDevice("mlx5_0");
+
+    // After disable: preferred is empty, avail still has mlx5_1 and mlx5_2
+    matrix = topology.getMatrix();
+    EXPECT_TRUE(matrix["cuda:0"].preferred_hca.empty());
+    ASSERT_EQ(matrix["cuda:0"].avail_hca.size(), 2u);
+
+    // selectDevice should still return a valid device index (not -1)
+    // since avail_hca entries are present.  retry_count=1 forces avail path.
+    int device = topology.selectDevice("cuda:0", 1);
+    EXPECT_GE(device, 0);
+}
+
+// Verify that an avail NIC appears in the topology for the GPU entry,
+// meaning DMA-BUF validation would have covered it (since validation now
+// checks both preferred_hca and avail_hca).
+TEST(FallbackPathTest, AvailNicInTopologyForDmaBufCoverage) {
+    mooncake::Topology topology;
+    // mlx5_2 is avail for cuda:0 and cuda:1
+    std::string json = R"({
+        "cuda:0": [["mlx5_0"], ["mlx5_2"]],
+        "cuda:1": [["mlx5_1"], ["mlx5_2"]],
+        "cpu:0":  [["mlx5_0", "mlx5_1", "mlx5_2"], []]
+    })";
+    topology.parse(json);
+
+    auto matrix = topology.getMatrix();
+
+    // mlx5_2 must be in avail_hca for both cuda:0 and cuda:1,
+    // confirming DMA-BUF validation covers the fallback path.
+    auto &cuda0_avail = matrix["cuda:0"].avail_hca;
+    EXPECT_NE(std::find(cuda0_avail.begin(), cuda0_avail.end(), "mlx5_2"),
+              cuda0_avail.end());
+
+    auto &cuda1_avail = matrix["cuda:1"].avail_hca;
+    EXPECT_NE(std::find(cuda1_avail.begin(), cuda1_avail.end(), "mlx5_2"),
+              cuda1_avail.end());
+
+    // After disabling both preferred NICs, mlx5_2 should still be selectable
+    topology.disableDevice("mlx5_0");
+    topology.disableDevice("mlx5_1");
+
+    int device0 = topology.selectDevice("cuda:0", 1);
+    int device1 = topology.selectDevice("cuda:1", 1);
+    EXPECT_GE(device0, 0);
+    EXPECT_GE(device1, 0);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

Two-commit series. Replaces the legacy `getPciDistance` GPU↔NIC selection
heuristic with NCCL-style PCI ancestor-chain walking and bandwidth-aware
ranking, plus 23 hardware-free unit tests for the new logic. Each commit
is self-contained and bisectable.

> **Note:** This PR was originally a four-commit series. Per reviewer
> request to split, the IPv6 RPC binding fix moved to #2014 and the
> DMA-BUF CUDA device index fix moved to #2015. This PR is now scoped to
> the topology rewrite + tests, with all reviewer feedback applied.

1. **`[TE]` Replace `getPciDistance` with NCCL-style PCI topology and
   bandwidth-aware NIC selection.**
   The old metric was a string-prefix-of-sysfs heuristic that broke on
   GB200/GB300 (GPUs and NICs on separate PCI domains share only
   `/sys/devices/pci000` as common prefix → flat artifact distances → only
   1 NIC per NUMA selected as preferred). Replaced with NCCL-style PCI
   ancestor-chain walking + path-type classification (PIX / PXB / PHB /
   NODE / SYS) and a 3-level NIC ranking (path type → hops → PCIe bandwidth
   from `current_link_speed * current_link_width`). The bandwidth tiebreaker
   auto-filters lower-bandwidth front-end NICs to `avail_hca` without
   requiring `MC_CUSTOM_TOPO_JSON` or a manual blacklist. Pure-logic helpers
   (`PciPathType`, `InfinibandDevice`, `normalizePciBusId`,
   `classifyGpuNicPath`, `selectPreferredHcas`) moved to
   `include/pci_topology.h` for testability and shared use between
   `discoverCudaTopology` and the unit tests.

2. **`[TE]` Add 23 PCI topology unit tests.**
   Hardware-free tests in `pci_topology_test.cpp` covering
   `normalizePciBusId` (5), `classifyGpuNicPath` (10 — all 5 path types
   plus edge cases), NIC selection ranking via the production
   `selectPreferredHcas` helper (6), and fallback paths (2).

### Reviewer feedback addressed

- Selection ranking extracted into `selectPreferredHcas()` in
  `pci_topology.h`; tests now exercise production code instead of a
  duplicate copy.
- HCA ancestor chains pre-computed once before the GPU loop in
  `discoverCudaTopology` (was O(N_gpu × N_hca) sysfs walks, now
  O(N_gpu + N_hca)).
- Redundant `<ctype.h>` removed from `topology.cpp` (kept `<cctype>`
  since the new code uses `std::tolower` / `std::isxdigit`).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix
- [x] Refactor

## How Has This Been Tested?

- **Unit tests:** 23 new tests in `pci_topology_test.cpp` (no hardware /
  sysfs dependency). All pass via `ctest -R pci_topology`.
- **GB300, single-host VRAM read (GPU 1 → GPU 0, auto-discovery, no custom
  topo):** 41.22 GB/s @ 64 MB block. The full 18 → 41 GB/s improvement
  requires this PR *together with* the companion DMA-BUF fix (#2015) —
  without that fix, only NICs at verbs index 0–3 pass DMA-BUF validation;
  with both PRs applied, all 10 NICs register and the topology rewrite
  promotes 8 of them to `preferred_hca`.

  | BlkSize | BW (GB/s) | Avg Lat (μs) | P99 Tx (μs) |
  |---|---|---|---|
  | 4 KB    | 0.51  | 8.1    | 8    |
  | 64 KB   | 6.10  | 10.7   | 11   |
  | 1 MB    | 29.10 | 36.0   | 36   |
  | 16 MB   | 40.27 | 416.7  | 421  |
  | 64 MB   | 41.22 | 1628.0 | 1635 |

- **GB300, same-node DRAM, auto-discovery:** 41.34 GB/s @ 64 MB block;
  bandwidth tiebreaker correctly demotes Gen4 front-end NICs to
  `avail_hca`.
- **GB200 (2 GPUs, 6 NICs, same-node DRAM):** auto-discovery with all 6
  NICs reaches 35.5 GB/s; flat topo with 4 backend NICs reaches 39.3 GB/s.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation. *(no user-facing API change; the
      bandwidth tiebreaker removes the need for `MC_CUSTOM_TOPO_JSON` on
      GB200/GB300, but the env var continues to work for manual overrides)*
- [x] I have added tests to prove my changes are effective.
