### PR TITLE
[Store] fix invalid acquire with release for atomic store

### DIFF
--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1155,7 +1155,7 @@ tl::expected<void, ErrorCode> StorageBackendAdaptor::ScanMeta(
     fs::path root = fs::path(file_storage_config_.storage_filepath) /
                     file_per_key_config_.fsdir;
     if (!fs::exists(root)) {
-        meta_scanned_.store(true, std::memory_order_acquire);
+        meta_scanned_.store(true, std::memory_order_release);
         return {};
     }
 
@@ -1228,7 +1228,7 @@ tl::expected<void, ErrorCode> StorageBackendAdaptor::ScanMeta(
         }
     }
 
-    meta_scanned_.store(true, std::memory_order_acquire);
+    meta_scanned_.store(true, std::memory_order_release);
     return {};
 }
 


### PR DESCRIPTION
## Description
Fix https://github.com/kvcache-ai/Mooncake/issues/1997
Using memory_order_acquire for std::atomic<bool>::store() is invalid
according to C++ standard, causing :
  'invalid memory model for __atomic_store_1'
  valid models are: relaxed, release, seq_cst

Although this may work on x86 due to strong memory ordering, it could
cause undefined behavior on weak-memory architectures like ARM.

Replace with memory_order_release to pair with the acquire load ensuring proper happens-before relationship.


```
template< class T >
void atomic_store( std::atomic<T>* obj,
                   typename std::atomic<T>::value_type desired ) noexcept;

Atomically replaces the value pointed to by obj with the value of desired as if by obj->store(desired, order). 
If order is one of std::memory_order_consume, std::memory_order_acquire and std::memory_order_acq_rel, the behavior is undefined.
Parameters
obj	-	pointer to the atomic object to modify
desired	-	the value to store in the atomic object
order	-	the memory synchronization ordering
```

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
