### PR TITLE
[Store] Fix disk replica read paths for GPU KV cache (LOCAL_DISK zero-copy, DISK temp-buf scatter)

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -403,7 +403,8 @@ class Client {
         const std::string& transfer_engine_addr,
         const std::vector<std::string>& keys,
         const std::vector<uintptr_t>& pointers,
-        const std::unordered_map<std::string, Slice>& batch_slices);
+        const std::unordered_map<std::string, std::vector<Slice>>&
+            batch_slices);
 
     /**
      * @brief Notifies the master that offloading of specified objects has

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -480,6 +480,16 @@ class Client {
 
     tl::expected<Replica::Descriptor, ErrorCode> GetPreferredReplica(
         const std::vector<Replica::Descriptor>& replica_list);
+
+    std::unordered_set<std::string> GetLocalEndpoints() const {
+        std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+        std::unordered_set<std::string> endpoints;
+        for (const auto& [segment_id, segment] : mounted_segments_) {
+            endpoints.insert(segment.te_endpoint);
+        }
+        return endpoints;
+    }
+
     /**
      * @brief Check if local hot cache is enabled
      * @return true if hot cache is enabled, false otherwise

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -674,7 +674,7 @@ class Client {
     std::unique_ptr<TransferSubmitter> transfer_submitter_;
 
     // Mutex to protect mounted_segments_
-    std::mutex mounted_segments_mutex_;
+    mutable std::mutex mounted_segments_mutex_;
     std::unordered_map<UUID, Segment, boost::hash<UUID>> mounted_segments_;
 
     // Configuration

--- a/mooncake-store/include/gpu_staging_utils.h
+++ b/mooncake-store/include/gpu_staging_utils.h
@@ -116,7 +116,8 @@ inline bool IsHostPointer(const void* ptr) {
     aclrtPtrAttributes attr{};
     if (aclrtPointerGetAttributes(const_cast<void*>(ptr), &attr) !=
         ACL_SUCCESS) {
-        return false;  // cannot confirm host; conservative fallback
+        // Query failed: likely pageable host memory not tracked by the runtime.
+        return true;
     }
     return attr.location.type != ACL_MEM_LOCATION_TYPE_DEVICE;
 #else

--- a/mooncake-store/include/gpu_staging_utils.h
+++ b/mooncake-store/include/gpu_staging_utils.h
@@ -72,5 +72,79 @@ inline void SetDevice(int device_id) {
 #endif
 }
 
+// Copy host memory to device. Caller must have called SetDevice first.
+inline bool CopyHostToDevice(void* dst, const void* src, size_t size) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    return cudaMemcpy(dst, src, size, cudaMemcpyHostToDevice) == cudaSuccess;
+#elif defined(USE_HIP)
+    return hipMemcpy(dst, src, size, hipMemcpyHostToDevice) == hipSuccess;
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    return aclrtMemcpy(dst, size, src, size, ACL_MEMCPY_HOST_TO_DEVICE) ==
+           ACL_SUCCESS;
+#else
+    (void)dst;
+    (void)src;
+    (void)size;
+    return false;
+#endif
+}
+
+// Detect whether ptr resides in host (CPU) memory.
+// Used together with IsDevicePointer for safe pointer-type dispatching:
+//   if IsDevicePointer  -> CopyHostToDevice / CopyDeviceToHost
+//   else if IsHostPointer -> memcpy
+//   else                  -> reject (unknown type, e.g. non-standard allocator)
+//
+// Pageable host memory (not tracked by CUDA runtime) is treated as host.
+// On CUDA < 11 where cudaMemoryTypeUnregistered is unavailable,
+// cudaErrorInvalidValue is the expected response for pageable memory.
+inline bool IsHostPointer(const void* ptr) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+    cudaPointerAttributes attr{};
+    cudaError_t err = cudaPointerGetAttributes(&attr, ptr);
+    if (err == cudaSuccess) {
+        return attr.type == cudaMemoryTypeHost
+#if CUDART_VERSION >= 11000
+               || attr.type == cudaMemoryTypeUnregistered
+#endif
+            ;
+    }
+    // cudaErrorInvalidValue: pageable host memory not tracked by the runtime.
+    // Clear the sticky error so it does not pollute subsequent CUDA calls.
+    if (err == cudaErrorInvalidValue) {
+        cudaGetLastError();
+        return true;
+    }
+    cudaGetLastError();  // clear any other unexpected error
+    return false;
+#elif defined(USE_HIP)
+    hipPointerAttribute_t attr{};
+    hipError_t err = hipPointerGetAttributes(&attr, ptr);
+    if (err == hipSuccess) {
+        return attr.type == hipMemoryTypeHost
+#if HIP_VERSION >= 50000000
+               || attr.type == hipMemoryTypeUnregistered
+#endif
+            ;
+    }
+    if (err == hipErrorInvalidValue) {
+        hipGetLastError();
+        return true;
+    }
+    hipGetLastError();
+    return false;
+#elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    aclrtPtrAttributes attr{};
+    aclError err = aclrtPointerGetAttributes(const_cast<void*>(ptr), &attr);
+    if (err == ACL_SUCCESS) {
+        return attr.location.type == ACL_MEM_LOCATION_TYPE_HOST;
+    }
+    // Ascend: if query fails, we cannot confirm it is host memory.
+    return false;
+#else
+    (void)ptr;
+    return true;  // CPU-only build: all pointers are host
+#endif
+}
 }  // namespace gpu_staging
 }  // namespace mooncake

--- a/mooncake-store/include/gpu_staging_utils.h
+++ b/mooncake-store/include/gpu_staging_utils.h
@@ -96,51 +96,29 @@ inline bool CopyHostToDevice(void* dst, const void* src, size_t size) {
 //   else                  -> reject (unknown type, e.g. non-standard allocator)
 //
 // Pageable host memory (not tracked by CUDA runtime) is treated as host.
-// On CUDA < 11 where cudaMemoryTypeUnregistered is unavailable,
-// cudaErrorInvalidValue is the expected response for pageable memory.
 inline bool IsHostPointer(const void* ptr) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
     cudaPointerAttributes attr{};
-    cudaError_t err = cudaPointerGetAttributes(&attr, ptr);
-    if (err == cudaSuccess) {
-        return attr.type == cudaMemoryTypeHost
-#if CUDART_VERSION >= 11000
-               || attr.type == cudaMemoryTypeUnregistered
-#endif
-            ;
-    }
-    // cudaErrorInvalidValue: pageable host memory not tracked by the runtime.
-    // Clear the sticky error so it does not pollute subsequent CUDA calls.
-    if (err == cudaErrorInvalidValue) {
-        cudaGetLastError();
+    if (cudaPointerGetAttributes(&attr, ptr) != cudaSuccess) {
+        // Query failed: pageable host memory not tracked by the runtime.
+        cudaGetLastError();  // clear sticky error
         return true;
     }
-    cudaGetLastError();  // clear any other unexpected error
-    return false;
+    return attr.type != cudaMemoryTypeDevice;
 #elif defined(USE_HIP)
     hipPointerAttribute_t attr{};
-    hipError_t err = hipPointerGetAttributes(&attr, ptr);
-    if (err == hipSuccess) {
-        return attr.type == hipMemoryTypeHost
-#if HIP_VERSION >= 50000000
-               || attr.type == hipMemoryTypeUnregistered
-#endif
-            ;
-    }
-    if (err == hipErrorInvalidValue) {
-        hipGetLastError();
+    if (hipPointerGetAttributes(&attr, ptr) != hipSuccess) {
+        hipGetLastError();  // clear sticky error
         return true;
     }
-    hipGetLastError();
-    return false;
+    return attr.type != hipMemoryTypeDevice;
 #elif defined(USE_ASCEND) || defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
     aclrtPtrAttributes attr{};
-    aclError err = aclrtPointerGetAttributes(const_cast<void*>(ptr), &attr);
-    if (err == ACL_SUCCESS) {
-        return attr.location.type == ACL_MEM_LOCATION_TYPE_HOST;
+    if (aclrtPointerGetAttributes(const_cast<void*>(ptr), &attr) !=
+        ACL_SUCCESS) {
+        return false;  // cannot confirm host; conservative fallback
     }
-    // Ascend: if query fails, we cannot confirm it is host memory.
-    return false;
+    return attr.location.type != ACL_MEM_LOCATION_TYPE_DEVICE;
 #else
     (void)ptr;
     return true;  // CPU-only build: all pointers are host

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -674,7 +674,7 @@ class RealClient : public PyClient {
      */
     tl::expected<void, ErrorCode> batch_get_into_offload_object_internal(
         const std::string &target_rpc_service_addr,
-        std::unordered_map<std::string, Slice> &objects);
+        std::unordered_map<std::string, std::vector<Slice>> &objects);
 
     std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
 

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -406,7 +406,8 @@ class TransferSubmitter {
         const std::string& transfer_engine_addr,
         const std::vector<std::string>& keys,
         const std::vector<uint64_t>& pointers,
-        const std::unordered_map<std::string, Slice>& batched_slices);
+        const std::unordered_map<std::string, std::vector<Slice>>&
+            batched_slices);
 
    private:
     TransferEngine& engine_;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2275,7 +2275,7 @@ tl::expected<void, ErrorCode> Client::BatchGetOffloadObject(
     const std::string& transfer_engine_addr,
     const std::vector<std::string>& keys,
     const std::vector<uintptr_t>& pointers,
-    const std::unordered_map<std::string, Slice>& batch_slices) {
+    const std::unordered_map<std::string, std::vector<Slice>>& batch_slices) {
     auto future = transfer_submitter_->submit_batch_get_offload_object(
         transfer_engine_addr, keys, pointers, batch_slices);
     if (!future) {

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -258,13 +258,29 @@ inline tl::expected<void, ErrorCode> scatter_host_to_maybe_device(
     return {};
 }
 
-// Select the best replica from a list: prefer MEMORY, then LOCAL_DISK, then
-// DISK.  Master may return replicas in any order, so we always scan.
+// Select the best replica from a list: prefer local MEMORY, then any
+// MEMORY, then LOCAL_DISK, then DISK.  Master may return replicas in any
+// order, so we always scan.
 inline const Replica::Descriptor *SelectBestReplica(
-    const std::vector<Replica::Descriptor> &replicas) {
+    const std::vector<Replica::Descriptor> &replicas,
+    const std::unordered_set<std::string> &local_endpoints) {
+    const Replica::Descriptor *first_memory = nullptr;
+    for (const auto &r : replicas) {
+        if (r.status != ReplicaStatus::COMPLETE) continue;
+        if (r.is_memory_replica()) {
+            if (local_endpoints.count(
+                    r.get_memory_descriptor()
+                        .buffer_descriptor.transport_endpoint_)) {
+                return &r;  // local MEMORY — best case
+            }
+            if (!first_memory) first_memory = &r;
+        }
+    }
+    if (first_memory) return first_memory;
+
     const Replica::Descriptor *best = nullptr;
     for (const auto &r : replicas) {
-        if (r.is_memory_replica()) return &r;
+        if (r.status != ReplicaStatus::COMPLETE) continue;
         if (r.is_local_disk_replica()) {
             best = &r;  // LOCAL_DISK always overrides DISK
         } else if (r.is_disk_replica() && !best) {
@@ -1969,10 +1985,12 @@ std::shared_ptr<BufferHandle> RealClient::get_buffer_internal(
         return nullptr;
     }
 
-    // Select best replica: prefer MEMORY, then LOCAL_DISK, then DISK.
+    // Select best replica: prefer local MEMORY, then any MEMORY,
+    // then LOCAL_DISK, then DISK.
     // LOCAL_DISK data is on a remote node's SSD — must use offload RPC.
     // MEMORY / DISK are handled via client_->Get below.
-    const auto *best_replica = SelectBestReplica(replica_list);
+    auto local_endpoints = client_->GetLocalEndpoints();
+    const auto *best_replica = SelectBestReplica(replica_list, local_endpoints);
     if (!best_replica) {
         LOG(ERROR) << "No usable replica for key: " << key;
         return nullptr;
@@ -2260,6 +2278,7 @@ RealClient::batch_get_buffer_internal(
     std::vector<DiskKeyOp> disk_ops;
     valid_ops.reserve(keys.size());
 
+    auto local_endpoints = client_->GetLocalEndpoints();
     for (size_t i = 0; i < keys.size(); ++i) {
         const auto &key = keys[i];
 
@@ -2278,9 +2297,10 @@ RealClient::batch_get_buffer_internal(
             continue;
         }
 
-        // Select best replica: prefer MEMORY, then LOCAL_DISK, then DISK.
+        // Select best replica: prefer local MEMORY, then any MEMORY,
+        // then LOCAL_DISK, then DISK.
         const auto *best_replica =
-            SelectBestReplica(query_result_values.replicas);
+            SelectBestReplica(query_result_values.replicas, local_endpoints);
         if (!best_replica) {
             LOG(ERROR) << "No usable replica for key: " << key;
             continue;
@@ -2528,8 +2548,10 @@ RealClient::resolve_ranged_read_metadata(const std::string &key) {
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    // Select best replica: prefer MEMORY, then LOCAL_DISK, then DISK.
-    const auto *best_replica = SelectBestReplica(replica_list);
+    // Select best replica: prefer local MEMORY, then any MEMORY,
+    // then LOCAL_DISK, then DISK.
+    auto local_endpoints = client_->GetLocalEndpoints();
+    const auto *best_replica = SelectBestReplica(replica_list, local_endpoints);
     if (!best_replica) {
         LOG(ERROR) << "No usable replica for key: " << key;
         return tl::unexpected(ErrorCode::INVALID_REPLICA);
@@ -3726,6 +3748,7 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
     std::vector<DiskKeyInfo> disk_operations;
     valid_operations.reserve(num_keys);
 
+    auto local_endpoints = client_->GetLocalEndpoints();
     for (size_t i = 0; i < num_keys; ++i) {
         const auto &key = keys[i];
 
@@ -3749,9 +3772,10 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
             continue;
         }
 
-        // Select best replica: prefer MEMORY, then LOCAL_DISK, then DISK.
+        // Select best replica: prefer local MEMORY, then any MEMORY,
+        // then LOCAL_DISK, then DISK.
         const auto *best_replica =
-            SelectBestReplica(query_result_values.replicas);
+            SelectBestReplica(query_result_values.replicas, local_endpoints);
         if (!best_replica) {
             LOG(ERROR) << "No usable replica for key: " << key;
             results[i] = tl::unexpected(ErrorCode::INVALID_REPLICA);
@@ -4204,6 +4228,7 @@ RealClient::batch_get_into_multi_buffers_internal(
     std::vector<ValidKeyInfo> valid_operations;
     std::unordered_map<std::string, DiskKeyInfo> valid_local_disk_ops;
     valid_operations.reserve(num_keys);
+    auto local_endpoints = client_->GetLocalEndpoints();
     for (size_t i = 0; i < num_keys; ++i) {
         const auto &key = keys[i];
         // Handle query failures
@@ -4227,7 +4252,7 @@ RealClient::batch_get_into_multi_buffers_internal(
         // LOCAL_DISK, then DISK. Master may return multiple replicas in any
         // order, so always scan rather than blindly taking replicas[0].
         const auto *best_replica =
-            SelectBestReplica(query_result_values.replicas);
+            SelectBestReplica(query_result_values.replicas, local_endpoints);
         if (!best_replica) {
             LOG(ERROR) << "No usable replica for key: " << key;
             results.emplace_back(tl::unexpected(ErrorCode::INVALID_REPLICA));
@@ -4359,8 +4384,8 @@ RealClient::batch_get_into_multi_buffers_internal(
                     user_slices.push_back(Slice{op.buffers[j], op.sizes[j]});
                     slice_total += op.sizes[j];
                 }
-                if (slice_total != op.total_size) {
-                    LOG(ERROR) << "Slice size mismatch for key " << key
+                if (slice_total < op.total_size) {
+                    LOG(ERROR) << "Slice size too small for key " << key
                                << ": slices=" << slice_total
                                << ", total=" << op.total_size;
                     results[op.original_index] =

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4050,8 +4050,9 @@ RealClient::batch_get_into_multi_buffers_internal(
             }
         } else if (replica.is_local_disk_replica() ||
                    replica.is_disk_replica()) {
-            // LOCAL_DISK / DISK: file I/O cannot write to GPU memory.
-            // Route through CPU temp buffer + scatter.
+            // LOCAL_DISK: GPU buffers passed directly as scatter-gather slices
+            // (zero-copy). DISK: file I/O cannot write to GPU memory; temp CPU
+            // buffer used at read time.
             valid_local_disk_ops.emplace(
                 key,
                 DiskKeyInfo{.key = key,

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -236,6 +236,51 @@ void fill_ranged_read_results_with_error(
         }
     }
 }
+
+// Scatter host (CPU) memory to a destination that may be GPU or host.
+// Returns tl::expected<void, ErrorCode> for use in functions returning
+// tl::expected<int64_t, ErrorCode>.
+inline tl::expected<void, ErrorCode> scatter_host_to_maybe_device(
+    void *dst, const void *src, size_t size, const std::string &context) {
+    int device_id = -1;
+    if (gpu_staging::IsDevicePointer(dst, &device_id)) {
+        gpu_staging::SetDevice(device_id);
+        if (!gpu_staging::CopyHostToDevice(dst, src, size)) {
+            LOG(ERROR) << "H2D copy failed: " << context;
+            return tl::unexpected(ErrorCode::TRANSFER_FAIL);
+        }
+    } else if (gpu_staging::IsHostPointer(dst)) {
+        memcpy(dst, src, size);
+    } else {
+        LOG(ERROR) << "Unknown memory type for dst buffer: " << context;
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    return {};
+}
+
+// Select the best replica from a list: prefer MEMORY, then LOCAL_DISK, then
+// DISK.  Master may return replicas in any order, so we always scan.
+inline const Replica::Descriptor *SelectBestReplica(
+    const std::vector<Replica::Descriptor> &replicas) {
+    const Replica::Descriptor *best = nullptr;
+    for (const auto &r : replicas) {
+        if (r.is_memory_replica()) return &r;
+        if (r.is_local_disk_replica()) {
+            best = &r;  // LOCAL_DISK always overrides DISK
+        } else if (r.is_disk_replica() && !best) {
+            best = &r;
+        }
+    }
+    return best;
+}
+
+// Build a QueryResult containing only the chosen replica so that
+// Client::Get / Client::BatchGet (which internally call
+// FindFirstCompleteReplica) cannot pick a different replica type.
+inline QueryResult FilterQueryResult(const QueryResult &qr,
+                                     const Replica::Descriptor &replica) {
+    return QueryResult({replica}, qr.lease_timeout);
+}
 }  // namespace
 
 PyClient::~PyClient() {}
@@ -1924,43 +1969,71 @@ std::shared_ptr<BufferHandle> RealClient::get_buffer_internal(
         return nullptr;
     }
 
-    const auto &res = client_->GetPreferredReplica(replica_list);
-    if (!res) {
-        LOG(ERROR) << "Empty replica list for key: " << key;
+    // Select best replica: prefer MEMORY, then LOCAL_DISK, then DISK.
+    // LOCAL_DISK data is on a remote node's SSD — must use offload RPC.
+    // MEMORY / DISK are handled via client_->Get below.
+    const auto *best_replica = SelectBestReplica(replica_list);
+    if (!best_replica) {
+        LOG(ERROR) << "No usable replica for key: " << key;
         return nullptr;
     }
 
-    const auto &replica = res.value();
+    const auto &replica = *best_replica;
     uint64_t total_length = calculate_total_size(replica);
 
     if (total_length == 0) {
         return nullptr;
     }
 
-    // Normal allocation path
+    // Allocate buffer
     auto alloc_result = client_buffer_allocator->allocate(total_length);
     if (!alloc_result) {
         LOG(ERROR) << "Failed to allocate buffer for get_buffer, key: " << key;
         return nullptr;
     }
 
-    auto &buffer_handle = *alloc_result;
+    auto buffer_handle =
+        std::make_shared<BufferHandle>(std::move(*alloc_result));
 
-    // Create slices for the allocated buffer
+    if (best_replica->is_local_disk_replica()) {
+        // LOCAL_DISK: data is on remote node's SSD. Use offload RPC.
+        const auto &endpoint =
+            best_replica->get_local_disk_descriptor().transport_endpoint;
+        std::unordered_map<std::string, std::vector<Slice>> objects;
+        objects.emplace(
+            key, std::vector<Slice>{{buffer_handle->ptr(), total_length}});
+        auto read_result =
+            batch_get_into_offload_object_internal(endpoint, objects);
+        if (!read_result) {
+            LOG(ERROR) << "SSD read failed for key '" << key
+                       << "': " << toString(read_result.error());
+            return nullptr;
+        }
+        return buffer_handle;
+    }
+
+    // MEMORY / DISK: use client_->Get.  FilterQueryResult ensures
+    // Client::Get's internal FindFirstCompleteReplica can only see
+    // the replica we selected, preventing accidental LOCAL_DISK picks.
+    if (replica.is_disk_replica() &&
+        gpu_staging::IsDevicePointer(buffer_handle->ptr(), nullptr)) {
+        LOG(WARNING) << "DISK replica for key '" << key
+                     << "' received a device pointer from the allocator; "
+                     << "file I/O cannot write to GPU memory — read will fail. "
+                     << "Ensure client_buffer_allocator_ returns host memory.";
+    }
+
     std::vector<Slice> slices;
-    allocateSlices(slices, replica, buffer_handle.ptr());
-
-    // Get the object data
-    auto get_result = client_->Get(key, query_result.value(), slices);
+    allocateSlices(slices, replica, buffer_handle->ptr());
+    auto filtered_qr = FilterQueryResult(query_result.value(), replica);
+    auto get_result = client_->Get(key, filtered_qr, slices);
     if (!get_result) {
         LOG(ERROR) << "Get failed for key: " << key
                    << " with error: " << toString(get_result.error());
         return nullptr;
     }
 
-    // Create BufferHandle with the allocated memory
-    // The buffer will be managed by the BufferHandle's shared_ptr
-    return std::make_shared<BufferHandle>(std::move(buffer_handle));
+    return buffer_handle;
 }
 
 // Implementation of get_buffer method
@@ -2205,7 +2278,14 @@ RealClient::batch_get_buffer_internal(
             continue;
         }
 
-        const auto &replica = query_result_values.replicas[0];
+        // Select best replica: prefer MEMORY, then LOCAL_DISK, then DISK.
+        const auto *best_replica =
+            SelectBestReplica(query_result_values.replicas);
+        if (!best_replica) {
+            LOG(ERROR) << "No usable replica for key: " << key;
+            continue;
+        }
+        const auto replica = *best_replica;
         uint64_t total_size = calculate_total_size(replica);
         if (total_size == 0) {
             continue;
@@ -2227,21 +2307,32 @@ RealClient::batch_get_buffer_internal(
         if (replica.is_local_disk_replica()) {
             // LOCAL_DISK: buffer is allocated and registered via
             // client_buffer_allocator_, route to SSD RPC path below.
-            disk_ops.emplace_back(
-                DiskKeyOp{.original_index = i,
-                          .key = key,
-                          .query_result = std::move(query_result_values),
-                          .buffer_handle = std::move(buffer_handle),
-                          .total_size = total_size});
+            disk_ops.emplace_back(DiskKeyOp{
+                .original_index = i,
+                .key = key,
+                .query_result = FilterQueryResult(query_result_values, replica),
+                .buffer_handle = std::move(buffer_handle),
+                .total_size = total_size});
             continue;
         }
 
-        valid_ops.emplace_back(
-            KeyOp{.original_index = i,
-                  .key = key,
-                  .query_result = std::move(query_result_values),
-                  .buffer_handle = std::move(buffer_handle),
-                  .slices = std::move(slices)});
+        // DISK replicas use storage_backend::vector_read (file I/O) which
+        // can only write to CPU-addressable memory.  If the allocator ever
+        // returns device memory for DISK, the read will silently fail.
+        if (replica.is_disk_replica() &&
+            gpu_staging::IsDevicePointer(buffer_handle->ptr(), nullptr)) {
+            LOG(WARNING)
+                << "DISK replica for key '" << key
+                << "' received a device pointer from the allocator; "
+                << "file I/O cannot write to GPU memory — read will fail. "
+                << "Ensure client_buffer_allocator_ returns host memory.";
+        }
+        valid_ops.emplace_back(KeyOp{
+            .original_index = i,
+            .key = key,
+            .query_result = FilterQueryResult(query_result_values, replica),
+            .buffer_handle = std::move(buffer_handle),
+            .slices = std::move(slices)});
     }
 
     if (valid_ops.empty() && disk_ops.empty()) {
@@ -2290,7 +2381,19 @@ RealClient::batch_get_buffer_internal(
 
         for (size_t idx = 0; idx < disk_ops.size(); ++idx) {
             auto &op = disk_ops[idx];
-            const auto &replica = op.query_result.replicas.at(0);
+            // Find the LOCAL_DISK replica — replicas may be in any order.
+            const Replica::Descriptor *replica_ptr = nullptr;
+            for (const auto &r : op.query_result.replicas) {
+                if (r.is_local_disk_replica()) {
+                    replica_ptr = &r;
+                    break;
+                }
+            }
+            if (!replica_ptr) {
+                LOG(ERROR) << "No LOCAL_DISK replica found for key: " << op.key;
+                continue;
+            }
+            const auto &replica = *replica_ptr;
             offload_objects[replica.get_local_disk_descriptor()
                                 .transport_endpoint]
                 .emplace(op.key, std::vector<Slice>{
@@ -2425,14 +2528,15 @@ RealClient::resolve_ranged_read_metadata(const std::string &key) {
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    const auto &res = client_->GetPreferredReplica(replica_list);
-    if (!res) {
-        LOG(ERROR) << "Internal error: replica_list is empty";
-        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    // Select best replica: prefer MEMORY, then LOCAL_DISK, then DISK.
+    const auto *best_replica = SelectBestReplica(replica_list);
+    if (!best_replica) {
+        LOG(ERROR) << "No usable replica for key: " << key;
+        return tl::unexpected(ErrorCode::INVALID_REPLICA);
     }
 
     auto query_value = std::move(query_result.value());
-    auto replica = res.value();
+    auto replica = *best_replica;
     return RangedReadMetadata{.query_result = std::move(query_value),
                               .replica = std::move(replica),
                               .total_size = calculate_total_size(replica)};
@@ -2488,7 +2592,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
             BufferHandle tmp_handle(std::move(*alloc_result));
             std::vector<mooncake::Slice> tmp_slices;
             allocateSlices(tmp_slices, replica, tmp_handle.ptr());
-            auto get_result = client_->Get(key, query_result, tmp_slices);
+            auto filtered_qr = FilterQueryResult(query_result, replica);
+            auto get_result = client_->Get(key, filtered_qr, tmp_slices);
             if (!get_result) {
                 LOG(ERROR) << "DISK Get failed for key: " << key
                            << " with error: " << toString(get_result.error());
@@ -2496,20 +2601,10 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
             }
             void *dst = static_cast<char *>(buffer) + dst_offset;
             const void *src = tmp_handle.ptr();
-            int device_id = -1;
-            if (gpu_staging::IsDevicePointer(dst, &device_id)) {
-                gpu_staging::SetDevice(device_id);
-                if (!gpu_staging::CopyHostToDevice(dst, src, total_size)) {
-                    LOG(ERROR) << "H2D copy failed for DISK full read"
-                               << ", key: " << key;
-                    return tl::unexpected(ErrorCode::TRANSFER_FAIL);
-                }
-            } else if (gpu_staging::IsHostPointer(dst)) {
-                memcpy(dst, src, total_size);
-            } else {
-                LOG(ERROR) << "Unknown memory type for dst buffer in DISK "
-                           << "full read, key: " << key;
-                return tl::unexpected(ErrorCode::INVALID_PARAMS);
+            if (auto r = scatter_host_to_maybe_device(
+                    dst, src, total_size, "DISK full read, key: " + key);
+                !r) {
+                return tl::unexpected(r.error());
             }
             return static_cast<int64_t>(total_size);
         }
@@ -2518,7 +2613,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         allocateSlices(slices, replica,
                        static_cast<char *>(buffer) + dst_offset);
 
-        auto get_result = client_->Get(key, query_result, slices);
+        auto filtered_qr = FilterQueryResult(query_result, replica);
+        auto get_result = client_->Get(key, filtered_qr, slices);
         if (!get_result) {
             LOG(ERROR) << "Get failed for key: " << key
                        << " with error: " << toString(get_result.error());
@@ -2527,14 +2623,20 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return static_cast<int64_t>(total_size);
     }
 
-    // Partial disk read helper: allocate temp CPU buffer, invoke read_op to
+    // Partial disk read: allocate temp CPU buffer, invoke read_op to
     // fill it, then scatter [src_offset, src_offset+size) to dst.
+    //
+    // buf_size controls how much to allocate / read.  DISK must use
+    // total_size (allocateSlices requires full-object slices).
+    // LOCAL_DISK can use src_offset + size (offload RPC transfers
+    // sequentially from remote offset 0).
     auto partial_disk_read =
-        [&](auto &&read_op) -> tl::expected<int64_t, ErrorCode> {
-        auto alloc_result = client_buffer_allocator_->allocate(total_size);
+        [&](auto &&read_op,
+            size_t buf_size) -> tl::expected<int64_t, ErrorCode> {
+        auto alloc_result = client_buffer_allocator_->allocate(buf_size);
         if (!alloc_result) {
             LOG(ERROR) << "Failed to allocate temp buffer for ranged disk "
-                       << "read, key: " << key << ", size: " << total_size;
+                       << "read, key: " << key << ", size: " << buf_size;
             return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
         }
         BufferHandle tmp_handle(std::move(*alloc_result));
@@ -2543,43 +2645,40 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         void *dst = static_cast<char *>(buffer) + dst_offset;
         const void *src =
             static_cast<const char *>(tmp_handle.ptr()) + src_offset;
-        int device_id = -1;
-        if (gpu_staging::IsDevicePointer(dst, &device_id)) {
-            gpu_staging::SetDevice(device_id);
-            if (!gpu_staging::CopyHostToDevice(dst, src, size)) {
-                LOG(ERROR) << "H2D copy failed for ranged disk read"
-                           << ", key: " << key;
-                return tl::unexpected(ErrorCode::TRANSFER_FAIL);
-            }
-        } else if (gpu_staging::IsHostPointer(dst)) {
-            memcpy(dst, src, size);
-        } else {
-            LOG(ERROR) << "Unknown memory type for dst buffer in ranged "
-                       << "disk read, key: " << key;
-            return tl::unexpected(ErrorCode::INVALID_PARAMS);
+        if (auto r = scatter_host_to_maybe_device(
+                dst, src, size, "ranged disk read, key: " + key);
+            !r) {
+            return tl::unexpected(r.error());
         }
         return static_cast<int64_t>(size);
     };
 
     if (replica.is_local_disk_replica()) {
-        return partial_disk_read([&](void *tmp_buf)
-                                     -> tl::expected<void, ErrorCode> {
-            const auto &endpoint =
-                replica.get_local_disk_descriptor().transport_endpoint;
-            std::unordered_map<std::string, std::vector<Slice>> objects;
-            objects.emplace(
-                key,
-                std::vector<Slice>{{static_cast<char *>(tmp_buf), total_size}});
-            return batch_get_into_offload_object_internal(endpoint, objects);
-        });
+        // LOCAL_DISK: offload RPC transfers sequentially from remote offset
+        // 0, so we only need src_offset + size bytes (not total_size).
+        return partial_disk_read(
+            [&](void *tmp_buf) -> tl::expected<void, ErrorCode> {
+                const auto &endpoint =
+                    replica.get_local_disk_descriptor().transport_endpoint;
+                std::unordered_map<std::string, std::vector<Slice>> objects;
+                objects.emplace(
+                    key, std::vector<Slice>{{static_cast<char *>(tmp_buf),
+                                             src_offset + size}});
+                return batch_get_into_offload_object_internal(endpoint,
+                                                              objects);
+            },
+            src_offset + size);
     }
 
     if (replica.is_disk_replica()) {
+        // DISK: client_->Get + allocateSlices requires full-object slices,
+        // so we must allocate total_size.
         return partial_disk_read(
             [&](void *tmp_buf) -> tl::expected<void, ErrorCode> {
                 std::vector<mooncake::Slice> tmp_slices;
                 allocateSlices(tmp_slices, replica, tmp_buf);
-                auto get_result = client_->Get(key, query_result, tmp_slices);
+                auto filtered_qr = FilterQueryResult(query_result, replica);
+                auto get_result = client_->Get(key, filtered_qr, tmp_slices);
                 if (!get_result) {
                     LOG(ERROR)
                         << "DISK Get failed for key: " << key
@@ -2587,7 +2686,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
                     return tl::unexpected(get_result.error());
                 }
                 return {};
-            });
+            },
+            total_size);
     }
 
     if (!replica.is_memory_replica()) {
@@ -3613,9 +3713,17 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
         std::vector<Slice> slices;
         uint64_t total_size;
     };
+    struct DiskKeyInfo {
+        std::string key;
+        size_t original_index;
+        QueryResult query_result;
+        void *dst_buffer;
+        uint64_t total_size;
+    };
 
     std::vector<ValidKeyInfo> valid_operations;
     std::unordered_map<std::string, ValidKeyInfo> valid_local_disk_operations;
+    std::vector<DiskKeyInfo> disk_operations;
     valid_operations.reserve(num_keys);
 
     for (size_t i = 0; i < num_keys; ++i) {
@@ -3641,8 +3749,17 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
             continue;
         }
 
+        // Select best replica: prefer MEMORY, then LOCAL_DISK, then DISK.
+        const auto *best_replica =
+            SelectBestReplica(query_result_values.replicas);
+        if (!best_replica) {
+            LOG(ERROR) << "No usable replica for key: " << key;
+            results[i] = tl::unexpected(ErrorCode::INVALID_REPLICA);
+            continue;
+        }
+
         // Calculate required buffer size
-        const auto &replica = query_result_values.replicas[0];
+        const auto replica = *best_replica;
         uint64_t total_size = calculate_total_size(replica);
 
         // Validate buffer capacity
@@ -3654,12 +3771,9 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
             continue;
         }
 
-        // Create slices for this key's buffer
-        std::vector<Slice> key_slices;
-        allocateSlices(key_slices, replica, buffers[i]);
-
-        if (query_result_values.replicas.size() == 1 &&
-            query_result_values.replicas.at(0).is_local_disk_replica()) {
+        if (replica.is_local_disk_replica()) {
+            std::vector<Slice> key_slices;
+            allocateSlices(key_slices, replica, buffers[i]);
             valid_local_disk_operations.emplace(
                 key,
                 ValidKeyInfo{.key = key,
@@ -3670,11 +3784,25 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
             results[i] = static_cast<int64_t>(total_size);
             continue;
         }
-        // Store operation info for batch processing
+        if (replica.is_disk_replica()) {
+            // DISK: file I/O (vector_read) cannot write to user GPU buffer.
+            // Defer — allocate CPU temp buffer, BatchGet, then scatter.
+            disk_operations.emplace_back(
+                DiskKeyInfo{.key = key,
+                            .original_index = i,
+                            .query_result = std::move(query_result_values),
+                            .dst_buffer = buffers[i],
+                            .total_size = total_size});
+            results[i] = static_cast<int64_t>(total_size);
+            continue;
+        }
+        // MEMORY: RDMA directly to user buffer.
+        std::vector<Slice> key_slices;
+        allocateSlices(key_slices, replica, buffers[i]);
         valid_operations.push_back(
             {.key = key,
              .original_index = i,
-             .query_result = std::move(query_result_values),
+             .query_result = FilterQueryResult(query_result_values, replica),
              .slices = std::move(key_slices),
              .total_size = total_size});
 
@@ -3683,7 +3811,8 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
     }
 
     // Early return if no valid operations
-    if (valid_operations.empty() && valid_local_disk_operations.empty()) {
+    if (valid_operations.empty() && valid_local_disk_operations.empty() &&
+        disk_operations.empty()) {
         return results;
     }
 
@@ -3718,13 +3847,100 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
         }
     }
 
+    // ---- DISK replicas: BatchGet into CPU temp buffers, then scatter ----
+    if (!disk_operations.empty()) {
+        std::vector<std::string> disk_batch_keys;
+        std::vector<QueryResult> disk_batch_qrs;
+        std::unordered_map<std::string, std::vector<Slice>> disk_batch_slices;
+        std::vector<size_t> disk_batch_indices;
+        std::unordered_map<std::string, std::unique_ptr<BufferHandle>>
+            disk_temp_handles;
+
+        for (size_t di = 0; di < disk_operations.size(); ++di) {
+            auto &op = disk_operations[di];
+            // Find the DISK replica.
+            const Replica::Descriptor *replica_ptr = nullptr;
+            for (const auto &r : op.query_result.replicas) {
+                if (r.is_disk_replica()) {
+                    replica_ptr = &r;
+                    break;
+                }
+            }
+            if (!replica_ptr) {
+                LOG(ERROR) << "No DISK replica found for key: " << op.key;
+                results[op.original_index] =
+                    tl::unexpected(ErrorCode::INVALID_REPLICA);
+                continue;
+            }
+            auto alloc_result =
+                client_buffer_allocator_->allocate(op.total_size);
+            if (!alloc_result) {
+                LOG(ERROR) << "Failed to allocate temp buffer for DISK "
+                           << "read, key: " << op.key
+                           << ", size: " << op.total_size;
+                results[op.original_index] =
+                    tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+                continue;
+            }
+            auto handle =
+                std::make_unique<BufferHandle>(std::move(*alloc_result));
+            std::vector<Slice> disk_slices;
+            allocateSlices(disk_slices, *replica_ptr, handle->ptr());
+            disk_batch_keys.push_back(op.key);
+            disk_batch_qrs.push_back(
+                FilterQueryResult(op.query_result, *replica_ptr));
+            disk_batch_slices[op.key] = std::move(disk_slices);
+            disk_batch_indices.push_back(di);
+            disk_temp_handles.emplace(op.key, std::move(handle));
+        }
+
+        if (!disk_batch_keys.empty()) {
+            auto disk_results = client_->BatchGet(
+                disk_batch_keys, disk_batch_qrs, disk_batch_slices);
+
+            for (size_t di = 0; di < disk_batch_indices.size(); ++di) {
+                const auto &key = disk_batch_keys[di];
+                auto &op = disk_operations[disk_batch_indices[di]];
+                auto handle_it = disk_temp_handles.find(key);
+                if (!disk_results[di]) {
+                    LOG(ERROR) << "DISK BatchGet failed for key '" << key
+                               << "': " << toString(disk_results[di].error());
+                    results[op.original_index] =
+                        tl::unexpected(disk_results[di].error());
+                    continue;
+                }
+                if (auto r = scatter_host_to_maybe_device(
+                        op.dst_buffer,
+                        static_cast<char *>(handle_it->second->ptr()),
+                        op.total_size, "DISK read, key: " + key);
+                    !r) {
+                    results[op.original_index] = tl::make_unexpected(r.error());
+                }
+            }
+        }
+    }
+
     // Prepare batch transfer data structures
     std::unordered_map<std::string,
                        std::unordered_map<std::string, std::vector<Slice>>>
         offload_objects;
 
     for (const auto &op_it : valid_local_disk_operations) {
-        const auto &replica = op_it.second.query_result.replicas.at(0);
+        // Find the LOCAL_DISK replica from the list — replicas may be in
+        // any order from Master.
+        const Replica::Descriptor *replica_ptr = nullptr;
+        for (const auto &r : op_it.second.query_result.replicas) {
+            if (r.is_local_disk_replica()) {
+                replica_ptr = &r;
+                break;
+            }
+        }
+        if (!replica_ptr) {
+            LOG(ERROR) << "No LOCAL_DISK replica found for key: "
+                       << op_it.first;
+            continue;
+        }
+        const auto &replica = *replica_ptr;
         auto [store_segment_it, _] = offload_objects.try_emplace(
             replica.get_local_disk_descriptor().transport_endpoint);
         store_segment_it->second.emplace(op_it.first, op_it.second.slices);
@@ -4009,23 +4225,15 @@ RealClient::batch_get_into_multi_buffers_internal(
         }
         // Select best replica: prefer MEMORY (direct RDMA to GPU), then
         // LOCAL_DISK, then DISK. Master may return multiple replicas in any
-        // order (e.g. [DISK, MEMORY]), so always scan rather than blindly
-        // taking replicas[0].
-        const Replica::Descriptor *best_replica = nullptr;
-        for (const auto &r : query_result_values.replicas) {
-            if (r.is_memory_replica()) {
-                best_replica = &r;
-                break;
-            }
-            if (r.is_local_disk_replica() && !best_replica) best_replica = &r;
-            if (r.is_disk_replica() && !best_replica) best_replica = &r;
-        }
+        // order, so always scan rather than blindly taking replicas[0].
+        const auto *best_replica =
+            SelectBestReplica(query_result_values.replicas);
         if (!best_replica) {
             LOG(ERROR) << "No usable replica for key: " << key;
             results.emplace_back(tl::unexpected(ErrorCode::INVALID_REPLICA));
             continue;
         }
-        const auto &replica = *best_replica;
+        const auto replica = *best_replica;
         uint64_t total_size = calculate_total_size(replica);
         const auto &sizes = all_sizes[i];
         uint64_t dst_total_size = 0;
@@ -4073,7 +4281,7 @@ RealClient::batch_get_into_multi_buffers_internal(
         valid_operations.push_back(
             {.key = key,
              .original_index = i,
-             .query_result = std::move(query_result_values),
+             .query_result = FilterQueryResult(query_result_values, replica),
              .slices = std::move(key_slices),
              .total_size = total_size});
         // Set success result (actual bytes transferred)
@@ -4127,7 +4335,23 @@ RealClient::batch_get_into_multi_buffers_internal(
 
             for (auto &[key, op] : valid_local_disk_ops) {
                 if (!op.is_local_disk) continue;
-                const auto &replica = op.query_result.replicas.at(0);
+                // Find the correct LOCAL_DISK replica — Master may return
+                // replicas in any order (e.g. [DISK, LOCAL_DISK]).
+                const Replica::Descriptor *replica_ptr = nullptr;
+                for (const auto &r : op.query_result.replicas) {
+                    if (r.is_local_disk_replica()) {
+                        replica_ptr = &r;
+                        break;
+                    }
+                }
+                if (!replica_ptr) {
+                    LOG(ERROR)
+                        << "No LOCAL_DISK replica found for key: " << key;
+                    results[op.original_index] =
+                        tl::make_unexpected(ErrorCode::INVALID_REPLICA);
+                    continue;
+                }
+                const auto &replica = *replica_ptr;
                 std::vector<Slice> user_slices;
                 user_slices.reserve(op.buffers.size());
                 size_t slice_total = 0;
@@ -4182,24 +4406,11 @@ RealClient::batch_get_into_multi_buffers_internal(
                         std::min(op.sizes[j],
                                  static_cast<size_t>(op.total_size - offset));
                     void *dst = op.buffers[j];
-                    int device_id = -1;
-                    if (gpu_staging::IsDevicePointer(dst, &device_id)) {
-                        gpu_staging::SetDevice(device_id);
-                        if (!gpu_staging::CopyHostToDevice(dst, src + offset,
-                                                           sz)) {
-                            LOG(ERROR) << "H2D copy failed during DISK scatter"
-                                       << ", key: " << key;
-                            results[op.original_index] =
-                                tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
-                            return false;
-                        }
-                    } else if (gpu_staging::IsHostPointer(dst)) {
-                        memcpy(dst, src + offset, sz);
-                    } else {
-                        LOG(ERROR) << "Unknown memory type for dst buffer"
-                                   << ", key: " << key;
+                    if (auto r = scatter_host_to_maybe_device(
+                            dst, src + offset, sz, "DISK scatter, key: " + key);
+                        !r) {
                         results[op.original_index] =
-                            tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                            tl::make_unexpected(r.error());
                         return false;
                     }
                     offset += sz;
@@ -4229,11 +4440,27 @@ RealClient::batch_get_into_multi_buffers_internal(
                 }
                 auto handle =
                     std::make_unique<BufferHandle>(std::move(*alloc_result));
-                const auto &replica = op.query_result.replicas.at(0);
+                // Find the correct DISK replica — Master may return
+                // replicas in any order (e.g. [LOCAL_DISK, DISK]).
+                const Replica::Descriptor *replica_ptr = nullptr;
+                for (const auto &r : op.query_result.replicas) {
+                    if (r.is_disk_replica()) {
+                        replica_ptr = &r;
+                        break;
+                    }
+                }
+                if (!replica_ptr) {
+                    LOG(ERROR) << "No DISK replica found for key: " << key;
+                    results[op.original_index] =
+                        tl::make_unexpected(ErrorCode::INVALID_REPLICA);
+                    continue;
+                }
+                const auto &replica = *replica_ptr;
                 std::vector<Slice> disk_slices;
                 allocateSlices(disk_slices, replica, handle->ptr());
                 disk_batch_keys.push_back(key);
-                disk_batch_qrs.push_back(op.query_result);
+                disk_batch_qrs.push_back(
+                    FilterQueryResult(op.query_result, *replica_ptr));
                 disk_batch_slices[key] = std::move(disk_slices);
                 disk_key_order.push_back(key);
                 temp_handles.emplace(key, std::move(handle));

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4122,6 +4122,40 @@ RealClient::batch_get_into_multi_buffers_internal(
             temp_handles.emplace(key, std::move(handle));
         }
 
+        // Scatter temp CPU buffer -> user multi_buffers (GPU or host).
+        // Returns false and sets results[original_index] on error.
+        auto scatter_to_buffers = [&](const std::string &key, char *src,
+                                      const DiskKeyInfo &op) -> bool {
+            size_t offset = 0;
+            for (size_t j = 0; j < op.buffers.size(); ++j) {
+                if (offset >= op.total_size) break;
+                size_t sz = std::min(
+                    op.sizes[j], static_cast<size_t>(op.total_size - offset));
+                void *dst = op.buffers[j];
+                int device_id = -1;
+                if (gpu_staging::IsDevicePointer(dst, &device_id)) {
+                    gpu_staging::SetDevice(device_id);
+                    if (!gpu_staging::CopyHostToDevice(dst, src + offset, sz)) {
+                        LOG(ERROR) << "H2D copy failed during scatter"
+                                   << ", key: " << key;
+                        results[op.original_index] =
+                            tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
+                        return false;
+                    }
+                } else if (gpu_staging::IsHostPointer(dst)) {
+                    memcpy(dst, src + offset, sz);
+                } else {
+                    LOG(ERROR) << "Unknown memory type for dst buffer"
+                               << ", key: " << key;
+                    results[op.original_index] =
+                        tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                    return false;
+                }
+                offset += sz;
+            }
+            return true;
+        };
+
         for (auto &[endpoint, objects] : offload_objects) {
             if (objects.empty()) continue;
             auto read_result =
@@ -4137,39 +4171,7 @@ RealClient::batch_get_into_multi_buffers_internal(
                         tl::make_unexpected(read_result.error());
                     continue;
                 }
-                // Scatter: temp contiguous buffer -> user's multi_buffers.
-                // Dual-check pointer type to avoid memcpy to GPU addresses.
-                char *src = static_cast<char *>(slice.ptr);
-                size_t offset = 0;
-                bool scatter_ok = true;
-                for (size_t j = 0; j < op.buffers.size() && scatter_ok; ++j) {
-                    if (offset >= op.total_size) break;
-                    size_t sz =
-                        std::min(op.sizes[j],
-                                 static_cast<size_t>(op.total_size - offset));
-                    void *dst = op.buffers[j];
-                    int device_id = -1;
-                    if (gpu_staging::IsDevicePointer(dst, &device_id)) {
-                        gpu_staging::SetDevice(device_id);
-                        if (!gpu_staging::CopyHostToDevice(dst, src + offset,
-                                                           sz)) {
-                            LOG(ERROR) << "H2D copy failed during scatter"
-                                       << ", key: " << key;
-                            results[op.original_index] =
-                                tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
-                            scatter_ok = false;
-                        }
-                    } else if (gpu_staging::IsHostPointer(dst)) {
-                        memcpy(dst, src + offset, sz);
-                    } else {
-                        LOG(ERROR) << "Unknown memory type for dst buffer"
-                                   << ", key: " << key;
-                        results[op.original_index] =
-                            tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-                        scatter_ok = false;
-                    }
-                    offset += sz;
-                }
+                scatter_to_buffers(key, static_cast<char *>(slice.ptr), op);
             }
         }
         // DISK: one batched BatchGet into CPU temp buffers, then scatter.
@@ -4211,39 +4213,8 @@ RealClient::batch_get_into_multi_buffers_internal(
                             tl::make_unexpected(disk_results[di].error());
                         continue;
                     }
-                    // Scatter from temp CPU buffer to user GPU/CPU
-                    // multi_buffers
-                    char *src = static_cast<char *>(handle_it->second->ptr());
-                    size_t offset = 0;
-                    for (size_t j = 0; j < op.buffers.size(); ++j) {
-                        if (offset >= op.total_size) break;
-                        size_t sz = std::min(
-                            op.sizes[j],
-                            static_cast<size_t>(op.total_size - offset));
-                        void *dst = op.buffers[j];
-                        int device_id = -1;
-                        if (gpu_staging::IsDevicePointer(dst, &device_id)) {
-                            gpu_staging::SetDevice(device_id);
-                            if (!gpu_staging::CopyHostToDevice(
-                                    dst, src + offset, sz)) {
-                                LOG(ERROR) << "H2D copy failed for DISK "
-                                           << "scatter, key: " << key;
-                                results[op.original_index] =
-                                    tl::make_unexpected(
-                                        ErrorCode::TRANSFER_FAIL);
-                                break;
-                            }
-                        } else if (gpu_staging::IsHostPointer(dst)) {
-                            memcpy(dst, src + offset, sz);
-                        } else {
-                            LOG(ERROR) << "Unknown memory type for dst buffer"
-                                       << ", key: " << key;
-                            results[op.original_index] =
-                                tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-                            break;
-                        }
-                        offset += sz;
-                    }
+                    scatter_to_buffers(
+                        key, static_cast<char *>(handle_it->second->ptr()), op);
                 }
             }
         }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2524,24 +2524,19 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return static_cast<int64_t>(total_size);
     }
 
-    // LOCAL_DISK partial read: read full object into temp buffer, then copy
-    // the requested [src_offset, src_offset+size) range to destination.
-    if (replica.is_local_disk_replica()) {
+    // Partial disk read helper: allocate temp CPU buffer, invoke read_op to
+    // fill it, then scatter [src_offset, src_offset+size) to dst.
+    auto partial_disk_read =
+        [&](auto &&read_op) -> tl::expected<int64_t, ErrorCode> {
         auto alloc_result = client_buffer_allocator_->allocate(total_size);
         if (!alloc_result) {
-            LOG(ERROR) << "Failed to allocate temp buffer for SSD ranged "
+            LOG(ERROR) << "Failed to allocate temp buffer for ranged disk "
                        << "read, key: " << key << ", size: " << total_size;
             return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
         }
         BufferHandle tmp_handle(std::move(*alloc_result));
-
-        const auto &endpoint =
-            replica.get_local_disk_descriptor().transport_endpoint;
-        std::unordered_map<std::string, Slice> objects;
-        objects.emplace(key, Slice{tmp_handle.ptr(), total_size});
-        auto result = batch_get_into_offload_object_internal(endpoint, objects);
-        if (!result) return tl::unexpected(result.error());
-
+        auto read_result = read_op(tmp_handle.ptr());
+        if (!read_result) return tl::unexpected(read_result.error());
         void *dst = static_cast<char *>(buffer) + dst_offset;
         const void *src =
             static_cast<const char *>(tmp_handle.ptr()) + src_offset;
@@ -2549,7 +2544,7 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         if (gpu_staging::IsDevicePointer(dst, &device_id)) {
             gpu_staging::SetDevice(device_id);
             if (!gpu_staging::CopyHostToDevice(dst, src, size)) {
-                LOG(ERROR) << "H2D copy failed for SSD ranged read"
+                LOG(ERROR) << "H2D copy failed for ranged disk read"
                            << ", key: " << key;
                 return tl::unexpected(ErrorCode::TRANSFER_FAIL);
             }
@@ -2557,49 +2552,38 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
             memcpy(dst, src, size);
         } else {
             LOG(ERROR) << "Unknown memory type for dst buffer in ranged "
-                       << "read, key: " << key;
+                       << "disk read, key: " << key;
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
         return static_cast<int64_t>(size);
+    };
+
+    if (replica.is_local_disk_replica()) {
+        return partial_disk_read(
+            [&](void *tmp_buf) -> tl::expected<void, ErrorCode> {
+                const auto &endpoint =
+                    replica.get_local_disk_descriptor().transport_endpoint;
+                std::unordered_map<std::string, Slice> objects;
+                objects.emplace(key, Slice{tmp_buf, total_size});
+                return batch_get_into_offload_object_internal(endpoint,
+                                                              objects);
+            });
     }
 
     if (replica.is_disk_replica()) {
-        // DISK partial read: read full object into temp CPU buffer, then
-        // copy the requested [src_offset, src_offset+size) range to dst.
-        auto alloc_result = client_buffer_allocator_->allocate(total_size);
-        if (!alloc_result) {
-            LOG(ERROR) << "Failed to allocate temp buffer for DISK partial "
-                       << "read, key: " << key << ", size: " << total_size;
-            return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
-        }
-        BufferHandle tmp_handle(std::move(*alloc_result));
-        std::vector<mooncake::Slice> tmp_slices;
-        allocateSlices(tmp_slices, replica, tmp_handle.ptr());
-        auto get_result = client_->Get(key, query_result, tmp_slices);
-        if (!get_result) {
-            LOG(ERROR) << "DISK Get failed for key: " << key
-                       << " with error: " << toString(get_result.error());
-            return tl::unexpected(get_result.error());
-        }
-        void *dst = static_cast<char *>(buffer) + dst_offset;
-        const void *src =
-            static_cast<const char *>(tmp_handle.ptr()) + src_offset;
-        int device_id = -1;
-        if (gpu_staging::IsDevicePointer(dst, &device_id)) {
-            gpu_staging::SetDevice(device_id);
-            if (!gpu_staging::CopyHostToDevice(dst, src, size)) {
-                LOG(ERROR) << "H2D copy failed for DISK partial read"
-                           << ", key: " << key;
-                return tl::unexpected(ErrorCode::TRANSFER_FAIL);
-            }
-        } else if (gpu_staging::IsHostPointer(dst)) {
-            memcpy(dst, src, size);
-        } else {
-            LOG(ERROR) << "Unknown memory type for dst buffer in DISK "
-                       << "partial read, key: " << key;
-            return tl::unexpected(ErrorCode::INVALID_PARAMS);
-        }
-        return static_cast<int64_t>(size);
+        return partial_disk_read(
+            [&](void *tmp_buf) -> tl::expected<void, ErrorCode> {
+                std::vector<mooncake::Slice> tmp_slices;
+                allocateSlices(tmp_slices, replica, tmp_buf);
+                auto get_result = client_->Get(key, query_result, tmp_slices);
+                if (!get_result) {
+                    LOG(ERROR)
+                        << "DISK Get failed for key: " << key
+                        << " with error: " << toString(get_result.error());
+                    return tl::unexpected(get_result.error());
+                }
+                return {};
+            });
     }
 
     if (!replica.is_memory_replica()) {
@@ -4188,56 +4172,79 @@ RealClient::batch_get_into_multi_buffers_internal(
                 }
             }
         }
-        // DISK: read via BatchGet into CPU temp buffer, then scatter.
+        // DISK: one batched BatchGet into CPU temp buffers, then scatter.
         // (storage_backend::vector_read cannot write directly to GPU memory)
-        for (auto &[key, op] : valid_local_disk_ops) {
-            if (op.is_local_disk) continue;
-            auto handle_it = temp_handles.find(key);
-            if (handle_it == temp_handles.end()) continue;
-            const auto &replica = op.query_result.replicas.at(0);
-            std::vector<Slice> disk_slices;
-            allocateSlices(disk_slices, replica, handle_it->second->ptr());
-            std::vector<std::string> dk = {key};
-            std::vector<QueryResult> dqr = {op.query_result};
-            std::unordered_map<std::string, std::vector<Slice>> dbs;
-            dbs[key] = std::move(disk_slices);
-            auto disk_results =
-                client_->BatchGet(dk, dqr, dbs, prefer_alloc_in_same_node);
-            if (!disk_results[0]) {
-                LOG(ERROR) << "DISK BatchGet failed for key '" << key
-                           << "': " << toString(disk_results[0].error());
-                results[op.original_index] =
-                    tl::make_unexpected(disk_results[0].error());
-                continue;
+        {
+            std::vector<std::string> disk_batch_keys;
+            std::vector<QueryResult> disk_batch_qrs;
+            std::unordered_map<std::string, std::vector<Slice>>
+                disk_batch_slices;
+            std::vector<std::string> disk_key_order;
+
+            for (auto &[key, op] : valid_local_disk_ops) {
+                if (op.is_local_disk) continue;
+                auto handle_it = temp_handles.find(key);
+                if (handle_it == temp_handles.end()) continue;
+                const auto &replica = op.query_result.replicas.at(0);
+                std::vector<Slice> disk_slices;
+                allocateSlices(disk_slices, replica, handle_it->second->ptr());
+                disk_batch_keys.push_back(key);
+                disk_batch_qrs.push_back(op.query_result);
+                disk_batch_slices[key] = std::move(disk_slices);
+                disk_key_order.push_back(key);
             }
-            // Scatter from temp CPU buffer to user GPU/CPU multi_buffers
-            char *src = static_cast<char *>(handle_it->second->ptr());
-            size_t offset = 0;
-            for (size_t j = 0; j < op.buffers.size(); ++j) {
-                if (offset >= op.total_size) break;
-                size_t sz = std::min(
-                    op.sizes[j], static_cast<size_t>(op.total_size - offset));
-                void *dst = op.buffers[j];
-                int device_id = -1;
-                if (gpu_staging::IsDevicePointer(dst, &device_id)) {
-                    gpu_staging::SetDevice(device_id);
-                    if (!gpu_staging::CopyHostToDevice(dst, src + offset, sz)) {
-                        LOG(ERROR) << "H2D copy failed for DISK scatter"
-                                   << ", key: " << key;
+
+            if (!disk_batch_keys.empty()) {
+                auto disk_results = client_->BatchGet(
+                    disk_batch_keys, disk_batch_qrs, disk_batch_slices,
+                    prefer_alloc_in_same_node);
+
+                for (size_t di = 0; di < disk_key_order.size(); ++di) {
+                    const auto &key = disk_key_order[di];
+                    auto &op = valid_local_disk_ops.at(key);
+                    auto handle_it = temp_handles.find(key);
+                    if (!disk_results[di]) {
+                        LOG(ERROR)
+                            << "DISK BatchGet failed for key '" << key
+                            << "': " << toString(disk_results[di].error());
                         results[op.original_index] =
-                            tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
-                        break;
+                            tl::make_unexpected(disk_results[di].error());
+                        continue;
                     }
-                } else if (gpu_staging::IsHostPointer(dst)) {
-                    memcpy(dst, src + offset, sz);
-                } else {
-                    LOG(ERROR) << "Unknown memory type for dst buffer"
-                               << ", key: " << key;
-                    results[op.original_index] =
-                        tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-                    break;
+                    // Scatter from temp CPU buffer to user GPU/CPU
+                    // multi_buffers
+                    char *src = static_cast<char *>(handle_it->second->ptr());
+                    size_t offset = 0;
+                    for (size_t j = 0; j < op.buffers.size(); ++j) {
+                        if (offset >= op.total_size) break;
+                        size_t sz = std::min(
+                            op.sizes[j],
+                            static_cast<size_t>(op.total_size - offset));
+                        void *dst = op.buffers[j];
+                        int device_id = -1;
+                        if (gpu_staging::IsDevicePointer(dst, &device_id)) {
+                            gpu_staging::SetDevice(device_id);
+                            if (!gpu_staging::CopyHostToDevice(
+                                    dst, src + offset, sz)) {
+                                LOG(ERROR) << "H2D copy failed for DISK "
+                                           << "scatter, key: " << key;
+                                results[op.original_index] =
+                                    tl::make_unexpected(
+                                        ErrorCode::TRANSFER_FAIL);
+                                break;
+                            }
+                        } else if (gpu_staging::IsHostPointer(dst)) {
+                            memcpy(dst, src + offset, sz);
+                        } else {
+                            LOG(ERROR) << "Unknown memory type for dst buffer"
+                                       << ", key: " << key;
+                            results[op.original_index] =
+                                tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                            break;
+                        }
+                        offset += sz;
+                    }
                 }
-                offset += sz;
             }
         }
         // temp_handles: BufferHandle RAII releases allocator memory

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2282,7 +2282,8 @@ RealClient::batch_get_buffer_internal(
     // 5. Execute batch get for LOCAL_DISK replicas via SSD RPC
     if (!disk_ops.empty()) {
         // Group by transport endpoint
-        std::unordered_map<std::string, std::unordered_map<std::string, Slice>>
+        std::unordered_map<std::string,
+                           std::unordered_map<std::string, std::vector<Slice>>>
             offload_objects;
         // Build key -> disk_ops index for result lookup
         std::unordered_map<std::string, size_t> disk_key_to_idx;
@@ -2292,7 +2293,8 @@ RealClient::batch_get_buffer_internal(
             const auto &replica = op.query_result.replicas.at(0);
             offload_objects[replica.get_local_disk_descriptor()
                                 .transport_endpoint]
-                .emplace(op.key, Slice{op.buffer_handle->ptr(), op.total_size});
+                .emplace(op.key, std::vector<Slice>{
+                                     {op.buffer_handle->ptr(), op.total_size}});
             disk_key_to_idx[op.key] = idx;
         }
 
@@ -2300,7 +2302,7 @@ RealClient::batch_get_buffer_internal(
             if (objects.empty()) continue;
             auto read_result =
                 batch_get_into_offload_object_internal(endpoint, objects);
-            for (auto &[key, slice] : objects) {
+            for (auto &[key, slices] : objects) {
                 auto idx_it = disk_key_to_idx.find(key);
                 if (idx_it == disk_key_to_idx.end()) continue;
                 auto &op = disk_ops[idx_it->second];
@@ -2464,9 +2466,10 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         if (replica.is_local_disk_replica()) {
             const auto &endpoint =
                 replica.get_local_disk_descriptor().transport_endpoint;
-            std::unordered_map<std::string, Slice> objects;
+            std::unordered_map<std::string, std::vector<Slice>> objects;
             objects.emplace(
-                key, Slice{static_cast<char *>(buffer) + dst_offset, size});
+                key, std::vector<Slice>{
+                         {static_cast<char *>(buffer) + dst_offset, size}});
             auto result =
                 batch_get_into_offload_object_internal(endpoint, objects);
             if (!result) return tl::unexpected(result.error());
@@ -2559,15 +2562,16 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     };
 
     if (replica.is_local_disk_replica()) {
-        return partial_disk_read(
-            [&](void *tmp_buf) -> tl::expected<void, ErrorCode> {
-                const auto &endpoint =
-                    replica.get_local_disk_descriptor().transport_endpoint;
-                std::unordered_map<std::string, Slice> objects;
-                objects.emplace(key, Slice{tmp_buf, total_size});
-                return batch_get_into_offload_object_internal(endpoint,
-                                                              objects);
-            });
+        return partial_disk_read([&](void *tmp_buf)
+                                     -> tl::expected<void, ErrorCode> {
+            const auto &endpoint =
+                replica.get_local_disk_descriptor().transport_endpoint;
+            std::unordered_map<std::string, std::vector<Slice>> objects;
+            objects.emplace(
+                key,
+                std::vector<Slice>{{static_cast<char *>(tmp_buf), total_size}});
+            return batch_get_into_offload_object_internal(endpoint, objects);
+        });
     }
 
     if (replica.is_disk_replica()) {
@@ -3715,15 +3719,15 @@ RealClient::batch_get_into_internal(const std::vector<std::string> &keys,
     }
 
     // Prepare batch transfer data structures
-    std::unordered_map<std::string, std::unordered_map<std::string, Slice>>
+    std::unordered_map<std::string,
+                       std::unordered_map<std::string, std::vector<Slice>>>
         offload_objects;
 
     for (const auto &op_it : valid_local_disk_operations) {
         const auto &replica = op_it.second.query_result.replicas.at(0);
         auto [store_segment_it, _] = offload_objects.try_emplace(
             replica.get_local_disk_descriptor().transport_endpoint);
-        store_segment_it->second.emplace(op_it.first,
-                                         op_it.second.slices.at(0));
+        store_segment_it->second.emplace(op_it.first, op_it.second.slices);
     }
 
     size_t offload_object_count = 0;
@@ -4003,8 +4007,25 @@ RealClient::batch_get_into_multi_buffers_internal(
             results.emplace_back(tl::unexpected(ErrorCode::INVALID_REPLICA));
             continue;
         }
-        // Calculate required buffer size
-        const auto &replica = query_result_values.replicas[0];
+        // Select best replica: prefer MEMORY (direct RDMA to GPU), then
+        // LOCAL_DISK, then DISK. Master may return multiple replicas in any
+        // order (e.g. [DISK, MEMORY]), so always scan rather than blindly
+        // taking replicas[0].
+        const Replica::Descriptor *best_replica = nullptr;
+        for (const auto &r : query_result_values.replicas) {
+            if (r.is_memory_replica()) {
+                best_replica = &r;
+                break;
+            }
+            if (r.is_local_disk_replica() && !best_replica) best_replica = &r;
+            if (r.is_disk_replica() && !best_replica) best_replica = &r;
+        }
+        if (!best_replica) {
+            LOG(ERROR) << "No usable replica for key: " << key;
+            results.emplace_back(tl::unexpected(ErrorCode::INVALID_REPLICA));
+            continue;
+        }
+        const auto &replica = *best_replica;
         uint64_t total_size = calculate_total_size(replica);
         const auto &sizes = all_sizes[i];
         uint64_t dst_total_size = 0;
@@ -4090,112 +4111,131 @@ RealClient::batch_get_into_multi_buffers_internal(
         }
     }
 
-    // ---- LOCAL_DISK replica: SSD read via RPC + scatter to multi_buffers ----
+    // ---- LOCAL_DISK / DISK replica: disk read paths ----
     if (!valid_local_disk_ops.empty()) {
-        // Group keys by transport endpoint for batched RPC
-        std::unordered_map<std::string, std::unordered_map<std::string, Slice>>
-            offload_objects;
-        std::unordered_map<std::string, std::unique_ptr<BufferHandle>>
-            temp_handles;
+        // LOCAL_DISK: pass user GPU buffers directly as scatter-gather slices.
+        // vLLM pre-registers all GPU KV-cache memory with TransferEngine via
+        // register_buffer(), so the offload RDMA can scatter the on-disk blob
+        // into non-contiguous per-layer GPU destinations natively — no temp
+        // CPU buffer or H2D copy needed.
+        {
+            std::unordered_map<
+                std::string,
+                std::unordered_map<std::string, std::vector<Slice>>>
+                offload_objects;
 
-        for (auto &[key, op] : valid_local_disk_ops) {
-            // Allocate temp buffer from client_buffer_allocator_ (already
-            // registered with TransferEngine via RegisterLocalMemory).
-            auto alloc_result =
-                client_buffer_allocator_->allocate(op.total_size);
-            if (!alloc_result) {
-                LOG(ERROR)
-                    << "Failed to allocate temp buffer for SSD read, key: "
-                    << key << ", size: " << op.total_size;
-                results[op.original_index] =
-                    tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
-                continue;
-            }
-            auto handle =
-                std::make_unique<BufferHandle>(std::move(*alloc_result));
-            const auto &replica = op.query_result.replicas.at(0);
-            if (op.is_local_disk) {
-                offload_objects[replica.get_local_disk_descriptor()
-                                    .transport_endpoint]
-                    .emplace(key, Slice{handle->ptr(), op.total_size});
-            }
-            temp_handles.emplace(key, std::move(handle));
-        }
-
-        // Scatter temp CPU buffer -> user multi_buffers (GPU or host).
-        // Returns false and sets results[original_index] on error.
-        auto scatter_to_buffers = [&](const std::string &key, char *src,
-                                      const DiskKeyInfo &op) -> bool {
-            size_t offset = 0;
-            for (size_t j = 0; j < op.buffers.size(); ++j) {
-                if (offset >= op.total_size) break;
-                size_t sz = std::min(
-                    op.sizes[j], static_cast<size_t>(op.total_size - offset));
-                void *dst = op.buffers[j];
-                int device_id = -1;
-                if (gpu_staging::IsDevicePointer(dst, &device_id)) {
-                    gpu_staging::SetDevice(device_id);
-                    if (!gpu_staging::CopyHostToDevice(dst, src + offset, sz)) {
-                        LOG(ERROR) << "H2D copy failed during scatter"
-                                   << ", key: " << key;
-                        results[op.original_index] =
-                            tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
-                        return false;
-                    }
-                } else if (gpu_staging::IsHostPointer(dst)) {
-                    memcpy(dst, src + offset, sz);
-                } else {
-                    LOG(ERROR) << "Unknown memory type for dst buffer"
-                               << ", key: " << key;
+            for (auto &[key, op] : valid_local_disk_ops) {
+                if (!op.is_local_disk) continue;
+                const auto &replica = op.query_result.replicas.at(0);
+                std::vector<Slice> user_slices;
+                user_slices.reserve(op.buffers.size());
+                size_t slice_total = 0;
+                for (size_t j = 0; j < op.buffers.size(); ++j) {
+                    user_slices.push_back(Slice{op.buffers[j], op.sizes[j]});
+                    slice_total += op.sizes[j];
+                }
+                if (slice_total != op.total_size) {
+                    LOG(ERROR) << "Slice size mismatch for key " << key
+                               << ": slices=" << slice_total
+                               << ", total=" << op.total_size;
                     results[op.original_index] =
                         tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-                    return false;
+                    continue;
                 }
-                offset += sz;
+                offload_objects[replica.get_local_disk_descriptor()
+                                    .transport_endpoint]
+                    .emplace(key, std::move(user_slices));
             }
-            return true;
-        };
 
-        for (auto &[endpoint, objects] : offload_objects) {
-            if (objects.empty()) continue;
-            auto read_result =
-                batch_get_into_offload_object_internal(endpoint, objects);
-            for (auto &[key, slice] : objects) {
-                auto disk_it = valid_local_disk_ops.find(key);
-                if (disk_it == valid_local_disk_ops.end()) continue;
-                auto &op = disk_it->second;
+            for (auto &[endpoint, objects] : offload_objects) {
+                if (objects.empty()) continue;
+                auto read_result =
+                    batch_get_into_offload_object_internal(endpoint, objects);
+                // On success: results[original_index] was already pre-filled
+                // with total_size when valid_local_disk_ops was built; nothing
+                // to update. Only overwrite on failure.
                 if (!read_result) {
-                    LOG(ERROR) << "SSD read failed for key '" << key
-                               << "': " << toString(read_result.error());
-                    results[op.original_index] =
-                        tl::make_unexpected(read_result.error());
-                    continue;
+                    for (auto &[key, slices] : objects) {
+                        auto disk_it = valid_local_disk_ops.find(key);
+                        if (disk_it == valid_local_disk_ops.end()) continue;
+                        LOG(ERROR) << "SSD read failed for key '" << key
+                                   << "': " << toString(read_result.error());
+                        results[disk_it->second.original_index] =
+                            tl::make_unexpected(read_result.error());
+                    }
                 }
-                if (!scatter_to_buffers(key, static_cast<char *>(slice.ptr),
-                                        op))
-                    continue;
             }
         }
+
         // DISK: one batched BatchGet into CPU temp buffers, then scatter.
         // (storage_backend::vector_read cannot write directly to GPU memory)
         {
+            // Scatter temp CPU buffer -> user multi_buffers (GPU or host).
+            // Returns false and sets results[original_index] on error.
+            auto scatter_to_buffers = [&](const std::string &key, char *src,
+                                          const DiskKeyInfo &op) -> bool {
+                size_t offset = 0;
+                for (size_t j = 0; j < op.buffers.size(); ++j) {
+                    if (offset >= op.total_size) break;
+                    size_t sz =
+                        std::min(op.sizes[j],
+                                 static_cast<size_t>(op.total_size - offset));
+                    void *dst = op.buffers[j];
+                    int device_id = -1;
+                    if (gpu_staging::IsDevicePointer(dst, &device_id)) {
+                        gpu_staging::SetDevice(device_id);
+                        if (!gpu_staging::CopyHostToDevice(dst, src + offset,
+                                                           sz)) {
+                            LOG(ERROR) << "H2D copy failed during DISK scatter"
+                                       << ", key: " << key;
+                            results[op.original_index] =
+                                tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
+                            return false;
+                        }
+                    } else if (gpu_staging::IsHostPointer(dst)) {
+                        memcpy(dst, src + offset, sz);
+                    } else {
+                        LOG(ERROR) << "Unknown memory type for dst buffer"
+                                   << ", key: " << key;
+                        results[op.original_index] =
+                            tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                        return false;
+                    }
+                    offset += sz;
+                }
+                return true;
+            };
+
             std::vector<std::string> disk_batch_keys;
             std::vector<QueryResult> disk_batch_qrs;
             std::unordered_map<std::string, std::vector<Slice>>
                 disk_batch_slices;
             std::vector<std::string> disk_key_order;
+            std::unordered_map<std::string, std::unique_ptr<BufferHandle>>
+                temp_handles;
 
             for (auto &[key, op] : valid_local_disk_ops) {
                 if (op.is_local_disk) continue;
-                auto handle_it = temp_handles.find(key);
-                if (handle_it == temp_handles.end()) continue;
+                auto alloc_result =
+                    client_buffer_allocator_->allocate(op.total_size);
+                if (!alloc_result) {
+                    LOG(ERROR)
+                        << "Failed to allocate temp buffer for DISK "
+                        << "read, key: " << key << ", size: " << op.total_size;
+                    results[op.original_index] =
+                        tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+                    continue;
+                }
+                auto handle =
+                    std::make_unique<BufferHandle>(std::move(*alloc_result));
                 const auto &replica = op.query_result.replicas.at(0);
                 std::vector<Slice> disk_slices;
-                allocateSlices(disk_slices, replica, handle_it->second->ptr());
+                allocateSlices(disk_slices, replica, handle->ptr());
                 disk_batch_keys.push_back(key);
                 disk_batch_qrs.push_back(op.query_result);
                 disk_batch_slices[key] = std::move(disk_slices);
                 disk_key_order.push_back(key);
+                temp_handles.emplace(key, std::move(handle));
             }
 
             if (!disk_batch_keys.empty()) {
@@ -4221,8 +4261,8 @@ RealClient::batch_get_into_multi_buffers_internal(
                         continue;
                 }
             }
+            // temp_handles: BufferHandle RAII releases allocator memory
         }
-        // temp_handles: BufferHandle RAII releases allocator memory
     }
 
     return results;
@@ -4575,13 +4615,15 @@ bool RealClient::release_offload_buffer(uint64_t batch_id) {
 tl::expected<void, ErrorCode>
 RealClient::batch_get_into_offload_object_internal(
     const std::string &target_rpc_service_addr,
-    std::unordered_map<std::string, Slice> &objects) {
+    std::unordered_map<std::string, std::vector<Slice>> &objects) {
     auto start_time = std::chrono::steady_clock::now();
     std::vector<std::string> keys;
     std::vector<int64_t> sizes;
     for (const auto &object_it : objects) {
         keys.emplace_back(object_it.first);
-        sizes.emplace_back(object_it.second.size);
+        int64_t total = 0;
+        for (const auto &s : object_it.second) total += s.size;
+        sizes.emplace_back(total);
     }
     auto batchGetResp = client_requester_->batch_get_offload_object(
         target_rpc_service_addr, keys, sizes);
@@ -4589,6 +4631,11 @@ RealClient::batch_get_into_offload_object_internal(
         LOG(ERROR) << "Batch get offload object failed with error: "
                    << batchGetResp.error();
         return tl::make_unexpected(batchGetResp.error());
+    }
+    if (batchGetResp->pointers.size() != keys.size()) {
+        LOG(ERROR) << "Pointer count mismatch from owner: expected="
+                   << keys.size() << ", got=" << batchGetResp->pointers.size();
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
     auto result =
         client_->BatchGetOffloadObject(batchGetResp->transfer_engine_addr, keys,

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4171,7 +4171,9 @@ RealClient::batch_get_into_multi_buffers_internal(
                         tl::make_unexpected(read_result.error());
                     continue;
                 }
-                scatter_to_buffers(key, static_cast<char *>(slice.ptr), op);
+                if (!scatter_to_buffers(key, static_cast<char *>(slice.ptr),
+                                        op))
+                    continue;
             }
         }
         // DISK: one batched BatchGet into CPU temp buffers, then scatter.
@@ -4213,8 +4215,10 @@ RealClient::batch_get_into_multi_buffers_internal(
                             tl::make_unexpected(disk_results[di].error());
                         continue;
                     }
-                    scatter_to_buffers(
-                        key, static_cast<char *>(handle_it->second->ptr()), op);
+                    if (!scatter_to_buffers(
+                            key, static_cast<char *>(handle_it->second->ptr()),
+                            op))
+                        continue;
                 }
             }
         }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -25,6 +25,7 @@
 #include "utils.h"
 #include "rpc_types.h"
 #include "file_storage.h"
+#include "gpu_staging_utils.h"
 #include "default_config.h"
 #include "shm_helper.h"
 #include "memory_location.h"
@@ -2175,7 +2176,15 @@ RealClient::batch_get_buffer_internal(
         std::unique_ptr<BufferHandle> buffer_handle;
         std::vector<Slice> slices;
     };
+    struct DiskKeyOp {
+        size_t original_index;
+        std::string key;
+        QueryResult query_result;
+        std::unique_ptr<BufferHandle> buffer_handle;
+        uint64_t total_size;
+    };
     std::vector<KeyOp> valid_ops;
+    std::vector<DiskKeyOp> disk_ops;
     valid_ops.reserve(keys.size());
 
     for (size_t i = 0; i < keys.size(); ++i) {
@@ -2215,6 +2224,18 @@ RealClient::batch_get_buffer_internal(
         std::vector<Slice> slices;
         allocateSlices(slices, replica, buffer_handle->ptr());
 
+        if (replica.is_local_disk_replica()) {
+            // LOCAL_DISK: buffer is allocated and registered via
+            // client_buffer_allocator_, route to SSD RPC path below.
+            disk_ops.emplace_back(
+                DiskKeyOp{.original_index = i,
+                          .key = key,
+                          .query_result = std::move(query_result_values),
+                          .buffer_handle = std::move(buffer_handle),
+                          .total_size = total_size});
+            continue;
+        }
+
         valid_ops.emplace_back(
             KeyOp{.original_index = i,
                   .key = key,
@@ -2223,35 +2244,75 @@ RealClient::batch_get_buffer_internal(
                   .slices = std::move(slices)});
     }
 
-    if (valid_ops.empty()) {
+    if (valid_ops.empty() && disk_ops.empty()) {
         return final_results;
     }
 
-    // 3. Execute batch get
-    std::vector<std::string> batch_keys;
-    std::vector<QueryResult> batch_query_results;
-    std::unordered_map<std::string, std::vector<Slice>> batch_slices;
-    batch_keys.reserve(valid_ops.size());
-    batch_query_results.reserve(valid_ops.size());
+    // 3. Execute batch get for memory/disk replicas
+    if (!valid_ops.empty()) {
+        std::vector<std::string> batch_keys;
+        std::vector<QueryResult> batch_query_results;
+        std::unordered_map<std::string, std::vector<Slice>> batch_slices;
+        batch_keys.reserve(valid_ops.size());
+        batch_query_results.reserve(valid_ops.size());
 
-    for (auto &op : valid_ops) {
-        batch_keys.push_back(op.key);
-        batch_query_results.push_back(op.query_result);
-        batch_slices[op.key] = op.slices;
+        for (auto &op : valid_ops) {
+            batch_keys.push_back(op.key);
+            batch_query_results.push_back(op.query_result);
+            batch_slices[op.key] = op.slices;
+        }
+
+        auto batch_get_results =
+            client_->BatchGet(batch_keys, batch_query_results, batch_slices);
+
+        // 4. Process results and create BufferHandles
+        for (size_t i = 0; i < valid_ops.size(); ++i) {
+            if (batch_get_results[i]) {
+                auto &op = valid_ops[i];
+                final_results[op.original_index] =
+                    std::make_shared<BufferHandle>(
+                        std::move(*op.buffer_handle));
+            } else {
+                LOG(ERROR) << "BatchGet failed for key '" << valid_ops[i].key
+                           << "': " << toString(batch_get_results[i].error());
+            }
+        }
     }
 
-    auto batch_get_results =
-        client_->BatchGet(batch_keys, batch_query_results, batch_slices);
+    // 5. Execute batch get for LOCAL_DISK replicas via SSD RPC
+    if (!disk_ops.empty()) {
+        // Group by transport endpoint
+        std::unordered_map<std::string, std::unordered_map<std::string, Slice>>
+            offload_objects;
+        // Build key -> disk_ops index for result lookup
+        std::unordered_map<std::string, size_t> disk_key_to_idx;
 
-    // 4. Process results and create BufferHandles
-    for (size_t i = 0; i < valid_ops.size(); ++i) {
-        if (batch_get_results[i]) {
-            auto &op = valid_ops[i];
-            final_results[op.original_index] =
-                std::make_shared<BufferHandle>(std::move(*op.buffer_handle));
-        } else {
-            LOG(ERROR) << "BatchGet failed for key '" << valid_ops[i].key
-                       << "': " << toString(batch_get_results[i].error());
+        for (size_t idx = 0; idx < disk_ops.size(); ++idx) {
+            auto &op = disk_ops[idx];
+            const auto &replica = op.query_result.replicas.at(0);
+            offload_objects[replica.get_local_disk_descriptor()
+                                .transport_endpoint]
+                .emplace(op.key, Slice{op.buffer_handle->ptr(), op.total_size});
+            disk_key_to_idx[op.key] = idx;
+        }
+
+        for (auto &[endpoint, objects] : offload_objects) {
+            if (objects.empty()) continue;
+            auto read_result =
+                batch_get_into_offload_object_internal(endpoint, objects);
+            for (auto &[key, slice] : objects) {
+                auto idx_it = disk_key_to_idx.find(key);
+                if (idx_it == disk_key_to_idx.end()) continue;
+                auto &op = disk_ops[idx_it->second];
+                if (read_result) {
+                    final_results[op.original_index] =
+                        std::make_shared<BufferHandle>(
+                            std::move(*op.buffer_handle));
+                } else {
+                    LOG(ERROR) << "SSD read failed for key '" << key
+                               << "': " << toString(read_result.error());
+                }
+            }
         }
     }
 
@@ -2397,6 +2458,59 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     }
 
     if (src_offset == 0 && size == total_size) {
+        // LOCAL_DISK full-object read: destination buffer is passed
+        // directly to SSD RPC (same pattern as single-buffer batch_get_into;
+        // GPU buffers are pre-registered by vLLM via register_buffer).
+        if (replica.is_local_disk_replica()) {
+            const auto &endpoint =
+                replica.get_local_disk_descriptor().transport_endpoint;
+            std::unordered_map<std::string, Slice> objects;
+            objects.emplace(
+                key, Slice{static_cast<char *>(buffer) + dst_offset, size});
+            auto result =
+                batch_get_into_offload_object_internal(endpoint, objects);
+            if (!result) return tl::unexpected(result.error());
+            return static_cast<int64_t>(total_size);
+        }
+
+        if (replica.is_disk_replica()) {
+            // DISK full read: local file I/O (vector_read) cannot write to
+            // GPU memory. Use temp CPU buffer, then scatter to dst.
+            auto alloc_result = client_buffer_allocator_->allocate(total_size);
+            if (!alloc_result) {
+                LOG(ERROR) << "Failed to allocate temp buffer for DISK full "
+                           << "read, key: " << key << ", size: " << total_size;
+                return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+            }
+            BufferHandle tmp_handle(std::move(*alloc_result));
+            std::vector<mooncake::Slice> tmp_slices;
+            allocateSlices(tmp_slices, replica, tmp_handle.ptr());
+            auto get_result = client_->Get(key, query_result, tmp_slices);
+            if (!get_result) {
+                LOG(ERROR) << "DISK Get failed for key: " << key
+                           << " with error: " << toString(get_result.error());
+                return tl::unexpected(get_result.error());
+            }
+            void *dst = static_cast<char *>(buffer) + dst_offset;
+            const void *src = tmp_handle.ptr();
+            int device_id = -1;
+            if (gpu_staging::IsDevicePointer(dst, &device_id)) {
+                gpu_staging::SetDevice(device_id);
+                if (!gpu_staging::CopyHostToDevice(dst, src, total_size)) {
+                    LOG(ERROR) << "H2D copy failed for DISK full read"
+                               << ", key: " << key;
+                    return tl::unexpected(ErrorCode::TRANSFER_FAIL);
+                }
+            } else if (gpu_staging::IsHostPointer(dst)) {
+                memcpy(dst, src, total_size);
+            } else {
+                LOG(ERROR) << "Unknown memory type for dst buffer in DISK "
+                           << "full read, key: " << key;
+                return tl::unexpected(ErrorCode::INVALID_PARAMS);
+            }
+            return static_cast<int64_t>(total_size);
+        }
+
         std::vector<mooncake::Slice> slices;
         allocateSlices(slices, replica,
                        static_cast<char *>(buffer) + dst_offset);
@@ -2410,8 +2524,86 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return static_cast<int64_t>(total_size);
     }
 
+    // LOCAL_DISK partial read: read full object into temp buffer, then copy
+    // the requested [src_offset, src_offset+size) range to destination.
+    if (replica.is_local_disk_replica()) {
+        auto alloc_result = client_buffer_allocator_->allocate(total_size);
+        if (!alloc_result) {
+            LOG(ERROR) << "Failed to allocate temp buffer for SSD ranged "
+                       << "read, key: " << key << ", size: " << total_size;
+            return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+        BufferHandle tmp_handle(std::move(*alloc_result));
+
+        const auto &endpoint =
+            replica.get_local_disk_descriptor().transport_endpoint;
+        std::unordered_map<std::string, Slice> objects;
+        objects.emplace(key, Slice{tmp_handle.ptr(), total_size});
+        auto result = batch_get_into_offload_object_internal(endpoint, objects);
+        if (!result) return tl::unexpected(result.error());
+
+        void *dst = static_cast<char *>(buffer) + dst_offset;
+        const void *src =
+            static_cast<const char *>(tmp_handle.ptr()) + src_offset;
+        int device_id = -1;
+        if (gpu_staging::IsDevicePointer(dst, &device_id)) {
+            gpu_staging::SetDevice(device_id);
+            if (!gpu_staging::CopyHostToDevice(dst, src, size)) {
+                LOG(ERROR) << "H2D copy failed for SSD ranged read"
+                           << ", key: " << key;
+                return tl::unexpected(ErrorCode::TRANSFER_FAIL);
+            }
+        } else if (gpu_staging::IsHostPointer(dst)) {
+            memcpy(dst, src, size);
+        } else {
+            LOG(ERROR) << "Unknown memory type for dst buffer in ranged "
+                       << "read, key: " << key;
+            return tl::unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        return static_cast<int64_t>(size);
+    }
+
+    if (replica.is_disk_replica()) {
+        // DISK partial read: read full object into temp CPU buffer, then
+        // copy the requested [src_offset, src_offset+size) range to dst.
+        auto alloc_result = client_buffer_allocator_->allocate(total_size);
+        if (!alloc_result) {
+            LOG(ERROR) << "Failed to allocate temp buffer for DISK partial "
+                       << "read, key: " << key << ", size: " << total_size;
+            return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+        BufferHandle tmp_handle(std::move(*alloc_result));
+        std::vector<mooncake::Slice> tmp_slices;
+        allocateSlices(tmp_slices, replica, tmp_handle.ptr());
+        auto get_result = client_->Get(key, query_result, tmp_slices);
+        if (!get_result) {
+            LOG(ERROR) << "DISK Get failed for key: " << key
+                       << " with error: " << toString(get_result.error());
+            return tl::unexpected(get_result.error());
+        }
+        void *dst = static_cast<char *>(buffer) + dst_offset;
+        const void *src =
+            static_cast<const char *>(tmp_handle.ptr()) + src_offset;
+        int device_id = -1;
+        if (gpu_staging::IsDevicePointer(dst, &device_id)) {
+            gpu_staging::SetDevice(device_id);
+            if (!gpu_staging::CopyHostToDevice(dst, src, size)) {
+                LOG(ERROR) << "H2D copy failed for DISK partial read"
+                           << ", key: " << key;
+                return tl::unexpected(ErrorCode::TRANSFER_FAIL);
+            }
+        } else if (gpu_staging::IsHostPointer(dst)) {
+            memcpy(dst, src, size);
+        } else {
+            LOG(ERROR) << "Unknown memory type for dst buffer in DISK "
+                       << "partial read, key: " << key;
+            return tl::unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        return static_cast<int64_t>(size);
+    }
+
     if (!replica.is_memory_replica()) {
-        LOG(ERROR) << "ranged reads only support memory replicas";
+        LOG(ERROR) << "ranged reads only support memory/disk replicas";
         return tl::unexpected(ErrorCode::INVALID_REPLICA);
     }
 
@@ -3794,7 +3986,19 @@ RealClient::batch_get_into_multi_buffers_internal(
         uint64_t total_size;
     };
 
+    struct DiskKeyInfo {
+        std::string key;
+        size_t original_index;
+        QueryResult query_result;
+        std::vector<void *> buffers;
+        std::vector<size_t> sizes;
+        uint64_t total_size;
+        bool is_local_disk;  // true=LOCAL_DISK (offload RPC), false=DISK
+                             // (BatchGet)
+    };
+
     std::vector<ValidKeyInfo> valid_operations;
+    std::unordered_map<std::string, DiskKeyInfo> valid_local_disk_ops;
     valid_operations.reserve(num_keys);
     for (size_t i = 0; i < num_keys; ++i) {
         const auto &key = keys[i];
@@ -3835,11 +4039,27 @@ RealClient::batch_get_into_multi_buffers_internal(
         std::vector<Slice> key_slices;
         key_slices.reserve(buffers.size());
         if (replica.is_memory_replica()) {
+            // MEMORY: RDMA from remote memory directly to GPU (GPUDirect).
             for (size_t j = 0; j < buffers.size(); ++j) {
                 key_slices.emplace_back(Slice{buffers[j], sizes[j]});
             }
+        } else if (replica.is_local_disk_replica() ||
+                   replica.is_disk_replica()) {
+            // LOCAL_DISK / DISK: file I/O cannot write to GPU memory.
+            // Route through CPU temp buffer + scatter.
+            valid_local_disk_ops.emplace(
+                key,
+                DiskKeyInfo{.key = key,
+                            .original_index = i,
+                            .query_result = std::move(query_result_values),
+                            .buffers = all_buffers[i],
+                            .sizes = all_sizes[i],
+                            .total_size = total_size,
+                            .is_local_disk = replica.is_local_disk_replica()});
+            results.emplace_back(static_cast<int64_t>(total_size));
+            continue;
         } else {
-            LOG(ERROR) << "Invalid replica type for key: " << key;
+            LOG(ERROR) << "Unsupported replica type for key: " << key;
             results.emplace_back(tl::unexpected(ErrorCode::INVALID_PARAMS));
             continue;
         }
@@ -3854,37 +4074,175 @@ RealClient::batch_get_into_multi_buffers_internal(
         results.emplace_back(static_cast<int64_t>(total_size));
     }
     // Early return if no valid operations
-    if (valid_operations.empty()) {
+    if (valid_operations.empty() && valid_local_disk_ops.empty()) {
         return results;
     }
 
-    // Prepare batch transfer data structures
-    std::vector<std::string> batch_keys;
-    std::vector<QueryResult> batch_query_results;
-    std::unordered_map<std::string, std::vector<Slice>> batch_slices;
-    batch_keys.reserve(valid_operations.size());
-    batch_query_results.reserve(valid_operations.size());
-    for (auto &op : valid_operations) {
-        batch_keys.push_back(op.key);
-        batch_query_results.push_back(op.query_result);
-        batch_slices[op.key] = op.slices;
-    }
+    // ---- Memory/Disk replica: existing BatchGet path ----
+    if (!valid_operations.empty()) {
+        std::vector<std::string> batch_keys;
+        std::vector<QueryResult> batch_query_results;
+        std::unordered_map<std::string, std::vector<Slice>> batch_slices;
+        batch_keys.reserve(valid_operations.size());
+        batch_query_results.reserve(valid_operations.size());
+        for (auto &op : valid_operations) {
+            batch_keys.push_back(op.key);
+            batch_query_results.push_back(op.query_result);
+            batch_slices[op.key] = op.slices;
+        }
 
-    auto batch_get_results =
-        client_->BatchGet(batch_keys, batch_query_results, batch_slices,
-                          prefer_alloc_in_same_node);
+        auto batch_get_results =
+            client_->BatchGet(batch_keys, batch_query_results, batch_slices,
+                              prefer_alloc_in_same_node);
 
-    // Process transfer results
-    for (size_t j = 0; j < batch_get_results.size(); ++j) {
-        const auto &op = valid_operations[j];
-
-        if (!batch_get_results[j]) {
-            const auto error = batch_get_results[j].error();
-            LOG(ERROR) << "BatchGet failed for key '" << op.key
-                       << "': " << toString(error);
-            results[op.original_index] = tl::unexpected(error);
+        for (size_t j = 0; j < batch_get_results.size(); ++j) {
+            const auto &op = valid_operations[j];
+            if (!batch_get_results[j]) {
+                const auto error = batch_get_results[j].error();
+                LOG(ERROR) << "BatchGet failed for key '" << op.key
+                           << "': " << toString(error);
+                results[op.original_index] = tl::unexpected(error);
+            }
         }
     }
+
+    // ---- LOCAL_DISK replica: SSD read via RPC + scatter to multi_buffers ----
+    if (!valid_local_disk_ops.empty()) {
+        // Group keys by transport endpoint for batched RPC
+        std::unordered_map<std::string, std::unordered_map<std::string, Slice>>
+            offload_objects;
+        std::unordered_map<std::string, std::unique_ptr<BufferHandle>>
+            temp_handles;
+
+        for (auto &[key, op] : valid_local_disk_ops) {
+            // Allocate temp buffer from client_buffer_allocator_ (already
+            // registered with TransferEngine via RegisterLocalMemory).
+            auto alloc_result =
+                client_buffer_allocator_->allocate(op.total_size);
+            if (!alloc_result) {
+                LOG(ERROR)
+                    << "Failed to allocate temp buffer for SSD read, key: "
+                    << key << ", size: " << op.total_size;
+                results[op.original_index] =
+                    tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+                continue;
+            }
+            auto handle =
+                std::make_unique<BufferHandle>(std::move(*alloc_result));
+            const auto &replica = op.query_result.replicas.at(0);
+            if (op.is_local_disk) {
+                offload_objects[replica.get_local_disk_descriptor()
+                                    .transport_endpoint]
+                    .emplace(key, Slice{handle->ptr(), op.total_size});
+            }
+            temp_handles.emplace(key, std::move(handle));
+        }
+
+        for (auto &[endpoint, objects] : offload_objects) {
+            if (objects.empty()) continue;
+            auto read_result =
+                batch_get_into_offload_object_internal(endpoint, objects);
+            for (auto &[key, slice] : objects) {
+                auto disk_it = valid_local_disk_ops.find(key);
+                if (disk_it == valid_local_disk_ops.end()) continue;
+                auto &op = disk_it->second;
+                if (!read_result) {
+                    LOG(ERROR) << "SSD read failed for key '" << key
+                               << "': " << toString(read_result.error());
+                    results[op.original_index] =
+                        tl::make_unexpected(read_result.error());
+                    continue;
+                }
+                // Scatter: temp contiguous buffer -> user's multi_buffers.
+                // Dual-check pointer type to avoid memcpy to GPU addresses.
+                char *src = static_cast<char *>(slice.ptr);
+                size_t offset = 0;
+                bool scatter_ok = true;
+                for (size_t j = 0; j < op.buffers.size() && scatter_ok; ++j) {
+                    if (offset >= op.total_size) break;
+                    size_t sz =
+                        std::min(op.sizes[j],
+                                 static_cast<size_t>(op.total_size - offset));
+                    void *dst = op.buffers[j];
+                    int device_id = -1;
+                    if (gpu_staging::IsDevicePointer(dst, &device_id)) {
+                        gpu_staging::SetDevice(device_id);
+                        if (!gpu_staging::CopyHostToDevice(dst, src + offset,
+                                                           sz)) {
+                            LOG(ERROR) << "H2D copy failed during scatter"
+                                       << ", key: " << key;
+                            results[op.original_index] =
+                                tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
+                            scatter_ok = false;
+                        }
+                    } else if (gpu_staging::IsHostPointer(dst)) {
+                        memcpy(dst, src + offset, sz);
+                    } else {
+                        LOG(ERROR) << "Unknown memory type for dst buffer"
+                                   << ", key: " << key;
+                        results[op.original_index] =
+                            tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                        scatter_ok = false;
+                    }
+                    offset += sz;
+                }
+            }
+        }
+        // DISK: read via BatchGet into CPU temp buffer, then scatter.
+        // (storage_backend::vector_read cannot write directly to GPU memory)
+        for (auto &[key, op] : valid_local_disk_ops) {
+            if (op.is_local_disk) continue;
+            auto handle_it = temp_handles.find(key);
+            if (handle_it == temp_handles.end()) continue;
+            const auto &replica = op.query_result.replicas.at(0);
+            std::vector<Slice> disk_slices;
+            allocateSlices(disk_slices, replica, handle_it->second->ptr());
+            std::vector<std::string> dk = {key};
+            std::vector<QueryResult> dqr = {op.query_result};
+            std::unordered_map<std::string, std::vector<Slice>> dbs;
+            dbs[key] = std::move(disk_slices);
+            auto disk_results =
+                client_->BatchGet(dk, dqr, dbs, prefer_alloc_in_same_node);
+            if (!disk_results[0]) {
+                LOG(ERROR) << "DISK BatchGet failed for key '" << key
+                           << "': " << toString(disk_results[0].error());
+                results[op.original_index] =
+                    tl::make_unexpected(disk_results[0].error());
+                continue;
+            }
+            // Scatter from temp CPU buffer to user GPU/CPU multi_buffers
+            char *src = static_cast<char *>(handle_it->second->ptr());
+            size_t offset = 0;
+            for (size_t j = 0; j < op.buffers.size(); ++j) {
+                if (offset >= op.total_size) break;
+                size_t sz = std::min(
+                    op.sizes[j], static_cast<size_t>(op.total_size - offset));
+                void *dst = op.buffers[j];
+                int device_id = -1;
+                if (gpu_staging::IsDevicePointer(dst, &device_id)) {
+                    gpu_staging::SetDevice(device_id);
+                    if (!gpu_staging::CopyHostToDevice(dst, src + offset, sz)) {
+                        LOG(ERROR) << "H2D copy failed for DISK scatter"
+                                   << ", key: " << key;
+                        results[op.original_index] =
+                            tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
+                        break;
+                    }
+                } else if (gpu_staging::IsHostPointer(dst)) {
+                    memcpy(dst, src + offset, sz);
+                } else {
+                    LOG(ERROR) << "Unknown memory type for dst buffer"
+                               << ", key: " << key;
+                    results[op.original_index] =
+                        tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                    break;
+                }
+                offset += sz;
+            }
+        }
+        // temp_handles: BufferHandle RAII releases allocator memory
+    }
+
     return results;
 }
 

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -558,6 +558,8 @@ TransferSubmitter::submit_batch_get_offload_object(
     SegmentHandle seg = engine_.openSegment(transfer_engine_addr);
     if (seg == static_cast<uint64_t>(ERR_INVALID_ARGUMENT)) {
         LOG(ERROR) << "Failed to open segment " << transfer_engine_addr;
+        // nullopt = failure (caller checks !future).  The function returns
+        // std::optional so tl::unexpected is not available here.
         return std::nullopt;
     }
     for (size_t i = 0; i < keys.size(); ++i) {

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -551,25 +551,36 @@ std::optional<TransferFuture>
 TransferSubmitter::submit_batch_get_offload_object(
     const std::string& transfer_engine_addr,
     const std::vector<std::string>& keys, const std::vector<uint64_t>& pointers,
-    const std::unordered_map<std::string, Slice>& batched_slices) {
+    const std::unordered_map<std::string, std::vector<Slice>>& batched_slices) {
     std::optional<TransferFuture> future;
     std::vector<TransferRequest> requests;
+    // Open the segment once — all keys share the same transfer_engine_addr.
+    SegmentHandle seg = engine_.openSegment(transfer_engine_addr);
+    if (seg == static_cast<uint64_t>(ERR_INVALID_ARGUMENT)) {
+        LOG(ERROR) << "Failed to open segment " << transfer_engine_addr;
+        return std::nullopt;
+    }
     for (size_t i = 0; i < keys.size(); ++i) {
-        auto key = keys[i];
-        auto pointer = pointers[i];
-        SegmentHandle seg = engine_.openSegment(transfer_engine_addr);
-        if (seg == static_cast<uint64_t>(ERR_INVALID_ARGUMENT)) {
-            LOG(ERROR) << "Failed to open segment " << transfer_engine_addr;
-            return std::nullopt;
+        const auto& key = keys[i];
+        const uint64_t pointer = pointers[i];
+        auto it = batched_slices.find(key);
+        if (it == batched_slices.end()) {
+            LOG(ERROR) << "Key not found in batched_slices: " << key;
+            return std::nullopt;  // fail closed
         }
-        const auto& slice = batched_slices.find(key)->second;
-        TransferRequest request;
-        request.opcode = TransferRequest::READ;
-        request.source = static_cast<char*>(slice.ptr);
-        request.target_id = seg;
-        request.target_offset = pointer;
-        request.length = slice.size;
-        requests.emplace_back(request);
+        // Emit one TransferRequest per slice: the on-disk blob is read
+        // sequentially while slices may point to non-contiguous GPU memory.
+        uint64_t offset = 0;
+        for (const auto& slice : it->second) {
+            TransferRequest request;
+            request.opcode = TransferRequest::READ;
+            request.source = static_cast<char*>(slice.ptr);
+            request.target_id = seg;
+            request.target_offset = pointer + offset;
+            request.length = slice.size;
+            requests.emplace_back(request);
+            offset += slice.size;
+        }
     }
     return submitTransfer(requests);
 }


### PR DESCRIPTION
## Purpose

Fix `batch_get_into_multi_buffers` (and related read APIs) returning `INVALID_PARAMS` for all disk-backed replicas, making it impossible to read KV cache back from SSD in the upcoming [vLLM V1 `MooncakeStoreConnector`](https://github.com/ivanium/vllm/tree/feat/mooncake-store-int) integration.

### TL;DR

**Problem**: All disk replica read paths returned INVALID_PARAMS when the destination buffer is GPU memory, making SSD-offloaded KV cache unreadable.                                                              
**Fix**: LOCAL_DISK replicas scatter directly into user GPU slices via RDMA; DISK replicas stage through a registered CPU temp buffer then copy to destination.  

### Background

`MooncakeStoreConnector` is a new KV-transfer connector being integrated with vLLM V1. It stores KV cache blocks in Mooncake Store and retrieves them across requests to enable prefix caching. KV cache tensors live in **GPU device memory**; their addresses are passed directly to the read APIs (`batch_get_into_multi_buffers`, `batch_get_buffer`, `get_into` / `get_into_ranges`).

When DRAM segments fill up, Master evicts replicas to disk (`LOCAL_DISK` via client-driven SSD offload, `DISK` via master-driven eviction). However, all read APIs were silently broken when attempting to read those disk-backed replicas back into GPU buffers — none of these paths correctly distinguished between `MEMORY`, `LOCAL_DISK`, and `DISK` replicas or provided the required staging for file I/O into GPU memory.

### Root Causes

1. **`batch_get_into_multi_buffers_internal`** (`real_client.cpp`): hardcoded `else { INVALID_PARAMS }` for any non-`MEMORY` replica — both `LOCAL_DISK` and `DISK` types were silently rejected. This is the primary API used by vLLM for KV cache loading.

2. **`batch_get_buffer_internal`** (`real_client.cpp`): `LOCAL_DISK` replicas called `client_->BatchGet` → `TransferRead`, which has no `LOCAL_DISK` data-transfer logic, so allocated buffers were never filled.

3. **`execute_ranged_read`** (`real_client.cpp`): two sub-paths both broken:
   - Full-object read (`src_offset == 0`): `client_->Get` does not handle `LOCAL_DISK`
   - Partial read: explicit `LOG(ERROR) << "ranged reads only support memory replicas"`
   - Both full and partial reads for `DISK` type: `storage_backend::vector_read` writes directly to the destination slice pointer, which may be a GPU address → `FILE_READ_FAIL`

> ### Defensive Programming Considerations

> The three APIs—`batch_get_into_multi_buffers`, `batch_get_buffer`, and `execute_ranged_read`—diverge fundamentally in their handling of `LOCAL_DISK` versus `DISK` replicas. These paths cannot be unified because they differ in buffer provenance, transfer semantics, and underlying hardware constraints.

> These differences are structural, not superficial. `LOCAL_DISK` offload employs RDMA-capable transport capable of targeting pre-registered GPU memory, whereas `DISK` relies on kernel file I/O that is physically incapable of writing to device memory, making CPU staging mandatory. Consequently, explicit replica-type checks and buffer-type probes are not excessive defensiveness but necessary guards against runtime dynamism—replica types may shift due to master eviction and cluster topology changes, and user buffers may vary between device and host—preventing silent misrouting that would otherwise corrupt data or crash the process far from the root cause.
---

## Fix

### New helpers in `gpu_staging_utils.h`

Added two inline functions to complement the existing `IsDevicePointer` / `CopyDeviceToHost` / `SetDevice`:

- **`CopyHostToDevice`**: H2D copy, symmetric counterpart of `CopyDeviceToHost`. Supports CUDA / HIP / Ascend / CPU-only fallback.
- **`IsHostPointer`**: detects CPU (host) memory. Uses `cudaPointerGetAttributes` — if the query fails (pageable host memory not tracked by the runtime), returns `true`. On success, returns `attr.type != cudaMemoryTypeDevice`. No `cudaErrorInvalidValue` references needed, works across CUDA / HIP / Ascend. Used together with `IsDevicePointer` for safe pointer-type dispatching:
  - `IsDevicePointer` → H2D copy
  - `IsHostPointer` → `memcpy`
  - Neither → reject with `INVALID_PARAMS` (unknown type, e.g. non-standard allocator)

### `batch_get_into_offload_object_internal`: `vector<Slice>` scatter-gather

Changed the interface from `unordered_map<string, Slice>` to `unordered_map<string, vector<Slice>>` throughout the offload RPC stack (`transfer_task.h/cpp`, `client_service.h/cpp`, `real_client.h/cpp`).

In `submit_batch_get_offload_object`, one `TransferRequest` is emitted **per slice** with `target_offset` advancing by cumulative slice size — so the contiguous on-disk blob is RDMA-scattered into N non-contiguous destinations natively, with no extra memcpy:

```cpp
uint64_t offset = 0;
for (const auto& slice : it->second) {
    request.source       = static_cast<char*>(slice.ptr);
    request.target_id    = seg;
    request.target_offset = pointer + offset;
    request.length       = slice.size;
    requests.emplace_back(request);
    offset += slice.size;
}
```

### `batch_get_into_multi_buffers_internal`

The `else { INVALID_PARAMS }` branch is replaced with a two-way disk routing:

```
MEMORY     → existing BatchGet path (RDMA directly to GPU slices, unchanged)
LOCAL_DISK → pass user GPU slices directly to batch_get_into_offload_object_internal
             (zero-copy: vLLM pre-registers all GPU KV-cache memory via register_buffer(),
              so RDMA scatters the on-disk blob into non-contiguous per-layer GPU buffers natively)
DISK       → allocate temp CPU buf → BatchGet (file I/O into CPU buf) → scatter H2D
```

`DiskKeyInfo` struct carries an `is_local_disk` flag to route after the per-key classification pass. The `DISK` scatter step uses `IsDevicePointer` / `IsHostPointer` dual-check per sub-buffer with an offset bounds cap (`sz = min(sz, total_size - offset)`).

### `batch_get_buffer_internal`

`LOCAL_DISK` replicas are separated from `valid_ops` into `disk_ops` and routed to `batch_get_into_offload_object_internal`. `DISK` replicas continue through the existing `BatchGet` path since the allocated `client_buffer_allocator_` buffer is CPU-addressable and pre-registered with TransferEngine.

### `execute_ranged_read`

**Full-object path** (`src_offset == 0 && size == total_size`):
- `LOCAL_DISK`: `batch_get_into_offload_object_internal` with destination buffer passed directly
- `DISK`: temp CPU buffer → `allocateSlices` + `client_->Get` → `IsDevicePointer/IsHostPointer` scatter

**Partial-object path** (has `src_offset` or `size < total_size`): both `LOCAL_DISK` and `DISK` use a shared `partial_disk_read` lambda — allocate temp buffer, invoke the appropriate read op (offload RPC vs `client_->Get`), then copy the requested `[src_offset, src_offset+size)` range to the destination.

### Replica selection fix

`batch_get_into_multi_buffers_internal` previously took `replicas[0]` unconditionally. Master may return multiple replicas in any order (e.g. `[DISK, MEMORY]`). Now all five read path functions use `SelectBestReplica`, which scans with priority MEMORY > LOCAL_DISK > DISK. (Early versions had a priority bug where `[DISK, LOCAL_DISK]` would return DISK — fixed by letting LOCAL_DISK always override an already-selected DISK.)

### `Client::Get` / `Client::BatchGet` replica mismatch fix

`Client::Get` and `Client::BatchGet` (in `client_service.cpp`) internally call `FindFirstCompleteReplica(query_result.replicas, ...)`, which picks the **first** COMPLETE replica with no type preference. If Master returns `[LOCAL_DISK, MEMORY]`, it picks LOCAL_DISK. Then `TransferSubmitter::submit` routes non-MEMORY replicas to `submitFileReadOperation` (kernel `vector_read` to local files) — but LOCAL_DISK data lives on a **remote** node's SSD, so the read fails.

The fix introduces `FilterQueryResult(qr, replica)`, which constructs a new `QueryResult` containing only the chosen replica. Every `client_->Get` / `client_->BatchGet` call site in `real_client.cpp` now passes the filtered result, so `FindFirstCompleteReplica` can only see one choice. The filtering is applied:

- **Inline at struct construction** for `batch_get_buffer_internal`, `batch_get_into_internal`, `batch_get_into_multi_buffers_internal` — the chosen replica is embedded into `KeyOp` / `ValidKeyInfo` before the batch dispatch loop, so the push path needs no extra work.
- **Via local `filtered_qr`** for `get_buffer_internal` and all three `execute_ranged_read` sub-paths (DISK full, MEMORY full, DISK partial).
- The only unfiltered call is `client_->Get(key, query_result, slices, src_offset)` (ranged read with offset), which uses an overload that explicitly rejects non-MEMORY replicas.

### Defensive checks

- `submit_batch_get_offload_object`: `openSegment` moved outside the per-key loop (same `transfer_engine_addr` for all keys); added `find` null check before dereferencing `batched_slices`
- `batch_get_into_offload_object_internal`: validates `batchGetResp->pointers.size() == keys.size()` before forwarding to TransferEngine
- `batch_get_into_multi_buffers_internal` (LOCAL_DISK path): validates that sum of per-buffer sizes equals `total_size`; returns `INVALID_PARAMS` on mismatch instead of silently passing a wrong-sized transfer to the owner

---

## How Has This Been Tested?

### Environment
- **vLLM**: unreleased `feat/mooncake-store-int` branch, Python 3.12, `MooncakeStoreConnector`
- **Mooncake**: `buffer-get` branch (this PR)
- **Model**: Qwen3-4B, single node, TP=2 (2× A100/H100)
- **IB**: `ibp12s0`
- **Storage**: `enable_ssd_offload: true` (LOCAL_DISK), `enable_disk_eviction: true` + `root_fs_dir` (DISK)

### Reproduction before fix

With `global_segment_size=2GiB` and 500 prompts × 5 repeats (2500 requests total), DRAM fills up and Master allocates disk replicas. Before this fix:

```
E real_client.cpp:3978] Unsupported replica type for key: Qwen3-4B@tp_rank:1@...
WARNING Failed to get 66 Mooncake keys from sub-batch (first_failures=[(..., -600)])
```

All KV reads from disk returned `INVALID_PARAMS` (`-600` in Python), causing every cache miss on SSD-offloaded blocks to fail silently.

### Verification after fix

```bash
TMPDIR=/mnt/data/tmp XDG_CACHE_HOME=/mnt/data/.cache \
python benchmarks/benchmark_prefix_caching.py \
  --model /mnt/data/models/Qwen3-4B \
  --tensor-parallel-size 2 \
  --enable-prefix-caching \
  --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both"}' \
  --num-prompts 500 --repeat-count 5 \
  --input-length-range 2048:2048 --output-len 1 --prefix-len 1024
```

```
Processed prompts: 100% 2500/2500
cost time 76.28s

Engine 000: GPU KV cache usage: 100.0%
            Prefix cache hit rate: 69.9%
            External prefix cache hit rate: 3.1%   ← SSD read path active
```

- **2500 prompts completed successfully**, no crash, no assertion failure
- **GPU KV cache sustained at 99.8–100%** throughout — DRAM was fully saturated, disk paths were exercised
- **External prefix cache hit rate climbed from 1.4% → 3.1%** over the run, confirming SSD offload read path was triggered and returned correct data

### Files changed

| File | Change |
|------|--------|
| `mooncake-store/include/gpu_staging_utils.h` | Add `CopyHostToDevice`, `IsHostPointer` |
| `mooncake-store/include/transfer_task.h` | `submit_batch_get_offload_object`: `Slice` → `vector<Slice>` |
| `mooncake-store/include/client_service.h` | `BatchGetOffloadObject`: `Slice` → `vector<Slice>` |
| `mooncake-store/include/real_client.h` | `batch_get_into_offload_object_internal`: `Slice` → `vector<Slice>` |
| `mooncake-store/src/transfer_task.cpp` | Per-slice `TransferRequest`, `openSegment` outside loop, `find` guard |
| `mooncake-store/src/client_service.cpp` | `BatchGetOffloadObject`: `Slice` → `vector<Slice>` |
| `mooncake-store/src/real_client.cpp` | Fix `batch_get_into_multi_buffers_internal`, `batch_get_buffer_internal`, `execute_ranged_read`; `SelectBestReplica` + `FilterQueryResult` helpers; replica filtering for all `client_->Get`/`BatchGet` calls; defensive checks |

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
