### PR TITLE
[Store] Fix LOCAL_MEMCPY segfault for multi-process-per-node deployments (e.g. vLLM data-parallel)

### DIFF
--- a/mooncake-store/include/gpu_staging_utils.h
+++ b/mooncake-store/include/gpu_staging_utils.h
@@ -70,13 +70,11 @@ inline bool CopyAuto(void* dst, const void* src, size_t size) {
     return hipMemcpy(dst, src, size, hipMemcpyDefault) == hipSuccess;
 #elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
     aclrtPtrAttributes src_attr{}, dst_attr{};
-    bool src_dev =
-        aclrtPointerGetAttributes(const_cast<void*>(src), &src_attr) ==
-            ACL_SUCCESS &&
-        src_attr.location.type == ACL_MEM_LOCATION_TYPE_DEVICE;
-    bool dst_dev =
-        aclrtPointerGetAttributes(dst, &dst_attr) == ACL_SUCCESS &&
-        dst_attr.location.type == ACL_MEM_LOCATION_TYPE_DEVICE;
+    bool src_dev = aclrtPointerGetAttributes(const_cast<void*>(src),
+                                             &src_attr) == ACL_SUCCESS &&
+                   src_attr.location.type == ACL_MEM_LOCATION_TYPE_DEVICE;
+    bool dst_dev = aclrtPointerGetAttributes(dst, &dst_attr) == ACL_SUCCESS &&
+                   dst_attr.location.type == ACL_MEM_LOCATION_TYPE_DEVICE;
     aclrtMemcpyKind kind = ACL_MEMCPY_HOST_TO_HOST;
     if (src_dev && dst_dev)
         kind = ACL_MEMCPY_DEVICE_TO_DEVICE;

--- a/mooncake-store/include/gpu_staging_utils.h
+++ b/mooncake-store/include/gpu_staging_utils.h
@@ -60,6 +60,39 @@ inline bool CopyDeviceToHost(void* dst, const void* src, size_t size) {
 #endif
 }
 
+// Auto-direction copy: runtime determines the transfer direction from pointer
+// attributes (cudaMemcpyDefault). Works for H2H, H2D, D2H, and D2D.
+// Caller must have called SetDevice first when device memory is involved.
+inline bool CopyAuto(void* dst, const void* src, size_t size) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    return cudaMemcpy(dst, src, size, cudaMemcpyDefault) == cudaSuccess;
+#elif defined(USE_HIP)
+    return hipMemcpy(dst, src, size, hipMemcpyDefault) == hipSuccess;
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    aclrtPtrAttributes src_attr{}, dst_attr{};
+    bool src_dev =
+        aclrtPointerGetAttributes(const_cast<void*>(src), &src_attr) ==
+            ACL_SUCCESS &&
+        src_attr.location.type == ACL_MEM_LOCATION_TYPE_DEVICE;
+    bool dst_dev =
+        aclrtPointerGetAttributes(dst, &dst_attr) == ACL_SUCCESS &&
+        dst_attr.location.type == ACL_MEM_LOCATION_TYPE_DEVICE;
+    aclrtMemcpyKind kind = ACL_MEMCPY_HOST_TO_HOST;
+    if (src_dev && dst_dev)
+        kind = ACL_MEMCPY_DEVICE_TO_DEVICE;
+    else if (src_dev)
+        kind = ACL_MEMCPY_DEVICE_TO_HOST;
+    else if (dst_dev)
+        kind = ACL_MEMCPY_HOST_TO_DEVICE;
+    return aclrtMemcpy(dst, size, src, size, kind) == ACL_SUCCESS;
+#else
+    (void)dst;
+    (void)src;
+    (void)size;
+    return false;
+#endif
+}
+
 // Bind the calling thread to the given device context.
 inline void SetDevice(int device_id) {
     if (device_id < 0) return;

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <sstream>
 #include <vector>
+#include "gpu_staging_utils.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
 
@@ -193,13 +194,35 @@ void MemcpyWorkerPool::workerThread() {
         // Execute the task if we have one
         if (task.state) {
             try {
+                bool ok = true;
                 for (const auto& op : task.operations) {
-                    std::memcpy(op.dest, op.src, op.size);
+                    int src_dev = -1, dst_dev = -1;
+                    bool src_on_gpu =
+                        gpu_staging::IsDevicePointer(op.src, &src_dev);
+                    bool dst_on_gpu =
+                        gpu_staging::IsDevicePointer(op.dest, &dst_dev);
+
+                    if (!src_on_gpu && !dst_on_gpu) {
+                        std::memcpy(op.dest, op.src, op.size);
+                    } else {
+                        int dev = src_on_gpu ? src_dev : dst_dev;
+                        gpu_staging::SetDevice(dev);
+                        if (!gpu_staging::CopyAuto(op.dest, op.src, op.size)) {
+                            LOG(ERROR)
+                                << "GPU memcpy failed: src_dev=" << src_dev
+                                << " dst_dev=" << dst_dev
+                                << " size=" << op.size;
+                            ok = false;
+                            break;
+                        }
+                    }
                 }
 
-                VLOG(2) << "Memcpy task completed successfully with "
-                        << task.operations.size() << " operations";
-                task.state->set_completed(ErrorCode::OK);
+                VLOG(2) << "Memcpy task completed with "
+                        << task.operations.size() << " operations"
+                        << (ok ? "" : " (with GPU copy failure)");
+                task.state->set_completed(ok ? ErrorCode::OK
+                                             : ErrorCode::TRANSFER_FAIL);
             } catch (const std::exception& e) {
                 LOG(ERROR) << "Exception during async memcpy: " << e.what();
                 task.state->set_completed(ErrorCode::TRANSFER_FAIL);
@@ -777,48 +800,16 @@ TransferStrategy TransferSubmitter::selectStrategy(
     return TransferStrategy::TRANSFER_ENGINE;
 }
 
-namespace {
-// Helper function to extract IP address from endpoint string (ip:port format)
-// Supports both IPv4 (ip:port) and IPv6 ([ipv6]:port) formats
-std::string extractIpAddress(const std::string& endpoint) {
-    if (endpoint.empty()) {
-        return "";
-    }
-
-    // Handle IPv6 format: [ipv6]:port
-    if (endpoint[0] == '[') {
-        size_t closing_bracket = endpoint.find(']');
-        if (closing_bracket == std::string::npos) {
-            LOG(WARNING) << "Invalid IPv6 endpoint format: " << endpoint;
-            // Return empty to disable local memcpy optimization
-            return "";
-        }
-        return endpoint.substr(1, closing_bracket - 1);  // Extract IPv6 address
-    }
-
-    // Handle IPv4 or hostname:port format
-    // Find the last colon (to handle IPv6 addresses without brackets)
-    size_t colon_pos = endpoint.rfind(':');
-    if (colon_pos != std::string::npos) {
-        return endpoint.substr(0, colon_pos);
-    }
-
-    // No colon found, return the whole string (might be just IP or hostname)
-    return endpoint;
-}
-}  // namespace
-
 bool TransferSubmitter::isLocalTransfer(
     const AllocatedBuffer::Descriptor& handle) const {
     std::string local_ep = engine_.getLocalIpAndPort();
-    std::string local_ip = extractIpAddress(local_ep);
 
     if (!local_ep.empty()) {
-        std::string handle_ip = extractIpAddress(handle.transport_endpoint_);
-        return !handle.transport_endpoint_.empty() && handle_ip == local_ip;
+        return !handle.transport_endpoint_.empty() &&
+               handle.transport_endpoint_ == local_ep;
     }
 
-    // Without a local IP we cannot prove locality; disable memcpy.
+    // Without a local endpoint we cannot prove locality; disable memcpy.
     return false;
 }
 


### PR DESCRIPTION
# Problem

When multiple Mooncake Store clients run as separate OS processes on the same node — for example, vLLM with --data-parallel-size 8 --distributed-executor-backend mp — the LOCAL_MEMCPY optimization causes segfaults, forcing users to work around it with MC_STORE_MEMCPY=false.
                                                                                                                                                                                                      
# Root Cause                                                         
                                         
There are two issues in the LOCAL_MEMCPY path:

1. isLocalTransfer() misidentifies cross-process transfers as local (introduced in #1226)      
```                                                                                                
Since #852 (P2PHANDSHAKE support), each process gets a unique ip:port endpoint via AutoPortBinder. The original isLocalTransfer() correctly compared full endpoints: return h.transport_endpoint_ == local_ep;  // e.g. "10.0.0.1:12345" == "10.0.0.1:12345".

In #1226 (Local Cache), this was changed to compare only IPs (stripping ports via extractIpAddress()):
  std::string handle_ip = extractIpAddress(handle.transport_endpoint_);  // "10.0.0.1"
  std::string local_ip = extractIpAddress(local_ep);                     // "10.0.0.1"
  return handle_ip == local_ip;  // all processes on the same node match!

Since all processes on the same machine share the same IP, they are all incorrectly identified as "local". The memcpy path then uses reinterpret_cast<void*>(handle.buffer_address_) to directly dereference the remote process's virtual address, which is invalid in the current process's address space → segfault.
```
                                                                                                                                                                                                      
  2. workerThread() uses std::memcpy which cannot handle GPU device pointers
  ```                                       
  Even for legitimate same-process transfers, the worker thread uses bare std::memcpy:

  for (const auto& op : task.operations) {
      std::memcpy(op.dest, op.src, op.size);  // segfault on cudaMalloc pointers
  }

  When the registered buffers are GPU memory (e.g. vLLM's KV cache allocated via cudaMalloc), CPU code cannot dereference device pointers — std::memcpy will segfault. The correct API is cudaMemcpy.
```
  # Fix

  Fix 1: Restore full ip:port endpoint comparison in isLocalTransfer(), removing the extractIpAddress() helper. Different processes on the same node have different ports (assigned by AutoPortBinder), so only true same-process transfers match.

  Fix 2: Make workerThread() GPU-aware. Detect device pointers via gpu_staging::IsDevicePointer() and use cudaMemcpy(cudaMemcpyDefault) for GPU memory, preserving std::memcpy for CPU-only transfers. Add gpu_staging::CopyAuto() utility to gpu_staging_utils.h for auto-direction copy (supports CUDA, HIP, and Ascend backends).

  # Changed Files                                                                                                                                                                                       
  
  - mooncake-store/src/transfer_task.cpp — Fix isLocalTransfer() and GPU-aware workerThread()                                                                                                         
  - mooncake-store/include/gpu_staging_utils.h — Add CopyAuto() function
                                         
  # Reproduction
vLLM with 8 data-parallel workers over TCP, WITHOUT the workaround:
```
export MC_STORE_MEMCPY=false  ← previously required to avoid segfault
vllm serve $MODEL \
      --data-parallel-size 8 \
      --distributed-executor-backend mp \
      --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both"}'
```

 After this fix, MC_STORE_MEMCPY=false is no longer needed. The auto-detection (MC_STORE_MEMCPY unset, TCP-only → enabled) works correctly.

  ---