### PR TITLE
[TENT] Recover cooled-down RDMA rails and add failover e2e tests

### DIFF
--- a/docs/source/design/tent/failover.md
+++ b/docs/source/design/tent/failover.md
@@ -1,0 +1,194 @@
+# TENT Failover
+
+TENT hides transfer failures from the application by recovering inside the data path.
+This document describes how the recovery works, which knobs control it, and how it is tested.
+
+The design has two layers:
+
+1. **Cross-transport failover** in `TransferEngineImpl`. When a transport fails a task at the completion stage, the engine moves that task to the next available transport (for example RDMA → TCP). Submit-stage failures are not retried today; see Known Gaps.
+2. **Intra-RDMA rail recovery** in `RailMonitor`. When a specific (local NIC, remote NIC) rail keeps failing, the monitor pauses it with exponential cooldown; a successful transfer or the cooldown expiry brings it back.
+
+Application code submits a batch and polls `getTransferStatus`. It never sees a `FAILED` task as long as any healthy path remains and the failover budget is not exhausted.
+
+## Fault Model
+
+TENT focuses on three kinds of transient faults:
+
+| Fault | Surface | Recovery action |
+|-------|---------|-----------------|
+| Work request completion error (WC error) | RDMA worker sees a bad completion | Rail-level `markFailed` + task-level resubmit |
+| QP / endpoint failure | `submitTransferTasks` returns non-OK | *Not retried today*: task surfaces as `FAILED`. See Known Gaps. |
+| Peer disconnect mid-transfer | `getTransferStatus` returns `FAILED` | Cross-transport failover |
+
+Permanent or application-visible errors (invalid arguments, out-of-memory, segment not found) are *not* retried; they are returned to the caller as-is.
+
+## Architecture
+
+```
+                +-------------------------+
+ submitTransfer |  TransferEngineImpl     |
+ ---------------> classify by TransportType
+                |  submitTransferTasks    |----failure----+
+                +-------------------------+               |
+                      |                                   v
+                      |                       resubmitTransferTask
+                      |                       (bump priority, pick next
+                      |                        transport, resubmit)
+                      v
+         +---------------------------+
+         | RdmaTransport / workers   |
+         |   +---------------------+ |
+         |   | RailMonitor         | |
+         |   |  per-rail state     | |
+         |   |  cooldown / recover | |
+         |   +---------------------+ |
+         +---------------------------+
+```
+
+* Each request is owned by one `TaskInfo`. `type` names the transport currently executing the task; `xport_priority` is the index into the ranked fallback list; `failover_count` caps how many times we may re-resolve the transport.
+* The ranked fallback list comes from `getTransportType(req, priority)`. Priority 0 yields the best available transport; increasing priority walks down the list; `UNSPEC` means no transport left.
+* RDMA rail state lives in `RailMonitor`. Its lifecycle is independent of the task-level state machine: a rail can be paused while tasks keep flowing on other rails.
+
+## State Machine
+
+### Cross-transport failover
+
+`resubmitTransferTask` is the single entry point that promotes a failing task to the next transport:
+
+```
+++task.failover_count
+if failover_count > max_failover_attempts  -> return error (exhausted)
+
+task.xport_priority++
+type = resolveTransport(task.request, task.xport_priority)
+if type == UNSPEC                          -> return error (no transport)
+
+transport_list_[type]->submitTransferTasks(...)
+```
+
+It has two callers, one per recoverable failure surface:
+
+1. **Completion-stage failure.** `getTransferStatus(batch_id, task_id, status)` and the batch-form overload call `resubmitTransferTask` once per `FAILED` completion. On success the task is re-marked `PENDING` so the aggregated batch status does not latch to `FAILED` because of a task that is actually retrying.
+
+2. **Exhaustion.** When the budget is hit, `resubmitTransferTask` sets the returned status to `InvalidEntry("Failover limit exceeded, all transports exhausted")`. Callers leave `task.type` unchanged; the task then reports `FAILED` through the normal status flow.
+
+Submit-stage failures (`submitTransferTasks` returning non-OK) are **not** retried today. They mark the task as `UNSPEC`, and `getTransferStatus` short-circuits to `FAILED`. See Known Gaps for why.
+
+### RDMA rail recovery
+
+Inside `RdmaTransport`, each completion drives the rail monitor:
+
+* Bad completion → `rail.markFailed(local_nic, remote_nic)`
+* Good completion → `rail.markRecovered(local_nic, remote_nic)`
+
+`markFailed` bumps `error_count` inside `error_window_`. Once the count hits `error_threshold_` the rail is paused until `now + cooldown_`; the cooldown doubles on every repeat failure up to `kMaxCooldown` (300 s).
+
+`markRecovered` clears the error count, un-pauses the rail, and resets the exponential-backoff memory so the next failure cycle starts from the initial cooldown. A fast path returns without work when the rail is already healthy, which is the common case on the completion hot path.
+
+`available(local, remote)` is the gate every work request passes through before posting. If the cooldown has expired, `available` itself resets all backoff state (error count, resume time, cooldown) and logs `Rail recovered: ... (cooldown expired)`. Otherwise it returns false and the scheduler picks another rail via `findBestRemoteDevice`.
+
+This produces two independent recovery signals — cooldown expiry and live success — so a flaky rail does not stall forever if no other rail is posted to, and a recovered rail returns to service at the first good completion instead of waiting for the full cooldown.
+
+## Configuration
+
+All knobs live in the top-level `transfer-engine.json`. Defaults are safe for production; tune only if you have evidence.
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `max_failover_attempts` | `3` | Upper bound on `resubmitTransferTask` calls per task. `0` disables cross-transport failover entirely. `1` allows exactly one switch. |
+| `transports/rdma/rail_error_threshold` | `3` | Number of failures inside `rail_error_window_secs` that trips a rail into the paused state. |
+| `transports/rdma/rail_error_window_secs` | `10` | Sliding window for counting rail errors. A failure older than the window resets `error_count` to 1. |
+| `transports/rdma/rail_cooldown_secs` | `30` | Initial cooldown after tripping. Doubles on each repeat failure, capped at 300 s. |
+
+The RDMA keys are read by `RailMonitor::load`. Example:
+
+```json
+{
+  "max_failover_attempts": 3,
+  "transports": {
+    "rdma": {
+      "rail_error_threshold": 3,
+      "rail_error_window_secs": 10,
+      "rail_cooldown_secs": 30
+    }
+  }
+}
+```
+
+## Observability
+
+### Metric
+
+`tent_transport_failover_total` is a counter incremented once per successful transport switch inside `resubmitTransferTask`. A non-zero rate means the engine is actively recovering; a sudden jump usually points at a single bad link or flaky peer.
+
+The counter is only built when TENT is compiled with `-DTENT_METRICS_ENABLED=ON` (see `metrics.md`). Without that flag the macro is a no-op.
+
+### Log keywords
+
+| Keyword | Interpretation |
+|---------|----------------|
+| `Transport failover: X -> Y (attempt N/M)` | A task has successfully switched transports. |
+| `Task failover limit reached (M), last transport=X` | Task exhausted its budget and will surface `FAILED`. |
+| `No more transports available after X failed` | `resolveTransport` returned `UNSPEC`; no further fallback exists for this request. |
+| `Rail recovered: local_nic=... remote_nic=... (cooldown expired)` | Cooldown elapsed and the rail is back in service. |
+| `Rail recovered: ... (un-paused by successful transfer)` | Live success on a previously paused rail brought it back early. |
+
+## Testing
+
+Real hardware faults are hard to stage, so TENT tests the failover machinery with decorator-style fault injection.
+
+### FaultProxyTransport
+
+`FaultProxyTransport` wraps any `Transport` and injects four policy-driven faults:
+
+* `submit_fail_rate` — probability that `submitTransferTasks` returns an error.
+* `status_corrupt_rate` — probability that `getTransferStatus` flips `COMPLETED → FAILED`.
+* `fail_after_n_submits` — deterministic variant: succeed the first N submits, then always fail.
+* `fail_install` — make `install()` fail, simulating a transport that cannot come up.
+
+Because it implements the `Transport` interface, the engine sees an ordinary transport. All failover paths (`submitTransfer`, `getTransferStatus`, `resubmitTransferTask`) run unmodified.
+
+### Test-only injection hook
+
+`TransferEngineImpl::swapTransportForTest` replaces the transport in one slot after `construct()`. This is the only way the end-to-end test can wrap the real transport with `FaultProxyTransport` without bypassing `resolveTransport` or `resubmitTransferTask`. Production code never calls it.
+
+### End-to-end suite
+
+The end-to-end failover test suite drives the real `TransferEngineImpl` with fake transports (`FakeTransport`) wrapped in `FaultProxyTransport`. It uses a `p2p` metadata backend on `127.0.0.1` so no external services are required — the whole suite is self-contained.
+
+Current cases:
+
+| Test | What it exercises |
+|------|-------------------|
+| `StatusCorruptionTriggersFailoverToSecondary` | Primary reports `FAILED` in `getTransferStatus`; engine must resubmit on the secondary. |
+| `BothTransportsFailExhaustsFailoverBudget` | Both transports fail at the completion stage; task must surface `FAILED` once the budget is drained. |
+| `MixedFaultsAcrossManySubmissions` | 10 one-request batches with 30% completion corruption on RDMA; every task must end `COMPLETED`, and submit-counter math must hold. |
+| `MaxFailoverAttemptsZeroDisablesFailover` | `max_failover_attempts = 0` → the first completion fault is permanent, TCP is never touched. |
+| `MaxFailoverAttemptsOneAllowsSingleFailover` | `max_failover_attempts = 1` → one switch allowed; RDMA fault → TCP success. |
+| `PerTaskFailoverCountsAreIndependent` | A failing task must not consume another task's budget; `failover_count` is strictly per-task. |
+
+A test-local `PerRequestFaultProxy` (in the same file) subclasses `FaultProxyTransport` to take a `std::function` predicate, remembers which sub-task ids it marked as "poisoned" at submit time, and flips only those completions from `COMPLETED` to `FAILED` at status-query time.
+
+### Running manually
+
+The TENT tests are **not** in CI today (the upstream workflow builds with `USE_TENT=OFF`). Run them locally:
+
+```bash
+cmake -S . -B build-tent -DUSE_TENT=ON -DUSE_CUDA=OFF
+cmake --build build-tent --target tent_engine_failover_e2e_test -j
+./build-tent/mooncake-transfer-engine/tent/tests/tent_engine_failover_e2e_test
+```
+
+Setting `USE_CUDA=OFF` forces `CpuPlatform`, which always reports `MTYPE_CPU`. With `USE_CUDA=ON` on a host without a GPU, `cudaPointerGetAttributes` fails, `getMemoryType` returns `MTYPE_UNKNOWN`, every transport reports unavailable, and `resolveTransport` returns `UNSPEC` before the fault injection ever runs.
+
+Companion unit tests cover the rail monitor and related building blocks: `tent_rail_monitor_test`, `tent_failover_test`, `tent_fault_proxy_test`.
+
+## Known Gaps
+
+* **Submit-stage failures do not trigger failover.** When `submitTransferTasks` returns non-OK, every task in that call is marked `UNSPEC` and surfaces as `FAILED`. A naive retry loop here is unsafe for two reasons:
+  1. **Merged requests.** When `merge_requests` is enabled (default), `task_id_list[type]` contains both the real merged task and its derived aliases. Resubmitting per task-id re-posts one logical transfer multiple times on the fallback transport, breaking the deduplication the merge pass established.
+  2. **Partial enqueue.** Some transports (for example `ShmTransport::submitTransferTasks`, `NVLinkTransport::submitTransferTasks`) enqueue or start work for earlier requests in `request_list` before returning an error on a later one. The return status alone does not tell us which tasks partially succeeded, so a blanket resubmit would duplicate already-started transfers.
+  A safe submit-stage recovery needs either (a) a transport-level "atomic submit" capability flag plus per-task skip of derived ids, or (b) per-request status returned from `submitTransferTasks`. Neither exists today.
+* `markRecovered` (and cooldown expiry in `available`) clears the exponential-backoff memory entirely. A rail that flaps repeatedly therefore does not accumulate a growing cooldown across recovery cycles. If this becomes a problem the fix is to decay rather than reset.
+* Cross-transport failover is driven purely by return status; there is no latency-based "this transport is healthy but too slow, try another" signal. That belongs to the scheduler, not this document.
+* TENT tests are not exercised by CI. A follow-up can add a CI job that builds with `-DUSE_TENT=ON -DUSE_CUDA=OFF` and runs the `tent_*` test targets; none of the code in this document changes in that case.

