### PR TITLE
[TENT] Fix batch getTransferStatus premature FAILED aggregation 

### DIFF
--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1398,7 +1398,9 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
     overall_status.s = PENDING;
     overall_status.transferred_bytes = 0;
     size_t success_tasks = 0;
+    size_t failed_tasks = 0;
     size_t total_tasks = 0;
+    TransferStatusEnum worst_failure = PENDING;
     for (size_t task_id = 0; task_id < batch->task_list.size(); ++task_id) {
         auto& task = batch->task_list[task_id];
         if (task.derived) continue;  // This task is performed by other tasks
@@ -1409,7 +1411,8 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
                 success_tasks++;
                 overall_status.transferred_bytes += task.request.length;
             } else {
-                overall_status.s = task.status;
+                failed_tasks++;
+                worst_failure = task.status;
             }
             continue;
         }
@@ -1419,7 +1422,8 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
         } else {
             if (task.type == UNSPEC) {
                 task.status = FAILED;
-                overall_status.s = FAILED;
+                failed_tasks++;
+                worst_failure = FAILED;
                 continue;
             }
             auto& transport = transport_list_[task.type];
@@ -1436,7 +1440,7 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
 
         // Attempt failover before status aggregation so that a
         // successfully resubmitted task appears as PENDING and does not
-        // overwrite a permanent FAILED from another task in the batch.
+        // latch the batch to a terminal state while retries are in-flight.
         if (task_status.s == FAILED &&
             resubmitTransferTask(batch, task_id).ok()) {
             task.status = PENDING;
@@ -1447,14 +1451,23 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
             success_tasks++;
             overall_status.transferred_bytes += task_status.transferred_bytes;
         } else if (task_status.s != PENDING) {
-            overall_status.s = task_status.s;
+            failed_tasks++;
+            worst_failure = task_status.s;
         }
 
         // Record metrics when task transitions to terminal state
         recordTaskCompletionMetrics(batch->task_list[task_id], prev_status,
                                     task_status.s);
     }
-    if (success_tasks == total_tasks) overall_status.s = COMPLETED;
+    // Determine overall status: COMPLETED only when all succeed; FAILED only
+    // when all tasks are terminal (no in-flight work) and at least one failed;
+    // otherwise PENDING (some tasks still running).
+    if (success_tasks == total_tasks) {
+        overall_status.s = COMPLETED;
+    } else if (success_tasks + failed_tasks == total_tasks) {
+        overall_status.s = worst_failure;
+    }
+    // else: some tasks still PENDING → overall_status.s stays PENDING
     CHECK_STATUS(maybeFireSubmitHooks(batch, overall_status.s == COMPLETED));
     return Status::OK();
 }

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1401,6 +1401,13 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
     size_t failed_tasks = 0;
     size_t total_tasks = 0;
     TransferStatusEnum worst_failure = PENDING;
+    auto isWorse = [](TransferStatusEnum cur, TransferStatusEnum best) {
+        static const std::unordered_map<TransferStatusEnum, int> severity = {
+            {INITIAL, 0},  {PENDING, 0}, {COMPLETED, 0}, {INVALID, 1},
+            {CANCELED, 2}, {TIMEOUT, 3}, {FAILED, 4},
+        };
+        return severity.at(cur) > severity.at(best);
+    };
     for (size_t task_id = 0; task_id < batch->task_list.size(); ++task_id) {
         auto& task = batch->task_list[task_id];
         if (task.derived) continue;  // This task is performed by other tasks
@@ -1412,7 +1419,8 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
                 overall_status.transferred_bytes += task.request.length;
             } else {
                 failed_tasks++;
-                worst_failure = task.status;
+                if (isWorse(task.status, worst_failure))
+                    worst_failure = task.status;
             }
             continue;
         }
