### PR TITLE
[Store][ADD] MC_STORE_TRANSFER_TIMEOUT environment

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -137,11 +137,12 @@ curl -s http://<master_host>:9003/metrics/summary
   - `MC_TE_METRIC` (default `0`/unset): Set to `1` to enable periodic engine metrics logging. **Note:** Not supported when using Transfer Engine TENT.
   - `MC_TE_METRIC_INTERVAL_SECONDS` (default `5`): Positive integer seconds between reports (effective only if metrics enabled).
 
-- Client metrics (enabled by default)
+- Client
   - `MC_STORE_CLIENT_METRIC` (default `1`): Client-side metrics on by default; set `0` to disable entirely.
   - `MC_STORE_CLIENT_METRIC_INTERVAL` (default `0`): Reporting interval in seconds; `0` collects but does not periodically report.
   - `MC_STORE_CLIENT_MIN_PORT` (default `12300`): Minimum local port for client connections. Must be in range 1024–32767 or 61000–65535 (well-known and ephemeral ports are excluded). Falls back to default on invalid input.
   - `MC_STORE_CLIENT_MAX_PORT` (default `14300`): Maximum local port for client connections. Same range constraints as `MC_STORE_CLIENT_MIN_PORT`; must be ≥ `MC_STORE_CLIENT_MIN_PORT`.
+  - `MC_STORE_TRANSFER_TIMEOUT` (default `60` seconds): Timeout for transfer operations. Controls how long a client waits for a transfer to complete before treating a transfer as failed.
 
 - Local memcpy optimization (Store transfer path)
   - `MC_STORE_MEMCPY` (default `0`/false): Set to `1` to prefer local memcpy when source/destination are on the same client.

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -837,6 +837,7 @@ The HTTP metadata server can be configured using the following parameters:
 - MC_STORE_CLIENT_METRIC_INTERVAL: Reporting interval in seconds, default 0 (collects but does not report).
 - MC_STORE_CLIENT_MIN_PORT: Minimum local port for client connections (default 12300). Must be in range 1024–32767 or 61000–65535; falls back to default on invalid input.
 - MC_STORE_CLIENT_MAX_PORT: Maximum local port for client connections (default 14300). Same range constraints; must be ≥ MC_STORE_CLIENT_MIN_PORT.
+- MC_STORE_TRANSFER_TIMEOUT: Timeout for transfer operations (default 60). Controls how long a client waits for a transfer to complete before considering it failed.
 - MC_STORE_USE_HUGEPAGE: Enables huge page support, disabled by default.
 - MC_STORE_HUGEPAGE_SIZE: Specifies the page size of the huge page to use, default 2M.
 - MC_MMAP_ARENA_POOL_SIZE: Size of the pre-allocated arena pool for mmap buffer allocations. Accepts human-readable sizes (e.g., `"8gb"`, `"20gb"`). Providing this variable explicitly enables the arena; when enabled via gflag without an env override, the default pool size is `8gb`. The arena is allocated once at first use and serves subsequent allocations via lock-free atomic bump pointer (~50ns per allocation vs ~1000ns for direct mmap).

--- a/docs/source/zh_archive/mooncake-store.md
+++ b/docs/source/zh_archive/mooncake-store.md
@@ -724,6 +724,7 @@ HTTP 元数据服务器可通过以下参数进行配置：
 - **MC_STORE_CLIENT_METRIC_INTERVAL**: 指标上报间隔(秒), 默认 0(仅收集不上报)
 - **MC_STORE_CLIENT_MIN_PORT**: 客户端使用的最小端口号, 默认 12300。端口范围必须在 1024–32767 或 61000–65535 之间（排除知名端口和临时端口）。无效值将回退为默认值。
 - **MC_STORE_CLIENT_MAX_PORT**: 客户端使用的最大端口号, 默认 14300。范围约束同上；必须 ≥ MC_STORE_CLIENT_MIN_PORT。
+- **MC_STORE_TRANSFER_TIMEOUT**: 传输操作超时时间（秒），默认 60 秒。
 - **MC_STORE_USE_HUGEPAGE**: 启用 hugepage 优化, 默认禁用, 设置为 1/true 启用
 - **MC_STORE_HUGEPAGE_SIZE**: hugepage 页大小, 默认 2M
 

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -331,8 +331,16 @@ void TransferEngineOperationState::wait_for_completion() {
         return;
     }
 
-    const int64_t timeout_milliseconds =
-        GetEnvOr<int64_t>("MC_STORE_TRANSFER_TIMEOUT", 60) * 1000;
+    static const int64_t timeout_milliseconds = [] {
+        constexpr int64_t kDefault = 60;
+        int64_t val = GetEnvOr<int64_t>("MC_STORE_TRANSFER_TIMEOUT", kDefault);
+        if (val <= 0) {
+            LOG(WARNING) << "MC_STORE_TRANSFER_TIMEOUT must be positive, got "
+                         << val << "; using default " << kDefault << "s";
+            val = kDefault;
+        }
+        return val * 1000;
+    }();
 
 #ifdef USE_EVENT_DRIVEN_COMPLETION
     VLOG(1) << "Waiting for transfer engine completion for batch " << batch_id_;

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -9,6 +9,7 @@
 #include "gpu_staging_utils.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
+#include "utils.h"
 
 namespace mooncake {
 
@@ -330,8 +331,8 @@ void TransferEngineOperationState::wait_for_completion() {
         return;
     }
 
-    // 60 seconds
-    constexpr int64_t timeout_milliseconds = 60 * 1000;
+    const int64_t timeout_milliseconds =
+        GetEnvOr<int64_t>("MC_STORE_TRANSFER_TIMEOUT", 60) * 1000;
 
 #ifdef USE_EVENT_DRIVEN_COMPLETION
     VLOG(1) << "Waiting for transfer engine completion for batch " << batch_id_;


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

I verified that the environment variables are applied correctly to both mooncake_client and the SGLang Mooncake HiCache backend, using a wheel built from GitHub CI.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
