### PR TITLE
fix(transfer-engine): add missing empty checks for batch methods

### DIFF
--- a/mooncake-transfer-engine/rust/src/transfer_engine.rs
+++ b/mooncake-transfer-engine/rust/src/transfer_engine.rs
@@ -150,6 +150,9 @@ impl TransferEngine {
         buffer_list: &[BufferEntry],
         location: &str,
     ) -> Result<()> {
+        if buffer_list.is_empty() {
+            return Ok(());
+        }
         let location_c = CString::new(location).map_err(|_| anyhow!("CString::new failed"))?;
         let mut buffer_list_c: Vec<bindings::buffer_entry_t> = vec![];
         let buffer_len_c = buffer_list.len();
@@ -175,6 +178,9 @@ impl TransferEngine {
     }
 
     pub fn unregister_local_memory_batch(&self, buffer_list: &[BufferEntry]) -> Result<()> {
+        if buffer_list.is_empty() {
+            return Ok(());
+        }
         let mut addr_list: Vec<*mut c_void> = buffer_list.iter().map(|entry| entry.addr).collect();
         let addr_len = buffer_list.len();
         let ret = unsafe {
@@ -201,6 +207,9 @@ impl TransferEngine {
         batch_id: BatchID,
         requests: &mut [TransferRequest],
     ) -> Result<()> {
+        if requests.is_empty() {
+            return Ok(());
+        }
         let mut requests_c: Vec<bindings::transfer_request_t> = vec![];
         for i in 0..requests.len() {
             requests_c.push(bindings::transfer_request_t {


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Add early return for empty arrays in register_local_memory_batch,
unregister_local_memory_batch, and submit_transfer to avoid


## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
