### PR TITLE
fix(rust): add missing empty check for batch_is_exist

### DIFF
--- a/mooncake-store/rust/src/store.rs
+++ b/mooncake-store/rust/src/store.rs
@@ -533,6 +533,9 @@ impl MooncakeStore {
         keys: &[&str],
     ) -> Result<Vec<bool>, StoreError> {
         let count = keys.len();
+        if count == 0 {
+            return Ok(Vec::new());
+        }
         let key_strings: Vec<CString> = keys
             .iter()
             .map(|k| CString::new(*k))


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
Add early return for empty keys array in batch_is_exist to match
the behavior of other batch methods (batch_put_from, batch_get_into).

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
