### PR TITLE
[TE] Fix CQE reliability to prevent infinite timeout events

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -43,6 +43,7 @@ class EndpointStore {
     virtual std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) = 0;
     virtual int deleteEndpoint(const std::string &peer_nic_path) = 0;
+    virtual int deleteEndpointRef(RdmaEndPoint *endpoint_ptr) = 0;
     virtual void evictEndpoint() = 0;
     // Takes endpoint_map_lock_; caller must not hold it (RWSpinlock is
     // non-reentrant, so recursive acquisition deadlocks).
@@ -76,6 +77,7 @@ class FIFOEndpointStore : public EndpointStore {
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) override;
     int deleteEndpoint(const std::string &peer_nic_path) override;
+    int deleteEndpointRef(RdmaEndPoint *endpoint_ptr) override;
     void evictEndpoint() override;
     void reclaimEndpoint() override;
     size_t getSize() override;
@@ -115,6 +117,7 @@ class SIEVEEndpointStore : public EndpointStore {
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) override;
     int deleteEndpoint(const std::string &peer_nic_path) override;
+    int deleteEndpointRef(RdmaEndPoint *endpoint_ptr) override;
     void evictEndpoint() override;
     void reclaimEndpoint() override;
     size_t getSize() override;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -111,6 +111,7 @@ class RdmaContext {
         const RdmaEndPoint *endpoint_ptr);
 
     int deleteEndpoint(const std::string &peer_nic_path);
+    int deleteEndpointRef(RdmaEndPoint *endpoint_ptr);
 
     // Drain the endpoint store's waiting list. Safe to call on any thread;
     // intended to be invoked periodically from monitorWorker so reclaim is

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -62,6 +62,7 @@ class RdmaEndPoint {
 
    public:
     void setPeerNicPath(const std::string &peer_nic_path);
+    const std::string &peerNicPath() const { return peer_nic_path_; }
 
     int setupConnectionsByActive();
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -108,6 +108,7 @@ class RdmaEndPoint {
     // actually destroys QPs and frees resources. Returns true if destruction
     // is complete, false if outstanding WRs remain.
     void beginDestroy();
+    void beginDestroyNoLock();  // Internal version without locking
     bool finishDestroy();
 
    private:

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -112,6 +112,8 @@ class RdmaEndPoint {
     void beginDestroyNoLock();  // Internal version without locking
     bool finishDestroy();
 
+    const std::string &peerNicPath() const { return peer_nic_path_; }
+
    private:
     int disconnectUnlocked();
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -94,6 +94,25 @@ int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     return 0;
 }
 
+int FIFOEndpointStore::deleteEndpointRef(RdmaEndPoint *endpoint_ptr) {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    // Find and remove the endpoint by pointer comparison
+    for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end(); ++iter) {
+        if (iter->second.get() == endpoint_ptr) {
+            waiting_list_len_++;
+            iter->second->beginDestroyNoLock();  // Caller may already hold lock_
+            waiting_list_.insert(iter->second);
+            std::string peer_nic_path = iter->first;
+            endpoint_map_.erase(iter);
+            auto fifo_iter = fifo_map_[peer_nic_path];
+            fifo_list_.erase(fifo_iter);
+            fifo_map_.erase(peer_nic_path);
+            return 0;
+        }
+    }
+    return 0;
+}
+
 void FIFOEndpointStore::evictEndpoint() {
     if (fifo_list_.empty()) return;
     std::string victim = fifo_list_.front();
@@ -224,6 +243,29 @@ int SIEVEEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
         }
         fifo_list_.erase(fifo_iter);
         fifo_map_.erase(peer_nic_path);
+    }
+    return 0;
+}
+
+int SIEVEEndpointStore::deleteEndpointRef(RdmaEndPoint *endpoint_ptr) {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    // Find and remove the endpoint by pointer comparison
+    for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end(); ++iter) {
+        if (iter->second.first.get() == endpoint_ptr) {
+            waiting_list_len_++;
+            iter->second.first->beginDestroyNoLock();  // Caller may already hold lock_
+            waiting_list_.insert(iter->second.first);
+            std::string peer_nic_path = iter->first;
+            endpoint_map_.erase(iter);
+            auto fifo_iter = fifo_map_[peer_nic_path];
+            if (hand_.has_value() && hand_.value() == fifo_iter) {
+                fifo_iter == fifo_list_.begin() ? hand_ = std::nullopt
+                                                : hand_ = std::prev(fifo_iter);
+            }
+            fifo_list_.erase(fifo_iter);
+            fifo_map_.erase(peer_nic_path);
+            return 0;
+        }
     }
     return 0;
 }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -97,10 +97,12 @@ int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
 int FIFOEndpointStore::deleteEndpointRef(RdmaEndPoint *endpoint_ptr) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     // Find and remove the endpoint by pointer comparison
