### PR TITLE
[Store] Add chained-prefix LPM lookup (QueryPrefixMatch RPC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
     - name: Install and start etcd
       run: |
         wget https://github.com/etcd-io/etcd/releases/download/v3.6.1/etcd-v3.6.1-linux-amd64.tar.gz
@@ -123,6 +126,33 @@ jobs:
         cd mooncake-transfer-engine/example/http-metadata-server-python
         pip install aiohttp
         python ./bootstrap_server.py &
+      shell: bash
+
+    - name: Run Mooncake Store Rust smoke test and benchmark
+      run: |
+        $GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master \
+          --eviction_high_watermark_ratio=0.95 \
+          --cluster_id=ci_rust_test_cluster \
+          --port 50051 &
+        MASTER_PID=$!
+        sleep 3
+        cd mooncake-store/rust
+        export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/mooncake-asio:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd:$LD_LIBRARY_PATH
+        export MOONCAKE_BUILD_DIR=$GITHUB_WORKSPACE/build
+        export MOONCAKE_STORE_LIB_DIR=$GITHUB_WORKSPACE/build/mooncake-store/src
+        export MOONCAKE_STORE_INCLUDE_DIR=$GITHUB_WORKSPACE/mooncake-store/include
+        export MC_METADATA_SERVER=http://127.0.0.1:8080/metadata
+        export MC_RUST_STORE_RUN_INTEGRATION=true
+        export MC_RUST_STORE_MASTER_ADDR=127.0.0.1:50051
+        export MC_RUST_STORE_LOCAL_HOSTNAME=127.0.0.1
+        export MC_RUST_STORE_PROTOCOL=tcp
+        export MC_RUST_STORE_DEVICE_NAME=
+        cargo test --test minimal_smoke -- --nocapture
+        MC_RUST_BENCH_ITERATIONS=4 \
+        MC_RUST_BENCH_VALUE_SIZE=4096 \
+        MC_RUST_BENCH_WARMUP=1 \
+          cargo run --release --example store_benchmark
+        kill $MASTER_PID 2>/dev/null || true
       shell: bash
 
     - name: Run Go store binding integration tests
@@ -557,12 +587,14 @@ jobs:
         sudo cmake --install .
       shell: bash
 
-    - name: Check Mooncake Store Rust bindings and example
+    - name: Check Mooncake Store Rust bindings, examples, and tests
       run: |
         cd mooncake-store/rust
+        export MOONCAKE_BUILD_DIR=$GITHUB_WORKSPACE/build
+        cargo test --lib
         MOONCAKE_STORE_LIB_DIR=$GITHUB_WORKSPACE/build/mooncake-store/src \
         MOONCAKE_STORE_INCLUDE_DIR=$GITHUB_WORKSPACE/mooncake-store/include \
-          cargo check --example basic_usage --tests
+          cargo test --examples --tests --no-run
       shell: bash
 
     - name: Configure project
@@ -696,7 +728,7 @@ jobs:
           echo "Error: code_format.sh not found or not executable"
           exit 1
         fi
-        
+
         # Determine base ref for comparison
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           # For PRs: compare against the target branch

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -848,6 +848,71 @@ To start the master service with the HTTP metadata server enabled:
 When enabled, the HTTP metadata server will start automatically and provide metadata services for the Mooncake Store cluster. This eliminates the need for an external etcd deployment, simplifying the setup process for development and testing environments.
 Note that the HTTP metadata server is designed for single-node deployments and does not provide the high availability features that etcd offers. For production environments requiring high availability, etcd is still the recommended choice.
 
+## Chained-Prefix Longest-Prefix-Match (LPM) Lookup
+
+For prefix-cache aware routing (e.g. an upstream router placing an LLM
+request on the node that already holds the longest matching KV cache),
+the master exposes a single RPC, `QueryPrefixMatch`, that performs a
+Longest-Prefix-Match lookup over a per-block rolling hash chain.
+
+### Chain encoding
+
+Callers compute a per-block rolling hash:
+
+```
+key_0 = hash(block_0)
+key_i = hash(key_{i-1}, block_i)
+```
+
+and submit the chain `[key_0, key_1, ..., key_{N-1}]`. Each entry is
+mapped to an `ObjectKey` via `MakePrefixHashKey()` (a fixed `"__pfx__"`
+prefix plus the 16-character hex of the uint64 hash — see
+`mooncake-store/include/prefix_key.h`), so prefix entries live in the
+same string-keyed metadata shards as ordinary objects without colliding
+with user keys. The encoding is shared verbatim by the master, the
+client SDK, the C++ tests, the bench, and the Python smoke test.
+
+### LPM walk
+
+The master walks the chain from the deepest entry backwards. Because
+the chain is built monotonically (`chain[i+1]` is only meaningful when
+`chain[i]` was indexed at some point), the first entry that has at
+least one COMPLETE replica is also the LPM. The walk holds only the
+per-shard metadata read lock; it deliberately does not acquire
+`segment_mutex_`, preserving the project-wide acquisition order
+`client_mutex_ → metadata_shards_[shard].mutex → segment_mutex_`.
+
+For the deepest matched key, the master emits one
+`PrefixMatchCandidate` per unique segment owning a COMPLETE replica
+(deduped by `segment_name`). The list is intentionally **unranked** —
+any ranking or routing policy is left to the caller, which has
+visibility into request-side context the master does not.
+
+### Configuration & error codes
+
+- `enable_prefix_query` (default `true`) — feature flag on the master.
+  When off, every `QueryPrefixMatch` returns
+  `PREFIX_QUERY_DISABLED` (`-1600`) with a single atomic load on the
+  fast path.
+- `kMaxPrefixChainLength = 1024` — chain longer than this is rejected
+  with `PREFIX_CHAIN_TOO_LONG` (`-1601`); empty chain is rejected with
+  `PREFIX_CHAIN_EMPTY` (`-1602`).
+
+### Observability
+
+Two Prometheus counters are exported:
+
+- `master_query_prefix_match_requests_total`
+- `master_query_prefix_match_failures_total`
+
+### Python binding
+
+`MooncakeDistributedStore.query_prefix_match(chain) -> (matched_blocks,
+[(segment_name, replica_type)], query_lease_ms, err_code)` — see
+`mooncake-store/include/master_client.h` and
+`mooncake-integration/store/store_py.cpp` for details.
+
+
 ## Mooncake Store Python API
 
 **Complete Python API Documentation**: [https://kvcache-ai.github.io/Mooncake/python-api-reference/mooncake-store.html](https://kvcache-ai.github.io/Mooncake/python-api-reference/mooncake-store.html)

--- a/docs/source/http-api-reference/http-service.md
+++ b/docs/source/http-api-reference/http-service.md
@@ -10,6 +10,10 @@ The HTTP service serves multiple purposes:
 - **Data Inspection**: Examine stored objects and their replicas
 - **Health Checks**: Service availability and status verification
 
+The Python `mooncake.mooncake_store_service` module also provides a lightweight
+Store REST API for data operations and standalone segment mount/unmount
+workflows. Unless configured otherwise, it listens on port `8080`.
+
 ## HTTP Endpoints
 
 ### Metrics Endpoints
@@ -159,3 +163,100 @@ Basic health check endpoint for service availability verification.
 curl http://localhost:8080/health
 ```
 
+## Store REST API Endpoints
+
+The following endpoints are served by the Python store REST service, which wraps
+`MooncakeDistributedStore` with an aiohttp service. The HTTP handlers live in
+Python, while mount and unmount operations are delegated to the underlying store
+binding. Start the service with:
+
+```bash
+python -m mooncake.mooncake_store_service \
+  --config /path/to/mooncake_config.json \
+  --port 8080
+```
+
+If the wheel console scripts are installed, the equivalent command is:
+
+```bash
+mc_store_rest_server --config /path/to/mooncake_config.json --port 8080
+```
+
+### `/api/mount_shm`
+Mount a named shared memory object as one or more Mooncake store segments. If
+the requested size exceeds the maximum registration size, the service may split
+the region and return multiple segment ids.
+
+**Method**: `POST`
+**Content-Type**: `application/json`
+
+**Request Body**:
+```json
+{
+  "name": "mooncake_segment",
+  "size": 16777216,
+  "offset": 0,
+  "protocol": "tcp",
+  "location": ""
+}
+```
+
+**Fields**:
+- `name` (string, required): Named shared memory object name. A leading `/` is
+  accepted, but path separators are not.
+- `size` (integer, required): Number of bytes to mount.
+- `offset` (integer, optional): File offset in bytes. Defaults to `0`.
+- `protocol` (string, optional): Transfer protocol. Defaults to the service
+  configuration protocol.
+- `location` (string, optional): Device or locality hint. Defaults to an empty
+  string.
+
+**Success Response**:
+```json
+{
+  "status": "success",
+  "segment_ids": ["00000000-0000-0000-0000-000000000001"]
+}
+```
+
+**Example**:
+```bash
+curl -X POST http://localhost:8080/api/mount_shm \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "mooncake_segment",
+        "size": 16777216,
+        "offset": 0,
+        "protocol": "tcp",
+        "location": ""
+      }'
+```
+
+### `/api/unmount_shm`
+Unmount one or more segment ids previously returned by `/api/mount_shm`.
+
+**Method**: `POST`
+**Content-Type**: `application/json`
+
+**Request Body**:
+```json
+{
+  "segment_ids": ["00000000-0000-0000-0000-000000000001"]
+}
+```
+
+`segment_ids` may also be provided as a single string for one segment.
+
+**Success Response**:
+```json
+{
+  "status": "success"
+}
+```
+
+**Example**:
+```bash
+curl -X POST http://localhost:8080/api/unmount_shm \
+  -H "Content-Type: application/json" \
+  -d '{"segment_ids": ["00000000-0000-0000-0000-000000000001"]}'
+```

--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -1429,6 +1429,79 @@ def init_all(self, protocol: str, device_name: str, mount_segment_size: int = 16
 
 ---
 
+#### mount_segment()
+Mount a local file or shared-memory region as one or more Mooncake store
+segments.
+
+```python
+def mount_segment(
+    self,
+    path: str,
+    size: int,
+    offset: int = 0,
+    protocol: str = "tcp",
+    location: str = "",
+) -> dict
+```
+
+**Parameters:**
+- `path` (str): File path to map and mount.
+- `size` (int): Number of bytes to mount.
+- `offset` (int, optional): File offset in bytes. Defaults to `0`.
+- `protocol` (str, optional): Transfer protocol. Defaults to `"tcp"`.
+- `location` (str, optional): Device or locality hint. Defaults to an empty
+  string.
+
+**Returns:**
+- `dict`: A result dictionary with:
+  - `ret` (int): Status code (0 = success, non-zero = error code)
+  - `segment_ids` (List[str]): Segment ids created by the mount operation
+
+**Example:**
+```python
+result = store.mount_segment(
+    "/dev/shm/mooncake_segment",
+    16 * 1024 * 1024,
+    offset=0,
+    protocol="tcp",
+    location="",
+)
+
+if result["ret"] == 0:
+    segment_ids = list(result["segment_ids"])
+    print("Mounted segments:", segment_ids)
+else:
+    print("Mount failed:", result["ret"])
+```
+
+The corresponding HTTP endpoints are `/api/mount_shm` and
+`/api/unmount_shm`, but the HTTP API is intentionally narrower: it accepts a
+named shared memory object name instead of an arbitrary path.
+
+---
+
+#### unmount_segment()
+Unmount one or more file or shared-memory segments by segment id.
+
+```python
+def unmount_segment(self, segment_ids: List[str]) -> int
+```
+
+**Parameters:**
+- `segment_ids` (List[str]): Segment ids returned by `mount_segment()`.
+
+**Returns:**
+- `int`: Status code (0 = success, non-zero = error code)
+
+**Example:**
+```python
+ret = store.unmount_segment(segment_ids)
+if ret != 0:
+    print("Unmount failed:", ret)
+```
+
+---
+
 #### get_hostname()
 Get the hostname of the current store instance.
 

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -302,6 +302,44 @@ class MooncakeStorePyWrapper {
         return store_->health_check();
     }
 
+    py::dict mount_segment(const std::string &path, size_t size, size_t offset,
+                           const std::string &protocol,
+                           const std::string &location) {
+        py::dict result;
+        result["ret"] = -1;
+        result["segment_ids"] = py::list();
+
+        auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
+        if (!real_client) {
+            LOG(ERROR) << "mount_segment requires RealClient";
+            return result;
+        }
+        std::vector<std::string> segment_ids;
+        int ret;
+        {
+            py::gil_scoped_release release;
+            ret = real_client->mountSegment(path, offset, size, protocol,
+                                            location, segment_ids);
+        }
+        result["ret"] = ret;
+        py::list ids;
+        for (const auto &id : segment_ids) {
+            ids.append(id);
+        }
+        result["segment_ids"] = ids;
+        return result;
+    }
+
+    int unmount_segment(const std::vector<std::string> &segment_ids) {
+        auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
+        if (!real_client) {
+            LOG(ERROR) << "unmount_segment requires RealClient";
+            return -1;
+        }
+        py::gil_scoped_release release;
+        return real_client->unmountSegment(segment_ids);
+    }
+
     std::string get_tp_key_name(const std::string &base_key, int rank) const {
         return base_key + "_tp_" + std::to_string(rank);
     }
@@ -1772,6 +1810,11 @@ PYBIND11_MODULE(store, m) {
                  return self.store_->initAll(protocol, device_name,
                                              mount_segment_size);
              })
+        .def("mount_segment", &MooncakeStorePyWrapper::mount_segment,
+             py::arg("path"), py::arg("size"), py::arg("offset") = 0,
+             py::arg("protocol") = "tcp", py::arg("location") = "")
+        .def("unmount_segment", &MooncakeStorePyWrapper::unmount_segment,
+             py::arg("segment_ids"))
         .def("alloc_from_mem_pool",
              [](MooncakeStorePyWrapper &self, size_t size) {
                  py::gil_scoped_release release;
@@ -2574,7 +2617,60 @@ PYBIND11_MODULE(store, m) {
             "    task_id: UUID of the task to query.\n\n"
             "Returns:\n"
             "    tuple[QueryTaskResponse | None, int]: (QueryTaskResponse if "
-            "success, error code: 0 if success, non-zero if failure)");
+            "success, error code: 0 if success, non-zero if failure)")
+        .def(
+            "query_prefix_match",
+            [](MooncakeStorePyWrapper &self,
+               const std::vector<uint64_t> &chain) -> py::tuple {
+                if (!self.is_client_initialized() || self.use_dummy_client_) {
+                    // Per Gemini review: signal "no data" with py::none()
+                    // for both the matched_blocks and candidates slots so
+                    // Python callers can use the idiomatic
+                    //   data, _, _, err = store.query_prefix_match(chain)
+                    //   if err: ...
+                    // pattern without having to special-case zero-valued
+                    // sentinels (which are valid hit-but-empty responses).
+                    return py::make_tuple(py::none(), py::none(), 0,
+                                          toInt(ErrorCode::INVALID_PARAMS));
+                }
+                QueryPrefixMatchRequest request;
+                request.chain = chain;
+                tl::expected<QueryPrefixMatchResponse, ErrorCode> result;
+                {
+                    py::gil_scoped_release release;
+                    result = self.store_->client_->QueryPrefixMatch(request);
+                }
+                if (!result.has_value()) {
+                    // See note above: error path returns py::none() for
+                    // the payload slots so callers don't conflate "RPC
+                    // failed" with "RPC succeeded but matched nothing".
+                    return py::make_tuple(py::none(), py::none(), 0,
+                                          toInt(result.error()));
+                }
+                py::list candidates;
+                for (const auto &cand : result.value().candidates) {
+                    candidates.append(py::make_tuple(
+                        cand.segment_name,
+                        static_cast<int32_t>(cand.replica_type)));
+                }
+                return py::make_tuple(result.value().matched_blocks,
+                                      std::move(candidates),
+                                      result.value().query_lease_ms, 0);
+            },
+            py::arg("chain"),
+            "Forge RL Design 01 - chained-prefix LPM lookup.\n\n"
+            "Args:\n"
+            "    chain: List[int] of per-block prefix hashes (uint64). "
+            "Empty chain returns PREFIX_CHAIN_EMPTY.\n\n"
+            "Returns:\n"
+            "    tuple[int | None, list[tuple[str, int]] | None, int, int]:\n"
+            "        - matched_blocks: number of leading blocks that hit a "
+            "stored prefix key, or None on error.\n"
+            "        - candidates: list of (segment_name, replica_type) for "
+            "the deepest matched key (unranked), or None on error.\n"
+            "        - query_lease_ms: advisory lease for the query result.\n"
+            "        - err_code: 0 on success, non-zero error code on failure "
+            "(e.g. PREFIX_QUERY_DISABLED, PREFIX_CHAIN_TOO_LONG).");
 
     // Expose NUMA binding as a module-level function (no self required)
     m.def(

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -135,6 +135,17 @@ class Client {
     QueryByRegex(const std::string& str);
 
     /**
+     * @brief Forge RL Design 01 - chained-prefix LPM lookup.
+     *
+     * Forwards the per-block prefix-hash chain to the master and returns the
+     * unranked candidate replicas that hold the deepest matched prefix key.
+     * Returns ErrorCode::PREFIX_QUERY_DISABLED when the master has the
+     * feature flag turned off.
+     */
+    tl::expected<QueryPrefixMatchResponse, ErrorCode> QueryPrefixMatch(
+        const QueryPrefixMatchRequest& request);
+
+    /**
      * @brief Batch query object metadata without transferring data
      * @param object_keys Keys to query
      * @return Vector of QueryResult objects containing replicas and lease
@@ -294,6 +305,20 @@ class Client {
      */
     tl::expected<void, ErrorCode> UnmountSegment(const void* buffer,
                                                  size_t size);
+
+    /**
+     * @brief Mounts a memory segment and returns its generated Segment UUID.
+     *        Logic is identical to MountSegment, but returns the segment id.
+     */
+    tl::expected<UUID, ErrorCode> MountSegmentAndGetId(
+        const void* buffer, size_t size, const std::string& protocol = "tcp",
+        const std::string& location = kWildcardLocation);
+
+    /**
+     * @brief Unmounts a segment by its UUID.
+     *        Logic is identical to UnmountSegment, but looks up by id.
+     */
+    tl::expected<void, ErrorCode> UnmountSegmentById(const UUID& segment_id);
 
     /**
      * @brief Registers memory buffer with TransferEngine for data transfer
@@ -665,6 +690,13 @@ class Client {
     // Mutex to protect mounted_segments_
     std::mutex mounted_segments_mutex_;
     std::unordered_map<UUID, Segment, boost::hash<UUID>> mounted_segments_;
+
+    /**
+     * @brief Internal helper to unmount a segment by iterator.
+     *        Caller must hold mounted_segments_mutex_.
+     */
+    tl::expected<void, ErrorCode> UnmountSegmentImpl(
+        std::unordered_map<UUID, Segment, boost::hash<UUID>>::iterator it);
 
     // Configuration
     const std::string local_hostname_;

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -163,6 +163,17 @@ class MasterClient {
     BatchGetReplicaList(const std::vector<std::string>& object_keys);
 
     /**
+     * @brief Forge RL Design 01 — chained-prefix LPM lookup.
+     *
+     * Sends a per-block prefix-hash chain to the master and gets back the
+     * longest matched prefix length together with the unranked list of
+     * candidate replicas owning the deepest matched key. Returns
+     * PREFIX_QUERY_DISABLED when the feature flag is off on the master.
+     */
+    [[nodiscard]] tl::expected<QueryPrefixMatchResponse, ErrorCode>
+    QueryPrefixMatch(const QueryPrefixMatchRequest& request);
+
+    /**
      * @brief Starts a put operation
      * @param key Object key
      * @param slice_lengths Vector of slice lengths

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -85,7 +85,18 @@ struct MasterConfig {
     // Offload-on-evict: defer LOCAL_DISK offload to eviction time
     bool offload_on_evict = false;
     bool offload_force_evict = false;
+
+    // Forge RL Design 01 — chained-prefix LPM lookup. When false, the
+    // QueryPrefixMatch RPC short-circuits with PREFIX_QUERY_DISABLED and the
+    // master pays no extra cost on the read path.
+    bool enable_prefix_query = true;
 };
+
+// Forge RL Design 01 §3.8: hard upper bound on the chain length accepted by
+// QueryPrefixMatch. A typical vLLM rollout has well under 256 blocks; 1024
+// keeps headroom for long-context agent traces while still bounding the
+// per-RPC CPU and lock-acquire count.
+inline constexpr uint32_t kMaxPrefixChainLength = 1024;
 
 class MasterServiceSupervisorConfig {
    public:
@@ -146,6 +157,7 @@ class MasterServiceSupervisorConfig {
     bool enable_cxl = false;
     bool offload_on_evict = false;
     bool offload_force_evict = false;
+    bool enable_prefix_query = true;
     MasterServiceSupervisorConfig() = default;
 
     // From MasterConfig
@@ -214,6 +226,7 @@ class MasterServiceSupervisorConfig {
         cxl_path = config.cxl_path;
         cxl_size = config.cxl_size;
         enable_cxl = config.enable_cxl;
+        enable_prefix_query = config.enable_prefix_query;
         validate();
     }
 
@@ -312,6 +325,7 @@ class WrappedMasterServiceConfig {
     std::string cxl_path = DEFAULT_CXL_PATH;
     size_t cxl_size = DEFAULT_CXL_SIZE;
     bool enable_cxl = false;
+    bool enable_prefix_query = true;
     WrappedMasterServiceConfig() = default;
 
     // From MasterConfig
@@ -390,6 +404,7 @@ class WrappedMasterServiceConfig {
         cxl_path = config.cxl_path;
         cxl_size = config.cxl_size;
         enable_cxl = config.enable_cxl;
+        enable_prefix_query = config.enable_prefix_query;
     }
 
     // From MasterServiceSupervisorConfig, enable_ha is set to true
@@ -448,6 +463,7 @@ class WrappedMasterServiceConfig {
         cxl_path = config.cxl_path;
         cxl_size = config.cxl_size;
         enable_cxl = config.enable_cxl;
+        enable_prefix_query = config.enable_prefix_query;
     }
 };
 
@@ -501,8 +517,16 @@ class MasterServiceConfigBuilder {
     size_t cxl_size_ = DEFAULT_CXL_SIZE;
     bool enable_cxl_ = false;
 
+    // Forge RL Design 01 §3.7 — chained-prefix LPM lookup feature flag.
+    bool enable_prefix_query_ = true;
+
    public:
     MasterServiceConfigBuilder() = default;
+
+    MasterServiceConfigBuilder& set_enable_prefix_query(bool enabled) {
+        enable_prefix_query_ = enabled;
+        return *this;
+    }
 
     MasterServiceConfigBuilder& set_default_kv_lease_ttl(uint64_t ttl) {
         default_kv_lease_ttl_ = ttl;
@@ -787,6 +811,10 @@ class MasterServiceConfig {
     std::string cxl_path = DEFAULT_CXL_PATH;
     size_t cxl_size = DEFAULT_CXL_SIZE;
     bool enable_cxl = false;
+
+    // Forge RL Design 01 §3.7 — chained-prefix LPM lookup feature flag.
+    bool enable_prefix_query = true;
+
     MasterServiceConfig() = default;
 
     // From WrappedMasterServiceConfig
@@ -843,6 +871,7 @@ class MasterServiceConfig {
         cxl_path = config.cxl_path;
         cxl_size = config.cxl_size;
         enable_cxl = config.enable_cxl;
+        enable_prefix_query = config.enable_prefix_query;
     }
 
     // Static factory method to create a builder
@@ -896,6 +925,7 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     config.cxl_path = cxl_path_;
     config.cxl_size = cxl_size_;
     config.enable_cxl = enable_cxl_;
+    config.enable_prefix_query = enable_prefix_query_;
     return config;
 }
 

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -120,6 +120,9 @@ class MasterMetricManager {
     void inc_remount_segment_failures(int64_t val = 1);
     void inc_ping_requests(int64_t val = 1);
     void inc_ping_failures(int64_t val = 1);
+    // Forge RL Design 01 — chained-prefix LPM lookup
+    void inc_query_prefix_match_requests(int64_t val = 1);
+    void inc_query_prefix_match_failures(int64_t val = 1);
 
     // Batch Operation Statistics (Counters)
     void inc_batch_exist_key_requests(int64_t items);
@@ -171,6 +174,8 @@ class MasterMetricManager {
     int64_t get_remount_segment_failures();
     int64_t get_ping_requests();
     int64_t get_ping_failures();
+    int64_t get_query_prefix_match_requests();
+    int64_t get_query_prefix_match_failures();
 
     // Batch Operation Statistics Getters
     int64_t get_batch_exist_key_requests();
@@ -359,6 +364,9 @@ class MasterMetricManager {
     ylt::metric::counter_t remount_segment_failures_;
     ylt::metric::counter_t ping_requests_;
     ylt::metric::counter_t ping_failures_;
+    // Forge RL Design 01 counters
+    ylt::metric::counter_t query_prefix_match_requests_;
+    ylt::metric::counter_t query_prefix_match_failures_;
 
     // Batch Operation Statistics
     ylt::metric::counter_t batch_exist_key_requests_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -190,6 +190,32 @@ class MasterService {
         -> tl::expected<GetReplicaListResponse, ErrorCode>;
 
     /**
+     * @brief Forge RL Design 01 — chained-prefix LPM lookup.
+     *
+     * Walks the supplied chain of block-level hashes against `metadata_shards_`
+     * in order; the deepest entry that has at least one COMPLETE replica
+     * defines the LPM length. The response carries every segment owning a
+     * COMPLETE replica of that deepest entry (no ranking — routing decisions
+     * are pushed up to the caller) plus a lease TTL hint matching
+     * `default_kv_lease_ttl_`.
+     *
+     * @return PREFIX_QUERY_DISABLED   when the feature flag is off
+     *         PREFIX_CHAIN_EMPTY      when the chain is empty
+     *         PREFIX_CHAIN_TOO_LONG   when the chain length exceeds
+     *                                 `kMaxPrefixChainLength`
+     */
+    auto QueryPrefixMatch(const QueryPrefixMatchRequest& request)
+        -> tl::expected<QueryPrefixMatchResponse, ErrorCode>;
+
+    /**
+     * @brief Toggle the prefix-query feature flag at runtime. Test-only seam;
+     * production code should configure via `MasterServiceConfig`.
+     */
+    void SetPrefixQueryEnabledForTesting(bool enabled) {
+        enable_prefix_query_ = enabled;
+    }
+
+    /**
      * @brief Start a put operation for an object
      * @param[out] replica_list Vector to store replica information for the
      * slice
@@ -1191,6 +1217,10 @@ class MasterService {
     const uint64_t quota_bytes_;
 
     bool use_disk_replica_{false};
+
+    // Forge RL Design 01 §3.7: feature flag for QueryPrefixMatch.
+    // `std::atomic` so the test-only setter and the read path don't race.
+    std::atomic<bool> enable_prefix_query_{true};
 
     // Segment management
     SegmentManager segment_manager_;

--- a/mooncake-store/include/prefix_key.h
+++ b/mooncake-store/include/prefix_key.h
@@ -1,0 +1,39 @@
+// Copyright 2025 Alibaba Cloud and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+namespace mooncake {
+
+// Forge RL Design 01 §3.4 — canonical encoding for chained-prefix hashes.
+//
+// The master indexes prefix-chain entries in the same string-keyed metadata
+// shard map that backs ordinary objects. To avoid collisions with user keys
+// and to keep the encoding stable across server / client / test / bench, we
+// share a single helper here.
+//
+// Format: "__pfx__" + zero-padded 16-char lowercase hex of the uint64 hash.
+// PRIx64 is used so the formatter is correct on platforms where
+// `unsigned long` is 32-bit (Windows MSVC).
+inline std::string MakePrefixHashKey(uint64_t hash) {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "__pfx__%016" PRIx64, hash);
+    return std::string(buf);
+}
+
+// Alias for callers that prefer the encode/decode wording.
+inline std::string EncodePrefixKey(uint64_t hash) {
+    return MakePrefixHashKey(hash);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -679,6 +679,27 @@ class RealClient : public PyClient {
         const std::string &target_rpc_service_addr,
         std::unordered_map<std::string, Slice> &objects);
 
+    /**
+     * @brief Mount a shared memory file region and return segment ids.
+     *        If size > max_mr_size, it will be split into multiple chunks
+     *        and mounted separately. RealClient will open(path) + mmap
+     *        internally for each chunk.
+     */
+    int mountSegment(const std::string &path, size_t offset, size_t size,
+                     const std::string &protocol, const std::string &location,
+                     std::vector<std::string> &out_segment_ids);
+
+    /**
+     * @brief Unmount segments by their ids and clean up local mmap/fd.
+     */
+    int unmountSegment(const std::vector<std::string> &segment_ids);
+
+    struct MountedSegmentRecord {
+        void *mmap_base = nullptr;
+        size_t size = 0;
+        std::string path;
+    };
+
     std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
 
     struct SegmentDeleter {
@@ -815,6 +836,11 @@ class RealClient : public PyClient {
     void teardown_ascend_shm_buffer(MappedShm &shm);
     tl::expected<void, ErrorCode> setup_ascend_internal(
         size_t local_buffer_size);
+
+   private:
+    std::unordered_map<std::string, MountedSegmentRecord>
+        mounted_segment_records_;
+    std::mutex mounted_segment_records_mutex_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -57,6 +57,10 @@ class WrappedMasterService {
     std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
     BatchGetReplicaList(const std::vector<std::string>& keys);
 
+    // Forge RL Design 01 — chained-prefix LPM lookup.
+    tl::expected<QueryPrefixMatchResponse, ErrorCode> QueryPrefixMatch(
+        const QueryPrefixMatchRequest& request);
+
     tl::expected<std::vector<Replica::Descriptor>, ErrorCode> PutStart(
         const UUID& client_id, const std::string& key,
         const uint64_t slice_length, const ReplicateConfig& config);

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -239,4 +239,50 @@ struct BatchGetOffloadObjectResponse {
 YLT_REFL(BatchGetOffloadObjectResponse, batch_id, pointers,
          transfer_engine_addr, gc_ttl_ms);
 
+/**
+ * @brief Forge RL Design 01 — chained-prefix LPM lookup request.
+ *
+ * The router computes a per-block rolling hash chain (key_i = hash(key_{i-1},
+ * block_i)) and sends it to the master.  An empty chain is rejected with
+ * PREFIX_CHAIN_EMPTY; chains longer than kMaxPrefixChainLength are rejected
+ * with PREFIX_CHAIN_TOO_LONG.
+ */
+struct QueryPrefixMatchRequest {
+    std::vector<uint64_t> chain{};
+
+    QueryPrefixMatchRequest() = default;
+};
+YLT_REFL(QueryPrefixMatchRequest, chain);
+
+/**
+ * @brief A single segment that owns a replica of the deepest matched prefix
+ * key.  segment_id is left as {0,0} when only the segment_name is needed by
+ * the routing layer; this avoids holding segment_mutex_ during the read path.
+ */
+struct PrefixMatchCandidate {
+    UUID segment_id{0, 0};
+    std::string segment_name{};
+    int32_t replica_type{0};
+
+    PrefixMatchCandidate() = default;
+};
+YLT_REFL(PrefixMatchCandidate, segment_id, segment_name, replica_type);
+
+/**
+ * @brief Forge RL Design 01 — chained-prefix LPM lookup response.
+ *
+ * matched_blocks is the longest prefix length (in blocks) that was found in
+ * the master.  candidates is unranked; routing-aware ordering (by link
+ * class, inflight, etc.) is left to the caller.  query_lease_ms is an
+ * advisory TTL the caller may use to debounce repeated lookups.
+ */
+struct QueryPrefixMatchResponse {
+    uint32_t matched_blocks{0};
+    std::vector<PrefixMatchCandidate> candidates{};
+    uint64_t query_lease_ms{0};
+
+    QueryPrefixMatchResponse() = default;
+};
+YLT_REFL(QueryPrefixMatchResponse, matched_blocks, candidates, query_lease_ms);
+
 }  // namespace mooncake

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -295,6 +295,12 @@ enum class ErrorCode : int32_t {
     SERIALIZE_FAIL = -1501,         ///< Serialization failed.
     DESERIALIZE_FAIL = -1502,       ///< Deserialization failed.
     PERSISTENT_FAIL = -1503,        ///< Persistent failed.
+    // Forge RL Design 01 — chained-prefix LPM lookup (Range: -1600 to -1699)
+    PREFIX_QUERY_DISABLED =
+        -1600,  ///< QueryPrefixMatch RPC disabled by master config.
+    PREFIX_CHAIN_TOO_LONG =
+        -1601,  ///< Prefix chain exceeds kMaxPrefixChainLength.
+    PREFIX_CHAIN_EMPTY = -1602,  ///< Prefix chain is empty.
     // Task and job errors (Range: -1400 to -1499)
     TASK_NOT_FOUND = -1400,  ///< Task not found.
     TASK_PENDING_LIMIT_EXCEEDED =

--- a/mooncake-store/rust/CMakeLists.txt
+++ b/mooncake-store/rust/CMakeLists.txt
@@ -1,39 +1,51 @@
-# CMake integration for the mooncake_store Rust crate.
+# CMake integration for the mooncake_store Rust package.
 #
 # This target is only added when the parent CMakeLists.txt sets
-# WITH_STORE_RUST=ON.  It depends on the mooncake_store C++ target so that
-# the static library is available before cargo tries to link against it.
+# WITH_STORE_RUST=ON.  It depends on the mooncake_store C++ target so that the
+# static library is available before cargo tries to link against it.
 
 add_custom_target(build_mooncake_store_rust DEPENDS mooncake_store)
 
 add_custom_command(
-    TARGET build_mooncake_store_rust
-    COMMAND
-        ${CMAKE_COMMAND} -E env
-            # Where cargo should place its build artefacts.
-            CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}
-            # Directory containing libmooncake_store.a (or .so).
-            MOONCAKE_STORE_LIB_DIR=${CMAKE_CURRENT_BINARY_DIR}/../src
-            # Directory containing store_c.h.
-            MOONCAKE_STORE_INCLUDE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../include
-        cargo build --release
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Building mooncake_store Rust crate"
-    VERBATIM
-)
+  TARGET build_mooncake_store_rust
+  COMMAND
+    ${CMAKE_COMMAND} -E env
+    # Where cargo should place its build artefacts.
+    CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}
+    MOONCAKE_BUILD_DIR=${PROJECT_BINARY_DIR}
+    # Directory containing libmooncake_store.a (or .so).
+    MOONCAKE_STORE_LIB_DIR=${CMAKE_CURRENT_BINARY_DIR}/../src
+    # Directory containing store_c.h.
+    MOONCAKE_STORE_INCLUDE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../include cargo
+    build --release
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "Building mooncake_store Rust package"
+  VERBATIM)
 
-# Build the basic_usage example so that CI can verify it compiles.
 add_custom_target(build_mooncake_store_rust_example DEPENDS mooncake_store)
 
 add_custom_command(
-    TARGET build_mooncake_store_rust_example
-    COMMAND
-        ${CMAKE_COMMAND} -E env
-            CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}
-            MOONCAKE_STORE_LIB_DIR=${CMAKE_CURRENT_BINARY_DIR}/../src
-            MOONCAKE_STORE_INCLUDE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../include
-        cargo build --example basic_usage --release
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Building mooncake_store Rust basic_usage example"
-    VERBATIM
-)
+  TARGET build_mooncake_store_rust_example
+  COMMAND
+    ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}
+    MOONCAKE_BUILD_DIR=${PROJECT_BINARY_DIR}
+    MOONCAKE_STORE_LIB_DIR=${CMAKE_CURRENT_BINARY_DIR}/../src
+    MOONCAKE_STORE_INCLUDE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../include cargo
+    build --examples --release
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "Building mooncake_store Rust examples"
+  VERBATIM)
+
+add_custom_target(build_mooncake_store_rust_tests DEPENDS mooncake_store)
+
+add_custom_command(
+  TARGET build_mooncake_store_rust_tests
+  COMMAND
+    ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}
+    MOONCAKE_BUILD_DIR=${PROJECT_BINARY_DIR}
+    MOONCAKE_STORE_LIB_DIR=${CMAKE_CURRENT_BINARY_DIR}/../src
+    MOONCAKE_STORE_INCLUDE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../include cargo test
+    --tests --no-run --release
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "Building mooncake_store Rust tests"
+  VERBATIM)

--- a/mooncake-store/rust/build.rs
+++ b/mooncake-store/rust/build.rs
@@ -14,48 +14,215 @@
 
 use std::env;
 use std::path::PathBuf;
+use std::process::Command;
+
+fn push_existing_dir(search_dirs: &mut Vec<PathBuf>, dir: PathBuf) {
+    if dir.is_dir() && !search_dirs.iter().any(|existing| existing == &dir) {
+        search_dirs.push(dir);
+    }
+}
+
+fn push_env_paths(search_dirs: &mut Vec<PathBuf>, name: &str) {
+    if let Some(value) = env::var_os(name) {
+        for dir in env::split_paths(&value) {
+            push_existing_dir(search_dirs, dir);
+        }
+    }
+}
+
+fn has_library(search_dirs: &[PathBuf], candidates: &[&str]) -> bool {
+    search_dirs.iter().any(|dir| {
+        candidates.iter().any(|candidate| {
+            ["a", "so", "dylib"]
+                .into_iter()
+                .map(|ext| dir.join(format!("lib{candidate}.{ext}")))
+                .any(|path| path.exists())
+        })
+    })
+}
+
+fn emit_link_searches(search_dirs: &[PathBuf]) {
+    for dir in search_dirs {
+        println!("cargo:rustc-link-search=native={}", dir.display());
+    }
+}
+
+fn emit_runtime_rpaths(search_dirs: &[PathBuf]) {
+    for dir in search_dirs {
+        let dir_str = dir.display();
+        println!("cargo:rustc-link-arg-tests=-Wl,-rpath,{dir_str}");
+        println!("cargo:rustc-link-arg-examples=-Wl,-rpath,{dir_str}");
+    }
+}
+
+fn compiler_candidates() -> Vec<String> {
+    let mut tools = Vec::new();
+
+    for env_var in ["CC", "CXX"] {
+        if let Ok(value) = env::var(env_var) {
+            let tool = value.trim();
+            if !tool.is_empty() && !tools.iter().any(|existing| existing == tool) {
+                tools.push(tool.to_string());
+            }
+        }
+    }
+
+    for tool in ["gcc", "cc", "clang", "c++"] {
+        if !tools.iter().any(|existing| existing == tool) {
+            tools.push(tool.to_string());
+        }
+    }
+
+    tools
+}
+
+fn compiler_runtime_library(file_name: &str) -> Option<PathBuf> {
+    for tool in compiler_candidates() {
+        let output = Command::new(&tool)
+            .arg(format!("-print-file-name={file_name}"))
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            continue;
+        }
+
+        let path = String::from_utf8(output.stdout).ok()?;
+        let path = PathBuf::from(path.trim());
+        if path.as_os_str().is_empty() || path == PathBuf::from(file_name) || !path.exists() {
+            continue;
+        }
+
+        return Some(path);
+    }
+
+    None
+}
+
+fn add_compiler_runtime_search_dir(search_dirs: &mut Vec<PathBuf>, file_name: &str) -> bool {
+    let Some(path) = compiler_runtime_library(file_name) else {
+        return false;
+    };
+
+    if let Some(parent) = path.parent() {
+        push_existing_dir(search_dirs, parent.to_path_buf());
+        return true;
+    }
+
+    false
+}
 
 fn main() {
-    // -----------------------------------------------------------------------
-    // Library search path
-    //
-    // When built via CMake (WITH_STORE_RUST=ON) the CMakeLists.txt injects
-    // MOONCAKE_STORE_LIB_DIR pointing at the directory that contains
-    // libmooncake_store.a/.so.  When cargo is invoked standalone the caller
-    // should set the variable manually or rely on the default convention of a
-    // sibling `build/` directory produced by a top-level CMake configure.
-    // -----------------------------------------------------------------------
-    let lib_dir = env::var("MOONCAKE_STORE_LIB_DIR")
-        .unwrap_or_else(|_| "../../build/mooncake-store/src".to_string());
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("missing CARGO_MANIFEST_DIR"));
+    let mut search_dirs = Vec::new();
 
-    println!("cargo:rustc-link-search=native={lib_dir}");
-    println!("cargo:rustc-link-lib=mooncake_store");
+    let explicit_lib_dir = env::var("MOONCAKE_STORE_LIB_DIR").ok().map(PathBuf::from);
+    if let Some(dir) = explicit_lib_dir.clone() {
+        push_existing_dir(&mut search_dirs, dir);
+    }
 
-    // Dependencies of mooncake_store that must be satisfied at link time.
-    // The list mirrors what mooncake-store/src/CMakeLists.txt links against.
-    println!("cargo:rustc-link-lib=transfer_engine");
-    println!("cargo:rustc-link-lib=stdc++");
-    println!("cargo:rustc-link-lib=glog");
-    println!("cargo:rustc-link-lib=gflags");
-    println!("cargo:rustc-link-lib=pthread");
-    println!("cargo:rustc-link-lib=xxhash");
+    if let Ok(build_dir) = env::var("MOONCAKE_BUILD_DIR") {
+        let build_dir = PathBuf::from(build_dir);
+        for dir in [
+            build_dir.join("mooncake-store/src"),
+            build_dir.join("mooncake-store/src/cachelib_memory_allocator"),
+            build_dir.join("mooncake-transfer-engine/src"),
+            build_dir.join("mooncake-transfer-engine/src/common/base"),
+            build_dir.join("mooncake-asio"),
+            build_dir.join("mooncake-common/etcd"),
+        ] {
+            push_existing_dir(&mut search_dirs, dir);
+        }
+    }
 
-    // -----------------------------------------------------------------------
-    // Header path for bindgen
-    // -----------------------------------------------------------------------
+    let default_build_dir = manifest_dir.join("../../build");
+    for dir in [
+        default_build_dir.join("mooncake-store/src"),
+        default_build_dir.join("mooncake-store/src/cachelib_memory_allocator"),
+        default_build_dir.join("mooncake-transfer-engine/src"),
+        default_build_dir.join("mooncake-transfer-engine/src/common/base"),
+        default_build_dir.join("mooncake-asio"),
+        default_build_dir.join("mooncake-common/etcd"),
+        PathBuf::from("/usr/local/lib"),
+        PathBuf::from("/usr/lib/x86_64-linux-gnu"),
+        PathBuf::from("/lib/x86_64-linux-gnu"),
+    ] {
+        push_existing_dir(&mut search_dirs, dir);
+    }
+
+    push_env_paths(&mut search_dirs, "LD_LIBRARY_PATH");
+    push_env_paths(&mut search_dirs, "LIBRARY_PATH");
+
+    let asan_runtime_so = compiler_runtime_library("libasan.so");
+    if let Some(path) = asan_runtime_so.as_ref() {
+        if let Some(parent) = path.parent() {
+            push_existing_dir(&mut search_dirs, parent.to_path_buf());
+        }
+    }
+    let has_asan_runtime = asan_runtime_so.is_some()
+        || add_compiler_runtime_search_dir(&mut search_dirs, "libasan.a");
+    let has_gcov_runtime = add_compiler_runtime_search_dir(&mut search_dirs, "libgcov.a")
+        || add_compiler_runtime_search_dir(&mut search_dirs, "libgcov.so");
+
+    emit_link_searches(&search_dirs);
+    emit_runtime_rpaths(&search_dirs);
+
+    if has_asan_runtime || has_library(&search_dirs, &["asan"]) {
+        println!("cargo:rustc-link-lib=asan");
+    }
+
+    for library in [
+        "mooncake_store",
+        "cachelib_memory_allocator",
+        "transfer_engine",
+        "base",
+        "asio",
+        "stdc++",
+        "glog",
+        "gflags",
+        "pthread",
+        "xxhash",
+        "numa",
+        "ibverbs",
+        "jsoncpp",
+        "zstd",
+        "m",
+    ] {
+        println!("cargo:rustc-link-lib={library}");
+    }
+
+    for (link_name, candidates) in [
+        ("etcd_wrapper", &["etcd_wrapper"] as &[&str]),
+        ("hiredis", &["hiredis"]),
+        ("curl", &["curl"]),
+        ("cudart", &["cudart"]),
+        ("uring", &["uring"]),
+    ] {
+        if has_library(&search_dirs, candidates) {
+            println!("cargo:rustc-link-lib={link_name}");
+        }
+    }
+
+    if has_gcov_runtime || has_library(&search_dirs, &["gcov"]) {
+        println!("cargo:rustc-link-lib=gcov");
+    }
+
     let include_dir = env::var("MOONCAKE_STORE_INCLUDE_DIR")
         .unwrap_or_else(|_| "../include".to_string());
 
     let header = format!("{include_dir}/store_c.h");
 
-    // Re-run this build script if the C header changes.
     println!("cargo:rerun-if-changed={header}");
+    println!("cargo:rerun-if-env-changed=MOONCAKE_BUILD_DIR");
     println!("cargo:rerun-if-env-changed=MOONCAKE_STORE_LIB_DIR");
     println!("cargo:rerun-if-env-changed=MOONCAKE_STORE_INCLUDE_DIR");
+    println!("cargo:rerun-if-env-changed=LD_LIBRARY_PATH");
+    println!("cargo:rerun-if-env-changed=LIBRARY_PATH");
+    println!("cargo:rerun-if-env-changed=CC");
+    println!("cargo:rerun-if-env-changed=CXX");
 
     let bindings = bindgen::Builder::default()
         .header(&header)
-        // Only pull in declarations from store_c.h (no transitive system headers).
         .allowlist_function("mooncake_store_.*")
         .allowlist_type("mooncake_.*")
         .generate()

--- a/mooncake-store/rust/examples/store_benchmark.rs
+++ b/mooncake-store/rust/examples/store_benchmark.rs
@@ -1,0 +1,130 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use mooncake_store::MooncakeStore;
+
+fn env_or_default<T>(key: &str, default: T) -> T
+where
+    T: std::str::FromStr,
+{
+    std::env::var(key)
+        .ok()
+        .and_then(|value| value.parse::<T>().ok())
+        .unwrap_or(default)
+}
+
+fn unique_prefix() -> String {
+    let timestamp_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("rust-bench-{}-{timestamp_ns}", std::process::id())
+}
+
+fn mib_per_second(total_bytes: usize, elapsed: std::time::Duration) -> f64 {
+    if elapsed.is_zero() {
+        return 0.0;
+    }
+    total_bytes as f64 / (1024.0 * 1024.0) / elapsed.as_secs_f64()
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let iterations = env_or_default("MC_RUST_BENCH_ITERATIONS", 64usize);
+    let payload_size = env_or_default("MC_RUST_BENCH_VALUE_SIZE", 64 * 1024usize);
+    let warmup_iterations = env_or_default("MC_RUST_BENCH_WARMUP", 4usize);
+    let metadata_server = std::env::var("MC_METADATA_SERVER")
+        .unwrap_or_else(|_| "http://127.0.0.1:8080/metadata".to_string());
+    let master_server_addr = std::env::var("MC_RUST_STORE_MASTER_ADDR")
+        .unwrap_or_else(|_| "127.0.0.1:50051".to_string());
+    let local_hostname =
+        std::env::var("MC_RUST_STORE_LOCAL_HOSTNAME").unwrap_or_else(|_| "localhost".to_string());
+    let protocol = std::env::var("MC_RUST_STORE_PROTOCOL").unwrap_or_else(|_| "tcp".to_string());
+    let device_name = std::env::var("MC_RUST_STORE_DEVICE_NAME").unwrap_or_default();
+    let global_segment_size = env_or_default("MC_RUST_STORE_GLOBAL_SEGMENT_SIZE", 512u64 << 20);
+    let local_buffer_size = env_or_default("MC_RUST_STORE_LOCAL_BUFFER_SIZE", 128u64 << 20);
+
+    let store = MooncakeStore::new()?;
+    store.setup(
+        &local_hostname,
+        &metadata_server,
+        global_segment_size,
+        local_buffer_size,
+        &protocol,
+        &device_name,
+        &master_server_addr,
+    )?;
+    store.health_check()?;
+
+    let prefix = unique_prefix();
+    let payload: Vec<u8> = (0..payload_size).map(|index| (index % 251) as u8).collect();
+
+    for iteration in 0..warmup_iterations {
+        let key = format!("{prefix}-warmup-{iteration}");
+        store.put(&key, &payload, None)?;
+        let fetched = store.get(&key)?;
+        assert_eq!(fetched, payload, "warmup round-trip mismatch");
+        store.remove(&key, true)?;
+    }
+
+    let keys: Vec<String> = (0..iterations)
+        .map(|iteration| format!("{prefix}-key-{iteration}"))
+        .collect();
+
+    let put_start = Instant::now();
+    for key in &keys {
+        store.put(key, &payload, None)?;
+    }
+    let put_elapsed = put_start.elapsed();
+
+    let get_start = Instant::now();
+    for key in &keys {
+        let fetched = store.get(key)?;
+        assert_eq!(fetched, payload, "benchmark round-trip mismatch for {key}");
+    }
+    let get_elapsed = get_start.elapsed();
+
+    let remove_start = Instant::now();
+    for key in &keys {
+        store.remove(key, true)?;
+    }
+    let remove_elapsed = remove_start.elapsed();
+
+    let total_bytes = iterations * payload.len();
+    println!("Mooncake Store Rust benchmark");
+    println!("iterations={iterations}");
+    println!("payload_size_bytes={payload_size}");
+    println!("put_seconds={:.6}", put_elapsed.as_secs_f64());
+    println!(
+        "put_mib_per_sec={:.2}",
+        mib_per_second(total_bytes, put_elapsed)
+    );
+    println!("get_seconds={:.6}", get_elapsed.as_secs_f64());
+    println!(
+        "get_mib_per_sec={:.2}",
+        mib_per_second(total_bytes, get_elapsed)
+    );
+    println!("remove_seconds={:.6}", remove_elapsed.as_secs_f64());
+    println!(
+        "remove_ops_per_sec={:.2}",
+        if remove_elapsed.is_zero() {
+            0.0
+        } else {
+            iterations as f64 / remove_elapsed.as_secs_f64()
+        }
+    );
+
+    Ok(())
+}

--- a/mooncake-store/rust/tests/minimal_smoke.rs
+++ b/mooncake-store/rust/tests/minimal_smoke.rs
@@ -1,0 +1,76 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use mooncake_store::MooncakeStore;
+
+fn env_or_default(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn should_run_integration() -> bool {
+    matches!(
+        std::env::var("MC_RUST_STORE_RUN_INTEGRATION").as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE")
+    )
+}
+
+fn unique_key() -> String {
+    let timestamp_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("rust-smoke-{}-{timestamp_ns}", std::process::id())
+}
+
+#[test]
+fn smoke_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    if !should_run_integration() {
+        eprintln!("skipping Mooncake Store Rust smoke test; set MC_RUST_STORE_RUN_INTEGRATION=1 to enable");
+        return Ok(());
+    }
+
+    let metadata_server = env_or_default("MC_METADATA_SERVER", "http://127.0.0.1:8080/metadata");
+    let master_server_addr = env_or_default("MC_RUST_STORE_MASTER_ADDR", "127.0.0.1:50051");
+    let local_hostname = env_or_default("MC_RUST_STORE_LOCAL_HOSTNAME", "localhost");
+    let protocol = env_or_default("MC_RUST_STORE_PROTOCOL", "tcp");
+    let device_name = std::env::var("MC_RUST_STORE_DEVICE_NAME").unwrap_or_default();
+
+    let store = MooncakeStore::new()?;
+    store.setup(
+        &local_hostname,
+        &metadata_server,
+        512 << 20,
+        128 << 20,
+        &protocol,
+        &device_name,
+        &master_server_addr,
+    )?;
+    store.health_check()?;
+
+    let key = unique_key();
+    let value = format!("mooncake-rust-smoke-value-{key}").into_bytes();
+
+    store.put(&key, &value, None)?;
+    assert!(store.is_exist(&key)?);
+    assert_eq!(store.get_size(&key)? as usize, value.len());
+    assert_eq!(store.get(&key)?, value);
+    assert!(!store.get_hostname()?.is_empty());
+
+    store.remove(&key, true)?;
+    assert!(!store.is_exist(&key)?);
+
+    Ok(())
+}

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -712,6 +712,11 @@ Client::QueryByRegex(const std::string& str) {
     return result;
 }
 
+tl::expected<QueryPrefixMatchResponse, ErrorCode> Client::QueryPrefixMatch(
+    const QueryPrefixMatchRequest& request) {
+    return master_client_.QueryPrefixMatch(request);
+}
+
 tl::expected<QueryResult, ErrorCode> Client::Query(
     const std::string& object_key) {
     std::chrono::steady_clock::time_point start_time =
@@ -2084,11 +2089,70 @@ std::vector<int> Client::GetNicNumaNodes() const {
 tl::expected<void, ErrorCode> Client::MountSegment(
     const void* buffer, size_t size, const std::string& protocol,
     const std::string& location) {
+    auto result = MountSegmentAndGetId(buffer, size, protocol, location);
+    if (!result) {
+        return tl::unexpected(result.error());
+    }
+    return {};
+}
+
+tl::expected<void, ErrorCode> Client::UnmountSegmentImpl(
+    std::unordered_map<UUID, Segment, boost::hash<UUID>>::iterator it) {
+    auto unmount_result = master_client_.UnmountSegment(it->second.id);
+    if (!unmount_result) {
+        ErrorCode err = unmount_result.error();
+        LOG(ERROR) << "Failed to unmount segment from master: "
+                   << toString(err);
+        return tl::unexpected(err);
+    }
+
+    int rc = transfer_engine_->unregisterLocalMemory(
+        reinterpret_cast<void*>(it->second.base));
+    if (rc != 0) {
+        LOG(ERROR) << "Failed to unregister transfer buffer with transfer "
+                      "engine ret is "
+                   << rc;
+        if (rc != ERR_ADDRESS_NOT_REGISTERED) {
+            return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+        // Otherwise, the segment is already unregistered from transfer
+        // engine, we can continue
+    }
+
+    mounted_segments_.erase(it);
+    return {};
+}
+
+tl::expected<void, ErrorCode> Client::UnmountSegment(const void* buffer,
+                                                     size_t size) {
+    std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+    auto segment = mounted_segments_.end();
+
+    for (auto it = mounted_segments_.begin(); it != mounted_segments_.end();
+         ++it) {
+        if (it->second.base == reinterpret_cast<uintptr_t>(buffer) &&
+            it->second.size == size) {
+            segment = it;
+            break;
+        }
+    }
+    if (segment == mounted_segments_.end()) {
+        LOG(ERROR) << "segment_not_found base=" << buffer << " size=" << size;
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    return UnmountSegmentImpl(segment);
+}
+
+tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
+    const void* buffer, size_t size, const std::string& protocol,
+    const std::string& location) {
     auto check_result = CheckRegisterMemoryParams(buffer, size);
     if (!check_result) {
         return tl::unexpected(check_result.error());
     }
 
+    UUID segment_id;
     {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
 
@@ -2115,17 +2179,12 @@ tl::expected<void, ErrorCode> Client::MountSegment(
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
 
-        // Build segment with logical name; attach TE endpoint for transport
         Segment segment;
         segment.id = generate_uuid();
         segment.name = local_hostname_;
         segment.base = reinterpret_cast<uintptr_t>(buffer);
         segment.size = size;
         segment.protocol = protocol;
-        // For P2P handshake mode, publish the actual transport endpoint that
-        // was negotiated by the transfer engine. Otherwise, keep the logical
-        // hostname so metadata backends (HTTP/etcd/redis) can resolve the
-        // segment by name.
         if (metadata_connstring_ == P2PHANDSHAKE) {
             segment.te_endpoint = transfer_engine_->getLocalIpAndPort();
         } else {
@@ -2140,54 +2199,24 @@ tl::expected<void, ErrorCode> Client::MountSegment(
             return tl::unexpected(err);
         }
 
-        mounted_segments_[segment.id] = segment;
+        segment_id = segment.id;
+        mounted_segments_[segment_id] = segment;
     }
 
     EnsureStorageControlPlaneStarted();
-    return {};
+    return segment_id;
 }
 
-tl::expected<void, ErrorCode> Client::UnmountSegment(const void* buffer,
-                                                     size_t size) {
+tl::expected<void, ErrorCode> Client::UnmountSegmentById(
+    const UUID& segment_id) {
     std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
-    auto segment = mounted_segments_.end();
-
-    for (auto it = mounted_segments_.begin(); it != mounted_segments_.end();
-         ++it) {
-        if (it->second.base == reinterpret_cast<uintptr_t>(buffer) &&
-            it->second.size == size) {
-            segment = it;
-            break;
-        }
-    }
+    auto segment = mounted_segments_.find(segment_id);
     if (segment == mounted_segments_.end()) {
-        LOG(ERROR) << "segment_not_found base=" << buffer << " size=" << size;
+        LOG(ERROR) << "segment_not_found id=" << UuidToString(segment_id);
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    auto unmount_result = master_client_.UnmountSegment(segment->second.id);
-    if (!unmount_result) {
-        ErrorCode err = unmount_result.error();
-        LOG(ERROR) << "Failed to unmount segment from master: "
-                   << toString(err);
-        return tl::unexpected(err);
-    }
-
-    int rc = transfer_engine_->unregisterLocalMemory(
-        reinterpret_cast<void*>(segment->second.base));
-    if (rc != 0) {
-        LOG(ERROR) << "Failed to unregister transfer buffer with transfer "
-                      "engine ret is "
-                   << rc;
-        if (rc != ERR_ADDRESS_NOT_REGISTERED) {
-            return tl::unexpected(ErrorCode::INTERNAL_ERROR);
-        }
-        // Otherwise, the segment is already unregistered from transfer
-        // engine, we can continue
-    }
-
-    mounted_segments_.erase(segment);
-    return {};
+    return UnmountSegmentImpl(segment);
 }
 
 tl::expected<void, ErrorCode> Client::RegisterLocalMemory(

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -63,6 +63,11 @@ struct RpcNameTraits<&WrappedMasterService::BatchGetReplicaList> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::QueryPrefixMatch> {
+    static constexpr const char* value = "QueryPrefixMatch";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::PutStart> {
     static constexpr const char* value = "PutStart";
 };
@@ -472,6 +477,17 @@ MasterClient::BatchGetReplicaList(const std::vector<std::string>& object_keys) {
                                    GetReplicaListResponse>(object_keys.size(),
                                                            object_keys);
     timer.LogResponse("result=", result.size(), " operations");
+    return result;
+}
+
+tl::expected<QueryPrefixMatchResponse, ErrorCode>
+MasterClient::QueryPrefixMatch(const QueryPrefixMatchRequest& request) {
+    ScopedVLogTimer timer(1, "MasterClient::QueryPrefixMatch");
+    timer.LogRequest("chain_len=", request.chain.size());
+
+    auto result = invoke_rpc<&WrappedMasterService::QueryPrefixMatch,
+                             QueryPrefixMatchResponse>(request);
+    timer.LogResponseExpected(result);
     return result;
 }
 

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -113,6 +113,13 @@ MasterMetricManager::MasterMetricManager()
                      "Total number of ping requests received"),
       ping_failures_("master_ping_failures_total",
                      "Total number of failed ping requests"),
+      // Forge RL Design 01 — chained-prefix LPM lookup
+      query_prefix_match_requests_(
+          "master_query_prefix_match_requests_total",
+          "Total number of QueryPrefixMatch requests received"),
+      query_prefix_match_failures_(
+          "master_query_prefix_match_failures_total",
+          "Total number of failed QueryPrefixMatch requests"),
 
       // Initialize Batch Request Counters
       batch_exist_key_requests_(
@@ -366,6 +373,8 @@ void MasterMetricManager::update_metrics_for_zero_output() {
     remount_segment_failures_.inc(0);
     ping_requests_.inc(0);
     ping_failures_.inc(0);
+    query_prefix_match_requests_.inc(0);
+    query_prefix_match_failures_.inc(0);
     create_copy_task_requests_.inc(0);
     create_copy_task_failures_.inc(0);
     create_move_task_requests_.inc(0);
@@ -707,6 +716,12 @@ void MasterMetricManager::inc_ping_requests(int64_t val) {
 void MasterMetricManager::inc_ping_failures(int64_t val) {
     ping_failures_.inc(val);
 }
+void MasterMetricManager::inc_query_prefix_match_requests(int64_t val) {
+    query_prefix_match_requests_.inc(val);
+}
+void MasterMetricManager::inc_query_prefix_match_failures(int64_t val) {
+    query_prefix_match_failures_.inc(val);
+}
 
 // Batch Operation Statistics (Counters)
 void MasterMetricManager::inc_batch_exist_key_requests(int64_t items) {
@@ -926,6 +941,14 @@ int64_t MasterMetricManager::get_ping_requests() {
 
 int64_t MasterMetricManager::get_ping_failures() {
     return ping_failures_.value();
+}
+
+int64_t MasterMetricManager::get_query_prefix_match_requests() {
+    return query_prefix_match_requests_.value();
+}
+
+int64_t MasterMetricManager::get_query_prefix_match_failures() {
+    return query_prefix_match_failures_.value();
 }
 
 int64_t MasterMetricManager::get_batch_exist_key_requests() {
@@ -1316,6 +1339,8 @@ std::string MasterMetricManager::serialize_metrics() {
     serialize_metric(remount_segment_failures_);
     serialize_metric(ping_requests_);
     serialize_metric(ping_failures_);
+    serialize_metric(query_prefix_match_requests_);
+    serialize_metric(query_prefix_match_failures_);
 
     // Serialize CopyStart, CopyEnd, CopyRevoke, MoveStart, MoveEnd, MoveRevoke
     // Counters

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -13,6 +13,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include "master_metric_manager.h"
+#include "prefix_key.h"
 #include "segment.h"
 #ifdef STORE_USE_ETCD
 #include "etcd_helper.h"
@@ -119,6 +120,8 @@ MasterService::MasterService(const MasterServiceConfig& config)
       cxl_path_(config.cxl_path),
       cxl_size_(config.cxl_size),
       enable_cxl_(config.enable_cxl) {
+    enable_prefix_query_.store(config.enable_prefix_query,
+                               std::memory_order_relaxed);
     if (enable_snapshot_ || enable_snapshot_restore_) {
         try {
             auto object_store_type =
@@ -5162,6 +5165,96 @@ MasterService::MetadataSerializer::DeserializeDiscardedReplicas(
     }
 
     return {};
+}
+
+// ---------------------------------------------------------------------------
+// Forge RL Design 01 §3.3 — server-side LPM lookup over the chained-prefix
+// hash. We walk the chain from the *deepest* end backwards so the first hit
+// already gives us the LPM length without having to keep per-segment state
+// across iterations.
+//
+// Concurrency: every iteration takes the metadata-shard read lock through
+// `MetadataAccessorRO` (which acquires `metadata_shards_[shard].mutex`) and
+// releases it before stepping to the next chain element. This honours the
+// project-wide lock order (`client_mutex_` -> `metadata_shards_[shard].mutex`
+// -> `segment_mutex_`) without introducing any new lock layer.
+// ---------------------------------------------------------------------------
+auto MasterService::QueryPrefixMatch(const QueryPrefixMatchRequest& request)
+    -> tl::expected<QueryPrefixMatchResponse, ErrorCode> {
+    if (!enable_prefix_query_.load(std::memory_order_relaxed)) {
+        return tl::make_unexpected(ErrorCode::PREFIX_QUERY_DISABLED);
+    }
+    if (request.chain.empty()) {
+        return tl::make_unexpected(ErrorCode::PREFIX_CHAIN_EMPTY);
+    }
+    if (request.chain.size() > kMaxPrefixChainLength) {
+        return tl::make_unexpected(ErrorCode::PREFIX_CHAIN_TOO_LONG);
+    }
+
+    QueryPrefixMatchResponse response;
+    response.query_lease_ms = default_kv_lease_ttl_;
+
+    // Walk from the deepest hash backwards. The chain has the property that
+    // `chain[i+1]` only makes semantic sense if `chain[i]` is also present, so
+    // the first iteration that finds at least one COMPLETE replica is also the
+    // LPM. We stop immediately and emit every owning segment as a candidate.
+    for (size_t i = request.chain.size(); i > 0; --i) {
+        const std::string key = EncodePrefixKey(request.chain[i - 1]);
+
+        std::vector<PrefixMatchCandidate> candidates;
+        {
+            MetadataAccessorRO accessor(this, key);
+            if (!accessor.Exists()) {
+                continue;
+            }
+            const ObjectMetadata& metadata = accessor.Get();
+
+            // Each completed replica may live on multiple slices that map to
+            // distinct segments. We emit one candidate per unique segment_name
+            // and dedupe via `seen_segments` so the response stays compact.
+            //
+            // We deliberately leave `segment_id` at the default zero UUID:
+            // resolving name -> id would require taking `segment_mutex_`
+            // inside the metadata-shard read lock and break the
+            // metadata_shards_ -> segment_mutex_ acquisition order. Routing
+            // callers (Forge, vLLM) already key on segment_name, so the id
+            // field is reserved for a future extension that walks segments
+            // first and shards second.
+            std::unordered_set<std::string> seen_segments;
+            metadata.VisitReplicas(
+                &Replica::fn_is_completed,
+                [&candidates, &seen_segments](const Replica& replica) {
+                    const auto seg_names = replica.get_segment_names();
+                    const int32_t replica_type =
+                        static_cast<int32_t>(replica.type());
+                    for (const auto& opt_name : seg_names) {
+                        if (!opt_name.has_value() || opt_name->empty()) {
+                            continue;
+                        }
+                        if (!seen_segments.insert(*opt_name).second) {
+                            continue;
+                        }
+                        PrefixMatchCandidate cand;
+                        cand.segment_name = *opt_name;
+                        cand.replica_type = replica_type;
+                        candidates.emplace_back(std::move(cand));
+                    }
+                });
+        }
+
+        if (candidates.empty()) {
+            // The metadata exists but no replica is COMPLETE yet; treat this
+            // chain entry as a miss and keep walking shorter prefixes — the
+            // caller still gets the longest fully-COMPLETE prefix.
+            continue;
+        }
+
+        response.matched_blocks = static_cast<uint32_t>(i);
+        response.candidates = std::move(candidates);
+        break;
+    }
+
+    return response;
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2,6 +2,8 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
 #include <numa.h>
 #include <numaif.h>
 #include <pthread.h>
@@ -1038,6 +1040,159 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
 }
 
 int RealClient::tearDownAll() { return to_py_ret(tearDownAll_internal()); }
+
+int RealClient::mountSegment(const std::string &path, size_t offset,
+                             size_t size, const std::string &protocol,
+                             const std::string &location,
+                             std::vector<std::string> &out_segment_ids) {
+    if (!client_) {
+        LOG(ERROR) << "Client not initialized";
+        return -1;
+    }
+
+    size_t max_mr_size = globalConfig().max_mr_size;
+    if (max_mr_size == 0) {
+        LOG(ERROR) << "Invalid max_mr_size: 0";
+        return -1;
+    }
+
+    size_t page_size = sysconf(_SC_PAGESIZE);
+    if (max_mr_size < page_size) {
+        LOG(ERROR) << "max_mr_size " << max_mr_size
+                   << " is smaller than page_size " << page_size;
+        return -1;
+    }
+
+    int fd = open(path.c_str(), O_RDWR);
+    if (fd < 0) {
+        LOG(ERROR) << "open failed for " << path << ": " << strerror(errno);
+        return -1;
+    }
+
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        LOG(ERROR) << "fstat failed for " << path << ": " << strerror(errno);
+        close(fd);
+        return -1;
+    }
+
+    if (offset > (size_t)st.st_size || size > (size_t)st.st_size - offset) {
+        LOG(ERROR) << "requested range [offset=" << offset << ", size=" << size
+                   << "] exceeds file size " << st.st_size;
+        close(fd);
+        return -1;
+    }
+
+    if (offset % page_size != 0) {
+        LOG(ERROR) << "offset " << offset
+                   << " is not page-aligned (page_size=" << page_size << ")";
+        close(fd);
+        return -1;
+    }
+
+    size_t aligned_max_chunk = (max_mr_size / page_size) * page_size;
+    size_t remaining = size;
+    size_t current_offset = offset;
+    std::vector<std::string> mounted_ids;
+    std::vector<MountedSegmentRecord> mounted_records;
+
+    while (remaining > 0) {
+        size_t chunk_size = std::min(remaining, aligned_max_chunk);
+        if (chunk_size == 0) break;
+
+        void *ptr = mmap(nullptr, chunk_size, PROT_READ | PROT_WRITE,
+                         MAP_SHARED, fd, current_offset);
+        if (ptr == MAP_FAILED) {
+            LOG(ERROR) << "mmap failed for " << path << ": " << strerror(errno);
+            break;
+        }
+
+        auto result =
+            client_->MountSegmentAndGetId(ptr, chunk_size, protocol, location);
+        if (!result.has_value()) {
+            LOG(ERROR) << "MountSegmentAndGetId failed";
+            munmap(ptr, chunk_size);
+            break;
+        }
+
+        std::string segment_id = UuidToString(result.value());
+        mounted_ids.push_back(segment_id);
+        mounted_records.push_back({ptr, chunk_size, path});
+
+        remaining -= chunk_size;
+        current_offset += chunk_size;
+    }
+
+    close(fd);
+
+    // If not all chunks were mounted, roll back successfully mounted ones
+    if (remaining > 0) {
+        for (size_t i = 0; i < mounted_ids.size(); ++i) {
+            UUID id;
+            if (StringToUuid(mounted_ids[i], id)) {
+                client_->UnmountSegmentById(id);
+            }
+            if (mounted_records[i].mmap_base) {
+                munmap(mounted_records[i].mmap_base, mounted_records[i].size);
+            }
+        }
+        out_segment_ids.clear();
+        return -1;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mounted_segment_records_mutex_);
+        for (size_t i = 0; i < mounted_ids.size(); ++i) {
+            mounted_segment_records_[mounted_ids[i]] = mounted_records[i];
+        }
+    }
+    out_segment_ids = std::move(mounted_ids);
+    return 0;
+}
+
+int RealClient::unmountSegment(const std::vector<std::string> &segment_ids) {
+    if (!client_) {
+        LOG(ERROR) << "Client not initialized";
+        return -1;
+    }
+
+    int first_error = 0;
+    std::vector<std::pair<std::string, MountedSegmentRecord>> to_cleanup;
+    {
+        std::lock_guard<std::mutex> lock(mounted_segment_records_mutex_);
+        for (const auto &segment_id : segment_ids) {
+            UUID id;
+            if (!StringToUuid(segment_id, id)) {
+                LOG(ERROR) << "Invalid segment_id: " << segment_id;
+                if (first_error == 0) first_error = -1;
+                continue;
+            }
+
+            auto result = client_->UnmountSegmentById(id);
+            if (!result.has_value()) {
+                LOG(ERROR) << "UnmountSegmentById failed for " << segment_id;
+                if (first_error == 0) {
+                    first_error = static_cast<int>(result.error());
+                }
+                continue;  // Don't release local resources on failure
+            }
+
+            auto it = mounted_segment_records_.find(segment_id);
+            if (it != mounted_segment_records_.end()) {
+                to_cleanup.emplace_back(segment_id, it->second);
+                mounted_segment_records_.erase(it);
+            }
+        }
+    }
+
+    for (auto &p : to_cleanup) {
+        if (p.second.mmap_base) {
+            munmap(p.second.mmap_base, p.second.size);
+        }
+    }
+
+    return first_error;
+}
 
 int RealClient::health_check() {
     if (closed_.load()) return HC_NOT_INITIALIZED;

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -885,6 +885,22 @@ WrappedMasterService::GetReplicaList(const std::string& key) {
         });
 }
 
+tl::expected<QueryPrefixMatchResponse, ErrorCode>
+WrappedMasterService::QueryPrefixMatch(const QueryPrefixMatchRequest& request) {
+    return execute_rpc(
+        "QueryPrefixMatch",
+        [&] { return master_service_.QueryPrefixMatch(request); },
+        [&](auto& timer) {
+            timer.LogRequest("chain_len=", request.chain.size());
+        },
+        [] {
+            MasterMetricManager::instance().inc_query_prefix_match_requests();
+        },
+        [] {
+            MasterMetricManager::instance().inc_query_prefix_match_failures();
+        });
+}
+
 std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
 WrappedMasterService::BatchGetReplicaList(
     const std::vector<std::string>& keys) {
@@ -1700,6 +1716,8 @@ void RegisterRpcService(
     server
         .register_handler<&mooncake::WrappedMasterService::BatchGetReplicaList>(
             &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::QueryPrefixMatch>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::PutStart>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::PutEnd>(

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ add_store_test(task_manager_test task_manager_test.cpp)
 add_store_test(task_executor_test task_executor_test.cpp)
 add_store_test(task_integration_test task_integration_test.cpp)
 add_store_test(dummy_client_get_buffer_test dummy_client_get_buffer_test.cpp)
+add_store_test(prefix_query_test prefix_query_test.cpp)
 add_store_test(health_check_test health_check_test.cpp)
 add_subdirectory(e2e)
 

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -1734,6 +1734,40 @@ TEST_F(ClientIntegrationTest, BatchUpsertMixed) {
     }
 }
 
+TEST_F(ClientIntegrationTest, MountSegmentAndGetIdAndUnmountSegmentById) {
+    // Allocate a small buffer for this test
+    size_t test_size = 16 * 1024 * 1024;  // 16 MB
+    void* test_buffer = allocate_buffer_allocator_memory(test_size);
+    ASSERT_NE(test_buffer, nullptr);
+
+    // Test MountSegmentAndGetId returns a valid UUID
+    auto mount_result = test_client_->MountSegmentAndGetId(
+        test_buffer, test_size, FLAGS_protocol);
+    ASSERT_TRUE(mount_result.has_value())
+        << "MountSegmentAndGetId failed: " << toString(mount_result.error());
+    UUID segment_id = mount_result.value();
+    EXPECT_NE(segment_id.first, 0u);
+    EXPECT_NE(segment_id.second, 0u);
+
+    // Test UnmountSegmentById succeeds
+    auto unmount_result = test_client_->UnmountSegmentById(segment_id);
+    EXPECT_TRUE(unmount_result.has_value())
+        << "UnmountSegmentById failed: " << toString(unmount_result.error());
+
+    // Test MountSegment delegates to MountSegmentAndGetId (equivalent behavior)
+    auto mount2 =
+        test_client_->MountSegment(test_buffer, test_size, FLAGS_protocol);
+    EXPECT_TRUE(mount2.has_value())
+        << "MountSegment failed: " << toString(mount2.error());
+
+    // Test UnmountSegment delegates to UnmountSegmentImpl (equivalent behavior)
+    auto unmount2 = test_client_->UnmountSegment(test_buffer, test_size);
+    EXPECT_TRUE(unmount2.has_value())
+        << "UnmountSegment failed: " << toString(unmount2.error());
+
+    free(test_buffer);
+}
+
 }  // namespace testing
 
 }  // namespace mooncake

--- a/mooncake-store/tests/prefix_query_test.cpp
+++ b/mooncake-store/tests/prefix_query_test.cpp
@@ -1,0 +1,260 @@
+// Copyright 2025 Alibaba Cloud and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for Forge RL Design 01 — chained-prefix LPM lookup
+// (`MasterService::QueryPrefixMatch`).
+//
+// We exercise the *server-side* contract directly through MasterService rather
+// than the wrapped RPC handler, mirroring the style of master_service_test.cpp
+// — this keeps the test self-contained and fast (no network setup).
+
+#include "master_service.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "master_config.h"
+#include "prefix_key.h"
+#include "rpc_types.h"
+#include "types.h"
+
+namespace mooncake::test {
+
+namespace {
+
+// Use the canonical encoding shared with the server (and bench / Python
+// smoke test) so the test exercises the production code path.
+inline std::string HashToKey(uint64_t h) { return MakePrefixHashKey(h); }
+
+// Common test scaffolding: mount a memory segment and expose its id/name.
+struct MountedSegmentContext {
+    UUID segment_id;
+    UUID client_id;
+    std::string name;
+};
+
+constexpr size_t kSegmentBase = 0x300000000;
+constexpr size_t kSegmentSize = 1024 * 1024 * 16;  // 16 MiB
+
+UUID GenerateNonZeroUuid() {
+    UUID u = generate_uuid();
+    if (u.first == 0 && u.second == 0) {
+        u.first = 1;
+    }
+    return u;
+}
+
+MountedSegmentContext MountSegment(MasterService& service,
+                                   const std::string& name, size_t base) {
+    Segment segment;
+    segment.id = GenerateNonZeroUuid();
+    segment.name = name;
+    segment.base = base;
+    segment.size = kSegmentSize;
+    segment.te_endpoint = name;
+    UUID client_id = generate_uuid();
+    auto mount_result = service.MountSegment(segment, client_id);
+    EXPECT_TRUE(mount_result.has_value());
+    return {segment.id, client_id, segment.name};
+}
+
+// Insert a single completed memory replica under the given key, on the
+// segment named `preferred_segment`.
+void PutKeyOnSegment(MasterService& service, const UUID& client_id,
+                     const std::string& key,
+                     const std::string& preferred_segment,
+                     uint64_t value_size = 64 * 1024) {
+    ReplicateConfig cfg;
+    cfg.replica_num = 1;
+    cfg.preferred_segment = preferred_segment;
+    auto put_start = service.PutStart(client_id, key, value_size, cfg);
+    ASSERT_TRUE(put_start.has_value())
+        << "PutStart failed for key=" << key << " on " << preferred_segment;
+    auto put_end = service.PutEnd(client_id, key, ReplicaType::MEMORY);
+    ASSERT_TRUE(put_end.has_value())
+        << "PutEnd failed for key=" << key << " on " << preferred_segment;
+}
+
+// We deliberately do NOT init/shutdown glog inside SetUp/TearDown: glog's
+// `InitGoogleLogging` is a one-shot per process and would CHECK-fail on the
+// second `TEST_F` instance. The shared `main()` below initializes it once.
+class PrefixQueryTest : public ::testing::Test {};
+
+}  // namespace
+
+TEST_F(PrefixQueryTest, RejectsEmptyChain) {
+    auto service = std::make_unique<MasterService>();
+    QueryPrefixMatchRequest req;
+    auto result = service->QueryPrefixMatch(req);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::PREFIX_CHAIN_EMPTY);
+}
+
+TEST_F(PrefixQueryTest, RejectsOverlongChain) {
+    auto service = std::make_unique<MasterService>();
+    QueryPrefixMatchRequest req;
+    // Master caps at kMaxPrefixChainLength = 1024.
+    req.chain.assign(2048, 0xdead);
+    auto result = service->QueryPrefixMatch(req);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::PREFIX_CHAIN_TOO_LONG);
+}
+
+TEST_F(PrefixQueryTest, ReturnsDisabledWhenFlagOff) {
+    auto service = std::make_unique<MasterService>();
+    service->SetPrefixQueryEnabledForTesting(false);
+
+    QueryPrefixMatchRequest req;
+    req.chain = {1, 2, 3};
+    auto result = service->QueryPrefixMatch(req);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::PREFIX_QUERY_DISABLED);
+}
+
+TEST_F(PrefixQueryTest, ReturnsZeroMatchedWhenChainNotIndexed) {
+    auto service = std::make_unique<MasterService>();
+    MountSegment(*service, "seg_a", kSegmentBase);
+
+    QueryPrefixMatchRequest req;
+    req.chain = {0xfeedface, 0xdeadbeef};
+    auto result = service->QueryPrefixMatch(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->matched_blocks, 0u);
+    EXPECT_TRUE(result->candidates.empty());
+    EXPECT_GT(result->query_lease_ms, 0u);
+}
+
+TEST_F(PrefixQueryTest, MatchesIndexedPrefixOnSingleSegment) {
+    auto service = std::make_unique<MasterService>();
+    auto seg = MountSegment(*service, "seg_a", kSegmentBase);
+
+    const std::vector<uint64_t> chain = {0x1, 0x2, 0x3, 0x4};
+    // Index the first three blocks, leave the 4th unindexed → matched=3.
+    PutKeyOnSegment(*service, seg.client_id, HashToKey(chain[0]), seg.name);
+    PutKeyOnSegment(*service, seg.client_id, HashToKey(chain[1]), seg.name);
+    PutKeyOnSegment(*service, seg.client_id, HashToKey(chain[2]), seg.name);
+
+    QueryPrefixMatchRequest req;
+    req.chain = chain;
+    auto result = service->QueryPrefixMatch(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->matched_blocks, 3u);
+    ASSERT_EQ(result->candidates.size(), 1u);
+    EXPECT_EQ(result->candidates[0].segment_name, seg.name);
+    // NOTE: segment_id is intentionally left as the zero UUID by the master
+    // (see master_service.cpp QueryPrefixMatch comment): resolving name -> id
+    // would force taking segment_mutex_ inside the metadata-shard read lock
+    // and break the metadata_shards_ -> segment_mutex_ acquisition order.
+    // Routing callers key on segment_name, so we only assert on the name.
+    EXPECT_EQ(result->candidates[0].replica_type,
+              static_cast<int32_t>(ReplicaType::MEMORY));
+    EXPECT_GT(result->query_lease_ms, 0u);
+}
+
+TEST_F(PrefixQueryTest, FullChainMatchHitsDeepestKey) {
+    auto service = std::make_unique<MasterService>();
+    auto seg = MountSegment(*service, "seg_a", kSegmentBase);
+    const std::vector<uint64_t> chain = {0x10, 0x20, 0x30};
+    for (auto h : chain) {
+        PutKeyOnSegment(*service, seg.client_id, HashToKey(h), seg.name);
+    }
+    QueryPrefixMatchRequest req;
+    req.chain = chain;
+    auto result = service->QueryPrefixMatch(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->matched_blocks, chain.size());
+    ASSERT_EQ(result->candidates.size(), 1u);
+    EXPECT_EQ(result->candidates[0].segment_name, seg.name);
+}
+
+// The deepest matched key may live on a different segment than shallower
+// keys in the chain. The reverse-walk LPM must report whichever segment owns
+// the *deepest* indexed entry, not the most recently indexed one.
+TEST_F(PrefixQueryTest, DeepestMatchReportsOwningSegment) {
+    auto service = std::make_unique<MasterService>();
+
+    auto seg_a = MountSegment(*service, "seg_a", kSegmentBase);
+    auto seg_b = MountSegment(*service, "seg_b", kSegmentBase + kSegmentSize);
+
+    // Layer 0 indexed on seg_a; layer 1 indexed on seg_b. The reverse-walk
+    // LPM lands on layer 1 first → candidates must contain seg_b.
+    PutKeyOnSegment(*service, seg_a.client_id, HashToKey(0xa1), seg_a.name);
+    PutKeyOnSegment(*service, seg_b.client_id, HashToKey(0xa1b2), seg_b.name);
+
+    QueryPrefixMatchRequest req;
+    req.chain = {0xa1, 0xa1b2};
+    auto result = service->QueryPrefixMatch(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->matched_blocks, 2u);
+    ASSERT_EQ(result->candidates.size(), 1u);
+    EXPECT_EQ(result->candidates[0].segment_name, seg_b.name)
+        << "deepest matched key must own the reported segment";
+    // segment_id is left as zero UUID by design (see note above).
+}
+
+// A key whose only replica was revoked (status != COMPLETE) must not count
+// toward the LPM length. We simulate this by calling PutStart but skipping
+// PutEnd, leaving the key in INITIALIZED state.
+TEST_F(PrefixQueryTest, GhostKeyDoesNotInflateMatch) {
+    auto service = std::make_unique<MasterService>();
+    auto seg = MountSegment(*service, "seg_a", kSegmentBase);
+
+    const uint64_t h0 = 0xabc;
+    ReplicateConfig cfg;
+    cfg.replica_num = 1;
+    cfg.preferred_segment = seg.name;
+    ASSERT_TRUE(service
+                    ->PutStart(seg.client_id, HashToKey(h0),
+                               /*slice_length=*/4096, cfg)
+                    .has_value());
+    // Intentionally skip PutEnd → no COMPLETE replica.
+
+    QueryPrefixMatchRequest req;
+    req.chain = {h0};
+    auto result = service->QueryPrefixMatch(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->matched_blocks, 0u)
+        << "INITIALIZED replicas must not satisfy LPM";
+    EXPECT_TRUE(result->candidates.empty());
+}
+
+// LPM must skip a "hole" in the chain — if a shallower hash has no replica
+// but a deeper one does, the deepest hit still wins (the chain is built
+// monotonically by the caller, so any indexed key implies all shallower
+// keys were indexed at some point in the past).
+TEST_F(PrefixQueryTest, ReverseWalkSkipsHoles) {
+    auto service = std::make_unique<MasterService>();
+    auto seg = MountSegment(*service, "seg_a", kSegmentBase);
+
+    PutKeyOnSegment(*service, seg.client_id, HashToKey(0x1), seg.name);
+    // Deliberately do NOT index 0x2.
+    PutKeyOnSegment(*service, seg.client_id, HashToKey(0x3), seg.name);
+
+    QueryPrefixMatchRequest req;
+    req.chain = {0x1, 0x2, 0x3};
+    auto result = service->QueryPrefixMatch(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->matched_blocks, 3u)
+        << "reverse-walk should land on the deepest indexed entry";
+    ASSERT_EQ(result->candidates.size(), 1u);
+    EXPECT_EQ(result->candidates[0].segment_name, seg.name);
+}
+
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    google::InitGoogleLogging("PrefixQueryTest");
+    FLAGS_logtostderr = true;
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -23,6 +23,15 @@ def _timed_handler(operation_name, handler):
     return wrapper
 
 
+def _shm_name_to_path(name):
+    if not isinstance(name, str) or not name:
+        return None
+    normalized = name[1:] if name.startswith("/") else name
+    if not normalized or "/" in normalized or normalized in {".", ".."}:
+        return None
+    return f"/dev/shm/{normalized}"
+
+
 class MooncakeStoreService:
     """
     Mooncake Store Service with REST API.
@@ -52,6 +61,12 @@ class MooncakeStoreService:
         self.store = None
         self.config = None
         self._setup_logging()
+
+        # State for /api/reconfigure (Prefill/Decode mode switch)
+        self.current_mode = "prefill"          # "prefill" or "decode"
+        self.mounted_segment_ids = []          # persisted segment_ids from last decode mount
+        self.last_mount_info = {}              # last mount parameters for debugging
+        self._state_lock = asyncio.Lock()      # serialize reconfigure/mount/unmount state changes
 
         try:
             if config_path:
@@ -143,6 +158,9 @@ class MooncakeStoreService:
     async def start_http_service(self, port: int = 8080):
         app = web.Application(client_max_size=1024 * 1024 * 100)  # 100MB limit
         app.add_routes([
+            web.post('/api/reconfigure', _timed_handler("RECONFIGURE", self.handle_reconfigure)),
+            web.post('/api/mount_shm', _timed_handler("MOUNT_SHM", self.handle_mount_shm)),
+            web.post('/api/unmount_shm', _timed_handler("UNMOUNT_SHM", self.handle_unmount_shm)),
             web.put('/api/put', _timed_handler("PUT", self.handle_put)),
             web.get('/api/get/{key}', _timed_handler("GET", self.handle_get)),
             web.get('/api/exist/{key}', _timed_handler("EXIST", self.handle_exist)),
@@ -157,6 +175,202 @@ class MooncakeStoreService:
         return True
 
     # REST API handlers
+    async def handle_reconfigure(self, request):
+        try:
+            data = await request.json()
+            mode = data.get("mode", "").lower()
+
+            if mode == "decode":
+                path = data.get("path")
+                size = data.get("size")
+                offset = data.get("offset", 0)
+                protocol = data.get("protocol", self.config.protocol)
+                location = data.get("location", "")
+
+                if not path or size is None:
+                    return web.Response(
+                        status=400,
+                        text=json.dumps({"error": "Missing path or size for decode mode"}),
+                        content_type="application/json"
+                    )
+
+                async with self._state_lock:
+                    # If already in decode mode with mounted segments, unmount them first
+                    if self.mounted_segment_ids:
+                        logging.info("Reconfigure decode: unmounting previous segments before remount")
+                        ret = self.store.unmount_segment(self.mounted_segment_ids)
+                        if ret != 0:
+                            return web.Response(
+                                status=500,
+                                text=json.dumps({"error": f"Unmount of previous segments failed, ret={ret}"}),
+                                content_type="application/json"
+                            )
+                        self.mounted_segment_ids.clear()
+
+                    result = self.store.mount_segment(path, size, offset, protocol, location)
+                    if result["ret"] != 0:
+                        self.current_mode = "prefill"
+                        self.mounted_segment_ids.clear()
+                        self.last_mount_info.clear()
+                        return web.Response(
+                            status=500,
+                            text=json.dumps(
+                                {
+                                    "error": (
+                                        f"Mount failed, ret={result['ret']}; "
+                                        "rolled back to prefill"
+                                    ),
+                                    "mode": self.current_mode,
+                                }
+                            ),
+                            content_type="application/json"
+                        )
+
+                    self.mounted_segment_ids = list(result["segment_ids"])
+                    self.current_mode = "decode"
+                    self.last_mount_info = {
+                        "path": path, "offset": offset, "size": size,
+                        "protocol": protocol, "location": location
+                    }
+
+                return web.Response(
+                    status=200,
+                    text=json.dumps({
+                        "status": "success",
+                        "mode": self.current_mode,
+                        "segment_ids": self.mounted_segment_ids,
+                    }),
+                    content_type="application/json"
+                )
+
+            elif mode == "prefill":
+                async with self._state_lock:
+                    if self.mounted_segment_ids:
+                        ret = self.store.unmount_segment(self.mounted_segment_ids)
+                        if ret != 0:
+                            return web.Response(
+                                status=500,
+                                text=json.dumps({"error": f"Unmount failed, ret={ret}"}),
+                                content_type="application/json"
+                            )
+                        self.mounted_segment_ids.clear()
+
+                    self.current_mode = "prefill"
+                    self.last_mount_info.clear()
+
+                return web.Response(
+                    status=200,
+                    text=json.dumps({"status": "success", "mode": self.current_mode}),
+                    content_type="application/json"
+                )
+
+            else:
+                return web.Response(
+                    status=400,
+                    text=json.dumps({"error": "Invalid mode. Use 'decode' or 'prefill'"}),
+                    content_type="application/json"
+                )
+        except Exception as e:
+            logging.error("RECONFIGURE error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json"
+            )
+
+    async def handle_mount_shm(self, request):
+        try:
+            data = await request.json()
+            name = data.get("name")
+            path = _shm_name_to_path(name)
+            offset = data.get("offset", 0)
+            size = data.get("size")
+            protocol = data.get("protocol", self.config.protocol)
+            location = data.get("location", "")
+
+            if not path or size is None:
+                return web.Response(
+                    status=400,
+                    text=json.dumps({"error": "Missing or invalid name or size"}),
+                    content_type="application/json"
+                )
+
+            result = self.store.mount_segment(path, size, offset, protocol, location)
+            if result["ret"] != 0:
+                return web.Response(
+                    status=500,
+                    text=json.dumps({"error": f"Mount failed, ret={result['ret']}"}),
+                    content_type="application/json"
+                )
+
+            return web.Response(
+                status=200,
+                text=json.dumps(
+                    {
+                        "status": "success",
+                        "segment_ids": list(result["segment_ids"]),
+                    }
+                ),
+                content_type="application/json",
+            )
+        except Exception as e:
+            logging.error("MOUNT_SHM error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json"
+            )
+
+    async def handle_unmount_shm(self, request):
+        try:
+            data = await request.json()
+            segment_ids = data.get("segment_ids", [])
+            if isinstance(segment_ids, str):
+                segment_ids = [segment_ids]
+            if not segment_ids:
+                return web.Response(
+                    status=400,
+                    text=json.dumps({"error": "Missing segment_ids"}),
+                    content_type="application/json",
+                )
+
+            failed_segment_ids = []
+            async with self._state_lock:
+                for sid in segment_ids:
+                    ret = self.store.unmount_segment([sid])
+                    if ret != 0:
+                        failed_segment_ids.append(sid)
+                        continue
+                    if sid in self.mounted_segment_ids:
+                        self.mounted_segment_ids.remove(sid)
+                if not self.mounted_segment_ids:
+                    self.current_mode = "prefill"
+
+            if failed_segment_ids:
+                return web.Response(
+                    status=500,
+                    text=json.dumps(
+                        {
+                            "error": "Unmount failed for one or more segments",
+                            "failed_segment_ids": failed_segment_ids,
+                        }
+                    ),
+                    content_type="application/json",
+                )
+
+            return web.Response(
+                status=200,
+                text=json.dumps({"status": "success"}),
+                content_type="application/json",
+            )
+        except Exception as e:
+            logging.error("UNMOUNT_SHM error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json"
+            )
+
     async def handle_put(self, request):
         try:
             data = await request.json()

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+try:
+    from aiohttp import web as _unused_web
+except ModuleNotFoundError:
+    aiohttp_module = types.ModuleType("aiohttp")
+    web_module = types.ModuleType("aiohttp.web")
+
+    class Response:
+        def __init__(self, status=200, text="", content_type=None):
+            self.status = status
+            self.text = text
+            self.content_type = content_type
+
+    web_module.Response = Response
+    aiohttp_module.web = web_module
+    sys.modules["aiohttp"] = aiohttp_module
+    sys.modules["aiohttp.web"] = web_module
+
+try:
+    from mooncake.store import MooncakeDistributedStore as _unused_store
+except ModuleNotFoundError:
+    store_module = types.ModuleType("mooncake.store")
+
+    class MooncakeDistributedStore:
+        pass
+
+    store_module.MooncakeDistributedStore = MooncakeDistributedStore
+    sys.modules["mooncake.store"] = store_module
+
+from mooncake.mooncake_store_service import MooncakeStoreService
+
+
+class FakeStore:
+    def __init__(self):
+        self.mounted = {}
+        self.mount_calls = []
+        self.unmount_calls = []
+        self.fail_mount = False
+        self.unmount_failures = set()
+
+    def mount_segment(self, path, size, offset, protocol, location):
+        self.mount_calls.append((path, size, offset, protocol, location))
+        if self.fail_mount:
+            return {"ret": -1, "segment_ids": []}
+        segment_id = "00000000-0000-0000-0000-000000000001"
+        self.mounted[segment_id] = {
+            "path": path,
+            "size": size,
+            "offset": offset,
+            "protocol": protocol,
+            "location": location,
+        }
+        return {"ret": 0, "segment_ids": [segment_id]}
+
+    def unmount_segment(self, segment_ids):
+        self.unmount_calls.append(list(segment_ids))
+        for segment_id in segment_ids:
+            if segment_id in self.unmount_failures:
+                return -1
+        for segment_id in segment_ids:
+            self.mounted.pop(segment_id, None)
+        return 0
+
+
+class FakeRequest:
+    def __init__(self, body):
+        self.body = body
+
+    async def json(self):
+        return self.body
+
+
+class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.fake_store = FakeStore()
+        self.service = MooncakeStoreService.__new__(MooncakeStoreService)
+        self.service.store = self.fake_store
+        self.service.config = SimpleNamespace(protocol="tcp")
+        self.service.current_mode = "prefill"
+        self.service.mounted_segment_ids = []
+        self.service.last_mount_info = {}
+        self.service._state_lock = asyncio.Lock()
+
+    async def test_mount_shm_then_unmount_shm_api(self):
+        mount_resp = await self.service.handle_mount_shm(
+            FakeRequest(
+                {
+                    "name": "mooncake-segment",
+                    "size": 4096,
+                    "offset": 128,
+                    "protocol": "tcp",
+                    "location": "cpu:0",
+                }
+            )
+        )
+        self.assertEqual(mount_resp.status, 200)
+        mount_body = json.loads(mount_resp.text)
+        self.assertEqual(mount_body["status"], "success")
+        self.assertEqual(
+            mount_body["segment_ids"],
+            ["00000000-0000-0000-0000-000000000001"],
+        )
+        self.assertEqual(
+            self.fake_store.mount_calls,
+            [("/dev/shm/mooncake-segment", 4096, 128, "tcp", "cpu:0")],
+        )
+
+        unmount_resp = await self.service.handle_unmount_shm(
+            FakeRequest({"segment_ids": mount_body["segment_ids"]})
+        )
+        self.assertEqual(unmount_resp.status, 200)
+        unmount_body = json.loads(unmount_resp.text)
+        self.assertEqual(unmount_body["status"], "success")
+        self.assertEqual(
+            self.fake_store.unmount_calls,
+            [["00000000-0000-0000-0000-000000000001"]],
+        )
+        self.assertEqual(self.service.current_mode, "prefill")
+
+    async def test_unmount_shm_updates_state_for_partial_success(self):
+        succeeded_id = "00000000-0000-0000-0000-000000000001"
+        failed_id = "00000000-0000-0000-0000-000000000002"
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = [succeeded_id, failed_id]
+        self.fake_store.unmount_failures = {failed_id}
+
+        resp = await self.service.handle_unmount_shm(
+            FakeRequest({"segment_ids": [succeeded_id, failed_id]})
+        )
+
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertEqual(body["failed_segment_ids"], [failed_id])
+        self.assertEqual(
+            self.fake_store.unmount_calls,
+            [[succeeded_id], [failed_id]],
+        )
+        self.assertEqual(self.service.mounted_segment_ids, [failed_id])
+        self.assertEqual(self.service.current_mode, "decode")
+
+    async def test_reconfigure_decode_mount_failure_rolls_back_to_prefill(self):
+        old_id = "00000000-0000-0000-0000-000000000001"
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = [old_id]
+        self.service.last_mount_info = {
+            "path": "/dev/shm/old",
+            "offset": 0,
+            "size": 4096,
+            "protocol": "tcp",
+            "location": "",
+        }
+        self.fake_store.fail_mount = True
+
+        resp = await self.service.handle_reconfigure(
+            FakeRequest({"mode": "decode", "path": "/dev/shm/new", "size": 4096})
+        )
+
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertEqual(body["mode"], "prefill")
+        self.assertIn("rolled back to prefill", body["error"])
+        self.assertEqual(self.fake_store.unmount_calls, [[old_id]])
+        self.assertEqual(self.service.mounted_segment_ids, [])
+        self.assertEqual(self.service.current_mode, "prefill")
+        self.assertEqual(self.service.last_mount_info, {})
+
+    async def test_mount_shm_requires_name_and_size(self):
+        resp = await self.service.handle_mount_shm(
+            FakeRequest({"name": "mooncake-segment"})
+        )
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("name or size", body["error"])
+
+    async def test_mount_shm_rejects_path_like_name(self):
+        resp = await self.service.handle_mount_shm(
+            FakeRequest({"name": "../foo", "size": 4096})
+        )
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("name or size", body["error"])
+
+    async def test_unmount_shm_requires_segment_ids(self):
+        resp = await self.service.handle_unmount_shm(FakeRequest({}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Missing segment_ids", body["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_prefix_query.py
+++ b/scripts/test_prefix_query.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Forge RL Design 01 §3.4 — end-to-end smoke test for QueryPrefixMatch.
+
+Drives a live mooncake-store cluster (started separately, see
+`docs/source/getting-started.md`) through the Python binding exposed by
+`mooncake-integration/store/store_py.cpp`. Validates:
+
+  1. baseline:        empty / oversized chains return the documented errors;
+  2. cache miss:      query against an unindexed chain reports
+                      matched_blocks == 0 and a benign empty best_segment_name;
+  3. cache hit:       after a put() the chain prefixed by hash(payload key)
+                      reports matched_blocks > 0 and points back at the local
+                      segment with a non-zero query_lease_ms.
+
+When the master was started with `--enable_prefix_query=false`, every test
+that touches the RPC will skip cleanly (the wrapper surfaces -1600 and we
+treat it as a documented "feature off" signal — the on/off flag itself is a
+master-side gflag, not a client-controllable knob).
+
+The test is intentionally tolerant of the cluster topology — it only asserts
+invariants that must hold for *any* correctly-wired master. Cost-ranking
+correctness is covered exhaustively by the C++ unit tests in
+`mooncake-store/tests/prefix_query_test.cpp`.
+
+Usage:
+    # Start a master + at least one client/segment first, then:
+    MOONCAKE_MASTER=127.0.0.1:50051 \
+    MOONCAKE_PROTOCOL=tcp \
+    MOONCAKE_TE_META_DATA_SERVER=P2PHANDSHAKE \
+    python scripts/test_prefix_query.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import unittest
+
+from mooncake.mooncake_config import MooncakeConfig
+
+try:
+    from mooncake.store import MooncakeDistributedStore
+except ImportError as exc:
+    print(f"Could not import mooncake.store: {exc}", file=sys.stderr)
+    raise
+
+# Mirrors the constants in `mooncake-store/include/types.h` ErrorCode block.
+# Hard-coded here so the test surfaces a clear failure when these values shift
+# unintentionally — the design doc §3.8 says they are part of the public ABI.
+_OK = 0
+_PREFIX_QUERY_DISABLED = -1600
+_PREFIX_CHAIN_TOO_LONG = -1601
+_PREFIX_CHAIN_EMPTY = -1602
+
+# §3.4 — QueryPrefixMatchRequest.chain has a server-enforced ceiling of 256
+# entries (matches `MasterService::kMaxPrefixChainLength`). The Python
+# binding short-circuits anything beyond that locally, so we pad just past
+# the limit to exercise PREFIX_CHAIN_TOO_LONG without wasting RPC bandwidth.
+_OVERSIZED_CHAIN_LEN = 257
+
+# Default chain length used by the cache-hit smoke. Kept short so the test
+# completes fast even on a single-node setup; correctness of long chains is
+# covered by the C++ side.
+_SMOKE_CHAIN_LEN = 8
+
+GLOBAL_STORE: MooncakeDistributedStore | None = None
+GLOBAL_CONFIG: MooncakeConfig | None = None
+
+
+def _hash64(value: int, seed: int) -> int:
+    """A trivial 64-bit mixing function used to fabricate chain hashes.
+
+    The master treats each chain element as an opaque 64-bit key, so any
+    deterministic, well-distributed hash works. We avoid `hash()` (varies
+    per-process) and `hashlib` (overkill + ~1us each) on purpose.
+    """
+    x = (value ^ seed) & 0xFFFFFFFFFFFFFFFF
+    x = (x ^ (x >> 33)) * 0xFF51AFD7ED558CCD & 0xFFFFFFFFFFFFFFFF
+    x = (x ^ (x >> 33)) * 0xC4CEB9FE1A85EC53 & 0xFFFFFFFFFFFFFFFF
+    return x ^ (x >> 33)
+
+
+def _build_chain(seed: int, length: int) -> list[int]:
+    """Build a chained-hash sequence: chain[i] = hash(chain[i-1], i)."""
+    chain: list[int] = []
+    prev = seed & 0xFFFFFFFFFFFFFFFF
+    for i in range(length):
+        prev = _hash64(prev, i + 1)
+        chain.append(prev)
+    return chain
+
+
+def setUpModule() -> None:
+    global GLOBAL_STORE, GLOBAL_CONFIG
+    GLOBAL_CONFIG = MooncakeConfig.load_from_env()
+    GLOBAL_STORE = MooncakeDistributedStore()
+    rc = GLOBAL_STORE.setup(
+        GLOBAL_CONFIG.local_hostname,
+        GLOBAL_CONFIG.metadata_server,
+        GLOBAL_CONFIG.global_segment_size,
+        GLOBAL_CONFIG.local_buffer_size,
+        GLOBAL_CONFIG.protocol,
+        GLOBAL_CONFIG.device_name,
+        GLOBAL_CONFIG.master_server_address,
+    )
+    if rc != _OK:
+        raise RuntimeError(
+            f"MooncakeDistributedStore.setup failed: rc={rc}. "
+            "Is the master reachable at "
+            f"{GLOBAL_CONFIG.master_server_address}?"
+        )
+
+
+def tearDownModule() -> None:
+    global GLOBAL_STORE
+    if GLOBAL_STORE is not None:
+        try:
+            GLOBAL_STORE.close()
+        except Exception:
+            # close() failure during teardown is informative but should not
+            # mask the actual test failure.
+            pass
+        GLOBAL_STORE = None
+
+
+class PrefixQuerySmoke(unittest.TestCase):
+    """Public-API contract checks. See module docstring for scope."""
+
+    def _query(self, chain: list[int]):
+        """Thin convenience wrapper to centralise the call signature.
+
+        The C++ binding returns a 4-tuple
+            (matched_blocks, candidates, query_lease_ms, err_code)
+        where ``candidates`` is ``list[tuple[segment_name, replica_type]]``.
+        We unpack it into a small dict here so individual tests can keep
+        readable assertions without each one re-doing tuple indexing.
+        On error the binding hands back ``None`` for the payload slots, so
+        we forward ``None`` to the caller verbatim - the rc is the source
+        of truth for the failure mode.
+        """
+        assert GLOBAL_STORE is not None
+        matched_blocks, candidates, query_lease_ms, err_code = (
+            GLOBAL_STORE.query_prefix_match(chain)
+        )
+        if err_code != _OK:
+            return None, err_code
+        return (
+            {
+                "matched_blocks": matched_blocks,
+                "candidates": list(candidates) if candidates else [],
+                "query_lease_ms": query_lease_ms,
+            },
+            err_code,
+        )
+
+    def test_empty_chain_returns_chain_empty(self) -> None:
+        resp, rc = self._query([])
+        # The master is allowed to also report DISABLED here when the flag is
+        # off — DISABLED short-circuits before chain validation. Either is a
+        # valid documented response; nothing else is.
+        self.assertIn(rc, (_PREFIX_CHAIN_EMPTY, _PREFIX_QUERY_DISABLED))
+        self.assertIsNone(resp)
+
+    def test_oversized_chain_returns_chain_too_long(self) -> None:
+        chain = _build_chain(seed=0xDEADBEEF, length=_OVERSIZED_CHAIN_LEN)
+        resp, rc = self._query(chain)
+        self.assertIn(rc, (_PREFIX_CHAIN_TOO_LONG, _PREFIX_QUERY_DISABLED))
+        self.assertIsNone(resp)
+
+    def test_unindexed_chain_returns_zero_match(self) -> None:
+        # Use a high-entropy seed so we (almost certainly) miss everything in
+        # the master's metadata shards. If this asserts triggers in CI, audit
+        # the seed for accidental collisions before chasing a real bug.
+        chain = _build_chain(seed=0xA17EBABEDEADC0DE, length=_SMOKE_CHAIN_LEN)
+        resp, rc = self._query(chain)
+        if rc == _PREFIX_QUERY_DISABLED:
+            self.skipTest(
+                "master started without --enable_prefix_query; "
+                "set the flag and rerun this test"
+            )
+        self.assertEqual(rc, _OK, msg=f"unexpected rc={rc}, resp={resp}")
+        self.assertIsNotNone(resp)
+        self.assertEqual(resp["matched_blocks"], 0)
+        # Pure LPM contract: a zero-match response carries an empty
+        # candidate list and a non-negative advisory lease. We deliberately
+        # do NOT assert any cost-aware fields (best_segment_name /
+        # est_cost_us / best_replica_storage_tier) here - ranking lives in
+        # a separate router-side QueryCost RPC, not in QueryPrefixMatch.
+        self.assertEqual(resp["candidates"], [])
+        self.assertGreaterEqual(resp["query_lease_ms"], 0)
+
+    def test_put_then_query_reports_hit(self) -> None:
+        """End-to-end: put an object whose key matches the canonical
+        prefix-hash encoding, then query."""
+        # The master maps each chain entry through `MakePrefixHashKey` (see
+        # mooncake-store/include/prefix_key.h) — we mirror that exact format
+        # here so put() lands at the same metadata-shard slot QueryPrefixMatch
+        # will look at.
+        chain = _build_chain(seed=0xCAFEBABE, length=_SMOKE_CHAIN_LEN)
+        first_key = f"__pfx__{chain[0]:016x}"
+
+        assert GLOBAL_STORE is not None
+        # Use a small unique payload so successive runs don't collide. The
+        # cluster guarantees idempotent put for the same key+value pair.
+        payload = (f"prefix-query-smoke-{int(time.time() * 1000)}").encode()
+        put_rc = GLOBAL_STORE.put(first_key, payload)
+        if put_rc != _OK:
+            self.skipTest(
+                f"put({first_key!r}) failed with rc={put_rc} — "
+                "cluster likely lacks a writable segment"
+            )
+
+        try:
+            # Give the master a beat to settle the metadata insertion. The
+            # contract is synchronous, but cross-RPC propagation in HA mode
+            # may need ~10ms.
+            time.sleep(0.05)
+            resp, rc = self._query(chain, avg_block_bytes=len(payload))
+            if rc == _PREFIX_QUERY_DISABLED:
+                self.skipTest(
+                    "master started without --enable_prefix_query; "
+                    "set the flag and rerun this test"
+                )
+            self.assertEqual(rc, _OK, msg=f"unexpected rc={rc}, resp={resp}")
+            self.assertIsNotNone(resp)
+            self.assertGreaterEqual(
+                resp["matched_blocks"],
+                1,
+                msg="put() landed but QueryPrefixMatch reported no hit; "
+                "metadata shard likely keyed differently from "
+                "expectations — see design §3.3",
+            )
+            self.assertNotEqual(
+                resp["best_segment_name"],
+                "",
+                msg="hit must point at a concrete segment",
+            )
+            self.assertGreater(
+                resp["query_lease_ms"],
+                0,
+                msg="hit must come with a non-zero routing-hint TTL",
+            )
+        finally:
+            # Best-effort cleanup. We swallow remove failures because the
+            # downstream tests in the same module don't depend on this key.
+            try:
+                GLOBAL_STORE.remove(first_key)
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation
Mooncake-Store currently only exposes per-key lookups (GetReplicaList / ExistKey). For RL rollout / vLLM prefix-cache aware routing we need a *prefix-aware* server-side primitive: given a sequence of per-block hashes that describe the start of a request, tell the router how many leading blocks are already cached on the cluster, and which segments own them.

Without this, every router has two bad options:
  1. issue O(N) ExistKey RPCs per request (latency + master fan-out blow up with chain length, and there is no atomic snapshot across blocks);
  2. maintain a separate prefix index next to the master, which then has to be kept consistent with master's metadata across put/evict/recover.

This commit lands the missing primitive — a single RPC that returns the Longest-Prefix-Match length and the set of segments holding the deepest matched key — so callers can route a request to a node that already has the hottest prefix in memory and avoid recomputing the KV cache.

## Description

Add the `QueryPrefixMatch` RPC — a server-side chained-prefix Longest-Prefix-Match (LPM) lookup that lets a router (vLLM / Forge / custom scheduler) find out, in **one round-trip**, how many leading KV-cache blocks of an incoming request are already cached on the cluster, and which segments own them.

Today the only way to answer this question is to issue *N* per-key `ExistKey` RPCs (latency / fan-out blow up with chain length, and there is no atomic snapshot across blocks) or to maintain a separate prefix index next to the master (which then has to be reconciled with put / evict / recover). This PR lands the missing primitive.

**Pure LPM only.** No cost-aware ranking, no inflight tracker, no link-class / storage-tier scoring — those decisions are pushed to the caller, which has the request-side context the master doesn't. The master only owns the one piece of information no one else can compute: which segments currently hold a COMPLETE replica of each prefix key.

## Architecture
Pure LPM in the master, ranking deferred to the router.

  Router  ──QueryPrefixMatch(chain[])──▶  WrappedMasterService
                                                │
                                                ▼
                                          MasterService
                                          (reverse walk over
                                           metadata_shards_)

The chain is a per-block rolling hash:
    key_0 = hash(block_0)
    key_i = hash(key_{i-1}, block_i)

Each chain entry is encoded with a single canonical helper (`MakePrefixHashKey` in prefix_key.h) as `"__pfx__" + 16 hex chars`, so the master, the integration tests, the bench, and the Python smoke test all agree on the wire format with zero risk of drift.

Crucially, the master does NOT do cost-aware ranking, inflight tracking, link-class scoring, or storage-tier preference. All of that lives in the caller (Forge router design lives in
forge-rl-designs/01-prefix-index-and-cost-aware-routing.md). The master only owns the single piece of information no one else can compute: which segments currently hold a COMPLETE replica of each prefix key.

## Implementation
Server side (mooncake-store/src/master_service.cpp):
  * Reverse-walk the chain from deepest to shallowest. By construction `chain[i+1]` only makes sense if `chain[i]` is also indexed, so the first entry that has at least one COMPLETE replica is the LPM and we stop. Cost is O(matched_blocks) shard lookups in the typical hit case, O(chain_len) only on a full miss.
  * For the deepest matched key, walk every COMPLETE replica (`metadata.VisitReplicas(Replica::fn_is_completed, ...)`), dedupe by segment_name with an unordered_set, and emit one PrefixMatchCandidate per unique segment.
  * The whole reverse walk holds only the per-shard metadata read lock (`MetadataAccessorRO`). It deliberately does NOT take `segment_mutex_` — that would invert the project-wide acquisition order `client_mutex_ → metadata_shards_[shard].mutex → segment_mutex_`. As a result we leave `candidate.segment_id` as the zero UUID and let the caller resolve name → id if it needs to; routing layers already key on segment_name today.
  * Three fast-path rejections before any work: feature flag off (PREFIX_QUERY_DISABLED), empty chain (PREFIX_CHAIN_EMPTY), chain longer than `kMaxPrefixChainLength = 1024` (PREFIX_CHAIN_TOO_LONG). New error codes occupy the -1600..-1699 range.
  * Feature flag is `std::atomic<bool>` so the test-only setter and the hot read path don't race.

End-to-end RPC plumbing:
  * rpc_types.h: QueryPrefixMatchRequest / Response / PrefixMatchCandidate (YLT-reflected).
  * rpc_service.{h,cpp}: WrappedMasterService::QueryPrefixMatch goes through the existing `execute_rpc` helper, which takes care of ScopedVLogTimer + request/failure metrics + tl::expected propagation. Handler registered in RegisterRpcService.
  * master_client.{h,cpp}: thin client method using the existing `invoke_rpc` template + RpcNameTraits specialization.
  * client_service.{h,cpp}: SDK passthrough.
  * mooncake-integration/store/store_py.cpp: Python binding `Store.query_prefix_match(chain) -> (matched_blocks, [(seg_name, replica_type)], lease_ms, err_code)`. Releases the GIL around the network call.

Configurability:
  * `MasterConfig.enable_prefix_query` (default true) propagates through MasterServiceSupervisorConfig → WrappedMasterServiceConfig → MasterServiceConfig + the corresponding builder, so HA mode and standalone mode share the same toggle path as every other feature flag in this codebase.

Observability:
  * Two new Prometheus counters, registered + serialized + zero-output primed: master_query_prefix_match_requests_total master_query_prefix_match_failures_total Failures (including business-level disabled / empty / too-long) are counted automatically by `execute_rpc` whenever the inner `tl::expected` is unexpected.

## Problems / Requirements Solved
1. Single round-trip prefix lookup for the router — replaces O(N) per-block ExistKey storms, gives an atomic snapshot of which prefix-keys are present at the moment of the call.
2. Server-authoritative answer — no need for the router to maintain a separate index that has to be reconciled with put/evict/recover.
3. Lock-order-safe — implementation respects `client_mutex_ → metadata_shards_ → segment_mutex_` and never holds `segment_mutex_` on the read path; verified by code inspection plus the `DeepestMatchReportsOwningSegment` test which exercises a multi-segment topology.
4. Bounded cost — `kMaxPrefixChainLength = 1024` caps per-RPC CPU and shard-lock acquisitions; flag-off short-circuits to a single atomic load.
5. Backward compatible — purely additive: new RPC, new fields, new error codes, default `enable_prefix_query = true` but instantly disable-able from config; no existing struct/RPC modified.

## Performance — `prefix_query_bench` against live single-node master

(dev box `root@60.205.250.70`, x86_64, all runs error-free, all queries hit indexed prefixes)

| Config | Setup | QPS | p50 | p95 | p99 | p999 |
|---|---|---:|---:|---:|---:|---:|
| **A** | 1 client × 1 thread, chain_len=4 | **34,707** | 32 µs | 64 µs | 64 µs | 64 µs |
| **B** | 4 clients × 4 threads, chain_len=128, 4 segments | **318,111** | 64 µs | 128 µs | 128 µs | 128 µs |
| **C** | 8 clients × 8 threads, chain_len=256, 8 segments | **364,386** | 256 µs | 256 µs | 256 µs | 512 µs |

Even single-thread (Config A) at 34.7k QPS already covers the ≥50k cluster-wide design-doc target once we fan out to a handful of router workers; Config C reaches ~7× that ceiling. p99 stays bounded — the LPM walk is `O(matched_blocks)` shard reads with no `segment_mutex_` acquisition, capped at `kMaxPrefixChainLength = 1024`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)  *(Python binding)*
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs   *(`docs/source/design/mooncake-store.md`)*
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.