### PR TITLE
[TENT] Fix RPC server IPv6 binding on IPv6-only hosts

### DIFF
--- a/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
+++ b/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
@@ -104,7 +104,8 @@ Status CoroRpcAgent::start(uint16_t& port, bool ipv6) {
         try {
             if (port == 0)
                 port = kStartPort + SimpleRandom::Get().next(kPortRange);
-            server_ = new coro_rpc::coro_rpc_server(kRpcThreads, port);
+            server_ = new coro_rpc::coro_rpc_server(kRpcThreads, port,
+                                                    ipv6 ? "::" : "0.0.0.0");
             server_->register_handler<&CoroRpcAgent::process>(this);
             server_->async_start();
             const auto err = server_->get_errc();


### PR DESCRIPTION
## Description

The `coro_rpc_server` constructor was called with only thread count and port,
defaulting to `"0.0.0.0"` (IPv4). The `ipv6` parameter passed to
`CoroRpcAgent::start()` was ignored entirely.

On IPv6-only hosts, the server listens on IPv4 while the client connects via
IPv6, resulting in "not connected" / "bad_address" errors during P2P handshake.

Pass `"::"` (IPv6 any) or `"0.0.0.0"` (IPv4 any) based on the `ipv6` parameter
so the server binds to the correct address family.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Reproduced on an IPv6-only host: before the fix, the P2P handshake failed
with `not connected` / `bad_address` errors because the server bound to IPv4
while the client dialed IPv6. After the fix, the server binds to `::` and
the handshake succeeds end-to-end.

Single file change (`mooncake-transfer-engine/tent/src/rpc/rpc.cpp`, +2/-1) —
verified the existing TENT build and test targets compile and link cleanly.
No new test added: the bug requires an IPv6-only host environment that the
current CI does not provision.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.