### PR TITLE
[PG] Inherit ProcessGroup to fix dynamic getSize() after extend_group_size_to

### DIFF
--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -11,18 +11,18 @@
 #include <sys/types.h>
 #include <torch/torch.h>
 #include <torch/csrc/distributed/c10d/Backend.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <transfer_engine.h>
 
 namespace mooncake {
 
-class MooncakeBackend final : public ::c10d::Backend {
+class MooncakeBackend final : public ::c10d::ProcessGroup {
    public:
-    struct MooncakeBackendOptions final : ::c10d::Backend::Options {
+    struct MooncakeBackendOptions final : torch::CustomClassHolder {
         explicit MooncakeBackendOptions(at::Tensor activeRanks)
-            : Options{"mooncake"}, activeRanks_{activeRanks} {}
+            : activeRanks_{activeRanks} {}
         MooncakeBackendOptions(at::Tensor activeRanks, bool isExtension)
-            : Options{"mooncake"},
-              activeRanks_{activeRanks},
+            : activeRanks_{activeRanks},
               isExtension_{isExtension} {}
 
         ~MooncakeBackendOptions() override = default;
@@ -50,19 +50,8 @@ class MooncakeBackend final : public ::c10d::Backend {
 
     const std::string getBackendName() const override;
 
-    /**
-     * @brief Return the stored Mooncake-specific backend options.
-     *
-     * PyTorch can use this to read Mooncake-specific options from an existing
-     * process group. This is used, for example, create sub-groups that inherit
-     * settings from the parent group.
-     *
-     * @return The stored backend options, or null when the backend was created
-     * without explicit Mooncake options.
-     */
-    c10::intrusive_ptr<::c10d::Backend::Options> getBackendOptions() override {
-        return c10::static_intrusive_pointer_cast<::c10d::Backend::Options>(
-            options_);
+    int getSize() const override {
+        return meta_ ? meta_->size : size_;
     }
 
     // Point-to-point send/recv for torch.distributed P2POp/batch_isend_irecv.

--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -22,8 +22,7 @@ class MooncakeBackend final : public ::c10d::ProcessGroup {
         explicit MooncakeBackendOptions(at::Tensor activeRanks)
             : activeRanks_{activeRanks} {}
         MooncakeBackendOptions(at::Tensor activeRanks, bool isExtension)
-            : activeRanks_{activeRanks},
-              isExtension_{isExtension} {}
+            : activeRanks_{activeRanks}, isExtension_{isExtension} {}
 
         ~MooncakeBackendOptions() override = default;
 
@@ -50,9 +49,7 @@ class MooncakeBackend final : public ::c10d::ProcessGroup {
 
     const std::string getBackendName() const override;
 
-    int getSize() const override {
-        return meta_ ? meta_->size : size_;
-    }
+    int getSize() const override { return meta_ ? meta_->size : size_; }
 
     // Point-to-point send/recv for torch.distributed P2POp/batch_isend_irecv.
     // Only single-tensor ops are supported.

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -99,7 +99,7 @@ MooncakeBackend::MooncakeBackend(
                    distBackendOpts.group_size),
       options_(std::move(options)),
       isCpu_(isCpu) {
-    auto store = distBackendOpts.store;
+    auto store = std::move(distBackendOpts.store);
     const int rank = distBackendOpts.group_rank;
     const int size = distBackendOpts.group_size;
     const auto& globalRanks = distBackendOpts.global_ranks_in_group;

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -95,10 +95,11 @@ class MooncakeP2PWork : public ::c10d::Work {
 MooncakeBackend::MooncakeBackend(
     c10d::DistributedBackendOptions distBackendOpts,
     c10::intrusive_ptr<MooncakeBackendOptions> options, bool isCpu)
-    : Backend(distBackendOpts.group_rank, distBackendOpts.group_size),
+    : ProcessGroup(distBackendOpts.store, distBackendOpts.group_rank,
+                   distBackendOpts.group_size),
       options_(std::move(options)),
       isCpu_(isCpu) {
-    auto store = std::move(distBackendOpts.store);
+    auto store = distBackendOpts.store;
     const int rank = distBackendOpts.group_rank;
     const int size = distBackendOpts.group_size;
     const auto& globalRanks = distBackendOpts.global_ranks_in_group;
@@ -311,7 +312,7 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::send(
     auto tensor = tensors.back();
 
     TORCH_CHECK(meta_->store, "P2P send requires a valid Store.");
-    TORCH_CHECK(dstRank >= 0 && dstRank < size_,
+    TORCH_CHECK(dstRank >= 0 && dstRank < meta_->size,
                 "P2P send: dstRank out of range.");
 
     auto contiguous = tensor.contiguous();
@@ -343,7 +344,7 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::recv(
     auto tensor = tensors.back();
 
     TORCH_CHECK(meta_->store, "P2P recv requires a valid Store.");
-    TORCH_CHECK(srcRank >= 0 && srcRank < size_,
+    TORCH_CHECK(srcRank >= 0 && srcRank < meta_->size,
                 "P2P recv: srcRank out of range.");
 
     auto target = tensor.is_contiguous() ? tensor : tensor.contiguous();

--- a/mooncake-pg/src/pg_py.cpp
+++ b/mooncake-pg/src/pg_py.cpp
@@ -9,7 +9,7 @@ namespace py = pybind11;
 
 namespace mooncake {
 
-c10::intrusive_ptr<c10d::Backend> createMooncakeBackend(
+c10::intrusive_ptr<c10d::ProcessGroup> createMooncakeBackend(
     c10d::DistributedBackendOptions distBackendOpts,
     c10::intrusive_ptr<MooncakeBackend::MooncakeBackendOptions>
         backendOptions) {
@@ -17,7 +17,7 @@ c10::intrusive_ptr<c10d::Backend> createMooncakeBackend(
                                                 std::move(backendOptions));
 }
 
-c10::intrusive_ptr<c10d::Backend> createMooncakeCpuBackend(
+c10::intrusive_ptr<c10d::ProcessGroup> createMooncakeCpuBackend(
     c10d::DistributedBackendOptions distBackendOpts,
     c10::intrusive_ptr<MooncakeBackend::MooncakeBackendOptions>
         backendOptions) {
@@ -39,46 +39,46 @@ __attribute__((constructor)) static void MooncakeBackendConstructor() {
                      /* extended_api */ true, **kwargsCuda);
 }
 
-std::string getPreferredHca(c10::intrusive_ptr<c10d::Backend> backend,
+std::string getPreferredHca(c10::intrusive_ptr<c10d::ProcessGroup> backend,
                             std::string location) {
     auto mooncakeBackend =
         c10::static_intrusive_pointer_cast<MooncakeBackend>(backend);
     return mooncakeBackend->getPreferredHca(location);
 }
 
-at::Tensor getActiveRanks(c10::intrusive_ptr<c10d::Backend> backend) {
+at::Tensor getActiveRanks(c10::intrusive_ptr<c10d::ProcessGroup> backend) {
     auto mooncakeBackend =
         c10::static_intrusive_pointer_cast<MooncakeBackend>(backend);
     return mooncakeBackend->getActiveRanksTensor();
 }
 
-int getNumSyncedRanks(c10::intrusive_ptr<c10d::Backend> backend) {
+int getNumSyncedRanks(c10::intrusive_ptr<c10d::ProcessGroup> backend) {
     auto mooncakeBackend =
         c10::static_intrusive_pointer_cast<MooncakeBackend>(backend);
     return mooncakeBackend->getNumSyncedRanks();
 }
 
-void extendGroupSizeTo(c10::intrusive_ptr<c10d::Backend> backend, int size) {
+void extendGroupSizeTo(c10::intrusive_ptr<c10d::ProcessGroup> backend, int size) {
     auto mooncakeBackend =
         c10::static_intrusive_pointer_cast<MooncakeBackend>(backend);
     mooncakeBackend->extendGroupSizeTo(size);
 }
 
-std::vector<bool> getPeerState(c10::intrusive_ptr<c10d::Backend> backend,
+std::vector<bool> getPeerState(c10::intrusive_ptr<c10d::ProcessGroup> backend,
                                const std::vector<int>& ranks) {
     auto mooncakeBackend =
         c10::static_intrusive_pointer_cast<MooncakeBackend>(backend);
     return mooncakeBackend->getPeerState(ranks);
 }
 
-void recoverRanks(c10::intrusive_ptr<c10d::Backend> backend,
+void recoverRanks(c10::intrusive_ptr<c10d::ProcessGroup> backend,
                   const std::vector<int>& ranks) {
     auto mooncakeBackend =
         c10::static_intrusive_pointer_cast<MooncakeBackend>(backend);
     mooncakeBackend->recoverRanks(ranks);
 }
 
-void joinGroup(c10::intrusive_ptr<c10d::Backend> backend) {
+void joinGroup(c10::intrusive_ptr<c10d::ProcessGroup> backend) {
     auto mooncakeBackend =
         c10::static_intrusive_pointer_cast<MooncakeBackend>(backend);
     mooncakeBackend->joinGroup();

--- a/mooncake-pg/src/pg_py.cpp
+++ b/mooncake-pg/src/pg_py.cpp
@@ -58,7 +58,8 @@ int getNumSyncedRanks(c10::intrusive_ptr<c10d::ProcessGroup> backend) {
     return mooncakeBackend->getNumSyncedRanks();
 }
 
-void extendGroupSizeTo(c10::intrusive_ptr<c10d::ProcessGroup> backend, int size) {
+void extendGroupSizeTo(c10::intrusive_ptr<c10d::ProcessGroup> backend,
+                       int size) {
     auto mooncakeBackend =
         c10::static_intrusive_pointer_cast<MooncakeBackend>(backend);
     mooncakeBackend->extendGroupSizeTo(size);

--- a/mooncake-pg/tests/pg_test_utils.py
+++ b/mooncake-pg/tests/pg_test_utils.py
@@ -148,8 +148,6 @@ def init_mooncake_group(
         "rank": rank,
         "world_size": world_size,
     }
-    if device_type == "cuda":
-        kwargs["device_id"] = device
     if use_pg_options:
         resolved_active_value = (
             1 if is_extension else 0 if active_value is None else active_value
@@ -184,7 +182,7 @@ def init_mooncake_cpu_group(
 def get_mooncake_backend(group=None, device_type: str = "cpu"):
     if group is None:
         group = dist.group.WORLD
-    return group._get_backend(torch.device(device_type))
+    return group
 
 
 @dataclass(slots=True)

--- a/mooncake-pg/tests/test_pg_elastic.py
+++ b/mooncake-pg/tests/test_pg_elastic.py
@@ -18,6 +18,29 @@ from pg_test_utils import (
 BROKEN_RANK = 1
 
 
+def _dynamic_world_size_worker(
+    ctx: MooncakePGWorkerContext,
+) -> None:
+    """Worker for testing that dist.get_world_size() reflects dynamic size after extend."""
+    initial_world_size = ctx.world_size
+    device = ctx.init_group()
+    backend = ctx.get_backend()
+
+    initial_ws = dist.get_world_size()
+    assert initial_ws == initial_world_size, (
+        f"rank {ctx.rank}: initial world_size={initial_ws}, expected {initial_world_size}"
+    )
+
+    pg.extend_group_size_to(backend, initial_world_size + 1)
+
+    new_ws = dist.get_world_size()
+    assert new_ws == initial_world_size + 1, (
+        f"rank {ctx.rank}: after extend world_size={new_ws}, expected {initial_world_size + 1}"
+    )
+
+    ctx.record_result({"initial_ws": initial_ws, "new_ws": new_ws})
+
+
 def _extension_worker(
     ctx: MooncakePGWorkerContext,
     extend_event: mp.Event,
@@ -186,6 +209,17 @@ def _replacement_recovery_worker(
 class _ElasticMixin:
     world_size = 4
     spawn_timeout_s = 30.0
+
+    def test_dynamic_world_size(self) -> None:
+        """Test that dist.get_world_size() returns updated value after extend_group_size_to."""
+        rows = self.spawn_backend_and_collect(
+            _dynamic_world_size_worker,
+            timeout_s=30.0,
+        )
+
+        self.assert_all_ok(rows)
+        for row in rows:
+            self.assertEqual(row["new_ws"], self.world_size + 1)
 
     def test_failed_rank(self) -> None:
         """Test that survivors can continue collective after a rank fails."""

--- a/mooncake-pg/tests/test_pg_elastic.py
+++ b/mooncake-pg/tests/test_pg_elastic.py
@@ -23,7 +23,7 @@ def _dynamic_world_size_worker(
 ) -> None:
     """Worker for testing that dist.get_world_size() reflects dynamic size after extend."""
     initial_world_size = ctx.world_size
-    device = ctx.init_group()
+    ctx.init_group()
     backend = ctx.get_backend()
 
     initial_ws = dist.get_world_size()

--- a/mooncake-wheel/mooncake/mooncake_ep_buffer.py
+++ b/mooncake-wheel/mooncake/mooncake_ep_buffer.py
@@ -71,9 +71,9 @@ class Buffer:
         self.group = group
         self.num_ep_buffer_bytes = num_ep_buffer_bytes
         # Get the index of the closest NIC
-        self.backend = self.group._get_backend(torch.device("cuda"))
+        self.backend = self.group
         preferred_hca = pg.get_preferred_hca(
-            self.backend, f"cuda:{torch.cuda.current_device()}"
+            self.group, f"cuda:{torch.cuda.current_device()}"
         )
         self.runtime = ep.Buffer(
             self.rank, self.group_size, num_ep_buffer_bytes, preferred_hca

--- a/mooncake-wheel/tests/test_mooncake_backend_elastic.py
+++ b/mooncake-wheel/tests/test_mooncake_backend_elastic.py
@@ -41,7 +41,7 @@ def _elastic_worker(rank, num_processes, signals):
         if rank == 0:
             signals["extend"] = 1
 
-        backend = dist.group.WORLD._get_backend(TEST_DEVICE)
+        backend = dist.group.WORLD
         # Extend world
         # Note: `extend_group_size_to` is non-blocking. Blocking will only
         # occur at the first communication if some peers have not yet connected.
@@ -64,6 +64,10 @@ def _elastic_worker(rank, num_processes, signals):
         f"Rank {rank} expected {sum(range(1, num_processes + 1))}, "
         f"get {tensor.item()}"
     )
+    assert dist.get_world_size() == num_processes, (
+        f"Rank {rank}: expected world_size={num_processes} after extension, "
+        f"got {dist.get_world_size()}"
+    )
 
 
 def _deferred_recovery_worker(rank, num_processes, signals):
@@ -75,7 +79,7 @@ def _deferred_recovery_worker(rank, num_processes, signals):
             rank=rank,
             world_size=num_processes,
         )
-        backend = dist.group.WORLD._get_backend(TEST_DEVICE)
+        backend = dist.group.WORLD
         while pg.get_num_synced_ranks(backend) < num_processes:
             time.sleep(0.1)
         if rank == broken_rank:
@@ -124,7 +128,7 @@ def _deferred_recovery_worker(rank, num_processes, signals):
             ),
         )
 
-        backend = dist.group.WORLD._get_backend(TEST_DEVICE)
+        backend = dist.group.WORLD
 
         # Deferred join starts in a local-only mode so collectives stay self-contained.
         tensor = torch.tensor([broken_rank], dtype=torch.int32, device=TEST_DEVICE)


### PR DESCRIPTION
## Description

`dist.get_world_size()` was not reflecting the updated size after `extend_group_size_to()`. The root cause: `MooncakeBackend` inherited `c10d::Backend`, whose `getSize()` is non-virtual, so the override had no effect.

Fix: make `MooncakeBackend` inherit `c10d::ProcessGroup` directly. `ProcessGroup::getSize()` is virtual, so overriding it to return `meta_->size` (the dynamic value) works correctly.

PyTorch's `_new_process_group_helper` has a shortcut: when the factory function returns a `ProcessGroup` subclass, it uses that instance directly as the PG without calling `_register_backend`. This means `_get_backend()` is no longer needed or valid on the returned object — callers that previously called `group._get_backend(device)` now use `group` directly.

## Module

- [x] PyTorch Backend (`mooncake-pg`)
- [x] Python Wheel (`mooncake-wheel`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Verified on k8s pod (`sunxun/mooncake-pg-process-group-test`, 1 GPU, CPU backend):
- 18/18 CPU collective tests pass (`test_pg_collectives.py -k CPU`)
- `test_dynamic_world_size` passes: `dist.get_world_size()` correctly returns `N+1` after `extend_group_size_to(N+1)`
- `test_elastic_extension` passes

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.