### PR TITLE
[TransferEngine] Init CUDA primary context before dmabuf-based mem registration

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -241,6 +241,17 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
         mrMeta.addr = addr;
         mrMeta.mr = ibv_reg_mr(pd_, addr, length, access);
     } else if (memType == CU_MEMORYTYPE_DEVICE) {
+        // Ensure a CUDA context is current — worker threads or callers
+        // from non-CUDA threads may lack one.
+        unsigned int devOrd = 0;
+        cuPointerGetAttribute(&devOrd, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
+                              (CUdeviceptr)addr);
+        CUdevice cuDev;
+        CUcontext cuCtx;
+        cuDeviceGet(&cuDev, devOrd);
+        cuDevicePrimaryCtxRetain(&cuCtx, cuDev);
+        cuCtxSetCurrent(cuCtx);
+
         size_t allocSize;
         result = cuPointerGetAttribute(
             &allocSize, CU_POINTER_ATTRIBUTE_RANGE_SIZE, (CUdeviceptr)addr);
@@ -249,6 +260,7 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
             cuGetErrorString(result, &errStr);
             LOG(ERROR) << "Failed to call cuPointerGetAttribute for "
                        << (uintptr_t)addr << " cuda error=" << errStr;
+            cuDevicePrimaryCtxRelease(cuDev);
             return ERR_CONTEXT;
         }
 
@@ -261,11 +273,13 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
             cuGetErrorString(result, &errStr);
             LOG(ERROR) << "Failed to retrieve dmabuf for " << (uintptr_t)addr
                        << " cuda error=" << errStr;
+            cuDevicePrimaryCtxRelease(cuDev);
             return ERR_CONTEXT;
         }
         mrMeta.addr = addr;
         mrMeta.mr = ibv_reg_dmabuf_mr(pd_, 0 /* offset */, length,
                                       (uintptr_t)addr, dmabuf_fd, access);
+        cuDevicePrimaryCtxRelease(cuDev);
     }
 #else
     mrMeta.addr = addr;


### PR DESCRIPTION
## Description

`cuMemGetHandleForAddressRange` and the `cuPointerGetAttribute` range
queries used by the dmabuf path of `registerMemoryRegionInternal`
require a current CUDA context on the calling thread. When the
function is invoked from a worker thread or any thread that has not
been bound to a CUDA context, which is common for engines that spawn
registration / IO threads on demand, these driver calls fail with
`CUDA_ERROR_INVALID_CONTEXT` and registration aborts before the NIC
ever sees the buffer.

This PR resolves the device ordinal of the pointer, retains the
device's primary context, and sets it current for the duration of
registration. The primary context is released on every exit path so
refcounts stay balanced.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Tested with https://github.com/vllm-project/vllm/pull/40900

- Built on the target system (`WITH_NVIDIA_PEERMEM=OFF`, `USE_CUDA=ON`).
- Pre-fix: registration from a non-CUDA worker thread fails with `CUDA_ERROR_INVALID_CONTEXT`; transfers cannot start.
- Post-fix: registration succeeds; end-to-end RDMA transfers proceed normally on GB200.
- Existing CPU-memory and `WITH_NVIDIA_PEERMEM=ON` paths are untouched.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.

### AI assistance disclosure

Claude is used to prep the PR but I have checked the code and PR.
