### PR TITLE
[TE] fix(efa): request libfabric API 1.18 so device RDMA is the default on all EFA generations

### DIFF
--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -89,9 +89,29 @@ int EfaContext::construct(size_t num_cq_list, size_t max_cqe,
         ;
     hints_->domain_attr->threading = FI_THREAD_SAFE;
 
-    // Get fabric info
+    // Get fabric info.
+    //
+    // Request libfabric API 1.18+ so the EFA provider's
+    // efa_rdm_get_use_device_rdma() takes the "new API" branch and keys
+    // the default for FI_EFA_USE_DEVICE_RDMA on hardware capability
+    // (hw_support) instead of vendor_part_id.  Under the older 1.14
+    // request, the provider's legacy branch hardcoded
+    //   default_val = (vendor_part_id == 0xefa0 || 0xefa1) ? false : true
+    // which silently disabled device RDMA on Nitro v4 EFA (p5/p5e, part
+    // id 0xefa1) while leaving it enabled on Nitro v5+ (p5en and newer).
+    // With device RDMA disabled, fi_write falls back to libfabric's
+    // emulated RDMA data path, and libfabric 2.4.0 has a thread-safety
+    // regression there between fi_av_insert and concurrent fi_cq_read
+    // that segfaults Mooncake once the handshake wave finishes and the
+    // first real transfers start.  Bumping the requested API to 1.18
+    // restores the same default path we already got on newer hardware,
+    // and applications that still want emulated RDMA can opt out with
+    // FI_EFA_USE_DEVICE_RDMA=0.
+    //
+    // 1.18 is from March 2023 (EFA installer 1.26+ ships 1.18 or later);
+    // all Mooncake deployments today run libfabric >> 1.18.
     int ret =
-        fi_getinfo(FI_VERSION(1, 14), nullptr, nullptr, 0, hints_, &fi_info_);
+        fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0, hints_, &fi_info_);
     if (ret) {
         LOG(ERROR) << "fi_getinfo failed for device " << device_name_ << ": "
                    << fi_strerror(-ret);


### PR DESCRIPTION
## Description

Mooncake's EFA `fi_getinfo()` requests `FI_VERSION(1, 14)`. The EFA provider's `efa_rdm_get_use_device_rdma()` keeps a legacy compatibility branch for callers on API < 1.18 that hardcodes the default for `FI_EFA_USE_DEVICE_RDMA` based on `vendor_part_id`: `0xefa0`/`0xefa1` → `false`, everything newer → `true` (see [libfabric `prov/efa/src/rdm/efa_rdm_util.c`](https://github.com/ofiwg/libfabric/blob/main/prov/efa/src/rdm/efa_rdm_util.c)). Under that legacy branch we silently disabled device RDMA on Nitro v4 EFA hardware (`p5.48xlarge`, `p5e.48xlarge` — `vendor_part_id = 0xefa1`) while leaving it enabled on Nitro v5+ (`p5en.48xlarge` and later).

Cross-node `transfer_engine_bench` reproduces the split on our side: `p5en` runs fine out of the box, `p5`/`p5e` segfault inside `libfabric.so` during `fi_cq_read` once the handshake wave finishes and the first real `fi_write`s start. The crashing stack has a concurrent `fi_av_insert` in flight on the same `EfaContext`, and the crashing `memcpy` is in the provider's emulated-RDMA CQE reconstruction path — i.e. a thread-safety regression in libfabric 2.4.0's emulated RDMA data path that only ever runs when device RDMA is off. Customers routinely work around it by exporting `FI_EFA_USE_DEVICE_RDMA=1`; this patch moves that to the default.

Request API 1.18 instead. With the 1.18+ code path the provider's default becomes `hw_support`, which is unconditionally true on every EFA hardware that supports RDMA (every Mooncake target starting from `p4d`). `p5`/`p5e` pick up the same device-RDMA default `p5en` already has, the emulated path is never entered, and the segfault is gone. Applications that still want the emulated path can opt out with `FI_EFA_USE_DEVICE_RDMA=0`.

1.18 is from March 2023 and is the oldest libfabric shipped with EFA installer 1.26 and up; every Mooncake EFA deployment today runs libfabric ≥ 2.0, so bumping the requested API costs nothing in compatibility. None of the other libfabric APIs Mooncake already uses (`fi_av_open`, `fi_endpoint`, `fi_cq_open`, `FI_MR_PROV_KEY`, `FI_HMEM`, `FI_THREAD_SAFE`) have semantic changes between 1.14 and 1.18.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- Reproduced the segfault on two `p5.48xlarge` nodes (libfabric 2.4.0amzn1.0, 32 EFA NICs per node, 8 × H100). Target crashes with SIGSEGV inside `libfabric.so` (`__memcpy_avx_unaligned_erms` called from the EFA provider's emulated CQE reconstruction) within ~4 seconds of the first `fi_write`. Core backtrace shows the crashing thread in `fi_cq_read` and a sibling thread in `fi_av_insert` — the known emulated-RDMA race in 2.4.0.
- With `FI_EFA_USE_DEVICE_RDMA=1` exported, same code runs stably at 377.74 GB/s.
- With this patch and no env set, the same cross-node run is stable at 377.93 GB/s — matches the explicit env case, which confirms the 1.18 API request is routing the provider to the same device-RDMA default.
- `transfer_engine_bench` loopback and `efa_transport_test` unit tests remain green after the bump.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
