### PR TITLE
[Docs] Update Mooncake Conductor design and API docs 

### DIFF
--- a/docs/source/design/conductor/conductor-architecture-design.md
+++ b/docs/source/design/conductor/conductor-architecture-design.md
@@ -1,0 +1,182 @@
+# Mooncake Conductor Architecture
+
+## Overview
+
+Mooncake Conductor is the kv-cache indexer used by cache-aware routers. It
+subscribes to KV cache events from inference engines or storage backends,
+normalizes those events, maintains a global prefix cache table, and exposes
+HTTP APIs for dynamic service registration and cache-hit queries.
+
+The design goal is to let routers answer a simple scheduling question:
+for this request prefix, which registered instance has the best reusable KV
+cache locality, and on which cache tiers is that prefix available?
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Router["Gateway or router"]
+        HTTPClient["HTTP client"]
+    end
+
+    subgraph Conductor["Mooncake Conductor"]
+        EventManager["EventManager"]
+        ZMQClient["ZMQClient"]
+        KVEventHandler["KVEventHandler"]
+        PrefixCacheTable["PrefixCacheTable"]
+    end
+
+    subgraph Publishers["vLLM, SGLang, Mooncake, or cache daemons"]
+        InferenceService["Inference or cache service"]
+        KVEvent["KV event stream"]
+    end
+
+    EventManager -->|creates and manages| ZMQClient
+    ZMQClient -->|registers handler| KVEventHandler
+    InferenceService -->|publishes events| KVEvent
+    KVEvent -->|ZMQ SUB or DEALER| ZMQClient
+    ZMQClient -->|decoded batches| KVEventHandler
+    KVEventHandler -->|normalizes events| PrefixCacheTable
+    HTTPClient -->|/query, /register, /unregister| EventManager
+    EventManager -->|cache-hit computation| PrefixCacheTable
+    PrefixCacheTable -->|hit result by instance| EventManager
+    EventManager -->|HTTP response| HTTPClient
+```
+
+## Components
+
+| Component | Responsibility |
+|---|---|
+| `EventManager` | Owns the Conductor lifecycle, HTTP server, dynamic registration, active service map, and tenant-to-instance map. |
+| `ZMQClient` | Connects to publisher endpoints, consumes event frames, decodes event batches, tracks sequence numbers, and requests replay after reconnects. |
+| `KVEventHandler` | Adapts decoded engine events into Conductor store/remove events enriched with registration metadata. |
+| `PrefixCacheTable` | Maintains model-context-specific prefix maps, engine-hash to conductor-hash mappings, medium metadata, DP-rank metadata, and query-time hit computation. |
+
+
+## Data model
+
+The prefix index is scoped by `ModelContext`:
+
+```text
+(tenant_id, model_name, lora_name, block_size, additional_salt, instance_id)
+```
+
+Within each context, Conductor stores:
+
+- a mapping from engine-provided block hash to Conductor prefix hash;
+- a prefix hash map that records replica count, medium set, DP-rank set, and
+  per-instance access metadata;
+- a DP-rank set used to report rank-level hit information.
+
+The current implementation computes complete-block prefix hashes from token IDs
+and ignores trailing partial blocks during `/query`.
+
+## Event flow
+
+1. A service is registered statically from `conductor_config.json` or
+   dynamically through `POST /register`.
+2. `EventManager` creates one `ZMQClient` per `(instance_id, tenant_id,
+   dp_rank)` service key.
+3. `ZMQClient` subscribes to the publisher endpoint and consumes frames in the
+   form `[topic, sequence, payload]`.
+4. The payload is decoded into a batch of engine events. Today, the implemented
+   parser supports vLLM `BlockStored` and `BlockRemoved` msgpack events.
+5. `KVEventHandler` enriches events with registration metadata such as model,
+   LoRA, tenant, instance, block size, and additional salt.
+6. `PrefixCacheTable` updates the prefix map for stored or removed blocks.
+7. If a reconnect detects missed sequence numbers, the `replay endpoint` can be
+   used to request missed events.
+
+## Query flow
+
+1. A router obtains prompt token IDs, usually from an engine tokenizer endpoint.
+2. The router calls `POST /query` with `model`, `token_ids`, `block_size`, and
+   optional `tenant_id`, `instance_id`, `lora_name`, and `cache_salt`.
+3. Conductor computes complete-block prefix hashes for the request.
+4. The prefix table is scanned in order. The first miss terminates the scan so
+   prefix continuity is preserved.
+5. Conductor returns per-instance `longest_matched`, medium hit counts, and
+   DP-rank hit counts.
+6. The router selects the best target instance and forwards the request.
+
+## Dynamic registration
+
+Conductor supports runtime registration so routers or control planes can add
+and remove KV event publishers without restarting the process.
+
+```json
+{
+  "endpoint": "tcp://127.0.0.1:5557",
+  "replay_endpoint": "tcp://127.0.0.1:5558",
+  "type": "vLLM",
+  "modelname": "qwen2.5",
+  "lora_name": "",
+  "tenant_id": "default",
+  "instance_id": "vllm-prefill-node1",
+  "block_size": 128,
+  "dp_rank": 0,
+  "additionalsalt": ""
+}
+```
+
+Static configuration uses the same fields under `kvevent_instance`:
+
+```json
+{
+  "http_server_port": 13333,
+  "kvevent_instance": {
+    "vllm-prefill-node1": {
+      "endpoint": "tcp://127.0.0.1:5557",
+      "replay_endpoint": "tcp://127.0.0.1:5558",
+      "type": "vLLM",
+      "modelname": "qwen2.5",
+      "lora_name": "",
+      "tenant_id": "default",
+      "instance_id": "vllm-prefill-node1",
+      "block_size": 128,
+      "dp_rank": 0,
+      "additionalsalt": ""
+    }
+  }
+}
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `CONDUCTOR_LOG_LEVEL` | `INFO` | Log level: `DEBUG`, `INFO`, `WARN`, or `ERROR`. |
+| `CONDUCTOR_CONFIG_PATH` | `~/.mooncake/conductor_config.json` | Path to the static configuration file. |
+| `CONDUCTOR_SEED` | random | Legacy seed option for hash computation experiments. |
+
+## Build and run
+
+```bash
+cd mooncake-conductor/conductor-ctrl
+go mod tidy
+go build -o mooncake_conductor .
+```
+
+```bash
+export CONDUCTOR_CONFIG_PATH=../example/conductor_config.json
+export CONDUCTOR_LOG_LEVEL=INFO
+./mooncake_conductor
+```
+
+## Project structure
+
+```text
+mooncake-conductor/
++-- conductor-ctrl/
+|   +-- common/        # shared types, helpers, and sync map
+|   +-- kvevent/       # EventManager and KVEventHandler
+|   +-- prefixindex/   # prefix cache table and hit computation
+|   +-- zmq/           # ZMQ client, event decoding, event types
+|   +-- main.go        # process entry point
++-- example/           # demo config and cache-aware proxy
++-- build.sh
++-- CMakeLists.txt
+```
+
+See [Indexer API](./indexer-api-design.md) for the HTTP API and KV Events wire
+format.

