### PR TITLE
[Store] Supplement startup parameters and enhance the ease of use of tiered_backend initialization parameters

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1006,7 +1006,8 @@ PYBIND11_MODULE(store, m) {
             "setup_p2p_real_client",
             [](MooncakeStorePyWrapper& self, const std::string& local_hostname,
                const std::string& metadata_server,
-               const std::string& tiered_backend_config_json = "",
+               const std::string& tiered_backend_config_json =
+                   "conf/tiered_backend.json",
                size_t local_buffer_size = 1024 * 1024 * 16,
                const std::string& protocol = "tcp",
                const std::string& rdma_devices = "",

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -7,6 +7,7 @@
 #include "real_client.h"
 
 #include <cstdlib>  // for atexit
+#include <map>
 
 #include "integration_utils.h"
 
@@ -1012,6 +1013,15 @@ PYBIND11_MODULE(store, m) {
                const std::string& master_server_addr = "127.0.0.1:50051",
                uint16_t client_rpc_port = 12345,
                uint32_t client_rpc_thread_num = 16,
+               size_t lock_shard_count = 1024,
+               size_t route_cache_max_memory = 300 * 1024 * 1024,
+               uint64_t route_cache_ttl_ms = 5 * 60 * 1000,
+               const std::string& local_transfer_mode = "te",
+               size_t local_memcpy_async_worker_num = 32,
+               uint16_t metrics_port = 9003, bool enable_metrics_http = true,
+               size_t async_sender_thread_count = 0,
+               size_t async_max_batch_size = 2000,
+               size_t async_route_queue_size = 0,
                const py::object& engine = py::none()) {
                 auto& resource_tracker = ResourceTracker::getInstance();
                 self.use_dummy_client_ = false;
@@ -1032,7 +1042,12 @@ PYBIND11_MODULE(store, m) {
                         : std::optional<std::string>(rdma_devices),
                     master_server_addr, tiered_backend_config_json,
                     local_buffer_size, transfer_engine, "", client_rpc_port,
-                    client_rpc_thread_num);
+                    client_rpc_thread_num, lock_shard_count,
+                    route_cache_max_memory, route_cache_ttl_ms,
+                    local_transfer_mode, local_memcpy_async_worker_num,
+                    metrics_port, enable_metrics_http, {},
+                    async_sender_thread_count, async_max_batch_size,
+                    async_route_queue_size);
 
                 auto ret = real_client->setup(config);
                 self.store_ = real_client;
@@ -1043,6 +1058,16 @@ PYBIND11_MODULE(store, m) {
             py::arg("protocol"), py::arg("rdma_devices"),
             py::arg("master_server_addr"), py::arg("client_rpc_port") = 12345,
             py::arg("client_rpc_thread_num") = 16,
+            py::arg("lock_shard_count") = 1024,
+            py::arg("route_cache_max_memory") = 300 * 1024 * 1024,
+            py::arg("route_cache_ttl_ms") = 5 * 60 * 1000,
+            py::arg("local_transfer_mode") = "te",
+            py::arg("local_memcpy_async_worker_num") = 32,
+            py::arg("metrics_port") = 9003,
+            py::arg("enable_metrics_http") = true,
+            py::arg("async_sender_thread_count") = 0,
+            py::arg("async_max_batch_size") = 2000,
+            py::arg("async_route_queue_size") = 0,
             py::arg("engine") = py::none(),
             "Setup the store in P2P architecture.")
         .def(
@@ -1054,7 +1079,9 @@ PYBIND11_MODULE(store, m) {
                const std::string& protocol = "tcp",
                const std::string& rdma_devices = "",
                const std::string& master_server_addr = "127.0.0.1:50051",
-               const py::object& engine = py::none()) {
+               const py::object& engine = py::none(),
+               bool enable_offload = false, uint16_t metrics_port = 9003,
+               bool enable_metrics_http = true) {
                 auto& resource_tracker = ResourceTracker::getInstance();
                 self.use_dummy_client_ = false;
                 auto real_client = std::make_shared<RealClient>();
@@ -1073,7 +1100,8 @@ PYBIND11_MODULE(store, m) {
                             ? std::optional<std::string>(std::nullopt)
                             : std::optional<std::string>(rdma_devices),
                         master_server_addr, global_segment_size,
-                        local_buffer_size, transfer_engine);
+                        local_buffer_size, transfer_engine, "", enable_offload,
+                        metrics_port, enable_metrics_http, {});
 
                 auto ret = real_client->setup(config);
                 self.store_ = real_client;
@@ -1082,7 +1110,9 @@ PYBIND11_MODULE(store, m) {
             py::arg("local_hostname"), py::arg("metadata_server"),
             py::arg("global_segment_size"), py::arg("local_buffer_size"),
             py::arg("protocol"), py::arg("rdma_devices"),
-            py::arg("master_server_addr"), py::arg("engine") = py::none())
+            py::arg("master_server_addr"), py::arg("engine") = py::none(),
+            py::arg("enable_offload") = false, py::arg("metrics_port") = 9003,
+            py::arg("enable_metrics_http") = true)
         .def(
             "setup_dummy",
             [](MooncakeStorePyWrapper& self, size_t mem_pool_size,

--- a/mooncake-store/conf/tiered_backend.json
+++ b/mooncake-store/conf/tiered_backend.json
@@ -1,0 +1,16 @@
+{
+    "tiers": [
+        {
+            "type": "DRAM",
+            "capacity": "100GB",
+            "priority": 10,
+            "allocator_type": "OFFSET"
+        }
+    ],
+    "scheduler": {
+        "policy": "LRU",
+        "low_watermark": 0.6,
+        "high_watermark": 0.8,
+        "eviction_mode": "sync"
+    }
+}

--- a/mooncake-store/conf/tiered_backend_config_example.md
+++ b/mooncake-store/conf/tiered_backend_config_example.md
@@ -1,0 +1,199 @@
+# TieredBackend Configuration Reference
+
+This document describes every JSON field consumed by `TieredBackend::Init()` and
+`ClientScheduler` when initialising a P2P real client.
+
+The configuration is passed via `tiered_backend_config_json` in
+`ClientConfigBuilder::build_p2p_real_client()`. It accepts either:
+- An **inline JSON string** (the string must start with `{`)
+- A **file path** to a JSON file (default: `conf/tiered_backend.json`)
+
+---
+
+## Top-level Schema
+
+```json
+{
+    "tiers": [ ... ],     // required – at least one tier
+    "scheduler": { ... }  // optional – defaults apply when omitted
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tiers` | array | yes | Storage tier definitions. At least one entry required. |
+| `scheduler` | object | no | Scheduler policy and tuning. All sub-fields optional. |
+
+---
+
+## Tier Fields
+
+### Common Fields (all tier types)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | yes | Tier type: `"DRAM"`, `"ASCEND_NPU"`, `"STORAGE"`, or `"DISK"` (`"DISK"` is an alias for `"STORAGE"`) |
+| `capacity` | integer or string | yes | Tier capacity. Accepts a plain byte count (`1073741824`) or a human-readable string (`"1GB"`, `"512MB"`, `"2TB"`). Strings are case-insensitive and may include a space before the unit. |
+| `priority` | integer | yes | Scheduling priority. Higher value = preferred for acquired write or read route. |
+| `tags` | string array | no | Arbitrary labels forwarded to the Master segment metadata. Used for topology-aware routing. |
+
+**Supported size units for string capacity values:** `B`, `KB`/`K`, `MB`/`M`, `GB`/`G`, `TB`/`T`, `"infinite"` (→ `UINT64_MAX`)
+
+---
+
+### DRAM Tier (`"type": "DRAM"`)
+
+Allocates memory directly from DRAM. Fastest tier; typically assigned the highest priority.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `allocator_type` | string | `"OFFSET"` | Buffer allocator implementation. `"OFFSET"` (offset allocator) or `"CACHELIB"` (Facebook CacheLib allocator). |
+| `numa_node` | integer | *(none)* | Pin allocation to a specific NUMA node via `numa_alloc_onnode`. Negative values are ignored and allocation falls back to the system default. |
+
+---
+
+### ASCEND NPU Tier (`"type": "ASCEND_NPU"`)
+
+Allocates on an Ascend NPU device. Only available when compiled with `USE_ASCEND_CACHE_TIER`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `device_id` | integer | `0` | Ascend device index. |
+
+---
+
+### STORAGE / DISK Tier (`"type": "STORAGE"` or `"type": "DISK"`)
+
+Persists data to local NVMe/SSD via a staging DRAM pool. Typically assigned the lowest priority.
+
+**Flush aggregation** — controls when the background flush thread writes staged data to disk:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size_threshold` | integer or string | `"64MB"` | Trigger a flush when the pending batch reaches this total byte size. Accepts human-readable strings. |
+| `batch_count_threshold` | integer | `1000` | Trigger a flush when the pending batch contains this many keys. |
+| `staging_buffer_capacity` | integer or string | `"128MB"` | Size of the staging DRAM pool used to buffer writes before they are flushed to disk.|
+
+**Storage backend** — JSON values take precedence over the corresponding environment variable:
+
+| Field | Type | Default | Env var override | Description |
+|-------|------|---------|-----------------|-------------|
+| `storage_backend_type` | string | `"bucket_storage_backend"` | `MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR` | StorageTier **only supports `"bucket_storage_backend"`**. Setting this to `"file_per_key_storage_backend"` will cause initialization to fail. |
+| `storage_filepath` | string  | `"/data/file_storage"` | `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` | Root directory for on-disk data files. Must be an absolute path. |
+| `total_size_limit` | integer or string  | `"2TB"` | `MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES` | Maximum on-disk data size. Used as the `GetCapacity()` fallback when no explicit `capacity` is set. |
+| `bucket_size_limit` | integer or string | `"256MB"` | `MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES` | Maximum total byte size of a single bucket. |
+| `bucket_keys_limit` | integer  | `500` | `MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT` | Maximum number of keys per bucket. |
+
+> **Note:** `heartbeat_interval_seconds`, `scanmeta_iterator_keys_limit`, and `total_keys_limit`
+> are `FileStorageConfig` fields used exclusively by the centralized-mode `FileStorage` class.
+> They have **no effect** in P2P StorageTier and should not be configured here.
+
+---
+
+## Scheduler Fields (`"scheduler"` object)
+
+The scheduler drives background promotion, eviction, and statistics collection.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `policy` | string | `"SIMPLE"` | Scheduling policy: `"SIMPLE"` (heat-score-based promotion) or `"LRU"` (least-recently-used eviction). |
+| `eviction_mode` | string | `"async"` | `"async"`: eviction runs in the background worker loop. `"sync"`: eviction is triggered synchronously on allocation failure. |
+| `loop_interval_ms` | integer | `1000` | Background scheduler worker loop interval in milliseconds. |
+| `stats_shards` | integer | *(internal default)* | Shard count for the access-statistics collector. Increase to reduce lock contention under high concurrency. |
+| `stats_snapshot_limit` | integer | *(internal default)* | Maximum number of entries in a single stats snapshot passed to the policy. |
+
+**SIMPLE policy only:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `promotion_threshold` | double | `5.0` | Minimum access count for a key to be eligible for promotion to a higher-priority tier. |
+
+**LRU policy only:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `high_watermark` | double | *(LRU default)* | Tier usage ratio (0–1) at which eviction begins. |
+| `low_watermark` | double | *(LRU default)* | Tier usage ratio (0–1) at which eviction stops. |
+
+---
+
+## Complete Examples
+
+### Minimal – single DRAM tier
+
+```json
+{
+    "tiers": [
+        {
+            "type": "DRAM",
+            "capacity": "4GB",
+            "priority": 10
+        }
+    ]
+}
+```
+
+### Multi-tier – DRAM (hot) + STORAGE (warm/cold), SIMPLE scheduler
+
+```json
+{
+    "tiers": [
+        {
+            "type": "DRAM",
+            "capacity": "8GB",
+            "priority": 100,
+            "allocator_type": "OFFSET",
+            "numa_node": 0,
+            "tags": ["fast", "local"]
+        },
+        {
+            "type": "STORAGE",
+            "capacity": "500GB",
+            "priority": 10,
+            "tags": ["nvme"],
+            "batch_size_threshold": "128MB",
+            "batch_count_threshold": 2000,
+            "storage_backend_type": "bucket_storage_backend",
+            "storage_filepath": "/nvme/mooncake_store",
+            "staging_buffer_capacity": "2GB",
+            "total_size_limit": "500GB",
+            "bucket_size_limit": "512MB",
+            "bucket_keys_limit": 1000
+        }
+    ],
+    "scheduler": {
+        "policy": "SIMPLE",
+        "promotion_threshold": 3.0,
+        "eviction_mode": "async",
+        "loop_interval_ms": 500
+    }
+}
+```
+
+### Multi-tier – DRAM + STORAGE, LRU scheduler
+
+```json
+{
+    "tiers": [
+        {
+            "type": "DRAM",
+            "capacity": "16GB",
+            "priority": 100
+        },
+        {
+            "type": "STORAGE",
+            "capacity": "1TB",
+            "priority": 10,
+            "storage_filepath": "/data/mooncake",
+            "local_buffer_size": "4GB"
+        }
+    ],
+    "scheduler": {
+        "policy": "LRU",
+        "eviction_mode": "async",
+        "high_watermark": 0.9,
+        "low_watermark": 0.7,
+        "loop_interval_ms": 1000
+    }
+}
+```

--- a/mooncake-store/include/client_config_builder.h
+++ b/mooncake-store/include/client_config_builder.h
@@ -8,6 +8,8 @@
 #include <algorithm>
 #include <cctype>
 #include <stdexcept>
+#include <fstream>
+#include <sstream>
 
 #include <glog/logging.h>
 #include <json/json.h>
@@ -180,6 +182,9 @@ struct P2PClientConfig : RealClientConfigBase {
  */
 class ClientConfigBuilder {
    public:
+    static constexpr const char* kDefaultTieredBackendConfigPath =
+        "conf/tiered_backend.json";
+
     static DummyClientConfig build_dummy(size_t mem_pool_size,
                                          size_t local_buffer_size,
                                          const std::string& real_client_addr,
@@ -219,7 +224,8 @@ class ClientConfigBuilder {
         const std::string& protocol = "tcp",
         const std::optional<std::string>& rdma_devices = std::nullopt,
         const std::string& master_server_entry = "127.0.0.1:50051",
-        const std::string& tiered_backend_config_json = "",
+        const std::string& tiered_backend_config_json =
+            kDefaultTieredBackendConfigPath,
         uint64_t local_buffer_size = 0,
         const std::shared_ptr<TransferEngine>& transfer_engine = nullptr,
         const std::string& ipc_socket_path = "",
@@ -253,32 +259,15 @@ class ClientConfigBuilder {
         config.async_max_batch_size = async_max_batch_size;
         config.async_route_queue_size = async_route_queue_size;
 
-        Json::Value tiered_config;
-        std::string actual_json = tiered_backend_config_json;
-        if (actual_json.empty()) {
-            if (const char* env_p = std::getenv("MOONCAKE_TIERED_CONFIG")) {
-                actual_json = env_p;
-            }
-        }
-
-        if (!actual_json.empty()) {
-            Json::CharReaderBuilder builder;
-            auto reader =
-                std::unique_ptr<Json::CharReader>(builder.newCharReader());
-            std::string errors;
-            if (!reader->parse(actual_json.data(),
-                               actual_json.data() + actual_json.length(),
-                               &tiered_config, &errors)) {
-                LOG(ERROR) << "Failed to parse tiered config: " << errors;
-            }
-        }
+        Json::Value tiered_config =
+            LoadTieredConfig(tiered_backend_config_json);
 
         if (tiered_config.isNull() || !tiered_config.isMember("tiers") ||
             tiered_config["tiers"].empty()) {
             throw std::runtime_error(
-                "Tiered backend configuration is missing. Please provide "
-                "tiered_backend_config_json or set MOONCAKE_TIERED_CONFIG "
-                "environment variable.");
+                "Tiered backend configuration is missing or invalid. Please "
+                "provide a valid JSON string or a path to a JSON config file "
+                "via tiered_backend_config_json parameter.");
         }
         config.tiered_backend_config = tiered_config;
 
@@ -286,6 +275,46 @@ class ClientConfigBuilder {
     }
 
    private:
+    static Json::Value LoadTieredConfig(const std::string& json_or_path) {
+        Json::Value config;
+        std::string json_content;
+
+        // Determine if input is a JSON string or a file path
+        std::string trimmed = json_or_path;
+        size_t start = trimmed.find_first_not_of(" \t\n\r");
+        if (start != std::string::npos) {
+            trimmed = trimmed.substr(start);
+        }
+
+        if (!trimmed.empty() && trimmed[0] == '{') {
+            // Treat as JSON string
+            json_content = json_or_path;
+        } else {
+            // Treat as file path
+            std::ifstream file(json_or_path);
+            if (!file.is_open()) {
+                LOG(ERROR) << "Failed to open tiered backend config file: "
+                           << json_or_path;
+                return config;  // Returns null Json::Value
+            }
+            std::ostringstream ss;
+            ss << file.rdbuf();
+            json_content = ss.str();
+        }
+
+        // Parse JSON
+        Json::CharReaderBuilder builder;
+        auto reader =
+            std::unique_ptr<Json::CharReader>(builder.newCharReader());
+        std::string errors;
+        if (!reader->parse(json_content.data(),
+                           json_content.data() + json_content.length(), &config,
+                           &errors)) {
+            LOG(ERROR) << "Failed to parse tiered config: " << errors;
+        }
+        return config;
+    }
+
     static void fill_real_client_config_base(
         RealClientConfigBase& config, const std::string& local_hostname,
         const std::string& metadata_connstring, const std::string& protocol,

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -12,6 +12,8 @@
 #include <thread>
 #include <vector>
 
+#include <json/json.h>
+
 #include "file_interface.h"
 #include "mutex.h"
 #include "types.h"
@@ -73,6 +75,8 @@ struct BucketBackendConfig {
     bool Validate() const;
 
     static BucketBackendConfig FromEnvironment();
+
+    void MergeFromJson(const Json::Value& v);
 };
 
 struct FileStorageConfig {
@@ -112,6 +116,8 @@ struct FileStorageConfig {
      * @return FileStorageConfig with values from env or defaults
      */
     static FileStorageConfig FromEnvironment();
+
+    void MergeFromJson(const Json::Value& v);
 };
 
 class StorageBackendInterface {
@@ -852,6 +858,10 @@ class BucketStorageBackend : public StorageBackendInterface {
 };
 
 tl::expected<std::shared_ptr<StorageBackendInterface>, ErrorCode>
-CreateStorageBackend(const FileStorageConfig& config);
+CreateStorageBackend(const FileStorageConfig& config,
+                     const Json::Value& tier_config = Json::Value{});
+
+tl::expected<std::shared_ptr<StorageBackendInterface>, ErrorCode>
+CreateStorageBackend(const Json::Value& tier_config);
 
 }  // namespace mooncake

--- a/mooncake-store/include/tiered_cache/tiers/storage_tier.h
+++ b/mooncake-store/include/tiered_cache/tiers/storage_tier.h
@@ -63,7 +63,6 @@ class StorageBuffer : public BufferBase {
         return Slice{static_cast<char*>(staging_buffer_->data()), size_};
     }
 
-    void SetKey(const std::string& key) { key_ = key; }
     void SetKey(std::string_view key) { key_ = key; }
     const std::string& GetKey() const { return key_; }
 

--- a/mooncake-store/include/tiered_cache/tiers/storage_tier.h
+++ b/mooncake-store/include/tiered_cache/tiers/storage_tier.h
@@ -11,6 +11,8 @@
 #include <thread>
 #include <condition_variable>
 
+#include <json/json.h>
+
 #include "tiered_cache/tiers/cache_tier.h"
 #include "storage_backend.h"
 
@@ -139,6 +141,10 @@ class StorageTier : public CacheTier {
     tl::expected<void, ErrorCode> Init(TieredBackend* backend,
                                        TransferEngine* engine) override;
 
+    tl::expected<void, ErrorCode> Init(TieredBackend* backend,
+                                       TransferEngine* engine,
+                                       const Json::Value& tier_config);
+
     tl::expected<void, ErrorCode> Allocate(size_t size,
                                            DataSource& data) override;
 
@@ -194,15 +200,15 @@ class StorageTier : public CacheTier {
     std::mutex flush_trigger_mutex_;
     std::atomic<bool> flush_requested_{false};
 
-    // Configurable thresholds
-    size_t batch_size_threshold_ = 64 * 1024 * 1024;  // 64MB
-    size_t batch_count_threshold_ = 1000;
+    // Flush aggregation thresholds
+    size_t batch_size_threshold_ = 64 * 1024 * 1024;  // default 64MB
+    size_t batch_count_threshold_ = 1000;             // default 64MB
 
     // Preallocated local staging pool for SSD writes.
     std::shared_ptr<BufferAllocatorBase> staging_allocator_;
     std::unique_ptr<char, void (*)(char*)> staging_memory_{
         nullptr, &StorageTier::FreeStagingMemory};
-    size_t staging_buffer_capacity_ = 0;
+    size_t staging_buffer_capacity_ = 128 * 1024 * 1024;  // default 128MB
 
     // Live persisted value bytes. This excludes backend metadata and any
     // bucket files already unlinked from the cache namespace but still pending

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -16,11 +16,11 @@ DEFINE_string(master_server_address, "127.0.0.1:50051",
 DEFINE_string(protocol, "tcp", "Protocol");
 DEFINE_int32(port, 50052, "Real Client service port");
 DEFINE_string(global_segment_size, "4 GB", "Size of global segment");
-DEFINE_int32(threads, 1, "Number of threads for client service");
+DEFINE_int32(threads, 1, "Number of rpc threads for dummy client");
 DEFINE_bool(enable_offload, false, "Enable offload availability");
-DEFINE_string(tiered_backend_config, "",
-              "Tiered backend config json. Empty means load from env "
-              "MOONCAKE_TIERED_CONFIG");
+DEFINE_string(tiered_backend_config, "conf/tiered_backend.json",
+              "Tiered backend config: accepts a JSON string or a path to a "
+              "JSON config file.");
 DEFINE_string(deployment_mode, "Centralization",
               "Client type: 'Centralization' or 'P2P'");
 DEFINE_uint32(client_rpc_port, 12345, "Client RPC service port (P2P mode)");

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -110,23 +110,35 @@ BucketBackendConfig BucketBackendConfig::FromEnvironment() {
 void BucketBackendConfig::MergeFromJson(const Json::Value& v) {
     if (v.isMember("bucket_size_limit")) {
         const auto& node = v["bucket_size_limit"];
-        bucket_size_limit =
-            node.isString()
-                ? static_cast<int64_t>(string_to_byte_size(node.asString()))
-                : node.asInt64();
+        if (node.isString()) {
+            bucket_size_limit =
+                static_cast<int64_t>(string_to_byte_size(node.asString()));
+        } else if (node.isIntegral()) {
+            bucket_size_limit = node.asInt64();
+        } else {
+            LOG(WARNING) << "bucket_size_limit has unexpected type, ignored";
+        }
     }
     if (v.isMember("bucket_keys_limit")) {
-        bucket_keys_limit = v["bucket_keys_limit"].asInt64();
+        const auto& node = v["bucket_keys_limit"];
+        if (node.isIntegral()) {
+            bucket_keys_limit = node.asInt64();
+        } else {
+            LOG(WARNING) << "bucket_keys_limit has unexpected type, ignored";
+        }
     }
 }
 
 void FileStorageConfig::MergeFromJson(const Json::Value& v) {
     if (v.isMember("storage_backend_type")) {
         const std::string t = v["storage_backend_type"].asString();
-        if (t == "file_per_key") {
+        if (t == "file_per_key_storage_backend") {
             storage_backend_type = StorageBackendType::kFilePerKey;
-        } else {
+        } else if (t == "bucket_storage_backend") {
             storage_backend_type = StorageBackendType::kBucket;
+        } else {
+            LOG(WARNING) << "Unknown storage_backend_type: " << t
+                         << ", keeping current value";
         }
     }
     if (v.isMember("storage_filepath")) {
@@ -134,17 +146,25 @@ void FileStorageConfig::MergeFromJson(const Json::Value& v) {
     }
     if (v.isMember("local_buffer_size")) {
         const auto& node = v["local_buffer_size"];
-        local_buffer_size =
-            node.isString()
-                ? static_cast<int64_t>(string_to_byte_size(node.asString()))
-                : node.asInt64();
+        if (node.isString()) {
+            local_buffer_size =
+                static_cast<int64_t>(string_to_byte_size(node.asString()));
+        } else if (node.isIntegral()) {
+            local_buffer_size = node.asInt64();
+        } else {
+            LOG(WARNING) << "local_buffer_size has unexpected type, ignored";
+        }
     }
     if (v.isMember("total_size_limit")) {
         const auto& node = v["total_size_limit"];
-        total_size_limit =
-            node.isString()
-                ? static_cast<int64_t>(string_to_byte_size(node.asString()))
-                : node.asInt64();
+        if (node.isString()) {
+            total_size_limit =
+                static_cast<int64_t>(string_to_byte_size(node.asString()));
+        } else if (node.isIntegral()) {
+            total_size_limit = node.asInt64();
+        } else {
+            LOG(WARNING) << "total_size_limit has unexpected type, ignored";
+        }
     }
 }
 

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -107,6 +107,47 @@ BucketBackendConfig BucketBackendConfig::FromEnvironment() {
     return config;
 }
 
+void BucketBackendConfig::MergeFromJson(const Json::Value& v) {
+    if (v.isMember("bucket_size_limit")) {
+        const auto& node = v["bucket_size_limit"];
+        bucket_size_limit =
+            node.isString()
+                ? static_cast<int64_t>(string_to_byte_size(node.asString()))
+                : node.asInt64();
+    }
+    if (v.isMember("bucket_keys_limit")) {
+        bucket_keys_limit = v["bucket_keys_limit"].asInt64();
+    }
+}
+
+void FileStorageConfig::MergeFromJson(const Json::Value& v) {
+    if (v.isMember("storage_backend_type")) {
+        const std::string t = v["storage_backend_type"].asString();
+        if (t == "file_per_key") {
+            storage_backend_type = StorageBackendType::kFilePerKey;
+        } else {
+            storage_backend_type = StorageBackendType::kBucket;
+        }
+    }
+    if (v.isMember("storage_filepath")) {
+        storage_filepath = v["storage_filepath"].asString();
+    }
+    if (v.isMember("local_buffer_size")) {
+        const auto& node = v["local_buffer_size"];
+        local_buffer_size =
+            node.isString()
+                ? static_cast<int64_t>(string_to_byte_size(node.asString()))
+                : node.asInt64();
+    }
+    if (v.isMember("total_size_limit")) {
+        const auto& node = v["total_size_limit"];
+        total_size_limit =
+            node.isString()
+                ? static_cast<int64_t>(string_to_byte_size(node.asString()))
+                : node.asInt64();
+    }
+}
+
 StorageBackendInterface::StorageBackendInterface(
     const FileStorageConfig& config)
     : file_storage_config_(config) {}
@@ -2610,10 +2651,12 @@ tl::expected<bool, ErrorCode> BucketStorageBackend::HasNext() {
 }
 
 tl::expected<std::shared_ptr<StorageBackendInterface>, ErrorCode>
-CreateStorageBackend(const FileStorageConfig& config) {
+CreateStorageBackend(const FileStorageConfig& config,
+                     const Json::Value& tier_config) {
     switch (config.storage_backend_type) {
         case StorageBackendType::kBucket: {
             auto bucket_backend_config = BucketBackendConfig::FromEnvironment();
+            bucket_backend_config.MergeFromJson(tier_config);
             if (!bucket_backend_config.Validate()) {
                 throw std::invalid_argument(
                     "Invalid StorageBackend configuration");
@@ -2636,6 +2679,13 @@ CreateStorageBackend(const FileStorageConfig& config) {
             return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
         }
     }
+}
+
+tl::expected<std::shared_ptr<StorageBackendInterface>, ErrorCode>
+CreateStorageBackend(const Json::Value& tier_config) {
+    auto config = FileStorageConfig::FromEnvironment();
+    config.MergeFromJson(tier_config);
+    return CreateStorageBackend(config, tier_config);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/tiered_cache/scheduler/client_scheduler.cpp
+++ b/mooncake-store/src/tiered_cache/scheduler/client_scheduler.cpp
@@ -51,6 +51,12 @@ ClientScheduler::ClientScheduler(TieredBackend* backend,
         }
     }
 
+    if (config.isMember("scheduler") &&
+        config["scheduler"].isMember("loop_interval_ms")) {
+        const auto v = config["scheduler"]["loop_interval_ms"].asInt();
+        if (v > 0) loop_interval_ms_ = v;
+    }
+
     if (policy_type == "LRU") {
         // Initialize LRU components
         stats_collector_ = std::make_unique<LRUStatsCollector>(

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -11,8 +11,16 @@
 #endif
 #include "tiered_cache/tiers/storage_tier.h"
 #include "tiered_cache/scheduler/client_scheduler.h"
+#include "utils.h"
 
 namespace mooncake {
+
+static size_t ParseByteSize(const Json::Value& v) {
+    if (v.isString()) {
+        return static_cast<size_t>(string_to_byte_size(v.asString()));
+    }
+    return static_cast<size_t>(v.asUInt64());
+}
 
 AllocationEntry::~AllocationEntry() {
     if (loc.tier) {
@@ -125,7 +133,7 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
         }
 
         std::string type = tier_config["type"].asString();
-        size_t capacity = tier_config["capacity"].asUInt64();
+        size_t capacity = ParseByteSize(tier_config["capacity"]);
         int priority = tier_config["priority"].asInt();
 
         // Validate capacity
@@ -224,7 +232,7 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
             LOG(INFO) << "Creating Storage tier: id=" << id
                       << ", capacity=" << capacity << ", priority=" << priority;
             auto tier = std::make_shared<StorageTier>(id, tags, capacity);
-            auto init_result = tier->Init(this, engine);
+            auto init_result = tier->Init(this, engine, tier_config);
             if (!init_result) {
                 LOG(ERROR) << "Failed to initialize Storage tier: id=" << id
                            << ", error=" << init_result.error();

--- a/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
@@ -78,13 +78,12 @@ tl::expected<void, ErrorCode> StorageTier::Init(
     static_cast<void>(engine);
     backend_ = backend;
     try {
-        // Validate backend type before creation: StorageTier only supports
-        // bucket backend (file_per_key lacks eviction support).
         {
             auto fs_config = FileStorageConfig::FromEnvironment();
             if (!tier_config.isNull()) {
                 fs_config.MergeFromJson(tier_config);
             }
+            // StorageTier only supports bucket backend
             if (fs_config.storage_backend_type != StorageBackendType::kBucket) {
                 LOG(ERROR)
                     << "StorageTier only supports bucket storage backend. "

--- a/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
@@ -69,32 +69,61 @@ StorageTier::~StorageTier() {
 
 tl::expected<void, ErrorCode> StorageTier::Init(TieredBackend* backend,
                                                 TransferEngine* engine) {
+    return Init(backend, engine, Json::Value{});
+}
+
+tl::expected<void, ErrorCode> StorageTier::Init(
+    TieredBackend* backend, TransferEngine* engine,
+    const Json::Value& tier_config) {
     static_cast<void>(engine);
     backend_ = backend;
     try {
-        auto config = FileStorageConfig::FromEnvironment();
-        if (!config.Validate()) {
-            LOG(ERROR) << "Invalid FileStorageConfig for StorageTier";
-            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        // Validate backend type before creation: StorageTier only supports
+        // bucket backend (file_per_key lacks eviction support).
+        {
+            auto fs_config = FileStorageConfig::FromEnvironment();
+            if (!tier_config.isNull()) {
+                fs_config.MergeFromJson(tier_config);
+            }
+            if (fs_config.storage_backend_type != StorageBackendType::kBucket) {
+                LOG(ERROR)
+                    << "StorageTier only supports bucket storage backend. "
+                       "Check MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR "
+                       "or the storage_backend_type field in tier config.";
+                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+            }
         }
-        if (config.local_buffer_size <= 0) {
-            LOG(ERROR) << "StorageTier local buffer size must be positive, got "
-                       << config.local_buffer_size;
-            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+
+        if (!tier_config.isNull()) {
+            if (tier_config.isMember("staging_buffer_capacity")) {
+                const auto& node = tier_config["staging_buffer_capacity"];
+                staging_buffer_capacity_ =
+                    node.isString() ? static_cast<size_t>(
+                                          string_to_byte_size(node.asString()))
+                                    : static_cast<size_t>(node.asUInt64());
+            }
+            if (tier_config.isMember("batch_size_threshold")) {
+                const auto& node = tier_config["batch_size_threshold"];
+                batch_size_threshold_ =
+                    node.isString() ? static_cast<size_t>(
+                                          string_to_byte_size(node.asString()))
+                                    : static_cast<size_t>(node.asUInt64());
+            }
+            if (tier_config.isMember("batch_count_threshold")) {
+                batch_count_threshold_ = static_cast<size_t>(
+                    tier_config["batch_count_threshold"].asUInt64());
+            }
         }
 
         constexpr size_t kStagingAlignment = 64;
         staging_memory_.reset(
             static_cast<char*>(allocate_buffer_allocator_memory(
-                static_cast<size_t>(config.local_buffer_size), "",
-                kStagingAlignment)));
+                staging_buffer_capacity_, "", kStagingAlignment)));
         if (!staging_memory_) {
             LOG(ERROR) << "Failed to preallocate storage staging pool, size="
-                       << config.local_buffer_size;
+                       << staging_buffer_capacity_;
             return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
         }
-        staging_buffer_capacity_ =
-            static_cast<size_t>(config.local_buffer_size);
         std::string segment_name = "storage_tier_staging_" +
                                    std::to_string(tier_id_.first) + "-" +
                                    std::to_string(tier_id_.second);
@@ -102,7 +131,7 @@ tl::expected<void, ErrorCode> StorageTier::Init(TieredBackend* backend,
             segment_name, reinterpret_cast<uintptr_t>(staging_memory_.get()),
             staging_buffer_capacity_, segment_name, tier_id_);
 
-        auto backend_res = CreateStorageBackend(config);
+        auto backend_res = CreateStorageBackend(tier_config);
         if (!backend_res) {
             LOG(ERROR) << "Failed to create underlying storage backend: "
                        << backend_res.error();

--- a/mooncake-store/tests/client_config_builder_test.cpp
+++ b/mooncake-store/tests/client_config_builder_test.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include <stdexcept>
+#include <fstream>
+#include <filesystem>
 
 #include "client_config_builder.h"
 
@@ -21,6 +23,9 @@ TEST(ClientConfigBuilderTest, BuildP2PClientConfigUsesDefaults) {
         "127.0.0.1:12345", "http://127.0.0.1:8080/metadata", "tcp",
         std::nullopt, "127.0.0.1:50051", kTieredConfigJson);
 
+    EXPECT_FALSE(config.tiered_backend_config.isNull());
+    EXPECT_TRUE(config.tiered_backend_config.isMember("tiers"));
+    EXPECT_EQ(config.tiered_backend_config["tiers"].size(), 1u);
     EXPECT_EQ(config.local_memcpy_async_worker_num, 32u);
     EXPECT_EQ(config.local_transfer_mode, LocalTransferMode::TE);
 }
@@ -43,6 +48,58 @@ TEST(ClientConfigBuilderTest, BuildP2PClientConfigRejectsInvalidTransferMode) {
             std::nullopt, "127.0.0.1:50051", kTieredConfigJson, 0, nullptr, "",
             12345, 8, 2048, 512 * 1024 * 1024, 120000, "invalid_mode"),
         std::runtime_error);
+}
+
+// ---- LoadTieredConfig: file path ----
+
+TEST(ClientConfigBuilderTest, LoadFromFilePath) {
+    const std::string tmp_path = "/tmp/mc_test_tiered_cfg.json";
+    {
+        std::ofstream f(tmp_path);
+        f << kTieredConfigJson;
+    }
+
+    auto config = ClientConfigBuilder::build_p2p_real_client(
+        "127.0.0.1:12345", "http://127.0.0.1:8080/metadata", "tcp",
+        std::nullopt, "127.0.0.1:50051", tmp_path);
+
+    EXPECT_FALSE(config.tiered_backend_config.isNull());
+    EXPECT_TRUE(config.tiered_backend_config.isMember("tiers"));
+    EXPECT_EQ(config.tiered_backend_config["tiers"].size(), 1u);
+
+    std::filesystem::remove(tmp_path);
+}
+
+// ---- LoadTieredConfig: invalid file path → throws ----
+
+TEST(ClientConfigBuilderTest, InvalidFilePathThrows) {
+    EXPECT_THROW(
+        ClientConfigBuilder::build_p2p_real_client(
+            "127.0.0.1:12345", "http://127.0.0.1:8080/metadata", "tcp",
+            std::nullopt, "127.0.0.1:50051", "/nonexistent/path/tiered.json"),
+        std::runtime_error);
+}
+
+// ---- LoadTieredConfig: malformed JSON string → throws ----
+
+TEST(ClientConfigBuilderTest, MalformedJsonStringThrows) {
+    // Starts with '{' so LoadTieredConfig treats it as inline JSON, but it is
+    // syntactically invalid and will fail to parse.
+    std::string bad_json = "{ not valid json";
+    EXPECT_THROW(ClientConfigBuilder::build_p2p_real_client(
+                     "127.0.0.1:12345", "http://127.0.0.1:8080/metadata", "tcp",
+                     std::nullopt, "127.0.0.1:50051", bad_json),
+                 std::runtime_error);
+}
+
+// ---- LoadTieredConfig: empty string → throws (tries to open file named "")
+// ----
+
+TEST(ClientConfigBuilderTest, EmptyStringThrows) {
+    EXPECT_THROW(ClientConfigBuilder::build_p2p_real_client(
+                     "127.0.0.1:12345", "http://127.0.0.1:8080/metadata", "tcp",
+                     std::nullopt, "127.0.0.1:50051", ""),
+                 std::runtime_error);
 }
 
 }  // namespace

--- a/mooncake-store/tests/storage_tier_test.cpp
+++ b/mooncake-store/tests/storage_tier_test.cpp
@@ -87,7 +87,7 @@ class StorageTierTest : public ::testing::Test {
 TEST_F(StorageTierTest, StorageTierBasic) {
     // Setup environment for Storage Backend (FilePerKey)
     setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
-           "file_per_key_storage_backend", 1);
+           "bucket_storage_backend", 1);
     setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", "/tmp/mooncake_test_storage",
            1);
 
@@ -148,17 +148,16 @@ TEST_F(StorageTierTest, StorageTierBasic) {
         auto get_result = backend.Get("storage_key");
         ASSERT_TRUE(get_result.has_value());
 
-        // Verify file exists on disk
-        bool found = false;
+        // Verify bucket files exist on disk
+        bool bucket_found = false;
+        bool meta_found = false;
         for (const auto& entry :
              fs::recursive_directory_iterator("/tmp/mooncake_test_storage")) {
-            if (entry.path().filename() == "storage_key") {
-                found = true;
-                break;
-            }
+            if (entry.path().extension() == ".bucket") bucket_found = true;
+            if (entry.path().extension() == ".meta") meta_found = true;
         }
-        EXPECT_TRUE(found)
-            << "File 'storage_key' not found in storage directory";
+        EXPECT_TRUE(bucket_found) << ".bucket file should be created";
+        EXPECT_TRUE(meta_found) << ".meta file should be created";
     }
 
     // Cleanup
@@ -167,11 +166,9 @@ TEST_F(StorageTierTest, StorageTierBasic) {
 
 TEST_F(StorageTierTest, StorageTierUsesConfiguredLocalBufferPool) {
     setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
-           "file_per_key_storage_backend", 1);
+           "bucket_storage_backend", 1);
     setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH",
            "/tmp/mooncake_test_local_buffer_pool", 1);
-    setenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES", "1024", 1);
-
     fs::remove_all("/tmp/mooncake_test_local_buffer_pool");
     fs::create_directories("/tmp/mooncake_test_local_buffer_pool");
 
@@ -181,6 +178,7 @@ TEST_F(StorageTierTest, StorageTierUsesConfiguredLocalBufferPool) {
                 "type": "STORAGE",
                 "capacity": 1073741824,
                 "priority": 5,
+                "staging_buffer_capacity": 1024,
                 "tags": ["ssd"]
             }
         ]
@@ -230,11 +228,9 @@ TEST_F(StorageTierTest, StorageTierUsesConfiguredLocalBufferPool) {
 
 TEST_F(StorageTierTest, StorageTierCapacityCountsUncommittedStaging) {
     setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
-           "file_per_key_storage_backend", 1);
+           "bucket_storage_backend", 1);
     setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH",
            "/tmp/mooncake_test_capacity_accounting", 1);
-    setenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES", "4096", 1);
-
     fs::remove_all("/tmp/mooncake_test_capacity_accounting");
     fs::create_directories("/tmp/mooncake_test_capacity_accounting");
 
@@ -244,6 +240,7 @@ TEST_F(StorageTierTest, StorageTierCapacityCountsUncommittedStaging) {
                 "type": "STORAGE",
                 "capacity": 2048,
                 "priority": 5,
+                "staging_buffer_capacity": 4096,
                 "tags": ["ssd"]
             }
         ]
@@ -281,11 +278,9 @@ TEST_F(StorageTierTest, StorageTierCapacityCountsUncommittedStaging) {
 TEST_F(StorageTierTest,
        StorageHandleKeepsPersistedDataAliveAfterBackendDestruction) {
     setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
-           "file_per_key_storage_backend", 1);
+           "bucket_storage_backend", 1);
     setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH",
            "/tmp/mooncake_test_handle_lifetime", 1);
-    setenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES", "4096", 1);
-
     fs::remove_all("/tmp/mooncake_test_handle_lifetime");
     fs::create_directories("/tmp/mooncake_test_handle_lifetime");
 
@@ -295,6 +290,7 @@ TEST_F(StorageTierTest,
                 "type": "STORAGE",
                 "capacity": 1073741824,
                 "priority": 5,
+                "staging_buffer_capacity": 4096,
                 "tags": ["ssd"]
             }
         ]
@@ -672,7 +668,7 @@ TEST_F(StorageTierTest, AutoEvictionOnCapacityExceeded) {
 // Test concurrent Allocate+Write+Commit and Get on TieredBackend
 TEST_F(StorageTierTest, ConcurrentReadWrite) {
     setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
-           "file_per_key_storage_backend", 1);
+           "bucket_storage_backend", 1);
     setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH",
            "/tmp/mooncake_test_concurrent_rw", 1);
 

--- a/mooncake-store/tests/tiered_backend_test.cpp
+++ b/mooncake-store/tests/tiered_backend_test.cpp
@@ -1159,9 +1159,8 @@ TEST_F(TieredBackendTest, ConcurrentAllocations) {
 
 // Test Interaction between DRAM and Storage Tier
 TEST_F(TieredBackendTest, MultiTierInteraction) {
-    // defaults to file_per_key for this test
     setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
-           "file_per_key_storage_backend", 1);
+           "bucket_storage_backend", 1);
     setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", "/tmp/mooncake_test_multitier",
            1);
     std::filesystem::remove_all("/tmp/mooncake_test_multitier");
@@ -1249,17 +1248,19 @@ TEST_F(TieredBackendTest, MultiTierInteraction) {
     ASSERT_TRUE(get_hot_storage.has_value());
     EXPECT_EQ(get_hot_storage.value()->loc.tier->GetTierId(), storage_id);
 
-    // Flux Storage to verify persistence
+    // Flush Storage to verify persistence
     const_cast<CacheTier*>(backend.GetTier(storage_id))->Flush();
-    // Check file exists for hot_key (since it was copied there)
-    // Filename in FilePerKey is hashed, but we can search.
+    // BucketStorageBackend writes data into bucket files named by bucket ID
+    // (e.g. "7281256148992.bucket"), not per-key files.
+    // Verify that at least one .bucket file was created, which confirms the
+    // flush wrote data to disk.
     bool found = false;
     for (const auto& entry : std::filesystem::recursive_directory_iterator(
              "/tmp/mooncake_test_multitier")) {
-        // key might be sanitized or hashed, but let's check if we find any file
-        // created recently? Actually, FilePerKey backend sanitizes key.
-        // "hot_key" -> "hot_key" usually.
-        if (entry.path().filename() == "hot_key") found = true;
+        if (entry.path().extension() == ".bucket") {
+            found = true;
+            break;
+        }
     }
     EXPECT_TRUE(found) << "hot_key should be present in storage backend";
 }
@@ -1288,12 +1289,11 @@ TEST_F(TieredBackendTest, StoragePrefetch) {
 
     TieredBackend backend;
 
-    // Configure Storage Backend (FilePerKey)
-    setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR", "file_per_key", 1);
-    setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH",
-           "/tmp/mooncake_test_prefetch/file_per_key_dir", 1);
-    std::filesystem::create_directories(
-        "/tmp/mooncake_test_prefetch/file_per_key_dir");
+    setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
+           "bucket_storage_backend", 1);
+    setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", "/tmp/mooncake_test_prefetch",
+           1);
+    std::filesystem::create_directories("/tmp/mooncake_test_prefetch");
 
     ASSERT_TRUE(InitTieredBackendForTest(backend, config).has_value());
 

--- a/mooncake-store/tests/tiered_backend_test.cpp
+++ b/mooncake-store/tests/tiered_backend_test.cpp
@@ -1353,4 +1353,50 @@ TEST_F(TieredBackendTest, StoragePrefetch) {
     std::filesystem::remove_all("/tmp/mooncake_test_prefetch");
 }
 
+// ---- ParseByteSize: capacity accepts human-readable string ----
+
+TEST_F(TieredBackendTest, CapacityAsHumanReadableString) {
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": "1GB",
+                "priority": 10
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    TieredBackend backend;
+    auto result = InitTieredBackendForTest(backend, config);
+    EXPECT_TRUE(result.has_value());
+
+    auto tier_views = backend.GetTierViews();
+    ASSERT_EQ(tier_views.size(), 1u);
+    EXPECT_EQ(tier_views[0].capacity, 1024ULL * 1024 * 1024);
+}
+
+TEST_F(TieredBackendTest, CapacityAsPlainInteger) {
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": 536870912,
+                "priority": 10
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    TieredBackend backend;
+    auto result = InitTieredBackendForTest(backend, config);
+    EXPECT_TRUE(result.has_value());
+
+    auto tier_views = backend.GetTierViews();
+    ASSERT_EQ(tier_views.size(), 1u);
+    EXPECT_EQ(tier_views[0].capacity, 512ULL * 1024 * 1024);
+}
+
 }  // namespace mooncake


### PR DESCRIPTION
## Description

1. Align the startup parameters of setup in store_py.cpp with real_client_main
2. Enhance the ease of use of tiered_backend initialization by adding initial documentation and default templates
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
