### PR TITLE
[Store] add SSD offload support for ascend platform

### DIFF
--- a/mooncake-store/include/aligned_client_buffer.hpp
+++ b/mooncake-store/include/aligned_client_buffer.hpp
@@ -56,6 +56,7 @@ class AlignedClientBufferAllocator : public ClientBufferAllocator {
     // Store whether we own the memory (for cleanup)
     bool owns_memory_;
     size_t allocated_size_;  // Store the actual allocated size for cleanup
+    std::string protocol_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -492,6 +492,8 @@ class Client {
         return transfer_engine_->getLocalIpAndPort();
     }
 
+    [[nodiscard]] const std::string& GetProtocol() const { return protocol_; }
+
     /**
      * @brief Get the endpoint address for segment operations.
      * @return For P2PHANDSHAKE mode, returns the actual RPC endpoint (IP:Port).

--- a/mooncake-store/src/aligned_client_buffer.cpp
+++ b/mooncake-store/src/aligned_client_buffer.cpp
@@ -4,10 +4,78 @@
 #include <sys/mman.h>
 #include <cstdlib>
 #include <cstring>
+#include <string_view>
 
 #include "utils.h"
 
 namespace mooncake {
+namespace {
+constexpr std::string_view kAscendProtocol = "ascend";
+constexpr std::string_view kUbshmemProtocol = "ubshmem";
+
+bool UseProtocolAllocator(const std::string& protocol) {
+    return protocol == kAscendProtocol || protocol == kUbshmemProtocol;
+}
+
+void FreeAlignedBuffer(void* buffer, size_t size, const std::string& protocol,
+                       bool use_hugepage) {
+    if (use_hugepage) {
+        free_buffer_mmap_memory(buffer, size);
+    } else if (UseProtocolAllocator(protocol)) {
+        free_memory(protocol, buffer);
+    } else {
+        free(buffer);
+    }
+}
+
+void* AllocateProtocolAlignedBuffer(size_t aligned_size,
+                                    const std::string& protocol) {
+    void* aligned_buffer = allocate_buffer_allocator_memory(
+        aligned_size, protocol,
+        AlignedClientBufferAllocator::kDirectIOAlignment);
+    if (!aligned_buffer) {
+        LOG(ERROR) << "AlignedClientBufferAllocator: failed to allocate "
+                   << "protocol-aware memory of size " << aligned_size
+                   << " for protocol " << protocol;
+    }
+    return aligned_buffer;
+}
+
+void* AllocateHugepageAlignedBuffer(size_t aligned_size) {
+    void* aligned_buffer = allocate_buffer_mmap_memory(
+        aligned_size, AlignedClientBufferAllocator::kDirectIOAlignment);
+    if (!aligned_buffer) {
+        LOG(ERROR) << "AlignedClientBufferAllocator: failed to allocate "
+                   << "hugepage memory of size " << aligned_size;
+    }
+    return aligned_buffer;
+}
+
+void* AllocatePosixAlignedBuffer(size_t aligned_size) {
+    void* aligned_buffer = nullptr;
+    int ret = posix_memalign(&aligned_buffer,
+                             AlignedClientBufferAllocator::kDirectIOAlignment,
+                             aligned_size);
+    if (ret != 0) {
+        LOG(ERROR) << "AlignedClientBufferAllocator: posix_memalign failed "
+                   << "with error " << ret << " (" << strerror(ret) << ")";
+        return nullptr;
+    }
+    memset(aligned_buffer, 0, aligned_size);
+    return aligned_buffer;
+}
+
+void* AllocateAlignedBuffer(size_t aligned_size, const std::string& protocol,
+                            bool use_mmap_hugepage) {
+    if (UseProtocolAllocator(protocol)) {
+        return AllocateProtocolAlignedBuffer(aligned_size, protocol);
+    }
+    if (use_mmap_hugepage) {
+        return AllocateHugepageAlignedBuffer(aligned_size);
+    }
+    return AllocatePosixAlignedBuffer(aligned_size);
+}
+}  // namespace
 
 std::shared_ptr<AlignedClientBufferAllocator>
 AlignedClientBufferAllocator::create(size_t size, const std::string& protocol,
@@ -21,40 +89,20 @@ AlignedClientBufferAllocator::create(size_t size, const std::string& protocol,
     // Align size up to kDirectIOAlignment
     size_t aligned_size = align_up(size, kDirectIOAlignment);
 
-    void* aligned_buffer = nullptr;
-
-    if (use_hugepage) {
-        // Use hugepage allocation (already aligned)
-        aligned_buffer =
-            allocate_buffer_mmap_memory(aligned_size, kDirectIOAlignment);
-        if (!aligned_buffer) {
-            LOG(ERROR) << "AlignedClientBufferAllocator: failed to allocate "
-                       << "hugepage memory of size " << aligned_size;
-            return nullptr;
-        }
-    } else {
-        // Use posix_memalign for 4096-byte alignment
-        int ret =
-            posix_memalign(&aligned_buffer, kDirectIOAlignment, aligned_size);
-        if (ret != 0) {
-            LOG(ERROR) << "AlignedClientBufferAllocator: posix_memalign failed "
-                       << "with error " << ret << " (" << strerror(ret) << ")";
-            return nullptr;
-        }
-
-        // Zero-initialize the allocated memory
-        memset(aligned_buffer, 0, aligned_size);
+    const bool use_protocol_allocator = UseProtocolAllocator(protocol);
+    const bool use_mmap_hugepage = use_hugepage && !use_protocol_allocator;
+    void* aligned_buffer =
+        AllocateAlignedBuffer(aligned_size, protocol, use_mmap_hugepage);
+    if (!aligned_buffer) {
+        return nullptr;
     }
 
     // Verify alignment
     if (reinterpret_cast<uintptr_t>(aligned_buffer) % kDirectIOAlignment != 0) {
         LOG(ERROR) << "AlignedClientBufferAllocator: allocated buffer is not "
                    << "aligned to " << kDirectIOAlignment << " bytes";
-        if (use_hugepage) {
-            free_buffer_mmap_memory(aligned_buffer, aligned_size);
-        } else {
-            free(aligned_buffer);
-        }
+        FreeAlignedBuffer(aligned_buffer, aligned_size, protocol,
+                          use_mmap_hugepage);
         return nullptr;
     }
 
@@ -65,7 +113,7 @@ AlignedClientBufferAllocator::create(size_t size, const std::string& protocol,
     // Use custom deleter to properly free the aligned memory
     return std::shared_ptr<AlignedClientBufferAllocator>(
         new AlignedClientBufferAllocator(aligned_buffer, aligned_size, protocol,
-                                         use_hugepage));
+                                         use_mmap_hugepage));
 }
 
 AlignedClientBufferAllocator::AlignedClientBufferAllocator(
@@ -73,7 +121,8 @@ AlignedClientBufferAllocator::AlignedClientBufferAllocator(
     bool use_hugepage)
     : ClientBufferAllocator(aligned_buffer, size, protocol),
       owns_memory_(true),
-      allocated_size_(size) {
+      allocated_size_(size),
+      protocol_(protocol) {
     // Store hugepage flag in parent class's use_hugepage_ member
     // We need this for proper cleanup
     use_hugepage_ = use_hugepage;
@@ -88,12 +137,14 @@ AlignedClientBufferAllocator::~AlignedClientBufferAllocator() {
             LOG(INFO)
                 << "AlignedClientBufferAllocator: freeing hugepage memory "
                 << "at " << buffer_ << " (" << allocated_size_ << " bytes)";
-            free_buffer_mmap_memory(buffer_, allocated_size_);
+            FreeAlignedBuffer(buffer_, allocated_size_, protocol_,
+                              use_hugepage_);
         } else {
             LOG(INFO) << "AlignedClientBufferAllocator: freeing aligned memory "
                       << "at " << buffer_ << " (" << allocated_size_
                       << " bytes)";
-            free(buffer_);
+            FreeAlignedBuffer(buffer_, allocated_size_, protocol_,
+                              use_hugepage_);
         }
         buffer_ = nullptr;
     }

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -161,8 +161,8 @@ FileStorage::FileStorage(const FileStorageConfig& config,
       ssd_metric_(ssd_metric),
       local_rpc_addr_(local_rpc_addr),
       pinned_buffer_pool_(std::make_unique<PinnedBufferPool>()),
-      client_buffer_allocator_(
-          AlignedClientBufferAllocator::create(config.local_buffer_size, "")) {
+      client_buffer_allocator_(AlignedClientBufferAllocator::create(
+          config.local_buffer_size, client ? client->GetProtocol() : "")) {
     if (!config.Validate()) {
         throw std::invalid_argument("Invalid FileStorage configuration");
     }


### PR DESCRIPTION
## Description

Fix `FileStorage` local buffer allocation for Ascend FabricMem mode.

Previously, `FileStorage` created `AlignedClientBufferAllocator` with an empty protocol, causing the SSD-offload buffer to be allocated by the generic host allocator. This memory type is not supported by the Ascend FabricMem path, which requires protocol-aware allocation.

This change passes the client's protocol into the aligned buffer allocator. For `ascend` and `ubshmem`, the buffer is now allocated and freed through Mooncake's protocol-aware memory helpers, while still keeping the 4096-byte alignment required by O_DIRECT / io_uring. Non-Ascend allocation behavior remains unchanged.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Construct offload test case
1. one client start with --enable_offload and small global_segment_size
2. another client start with --global_segment_size=0
3. continuously call batch_put/batch_get_into_multi_buffers, check SSD storage and get result

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
