### PR TITLE
[Store] Add DSA-like allocator benchmark workload

### DIFF
--- a/docs/source/performance/allocator-benchmark-result.md
+++ b/docs/source/performance/allocator-benchmark-result.md
@@ -36,8 +36,9 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 
 **OffsetAllocator (After Optimization)**
 
+
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-|------------|----------------|----------------|-----------|
+| ---------- | -------------- | -------------- | --------- |
 | 32         | 1              | 1              | 544       |
 | 128        | 1              | 1              | 417       |
 | 512        | 1              | 1              | 174       |
@@ -50,10 +51,12 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 8388608    | 1              | 1              | 99        |
 | 33554432   | 1              | 1              | 98        |
 
+
 **OffsetAllocator (Before Optimization)**
 
+
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-|------------|----------------|----------------|-----------|
+| ---------- | -------------- | -------------- | --------- |
 | 32         | 1              | 1              | 539       |
 | 128        | 1              | 1              | 419       |
 | 512        | 1              | 1              | 217       |
@@ -66,12 +69,14 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 8388608    | 1              | 1              | 98        |
 | 33554432   | 1              | 1              | 98        |
 
+
 ### Uniform size, size equals power of 2 +/- 17
 
 **OffsetAllocator (After Optimization)**
 
+
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-|------------|----------------|----------------|-----------|
+| ---------- | -------------- | -------------- | --------- |
 | 15         | 1              | 1              | 568       |
 | 111        | 0.991071       | 0.991071       | 441       |
 | 495        | 0.966797       | 0.966797       | 178       |
@@ -95,10 +100,12 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 8388625    | 0.886721       | 0.886721       | 100       |
 | 33554449   | 0.875          | 0.875          | 100       |
 
+
 **OffsetAllocator (Before Optimization)**
 
+
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-|------------|----------------|----------------|-----------|
+| ---------- | -------------- | -------------- | --------- |
 | 15         | 1              | 1              | 566       |
 | 111        | 0.669866       | 0.710845       | 703       |
 | 495        | 0.665779       | 0.676874       | 238       |
@@ -122,12 +129,14 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 8388625    | 0.60547        | 0.665131       | 121       |
 | 33554449   | 0.546875       | 0.660917       | 120       |
 
+
 ### Uniform size, size equals power of 2 multiply 0.9 or 1.1
 
 **OffsetAllocator (After Optimization)**
 
+
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-|------------|----------------|----------------|-----------|
+| ---------- | -------------- | -------------- | --------- |
 | 28         | 1              | 1              | 543       |
 | 115        | 0.958333       | 0.958333       | 418       |
 | 460        | 0.958332       | 0.958332       | 189       |
@@ -151,10 +160,12 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 9227468    | 0.975391       | 0.975391       | 99        |
 | 36909875   | 0.9625         | 0.9625         | 100       |
 
+
 **OffsetAllocator (Before Optimization)**
 
+
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-|------------|----------------|----------------|-----------|
+| ---------- | -------------- | -------------- | --------- |
 | 28         | 1              | 1              | 539       |
 | 115        | 0.669299       | 0.709245       | 701       |
 | 460        | 0.665825       | 0.677532       | 255       |
@@ -178,6 +189,7 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 9227468    | 0.597266       | 0.666037       | 118       |
 | 36909875   | 0.55           | 0.669564       | 121       |
 
+
 ### Random Size
 
 **OffsetAllocator (After Optimization)**
@@ -199,7 +211,12 @@ avg alloc time: 142.508508 ns/op
 ### Paired KV/Indexer Allocation Benchmark (DSA)
 
 In the DSA scenario, Mooncake Store stores both KV cache objects and indexer objects.
-We evaluated OffsetAllocator under a paired allocation workload using object sizes from GLM-5.1-FP8.
+We evaluated OffsetAllocator under a paired allocation workload using object sizes derived from a GLM-5.1-FP8 DSA serving configuration.
+
+In this configuration, Mooncake Store stores data at the page granularity, where each page contains 64 tokens. Therefore, the object sizes observed by the allocator are the packed page-level sizes rather than the per-token sizes:
+
+- KV cache object size: 3.12 MB
+- Indexer object size: 643 KB
 
 **OffsetAllocator**
 

