### PR TITLE
[TENT] Add reference counting to RdmaTask to prevent UAF

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -47,7 +47,7 @@ class LocalBuffers;
 using RdmaContextSet = std::vector<std::shared_ptr<RdmaContext>>;
 
 struct RdmaSubBatch : public Transport::SubBatch {
-    std::vector<RdmaTask> task_list;
+    std::vector<RdmaTask*> task_list;
     std::vector<RdmaSlice*> slice_chain;
     size_t max_size;
     virtual size_t size() const { return task_list.size(); }

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -109,6 +109,7 @@ static inline void updateSliceStatus(RdmaSlice* slice,
         if (final_st == PENDING) final_st = FAILED;
         __sync_bool_compare_and_swap(&task->status_word, PENDING, final_st);
     }
+    task->deref();
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -39,6 +39,13 @@ struct RdmaSliceList {
     int num_slices = 0;
 };
 
+// Forward declarations
+class RdmaEndPoint;
+struct RdmaTask;
+
+using RdmaSliceStorage = Slab<RdmaSlice>;
+using RdmaTaskStorage = Slab<RdmaTask>;
+
 struct RdmaTask {
     int num_slices;
     Request request;
@@ -47,6 +54,16 @@ struct RdmaTask {
     volatile int success_slices;
     volatile int resolved_slices;
     volatile TransferStatusEnum first_error = PENDING;
+
+    // Reference counting for UAF protection
+    std::atomic<int> ref_count{0};
+
+    void ref() { ref_count.fetch_add(1, std::memory_order_relaxed); }
+    void deref() {
+        if (ref_count.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            RdmaTaskStorage::Get().deallocate(this);
+        }
+    }
 };
 
 class RdmaEndPoint;
@@ -72,8 +89,6 @@ struct RdmaSlice {
     uint64_t enqueue_ts = 0;
     uint64_t submit_ts = 0;
 };
-
-using RdmaSliceStorage = Slab<RdmaSlice>;
 
 static inline void updateSliceStatus(RdmaSlice* slice,
                                      TransferStatusEnum status) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -293,6 +293,10 @@ Status RdmaTransport::freeSubBatch(SubBatchRef& batch) {
     auto rdma_batch = dynamic_cast<RdmaSubBatch*>(batch);
     if (!rdma_batch)
         return Status::InvalidArgument("Invalid RDMA sub-batch" LOC_MARK);
+    for (auto* task : rdma_batch->task_list) {
+        task->deref();
+    }
+    rdma_batch->task_list.clear();
     for (auto slice : rdma_batch->slice_chain) {
         while (slice) {
             auto next = slice->next;
@@ -336,12 +340,13 @@ Status RdmaTransport::submitTransferTasks(
         size_t max_slice_count = 64;
         if (type == MTYPE_CUDA || opcode == Request::WRITE)
             max_slice_count = 32;
-        rdma_batch->task_list.push_back(RdmaTask{});
-        auto& task = rdma_batch->task_list.back();
-        task.request = request;
-        task.num_slices = 0;
-        task.status_word = PENDING;
-        task.transferred_bytes = 0;
+        auto* task = RdmaTaskStorage::Get().allocate();
+        rdma_batch->task_list.push_back(task);
+        task->request = request;
+        task->num_slices = 0;
+        task->status_word = PENDING;
+        task->transferred_bytes = 0;
+        task->ref_count = 0;
 
         const double merge_ratio = 0.25;
         uint64_t base_block = default_block_size;
@@ -371,13 +376,14 @@ Status RdmaTransport::submitTransferTasks(
             slice->source_addr = (char*)request.source + offset;
             slice->target_addr = request.target_offset + offset;
             slice->length = length;
-            slice->task = &task;
+            slice->task = task;
             slice->retry_count = 0;
             slice->ep_weak_ptr.reset();
             slice->word = PENDING;
             slice->next = nullptr;
             slice->enqueue_ts = enqueue_ts;
-            task.num_slices++;
+            task->num_slices++;
+            task->ref();  // Each slice holds a reference to the task
             offset += length;
             int part_id =
                 ((enable_spray ? submit_slices : static_cast<int>(slice_idx)) /
@@ -411,8 +417,8 @@ Status RdmaTransport::getTransferStatus(SubBatchRef batch, int task_id,
     if (task_id < 0 || task_id >= (int)rdma_batch->task_list.size()) {
         return Status::InvalidArgument("Invalid task ID" LOC_MARK);
     }
-    auto& task = rdma_batch->task_list[task_id];
-    status = TransferStatus{task.status_word, task.transferred_bytes};
+    auto* task = rdma_batch->task_list[task_id];
+    status = TransferStatus{task->status_word, task->transferred_bytes};
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -294,7 +294,7 @@ Status RdmaTransport::freeSubBatch(SubBatchRef& batch) {
     if (!rdma_batch)
         return Status::InvalidArgument("Invalid RDMA sub-batch" LOC_MARK);
     for (auto* task : rdma_batch->task_list) {
-        task->deref();
+        task->deref();  // Release batch's reference to the task
     }
     rdma_batch->task_list.clear();
     for (auto slice : rdma_batch->slice_chain) {
@@ -347,6 +347,7 @@ Status RdmaTransport::submitTransferTasks(
         task->status_word = PENDING;
         task->transferred_bytes = 0;
         task->ref_count = 0;
+        task->ref();  // Batch holds a reference to the task
 
         const double merge_ratio = 0.25;
         uint64_t base_block = default_block_size;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -346,7 +346,6 @@ Status RdmaTransport::submitTransferTasks(
         task->num_slices = 0;
         task->status_word = PENDING;
         task->transferred_bytes = 0;
-        task->ref_count = 0;
         task->ref();  // Batch holds a reference to the task
 
         const double merge_ratio = 0.25;


### PR DESCRIPTION
## Description

- Convert RdmaSubBatch::task_list from value to pointer storage
- Add atomic reference counting to RdmaTask with Slab allocator integration
- Properly dereference tasks in freeSubBatch cleanup path
- Each slice holds a reference to its parent task

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
