### PR TITLE
fix: hardcode Ascend mirror URL and remove pull_request_target routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
     types: [opened, synchronize, reopened, labeled]
+  pull_request_target:
+    branches: [ "main" ]
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch: {}
 
 permissions:
@@ -748,13 +751,29 @@ jobs:
 
   ascend-test:
     needs: [build, check-paths]
-    if: needs.check-paths.outputs.should-run-downstream == 'true'
+    if: >-
+      needs.check-paths.outputs.should-run-downstream == 'true' &&
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
+        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork)
+      )
     uses: ./.github/workflows/ci_ascend.yml
     secrets: inherit
+    with:
+      checkout_ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
 
   integration-test:
     needs: [build, check-paths]
-    if: needs.check-paths.outputs.should-run-downstream == 'true'
+    if: >-
+      needs.check-paths.outputs.should-run-downstream == 'true' &&
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
+        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork)
+      )
     uses: ./.github/workflows/integration-test.yml
     secrets: inherit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
     types: [opened, synchronize, reopened, labeled]
-  pull_request_target:
-    branches: [ "main" ]
-    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch: {}
 
 permissions:
@@ -641,10 +638,10 @@ jobs:
   spell-check:
     name: Spell Check with Typos
     if: >-
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event.action == 'opened' ||
-      contains(github.event.pull_request.labels.*.name, 'run-ci')
+      (github.event_name == 'push' ||
+       github.event_name == 'workflow_dispatch' ||
+       github.event.action == 'opened' ||
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Actions Repository
@@ -657,10 +654,10 @@ jobs:
   clang-format:
     name: Check code format
     if: >-
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event.action == 'opened' ||
-      contains(github.event.pull_request.labels.*.name, 'run-ci')
+      (github.event_name == 'push' ||
+       github.event_name == 'workflow_dispatch' ||
+       github.event.action == 'opened' ||
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Actions Repository
@@ -751,29 +748,13 @@ jobs:
 
   ascend-test:
     needs: [build, check-paths]
-    if: >-
-      needs.check-paths.outputs.should-run-downstream == 'true' &&
-      (
-        github.event_name == 'push' ||
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
-        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork)
-      )
+    if: needs.check-paths.outputs.should-run-downstream == 'true'
     uses: ./.github/workflows/ci_ascend.yml
     secrets: inherit
-    with:
-      checkout_ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
 
   integration-test:
     needs: [build, check-paths]
-    if: >-
-      needs.check-paths.outputs.should-run-downstream == 'true' &&
-      (
-        github.event_name == 'push' ||
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
-        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork)
-      )
+    if: needs.check-paths.outputs.should-run-downstream == 'true'
     uses: ./.github/workflows/integration-test.yml
     secrets: inherit
 

--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -49,7 +49,7 @@ jobs:
       if: steps.checkout_code.outcome == 'failure'
       shell: bash
       env:
-        ASCEND_GITHUB_MIRROR_URLS: ${{ vars.ASCEND_GITHUB_MIRROR_URLS }}
+        ASCEND_GITHUB_MIRROR_URLS: 'https://ghfast.top/'
         CHECKOUT_REF: ${{ inputs.checkout_ref || github.sha }}
       run: |
         set -euo pipefail
@@ -108,7 +108,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       env:
-        ASCEND_GITHUB_MIRROR_URLS: ${{ vars.ASCEND_GITHUB_MIRROR_URLS }}
+        ASCEND_GITHUB_MIRROR_URLS: 'https://ghfast.top/'
       run: |
         source /usr/local/Ascend/cann-9.0.0/set_env.sh
         pwd

--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       checkout_ref:
-        description: 'Git ref to checkout (PR head SHA for pull_request_target)'
+        description: 'Git ref to checkout (PR head SHA)'
         required: false
         type: string
 

--- a/scripts/ascend/dependencies_ascend_installation.sh
+++ b/scripts/ascend/dependencies_ascend_installation.sh
@@ -18,12 +18,27 @@
 
 #!/bin/bash
 