--- a/docs/source/performance/allocator-benchmark-result.md
+++ b/docs/source/performance/allocator-benchmark-result.md
@@ -36,9 +36,8 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 
 **OffsetAllocator (After Optimization)**
 
-
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-| ---------- | -------------- | -------------- | --------- |
+|------------|----------------|----------------|-----------|
 | 32         | 1              | 1              | 544       |
 | 128        | 1              | 1              | 417       |
 | 512        | 1              | 1              | 174       |
@@ -51,12 +50,10 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 8388608    | 1              | 1              | 99        |
 | 33554432   | 1              | 1              | 98        |
 
-
 **OffsetAllocator (Before Optimization)**
 
-
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-| ---------- | -------------- | -------------- | --------- |
+|------------|----------------|----------------|-----------|
 | 32         | 1              | 1              | 539       |
 | 128        | 1              | 1              | 419       |
 | 512        | 1              | 1              | 217       |
@@ -69,14 +66,12 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 8388608    | 1              | 1              | 98        |
 | 33554432   | 1              | 1              | 98        |
 
-
 ### Uniform size, size equals power of 2 +/- 17
 
 **OffsetAllocator (After Optimization)**
 
-
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-| ---------- | -------------- | -------------- | --------- |
+|------------|----------------|----------------|-----------|
 | 15         | 1              | 1              | 568       |
 | 111        | 0.991071       | 0.991071       | 441       |
 | 495        | 0.966797       | 0.966797       | 178       |
@@ -100,12 +95,10 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 8388625    | 0.886721       | 0.886721       | 100       |
 | 33554449   | 0.875          | 0.875          | 100       |
 
-
 **OffsetAllocator (Before Optimization)**
 
-
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-| ---------- | -------------- | -------------- | --------- |
+|------------|----------------|----------------|-----------|
 | 15         | 1              | 1              | 566       |
 | 111        | 0.669866       | 0.710845       | 703       |
 | 495        | 0.665779       | 0.676874       | 238       |
@@ -129,14 +122,12 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 8388625    | 0.60547        | 0.665131       | 121       |
 | 33554449   | 0.546875       | 0.660917       | 120       |
 
-
 ### Uniform size, size equals power of 2 multiply 0.9 or 1.1
 
 **OffsetAllocator (After Optimization)**
 
-
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-| ---------- | -------------- | -------------- | --------- |
+|------------|----------------|----------------|-----------|
 | 28         | 1              | 1              | 543       |
 | 115        | 0.958333       | 0.958333       | 418       |
 | 460        | 0.958332       | 0.958332       | 189       |
@@ -160,12 +151,10 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 9227468    | 0.975391       | 0.975391       | 99        |
 | 36909875   | 0.9625         | 0.9625         | 100       |
 
-
 **OffsetAllocator (Before Optimization)**
 
-
 | Alloc Size | Min Util Ratio | Avg Util Ratio | Time (ns) |
-| ---------- | -------------- | -------------- | --------- |
+|------------|----------------|----------------|-----------|
 | 28         | 1              | 1              | 539       |
 | 115        | 0.669299       | 0.709245       | 701       |
 | 460        | 0.665825       | 0.677532       | 255       |
@@ -189,7 +178,6 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 | 9227468    | 0.597266       | 0.666037       | 118       |
 | 36909875   | 0.55           | 0.669564       | 121       |
 
-
 ### Random Size
 
 **OffsetAllocator (After Optimization)**
@@ -198,6 +186,14 @@ To address this, we introduced targeted optimizations for uniform-size workloads
 util ratio (min / p99 / p90 / p50 / max / avg):
 0.544250 / 0.713338 / 0.779739 / 0.847867 / 0.952591 / 0.841576
 avg alloc time: 145.575738 ns/op
