### PR TITLE
[Store] Reduce the count of copies of keys in the read-write path

### DIFF
--- a/mooncake-store/benchmarks/master_bench.cpp
+++ b/mooncake-store/benchmarks/master_bench.cpp
@@ -243,7 +243,8 @@ class BenchClient {
 
     uint64_t BatchGet(const std::vector<std::string>& keys) {
         uint64_t success_cnt = 0;
-        auto get_results = master_client_.BatchGetReplicaList(keys);
+        std::vector<std::string_view> key_views(keys.begin(), keys.end());
+        auto get_results = master_client_.BatchGetReplicaList(key_views);
         for (auto& get_result : get_results) {
             if (get_result.has_value() ||
                 get_result.error() == mooncake::ErrorCode::OBJECT_NOT_FOUND) {

--- a/mooncake-store/include/async_memcpy_executor.h
+++ b/mooncake-store/include/async_memcpy_executor.h
@@ -16,26 +16,7 @@
 #include <async_simple/Promise.h>
 #include <glog/logging.h>
 
-#include "tiered_cache/tiered_backend.h"
-#include "types.h"
-
 namespace mooncake {
-
-// ============================================================================
-// LocalCopyPlan — describes a local memcpy operation
-// ============================================================================
-
-struct LocalCopyPlan {
-    AllocationHandle source_handle;
-    const char* source_ptr = nullptr;
-    size_t source_size = 0;
-    bool use_single_dest = false;
-    void* single_dest_ptr = nullptr;
-    size_t single_dest_size = 0;
-    std::vector<Slice> dest_slices;
-};
-
-ErrorCode ExecuteLocalCopyPlan(const LocalCopyPlan& plan);
 
 // ============================================================================
 // AsyncMemcpyExecutor

--- a/mooncake-store/include/async_metadata_notifier.h
+++ b/mooncake-store/include/async_metadata_notifier.h
@@ -21,7 +21,7 @@ namespace mooncake {
 // Called when an async ADD fails with a non-transient error.
 // Caller should delete the local replica.
 using SyncFailureCallback = std::function<void(
-    const std::string& key, const UUID& segment_id, ErrorCode error)>;
+    std::string_view key, const UUID& segment_id, ErrorCode error)>;
 
 class AsyncMetadataNotifier {
    public:
@@ -42,15 +42,15 @@ class AsyncMetadataNotifier {
     void Stop(bool drop_pending = false);
 
     // --- Normal priority ---
-    tl::expected<void, ErrorCode> EnqueueAdd(const std::string& key,
+    tl::expected<void, ErrorCode> EnqueueAdd(std::string_view key,
                                              const UUID& segment_id,
                                              size_t size);
 
-    tl::expected<void, ErrorCode> EnqueueRemove(const std::string& key,
+    tl::expected<void, ErrorCode> EnqueueRemove(std::string_view key,
                                                 const UUID& segment_id);
 
     // --- Recovery priority (lower send priority) ---
-    tl::expected<void, ErrorCode> EnqueueRecoveryAdd(const std::string& key,
+    tl::expected<void, ErrorCode> EnqueueRecoveryAdd(std::string_view key,
                                                      const UUID& segment_id,
                                                      size_t size);
 

--- a/mooncake-store/include/centralized_master_service.h
+++ b/mooncake-store/include/centralized_master_service.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -44,7 +45,7 @@ class CentralizedMasterService final : public MasterService {
     explicit CentralizedMasterService(const MasterServiceConfig& config);
     ~CentralizedMasterService() override;
 
-    auto GetReplicaList(const std::string& key,
+    auto GetReplicaList(std::string_view key,
                         const GetReplicaListRequestConfig& config =
                             GetReplicaListRequestConfig())
         -> tl::expected<GetReplicaListResponse, ErrorCode> override;
@@ -301,7 +302,8 @@ class CentralizedMasterService final : public MasterService {
     struct CentralizedMetadataShard : public MetadataShard {
         // Keys currently being written (PutStart called, but not yet PutEnd)
         // Protected by the inherited mutex from MetadataShard
-        std::unordered_set<std::string> processing_keys GUARDED_BY(mutex);
+        std::unordered_set<std::string, StringHash, std::equal_to<>>
+            processing_keys GUARDED_BY(mutex);
     };
 
     // Override GetShard to return our extended shard type
@@ -321,8 +323,8 @@ class CentralizedMasterService final : public MasterService {
     }
     static constexpr size_t kNumShards = 1024;  // Number of metadata shards
     // Helper to get shard index from key
-    size_t GetShardIndex(const std::string& key) const override {
-        return std::hash<std::string>{}(key) % kNumShards;
+    size_t GetShardIndex(std::string_view key) const override {
+        return std::hash<std::string_view>{}(key) % kNumShards;
     }
     size_t GetShardCount() const override { return kNumShards; }
 
@@ -331,7 +333,7 @@ class CentralizedMasterService final : public MasterService {
         : public MasterService::MetadataAccessor {
        public:
         CentralizedMetadataAccessor(CentralizedMasterService* service,
-                                    const std::string& key)
+                                    std::string_view key)
             : MasterService::MetadataAccessor(service, key),
               c_shard_(static_cast<CentralizedMetadataShard&>(shard_)),
               processing_it_(c_shard_.processing_keys.find(key)) {}
@@ -355,11 +357,12 @@ class CentralizedMasterService final : public MasterService {
 
        private:
         CentralizedMetadataShard& c_shard_;
-        std::unordered_set<std::string>::iterator processing_it_;
+        std::unordered_set<std::string, StringHash, std::equal_to<>>::iterator
+            processing_it_;
     };
 
     std::unique_ptr<MetadataAccessor> GetMetadataAccessor(
-        const std::string& key) override {
+        std::string_view key) override {
         return std::make_unique<CentralizedMetadataAccessor>(this, key);
     }
 

--- a/mooncake-store/include/client_rpc_types.h
+++ b/mooncake-store/include/client_rpc_types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 #include <cstdint>
 #include "types.h"
@@ -26,7 +27,7 @@ YLT_REFL(RemoteBufferDesc, segment_endpoint, addr, size);
  * @brief RPC request for reading remote data
  */
 struct RemoteReadRequest {
-    std::string key;  // Object key to read
+    std::string_view key;  // Object key to read
     std::vector<RemoteBufferDesc>
         dest_buffers;  // Destination buffers on remote client
 };
@@ -38,7 +39,7 @@ YLT_REFL(RemoteReadRequest, key, dest_buffers);
  * @brief RPC request for writing remote data
  */
 struct RemoteWriteRequest {
-    std::string key;
+    std::string_view key;
     std::vector<RemoteBufferDesc> src_buffers;
     std::optional<UUID> target_tier_id;
 };
@@ -50,7 +51,7 @@ YLT_REFL(RemoteWriteRequest, key, src_buffers, target_tier_id);
  * @brief Batch RPC request for reading multiple remote data objects
  */
 struct BatchRemoteReadRequest {
-    std::vector<std::string> keys;  // Object keys to read
+    std::vector<std::string_view> keys;  // Object keys to read
     std::vector<std::vector<RemoteBufferDesc>>
         dest_buffers_list;  // Destination buffers for each key
 };
@@ -62,7 +63,7 @@ YLT_REFL(BatchRemoteReadRequest, keys, dest_buffers_list);
  * @brief Batch RPC request for writing multiple remote data objects
  */
 struct BatchRemoteWriteRequest {
-    std::vector<std::string> keys;  // Object keys to write
+    std::vector<std::string_view> keys;  // Object keys to write
     std::vector<std::vector<RemoteBufferDesc>>
         src_buffers_list;  // Source buffers for each key
     std::vector<std::optional<UUID>>

--- a/mooncake-store/include/client_rpc_types.h
+++ b/mooncake-store/include/client_rpc_types.h
@@ -25,9 +25,12 @@ YLT_REFL(RemoteBufferDesc, segment_endpoint, addr, size);
 /**
  * @struct RemoteReadRequest
  * @brief RPC request for reading remote data
+ *
+ * LIFETIME: `key` is a non-owning view. The caller must guarantee that the
+ * string outlives tnis request AND all async tasks dispatched from it.
  */
 struct RemoteReadRequest {
-    std::string_view key;  // Object key to read
+    std::string_view key;
     std::vector<RemoteBufferDesc>
         dest_buffers;  // Destination buffers on remote client
 };
@@ -37,6 +40,9 @@ YLT_REFL(RemoteReadRequest, key, dest_buffers);
 /**
  * @struct RemoteWriteRequest
  * @brief RPC request for writing remote data
+ *
+ * LIFETIME: `key` is a non-owning view. The caller must guarantee that the
+ * string outlives tnis request AND all async tasks dispatched from it.
  */
 struct RemoteWriteRequest {
     std::string_view key;
@@ -49,9 +55,12 @@ YLT_REFL(RemoteWriteRequest, key, src_buffers, target_tier_id);
 /**
  * @struct BatchRemoteReadRequest
  * @brief Batch RPC request for reading multiple remote data objects
+ *
+ * LIFETIME: each element of `keys` is a non-owning view. The caller must
+ * guarantee that all strings outlive this request and the RPC call.
  */
 struct BatchRemoteReadRequest {
-    std::vector<std::string_view> keys;  // Object keys to read
+    std::vector<std::string_view> keys;
     std::vector<std::vector<RemoteBufferDesc>>
         dest_buffers_list;  // Destination buffers for each key
 };
@@ -61,9 +70,12 @@ YLT_REFL(BatchRemoteReadRequest, keys, dest_buffers_list);
 /**
  * @struct BatchRemoteWriteRequest
  * @brief Batch RPC request for writing multiple remote data objects
+ *
+ * LIFETIME: each element of `keys` is a non-owning view. The caller must
+ * guarantee that all strings outlive this request and the RPC call.
  */
 struct BatchRemoteWriteRequest {
-    std::vector<std::string_view> keys;  // Object keys to write
+    std::vector<std::string_view> keys;
     std::vector<std::vector<RemoteBufferDesc>>
         src_buffers_list;  // Source buffers for each key
     std::vector<std::optional<UUID>>

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -3,6 +3,7 @@
 #include <shared_mutex>
 #include <vector>
 #include <string>
+#include <string_view>
 #include <memory>
 #include <optional>
 #include <ylt/util/tl/expected.hpp>
@@ -102,7 +103,7 @@ class DataManager {
     // returned TaskHandle may capture raw pointers from the slices for
     // asynchronous transfer.
     tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode> Put(
-        const std::string& key, std::vector<Slice>& slices);
+        std::string_view key, std::vector<Slice>& slices);
 
     // Attention!!!
     // Get() method run without key lock.
@@ -117,21 +118,20 @@ class DataManager {
     // returned TaskHandle may capture raw pointers from the slices for
     // asynchronous data copy.
     tl::expected<ReadTaskHandle, ErrorCode> Get(
-        const std::string& key, const std::vector<Slice>& slices);
+        std::string_view key, const std::vector<Slice>& slices);
 
     tl::expected<ReadTaskHandle, ErrorCode> Get(
-        const std::string& key,
-        std::shared_ptr<ClientBufferAllocator> allocator);
+        std::string_view key, std::shared_ptr<ClientBufferAllocator> allocator);
 
     /**
      * @brief Query the size of an object.
      * @param key Object key
      * @return Object size in bytes, or ErrorCode on failure
      */
-    tl::expected<size_t, ErrorCode> QueryObjectSize(const std::string& key);
+    tl::expected<size_t, ErrorCode> QueryObjectSize(std::string_view key);
 
     tl::expected<void, ErrorCode> Delete(
-        const std::string& key, std::optional<UUID> tier_id = std::nullopt);
+        std::string_view key, std::optional<UUID> tier_id = std::nullopt);
 
     /**
      * @brief Get tier views from underlying tiered storage
@@ -158,7 +158,7 @@ class DataManager {
     /**
      * @brief Get all tier IDs where a key has replicas.
      */
-    std::vector<UUID> GetReplicaTierIds(const std::string& key) const;
+    std::vector<UUID> GetReplicaTierIds(std::string_view key) const;
 
     /**
      * @brief Read data and transfer to remote destination buffers
@@ -172,7 +172,7 @@ class DataManager {
      * @return ErrorCode indicating success or failure
      */
     tl::expected<void, ErrorCode> ReadRemoteData(
-        const std::string& key,
+        std::string_view key,
         const std::vector<RemoteBufferDesc>& dest_buffers);
 
     /**
@@ -183,8 +183,7 @@ class DataManager {
      * @return UUID of the tier (segment) where data was written, or ErrorCode
      */
     tl::expected<UUID, ErrorCode> WriteRemoteData(
-        const std::string& key,
-        const std::vector<RemoteBufferDesc>& src_buffers,
+        std::string_view key, const std::vector<RemoteBufferDesc>& src_buffers,
         std::optional<UUID> tier_id = std::nullopt);
 
     // ================================================================
@@ -199,7 +198,7 @@ class DataManager {
      * @param tier_id Optional tier ID. If specified, only checks the given
      *        tier; if nullopt, checks all tiers.
      */
-    void RectifyReadRoute(const std::string& key,
+    void RectifyReadRoute(std::string_view key,
                           std::optional<UUID> tier_id = std::nullopt);
 
     /**
@@ -207,14 +206,14 @@ class DataManager {
      * @param fn Callback invoked when key not found locally.
      */
     void SetRectifyCallback(
-        std::function<void(const std::string&, std::optional<UUID>)> fn);
+        std::function<void(std::string_view, std::optional<UUID>)> fn);
 
-    bool Exist(const std::string& key,
+    bool Exist(std::string_view key,
                std::optional<UUID> tier_id = std::nullopt) const;
 
    private:
-    std::shared_mutex& GetKeyLock(const std::string& key) {
-        size_t hash = std::hash<std::string>{}(key);
+    std::shared_mutex& GetKeyLock(std::string_view key) {
+        size_t hash = std::hash<std::string_view>{}(key);
         return lock_shards_[hash % lock_shard_count_];
     }
 
@@ -240,23 +239,22 @@ class DataManager {
         const std::vector<RemoteBufferDesc>& src_buffers);
 
     tl::expected<ReadTaskHandle, ErrorCode> BuildDataCopier(
-        const AllocationHandle& handle, const std::string& key,
+        const AllocationHandle& handle, std::string_view key,
         const std::vector<Slice>& slices);
 
     tl::expected<ReadTaskHandle, ErrorCode> BuildDataCopierViaTe(
         const AllocationHandle& handle, const std::vector<Slice>& slices);
 
     tl::expected<ReadTaskHandle, ErrorCode> BuildDataCopierViaMemcpy(
-        const AllocationHandle& handle, const std::string& key,
+        const AllocationHandle& handle, std::string_view key,
         const std::vector<Slice>& slices);
 
     // --- Put dispatch by transfer mode ---
-
     tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode> PutViaTe(
-        const std::string& key, std::vector<Slice>& slices);
+        std::string_view key, std::vector<Slice>& slices);
 
     tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode> PutViaMemcpy(
-        const std::string& key, std::vector<Slice>& slices);
+        std::string_view key, std::vector<Slice>& slices);
 
     // --- Conversion helpers ---
 
@@ -373,7 +371,7 @@ class DataManager {
     std::vector<std::shared_mutex> lock_shards_;
 
     // Callback for rectifying stale read routes
-    std::function<void(const std::string&, std::optional<UUID>)>
+    std::function<void(std::string_view, std::optional<UUID>)>
         rectify_wrong_route_fn_;
 
     LocalTransferConfig local_transfer_config_;

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -250,9 +250,6 @@ class DataManager {
         const AllocationHandle& handle, const std::string& key,
         const std::vector<Slice>& slices);
 
-    tl::expected<LocalCopyPlan, ErrorCode> BuildLocalCopyPlan(
-        const std::string& key, const AllocationHandle& handle,
-        const std::vector<Slice>& slices) const;
     // --- Put dispatch by transfer mode ---
 
     tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode> PutViaTe(

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <cstdlib>
 #include <boost/functional/hash.hpp>
@@ -49,7 +50,7 @@ class MasterClient {
      * @return tl::expected<bool, ErrorCode> indicating exist or not
      */
     [[nodiscard]] tl::expected<bool, ErrorCode> ExistKey(
-        const std::string& object_key);
+        std::string_view object_key);
 
     /**
      * @brief Checks if multiple objects exist
@@ -57,7 +58,7 @@ class MasterClient {
      * @return Vector containing existence status for each key
      */
     [[nodiscard]] std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
-        const std::vector<std::string>& object_keys);
+        const std::vector<std::string_view>& object_keys);
     /**
      * @brief Gets replica list for an object
      * @param object_key Key to query
@@ -65,13 +66,13 @@ class MasterClient {
      * @return ErrorCode indicating success/failure
      */
     [[nodiscard]] tl::expected<GetReplicaListResponse, ErrorCode>
-    GetReplicaList(const std::string& key,
+    GetReplicaList(std::string_view key,
                    const GetReplicaListRequestConfig& config =
                        GetReplicaListRequestConfig());
 
     [[nodiscard]] async_simple::coro::Lazy<
         tl::expected<GetReplicaListResponse, ErrorCode>>
-    AsyncGetReplicaList(const std::string& key,
+    AsyncGetReplicaList(std::string_view key,
                         const GetReplicaListRequestConfig& config =
                             GetReplicaListRequestConfig());
 
@@ -79,7 +80,7 @@ class MasterClient {
      * @brief Batch query read routes
      */
     [[nodiscard]] std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
-    BatchGetReplicaList(const std::vector<std::string>& keys,
+    BatchGetReplicaList(const std::vector<std::string_view>& keys,
                         const GetReplicaListRequestConfig& config =
                             GetReplicaListRequestConfig());
 
@@ -119,7 +120,7 @@ class MasterClient {
      * @param key Key to remove
      * @return tl::expected<void, ErrorCode> indicating success/failure
      */
-    [[nodiscard]] tl::expected<void, ErrorCode> Remove(const std::string& key);
+    [[nodiscard]] tl::expected<void, ErrorCode> Remove(std::string_view key);
 
     /**
      * @brief Removes objects from the master whose keys match a regex pattern.
@@ -128,7 +129,7 @@ class MasterClient {
      * success, or an ErrorCode on failure.
      */
     [[nodiscard]] tl::expected<long, ErrorCode> RemoveByRegex(
-        const std::string& str);
+        std::string_view str);
 
     /**
      * @brief Removes all objects and all its replicas

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -11,6 +11,7 @@
 #include "rpc_types.h"
 #include "replica.h"
 #include "master_config.h"
+#include "utils.h"
 
 namespace mooncake {
 class ClientManager;
@@ -83,10 +84,10 @@ class MasterService {
      * @brief Check if an object exists
      * @return ErrorCode::OK if exists, otherwise return other ErrorCode
      */
-    auto ExistKey(const std::string& key) -> tl::expected<bool, ErrorCode>;
+    auto ExistKey(std::string_view key) -> tl::expected<bool, ErrorCode>;
 
     std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
-        const std::vector<std::string>& keys);
+        const std::vector<std::string_view>& keys);
 
     /**
      * @brief Fetch all keys
@@ -160,7 +161,7 @@ class MasterService {
      * @return An expected object containing the replica list on success, or an
      * ErrorCode on failure.
      */
-    virtual auto GetReplicaList(const std::string& key,
+    virtual auto GetReplicaList(std::string_view key,
                                 const GetReplicaListRequestConfig& config =
                                     GetReplicaListRequestConfig())
         -> tl::expected<GetReplicaListResponse, ErrorCode>;
@@ -170,7 +171,7 @@ class MasterService {
      * @return ErrorCode::OK on success, ErrorCode::OBJECT_NOT_FOUND if not
      * found
      */
-    auto Remove(const std::string& key) -> tl::expected<void, ErrorCode>;
+    auto Remove(std::string_view key) -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Removes objects from the master whose keys match a regex pattern.
@@ -178,7 +179,7 @@ class MasterService {
      * @return An expected object containing the number of removed objects on
      * success, or an ErrorCode on failure.
      */
-    auto RemoveByRegex(const std::string& str) -> tl::expected<long, ErrorCode>;
+    auto RemoveByRegex(std::string_view str) -> tl::expected<long, ErrorCode>;
 
     /**
      * @brief Remove all objects and their replicas
@@ -271,7 +272,8 @@ class MasterService {
     //    first remove the corresponding key from `segment_key_index`.
     struct MetadataShard {
         mutable Mutex mutex;
-        std::unordered_map<std::string, std::unique_ptr<ObjectMetadata>>
+        std::unordered_map<std::string, std::unique_ptr<ObjectMetadata>,
+                           StringHash, std::equal_to<>>
             metadata GUARDED_BY(mutex);
 
         // segment_id -> { key -> replica_reference_count }.
@@ -282,7 +284,7 @@ class MasterService {
     // Virtual function to access shards
     virtual MetadataShard& GetShard(size_t idx) = 0;
     virtual const MetadataShard& GetShard(size_t idx) const = 0;
-    virtual size_t GetShardIndex(const std::string& key) const = 0;
+    virtual size_t GetShardIndex(std::string_view key) const = 0;
     virtual size_t GetShardCount() const = 0;
 
     // Helpers for maintaining per-shard segment_key_index.
@@ -303,9 +305,8 @@ class MasterService {
     // Helper class for accessing metadata with automatic locking
     class MetadataAccessor {
        public:
-        MetadataAccessor(MasterService* service, const std::string& key)
+        MetadataAccessor(MasterService* service, std::string_view key)
             : service_(service),
-              key_(key),
               shard_idx_(service_->GetShardIndex(key)),
               shard_(service_->GetShard(shard_idx_)),
               lock_(&shard_.mutex),
@@ -341,16 +342,17 @@ class MasterService {
 
        protected:
         MasterService* service_;
-        std::string key_;
         size_t shard_idx_;
         MetadataShard& shard_;
         MutexLocker lock_;
-        std::unordered_map<std::string,
-                           std::unique_ptr<ObjectMetadata>>::iterator it_;
+        using MetadataMap =
+            std::unordered_map<std::string, std::unique_ptr<ObjectMetadata>,
+                               StringHash, std::equal_to<>>;
+        MetadataMap::iterator it_;
     };
 
     virtual std::unique_ptr<MetadataAccessor> GetMetadataAccessor(
-        const std::string& key) {
+        std::string_view key) {
         return std::make_unique<MetadataAccessor>(this, key);
     }
 

--- a/mooncake-store/include/p2p_client_service.h
+++ b/mooncake-store/include/p2p_client_service.h
@@ -207,14 +207,14 @@ class P2PClientService final : public ClientService {
     /**
      * @brief handle COMMIT type callback: notify master to add new replica
      */
-    tl::expected<void, ErrorCode> SyncAddReplica(const std::string& key,
+    tl::expected<void, ErrorCode> SyncAddReplica(std::string_view key,
                                                  const UUID& tier_id,
                                                  size_t size);
 
     /**
      * @brief handle DELETE type callback: notify master to remove replica
      */
-    tl::expected<void, ErrorCode> SyncRemoveReplica(const std::string& key,
+    tl::expected<void, ErrorCode> SyncRemoveReplica(std::string_view key,
                                                     const UUID& tier_id);
 
     /**
@@ -225,7 +225,7 @@ class P2PClientService final : public ClientService {
      * @return Vector of ErrorCode results for each segment
      */
     std::vector<tl::expected<void, ErrorCode>> SyncBatchRemoveReplica(
-        const std::string& key, std::vector<UUID> segment_ids);
+        std::string_view key, std::vector<UUID> segment_ids);
 
     /**
      * @brief Collect tier info from DataManager and build P2P Segments.
@@ -263,8 +263,7 @@ class P2PClientService final : public ClientService {
                               BatchGetWriteRouteResponse& batch_resp);
 
     tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
-    CreatePutHandleFromLocal(const std::string& key,
-                             std::vector<Slice>& slices);
+    CreatePutHandleFromLocal(std::string_view key, std::vector<Slice>& slices);
 
     std::vector<tl::expected<void, ErrorCode>> CollectResults(
         std::vector<tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>>&
@@ -285,11 +284,11 @@ class P2PClientService final : public ClientService {
 
     struct LocalWriteOp : WriteOp {
         DataManager* data_manager;
-        std::string key;
+        std::string_view key;
         std::vector<Slice>* slices;
 
-        LocalWriteOp(DataManager* dm, std::string k, std::vector<Slice>* s)
-            : data_manager(dm), key(std::move(k)), slices(s) {}
+        LocalWriteOp(DataManager* dm, std::string_view k, std::vector<Slice>* s)
+            : data_manager(dm), key(k), slices(s) {}
 
         std::string_view route() const override { return "local"; }
         std::unique_ptr<TaskHandle<void>> Dispatch() override;
@@ -315,7 +314,7 @@ class P2PClientService final : public ClientService {
     };
 
     tl::expected<std::vector<std::unique_ptr<WriteOp>>, ErrorCode>
-    BuildWriteOps(const std::string& key, std::vector<Slice>& slices,
+    BuildWriteOps(std::string_view key, std::vector<Slice>& slices,
                   const WriteRouteRequestConfig& config,
                   std::vector<WriteCandidate> candidates);
 
@@ -324,7 +323,8 @@ class P2PClientService final : public ClientService {
             promise,
         std::unique_ptr<TaskHandle<void>> current_task,
         std::string current_route,
-        std::vector<std::unique_ptr<WriteOp>> retry_op_list, std::string key);
+        std::vector<std::unique_ptr<WriteOp>> retry_op_list,
+        std::string_view key);
 
    private:
     struct ResolvedRoute {
@@ -341,7 +341,7 @@ class P2PClientService final : public ClientService {
         using MasterFetch = std::function<
             async_simple::coro::Lazy<std::vector<ResolvedRoute>>()>;
 
-        RouteIterator(std::string key, std::vector<ResolvedRoute> initial,
+        RouteIterator(std::string_view key, std::vector<ResolvedRoute> initial,
                       uint64_t object_size, RouteCache* route_cache,
                       MasterFetch master_fetch);
 
@@ -370,10 +370,10 @@ class P2PClientService final : public ClientService {
         const std::vector<Replica::Descriptor>& replicas);
 
     tl::expected<RouteIterator, ErrorCode> BuildRouteIter(
-        const std::string& key, const ReadRouteConfig& config);
+        std::string_view key, const ReadRouteConfig& config);
 
     tl::expected<RouteIterator, ErrorCode> BuildRouteIter(
-        const std::string& key, const ReadRouteConfig& config,
+        std::string_view key, const ReadRouteConfig& config,
         std::vector<ResolvedRoute> pre_fetched);
 
    private:
@@ -403,12 +403,11 @@ class P2PClientService final : public ClientService {
                          const ReadRouteConfig& config);
 
     tl::expected<ReadTaskHandle, ErrorCode> CreateRemoteGetHandle(
-        const std::string& key,
-        std::shared_ptr<ClientBufferAllocator> allocator,
+        std::string_view key, std::shared_ptr<ClientBufferAllocator> allocator,
         const ReadRouteConfig& config, std::vector<ResolvedRoute> pre_fetched);
 
     tl::expected<ReadTaskHandle, ErrorCode> CreateRemoteGetHandle(
-        const std::string& key, std::vector<Slice>& slices,
+        std::string_view key, std::vector<Slice>& slices,
         const ReadRouteConfig& config, std::vector<ResolvedRoute> pre_fetched);
 
     /**
@@ -418,7 +417,7 @@ class P2PClientService final : public ClientService {
      * and chains subsequent candidates on failure (no stack recursion).
      */
     tl::expected<ReadTaskHandle, ErrorCode> InnerGetViaRoute(
-        const std::string& key, std::vector<Slice>& slices, RouteIterator iter);
+        std::string_view key, std::vector<Slice>& slices, RouteIterator iter);
 
     async_simple::coro::Lazy<void> RunReadWithRetry(
         RouteIterator iter, std::shared_ptr<RemoteReadRequest> req,
@@ -426,7 +425,7 @@ class P2PClientService final : public ClientService {
             promise);
 
     async_simple::coro::Lazy<std::vector<ResolvedRoute>>
-    AsyncResolveRoutesFromMaster(const std::string& key,
+    AsyncResolveRoutesFromMaster(std::string_view key,
                                  const ReadRouteConfig& config);
 
     /**

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -77,8 +77,8 @@ class P2PMasterService : public MasterService {
     }
     static constexpr size_t kNumShards = 1024;  // Number of metadata shards
     // Helper to get shard index from key
-    size_t GetShardIndex(const std::string& key) const override {
-        return std::hash<std::string>{}(key) % kNumShards;
+    size_t GetShardIndex(std::string_view key) const override {
+        return std::hash<std::string_view>{}(key) % kNumShards;
     }
     size_t GetShardCount() const override { return kNumShards; }
 
@@ -91,11 +91,11 @@ class P2PMasterService : public MasterService {
 
    private:
     tl::expected<void, ErrorCode> InnerAddReplica(
-        MetadataShard& shard, const std::string& key, const UUID& client_id,
+        MetadataShard& shard, std::string_view key, const UUID& client_id,
         const UUID& segment_id, size_t size,
         const std::shared_ptr<P2PClientMeta>& client) NO_THREAD_SAFETY_ANALYSIS;
     tl::expected<void, ErrorCode> InnerRemoveReplica(
-        MetadataShard& shard, const std::string& key, const UUID& client_id,
+        MetadataShard& shard, std::string_view key, const UUID& client_id,
         const UUID& segment_id) NO_THREAD_SAFETY_ANALYSIS;
 
     std::shared_ptr<P2PClientManager> client_manager_;

--- a/mooncake-store/include/p2p_rpc_types.h
+++ b/mooncake-store/include/p2p_rpc_types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "replica.h"
@@ -46,7 +47,8 @@ inline std::ostream& operator<<(std::ostream& os,
  * @brief Request structure for getting write route.
  */
 struct WriteRouteRequest {
-    std::string key;  // used for pre-filter with limitation of replica number
+    // used for pre-filter with limitation of replica number
+    std::string_view key;
     UUID client_id;
     size_t size = 0;
     WriteRouteRequestConfig config;
@@ -76,7 +78,7 @@ YLT_REFL(WriteRouteResponse, candidates);
  */
 struct BatchGetWriteRouteRequest {
     UUID client_id;
-    std::vector<std::string> keys;
+    std::vector<std::string_view> keys;
     std::vector<size_t> sizes;
     WriteRouteRequestConfig config;  // shared config for all keys
 };
@@ -97,7 +99,7 @@ YLT_REFL(BatchGetWriteRouteResponse, responses, error_codes);
  *        Master resolves ip_address/rpc_port from registered client info.
  */
 struct AddReplicaRequest {
-    std::string key;
+    std::string_view key;
     size_t size;
     UUID client_id;
     UUID segment_id;
@@ -108,7 +110,7 @@ YLT_REFL(AddReplicaRequest, key, size, client_id, segment_id);
  * @brief Request to remove a replica
  */
 struct RemoveReplicaRequest {
-    std::string key;
+    std::string_view key;
     UUID client_id;
     UUID segment_id;
 };
@@ -118,7 +120,7 @@ YLT_REFL(RemoveReplicaRequest, key, client_id, segment_id);
  * @brief Request to remove replicas from multiple segments in one call
  */
 struct BatchRemoveReplicaRequest {
-    std::string key;
+    std::string_view key;
     UUID client_id;
     std::vector<UUID> segment_ids;
 };
@@ -131,11 +133,11 @@ YLT_REFL(BatchRemoveReplicaRequest, key, client_id, segment_ids);
 struct BatchSyncReplicaRequest {
     UUID client_id;
     // ADD operations
-    std::vector<std::string> add_keys;
+    std::vector<std::string_view> add_keys;
     std::vector<size_t> add_sizes;
     std::vector<UUID> add_segment_ids;
     // REMOVE operations
-    std::vector<std::string> remove_keys;
+    std::vector<std::string_view> remove_keys;
     std::vector<UUID> remove_segment_ids;
 };
 YLT_REFL(BatchSyncReplicaRequest, client_id, add_keys, add_sizes,

--- a/mooncake-store/include/peer_client.h
+++ b/mooncake-store/include/peer_client.h
@@ -17,6 +17,10 @@ class PeerClient {
     tl::expected<void, ErrorCode> Connect(const std::string& endpoint);
 
     // --- Async single-key interfaces ---
+    // LIFETIME: `request` of sync read and write must remain valid
+    // until the returned Lazy coroutine completes.
+    // Otherwise, the string_view of `request` might be UAF.
+
     async_simple::coro::Lazy<tl::expected<void, ErrorCode>> AsyncReadRemoteData(
         const RemoteReadRequest& request);
 

--- a/mooncake-store/include/route_cache.h
+++ b/mooncake-store/include/route_cache.h
@@ -6,6 +6,7 @@
 #include <deque>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <span>
 #include <vector>
@@ -51,7 +52,7 @@ struct P2PRouteData {
      * @brief Serialize replica data and key into a continuous memory block.
      * @return Total bytes written.
      */
-    static size_t Serialize(void* dest, const std::string& key,
+    static size_t Serialize(void* dest, std::string_view key,
                             const std::vector<P2PProxyDescriptor>& replicas);
 };
 
@@ -105,21 +106,21 @@ class RouteCache {
     /**
      * @brief Lock-free lookup protected by EBR epoch guard.
      */
-    P2PRouteHandle Get(const std::string& key);
+    P2PRouteHandle Get(std::string_view key);
 
     /**
      * @brief overwrite
      */
-    void Replace(const std::string& key,
+    void Replace(std::string_view key,
                  const std::vector<P2PProxyDescriptor>& replicas);
 
     /**
      * @brief update if key exists, otherwise insert
      */
-    void Upsert(const std::string& key,
+    void Upsert(std::string_view key,
                 const std::vector<P2PProxyDescriptor>& replicas);
 
-    void RemoveReplica(const std::string& key,
+    void RemoveReplica(std::string_view key,
                        const std::vector<P2PProxyDescriptor>& remove_replicas);
 
     struct Metrics {
@@ -308,7 +309,7 @@ class RouteCache {
 
    private:
     void InnerPut(Shard& shard, size_t bucket_idx, size_t hash_val,
-                  const std::string& key,
+                  std::string_view key,
                   const std::vector<P2PProxyDescriptor>& replicas, bool merge);
 
     void BuildReplicaList(

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -25,13 +25,13 @@ class WrappedMasterService {
 
     void init_http_server();
 
-    tl::expected<bool, ErrorCode> ExistKey(const std::string& key);
+    tl::expected<bool, ErrorCode> ExistKey(std::string_view key);
 
     tl::expected<MasterMetricManager::CacheHitStatDict, ErrorCode>
     CalcCacheStats();
 
     std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
-        const std::vector<std::string>& keys);
+        const std::vector<std::string_view>& keys);
 
     tl::expected<
         std::unordered_map<UUID, std::vector<std::string>, boost::hash<UUID>>,
@@ -44,17 +44,17 @@ class WrappedMasterService {
     GetReplicaListByRegex(const std::string& str);
 
     tl::expected<GetReplicaListResponse, ErrorCode> GetReplicaList(
-        const std::string& key, const GetReplicaListRequestConfig& config =
-                                    GetReplicaListRequestConfig());
+        std::string_view key, const GetReplicaListRequestConfig& config =
+                                  GetReplicaListRequestConfig());
 
     std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
-    BatchGetReplicaList(const std::vector<std::string>& keys,
+    BatchGetReplicaList(const std::vector<std::string_view>& keys,
                         const GetReplicaListRequestConfig& config =
                             GetReplicaListRequestConfig());
 
-    tl::expected<void, ErrorCode> Remove(const std::string& key);
+    tl::expected<void, ErrorCode> Remove(std::string_view key);
 
-    tl::expected<long, ErrorCode> RemoveByRegex(const std::string& str);
+    tl::expected<long, ErrorCode> RemoveByRegex(std::string_view str);
 
     long RemoveAll();
 

--- a/mooncake-store/include/tiered_cache/scheduler/client_scheduler.h
+++ b/mooncake-store/include/tiered_cache/scheduler/client_scheduler.h
@@ -11,10 +11,12 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <string_view>
+#include <boost/functional/hash.hpp>
 #include "mutex.h"
 #include "tiered_cache/scheduler/scheduler_policy.h"
 #include "tiered_cache/scheduler/stats_collector.h"
 #include "types.h"
+#include "utils.h"
 
 #include <json/value.h>
 
@@ -41,7 +43,7 @@ class ClientScheduler {
     void RegisterTier(CacheTier* tier);
 
     // Incoming event hook (thread-safe)
-    void OnAccess(const std::string& key);
+    void OnAccess(std::string_view key);
 
     /**
      * @brief Get current hot key statistics for HA recovery prioritization.
@@ -49,10 +51,10 @@ class ClientScheduler {
     AccessStats GetHotKeyStats() const;
 
     // Called when a replica is committed or updated
-    void OnCommit(const std::string& key, UUID tier_id, size_t size_bytes);
+    void OnCommit(std::string_view key, UUID tier_id, size_t size_bytes);
 
     // Called when a key or a replica is deleted
-    void OnDelete(const std::string& key,
+    void OnDelete(std::string_view key,
                   std::optional<UUID> tier_id = std::nullopt);
 
     // Called when allocation fails due to insufficient space
@@ -107,9 +109,12 @@ class ClientScheduler {
 
     struct KeyCacheShard {
         mutable Mutex mutex;
-        std::unordered_map<std::string, CachedKeyState> key_cache
-            GUARDED_BY(mutex);
-        std::unordered_map<UUID, std::unordered_set<std::string>>
+        std::unordered_map<std::string, CachedKeyState, StringHash,
+                           std::equal_to<>>
+            key_cache GUARDED_BY(mutex);
+        std::unordered_map<
+            UUID, std::unordered_set<std::string, StringHash, std::equal_to<>>,
+            boost::hash<UUID>>
             tier_resident_keys GUARDED_BY(mutex);
     };
 
@@ -133,10 +138,10 @@ class ClientScheduler {
         const AccessStatEntry* stat_entry = nullptr) const;
     size_t GetCachedKeySize(const std::string& key) const;
 
-    void TrackReplicaLocked(KeyCacheShard& shard, const std::string& key,
+    void TrackReplicaLocked(KeyCacheShard& shard, std::string_view key,
                             UUID tier_id, size_t size_bytes)
         REQUIRES(shard.mutex);
-    bool RemoveReplicaLocked(KeyCacheShard& shard, const std::string& key,
+    bool RemoveReplicaLocked(KeyCacheShard& shard, std::string_view key,
                              std::optional<UUID> tier_id) REQUIRES(shard.mutex);
 
    private:

--- a/mooncake-store/include/tiered_cache/scheduler/lru_stats_collector.h
+++ b/mooncake-store/include/tiered_cache/scheduler/lru_stats_collector.h
@@ -5,10 +5,12 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
 #include "tiered_cache/scheduler/stats_collector.h"
+#include "utils.h"
 
 namespace mooncake {
 
@@ -27,12 +29,17 @@ class LRUStatsCollector : public StatsCollector {
           max_snapshot_keys_(
               detail::NormalizeSnapshotLimit(max_snapshot_keys)) {}
 
-    void RecordAccess(const std::string& key) override {
+    void RecordAccess(std::string_view key) override {
         const uint64_t sequence =
             next_sequence_.fetch_add(1, std::memory_order_relaxed);
         auto& shard = GetShard(key);
         std::lock_guard<std::mutex> lock(shard.mutex);
-        shard.pending_updates[key] = sequence;
+        auto it = shard.pending_updates.find(key);
+        if (it != shard.pending_updates.end()) {
+            it->second = sequence;
+        } else {
+            shard.pending_updates.emplace(std::string(key), sequence);
+        }
     }
 
     AccessStats GetSnapshot() override {
@@ -41,11 +48,14 @@ class LRUStatsCollector : public StatsCollector {
         return BuildSnapshot();
     }
 
-    void RemoveKey(const std::string& key) override {
+    void RemoveKey(std::string_view key) override {
         auto& shard = GetShard(key);
         std::lock_guard<std::mutex> lock(shard.mutex);
-        shard.pending_updates.erase(key);
-        shard.pending_deletes.push_back(key);
+        auto it = shard.pending_updates.find(key);
+        if (it != shard.pending_updates.end()) {
+            shard.pending_updates.erase(it);
+        }
+        shard.pending_deletes.emplace_back(key);
     }
 
    private:
@@ -65,18 +75,21 @@ class LRUStatsCollector : public StatsCollector {
 
     struct alignas(64) Shard {
         std::mutex mutex;
-        std::unordered_map<std::string, uint64_t> pending_updates;
+        std::unordered_map<std::string, uint64_t, StringHash, std::equal_to<>>
+            pending_updates;
         std::vector<std::string> pending_deletes;
     };
 
-    Shard& GetShard(const std::string& key) {
-        const auto shard_index = std::hash<std::string>{}(key)&shard_mask_;
+    Shard& GetShard(std::string_view key) {
+        const auto shard_index = std::hash<std::string_view>{}(key)&shard_mask_;
         return shards_[shard_index];
     }
 
     void ApplyPendingChanges() {
         for (auto& shard : shards_) {
-            std::unordered_map<std::string, uint64_t> pending_updates;
+            std::unordered_map<std::string, uint64_t, StringHash,
+                               std::equal_to<>>
+                pending_updates;
             std::vector<std::string> pending_deletes;
 
             {

--- a/mooncake-store/include/tiered_cache/scheduler/stats_collector.h
+++ b/mooncake-store/include/tiered_cache/scheduler/stats_collector.h
@@ -9,12 +9,14 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "tiered_cache/scheduler/scheduler_policy.h"
+#include "utils.h"
 
 namespace mooncake {
 
@@ -79,13 +81,13 @@ class StatsCollector {
     virtual ~StatsCollector() = default;
 
     // Record an access event for a key
-    virtual void RecordAccess(const std::string& key) = 0;
+    virtual void RecordAccess(std::string_view key) = 0;
 
     // Get a snapshot of current stats for policy decision
     virtual AccessStats GetSnapshot() = 0;
 
     // Remove a key from tracking (called when key is deleted)
-    virtual void RemoveKey(const std::string& key) = 0;
+    virtual void RemoveKey(std::string_view key) = 0;
 };
 
 /**
@@ -115,10 +117,15 @@ class SimpleStatsCollector : public StatsCollector {
         last_aggregate_update_time_ = now_fn_();
     }
 
-    void RecordAccess(const std::string& key) override {
+    void RecordAccess(std::string_view key) override {
         auto& shard = GetShard(key);
         std::lock_guard<std::mutex> lock(shard.mutex);
-        shard.pending_counts[key]++;
+        auto it = shard.pending_counts.find(key);
+        if (it != shard.pending_counts.end()) {
+            ++it->second;
+        } else {
+            shard.pending_counts.emplace(std::string(key), 1);
+        }
     }
 
     AccessStats GetSnapshot() override {
@@ -132,11 +139,14 @@ class SimpleStatsCollector : public StatsCollector {
         return stats;
     }
 
-    void RemoveKey(const std::string& key) override {
+    void RemoveKey(std::string_view key) override {
         auto& shard = GetShard(key);
         std::lock_guard<std::mutex> lock(shard.mutex);
-        shard.pending_counts.erase(key);
-        shard.pending_deletes.push_back(key);
+        auto it = shard.pending_counts.find(key);
+        if (it != shard.pending_counts.end()) {
+            shard.pending_counts.erase(it);
+        }
+        shard.pending_deletes.emplace_back(key);
     }
 
    private:
@@ -156,18 +166,21 @@ class SimpleStatsCollector : public StatsCollector {
 
     struct alignas(64) Shard {
         std::mutex mutex;
-        std::unordered_map<std::string, uint64_t> pending_counts;
+        std::unordered_map<std::string, uint64_t, StringHash, std::equal_to<>>
+            pending_counts;
         std::vector<std::string> pending_deletes;
     };
 
-    Shard& GetShard(const std::string& key) {
-        const auto shard_index = std::hash<std::string>{}(key)&shard_mask_;
+    Shard& GetShard(std::string_view key) {
+        const auto shard_index = std::hash<std::string_view>{}(key)&shard_mask_;
         return shards_[shard_index];
     }
 
     void ApplyPendingChanges() {
         for (auto& shard : shards_) {
-            std::unordered_map<std::string, uint64_t> pending_counts;
+            std::unordered_map<std::string, uint64_t, StringHash,
+                               std::equal_to<>>
+                pending_counts;
             std::vector<std::string> pending_deletes;
 
             {

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <atomic>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <memory>
 #include <unordered_map>
@@ -15,6 +16,7 @@
 #include "tiered_cache/data_copier.h"
 #include "tiered_cache/scheduler/stats_collector.h"
 #include "rpc_types.h"
+#include "utils.h"
 
 namespace mooncake {
 
@@ -84,15 +86,14 @@ using AllocationHandle = std::shared_ptr<AllocationEntry>;
  * Returns true if sync succeeds, false otherwise.
  */
 using AddReplicaCallback = std::function<tl::expected<void, ErrorCode>(
-    const std::string& key, const UUID& tier_id, size_t size)>;
+    std::string_view key, const UUID& tier_id, size_t size)>;
 
 /**
  * @brief Callback for metadata synchronization when a replica is removed.
  * Returns true if sync succeeds, false otherwise.
  */
 using RemoveReplicaCallback = std::function<tl::expected<void, ErrorCode>(
-    const std::string& key, const UUID& tier_id,
-    enum REMOVE_CALLBACK_TYPE type)>;
+    std::string_view key, const UUID& tier_id, enum REMOVE_CALLBACK_TYPE type)>;
 
 /**
  * @brief Callback for segment lifecycle synchronization.
@@ -164,7 +165,7 @@ class TieredBackend {
      * Returns CAS_FAILED if mismatch.
      */
     tl::expected<void, ErrorCode> Commit(
-        const std::string& key, AllocationHandle handle,
+        std::string_view key, AllocationHandle handle,
         std::optional<uint64_t> expected_version = std::nullopt,
         bool record_access = true);
 
@@ -174,7 +175,7 @@ class TieredBackend {
      * @param tier_id Optional tier ID. If specified, checks only the given
      *        tier; if nullopt, checks any tier.
      */
-    bool Exist(const std::string& key,
+    bool Exist(std::string_view key,
                std::optional<UUID> tier_id = std::nullopt) const;
 
     /**
@@ -184,7 +185,7 @@ class TieredBackend {
      * metadata entry.
      */
     tl::expected<AllocationHandle, ErrorCode> Get(
-        const std::string& key, std::optional<UUID> tier_id = std::nullopt,
+        std::string_view key, std::optional<UUID> tier_id = std::nullopt,
         bool record_access = true, uint64_t* out_version = nullptr);
 
     /**
@@ -194,16 +195,16 @@ class TieredBackend {
      * If nullopt, removes ALL replicas for this key (and the key entry itself).
      */
     tl::expected<void, ErrorCode> Delete(
-        const std::string& key, std::optional<UUID> tier_id = std::nullopt);
+        std::string_view key, std::optional<UUID> tier_id = std::nullopt);
 
     // --- Composite Operations ---
 
     tl::expected<void, ErrorCode> CopyData(
-        const std::string& key, const DataSource& source, UUID dest_tier_id,
+        std::string_view key, const DataSource& source, UUID dest_tier_id,
         std::optional<uint64_t> expected_version = std::nullopt,
         bool record_access = true);
 
-    tl::expected<void, ErrorCode> Transfer(const std::string& key,
+    tl::expected<void, ErrorCode> Transfer(std::string_view key,
                                            UUID source_tier_id,
                                            UUID dest_tier_id,
                                            bool record_access = true);
@@ -211,7 +212,7 @@ class TieredBackend {
     // --- Introspection & Internal ---
 
     std::vector<TierView> GetTierViews() const;
-    std::vector<UUID> GetReplicaTierIds(const std::string& key) const;
+    std::vector<UUID> GetReplicaTierIds(std::string_view key) const;
     const CacheTier* GetTier(UUID tier_id) const;
     const DataCopier& GetDataCopier() const;
 
@@ -270,18 +271,20 @@ class TieredBackend {
     // Each shard has its own mutex for fine-grained locking.
     struct MetadataShard {
         mutable std::shared_mutex mutex;
-        std::unordered_map<std::string, std::shared_ptr<MetadataEntry>> index;
+        std::unordered_map<std::string, std::shared_ptr<MetadataEntry>,
+                           StringHash, std::equal_to<>>
+            index;
     };
 
     static constexpr size_t kMetadataShardCount = 64;
     std::array<MetadataShard, kMetadataShardCount> metadata_shards_;
 
-    MetadataShard& GetMetadataShard(const std::string& key) {
-        return metadata_shards_[std::hash<std::string>{}(key) %
+    MetadataShard& GetMetadataShard(std::string_view key) {
+        return metadata_shards_[std::hash<std::string_view>{}(key) %
                                 kMetadataShardCount];
     }
-    const MetadataShard& GetMetadataShard(const std::string& key) const {
-        return metadata_shards_[std::hash<std::string>{}(key) %
+    const MetadataShard& GetMetadataShard(std::string_view key) const {
+        return metadata_shards_[std::hash<std::string_view>{}(key) %
                                 kMetadataShardCount];
     }
 

--- a/mooncake-store/include/tiered_cache/tiers/cache_tier.h
+++ b/mooncake-store/include/tiered_cache/tiers/cache_tier.h
@@ -142,7 +142,7 @@ class CacheTier {
      * Registers the key and finalizes the storage.
      * For Storage Tiers, this triggers the actual persistence (or buffering).
      */
-    virtual tl::expected<void, ErrorCode> Commit(const std::string& key,
+    virtual tl::expected<void, ErrorCode> Commit(std::string_view key,
                                                  const DataSource& data) {
         return {};
     }

--- a/mooncake-store/include/tiered_cache/tiers/storage_tier.h
+++ b/mooncake-store/include/tiered_cache/tiers/storage_tier.h
@@ -144,7 +144,7 @@ class StorageTier : public CacheTier {
 
     tl::expected<void, ErrorCode> Free(DataSource data) override;
 
-    tl::expected<void, ErrorCode> Commit(const std::string& key,
+    tl::expected<void, ErrorCode> Commit(std::string_view key,
                                          const DataSource& data) override;
 
     tl::expected<void, ErrorCode> Flush() override;

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -2,8 +2,10 @@
 
 #include <cstddef>
 #include <cstdlib>
-#include <string>
+#include <functional>
 #include <limits>
+#include <string>
+#include <string_view>
 #include <ylt/util/tl/expected.hpp>
 
 #include "types.h"
@@ -244,6 +246,16 @@ std::vector<std::string> splitString(const std::string& str,
                                      char delimiter = ',',
                                      bool trim_spaces = true,
                                      bool keep_empty = false);
+
+/// @brief Transparent hasher enabling heterogeneous string_view lookup
+/// in unordered containers keyed by std::string.
+/// std::string implicitly converts to string_view, so one overload suffices.
+struct StringHash {
+    using is_transparent = void;
+    size_t operator()(std::string_view sv) const noexcept {
+        return std::hash<std::string_view>{}(sv);
+    }
+};
 
 // Network utility functions
 

--- a/mooncake-store/src/async_memcpy_executor.cpp
+++ b/mooncake-store/src/async_memcpy_executor.cpp
@@ -1,54 +1,8 @@
 #include "async_memcpy_executor.h"
 
 #include <algorithm>
-#include <cstring>
 
 namespace mooncake {
-
-// ============================================================================
-// ExecuteLocalCopyPlan
-// ============================================================================
-
-ErrorCode ExecuteLocalCopyPlan(const LocalCopyPlan& plan) {
-    if (plan.use_single_dest) {
-        if (!plan.single_dest_ptr) {
-            LOG(ERROR) << "Local copy destination buffer is null";
-            return ErrorCode::INVALID_PARAMS;
-        }
-        if (plan.single_dest_size < plan.source_size) {
-            LOG(ERROR) << "Local copy destination is too small, required="
-                       << plan.source_size
-                       << ", provided=" << plan.single_dest_size;
-            return ErrorCode::INVALID_PARAMS;
-        }
-        if (plan.source_size > 0) {
-            std::memcpy(plan.single_dest_ptr, plan.source_ptr,
-                        plan.source_size);
-        }
-        return ErrorCode::OK;
-    }
-
-    size_t offset = 0;
-    for (const auto& slice : plan.dest_slices) {
-        if (offset >= plan.source_size) break;
-        const size_t copy_size =
-            std::min(slice.size, plan.source_size - offset);
-        if (copy_size == 0) continue;
-        if (!slice.ptr) {
-            LOG(ERROR) << "Local copy destination buffer is null";
-            return ErrorCode::INVALID_PARAMS;
-        }
-        std::memcpy(slice.ptr, plan.source_ptr + offset, copy_size);
-        offset += copy_size;
-    }
-
-    if (offset != plan.source_size) {
-        LOG(ERROR) << "Local copy did not complete, copied=" << offset
-                   << ", source_size=" << plan.source_size;
-        return ErrorCode::INTERNAL_ERROR;
-    }
-    return ErrorCode::OK;
-}
 
 // ============================================================================
 // AsyncMemcpyExecutor

--- a/mooncake-store/src/async_metadata_notifier.cpp
+++ b/mooncake-store/src/async_metadata_notifier.cpp
@@ -117,29 +117,29 @@ void AsyncMetadataNotifier::ResetShard(SenderShard& shard) {
 // ============================================================================
 
 tl::expected<void, ErrorCode> AsyncMetadataNotifier::EnqueueAdd(
-    const std::string& key, const UUID& segment_id, size_t size) {
+    std::string_view key, const UUID& segment_id, size_t size) {
     PendingOp op;
     op.type = PendingOp::ADD;
-    op.key = key;
+    op.key = key;  // copy string
     op.segment_id = segment_id;
     op.size = size;
     return DoEnqueue(std::move(op), /*is_recovery=*/false);
 }
 
 tl::expected<void, ErrorCode> AsyncMetadataNotifier::EnqueueRemove(
-    const std::string& key, const UUID& segment_id) {
+    std::string_view key, const UUID& segment_id) {
     PendingOp op;
     op.type = PendingOp::REMOVE;
-    op.key = key;
+    op.key = key;  // copy string
     op.segment_id = segment_id;
     return DoEnqueue(std::move(op), /*is_recovery=*/false);
 }
 
 tl::expected<void, ErrorCode> AsyncMetadataNotifier::EnqueueRecoveryAdd(
-    const std::string& key, const UUID& segment_id, size_t size) {
+    std::string_view key, const UUID& segment_id, size_t size) {
     PendingOp op;
     op.type = PendingOp::ADD;
-    op.key = key;
+    op.key = key;  // copy string
     op.segment_id = segment_id;
     op.size = size;
     return DoEnqueue(std::move(op), /*is_recovery=*/true);
@@ -356,11 +356,11 @@ void AsyncMetadataNotifier::SendBatch(std::vector<PendingOp>& batch,
     for (size_t i = 0; i < count; ++i) {
         auto& op = batch[i];
         if (op.type == PendingOp::ADD) {
-            req.add_keys.push_back(std::move(op.key));
+            req.add_keys.push_back(std::string_view(op.key));
             req.add_sizes.push_back(op.size);
             req.add_segment_ids.push_back(op.segment_id);
         } else {
-            req.remove_keys.push_back(std::move(op.key));
+            req.remove_keys.push_back(std::string_view(op.key));
             req.remove_segment_ids.push_back(op.segment_id);
         }
     }

--- a/mooncake-store/src/centralized_client_service.cpp
+++ b/mooncake-store/src/centralized_client_service.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <string_view>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -276,7 +277,9 @@ CentralizedClientService::BatchQuery(
     }
     std::chrono::steady_clock::time_point start_time =
         std::chrono::steady_clock::now();
-    auto response = master_client_.BatchGetReplicaList(object_keys, config);
+    std::vector<std::string_view> key_views(object_keys.begin(),
+                                            object_keys.end());
+    auto response = master_client_.BatchGetReplicaList(key_views, config);
 
     // Check if we got the expected number of responses
     if (response.size() != object_keys.size()) {
@@ -338,7 +341,8 @@ CentralizedClientService::BatchIsExist(const std::vector<std::string>& keys) {
         return std::vector<tl::expected<bool, ErrorCode>>(
             keys.size(), tl::unexpected(ErrorCode::SHUTTING_DOWN));
     }
-    auto results = master_client_.BatchExistKey(keys);
+    std::vector<std::string_view> key_views(keys.begin(), keys.end());
+    auto results = master_client_.BatchExistKey(key_views);
     for (size_t i = 0; i < results.size(); ++i) {
         if (!results[i]) {
             LOG(ERROR) << "Failed to query key"

--- a/mooncake-store/src/centralized_master_service.cpp
+++ b/mooncake-store/src/centralized_master_service.cpp
@@ -380,7 +380,7 @@ void CentralizedMasterService::OnReplicaAdded(const Replica& replica) {
 }
 
 auto CentralizedMasterService::GetReplicaList(
-    const std::string& key, const GetReplicaListRequestConfig& config)
+    std::string_view key, const GetReplicaListRequestConfig& config)
     -> tl::expected<GetReplicaListResponse, ErrorCode> {
     auto res = MasterService::GetReplicaList(key, config);
     if (!res) {

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -1,5 +1,7 @@
 #include "data_manager.h"
 
+#include <algorithm>
+#include <cstring>
 #include <glog/logging.h>
 #include <thread>
 #include <chrono>
@@ -17,6 +19,101 @@
 #include "utils.h"
 
 namespace mooncake {
+
+namespace {
+
+struct LocalCopyPlan {
+    AllocationHandle source_handle;
+    const char* source_ptr = nullptr;
+    size_t source_size = 0;
+    bool use_single_dest = false;
+    void* single_dest_ptr = nullptr;
+    size_t single_dest_size = 0;
+    std::vector<Slice> dest_slices;
+};
+
+tl::expected<LocalCopyPlan, ErrorCode> BuildLocalCopyPlan(
+    const std::string& key, const AllocationHandle& handle,
+    const std::vector<Slice>& slices) {
+    if (!handle) {
+        LOG(ERROR) << "Invalid local allocation handle for key: " << key;
+        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+
+    const auto& loc = handle->loc;
+    if (!loc.data.buffer) {
+        LOG(ERROR) << "Allocation handle has null buffer for key: " << key;
+        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+
+    const char* src = reinterpret_cast<const char*>(loc.data.buffer->data());
+    const size_t src_size = loc.data.buffer->size();
+    size_t provided_size = 0;
+    for (const auto& s : slices) provided_size += s.size;
+    if (provided_size < src_size) {
+        LOG(ERROR) << "Buffer too small for local key '" << key
+                   << "': required=" << src_size
+                   << ", provided=" << provided_size;
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    LocalCopyPlan plan;
+    plan.source_handle = handle;
+    plan.source_ptr = src;
+    plan.source_size = src_size;
+    if (slices.size() == 1) {
+        plan.use_single_dest = true;
+        plan.single_dest_ptr = slices[0].ptr;
+        plan.single_dest_size = slices[0].size;
+    } else {
+        plan.dest_slices = slices;
+    }
+    return plan;
+}
+
+ErrorCode ExecuteLocalCopyPlan(const LocalCopyPlan& plan) {
+    if (plan.use_single_dest) {
+        if (!plan.single_dest_ptr) {
+            LOG(ERROR) << "Local copy destination buffer is null";
+            return ErrorCode::INVALID_PARAMS;
+        }
+        if (plan.single_dest_size < plan.source_size) {
+            LOG(ERROR) << "Local copy destination is too small, required="
+                       << plan.source_size
+                       << ", provided=" << plan.single_dest_size;
+            return ErrorCode::INVALID_PARAMS;
+        }
+        if (plan.source_size > 0) {
+            std::memcpy(plan.single_dest_ptr, plan.source_ptr,
+                        plan.source_size);
+        }
+        return ErrorCode::OK;
+    }
+
+    size_t offset = 0;
+    for (const auto& slice : plan.dest_slices) {
+        if (offset >= plan.source_size) break;
+        const size_t copy_size =
+            std::min(slice.size, plan.source_size - offset);
+        if (copy_size == 0) continue;
+        if (!slice.ptr) {
+            LOG(ERROR) << "Local copy destination buffer is null";
+            return ErrorCode::INVALID_PARAMS;
+        }
+        std::memcpy(slice.ptr, plan.source_ptr + offset, copy_size);
+        offset += copy_size;
+    }
+
+    if (offset != plan.source_size) {
+        LOG(ERROR) << "Local copy did not complete, copied=" << offset
+                   << ", source_size=" << plan.source_size;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+}  // namespace
+
 // ================================================================
 // Constructor
 // ================================================================
@@ -386,85 +483,31 @@ tl::expected<ReadTaskHandle, ErrorCode> DataManager::BuildDataCopierViaMemcpy(
     ReadTaskHandle res;
     res.data_size = static_cast<int64_t>(plan_result.value().source_size);
 
+    auto read_fn = [plan = std::move(plan_result.value()),
+                    key]() mutable -> tl::expected<void, ErrorCode> {
+        ScopedVLogTimer timer(1, "DataManager::BuildDataCopierViaMemcpy");
+        timer.LogRequest("key=", key);
+        ErrorCode ec = ExecuteLocalCopyPlan(plan);
+        if (ec != ErrorCode::OK) {
+            LOG(ERROR) << "Failed to execute local copy plan"
+                       << ", key=" << key << ", error_code=" << ec;
+            return tl::unexpected(ec);
+        }
+        timer.LogResponse("error_code=", ErrorCode::OK);
+        return {};
+    };
+
     if (async_memcpy_executor_) {
-        auto future =
-            async_memcpy_executor_
-                ->SubmitSingleTask<tl::expected<void, ErrorCode>>(
-                    [plan = plan_result.value(),
-                     key]() -> tl::expected<void, ErrorCode> {
-                        ScopedVLogTimer timer(
-                            1, "DataManager::BuildDataCopierViaMemcpy");
-                        timer.LogRequest("key=", key);
-                        ErrorCode ec = ExecuteLocalCopyPlan(plan);
-                        if (ec != ErrorCode::OK) {
-                            LOG(ERROR)
-                                << "Failed to execute local copy plan"
-                                << ", key=" << key << ", error_code=" << ec;
-                            return tl::unexpected(ec);
-                        }
-                        timer.LogResponse("error_code=", ErrorCode::OK);
-                        return {};
-                    });
+        auto future = async_memcpy_executor_
+                          ->SubmitSingleTask<tl::expected<void, ErrorCode>>(
+                              std::move(read_fn));
         res.task_handle = FutureHandle<void>::Create(std::shared_ptr<void>{},
                                                      std::move(future));
     } else {
-        res.task_handle = CallableTaskHandle<void>::Create(
-            [plan = std::move(plan_result.value()),
-             key]() mutable -> tl::expected<void, ErrorCode> {
-                ScopedVLogTimer timer(1,
-                                      "DataManager::BuildDataCopierViaMemcpy");
-                timer.LogRequest("key=", key);
-                ErrorCode ec = ExecuteLocalCopyPlan(plan);
-                if (ec != ErrorCode::OK) {
-                    LOG(ERROR) << "Failed to execute local copy plan"
-                               << ", key=" << key << ", error_code=" << ec;
-                    return tl::unexpected(ec);
-                }
-                timer.LogResponse("error_code=", ErrorCode::OK);
-                return {};
-            });
+        res.task_handle = CallableTaskHandle<void>::Create(std::move(read_fn));
     }
 
     return res;
-}
-
-tl::expected<LocalCopyPlan, ErrorCode> DataManager::BuildLocalCopyPlan(
-    const std::string& key, const AllocationHandle& handle,
-    const std::vector<Slice>& slices) const {
-    if (!handle) {
-        LOG(ERROR) << "Invalid local allocation handle for key: " << key;
-        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
-    }
-
-    const auto& loc = handle->loc;
-    if (!loc.data.buffer) {
-        LOG(ERROR) << "Allocation handle has null buffer for key: " << key;
-        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
-    }
-
-    const char* src = reinterpret_cast<const char*>(loc.data.buffer->data());
-    const size_t src_size = loc.data.buffer->size();
-    size_t provided_size = 0;
-    for (const auto& s : slices) provided_size += s.size;
-    if (provided_size < src_size) {
-        LOG(ERROR) << "Buffer too small for local key '" << key
-                   << "': required=" << src_size
-                   << ", provided=" << provided_size;
-        return tl::unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    LocalCopyPlan plan;
-    plan.source_handle = handle;
-    plan.source_ptr = src;
-    plan.source_size = src_size;
-    if (slices.size() == 1) {
-        plan.use_single_dest = true;
-        plan.single_dest_ptr = slices[0].ptr;
-        plan.single_dest_size = slices[0].size;
-    } else {
-        plan.dest_slices = slices;
-    }
-    return plan;
 }
 
 // ================================================================

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -33,7 +33,7 @@ struct LocalCopyPlan {
 };
 
 tl::expected<LocalCopyPlan, ErrorCode> BuildLocalCopyPlan(
-    const std::string& key, const AllocationHandle& handle,
+    std::string_view key, const AllocationHandle& handle,
     const std::vector<Slice>& slices) {
     if (!handle) {
         LOG(ERROR) << "Invalid local allocation handle for key: " << key;
@@ -164,7 +164,7 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
 // In future, we will add a pre-occupation mechanism in the Allocation stage
 // to optimize this issue.
 tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode> DataManager::Put(
-    const std::string& key, std::vector<Slice>& slices) {
+    std::string_view key, std::vector<Slice>& slices) {
     switch (local_transfer_config_.mode) {
         case LocalTransferMode::TE:
             return PutViaTe(key, slices);
@@ -185,7 +185,7 @@ tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode> DataManager::Put(
 //   (3) introduce a completion callback from transfer_engine itself.
 // Once any of these lands, switch the return type to FutureHandle.
 tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
-DataManager::PutViaTe(const std::string& key, std::vector<Slice>& slices) {
+DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
     // using Te, treat local memory as remote memory
     size_t total_size = 0;
     for (const auto& s : slices) total_size += s.size;
@@ -271,7 +271,7 @@ DataManager::PutViaTe(const std::string& key, std::vector<Slice>& slices) {
 }
 
 tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
-DataManager::PutViaMemcpy(const std::string& key, std::vector<Slice>& slices) {
+DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
     if (slices.size() != 1) {
         LOG(ERROR) << "PutLocal in memcpy mode only supports a single slice";
         return tl::unexpected(ErrorCode::NOT_IMPLEMENTED);
@@ -365,7 +365,7 @@ DataManager::PutViaMemcpy(const std::string& key, std::vector<Slice>& slices) {
 // ================================================================
 
 tl::expected<ReadTaskHandle, ErrorCode> DataManager::Get(
-    const std::string& key, std::shared_ptr<ClientBufferAllocator> allocator) {
+    std::string_view key, std::shared_ptr<ClientBufferAllocator> allocator) {
     auto handle = tiered_backend_->Get(key);
     if (!handle) {
         if (handle.error() != ErrorCode::OBJECT_NOT_FOUND) {
@@ -398,7 +398,7 @@ tl::expected<ReadTaskHandle, ErrorCode> DataManager::Get(
 }
 
 tl::expected<ReadTaskHandle, ErrorCode> DataManager::Get(
-    const std::string& key, const std::vector<Slice>& slices) {
+    std::string_view key, const std::vector<Slice>& slices) {
     auto handle = tiered_backend_->Get(key);
     if (!handle) {
         if (handle.error() != ErrorCode::OBJECT_NOT_FOUND) {
@@ -416,7 +416,7 @@ tl::expected<ReadTaskHandle, ErrorCode> DataManager::Get(
 }
 
 tl::expected<ReadTaskHandle, ErrorCode> DataManager::BuildDataCopier(
-    const AllocationHandle& handle, const std::string& key,
+    const AllocationHandle& handle, std::string_view key,
     const std::vector<Slice>& slices) {
     if (!handle || !handle->loc.data.buffer) {
         LOG(ERROR) << "Failed to get data for key: " << key;
@@ -471,7 +471,7 @@ tl::expected<ReadTaskHandle, ErrorCode> DataManager::BuildDataCopierViaTe(
 }
 
 tl::expected<ReadTaskHandle, ErrorCode> DataManager::BuildDataCopierViaMemcpy(
-    const AllocationHandle& handle, const std::string& key,
+    const AllocationHandle& handle, std::string_view key,
     const std::vector<Slice>& slices) {
     auto plan_result = BuildLocalCopyPlan(key, handle, slices);
     if (!plan_result) {
@@ -517,7 +517,7 @@ tl::expected<ReadTaskHandle, ErrorCode> DataManager::BuildDataCopierViaMemcpy(
 // Attention!!!
 // This method runs without key lock.
 tl::expected<void, ErrorCode> DataManager::ReadRemoteData(
-    const std::string& key, const std::vector<RemoteBufferDesc>& dest_buffers) {
+    std::string_view key, const std::vector<RemoteBufferDesc>& dest_buffers) {
     ScopedVLogTimer timer(1, "DataManager::ReadRemoteData");
     timer.LogRequest("key=", key, "buffer_count=", dest_buffers.size());
 
@@ -557,7 +557,7 @@ tl::expected<void, ErrorCode> DataManager::TransferDataToRemote(
 }
 
 tl::expected<UUID, ErrorCode> DataManager::WriteRemoteData(
-    const std::string& key, const std::vector<RemoteBufferDesc>& src_buffers,
+    std::string_view key, const std::vector<RemoteBufferDesc>& src_buffers,
     std::optional<UUID> tier_id) {
     ScopedVLogTimer timer(1, "DataManager::WriteRemoteData");
     timer.LogRequest("key=", key, "buffer_count=", src_buffers.size());
@@ -1119,7 +1119,7 @@ std::vector<RemoteBufferDesc> DataManager::SlicesToRemoteBufferDescs(
 // ================================================================
 
 tl::expected<size_t, ErrorCode> DataManager::QueryObjectSize(
-    const std::string& key) {
+    std::string_view key) {
     auto handle = tiered_backend_->Get(key);
     if (!handle) {
         return tl::unexpected(handle.error());
@@ -1129,7 +1129,7 @@ tl::expected<size_t, ErrorCode> DataManager::QueryObjectSize(
     return size;
 }
 
-tl::expected<void, ErrorCode> DataManager::Delete(const std::string& key,
+tl::expected<void, ErrorCode> DataManager::Delete(std::string_view key,
                                                   std::optional<UUID> tier_id) {
     ScopedVLogTimer timer(1, "DataManager::Delete");
     timer.LogRequest("key=", key);
@@ -1147,7 +1147,7 @@ tl::expected<void, ErrorCode> DataManager::Delete(const std::string& key,
     return {};
 }
 
-bool DataManager::Exist(const std::string& key,
+bool DataManager::Exist(std::string_view key,
                         std::optional<UUID> tier_id) const {
     return tiered_backend_->Exist(key, tier_id);
 }
@@ -1164,7 +1164,7 @@ AccessStats DataManager::GetHotKeyStats() const {
     return tiered_backend_->GetHotKeyStats();
 }
 
-std::vector<UUID> DataManager::GetReplicaTierIds(const std::string& key) const {
+std::vector<UUID> DataManager::GetReplicaTierIds(std::string_view key) const {
     if (!tiered_backend_) return {};
     return tiered_backend_->GetReplicaTierIds(key);
 }
@@ -1175,7 +1175,7 @@ std::vector<UUID> DataManager::GetReplicaTierIds(const std::string& key) const {
 
 // If a client attempts to access data via a read route and the data is not
 // found locally, it calls this function to rectify the stale route in master.
-void DataManager::RectifyReadRoute(const std::string& key,
+void DataManager::RectifyReadRoute(std::string_view key,
                                    std::optional<UUID> tier_id) {
     if (!rectify_wrong_route_fn_) return;
 
@@ -1189,12 +1189,13 @@ void DataManager::RectifyReadRoute(const std::string& key,
                                    std::to_string(tier_id.value().second)
                              : "")
                      << ", removing replica from master for key: " << key;
+        // Callback signature pins const std::string&; copy at the boundary.
         rectify_wrong_route_fn_(key, tier_id);
     }
 }
 
 void DataManager::SetRectifyCallback(
-    std::function<void(const std::string&, std::optional<UUID>)> fn) {
+    std::function<void(std::string_view, std::optional<UUID>)> fn) {
     rectify_wrong_route_fn_ = std::move(fn);
 }
 

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -2,6 +2,7 @@
 
 #include <coroutine>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <ylt/coro_rpc/impl/coro_rpc_client.hpp>
 #include <ylt/util/tl/expected.hpp>
@@ -137,7 +138,7 @@ ErrorCode MasterClient::Connect(const std::string& master_addr) {
 }
 
 tl::expected<bool, ErrorCode> MasterClient::ExistKey(
-    const std::string& object_key) {
+    std::string_view object_key) {
     ScopedVLogTimer timer(1, "MasterClient::ExistKey");
     timer.LogRequest("object_key=", object_key);
 
@@ -147,7 +148,7 @@ tl::expected<bool, ErrorCode> MasterClient::ExistKey(
 }
 
 std::vector<tl::expected<bool, ErrorCode>> MasterClient::BatchExistKey(
-    const std::vector<std::string>& object_keys) {
+    const std::vector<std::string_view>& object_keys) {
     ScopedVLogTimer timer(1, "MasterClient::BatchExistKey");
     timer.LogRequest("keys_count=", object_keys.size());
 
@@ -158,7 +159,7 @@ std::vector<tl::expected<bool, ErrorCode>> MasterClient::BatchExistKey(
 }
 
 tl::expected<GetReplicaListResponse, ErrorCode> MasterClient::GetReplicaList(
-    const std::string& key, const GetReplicaListRequestConfig& config) {
+    std::string_view key, const GetReplicaListRequestConfig& config) {
     ScopedVLogTimer timer(1, "MasterClient::GetReplicaList");
     timer.LogRequest("object_key=", key);
 
@@ -169,7 +170,7 @@ tl::expected<GetReplicaListResponse, ErrorCode> MasterClient::GetReplicaList(
 }
 
 async_simple::coro::Lazy<tl::expected<GetReplicaListResponse, ErrorCode>>
-MasterClient::AsyncGetReplicaList(const std::string& key,
+MasterClient::AsyncGetReplicaList(std::string_view key,
                                   const GetReplicaListRequestConfig& config) {
     auto result =
         co_await invoke_rpc_async<&WrappedMasterService::GetReplicaList,
@@ -178,7 +179,7 @@ MasterClient::AsyncGetReplicaList(const std::string& key,
 }
 
 std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
-MasterClient::BatchGetReplicaList(const std::vector<std::string>& keys,
+MasterClient::BatchGetReplicaList(const std::vector<std::string_view>& keys,
                                   const GetReplicaListRequestConfig& config) {
     ScopedVLogTimer timer(1, "MasterClient::BatchGetReplicaList");
     timer.LogRequest("requests_count=", keys.size());
@@ -233,7 +234,7 @@ MasterClient::GetReplicaListByRegex(const std::string& str) {
     return result;
 }
 
-tl::expected<void, ErrorCode> MasterClient::Remove(const std::string& key) {
+tl::expected<void, ErrorCode> MasterClient::Remove(std::string_view key) {
     ScopedVLogTimer timer(1, "MasterClient::Remove");
     timer.LogRequest("key=", key);
 
@@ -243,7 +244,7 @@ tl::expected<void, ErrorCode> MasterClient::Remove(const std::string& key) {
 }
 
 tl::expected<long, ErrorCode> MasterClient::RemoveByRegex(
-    const std::string& str) {
+    std::string_view str) {
     ScopedVLogTimer timer(1, "MasterClient::RemoveByRegex");
     timer.LogRequest("key=", str);
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -193,7 +193,7 @@ auto MasterService::QueryClientStatus(const QueryClientStatusRequest& req)
     return GetClientManager().QueryClientStatus(req);
 }
 
-auto MasterService::ExistKey(const std::string& key)
+auto MasterService::ExistKey(std::string_view key)
     -> tl::expected<bool, ErrorCode> {
     auto accessor = GetMetadataAccessor(key);
     if (!accessor->Exists()) {
@@ -211,7 +211,7 @@ auto MasterService::ExistKey(const std::string& key)
 }
 
 std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
-    const std::vector<std::string>& keys) {
+    const std::vector<std::string_view>& keys) {
     std::vector<tl::expected<bool, ErrorCode>> results;
     results.reserve(keys.size());
     for (const auto& key : keys) {
@@ -338,10 +338,10 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
     return results;
 }
 
-auto MasterService::GetReplicaList(const std::string& key,
+auto MasterService::GetReplicaList(std::string_view key,
                                    const GetReplicaListRequestConfig& config)
     -> tl::expected<GetReplicaListResponse, ErrorCode> {
-    auto accessor = GetMetadataAccessor(std::string(key));
+    auto accessor = GetMetadataAccessor(key);
 
     MasterMetricManager::instance().inc_total_get_nums();
 
@@ -373,7 +373,7 @@ auto MasterService::GetReplicaList(const std::string& key,
     return resp;
 }
 
-auto MasterService::Remove(const std::string& key)
+auto MasterService::Remove(std::string_view key)
     -> tl::expected<void, ErrorCode> {
     auto accessor = GetMetadataAccessor(key);
     if (!accessor->Exists()) {
@@ -394,13 +394,15 @@ auto MasterService::Remove(const std::string& key)
     return {};
 }
 
-auto MasterService::RemoveByRegex(const std::string& regex_pattern)
+auto MasterService::RemoveByRegex(std::string_view regex_pattern)
     -> tl::expected<long, ErrorCode> {
     long removed_count = 0;
     std::regex pattern;
 
     try {
-        pattern = std::regex(regex_pattern, std::regex::ECMAScript);
+        pattern = std::regex(regex_pattern.data(),
+                             regex_pattern.data() + regex_pattern.size(),
+                             std::regex::ECMAScript);
     } catch (const std::regex_error& e) {
         LOG(ERROR) << "Invalid regex pattern: " << regex_pattern
                    << ", error: " << e.what();

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -165,7 +165,7 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
     if (config.async_sender_thread_count > 0) {
         // When async ADD is rejected by Master, delete the local replica
         // since Master won't track it.
-        SyncFailureCallback failure_cb = [this](const std::string& key,
+        SyncFailureCallback failure_cb = [this](std::string_view key,
                                                 const UUID& segment_id,
                                                 ErrorCode error) {
             LOG(WARNING) << "Async ADD rejected by Master, deleting local"
@@ -251,7 +251,7 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
     data_manager_ = DataManager(std::move(tiered_backend), transfer_engine_,
                                 config.lock_shard_count, local_transfer_config);
     // Set rectify callback on DataManager to remove stale replicas from master
-    data_manager_->SetRectifyCallback([this](const std::string& key,
+    data_manager_->SetRectifyCallback([this](std::string_view key,
                                              std::optional<UUID> tier_id) {
         if (async_route_notifier_) {
             if (!tier_id.has_value()) {
@@ -296,7 +296,7 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
 }
 
 AddReplicaCallback P2PClientService::BuildAddReplicaCallback() {
-    return [this](const std::string& key, const UUID& tier_id,
+    return [this](std::string_view key, const UUID& tier_id,
                   size_t size) -> tl::expected<void, ErrorCode> {
         // In degraded mode, skip metadata notification to Master.
         // The data is stored locally; the recovery pipeline will re-sync
@@ -314,7 +314,7 @@ AddReplicaCallback P2PClientService::BuildAddReplicaCallback() {
 RemoveReplicaCallback P2PClientService::BuildRemoveReplicaCallback() {
     return
         [this](
-            const std::string& key, const UUID& tier_id,
+            std::string_view key, const UUID& tier_id,
             enum REMOVE_CALLBACK_TYPE type) -> tl::expected<void, ErrorCode> {
             // In degraded mode, skip metadata notification to Master.
             // The recovery pipeline will re-sync all local metadata,
@@ -344,7 +344,7 @@ RemoveReplicaCallback P2PClientService::BuildRemoveReplicaCallback() {
 }
 
 tl::expected<void, ErrorCode> P2PClientService::SyncAddReplica(
-    const std::string& key, const UUID& tier_id, size_t size) {
+    std::string_view key, const UUID& tier_id, size_t size) {
     AddReplicaRequest req;
     req.key = key;
     req.size = size;
@@ -360,7 +360,7 @@ tl::expected<void, ErrorCode> P2PClientService::SyncAddReplica(
 }
 
 tl::expected<void, ErrorCode> P2PClientService::SyncRemoveReplica(
-    const std::string& key, const UUID& tier_id) {
+    std::string_view key, const UUID& tier_id) {
     RemoveReplicaRequest req;
     req.key = key;
     req.client_id = client_id_;
@@ -375,7 +375,7 @@ tl::expected<void, ErrorCode> P2PClientService::SyncRemoveReplica(
 }
 
 std::vector<tl::expected<void, ErrorCode>>
-P2PClientService::SyncBatchRemoveReplica(const std::string& key,
+P2PClientService::SyncBatchRemoveReplica(std::string_view key,
                                          std::vector<UUID> segment_ids) {
     BatchRemoveReplicaRequest req;
     req.key = key;
@@ -629,7 +629,7 @@ P2PClientService::InnerBatchPutDegraded(
 }
 
 tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
-P2PClientService::CreatePutHandleFromLocal(const std::string& key,
+P2PClientService::CreatePutHandleFromLocal(std::string_view key,
                                            std::vector<Slice>& slices) {
     if (!data_manager_.has_value()) {
         LOG(ERROR) << "Data manager not initialized";
@@ -788,13 +788,13 @@ P2PClientService::CreatePutHandlesFromRoute(
             handles.push_back(tl::unexpected(tasks[i].error()));
             continue;
         }
-        auto& t = *tasks[i];
+        auto& task = *tasks[i];
         auto promise = std::make_shared<
             async_simple::Promise<tl::expected<void, ErrorCode>>>();
         auto future = promise->getFuture();
-        RunWriteWithRetry(std::move(promise), std::move(t.first_task),
-                          std::move(t.first_route), std::move(t.retry_op_list),
-                          keys[i])
+        RunWriteWithRetry(std::move(promise), std::move(task.first_task),
+                          std::move(task.first_route),
+                          std::move(task.retry_op_list), keys[i])
             .start([](auto&&) {});
         handles.push_back(FutureHandle<void>::Create(std::shared_ptr<void>{},
                                                      std::move(future)));
@@ -802,7 +802,7 @@ P2PClientService::CreatePutHandlesFromRoute(
     return handles;
 }
 
-auto P2PClientService::BuildWriteOps(const std::string& key,
+auto P2PClientService::BuildWriteOps(std::string_view key,
                                      std::vector<Slice>& slices,
                                      const WriteRouteRequestConfig& config,
                                      std::vector<WriteCandidate> candidates)
@@ -934,7 +934,7 @@ async_simple::coro::Lazy<void> P2PClientService::RunWriteWithRetry(
     std::shared_ptr<async_simple::Promise<tl::expected<void, ErrorCode>>>
         promise,
     std::unique_ptr<TaskHandle<void>> current_task, std::string current_route,
-    std::vector<std::unique_ptr<WriteOp>> retry_op_list, std::string key) {
+    std::vector<std::unique_ptr<WriteOp>> retry_op_list, std::string_view key) {
     size_t retry_cnt = 0;
     while (current_task) {
         tl::expected<void, ErrorCode> result;
@@ -1127,7 +1127,7 @@ P2PClientService::BatchCreateGetHandles(
     const std::vector<std::string>& keys,
     std::shared_ptr<ClientBufferAllocator> allocator,
     const ReadRouteConfig& config) {
-    auto local_get = [&](const std::string& key,
+    auto local_get = [&](std::string_view key,
                          size_t) -> tl::expected<ReadTaskHandle, ErrorCode> {
         if (!data_manager_.has_value()) {
             LOG(ERROR) << "Data manager is not initialized";
@@ -1135,7 +1135,7 @@ P2PClientService::BatchCreateGetHandles(
         }
         return data_manager_->Get(key, allocator);
     };
-    auto remote_get = [&](const std::string& key, size_t,
+    auto remote_get = [&](std::string_view key, size_t,
                           std::vector<ResolvedRoute> routes) {
         return CreateRemoteGetHandle(key, allocator, config, std::move(routes));
     };
@@ -1147,7 +1147,7 @@ P2PClientService::BatchCreateGetHandles(
     const std::vector<std::string>& keys,
     std::vector<std::vector<Slice>>& all_slices,
     const ReadRouteConfig& config) {
-    auto local_get = [&](const std::string& key,
+    auto local_get = [&](std::string_view key,
                          size_t i) -> tl::expected<ReadTaskHandle, ErrorCode> {
         if (!data_manager_.has_value()) {
             LOG(ERROR) << "Data manager is not initialized";
@@ -1155,7 +1155,7 @@ P2PClientService::BatchCreateGetHandles(
         }
         return data_manager_->Get(key, all_slices[i]);
     };
-    auto remote_get = [&](const std::string& key, size_t i,
+    auto remote_get = [&](std::string_view key, size_t i,
                           std::vector<ResolvedRoute> routes) {
         return CreateRemoteGetHandle(key, all_slices[i], config,
                                      std::move(routes));
@@ -1231,15 +1231,14 @@ P2PClientService::BatchFetchReadRoutes(
         keys.size(), std::vector<ResolvedRoute>{});
 
     // check route cache, collect misses
-    std::vector<std::string> miss_keys;
+    std::vector<std::string_view> miss_keys;
     std::vector<size_t> miss_pos;
     for (size_t i = 0; i < keys.size(); ++i) {
         auto cached = LoadCachedRoutes(keys[i]);
         if (!cached.empty()) {
             result[i] = std::move(cached);
         } else {
-            // TODO: reduce the extra copy in the next PR
-            miss_keys.push_back(std::string(keys[i]));
+            miss_keys.push_back(keys[i]);
             miss_pos.push_back(i);
         }
     }
@@ -1272,8 +1271,7 @@ P2PClientService::BatchFetchReadRoutes(
             for (const auto& r : routes) {
                 descriptors.push_back(r.proxy);
             }
-            route_cache_->Upsert(std::string(miss_keys[k]),
-                                 std::move(descriptors));
+            route_cache_->Upsert(miss_keys[k], std::move(descriptors));
         }
         result[miss_pos[k]] = std::move(routes);
     }
@@ -1284,7 +1282,7 @@ std::vector<P2PClientService::ResolvedRoute> P2PClientService::LoadCachedRoutes(
     std::string_view key) {
     std::vector<ResolvedRoute> routes;
     if (route_cache_) {
-        for (const auto& item : route_cache_->Get(std::string(key)).items()) {
+        for (const auto& item : route_cache_->Get(key).items()) {
             P2PProxyDescriptor proxy;
             proxy.client_id = item.client_id;
             proxy.segment_id = item.segment_id;
@@ -1332,7 +1330,7 @@ std::vector<P2PClientService::ResolvedRoute> P2PClientService::ReplicasToRoutes(
 }
 
 tl::expected<ReadTaskHandle, ErrorCode> P2PClientService::CreateRemoteGetHandle(
-    const std::string& key, std::shared_ptr<ClientBufferAllocator> allocator,
+    std::string_view key, std::shared_ptr<ClientBufferAllocator> allocator,
     const ReadRouteConfig& config, std::vector<ResolvedRoute> pre_fetched) {
     auto iter = BuildRouteIter(key, config, std::move(pre_fetched));
     if (!iter) {
@@ -1364,7 +1362,7 @@ tl::expected<ReadTaskHandle, ErrorCode> P2PClientService::CreateRemoteGetHandle(
 }
 
 tl::expected<ReadTaskHandle, ErrorCode> P2PClientService::CreateRemoteGetHandle(
-    const std::string& key, std::vector<Slice>& slices,
+    std::string_view key, std::vector<Slice>& slices,
     const ReadRouteConfig& config, std::vector<ResolvedRoute> pre_fetched) {
     auto iter = BuildRouteIter(key, config, std::move(pre_fetched));
     if (!iter) {
@@ -1384,7 +1382,7 @@ tl::expected<ReadTaskHandle, ErrorCode> P2PClientService::CreateRemoteGetHandle(
 }
 
 tl::expected<ReadTaskHandle, ErrorCode> P2PClientService::InnerGetViaRoute(
-    const std::string& key, std::vector<Slice>& slices, RouteIterator iter) {
+    std::string_view key, std::vector<Slice>& slices, RouteIterator iter) {
     auto req = std::make_shared<RemoteReadRequest>();
     req->key = key;
     for (const auto& s : slices) {
@@ -1452,9 +1450,9 @@ async_simple::coro::Lazy<void> P2PClientService::RunReadWithRetry(
 // ============================================================================
 
 P2PClientService::RouteIterator::RouteIterator(
-    std::string key, std::vector<ResolvedRoute> initial, uint64_t object_size,
-    RouteCache* route_cache, MasterFetch master_fetch)
-    : key_(std::move(key)),
+    std::string_view key, std::vector<ResolvedRoute> initial,
+    uint64_t object_size, RouteCache* route_cache, MasterFetch master_fetch)
+    : key_(key),
       routes_(std::move(initial)),
       object_size_(object_size),
       route_cache_(route_cache),
@@ -1526,13 +1524,13 @@ void P2PClientService::RouteIterator::Evict(const ResolvedRoute& route) {
 }
 
 tl::expected<P2PClientService::RouteIterator, ErrorCode>
-P2PClientService::BuildRouteIter(const std::string& key,
+P2PClientService::BuildRouteIter(std::string_view key,
                                  const ReadRouteConfig& config) {
     return BuildRouteIter(key, config, LoadCachedRoutes(key));
 }
 
 tl::expected<P2PClientService::RouteIterator, ErrorCode>
-P2PClientService::BuildRouteIter(const std::string& key,
+P2PClientService::BuildRouteIter(std::string_view key,
                                  const ReadRouteConfig& config,
                                  std::vector<ResolvedRoute> pre_fetched) {
     auto routes = std::move(pre_fetched);
@@ -1552,7 +1550,7 @@ P2PClientService::BuildRouteIter(const std::string& key,
 }
 
 async_simple::coro::Lazy<std::vector<P2PClientService::ResolvedRoute>>
-P2PClientService::AsyncResolveRoutesFromMaster(const std::string& key,
+P2PClientService::AsyncResolveRoutesFromMaster(std::string_view key,
                                                const ReadRouteConfig& config) {
     auto replica_result =
         co_await master_client_.AsyncGetReplicaList(key, config);
@@ -1607,7 +1605,7 @@ std::vector<tl::expected<bool, ErrorCode>> P2PClientService::BatchIsExist(
 
     std::vector<tl::expected<bool, ErrorCode>> results(keys.size());
     std::vector<size_t> miss_indices;
-    std::vector<std::string> miss_keys;
+    std::vector<std::string_view> miss_keys;
 
     // Batch local check
     for (size_t i = 0; i < keys.size(); ++i) {
@@ -1617,7 +1615,7 @@ std::vector<tl::expected<bool, ErrorCode>> P2PClientService::BatchIsExist(
             results[i] = true;
         } else {
             miss_indices.push_back(i);
-            miss_keys.push_back(keys[i]);
+            miss_keys.emplace_back(keys[i]);
         }
     }
 
@@ -1676,7 +1674,9 @@ P2PClientService::BatchQuery(const std::vector<std::string>& object_keys,
         }
         return results;
     }
-    auto responses = master_client_.BatchGetReplicaList(object_keys, config);
+    std::vector<std::string_view> key_views(object_keys.begin(),
+                                            object_keys.end());
+    auto responses = master_client_.BatchGetReplicaList(key_views, config);
     std::vector<tl::expected<std::unique_ptr<QueryResult>, ErrorCode>> results;
     results.reserve(responses.size());
     for (size_t i = 0; i < responses.size(); ++i) {

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -187,7 +187,7 @@ auto P2PMasterService::AddReplica(const AddReplicaRequest& req)
 }
 
 tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
-    MetadataShard& shard, const std::string& key, const UUID& client_id,
+    MetadataShard& shard, std::string_view key, const UUID& client_id,
     const UUID& segment_id, size_t size,
     const std::shared_ptr<P2PClientMeta>& client) {
     auto segment_res = client->QuerySegment(segment_id);
@@ -231,7 +231,7 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
                 return tl::make_unexpected(ErrorCode::REPLICA_ALREADY_EXISTS);
             }
         }
-        AddReplicaToSegmentIndex(shard, key, new_replica);
+        AddReplicaToSegmentIndex(shard, it->first, new_replica);
         OnReplicaAdded(new_replica);
         metadata.replicas_.push_back(std::move(new_replica));
     } else {
@@ -240,7 +240,7 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
         auto new_meta =
             std::make_unique<ObjectMetadata>(size, std::move(replicas));
         auto emplace_it =
-            shard.metadata.emplace(key, std::move(new_meta)).first;
+            shard.metadata.emplace(std::string(key), std::move(new_meta)).first;
         AddReplicaToSegmentIndex(shard, emplace_it->first,
                                  emplace_it->second->replicas_[0]);
         OnReplicaAdded(emplace_it->second->replicas_[0]);
@@ -256,7 +256,7 @@ auto P2PMasterService::RemoveReplica(const RemoveReplicaRequest& req)
 }
 
 tl::expected<void, ErrorCode> P2PMasterService::InnerRemoveReplica(
-    MetadataShard& shard, const std::string& key, const UUID& client_id,
+    MetadataShard& shard, std::string_view key, const UUID& client_id,
     const UUID& segment_id) {
     auto it = shard.metadata.find(key);
     if (it == shard.metadata.end()) {
@@ -279,7 +279,7 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerRemoveReplica(
         auto seg_id = rit->get_segment_id();
         auto cli_id = rit->get_p2p_client_id();
         if (cli_id && seg_id && cli_id == client_id && *seg_id == segment_id) {
-            RemoveReplicaFromSegmentIndex(shard, key, *rit);
+            RemoveReplicaFromSegmentIndex(shard, it->first, *rit);
             OnReplicaRemoved(*rit);
             metadata.replicas_.erase(rit);
             if (metadata.replicas_.empty()) {

--- a/mooncake-store/src/route_cache.cpp
+++ b/mooncake-store/src/route_cache.cpp
@@ -6,7 +6,7 @@
 namespace mooncake {
 
 size_t P2PRouteData::Serialize(
-    void* dest, const std::string& key,
+    void* dest, std::string_view key,
     const std::vector<P2PProxyDescriptor>& replicas) {
     size_t record_size = P2PRouteData::CalculateSize(replicas.size());
     char* base_ptr = reinterpret_cast<char*>(dest);
@@ -128,11 +128,10 @@ uint64_t RouteCache::ComputeSafeEpoch() const {
 // 2. [Return Handle]: After Get() returns, the Caller is protected by
 //    the shared_ptr within P2PRouteHandle. Even if the Node is recycled, the
 //    underlying P2PRouteData memory remains valid and unchanged.
-P2PRouteHandle RouteCache::Get(const std::string& key)
-    NO_THREAD_SAFETY_ANALYSIS {
+P2PRouteHandle RouteCache::Get(std::string_view key) NO_THREAD_SAFETY_ANALYSIS {
     EpochGuard guard(this);
 
-    size_t hash_val = std::hash<std::string>{}(key);
+    size_t hash_val = std::hash<std::string_view>{}(key);
     auto& shard = *shards_[hash_val % shard_count_];
     size_t bucket_idx = hash_val % buckets_per_shard_;
 
@@ -185,10 +184,10 @@ P2PRouteHandle RouteCache::Get(const std::string& key)
     return P2PRouteHandle();
 }
 
-void RouteCache::Replace(const std::string& key,
+void RouteCache::Replace(std::string_view key,
                          const std::vector<P2PProxyDescriptor>& replicas)
     NO_THREAD_SAFETY_ANALYSIS {
-    size_t hash_val = std::hash<std::string>{}(key);
+    size_t hash_val = std::hash<std::string_view>{}(key);
     auto& shard = *shards_[hash_val % shard_count_];
     size_t bucket_idx = hash_val % buckets_per_shard_;
 
@@ -204,10 +203,10 @@ void RouteCache::Replace(const std::string& key,
     InnerPut(shard, bucket_idx, hash_val, key, replicas, false);
 }
 
-void RouteCache::Upsert(const std::string& key,
+void RouteCache::Upsert(std::string_view key,
                         const std::vector<P2PProxyDescriptor>& replicas)
     NO_THREAD_SAFETY_ANALYSIS {
-    size_t hash_val = std::hash<std::string>{}(key);
+    size_t hash_val = std::hash<std::string_view>{}(key);
     auto& shard = *shards_[hash_val % shard_count_];
     size_t bucket_idx = hash_val % buckets_per_shard_;
 
@@ -224,7 +223,7 @@ void RouteCache::Upsert(const std::string& key,
 }
 
 void RouteCache::InnerPut(Shard& shard, size_t bucket_idx, size_t hash_val,
-                          const std::string& key,
+                          std::string_view key,
                           const std::vector<P2PProxyDescriptor>& replicas,
                           bool merge) REQUIRES(shard.mtx_) {
     // 1. Identify target node
@@ -282,10 +281,10 @@ void RouteCache::InnerPut(Shard& shard, size_t bucket_idx, size_t hash_val,
     shard.buckets_[bucket_idx].store(new_node, std::memory_order_release);
 }
 
-void RouteCache::RemoveReplica(const std::string& key,
+void RouteCache::RemoveReplica(std::string_view key,
                                const std::vector<P2PProxyDescriptor>&
                                    remove_replicas) NO_THREAD_SAFETY_ANALYSIS {
-    size_t hash_val = std::hash<std::string>{}(key);
+    size_t hash_val = std::hash<std::string_view>{}(key);
     auto& shard = *shards_[hash_val % shard_count_];
     size_t bucket_idx = hash_val % buckets_per_shard_;
     auto now = std::chrono::steady_clock::now().time_since_epoch().count();

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -102,7 +102,7 @@ WrappedMasterService::CalcCacheStats() {
 }
 
 tl::expected<bool, ErrorCode> WrappedMasterService::ExistKey(
-    const std::string& key) {
+    std::string_view key) {
     return execute_rpc(
         "ExistKey", [&] { return GetMasterService().ExistKey(key); },
         [&](auto& timer) { timer.LogRequest("key=", key); },
@@ -111,7 +111,7 @@ tl::expected<bool, ErrorCode> WrappedMasterService::ExistKey(
 }
 
 std::vector<tl::expected<bool, ErrorCode>> WrappedMasterService::BatchExistKey(
-    const std::vector<std::string>& keys) {
+    const std::vector<std::string_view>& keys) {
     ScopedVLogTimer timer(1, "BatchExistKey");
     const size_t total_keys = keys.size();
     timer.LogRequest("keys_count=", total_keys);
@@ -202,7 +202,7 @@ WrappedMasterService::GetReplicaListByRegex(const std::string& str) {
 
 tl::expected<GetReplicaListResponse, ErrorCode>
 WrappedMasterService::GetReplicaList(
-    const std::string& key, const GetReplicaListRequestConfig& config) {
+    std::string_view key, const GetReplicaListRequestConfig& config) {
     return execute_rpc(
         "GetReplicaList",
         [&] { return GetMasterService().GetReplicaList(key, config); },
@@ -215,7 +215,7 @@ WrappedMasterService::GetReplicaList(
 
 std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
 WrappedMasterService::BatchGetReplicaList(
-    const std::vector<std::string>& keys,
+    const std::vector<std::string_view>& keys,
     const GetReplicaListRequestConfig& config) {
     ScopedVLogTimer timer(1, "BatchGetReplicaList");
     const size_t total_requests = keys.size();
@@ -261,7 +261,7 @@ WrappedMasterService::BatchGetReplicaList(
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::Remove(
-    const std::string& key) {
+    std::string_view key) {
     return execute_rpc(
         "Remove", [&] { return GetMasterService().Remove(key); },
         [&](auto& timer) { timer.LogRequest("key=", key); },
@@ -270,7 +270,7 @@ tl::expected<void, ErrorCode> WrappedMasterService::Remove(
 }
 
 tl::expected<long, ErrorCode> WrappedMasterService::RemoveByRegex(
-    const std::string& str) {
+    std::string_view str) {
     return execute_rpc(
         "RemoveByRegex", [&] { return GetMasterService().RemoveByRegex(str); },
         [&](auto& timer) { timer.LogRequest("regex=", str); },

--- a/mooncake-store/src/tiered_cache/scheduler/client_scheduler.cpp
+++ b/mooncake-store/src/tiered_cache/scheduler/client_scheduler.cpp
@@ -122,7 +122,7 @@ void ClientScheduler::Stop() {
     }
 }
 
-void ClientScheduler::OnAccess(const std::string& key) {
+void ClientScheduler::OnAccess(std::string_view key) {
     if (stats_collector_) {
         stats_collector_->RecordAccess(key);
     }
@@ -135,14 +135,14 @@ AccessStats ClientScheduler::GetHotKeyStats() const {
     return {};
 }
 
-void ClientScheduler::OnCommit(const std::string& key, UUID tier_id,
+void ClientScheduler::OnCommit(std::string_view key, UUID tier_id,
                                size_t size_bytes) {
     auto& shard = GetKeyCacheShard(key);
     MutexLocker lock(&shard.mutex);
     TrackReplicaLocked(shard, key, tier_id, size_bytes);
 }
 
-void ClientScheduler::OnDelete(const std::string& key,
+void ClientScheduler::OnDelete(std::string_view key,
                                std::optional<UUID> tier_id) {
     bool remove_stats = false;
     {
@@ -358,9 +358,14 @@ size_t ClientScheduler::GetCachedKeySize(const std::string& key) const {
 }
 
 void ClientScheduler::TrackReplicaLocked(KeyCacheShard& shard,
-                                         const std::string& key, UUID tier_id,
+                                         std::string_view key, UUID tier_id,
                                          size_t size_bytes) {
-    auto& state = shard.key_cache[key];
+    auto cache_it = shard.key_cache.find(key);
+    if (cache_it == shard.key_cache.end()) {
+        cache_it =
+            shard.key_cache.emplace(std::string(key), CachedKeyState{}).first;
+    }
+    auto& state = cache_it->second;
     state.size_bytes = size_bytes;
 
     const auto existing_it = std::find(state.current_locations.begin(),
@@ -369,22 +374,32 @@ void ClientScheduler::TrackReplicaLocked(KeyCacheShard& shard,
         state.current_locations.push_back(tier_id);
     }
 
-    shard.tier_resident_keys[tier_id].insert(key);
+    auto& tier_set = shard.tier_resident_keys[tier_id];
+    if (tier_set.find(key) == tier_set.end()) {
+        tier_set.emplace(std::string(key));
+    }
 }
 
 bool ClientScheduler::RemoveReplicaLocked(KeyCacheShard& shard,
-                                          const std::string& key,
+                                          std::string_view key,
                                           std::optional<UUID> tier_id) {
     auto cache_it = shard.key_cache.find(key);
     if (cache_it == shard.key_cache.end()) {
         return true;
     }
 
+    auto erase_resident = [&](auto& resident_set) {
+        auto rit = resident_set.find(key);
+        if (rit != resident_set.end()) {
+            resident_set.erase(rit);
+        }
+    };
+
     if (!tier_id.has_value()) {
         for (const auto& resident_tier : cache_it->second.current_locations) {
             auto resident_it = shard.tier_resident_keys.find(resident_tier);
             if (resident_it != shard.tier_resident_keys.end()) {
-                resident_it->second.erase(key);
+                erase_resident(resident_it->second);
             }
         }
         shard.key_cache.erase(cache_it);
@@ -399,7 +414,7 @@ bool ClientScheduler::RemoveReplicaLocked(KeyCacheShard& shard,
 
     auto resident_it = shard.tier_resident_keys.find(tier_id.value());
     if (resident_it != shard.tier_resident_keys.end()) {
-        resident_it->second.erase(key);
+        erase_resident(resident_it->second);
     }
 
     if (current_locations.empty()) {

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -447,7 +447,7 @@ tl::expected<void, ErrorCode> TieredBackend::Write(const DataSource& source,
 }
 
 tl::expected<void, ErrorCode> TieredBackend::Commit(
-    const std::string& key, AllocationHandle handle,
+    std::string_view key, AllocationHandle handle,
     std::optional<uint64_t> expected_version, bool record_access) {
     if (is_shutting_down_.load(std::memory_order_acquire)) {
         LOG(ERROR) << "TieredBackend is shutting down";
@@ -479,7 +479,7 @@ tl::expected<void, ErrorCode> TieredBackend::Commit(
             entry = it->second;
         } else {
             entry = std::make_shared<MetadataEntry>();
-            shard.index[key] = entry;
+            shard.index.emplace(std::string(key), entry);
         }
     }
 
@@ -565,7 +565,7 @@ tl::expected<void, ErrorCode> TieredBackend::Commit(
 }
 
 tl::expected<AllocationHandle, ErrorCode> TieredBackend::Get(
-    const std::string& key, std::optional<UUID> tier_id, bool record_access,
+    std::string_view key, std::optional<UUID> tier_id, bool record_access,
     uint64_t* out_version) {
     if (is_shutting_down_.load(std::memory_order_acquire)) {
         LOG(ERROR) << "TieredBackend is shutting down";
@@ -616,7 +616,7 @@ tl::expected<AllocationHandle, ErrorCode> TieredBackend::Get(
     return entry->replicas.begin()->second;
 }
 
-bool TieredBackend::Exist(const std::string& key,
+bool TieredBackend::Exist(std::string_view key,
                           std::optional<UUID> tier_id) const {
     auto& shard = GetMetadataShard(key);
     std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
@@ -639,7 +639,7 @@ bool TieredBackend::Exist(const std::string& key,
 }
 
 tl::expected<void, ErrorCode> TieredBackend::Delete(
-    const std::string& key, std::optional<UUID> tier_id) {
+    std::string_view key, std::optional<UUID> tier_id) {
     if (is_shutting_down_.load(std::memory_order_acquire)) {
         LOG(ERROR) << "TieredBackend is shutting down";
         return tl::make_unexpected(ErrorCode::SHUTTING_DOWN);
@@ -774,7 +774,7 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
 }
 
 tl::expected<void, ErrorCode> TieredBackend::CopyData(
-    const std::string& key, const DataSource& source, UUID dest_tier_id,
+    std::string_view key, const DataSource& source, UUID dest_tier_id,
     std::optional<uint64_t> expected_version, bool record_access) {
     if (is_shutting_down_.load(std::memory_order_acquire)) {
         LOG(ERROR) << "TieredBackend is shutting down";
@@ -798,8 +798,6 @@ tl::expected<void, ErrorCode> TieredBackend::CopyData(
         return tl::make_unexpected(write_result.error());
     }
 
-    // Commit (Add Replica)
-    // Takes ownership of dest_handle into the map
     auto commit_result =
         Commit(key, dest_handle.value(), expected_version, record_access);
     if (!commit_result.has_value()) {
@@ -814,7 +812,7 @@ tl::expected<void, ErrorCode> TieredBackend::CopyData(
     return tl::expected<void, ErrorCode>{};
 }
 
-tl::expected<void, ErrorCode> TieredBackend::Transfer(const std::string& key,
+tl::expected<void, ErrorCode> TieredBackend::Transfer(std::string_view key,
                                                       UUID source_tier_id,
                                                       UUID dest_tier_id,
                                                       bool record_access) {
@@ -865,8 +863,7 @@ std::vector<TierView> TieredBackend::GetTierViews() const {
     return views;
 }
 
-std::vector<UUID> TieredBackend::GetReplicaTierIds(
-    const std::string& key) const {
+std::vector<UUID> TieredBackend::GetReplicaTierIds(std::string_view key) const {
     auto& shard = GetMetadataShard(key);
     std::shared_lock map_lock(shard.mutex);
     auto it = shard.index.find(key);

--- a/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
@@ -238,7 +238,7 @@ tl::expected<void, ErrorCode> StorageTier::Free(DataSource data) {
     return {};
 }
 
-tl::expected<void, ErrorCode> StorageTier::Commit(const std::string& key,
+tl::expected<void, ErrorCode> StorageTier::Commit(std::string_view key,
                                                   const DataSource& data) {
     auto* staging = static_cast<StorageBuffer*>(data.buffer.get());
     if (!staging) {
@@ -250,8 +250,9 @@ tl::expected<void, ErrorCode> StorageTier::Commit(const std::string& key,
         std::unique_lock<std::mutex> lock(batch_mutex_);
 
         // Add to pending batch
-        staging->SetKey(key);
-        pending_batch_[key] = staging;
+        std::string key_str(key);
+        staging->SetKey(key_str);
+        pending_batch_.emplace(std::move(key_str), staging);
         pending_batch_size_.fetch_add(staging->size());
 
         // Check thresholds for async flush trigger

--- a/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
@@ -250,9 +250,8 @@ tl::expected<void, ErrorCode> StorageTier::Commit(std::string_view key,
         std::unique_lock<std::mutex> lock(batch_mutex_);
 
         // Add to pending batch
-        std::string key_str(key);
-        staging->SetKey(key_str);
-        pending_batch_.emplace(std::move(key_str), staging);
+        staging->SetKey(key);
+        pending_batch_.emplace(key, staging);
         pending_batch_size_.fetch_add(staging->size());
 
         // Check thresholds for async flush trigger

--- a/mooncake-store/tests/async_metadata_notifier_test.cpp
+++ b/mooncake-store/tests/async_metadata_notifier_test.cpp
@@ -238,7 +238,7 @@ TEST_F(AsyncMetadataNotifierTest, FailureCallbackInvoked) {
     ASSERT_EQ(ec, ErrorCode::OK);
 
     std::atomic<int> failure_count{0};
-    SyncFailureCallback cb = [&](const std::string& key, const UUID& seg_id,
+    SyncFailureCallback cb = [&](std::string_view key, const UUID& seg_id,
                                  ErrorCode err) {
         failure_count.fetch_add(1, std::memory_order_relaxed);
     };

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -333,6 +333,7 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
     UUID client_id = generate_uuid();
 
     std::vector<std::string> keys = {"test_key1", "test_key2", "test_key3"};
+    std::vector<std::string_view> key_views(keys.begin(), keys.end());
     std::vector<uint64_t> value_lengths = {1024, 2048, 512};
     ReplicateConfig config;
     config.replica_num = 1;
@@ -348,7 +349,7 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
     ASSERT_TRUE(mount_result.has_value());
 
     // Test BatchExistKey request (should all return false initially)
-    auto batch_exist_result = service_.BatchExistKey(keys);
+    auto batch_exist_result = service_.BatchExistKey(key_views);
     ASSERT_EQ(batch_exist_result.size(), 3);
     ASSERT_EQ(metrics.get_batch_exist_key_requests(), 1);
     ASSERT_EQ(metrics.get_batch_exist_key_partial_successes(), 0);
@@ -367,7 +368,7 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
     ASSERT_EQ(metrics.get_batch_put_start_failed_items(), 0);
 
     // Test BatchGetReplicaList request (should all fail)
-    auto batch_get_replica_result = service_.BatchGetReplicaList(keys);
+    auto batch_get_replica_result = service_.BatchGetReplicaList(key_views);
     ASSERT_EQ(batch_get_replica_result.size(), 3);
     ASSERT_EQ(metrics.get_batch_get_replica_list_requests(), 1);
     ASSERT_EQ(metrics.get_batch_get_replica_list_partial_successes(), 0);
@@ -385,7 +386,7 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
     ASSERT_EQ(metrics.get_batch_put_end_failed_items(), 0);
 
     // Test BatchExistKey again (should all return true now)
-    auto batch_exist_result2 = service_.BatchExistKey(keys);
+    auto batch_exist_result2 = service_.BatchExistKey(key_views);
     ASSERT_EQ(batch_exist_result2.size(), 3);
     ASSERT_EQ(metrics.get_batch_exist_key_requests(), 2);
     ASSERT_EQ(metrics.get_batch_exist_key_partial_successes(), 0);
@@ -394,7 +395,7 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
     ASSERT_EQ(metrics.get_batch_exist_key_failed_items(), 0);
 
     // Test BatchGetReplicaList again (should all succeed now)
-    auto batch_get_replica_result2 = service_.BatchGetReplicaList(keys);
+    auto batch_get_replica_result2 = service_.BatchGetReplicaList(key_views);
     ASSERT_EQ(batch_get_replica_result2.size(), 3);
     ASSERT_EQ(metrics.get_batch_get_replica_list_requests(), 2);
     ASSERT_EQ(metrics.get_batch_get_replica_list_partial_successes(), 0);
@@ -413,8 +414,9 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
 
     // Test partial success
     keys.push_back("test_key4");
+    key_views = std::vector<std::string_view>(keys.begin(), keys.end());
     value_lengths.push_back(512);
-    auto batch_get_replica_result3 = service_.BatchGetReplicaList(keys);
+    auto batch_get_replica_result3 = service_.BatchGetReplicaList(key_views);
     ASSERT_EQ(batch_get_replica_result3.size(), 4);
     ASSERT_EQ(metrics.get_batch_get_replica_list_requests(), 3);
     ASSERT_EQ(metrics.get_batch_get_replica_list_partial_successes(), 1);

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -2168,7 +2168,9 @@ TEST_F(MasterServiceTest, BatchExistKeyTest) {
 
     // Tets batch
     test_keys.push_back("non_existent_key");
-    auto exist_resp = service_->BatchExistKey(test_keys);
+    std::vector<std::string_view> test_key_views(test_keys.begin(),
+                                                 test_keys.end());
+    auto exist_resp = service_->BatchExistKey(test_key_views);
     for (int i = 0; i < test_object_num; ++i) {
         ASSERT_TRUE(exist_resp[i].value());
     }

--- a/mooncake-store/tests/peer_client_perf_test.cpp
+++ b/mooncake-store/tests/peer_client_perf_test.cpp
@@ -126,9 +126,9 @@ class PeerClientPerfTest : public ::testing::Test {
         google::ShutdownGoogleLogging();
     }
 
-    RemoteReadRequest MakeReadRequest(size_t index) {
+    RemoteReadRequest MakeReadRequest(std::string_view key, size_t index) {
         RemoteReadRequest request;
-        request.key = "perf_key_" + std::to_string(index);
+        request.key = key;
         RemoteBufferDesc desc;
         desc.segment_endpoint = "perf_segment";
         desc.addr = 0x1000 + index * 0x100;
@@ -137,9 +137,9 @@ class PeerClientPerfTest : public ::testing::Test {
         return request;
     }
 
-    RemoteWriteRequest MakeWriteRequest(size_t index) {
+    RemoteWriteRequest MakeWriteRequest(std::string_view key, size_t index) {
         RemoteWriteRequest request;
-        request.key = "perf_write_key_" + std::to_string(index);
+        request.key = key;
         RemoteBufferDesc desc;
         desc.segment_endpoint = "perf_segment";
         desc.addr = 0x1000 + index * 0x100;
@@ -162,7 +162,8 @@ class PeerClientPerfTest : public ::testing::Test {
     double RunSyncReads(size_t n) {
         auto start = std::chrono::steady_clock::now();
         for (size_t i = 0; i < n; ++i) {
-            auto req = MakeReadRequest(i);
+            std::string key = "perf_key_" + std::to_string(i);
+            auto req = MakeReadRequest(key, i);
             auto result = peer_client_->ReadRemoteData(req);
             (void)result;
         }
@@ -175,12 +176,16 @@ class PeerClientPerfTest : public ::testing::Test {
         auto start = std::chrono::steady_clock::now();
 
         auto coro = [this, n]() -> async_simple::coro::Lazy<void> {
-            // Requests must outlive all coroutines since
-            // AsyncReadRemoteData takes const& references.
+            // Keys and requests must outlive all coroutines:
+            // AsyncReadRemoteData holds a const& to the request, which holds a
+            // string_view of key.
+            std::vector<std::string> keys(n);
+            for (size_t i = 0; i < n; ++i)
+                keys[i] = "perf_key_" + std::to_string(i);
             std::vector<RemoteReadRequest> requests;
             requests.reserve(n);
             for (size_t i = 0; i < n; ++i) {
-                requests.push_back(MakeReadRequest(i));
+                requests.push_back(MakeReadRequest(keys[i], i));
             }
 
             std::vector<async_simple::coro::Lazy<tl::expected<void, ErrorCode>>>
@@ -205,7 +210,8 @@ class PeerClientPerfTest : public ::testing::Test {
     double RunSyncWrites(size_t n) {
         auto start = std::chrono::steady_clock::now();
         for (size_t i = 0; i < n; ++i) {
-            auto req = MakeWriteRequest(i);
+            std::string key = "perf_write_key_" + std::to_string(i);
+            auto req = MakeWriteRequest(key, i);
             auto result = peer_client_->WriteRemoteData(req);
             (void)result;
         }
@@ -218,10 +224,13 @@ class PeerClientPerfTest : public ::testing::Test {
         auto start = std::chrono::steady_clock::now();
 
         auto coro = [this, n]() -> async_simple::coro::Lazy<void> {
+            std::vector<std::string> keys(n);
+            for (size_t i = 0; i < n; ++i)
+                keys[i] = "perf_write_key_" + std::to_string(i);
             std::vector<RemoteWriteRequest> requests;
             requests.reserve(n);
             for (size_t i = 0; i < n; ++i) {
-                requests.push_back(MakeWriteRequest(i));
+                requests.push_back(MakeWriteRequest(keys[i], i));
             }
 
             std::vector<async_simple::coro::Lazy<tl::expected<UUID, ErrorCode>>>
@@ -405,10 +414,13 @@ TEST_F(PeerClientPerfTest, WindowedAsyncConcurrency) {
         auto start = std::chrono::steady_clock::now();
 
         auto coro = [this, total, w]() -> async_simple::coro::Lazy<void> {
+            std::vector<std::string> keys(total);
+            for (size_t i = 0; i < total; ++i)
+                keys[i] = "perf_key_" + std::to_string(i);
             std::vector<RemoteReadRequest> requests;
             requests.reserve(total);
             for (size_t i = 0; i < total; ++i) {
-                requests.push_back(MakeReadRequest(i));
+                requests.push_back(MakeReadRequest(keys[i], i));
             }
 
             std::vector<async_simple::coro::Lazy<tl::expected<void, ErrorCode>>>
@@ -606,9 +618,10 @@ class PeerClientRdmaPerfTest : public ::testing::Test {
         rc.value()->Wait();
     }
 
-    RemoteReadRequest MakeRdmaReadRequest(size_t index, size_t data_size) {
+    RemoteReadRequest MakeRdmaReadRequest(std::string_view key, size_t index,
+                                          size_t data_size) {
         RemoteReadRequest request;
-        request.key = "rdma_perf_key_" + std::to_string(index);
+        request.key = key;
         RemoteBufferDesc desc;
         desc.segment_endpoint = local_hostname_;
         desc.addr = reinterpret_cast<uintptr_t>(
@@ -618,9 +631,10 @@ class PeerClientRdmaPerfTest : public ::testing::Test {
         return request;
     }
 
-    RemoteWriteRequest MakeRdmaWriteRequest(size_t index, size_t data_size) {
+    RemoteWriteRequest MakeRdmaWriteRequest(std::string_view key, size_t index,
+                                            size_t data_size) {
         RemoteWriteRequest request;
-        request.key = "rdma_perf_write_key_" + std::to_string(index);
+        request.key = key;
         // Pre-fill source region with data
         char* src = static_cast<char*>(rdma_buffer_) + index * data_size;
         std::memset(src, 'B', data_size);
@@ -648,7 +662,8 @@ class PeerClientRdmaPerfTest : public ::testing::Test {
     double RunRdmaSyncReads(size_t n, size_t data_size) {
         auto start = std::chrono::steady_clock::now();
         for (size_t i = 0; i < n; ++i) {
-            auto req = MakeRdmaReadRequest(i, data_size);
+            std::string key = "rdma_perf_key_" + std::to_string(i);
+            auto req = MakeRdmaReadRequest(key, i, data_size);
             auto result = peer_client_->ReadRemoteData(req);
             (void)result;
         }
@@ -663,10 +678,13 @@ class PeerClientRdmaPerfTest : public ::testing::Test {
 
         auto coro = [this, n, data_size,
                      window]() -> async_simple::coro::Lazy<void> {
+            std::vector<std::string> keys(n);
+            for (size_t i = 0; i < n; ++i)
+                keys[i] = "rdma_perf_key_" + std::to_string(i);
             std::vector<RemoteReadRequest> requests;
             requests.reserve(n);
             for (size_t i = 0; i < n; ++i) {
-                requests.push_back(MakeRdmaReadRequest(i, data_size));
+                requests.push_back(MakeRdmaReadRequest(keys[i], i, data_size));
             }
 
             std::vector<async_simple::coro::Lazy<tl::expected<void, ErrorCode>>>
@@ -698,7 +716,8 @@ class PeerClientRdmaPerfTest : public ::testing::Test {
     double RunRdmaSyncWrites(size_t n, size_t data_size) {
         auto start = std::chrono::steady_clock::now();
         for (size_t i = 0; i < n; ++i) {
-            auto req = MakeRdmaWriteRequest(i, data_size);
+            std::string key = "rdma_perf_write_key_" + std::to_string(i);
+            auto req = MakeRdmaWriteRequest(key, i, data_size);
             auto result = peer_client_->WriteRemoteData(req);
             (void)result;
         }
@@ -713,10 +732,13 @@ class PeerClientRdmaPerfTest : public ::testing::Test {
 
         auto coro = [this, n, data_size,
                      window]() -> async_simple::coro::Lazy<void> {
+            std::vector<std::string> keys(n);
+            for (size_t i = 0; i < n; ++i)
+                keys[i] = "rdma_perf_write_key_" + std::to_string(i);
             std::vector<RemoteWriteRequest> requests;
             requests.reserve(n);
             for (size_t i = 0; i < n; ++i) {
-                requests.push_back(MakeRdmaWriteRequest(i, data_size));
+                requests.push_back(MakeRdmaWriteRequest(keys[i], i, data_size));
             }
 
             std::vector<async_simple::coro::Lazy<tl::expected<UUID, ErrorCode>>>

--- a/mooncake-store/tests/scheduler_integration_test.cpp
+++ b/mooncake-store/tests/scheduler_integration_test.cpp
@@ -889,7 +889,7 @@ TEST_F(ConcurrencyTest, CASFailureNoCallbackInvoked) {
     // Re-init backend with a counting callback
     std::atomic<int> commit_count{0};
     AddReplicaCallback counting_cb =
-        [&commit_count](const std::string&, const UUID&,
+        [&commit_count](std::string_view, const UUID&,
                         size_t) -> tl::expected<void, ErrorCode> {
         commit_count.fetch_add(1);
         return {};


### PR DESCRIPTION
## Description
using string_view rather than string reference in parameters of function or vars in struct

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
