### PR TITLE
[Store] fix(test): avoid in-process master port collisions

### DIFF
--- a/mooncake-store/tests/test_server_helpers.h
+++ b/mooncake-store/tests/test_server_helpers.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdlib>
 #include <memory>
 #include <optional>
+#include <vector>
 #include <string>
 #include <thread>
 #include <csignal>
@@ -35,17 +37,44 @@ class InProcMaster {
             int needed = (!config.rpc_port.has_value()) +
                          (!config.http_metrics_port.has_value()) +
                          (!config.http_metadata_port.has_value());
-            auto free_ports = getFreeTcpPorts(needed);
-            if (static_cast<int>(free_ports.size()) < needed) return false;
+            std::vector<int> available_ports;
+            if (needed > 0) {
+                std::vector<int> reserved_ports;
+                if (config.rpc_port.has_value()) {
+                    reserved_ports.push_back(config.rpc_port.value());
+                }
+                if (config.http_metrics_port.has_value()) {
+                    reserved_ports.push_back(config.http_metrics_port.value());
+                }
+                if (config.http_metadata_port.has_value()) {
+                    reserved_ports.push_back(config.http_metadata_port.value());
+                }
+                auto free_ports = getFreeTcpPorts(
+                    needed + static_cast<int>(reserved_ports.size()));
+                available_ports.reserve(needed);
+                for (int port : free_ports) {
+                    if (std::find(reserved_ports.begin(), reserved_ports.end(),
+                                  port) == reserved_ports.end()) {
+                        available_ports.push_back(port);
+                        if (static_cast<int>(available_ports.size()) ==
+                            needed) {
+                            break;
+                        }
+                    }
+                }
+                if (static_cast<int>(available_ports.size()) < needed) {
+                    return false;
+                }
+            }
             int idx = 0;
             rpc_port_ = config.rpc_port.has_value() ? config.rpc_port.value()
-                                                    : free_ports[idx++];
+                                                    : available_ports[idx++];
             http_metrics_port_ = config.http_metrics_port.has_value()
                                      ? config.http_metrics_port.value()
-                                     : free_ports[idx++];
+                                     : available_ports[idx++];
             http_metadata_port_ = config.http_metadata_port.has_value()
                                       ? config.http_metadata_port.value()
-                                      : free_ports[idx++];
+                                      : available_ports[idx++];
 
             // Optional HTTP metadata server
             if (http_metadata_port_ > 0) {


### PR DESCRIPTION
## Description

Fix a flaky CI failure in `TaskExecutorIntegrationTest.DrainJobCompleteFlow`
caused by in-process master test ports colliding.

Observed in CI:
https://github.com/kvcache-ai/Mooncake/actions/runs/24974900238/job/73124856627

`task_integration_test` may provide a preselected `http_metadata_port`, while `InProcMaster::Start()` allocates any missing ports for RPC and master admin HTTP. Because `getFreeTcpPort()` releases the socket immediately, a previously selected metadata port can be returned again when allocating the remaining ports. In CI this caused both the HTTP metadata server and the master admin server to use the same port, making master startup fail.

This change makes `InProcMaster::Start()` track explicitly configured ports as reserved and filter them out when choosing ports for unspecified services.


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- Built and installed locally:

```bash
cmake --build build --target task_integration_test
sudo make install
```

- Ran the affected CI test case locally:

```bash
cd build
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
DEFAULT_KV_LEASE_TTL=500 ./mooncake-store/tests/task_integration_test --gtest_filter='TaskExecutorIntegrationTest.DrainJobCompleteFlow'
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.