### PR TITLE
[transfer_engine] feat: make RDMA QP pkey_index configurable via MC_PKEY_INDEX

### DIFF
--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -276,6 +276,7 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_IB_TC` Adjust RDMA NIC Traffic Class when switch/NIC defaults differ or for traffic planning. Default value -1
 - `MC_IB_PCI_RELAXED_ORDERING` Setting the PCIe ordering to relaxed for the network adapter sometimes results in better performance. Can set 1 to enable RO function. Default value 0
 - `MC_GID_INDEX` The GID index used per device instance, default value 3 (or the maximum value supported by the platform)
+- `MC_PKEY_INDEX` The QP `pkey_index` (partition key table index) used when transitioning the QP to the INIT state. Valid range: 0 to 65535. Default value 0. Set this when the partition key required for your fabric is not at index 0 of the HCA's pkey table
 - `MC_MAX_CQE_PER_CTX` The CQ buffer size per device instance, default value 4096
 - `MC_MAX_EP_PER_CTX` The maximum number of active EndPoint per device instance, default value 65536. **Note:** For versions prior to 0.3.7.post1, the default value is 256, and it cannot be manually set to 65536. The maximum supported value is 65535!
 - `MC_NUM_QP_PER_EP` The number of QPs per EndPoint, the more the number, the better the fine-grained I/O performance, default value 2

--- a/docs/source/zh_archive/transfer-engine.md
+++ b/docs/source/zh_archive/transfer-engine.md
@@ -396,6 +396,7 @@ int init(const std::string &metadata_conn_string,
 - `MC_IB_TC` 当使用`RDMA`通信协议时，在交换机和网卡默认配置不一致场景/需要流量规划场景下，可能需要修改 RDMA 网卡的 Traffic Class 配置，默认值 -1
 - `MC_IB_PCI_RELAXED_ORDERING` 将网络适配器的PCIe顺序设置为放宽有时会带来更好的性能。可设置 1 以启用RO功能，默认值 0
 - `MC_GID_INDEX` 每个设备实例使用的 GID 序号，默认值 3（或平台支持的最大值）
+- `MC_PKEY_INDEX` QP 转换到 INIT 状态时使用的 `pkey_index`（partition key 表索引）。有效范围：0 到 65535，默认值 0。当 fabric 所需的 partition key 不在 HCA pkey 表的 0 号位置时需要设置该值
 - `MC_MAX_CQE_PER_CTX` 每个设备实例中 CQ 缓冲区大小，默认值 4096
 - `MC_MAX_EP_PER_CTX` 每个设备实例中活跃 EndPoint 数量上限，默认值 65536。**注意：** 小于 0.3.7.post1 的版本，这里默认值是 256，但是无法手动设置为 65536，最大值支持 65535！请注意
 - `MC_NUM_QP_PER_EP` 每个 EndPoint 中 QP 数量，数量越多则细粒度 I/O 性能越好，默认值 2

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -34,7 +34,7 @@ struct GlobalConfig {
     size_t num_cq_per_ctx = 1;
     size_t num_comp_channels_per_ctx = 1;
     uint8_t port = 1;
-    int gid_index = -1;  // -1 for auto-selection, >=0 for user-specified
+    int gid_index = -1;       // -1 for auto-selection, >=0 for user-specified
     uint16_t pkey_index = 0;  // QP attr.pkey_index; override via MC_PKEY_INDEX
     uint64_t max_mr_size = 0x10000000000;
     size_t max_cqe = 4096;

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -35,6 +35,7 @@ struct GlobalConfig {
     size_t num_comp_channels_per_ctx = 1;
     uint8_t port = 1;
     int gid_index = -1;  // -1 for auto-selection, >=0 for user-specified
+    uint16_t pkey_index = 0;  // QP attr.pkey_index; override via MC_PKEY_INDEX
     uint64_t max_mr_size = 0x10000000000;
     size_t max_cqe = 4096;
     int max_ep_per_ctx = 65536;

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -69,12 +69,20 @@ void loadGlobalConfig(GlobalConfig& config) {
 
     const char* pkey_index_env = std::getenv("MC_PKEY_INDEX");
     if (pkey_index_env) {
-        int val = atoi(pkey_index_env);
-        if (val >= 0 && val <= UINT16_MAX)
-            config.pkey_index = static_cast<uint16_t>(val);
-        else
-            LOG(WARNING)
-                << "Ignore value from environment variable MC_PKEY_INDEX";
+        try {
+            int val = std::stoi(pkey_index_env);
+            if (val >= 0 && val <= UINT16_MAX) {
+                config.pkey_index = static_cast<uint16_t>(val);
+            } else {
+                LOG(WARNING)
+                    << "Ignore value from environment variable MC_PKEY_INDEX, "
+                    << "value " << pkey_index_env
+                    << " out of range (should be 0-65535)";
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "Invalid MC_PKEY_INDEX environment value: "
+                         << pkey_index_env << ". Error: " << e.what();
+        }
     }
 
     const char* max_cqe_per_ctx_env = std::getenv("MC_MAX_CQE_PER_CTX");

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -67,6 +67,16 @@ void loadGlobalConfig(GlobalConfig& config) {
                 << "Ignore value from environment variable MC_GID_INDEX";
     }
 
+    const char* pkey_index_env = std::getenv("MC_PKEY_INDEX");
+    if (pkey_index_env) {
+        int val = atoi(pkey_index_env);
+        if (val >= 0 && val <= UINT16_MAX)
+            config.pkey_index = static_cast<uint16_t>(val);
+        else
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_PKEY_INDEX";
+    }
+
     const char* max_cqe_per_ctx_env = std::getenv("MC_MAX_CQE_PER_CTX");
     if (max_cqe_per_ctx_env) {
         size_t val = atoi(max_cqe_per_ctx_env);

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -417,6 +417,7 @@ void dumpGlobalConfig() {
               << config.num_comp_channels_per_ctx;
     LOG(INFO) << "port = " << config.port;
     LOG(INFO) << "gid_index = " << config.gid_index;
+    LOG(INFO) << "pkey_index = " << config.pkey_index;
     LOG(INFO) << "max_mr_size = " << config.max_mr_size;
     LOG(INFO) << "max_cqe = " << config.max_cqe;
     LOG(INFO) << "max_ep_per_ctx = " << config.max_ep_per_ctx;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -589,7 +589,7 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const std::string &peer_gid,
     memset(&attr, 0, sizeof(attr));
     attr.qp_state = IBV_QPS_INIT;
     attr.port_num = context_.portNum();
-    attr.pkey_index = 0;
+    attr.pkey_index = globalConfig().pkey_index;
     attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
                            IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_ATOMIC;
     ret = ibv_modify_qp(

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -110,6 +110,10 @@ add_executable(common_test ${WORKSPACE}/common_test.cpp)
 target_link_libraries(common_test PUBLIC transfer_engine gtest gtest_main)
 add_test(NAME common_test COMMAND common_test)
 
+add_executable(config_test ${WORKSPACE}/config_test.cpp)
+target_link_libraries(config_test PUBLIC transfer_engine gtest gtest_main)
+add_test(NAME config_test COMMAND config_test)
+
 if (USE_ASCEND_DIRECT)
     # AscendDirectTransport unit test with mock implementations
     # Mock implementations are included in the test file via anonymous namespace

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -110,10 +110,6 @@ add_executable(common_test ${WORKSPACE}/common_test.cpp)
 target_link_libraries(common_test PUBLIC transfer_engine gtest gtest_main)
 add_test(NAME common_test COMMAND common_test)
 
-add_executable(config_test ${WORKSPACE}/config_test.cpp)
-target_link_libraries(config_test PUBLIC transfer_engine gtest gtest_main)
-add_test(NAME config_test COMMAND config_test)
-
 if (USE_ASCEND_DIRECT)
     # AscendDirectTransport unit test with mock implementations
     # Mock implementations are included in the test file via anonymous namespace

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -64,14 +64,19 @@ TEST_F(PkeyIndexEnvTest, NegativeIsIgnored) {
 }
 
 TEST_F(PkeyIndexEnvTest, NonNumericKeepsDefault) {
-    // atoi() parses "abc" as 0, which is in range — so the override
-    // succeeds and lands at 0. Pinning this behavior catches accidental
-    // changes to the parser.
     ASSERT_EQ(::setenv("MC_PKEY_INDEX", "abc", 1), 0);
     GlobalConfig config;
     config.pkey_index = 9;
     loadGlobalConfig(config);
-    EXPECT_EQ(config.pkey_index, 0);
+    EXPECT_EQ(config.pkey_index, 9);
+}
+
+TEST_F(PkeyIndexEnvTest, EmptyStringKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_PKEY_INDEX", "", 1), 0);
+    GlobalConfig config;
+    config.pkey_index = 4;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.pkey_index, 4);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -1,0 +1,78 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "config.h"
+
+namespace mooncake {
+namespace {
+
+class PkeyIndexEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_PKEY_INDEX"); }
+};
+
+TEST_F(PkeyIndexEnvTest, DefaultIsZeroWhenUnset) {
+    ::unsetenv("MC_PKEY_INDEX");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.pkey_index, 0);
+}
+
+TEST_F(PkeyIndexEnvTest, ValidOverrideIsApplied) {
+    ASSERT_EQ(::setenv("MC_PKEY_INDEX", "7", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.pkey_index, 7);
+}
+
+TEST_F(PkeyIndexEnvTest, MaxBoundaryIsApplied) {
+    ASSERT_EQ(::setenv("MC_PKEY_INDEX", "65535", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.pkey_index, 65535);
+}
+
+TEST_F(PkeyIndexEnvTest, OutOfRangeIsIgnored) {
+    ASSERT_EQ(::setenv("MC_PKEY_INDEX", "70000", 1), 0);
+    GlobalConfig config;
+    config.pkey_index = 3;  // sentinel preserved when env var is rejected
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.pkey_index, 3);
+}
+
+TEST_F(PkeyIndexEnvTest, NegativeIsIgnored) {
+    ASSERT_EQ(::setenv("MC_PKEY_INDEX", "-1", 1), 0);
+    GlobalConfig config;
+    config.pkey_index = 5;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.pkey_index, 5);
+}
+
+TEST_F(PkeyIndexEnvTest, NonNumericKeepsDefault) {
+    // atoi() parses "abc" as 0, which is in range — so the override
+    // succeeds and lands at 0. Pinning this behavior catches accidental
+    // changes to the parser.
+    ASSERT_EQ(::setenv("MC_PKEY_INDEX", "abc", 1), 0);
+    GlobalConfig config;
+    config.pkey_index = 9;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.pkey_index, 0);
+}
+
+}  // namespace
+}  // namespace mooncake


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Previously the QP attr.pkey_index was hardcoded to 0 during connection setup, which prevented use of non-default partition keys. Add a pkey_index field to GlobalConfig (default 0) that can be overridden through the MC_PKEY_INDEX environment variable, and apply it when transitioning the QP to INIT state.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->
I patched this change to sglang:deepseek-v4 to setup PD disagg

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
