### PR TITLE
[bugfix] Enable Mermaid rendering in Sphinx docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,11 +46,13 @@ extensions = [
     "sphinxarg.ext",
     "sphinx_design",
     "sphinx_togglebutton",
+    "sphinxcontrib.mermaid",
 ]
 myst_enable_extensions = [
     "colon_fence",
     "fieldlist",
 ]
+myst_fence_as_directive = ["mermaid"]
 autodoc2_packages = [
     {
         "path": "../../Mooncake",

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -4,6 +4,7 @@ sphinx-book-theme==1.1.4
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-togglebutton==0.3.2
+sphinxcontrib-mermaid==2.0.1
 myst-parser==3.0.1  # `myst-parser==4.0.1` breaks inline code in titles
 msgspec
 snowballstemmer<3  # https://github.com/snowballstem/snowball/issues/229


### PR DESCRIPTION
## Description
refer to https://github.com/kvcache-ai/Mooncake/issues/1980
Mermaid code block will be rendered it as a highlighted code block instead of a diagram. 
This PR adds the Mermaid Sphinx extension and configures MyST to treat `mermaid` fenced blocks as directives.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

```bash
cd docs
make clean
make html
```

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
