### PR TITLE
Allow customizing client port range

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -140,6 +140,8 @@ curl -s http://<master_host>:9003/metrics/summary
 - Client metrics (enabled by default)
   - `MC_STORE_CLIENT_METRIC` (default `1`): Client-side metrics on by default; set `0` to disable entirely.
   - `MC_STORE_CLIENT_METRIC_INTERVAL` (default `0`): Reporting interval in seconds; `0` collects but does not periodically report.
+  - `MC_STORE_CLIENT_MIN_PORT` (default `12300`): Minimum local port for client connections.
+  - `MC_STORE_CLIENT_MAX_PORT` (default `14300`): Maximum local port for client connections.
 
 - Local memcpy optimization (Store transfer path)
   - `MC_STORE_MEMCPY` (default `0`/false): Set to `1` to prefer local memcpy when source/destination are on the same client.

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -140,8 +140,8 @@ curl -s http://<master_host>:9003/metrics/summary
 - Client metrics (enabled by default)
   - `MC_STORE_CLIENT_METRIC` (default `1`): Client-side metrics on by default; set `0` to disable entirely.
   - `MC_STORE_CLIENT_METRIC_INTERVAL` (default `0`): Reporting interval in seconds; `0` collects but does not periodically report.
-  - `MC_STORE_CLIENT_MIN_PORT` (default `12300`): Minimum local port for client connections.
-  - `MC_STORE_CLIENT_MAX_PORT` (default `14300`): Maximum local port for client connections.
+  - `MC_STORE_CLIENT_MIN_PORT` (default `12300`): Minimum local port for client connections. Must be in range 1024–32767 or 61000–65535 (well-known and ephemeral ports are excluded). Falls back to default on invalid input.
+  - `MC_STORE_CLIENT_MAX_PORT` (default `14300`): Maximum local port for client connections. Same range constraints as `MC_STORE_CLIENT_MIN_PORT`; must be ≥ `MC_STORE_CLIENT_MIN_PORT`.
 
 - Local memcpy optimization (Store transfer path)
   - `MC_STORE_MEMCPY` (default `0`/false): Set to `1` to prefer local memcpy when source/destination are on the same client.

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -835,6 +835,8 @@ The HTTP metadata server can be configured using the following parameters:
 - MC_STORE_MEMCPY: Enables or disables local memcpy optimization, set to 1/true to enable, 0/false to disable.
 - MC_STORE_CLIENT_METRIC: Enables client metric reporting, enabled by default; set to 0/false to disable.
 - MC_STORE_CLIENT_METRIC_INTERVAL: Reporting interval in seconds, default 0 (collects but does not report).
+- MC_STORE_CLIENT_MIN_PORT: Minimum local port for client connections.
+- MC_STORE_CLIENT_MAX_PORT: Maximum local port for client connections.
 - MC_STORE_USE_HUGEPAGE: Enables huge page support, disabled by default.
 - MC_STORE_HUGEPAGE_SIZE: Specifies the page size of the huge page to use, default 2M.
 #### Usage Example

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -835,8 +835,8 @@ The HTTP metadata server can be configured using the following parameters:
 - MC_STORE_MEMCPY: Enables or disables local memcpy optimization, set to 1/true to enable, 0/false to disable.
 - MC_STORE_CLIENT_METRIC: Enables client metric reporting, enabled by default; set to 0/false to disable.
 - MC_STORE_CLIENT_METRIC_INTERVAL: Reporting interval in seconds, default 0 (collects but does not report).
-- MC_STORE_CLIENT_MIN_PORT: Minimum local port for client connections.
-- MC_STORE_CLIENT_MAX_PORT: Maximum local port for client connections.
+- MC_STORE_CLIENT_MIN_PORT: Minimum local port for client connections (default 12300). Must be in range 1024–32767 or 61000–65535; falls back to default on invalid input.
+- MC_STORE_CLIENT_MAX_PORT: Maximum local port for client connections (default 14300). Same range constraints; must be ≥ MC_STORE_CLIENT_MIN_PORT.
 - MC_STORE_USE_HUGEPAGE: Enables huge page support, disabled by default.
 - MC_STORE_HUGEPAGE_SIZE: Specifies the page size of the huge page to use, default 2M.
 #### Usage Example

--- a/docs/source/zh_archive/mooncake-store.md
+++ b/docs/source/zh_archive/mooncake-store.md
@@ -722,8 +722,8 @@ HTTP 元数据服务器可通过以下参数进行配置：
 - **MC_STORE_MEMCPY**: 控制是否启用本地 memcpy 优化, 1/true 启用, 0/false 禁用
 - **MC_STORE_CLIENT_METRIC**: 启用客户端指标上报, 默认启用；设为 0/false 禁用
 - **MC_STORE_CLIENT_METRIC_INTERVAL**: 指标上报间隔(秒), 默认 0(仅收集不上报)
