### PR TITLE
Save the active device with hipGetDevice on entry and restore it before

### DIFF
--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -251,6 +251,17 @@ static int setDeviceContext(void* source_ptr, int& device_id) {
 }
 
 static void setupP2PAccess(int num_devices) {
+    // Save the active device. The loop below calls hipSetDevice once per
+    // iteration; without restoring it before returning, the calling thread is
+    // left with its active device pinned to num_devices-1, causing downstream
+    // HIP calls on the same thread (e.g. PyTorch allocations in TP workers) to
+    // target the wrong GPU.
+    int original_device = -1;
+    if (!checkHip(hipGetDevice(&original_device),
+                  "HipTransport: failed to get current device")) {
+        original_device = -1;
+    }
+
     auto clearStickyPeerAccessError = [](int src_device, int dst_device) {
         // hipDeviceEnablePeerAccess may leave hipErrorPeerAccessAlreadyEnabled
         // in the runtime's last-error slot. Clear it so subsequent PyTorch HIP
@@ -299,6 +310,11 @@ static void setupP2PAccess(int num_devices) {
                     << i << " and device " << j;
             }
         }
+    }
+
+    // Restore the active device so this function is transparent to the caller.
+    if (original_device >= 0) {
+        (void)hipSetDevice(original_device);
     }
 }
 

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -259,7 +259,7 @@ static void setupP2PAccess(int num_devices) {
     int original_device = -1;
     if (!checkHip(hipGetDevice(&original_device),
                   "HipTransport: failed to get current device")) {
-        original_device = -1;
+        return;
     }
 
     auto clearStickyPeerAccessError = [](int src_device, int dst_device) {
@@ -314,7 +314,8 @@ static void setupP2PAccess(int num_devices) {
 
     // Restore the active device so this function is transparent to the caller.
     if (original_device >= 0) {
-        (void)hipSetDevice(original_device);
+        (void)checkHip(hipSetDevice(original_device),
+                       "HipTransport: failed to restore device");
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes `mooncake::HipTransport::setupP2PAccess(int num_devices)` so it no longer changes the caller's active HIP device.

Previously, `setupP2PAccess` walked every visible GPU with `hipSetDevice(i)` to enable peer access, but never restored the device that was active when the function was called. Since `hipSetDevice` is per-thread state, this can leave the caller thread pinned to the last GPU, usually `num_devices - 1`.

In a multi-process tensor-parallel worker setup, for example SGLang TP=8 with PD disaggregation, this causes all ranks to allocate through the same active HIP device after Mooncake initialization. The result is that the highest-numbered GPU runs out of memory while the other GPUs remain mostly unused.

Symptom observed on an 8-GPU node with TP=8:

```text
WARNING: current device is not 2, but 7, which may cause useless memory
         allocation for torch CUDA context

torch.OutOfMemoryError: HIP out of memory. Tried to allocate 28.00 MiB.
GPU 7 has a total capacity of 287.98 GiB of which 0 bytes is free.
```

The fix saves the entry device with hipGetDevice(&original_device) before the peer-access loop, and restores it with hipSetDevice(original_device) before returning. The function is now transparent to the caller's HIP context.

The restore is guarded by original_device >= 0, so if the initial device query ever fails, the patch does not make behavior worse than before.

The existing handling for hipErrorPeerAccessAlreadyEnabled remains independent from this change. This PR only addresses active-device restoration.

for bug details please check: https://github.com/kvcache-ai/Mooncake/issues/2016

## Module

- [ * ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ * ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Tested on:

2x nodes, each with 8x AMD Instinct MI355X (gfx950)
ROCm 7.2 / libamdhip64.so.7
PyTorch with HIP backend
SGLang 0.5.10.post1 PD disaggregation
TP=8 per role

Before this PR, using upstream HEAD with -DUSE_HIP=ON:

All TP=8 ranks failed during model load with the OOM cascade above.
GPU 7 saturated while GPUs 0–6 remained near empty.
The server never reached a healthy state.

After this PR:

All 8 ranks reached HTTP server is started.
VRAM was balanced across all 8 GPUs.
Prefill node: approximately 156 GB per GPU.
Decode node: approximately 201 GB per GPU.
The warning current device is not X, but 7 no longer appeared.
No OOM occurred at startup.

This bug is unlikely to be caught by simple single-process tests, because it requires HipTransport to be constructed in a process/thread that already has a meaningful active HIP device, such as one TP worker per GPU.

## Checklist

- [ * ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