@@ -1423,7 +1431,7 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
             if (task.type == UNSPEC) {
                 task.status = FAILED;
                 failed_tasks++;
-                worst_failure = FAILED;
+                if (isWorse(FAILED, worst_failure)) worst_failure = FAILED;
                 continue;
             }
             auto& transport = transport_list_[task.type];
@@ -1452,7 +1460,8 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
             overall_status.transferred_bytes += task_status.transferred_bytes;
         } else if (task_status.s != PENDING) {
             failed_tasks++;
-            worst_failure = task_status.s;
+            if (isWorse(task_status.s, worst_failure))
+                worst_failure = task_status.s;
         }
 
         // Record metrics when task transitions to terminal state

--- a/mooncake-transfer-engine/tent/tests/failover_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/failover_test.cpp
@@ -15,7 +15,6 @@
 #include <gtest/gtest.h>
 
 #include <memory>
-#include <set>
 #include <string>
 
 #include "tent/common/config.h"
@@ -118,21 +117,11 @@ TEST(FailoverConfigTest, ZeroDisablesFailover) {
 // verify the enum values are well-defined and usable in switch)
 // ---------------------------------------------------------------------------
 
-TEST(TransportTypeTest, AllEnumValuesDistinct) {
-    // Verify no accidental collisions in the enum
-    std::set<int> seen;
-    TransportType types[] = {RDMA,    MNNVL, SHM,          NVLINK, GDS,
-                             IOURING, TCP,   AscendDirect, UNSPEC};
-    for (auto t : types) {
-        EXPECT_TRUE(seen.insert(static_cast<int>(t)).second)
-            << "Duplicate TransportType value: " << static_cast<int>(t);
-    }
-}
-
-TEST(TransportTypeTest, SupportedCount) {
-    // kSupportedTransportTypes should cover all types except UNSPEC
-    EXPECT_EQ(kSupportedTransportTypes, 8u);
-    EXPECT_EQ(static_cast<int>(UNSPEC), 8);
+TEST(TransportTypeTest, UnspecIsSentinel) {
+    // UNSPEC must be the last enum value so that types [0, UNSPEC) are the
+    // valid transport types and kSupportedTransportTypes == (int)UNSPEC.
+    EXPECT_GT(kSupportedTransportTypes, 0);
+    EXPECT_EQ(kSupportedTransportTypes, static_cast<int>(UNSPEC));
 }
 
 // ---------------------------------------------------------------------------

--- a/mooncake-transfer-engine/tent/tests/failover_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/failover_test.cpp
@@ -214,6 +214,92 @@ TEST(FailoverStateMachineTest, StagingBypassesPriorityIncrement) {
     EXPECT_EQ(task.xport_priority, 0);  // Should NOT have incremented
 }
 
+// ---------------------------------------------------------------------------
+// Batch status aggregation correctness
+// ---------------------------------------------------------------------------
+
+// Verifies the invariant: a batch with one permanently-FAILED task and
+// another still-PENDING task must report PENDING (not FAILED) overall,
+// because the PENDING task may still complete.  The old code latched
+// overall_status to FAILED as soon as any task was terminal.
+TEST(BatchStatusAggregationTest, PendingTaskPreventsEarlyBatchFailure) {
+    // Two tasks in a batch scenario (simulated):
+    // Task A: permanently FAILED (exhausted failover budget)
+    // Task B: still PENDING (retrying on secondary transport)
+    //
+    // Expected overall status: PENDING (not FAILED), because Task B is
+    // still in-flight.  Only once Task B reaches a terminal state should
+    // the batch become terminal.
+
+    struct MockTask {
+        TransferStatusEnum status{PENDING};
+        bool derived{false};
+        size_t length{1024};
+    };
+
+    auto aggregateStatus = [](const std::vector<MockTask>& tasks)
+        -> TransferStatusEnum {
+        size_t success_tasks = 0;
+        size_t failed_tasks = 0;
+        size_t total_tasks = 0;
+        for (auto& t : tasks) {
+            if (t.derived) continue;
+            total_tasks++;
+            if (t.status == COMPLETED)
+                success_tasks++;
+            else if (t.status != PENDING)
+                failed_tasks++;
+        }
+        if (success_tasks == total_tasks) return COMPLETED;
+        if (success_tasks + failed_tasks == total_tasks) return FAILED;
+        return PENDING;
+    };
+
+    // Case 1: one FAILED + one PENDING → overall PENDING
+    {
+        std::vector<MockTask> tasks = {{FAILED, false, 1024},
+                                       {PENDING, false, 1024}};
+        EXPECT_EQ(aggregateStatus(tasks), PENDING);
+    }
+
+    // Case 2: one FAILED + one COMPLETED → overall FAILED
+    {
+        std::vector<MockTask> tasks = {{FAILED, false, 1024},
+                                       {COMPLETED, false, 1024}};
+        EXPECT_EQ(aggregateStatus(tasks), FAILED);
+    }
+
+    // Case 3: all COMPLETED → overall COMPLETED
+    {
+        std::vector<MockTask> tasks = {{COMPLETED, false, 1024},
+                                       {COMPLETED, false, 1024}};
+        EXPECT_EQ(aggregateStatus(tasks), COMPLETED);
+    }
+
+    // Case 4: all PENDING → overall PENDING
+    {
+        std::vector<MockTask> tasks = {{PENDING, false, 1024},
+                                       {PENDING, false, 1024}};
+        EXPECT_EQ(aggregateStatus(tasks), PENDING);
+    }
+
+    // Case 5: derived tasks are skipped
+    {
+        std::vector<MockTask> tasks = {{FAILED, false, 1024},
+                                       {FAILED, true, 1024},  // derived: skip
+                                       {PENDING, false, 1024}};
+        EXPECT_EQ(aggregateStatus(tasks), PENDING);
+    }
+
+    // Case 6: all non-derived are terminal with at least one failure
+    {
+        std::vector<MockTask> tasks = {{COMPLETED, false, 1024},
+                                       {FAILED, true, 1024},  // derived: skip
+                                       {FAILED, false, 1024}};
+        EXPECT_EQ(aggregateStatus(tasks), FAILED);
+    }
+}
+
 }  // namespace
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/failover_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/failover_test.cpp
@@ -226,8 +226,8 @@ TEST(BatchStatusAggregationTest, PendingTaskPreventsEarlyBatchFailure) {
         size_t length{1024};
     };
 
-    auto aggregateStatus = [](const std::vector<MockTask>& tasks)
-        -> TransferStatusEnum {
+    auto aggregateStatus =
+        [](const std::vector<MockTask>& tasks) -> TransferStatusEnum {
         size_t success_tasks = 0;
         size_t failed_tasks = 0;
         size_t total_tasks = 0;


### PR DESCRIPTION
  ## Description

  Fix a bug where `getTransferStatus` prematurely reported a batch as FAILED when one task failed but other task(s) were still in-flight (PENDING). The root cause was that `overall_status.s` was overwritten by each task's status in iteration order, so the last non-PENDING task "won" regardless of whether other tasks
  were still running.

  Also replaces two hardcoded `TransportType` tests (`AllEnumValuesDistinct` and `SupportedCount`) with a dynamic `UnspecIsSentinel` test that doesn't need updating when new transport types are added.

  ## Module

  - [x] Transfer Engine (`mooncake-transfer-engine`)

  ## Type of Change

  - [x] Bug fix

  ## How Has This Been Tested?

  - `tent_failover_test` — new `BatchStatusAggregationTest` (6 cases covering FAILED+PENDING, FAILED+COMPLETED, all-COMPLETED, all-PENDING, derived-task skip, mixed derived+non-derived)
  - `tent_engine_failover_e2e_test` — 6 e2e failover scenarios, all passing
  - Code format check (`./scripts/code_format.sh`), all files OK

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
  - [ ] I have updated the documentation.
  - [x] I have added tests to prove my changes are effective.