### PR TITLE
[TransferEngine] Use allocation base addr for dmabuf-based mem registration

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -259,8 +259,8 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
         // the exact allocation boundaries.
         CUdeviceptr allocBase;
         size_t allocSize;
-        result = cuMemGetAddressRange(&allocBase, &allocSize,
-                                      (CUdeviceptr)addr);
+        result =
+            cuMemGetAddressRange(&allocBase, &allocSize, (CUdeviceptr)addr);
         if (result != CUDA_SUCCESS) {
             const char *errStr;
             cuGetErrorString(result, &errStr);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -252,13 +252,19 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
         cuDevicePrimaryCtxRetain(&cuCtx, cuDev);
         cuCtxSetCurrent(cuCtx);
 
+        // Use cuMemGetAddressRange to get the true allocation base and
+        // size — addr may sit at an offset within a larger cudaMalloc
+        // block (e.g. PyTorch caching allocator packs multiple tensors
+        // into one allocation).  cuMemGetHandleForAddressRange requires
+        // the exact allocation boundaries.
+        CUdeviceptr allocBase;
         size_t allocSize;
-        result = cuPointerGetAttribute(
-            &allocSize, CU_POINTER_ATTRIBUTE_RANGE_SIZE, (CUdeviceptr)addr);
+        result = cuMemGetAddressRange(&allocBase, &allocSize,
+                                      (CUdeviceptr)addr);
         if (result != CUDA_SUCCESS) {
             const char *errStr;
             cuGetErrorString(result, &errStr);
-            LOG(ERROR) << "Failed to call cuPointerGetAttribute for "
+            LOG(ERROR) << "Failed to call cuMemGetAddressRange for "
                        << (uintptr_t)addr << " cuda error=" << errStr;
             cuDevicePrimaryCtxRelease(cuDev);
             return ERR_CONTEXT;
@@ -266,7 +272,7 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
 
         int dmabuf_fd;
         result = cuMemGetHandleForAddressRange(
-            &dmabuf_fd, (CUdeviceptr)addr, allocSize,
+            &dmabuf_fd, allocBase, allocSize,
             CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
         if (result != CUDA_SUCCESS) {
             const char *errStr;
@@ -277,7 +283,8 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
             return ERR_CONTEXT;
         }
         mrMeta.addr = addr;
-        mrMeta.mr = ibv_reg_dmabuf_mr(pd_, 0 /* offset */, length,
+        uint64_t dmabuf_offset = (uintptr_t)addr - allocBase;
+        mrMeta.mr = ibv_reg_dmabuf_mr(pd_, dmabuf_offset, length,
                                       (uintptr_t)addr, dmabuf_fd, access);
         cuDevicePrimaryCtxRelease(cuDev);
     }


### PR DESCRIPTION
## Description

`cuMemGetHandleForAddressRange` requires the exact allocation
boundaries. The current dmabuf path of `registerMemoryRegionInternal`
passes the user-provided `addr` together with
`CU_POINTER_ATTRIBUTE_RANGE_SIZE`, which is wrong whenever `addr`
sits at an offset inside a larger allocation — for example, PyTorch's
caching allocator packs many tensors into a single `cudaMalloc`
block, so the `addr` handed to `registerMemory` is rarely the
allocation base.

In that case the dmabuf-fd lookup either fails outright or maps a
region that does not actually correspond to the user's buffer, and
`ibv_reg_dmabuf_mr` is then called with a hard-coded
`offset = 0 /* offset */`, which makes the resulting MR point at the
wrong bytes even when the lookup happens to succeed.

This PR uses `cuMemGetAddressRange` to obtain the true allocation
base and size, passes those to `cuMemGetHandleForAddressRange`, and
computes `dmabuf_offset = addr - allocBase` for `ibv_reg_dmabuf_mr`.

### Relationship to PR #2019

PR #2019 has also addressed this issue with `cuPointerGetAttribute(CU_POINTER_ATTRIBUTE_RANGE_START_ADDR)`. This is functionally the same as this PR, but I personally think `cuMemGetAddressRange` is more reliable for physical memory related usages such as RDMA.
Also #2019 bundles some other changes to MACA.

Happy to defer to whichever lands first.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Tested with https://github.com/vllm-project/vllm/pull/40900

- Built on a system with `WITH_NVIDIA_PEERMEM=OFF`, `USE_CUDA=ON`.
- Pre-fix: registering a tensor whose address is **not** the
  `cudaMalloc` base (typical PyTorch caching-allocator output)
  produces either a dmabuf lookup failure or an MR that points at
  the wrong bytes, leading to silently-wrong transfers.
- Post-fix: registration succeeds for both base-aligned and offset
  addresses; end-to-end RDMA transfer of arbitrary PyTorch tensors
  on GB200 produces correct data.
- Existing CPU-memory and `WITH_NVIDIA_PEERMEM=ON` paths are
  untouched.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.

### AI assistance disclosure
Claude is used to prep the PR but I have checked the code and PR.