### PR TITLE
[TE][FIX]: Typo: PRC -> RPC in min/max ports

### DIFF
--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -301,8 +301,8 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_FORCE_MNNVL` Force to use Multi-Node NVLink as the active transport regardless whether RDMA devices are installed.
 - `MC_INTRA_NVLINK` Enable intra-node NVLINK transport, and cannot be used together with MC_FORCE_MNNVL.
 - `MC_FORCE_TCP` Force to use TCP as the active transport regardless whether RDMA devices are installed.
-- `MC_MIN_PRC_PORT` Specifies the minimum port number for RPC service. The default value is 15000.
-- `MC_MAX_PRC_PORT` Specifies the maximum port number for RPC service. The default value is 17000.
+- `MC_MIN_RPC_PORT` Specifies the minimum port number for RPC service. The default value is 15000.
+- `MC_MAX_RPC_PORT` Specifies the maximum port number for RPC service. The default value is 17000.
 - `MC_PATH_ROUNDROBIN` Use round-robin mode in the RDMA path selection. This may be beneficial for transferring large bulks.
 - `MC_ENDPOINT_STORE_TYPE` Choose FIFO Endpoint Store (`FIFO`) or Sieve Endpoint Store (`SIEVE`), default is `SIEVE`.
 - `MC_TCP_ENABLE_CONNECTION_POOL` Enable TCP Connection Pool to avoid excessive sockets.

--- a/docs/source/zh_archive/transfer-engine.md
+++ b/docs/source/zh_archive/transfer-engine.md
@@ -419,7 +419,7 @@ int init(const std::string &metadata_conn_string,
 - `MC_FORCE_MNNVL` 强制使用 Multi-Node NVLink 作为主要传输方式，无论是否安装了有效的 RDMA 网卡
 - `MC_INTRA_NVLINK` 指定使用Intra-Node NVLink 作为主要传输方式，同时注意该设置不能与MC_FORCE_MNNVL一起使用
 - `MC_FORCE_TCP` 强制使用 TCP 作为主要传输方式，无论是否安装了有效的 RDMA 网卡
-- `MC_MIN_PRC_PORT` 指定 RPC 服务使用的最小端口号。默认值为 15000。
-- `MC_MAX_PRC_PORT` 指定 RPC 服务使用的最大端口号。默认值为 17000。
+- `MC_MIN_RPC_PORT` 指定 RPC 服务使用的最小端口号。默认值为 15000。
+- `MC_MAX_RPC_PORT` 指定 RPC 服务使用的最大端口号。默认值为 17000。
 - `MC_PATH_ROUNDROBIN` 指定 RDMA 路径选择使用 Round Robin 模式，这对于传输大块数据可能有利。
 - `MC_ENDPOINT_STORE_TYPE` 选择 FIFO Endpoint Store (`FIFO`) 或者 Sieve Endpoint Store (`SIEVE`)，模式是 `SIEVE`。

--- a/mooncake-common/include/environ.h
+++ b/mooncake-common/include/environ.h
@@ -40,8 +40,8 @@ class Environ {
         return enable_dest_device_affinity_;
     }
     bool GetUseIpv6() const { return use_ipv6_; }
-    int GetMinPrcPort() const { return min_prc_port_; }
-    int GetMaxPrcPort() const { return max_prc_port_; }
+    int GetMinRpcPort() const { return min_rpc_port_; }
+    int GetMaxRpcPort() const { return max_rpc_port_; }
     int GetEnableParallelRegMr() const { return enable_parallel_reg_mr_; }
     std::string GetEndpointStoreType() const { return endpoint_store_type_; }
     bool GetForceTcp() const { return force_tcp_; }
@@ -90,8 +90,8 @@ class Environ {
     int fragment_ratio_;
     bool enable_dest_device_affinity_;
     bool use_ipv6_;
-    int min_prc_port_;
-    int max_prc_port_;
+    int min_rpc_port_;
+    int max_rpc_port_;
     int enable_parallel_reg_mr_;
     std::string endpoint_store_type_;
     bool force_tcp_;

--- a/mooncake-common/src/environ.cpp
+++ b/mooncake-common/src/environ.cpp
@@ -72,8 +72,8 @@ Environ::Environ() {
     enable_dest_device_affinity_ =
         GetBool("MC_ENABLE_DEST_DEVICE_AFFINITY", false);
     use_ipv6_ = GetBool("MC_USE_IPV6", false);
-    min_prc_port_ = GetInt("MC_MIN_PRC_PORT", 15000);
-    max_prc_port_ = GetInt("MC_MAX_PRC_PORT", 17000);
+    min_rpc_port_ = GetInt("MC_MIN_RPC_PORT", GetInt("MC_MIN_PRC_PORT", 15000));
+    max_rpc_port_ = GetInt("MC_MAX_RPC_PORT", GetInt("MC_MAX_PRC_PORT", 17000));
     enable_parallel_reg_mr_ = GetInt("MC_ENABLE_PARALLEL_REG_MR", -1);
     endpoint_store_type_ = GetString("MC_ENDPOINT_STORE_TYPE", "SIEVE");
     force_tcp_ = GetBool("MC_FORCE_TCP", false);

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -285,8 +285,10 @@ void loadGlobalConfig(GlobalConfig& config) {
         }
     }
 
-    const char* min_port_env = std::getenv("MC_MIN_PRC_PORT");
-    const char* max_port_env = std::getenv("MC_MAX_PRC_PORT");
+    const char* min_port_env = std::getenv("MC_MIN_RPC_PORT");
+    if (!min_port_env) min_port_env = std::getenv("MC_MIN_PRC_PORT");
+    const char* max_port_env = std::getenv("MC_MAX_RPC_PORT");
+    if (!max_port_env) max_port_env = std::getenv("MC_MAX_PRC_PORT");
     {
         int raw_min = min_port_env ? atoi(min_port_env) : config.rpc_min_port;
         int raw_max = max_port_env ? atoi(max_port_env) : config.rpc_max_port;


### PR DESCRIPTION
## Description

Fix typo in transfer engine: MC_MIN_**PRC**_PORT -> **MC_MIN_RPC_PORT**.
Backward compatibility is preserved.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [x] Other

## How Has This Been Tested?

Existing tests completed successfully

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