-- **MC_STORE_CLIENT_MIN_PORT**: 客户端使用的最小端口号, 默认 12300
-- **MC_STORE_CLIENT_MAX_PORT**: 客户端使用的最大端口号, 默认 14300
+- **MC_STORE_CLIENT_MIN_PORT**: 客户端使用的最小端口号, 默认 12300。端口范围必须在 1024–32767 或 61000–65535 之间（排除知名端口和临时端口）。无效值将回退为默认值。
+- **MC_STORE_CLIENT_MAX_PORT**: 客户端使用的最大端口号, 默认 14300。范围约束同上；必须 ≥ MC_STORE_CLIENT_MIN_PORT。
 - **MC_STORE_USE_HUGEPAGE**: 启用 hugepage 优化, 默认禁用, 设置为 1/true 启用
 - **MC_STORE_HUGEPAGE_SIZE**: hugepage 页大小, 默认 2M
 

--- a/docs/source/zh_archive/mooncake-store.md
+++ b/docs/source/zh_archive/mooncake-store.md
@@ -722,6 +722,8 @@ HTTP 元数据服务器可通过以下参数进行配置：
 - **MC_STORE_MEMCPY**: 控制是否启用本地 memcpy 优化, 1/true 启用, 0/false 禁用
 - **MC_STORE_CLIENT_METRIC**: 启用客户端指标上报, 默认启用；设为 0/false 禁用
 - **MC_STORE_CLIENT_METRIC_INTERVAL**: 指标上报间隔(秒), 默认 0(仅收集不上报)
+- **MC_STORE_CLIENT_MIN_PORT**: 客户端使用的最小端口号, 默认 12300
+- **MC_STORE_CLIENT_MAX_PORT**: 客户端使用的最大端口号, 默认 14300
 - **MC_STORE_USE_HUGEPAGE**: 启用 hugepage 优化, 默认禁用, 设置为 1/true 启用
 - **MC_STORE_HUGEPAGE_SIZE**: hugepage 页大小, 默认 2M
 

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -6,6 +6,7 @@
 #include <linux/mman.h>
 #include <string>
 #include <limits>
+#include <utility>
 #include <ylt/util/tl/expected.hpp>
 
 #include "rpc_types.h"
@@ -424,6 +425,30 @@ T GetEnvOr(const char* name, T default_value) {
     } catch (...) {
         return default_value;
     }
+}
+
+// Validates a port range. Returns {default_min, default_max} on invalid input.
+// Rejects: min > max, well-known ports (0-1023), ephemeral ports (32768-60999).
+inline std::pair<int, int> ValidatePortRange(int min_port, int max_port,
+                                             int default_min, int default_max) {
+    constexpr int kMinAllowed = 1024;
+    constexpr int kEphemeralStart = 32768;
+    constexpr int kEphemeralEnd = 60999;
+    constexpr int kMaxAllowed = 65535;
+
+    auto is_valid_port = [&](int p) {
+        return p >= kMinAllowed && p <= kMaxAllowed &&
+               !(p >= kEphemeralStart && p <= kEphemeralEnd);
+    };
+
+    if (!is_valid_port(min_port) || !is_valid_port(max_port) ||
+        min_port > max_port) {
+        LOG(WARNING) << "Invalid port range [" << min_port << ", " << max_port
+                     << "], falling back to default [" << default_min << ", "
+                     << default_max << "]";
+        return {default_min, default_max};
+    }
+    return {min_port, max_port};
 }
 
 std::string GetEnvStringOr(const char* name, const std::string& default_value);

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -6,7 +6,6 @@
 #include <linux/mman.h>
 #include <string>
 #include <limits>
-#include <utility>
 #include <ylt/util/tl/expected.hpp>
 
 #include "rpc_types.h"
@@ -425,30 +424,6 @@ T GetEnvOr(const char* name, T default_value) {
     } catch (...) {
         return default_value;
     }
-}
-
-// Validates a port range. Returns {default_min, default_max} on invalid input.
-// Rejects: min > max, well-known ports (0-1023), ephemeral ports (32768-60999).
-inline std::pair<int, int> ValidatePortRange(int min_port, int max_port,
-                                             int default_min, int default_max) {
-    constexpr int kMinAllowed = 1024;
-    constexpr int kEphemeralStart = 32768;
-    constexpr int kEphemeralEnd = 60999;
-    constexpr int kMaxAllowed = 65535;
-
-    auto is_valid_port = [&](int p) {
-        return p >= kMinAllowed && p <= kMaxAllowed &&
-               !(p >= kEphemeralStart && p <= kEphemeralEnd);
-    };
-
-    if (!is_valid_port(min_port) || !is_valid_port(max_port) ||
-        min_port > max_port) {
-        LOG(WARNING) << "Invalid port range [" << min_port << ", " << max_port
-                     << "], falling back to default [" << default_min << ", "
-                     << default_max << "]";
-        return {default_min, default_max};
-    }
-    return {min_port, max_port};
 }
 
 std::string GetEnvStringOr(const char* name, const std::string& default_value);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -603,11 +603,13 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         // Auto port binding with retry on metadata registration failure
         const int kMaxRetries =
             GetEnvOr<int>("MC_STORE_CLIENT_SETUP_RETRIES", 20);
