### PR TITLE
[TransferEngine] Unify fabric allocator plumbing

### DIFF
--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -1,34 +1,39 @@
 file(GLOB SOURCES "*.cpp")
 include(${CMAKE_CURRENT_LIST_DIR}/../mooncake-common/SetupPython.cmake)
 execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import sys; print([s for s in sys.path if 'packages' in s][0])"
-    OUTPUT_VARIABLE PYTHON_SYS_PATH
-)
+  COMMAND ${PYTHON_EXECUTABLE} -c
+          "import sys; print([s for s in sys.path if 'packages' in s][0])"
+  OUTPUT_VARIABLE PYTHON_SYS_PATH)
 string(STRIP ${PYTHON_SYS_PATH} PYTHON_SYS_PATH)
 
 if("${PYTHON_SYS_PATH}" STREQUAL "")
-    message(FATAL_ERROR "Python path is empty! Please check the python env.")
+  message(FATAL_ERROR "Python path is empty! Please check the python env.")
 endif()
 
-if (WITH_STORE)
-    include_directories("../mooncake-store/include")
-    include_directories("../mooncake-store/include/cachelib_memory_allocator")
+if(WITH_STORE)
+  include_directories("../mooncake-store/include")
+  include_directories("../mooncake-store/include/cachelib_memory_allocator")
 
-    include_directories("../mooncake-store/include/cachelib_memory_allocator/include")
-    include_directories("../mooncake-store/include/cachelib_memory_allocator/fake_include")
+  include_directories(
+    "../mooncake-store/include/cachelib_memory_allocator/include")
+  include_directories(
+    "../mooncake-store/include/cachelib_memory_allocator/fake_include")
 endif()
 
 include_directories("/usr/include/jsoncpp")
 include_directories("./")
 include_directories("../mooncake-transfer-engine/include")
 
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+find_package(
+  Python3
+  COMPONENTS Interpreter Development
+  REQUIRED)
 
 execute_process(
-    COMMAND ${Python3_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"
-    OUTPUT_VARIABLE PYTHON_EXT_SUFFIX
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+  COMMAND ${Python3_EXECUTABLE} -c
+          "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"
+  OUTPUT_VARIABLE PYTHON_EXT_SUFFIX
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
@@ -37,179 +42,161 @@ message("${PYTHON_SYS_PATH}")
 
 set(PYTHON_PACKAGE_NAME "mooncake")
 
-if (WITH_TE)
-    pybind11_add_module(engine ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
-        transfer_engine/transfer_engine_py.cpp
-    )
-    set_target_properties(engine PROPERTIES
-        INSTALL_RPATH "$ORIGIN"
-    )
+if(WITH_TE)
+  pybind11_add_module(engine ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
+                      transfer_engine/transfer_engine_py.cpp)
+  set_target_properties(engine PROPERTIES INSTALL_RPATH "$ORIGIN")
 
-    # Propagate EFA compile definition to engine target
-    if(USE_EFA)
-        target_compile_definitions(engine PRIVATE USE_EFA)
-    endif()
+  # Propagate EFA compile definition to engine target
+  if(USE_EFA)
+    target_compile_definitions(engine PRIVATE USE_EFA)
+  endif()
 
-    target_link_libraries(engine PRIVATE
-        $<TARGET_OBJECTS:rpc_communicator>
-    )
+  target_link_libraries(engine PRIVATE $<TARGET_OBJECTS:rpc_communicator>)
 
-    target_link_libraries(engine PRIVATE ${Python3_LIBRARIES})
-    target_include_directories(engine PRIVATE ${Python3_INCLUDE_DIRS})
-    if (USE_ASCEND_DIRECT)
-        target_link_libraries(engine PUBLIC
-            ascendcl
-            transfer_engine
-            glog::glog
-            gflags::gflags
-        )
-    else()
-        target_link_libraries(engine PUBLIC
-            transfer_engine
-            glog::glog
-            gflags::gflags
-        )
-    endif()
+  target_link_libraries(engine PRIVATE ${Python3_LIBRARIES})
+  target_include_directories(engine PRIVATE ${Python3_INCLUDE_DIRS})
+  if(USE_ASCEND_DIRECT)
+    target_link_libraries(engine PUBLIC ascendcl transfer_engine glog::glog
+                                        gflags::gflags)
+  else()
+    target_link_libraries(engine PUBLIC transfer_engine glog::glog
+                                        gflags::gflags)
+  endif()
 
-    if (USE_CUDA)
-        find_package(CUDAToolkit REQUIRED)
-        target_link_libraries(engine PRIVATE CUDA::cudart)
-    endif()
+  if(USE_CUDA)
+    find_package(CUDAToolkit REQUIRED)
+    target_link_libraries(engine PRIVATE CUDA::cudart)
+  endif()
 endif()
 
-
-set(ALLOCATOR_SO_PATH "${CMAKE_BINARY_DIR}/mooncake-transfer-engine/nvlink-allocator/nvlink_allocator.so")
-set(UBSHMEM_ALLOCATOR_SO_PATH "${CMAKE_BINARY_DIR}/mooncake-transfer-engine/ubshmem-allocator/ubshmem_fabric_allocator.so")
+set(ALLOCATOR_SO_PATH
+    "${CMAKE_BINARY_DIR}/mooncake-transfer-engine/nvlink-allocator/nvlink_allocator.so"
+)
+set(UBSHMEM_ALLOCATOR_SO_PATH
+    "${CMAKE_BINARY_DIR}/mooncake-transfer-engine/ubshmem-allocator/ubshmem_fabric_allocator.so"
+)
 
 if(USE_MNNVL)
-    message(STATUS "USE_MNNVL is enabled, nvlink_allocator.so will be installed in the Python package")
-    install(FILES
-        "${ALLOCATOR_SO_PATH}"
-        DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}
-    )
+  message(
+    STATUS
+      "USE_MNNVL is enabled, nvlink_allocator.so will be installed in the Python package"
+  )
+  install(FILES "${ALLOCATOR_SO_PATH}"
+          DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
 endif()
 
 if(USE_UBSHMEM)
-    message(STATUS "USE_UBSHMEM is enabled, ubshmem_fabric_allocator.so will be installed in the Python package")
-    install(FILES
-        "${UBSHMEM_ALLOCATOR_SO_PATH}"
-        DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}
-    )
+  message(
+    STATUS
+      "USE_UBSHMEM is enabled, ubshmem_fabric_allocator.so will be installed in the Python package"
+  )
+  install(FILES "${UBSHMEM_ALLOCATOR_SO_PATH}"
+          DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
 endif()
 
-if (WITH_STORE)
-    pybind11_add_module(store ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
-        store/store_py.cpp
-        integration_utils.h
-    )
-    set_target_properties(store PROPERTIES
-        INSTALL_RPATH "$ORIGIN"
-    )
-    if (USE_ASCEND_DIRECT)
-        target_link_libraries(store PUBLIC
-            ascendcl
-            transfer_engine
-            glog::glog
-            gflags::gflags
-            mooncake_store
-            cachelib_memory_allocator
-        )
-    else()
-        target_link_libraries(store PUBLIC
-            transfer_engine
-            glog::glog
-            gflags::gflags
-            mooncake_store
-            cachelib_memory_allocator
-        )
-    endif()
+if(WITH_STORE)
+  pybind11_add_module(store ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
+                      store/store_py.cpp integration_utils.h)
+  set_target_properties(store PROPERTIES INSTALL_RPATH "$ORIGIN")
+  if(USE_ASCEND_DIRECT)
+    target_link_libraries(
+      store PUBLIC ascendcl transfer_engine glog::glog gflags::gflags
+                   mooncake_store cachelib_memory_allocator)
+  else()
+    target_link_libraries(
+      store PUBLIC transfer_engine glog::glog gflags::gflags mooncake_store
+                   cachelib_memory_allocator)
+  endif()
 endif()
 
 message("${PYTHON_SYS_PATH}")
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_PACKAGE_NAME}/__init__.py
-    "# Auto-generated by CMake\n"
-)
+     "# Auto-generated by CMake\n")
 
