### PR TITLE
[Store] Fix DSO missing error when building with USE_3FS=ON

### DIFF
--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -157,6 +157,7 @@ target_link_libraries(mooncake_store
         gflags::gflags
         ${EXTRA_LIBS}
         asio_shared
+        zstd
     PRIVATE
         transfer_engine
 )

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -118,7 +118,7 @@ if(USE_3FS)
   if(NOT HF3FS_API_LIB)
     message(FATAL_ERROR "hf3fs_api_shared library not found in /usr/lib")
   endif()
-  set(EXTRA_LIBS ${HF3FS_API_LIB})
+  list(APPEND EXTRA_LIBS ${HF3FS_API_LIB})
 endif()
 
 # io_uring support (auto-detected)
@@ -157,7 +157,6 @@ target_link_libraries(mooncake_store
         gflags::gflags
         ${EXTRA_LIBS}
         asio_shared
-        zstd
     PRIVATE
         transfer_engine
 )

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -11,8 +11,7 @@ function(add_store_test name)
            ibverbs
            gtest
            gtest_main
-           pthread
-           zstd)
+           pthread)
   add_test(NAME ${name} COMMAND ${name})
 endfunction()
 

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -11,7 +11,8 @@ function(add_store_test name)
            ibverbs
            gtest
            gtest_main
-           pthread)
+           pthread
+           zstd)
   add_test(NAME ${name} COMMAND ${name})
 endfunction()
 


### PR DESCRIPTION
## Description

Fix DSO missing error when building with  -DUSE_3FS=ON.

Error Info:
/usr/bin/ld: ../src/libmooncake_store.a(master_service.cpp.o): undefined reference to symbol 'ZSTD_compress'
/usr/bin/ld: /lib/x86_64-linux-gnu/libzstd.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [mooncake-store/tests/CMakeFiles/client_local_hot_cache_test.dir/build.make:121: mooncake-store/tests/client_local_hot_cache_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:2179: mooncake-store/tests/CMakeFiles/client_local_hot_cache_test.dir/all] Error 2
/usr/bin/ld: ../src/libmooncake_store.a(master_service.cpp.o): undefined reference to symbol 'ZSTD_compress'
/usr/bin/ld: /lib/x86_64-linux-gnu/libzstd.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [mooncake-store/tests/CMakeFiles/pybind_client_test.dir/build.make:121: mooncake-store/tests/pybind_client_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:2213: mooncake-store/tests/CMakeFiles/pybind_client_test.dir/all] Error 2
/usr/bin/ld: ../src/libmooncake_store.a(master_service.cpp.o): undefined reference to symbol 'ZSTD_compress'
/usr/bin/ld: /lib/x86_64-linux-gnu/libzstd.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [mooncake-store/tests/CMakeFiles/ipv6_client_test.dir/build.make:121: mooncake-store/tests/ipv6_client_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:2247: mooncake-store/tests/CMakeFiles/ipv6_client_test.dir/all] Error 2

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

```
make build
cd buil
cmake .. -DUSE_CUDA=ON -DUSE_NVMEOF=ON -DUSE_ETCD=ON -DWITH_STORE=ON -DUSE_3FS=ON
make -j
```
## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
