### PR TITLE
[Build] Define BUILD_BENCHMARK option and gate benchmark subdirectories

### DIFF
--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -59,6 +59,7 @@ add_compile_options(-fno-tree-slp-vectorize)
 option(BUILD_EXAMPLES "Build examples" ON)
 
 option(BUILD_UNIT_TESTS "Build unit tests" ON)
+option(BUILD_BENCHMARK "Build benchmarks" ON)
 option(USE_CUDA "option for enabling gpu features for NVIDIA GPU" OFF)
 option(USE_MLU "option for enabling Cambricon MLU features" OFF)
 option(USE_MUSA "option for enabling gpu features for MTHREADS GPU" OFF)

--- a/mooncake-store/CMakeLists.txt
+++ b/mooncake-store/CMakeLists.txt
@@ -37,5 +37,8 @@ add_subdirectory(src)
 
 if (BUILD_UNIT_TESTS)
     add_subdirectory(tests)
+endif()
+
+if (BUILD_BENCHMARK)
     add_subdirectory(benchmarks)
 endif()

--- a/mooncake-transfer-engine/CMakeLists.txt
+++ b/mooncake-transfer-engine/CMakeLists.txt
@@ -73,8 +73,7 @@ endif()
 
 if (USE_TENT)
   add_subdirectory(tent)
-endif()
-
-if (USE_TENT AND BUILD_BENCHMARK)
-  add_subdirectory(benchmark)
+  if (BUILD_BENCHMARK)
+    add_subdirectory(benchmark)
+  endif()
 endif()

--- a/mooncake-transfer-engine/CMakeLists.txt
+++ b/mooncake-transfer-engine/CMakeLists.txt
@@ -73,5 +73,8 @@ endif()
 
 if (USE_TENT)
   add_subdirectory(tent)
+endif()
+
+if (USE_TENT AND BUILD_BENCHMARK)
   add_subdirectory(benchmark)
 endif()


### PR DESCRIPTION
## Summary

`-DBUILD_BENCHMARK=OFF` will now actually skip the benchmark subdirectories that the docs and dependency scripts have been promising. Closes #1385.

## Why this matters

Five files in the repo tell users to pass `-DBUILD_BENCHMARK=OFF`:

- `docs/source/getting_started/build.md:157`
- `docs/source/zh_archive/build.md:152`
- `dependencies.sh:171`
- `scripts/ascend/dependencies_ascend.sh:125`
- `scripts/ascend/dependencies_ascend_installation.sh:146`

But the option was never declared - CMake silently accepted it and built benchmarks anyway. The actual `add_subdirectory(benchmark)` calls were gated on the wrong flags: `mooncake-transfer-engine/CMakeLists.txt` bundled benchmark with `USE_TENT`, and `mooncake-store/CMakeLists.txt` bundled benchmarks with `BUILD_UNIT_TESTS`.

## Testing

`cmake .. -DBUILD_BENCHMARK=OFF` now skips both benchmark subdirectories. `cmake .. -DBUILD_BENCHMARK=ON` (the default) keeps existing behavior.
