### PR TITLE
[TE] Fix EFA segfault race and DP>1 peer_map_ thrashing

### DIFF
--- a/mooncake-transfer-engine/include/transport/efa_transport/efa_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/efa_transport/efa_endpoint.h
@@ -124,6 +124,13 @@ class EfaEndPoint {
     RWSpinlock lock_;  // protects peer_nic_path_ and status_
     std::string peer_nic_path_;
     fi_addr_t peer_fi_addr_;  // slot in context_.av()
+    // Last peer EFA address successfully inserted into the AV.  Used to
+    // make passive handshakes idempotent: when both peers initiate a
+    // handshake concurrently (the common case under bilateral sglang PD
+    // traffic), the second passive handshake carries the same EFA
+    // address as the cached value, and we can skip the fi_av_remove/
+    // fi_av_insert churn entirely.
+    std::string cached_peer_addr_;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -458,16 +458,31 @@ void* EfaContext::mrDesc(void* addr) {
 
 std::shared_ptr<EfaEndPoint> EfaContext::endpoint(
     const std::string& peer_nic_path) {
-    // Use normalized key (strip port) so the same physical peer reuses its
-    // handle across reconnections.  Each P2PHANDSHAKE run picks a random
-    // port, producing a different peer_nic_path for the same peer host+NIC.
-    std::string key = normalizeNicPath(peer_nic_path);
+    // Key the peer map by the full "host:port@nic" path, not the
+    // port-stripped form.  Under sglang DP>1 every DP worker on a peer
+    // host is a distinct process with its own Mooncake TransferEngine
+    // and its own P2PHANDSHAKE RPC port.  They share the same host+NIC
+    // but map to different EFA QPNs / memory regions.  If we normalize
+    // the port away, every DP worker on that host collapses onto the
+    // same EfaEndPoint slot: each arriving handshake looks like a
+    // "peer reconnected with new address" to the previous holder,
+    // triggering fi_av_remove + fi_av_insert (and an AH warm-up) on
+    // every KV transfer.  At high DP this devolves into permanent
+    // thrashing and eventually "Remote MR invalid" when an in-flight
+    // fi_write runs against a stale AV slot.
+    //
+    // The port is stable for the lifetime of a sglang worker process
+    // (Mooncake only calls initialize() once), so keying by full path
+    // costs nothing in steady state.  A genuine peer restart (process
+    // re-launch → new RPC port) creates a new map entry and leaks the
+    // old EfaEndPoint — that's at most a few bytes per ex-worker and
+    // far cheaper than the churn the old normalization caused.
+    const std::string& key = peer_nic_path;
 
     {
         RWSpinlock::ReadGuard guard(peer_map_lock_);
         auto it = peer_map_.find(key);
         if (it != peer_map_.end()) {
-            it->second->setPeerNicPath(peer_nic_path);
             return it->second;
         }
     }
@@ -478,7 +493,6 @@ std::shared_ptr<EfaEndPoint> EfaContext::endpoint(
     RWSpinlock::WriteGuard guard(peer_map_lock_);
     auto it = peer_map_.find(key);
     if (it != peer_map_.end()) {
-        it->second->setPeerNicPath(peer_nic_path);
         return it->second;
     }
     peer_map_[key] = new_ep;
@@ -488,7 +502,7 @@ std::shared_ptr<EfaEndPoint> EfaContext::endpoint(
 std::shared_ptr<EfaEndPoint> EfaContext::peekEndpoint(
     const std::string& peer_nic_path) {
     RWSpinlock::ReadGuard guard(peer_map_lock_);
-    auto it = peer_map_.find(normalizeNicPath(peer_nic_path));
+    auto it = peer_map_.find(peer_nic_path);
     if (it == peer_map_.end()) return nullptr;
     return it->second;
 }
@@ -497,7 +511,7 @@ int EfaContext::deleteEndpoint(const std::string& peer_nic_path) {
     std::shared_ptr<EfaEndPoint> ep;
     {
         RWSpinlock::WriteGuard guard(peer_map_lock_);
-        auto it = peer_map_.find(normalizeNicPath(peer_nic_path));
+        auto it = peer_map_.find(peer_nic_path);
         if (it == peer_map_.end()) return 0;
         ep = it->second;
         peer_map_.erase(it);
@@ -656,7 +670,7 @@ int EfaContext::submitPostSend(
         // freeing its AV entry for reuse.  Under the shared-endpoint model
         // this is cheap (no fid_ep to destroy).
         if (rc != 0 && !ep->connected()) {
-            deleteEndpoint(normalizeNicPath(peer_nic_path));
+            deleteEndpoint(peer_nic_path);
         }
     }
 

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
@@ -165,11 +165,26 @@ int EfaEndPoint::submitPostSend(
         }
     }
 
-    fi_addr_t peer;
-    {
-        RWSpinlock::ReadGuard guard(lock_);
-        peer = peer_fi_addr_;
+    // Hold a read lock for the entire submit window so setPeerNicPath() /
+    // disconnect() (which take the write lock) cannot fi_av_remove() our
+    // slot while an fi_write() inside submitSlicesOnPeer is still in
+    // flight.  The previous code latched peer_fi_addr_ under the lock and
+    // released it before calling into the context, leaving a race: a
+    // concurrent peer reconnect could remove the AV entry after the latch,
+    // and libfabric would segfault on the stale fi_addr_t.  Read locks
+    // stack, so multiple senders to the same peer still submit in parallel.
+    RWSpinlock::ReadGuard guard(lock_);
+
+    // Re-check status under the lock — a racing disconnect() could have
+    // flipped us to UNCONNECTED between the outer check and acquiring the
+    // lock.  Fail the batch so the caller retries with a fresh setup.
+    if (status_.load(std::memory_order_acquire) != CONNECTED) {
+        for (auto* slice : slice_list) failed_slice_list.push_back(slice);
+        slice_list.clear();
+        return ERR_ENDPOINT;
     }
+
+    fi_addr_t peer = peer_fi_addr_;
     if (peer == FI_ADDR_UNSPEC) {
         for (auto* slice : slice_list) failed_slice_list.push_back(slice);
         slice_list.clear();

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
@@ -31,31 +31,6 @@ EfaEndPoint::~EfaEndPoint() { disconnect(); }
 void EfaEndPoint::setPeerNicPath(const std::string& peer_nic_path) {
     RWSpinlock::WriteGuard guard(lock_);
     if (peer_nic_path_ == peer_nic_path) return;  // No change
-
-    // The P2PHANDSHAKE transport assigns a fresh RPC port per bootstrap,
-    // so every sglang KV transfer arrives with a different peer_nic_path
-    // string ("host:PORT@nicX") even though the EFA peer has not moved.
-    // The RPC port is pure metadata — EFA SRD addressing is keyed on the
-    // binary efa_addr (GID/QPN) returned by fi_getname(), which only
-    // changes on actual peer process restart.  Treating a port change as
-    // a reconnect would fi_av_remove + fi_av_insert on every KV transfer,
-    // tearing down the provider's AH activation / RNR state and paying a
-    // first-packet AH warm-up latency each time.
-    //
-    // If the normalized nic path (host+NIC, no port) is unchanged, keep
-    // the AV slot intact and only refresh the stored string.  A real peer
-    // restart still gets caught in setupConnectionsByPassive by comparing
-    // peer_desc.efa_addr against cached_peer_addr_.
-    if (normalizeNicPath(peer_nic_path_) == normalizeNicPath(peer_nic_path)) {
-        VLOG(1) << "Peer RPC port rotated, keeping AV slot: " << peer_nic_path_
-                << " -> " << peer_nic_path;
-        peer_nic_path_ = peer_nic_path;
-        return;
-    }
-
-    // Different host or different NIC reached the same endpoint slot — this
-    // should not normally happen because EfaContext::endpoint() keys the map
-    // by normalized nic path, but handle it defensively.
     if (status_.load(std::memory_order_relaxed) == CONNECTED) {
         LOG(INFO) << "Peer reconnected with new address, re-establishing: "
                   << peer_nic_path_ << " -> " << peer_nic_path;
@@ -117,12 +92,8 @@ int EfaEndPoint::setupConnectionsByPassive(const HandShakeDesc& peer_desc,
                                            HandShakeDesc& local_desc) {
     RWSpinlock::WriteGuard guard(lock_);
 
-    // Compare against the normalized peer path so RPC port rotation (see
-    // setPeerNicPath()) does not trip this sanity check.  context_.nicPath()
-    // has no port to begin with, so a direct string compare is fine for it.
     if (peer_desc.peer_nic_path != context_.nicPath() ||
-        normalizeNicPath(peer_desc.local_nic_path) !=
-            normalizeNicPath(peer_nic_path_)) {
+        peer_desc.local_nic_path != peer_nic_path_) {
         local_desc.reply_msg = "EFA nic path inconsistency";
         LOG(ERROR) << "Invalid argument: peer EFA nic path inconsistency"
                    << " peer_nic_path=" << peer_desc.peer_nic_path

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
@@ -109,28 +109,29 @@ int EfaEndPoint::setupConnectionsByPassive(const HandShakeDesc& peer_desc,
         return ERR_REJECT_HANDSHAKE;
     }
 
-    // Idempotent fast path: under bilateral sglang PD traffic, both peers
-    // initiate handshakes, so each side's passive handler fires *after* the
-    // active side has already connected.  The peer address in that second
-    // handshake is identical to what we already inserted — no need to churn
-    // the AV (fi_av_remove + fi_av_insert), which was only noisy and
-    // introduced a brief window where in-flight fi_write could see a stale
-    // fi_addr_t.  Just echo our local desc back.
-    if (status_.load(std::memory_order_relaxed) == CONNECTED &&
-        peer_desc.efa_addr == cached_peer_addr_) {
-        local_desc.local_nic_path = context_.nicPath();
-        local_desc.peer_nic_path = peer_nic_path_;
-        local_desc.efa_addr = context_.localEpAddr();
-        VLOG(1) << "EFA passive handshake (idempotent): " << toString();
-        return 0;
-    }
-
-    // Peer address genuinely changed (peer process restart, AV slot reshuffle).
-    // Tear down the old slot and reinsert.  INFO level — this is rare and
-    // operationally interesting, unlike the bilateral-handshake case above.
+    // Classify this passive handshake so we can emit the right log level
+    // without changing functional behavior: the AV reinsert below must
+    // still happen on every handshake because libfabric's EFA provider
+    // tracks per-peer transport state that depends on a fresh
+    // fi_av_insert (e.g. provider-internal AH activation and RNR state).
+    // Skipping reinsert caused request-level stalls under bilateral
+    // sglang P/D load even when the peer EFA address was unchanged.
+    //
+    // Log semantics:
+    //   * Same cached peer address → benign symmetric handshake under
+    //     bilateral traffic.  Demote to INFO to keep decode logs readable
+    //     without hiding real reconnects.
+    //   * Different cached peer address → genuine reconnect (peer
+    //     restart, port reshuffle that reached disconnect first, etc.).
+    //     Keep at WARNING so it stays visible.
     if (status_.load(std::memory_order_relaxed) == CONNECTED) {
-        LOG(INFO) << "Peer EFA address changed, re-establishing: "
-                  << toString();
+        if (!cached_peer_addr_.empty() &&
+            peer_desc.efa_addr == cached_peer_addr_) {
+            VLOG(1) << "EFA passive handshake (same peer addr): "
+                    << toString();
+        } else {
+            LOG(WARNING) << "Re-establish EFA connection: " << toString();
+        }
         disconnectUnlocked();
     }
 

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
@@ -80,6 +80,7 @@ int EfaEndPoint::setupConnectionsByActive() {
 
     rc = context_.insertPeerAddr(peer_desc.efa_addr, peer_fi_addr_);
     if (rc != 0) return rc;
+    cached_peer_addr_ = peer_desc.efa_addr;
 
     status_.store(CONNECTED, std::memory_order_release);
     VLOG(1) << "EFA connection established: " << toString()
@@ -90,10 +91,6 @@ int EfaEndPoint::setupConnectionsByActive() {
 int EfaEndPoint::setupConnectionsByPassive(const HandShakeDesc& peer_desc,
                                            HandShakeDesc& local_desc) {
     RWSpinlock::WriteGuard guard(lock_);
-    if (status_.load(std::memory_order_relaxed) == CONNECTED) {
-        LOG(WARNING) << "Re-establish EFA connection: " << toString();
-        disconnectUnlocked();
-    }
 
     if (peer_desc.peer_nic_path != context_.nicPath() ||
         peer_desc.local_nic_path != peer_nic_path_) {
@@ -112,11 +109,37 @@ int EfaEndPoint::setupConnectionsByPassive(const HandShakeDesc& peer_desc,
         return ERR_REJECT_HANDSHAKE;
     }
 
+    // Idempotent fast path: under bilateral sglang PD traffic, both peers
+    // initiate handshakes, so each side's passive handler fires *after* the
+    // active side has already connected.  The peer address in that second
+    // handshake is identical to what we already inserted — no need to churn
+    // the AV (fi_av_remove + fi_av_insert), which was only noisy and
+    // introduced a brief window where in-flight fi_write could see a stale
+    // fi_addr_t.  Just echo our local desc back.
+    if (status_.load(std::memory_order_relaxed) == CONNECTED &&
+        peer_desc.efa_addr == cached_peer_addr_) {
+        local_desc.local_nic_path = context_.nicPath();
+        local_desc.peer_nic_path = peer_nic_path_;
+        local_desc.efa_addr = context_.localEpAddr();
+        VLOG(1) << "EFA passive handshake (idempotent): " << toString();
+        return 0;
+    }
+
+    // Peer address genuinely changed (peer process restart, AV slot reshuffle).
+    // Tear down the old slot and reinsert.  INFO level — this is rare and
+    // operationally interesting, unlike the bilateral-handshake case above.
+    if (status_.load(std::memory_order_relaxed) == CONNECTED) {
+        LOG(INFO) << "Peer EFA address changed, re-establishing: "
+                  << toString();
+        disconnectUnlocked();
+    }
+
     int ret = context_.insertPeerAddr(peer_desc.efa_addr, peer_fi_addr_);
     if (ret != 0) {
         local_desc.reply_msg = "Failed to insert peer address";
         return ret;
     }
+    cached_peer_addr_ = peer_desc.efa_addr;
 
     local_desc.local_nic_path = context_.nicPath();
     local_desc.peer_nic_path = peer_nic_path_;
@@ -138,12 +161,14 @@ void EfaEndPoint::disconnectUnlocked() {
         context_.removePeerAddr(peer_fi_addr_);
         peer_fi_addr_ = FI_ADDR_UNSPEC;
     }
+    cached_peer_addr_.clear();
     status_.store(UNCONNECTED, std::memory_order_release);
 }
 
 void EfaEndPoint::markDetachedForTeardown() {
     RWSpinlock::WriteGuard guard(lock_);
     peer_fi_addr_ = FI_ADDR_UNSPEC;
+    cached_peer_addr_.clear();
     status_.store(UNCONNECTED, std::memory_order_release);
 }
 

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
@@ -127,8 +127,7 @@ int EfaEndPoint::setupConnectionsByPassive(const HandShakeDesc& peer_desc,
     if (status_.load(std::memory_order_relaxed) == CONNECTED) {
         if (!cached_peer_addr_.empty() &&
             peer_desc.efa_addr == cached_peer_addr_) {
-            VLOG(1) << "EFA passive handshake (same peer addr): "
-                    << toString();
+            VLOG(1) << "EFA passive handshake (same peer addr): " << toString();
         } else {
             LOG(WARNING) << "Re-establish EFA connection: " << toString();
         }

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_endpoint.cpp
@@ -31,6 +31,31 @@ EfaEndPoint::~EfaEndPoint() { disconnect(); }
 void EfaEndPoint::setPeerNicPath(const std::string& peer_nic_path) {
     RWSpinlock::WriteGuard guard(lock_);
     if (peer_nic_path_ == peer_nic_path) return;  // No change
+
+    // The P2PHANDSHAKE transport assigns a fresh RPC port per bootstrap,
+    // so every sglang KV transfer arrives with a different peer_nic_path
+    // string ("host:PORT@nicX") even though the EFA peer has not moved.
+    // The RPC port is pure metadata — EFA SRD addressing is keyed on the
+    // binary efa_addr (GID/QPN) returned by fi_getname(), which only
+    // changes on actual peer process restart.  Treating a port change as
+    // a reconnect would fi_av_remove + fi_av_insert on every KV transfer,
+    // tearing down the provider's AH activation / RNR state and paying a
+    // first-packet AH warm-up latency each time.
+    //
+    // If the normalized nic path (host+NIC, no port) is unchanged, keep
+    // the AV slot intact and only refresh the stored string.  A real peer
+    // restart still gets caught in setupConnectionsByPassive by comparing
+    // peer_desc.efa_addr against cached_peer_addr_.
+    if (normalizeNicPath(peer_nic_path_) == normalizeNicPath(peer_nic_path)) {
+        VLOG(1) << "Peer RPC port rotated, keeping AV slot: " << peer_nic_path_
+                << " -> " << peer_nic_path;
+        peer_nic_path_ = peer_nic_path;
+        return;
+    }
+
+    // Different host or different NIC reached the same endpoint slot — this
+    // should not normally happen because EfaContext::endpoint() keys the map
+    // by normalized nic path, but handle it defensively.
     if (status_.load(std::memory_order_relaxed) == CONNECTED) {
         LOG(INFO) << "Peer reconnected with new address, re-establishing: "
                   << peer_nic_path_ << " -> " << peer_nic_path;
@@ -92,8 +117,12 @@ int EfaEndPoint::setupConnectionsByPassive(const HandShakeDesc& peer_desc,
                                            HandShakeDesc& local_desc) {
     RWSpinlock::WriteGuard guard(lock_);
 
+    // Compare against the normalized peer path so RPC port rotation (see
+    // setPeerNicPath()) does not trip this sanity check.  context_.nicPath()
+    // has no port to begin with, so a direct string compare is fine for it.
     if (peer_desc.peer_nic_path != context_.nicPath() ||
-        peer_desc.local_nic_path != peer_nic_path_) {
+        normalizeNicPath(peer_desc.local_nic_path) !=
+            normalizeNicPath(peer_nic_path_)) {
         local_desc.reply_msg = "EFA nic path inconsistency";
         LOG(ERROR) << "Invalid argument: peer EFA nic path inconsistency"
                    << " peer_nic_path=" << peer_desc.peer_nic_path

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -745,7 +745,7 @@ int EfaTransport::warmupSegment(const std::string& segment_name) {
                         // slot is freed and the next warmup retry starts
                         // clean.  Cheap under the shared-endpoint model —
                         // no fi_endpoint teardown required.
-                        ctx->deleteEndpoint(normalizeNicPath(path));
+                        ctx->deleteEndpoint(path);
                     }
                     return rc;
                 }));


### PR DESCRIPTION
## Description

Fixes #2022. The investigation uncovered two separate EFA-path bugs that jointly wrecked sglang P/D disaggregation on any DP>1 deployment. This PR bundles both since they surfaced together and the second one exposed the first.

**Bug 1 — segfault race between `setPeerNicPath` and in-flight `submitPostSend`.** `submitPostSend` latched `peer_fi_addr_` under `lock_` and released the lock before calling `EfaContext::submitSlicesOnPeer`, which issues `fi_write(shared_ep_, ..., peer_fi_addr, ...)` outside the lock. A concurrent `setPeerNicPath()` / `disconnect()` (both take the write lock and call `context_.removePeerAddr` → `fi_av_remove`) could invalidate the AV slot between the latch and the `fi_write`, causing libfabric's EFA provider to dereference a stale entry and segfault. Originally reproduced on SGLang 2P2D GLM-5.1-FP8 prefill, PP=2 TP=8 CP=8 EP=8, `moe_a2a=deepep`, 16 EFA NICs, `MC_MAX_WR=16384`. Fix: hold the read lock across the entire `submitSlicesOnPeer` call and re-check `status_` under the lock so a racing disconnect fails the batch cleanly and the caller retries via `setupConnectionsByActive()`. Read locks still stack, so multiple senders to the same peer submit in parallel with no throughput regression; disconnect is a low-frequency event dominated by handshake latency and waits at most one batch of `fi_write` calls (μs–ms) to drain.

**Bug 2 — `peer_map_` collapses multi-process peers on the same host, causing AV thrashing.** `EfaContext::endpoint()` keyed `peer_map_` by `normalizeNicPath(peer)`, which strips the RPC port. The original intent was handle reuse across P2PHANDSHAKE port reshuffles, under the assumption of one Mooncake process per peer host. That assumption held for DP=1 benchmarks but broke entirely under sglang's P/D disaggregation: each DP worker is a separate Python process with its own `TransferEngine` and its own `rpc_port` (see `sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py` — `TransferEngine()` + `initialize()` + `session_id = f"{host}:{get_rpc_port()}"`), and all N workers share the same host IP and EFA NICs. With N workers on the peer host, all N collapsed onto a single `peer_map_` slot; every handshake arriving from a different DP worker looked like "peer reconnected with a new address" to the previous holder, so `setPeerNicPath()` tore down the AV slot (`fi_av_remove` + `fi_av_insert`) and the next `fi_write` paid an AH warm-up on the first packet. The user's observations track this model precisely: DP=1/2 showed no spam and normal performance; DP=4/8 produced thousands of "Peer reconnected with new address" per second, decode `#running-req` degraded to 1, prefill `#inflight-req` pinned at 128, with timeouts and `EFA CQ error: Remote memory registration is invalid` once stale AV entries started being addressed against the wrong worker's MR table. Fix: key `peer_map_` by the full `"host:port@nic"` path. Each DP worker is a stable, distinct process with a stable port for its entire lifetime, so every steady-state lookup hits the cache — no churn. A genuine peer process restart (new `rpc_port`) leaves the old `EfaEndPoint` in the map; that is a few bytes per ex-worker, far cheaper than the per-transfer AV teardown it replaces. `peekEndpoint`, `deleteEndpoint`, and `warmupSegment`'s post-failure cleanup switch to the full path for consistency. `setPeerNicPath()` becomes effectively dead code in the common path — each new DP worker now gets its own endpoint rather than displacing an existing one.

The two fixes are independent — Bug 1's race could fire under any reconnect-heavy scenario, and Bug 2's thrashing would remain even without the race — but Bug 2's AV churn was the primary driver in practice, so with this fix the `fi_av_remove`/`fi_av_insert` path in the hot loop is essentially retired and Bug 1's read-lock widening becomes defense-in-depth for the rare real reconnect.

A few intermediate commits explored optimizations (skipping `fi_av_insert` on "duplicate" passive handshakes, treating port-only changes as no-ops in `setPeerNicPath`) before the `peer_map_` key turned out to be the actual load-bearing issue. Those commits were reverted in-tree; the final state is the three meaningful commits `f421bad0`, `fc0a30e8` (log-level demotion for benign symmetric handshakes), and `4a306de8`.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- Original segfault from #2022 (SGLang 2P2D GLM-5.1-FP8, PP=2 TP=8 CP=8 EP=8, `moe_a2a=deepep`, 16 EFA NICs, `MC_MAX_WR=16384`) no longer triggers; racing disconnects now fail the batch with `ERR_ENDPOINT` and the caller retries via `setupConnectionsByActive()`.
- Verified on sglang P/D disaggregation benchmark `benchmark.sh single 3072 1024 500 18 128` across DP=1, 2, 4, 8, and 16 on 2P2D. Prior to the fix DP≥4 produced `#transfer-req` stalls and decode timeouts; with the fix all DP values run to completion. DP=16 is the highest configuration validated.
- "Peer reconnected with new address, re-establishing" log volume on decode nodes drops from tens of thousands per second (DP=8) to single-digit occurrences tied to actual peer restarts.
- Decode TTFT and ITL improve at higher DP since `fi_write` no longer pays a first-packet AH warm-up per KV transfer.
- EFA `transfer_engine_bench` throughput smoke on P5EN (16 NICs) unchanged from baseline.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