+        const int minPort = GetEnvOr<int>("MC_STORE_CLIENT_MIN_PORT", 12300);
+        const int maxPort = GetEnvOr<int>("MC_STORE_CLIENT_MAX_PORT", 14300);
         bool success = false;
 
         for (int retry = 0; retry < kMaxRetries; ++retry) {
             // Create port binder to hold a port
-            port_binder_ = std::make_unique<AutoPortBinder>();
+            port_binder_ = std::make_unique<AutoPortBinder>(minPort, maxPort);
             int port = port_binder_->getPort();
             if (port < 0) {
                 LOG(WARNING) << "Failed to bind available port, retry "

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -603,8 +603,12 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         // Auto port binding with retry on metadata registration failure
         const int kMaxRetries =
             GetEnvOr<int>("MC_STORE_CLIENT_SETUP_RETRIES", 20);
-        const int minPort = GetEnvOr<int>("MC_STORE_CLIENT_MIN_PORT", 12300);
-        const int maxPort = GetEnvOr<int>("MC_STORE_CLIENT_MAX_PORT", 14300);
+        const int rawMinPort = GetEnvOr<int>("MC_STORE_CLIENT_MIN_PORT", 12300);
+        const int rawMaxPort = GetEnvOr<int>("MC_STORE_CLIENT_MAX_PORT", 14300);
+        constexpr int kDefaultMinPort = 12300;
+        constexpr int kDefaultMaxPort = 14300;
+        auto [minPort, maxPort] = ValidatePortRange(
+            rawMinPort, rawMaxPort, kDefaultMinPort, kDefaultMaxPort);
         bool success = false;
 
         for (int retry = 0; retry < kMaxRetries; ++retry) {

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <mutex>
 #include <string>
+#include <utility>
 
 namespace mooncake {
 
@@ -91,6 +92,11 @@ void updateGlobalConfig(ibv_device_attr& device_attr);
 GlobalConfig& globalConfig();
 
 uint16_t getDefaultHandshakePort();
+
+// Validates a port range. Returns {default_min, default_max} on invalid input.
+// Rejects: min > max, well-known ports (0-1023), ephemeral ports (32768-60999).
+std::pair<int, int> ValidatePortRange(int min_port, int max_port,
+                                      int default_min, int default_max);
 
 }  // namespace mooncake
 

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -286,23 +286,14 @@ void loadGlobalConfig(GlobalConfig& config) {
     }
 
     const char* min_port_env = std::getenv("MC_MIN_PRC_PORT");
-    if (min_port_env) {
-        int val = atoi(min_port_env);
-        if (val > 0 && val < 65536)
-            config.rpc_min_port = val;
-        else
-            LOG(WARNING)
-                << "Ignore value from environment variable MC_PRC_MIN_PORT";
-    }
-
     const char* max_port_env = std::getenv("MC_MAX_PRC_PORT");
-    if (max_port_env) {
-        int val = atoi(max_port_env);
-        if (val > 0 && val < 65536)
-            config.rpc_max_port = val;
-        else
-            LOG(WARNING)
-                << "Ignore value from environment variable MC_PRC_MAX_PORT";
+    {
+        int raw_min = min_port_env ? atoi(min_port_env) : config.rpc_min_port;
+        int raw_max = max_port_env ? atoi(max_port_env) : config.rpc_max_port;
+        auto [validated_min, validated_max] =
+            ValidatePortRange(raw_min, raw_max, 15000, 17000);
+        config.rpc_min_port = validated_min;
+        config.rpc_max_port = validated_max;
     }
 
     if (std::getenv("MC_USE_IPV6")) {
@@ -438,4 +429,26 @@ GlobalConfig& globalConfig() {
 }
 
 uint16_t getDefaultHandshakePort() { return globalConfig().handshake_port; }
+
+std::pair<int, int> ValidatePortRange(int min_port, int max_port,
+                                      int default_min, int default_max) {
+    constexpr int kMinAllowed = 1024;
+    constexpr int kEphemeralStart = 32768;
+    constexpr int kEphemeralEnd = 60999;
+    constexpr int kMaxAllowed = 65535;
+
+    auto is_valid_port = [&](int p) {
+        return p >= kMinAllowed && p <= kMaxAllowed &&
+               !(p >= kEphemeralStart && p <= kEphemeralEnd);
+    };
+
+    if (!is_valid_port(min_port) || !is_valid_port(max_port) ||
+        min_port > max_port) {
+        LOG(WARNING) << "Invalid port range [" << min_port << ", " << max_port
+                     << "], falling back to default [" << default_min << ", "
+                     << default_max << "]";
+        return {default_min, default_max};
+    }
+    return {min_port, max_port};
+}
 }  // namespace mooncake


### PR DESCRIPTION
## Description

Same motivation as in https://github.com/kvcache-ai/Mooncake/pull/873, some servers restrict the allowed port range, it's better to not hardcode it.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

I verified that the environment variables are applied correctly to both mooncake_client and the SGLang Mooncake HiCache backend, using a wheel built from GitHub CI.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
