### PR TITLE
[Bugfix][Store] fix storage_tier compile (#1982)

### DIFF
--- a/mooncake-store/include/tiered_cache/tiers/storage_tier.h
+++ b/mooncake-store/include/tiered_cache/tiers/storage_tier.h
@@ -64,6 +64,7 @@ class StorageBuffer : public BufferBase {
     }
 
     void SetKey(const std::string& key) { key_ = key; }
+    void SetKey(std::string_view key) { key_ = key; }
     const std::string& GetKey() const { return key_; }
 
     // Transition from staging pool -> on disk.


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
