### PR TITLE
[Store] Split RequestMetric latency into success/failure histograms

### DIFF
--- a/mooncake-store/include/p2p_client_metric.h
+++ b/mooncake-store/include/p2p_client_metric.h
@@ -12,13 +12,15 @@ struct RequestMetric {
     ylt::metric::counter_t get_misses;
     ylt::metric::counter_t get_failures;
     ylt::metric::counter_t get_bytes;
-    ylt::metric::histogram_t get_latency;
+    ylt::metric::histogram_t get_latency_success;
+    ylt::metric::histogram_t get_latency_failure;
 
     // Put metrics
     ylt::metric::counter_t put_requests;
     ylt::metric::counter_t put_failures;
     ylt::metric::counter_t put_bytes;
-    ylt::metric::histogram_t put_latency;
+    ylt::metric::histogram_t put_latency_success;
+    ylt::metric::histogram_t put_latency_failure;
 
     explicit RequestMetric(
         const std::string& prefix,

--- a/mooncake-store/src/client_rpc_service.cpp
+++ b/mooncake-store/src/client_rpc_service.cpp
@@ -87,17 +87,14 @@ tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
         timer.LogResponse("error_code=", result.error());
         if (result.error() == ErrorCode::OBJECT_NOT_FOUND) {
             data_manager_.RectifyReadRoute(request.key);
-            if (metrics_) {
+        }
+        if (metrics_) {
+            if (result.error() == ErrorCode::OBJECT_NOT_FOUND) {
                 metrics_->peer_request.get_misses.inc();
-                metrics_->peer_request.get_latency_failure.observe(
-                    sw.elapsed_us());
-            }
-        } else {
-            if (metrics_) {
+            } else {
                 metrics_->peer_request.get_failures.inc();
-                metrics_->peer_request.get_latency_failure.observe(
-                    sw.elapsed_us());
             }
+            metrics_->peer_request.get_latency_failure.observe(sw.elapsed_us());
         }
         return result;
     }

--- a/mooncake-store/src/client_rpc_service.cpp
+++ b/mooncake-store/src/client_rpc_service.cpp
@@ -72,6 +72,7 @@ tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
         if (metrics_) {
             metrics_->peer_request.get_failures.inc();
+            metrics_->peer_request.get_latency_failure.observe(sw.elapsed_us());
         }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -88,10 +89,14 @@ tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
             data_manager_.RectifyReadRoute(request.key);
             if (metrics_) {
                 metrics_->peer_request.get_misses.inc();
+                metrics_->peer_request.get_latency_failure.observe(
+                    sw.elapsed_us());
             }
         } else {
             if (metrics_) {
                 metrics_->peer_request.get_failures.inc();
+                metrics_->peer_request.get_latency_failure.observe(
+                    sw.elapsed_us());
             }
         }
         return result;
@@ -102,7 +107,7 @@ tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
         metrics_->peer_request.get_hits.inc();
         metrics_->peer_request.get_bytes.inc(
             CalculateBufferSize(request.dest_buffers));
-        metrics_->peer_request.get_latency.observe(sw.elapsed_us());
+        metrics_->peer_request.get_latency_success.observe(sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);
@@ -124,6 +129,7 @@ tl::expected<UUID, ErrorCode> ClientRpcService::WriteRemoteData(
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
         if (metrics_) {
             metrics_->peer_request.put_failures.inc();
+            metrics_->peer_request.put_latency_failure.observe(sw.elapsed_us());
         }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -138,6 +144,7 @@ tl::expected<UUID, ErrorCode> ClientRpcService::WriteRemoteData(
         timer.LogResponse("error_code=", result.error());
         if (metrics_) {
             metrics_->peer_request.put_failures.inc();
+            metrics_->peer_request.put_latency_failure.observe(sw.elapsed_us());
         }
         return result;
     }
@@ -146,7 +153,7 @@ tl::expected<UUID, ErrorCode> ClientRpcService::WriteRemoteData(
     if (metrics_) {
         metrics_->peer_request.put_bytes.inc(
             CalculateBufferSize(request.src_buffers));
-        metrics_->peer_request.put_latency.observe(sw.elapsed_us());
+        metrics_->peer_request.put_latency_success.observe(sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -13,16 +13,24 @@ RequestMetric::RequestMetric(const std::string& prefix,
       get_failures(prefix + "_get_failures_total",
                    "Total number of failed Get requests", labels),
       get_bytes(prefix + "_get_bytes_total", "Total bytes read by Get", labels),
-      get_latency(prefix + "_get_latency_us", "Get latency (us)",
-                  kLatencyBucket, labels),
+      get_latency_success(prefix + "_get_latency_success_us",
+                          "Get latency for successful requests (us)",
+                          kLatencyBucket, labels),
+      get_latency_failure(prefix + "_get_latency_failure_us",
+                          "Get latency for failed requests (us)",
+                          kLatencyBucket, labels),
       put_requests(prefix + "_put_requests_total",
                    "Total number of Put requests", labels),
       put_failures(prefix + "_put_failures_total",
                    "Total number of failed Put requests", labels),
       put_bytes(prefix + "_put_bytes_total", "Total bytes written by Put",
                 labels),
-      put_latency(prefix + "_put_latency_us", "Put latency (us)",
-                  kLatencyBucket, labels) {}
+      put_latency_success(prefix + "_put_latency_success_us",
+                          "Put latency for successful requests (us)",
+                          kLatencyBucket, labels),
+      put_latency_failure(prefix + "_put_latency_failure_us",
+                          "Put latency for failed requests (us)",
+                          kLatencyBucket, labels) {}
 
 void RequestMetric::serialize(std::string& str) {
     get_requests.serialize(str);
@@ -30,11 +38,13 @@ void RequestMetric::serialize(std::string& str) {
     get_misses.serialize(str);
     get_failures.serialize(str);
     get_bytes.serialize(str);
-    get_latency.serialize(str);
+    get_latency_success.serialize(str);
+    get_latency_failure.serialize(str);
     put_requests.serialize(str);
     put_failures.serialize(str);
     put_bytes.serialize(str);
-    put_latency.serialize(str);
+    put_latency_success.serialize(str);
+    put_latency_failure.serialize(str);
 }
 
 std::string RequestMetric::summary_metrics() {

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -580,24 +580,27 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::BatchPut(
     for (size_t i = 0; i < results.size(); ++i) {
         if (results[i].has_value()) {
             success_count++;
-            if (metrics_) {
-                metrics_->local_request.put_bytes.inc(
-                    ClientService::CalculateSliceSize(batched_slices[i]));
-            }
         }
     }
+
     if (metrics_) {
-        size_t failure_count = keys.size() - success_count;
+        const auto elapsed = stopwatch.elapsed_us();
+        const double avg_latency =
+            keys.empty() ? 0.0 : static_cast<double>(elapsed) / keys.size();
+        for (size_t i = 0; i < results.size(); ++i) {
+            if (results[i].has_value()) {
+                metrics_->local_request.put_bytes.inc(
+                    ClientService::CalculateSliceSize(batched_slices[i]));
+                metrics_->local_request.put_latency_success.observe(
+                    avg_latency);
+            } else {
+                metrics_->local_request.put_latency_failure.observe(
+                    avg_latency);
+            }
+        }
+        const size_t failure_count = keys.size() - success_count;
         if (failure_count > 0) {
             metrics_->local_request.put_failures.inc(failure_count);
-        }
-        const auto elapsed = stopwatch.elapsed_us();
-        if (!keys.empty()) {
-            const double avg_latency =
-                static_cast<double>(elapsed) / keys.size();
-            for (size_t i = 0; i < keys.size(); ++i) {
-                metrics_->local_request.put_latency.observe(avg_latency);
-            }
         }
     }
 
@@ -1105,23 +1108,26 @@ std::vector<tl::expected<ResultT, ErrorCode>> P2PClientService::BatchGetImpl(
     for (size_t i = 0; i < results.size(); ++i) {
         if (results[i].has_value()) {
             success_count++;
-            if (metrics_) {
-                metrics_->local_request.get_bytes.inc(handles[i]->data_size);
-            }
         }
     }
+
     if (metrics_) {
-        size_t failure_count = keys.size() - success_count;
+        const auto elapsed = stopwatch.elapsed_us();
+        const double avg_latency =
+            keys.empty() ? 0.0 : static_cast<double>(elapsed) / keys.size();
+        for (size_t i = 0; i < results.size(); ++i) {
+            if (results[i].has_value()) {
+                metrics_->local_request.get_bytes.inc(handles[i]->data_size);
+                metrics_->local_request.get_latency_success.observe(
+                    avg_latency);
+            } else {
+                metrics_->local_request.get_latency_failure.observe(
+                    avg_latency);
+            }
+        }
+        const size_t failure_count = keys.size() - success_count;
         if (failure_count > 0) {
             metrics_->local_request.get_failures.inc(failure_count);
-        }
-        const auto elapsed = stopwatch.elapsed_us();
-        if (!keys.empty()) {
-            const double avg_latency =
-                static_cast<double>(elapsed) / keys.size();
-            for (size_t i = 0; i < keys.size(); ++i) {
-                metrics_->local_request.get_latency.observe(avg_latency);
-            }
         }
     }
 

--- a/mooncake-store/tests/client_http_metrics_test.cpp
+++ b/mooncake-store/tests/client_http_metrics_test.cpp
@@ -223,6 +223,7 @@ TEST_F(ClientHttpMetricsTest, P2PClientMetricsHttpEndpointsTest) {
     p2p_metrics->local_request.put_bytes.inc(5 * 1024 * 1024);  // 5 MB
     p2p_metrics->local_request.put_latency_success.observe(200);
     p2p_metrics->local_request.put_latency_success.observe(300);
+    p2p_metrics->local_request.put_latency_failure.observe(500);
 
     // Local Get metrics
     p2p_metrics->local_request.get_requests.inc(100);
@@ -232,6 +233,7 @@ TEST_F(ClientHttpMetricsTest, P2PClientMetricsHttpEndpointsTest) {
     p2p_metrics->local_request.get_bytes.inc(20 * 1024 * 1024);  // 20 MB
     p2p_metrics->local_request.get_latency_success.observe(100);
     p2p_metrics->local_request.get_latency_success.observe(150);
+    p2p_metrics->local_request.get_latency_failure.observe(400);
 
     // Create and start HTTP server
     coro_http::coro_http_server server(1, test_port);
@@ -280,7 +282,11 @@ TEST_F(ClientHttpMetricsTest, P2PClientMetricsHttpEndpointsTest) {
         EXPECT_TRUE(
             resp.resp_body.find("mooncake_p2p_local_put_latency_success_us") !=
             std::string::npos)
-            << "Metrics should contain P2P put latency metric";
+            << "Metrics should contain P2P put latency success metric";
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_local_put_latency_failure_us") !=
+            std::string::npos)
+            << "Metrics should contain P2P put latency failure metric";
 
         // Check P2P Get metrics
         EXPECT_TRUE(
@@ -304,7 +310,11 @@ TEST_F(ClientHttpMetricsTest, P2PClientMetricsHttpEndpointsTest) {
         EXPECT_TRUE(
             resp.resp_body.find("mooncake_p2p_local_get_latency_success_us") !=
             std::string::npos)
-            << "Metrics should contain P2P get latency metric";
+            << "Metrics should contain P2P get latency success metric";
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_local_get_latency_failure_us") !=
+            std::string::npos)
+            << "Metrics should contain P2P get latency failure metric";
 
         // Check labels
         EXPECT_TRUE(resp.resp_body.find("p2p_label") != std::string::npos)

--- a/mooncake-store/tests/client_http_metrics_test.cpp
+++ b/mooncake-store/tests/client_http_metrics_test.cpp
@@ -221,8 +221,8 @@ TEST_F(ClientHttpMetricsTest, P2PClientMetricsHttpEndpointsTest) {
     // Local Put metrics
     p2p_metrics->local_request.put_requests.inc(10);
     p2p_metrics->local_request.put_bytes.inc(5 * 1024 * 1024);  // 5 MB
-    p2p_metrics->local_request.put_latency.observe(200);
-    p2p_metrics->local_request.put_latency.observe(300);
+    p2p_metrics->local_request.put_latency_success.observe(200);
+    p2p_metrics->local_request.put_latency_success.observe(300);
 
     // Local Get metrics
     p2p_metrics->local_request.get_requests.inc(100);
@@ -230,8 +230,8 @@ TEST_F(ClientHttpMetricsTest, P2PClientMetricsHttpEndpointsTest) {
     p2p_metrics->local_request.get_misses.inc(15);
     p2p_metrics->local_request.get_failures.inc(5);
     p2p_metrics->local_request.get_bytes.inc(20 * 1024 * 1024);  // 20 MB
-    p2p_metrics->local_request.get_latency.observe(100);
-    p2p_metrics->local_request.get_latency.observe(150);
+    p2p_metrics->local_request.get_latency_success.observe(100);
+    p2p_metrics->local_request.get_latency_success.observe(150);
 
     // Create and start HTTP server
     coro_http::coro_http_server server(1, test_port);
@@ -277,8 +277,9 @@ TEST_F(ClientHttpMetricsTest, P2PClientMetricsHttpEndpointsTest) {
         EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_local_put_bytes_total") !=
                     std::string::npos)
             << "Metrics should contain P2P put bytes metric";
-        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_local_put_latency_us") !=
-                    std::string::npos)
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_local_put_latency_success_us") !=
+            std::string::npos)
             << "Metrics should contain P2P put latency metric";
 
         // Check P2P Get metrics
@@ -300,8 +301,9 @@ TEST_F(ClientHttpMetricsTest, P2PClientMetricsHttpEndpointsTest) {
         EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_local_get_bytes_total") !=
                     std::string::npos)
             << "Metrics should contain P2P get bytes metric";
-        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_local_get_latency_us") !=
-                    std::string::npos)
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_local_get_latency_success_us") !=
+            std::string::npos)
             << "Metrics should contain P2P get latency metric";
 
         // Check labels
@@ -472,7 +474,7 @@ TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
     // Local Put metrics
     p2p_metrics->local_request.put_requests.inc(10);
     p2p_metrics->local_request.put_bytes.inc(5 * 1024 * 1024);  // 5 MB
-    p2p_metrics->local_request.put_latency.observe(200);
+    p2p_metrics->local_request.put_latency_success.observe(200);
 
     // Local Get metrics
     p2p_metrics->local_request.get_requests.inc(100);
@@ -480,13 +482,14 @@ TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
     p2p_metrics->local_request.get_misses.inc(15);
     p2p_metrics->local_request.get_failures.inc(5);
     p2p_metrics->local_request.get_bytes.inc(20 * 1024 * 1024);  // 20 MB
-    p2p_metrics->local_request.get_latency.observe(100);
+    p2p_metrics->local_request.get_latency_success.observe(100);
 
     // Peer Put metrics
     p2p_metrics->peer_request.put_requests.inc(30);
     p2p_metrics->peer_request.put_bytes.inc(15 * 1024 * 1024);  // 15 MB
     p2p_metrics->peer_request.put_failures.inc(2);
-    p2p_metrics->peer_request.put_latency.observe(250);
+    p2p_metrics->peer_request.put_latency_success.observe(250);
+    p2p_metrics->peer_request.put_latency_failure.observe(350);
 
     // Peer Get metrics
     p2p_metrics->peer_request.get_requests.inc(200);
@@ -494,7 +497,8 @@ TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
     p2p_metrics->peer_request.get_misses.inc(40);
     p2p_metrics->peer_request.get_failures.inc(10);
     p2p_metrics->peer_request.get_bytes.inc(40 * 1024 * 1024);  // 40 MB
-    p2p_metrics->peer_request.get_latency.observe(120);
+    p2p_metrics->peer_request.get_latency_success.observe(120);
+    p2p_metrics->peer_request.get_latency_failure.observe(220);
 
     // Create and start HTTP server
     coro_http::coro_http_server server(1, test_port);
@@ -560,9 +564,14 @@ TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
         EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_get_bytes_total") !=
                     std::string::npos)
             << "Metrics should contain peer get bytes metric";
-        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_get_latency_us") !=
-                    std::string::npos)
-            << "Metrics should contain peer get latency metric";
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_peer_get_latency_success_us") !=
+            std::string::npos)
+            << "Metrics should contain peer get latency success metric";
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_peer_get_latency_failure_us") !=
+            std::string::npos)
+            << "Metrics should contain peer get latency failure metric";
         EXPECT_TRUE(
             resp.resp_body.find("mooncake_p2p_peer_put_requests_total") !=
             std::string::npos)
@@ -574,9 +583,14 @@ TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
         EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_put_bytes_total") !=
                     std::string::npos)
             << "Metrics should contain peer put bytes metric";
-        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_put_latency_us") !=
-                    std::string::npos)
-            << "Metrics should contain peer put latency metric";
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_peer_put_latency_success_us") !=
+            std::string::npos)
+            << "Metrics should contain peer put latency success metric";
+        EXPECT_TRUE(
+            resp.resp_body.find("mooncake_p2p_peer_put_latency_failure_us") !=
+            std::string::npos)
+            << "Metrics should contain peer put latency failure metric";
 
         // Check actual values
         EXPECT_TRUE(

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -283,6 +283,7 @@ TEST_F(ClientMetricsTest, P2PClientMetricBasicTest) {
     metrics.local_request.put_bytes.inc(1024 * 1024);  // 1 MB
     metrics.local_request.put_latency_success.observe(200);
     metrics.local_request.put_latency_success.observe(300);
+    metrics.local_request.put_latency_failure.observe(500);
 
     // Add get data
     metrics.local_request.get_requests.inc();
@@ -294,6 +295,7 @@ TEST_F(ClientMetricsTest, P2PClientMetricBasicTest) {
     metrics.local_request.get_bytes.inc(2 * 1024 * 1024);  // 2 MB
     metrics.local_request.get_latency_success.observe(100);
     metrics.local_request.get_latency_success.observe(150);
+    metrics.local_request.get_latency_failure.observe(400);
 
     summary = metrics.summary_metrics();
     EXPECT_TRUE(summary.find("Put: 2 requests") != std::string::npos);
@@ -320,7 +322,9 @@ TEST_F(ClientMetricsTest, P2PClientMetricSerializeTest) {
     // Add latency data to test histogram output
     metrics.local_request.put_latency_success.observe(200);
     metrics.local_request.put_latency_success.observe(300);
+    metrics.local_request.put_latency_failure.observe(500);
     metrics.local_request.get_latency_success.observe(100);
+    metrics.local_request.get_latency_failure.observe(400);
 
     std::string serialized;
     metrics.serialize(serialized);
@@ -344,7 +348,11 @@ TEST_F(ClientMetricsTest, P2PClientMetricSerializeTest) {
     // Verify histogram metrics are present (only output when data exists)
     EXPECT_TRUE(serialized.find("mooncake_p2p_local_put_latency_success_us") !=
                 std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_local_put_latency_failure_us") !=
+                std::string::npos);
     EXPECT_TRUE(serialized.find("mooncake_p2p_local_get_latency_success_us") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_local_get_latency_failure_us") !=
                 std::string::npos);
 
     std::cout << "P2P Client Serialized Metrics:\n" << serialized << std::endl;

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -281,8 +281,8 @@ TEST_F(ClientMetricsTest, P2PClientMetricBasicTest) {
     metrics.local_request.put_requests.inc();
     metrics.local_request.put_failures.inc();
     metrics.local_request.put_bytes.inc(1024 * 1024);  // 1 MB
-    metrics.local_request.put_latency.observe(200);
-    metrics.local_request.put_latency.observe(300);
+    metrics.local_request.put_latency_success.observe(200);
+    metrics.local_request.put_latency_success.observe(300);
 
     // Add get data
     metrics.local_request.get_requests.inc();
@@ -292,8 +292,8 @@ TEST_F(ClientMetricsTest, P2PClientMetricBasicTest) {
     metrics.local_request.get_misses.inc();
     metrics.local_request.get_hits.inc();
     metrics.local_request.get_bytes.inc(2 * 1024 * 1024);  // 2 MB
-    metrics.local_request.get_latency.observe(100);
-    metrics.local_request.get_latency.observe(150);
+    metrics.local_request.get_latency_success.observe(100);
+    metrics.local_request.get_latency_success.observe(150);
 
     summary = metrics.summary_metrics();
     EXPECT_TRUE(summary.find("Put: 2 requests") != std::string::npos);
@@ -318,9 +318,9 @@ TEST_F(ClientMetricsTest, P2PClientMetricSerializeTest) {
     metrics.local_request.get_bytes.inc(100 * 1024 * 1024);  // 100 MB
 
     // Add latency data to test histogram output
-    metrics.local_request.put_latency.observe(200);
-    metrics.local_request.put_latency.observe(300);
-    metrics.local_request.get_latency.observe(100);
+    metrics.local_request.put_latency_success.observe(200);
+    metrics.local_request.put_latency_success.observe(300);
+    metrics.local_request.get_latency_success.observe(100);
 
     std::string serialized;
     metrics.serialize(serialized);
@@ -342,9 +342,9 @@ TEST_F(ClientMetricsTest, P2PClientMetricSerializeTest) {
         std::string::npos);
 
     // Verify histogram metrics are present (only output when data exists)
-    EXPECT_TRUE(serialized.find("mooncake_p2p_local_put_latency_us") !=
+    EXPECT_TRUE(serialized.find("mooncake_p2p_local_put_latency_success_us") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_local_get_latency_us") !=
+    EXPECT_TRUE(serialized.find("mooncake_p2p_local_get_latency_success_us") !=
                 std::string::npos);
 
     std::cout << "P2P Client Serialized Metrics:\n" << serialized << std::endl;
@@ -415,14 +415,18 @@ TEST_F(ClientMetricsTest, P2PClientMetricPeerRequestTest) {
     metrics.peer_request.get_misses.inc(15);
     metrics.peer_request.get_failures.inc(5);
     metrics.peer_request.get_bytes.inc(10 * 1024 * 1024);  // 10 MB
-    metrics.peer_request.get_latency.observe(100);
-    metrics.peer_request.get_latency.observe(200);
+    metrics.peer_request.get_latency_success.observe(100);
+    metrics.peer_request.get_latency_success.observe(200);
+    metrics.peer_request.get_latency_failure.observe(500);
+    metrics.peer_request.get_latency_failure.observe(600);
 
     metrics.peer_request.put_requests.inc(50);
     metrics.peer_request.put_failures.inc(2);
     metrics.peer_request.put_bytes.inc(5 * 1024 * 1024);  // 5 MB
-    metrics.peer_request.put_latency.observe(300);
-    metrics.peer_request.put_latency.observe(400);
+    metrics.peer_request.put_latency_success.observe(300);
+    metrics.peer_request.put_latency_success.observe(400);
+    metrics.peer_request.put_latency_failure.observe(700);
+    metrics.peer_request.put_latency_failure.observe(800);
 
     // Test serialize includes peer_request metrics
     std::string serialized;
@@ -439,7 +443,9 @@ TEST_F(ClientMetricsTest, P2PClientMetricPeerRequestTest) {
                 std::string::npos);
     EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_bytes_total") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_latency_us") !=
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_latency_success_us") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_latency_failure_us") !=
                 std::string::npos);
     EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_requests_total 50") !=
                 std::string::npos);
@@ -447,7 +453,9 @@ TEST_F(ClientMetricsTest, P2PClientMetricPeerRequestTest) {
                 std::string::npos);
     EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_bytes_total") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_latency_us") !=
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_latency_success_us") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_latency_failure_us") !=
                 std::string::npos);
 
     // Test summary_metrics includes peer_request metrics


### PR DESCRIPTION
  Separate get_latency and put_latency into get_latency_success/get_latency_failure and put_latency_success/put_latency_failure, so that
  latency distributions for successful and failed requests can be observed independently.

  ## Description

  Split `RequestMetric`'s `get_latency` and `put_latency` histogram fields into success/failure variants:
  - `get_latency` → `get_latency_success` + `get_latency_failure`
  - `put_latency` → `put_latency_success` + `put_latency_failure`

  This allows independent observation of latency distributions for successful and failed requests in both `local_request` and `peer_request`
  metric groups.

  Changes:
  - `p2p_client_metric.h` / `p2p_client_metric.cpp`: Split histogram fields and update constructor, serialize method, and metric names
  - `client_rpc_service.cpp`: Record latency to `*_latency_failure` on error paths and `*_latency_success` on success path for peer_request
  - `p2p_client_service.cpp`: Record latency to `*_latency_failure` / `*_latency_success` per request result for local_request (BatchPut,
  BatchGetImpl)
  - Updated test files to match new field names and metric name assertions

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [x] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] PyTorch Backend (`mooncake-pg`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] Refactor
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Other

  ## How Has This Been Tested?

  - `client_metrics_test`: 16/16 passed
  - `client_http_metrics_test`: 7/7 passed
  - Clean build passed
  - Code format (`./scripts/code_format.sh`) passed

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
  - [ ] I have updated the documentation.
  - [x] I have added tests to prove my changes are effective.