### PR TITLE
[CI] route fork PR to pull_request_target for ascend/integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
     types: [opened, synchronize, reopened, labeled]
+  pull_request_target:
+    branches: [ "main" ]
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch: {}
 
 permissions:
@@ -748,13 +751,29 @@ jobs:
 
   ascend-test:
     needs: [build, check-paths]
-    if: needs.check-paths.outputs.should-run-downstream == 'true'
+    if: >-
+      needs.check-paths.outputs.should-run-downstream == 'true' &&
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
+        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork)
+      )
     uses: ./.github/workflows/ci_ascend.yml
     secrets: inherit
+    with:
+      checkout_ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
 
   integration-test:
     needs: [build, check-paths]
-    if: needs.check-paths.outputs.should-run-downstream == 'true'
+    if: >-
+      needs.check-paths.outputs.should-run-downstream == 'true' &&
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
+        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork)
+      )
     uses: ./.github/workflows/integration-test.yml
     secrets: inherit
 


### PR DESCRIPTION
## Description

Fork-based PRs trigger `pull_request` events where GitHub Actions withholds `secrets` and `vars` for security — with the exception of `GITHUB_TOKEN` (read-only), neither secrets nor configuration variables are passed to the runner. 

This causes `vars.ASCEND_GITHUB_MIRROR_URLS` to resolve as empty in `ci_ascend.yml`, and the self-hosted Ascend runner fails with "Checkout from GitHub failed and ASCEND_GITHUB_MIRROR_URLS is not set" because it cannot reach GitHub directly.

This PR adds `pull_request_target` as a complementary trigger and routes `ascend-test` / `integration-test` by whether the PR originates from a fork:

- **`pull_request` + non-fork PR** — runs as before (`vars` / `secrets` available)
- **`pull_request` + fork PR** — skipped (`vars` / `secrets` unavailable; `pull_request_target` takes over)
- **`pull_request_target` + fork PR** — runs (`vars` / `secrets` available per [pull_request_target docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target))
- **`pull_request_target` + non-fork PR** — skipped (avoids duplicate run with `pull_request`)
- **`push` / `workflow_dispatch`** — runs as before

For `pull_request_target`, `ascend-test` explicitly passes `checkout_ref: ${{ github.event.pull_request.head.sha }}` so the reusable workflow checks out the PR head rather than the merge commit.

The workflow definition for `pull_request_target` always runs from `main`, so PR authors cannot tamper with it. The existing job condition `github.repository == 'kvcache-ai/Mooncake'` in `ci_ascend.yml` continues to guard execution to the upstream repository only.

## Module

- [x] CI/CD

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

The `pull_request_target` trigger behavior requires merging to `main` for end-to-end validation — GitHub resolves this event's workflow definition from the base branch. The YAML syntax has been reviewed locally.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.