--- a/docs/source/design/tent/overview.md
+++ b/docs/source/design/tent/overview.md
@@ -88,3 +88,11 @@ cpp-api
 
 metrics
 :::
+
+## TENT Failover
+
+:::{toctree}
+:maxdepth: 1
+
+failover
+:::

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -158,6 +158,18 @@ class TransferEngineImpl {
 
     Status unlockStageBuffer(uint64_t addr);
 
+    // Test-only hook: replace the transport in a given slot after construct().
+    // Production code never calls this. Used by failover integration tests to
+    // inject a FaultProxyTransport without bypassing resubmitTransferTask,
+    // resolveTransport, or any other engine state. Not thread-safe with any
+    // in-flight transfer on that slot.
+    void swapTransportForTest(TransportType type,
+                              std::shared_ptr<Transport> xport) {
+        if (type >= 0 && type < (TransportType)kSupportedTransportTypes) {
+            transport_list_[type] = std::move(xport);
+        }
+    }
+
    private:
     Status construct();
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rail_monitor.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rail_monitor.h
@@ -21,8 +21,26 @@
 
 namespace mooncake {
 namespace tent {
+// Not thread-safe. Each RDMA worker owns its own RailMonitor via
+// WorkerContext::rails, so markFailed / markRecovered / available / load
+// all execute on a single worker thread. Do not share across threads
+// without adding external synchronization.
 class RailMonitor {
     const static size_t kMaxNuma = 16;
+
+    // Upper bound on the exponential-backoff cooldown; prevents the
+    // per-rail pause from growing without bound under repeated failure.
+    static constexpr std::chrono::seconds kMaxCooldown{300};
+
+   public:
+    // Config keys. Exposed as constants so callers (and docs) reference
+    // a single source of truth instead of duplicating the string path.
+    static constexpr const char *kCfgErrorThreshold =
+        "transports/rdma/rail_error_threshold";
+    static constexpr const char *kCfgErrorWindowSecs =
+        "transports/rdma/rail_error_window_secs";
+    static constexpr const char *kCfgCooldownSecs =
+        "transports/rdma/rail_cooldown_secs";
 
    public:
     RailMonitor() = default;
@@ -33,8 +51,13 @@ class RailMonitor {
     RailMonitor &operator=(const RailMonitor &) = delete;
 
    public:
+    // rail_topo_json: optional JSON string describing rail topology.
+    // conf: optional Config pointer; when non-null, overrides the default
+    //   error_threshold / error_window_secs / cooldown_secs values via
+    //   kCfgErrorThreshold / kCfgErrorWindowSecs / kCfgCooldownSecs.
     Status load(const Topology *local, const Topology *remote,
-                const std::string &rail_topo_json = "");
+                const std::string &rail_topo_json = "",
+                const Config *conf = nullptr);
 
     bool ready() { return ready_; }
 
@@ -71,8 +94,12 @@ class RailMonitor {
         int error_count = 0;
         std::chrono::seconds cooldown{0};
         std::chrono::steady_clock::time_point last_error{};
-        bool paused = false;
         std::chrono::steady_clock::time_point resume_time{};
+
+        // Derived: a rail is paused iff a resume_time has been armed.
+        bool paused() const {
+            return resume_time != std::chrono::steady_clock::time_point{};
+        }
     };
 
     std::unordered_map<std::pair<int, int>, RailState, PairHash> rail_states_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -71,6 +71,9 @@ struct RdmaSlice {
     bool failed = false;
     uint64_t enqueue_ts = 0;
     uint64_t submit_ts = 0;
+    // Cached target machine_id, set in generatePostPath so that
+    // asyncPollCq can call markRecovered on success without a segment lookup.
+    std::string target_machine_id;
 };
 
 using RdmaSliceStorage = Slab<RdmaSlice>;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -33,6 +33,7 @@
 namespace mooncake {
 namespace tent {
 struct RdmaSlice;
+class RailMonitor;
 
 struct RdmaSliceList {
     RdmaSlice* first = nullptr;
@@ -71,9 +72,13 @@ struct RdmaSlice {
     bool failed = false;
     uint64_t enqueue_ts = 0;
     uint64_t submit_ts = 0;
-    // Cached target machine_id, set in generatePostPath so that
-    // asyncPollCq can call markRecovered on success without a segment lookup.
-    std::string target_machine_id;
+    // Non-owning pointer to the per-worker RailMonitor for this slice's
+    // target machine, resolved once in generatePostPath. Lets asyncPollCq
+    // and disableEndpoint call markRecovered / markFailed without a
+    // string-keyed map lookup on the RDMA hot path. Stable because
+    // WorkerContext::rails stores values via unique_ptr, so rehashes do
+    // not invalidate the pointee.
+    RailMonitor* rail_monitor = nullptr;
 };
 
 using RdmaSliceStorage = Slab<RdmaSlice>;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -16,6 +16,7 @@
 #define TENT_WORKERS_H
 
 #include <future>
+#include <memory>
 #include <queue>
 #include <thread>
 #include <unordered_set>
@@ -186,7 +187,10 @@ class Workers {
         std::condition_variable cv;
         volatile bool in_suspend = false;
 
-        std::unordered_map<std::string, RailMonitor> rails;
+        // Values are held via unique_ptr so that map rehashing does not
+        // invalidate pointers into RailMonitor stored on in-flight slices
+        // (see RdmaSlice::rail_monitor).
+        std::unordered_map<std::string, std::unique_ptr<RailMonitor>> rails;
         PerfMetricSummary perf;
         uint64_t padding[16];
     };

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
@@ -18,9 +18,20 @@ namespace mooncake {
 namespace tent {
 
 Status RailMonitor::load(const Topology *local, const Topology *remote,
-                         const std::string &rail_topo_json) {
+                         const std::string &rail_topo_json,
+                         const Config *conf) {
     local_ = local;
     remote_ = remote;
+    if (conf) {
+        error_threshold_ = conf->get(kCfgErrorThreshold, error_threshold_);
+        error_window_ = std::chrono::seconds(
+            conf->get(kCfgErrorWindowSecs, (int)error_window_.count()));
+        cooldown_ = std::chrono::seconds(
+            conf->get(kCfgCooldownSecs, (int)cooldown_.count()));
+        LOG(INFO) << "RailMonitor: error_threshold=" << error_threshold_
+                  << " error_window=" << error_window_.count() << "s"
+                  << " cooldown=" << cooldown_.count() << "s";
+    }
     if (!rail_topo_json.empty()) {
         auto status = loadFromJson(rail_topo_json);
         if (status.ok()) return status;
@@ -33,16 +44,16 @@ bool RailMonitor::available(int local_nic, int remote_nic) {
     auto it = rail_states_.find(std::make_pair(local_nic, remote_nic));
     if (it == rail_states_.end()) return false;
     auto &st = it->second;
-    if (st.paused) {
-        auto now = std::chrono::steady_clock::now();
-        if (now >= st.resume_time) {
-            st.paused = false;
-            st.error_count = 0;
-            updateBestMapping();
-            return true;
-        }
-        return false;
-    }
+    if (!st.paused()) return true;
+    if (std::chrono::steady_clock::now() < st.resume_time) return false;
+    // Cooldown expired: clear all exponential-backoff memory so a fresh
+    // failure cycle starts from the initial cooldown_, not a doubled value.
+    st.resume_time = {};
+    st.error_count = 0;
+    st.cooldown = std::chrono::seconds(0);
+    updateBestMapping();
+    LOG(INFO) << "Rail recovered: local_nic=" << local_nic
+              << " remote_nic=" << remote_nic << " (cooldown expired)";
     return true;
 }
 
@@ -61,11 +72,9 @@ void RailMonitor::markFailed(int local_nic, int remote_nic) {
         st.cooldown = cooldown_;
     } else {
         st.cooldown *= 2;
-        if (st.cooldown > std::chrono::seconds(300))
-            st.cooldown = std::chrono::seconds(300);
+        if (st.cooldown > kMaxCooldown) st.cooldown = kMaxCooldown;
     }
     if (st.error_count >= error_threshold_) {
-        st.paused = true;
         st.resume_time = now + st.cooldown;
         updateBestMapping();
     }
@@ -75,10 +84,22 @@ void RailMonitor::markRecovered(int local_nic, int remote_nic) {
     auto it = rail_states_.find(std::make_pair(local_nic, remote_nic));
     if (it == rail_states_.end()) return;
     auto &st = it->second;
+    // Fast path: a healthy rail stays healthy. 99%+ of completions land
+    // here, so we must not touch best_mapping_ or write any field.
+    if (!st.paused() && st.error_count == 0 && st.cooldown.count() == 0) return;
+    bool was_paused = st.paused();
+    // Clear all exponential-backoff memory: the next failure cycle must
+    // start from the initial cooldown_, not a doubled value left over
+    // from the previous cycle.
     st.error_count = 0;
-    st.paused = false;
     st.resume_time = {};
-    updateBestMapping();
+    st.cooldown = std::chrono::seconds(0);
+    if (was_paused) {
+        LOG(INFO) << "Rail recovered: local_nic=" << local_nic
+                  << " remote_nic=" << remote_nic
+                  << " (un-paused by successful transfer)";
+        updateBestMapping();
+    }
 }
 
 int RailMonitor::findBestRemoteDevice(int local_nic, int remote_numa) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -19,6 +19,7 @@
 #include <cassert>
 
 #include "tent/transport/rdma/endpoint_store.h"
+#include "tent/transport/rdma/rail_monitor.h"
 #include "tent/common/utils/ip.h"
 #include "tent/common/utils/string_builder.h"
 #include "tent/common/utils/os.h"
@@ -27,6 +28,21 @@
 namespace mooncake {
 namespace tent {
 thread_local int tl_wid = -1;
+
+namespace {
+// Look up (or create) the RailMonitor for `machine_id` on this worker's
+// map. Returning a stable reference is safe because the map stores values
+// via unique_ptr -- rehashes move the pointer slot, not the RailMonitor.
+RailMonitor& getOrCreateRail(
+    std::unordered_map<std::string, std::unique_ptr<RailMonitor>>& rails,
+    const std::string& machine_id) {
+    auto it = rails.find(machine_id);
+    if (it != rails.end()) return *it->second;
+    auto [ins, _] = rails.emplace(machine_id, std::make_unique<RailMonitor>());
+    return *ins->second;
+}
+}  // namespace
+
 Workers::Workers(RdmaTransport* transport)
     : transport_(transport), num_workers_(0), running_(false) {
     device_quota_ = std::make_unique<DeviceQuota>();
@@ -188,19 +204,8 @@ std::shared_ptr<RdmaEndPoint> Workers::getEndpoint(Workers::PostPath path) {
 }
 
 void Workers::disableEndpoint(RdmaSlice* slice) {
-    SegmentDesc* desc = nullptr;
-    auto& segment_manager = transport_->metadata_->segmentManager();
-    auto target_id = slice->task->request.target_id;
-    if (target_id == LOCAL_SEGMENT_ID) {
-        desc = segment_manager.getLocal().get();
-    } else {
-        auto status = segment_manager.getRemoteCached(desc, target_id);
-        if (!status.ok()) return;
-    }
-    if (desc) {
-        auto& worker = worker_context_[tl_wid];
-        auto& rail = worker.rails[desc->machine_id];
-        rail.markFailed(slice->source_dev_id, slice->target_dev_id);
+    if (auto* rail = slice->rail_monitor) {
+        rail->markFailed(slice->source_dev_id, slice->target_dev_id);
     }
     if (auto ep = slice->ep_weak_ptr.lock()) {
         ep->acknowledge(slice, FAILED);
@@ -364,13 +369,11 @@ void Workers::asyncPollCq() {
                 // A successful transfer proves this rail is healthy; clear
                 // any accumulated error count so a previously-cooled-down
                 // rail can be used again without waiting for the full
-                // cooldown to expire. Use find() to avoid default-
-                // constructing a RailMonitor on the completion hot path
-                // when the machine_id was not yet loaded.
-                auto it = worker.rails.find(slice->target_machine_id);
-                if (it != worker.rails.end() && it->second.ready())
-                    it->second.markRecovered(slice->source_dev_id,
-                                             slice->target_dev_id);
+                // cooldown to expire. The monitor pointer is resolved once
+                // in generatePostPath, so no map lookup is needed here.
+                if (auto* rail = slice->rail_monitor; rail && rail->ready())
+                    rail->markRecovered(slice->source_dev_id,
+                                        slice->target_dev_id);
                 worker.perf.inflight_lat.add(inflight_lat);
                 worker.perf.enqueue_lat.add(enqueue_lat);
             }
@@ -542,7 +545,7 @@ Status Workers::selectOptimalDevice(RouteHint& source, RouteHint& target,
         return Status::DeviceNotFound(
             "No device could access the slice memory region" LOC_MARK);
 
-    auto& rail = worker.rails[target.segment->machine_id];
+    auto& rail = getOrCreateRail(worker.rails, target.segment->machine_id);
     if (!rail.ready() || target.topo != rail.remote())
         rail.load(source.topo, target.topo, /*rail_topo_json=*/"",
                   transport_->conf_.get());
@@ -641,7 +644,8 @@ Status Workers::selectFallbackDevice(RouteHint& source, RouteHint& target,
             reachable = (sdev == tdev);  // loopback is safe
         } else {
             auto& worker = worker_context_[tl_wid];
-            auto& rail = worker.rails[target.segment->machine_id];
+            auto& rail =
+                getOrCreateRail(worker.rails, target.segment->machine_id);
             reachable = rail.available(sdev, tdev);
         }
 
@@ -674,9 +678,11 @@ Status Workers::generatePostPath(RdmaSlice* slice) {
         CHECK_STATUS(selectFallbackDevice(source, target, slice));
     slice->source_lkey = source.buffer->lkey[slice->source_dev_id];
     slice->target_rkey = target.buffer->rkey[slice->target_dev_id];
-    // Cache machine_id so asyncPollCq can call markRecovered without a
-    // segment lookup on the hot success path.
-    slice->target_machine_id = target.segment->machine_id;
+    // Cache the RailMonitor pointer so asyncPollCq / disableEndpoint can
+    // update rail state without a segment lookup or string-keyed map
+    // lookup on the hot path.
+    slice->rail_monitor = &getOrCreateRail(worker_context_[tl_wid].rails,
+                                           target.segment->machine_id);
     return Status::OK();
 }
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -361,6 +361,16 @@ void Workers::asyncPollCq() {
                 }
             } else {
                 num_slices += ep->acknowledge(slice, COMPLETED);
+                // A successful transfer proves this rail is healthy; clear
+                // any accumulated error count so a previously-cooled-down
+                // rail can be used again without waiting for the full
+                // cooldown to expire. Use find() to avoid default-
+                // constructing a RailMonitor on the completion hot path
+                // when the machine_id was not yet loaded.
+                auto it = worker.rails.find(slice->target_machine_id);
+                if (it != worker.rails.end() && it->second.ready())
+                    it->second.markRecovered(slice->source_dev_id,
+                                             slice->target_dev_id);
                 worker.perf.inflight_lat.add(inflight_lat);
                 worker.perf.enqueue_lat.add(enqueue_lat);
             }
@@ -534,7 +544,8 @@ Status Workers::selectOptimalDevice(RouteHint& source, RouteHint& target,
 
     auto& rail = worker.rails[target.segment->machine_id];
     if (!rail.ready() || target.topo != rail.remote())
-        rail.load(source.topo, target.topo);
+        rail.load(source.topo, target.topo, /*rail_topo_json=*/"",
+                  transport_->conf_.get());
     if (slice->target_dev_id < 0) {
         int mapped_dev_id = rail.findBestRemoteDevice(
             slice->source_dev_id, target.topo_entry->numa_node);
@@ -663,6 +674,9 @@ Status Workers::generatePostPath(RdmaSlice* slice) {
         CHECK_STATUS(selectFallbackDevice(source, target, slice));
     slice->source_lkey = source.buffer->lkey[slice->source_dev_id];
     slice->target_rkey = target.buffer->rkey[slice->target_dev_id];
+    // Cache machine_id so asyncPollCq can call markRecovered without a
+    // segment lookup on the hot success path.
+    slice->target_machine_id = target.segment->machine_id;
     return Status::OK();
 }
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -77,3 +77,10 @@ target_link_libraries(tent_fault_proxy_test PRIVATE gtest gtest_main
 target_include_directories(tent_fault_proxy_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_fault_proxy_test COMMAND tent_fault_proxy_test)
+
+add_executable(tent_rail_monitor_test rail_monitor_test.cpp)
+target_link_libraries(tent_rail_monitor_test PRIVATE gtest gtest_main
+                                                      tent_link_group)
+target_include_directories(tent_rail_monitor_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_rail_monitor_test COMMAND tent_rail_monitor_test)

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -84,3 +84,16 @@ target_link_libraries(tent_rail_monitor_test PRIVATE gtest gtest_main
 target_include_directories(tent_rail_monitor_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_rail_monitor_test COMMAND tent_rail_monitor_test)
+
+# End-to-end failover test: drives real TransferEngineImpl with
+# FaultProxyTransport-wrapped fakes to exercise resubmitTransferTask.
+add_executable(tent_engine_failover_e2e_test engine_failover_e2e_test.cpp)
+target_link_libraries(tent_engine_failover_e2e_test
+                      PRIVATE gtest gtest_main tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_engine_failover_e2e_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_engine_failover_e2e_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_engine_failover_e2e_test
+         COMMAND tent_engine_failover_e2e_test)

--- a/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
@@ -1,0 +1,653 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// End-to-end failover test: drives the real TransferEngineImpl through
+// submitTransfer() / getTransferStatus() / resubmitTransferTask() by swapping
+// two FakeTransports into the engine's transport_list_ and wrapping the
+// primary one in a FaultProxyTransport.
+//
+// ---------------------------------------------------------------------------
+// Scenarios:
+//   P0: Primary succeeds at submit but getTransferStatus reports FAILED
+//       (simulates WC error / QP error / peer drop mid-transfer).
+//       -> engine must failover to the secondary and succeed.
+//
+// Submit-stage failures are NOT tested here. Today submitTransferTasks
+// failures are marked UNSPEC and surface as FAILED without a failover
+// attempt -- see the "Known gaps" section of docs/source/design/tent/
+// failover.md for why. Tests for that path belong in a future change
+// that makes submit-stage recovery safe (see known gaps).
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <set>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/runtime/segment.h"
+#include "tent/runtime/transfer_engine_impl.h"
+#include "tent/runtime/transport.h"
+#include "tent/transport/fault_proxy/fault_proxy_transport.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// ---------------------------------------------------------------------------
+// FakeTransport: declares itself capable of dram_to_dram, records itself in
+// BufferDesc::transports under a configurable slot, and always completes
+// transfers. Enough to satisfy checkAvailability() + resolveTransport() in
+// TransferEngineImpl.
+// ---------------------------------------------------------------------------
+
+class FakeSubBatch : public Transport::SubBatch {
+   public:
+    size_t size() const override { return task_count; }
+    size_t task_count = 0;
+    std::vector<TransferStatus> statuses;
+};
+
+class FakeTransport : public Transport {
+   public:
+    explicit FakeTransport(TransportType self_type) : self_type_(self_type) {
+        caps.dram_to_dram = true;  // so checkAvailability returns true
+    }
+
+    std::atomic<int> install_calls{0};
+    std::atomic<int> submit_calls{0};
+    std::atomic<int> status_calls{0};
+    std::atomic<int> add_mem_calls{0};
+
+    Status install(std::string& /*local_segment_name*/,
+                   std::shared_ptr<ControlService> /*metadata*/,
+                   std::shared_ptr<Topology> /*local_topology*/,
+                   std::shared_ptr<Config> /*conf*/ = nullptr) override {
+        ++install_calls;
+        return Status::OK();
+    }
+
+    Status allocateSubBatch(SubBatchRef& batch, size_t /*max_size*/) override {
+        batch = new FakeSubBatch();
+        return Status::OK();
+    }
+
+    Status freeSubBatch(SubBatchRef& batch) override {
+        delete batch;
+        batch = nullptr;
+        return Status::OK();
+    }
+
+    Status submitTransferTasks(
+        SubBatchRef batch, const std::vector<Request>& request_list) override {
+        ++submit_calls;
+        auto* fb = static_cast<FakeSubBatch*>(batch);
+        for (const auto& req : request_list) {
+            fb->statuses.push_back({TransferStatusEnum::COMPLETED, req.length});
+            fb->task_count++;
+        }
+        return Status::OK();
+    }
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override {
+        ++status_calls;
+        auto* fb = static_cast<FakeSubBatch*>(batch);
+        if (task_id < 0 || task_id >= (int)fb->statuses.size()) {
+            return Status::InvalidArgument("bad task_id" LOC_MARK);
+        }
+        status = fb->statuses[task_id];
+        return Status::OK();
+    }
+
+    // Tag ourselves into the BufferDesc so resolveTransport() considers us.
+    Status addMemoryBuffer(BufferDesc& desc,
+                           const MemoryOptions& /*options*/) override {
+        ++add_mem_calls;
+        desc.transports.push_back(self_type_);
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(std::vector<BufferDesc>& desc_list,
+                           const MemoryOptions& options) override {
+        for (auto& d : desc_list) {
+            auto s = addMemoryBuffer(d, options);
+            if (!s.ok()) return s;
+        }
+        return Status::OK();
+    }
+
+    Status removeMemoryBuffer(BufferDesc& /*desc*/) override {
+        return Status::OK();
+    }
+
+    Status allocateLocalMemory(void** addr, size_t size,
+                               MemoryOptions& /*options*/) override {
+        *addr = std::malloc(size);
+        if (!*addr) return Status::InternalError("malloc failed" LOC_MARK);
+        return Status::OK();
+    }
+
+    Status freeLocalMemory(void* addr, size_t /*size*/) override {
+        std::free(addr);
+        return Status::OK();
+    }
+
+    bool warmupMemory(void* /*addr*/, size_t /*length*/) override {
+        return false;  // no pinning; engine will fall back to its own path
+    }
+
+    const char* getName() const override {
+        return self_type_ == RDMA ? "<fake-rdma>" : "<fake-tcp>";
+    }
+
+   private:
+    TransportType self_type_;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+std::shared_ptr<Config> makeMinimalP2PConfig() {
+    auto cfg = std::make_shared<Config>();
+    // p2p metadata avoids needing an external redis/etcd/http server.
+    cfg->set("metadata_type", "p2p");
+    cfg->set("metadata_servers", "");
+    cfg->set("rpc_server_hostname", "127.0.0.1");
+    cfg->set("rpc_server_port", "0");
+    cfg->set("log_level", "warning");
+    cfg->set("merge_requests", false);
+
+    // Disable every real transport. We'll inject fakes into the slots we care
+    // about via swapTransportForTest.
+    cfg->set("transports/tcp/enable", false);
+    cfg->set("transports/shm/enable", false);
+    cfg->set("transports/rdma/enable", false);
+    cfg->set("transports/io_uring/enable", false);
+    cfg->set("transports/nvlink/enable", false);
+    cfg->set("transports/mnnvl/enable", false);
+    cfg->set("transports/gds/enable", false);
+    cfg->set("transports/ascend_direct/enable", false);
+
+    // Keep failover limit at default (3) but make it explicit.
+    cfg->set("max_failover_attempts", 3);
+    return cfg;
+}
+
+// Wait for a task to leave PENDING. Bounded so tests fail fast.
+TransferStatus pollUntilDone(
+    TransferEngineImpl& engine, BatchID batch_id, size_t task_id,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(2000)) {
+    TransferStatus ts{};
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        ts = {};
+        auto s = engine.getTransferStatus(batch_id, task_id, ts);
+        if (!s.ok()) {
+            ADD_FAILURE() << "getTransferStatus returned error: "
+                          << s.ToString();
+            return ts;
+        }
+        if (ts.s == TransferStatusEnum::COMPLETED ||
+            ts.s == TransferStatusEnum::FAILED) {
+            return ts;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return ts;
+}
+
+// ---------------------------------------------------------------------------
+// P0: Completion reports FAILED (simulates WC error / QP error / peer drop
+// mid-transfer). Engine must failover.
+// ---------------------------------------------------------------------------
+
+TEST(EngineFailoverE2E, StatusCorruptionTriggersFailoverToSecondary) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+
+    FaultPolicy rdma_policy;
+    rdma_policy.status_corrupt_rate = 1.0;  // every COMPLETED flipped to FAILED
+    auto proxied_rdma =
+        std::make_shared<FaultProxyTransport>(fake_rdma, rdma_policy);
+
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(proxied_rdma->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg_name, nullptr, nullptr).ok());
+
+    engine.swapTransportForTest(RDMA, proxied_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0xCD);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(8);
+    ASSERT_NE(batch_id, (BatchID)0);
+
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+    req.length = kBufLen;
+
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {req}).ok());
+
+    auto final_status = pollUntilDone(engine, batch_id, 0);
+    EXPECT_EQ(final_status.s, TransferStatusEnum::COMPLETED);
+
+    // RDMA saw exactly one submit (succeeded on the wire), then its status
+    // was corrupted; engine failed over.
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+    EXPECT_GE(fake_tcp->submit_calls.load(), 1);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// P1b: Both transports keep failing at status stage -> failover limit reached.
+// ---------------------------------------------------------------------------
+
+TEST(EngineFailoverE2E, BothTransportsFailExhaustsFailoverBudget) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("max_failover_attempts", 2);  // tighten budget
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+
+    FaultPolicy always_corrupt;
+    always_corrupt.status_corrupt_rate = 1.0;
+
+    auto proxied_rdma =
+        std::make_shared<FaultProxyTransport>(fake_rdma, always_corrupt);
+    auto proxied_tcp =
+        std::make_shared<FaultProxyTransport>(fake_tcp, always_corrupt);
+
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(proxied_rdma->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(proxied_tcp->install(seg_name, nullptr, nullptr).ok());
+
+    engine.swapTransportForTest(RDMA, proxied_rdma);
+    engine.swapTransportForTest(TCP, proxied_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0xEF);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(8);
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+    req.length = kBufLen;
+
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {req}).ok());
+
+    auto final_status = pollUntilDone(engine, batch_id, 0);
+    EXPECT_EQ(final_status.s, TransferStatusEnum::FAILED)
+        << "after exhausting failover budget, task must be permanently FAILED";
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// PerRequestFaultProxy
+//
+// FaultProxyTransport corrupts completions uniformly based on a rate. For
+// tests that need per-request control (e.g. "fail task0 but not task1"),
+// this subclass inspects each Request at submit time, records the sub_task
+// indices of "poisoned" requests, and flips only those from COMPLETED to
+// FAILED in getTransferStatus(). Completions for non-poisoned requests
+// pass through unchanged. Submit is never rejected.
+//
+// Tests submit each request in its own one-request batch, so the engine's
+// failover logic routes each task individually.
+// ---------------------------------------------------------------------------
+
+class PerRequestFaultProxy : public FaultProxyTransport {
+   public:
+    using Predicate = std::function<bool(const Request&)>;
+
+    PerRequestFaultProxy(std::shared_ptr<Transport> real, Predicate pred)
+        : FaultProxyTransport(std::move(real), FaultPolicy{}),
+          should_fail_(std::move(pred)) {}
+
+    Status submitTransferTasks(
+        SubBatchRef batch, const std::vector<Request>& request_list) override {
+        // Remember (sub_batch, sub_task_id) pairs for "poisoned" requests
+        // so getTransferStatus() can flip only those to FAILED later. The
+        // sub_batch pointer must be part of the key: different engine
+        // batches (BatchID) have different SubBatchRefs per transport, so
+        // sub_task_id=0 in batch A is a different task than sub_task_id=0
+        // in batch B. Keying only on sub_task_id would cross-contaminate.
+        const int base = static_cast<int>(batch->size());
+        for (size_t i = 0; i < request_list.size(); ++i) {
+            if (should_fail_(request_list[i])) {
+                poisoned_.insert({batch, base + static_cast<int>(i)});
+            }
+        }
+        return FaultProxyTransport::submitTransferTasks(batch, request_list);
+    }
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override {
+        auto s = FaultProxyTransport::getTransferStatus(batch, task_id, status);
+        if (!s.ok()) return s;
+        if (poisoned_.count({batch, task_id}) &&
+            status.s == TransferStatusEnum::COMPLETED) {
+            status.s = TransferStatusEnum::FAILED;
+        }
+        return s;
+    }
+
+   private:
+    Predicate should_fail_;
+    std::set<std::pair<SubBatchRef, int>> poisoned_;
+};
+
+// ---------------------------------------------------------------------------
+// A: Mixed faults across many independent single-request submissions.
+//
+// Submit 10 one-request batches. For each submission, RDMA's completion
+// reports FAILED with 30% probability. Assert every task ultimately
+// COMPLETES and that RDMA/TCP submit counts add up consistently: every
+// failed RDMA completion must be followed by a TCP success.
+// ---------------------------------------------------------------------------
+
+TEST(EngineFailoverE2E, MixedFaultsAcrossManySubmissions) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+
+    FaultPolicy rdma_policy;
+    rdma_policy.status_corrupt_rate = 0.3;  // 30% of completions flip to FAILED
+    auto proxied_rdma =
+        std::make_shared<FaultProxyTransport>(fake_rdma, rdma_policy);
+
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(proxied_rdma->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, proxied_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    constexpr int kNumTasks = 10;
+    std::vector<uint8_t> buf(kBufLen * kNumTasks, 0x77);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    std::vector<BatchID> batches;
+    batches.reserve(kNumTasks);
+    for (int i = 0; i < kNumTasks; ++i) {
+        BatchID b = engine.allocateBatch(1);
+        ASSERT_NE(b, (BatchID)0);
+
+        Request req;
+        req.opcode = Request::WRITE;
+        req.source = buf.data() + (size_t)i * kBufLen;
+        req.target_id = LOCAL_SEGMENT_ID;
+        req.target_offset = reinterpret_cast<uint64_t>(req.source);
+        req.length = kBufLen;
+
+        ASSERT_TRUE(engine.submitTransfer(b, {req}).ok());
+        batches.push_back(b);
+    }
+
+    int completed = 0;
+    for (int i = 0; i < kNumTasks; ++i) {
+        auto ts = pollUntilDone(engine, batches[i], 0);
+        EXPECT_EQ(ts.s, TransferStatusEnum::COMPLETED)
+            << "task " << i << " did not complete";
+        if (ts.s == TransferStatusEnum::COMPLETED) ++completed;
+    }
+    EXPECT_EQ(completed, kNumTasks);
+
+    // Sanity on submit counts under status-corruption injection:
+    //   - Every task hits RDMA at submit time (submit itself succeeds,
+    //     the proxy only corrupts getTransferStatus), so rdma_ok == kNumTasks.
+    //   - A corrupted completion triggers a TCP failover (+1 tcp).
+    //     A clean completion stays on RDMA (+0 tcp).
+    //   - Therefore tcp_ok equals the number of corrupted completions,
+    //     which is in [0, kNumTasks].
+    const int rdma_ok = fake_rdma->submit_calls.load();
+    const int tcp_ok = fake_tcp->submit_calls.load();
+    EXPECT_EQ(rdma_ok, kNumTasks)
+        << "every task must attempt RDMA first (submit is always accepted)";
+    EXPECT_GE(tcp_ok, 0);
+    EXPECT_LE(tcp_ok, kNumTasks);
+
+    // With 30% corruption rate over 10 tasks, both branches are exercised
+    // with overwhelming probability (0.7^10 ~= 2.8% no failover; 0.3^10 ~=
+    // 6e-6 all failover). We don't assert strict counts because this is
+    // rate-based.
+
+    for (auto b : batches) EXPECT_TRUE(engine.freeBatch(b).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
+// ---------------------------------------------------------------------------
+// C1: max_failover_attempts = 0 disables failover entirely.
+//
+// resubmitTransferTask bumps failover_count and compares it against the
+// budget before anything else. With budget=0, the very first attempted
+// failover is rejected (++count == 1 > 0), so a single RDMA fault must
+// result in a permanently FAILED task without touching TCP.
+// ---------------------------------------------------------------------------
+
+TEST(EngineFailoverE2E, MaxFailoverAttemptsZeroDisablesFailover) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("max_failover_attempts", 0);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+
+    FaultPolicy always_fail;
+    always_fail.status_corrupt_rate = 1.0;  // every completion flips to FAILED
+    auto proxied_rdma =
+        std::make_shared<FaultProxyTransport>(fake_rdma, always_fail);
+
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(proxied_rdma->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, proxied_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0x11);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(1);
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+    req.length = kBufLen;
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {req}).ok());
+
+    auto ts = pollUntilDone(engine, batch_id, 0);
+    EXPECT_EQ(ts.s, TransferStatusEnum::FAILED)
+        << "with budget=0 the first fault must be permanent";
+
+    // TCP must never have been touched: budget=0 means no failover attempt.
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// C2: max_failover_attempts = 1 allows exactly one failover.
+//
+// RDMA submit fails -> engine spends its single budget to switch to TCP
+// -> TCP succeeds -> task COMPLETES. A symmetric run where *both* fake
+// transports always fail is covered by BothTransportsFailExhaustsFailoverBudget
+// at budget=2; here we just confirm the happy-path boundary.
+
+TEST(EngineFailoverE2E, MaxFailoverAttemptsOneAllowsSingleFailover) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("max_failover_attempts", 1);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+
+    FaultPolicy rdma_fail;
+    rdma_fail.status_corrupt_rate = 1.0;  // every completion flips to FAILED
+    auto proxied_rdma =
+        std::make_shared<FaultProxyTransport>(fake_rdma, rdma_fail);
+
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(proxied_rdma->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, proxied_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0x22);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(1);
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+    req.length = kBufLen;
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {req}).ok());
+
+    auto ts = pollUntilDone(engine, batch_id, 0);
+    EXPECT_EQ(ts.s, TransferStatusEnum::COMPLETED)
+        << "budget=1 must permit exactly one failover to TCP";
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 1);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// D: Tasks in the same logical workload maintain independent failover
+//    state.
+//
+// Workload is two submissions:
+//   - task0: RDMA *and* TCP always fail -> must end FAILED
+//   - task1: RDMA succeeds              -> must end COMPLETED, no TCP hit
+//
+// This pins down that one task's exhausted failover budget does not
+// "infect" another task: the engine must track failover_count per-task,
+// not per-batch, per-transport, or per-engine. A regression that made
+// the counter global or batch-scoped would flip task1 to FAILED or
+// trigger a spurious TCP submit.
+//
+// Uses PerRequestFaultProxy so we can make RDMA fail *only* for the
+// specific buffer address of task0.
+// ---------------------------------------------------------------------------
+
+TEST(EngineFailoverE2E, PerTaskFailoverCountsAreIndependent) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf0(kBufLen, 0xAA);
+    std::vector<uint8_t> buf1(kBufLen, 0xBB);
+
+    const uint64_t failing_addr = reinterpret_cast<uint64_t>(buf0.data());
+
+    auto proxied_rdma = std::make_shared<PerRequestFaultProxy>(
+        fake_rdma, [failing_addr](const Request& r) {
+            return r.target_offset == failing_addr;
+        });
+    auto proxied_tcp = std::make_shared<PerRequestFaultProxy>(
+        fake_tcp, [failing_addr](const Request& r) {
+            return r.target_offset == failing_addr;
+        });
+
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(proxied_rdma->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(proxied_tcp->install(seg_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, proxied_rdma);
+    engine.swapTransportForTest(TCP, proxied_tcp);
+
+    ASSERT_TRUE(engine.registerLocalMemory(buf0.data(), kBufLen).ok());
+    ASSERT_TRUE(engine.registerLocalMemory(buf1.data(), kBufLen).ok());
+
+    auto submit = [&](uint8_t* source) -> BatchID {
+        BatchID b = engine.allocateBatch(1);
+        EXPECT_NE(b, (BatchID)0);
+        Request req;
+        req.opcode = Request::WRITE;
+        req.source = source;
+        req.target_id = LOCAL_SEGMENT_ID;
+        req.target_offset = reinterpret_cast<uint64_t>(source);
+        req.length = kBufLen;
+        EXPECT_TRUE(engine.submitTransfer(b, {req}).ok());
+        return b;
+    };
+
+    BatchID b0 = submit(buf0.data());  // must FAIL on both
+    BatchID b1 = submit(buf1.data());  // must SUCCEED on RDMA
+
+    auto ts0 = pollUntilDone(engine, b0, 0);
+    auto ts1 = pollUntilDone(engine, b1, 0);
+
+    EXPECT_EQ(ts0.s, TransferStatusEnum::FAILED)
+        << "task0 should exhaust all transports and end FAILED";
+    EXPECT_EQ(ts1.s, TransferStatusEnum::COMPLETED)
+        << "task1 must be unaffected by task0's failover exhaustion";
+
+    // Under status-corruption injection submits always succeed; the proxy
+    // corrupts only getTransferStatus. So both tasks hit RDMA at submit
+    // (rdma +2). task0's RDMA completion is corrupted -> failover to TCP
+    // -> TCP submit (+1), also corrupted -> no more transports -> FAILED.
+    // task1 completes cleanly on RDMA with no TCP touch.
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 2);
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 1);
+
+    EXPECT_TRUE(engine.freeBatch(b0).ok());
+    EXPECT_TRUE(engine.freeBatch(b1).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf0.data(), kBufLen).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf1.data(), kBufLen).ok());
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/rail_monitor_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rail_monitor_test.cpp
@@ -1,0 +1,194 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+
+#include "tent/common/config.h"
+#include "tent/transport/rdma/rail_monitor.h"
+#include "tent/runtime/topology.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal single-NIC Topology via Topology::parse().
+//
+// JSON keys expected by parse(): "nics" / "mems"
+// NicType enum:  NIC_RDMA=0, NIC_TCP=1, NIC_UNKNOWN=2
+// MemType enum:  MEM_HOST=0, MEM_CUDA=1, ...
+// device_list keys: "rank0", "rank1", ...
+// ---------------------------------------------------------------------------
+
+static std::shared_ptr<Topology> makeSingleNicTopology(const std::string& nic,
+                                                       int numa_node = 0) {
+    // One RDMA NIC (type=0) and one CUDA mem region (type=1) referencing it.
+    auto json_str = R"({
+        "nics": [{"name": ")" +
+                    nic + R"(", "type": 0, "numa_node": )" +
+                    std::to_string(numa_node) + R"(}],
+        "mems": [{
+            "name": "cuda0",
+            "type": 1,
+            "numa_node": )" +
+                    std::to_string(numa_node) +
+                    R"(,
+            "device_list": {"rank0": [0]}
+        }]
+    })";
+    auto topo = std::make_shared<Topology>();
+    auto status = topo->parse(json_str);
+    if (!status.ok()) {
+        ADD_FAILURE() << "Topology::parse failed: " << status.ToString();
+    }
+    return topo;
+}
+
+// ---------------------------------------------------------------------------
+// markRecovered resets error_count so failures start accumulating fresh
+// ---------------------------------------------------------------------------
+
+TEST(RailMonitorRecoverTest, RecoverResetsErrorCount) {
+    auto local = makeSingleNicTopology("mlx5_0");
+    auto remote = makeSingleNicTopology("mlx5_1");
+    RailMonitor rail;
+    ASSERT_TRUE(rail.load(local.get(), remote.get()).ok());
+    ASSERT_TRUE(rail.ready());
+
+    // Initially available
+    EXPECT_TRUE(rail.available(0, 0));
+
+    // One failure — not yet past default threshold (3)
+    rail.markFailed(0, 0);
+    EXPECT_TRUE(rail.available(0, 0));  // error_count=1, not paused
+
+    // A successful transfer — reset error_count back to 0
+    rail.markRecovered(0, 0);
+    EXPECT_TRUE(rail.available(0, 0));
+
+    // Failure again — counter starts fresh from 0, one hit is not enough
+    rail.markFailed(0, 0);
+    EXPECT_TRUE(rail.available(0, 0));
+}
+
+// ---------------------------------------------------------------------------
+// markRecovered un-pauses a rail that reached the failure threshold
+// ---------------------------------------------------------------------------
+
+TEST(RailMonitorRecoverTest, RecoverUnpausesPausedRail) {
+    auto local = makeSingleNicTopology("mlx5_0");
+    auto remote = makeSingleNicTopology("mlx5_1");
+    RailMonitor rail;
+    ASSERT_TRUE(rail.load(local.get(), remote.get()).ok());
+
+    // Drive error_count to the default threshold (3) to trigger pause
+    for (int i = 0; i < 3; ++i) rail.markFailed(0, 0);
+    EXPECT_FALSE(rail.available(0, 0))
+        << "Rail should be paused after 3 failures";
+
+    // A successful transfer proves the path is live — should un-pause
+    // immediately
+    rail.markRecovered(0, 0);
+    EXPECT_TRUE(rail.available(0, 0))
+        << "Rail should be available after recovery";
+}
+
+// ---------------------------------------------------------------------------
+// markRecovered on an unknown NIC pair is a no-op (no crash / no assert)
+// ---------------------------------------------------------------------------
+
+TEST(RailMonitorRecoverTest, RecoverUnknownPairIsNoop) {
+    auto local = makeSingleNicTopology("mlx5_0");
+    auto remote = makeSingleNicTopology("mlx5_1");
+    RailMonitor rail;
+    ASSERT_TRUE(rail.load(local.get(), remote.get()).ok());
+
+    // NIC IDs 5 and 7 are not in the topology — must not crash
+    EXPECT_NO_FATAL_FAILURE(rail.markRecovered(5, 7));
+}
+
+// ---------------------------------------------------------------------------
+// After recovery, findBestRemoteDevice maps back to the (only) available rail
+// ---------------------------------------------------------------------------
+
+TEST(RailMonitorRecoverTest, FindBestAfterRecovery) {
+    auto local = makeSingleNicTopology("mlx5_0");
+    auto remote = makeSingleNicTopology("mlx5_1");
+    RailMonitor rail;
+    ASSERT_TRUE(rail.load(local.get(), remote.get()).ok());
+
+    // Pause the only available rail
+    for (int i = 0; i < 3; ++i) rail.markFailed(0, 0);
+    EXPECT_FALSE(rail.available(0, 0));
+
+    // Recovery must rebuild best_mapping so findBestRemoteDevice works again
+    rail.markRecovered(0, 0);
+    EXPECT_TRUE(rail.available(0, 0));
+    int best = rail.findBestRemoteDevice(/*local_nic=*/0, /*remote_numa=*/0);
+    EXPECT_EQ(best, 0) << "Recovered rail should be the best remote device";
+}
+
+// ---------------------------------------------------------------------------
+// After recovery, the cooldown on the next pause must start from the
+// configured initial value, not a doubled value left over from the
+// previous cycle.
+//
+// Uses error_threshold=1 and cooldown=1s so each single failure triggers
+// a pause. If cooldown is correctly reset on recovery, the second pause
+// expires in ~1s; if the cooldown had carried over (bug), the second
+// pause would expire in ~2s.
+// ---------------------------------------------------------------------------
+
+TEST(RailMonitorRecoverTest, CooldownDoesNotCarryOverAfterRecovery) {
+    auto local = makeSingleNicTopology("mlx5_0");
+    auto remote = makeSingleNicTopology("mlx5_1");
+
+    Config cfg;
+    cfg.set(RailMonitor::kCfgErrorThreshold, 1);    // pause on first failure
+    cfg.set(RailMonitor::kCfgErrorWindowSecs, 60);  // wide: no window resets
+    cfg.set(RailMonitor::kCfgCooldownSecs, 1);      // small initial cooldown
+
+    RailMonitor rail;
+    ASSERT_TRUE(rail.load(local.get(), remote.get(), "", &cfg).ok());
+
+    // First pause cycle: single failure arms resume_time at now+1s.
+    rail.markFailed(0, 0);
+    EXPECT_FALSE(rail.available(0, 0));
+
+    // Recover: must clear st.cooldown so the next pause uses 1s again,
+    // not the 1s left over from cycle 1 (which would double to 2s).
+    rail.markRecovered(0, 0);
+    EXPECT_TRUE(rail.available(0, 0));
+
+    // Second pause cycle: single failure must arm resume_time at now+1s.
+    rail.markFailed(0, 0);
+    EXPECT_FALSE(rail.available(0, 0));
+
+    // Wait 1.5s: longer than the initial 1s cooldown, shorter than the
+    // 2s value the bug would produce. If cooldown was correctly reset on
+    // recovery, available() returns true; if it carried over, available()
+    // stays false until ~2s elapses.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    EXPECT_TRUE(rail.available(0, 0))
+        << "After recovery, the next pause must use the initial cooldown "
+           "(1s); staying paused past 1.5s indicates cooldown carried over "
+           "from the previous cycle.";
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

TENT's `RailMonitor` pauses a rail after repeated failures but never un-pauses it, so a transient RDMA issue permanently excludes the rail from scheduling. This PR closes that loop and adds end-to-end coverage for the broader cross-transport failover path.

- **Rail recovery.** Un-pause a cooled-down rail both (a) on a successful transfer (`markRecovered` from the RDMA worker hot path) and (b) on cooldown expiry (inside `available()`). Both paths also reset the exponential-backoff memory so the next failure cycle starts from the initial cooldown, not a doubled value carried over from the previous cycle.
- **Configurable thresholds.** `rail_error_threshold`, `rail_error_window_secs`, and `rail_cooldown_secs` are now read from `Config` instead of hard-coded, with an upper bound (`kMaxCooldown = 300s`) on the exponential backoff.
- **E2E tests.** `engine_failover_e2e_test.cpp` drives the real `TransferEngineImpl` (not a mock) through `submitTransfer` / `getTransferStatus` / `resubmitTransferTask` with `FaultProxyTransport`- wrapped fake transports. Self-contained (p2p metadata on 127.0.0.1, `USE_CUDA=OFF`), so no external services or GPU are required. Not wired into CI — upstream still builds with `USE_TENT=OFF`.
- **Design doc.** `docs/source/design/tent/failover.md` describes both layers (cross-transport failover + per-rail cooldown), config knobs, observability, and known gaps (why submit-stage failover is not retried today).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

Built locally with `cmake -S . -B build-tent -DUSE_TENT=ON -DUSE_CUDA=OFF`
and ran the relevant test targets:

- `tent_rail_monitor_test` — unit tests covering recovery on success, recovery on cooldown expiry, that the cooldown does not carry over across recovery cycles, and that `findBestRemoteDevice` still works after a rail is recovered.
- `tent_engine_failover_e2e_test` — six end-to-end cases driving the real `TransferEngineImpl`:
  - `StatusCorruptionTriggersFailoverToSecondary`
  - `BothTransportsFailExhaustsFailoverBudget`
  - `MixedFaultsAcrossManySubmissions` (10 batches, 30% corruption)
  - `MaxFailoverAttemptsZeroDisablesFailover`
  - `MaxFailoverAttemptsOneAllowsSingleFailover`
  - `PerTaskFailoverCountsAreIndependent`

Both binaries green. CI does not exercise these — upstream builds with `USE_TENT=OFF`; see the "Known Gaps" section of `failover.md`.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.