+```
+
+**OffsetAllocator (Before Optimization)**
+
+```
+util ratio (min / p99 / p90 / p50 / max / avg):
+0.569255 / 0.712076 / 0.781224 / 0.855046 / 0.976057 / 0.848873
+avg alloc time: 142.508508 ns/op
 ```
 
 **OffsetAllocator (Before Optimization)**

--- a/docs/source/performance/allocator-benchmark-result.md
+++ b/docs/source/performance/allocator-benchmark-result.md
@@ -199,7 +199,7 @@ avg alloc time: 142.508508 ns/op
 ### Paired KV/Indexer Allocation Benchmark (DSA)
 
 In the DSA scenario, Mooncake Store stores both KV cache objects and indexer objects.
-We evaluated OffsetAllocator under a paired allocation workload using object sizes from GLM-5.1.
+We evaluated OffsetAllocator under a paired allocation workload using object sizes from GLM-5.1-FP8.
 
 **OffsetAllocator**
 

--- a/docs/source/performance/allocator-benchmark-result.md
+++ b/docs/source/performance/allocator-benchmark-result.md
@@ -198,7 +198,8 @@ avg alloc time: 142.508508 ns/op
 
 ### Paired KV/Indexer Allocation Benchmark (DSA)
 
-In the DSA scenario, Mooncake Store stores both KV cache objects and indexer objects. We evaluated OffsetAllocator under a paired allocation workload with two production-like object sizes.
+In the DSA scenario, Mooncake Store stores both KV cache objects and indexer objects.
+We evaluated OffsetAllocator under a paired allocation workload using object sizes from GLM-5.1.
 
 **OffsetAllocator**
 

--- a/docs/source/performance/allocator-benchmark-result.md
+++ b/docs/source/performance/allocator-benchmark-result.md
@@ -195,3 +195,15 @@ util ratio (min / p99 / p90 / p50 / max / avg):
 0.569255 / 0.712076 / 0.781224 / 0.855046 / 0.976057 / 0.848873
 avg alloc time: 142.508508 ns/op
 ```
+
+### Paired KV/Indexer Allocation Benchmark (DSA)
+
+In the DSA scenario, Mooncake Store stores both KV cache objects and indexer objects. We evaluated OffsetAllocator under a paired allocation workload with two production-like object sizes.
+
+**OffsetAllocator**
+
+```
+util ratio (min / p99 / p90 / p50 / max / avg):
+0.948299 / 0.948765 / 0.949311 / 0.949884 / 0.952491 / 0.950091
+avg alloc time: 232.420141 ns/op
+```

