### PR TITLE
[Store] feat(store): add allocate-backed segment mount and unmount APIs

### DIFF
--- a/docs/source/http-api-reference/http-service.md
+++ b/docs/source/http-api-reference/http-service.md
@@ -260,3 +260,74 @@ curl -X POST http://localhost:8080/api/unmount_shm \
   -H "Content-Type: application/json" \
   -d '{"segment_ids": ["00000000-0000-0000-0000-000000000001"]}'
 ```
+
+### `/api/mount`
+Allocate memory inside the store process and mount it as one or more Mooncake
+store segments. If the requested size exceeds the maximum registration size,
+the service may split it and return multiple segment ids. The response includes
+the actual allocated size after alignment.
+
+**Method**: `POST`
+**Content-Type**: `application/json`
+
+**Request Body**:
+```json
+{
+  "size": 16777216,
+  "protocol": "tcp",
+  "location": ""
+}
+```
+
+**Fields**:
+- `size` (integer, required): Number of bytes requested. Must be positive.
+- `protocol` (string, optional): Transfer protocol. Defaults to the service
+  configuration protocol.
+- `location` (string, optional): Device or locality hint. Defaults to an empty
+  string.
+
+**Success Response**:
+```json
+{
+  "status": "success",
+  "segment_ids": ["00000000-0000-0000-0000-000000000002"],
+  "allocated_size": 16777216
+}
+```
+
+**Example**:
+```bash
+curl -X POST http://localhost:8080/api/mount \
+  -H "Content-Type: application/json" \
+  -d '{"size": 16777216, "protocol": "tcp", "location": ""}'
+```
+
+### `/api/unmount`
+Unmount one or more segment ids previously returned by `/api/mount` and free
+the memory allocated by the store process.
+
+**Method**: `POST`
+**Content-Type**: `application/json`
+
+**Request Body**:
+```json
+{
+  "segment_ids": ["00000000-0000-0000-0000-000000000002"]
+}
+```
+
+`segment_ids` may also be provided as a single string for one segment.
+
+**Success Response**:
+```json
+{
+  "status": "success"
+}
+```
+
+**Example**:
+```bash
+curl -X POST http://localhost:8080/api/unmount \
+  -H "Content-Type: application/json" \
+  -d '{"segment_ids": ["00000000-0000-0000-0000-000000000002"]}'
+```

--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -1445,7 +1445,7 @@ def mount_segment(
 ```
 
 **Parameters:**
-- `path` (str): File path to map and mount.
+- `path` (str): File or shared-memory path to map and mount.
 - `size` (int): Number of bytes to mount.
 - `offset` (int, optional): File offset in bytes. Defaults to `0`.
 - `protocol` (str, optional): Transfer protocol. Defaults to `"tcp"`.
@@ -1498,6 +1498,73 @@ def unmount_segment(self, segment_ids: List[str]) -> int
 ret = store.unmount_segment(segment_ids)
 if ret != 0:
     print("Unmount failed:", ret)