-    for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end(); ++iter) {
+    for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end();
+         ++iter) {
         if (iter->second.get() == endpoint_ptr) {
             waiting_list_len_++;
-            iter->second->beginDestroyNoLock();  // Caller may already hold lock_
+            iter->second
+                ->beginDestroyNoLock();  // Caller may already hold lock_
             waiting_list_.insert(iter->second);
             std::string peer_nic_path = iter->first;
             endpoint_map_.erase(iter);
@@ -250,10 +252,12 @@ int SIEVEEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
 int SIEVEEndpointStore::deleteEndpointRef(RdmaEndPoint *endpoint_ptr) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     // Find and remove the endpoint by pointer comparison
-    for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end(); ++iter) {
+    for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end();
+         ++iter) {
         if (iter->second.first.get() == endpoint_ptr) {
             waiting_list_len_++;
-            iter->second.first->beginDestroyNoLock();  // Caller may already hold lock_
+            iter->second.first
+                ->beginDestroyNoLock();  // Caller may already hold lock_
             waiting_list_.insert(iter->second.first);
             std::string peer_nic_path = iter->first;
             endpoint_map_.erase(iter);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -38,9 +38,10 @@ std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::getEndpoint(
 std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::getEndpointByPtr(
     const RdmaEndPoint *endpoint_ptr) {
     RWSpinlock::ReadGuard guard(endpoint_map_lock_);
-    for (auto &kv : endpoint_map_) {
-        if (kv.second.get() == endpoint_ptr) return kv.second;
-    }
+    // O(1) lookup using peerNicPath() instead of O(N) iteration
+    auto iter = endpoint_map_.find(endpoint_ptr->peerNicPath());
+    if (iter != endpoint_map_.end() && iter->second.get() == endpoint_ptr)
+        return iter->second;
     for (auto &endpoint : waiting_list_)
         if (endpoint.get() == endpoint_ptr) return endpoint;
     return nullptr;
@@ -96,21 +97,18 @@ int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
 
 int FIFOEndpointStore::deleteEndpointRef(RdmaEndPoint *endpoint_ptr) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
-    // Find and remove the endpoint by pointer comparison
-    for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end();
-         ++iter) {
-        if (iter->second.get() == endpoint_ptr) {
-            waiting_list_len_++;
-            iter->second
-                ->beginDestroyNoLock();  // Caller may already hold lock_
-            waiting_list_.insert(iter->second);
-            std::string peer_nic_path = iter->first;
-            endpoint_map_.erase(iter);
-            auto fifo_iter = fifo_map_[peer_nic_path];
-            fifo_list_.erase(fifo_iter);
-            fifo_map_.erase(peer_nic_path);
-            return 0;
-        }
+    // O(1) lookup using peerNicPath() instead of O(N) iteration
+    const std::string &peer_nic_path = endpoint_ptr->peerNicPath();
+    auto iter = endpoint_map_.find(peer_nic_path);
+    if (iter != endpoint_map_.end() && iter->second.get() == endpoint_ptr) {
+        waiting_list_len_++;
+        iter->second->beginDestroyNoLock();  // Caller may already hold lock_
+        waiting_list_.insert(iter->second);
+        endpoint_map_.erase(iter);
+        auto fifo_iter = fifo_map_[peer_nic_path];
+        fifo_list_.erase(fifo_iter);
+        fifo_map_.erase(peer_nic_path);
+        return 0;
     }
     return 0;
 }
@@ -190,9 +188,10 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::getEndpoint(
 std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::getEndpointByPtr(
     const RdmaEndPoint *endpoint_ptr) {
     RWSpinlock::ReadGuard guard(endpoint_map_lock_);
-    for (auto &kv : endpoint_map_) {
-        if (kv.second.first.get() == endpoint_ptr) return kv.second.first;
-    }
+    // O(1) lookup using peerNicPath() instead of O(N) iteration
+    auto iter = endpoint_map_.find(endpoint_ptr->peerNicPath());
+    if (iter != endpoint_map_.end() && iter->second.first.get() == endpoint_ptr)
+        return iter->second.first;
     for (auto &endpoint : waiting_list_)
         if (endpoint.get() == endpoint_ptr) return endpoint;
     return nullptr;
@@ -251,25 +250,24 @@ int SIEVEEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
 
 int SIEVEEndpointStore::deleteEndpointRef(RdmaEndPoint *endpoint_ptr) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
-    // Find and remove the endpoint by pointer comparison
-    for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end();
-         ++iter) {
-        if (iter->second.first.get() == endpoint_ptr) {
-            waiting_list_len_++;
-            iter->second.first
-                ->beginDestroyNoLock();  // Caller may already hold lock_
-            waiting_list_.insert(iter->second.first);
-            std::string peer_nic_path = iter->first;
-            endpoint_map_.erase(iter);
-            auto fifo_iter = fifo_map_[peer_nic_path];
-            if (hand_.has_value() && hand_.value() == fifo_iter) {
-                fifo_iter == fifo_list_.begin() ? hand_ = std::nullopt
-                                                : hand_ = std::prev(fifo_iter);
-            }
-            fifo_list_.erase(fifo_iter);
-            fifo_map_.erase(peer_nic_path);
-            return 0;
+    // O(1) lookup using peerNicPath() instead of O(N) iteration
+    const std::string &peer_nic_path = endpoint_ptr->peerNicPath();
+    auto iter = endpoint_map_.find(peer_nic_path);
+    if (iter != endpoint_map_.end() &&
+        iter->second.first.get() == endpoint_ptr) {
+        waiting_list_len_++;
+        iter->second.first
+            ->beginDestroyNoLock();  // Caller may already hold lock_
+        waiting_list_.insert(iter->second.first);
+        endpoint_map_.erase(iter);
+        auto fifo_iter = fifo_map_[peer_nic_path];
+        if (hand_.has_value() && hand_.value() == fifo_iter) {
+            fifo_iter == fifo_list_.begin() ? hand_ = std::nullopt
+                                            : hand_ = std::prev(fifo_iter);
         }
+        fifo_list_.erase(fifo_iter);
+        fifo_map_.erase(peer_nic_path);
+        return 0;
     }
     return 0;
 }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -409,6 +409,10 @@ int RdmaContext::deleteEndpoint(const std::string &peer_nic_path) {
     return endpoint_store_->deleteEndpoint(peer_nic_path);
 }
 
+int RdmaContext::deleteEndpointRef(RdmaEndPoint *endpoint_ptr) {
+    return endpoint_store_->deleteEndpointRef(endpoint_ptr);
+}
+
 void RdmaContext::reclaimEndpoints() { endpoint_store_->reclaimEndpoint(); }
 
 size_t RdmaContext::waitingListSize() const {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -220,9 +220,10 @@ bool RdmaEndPoint::finishDestroy() {
             // Log outstanding WRs for each QP before forcing destruction
             for (size_t i = 0; i < qp_list_.size(); ++i) {
                 if (wr_depth_list_[i] != 0) {
-                    LOG(ERROR) << "finishDestroy timeout: QP[" << i
-                               << "] has " << wr_depth_list_[i]
-                               << " outstanding WRs (cq_outstanding leak expected)";
+                    LOG(ERROR)
+                        << "finishDestroy timeout: QP[" << i << "] has "
+                        << wr_depth_list_[i]
+                        << " outstanding WRs (cq_outstanding leak expected)";
                 }
             }
             LOG(WARNING) << "finishDestroy timed out after " << elapsed

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -125,21 +125,11 @@ int RdmaEndPoint::deconstruct() {
 }
 
 int RdmaEndPoint::deconstructLocked() {
-    // Adjust cq_outstanding_ before destroying QPs, so the counter is
-    // always corrected even if ibv_destroy_qp fails and we return early.
-    bool displayed = false;
-    for (size_t i = 0; i < qp_list_.size(); ++i) {
-        if (wr_depth_list_[i] != 0) {
-            if (!displayed) {
-                LOG(WARNING) << "Outstanding work requests found, CQ will not "
-                                "be generated";
-                displayed = true;
-            }
-            __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
-            wr_depth_list_[i] = 0;
-        }
-    }
-
+    // Note: We no longer manually adjust wr_depth_list_/cq_outstanding_ here.
+    // This function should only be called after all CQEs have been drained
+    // (via the two-phase beginDestroy/finishDestroy flow), so counters should
+    // already be zero. Manual adjustment would race with CQE processing in
+    // performPollCq() and cause double-counting.
     int result = 0;
     for (size_t i = 0; i < qp_list_.size(); ++i) {
         if (!qp_list_[i]) continue;  // already destroyed in a previous call
@@ -164,6 +154,10 @@ int RdmaEndPoint::destroyQP() { return deconstruct(); }
 
 void RdmaEndPoint::beginDestroy() {
     RWSpinlock::WriteGuard guard(lock_);
+    beginDestroyNoLock();
+}
+
+void RdmaEndPoint::beginDestroyNoLock() {
     auto current_status = status_.load(std::memory_order_relaxed);
     if (current_status == DESTROYING || current_status == DESTROYED) return;
 
@@ -223,14 +217,23 @@ bool RdmaEndPoint::finishDestroy() {
         if (has_outstanding) {
             double elapsed = (getCurrentTimeInNano() - inactive_time_) / 1e9;
             if (elapsed < kFinishDestroyTimeoutSec) return false;
+            // Log outstanding WRs for each QP before forcing destruction
+            for (size_t i = 0; i < qp_list_.size(); ++i) {
+                if (wr_depth_list_[i] != 0) {
+                    LOG(ERROR) << "finishDestroy timeout: QP[" << i
+                               << "] has " << wr_depth_list_[i]
+                               << " outstanding WRs (cq_outstanding leak expected)";
+                }
+            }
             LOG(WARNING) << "finishDestroy timed out after " << elapsed
                          << "s with outstanding WRs, forcing destruction";
         }
     }
 
-    // Unified destroy: tear down QPs (deconstructLocked handles
-    // cq_outstanding_ adjustment internally) and bound retries to avoid
-    // log flooding when ibv_destroy_qp fails permanently.
+    // Unified destroy: tear down QPs and bound retries to avoid log
+    // flooding when ibv_destroy_qp fails permanently.
+    // Note: If timed out with outstanding WRs, counters will leak (accept
+    // as this is an abnormal situation).
     int ret = deconstructLocked();
     if (ret) {
         finish_destroy_retries_++;
@@ -247,9 +250,9 @@ bool RdmaEndPoint::finishDestroy() {
 
 void RdmaEndPoint::setPeerNicPath(const std::string &peer_nic_path) {
     RWSpinlock::WriteGuard guard(lock_);
-    if (connected()) {
-        LOG(WARNING) << "Previous connection will be discarded";
-        disconnectUnlocked();
+    if (connected() && peer_nic_path_ != peer_nic_path) {
+        LOG(WARNING) << "PeerNicPath of RdmaEndPoint has been assigned";
+        return;
     }
     peer_nic_path_ = peer_nic_path;
 }
@@ -368,8 +371,8 @@ int RdmaEndPoint::setupConnectionsByActive() {
                         "re-establishing connection: "
                      << toString();
 
-        int ret = resetConnection("re-establishing connection (active)");
-        if (ret) return ret;
+        resetConnection("re-establishing connection (active)");
+        return ERR_ENDPOINT;
     }
 
     if (!peer_desc.reply_msg.empty()) {
@@ -437,8 +440,8 @@ int RdmaEndPoint::setupConnectionsByPassive(const HandShakeDesc &peer_desc,
         // Different peer (e.g., peer restarted)
         LOG(WARNING) << "Re-establish connection: " << toString();
 
-        int ret = resetConnection("re-establishing connection (passive)");
-        if (ret) return ret;
+        resetConnection("re-establishing connection (passive)");
+        return ERR_ENDPOINT;
     }
 
     // At this point, the state can only be UNCONNECTED or CONNECTING.
@@ -516,26 +519,19 @@ int RdmaEndPoint::disconnectUnlocked() {
 
     ibv_qp_attr attr;
     memset(&attr, 0, sizeof(attr));
-    attr.qp_state = IBV_QPS_RESET;
+    attr.qp_state = IBV_QPS_ERR;
     int ret = 0;
     for (size_t i = 0; i < qp_list_.size(); ++i) {
         int curr_ret = ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE);
         if (curr_ret) {
-            PLOG(ERROR) << "Failed to modify QP to RESET";
+            PLOG(ERROR) << "Failed to modify QP to ERR";
             ret = ERR_ENDPOINT;
         }
-        // After resetting QP, the wr_depth_list_ won't change
-        bool displayed = false;
-        if (wr_depth_list_[i] != 0) {
-            if (!displayed) {
-                LOG(WARNING) << "Outstanding work requests found, CQ will not "
-                                "be generated";
-                displayed = true;
-            }
-            __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
-            wr_depth_list_[i] = 0;
-        }
     }
+    // Note: We no longer manually adjust wr_depth_list_/cq_outstanding_ here.
+    // ERR state flushes all inflight WRs to CQ as FLUSH errors, which will be
+    // processed by performPollCq() and naturally decrement the counters.
+    // Manual adjustment would cause double-counting with CQE processing.
     peer_qp_num_list_.clear();
     status_.store(UNCONNECTED, std::memory_order_release);
     return ret;
@@ -545,20 +541,16 @@ int RdmaEndPoint::resetConnection(const std::string &reason) {
     auto curr_status = status_.load(std::memory_order_acquire);
     if (curr_status != CONNECTING && curr_status != CONNECTED) return 0;
 
-#ifdef CONFIG_ERDMA
-    int ret = reconstruct();
-#else
-    int ret = disconnectUnlocked();
-#endif
+    active_ = false;
+    inactive_time_ = getCurrentTimeInNano();
+    status_.store(UNCONNECTED, std::memory_order_release);
+    LOG(INFO) << "Endpoint marked inactive: " << reason;
 
-    if (ret) {
-        LOG(ERROR) << "Failed to reset the endpoint (triggered by: " << reason
-                   << "): error=" << ret;
-    } else {
-        LOG(INFO) << "Successfully reset the endpoint (triggered by: " << reason
-                  << ").";
-    }
-    return ret;
+    // Delete from endpoint store so endpoint() won't return this endpoint.
+    // Uses deleteEndpointRef which calls beginDestroyNoLock() to avoid
+    // deadlocking when caller already holds lock_.
+    context_.deleteEndpointRef(this);
+    return 0;
 }
 
 const std::string RdmaEndPoint::toString() const {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -130,8 +130,12 @@ int RdmaEndPoint::deconstructLocked() {
     // (via the two-phase beginDestroy/finishDestroy flow), so counters should
     // already be zero. Manual adjustment would race with CQE processing in
     // performPollCq() and cause double-counting.
+
+    // Save the size before clearing qp_list_
+    size_t num_qp = qp_list_.size();
+
     int result = 0;
-    for (size_t i = 0; i < qp_list_.size(); ++i) {
+    for (size_t i = 0; i < num_qp; ++i) {
         if (!qp_list_[i]) continue;  // already destroyed in a previous call
         if (ibv_destroy_qp(qp_list_[i])) {
             PLOG(ERROR) << "Failed to destroy QP[" << i << "]";
@@ -145,8 +149,28 @@ int RdmaEndPoint::deconstructLocked() {
 
     qp_list_.clear();
     peer_qp_num_list_.clear();
-    delete[] wr_depth_list_;
-    wr_depth_list_ = nullptr;
+
+    // Check for outstanding WRs before deleting wr_depth_list_ to prevent UAF.
+    // Slices hold pointers to wr_depth_list_ entries (slice->rdma.qp_depth),
+    // and worker threads may still access them when processing CQEs.
+    // If there are outstanding WRs, leak the memory to prevent UAF.
+    bool has_outstanding = false;
+    if (wr_depth_list_) {
+        for (size_t i = 0; i < num_qp; ++i) {
+            if (wr_depth_list_[i] != 0) {
+                has_outstanding = true;
+                break;
+            }
+        }
+        // Only delete if no outstanding WRs (safe to free)
+        if (!has_outstanding) {
+            delete[] wr_depth_list_;
+            wr_depth_list_ = nullptr;
+        } else {
+            LOG(WARNING) << "Leaking wr_depth_list_ due to outstanding WRs to "
+                            "prevent UAF";
+        }
+    }
     return 0;
 }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -234,8 +234,7 @@ void WorkerPool::performPostSend(int thread_id) {
         }
         if (!endpoint->active()) {
             if (endpoint->inactiveTime() > 1.0)
-                context_.deleteEndpoint(
-                    entry.first);  // enable for re-establishation
+                context_.deleteEndpointRef(endpoint.get());
             for (auto &slice : entry.second) failed_slice_list.push_back(slice);
             entry.second.clear();
             continue;


### PR DESCRIPTION
## Description

This patch fixes CQE (Completion Queue Entry) reliability issues in the RDMA transport layer to     
  prevent infinite timeout events. Key changes include: (1) endpoints are now single-use—inactive
  endpoints are immediately evicted instead of being reused; (2) added deleteEndpointRef() for safe   
  deletion by pointer and beginDestroyNoLock() to avoid deadlocks; (3) removed manual counter
  adjustments in disconnectUnlocked() and deconstructLocked(), relying solely on CQE processing; (4)
  changed QP state transitions from RESET to ERR to ensure all inflight WRs generate FLUSH CQEs
  instead of being silently dropped. This ensures every successfully submitted work request receives a
   CQE, preventing resource leaks and infinite timeout events.

Core changes:
- Endpoint is now single-use: once marked inactive, it is evicted
- deleteEndpointRef() added to delete by pointer, avoiding peer_nic_path errors
- beginDestroyNoLock() added to avoid deadlock when caller holds lock
- resetConnection() now marks inactive and calls deleteEndpointRef()
- disconnectUnlocked() and deconstructLocked() no longer manually adjust counters
- ERR state used instead of RESET to ensure WRs are flushed with FLUSH CQEs
- Timeout scenario logs counter leak details

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
