### PR TITLE
[Store] Add peer_request metrics for ClientRpcService

### DIFF
--- a/mooncake-store/include/client_rpc_service.h
+++ b/mooncake-store/include/client_rpc_service.h
@@ -4,6 +4,7 @@
 #include <ylt/util/tl/expected.hpp>
 #include "client_rpc_types.h"
 #include "data_manager.h"
+#include "p2p_client_metric.h"
 #include "types.h"
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
 
@@ -24,8 +25,11 @@ class ClientRpcService {
      * @brief Constructor
      * @param data_manager Reference to DataManager instance (must outlive this
      * object)
+     * @param metrics Optional pointer to P2PClientMetric for recording peer
+     * request metrics
      */
-    explicit ClientRpcService(DataManager& data_manager);
+    explicit ClientRpcService(DataManager& data_manager,
+                              P2PClientMetric* metrics = nullptr);
 
     /**
      * @brief Read remote data: Client A requests Client B to read data and
@@ -53,6 +57,7 @@ class ClientRpcService {
 
    private:
     DataManager& data_manager_;  // Reference: owned by Client, same lifetime
+    P2PClientMetric* metrics_;   // Optional: owned by P2PClientService
 };
 
 /**

--- a/mooncake-store/include/p2p_client_metric.h
+++ b/mooncake-store/include/p2p_client_metric.h
@@ -32,6 +32,8 @@ struct RequestMetric {
 struct P2PClientMetric : public ClientMetric {
     // Local request metrics (Get/Put)
     RequestMetric local_request;
+    // Peer request metrics (requests from other clients)
+    RequestMetric peer_request;
 
     /**
      * @brief Creates a P2PClientMetric instance based on environment variables

--- a/mooncake-store/src/client_rpc_service.cpp
+++ b/mooncake-store/src/client_rpc_service.cpp
@@ -5,8 +5,19 @@
 
 namespace mooncake {
 
-ClientRpcService::ClientRpcService(DataManager& data_manager)
-    : data_manager_(data_manager) {}
+namespace {
+
+size_t CalculateBufferSize(const std::vector<RemoteBufferDesc>& buffers) {
+    size_t total = 0;
+    for (const auto& buf : buffers) total += buf.size;
+    return total;
+}
+
+}  // namespace
+
+ClientRpcService::ClientRpcService(DataManager& data_manager,
+                                   P2PClientMetric* metrics)
+    : data_manager_(data_manager), metrics_(metrics) {}
 
 tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
     const RemoteReadRequest& request) {
@@ -14,24 +25,37 @@ tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
     timer.LogRequest("key=", request.key,
                      "buffer_count=", request.dest_buffers.size());
 
+    if (metrics_) {
+        metrics_->peer_request.get_requests.inc();
+    }
+    Stopwatch sw;
+
     if (request.key.empty()) {
         LOG(ERROR) << "ReadRemoteData: empty key";
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        if (metrics_) {
+            metrics_->peer_request.get_failures.inc();
+        }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
     if (request.dest_buffers.empty()) {
         LOG(ERROR) << "ReadRemoteData: empty destination buffers";
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        if (metrics_) {
+            metrics_->peer_request.get_failures.inc();
+        }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    // Validate buffers (segment name validation is done in DataManager)
     for (const auto& buffer_desc : request.dest_buffers) {
         if (buffer_desc.size == 0 || buffer_desc.addr == 0) {
             LOG(ERROR)
                 << "ReadRemoteData: invalid buffer (zero size or null address)";
             timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+            if (metrics_) {
+                metrics_->peer_request.get_failures.inc();
+            }
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
     }
@@ -44,12 +68,25 @@ tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
         LOG(ERROR) << "ReadRemoteData failed for key: " << request.key
                    << ", error: " << toString(result.error());
         timer.LogResponse("error_code=", result.error());
-
-        // Rectify stale route when key not found
         if (result.error() == ErrorCode::OBJECT_NOT_FOUND) {
             data_manager_.RectifyReadRoute(request.key);
+            if (metrics_) {
+                metrics_->peer_request.get_misses.inc();
+            }
+        } else {
+            if (metrics_) {
+                metrics_->peer_request.get_failures.inc();
+            }
         }
         return result;
+    }
+
+    // Record successful get: hits + bytes + latency
+    if (metrics_) {
+        metrics_->peer_request.get_hits.inc();
+        metrics_->peer_request.get_bytes.inc(
+            CalculateBufferSize(request.dest_buffers));
+        metrics_->peer_request.get_latency.observe(sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);
@@ -62,24 +99,37 @@ tl::expected<UUID, ErrorCode> ClientRpcService::WriteRemoteData(
     timer.LogRequest("key=", request.key,
                      "buffer_count=", request.src_buffers.size());
 
+    if (metrics_) {
+        metrics_->peer_request.put_requests.inc();
+    }
+    Stopwatch sw;
+
     if (request.key.empty()) {
         LOG(ERROR) << "WriteRemoteData: empty key";
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        if (metrics_) {
+            metrics_->peer_request.put_failures.inc();
+        }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
     if (request.src_buffers.empty()) {
         LOG(ERROR) << "WriteRemoteData: empty source buffers";
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        if (metrics_) {
+            metrics_->peer_request.put_failures.inc();
+        }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    // Validate buffers (segment name validation is done in DataManager)
     for (const auto& buffer_desc : request.src_buffers) {
         if (buffer_desc.size == 0 || buffer_desc.addr == 0) {
             LOG(ERROR) << "WriteRemoteData: invalid buffer (zero size or null "
                           "address)";
             timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+            if (metrics_) {
+                metrics_->peer_request.put_failures.inc();
+            }
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
     }
@@ -92,7 +142,17 @@ tl::expected<UUID, ErrorCode> ClientRpcService::WriteRemoteData(
         LOG(ERROR) << "WriteRemoteData failed for key: " << request.key
                    << ", error: " << toString(result.error());
         timer.LogResponse("error_code=", result.error());
+        if (metrics_) {
+            metrics_->peer_request.put_failures.inc();
+        }
         return result;
+    }
+
+    // Record successful put: bytes + latency
+    if (metrics_) {
+        metrics_->peer_request.put_bytes.inc(
+            CalculateBufferSize(request.src_buffers));
+        metrics_->peer_request.put_latency.observe(sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);

--- a/mooncake-store/src/client_rpc_service.cpp
+++ b/mooncake-store/src/client_rpc_service.cpp
@@ -13,7 +13,45 @@ size_t CalculateBufferSize(const std::vector<RemoteBufferDesc>& buffers) {
     return total;
 }
 
-}  // namespace
+bool IsValidRequest(const RemoteReadRequest& request) {
+    if (request.key.empty()) {
+        LOG(ERROR) << "RemoteReadRequest: empty key";
+        return false;
+    }
+    if (request.dest_buffers.empty()) {
+        LOG(ERROR) << "RemoteReadRequest: empty buffers";
+        return false;
+    }
+    for (const auto& buf : request.dest_buffers) {
+        if (buf.size == 0 || buf.addr == 0) {
+            LOG(ERROR) << "RemoteReadRequest: invalid buffer (zero size or "
+                          "null address)";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool IsValidRequest(const RemoteWriteRequest& request) {
+    if (request.key.empty()) {
+        LOG(ERROR) << "RemoteWriteRequest: empty key";
+        return false;
+    }
+    if (request.src_buffers.empty()) {
+        LOG(ERROR) << "RemoteWriteRequest: empty buffers";
+        return false;
+    }
+    for (const auto& buf : request.src_buffers) {
+        if (buf.size == 0 || buf.addr == 0) {
+            LOG(ERROR) << "RemoteWriteRequest: invalid buffer (zero size or "
+                          "null address)";
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // anonymous namespace
 
 ClientRpcService::ClientRpcService(DataManager& data_manager,
                                    P2PClientMetric* metrics)
@@ -30,34 +68,12 @@ tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
     }
     Stopwatch sw;
 
-    if (request.key.empty()) {
-        LOG(ERROR) << "ReadRemoteData: empty key";
+    if (!IsValidRequest(request)) {
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
         if (metrics_) {
             metrics_->peer_request.get_failures.inc();
         }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    if (request.dest_buffers.empty()) {
-        LOG(ERROR) << "ReadRemoteData: empty destination buffers";
-        timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
-        if (metrics_) {
-            metrics_->peer_request.get_failures.inc();
-        }
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    for (const auto& buffer_desc : request.dest_buffers) {
-        if (buffer_desc.size == 0 || buffer_desc.addr == 0) {
-            LOG(ERROR)
-                << "ReadRemoteData: invalid buffer (zero size or null address)";
-            timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
-            if (metrics_) {
-                metrics_->peer_request.get_failures.inc();
-            }
-            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-        }
     }
 
     // Delegate to DataManager
@@ -104,34 +120,12 @@ tl::expected<UUID, ErrorCode> ClientRpcService::WriteRemoteData(
     }
     Stopwatch sw;
 
-    if (request.key.empty()) {
-        LOG(ERROR) << "WriteRemoteData: empty key";
+    if (!IsValidRequest(request)) {
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
         if (metrics_) {
             metrics_->peer_request.put_failures.inc();
         }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    if (request.src_buffers.empty()) {
-        LOG(ERROR) << "WriteRemoteData: empty source buffers";
-        timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
-        if (metrics_) {
-            metrics_->peer_request.put_failures.inc();
-        }
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    for (const auto& buffer_desc : request.src_buffers) {
-        if (buffer_desc.size == 0 || buffer_desc.addr == 0) {
-            LOG(ERROR) << "WriteRemoteData: invalid buffer (zero size or null "
-                          "address)";
-            timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
-            if (metrics_) {
-                metrics_->peer_request.put_failures.inc();
-            }
-            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-        }
     }
 
     // Delegate to DataManager

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -53,7 +53,8 @@ std::string RequestMetric::summary_metrics() {
 P2PClientMetric::P2PClientMetric(
     uint64_t interval_seconds, const std::map<std::string, std::string>& labels)
     : ClientMetric(interval_seconds, labels),
-      local_request("mooncake_p2p_local", labels) {}
+      local_request("mooncake_p2p_local", labels),
+      peer_request("mooncake_p2p_peer", labels) {}
 
 void P2PClientMetric::serialize(std::string& str) {
     // Call base class serialize first
@@ -61,6 +62,7 @@ void P2PClientMetric::serialize(std::string& str) {
 
     // Then serialize P2P-specific metrics
     local_request.serialize(str);
+    peer_request.serialize(str);
 }
 
 std::string P2PClientMetric::summary_metrics() {
@@ -71,6 +73,9 @@ std::string P2PClientMetric::summary_metrics() {
     // Then add P2P-specific metrics
     ss << "=== P2P Local Request Metrics ===\n";
     ss << local_request.summary_metrics();
+
+    ss << "=== P2P Peer Request Metrics ===\n";
+    ss << peer_request.summary_metrics();
 
     return ss.str();
 }

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -189,7 +189,7 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
     }
 
     // 8. Start P2P client RPC service
-    client_rpc_service_.emplace(*data_manager_);
+    client_rpc_service_.emplace(*data_manager_, metrics_.get());
     client_rpc_server_ = std::make_unique<coro_rpc::coro_rpc_server>(
         config.rpc_thread_num, client_rpc_port_);
     RegisterClientRpcService(*client_rpc_server_, *client_rpc_service_);

--- a/mooncake-store/tests/client_http_metrics_test.cpp
+++ b/mooncake-store/tests/client_http_metrics_test.cpp
@@ -460,4 +460,179 @@ TEST_F(ClientHttpMetricsTest, CombinedMetricsHttpEndpointsTest) {
     server.stop();
 }
 
+// Test P2P client peer_request metrics HTTP endpoints
+TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
+    const uint16_t test_port = 19006;
+
+    // Create P2PClientMetric instance
+    auto p2p_metrics = P2PClientMetric::Create({{"p2p_label", "peer_test"}});
+    ASSERT_NE(p2p_metrics, nullptr);
+
+    // Add test data to both local_request and peer_request
+    // Local Put metrics
+    p2p_metrics->local_request.put_requests.inc(10);
+    p2p_metrics->local_request.put_bytes.inc(5 * 1024 * 1024);  // 5 MB
+    p2p_metrics->local_request.put_latency.observe(200);
+
+    // Local Get metrics
+    p2p_metrics->local_request.get_requests.inc(100);
+    p2p_metrics->local_request.get_hits.inc(80);
+    p2p_metrics->local_request.get_misses.inc(15);
+    p2p_metrics->local_request.get_failures.inc(5);
+    p2p_metrics->local_request.get_bytes.inc(20 * 1024 * 1024);  // 20 MB
+    p2p_metrics->local_request.get_latency.observe(100);
+
+    // Peer Put metrics
+    p2p_metrics->peer_request.put_requests.inc(30);
+    p2p_metrics->peer_request.put_bytes.inc(15 * 1024 * 1024);  // 15 MB
+    p2p_metrics->peer_request.put_failures.inc(2);
+    p2p_metrics->peer_request.put_latency.observe(250);
+
+    // Peer Get metrics
+    p2p_metrics->peer_request.get_requests.inc(200);
+    p2p_metrics->peer_request.get_hits.inc(150);
+    p2p_metrics->peer_request.get_misses.inc(40);
+    p2p_metrics->peer_request.get_failures.inc(10);
+    p2p_metrics->peer_request.get_bytes.inc(40 * 1024 * 1024);  // 40 MB
+    p2p_metrics->peer_request.get_latency.observe(120);
+
+    // Create and start HTTP server
+    coro_http::coro_http_server server(1, test_port);
+
+    using namespace coro_http;
+
+    // Register handlers for P2P metrics
+    server.set_http_handler<GET>("/metrics", [&p2p_metrics](
+                                                 coro_http_request& req,
+                                                 coro_http_response& resp) {
+        std::string metrics_str;
+        p2p_metrics->serialize(metrics_str);
+        resp.add_header("Content-Type", "text/plain; version=0.0.4");
+        resp.set_status_and_content(status_type::ok, std::move(metrics_str));
+    });
+
+    server.set_http_handler<GET>(
+        "/metrics/summary",
+        [&p2p_metrics](coro_http_request& req, coro_http_response& resp) {
+            std::string summary = p2p_metrics->summary_metrics();
+            resp.add_header("Content-Type", "text/plain; version=0.0.4");
+            resp.set_status_and_content(status_type::ok, std::move(summary));
+        });
+
+    server.async_start();
+
+    // Wait for server to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Test /metrics endpoint for P2P peer metrics
+    {
+        coro_http::coro_http_client client;
+        auto resp = client.get("http://127.0.0.1:" + std::to_string(test_port) +
+                               "/metrics");
+        EXPECT_EQ(resp.status, 200)
+            << "P2P peer metrics endpoint returned wrong status";
+
+        // Check local metrics are present
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_local_get_requests_total") !=
+            std::string::npos)
+            << "Metrics should contain local get requests metric";
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_local_put_requests_total") !=
+            std::string::npos)
+            << "Metrics should contain local put requests metric";
+
+        // Check peer metrics are present
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_peer_get_requests_total") !=
+            std::string::npos)
+            << "Metrics should contain peer get requests metric";
+        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_get_hits_total") !=
+                    std::string::npos)
+            << "Metrics should contain peer get hits metric";
+        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_get_misses_total") !=
+                    std::string::npos)
+            << "Metrics should contain peer get misses metric";
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_peer_get_failures_total") !=
+            std::string::npos)
+            << "Metrics should contain peer get failures metric";
+        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_get_bytes_total") !=
+                    std::string::npos)
+            << "Metrics should contain peer get bytes metric";
+        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_get_latency_us") !=
+                    std::string::npos)
+            << "Metrics should contain peer get latency metric";
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_peer_put_requests_total") !=
+            std::string::npos)
+            << "Metrics should contain peer put requests metric";
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_peer_put_failures_total") !=
+            std::string::npos)
+            << "Metrics should contain peer put failures metric";
+        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_put_bytes_total") !=
+                    std::string::npos)
+            << "Metrics should contain peer put bytes metric";
+        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_put_latency_us") !=
+                    std::string::npos)
+            << "Metrics should contain peer put latency metric";
+
+        // Check actual values
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_peer_get_requests_total") !=
+                std::string::npos &&
+            resp.resp_body.find("} 200\n") != std::string::npos)
+            << "Peer get requests should be 200";
+        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_get_hits_total") !=
+                        std::string::npos &&
+                    resp.resp_body.find("} 150\n") != std::string::npos)
+            << "Peer get hits should be 150";
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_peer_put_requests_total") !=
+                std::string::npos &&
+            resp.resp_body.find("} 30\n") != std::string::npos)
+            << "Peer put requests should be 30";
+    }
+
+    // Test /metrics/summary endpoint for P2P peer metrics
+    {
+        coro_http::coro_http_client client;
+        auto resp = client.get("http://127.0.0.1:" + std::to_string(test_port) +
+                               "/metrics/summary");
+        EXPECT_EQ(resp.status, 200)
+            << "P2P peer metrics summary endpoint returned wrong status";
+
+        // Check summary contains both local and peer metrics
+        EXPECT_TRUE(resp.resp_body.find("P2P Local Request Metrics") !=
+                    std::string::npos)
+            << "Summary should contain local metrics header";
+        EXPECT_TRUE(resp.resp_body.find("P2P Peer Request Metrics") !=
+                    std::string::npos)
+            << "Summary should contain peer metrics header";
+
+        // Check local metrics in summary
+        EXPECT_TRUE(resp.resp_body.find("100 requests") != std::string::npos)
+            << "Summary should show 100 local get requests";
+        EXPECT_TRUE(resp.resp_body.find("80 hits") != std::string::npos)
+            << "Summary should show 80 local get hits";
+
+        // Check peer metrics in summary
+        EXPECT_TRUE(resp.resp_body.find("200 requests") != std::string::npos)
+            << "Summary should show 200 peer get requests";
+        EXPECT_TRUE(resp.resp_body.find("150 hits") != std::string::npos)
+            << "Summary should show 150 peer get hits";
+        EXPECT_TRUE(resp.resp_body.find("40 misses") != std::string::npos)
+            << "Summary should show 40 peer get misses";
+        EXPECT_TRUE(resp.resp_body.find("10 failures") != std::string::npos)
+            << "Summary should show 10 peer get failures";
+        EXPECT_TRUE(resp.resp_body.find("40.00 MB") != std::string::npos)
+            << "Summary should show 40.00 MB read for peer";
+        EXPECT_TRUE(resp.resp_body.find("15.00 MB") != std::string::npos)
+            << "Summary should show 15.00 MB written for peer";
+    }
+
+    server.stop();
+}
+
 }  // namespace mooncake::test

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -405,6 +405,104 @@ TEST_F(ClientMetricsTest, P2PClientMetricInheritanceTest) {
     EXPECT_TRUE(summary.find("Put: 50 requests") != std::string::npos);
 }
 
+// Test P2PClientMetric peer_request metrics
+TEST_F(ClientMetricsTest, P2PClientMetricPeerRequestTest) {
+    P2PClientMetric metrics;
+
+    // Test peer_request metrics are present and work correctly
+    metrics.peer_request.get_requests.inc(100);
+    metrics.peer_request.get_hits.inc(80);
+    metrics.peer_request.get_misses.inc(15);
+    metrics.peer_request.get_failures.inc(5);
+    metrics.peer_request.get_bytes.inc(10 * 1024 * 1024);  // 10 MB
+    metrics.peer_request.get_latency.observe(100);
+    metrics.peer_request.get_latency.observe(200);
+
+    metrics.peer_request.put_requests.inc(50);
+    metrics.peer_request.put_failures.inc(2);
+    metrics.peer_request.put_bytes.inc(5 * 1024 * 1024);  // 5 MB
+    metrics.peer_request.put_latency.observe(300);
+    metrics.peer_request.put_latency.observe(400);
+
+    // Test serialize includes peer_request metrics
+    std::string serialized;
+    metrics.serialize(serialized);
+
+    // Verify peer_request metrics are present with correct prefix
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_requests_total 100") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_hits_total 80") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_misses_total 15") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_failures_total 5") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_bytes_total") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_latency_us") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_requests_total 50") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_failures_total 2") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_bytes_total") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_latency_us") !=
+                std::string::npos);
+
+    // Test summary_metrics includes peer_request metrics
+    std::string summary = metrics.summary_metrics();
+    EXPECT_TRUE(summary.find("P2P Peer Request Metrics") != std::string::npos);
+    EXPECT_TRUE(summary.find("Get: 100 requests") != std::string::npos);
+    EXPECT_TRUE(summary.find("80 hits") != std::string::npos);
+    EXPECT_TRUE(summary.find("15 misses") != std::string::npos);
+    EXPECT_TRUE(summary.find("5 failures") != std::string::npos);
+    EXPECT_TRUE(summary.find("Put: 50 requests") != std::string::npos);
+    EXPECT_TRUE(summary.find("2 failures") != std::string::npos);
+
+    std::cout << "P2P Peer Request Metrics Summary:\n" << summary << std::endl;
+}
+
+// Test both local_request and peer_request together
+TEST_F(ClientMetricsTest, P2PClientMetricBothLocalAndPeerTest) {
+    P2PClientMetric metrics;
+
+    // Add data to both local_request and peer_request
+    metrics.local_request.get_requests.inc(1000);
+    metrics.local_request.get_hits.inc(900);
+    metrics.local_request.get_misses.inc(50);
+    metrics.local_request.get_failures.inc(50);
+    metrics.local_request.get_bytes.inc(100 * 1024 * 1024);  // 100 MB
+
+    metrics.peer_request.get_requests.inc(500);
+    metrics.peer_request.get_hits.inc(400);
+    metrics.peer_request.get_misses.inc(80);
+    metrics.peer_request.get_failures.inc(20);
+    metrics.peer_request.get_bytes.inc(50 * 1024 * 1024);  // 50 MB
+
+    // Test serialize includes both
+    std::string serialized;
+    metrics.serialize(serialized);
+
+    // Verify both local and peer metrics are present
+    EXPECT_TRUE(serialized.find("mooncake_p2p_local_get_requests_total 1000") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_requests_total 500") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_local_get_hits_total 900") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_hits_total 400") !=
+                std::string::npos);
+
+    // Test summary_metrics includes both
+    std::string summary = metrics.summary_metrics();
+    EXPECT_TRUE(summary.find("P2P Local Request Metrics") != std::string::npos);
+    EXPECT_TRUE(summary.find("P2P Peer Request Metrics") != std::string::npos);
+
+    std::cout << "P2P Both Local and Peer Metrics Summary:\n"
+              << summary << std::endl;
+}
+
 // Test ClientMetric::Create returns nullptr when disabled
 TEST_F(ClientMetricsTest, ClientMetricCreateDisabledTest) {
     // Save current env and set to disable


### PR DESCRIPTION
  Add peer_request (RequestMetric) to P2PClientMetric for tracking remote Get/Put requests from other clients in ClientRpcService.

  Changes:
  - Add peer_request member to P2PClientMetric with "mooncake_p2p_peer" prefix
  - Update ClientRpcService to accept optional P2PClientMetric pointer
  - Add metrics recording in ReadRemoteData/WriteRemoteData:
    - get_requests, get_hits, get_misses, get_failures, get_bytes, get_latency
    - put_requests, put_failures, put_bytes, put_latency
  - Pass metrics pointer from P2PClientService to ClientRpcService
  - Add tests for peer_request metrics

  ## Description

  Add `peer_request` metrics to `P2PClientMetric` for tracking remote Get/Put requests from other clients in `ClientRpcService`. This mirrors
  the existing `local_request` metrics pattern, using the `mooncake_p2p_peer` prefix to distinguish peer-served requests from locally-initiated
   ones.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [x] Mooncake Store (`mooncake-store`)
  - [ ] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] PyTorch Backend (`mooncake-pg`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Other

  ## How Has This Been Tested?

  - [x] `client_metrics_test` — 16/16 passed (including P2PClientMetricPeerRequestTest, P2PClientMetricBothLocalAndPeerTest)
  - [x] `client_http_metrics_test` — 7/7 passed (including P2PClientPeerMetricsHttpEndpointsTest)
  - [x] Clean build passed in mooncake-dev container
  - [x] Code format check passed (`./scripts/code_format.sh` — 0 files need formatting)

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
  - [ ] I have updated the documentation.
  - [x] I have added tests to prove my changes are effective.