+```
+
+---
+
+#### allocate_and_mount_segment()
+Allocate memory inside the store process and mount it as one or more Mooncake
+store segments.
+
+```python
+def allocate_and_mount_segment(
+    self,
+    size: int,
+    protocol: str = "tcp",
+    location: str = "",
+) -> dict
+```
+
+**Parameters:**
+- `size` (int): Number of bytes requested. The allocated size may be rounded up
+  for alignment.
+- `protocol` (str, optional): Transfer protocol. Defaults to `"tcp"`.
+- `location` (str, optional): Device or locality hint. Defaults to an empty
+  string.
+
+**Returns:**
+- `dict`: A result dictionary with:
+  - `ret` (int): Status code (0 = success, non-zero = error code)
+  - `segment_ids` (List[str]): Segment ids created by the mount operation
+  - `allocated_size` (int): Actual allocated size in bytes
+
+**Example:**
+```python
+result = store.allocate_and_mount_segment(
+    16 * 1024 * 1024,
+    protocol="tcp",
+    location="",
+)
+
+if result["ret"] == 0:
+    segment_ids = list(result["segment_ids"])
+    allocated_size = result["allocated_size"]
+```
+
+The corresponding HTTP endpoints are `/api/mount` and `/api/unmount`.
+
+---
+
+#### unmount_and_free_segment()
+Unmount one or more internally allocated segments by segment id and free their
+local memory.
+
+```python
+def unmount_and_free_segment(self, segment_ids: List[str]) -> int
+```
+
+**Parameters:**
+- `segment_ids` (List[str]): Segment ids returned by
+  `allocate_and_mount_segment()`.
+
+**Returns:**
+- `int`: Status code (0 = success, non-zero = error code)
+
+**Example:**
+```python
+ret = store.unmount_and_free_segment(segment_ids)
+if ret != 0:
+    print("Unmount and free failed:", ret)
 ```
 
 ---

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -340,6 +340,47 @@ class MooncakeStorePyWrapper {
         return real_client->unmountSegment(segment_ids);
     }
 
+    py::dict allocate_and_mount_segment(size_t size,
+                                        const std::string &protocol,
+                                        const std::string &location) {
+        py::dict result;
+        result["ret"] = -1;
+        result["segment_ids"] = py::list();
+        result["allocated_size"] = 0;
+
+        auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
+        if (!real_client) {
+            LOG(ERROR) << "allocate_and_mount_segment requires RealClient";
+            return result;
+        }
+        std::vector<std::string> segment_ids;
+        size_t allocated_size = 0;
+        int ret;
+        {
+            py::gil_scoped_release release;
+            ret = real_client->allocateAndMountSegment(
+                size, protocol, location, segment_ids, &allocated_size);
+        }
+        result["ret"] = ret;
+        py::list ids;
+        for (const auto &id : segment_ids) {
+            ids.append(id);
+        }
+        result["segment_ids"] = ids;
+        result["allocated_size"] = allocated_size;
+        return result;
+    }
+
+    int unmount_and_free_segment(const std::vector<std::string> &segment_ids) {
+        auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
+        if (!real_client) {
+            LOG(ERROR) << "unmount_and_free_segment requires RealClient";
+            return -1;
+        }
+        py::gil_scoped_release release;
+        return real_client->unmountAndFreeSegment(segment_ids);
+    }
+
     std::string get_tp_key_name(const std::string &base_key, int rank) const {
         return base_key + "_tp_" + std::to_string(rank);
     }
@@ -1814,6 +1855,13 @@ PYBIND11_MODULE(store, m) {
              py::arg("path"), py::arg("size"), py::arg("offset") = 0,
              py::arg("protocol") = "tcp", py::arg("location") = "")
         .def("unmount_segment", &MooncakeStorePyWrapper::unmount_segment,
+             py::arg("segment_ids"))
+        .def("allocate_and_mount_segment",
+             &MooncakeStorePyWrapper::allocate_and_mount_segment,
+             py::arg("size"), py::arg("protocol") = "tcp",
+             py::arg("location") = "")
+        .def("unmount_and_free_segment",
+             &MooncakeStorePyWrapper::unmount_and_free_segment,
              py::arg("segment_ids"))
         .def("alloc_from_mem_pool",
              [](MooncakeStorePyWrapper &self, size_t size) {

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -362,11 +362,7 @@ class MooncakeStorePyWrapper {
                 size, protocol, location, segment_ids, &allocated_size);
         }
         result["ret"] = ret;
-        py::list ids;
-        for (const auto &id : segment_ids) {
-            ids.append(id);
-        }
-        result["segment_ids"] = ids;
+        result["segment_ids"] = py::cast(segment_ids);
         result["allocated_size"] = allocated_size;
         return result;
     }

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -698,10 +698,33 @@ class RealClient : public PyClient {
      */
     int unmountSegment(const std::vector<std::string> &segment_ids);
 
+    /**
+     * @brief Allocate memory internally and mount segments to master.
+     *        If size > max_mr_size, it will be split into multiple chunks.
+     *        Memory is allocated via allocate_buffer_allocator_memory.
+     *        The actual allocated size (aligned up to Slab::kSize) is written
+     *        to out_allocated_size if non-null.
+     */
+    int allocateAndMountSegment(size_t size, const std::string &protocol,
+                                const std::string &location,
+                                std::vector<std::string> &out_segment_ids,
+                                size_t *out_allocated_size = nullptr);
+
+    /**
+     * @brief Unmount segments by their ids and free locally allocated memory.
+     */
+    int unmountAndFreeSegment(const std::vector<std::string> &segment_ids);
+
     struct MountedSegmentRecord {
         void *mmap_base = nullptr;
         size_t size = 0;
         std::string path;
+    };
+
+    struct AllocatedSegmentRecord {
+        void *base = nullptr;
+        size_t size = 0;
+        std::string protocol;
     };
 
     std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
@@ -845,6 +868,10 @@ class RealClient : public PyClient {
     std::unordered_map<std::string, MountedSegmentRecord>
         mounted_segment_records_;
     std::mutex mounted_segment_records_mutex_;
+
+    std::unordered_map<std::string, AllocatedSegmentRecord>
+        allocated_segment_records_;
+    std::mutex allocated_segment_records_mutex_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1174,6 +1174,14 @@ int RealClient::unmountSegment(const std::vector<std::string> &segment_ids) {
                 continue;
             }
 
+            auto it = mounted_segment_records_.find(segment_id);
+            if (it == mounted_segment_records_.end()) {
+                LOG(ERROR) << "segment_id not found in mounted records: "
+                           << segment_id;
+                if (first_error == 0) first_error = -1;
+                continue;
+            }
+
             auto result = client_->UnmountSegmentById(id);
             if (!result.has_value()) {
                 LOG(ERROR) << "UnmountSegmentById failed for " << segment_id;
@@ -1183,17 +1191,167 @@ int RealClient::unmountSegment(const std::vector<std::string> &segment_ids) {
                 continue;  // Don't release local resources on failure
             }
 
-            auto it = mounted_segment_records_.find(segment_id);
-            if (it != mounted_segment_records_.end()) {
-                to_cleanup.emplace_back(segment_id, it->second);
-                mounted_segment_records_.erase(it);
-            }
+            to_cleanup.emplace_back(segment_id, it->second);
+            mounted_segment_records_.erase(it);
         }
     }
 
     for (auto &p : to_cleanup) {
         if (p.second.mmap_base) {
             munmap(p.second.mmap_base, p.second.size);
+        }
+    }
+
+    return first_error;
+}
+
+int RealClient::allocateAndMountSegment(
+    size_t size, const std::string &protocol, const std::string &location,
+    std::vector<std::string> &out_segment_ids, size_t *out_allocated_size) {
+    if (!client_) {
+        LOG(ERROR) << "Client not initialized";
+        return -1;
+    }
+
+    size_t max_mr_size = globalConfig().max_mr_size;
+    if (max_mr_size == 0) {
+        LOG(ERROR) << "Invalid max_mr_size: 0";
+        return -1;
+    }
+
+    if (size == 0) {
+        LOG(ERROR) << "size is 0";
+        return -1;
+    }
+
+    const size_t slab_size = facebook::cachelib::Slab::kSize;
+    size_t page_size = sysconf(_SC_PAGESIZE);
+    if (max_mr_size < page_size) {
+        LOG(ERROR) << "max_mr_size " << max_mr_size
+                   << " is smaller than page_size " << page_size;
+        return -1;
+    }
+
+    size_t aligned_max_chunk = (max_mr_size / page_size) * page_size;
+    if (aligned_max_chunk < slab_size) {
+        LOG(ERROR) << "max_mr_size " << max_mr_size
+                   << " is smaller than slab_size " << slab_size;
+        return -1;
+    }
+    // Round down chunk size to slab_size multiple
+    aligned_max_chunk = (aligned_max_chunk / slab_size) * slab_size;
+
+    // Check overflow before aligning up to slab_size
+    if (size > std::numeric_limits<size_t>::max() - (slab_size - 1)) {
+        LOG(ERROR) << "size " << size
+                   << " overflows when aligning to slab_size";
+        return -1;
+    }
+    // Round up total size to slab_size multiple
+    size_t aligned_total_size =
+        ((size + slab_size - 1) / slab_size) * slab_size;
+    size_t remaining = aligned_total_size;
+    std::vector<std::string> mounted_ids;
+    std::vector<AllocatedSegmentRecord> allocated_records;
+
+    while (remaining > 0) {
+        size_t chunk_size = std::min(remaining, aligned_max_chunk);
+        if (chunk_size == 0) break;
+
+        void *ptr = allocate_buffer_allocator_memory(chunk_size, protocol);
+        if (!ptr) {
+            LOG(ERROR) << "allocate_buffer_allocator_memory failed for size "
+                       << chunk_size;
+            break;
+        }
+
+        auto result =
+            client_->MountSegmentAndGetId(ptr, chunk_size, protocol, location);
+        if (!result.has_value()) {
+            LOG(ERROR) << "MountSegmentAndGetId failed";
+            free_memory(protocol, ptr);
+            break;
+        }
+
+        std::string segment_id = UuidToString(result.value());
+        mounted_ids.push_back(segment_id);
+        allocated_records.push_back({ptr, chunk_size, protocol});
+
+        remaining -= chunk_size;
+    }
+
+    if (remaining > 0) {
+        for (size_t i = 0; i < mounted_ids.size(); ++i) {
+            UUID id;
+            if (StringToUuid(mounted_ids[i], id)) {
+                client_->UnmountSegmentById(id);
+            }
+            if (allocated_records[i].base) {
+                free_memory(allocated_records[i].protocol,
+                            allocated_records[i].base);
+            }
+        }
+        out_segment_ids.clear();
+        return -1;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(allocated_segment_records_mutex_);
+        for (size_t i = 0; i < mounted_ids.size(); ++i) {
+            allocated_segment_records_[mounted_ids[i]] = allocated_records[i];
+        }
+    }
+    if (out_allocated_size) {
+        *out_allocated_size = aligned_total_size;
+    }
+    out_segment_ids = std::move(mounted_ids);
+    return 0;
+}
+
+int RealClient::unmountAndFreeSegment(
+    const std::vector<std::string> &segment_ids) {
+    if (!client_) {
+        LOG(ERROR) << "Client not initialized";
+        return -1;
+    }
+
+    int first_error = 0;
+    std::vector<std::pair<std::string, AllocatedSegmentRecord>> to_cleanup;
+    {
+        std::lock_guard<std::mutex> lock(allocated_segment_records_mutex_);
+        for (const auto &segment_id : segment_ids) {
+            UUID id;
+            if (!StringToUuid(segment_id, id)) {
+                LOG(ERROR) << "Invalid segment_id: " << segment_id;
+                if (first_error == 0) first_error = -1;
+                continue;
+            }
+
+            auto it = allocated_segment_records_.find(segment_id);
+            if (it == allocated_segment_records_.end()) {
+                LOG(ERROR) << "segment_id not found in allocated records: "
+                           << segment_id;
+                if (first_error == 0) first_error = -1;
+                continue;
+            }
+
+            auto result = client_->UnmountSegmentById(id);
+            if (!result.has_value()) {
+                LOG(ERROR) << "UnmountSegmentById failed for " << segment_id;
+                if (first_error == 0) {
+                    first_error = static_cast<int>(result.error());
+                }
+                continue;  // Don't release local resources on failure
+            }
+
+            to_cleanup.emplace_back(segment_id, it->second);
+            allocated_segment_records_.erase(it);
+        }
+    }
+
+    for (auto &p : to_cleanup) {
+        if (p.second.base) {
+            free_memory(p.second.protocol, p.second.base);
         }
     }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1011,18 +1011,14 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
         }
     }
 
-    std::vector<AllocatedSegmentRecord> allocated_records_to_free;
+    std::unordered_map<std::string, AllocatedSegmentRecord> records_to_free;
     {
         std::lock_guard<std::mutex> lock(allocated_segment_records_mutex_);
-        allocated_records_to_free.reserve(allocated_segment_records_.size());
-        for (auto &entry : allocated_segment_records_) {
-            allocated_records_to_free.push_back(entry.second);
-        }
-        allocated_segment_records_.clear();
+        records_to_free.swap(allocated_segment_records_);
     }
-    for (auto &record : allocated_records_to_free) {
-        if (record.base) {
-            free_memory(record.protocol, record.base);
+    for (const auto &entry : records_to_free) {
+        if (entry.second.base) {
+            free_memory(entry.second.protocol, entry.second.base);
         }
     }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1010,6 +1010,22 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
                 << toString(unregister_result.error());
         }
     }
+
+    std::vector<AllocatedSegmentRecord> allocated_records_to_free;
+    {
+        std::lock_guard<std::mutex> lock(allocated_segment_records_mutex_);
+        allocated_records_to_free.reserve(allocated_segment_records_.size());
+        for (auto &entry : allocated_segment_records_) {
+            allocated_records_to_free.push_back(entry.second);
+        }
+        allocated_segment_records_.clear();
+    }
+    for (auto &record : allocated_records_to_free) {
+        if (record.base) {
+            free_memory(record.protocol, record.base);
+        }
+    }
+
     // Reset all resources
     client_.reset();
     client_buffer_allocator_.reset();

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -136,6 +136,23 @@ TEST_F(RealClientTest, AllocateAndMountSegmentRejectsOverflowSize) {
     EXPECT_EQ(allocated_size, 0);
 }
 
+TEST_F(RealClientTest, AllocateAndMountSegmentFreesOnTearDown) {
+    StartMasterAndSetupClient();
+
+    std::vector<std::string> segment_ids;
+    size_t allocated_size = 0;
+    ASSERT_EQ(py_client_->allocateAndMountSegment(1, FLAGS_protocol, "",
+                                                  segment_ids, &allocated_size),
+              0);
+    ASSERT_FALSE(segment_ids.empty());
+    EXPECT_GT(allocated_size, 0);
+
+    EXPECT_EQ(py_client_->tearDownAll(), 0);
+
+    GLogMuter muter;
+    EXPECT_NE(py_client_->unmountAndFreeSegment(segment_ids), 0);
+}
+
 TEST_F(RealClientTest, MountAndAllocateUnmountApisRejectForeignSegments) {
     StartMasterAndSetupClient();
 

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -6,6 +6,10 @@
 #include <string>
 #include <random>
 #include <barrier>
+#include <cstdio>
+#include <fcntl.h>
+#include <limits>
+#include <unistd.h>
 
 #include "real_client.h"
 #include "test_server_helpers.h"
@@ -63,7 +67,103 @@ class RealClientTest : public ::testing::Test {
     // In-proc master for tests
     mooncake::testing::InProcMaster master_;
     std::string master_address_;
+
+    void StartMasterAndSetupClient() {
+        ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder().build()))
+            << "Failed to start in-proc master";
+        master_address_ = master_.master_address();
+
+        const std::string rdma_devices = (FLAGS_protocol == std::string("rdma"))
+                                             ? FLAGS_device_name
+                                             : std::string("");
+        ASSERT_EQ(py_client_->setup_real("localhost:17813", "P2PHANDSHAKE",
+                                         16 * 1024 * 1024, 16 * 1024 * 1024,
+                                         FLAGS_protocol, rdma_devices,
+                                         master_address_),
+                  0);
+    }
+
+    std::string CreateTempSegmentFile(size_t size) {
+        std::string path = "/tmp/mooncake_real_client_segment_XXXXXX";
+        int fd = mkstemp(path.data());
+        EXPECT_GE(fd, 0) << "Failed to create temp segment file";
+        if (fd < 0) {
+            return "";
+        }
+        EXPECT_EQ(ftruncate(fd, size), 0)
+            << "Failed to resize temp segment file";
+        close(fd);
+        return path;
+    }
 };
+
+TEST_F(RealClientTest, AllocateAndMountSegmentAlignsAndUnmounts) {
+    StartMasterAndSetupClient();
+
+    const size_t slab_size = facebook::cachelib::Slab::kSize;
+    std::vector<std::string> segment_ids;
+    size_t allocated_size = 0;
+
+    ASSERT_EQ(py_client_->allocateAndMountSegment(1, FLAGS_protocol, "",
+                                                  segment_ids, &allocated_size),
+              0);
+    EXPECT_EQ(allocated_size, slab_size);
+    ASSERT_FALSE(segment_ids.empty());
+    EXPECT_EQ(py_client_->unmountAndFreeSegment(segment_ids), 0);
+
+    segment_ids.clear();
+    allocated_size = 0;
+    ASSERT_EQ(
+        py_client_->allocateAndMountSegment(slab_size + 1, FLAGS_protocol, "",
+                                            segment_ids, &allocated_size),
+        0);
+    EXPECT_EQ(allocated_size, slab_size * 2);
+    ASSERT_FALSE(segment_ids.empty());
+    EXPECT_EQ(py_client_->unmountAndFreeSegment(segment_ids), 0);
+}
+
+TEST_F(RealClientTest, AllocateAndMountSegmentRejectsOverflowSize) {
+    StartMasterAndSetupClient();
+
+    std::vector<std::string> segment_ids;
+    size_t allocated_size = 0;
+
+    EXPECT_NE(py_client_->allocateAndMountSegment(
+                  std::numeric_limits<size_t>::max(), FLAGS_protocol, "",
+                  segment_ids, &allocated_size),
+              0);
+    EXPECT_TRUE(segment_ids.empty());
+    EXPECT_EQ(allocated_size, 0);
+}
+
+TEST_F(RealClientTest, MountAndAllocateUnmountApisRejectForeignSegments) {
+    StartMasterAndSetupClient();
+
+    const size_t slab_size = facebook::cachelib::Slab::kSize;
+    std::vector<std::string> allocated_segment_ids;
+    size_t allocated_size = 0;
+
+    ASSERT_EQ(
+        py_client_->allocateAndMountSegment(
+            1, FLAGS_protocol, "", allocated_segment_ids, &allocated_size),
+        0);
+    ASSERT_FALSE(allocated_segment_ids.empty());
+    EXPECT_NE(py_client_->unmountSegment(allocated_segment_ids), 0);
+    EXPECT_EQ(py_client_->unmountAndFreeSegment(allocated_segment_ids), 0);
+
+    std::string path = CreateTempSegmentFile(slab_size);
+    ASSERT_FALSE(path.empty());
+
+    std::vector<std::string> mounted_segment_ids;
+    ASSERT_EQ(py_client_->mountSegment(path, 0, slab_size, FLAGS_protocol, "",
+                                       mounted_segment_ids),
+              0);
+    ASSERT_FALSE(mounted_segment_ids.empty());
+    EXPECT_NE(py_client_->unmountAndFreeSegment(mounted_segment_ids), 0);
+    EXPECT_EQ(py_client_->unmountSegment(mounted_segment_ids), 0);
+
+    EXPECT_EQ(std::remove(path.c_str()), 0);
+}
 
 // Test basic Put and Get operations
 TEST_F(RealClientTest, BasicPutGetOperations) {

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -161,6 +161,8 @@ class MooncakeStoreService:
             web.post('/api/reconfigure', _timed_handler("RECONFIGURE", self.handle_reconfigure)),
             web.post('/api/mount_shm', _timed_handler("MOUNT_SHM", self.handle_mount_shm)),
             web.post('/api/unmount_shm', _timed_handler("UNMOUNT_SHM", self.handle_unmount_shm)),
+            web.post('/api/mount', _timed_handler("MOUNT", self.handle_mount)),
+            web.post('/api/unmount', _timed_handler("UNMOUNT", self.handle_unmount)),
             web.put('/api/put', _timed_handler("PUT", self.handle_put)),
             web.get('/api/get/{key}', _timed_handler("GET", self.handle_get)),
             web.get('/api/exist/{key}', _timed_handler("EXIST", self.handle_exist)),
@@ -365,6 +367,83 @@ class MooncakeStoreService:
             )
         except Exception as e:
             logging.error("UNMOUNT_SHM error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json"
+            )
+
+    async def handle_mount(self, request):
+        try:
+            data = await request.json()
+            size = data.get("size")
+            protocol = data.get("protocol", self.config.protocol)
+            location = data.get("location", "")
+
+            if type(size) is not int or size <= 0:
+                return web.Response(
+                    status=400,
+                    text=json.dumps({"error": "Invalid size, must be a positive integer"}),
+                    content_type="application/json"
+                )
+
+            result = self.store.allocate_and_mount_segment(size, protocol, location)
+            if result["ret"] != 0:
+                return web.Response(
+                    status=500,
+                    text=json.dumps({"error": f"Allocate and mount failed, ret={result['ret']}"}),
+                    content_type="application/json"
+                )
+
+            return web.Response(
+                status=200,
+                text=json.dumps(
+                    {
+                        "status": "success",
+                        "segment_ids": list(result["segment_ids"]),
+                        "allocated_size": result["allocated_size"],
+                    }
+                ),
+                content_type="application/json",
+            )
+        except Exception as e:
+            logging.error("MOUNT error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json"
+            )
+
+    async def handle_unmount(self, request):
+        try:
+            data = await request.json()
+            segment_ids = data.get("segment_ids", [])
+            if isinstance(segment_ids, str):
+                segment_ids = [segment_ids]
+            if not segment_ids:
+                return web.Response(
+                    status=400,
+                    text=json.dumps({"error": "Missing segment_ids"}),
+                    content_type="application/json",
+                )
+
+            ret = self.store.unmount_and_free_segment(segment_ids)
+            if ret != 0:
+                return web.Response(
+                    status=500,
+                    text=json.dumps(
+                        {"error": f"Unmount and free failed, ret={ret}"}
+                    ),
+                    content_type="application/json",
+                )
+
+            return web.Response(
+                status=200,
+                text=json.dumps({"status": "success"}),
+                content_type="application/json",
+            )
+        except Exception as e:
+            logging.error("UNMOUNT error: %s", e)
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -47,6 +47,8 @@ class FakeStore:
         self.unmount_calls = []
         self.fail_mount = False
         self.unmount_failures = set()
+        self.allocated_mount_calls = []
+        self.free_unmount_calls = []
 
     def mount_segment(self, path, size, offset, protocol, location):
         self.mount_calls.append((path, size, offset, protocol, location))
@@ -69,6 +71,19 @@ class FakeStore:
                 return -1
         for segment_id in segment_ids:
             self.mounted.pop(segment_id, None)
+        return 0
+
+    def allocate_and_mount_segment(self, size, protocol, location):
+        self.allocated_mount_calls.append((size, protocol, location))
+        segment_id = "00000000-0000-0000-0000-000000000002"
+        return {
+            "ret": 0,
+            "segment_ids": [segment_id],
+            "allocated_size": 4096,
+        }
+
+    def unmount_and_free_segment(self, segment_ids):
+        self.free_unmount_calls.append(list(segment_ids))
         return 0
 
 
@@ -174,6 +189,32 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.service.current_mode, "prefill")
         self.assertEqual(self.service.last_mount_info, {})
 
+    async def test_mount_allocates_and_frees_on_unmount(self):
+        mount_resp = await self.service.handle_mount(
+            FakeRequest({"size": 1, "protocol": "tcp", "location": "cpu:0"})
+        )
+        self.assertEqual(mount_resp.status, 200)
+        mount_body = json.loads(mount_resp.text)
+        self.assertEqual(mount_body["status"], "success")
+        self.assertEqual(
+            mount_body["segment_ids"],
+            ["00000000-0000-0000-0000-000000000002"],
+        )
+        self.assertEqual(mount_body["allocated_size"], 4096)
+        self.assertEqual(self.fake_store.allocated_mount_calls,
+                         [(1, "tcp", "cpu:0")])
+
+        unmount_resp = await self.service.handle_unmount(
+            FakeRequest({"segment_ids": mount_body["segment_ids"]})
+        )
+        self.assertEqual(unmount_resp.status, 200)
+        unmount_body = json.loads(unmount_resp.text)
+        self.assertEqual(unmount_body["status"], "success")
+        self.assertEqual(
+            self.fake_store.free_unmount_calls,
+            [["00000000-0000-0000-0000-000000000002"]],
+        )
+
     async def test_mount_shm_requires_name_and_size(self):
         resp = await self.service.handle_mount_shm(
             FakeRequest({"name": "mooncake-segment"})
@@ -189,6 +230,12 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resp.status, 400)
         body = json.loads(resp.text)
         self.assertIn("name or size", body["error"])
+
+    async def test_mount_requires_positive_size(self):
+        resp = await self.service.handle_mount(FakeRequest({"size": 0}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Invalid size", body["error"])
 
     async def test_unmount_shm_requires_segment_ids(self):
         resp = await self.service.handle_unmount_shm(FakeRequest({}))


### PR DESCRIPTION
## Description

This PR adds an allocate-backed segment mount/unmount workflow for Mooncake Store.

The existing standalone REST flow mounts an externally provided shared memory object through `/api/mount_shm` and unmounts it with `/api/unmount_shm`. This PR adds a complementary flow where the store process allocates memory internally, mounts it as one or more store segments, and later unmounts the segments while freeing the local allocated memory.

Main changes:
- Add `RealClient::allocateAndMountSegment()` and `RealClient::unmountAndFreeSegment()`.
- Track internally allocated segment records separately from file/shm-backed mounted segment records, so the two unmount paths cannot accidentally free each other's resources.
- Expose Python bindings:
  - `allocate_and_mount_segment(size, protocol="tcp", location="")`
  - `unmount_and_free_segment(segment_ids)`
- Add Python REST endpoints:
  - `POST /api/mount`
  - `POST /api/unmount`
- Return the actual aligned allocated size from the allocate-backed mount API.
- Release any remaining allocate-backed mount buffers during teardown.
- Update HTTP and Python API documentation.
- Add C++ and Python API tests for the new workflow.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

Tested with the relevant store, pybind, and HTTP API coverage:

- `cmake --build build --target pybind_client_test -j 8`
- `build/mooncake-store/tests/pybind_client_test --gtest_filter='RealClientTest.AllocateAndMountSegmentAlignsAndUnmounts:RealClientTest.AllocateAndMountSegmentRejectsOverflowSize:RealClientTest.AllocateAndMountSegmentFreesOnTearDown:RealClientTest.MountAndAllocateUnmountApisRejectForeignSegments'`
- `python3 -m unittest mooncake-wheel.tests.test_mooncake_store_service_api`

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.