+# Try git clone with GitHub mirror fallback via https://ghfast.top/
+git_with_github_mirror_fallback() {
+    local repo_dir="$1"
+    local repo_url="$2"
+    shift 2
+
+    if git clone "$repo_url" "$@"; then
+        return 0
+    fi
+
+    echo "Direct clone failed, retrying with mirror https://ghfast.top/"
+    local mirror_url="https://ghfast.top/${repo_url}"
+    git clone "$mirror_url" "$@"
+}
+
 clone_repo_if_not_exists() {
     local repo_dir=$1
     local repo_url=$2
 
     if [ ! -d "$repo_dir" ]; then
-        git clone "$repo_url"
+        git_with_github_mirror_fallback "$repo_dir" "$repo_url"
     else
         echo "Directory $repo_dir already exists, skipping clone."
     fi

--- a/scripts/ascend/dependencies_ascend_installation.sh
+++ b/scripts/ascend/dependencies_ascend_installation.sh
@@ -24,13 +24,14 @@ git_with_github_mirror_fallback() {
     local repo_url="$2"
     shift 2
 
-    if git clone "$repo_url" "$@"; then
+    if git clone "$repo_url" "$repo_dir" "$@"; then
         return 0
     fi
 
     echo "Direct clone failed, retrying with mirror https://ghfast.top/"
+    rm -rf "$repo_dir"
     local mirror_url="https://ghfast.top/${repo_url}"
-    git clone "$mirror_url" "$@"
+    git clone "$mirror_url" "$repo_dir" "$@"
 }
 
 clone_repo_if_not_exists() {

--- a/scripts/ascend/dependencies_ascend_installation.sh
+++ b/scripts/ascend/dependencies_ascend_installation.sh
@@ -35,11 +35,12 @@ git_with_github_mirror_fallback() {
 }
 
 clone_repo_if_not_exists() {
-    local repo_dir=$1
-    local repo_url=$2
+    local repo_dir="$1"
+    local repo_url="$2"
+    shift 2
 
     if [ ! -d "$repo_dir" ]; then
-        git_with_github_mirror_fallback "$repo_dir" "$repo_url"
+        git_with_github_mirror_fallback "$repo_dir" "$repo_url" "$@"
     else
         echo "Directory $repo_dir already exists, skipping clone."
     fi
@@ -117,7 +118,7 @@ elif command -v yum &> /dev/null; then
     cd ../..
 
     # Install msgpack-c
-    clone_repo_if_not_exists "msgpack" "https://github.com/msgpack/msgpack-c.git"
+    clone_repo_if_not_exists "msgpack-c" "https://github.com/msgpack/msgpack-c.git"
     cd msgpack-c || exit
     git checkout cpp-7.0.0
     rm -rf build


### PR DESCRIPTION
## Description

PR #1989 added `pull_request_target` to pass `vars.ASCEND_GITHUB_MIRROR_URLS` into fork PR CI runs, where `pull_request` withholds configuration variables. This caused basic CI jobs (lint, build, build-flags, wheel, etc.) to execute twice for fork PRs — once from `pull_request` and once from `pull_request_target` — because only `ascend-test` and `integration-test` had fork-aware routing conditions.

This PR removes the need for `pull_request_target` entirely by hardcoding the mirror URL (`https://ghfast.top/`) directly in `ci_ascend.yml`, eliminating the dependency on `vars`. Fork PRs now run through the normal `pull_request` path without duplicate job execution.

Changes:

- **`ci_ascend.yml`**: replace `${{ vars.ASCEND_GITHUB_MIRROR_URLS }}` with hardcoded `https://ghfast.top/` in both retry-checkout and cmake-configure steps; remove stale `pull_request_target` reference from `checkout_ref` input description
- **`ci.yml`**: remove `pull_request_target` trigger and all fork-routing logic (`ascend-test-fork`, `integration-test-fork`, `checkout_ref` passthrough); restore `ascend-test` and `integration-test` to their original simple conditions
- **`scripts/ascend/dependencies_ascend_installation.sh`**: add `git_with_github_mirror_fallback` helper so dependency clones (yaml-cpp, msgpack-c, yalantinglibs) also fall back to `https://ghfast.top/` on failure; explicitly use `$repo_dir` and `rm -rf` before mirror retry to avoid "already exists" errors from partial clones

## Module

- [x] CI/CD

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

The `pull_request_target` removal means the workflow now executes exclusively under `pull_request`, where fork PRs have the same restricted context as before PR #1989. The YAML syntax and shell scripts in `ci_ascend.yml` have been reviewed for compatibility with the hardcoded URL — the existing `normalize_base` / mirror-candidate loop in the retry step handles the single static URL without changes. Full end-to-end validation requires merging to `main`, since fork PR workflow behavior depends on the base-branch workflow definition.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)