### PR TITLE
[TE] Fix DMA-BUF validation using wrong CUDA device index

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -14,11 +14,13 @@
 
 #include "transport/rdma_transport/rdma_context.h"
 
+#include <algorithm>
 #include <fcntl.h>
 #include <sys/epoll.h>
 
 #include <atomic>
 #include <cassert>
+#include <exception>
 #include <fstream>
 #include <memory>
 #include <thread>
@@ -582,25 +584,81 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         }
 
 #if !defined(WITH_NVIDIA_PEERMEM) && defined(USE_CUDA)
-        // Verify dmabuf support which is required if not using nvidia-peermem.
-        // Assume device index matches.
-        CUdevice cuDevice;
-        CUresult result = cuDeviceGet(&cuDevice, i);
-        if (result != CUDA_SUCCESS) {
-            LOG(ERROR) << "Failed to query CUDA device";
-            return ERR_CONTEXT;
+        // Verify DMA-BUF support against the CUDA device(s) that the local
+        // topology explicitly maps to this RNIC, rather than assuming the
+        // verbs enumeration order matches CUDA enumeration.
+        // Validate DMA-BUF support for every GPU that can reach this RNIC,
+        // not just GPUs listing it as preferred.  Runtime selection falls
+        // back to avail_hca when a preferred NIC is disabled, so we must
+        // validate both lists.
+        std::vector<int> mapped_cuda_devices;
+        if (engine_.local_topology_) {
+            const auto topology_matrix = engine_.local_topology_->getMatrix();
+            for (const auto &entry : topology_matrix) {
+                if (entry.first.rfind(GPU_PREFIX, 0) != 0) continue;
+                bool in_preferred =
+                    std::find(entry.second.preferred_hca.begin(),
+                              entry.second.preferred_hca.end(),
+                              device_name) != entry.second.preferred_hca.end();
+                bool in_avail =
+                    std::find(entry.second.avail_hca.begin(),
+                              entry.second.avail_hca.end(),
+                              device_name) != entry.second.avail_hca.end();
+                if (!in_preferred && !in_avail) continue;
+
+                try {
+                    mapped_cuda_devices.push_back(
+                        std::stoi(entry.first.substr(GPU_PREFIX.size())));
+                } catch (const std::exception &e) {
+                    LOG(WARNING) << "Ignore malformed topology GPU entry "
+                                 << entry.first << ": " << e.what();
+                }
+            }
         }
-        int dmaBufSupported;
-        result = cuDeviceGetAttribute(
-            &dmaBufSupported, CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, cuDevice);
-        if (result != CUDA_SUCCESS) {
-            LOG(ERROR) << "Failed to query CUDA device attributes";
-            return ERR_CONTEXT;
-        }
-        if (!dmaBufSupported) {
-            LOG(ERROR) << "DMA BUF supported required for GPU RDMA without "
-                          "nvidia-peermem";
-            return ERR_CONTEXT;
+
+        std::sort(mapped_cuda_devices.begin(), mapped_cuda_devices.end());
+        mapped_cuda_devices.erase(
+            std::unique(mapped_cuda_devices.begin(), mapped_cuda_devices.end()),
+            mapped_cuda_devices.end());
+
+        if (mapped_cuda_devices.empty()) {
+            LOG(INFO) << "No CUDA device is explicitly mapped to RNIC "
+                      << device_name << "; skip DMA-BUF affinity validation";
+        } else {
+            // cuInit is process-global and idempotent; call it once before
+            // the per-device loop, not per cuDeviceGet.
+            CUresult result = cuInit(0);
+            if (result != CUDA_SUCCESS) {
+                LOG(ERROR) << "Failed to initialize CUDA driver for RNIC "
+                           << device_name;
+                goto cleanup_context_and_devices;
+            }
+            for (int cuda_device : mapped_cuda_devices) {
+                CUdevice cuDevice;
+                result = cuDeviceGet(&cuDevice, cuda_device);
+                if (result != CUDA_SUCCESS) {
+                    LOG(ERROR) << "Failed to query CUDA device " << cuda_device
+                               << " for RNIC " << device_name;
+                    goto cleanup_context_and_devices;
+                }
+                int dmaBufSupported;
+                result = cuDeviceGetAttribute(
+                    &dmaBufSupported, CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED,
+                    cuDevice);
+                if (result != CUDA_SUCCESS) {
+                    LOG(ERROR) << "Failed to query CUDA device attributes for "
+                               << "CUDA device " << cuda_device << " and RNIC "
+                               << device_name;
+                    goto cleanup_context_and_devices;
+                }
+                if (!dmaBufSupported) {
+                    LOG(ERROR)
+                        << "DMA BUF supported required for GPU RDMA without "
+                           "nvidia-peermem on CUDA device "
+                        << cuda_device << " mapped to RNIC " << device_name;
+                    goto cleanup_context_and_devices;
+                }
+            }
         }
 #endif
 


### PR DESCRIPTION
## Description

When `WITH_NVIDIA_PEERMEM=OFF`, `openRdmaDevice()` validated DMA-BUF support
by calling `cuDeviceGet(&cuDevice, i)` where `i` is the verbs enumeration
index from `ibv_get_device_list()`. This assumed verbs device order matches
CUDA device order, which is incorrect.

On a GB300 with 10 NICs and 4 GPUs, NICs at verbs index 4–9 called
`cuDeviceGet` with indices 4–9, which don't exist. This disabled 6 of 10
NICs with "Failed to query CUDA device", limiting RDMA throughput to 4 NICs
(~18 GB/s) instead of all 10 (~41 GB/s).

### Fix

- Look up the topology matrix to find which CUDA devices list this RNIC in
  their `preferred_hca` or `avail_hca`, then validate DMA-BUF only for those
  specific devices.
- Check `avail_hca` in addition to `preferred_hca` because runtime NIC
  selection can fall back to `avail_hca` after `disableDevice()` removes a
  failed preferred NIC. Without this, the fallback NIC may not have been
  validated for the GPU that ends up using it.
- Call `cuInit(0)` once before the per-device validation loop (not per
  device — `cuInit` is process-global and idempotent). This also removes
  a fragile ordering dependency where the old code relied on implicit
  driver init from a prior `cudaGetDeviceCount` call in topology discovery.

### Scope

The change is gated under `#if !defined(WITH_NVIDIA_PEERMEM) && defined(USE_CUDA)`,
so it applies only to NVIDIA without nvidia-peermem. MLU and other vendor
paths are unaffected.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Validated on a GB300 host (4 GPUs, 10 NICs) with `WITH_NVIDIA_PEERMEM=OFF`
and `USE_CUDA=ON`:

```
Topology discovery complete. Found 10 HCAs.
RDMA device: mlx5_0 ... mlx5_9   [all 10 register]
```

Pre-fix only the 4 NICs at verbs index 0–3 passed validation; mlx5_4–9 were
disabled with "Failed to query CUDA device". With the fix, all 10 NICs
register successfully. End-to-end VRAM-read throughput improves from ~18
GB/s to ~41 GB/s once paired with the topology rewrite that promotes them
out of `avail_hca`.

Build verified: `cmake --build build --target transfer_engine` compiles
cleanly with no new warnings.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