-if (USE_MNNVL)
-    message(STATUS "allocator.py will be installed in the Python package")
-    install(FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/allocator.py"
-        DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}
-    )
+if(USE_MNNVL)
+  message(STATUS "allocator.py will be installed in the Python package")
+  install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/allocator.py"
+          DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
 endif()
 
-if (USE_UBSHMEM)
-    message(STATUS "allocator_ascend_npu.py will be installed in the Python package")
-    install(FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/allocator_ascend_npu.py"
-        DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}
-    )
+if(USE_UBSHMEM)
+  message(
+    STATUS "allocator_ascend_npu.py will be installed in the Python package")
+  install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/allocator_ascend_npu.py"
+          DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
+endif()
+
+if(USE_MNNVL OR USE_UBSHMEM)
+  message(
+    STATUS "fabric_allocator_utils.py will be installed in the Python package")
+  install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/fabric_allocator_utils.py"
+          DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
 endif()
 
 if(USE_INTRA_NVLINK)
-    message(STATUS "USE_INTRA_NVLINK is enabled, IntraNode nvlink is now activated")
+  message(
+    STATUS "USE_INTRA_NVLINK is enabled, IntraNode nvlink is now activated")
 endif()
 
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/store/async_store.py" DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/store/async_store.py"
+        DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
 
-#Install Python scripts from mooncake - wheel / mooncake / directory
-install(FILES
+# Install Python scripts from mooncake - wheel / mooncake / directory
+install(
+  FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/http_metadata_server.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/cli_bench.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/transfer_engine_topology_dump.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_connector_v1.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/vllm_v1_proxy_server.py"
-    DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}
-)
+  DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
 
