### PR TITLE
[PG] Fix P2P regression caused by ProcessGroup inheritance (#2040)

### DIFF
--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -16,6 +16,44 @@
 
 namespace mooncake {
 
+// Lightweight Backend shim that delegates P2P send/recv back to the owning
+// MooncakeBackend.  PyTorch's P2P dispatch (batch_isend_irecv, isend, irecv)
+// requires getBackend() to return a registered c10d::Backend instance.
+// Since MooncakeBackend inherits from ProcessGroup (not Backend), we register
+// this shim in the ProcessGroup's deviceTypeToBackend_ map so that the P2P
+// path can find it.  The shim holds a non-owning pointer to its owner and
+// delegates only the operations that the P2P dispatch path calls (send, recv,
+// getBackendName, supportsCoalescing).
+class MooncakeP2PShim final : public ::c10d::Backend {
+   public:
+    MooncakeP2PShim(MooncakeBackend* owner, c10::DeviceType deviceType)
+        : Backend(owner->getRank(), owner->getSize()),
+          owner_(owner),
+          deviceType_(deviceType) {}
+
+    const std::string getBackendName() const override;
+
+    bool supportsCoalescing() const override { return false; }
+
+    c10::intrusive_ptr<c10d::Work> send(std::vector<at::Tensor>& tensors,
+                                        int dstRank, int tag) override;
+
+    c10::intrusive_ptr<c10d::Work> recv(std::vector<at::Tensor>& tensors,
+                                        int srcRank, int tag) override;
+
+    c10::intrusive_ptr<c10d::Work> recvAnysource(
+        std::vector<at::Tensor>& tensors, int tag) override;
+
+    c10::intrusive_ptr<c10d::Work> barrier(
+        const c10d::BarrierOptions& opts) override;
+
+   private:
+    // Non-owning: the shim is stored in ProcessGroup's backend maps which are
+    // cleared on destruction, and MooncakeBackend always outlives the shim.
+    MooncakeBackend* owner_;
+    c10::DeviceType deviceType_;
+};
+
 class MooncakeBackend final : public ::c10d::ProcessGroup {
    public:
     struct MooncakeBackendOptions final : torch::CustomClassHolder {

--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -30,7 +30,7 @@ class MooncakeBackend;
 // getBackendName, supportsCoalescing).
 class MooncakeP2PShim final : public ::c10d::Backend {
    public:
-    MooncakeP2PShim(MooncakeBackend* owner, c10::DeviceType deviceType);
+    MooncakeP2PShim(MooncakeBackend* owner);
 
     const std::string getBackendName() const override;
 
@@ -52,7 +52,6 @@ class MooncakeP2PShim final : public ::c10d::Backend {
     // Non-owning: the shim is stored in ProcessGroup's backend maps which are
     // cleared on destruction, and MooncakeBackend always outlives the shim.
     MooncakeBackend* owner_;
-    c10::DeviceType deviceType_;
 };
 
 class MooncakeBackend final : public ::c10d::ProcessGroup {

--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -16,6 +16,10 @@
 
 namespace mooncake {
 
+// Forward declaration – MooncakeP2PShim holds a non-owning pointer to
+// MooncakeBackend, which is defined below.
+class MooncakeBackend;
+
 // Lightweight Backend shim that delegates P2P send/recv back to the owning
 // MooncakeBackend.  PyTorch's P2P dispatch (batch_isend_irecv, isend, irecv)
 // requires getBackend() to return a registered c10d::Backend instance.
@@ -26,10 +30,7 @@ namespace mooncake {
 // getBackendName, supportsCoalescing).
 class MooncakeP2PShim final : public ::c10d::Backend {
    public:
-    MooncakeP2PShim(MooncakeBackend* owner, c10::DeviceType deviceType)
-        : Backend(owner->getRank(), owner->getSize()),
-          owner_(owner),
-          deviceType_(deviceType) {}
+    MooncakeP2PShim(MooncakeBackend* owner, c10::DeviceType deviceType);
 
     const std::string getBackendName() const override;
 

--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -30,7 +30,7 @@ class MooncakeBackend;
 // getBackendName, supportsCoalescing).
 class MooncakeP2PShim final : public ::c10d::Backend {
    public:
-    MooncakeP2PShim(MooncakeBackend* owner);
+    explicit MooncakeP2PShim(MooncakeBackend* owner);
 
     const std::string getBackendName() const override;
 

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -301,6 +301,7 @@ MooncakeBackend::MooncakeBackend(
     auto deviceType = isCpu ? c10::DeviceType::CPU : c10::DeviceType::CUDA;
     auto shim = c10::make_intrusive<MooncakeP2PShim>(this, deviceType);
     setBackend(deviceType, BackendType::CUSTOM, shim);
+    setDefaultBackend(BackendType::CUSTOM);
 
     // Increment backend index
     ++backendIndex_;

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -314,10 +314,10 @@ const std::string MooncakeBackend::getBackendName() const { return "mooncake"; }
 // ---- MooncakeP2PShim implementation ----
 
 MooncakeP2PShim::MooncakeP2PShim(MooncakeBackend* owner)
-    : Backend(owner->getRank(), owner->getSize()),
-      owner_(owner) {}
+    : Backend(owner->getRank(), owner->getSize()), owner_(owner) {}
 
-const std::string MooncakeP2PShim::getBackendName() const {
+const std::string
+MooncakeP2PShim::getBackendName() const {
     return "mooncake";
 }
 

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -299,7 +299,7 @@ MooncakeBackend::MooncakeBackend(
     // (batch_isend_irecv → _get_backend → getBackend) can find a registered
     // Backend for this ProcessGroup.  The shim delegates send/recv back to us.
     auto deviceType = isCpu ? c10::DeviceType::CPU : c10::DeviceType::CUDA;
-    auto shim = c10::make_intrusive<MooncakeP2PShim>(this, deviceType);
+    auto shim = c10::make_intrusive<MooncakeP2PShim>(this);
     setBackend(deviceType, BackendType::CUSTOM, shim);
     setDefaultBackend(BackendType::CUSTOM);
 
@@ -313,11 +313,9 @@ const std::string MooncakeBackend::getBackendName() const { return "mooncake"; }
 
 // ---- MooncakeP2PShim implementation ----
 
-MooncakeP2PShim::MooncakeP2PShim(MooncakeBackend* owner,
-                                 c10::DeviceType deviceType)
+MooncakeP2PShim::MooncakeP2PShim(MooncakeBackend* owner)
     : Backend(owner->getRank(), owner->getSize()),
-      owner_(owner),
-      deviceType_(deviceType) {}
+      owner_(owner) {}
 
 const std::string MooncakeP2PShim::getBackendName() const {
     return "mooncake";
@@ -342,8 +340,6 @@ c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::recvAnysource(
 
 c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::barrier(
     const c10d::BarrierOptions& opts) {
-    std::vector<at::Tensor> dummy = {
-        at::empty({1}, at::dtype(at::kFloat).device(at::kCPU))};
     return owner_->barrier(opts);
 }
 

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -312,6 +312,12 @@ const std::string MooncakeBackend::getBackendName() const { return "mooncake"; }
 
 // ---- MooncakeP2PShim implementation ----
 
+MooncakeP2PShim::MooncakeP2PShim(MooncakeBackend* owner,
+                                 c10::DeviceType deviceType)
+    : Backend(owner->getRank(), owner->getSize()),
+      owner_(owner),
+      deviceType_(deviceType) {}
+
 const std::string MooncakeP2PShim::getBackendName() const {
     return "mooncake";
 }

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -295,6 +295,13 @@ MooncakeBackend::MooncakeBackend(
         connection_ctx_->waitUntilAllConnected();
     }
 
+    // Register a lightweight Backend shim so that PyTorch's P2P dispatch path
+    // (batch_isend_irecv → _get_backend → getBackend) can find a registered
+    // Backend for this ProcessGroup.  The shim delegates send/recv back to us.
+    auto deviceType = isCpu ? c10::DeviceType::CPU : c10::DeviceType::CUDA;
+    auto shim = c10::make_intrusive<MooncakeP2PShim>(this, deviceType);
+    setBackend(deviceType, BackendType::CUSTOM, shim);
+
     // Increment backend index
     ++backendIndex_;
 }
@@ -302,6 +309,36 @@ MooncakeBackend::MooncakeBackend(
 MooncakeBackend::~MooncakeBackend() { shutdown(); }
 
 const std::string MooncakeBackend::getBackendName() const { return "mooncake"; }
+
+// ---- MooncakeP2PShim implementation ----
+
+const std::string MooncakeP2PShim::getBackendName() const {
+    return "mooncake";
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::send(
+    std::vector<at::Tensor>& tensors, int dstRank, int tag) {
+    return owner_->send(tensors, dstRank, tag);
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::recv(
+    std::vector<at::Tensor>& tensors, int srcRank, int tag) {
+    return owner_->recv(tensors, srcRank, tag);
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::recvAnysource(
+    std::vector<at::Tensor>& tensors, int tag) {
+    // MooncakeBackend doesn't implement recvAnysource; fall back to
+    // the base class which will raise a clear error.
+    return ::c10d::Backend::recvAnysource(tensors, tag);
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::barrier(
+    const c10d::BarrierOptions& opts) {
+    std::vector<at::Tensor> dummy = {
+        at::empty({1}, at::dtype(at::kFloat).device(at::kCPU))};
+    return owner_->barrier(opts);
+}
 
 c10::intrusive_ptr<c10d::Work> MooncakeBackend::send(
     std::vector<at::Tensor>& tensors, int dstRank, int tag) {

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -316,10 +316,7 @@ const std::string MooncakeBackend::getBackendName() const { return "mooncake"; }
 MooncakeP2PShim::MooncakeP2PShim(MooncakeBackend* owner)
     : Backend(owner->getRank(), owner->getSize()), owner_(owner) {}
 
-const std::string
-MooncakeP2PShim::getBackendName() const {
-    return "mooncake";
-}
+const std::string MooncakeP2PShim::getBackendName() const { return "mooncake"; }
 
 c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::send(
     std::vector<at::Tensor>& tensors, int dstRank, int tag) {


### PR DESCRIPTION
## Problem

After #2040 changed `MooncakeBackend` to inherit from `c10d::ProcessGroup` instead of `c10d::Backend`, all P2P operations (`dist.isend()`, `dist.irecv()`, `dist.batch_isend_irecv()`) broke with:

```
RuntimeError: No backend type associated with device type cuda
```

**Root cause**: In PyTorch's architecture, `ProcessGroup` and `Backend` are **sibling classes** (both inherit `CustomClassHolder`). Collective operations dispatch through `ProcessGroup` virtual methods (vtable), but P2P operations go through `getBackend(deviceType)` which looks up the `deviceTypeToBackend_` map. Since `MooncakeBackend` is now a `ProcessGroup` (not a `Backend`), this map is empty and the lookup fails.

| Path | Dispatch mechanism | Works after #2040? |
|------|--------------------|---------------------|
| Collectives (`all_reduce`, etc.) | `ProcessGroup::allreduce()` virtual → vtable | ✅ Direct virtual dispatch |
| P2P (`isend`/`irecv`/`batch_isend_irecv`) | `_get_backend(device)` → `getBackend()` map lookup | ❌ Map is empty |

## Solution

Introduce `MooncakeP2PShim` — a lightweight `Backend` subclass that holds a non-owning pointer back to its owning `MooncakeBackend` and delegates `send()`/`recv()` to it. The shim is registered in `deviceTypeToBackend_` during MooncakeBackend construction so that `getBackend()` lookups succeed.

```
ProcessGroup (MooncakeBackend)
  └── deviceTypeToBackend_[CPU|CUDA] → MooncakeP2PShim (Backend)
                                            └── owner_ → MooncakeBackend*
                                                  └── send()/recv() delegates back
```

Key design choices:
- **Raw pointer** (`MooncakeBackend*`) avoids `intrusive_ptr` circular reference (shim lives in MooncakeBackend's maps, cleared on destruction)
- **`BackendType::CUSTOM`** for registration (mooncake is not a built-in backend type)
- **`setDefaultBackend(CUSTOM)`** eliminates `hasHooks()` warning about `UNDEFINED` backend type
- **Constructor in `.cpp`** (not header) to avoid forward-declaration issues with `mooncake_worker.cu`

## Testing

All tests run on GPU+RDMA node (8×H20, `MOONCAKE_PGTEST_DEVICE_FILTERS=mlx5_4`):

### mooncake-pg/tests/

| Test | Result |
|------|--------|
| `test_pg_collectives.py` CPU (14) + CUDA (14) | **28 passed** |
| `test_pg_elastic.py` CPU (4) + CUDA (4) | **8 passed** |
| `test_pg_p2p.py` CPU (4) | **4 passed** ✅ (all failed before) |
| `test_pg_p2p.py` CUDA (4) | **2 passed, 2 flaky** (RDMA env issue, not shim) |

### mooncake-wheel/tests/

| Test | Result |
|------|--------|
| `test_mooncake_backend.py` (9 GPU collective) | **9 passed** |
| `test_mooncake_backend_cpu.py` (6 CPU collective) | **6 passed** |
| `test_mooncake_backend_elastic.py` (2 GPU elastic) | **2 passed** |
| `test_mooncake_backend_p2p_cpu.py` (3 CPU P2P) | **3 passed** ✅ (all failed before) |

GPU P2P intermittency (`remote access error` in `P2PProxy::StepRecvTailCommit`) is a pre-existing RDMA environment issue — single-run 2-rank P2P tests always pass.