--- a/mooncake-store/benchmarks/allocator_bench.cpp
+++ b/mooncake-store/benchmarks/allocator_bench.cpp
@@ -12,7 +12,7 @@ using namespace mooncake::offset_allocator;
 
 class OffsetAllocatorBenchHelper {
    public:
-    OffsetAllocatorBenchHelper(uint64_t baseAddress, uint32_t poolSize,
+    OffsetAllocatorBenchHelper(uint64_t baseAddress, size_t poolSize,
                                uint32_t maxAllocs)
         : pool_size_(poolSize),
           allocated_size_(0),
@@ -160,13 +160,11 @@ void random_size_allocation_benchmark() {
         static_cast<double>(benchmark_num);
 
     std::sort(util_ratios.begin(), util_ratios.end());
-
     const double min_util = util_ratios.front();
     const double max_util = util_ratios.back();
     const double p50 = util_ratios[util_ratios.size() * 0.50];
     const double p90 = util_ratios[util_ratios.size() * 0.10];
     const double p99 = util_ratios[util_ratios.size() * 0.01];
-
     const double mean_util =
         std::accumulate(util_ratios.begin(), util_ratios.end(), 0.0) /
         util_ratios.size();
@@ -178,8 +176,85 @@ void random_size_allocation_benchmark() {
     std::cout << "avg alloc time: " << avg_time_ns << " ns/op" << std::endl;
 }
 
+template <typename BenchHelper>
+void paired_kv_indexer_allocation_benchmark() {
+    std::cout << std::endl
+              << "=== Paired KV/Indexer Allocation Benchmark (DSA) ==="
+              << std::endl;
+
+    const uint32_t kvcache_size = 3274752;                 // 3,274,752 B
+    const uint32_t indexer_size = 643u * 1024;             // 643 KB
+    const size_t pool_size = 600ull * 1024 * 1024 * 1024;  // 600 GB
+    const int max_per_round = 128;
+    const int warmup_rounds = 5000;
+    const int num_rounds = 500000;
+
+    size_t max_allocs = pool_size / indexer_size + 1024;
+    BenchHelper bench_helper(0x1000, pool_size, max_allocs);
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<int> per_round_dist(1, max_per_round);
+
+    // Warmup
+    for (int round = 0; round < warmup_rounds; round++) {
+        int per_round = per_round_dist(gen);
+        for (int i = 0; i < per_round; i++) {
+            bench_helper.allocate(kvcache_size);
+        }
+        for (int i = 0; i < per_round; i++) {
+            bench_helper.allocate(indexer_size);
+        }
+    }
+
+    std::vector<double> util_ratios;
+    util_ratios.reserve(static_cast<size_t>(num_rounds) * 2 * max_per_round);
+
+    auto start_time = std::chrono::high_resolution_clock::now();
+    for (int round = 0; round < num_rounds; round++) {
+        int per_round = per_round_dist(gen);
+        for (int i = 0; i < per_round; i++) {
+            bench_helper.allocate(kvcache_size);
+            util_ratios.push_back(bench_helper.get_allocated_ratio());
+        }
+        for (int i = 0; i < per_round; i++) {
+            bench_helper.allocate(indexer_size);
+            util_ratios.push_back(bench_helper.get_allocated_ratio());
+        }
+    }
+    auto end_time = std::chrono::high_resolution_clock::now();
+
+    const double avg_time_ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(end_time -
+                                                             start_time)
+            .count() /
+        static_cast<double>(util_ratios.size());
+
+    std::sort(util_ratios.begin(), util_ratios.end());
+    const double min_util = util_ratios.front();
+    const double max_util = util_ratios.back();
+    const double p50 = util_ratios[util_ratios.size() * 0.50];
+    const double p90 = util_ratios[util_ratios.size() * 0.10];
+    const double p99 = util_ratios[util_ratios.size() * 0.01];
+    const double mean_util =
+        std::accumulate(util_ratios.begin(), util_ratios.end(), 0.0) /
+        util_ratios.size();
+
+    std::cout << std::fixed << std::setprecision(6);
+    std::cout << "kvcache size: " << kvcache_size
+              << " B, indexer size: " << indexer_size << " B" << std::endl;
+    std::cout << "pool size: " << (pool_size / (1024.0 * 1024 * 1024))
+              << " GB, warmup rounds: " << warmup_rounds
+              << ", benchmark rounds: " << num_rounds << std::endl;
+    std::cout << "util ratio (min / p99 / p90 / p50 / max / avg): " << min_util
+              << " / " << p99 << " / " << p90 << " / " << p50 << " / "
+              << max_util << " / " << mean_util << std::endl;
+    std::cout << "avg alloc time: " << avg_time_ns << " ns/op" << std::endl;
+}
+
 int main() {
     std::cout << "=== OffsetAllocator Benchmark ===" << std::endl;
     uniform_size_allocation_benchmark<OffsetAllocatorBenchHelper>();
     random_size_allocation_benchmark<OffsetAllocatorBenchHelper>();
+    paired_kv_indexer_allocation_benchmark<OffsetAllocatorBenchHelper>();
 }


### PR DESCRIPTION
## Description

This PR adds a DSA-like workload to the OffsetAllocator benchmark and updates the allocator performance documentation.

The new benchmark evaluates paired KV cache and indexer allocation using production-like object sizes:

- KV cache object size: 3,274,752 B
- Indexer object size: 658,432 B

This workload is intended to better reflect the allocation pattern in DSA scenarios where KV cache objects and indexer objects are stored in the allocator-managed space.

Benchmark result:

```
=== Paired KV/Indexer Allocation Benchmark (DSA) ===
kvcache size: 3274752 B, indexer size: 658432 B
pool size: 600.000000 GB, warmup rounds: 5000, benchmark rounds: 500000
util ratio (min / p99 / p90 / p50 / max / avg):
0.948299 / 0.948765 / 0.949311 / 0.949884 / 0.952491 / 0.950091
avg alloc time: 232.420141 ns/op
```
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

Ran the allocator benchmark:

```bash
./mooncake-store/benchmarks/allocator_bench
```

The DSA benchmark result is:

```text
util ratio (min / p99 / p90 / p50 / max / avg):
0.948299 / 0.948765 / 0.949311 / 0.949884 / 0.952491 / 0.950091
avg alloc time: 232.420141 ns/op
```

Ran local checks:

```bash
git diff --check

pre-commit run --files \
  mooncake-store/benchmarks/allocator_bench.cpp \
  docs/source/performance/allocator-benchmark-result.md
```

All pre-commit checks passed.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
