### PR TITLE
fix (CI): remove pull_request_target trigger completely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
     types: [opened, synchronize, reopened, labeled]
-  pull_request_target:
-    branches: [ "main" ]
-    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch: {}
 
 permissions:
@@ -767,29 +764,13 @@ jobs:
 
   ascend-test:
     needs: [build, check-paths]
-    if: >-
-      needs.check-paths.outputs.should-run-downstream == 'true' &&
-      (
-        github.event_name == 'push' ||
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
-        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork)
-      )
+    if: needs.check-paths.outputs.should-run-downstream == 'true'
     uses: ./.github/workflows/ci_ascend.yml
     secrets: inherit
-    with:
-      checkout_ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
 
   integration-test:
     needs: [build, check-paths]
-    if: >-
-      needs.check-paths.outputs.should-run-downstream == 'true' &&
-      (
-        github.event_name == 'push' ||
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
-        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork)
-      )
+    if: needs.check-paths.outputs.should-run-downstream == 'true'
     uses: ./.github/workflows/integration-test.yml
     secrets: inherit
 


### PR DESCRIPTION
## Description

PR #1992 removed the dependency on `vars.ASCEND_GITHUB_MIRROR_URLS` by hardcoding `https://ghfast.top/` in `ci_ascend.yml`. However, due to a merge conflict during #1992's integration, the `pull_request_target` trigger and fork-routing conditions in `ci.yml` were not removed as intended — the conflict resolution incorrectly preserved them from the target branch.

As a result, fork PRs still trigger duplicate CI runs via `pull_request_target`, even though `vars` access is no longer needed. This PR completes the cleanup by removing the leftover `pull_request_target` infrastructure from `ci.yml`.

## Module

- [x] CI/CD

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Verified on fork (staryxchen/Mooncake#3): after merging this change to fork main, `Build & Test (Linux)` no longer triggers via `pull_request_target` — only `pull_request` events fire. Basic lint jobs (`spell-check`, `clang-format`, `check-paths`) all passed, and no job executed twice.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.