--- a/docs/source/design/conductor/indexer-api-design.md
+++ b/docs/source/design/conductor/indexer-api-design.md
@@ -1,224 +1,362 @@
-# Mooncake Conductor Indexer
+# Mooncake Conductor Indexer API
 
-## Introduction
-The Mooncake Conductor Indexer is a specialized service designed to efficiently track and report token hit counts across various caching levels for different model instances. It provides a list of APIs that allow users to query token hit statistics based on token ID or chunked token hash, thereby facilitating optimized the performance of LLM inference.The figure below illustrates the architecture of Mooncake KVindexer: ![Mooncake KVindexer](../../image/conductor/architecture.png)
+## Overview
 
-## tiered storage & pools
-We drew inspiration from the definition of [KVBM components](https://github.com/ai-dynamo/dynamo/blob/main/docs/kvbm/kvbm_components.md) and divided the KV cache into three levels: G1, G2, and G3. The detailed introduction is as follows:
+Mooncake Conductor is a KV cache indexer used by routers and gateways to make
+cache-aware scheduling decisions. It consumes KV cache events from inference
+engines or storage backends, maintains prefix-hit metadata across cache tiers,
+and exposes HTTP APIs for service registration and cache-hit queries.
 
-- **Device Pool(G1)**: Device-resident KV block pool. Allocates mutable device blocks, registers completed blocks (immutable), serves lookups by sequence hash, and is the target for onboarding (Host→Device, Disk→Device).
-- **Host Pool(G2)**: Mooncake registered memory KV pool. Receives Device offloads (Device→Host), can onboard to Device (Host→Device), and offloads to Disk. For high-performance, zero-copy data transfers, it utilizes the Mooncake Transfer-Engine.
-- **Disk Pool(G3)**: SSD NVMe-backed KV pool. Receives Host offloads (Host→Disk), and provides large space for storing KV. 
+This document incorporates the latest API direction from:
 
+- [RFC #1403: Mooncake KV-Store Indexer API Standardization](https://github.com/kvcache-ai/Mooncake/issues/1403)
+- [RFC #1527: KV Events API Standardization](https://github.com/kvcache-ai/Mooncake/issues/1527)
 
-## Indexer API
+The Conductor can serve multiple model groups in one process. Each query is
+scoped by model identity, block size, LoRA identity, tenant isolation, and the
+registered instance that can receive traffic.
+
+## Concepts
+
+### Storage tiers
+
+The indexer tracks KV cache availability across three logical tiers:
+
+- **G1, Device Pool**: Device-resident KV blocks, such as GPU, NPU, HBM, or
+  other accelerator memory owned by inference engines.
+- **G2, Host Pool**: CPU or host DRAM KV blocks, including Mooncake registered
+  memory pools.
+- **G3, Disk Pool**: SSD, 3FS, DFS, NFS, or other disk-backed KV storage.
+
+The `medium` field identifies the concrete tier or device type. Common values
+are `gpu`, `cpu`, and `disk`. Engines may add other values as new media are
+supported.
+
+### Identity dimensions
+
+KV cache hits are interpreted under the following dimensions:
+
+| Dimension | Description |
+|---|---|
+| `model_name` or `model` | Model identifier. KV blocks from different models are incompatible. |
+| `block_size` | Number of tokens per KV block. Different block sizes produce different token-to-block mappings. |
+| `additional_salt` | Opaque salt used to separate hash namespaces for quantization, model revision, tenant isolation, or other deployment-specific dimensions. |
+|`cache_salt`| Ensure cached data blocks are kept separate for different customers|
+| `lora_name` | LoRA adapter name. Empty or `null` means the base model. |
+| `tenant_id` | Upstream tenant or customer identity. Used for isolation and to keep query output bounded. |
+| `instance_id` | Routable API server or engine instance returned by the Indexer API. Routers use this value as the scheduling target. |
+| `backend_id` | KV Events identity for the entity that owns the KV blocks. It may be an inference worker, a Mooncake storage daemon, or another cache backend. |
+| `medium` | Cache medium where the blocks are present. |
+| `dp_rank` | Data-parallel rank that owns or can serve the blocks. |
+
+`instance_id` and `backend_id` intentionally have different meanings.
+`instance_id` is the router-facing target in the Indexer API. `backend_id` is
+the event-facing cache owner in the KV Events API. In deployments where cache
+storage is decoupled from inference workers, `backend_id` can identify a cache
+daemon while `instance_id` still identifies the engine endpoint that receives
+requests.
+
+## Hashing standard
+
+The standardized event contract recommends **XXH3-64 with seed `S`**.
+
+- **Local block hash**:
+  `XXH3(token_bytes_le, S)`, where tokens are little-endian `u32` values
+  concatenated for one block.
+- **Rolling sequence hash**:
+  The first block uses `seq_hash[0] = local_block_hash[0]`. Each subsequent
+  block uses:
+
+  ```text
+  seq_hash[i] = XXH3(seq_hash[i-1]_le || local_block_hash[i]_le, S)
+  ```
+
+  Here `||` means byte concatenation, not a logical OR.
+
+All hashes used by the standardized KV Events API are rolling sequence hashes.
+A `seq_hash` identifies the whole prefix up to that block depth, so equal
+prefixes produce equal hashes until the first differing block.
+
+If an engine does not follow the standardized hashing scheme, it must provide
+`token_ids` in `stored` events so the consumer can recompute the indexer's hash
+representation.
+
+## HTTP APIs
+
+### `POST /register`
+
+Registers a KV event publisher and starts consuming events from it.
+
+```json
+{
+  "endpoint": "tcp://1.1.1.1:5557",
+  "replay_endpoint": "tcp://1.1.1.1:5558",
+  "type": "vLLM",
+  "modelname": "deepseek",
+  "lora_name": "sql-adapter",
+  "tenant_id": "default",
+  "instance_id": "vllm-prefill-node1",
+  "block_size": 128,
+  "dp_rank": 0,
+  "additionalsalt": "w8a8"
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `endpoint` | Yes | ZMQ KV event publisher endpoint. |
+| `replay_endpoint` | No | ZMQ replay endpoint used to recover missed events. |
+| `type` | Yes | Publisher type, such as `vLLM`, `SGLang`, or `Mooncake`. |
+| `modelname` | Yes | Model name for this publisher. This is the HTTP API wire name for `model_name`. |
+| `lora_name` | No | LoRA adapter name. Empty or omitted means base model. |
+| `tenant_id` | No | Tenant identity. Defaults to `default`. |
+| `instance_id` | Yes | Router-facing engine or API server instance identity. |
+| `block_size` | Yes | KV block size in tokens. |
+| `dp_rank` | Yes | Data-parallel rank for this publisher. |
+| `additionalsalt` | No | HTTP API wire name for `additional_salt`. Defaults to an empty string. |
+
+Successful response:
+
+```json
+{
+  "status": "registered successfully",
+  "instance_id": "vllm-prefill-node1"
+}
+```
+
+### `POST /unregister`
+
+Stops consuming events for a registered publisher.
+
+```json
+{
+  "type": "vLLM",
+  "modelname": "deepseek",
+  "lora_name": "sql-adapter",
+  "tenant_id": "default",
+  "instance_id": "vllm-prefill-node1",
+  "block_size": 128,
+  "dp_rank": 0
+}
+```
+
+`tenant_id` defaults to `default`. The current implementation removes the
+subscription identified by `(instance_id, tenant_id, dp_rank)`.
+
+Successful response:
+
+```json
+{
+  "status": "unregistered successfully",
+  "removed_instances": ["vllm-prefill-node1|default|0"]
+}
+```
 
 ### `POST /query`
- query token hit count.
-- **Input**:
-    - **Body** (JSON):
-        ```json
-        {
-            "model": "deepseek",
-            "lora_name": "xx-adapter",
-            "lora_id": 12, // defined for backward compatibility and should not be used together with `lora_name`
-            "token_ids": [1, 15, 100],
-            "tenant_id": None,
-            "cache_salt": None,
-        }
-        ```
-    - **Parameter Description**:
-        - `model`: (required, string) model name
-        - `lora_name`: (optional, string) The name of the LoRA adapter, default is `None`(indicating no LoRA adapter is used)
-        - `lora_id`: (optional, int) The ID of the LoRA adapter. This parameter is defined for backward compatibility and should not be used together with `lora_name`(Only one of them can be specified). Default is `-1`(indicating no LoRA adapter is used)
-        - `token_ids`: (required, [int]) prompt token id list
-        - `tenant_id`: (optional, int) In a multi-tenant architecture, tenant_id is the key identifier for distinguishing and isolating data from different tenants (such as different companies or user groups). All data operations are logically isolated based on this ID. If you provide it, the indexer will only return the token hit information for this tenant. Default is None(meaning there is only one tenant)
-        - `cache_salt`: (optional, int) An optional salt value to ensure cached data blocks are kept separate for different customers. This prevents one customer's kv-index data from being served to another. Default is None, meaning no salt is used.
-    - **example**:
-        ```json
-        {
-            "model": "deepseek-v3",
-            "lora_name": "sql_adapter",
-            "token_ids": [101, 15, 100, 55, 89],
-        }
-        ```
-- **Output**:
-    ```json
-    {
-        "data": {
-            "tenant_id": {
-                "api_server_unique_name": {
-                    "longest_matched": 100, // the number of longest prefix matched token among multiple DPs(if there are)
-                    "GPU": 20,
-                    "DP": {
-                        0: 10,
-                        1: 20
-                    },
-                    "CPU": 60,
-                    "DISK": 10
-                },
-                ... // other engine instance
-            },
-            ... // other tenant
-        }
-    }
-    ```
-    - **Parameter Description**
-        - `tenant_id`: tenant id, only used in multi-tenant scenario.
-        - `api_server_unique_name`: it is a unique name for a LLM API server endpoint in the engine side. For example, two service instances are currently started separately by running the `vllm server` command, and they are registered in the indexer with different names(such as vllm-1,vllm-2)
-        - `longest_matched`: the number of longest prefix matched token among G1/G2/G3. Indexer will sequentially query the hit status of each token-block according to the prefix order. If it hits, count the situation of this token-block at each level; If it missed, terminate the query (ensuring prefix continuity).
-        - `GPU`, `CPU`, `DISK`: token ids hit count for each tiered storage medium. The Indexer will track the storage status of KV-cache across various media. This requires different KV publishers to inform the Indexer of the actual storage medium type via kv-events. The following examples list several common names, such as using GPU or NPU to represent the Device Pool, using CPU to represent the Host Pool, and using DISK to represent the Disk Pool.
-        - `DP`: token ids hit count for each DP rank.
-    - **example**:
 
-        Assume the input token_ids are [101, 15, 100, 55, 89, 63], the block_size is 2, and the dp2 strategy is enabled. There are three block hashes to match [H1, H2, H3], where H1 hits in GPU (dp0, dp1), CPU, and DISK; H2 hits in GPU (dp0) and CPU; and H3 hits in DISK.
-        ```json
-        {
-            "vllm-1": {
-                "longest_matched": 6,
-                "GPU": 4,
-                "DP": {
-                    0: 4,
-                    1: 2
-                },
-                "CPU": 4,
-                "DISK": 4
-            }
-        }
-        ```
+Query cache hits by token IDs.
+
+```json
+{
+  "model": "deepseek",
+  "lora_name": "sql-adapter",
+  "token_ids": [101, 15, 100, 55, 89],
+  "tenant_id": "default",
+  "instance_id": "vllm-prefill-node1",
+  "block_size": 64,
+  "cache_salt": "w8a8"
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `model` | Yes | Model name. |
+| `lora_name` | No | LoRA adapter name. Empty or omitted means base model. |
+| `lora_id` | No | Deprecated compatibility field. Do not use together with `lora_name`. |
+| `token_ids` | Yes | Prompt token IDs. Only complete blocks are considered. |
+| `tenant_id` | No | Tenant identity. Defaults to `default`. |
+| `instance_id` | No | If set, query one instance. If omitted, query all instances registered under the tenant. |
+| `block_size` | Yes | KV block size in tokens. |
+| `cache_salt` | No | Query-side hash namespace salt. Corresponds to the event `additional_salt` concept. |
+
+Response:
+
+```json
+{
+  "default": {
+    "vllm-prefill-node1": {
+      "longest_matched": 256,
+      "GPU": 128,
+      "DP": {
+        "0": 128,
+        "1": 256
+      },
+      "CPU": 256,
+      "DISK": 0
+    }
+  }
+}
+```
+
+| Field | Description |
+|---|---|
+| `longest_matched` | Longest continuous prefix hit in tokens across all tracked media and DP ranks for this instance. |
+| `GPU`, `CPU`, `DISK` | Matched prefix tokens available on each medium. Names are examples; future media can be added. |
+| `DP` | Matched prefix tokens grouped by data-parallel rank. |
 
 ### `POST /query_by_hash`
- query token hit count by chunked_token hash key. Each model service uses its own independent page_size, `longest_matched = page_size * matched hash_key`
-- **Input**:
-    - **Body** (JSON):
-        ```json
-        {
-            "model": "deepseek",
-            "lora_name": "xx-adapter",
-            "lora_id": 12, // defined for backward compatibility and should not be used together with `lora_name`
-            "block_hash": ["hash_key_by_chunked_tokens"],
-            "tenant_id": None,
-            "cache_salt": None,
-        }
-        ```
-    - **Parameter Description**:
-        - `model`: (required, string) model name
-        - `lora_name`: (optional, string) The name of the LoRA adapter, default is `None`(indicating no LoRA adapter is used)
-        - `lora_id`: (optional, int) The ID of the LoRA adapter. This parameter is defined for backward compatibility and should not be used together with `lora_name`(Only one of them can be specified). Default is `-1`(indicating no LoRA adapter is used)
-        - `block_hash`: (required, [int]) chunk_token hash list
-        - `tenant_id`: (optional, int) In a multi-tenant architecture, tenant_id is the key identifier for distinguishing and isolating data from different tenants (such as different companies or user groups). All data operations are logically isolated based on this ID. If you provide it, the indexer will only return the token hit information for this tenant. Default is None(meaning there is only one tenant)
-        - `cache_salt`: (optional, int) An optional salt value to ensure cached data blocks are kept separate for different customers. This prevents one customer's kv-index data from being served to another. Default is None, meaning no salt is used.
-- **Output**:
-    ```json
-    {
-        "data": {
-            "tenant_id": {
-                "api_server_unique_name": {
-                    "longest_matched": 100, // the number of longest prefix matched token among multiple DPs(if there are)
-                    "GPU": 20,
-                    "DP": {
-                        0: 10,
-                        1: 20
-                    },
-                    "CPU": 60,
-                    "DISK": 10
-                },
-                ... // other engine instance
-            },
-            ... // other tenant
-        }
-    }
-    ```
-    - **Parameter Description**: The output result is same as `/query` api.
 
+Queries cache hits by precomputed rolling sequence hashes. This API avoids
+sending long token lists over the network.
 
-## Indexer KVEvents Structure
-Typically, the device pool is used for loading model weights, with the remaining space registered for KV blocks by the model inference service runtime, the host pool and disk pool are managed uniformly by the Mooncake Store. There is a difference in the management unit for KV data between the two: the device pool uses blocks as the smallest unit for KV data, while the host pool and disk pool use Mooncake Store Objects as the smallest unit for KV storage. In practice, users may split a complete KV block into multiple Mooncake Store Objects for maintenance according to parallel strategies such as tensor parallelism (tp) and context parallelism (cp).
-
-### G1 KVEvents
-[vLLM](https://github.com/vllm-project/vllm/blob/main/vllm/distributed/kv_events.py) and [SGLang](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/disaggregation/kv_events.py) publishes events using the `EventBatch` structure, with each batch containing three types of events:
-
-- `BlockStored`：Adds a single KV block.
-- `BlockRemoved`：Removes a single KV block.
-- `AllBlocksCleared`：Clears all KV blocks.
-
-```py
-EventBatch：
+```json
 {
-    ts: float， # timestamp
-    events：list[BlockStored | BlockRemoved | AllBlocksCleared]，
-    data_parallel_rank: int | None = None,  # vLLM use this to indicate dp rank
-    attn_dp_rank: int | None = None,        # SGLang use this to indicate dp rank
+  "model": "deepseek",
+  "lora_name": "sql-adapter",
+  "seq_hashes": [1234567890, 9876543210],
+  "tenant_id": "default",
+  "instance_id": "vllm-prefill-node1",
+  "block_size": 64,
+  "cache_salt": "w8a8"
 }
-
-
-BlockStored:
-{
-    block_hashes: list[int]
-    parent_block_hash: int | None
-    token_ids: list[int]
-    block_size: int
-
-    lora_id: int | None
-    """Deprecated: use `lora_name` for KV block key hash.
-    Retained for backward compatibility.
-    """
-    
-    medium: str | None
-    """KV cache is categorized by tier. Currently, the following types are supported:
-    set "GPU", "NPU" for device pool(G1), 
-    set "CPU" for host pool(G2), 
-    set "DISK" for disk pool(G3).
-    In the future, more medium types can be supported for each tier. For example, "TPU" and "AMD" could be added for device pool.
-    """
-    lora_name: str | None
-}
-
-BlockRemoved:
-{
-    block_hashes: list[int]
-    lora_name: str | None
-}
-
 ```
 
-### G2/G3 KVEvents
-Mooncake Store is a distributed key-value (KV) store. To ensure system consistency, a timestamp is assigned to each KVEvent for maintenance.
+For compatibility with earlier drafts, clients may call the hash list
+`block_hash`, but new clients should use `seq_hashes` to make it explicit that
+the values are rolling sequence hashes rather than local block hashes.
 
-Mooncake publishes events using the `EventBatch` structure, with each batch containing three types of events:
-- `BlockStoreEvent`：Adds a single Mooncake Store Object.
-- `BlockUpdateEvent`：Updates a single Mooncake Store Object.
-- `RemoveAllEvent`：Removes all Mooncake Store Objects.
+The response shape is the same as `/query`. For this API,
+`longest_matched = block_size * matched_hash_count`.
 
-```cpp
-EventBatch {
-    std::vector<std::variant<BlockStoreEvent, BlockUpdateEvent, RemoveAllEvent>> events,
-}
 
-BlockStoreEvent {
-    "BlockStoreEvent", // Event type identifier, string type
-    float ts,          // timestamp
-    std::string mooncake_key,
-    std::vector<std::string> addr_list, // Storage location of each replica
+## KV Events API
 
-    uint64_t block_hash,
-    uint64_t parent_block_hash,
-    std::vector<uint32_t> token_id,
-    uint32_t block_size,
+The KV Events API is the wire contract between cache owners and indexers.
+Conductor normalizes engine-specific events into this model.
 
-    std::string model_name,
-    std::string lora_name,
-    uint32_t lora_id, // Retained for backward compatibility
-}
+### Event envelope
 
-BlockUpdateEvent {
-    "BlockUpdateEvent",
-    float ts,          // timestamp
-    mooncake_key,
-    std::vector<std::string> addr_list,
-}
+Every standardized event carries the same envelope:
 
-RemoveAllEvent {
-    "RemoveAllEvent"
+```json
+{
+  "event_id": 42,
+  "timestamp": 1739145600000,
+  "event_type": "stored",
+  "model_name": "llama-3.1-8b",
+  "block_size": 64,
+  "additional_salt": null,
+  "lora_name": null,
+  "tenant_id": "default",
+  "backend_id": "worker-0",
+  "medium": "gpu",
+  "dp_rank": 0
 }
 ```
+
+| Field | Type | Description |
+|---|---|---|
+| `event_id` | `u64` | Monotonically increasing sequence number scoped by the event stream dimensions. Authoritative for ordering. |
+| `timestamp` | `u64 or null` | Unix epoch milliseconds. Informational only, not used for ordering. |
+| `event_type` | `string` | One of `stored`, `removed`, or `cleared`. |
+| `model_name` | `string or null` | Model identifier. |
+| `block_size` | `u32 or null` | Tokens per block. |
+| `additional_salt` | `string or null` | Opaque deployment salt or namespace. |
+| `lora_name` | `string or null` | LoRA adapter name, or `null` for the base model. |
+| `tenant_id` | `string` | Tenant or customer identity. |
+| `backend_id` | `string` | Entity that owns the KV blocks. This can be an engine worker or a decoupled cache daemon. |
+| `medium` | `string or null` | Cache medium such as `gpu`, `cpu`, or `disk`. |
+| `dp_rank` | `u32 or null` | Data-parallel rank. |
+
+Events must be processed in consecutive `event_id` order within each stream
+identified by `(model_name, block_size, additional_salt, lora_name, tenant_id,
+backend_id, medium, dp_rank)`.
+
+### `stored`
+
+Published when one or more consecutive blocks are committed to a KV cache.
+
+```json
+{
+  "event_id": 42,
+  "timestamp": 1739145600000,
+  "event_type": "stored",
+  "model_name": "llama-3.1-8b",
+  "block_size": 64,
+  "additional_salt": null,
+  "lora_name": null,
+  "tenant_id": "default",
+  "backend_id": "worker-0",
+  "medium": "gpu",
+  "dp_rank": 0,
+  "seq_hashes": [1234567890, 9876543210, 1122334455],
+  "base_block_idx": 5,
+  "parent_hash": 9999999999,
+  "token_ids": null
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `seq_hashes` | `u64[]` | Rolling sequence hashes of consecutive stored blocks. |
+| `base_block_idx` | `u32 or null` | Zero-based depth of the first block in this event. |
+| `parent_hash` | `u64 or null` | Rolling sequence hash at depth `base_block_idx - 1`; `null` at the root. |
+| `token_ids` | `u32[] or null` | Tokens across all blocks in this event. Required when the publisher does not use the standardized hash. |
+
+At least one of `base_block_idx` or `parent_hash` must be present so the
+consumer can locate the blocks in the sequence.
+
+### `removed`
+
+Published when one or more blocks are evicted.
+
+```json
+{
+  "event_id": 43,
+  "timestamp": 1739145601000,
+  "event_type": "removed",
+  "model_name": "llama-3.1-8b",
+  "block_size": 64,
+  "additional_salt": null,
+  "lora_name": null,
+  "tenant_id": "default",
+  "backend_id": "worker-0",
+  "medium": "gpu",
+  "dp_rank": 0,
+  "seq_hashes": [1122334455],
+  "base_block_idx": 7
+}
+```
+
+`seq_hashes` is required. `base_block_idx` is optional but recommended for
+collision detection and observability.
+
+### `cleared`
+
+Published when all blocks for the event stream dimensions are purged.
+
+```json
+{
+  "event_id": 44,
+  "timestamp": 1739145602000,
+  "event_type": "cleared",
+  "model_name": "llama-3.1-8b",
+  "block_size": 64,
+  "additional_salt": null,
+  "lora_name": null,
+  "tenant_id": "default",
+  "backend_id": "worker-0",
+  "medium": "gpu",
+  "dp_rank": 0
+}
+```
+
+No additional payload fields are required.
+
+## Compatibility notes
+
+The current Conductor implementation consumes vLLM ZMQ msgpack batches and
+normalizes `BlockStored` and `BlockRemoved` into the internal prefix index.
+Registration metadata supplies fields such as `modelname`, `tenant_id`,
+`instance_id`, `block_size`, and `additionalsalt` when the engine event does
+not carry the full standardized envelope.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -114,6 +114,8 @@ design/transfer-engine/index
 design/tent/overview
 design/tent/tebench
 design/hicache-design
+design/conductor/conductor-architecture-design
+design/conductor/indexer-api-design
 :::
 
 % Q&A for Mooncake


### PR DESCRIPTION
## Description
The previous Conductor Indexer API document was based on an older API draft and did not clearly reflect the latest naming. So i update the Mooncake Conductor design documentation to align the Indexer API and KV Events API with the latest RFC discussions.

This PR refreshes the design docs so they can serve as the source of truth for the next stage of Conductor implementation.

## Changes

- Rewrite `docs/source/design/conductor/indexer-api-design.md`
  - Add updated Indexer API definitions for `/register`, `/unregister`, `/query`, `/query_by_hash`, and `/global_view`
  - Clarify `instance_id` as the router-facing scheduling target
  - Clarify `backend_id` as the KV Events cache-owner identity
  - Document tenant, model, LoRA, block size, medium, DP rank, and salt dimensions
  - Add the recommended XXH3  hash  standard
  - Add standardized KV Events envelope and `stored`, `removed`, `cleared` event formats

- Add `docs/source/design/conductor/conductor-architecture-design.md`
  - Document Conductor architecture, components, event flow, query flow, dynamic registration, configuration, and project structure

- Update `docs/source/index.md`
  - Add Conductor architecture and API design docs to the Design Documents toctree


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