-if (WITH_STORE)
-    install(FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_store_service.py"
-        "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_config.py"
-        "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/cli.py"
-        DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}
-    )
+if(WITH_STORE)
+  install(
+    FILES
+      "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_store_service.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_config.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/cli.py"
+    DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
 endif()
 
-install(
-    DIRECTORY
-        ${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_PACKAGE_NAME}/
-    DESTINATION
-        ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}
-)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_PACKAGE_NAME}/
+        DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
 
 install(
-    CODE "
+  CODE "
         execute_process(COMMAND chmod 767 \"${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}\")
         execute_process(COMMAND chmod 766 \"${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}/__init__.py\")
-    "
-)
+    ")
 
-if (WITH_STORE)
-    install(TARGETS store DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
+if(WITH_STORE)
+  install(TARGETS store DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
 endif()
 
-if (WITH_TE)
-    install(TARGETS engine DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
-    install(TARGETS asio_shared DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
+if(WITH_TE)
+  install(TARGETS engine DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
+  install(TARGETS asio_shared
+          DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
 endif()
 
-if (WITH_EP)
-    install(
-        DIRECTORY "${EP_PG_STAGING_DIR}/"
-        DESTINATION "${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}"
-        FILES_MATCHING PATTERN "*.so"
-    )
-    install(FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/ep.py"
-        "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_ep_buffer.py"
-        "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/pg.py"
-        DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}
-    )
-    # ep.so / pg.so link against engine.so by that exact bare name.
-    # Create a engine.so -> engine<EXT_SUFFIX> symlink so they can find it.
-    install(CODE "
+if(WITH_EP)
+  install(
+    DIRECTORY "${EP_PG_STAGING_DIR}/"
+    DESTINATION "${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}"
+    FILES_MATCHING
+    PATTERN "*.so")
+  install(
+    FILES
+      "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/ep.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_ep_buffer.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/pg.py"
+    DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
+  # ep.so / pg.so link against engine.so by that exact bare name. Create a
+  # engine.so -> engine<EXT_SUFFIX> symlink so they can find it.
+  install(
+    CODE "
         execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
             \"engine${PYTHON_EXT_SUFFIX}\"
             \"${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME}/engine.so\"

--- a/mooncake-integration/allocator.py
+++ b/mooncake-integration/allocator.py
@@ -3,20 +3,22 @@ import logging
 import os
 import threading
 from importlib import resources
-from typing import Dict, Final, Optional
+from typing import Dict, Final
 from enum import IntEnum
 
 from torch import device as torch_device
 from torch.cuda.memory import CUDAPluggableAllocator
 
+from .fabric_allocator_utils import get_mooncake_so_path, probe_allocator_backend
+
 logger = logging.getLogger(__name__)
 
 
 class MemoryBackend(IntEnum):
-    USE_CUDAMALLOC  = 0
+    USE_CUDAMALLOC = 0
     USE_CUMEMCREATE = 1
-    UNKNOWN         = -1
-    UNSUPPORTED     = -2
+    UNKNOWN = -1
+    UNSUPPORTED = -2
 
 
 class NVLinkAllocator:
@@ -27,65 +29,34 @@ class NVLinkAllocator:
 
     @classmethod
     def _get_so_path(cls) -> str:
-        """Dynamically locate nvlink_allocator.so in the mooncake package installation"""
-        try:
-            # Attempt to locate package resource
-            with resources.path("mooncake", "nvlink_allocator.so") as so_path:
-                if so_path.exists():
-                    return str(so_path)
-        except (ImportError, FileNotFoundError, TypeError):
-            pass
-
-        # Fallback strategy: check in package location via import metadata
-        try:
-            import mooncake
-
-            base_path = os.path.dirname(os.path.abspath(mooncake.__file__))
-            so_path = os.path.join(base_path, "nvlink_allocator.so")
-            if os.path.exists(so_path):
-                return so_path
-        except (ImportError, FileNotFoundError, TypeError):
-            raise ImportError(
-                "SGLANG_MOONCAKE_CUSTOM_MEM_POOL require mooncake-transfer-engine >= 0.3.3.post2."
-            )
+        return get_mooncake_so_path(
+            "nvlink_allocator.so",
+            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL require mooncake-transfer-engine >= 0.3.3.post2.",
+        )
 
     @classmethod
     def _probe_fabric_memory_support(cls, so_path: str) -> MemoryBackend:
-        """
-        Probe whether the system supports fabric memory by calling a C++ function
-        that attempts cuMemCreate with CU_MEM_HANDLE_TYPE_FABRIC.
-        We assume the shared library exports a symbol like:
-            extern "C" MemoryBackendType mc_probe_fabric_support(int device_id);
-        """
+        supported_type = probe_allocator_backend(
+            so_path,
+            "mc_allocator_probe",
+            ctypes.c_int,
+            int(MemoryBackend.UNSUPPORTED),
+        )
         try:
+            backend = MemoryBackend(supported_type)
+        except ValueError:
+            logger.info("Unknown Backend error")
+            return MemoryBackend.UNKNOWN
 
-            lib = ctypes.CDLL(so_path)
-
-            # Try to get the probe function
-            probe_func = lib.mc_probe_fabric_support
-            probe_func.argtypes = [ctypes.c_int]
-            probe_func.restype = ctypes.c_int
-
-            # Use device 0 for probing
-            dev_id = 0
-            supported_type = probe_func(dev_id)
-            if supported_type == MemoryBackend.USE_CUDAMALLOC:
-                logger.info(f"Use CudaMalloc fallback")
-            elif supported_type == MemoryBackend.USE_CUMEMCREATE:
-                logger.info(f"Supports Fabric Memory")
-            else:
-                logger.info("Unknown Backend error")
-            return supported_type
-
-        except AttributeError:
-            logger.warning(
-                "Symbol 'mc_probe_fabric_support' not found in nvlink_allocator.so. "
-                "Assuming fabric memory is NOT supported (you may need to update the library)."
-            )
-            return MemoryBackend.UNSUPPORTED
-        except Exception as e:
-            logger.warning(f"Failed to probe fabric memory support: {e}")
-            return MemoryBackend.UNSUPPORTED
+        if backend == MemoryBackend.USE_CUDAMALLOC:
+            logger.info("Use CudaMalloc fallback")
+        elif backend == MemoryBackend.USE_CUMEMCREATE:
+            logger.info("Supports Fabric Memory")
+        elif backend == MemoryBackend.UNSUPPORTED:
+            logger.info("Allocator backend probing is unsupported")
+        else:
+            logger.info("Unknown Backend error")
+        return backend
 
     @classmethod
     def detect_mem_backend(cls) -> MemoryBackend:
@@ -93,14 +64,15 @@ class NVLinkAllocator:
         if not cls._probe_done:
             with cls._lock:
                 if cls._probe_done:
-                    return
-                so_path = None
+                    return cls._supports_fabric
                 try:
-                    so_path = cls._get_so_path()
-                    # First try dedicated probe function
-                    cls._supports_fabric = cls._probe_fabric_memory_support(so_path)
+                    cls._supports_fabric = cls._probe_fabric_memory_support(
+                        cls._get_so_path()
+                    )
                 except Exception as e:
-                    logger.error(f"Critical error during fabric memory probe setup: {e}")
+                    logger.error(
+                        f"Critical error during fabric memory probe setup: {e}"
+                    )
                     cls._supports_fabric = MemoryBackend.UNSUPPORTED
 
                 cls._probe_done = True
@@ -112,7 +84,7 @@ class NVLinkAllocator:
             if device not in cls._instances:
                 so_path = cls._get_so_path()
                 cls._instances[device] = CUDAPluggableAllocator(
-                    so_path, "mc_nvlink_malloc", "mc_nvlink_free"
+                    so_path, "mc_allocator_malloc", "mc_allocator_free"
                 )
             return cls._instances[device]
 

--- a/mooncake-integration/allocator_ascend_npu.py
+++ b/mooncake-integration/allocator_ascend_npu.py
@@ -1,13 +1,12 @@
 import ctypes
 import logging
-import os
 import threading
-from importlib import resources
 from typing import Dict, Final
-import torch_npu
 
 from torch import device as torch_device
 from torch_npu.npu.memory import NPUPluggableAllocator
+
+from .fabric_allocator_utils import get_mooncake_so_path, probe_allocator_backend
 
 logger = logging.getLogger(__name__)
 
@@ -20,62 +19,26 @@ class UBShmemAllocator:
 
     @classmethod
     def _get_so_path(cls) -> str:
-        """Dynamically locate ubshmem_fabric_allocator.so in the mooncake package installation"""
-        try:
-            # Attempt to locate package resource
-            with resources.path("mooncake", "ubshmem_fabric_allocator.so") as so_path:
-                if so_path.exists():
-                    return str(so_path)
-        except (ImportError, FileNotFoundError, TypeError):
-            pass
-
-        # Fallback strategy: check in package location via import metadata
-        try:
-            import mooncake
-
-            base_path = os.path.dirname(os.path.abspath(mooncake.__file__))
-            so_path = os.path.join(base_path, "ubshmem_fabric_allocator.so")
-            if os.path.exists(so_path):
-                return so_path
-        except (ImportError, FileNotFoundError, TypeError):
-            raise ImportError(
-                "UBShmemAllocator require mooncake-transfer-engine with USE_UBSHMEM enabled."
-            )
+        return get_mooncake_so_path(
+            "ubshmem_fabric_allocator.so",
+            "UBShmemAllocator require mooncake-transfer-engine with USE_UBSHMEM enabled.",
+        )
 
     @classmethod
     def _probe_fabric_memory_support(cls, so_path: str) -> bool:
-        """
-        Probe whether the system supports fabric memory by calling a C++ function
-        that attempts aclrtMallocPhysical with fabric memory support.
-        The shared library exports a symbol like:
-            extern "C" bool mc_probe_ub_fabric_support(int device_id);
-        """
-        try:
-            lib = ctypes.CDLL(so_path)
-
-            # Try to get the probe function
-            probe_func = lib.mc_probe_ub_fabric_support
-            probe_func.argtypes = [ctypes.c_int]
-            probe_func.restype = ctypes.c_bool
-
-            # Use device 0 for probing
-            dev_id = 0
-            supported = probe_func(dev_id)
-            if supported:
-                logger.info(f"Supports Fabric Memory with aclMallocPhysical")
-            else:
-                logger.info("Fabric memory not supported")
-            return supported
-
-        except AttributeError:
-            logger.warning(
-                "Symbol 'mc_probe_ub_fabric_support' not found in ubshmem_fabric_allocator.so. "
-                "Assuming fabric memory is NOT supported (you may need to update the library)."
+        supported = bool(
+            probe_allocator_backend(
+                so_path,
+                "mc_allocator_probe",
+                ctypes.c_int,
+                0,
             )
-            return False
-        except Exception as e:
-            logger.warning(f"Failed to probe fabric memory support: {e}")
-            return False
+        )
+        if supported:
+            logger.info("Supports Fabric Memory with aclMallocPhysical")
+        else:
+            logger.info("Fabric memory not supported")
+        return supported
 
     @classmethod
     def detect_mem_backend(cls) -> bool:
@@ -84,13 +47,14 @@ class UBShmemAllocator:
             with cls._lock:
                 if cls._probe_done:
                     return cls._supports_fabric
-                so_path = None
                 try:
-                    so_path = cls._get_so_path()
-                    # First try dedicated probe function
-                    cls._supports_fabric = cls._probe_fabric_memory_support(so_path)
+                    cls._supports_fabric = cls._probe_fabric_memory_support(
+                        cls._get_so_path()
+                    )
                 except Exception as e:
-                    logger.error(f"Critical error during fabric memory probe setup: {e}")
+                    logger.error(
+                        f"Critical error during fabric memory probe setup: {e}"
+                    )
                     cls._supports_fabric = False
 
                 cls._probe_done = True
@@ -102,6 +66,6 @@ class UBShmemAllocator:
             if device not in cls._instances:
                 so_path = cls._get_so_path()
                 cls._instances[device] = NPUPluggableAllocator(
-                    so_path, "mc_ub_fabric_malloc", "mc_ub_fabric_free"
+                    so_path, "mc_allocator_malloc", "mc_allocator_free"
                 )
             return cls._instances[device]

--- a/mooncake-integration/fabric_allocator_utils.py
+++ b/mooncake-integration/fabric_allocator_utils.py
@@ -1,0 +1,58 @@
+import ctypes
+import logging
+import os
+from importlib import resources
+from typing import Any, TypeVar
+
+logger = logging.getLogger(__name__)
+
+ProbeValue = TypeVar("ProbeValue")
+
+
+def get_mooncake_so_path(so_name: str, import_error_message: str) -> str:
+    try:
+        with resources.path("mooncake", so_name) as so_path:
+            if so_path.exists():
+                return str(so_path)
+    except (ImportError, FileNotFoundError, TypeError):
+        pass
+
+    try:
+        import mooncake
+
+        base_path = os.path.dirname(os.path.abspath(mooncake.__file__))
+        so_path = os.path.join(base_path, so_name)
+        if os.path.exists(so_path):
+            return so_path
+    except (ImportError, FileNotFoundError, TypeError):
+        pass
+
+    raise ImportError(import_error_message)
+
+
+def probe_allocator_backend(
+    so_path: str,
+    probe_symbol: str,
+    restype: Any,
+    unsupported_value: ProbeValue,
+) -> ProbeValue:
+    try:
+        lib = ctypes.CDLL(so_path)
+        probe_func = getattr(lib, probe_symbol)
+        probe_func.argtypes = [ctypes.c_int]
+        probe_func.restype = restype
+        return probe_func(0)
+    except AttributeError:
+        logger.warning(
+            "Symbol '%s' not found in %s. Assuming allocator probing is unsupported.",
+            probe_symbol,
+            os.path.basename(so_path),
+        )
+        return unsupported_value
+    except Exception as exc:
+        logger.warning(
+            "Failed to probe allocator backend from %s: %s",
+            os.path.basename(so_path),
+            exc,
+        )
+        return unsupported_value

--- a/mooncake-transfer-engine/fabric_allocator.cmake
+++ b/mooncake-transfer-engine/fabric_allocator.cmake
@@ -1,0 +1,39 @@
+function(add_fabric_allocator_build_target)
+  set(options)
+  set(oneValueArgs TARGET_NAME BUILD_SCRIPT COMMENT ENABLE_BUILD)
+  set(multiValueArgs BUILD_ARGS)
+  cmake_parse_arguments(FAB "${options}" "${oneValueArgs}" "${multiValueArgs}"
+                        ${ARGN})
+
+  if(NOT FAB_TARGET_NAME)
+    message(
+      FATAL_ERROR
+        "TARGET_NAME is required for add_fabric_allocator_build_target")
+  endif()
+  if(NOT FAB_BUILD_SCRIPT)
+    message(
+      FATAL_ERROR
+        "BUILD_SCRIPT is required for add_fabric_allocator_build_target")
+  endif()
+
+  add_custom_target(${FAB_TARGET_NAME} DEPENDS transfer_engine)
+
+  get_target_property(_include_dirs ${FAB_TARGET_NAME} INCLUDE_DIRECTORIES)
+  if(NOT _include_dirs)
+    set(_include_dirs "")
+  endif()
+  string(REPLACE ";" " " _include_dirs_str "${_include_dirs}")
+
+  if(FAB_ENABLE_BUILD)
+    add_custom_command(
+      TARGET ${FAB_TARGET_NAME}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND bash ${FAB_BUILD_SCRIPT} ${FAB_BUILD_ARGS}
+              ${CMAKE_CURRENT_BINARY_DIR} "${_include_dirs_str}"
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      COMMENT "${FAB_COMMENT}"
+      VERBATIM)
+  endif()
+
+  set_property(TARGET ${FAB_TARGET_NAME} PROPERTY EXCLUDE_FROM_ALL FALSE)
+endfunction()

--- a/mooncake-transfer-engine/nvlink-allocator/CMakeLists.txt
+++ b/mooncake-transfer-engine/nvlink-allocator/CMakeLists.txt
@@ -1,25 +1,27 @@
-# Build nvlink allocator and output to build directory
-
-add_custom_target(build_nvlink_allocator DEPENDS transfer_engine)
-
-get_target_property(INCLUDE_DIRS build_nvlink_allocator INCLUDE_DIRECTORIES)
-string(REPLACE ";" " " INCLUDE_DIRS_STR "${INCLUDE_DIRS}")
+include(${CMAKE_CURRENT_SOURCE_DIR}/../fabric_allocator.cmake)
 
 set(_extra_build_opts "")
-if (USE_HIP)
-    set(_extra_build_opts "--use-hipcc")
-elseif (USE_MUSA)
-    set(_extra_build_opts "--use-mcc")
+if(USE_HIP)
+  list(APPEND _extra_build_opts --use-hipcc)
+elseif(USE_MUSA)
+  list(APPEND _extra_build_opts --use-mcc)
 endif()
 
-if (USE_CUDA OR USE_HIP OR USE_MUSA)
-    add_custom_command(
-        TARGET build_nvlink_allocator
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}
-        COMMAND bash build.sh ${_extra_build_opts} ${CMAKE_CURRENT_BINARY_DIR} "${INCLUDE_DIRS_STR}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMENT "Building nvlink allocator to ${CMAKE_CURRENT_BINARY_DIR}"
-    )
+set(_enable_nvlink_allocator_build FALSE)
+if(USE_CUDA
+   OR USE_HIP
+   OR USE_MUSA)
+  set(_enable_nvlink_allocator_build TRUE)
 endif()
 
-set_property(TARGET build_nvlink_allocator PROPERTY EXCLUDE_FROM_ALL FALSE)
+add_fabric_allocator_build_target(
+  TARGET_NAME
+  build_nvlink_allocator
+  BUILD_SCRIPT
+  ${CMAKE_CURRENT_SOURCE_DIR}/build.sh
+  BUILD_ARGS
+  ${_extra_build_opts}
+  COMMENT
+  "Building nvlink allocator to ${CMAKE_CURRENT_BINARY_DIR}"
+  ENABLE_BUILD
+  ${_enable_nvlink_allocator_build})

--- a/mooncake-transfer-engine/nvlink-allocator/build.sh
+++ b/mooncake-transfer-engine/nvlink-allocator/build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source "$(dirname "$(readlink -f "$0")")/../scripts/allocator_build_common.sh"
+
 # Check for flags
 USE_NVCC=false
 USE_HIPCC=false
@@ -25,27 +27,11 @@ fi
 # Get output directory from command line argument, default to current directory
 OUTPUT_DIR=${1:-.}
 
-# Get include directories from second argument (if provided)
-INCLUDE_LIST=""
-if [ $# -ge 2 ]; then
-    INCLUDE_LIST=${2}
-fi
-
-# Add include directory for cuda_alike.h (relative to build.sh location)
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-INCLUDE_LIST="${INCLUDE_LIST:+${INCLUDE_LIST} }${SCRIPT_DIR}/../include"
-
-# Process include directories into flags
-INCLUDE_FLAGS=""
-if [ -n "$INCLUDE_LIST" ]; then
-    INCLUDE_FLAGS=$(echo "$INCLUDE_LIST" | tr ' ' '\n' | sed 's/^/-I/' | paste -sd' ' -)
-fi
+prepare_allocator_build_env "$OUTPUT_DIR" "${2:-}"
 
 echo "Building nvlink allocator to: $OUTPUT_DIR"
-# Create output directory if it doesn't exist
-mkdir -p "$OUTPUT_DIR"
 
-CPP_FILE=$(dirname $(readlink -f $0))/nvlink_allocator.cpp  # get cpp file path, under same dir with this script
+CPP_FILE="${SCRIPT_DIR}/nvlink_allocator.cpp"
 
 # Choose build command based on flags
 if [ "$CI_BUILD" = true ]; then

--- a/mooncake-transfer-engine/nvlink-allocator/nvlink_allocator.cpp
+++ b/mooncake-transfer-engine/nvlink-allocator/nvlink_allocator.cpp
@@ -19,16 +19,15 @@ static CUresult cuMemCreateTryFabric(CUmemGenericAllocationHandle *handle,
 
 enum class MemoryBackendType { use_cudamalloc, use_cumemcreate, unknown };
 
-extern "C" {
+namespace {
 
-MemoryBackendType mc_probe_fabric_support(int device_id) {
+MemoryBackendType ProbeAllocatorBackend(int device_id) {
     CUdevice dev;
     CUresult res = cuDeviceGet(&dev, device_id);
     if (res != CUDA_SUCCESS) {
         return MemoryBackendType::unknown;
     }
 
-    // Check device attribute first
     int fabric_attr = 0;
     res = cuDeviceGetAttribute(
         &fabric_attr, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, dev);
@@ -40,28 +39,26 @@ MemoryBackendType mc_probe_fabric_support(int device_id) {
     prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
     prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
     prop.location.id = dev;
-    prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;  // require fabric
+    prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
 
     CUmemGenericAllocationHandle handle;
     size_t size = 4096;
 
     res = cuMemCreate(&handle, size, &prop, 0);
-
     if (res == CUDA_SUCCESS) {
-        cuMemRelease(handle);  // success → clean up
+        cuMemRelease(handle);
         return MemoryBackendType::use_cumemcreate;
-    } else {
-        return MemoryBackendType::use_cudamalloc;
     }
+    return MemoryBackendType::use_cudamalloc;
 }
 
-void *mc_nvlink_malloc(ssize_t size, int device, cudaStream_t stream) {
+void *AllocateFabricMemory(ssize_t size, int device, cudaStream_t stream) {
+    (void)stream;
     size_t granularity = 0;
     CUdevice currentDev;
     CUmemAllocationProp prop = {};
     CUmemGenericAllocationHandle handle;
     void *ptr = nullptr;
-    int cudaDev;
     int flag = 0;
     CUresult result = cuDeviceGet(&currentDev, device);
     if (result != CUDA_SUCCESS) {
@@ -98,7 +95,6 @@ void *mc_nvlink_malloc(ssize_t size, int device, cudaStream_t stream) {
         std::cerr << "cuMemGetAllocationGranularity failed: " << result;
         return nullptr;
     }
-    // fix size
     size = (size + granularity - 1) & ~(granularity - 1);
     if (size == 0) size = granularity;
     result = cuMemCreateTryFabric(&handle, size, &prop, 0);
@@ -138,7 +134,11 @@ void *mc_nvlink_malloc(ssize_t size, int device, cudaStream_t stream) {
     return ptr;
 }
 
-void mc_nvlink_free(void *ptr, ssize_t ssize, int device, cudaStream_t stream) {
+void FreeFabricMemory(void *ptr, ssize_t ssize, int device,
+                      cudaStream_t stream) {
+    (void)ssize;
+    (void)device;
+    (void)stream;
     CUmemGenericAllocationHandle handle;
     size_t size = 0;
     if (!ptr) return;
@@ -153,5 +153,34 @@ void mc_nvlink_free(void *ptr, ssize_t ssize, int device, cudaStream_t stream) {
         cuMemAddressFree((CUdeviceptr)ptr, size);
     }
     cuMemRelease(handle);
+}
+
+}  // namespace
+
+extern "C" {
+
+MemoryBackendType mc_probe_fabric_support(int device_id) {
+    return ProbeAllocatorBackend(device_id);
+}
+
+int mc_allocator_probe(int device_id) {
+    return static_cast<int>(ProbeAllocatorBackend(device_id));
+}
+
+void *mc_allocator_malloc(ssize_t size, int device, cudaStream_t stream) {
+    return AllocateFabricMemory(size, device, stream);
+}
+
+void *mc_nvlink_malloc(ssize_t size, int device, cudaStream_t stream) {
+    return mc_allocator_malloc(size, device, stream);
+}
+
+void mc_allocator_free(void *ptr, ssize_t ssize, int device,
+                       cudaStream_t stream) {
+    FreeFabricMemory(ptr, ssize, device, stream);
+}
+
+void mc_nvlink_free(void *ptr, ssize_t ssize, int device, cudaStream_t stream) {
+    mc_allocator_free(ptr, ssize, device, stream);
 }
 }

--- a/mooncake-transfer-engine/scripts/allocator_build_common.sh
+++ b/mooncake-transfer-engine/scripts/allocator_build_common.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+resolve_allocator_script_dir() {
+    cd "$(dirname "$(readlink -f "$0")")" &>/dev/null && pwd
+}
+
+prepare_allocator_build_env() {
+    OUTPUT_DIR=${1:-.}
+    local include_list=${2:-}
+
+    SCRIPT_DIR=$(resolve_allocator_script_dir)
+    include_list="${include_list:+${include_list} }${SCRIPT_DIR}/../include"
+
+    INCLUDE_FLAGS=""
+    if [ -n "$include_list" ]; then
+        INCLUDE_FLAGS=$(printf '%s\n' "$include_list" | tr ' ' '\n' | sed '/^$/d; s/^/-I/' | paste -sd' ' -)
+    fi
+
+    mkdir -p "$OUTPUT_DIR"
+}

--- a/mooncake-transfer-engine/ubshmem-allocator/CMakeLists.txt
+++ b/mooncake-transfer-engine/ubshmem-allocator/CMakeLists.txt
@@ -1,18 +1,16 @@
-# Build ubshmem allocator and output to build directory
+include(${CMAKE_CURRENT_SOURCE_DIR}/../fabric_allocator.cmake)
 
-add_custom_target(build_ubshmem_allocator DEPENDS transfer_engine)
-
-get_target_property(INCLUDE_DIRS build_ubshmem_allocator INCLUDE_DIRECTORIES)
-string(REPLACE ";" " " INCLUDE_DIRS_STR "${INCLUDE_DIRS}")
-
-if (USE_UBSHMEM)
-    add_custom_command(
-        TARGET build_ubshmem_allocator
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}
-        COMMAND bash build.sh ${CMAKE_CURRENT_BINARY_DIR} "${INCLUDE_DIRS_STR}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMENT "Building ubshmem allocator to ${CMAKE_CURRENT_BINARY_DIR}"
-    )
+set(_enable_ubshmem_allocator_build FALSE)
+if(USE_UBSHMEM)
+  set(_enable_ubshmem_allocator_build TRUE)
 endif()
 
-set_property(TARGET build_ubshmem_allocator PROPERTY EXCLUDE_FROM_ALL FALSE)
+add_fabric_allocator_build_target(
+  TARGET_NAME
+  build_ubshmem_allocator
+  BUILD_SCRIPT
+  ${CMAKE_CURRENT_SOURCE_DIR}/build.sh
+  COMMENT
+  "Building ubshmem allocator to ${CMAKE_CURRENT_BINARY_DIR}"
+  ENABLE_BUILD
+  ${_enable_ubshmem_allocator_build})

--- a/mooncake-transfer-engine/ubshmem-allocator/build.sh
+++ b/mooncake-transfer-engine/ubshmem-allocator/build.sh
@@ -2,30 +2,16 @@
 
 set -e
 
+source "$(dirname "$(readlink -f "$0")")/../scripts/allocator_build_common.sh"
+
 # Get output directory from command line argument, default to current directory
 OUTPUT_DIR=${1:-.}
 
-# Get include directories from second argument (if provided)
-INCLUDE_LIST=""
-if [ $# -ge 2 ]; then
-    INCLUDE_LIST=${2}
-fi
-
-# Add include directory for cuda (relative to build.sh location)
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-INCLUDE_LIST="${INCLUDE_LIST:+${INCLUDE_LIST} }${SCRIPT_DIR}/../include"
-
-# Process include directories into flags
-INCLUDE_FLAGS=""
-if [ -n "$INCLUDE_LIST" ]; then
-    INCLUDE_FLAGS=$(echo "$INCLUDE_LIST" | tr ' ' '\n' | sed 's/^/-I/' | paste -sd' ' -)
-fi
+prepare_allocator_build_env "$OUTPUT_DIR" "${2:-}"
 
 echo "Building ubshmem fabric allocator to: $OUTPUT_DIR"
-# Create output directory if it doesn't exist
-mkdir -p "$OUTPUT_DIR"
 
-CPP_FILE=$(dirname $(readlink -f $0))/ubshmem_fabric_allocator.cpp
+CPP_FILE="${SCRIPT_DIR}/ubshmem_fabric_allocator.cpp"
 
 # Detect CPU architecture
 CURRENT_CPU=$(uname -m)

--- a/mooncake-transfer-engine/ubshmem-allocator/ubshmem_fabric_allocator.cpp
+++ b/mooncake-transfer-engine/ubshmem-allocator/ubshmem_fabric_allocator.cpp
@@ -3,9 +3,9 @@
 
 #include <iostream>
 
-extern "C" {
+namespace {
 
-bool mc_probe_ub_fabric_support(int device_id) {
+bool ProbeAllocatorBackend(int device_id) {
     aclError res = aclrtSetDevice(device_id);
     if (res != ACL_ERROR_NONE) {
         std::cerr << "Set device failed: " << device_id << ", result" << res;
@@ -19,25 +19,22 @@ bool mc_probe_ub_fabric_support(int device_id) {
     prop.memAttr = ACL_HBM_MEM_HUGE;
 
     aclrtDrvMemHandle handle;
-    // try to allocate 2M fabric mem
     size_t size = 2 * 1024 * 1024;
 
     res = aclrtMallocPhysical(&handle, size, &prop, 0);
     if (res == ACL_ERROR_NONE) {
-        aclrtFreePhysical(handle);  // success → clean up
+        aclrtFreePhysical(handle);
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
-void *mc_ub_fabric_malloc(ssize_t size, int device) {
+void *AllocateFabricMemory(ssize_t size, int device) {
     size_t granularity = 0;
     aclrtPhysicalMemProp prop = {};
     aclrtDrvMemHandle handle;
     void *ptr = nullptr;
 
-    // Align size to 2M
     const size_t alignment = 2 * 1024 * 1024;
     size = (size + alignment - 1) & ~(alignment - 1);
 
@@ -54,7 +51,6 @@ void *mc_ub_fabric_malloc(ssize_t size, int device) {
         return nullptr;
     }
     uint64_t page_type = 1;
-    // now granularity is reserved to 0
     result =
         aclrtReserveMemAddress(&ptr, size, granularity, nullptr, page_type);
     if (result != ACL_ERROR_NONE) {
@@ -73,7 +69,8 @@ void *mc_ub_fabric_malloc(ssize_t size, int device) {
     return ptr;
 }
 
-void mc_ub_fabric_free(void *ptr, int device) {
+void FreeFabricMemory(void *ptr, int device) {
+    (void)device;
     aclrtDrvMemHandle handle;
     if (!ptr) {
         return;
@@ -83,10 +80,35 @@ void mc_ub_fabric_free(void *ptr, int device) {
         std::cerr << "aclrtMemRetainAllocationHandle failed: " << result
                   << "\n";
         return;
-    } else {
-        (void)aclrtUnmapMem(ptr);
-        (void)aclrtReleaseMemAddress(ptr);
     }
+    (void)aclrtUnmapMem(ptr);
+    (void)aclrtReleaseMemAddress(ptr);
     (void)aclrtFreePhysical(handle);
+}
+
+}  // namespace
+
+extern "C" {
+
+bool mc_probe_ub_fabric_support(int device_id) {
+    return ProbeAllocatorBackend(device_id);
+}
+
+int mc_allocator_probe(int device_id) {
+    return ProbeAllocatorBackend(device_id) ? 1 : 0;
+}
+
+void *mc_allocator_malloc(ssize_t size, int device) {
+    return AllocateFabricMemory(size, device);
+}
+
+void *mc_ub_fabric_malloc(ssize_t size, int device) {
+    return mc_allocator_malloc(size, device);
+}
+
+void mc_allocator_free(void *ptr, int device) { FreeFabricMemory(ptr, device); }
+
+void mc_ub_fabric_free(void *ptr, int device) {
+    mc_allocator_free(ptr, device);
 }
 }

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -25,6 +25,9 @@ rm -f mooncake-wheel/mooncake/*.so
 
 echo "Creating directory structure..."
 
+# Copy shared allocator helper used by both CUDA and Ascend pluggable allocators.
+cp mooncake-integration/fabric_allocator_utils.py mooncake-wheel/mooncake/fabric_allocator_utils.py
+
 # Copy engine.so to mooncake directory (will be imported by transfer module)
 cp build/mooncake-integration/engine.*.so mooncake-wheel/mooncake/engine.so
 


### PR DESCRIPTION
## Summary
Unify the nvlink and ubshmem allocator plumbing across C++, Python packaging, and build entrypoints.

## What changed
- expose a shared allocator probe/malloc/free ABI while keeping the legacy allocator symbols available
- share Python-side allocator `.so` discovery and probe logic between CUDA and Ascend wrappers
- centralize allocator CMake and shell build scaffolding for nvlink and ubshmem allocators
- install/package the shared Python helper in both `make install` and wheel flows

## Validation
- `py_compile` passed for the updated Python allocator wrappers
- `bash -n` passed for the shared allocator shell helper and both allocator build scripts
- direct CUDA build succeeded: `bash mooncake-transfer-engine/nvlink-allocator/build.sh --use-nvcc ...`
- CMake-driven CUDA build succeeded through `build_nvlink_allocator`
- verified exported symbols include both `mc_allocator_*` and `mc_nvlink_*`
