### PR TITLE
[Store] Implement 3-phase read/write contexts in DataManager

### DIFF
--- a/docs/source/troubleshooting/error-code.md
+++ b/docs/source/troubleshooting/error-code.md
@@ -48,6 +48,7 @@ Mooncake Store may generate various types of errors during execution. For most A
 |                          | OBJECT_ALREADY_EXISTS (-705)   | Object already exists                                                                                     |
 |                          | OBJECT_HAS_LEASE (-706)        | Object has lease                                                                                          |
 |                          | LEASE_EXPIRED (-707)           | Lease expired before data transfer completed                                                              |
+|                          | REPLICA_IS_PROCESSING (-711)   | Replica is processing an in-flight write                                                                  |
 | Transfer                 | TRANSFER_FAIL (-800)           | Transfer operation failed                                                                                 |
 | RPC                      | RPC_FAIL (-900)                | RPC operation failed                                                                                      |
 | High Availability        | ETCD_OPERATION_ERROR (-1000)   | etcd operation failed                                                                                     |

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -7,6 +7,7 @@
 #include "real_client.h"
 
 #include <cstdlib>  // for atexit
+#include <cstdint>
 #include <map>
 
 #include "integration_utils.h"
@@ -1109,6 +1110,8 @@ PYBIND11_MODULE(store, m) {
                size_t async_sender_thread_count = 0,
                size_t async_max_batch_size = 2000,
                size_t async_route_queue_size = 0,
+               uint32_t p2p_key_lease_duration_ms = 2000,
+               uint32_t p2p_key_lease_scan_interval_ms = 500,
                const py::object& engine = py::none()) {
                 auto& resource_tracker = ResourceTracker::getInstance();
                 self.use_dummy_client_ = false;
@@ -1134,7 +1137,8 @@ PYBIND11_MODULE(store, m) {
                     local_transfer_mode, local_memcpy_async_worker_num,
                     metrics_port, enable_metrics_http, {},
                     async_sender_thread_count, async_max_batch_size,
-                    async_route_queue_size);
+                    async_route_queue_size, p2p_key_lease_duration_ms,
+                    p2p_key_lease_scan_interval_ms);
 
                 auto ret = real_client->setup(config);
                 self.store_ = real_client;
@@ -1155,6 +1159,8 @@ PYBIND11_MODULE(store, m) {
             py::arg("async_sender_thread_count") = 0,
             py::arg("async_max_batch_size") = 2000,
             py::arg("async_route_queue_size") = 0,
+            py::arg("p2p_key_lease_duration_ms") = 2000,
+            py::arg("p2p_key_lease_scan_interval_ms") = 500,
             py::arg("engine") = py::none(),
             "Setup the store in P2P architecture.")
         .def(

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1110,8 +1110,8 @@ PYBIND11_MODULE(store, m) {
                size_t async_sender_thread_count = 0,
                size_t async_max_batch_size = 2000,
                size_t async_route_queue_size = 0,
-               uint32_t p2p_key_lease_duration_ms = 2000,
-               uint32_t p2p_key_lease_scan_interval_ms = 500,
+               uint32_t p2p_key_lease_duration_ms = 5000,
+               uint32_t p2p_key_lease_scan_interval_ms = 1000,
                const py::object& engine = py::none()) {
                 auto& resource_tracker = ResourceTracker::getInstance();
                 self.use_dummy_client_ = false;
@@ -1159,8 +1159,8 @@ PYBIND11_MODULE(store, m) {
             py::arg("async_sender_thread_count") = 0,
             py::arg("async_max_batch_size") = 2000,
             py::arg("async_route_queue_size") = 0,
-            py::arg("p2p_key_lease_duration_ms") = 2000,
-            py::arg("p2p_key_lease_scan_interval_ms") = 500,
+            py::arg("p2p_key_lease_duration_ms") = 5000,
+            py::arg("p2p_key_lease_scan_interval_ms") = 1000,
             py::arg("engine") = py::none(),
             "Setup the store in P2P architecture.")
         .def(

--- a/mooncake-store/include/client_config_builder.h
+++ b/mooncake-store/include/client_config_builder.h
@@ -144,8 +144,8 @@ struct P2PClientConfig : RealClientConfigBase {
     // Parsed custom tiered backend configuration
     Json::Value tiered_backend_config;
 
-    // Number of key lock shards for DataManager.
-    // Higher values reduce contention of key.
+    // Number of TieredBackend metadata index shards (and matching DataManager
+    // pending-write/pinned-key lease shards). Higher values reduce contention.
     size_t lock_shard_count = 1024;
 
     // RouteCache configuration

--- a/mooncake-store/include/client_config_builder.h
+++ b/mooncake-store/include/client_config_builder.h
@@ -285,7 +285,8 @@ class ClientConfigBuilder {
             config.p2p_key_lease_duration_ms = p2p_key_lease_duration_ms;
         }
         if (p2p_key_lease_scan_interval_ms > 0) {
-            config.p2p_key_lease_scan_interval_ms = p2p_key_lease_scan_interval_ms;
+            config.p2p_key_lease_scan_interval_ms =
+                p2p_key_lease_scan_interval_ms;
         }
 
         return config;

--- a/mooncake-store/include/client_config_builder.h
+++ b/mooncake-store/include/client_config_builder.h
@@ -171,6 +171,14 @@ struct P2PClientConfig : RealClientConfigBase {
     // When local_transfer_mode == MEMCPY, the following parameter is used:
     // 0 means forbid async memcpy (fall back to synchronous).
     size_t local_memcpy_async_worker_num = 32;
+
+    // PreWrite / PinKey key lease: maximum time (ms) a key may stay in
+    // intermediate (lease-protected) state before expiring.
+    static constexpr uint32_t kP2pDefaultKeyLeaseDurationMs = 5000;
+    // Interval (ms) for the background scanner that removes expired leases.
+    static constexpr uint32_t kP2pDefaultKeyLeaseScanIntervalMs = 1000;
+    uint32_t p2p_key_lease_duration_ms = kP2pDefaultKeyLeaseDurationMs;
+    uint32_t p2p_key_lease_scan_interval_ms = kP2pDefaultKeyLeaseScanIntervalMs;
 };
 
 // ============================================================================
@@ -238,7 +246,9 @@ class ClientConfigBuilder {
         bool enable_metrics_http = true,
         const std::map<std::string, std::string>& labels = {},
         size_t async_sender_thread_count = 0,
-        size_t async_max_batch_size = 2000, size_t async_route_queue_size = 0) {
+        size_t async_max_batch_size = 2000, size_t async_route_queue_size = 0,
+        uint32_t p2p_key_lease_duration_ms = 0,
+        uint32_t p2p_key_lease_scan_interval_ms = 0) {
         P2PClientConfig config;
         fill_real_client_config_base(
             config, local_hostname, metadata_connstring, protocol, rdma_devices,
@@ -270,6 +280,13 @@ class ClientConfigBuilder {
                 "via tiered_backend_config_json parameter.");
         }
         config.tiered_backend_config = tiered_config;
+
+        if (p2p_key_lease_duration_ms > 0) {
+            config.p2p_key_lease_duration_ms = p2p_key_lease_duration_ms;
+        }
+        if (p2p_key_lease_scan_interval_ms > 0) {
+            config.p2p_key_lease_scan_interval_ms = p2p_key_lease_scan_interval_ms;
+        }
 
         return config;
     }

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -69,13 +69,11 @@ class DataManager {
 
     struct PreWriteResult {
         RemoteBufferDesc remote_buffer;
-        uint64_t deadline_ms = 0;
         UUID pending_write_token{0, 0};
     };
 
     struct PinKeyResult {
         RemoteBufferDesc remote_buffer;
-        uint64_t deadline_ms = 0;
         UUID pin_token{0, 0};
     };
 
@@ -460,8 +458,6 @@ class DataManager {
     const std::chrono::milliseconds& lease_duration() const {
         return lease_duration_;
     }
-    uint64_t TimePointToDeadlineMs(TimePoint deadline) const;
-    TimePoint DeadlineMsToTimePoint(uint64_t deadline_ms) const;
     bool IsExpired(TimePoint deadline) const;
     RemoteBufferDesc BuildRemoteBufferDesc(
         const AllocationHandle& handle) const;

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -242,6 +242,8 @@ class DataManager {
                std::optional<UUID> tier_id = std::nullopt) const;
 
    private:
+    void ClearLeaseRecords();
+
     struct KeyCtx {
         std::string_view key;
         std::string key_string;

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -483,7 +483,6 @@ class DataManager {
     const std::chrono::milliseconds& lease_duration() const {
         return lease_duration_;
     }
-    bool IsExpired(TimePoint deadline) const;
     tl::expected<RemoteBufferDesc, ErrorCode> BuildRemoteBufferDesc(
         const AllocationHandle& handle) const;
     void LeaseScannerMain();

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -207,8 +207,8 @@ class DataManager {
         std::string_view key, size_t size_bytes,
         std::optional<UUID> tier_id = std::nullopt);
 
-    tl::expected<void, ErrorCode> WriteCommit(
-        std::string_view key, const UUID& pending_write_token);
+    tl::expected<void, ErrorCode> WriteCommit(std::string_view key,
+                                              const UUID& pending_write_token);
 
     tl::expected<PinKeyResult, ErrorCode> PinKey(
         std::string_view key, std::optional<UUID> tier_id = std::nullopt);
@@ -262,8 +262,8 @@ class DataManager {
 
     tl::expected<PreWriteResult, ErrorCode> PreWriteInternal(
         const KeyCtx& ctx, size_t size_bytes, std::optional<UUID> tier_id);
-    tl::expected<void, ErrorCode> WriteCommitInternal(const KeyCtx& ctx,
-                                                      const UUID& pending_write_token);
+    tl::expected<void, ErrorCode> WriteCommitInternal(
+        const KeyCtx& ctx, const UUID& pending_write_token);
     tl::expected<PinKeyResult, ErrorCode> PinKeyInternal(
         const KeyCtx& ctx, std::optional<UUID> tier_id);
     tl::expected<void, ErrorCode> UnPinKeyInternal(const KeyCtx& ctx,
@@ -463,7 +463,8 @@ class DataManager {
     uint64_t TimePointToDeadlineMs(TimePoint deadline) const;
     TimePoint DeadlineMsToTimePoint(uint64_t deadline_ms) const;
     bool IsExpired(TimePoint deadline) const;
-    RemoteBufferDesc BuildRemoteBufferDesc(const AllocationHandle& handle) const;
+    RemoteBufferDesc BuildRemoteBufferDesc(
+        const AllocationHandle& handle) const;
     void LeaseScannerMain();
     void ShutdownLeaseScanner();
     size_t ScanExpiredPendingWrites(PendingWriteShard& shard, TimePoint now);
@@ -472,8 +473,7 @@ class DataManager {
                                  const std::string& key);
     bool ErasePinnedKeyLocked(PinnedKeyShard& shard, const std::string& key);
     bool RemoveExpiredPendingWriteLocked(PendingWriteShard& shard,
-                                         const std::string& key,
-                                         TimePoint now);
+                                         const std::string& key, TimePoint now);
     bool RemoveExpiredPinnedKeyLocked(PinnedKeyShard& shard,
                                       const std::string& key, TimePoint now);
     void TouchOrderedDeadlineNode(OrderedDeadlineList& ordered_list,
@@ -484,7 +484,8 @@ class DataManager {
         std::string_view key, const UUID& pending_write_token);
     tl::expected<AllocationHandle, ErrorCode> LookupPinnedKeyHandle(
         std::string_view key, const UUID& pin_token);
-    void AbortPendingWrite(std::string_view key, const UUID& pending_write_token);
+    void AbortPendingWrite(std::string_view key,
+                           const UUID& pending_write_token);
 
    private:
     std::unique_ptr<TieredBackend> tiered_backend_;    // Owned by DataManager

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -1,11 +1,18 @@
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <optional>
 #include <shared_mutex>
-#include <vector>
 #include <string>
 #include <string_view>
-#include <memory>
-#include <optional>
+#include <thread>
+#include <unordered_map>
+#include <vector>
 #include <ylt/util/tl/expected.hpp>
 #include "async_memcpy_executor.h"
 #include "client_buffer.hpp"
@@ -58,6 +65,20 @@ class DataManager {
     friend class DataManagerTest;
 
    public:
+    using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
+
+    struct PreWriteResult {
+        RemoteBufferDesc remote_buffer;
+        uint64_t deadline_ms = 0;
+        UUID pending_write_token{0, 0};
+    };
+
+    struct PinKeyResult {
+        RemoteBufferDesc remote_buffer;
+        uint64_t deadline_ms = 0;
+        UUID pin_token{0, 0};
+    };
+
     /**
      * @brief Constructor
      * @param tiered_backend Unique pointer to TieredBackend instance (takes
@@ -70,14 +91,9 @@ class DataManager {
                 size_t lock_shard_count = 1024,
                 const LocalTransferConfig& local_transfer_config = {});
 
-    void Stop() {
-        if (async_memcpy_executor_) {
-            async_memcpy_executor_->Shutdown();
-        }
-        if (tiered_backend_) {
-            tiered_backend_->Stop();
-        }
-    }
+    ~DataManager();
+
+    void Stop();
 
     /**
      * @brief Cleanup: delegates to TieredBackend::Destroy().
@@ -187,6 +203,19 @@ class DataManager {
         std::string_view key, const std::vector<RemoteBufferDesc>& src_buffers,
         std::optional<UUID> tier_id = std::nullopt);
 
+    tl::expected<PreWriteResult, ErrorCode> PreWrite(
+        std::string_view key, size_t size_bytes,
+        std::optional<UUID> tier_id = std::nullopt);
+
+    tl::expected<void, ErrorCode> WriteCommit(
+        std::string_view key, const UUID& pending_write_token);
+
+    tl::expected<PinKeyResult, ErrorCode> PinKey(
+        std::string_view key, std::optional<UUID> tier_id = std::nullopt);
+
+    tl::expected<void, ErrorCode> UnPinKey(std::string_view key,
+                                           const UUID& pin_token);
+
     // ================================================================
     // Utilities
     // ================================================================
@@ -213,6 +242,34 @@ class DataManager {
                std::optional<UUID> tier_id = std::nullopt) const;
 
    private:
+    struct KeyCtx {
+        std::string_view key;
+        std::string key_string;
+        size_t hash = 0;
+        size_t pending_write_shard_idx = 0;
+        size_t pinned_key_shard_idx = 0;
+    };
+
+    KeyCtx BuildKeyCtx(std::string_view key) const;
+    PendingWriteShard& GetPendingWriteShard(const KeyCtx& ctx);
+    PinnedKeyShard& GetPinnedKeyShard(const KeyCtx& ctx);
+
+    tl::expected<PreWriteResult, ErrorCode> PreWriteInternal(
+        const KeyCtx& ctx, size_t size_bytes, std::optional<UUID> tier_id);
+    tl::expected<void, ErrorCode> WriteCommitInternal(const KeyCtx& ctx,
+                                                      const UUID& pending_write_token);
+    tl::expected<PinKeyResult, ErrorCode> PinKeyInternal(
+        const KeyCtx& ctx, std::optional<UUID> tier_id);
+    tl::expected<void, ErrorCode> UnPinKeyInternal(const KeyCtx& ctx,
+                                                   const UUID& pin_token);
+
+    tl::expected<AllocationHandle, ErrorCode> LookupPendingWriteHandleInternal(
+        const KeyCtx& ctx, const UUID& pending_write_token);
+    tl::expected<AllocationHandle, ErrorCode> LookupPinnedKeyHandleInternal(
+        const KeyCtx& ctx, const UUID& pin_token);
+    void AbortPendingWriteInternal(const KeyCtx& ctx,
+                                   const UUID& pending_write_token);
+
     std::shared_mutex& GetKeyLock(std::string_view key) {
         size_t hash = std::hash<std::string_view>{}(key);
         return lock_shards_[hash % lock_shard_count_];
@@ -361,6 +418,68 @@ class DataManager {
     // Wait for all tasks to reach a terminal state, then free the batch.
     void CancelBatchTETask(Transport::BatchID batch_id, size_t num_tasks);
 
+    using OrderedDeadlineList = std::list<std::pair<std::string, TimePoint>>;
+    using OrderedDeadlineListIt = OrderedDeadlineList::iterator;
+
+    struct PendingWriteRecord {
+        UUID pending_write_token{0, 0};
+        TimePoint deadline{};
+        AllocationHandle handle;
+        OrderedDeadlineListIt list_it;
+    };
+
+    struct PinnedKeyRecord {
+        UUID pin_token{0, 0};
+        TimePoint deadline{};
+        AllocationHandle handle;
+        uint32_t ref_count = 1;
+        OrderedDeadlineListIt list_it;
+    };
+
+    struct PendingWriteShard {
+        mutable std::shared_mutex mutex;
+        std::unordered_map<std::string, PendingWriteRecord> by_key;
+        OrderedDeadlineList ordered_list;
+    };
+
+    struct PinnedKeyShard {
+        mutable std::shared_mutex mutex;
+        std::unordered_map<std::string, PinnedKeyRecord> by_key;
+        OrderedDeadlineList ordered_list;
+    };
+
+    size_t HashKey(std::string_view key) const;
+    PendingWriteShard& GetPendingWriteShard(std::string_view key);
+    PinnedKeyShard& GetPinnedKeyShard(std::string_view key);
+    const std::chrono::milliseconds& lease_duration() const {
+        return lease_duration_;
+    }
+    uint64_t TimePointToDeadlineMs(TimePoint deadline) const;
+    TimePoint DeadlineMsToTimePoint(uint64_t deadline_ms) const;
+    bool IsExpired(TimePoint deadline) const;
+    RemoteBufferDesc BuildRemoteBufferDesc(const AllocationHandle& handle) const;
+    void LeaseScannerMain();
+    void ShutdownLeaseScanner();
+    size_t ScanExpiredPendingWrites(PendingWriteShard& shard, TimePoint now);
+    size_t ScanExpiredPinnedKeys(PinnedKeyShard& shard, TimePoint now);
+    bool ErasePendingWriteLocked(PendingWriteShard& shard,
+                                 const std::string& key);
+    bool ErasePinnedKeyLocked(PinnedKeyShard& shard, const std::string& key);
+    bool RemoveExpiredPendingWriteLocked(PendingWriteShard& shard,
+                                         const std::string& key,
+                                         TimePoint now);
+    bool RemoveExpiredPinnedKeyLocked(PinnedKeyShard& shard,
+                                      const std::string& key, TimePoint now);
+    void TouchOrderedDeadlineNode(OrderedDeadlineList& ordered_list,
+                                  OrderedDeadlineListIt it,
+                                  const std::string& key, TimePoint deadline);
+
+    tl::expected<AllocationHandle, ErrorCode> LookupPendingWriteHandle(
+        std::string_view key, const UUID& pending_write_token);
+    tl::expected<AllocationHandle, ErrorCode> LookupPinnedKeyHandle(
+        std::string_view key, const UUID& pin_token);
+    void AbortPendingWrite(std::string_view key, const UUID& pending_write_token);
+
    private:
     std::unique_ptr<TieredBackend> tiered_backend_;    // Owned by DataManager
     std::shared_ptr<TransferEngine> transfer_engine_;  // Shared with Client
@@ -370,6 +489,8 @@ class DataManager {
     // (default: 1024)
     size_t lock_shard_count_;
     std::vector<std::shared_mutex> lock_shards_;
+    std::vector<PendingWriteShard> pending_write_shards_;
+    std::vector<PinnedKeyShard> pinned_key_shards_;
 
     // Callback for rectifying stale read routes
     std::function<void(std::string_view, std::optional<UUID>)>
@@ -377,6 +498,12 @@ class DataManager {
 
     LocalTransferConfig local_transfer_config_;
     std::unique_ptr<AsyncMemcpyExecutor> async_memcpy_executor_;
+    std::chrono::milliseconds lease_duration_;
+    std::chrono::milliseconds lease_scan_interval_;
+    std::atomic<bool> lease_scanner_stop_requested_{false};
+    std::condition_variable lease_scanner_cv_;
+    std::mutex lease_scanner_mutex_;
+    std::thread lease_scanner_thread_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -51,6 +51,13 @@ struct LocalTransferConfig {
     // When mode == MEMCPY, the following parameters are used:
     // 0 means forbid async memcpy (fall back to synchronous).
     size_t local_memcpy_async_worker_num = 32;
+
+    // PreWrite / PinKey key lease: max lifetime (ms) of intermediate state on a
+    // key. 0 means use DataManager built-in default.
+    uint32_t p2p_key_lease_duration_ms = 0;
+    // Background scan interval (ms) for expired key leases. 0 means use
+    // DataManager built-in default.
+    uint32_t p2p_key_lease_scan_interval_ms = 0;
 };
 
 /**
@@ -69,12 +76,12 @@ class DataManager {
 
     struct PreWriteResult {
         RemoteBufferDesc remote_buffer;
-        UUID pending_write_token{0, 0};
+        UUID write_operation_id{0, 0};
     };
 
     struct PinKeyResult {
         RemoteBufferDesc remote_buffer;
-        UUID pin_token{0, 0};
+        UUID read_operation_id{0, 0};
     };
 
     /**
@@ -206,13 +213,13 @@ class DataManager {
         std::optional<UUID> tier_id = std::nullopt);
 
     tl::expected<void, ErrorCode> WriteCommit(std::string_view key,
-                                              const UUID& pending_write_token);
+                                              const UUID& write_operation_id);
 
     tl::expected<PinKeyResult, ErrorCode> PinKey(
         std::string_view key, std::optional<UUID> tier_id = std::nullopt);
 
     tl::expected<void, ErrorCode> UnPinKey(std::string_view key,
-                                           const UUID& pin_token);
+                                           const UUID& read_operation_id);
 
     // ================================================================
     // Utilities
@@ -261,18 +268,18 @@ class DataManager {
     tl::expected<PreWriteResult, ErrorCode> PreWriteInternal(
         const KeyCtx& ctx, size_t size_bytes, std::optional<UUID> tier_id);
     tl::expected<void, ErrorCode> WriteCommitInternal(
-        const KeyCtx& ctx, const UUID& pending_write_token);
+        const KeyCtx& ctx, const UUID& write_operation_id);
     tl::expected<PinKeyResult, ErrorCode> PinKeyInternal(
         const KeyCtx& ctx, std::optional<UUID> tier_id);
     tl::expected<void, ErrorCode> UnPinKeyInternal(const KeyCtx& ctx,
-                                                   const UUID& pin_token);
+                                                   const UUID& read_operation_id);
 
     tl::expected<AllocationHandle, ErrorCode> LookupPendingWriteHandleInternal(
-        const KeyCtx& ctx, const UUID& pending_write_token);
+        const KeyCtx& ctx, const UUID& write_operation_id);
     tl::expected<AllocationHandle, ErrorCode> LookupPinnedKeyHandleInternal(
-        const KeyCtx& ctx, const UUID& pin_token);
+        const KeyCtx& ctx, const UUID& read_operation_id);
     void AbortPendingWriteInternal(const KeyCtx& ctx,
-                                   const UUID& pending_write_token);
+                                   const UUID& write_operation_id);
 
     std::shared_mutex& GetKeyLock(std::string_view key) {
         size_t hash = std::hash<std::string_view>{}(key);
@@ -426,14 +433,14 @@ class DataManager {
     using OrderedDeadlineListIt = OrderedDeadlineList::iterator;
 
     struct PendingWriteRecord {
-        UUID pending_write_token{0, 0};
+        UUID write_operation_id{0, 0};
         TimePoint deadline{};
         AllocationHandle handle;
         OrderedDeadlineListIt list_it;
     };
 
     struct PinnedKeyRecord {
-        UUID pin_token{0, 0};
+        UUID read_operation_id{0, 0};
         TimePoint deadline{};
         AllocationHandle handle;
         uint32_t ref_count = 1;
@@ -477,11 +484,11 @@ class DataManager {
                                   const std::string& key, TimePoint deadline);
 
     tl::expected<AllocationHandle, ErrorCode> LookupPendingWriteHandle(
-        std::string_view key, const UUID& pending_write_token);
+        std::string_view key, const UUID& write_operation_id);
     tl::expected<AllocationHandle, ErrorCode> LookupPinnedKeyHandle(
-        std::string_view key, const UUID& pin_token);
+        std::string_view key, const UUID& read_operation_id);
     void AbortPendingWrite(std::string_view key,
-                           const UUID& pending_write_token);
+                           const UUID& write_operation_id);
 
    private:
     std::unique_ptr<TieredBackend> tiered_backend_;    // Owned by DataManager

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -237,8 +237,8 @@ class DataManager {
     // ================================================================
 
     /**
-     * @brief Rectify stale read route by checking local key existence
-     * and removing replica from master if key is not found locally.
+     * @brief Rectify stale read route via TieredBackend::conditionalExecute:
+     *        if the key is not found locally, remove the replica from master.
      *
      * @param key Object key to rectify
      * @param tier_id Optional tier ID. If specified, only checks the given
@@ -335,10 +335,6 @@ class DataManager {
     tl::expected<AllocationHandle, ErrorCode> ValidatePendingWriteForCommit(
         PendingWriteShard& shard, std::string_view key, TimePoint now,
         const UUID& write_operation_id);
-
-    std::shared_mutex& GetKeyLock(std::string_view key) {
-        return lock_shards_[StringHash{}(key) % lock_shard_count_];
-    }
 
     /**
      * @brief Transfer data from local source to remote destination buffers
@@ -497,11 +493,9 @@ class DataManager {
     std::unique_ptr<TieredBackend> tiered_backend_;    // Owned by DataManager
     std::shared_ptr<TransferEngine> transfer_engine_;  // Shared with Client
 
-    // Sharded locks for concurrent access
-    // Configurable via MOONCAKE_DM_LOCK_SHARD_COUNT environment variable
-    // (default: 1024)
+    // Shard count for pending-write and pinned-key lease tables (same value as
+    // TieredBackend metadata shard count when set via lock_shard_count).
     size_t lock_shard_count_;
-    std::vector<std::shared_mutex> lock_shards_;
     std::vector<PendingWriteShard> pending_write_shards_;
     std::vector<PinnedKeyShard> pinned_key_shards_;
 

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -244,6 +244,10 @@ class DataManager {
    private:
     void ClearLeaseRecords();
 
+    // Forward declarations for nested shard structs used by internal helpers.
+    struct PendingWriteShard;
+    struct PinnedKeyShard;
+
     struct KeyCtx {
         std::string_view key;
         std::string key_string;

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -53,13 +53,18 @@ struct LocalTransferConfig {
     // When mode == MEMCPY, the following parameters are used:
     // 0 means forbid async memcpy (fall back to synchronous).
     size_t local_memcpy_async_worker_num = 32;
+};
 
-    // PreWrite / PinKey key lease: max lifetime (ms) of intermediate state on a
-    // key. 0 means use DataManager built-in default.
-    uint32_t p2p_key_lease_duration_ms = 0;
-    // Background scan interval (ms) for expired key leases. 0 means use
-    // DataManager built-in default.
-    uint32_t p2p_key_lease_scan_interval_ms = 0;
+/**
+ * @struct KeyLeaseConfig
+ * @brief PreWrite / PinKey key lease timing (independent of local transfer).
+ */
+struct KeyLeaseConfig {
+    // Max lifetime (ms) of intermediate lease state on a key. 0 = built-in
+    // default.
+    uint32_t duration_ms = 0;
+    // Background scan interval (ms) for expired leases. 0 = built-in default.
+    uint32_t scan_interval_ms = 0;
 };
 
 /**
@@ -96,7 +101,8 @@ class DataManager {
     DataManager(std::unique_ptr<TieredBackend> tiered_backend,
                 std::shared_ptr<TransferEngine> transfer_engine,
                 size_t lock_shard_count = 1024,
-                const LocalTransferConfig& local_transfer_config = {});
+                const LocalTransferConfig& local_transfer_config = {},
+                const KeyLeaseConfig& key_lease_config = {});
 
     ~DataManager();
 
@@ -252,11 +258,10 @@ class DataManager {
     void ClearLeaseRecords();
 
     struct KeyCtx {
-        // Stable copy of the logical key. Incoming std::string_view often
-        // points at RPC/coro request buffers and is only valid for the lifetime
-        // of that handler; BuildKeyCtx copies immediately so async work, maps,
-        // and locks never retain dangling views.
-        std::string key;
+        // Non-owning view; valid only while caller storage (e.g. RPC/coro
+        // request buffers) remains alive. KeyCtx is stack-scoped within
+        // DataManager and must not be stored. Maps copy keys on insert.
+        std::string_view key;
         size_t hash = 0;
         size_t pending_write_shard_idx = 0;
         size_t pinned_key_shard_idx = 0;
@@ -284,15 +289,15 @@ class DataManager {
     struct RecordShard {
         mutable std::shared_mutex mutex;
         std::unordered_map<std::string, Record, StringHash, std::equal_to<>>
-            by_key;
+            existed_operation_key_map;
         OrderedDeadlineList ordered_list;
     };
 
     using PendingWriteShard = RecordShard<PendingWriteRecord>;
     using PinnedKeyShard = RecordShard<PinnedKeyRecord>;
 
-    // `key` must still point at valid storage for the duration of this call
-    // only (typically RPC/coro request buffers).
+    // `key` must point at storage that outlives the returned KeyCtx and any
+    // synchronous use on the current call stack (typically RPC/coro buffers).
     KeyCtx BuildKeyCtx(std::string_view key) const;
     PendingWriteShard& GetPendingWriteShard(const KeyCtx& ctx);
     PinnedKeyShard& GetPinnedKeyShard(const KeyCtx& ctx);
@@ -310,6 +315,25 @@ class DataManager {
         const KeyCtx& ctx, const UUID& write_operation_id);
     void AbortPendingWriteInternal(const KeyCtx& ctx,
                                    const UUID& write_operation_id);
+
+    enum class PendingWriteEraseResult {
+        Erased,
+        NotFound,
+        WriteOperationIdMismatch,
+    };
+
+    PendingWriteEraseResult ErasePendingWriteRecord(
+        PendingWriteShard& shard, std::string_view key,
+        const UUID& write_operation_id);
+    tl::expected<void, ErrorCode> ReservePendingWriteSlot(
+        PendingWriteShard& shard, std::string_view key, TimePoint now,
+        TimePoint deadline, const UUID& write_operation_id);
+    tl::expected<void, ErrorCode> AttachPendingWriteHandle(
+        PendingWriteShard& shard, std::string_view key,
+        const UUID& write_operation_id, const AllocationHandle& handle);
+    tl::expected<AllocationHandle, ErrorCode> TakePendingWriteForCommit(
+        PendingWriteShard& shard, std::string_view key, TimePoint now,
+        const UUID& write_operation_id);
 
     std::shared_mutex& GetKeyLock(std::string_view key) {
         return lock_shards_[StringHash{}(key) % lock_shard_count_];

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -251,10 +251,6 @@ class DataManager {
    private:
     void ClearLeaseRecords();
 
-    // Forward declarations for nested shard structs used by internal helpers.
-    struct PendingWriteShard;
-    struct PinnedKeyShard;
-
     struct KeyCtx {
         // Stable copy of the logical key. Incoming std::string_view often
         // points at RPC/coro request buffers and is only valid for the lifetime
@@ -265,6 +261,35 @@ class DataManager {
         size_t pending_write_shard_idx = 0;
         size_t pinned_key_shard_idx = 0;
     };
+
+    using OrderedDeadlineList = std::list<std::pair<std::string, TimePoint>>;
+    using OrderedDeadlineListIt = OrderedDeadlineList::iterator;
+
+    struct PendingWriteRecord {
+        UUID write_operation_id{0, 0};
+        TimePoint deadline{};
+        AllocationHandle handle;
+        OrderedDeadlineListIt list_it;
+    };
+
+    struct PinnedKeyRecord {
+        UUID read_operation_id{0, 0};
+        TimePoint deadline{};
+        AllocationHandle handle;
+        uint32_t ref_count = 1;
+        OrderedDeadlineListIt list_it;
+    };
+
+    template <typename Record>
+    struct RecordShard {
+        mutable std::shared_mutex mutex;
+        std::unordered_map<std::string, Record, StringHash, std::equal_to<>>
+            by_key;
+        OrderedDeadlineList ordered_list;
+    };
+
+    using PendingWriteShard = RecordShard<PendingWriteRecord>;
+    using PinnedKeyShard = RecordShard<PinnedKeyRecord>;
 
     // `key` must still point at valid storage for the duration of this call
     // only (typically RPC/coro request buffers).
@@ -433,40 +458,6 @@ class DataManager {
     // Wait for all tasks to reach a terminal state, then free the batch.
     void CancelBatchTETask(Transport::BatchID batch_id, size_t num_tasks);
 
-    using OrderedDeadlineList = std::list<std::pair<std::string, TimePoint>>;
-    using OrderedDeadlineListIt = OrderedDeadlineList::iterator;
-
-    struct PendingWriteRecord {
-        UUID write_operation_id{0, 0};
-        TimePoint deadline{};
-        AllocationHandle handle;
-        OrderedDeadlineListIt list_it;
-    };
-
-    struct PinnedKeyRecord {
-        UUID read_operation_id{0, 0};
-        TimePoint deadline{};
-        AllocationHandle handle;
-        uint32_t ref_count = 1;
-        OrderedDeadlineListIt list_it;
-    };
-
-    struct PendingWriteShard {
-        mutable std::shared_mutex mutex;
-        std::unordered_map<std::string, PendingWriteRecord,
-                           StringHash, std::equal_to<>>
-            by_key;
-        OrderedDeadlineList ordered_list;
-    };
-
-    struct PinnedKeyShard {
-        mutable std::shared_mutex mutex;
-        std::unordered_map<std::string, PinnedKeyRecord,
-                           StringHash, std::equal_to<>>
-            by_key;
-        OrderedDeadlineList ordered_list;
-    };
-
     const std::chrono::milliseconds& lease_duration() const {
         return lease_duration_;
     }
@@ -475,9 +466,9 @@ class DataManager {
         const AllocationHandle& handle) const;
     void LeaseScannerMain();
     void ShutdownLeaseScanner();
-    size_t ScanExpiredPendingWrites(PendingWriteShard& shard, TimePoint now);
-    size_t ScanExpiredPinnedKeys(PinnedKeyShard& shard, TimePoint now);
-   private:
+    template <typename Record>
+    size_t ScanExpiredRecordShard(RecordShard<Record>& shard, TimePoint now);
+
     std::unique_ptr<TieredBackend> tiered_backend_;    // Owned by DataManager
     std::shared_ptr<TransferEngine> transfer_engine_;  // Shared with Client
 

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -84,6 +84,9 @@ class DataManager {
     struct PreWriteResult {
         RemoteBufferDesc remote_buffer;
         UUID write_operation_id{0, 0};
+        // Filled by PreWriteInternal for in-process callers (Put/WriteRemoteData).
+        // Public PreWrite omits this field for RPC responses.
+        AllocationHandle handle;
     };
 
     struct PinKeyResult {
@@ -311,8 +314,6 @@ class DataManager {
     tl::expected<void, ErrorCode> UnPinKeyInternal(
         const KeyCtx& ctx, const UUID& read_operation_id);
 
-    tl::expected<AllocationHandle, ErrorCode> LookupPendingWriteHandleInternal(
-        const KeyCtx& ctx, const UUID& write_operation_id);
     void AbortPendingWriteInternal(const KeyCtx& ctx,
                                    const UUID& write_operation_id);
 
@@ -331,7 +332,7 @@ class DataManager {
     tl::expected<void, ErrorCode> AttachPendingWriteHandle(
         PendingWriteShard& shard, std::string_view key,
         const UUID& write_operation_id, const AllocationHandle& handle);
-    tl::expected<AllocationHandle, ErrorCode> TakePendingWriteForCommit(
+    tl::expected<AllocationHandle, ErrorCode> ValidatePendingWriteForCommit(
         PendingWriteShard& shard, std::string_view key, TimePoint now,
         const UUID& write_operation_id);
 

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -283,8 +283,6 @@ class DataManager {
 
     tl::expected<AllocationHandle, ErrorCode> LookupPendingWriteHandleInternal(
         const KeyCtx& ctx, const UUID& write_operation_id);
-    tl::expected<AllocationHandle, ErrorCode> LookupPinnedKeyHandleInternal(
-        const KeyCtx& ctx, const UUID& read_operation_id);
     void AbortPendingWriteInternal(const KeyCtx& ctx,
                                    const UUID& write_operation_id);
 
@@ -473,30 +471,12 @@ class DataManager {
         return lease_duration_;
     }
     bool IsExpired(TimePoint deadline) const;
-    RemoteBufferDesc BuildRemoteBufferDesc(
+    tl::expected<RemoteBufferDesc, ErrorCode> BuildRemoteBufferDesc(
         const AllocationHandle& handle) const;
     void LeaseScannerMain();
     void ShutdownLeaseScanner();
     size_t ScanExpiredPendingWrites(PendingWriteShard& shard, TimePoint now);
     size_t ScanExpiredPinnedKeys(PinnedKeyShard& shard, TimePoint now);
-    bool ErasePendingWriteLocked(PendingWriteShard& shard,
-                                 std::string_view key);
-    bool ErasePinnedKeyLocked(PinnedKeyShard& shard, std::string_view key);
-    bool RemoveExpiredPendingWriteLocked(PendingWriteShard& shard,
-                                         std::string_view key, TimePoint now);
-    bool RemoveExpiredPinnedKeyLocked(PinnedKeyShard& shard,
-                                      std::string_view key, TimePoint now);
-    void TouchOrderedDeadlineNode(OrderedDeadlineList& ordered_list,
-                                  OrderedDeadlineListIt it,
-                                  std::string_view key, TimePoint deadline);
-
-    tl::expected<AllocationHandle, ErrorCode> LookupPendingWriteHandle(
-        std::string_view key, const UUID& write_operation_id);
-    tl::expected<AllocationHandle, ErrorCode> LookupPinnedKeyHandle(
-        std::string_view key, const UUID& read_operation_id);
-    void AbortPendingWrite(std::string_view key,
-                           const UUID& write_operation_id);
-
    private:
     std::unique_ptr<TieredBackend> tiered_backend_;    // Owned by DataManager
     std::shared_ptr<TransferEngine> transfer_engine_;  // Shared with Client

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -303,8 +303,8 @@ class DataManager {
         const KeyCtx& ctx, const UUID& write_operation_id);
     tl::expected<PinKeyResult, ErrorCode> PinKeyInternal(
         const KeyCtx& ctx, std::optional<UUID> tier_id);
-    tl::expected<void, ErrorCode> UnPinKeyInternal(const KeyCtx& ctx,
-                                                   const UUID& read_operation_id);
+    tl::expected<void, ErrorCode> UnPinKeyInternal(
+        const KeyCtx& ctx, const UUID& read_operation_id);
 
     tl::expected<AllocationHandle, ErrorCode> LookupPendingWriteHandleInternal(
         const KeyCtx& ctx, const UUID& write_operation_id);

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -13,6 +13,7 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <functional>
 #include <ylt/util/tl/expected.hpp>
 #include "async_memcpy_executor.h"
 #include "client_buffer.hpp"
@@ -21,6 +22,7 @@
 #include "tiered_cache/tiered_backend.h"
 #include "transfer_engine.h"
 #include "types.h"
+#include "utils.h"
 #include "client_rpc_types.h"
 
 namespace mooncake {
@@ -254,13 +256,18 @@ class DataManager {
     struct PinnedKeyShard;
 
     struct KeyCtx {
-        std::string_view key;
-        std::string key_string;
+        // Stable copy of the logical key. Incoming std::string_view often
+        // points at RPC/coro request buffers and is only valid for the lifetime
+        // of that handler; BuildKeyCtx copies immediately so async work, maps,
+        // and locks never retain dangling views.
+        std::string key;
         size_t hash = 0;
         size_t pending_write_shard_idx = 0;
         size_t pinned_key_shard_idx = 0;
     };
 
+    // `key` must still point at valid storage for the duration of this call
+    // only (typically RPC/coro request buffers).
     KeyCtx BuildKeyCtx(std::string_view key) const;
     PendingWriteShard& GetPendingWriteShard(const KeyCtx& ctx);
     PinnedKeyShard& GetPinnedKeyShard(const KeyCtx& ctx);
@@ -282,8 +289,7 @@ class DataManager {
                                    const UUID& write_operation_id);
 
     std::shared_mutex& GetKeyLock(std::string_view key) {
-        size_t hash = std::hash<std::string_view>{}(key);
-        return lock_shards_[hash % lock_shard_count_];
+        return lock_shards_[StringHash{}(key) % lock_shard_count_];
     }
 
     /**
@@ -449,19 +455,20 @@ class DataManager {
 
     struct PendingWriteShard {
         mutable std::shared_mutex mutex;
-        std::unordered_map<std::string, PendingWriteRecord> by_key;
+        std::unordered_map<std::string, PendingWriteRecord,
+                           StringHash, std::equal_to<>>
+            by_key;
         OrderedDeadlineList ordered_list;
     };
 
     struct PinnedKeyShard {
         mutable std::shared_mutex mutex;
-        std::unordered_map<std::string, PinnedKeyRecord> by_key;
+        std::unordered_map<std::string, PinnedKeyRecord,
+                           StringHash, std::equal_to<>>
+            by_key;
         OrderedDeadlineList ordered_list;
     };
 
-    size_t HashKey(std::string_view key) const;
-    PendingWriteShard& GetPendingWriteShard(std::string_view key);
-    PinnedKeyShard& GetPinnedKeyShard(std::string_view key);
     const std::chrono::milliseconds& lease_duration() const {
         return lease_duration_;
     }
@@ -473,15 +480,15 @@ class DataManager {
     size_t ScanExpiredPendingWrites(PendingWriteShard& shard, TimePoint now);
     size_t ScanExpiredPinnedKeys(PinnedKeyShard& shard, TimePoint now);
     bool ErasePendingWriteLocked(PendingWriteShard& shard,
-                                 const std::string& key);
-    bool ErasePinnedKeyLocked(PinnedKeyShard& shard, const std::string& key);
+                                 std::string_view key);
+    bool ErasePinnedKeyLocked(PinnedKeyShard& shard, std::string_view key);
     bool RemoveExpiredPendingWriteLocked(PendingWriteShard& shard,
-                                         const std::string& key, TimePoint now);
+                                         std::string_view key, TimePoint now);
     bool RemoveExpiredPinnedKeyLocked(PinnedKeyShard& shard,
-                                      const std::string& key, TimePoint now);
+                                      std::string_view key, TimePoint now);
     void TouchOrderedDeadlineNode(OrderedDeadlineList& ordered_list,
                                   OrderedDeadlineListIt it,
-                                  const std::string& key, TimePoint deadline);
+                                  std::string_view key, TimePoint deadline);
 
     tl::expected<AllocationHandle, ErrorCode> LookupPendingWriteHandle(
         std::string_view key, const UUID& write_operation_id);

--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -84,8 +84,9 @@ class DataManager {
     struct PreWriteResult {
         RemoteBufferDesc remote_buffer;
         UUID write_operation_id{0, 0};
-        // Filled by PreWriteInternal for in-process callers (Put/WriteRemoteData).
-        // Public PreWrite omits this field for RPC responses.
+        // Filled by PreWriteInternal for in-process callers
+        // (Put/WriteRemoteData). Public PreWrite omits this field for RPC
+        // responses.
         AllocationHandle handle;
     };
 

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -309,15 +309,15 @@ class TieredBackend {
     static constexpr size_t kDefaultMetadataShardCount = 64;
 
     size_t metadata_shard_count_ = kDefaultMetadataShardCount;
-    std::vector<MetadataShard> metadata_shards_{kDefaultMetadataShardCount};
+    std::vector<std::unique_ptr<MetadataShard>> metadata_shards_;
 
     MetadataShard& GetMetadataShard(std::string_view key) {
-        return metadata_shards_[std::hash<std::string_view>{}(key) %
-                                metadata_shard_count_];
+        return *metadata_shards_[std::hash<std::string_view>{}(key) %
+                                 metadata_shard_count_];
     }
     const MetadataShard& GetMetadataShard(std::string_view key) const {
-        return metadata_shards_[std::hash<std::string_view>{}(key) %
-                                metadata_shard_count_];
+        return *metadata_shards_[std::hash<std::string_view>{}(key) %
+                                 metadata_shard_count_];
     }
 
     static bool KeyExistsInShard(const MetadataShard& shard,

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <array>
 #include <atomic>
 #include <string>
 #include <string_view>
@@ -96,6 +95,15 @@ using RemoveReplicaCallback = std::function<tl::expected<void, ErrorCode>(
     std::string_view key, const UUID& tier_id, enum REMOVE_CALLBACK_TYPE type)>;
 
 /**
+ * @brief Result of TieredBackend::conditionalExecute.
+ */
+template <typename T>
+struct ConditionalExecuteResult {
+    bool key_exists = false;
+    T callback_result{};
+};
+
+/**
  * @brief Callback for segment lifecycle synchronization.
  * Invoked when a tier is created (mount=true) or destroyed (mount=false).
  * The callback should register/unregister the segment with Master.
@@ -112,6 +120,12 @@ class TieredBackend {
    public:
     TieredBackend();
     ~TieredBackend();
+
+    /**
+     * @brief Sets the number of metadata index shards.
+     * Must be called before Init(). Default is 64.
+     */
+    void SetMetadataShardCount(size_t count);
 
     /**
      * @brief 1. stops any backend thread;
@@ -177,6 +191,21 @@ class TieredBackend {
      */
     bool Exist(std::string_view key,
                std::optional<UUID> tier_id = std::nullopt) const;
+
+    /**
+     * @brief Checks key existence under the metadata shard lock, then runs
+     *        exactly one callback.
+     * @return key_exists and the return value of the invoked callback.
+     */
+    template <typename R>
+    ConditionalExecuteResult<R> conditionalExecute(
+        std::string_view key, std::optional<UUID> tier_id,
+        std::function<R()> on_exists, std::function<R()> on_not_exists) const;
+
+    ConditionalExecuteResult<void> conditionalExecute(
+        std::string_view key, std::optional<UUID> tier_id,
+        std::function<void()> on_exists,
+        std::function<void()> on_not_exists) const;
 
     /**
      * @brief Get
@@ -277,17 +306,23 @@ class TieredBackend {
             index;
     };
 
-    static constexpr size_t kMetadataShardCount = 64;
-    std::array<MetadataShard, kMetadataShardCount> metadata_shards_;
+    static constexpr size_t kDefaultMetadataShardCount = 64;
+
+    size_t metadata_shard_count_ = kDefaultMetadataShardCount;
+    std::vector<MetadataShard> metadata_shards_{kDefaultMetadataShardCount};
 
     MetadataShard& GetMetadataShard(std::string_view key) {
         return metadata_shards_[std::hash<std::string_view>{}(key) %
-                                kMetadataShardCount];
+                                metadata_shard_count_];
     }
     const MetadataShard& GetMetadataShard(std::string_view key) const {
         return metadata_shards_[std::hash<std::string_view>{}(key) %
-                                kMetadataShardCount];
+                                metadata_shard_count_];
     }
+
+    static bool KeyExistsInShard(const MetadataShard& shard,
+                                 std::string_view key,
+                                 std::optional<UUID> tier_id);
 
     std::unique_ptr<DataCopier> data_copier_;
     // Callbacks for metadata synchronization with Master
@@ -305,5 +340,28 @@ class TieredBackend {
     // Destroy flag
     std::atomic<bool> is_destroyed_{false};
 };
+
+template <>
+struct ConditionalExecuteResult<void> {
+    bool key_exists = false;
+};
+
+template <typename R>
+ConditionalExecuteResult<R> TieredBackend::conditionalExecute(
+    std::string_view key, std::optional<UUID> tier_id,
+    std::function<R()> on_exists, std::function<R()> on_not_exists) const {
+    auto& shard = GetMetadataShard(key);
+    std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
+    const bool exists = KeyExistsInShard(shard, key, tier_id);
+
+    ConditionalExecuteResult<R> result;
+    result.key_exists = exists;
+    if (exists) {
+        result.callback_result = on_exists();
+    } else {
+        result.callback_result = on_not_exists();
+    }
+    return result;
+}
 
 }  // namespace mooncake

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -103,6 +103,11 @@ struct ConditionalExecuteResult {
     T callback_result{};
 };
 
+template <>
+struct ConditionalExecuteResult<void> {
+    bool key_exists = false;
+};
+
 /**
  * @brief Callback for segment lifecycle synchronization.
  * Invoked when a tier is created (mount=true) or destroyed (mount=false).
@@ -118,14 +123,15 @@ using SegmentSyncCallback = std::function<tl::expected<void, ErrorCode>(
  */
 class TieredBackend {
    public:
-    TieredBackend();
-    ~TieredBackend();
+    static constexpr size_t kDefaultMetadataShardCount = 64;
 
     /**
-     * @brief Sets the number of metadata index shards.
-     * Must be called before Init(). Default is 64.
+     * @param metadata_shard_count Number of metadata index shards. Values <= 0
+     *        use the default (64).
      */
-    void SetMetadataShardCount(size_t count);
+    explicit TieredBackend(
+        size_t metadata_shard_count = kDefaultMetadataShardCount);
+    ~TieredBackend();
 
     /**
      * @brief 1. stops any backend thread;
@@ -306,8 +312,6 @@ class TieredBackend {
             index;
     };
 
-    static constexpr size_t kDefaultMetadataShardCount = 64;
-
     size_t metadata_shard_count_ = kDefaultMetadataShardCount;
     std::vector<std::unique_ptr<MetadataShard>> metadata_shards_;
 
@@ -320,9 +324,8 @@ class TieredBackend {
                                  metadata_shard_count_];
     }
 
-    static bool KeyExistsInShard(const MetadataShard& shard,
-                                 std::string_view key,
-                                 std::optional<UUID> tier_id);
+    static bool InnerExist(const MetadataShard& shard, std::string_view key,
+                           std::optional<UUID> tier_id);
 
     std::unique_ptr<DataCopier> data_copier_;
     // Callbacks for metadata synchronization with Master
@@ -341,18 +344,13 @@ class TieredBackend {
     std::atomic<bool> is_destroyed_{false};
 };
 
-template <>
-struct ConditionalExecuteResult<void> {
-    bool key_exists = false;
-};
-
 template <typename R>
 ConditionalExecuteResult<R> TieredBackend::conditionalExecute(
     std::string_view key, std::optional<UUID> tier_id,
     std::function<R()> on_exists, std::function<R()> on_not_exists) const {
     auto& shard = GetMetadataShard(key);
     std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
-    const bool exists = KeyExistsInShard(shard, key, tier_id);
+    const bool exists = InnerExist(shard, key, tier_id);
 
     ConditionalExecuteResult<R> result;
     result.key_exists = exists;

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -133,7 +133,7 @@ enum class ErrorCode : int32_t {
     INVALID_PARAMS = -600,  ///< Invalid parameters.
     ILLEGAL_CLIENT = -601,  ///< Illegal client to do the operation.
 
-    // Engine operation errors (Range: -700 to -710)
+    // Engine operation errors (Range: -700 to -711)
     INVALID_WRITE = -700,    ///< Invalid write operation.
     INVALID_READ = -701,     ///< Invalid read operation.
     INVALID_REPLICA = -702,  ///< Invalid replica operation.
@@ -152,6 +152,7 @@ enum class ErrorCode : int32_t {
     REPLICA_ALREADY_EXISTS = -711,  ///< Replica already exists.
     REPLICA_IS_GONE = -712,         ///< Replica existed once, but is gone now.
     REPLICA_NUM_EXCEEDED = -713,    ///< Replica number exceeded.
+    REPLICA_IS_PROCESSING = -714,  ///< Replica is processing an in-flight write.
 
     // Transfer errors (Range: -800 to -899)
     TRANSFER_FAIL = -800,  ///< Transfer operation failed.

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -152,7 +152,8 @@ enum class ErrorCode : int32_t {
     REPLICA_ALREADY_EXISTS = -711,  ///< Replica already exists.
     REPLICA_IS_GONE = -712,         ///< Replica existed once, but is gone now.
     REPLICA_NUM_EXCEEDED = -713,    ///< Replica number exceeded.
-    REPLICA_IS_PROCESSING = -714,  ///< Replica is processing an in-flight write.
+    REPLICA_IS_PROCESSING =
+        -714,  ///< Replica is processing an in-flight write.
 
     // Transfer errors (Range: -800 to -899)
     TRANSFER_FAIL = -800,  ///< Transfer operation failed.

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -133,7 +133,6 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
     : tiered_backend_(std::move(tiered_backend)),
       transfer_engine_(transfer_engine),
       lock_shard_count_(lock_shard_count > 0 ? lock_shard_count : 1024),
-      lock_shards_(lock_shard_count_),
       pending_write_shards_(lock_shard_count_),
       pinned_key_shards_(lock_shard_count_),
       local_transfer_config_(local_transfer_config) {
@@ -1014,15 +1013,11 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
     }
     AllocationHandle handle = std::move(handle_result.value());
 
-    // key_lock: serialize tiered_backend_->Commit vs Delete on this key.
     // PendingWriteRecord is erased only after Commit (see Erase below); while
     // it remains in existed_operation_key_map, another PreWrite on this key
-    // gets REPLICA_IS_PROCESSING at Reserve.
-    tl::expected<void, ErrorCode> commit_result;
-    {
-        std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
-        commit_result = tiered_backend_->Commit(ctx.key, handle);
-    }
+    // gets REPLICA_IS_PROCESSING at Reserve. TieredBackend::Commit serializes
+    // metadata updates on this key via its internal shard lock.
+    auto commit_result = tiered_backend_->Commit(ctx.key, handle);
 
     const auto erased = ErasePendingWriteRecord(
         pending_write_shard, ctx.key, write_operation_id);
@@ -1727,8 +1722,6 @@ tl::expected<void, ErrorCode> DataManager::Delete(std::string_view key,
     //   lease cleanup.
     // - PinnedKeyRecord holds a strong handle reference until UnPinKey reaches
     //   ref_count==0 or lease cleanup.
-    std::unique_lock lock(GetKeyLock(key));
-
     auto result = tiered_backend_->Delete(key, tier_id, notify_master);
     if (!result.has_value()) {
         LOG(ERROR) << "Failed to delete key: " << key;
@@ -1772,19 +1765,19 @@ void DataManager::RectifyReadRoute(std::string_view key,
                                    std::optional<UUID> tier_id) {
     if (!rectify_wrong_route_fn_) return;
 
-    std::shared_lock lock(GetKeyLock(key));
-
-    if (!tiered_backend_->Exist(key, tier_id)) {
-        LOG(WARNING) << "RectifyReadRoute: key not found locally"
-                     << (tier_id.has_value()
-                             ? " on tier " +
-                                   std::to_string(tier_id.value().first) + "_" +
-                                   std::to_string(tier_id.value().second)
-                             : "")
-                     << ", removing replica from master for key: " << key;
-        // Callback signature pins const std::string&; copy at the boundary.
-        rectify_wrong_route_fn_(key, tier_id);
-    }
+    tiered_backend_->conditionalExecute(
+        key, tier_id, []() {},
+        [this, key, tier_id]() {
+            LOG(WARNING) << "RectifyReadRoute: key not found locally"
+                         << (tier_id.has_value()
+                                 ? " on tier " +
+                                       std::to_string(tier_id.value().first) +
+                                       "_" +
+                                       std::to_string(tier_id.value().second)
+                                 : "")
+                         << ", removing replica from master for key: " << key;
+            rectify_wrong_route_fn_(key, tier_id);
+        });
 }
 
 void DataManager::SetRectifyCallback(

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -824,7 +824,6 @@ tl::expected<void, ErrorCode> DataManager::ReadRemoteData(
     std::string_view key, const std::vector<RemoteBufferDesc>& dest_buffers) {
     ScopedVLogTimer timer(1, "DataManager::ReadRemoteData");
     timer.LogRequest("key=", key, "buffer_count=", dest_buffers.size());
-    const KeyCtx kctx = BuildKeyCtx(key);
 
     auto validate_result = ValidateRemoteBuffers(dest_buffers);
     if (!validate_result) {
@@ -834,38 +833,19 @@ tl::expected<void, ErrorCode> DataManager::ReadRemoteData(
         return tl::make_unexpected(validate_result.error());
     }
 
-    // Reverse RDMA path: use the same 3-phase pin/unpin semantics even though
-    // the control plane is still a single RPC.
-    auto pin_result = PinKeyInternal(kctx, std::nullopt);
-    if (!pin_result) {
-        timer.LogResponse("error_code=", pin_result.error());
-        return tl::make_unexpected(pin_result.error());
-    }
-    const UUID pin_token = pin_result->pin_token;
-
-    auto handle_result = LookupPinnedKeyHandleInternal(kctx, pin_token);
+    // Reverse RDMA read stays on the direct object-handle path. Only forward
+    // RDMA read uses the 3-phase PinKey -> TE Read -> UnPinKey flow.
+    auto handle_result = tiered_backend_->Get(key);
     if (!handle_result) {
-        (void)UnPinKeyInternal(kctx, pin_token);
         timer.LogResponse("error_code=", handle_result.error());
         return tl::make_unexpected(handle_result.error());
     }
 
     auto transfer_result =
         TransferDataToRemote(handle_result.value(), dest_buffers);
-    auto unpin_result = UnPinKeyInternal(kctx, pin_token);
-
     if (!transfer_result) {
         timer.LogResponse("error_code=", transfer_result.error());
-        if (!unpin_result) {
-            LOG(ERROR) << "Also failed to unpin key " << kctx.key
-                       << " after transfer failure: "
-                       << toString(unpin_result.error());
-        }
         return tl::make_unexpected(transfer_result.error());
-    }
-    if (!unpin_result) {
-        timer.LogResponse("error_code=", unpin_result.error());
-        return tl::make_unexpected(unpin_result.error());
     }
     timer.LogResponse("error_code=", ErrorCode::OK);
     return {};

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -228,74 +228,19 @@ bool DataManager::IsExpired(TimePoint deadline) const {
     return deadline <= std::chrono::steady_clock::now();
 }
 
-RemoteBufferDesc DataManager::BuildRemoteBufferDesc(
+tl::expected<RemoteBufferDesc, ErrorCode> DataManager::BuildRemoteBufferDesc(
     const AllocationHandle& handle) const {
     const auto& loc_data = handle->loc.data;
+    if (!loc_data.buffer) {
+        LOG(ERROR) << "BuildRemoteBufferDesc: allocation handle has no buffer";
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
     RemoteBufferDesc remote_buffer;
     remote_buffer.segment_endpoint = local_transfer_config_.te_endpoint;
-    remote_buffer.addr = 0;
-    remote_buffer.size = 0;
-    if (loc_data.buffer) {
-        remote_buffer.addr =
-            reinterpret_cast<uintptr_t>(loc_data.buffer->data());
-        remote_buffer.size = loc_data.buffer->size();
-    }
+    remote_buffer.addr =
+        reinterpret_cast<uintptr_t>(loc_data.buffer->data());
+    remote_buffer.size = loc_data.buffer->size();
     return remote_buffer;
-}
-
-void DataManager::TouchOrderedDeadlineNode(OrderedDeadlineList& ordered_list,
-                                           OrderedDeadlineListIt it,
-                                           std::string_view key,
-                                           TimePoint deadline) {
-    it->first.assign(key.data(), key.size());
-    it->second = deadline;
-    ordered_list.splice(ordered_list.end(), ordered_list, it);
-}
-
-bool DataManager::ErasePendingWriteLocked(PendingWriteShard& shard,
-                                         std::string_view key) {
-    auto it = shard.by_key.find(key);
-    if (it == shard.by_key.end()) {
-        return false;
-    }
-    shard.ordered_list.erase(it->second.list_it);
-    shard.by_key.erase(it);
-    return true;
-}
-
-bool DataManager::ErasePinnedKeyLocked(PinnedKeyShard& shard,
-                                      std::string_view key) {
-    auto it = shard.by_key.find(key);
-    if (it == shard.by_key.end()) {
-        return false;
-    }
-    shard.ordered_list.erase(it->second.list_it);
-    shard.by_key.erase(it);
-    return true;
-}
-
-bool DataManager::RemoveExpiredPendingWriteLocked(PendingWriteShard& shard,
-                                                 std::string_view key,
-                                                 TimePoint now) {
-    auto it = shard.by_key.find(key);
-    if (it == shard.by_key.end() || it->second.deadline > now) {
-        return false;
-    }
-    shard.ordered_list.erase(it->second.list_it);
-    shard.by_key.erase(it);
-    return true;
-}
-
-bool DataManager::RemoveExpiredPinnedKeyLocked(PinnedKeyShard& shard,
-                                               const std::string& key,
-                                               TimePoint now) {
-    auto it = shard.by_key.find(key);
-    if (it == shard.by_key.end() || it->second.deadline > now) {
-        return false;
-    }
-    shard.ordered_list.erase(it->second.list_it);
-    shard.by_key.erase(it);
-    return true;
 }
 
 size_t DataManager::ScanExpiredPendingWrites(PendingWriteShard& shard,
@@ -340,71 +285,51 @@ size_t DataManager::ScanExpiredPinnedKeys(PinnedKeyShard& shard,
     return removed;
 }
 
-tl::expected<AllocationHandle, ErrorCode> DataManager::LookupPendingWriteHandle(
-    std::string_view key, const UUID& write_operation_id) {
-    return LookupPendingWriteHandleInternal(BuildKeyCtx(key),
-                                            write_operation_id);
-}
-
 tl::expected<AllocationHandle, ErrorCode>
 DataManager::LookupPendingWriteHandleInternal(const KeyCtx& ctx,
                                               const UUID& write_operation_id) {
     const auto now = std::chrono::steady_clock::now();
-    auto& shard = GetPendingWriteShard(ctx);
-    std::shared_lock shard_lock(shard.mutex);
-    auto it = shard.by_key.find(ctx.key);
-    if (it == shard.by_key.end()) {
+    auto& pending_write_shard = GetPendingWriteShard(ctx);
+    std::shared_lock pending_write_shard_lock(pending_write_shard.mutex);
+    auto it = pending_write_shard.by_key.find(ctx.key);
+    if (it == pending_write_shard.by_key.end()) {
+        LOG(ERROR) << "LookupPendingWriteHandle: no pending write for key: "
+                   << ctx.key;
         return tl::unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
     if (it->second.deadline <= now) {
+        LOG(ERROR) << "LookupPendingWriteHandle: lease expired for key: "
+                   << ctx.key;
         return tl::unexpected(ErrorCode::LEASE_EXPIRED);
     }
     if (it->second.write_operation_id != write_operation_id) {
+        LOG(ERROR) << "LookupPendingWriteHandle: write_operation_id mismatch "
+                      "for key: "
+                   << ctx.key;
         return tl::unexpected(ErrorCode::INVALID_WRITE);
     }
     return it->second.handle;
-}
-
-tl::expected<AllocationHandle, ErrorCode> DataManager::LookupPinnedKeyHandle(
-    std::string_view key, const UUID& read_operation_id) {
-    return LookupPinnedKeyHandleInternal(BuildKeyCtx(key), read_operation_id);
-}
-
-tl::expected<AllocationHandle, ErrorCode>
-DataManager::LookupPinnedKeyHandleInternal(const KeyCtx& ctx,
-                                           const UUID& read_operation_id) {
-    const auto now = std::chrono::steady_clock::now();
-    auto& shard = GetPinnedKeyShard(ctx);
-    std::shared_lock shard_lock(shard.mutex);
-    auto it = shard.by_key.find(ctx.key);
-    if (it == shard.by_key.end()) {
-        return tl::unexpected(ErrorCode::OBJECT_NOT_FOUND);
-    }
-    if (it->second.deadline <= now) {
-        return tl::unexpected(ErrorCode::LEASE_EXPIRED);
-    }
-    if (it->second.read_operation_id != read_operation_id) {
-        return tl::unexpected(ErrorCode::INVALID_READ);
-    }
-    return it->second.handle;
-}
-
-void DataManager::AbortPendingWrite(std::string_view key,
-                                    const UUID& write_operation_id) {
-    AbortPendingWriteInternal(BuildKeyCtx(key), write_operation_id);
 }
 
 void DataManager::AbortPendingWriteInternal(const KeyCtx& ctx,
                                             const UUID& write_operation_id) {
     if (ctx.key.empty() || IsZeroUUID(write_operation_id)) return;
     std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
-    auto& shard = GetPendingWriteShard(ctx);
-    std::unique_lock shard_lock(shard.mutex);
-    auto it = shard.by_key.find(ctx.key);
-    if (it == shard.by_key.end()) return;
-    if (it->second.write_operation_id != write_operation_id) return;
-    shard.ordered_list.erase(it->second.list_it);
-    shard.by_key.erase(it);
+    auto& pending_write_shard = GetPendingWriteShard(ctx);
+    std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
+    auto it = pending_write_shard.by_key.find(ctx.key);
+    if (it == pending_write_shard.by_key.end()) {
+        LOG(WARNING) << "AbortPendingWrite: no pending write record for key: "
+                     << ctx.key;
+        return;
+    }
+    if (it->second.write_operation_id != write_operation_id) {
+        LOG(ERROR) << "AbortPendingWrite: write_operation_id mismatch for key: "
+                   << ctx.key;
+        return;
+    }
+    pending_write_shard.ordered_list.erase(it->second.list_it);
+    pending_write_shard.by_key.erase(it);
 }
 
 void DataManager::ShutdownLeaseScanner() {
@@ -488,6 +413,9 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
 
     auto prewrite_result = PreWriteInternal(kctx, total_size, std::nullopt);
     if (!prewrite_result) {
+        LOG(ERROR) << "PutViaTe: PreWrite failed"
+                   << ", key=" << key
+                   << ", error=" << toString(prewrite_result.error());
         return tl::unexpected(prewrite_result.error());
     }
     const UUID write_operation_id = prewrite_result->write_operation_id;
@@ -545,6 +473,9 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
 
             auto commit_result = WriteCommitInternal(kctx, write_operation_id);
             if (!commit_result) {
+                LOG(ERROR) << "PutViaTe: WriteCommit failed"
+                           << ", key=" << kctx.key
+                           << ", error=" << toString(commit_result.error());
                 return tl::unexpected(commit_result.error());
             }
             timer.LogResponse("error_code=", ErrorCode::OK);
@@ -563,6 +494,9 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
 
     auto prewrite_result = PreWriteInternal(kctx, slice.size, std::nullopt);
     if (!prewrite_result) {
+        LOG(ERROR) << "PutViaMemcpy: PreWrite failed"
+                   << ", key=" << key
+                   << ", error=" << toString(prewrite_result.error());
         return tl::unexpected(prewrite_result.error());
     }
     const UUID write_operation_id = prewrite_result->write_operation_id;
@@ -805,6 +739,9 @@ tl::expected<void, ErrorCode> DataManager::ReadRemoteData(
     // RDMA read uses the 3-phase PinKey -> TE Read -> UnPinKey flow.
     auto handle_result = tiered_backend_->Get(key);
     if (!handle_result) {
+        LOG(ERROR) << "ReadRemoteData: Get failed"
+                   << ", key=" << key
+                   << ", error=" << toString(handle_result.error());
         timer.LogResponse("error_code=", handle_result.error());
         return tl::make_unexpected(handle_result.error());
     }
@@ -812,6 +749,9 @@ tl::expected<void, ErrorCode> DataManager::ReadRemoteData(
     auto transfer_result =
         TransferDataToRemote(handle_result.value(), dest_buffers);
     if (!transfer_result) {
+        LOG(ERROR) << "ReadRemoteData: TransferDataToRemote failed"
+                   << ", key=" << key
+                   << ", error=" << toString(transfer_result.error());
         timer.LogResponse("error_code=", transfer_result.error());
         return tl::make_unexpected(transfer_result.error());
     }
@@ -911,28 +851,45 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
     const auto deadline = now + lease_duration_;
 
     std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
-    auto& shard = GetPendingWriteShard(ctx);
-    std::unique_lock shard_lock(shard.mutex);
+    auto& pending_write_shard = GetPendingWriteShard(ctx);
+    std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
 
-    RemoveExpiredPendingWriteLocked(shard, ctx.key, now);
-    if (shard.by_key.find(ctx.key) != shard.by_key.end()) {
-        timer.LogResponse("error_code=", ErrorCode::OBJECT_HAS_LEASE);
-        return tl::make_unexpected(ErrorCode::OBJECT_HAS_LEASE);
+    auto pending_it = pending_write_shard.by_key.find(ctx.key);
+    if (pending_it != pending_write_shard.by_key.end()) {
+        if (pending_it->second.deadline <= now) {
+            pending_write_shard.ordered_list.erase(pending_it->second.list_it);
+            pending_write_shard.by_key.erase(pending_it);
+        } else {
+            timer.LogResponse("error_code=", ErrorCode::OBJECT_HAS_LEASE);
+            return tl::make_unexpected(ErrorCode::OBJECT_HAS_LEASE);
+        }
     }
     if (tiered_backend_->Exist(ctx.key)) {
+        LOG(ERROR) << "PreWrite: key already exists"
+                   << ", key=" << ctx.key
+                   << ", error=" << toString(ErrorCode::OBJECT_ALREADY_EXISTS);
         timer.LogResponse("error_code=", ErrorCode::OBJECT_ALREADY_EXISTS);
         return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
     }
 
     auto handle_result = tiered_backend_->Allocate(size_bytes, tier_id);
     if (!handle_result) {
+        LOG(ERROR) << "PreWrite: Allocate failed"
+                   << ", key=" << ctx.key
+                   << ", error=" << toString(handle_result.error());
         timer.LogResponse("error_code=", handle_result.error());
         return tl::make_unexpected(handle_result.error());
     }
 
     auto handle = std::move(handle_result.value());
-    auto list_it = shard.ordered_list.emplace(shard.ordered_list.end(),
-                                              ctx.key, deadline);
+    auto remote_buffer_result = BuildRemoteBufferDesc(handle);
+    if (!remote_buffer_result) {
+        timer.LogResponse("error_code=", remote_buffer_result.error());
+        return tl::make_unexpected(remote_buffer_result.error());
+    }
+
+    auto list_it = pending_write_shard.ordered_list.emplace(
+        pending_write_shard.ordered_list.end(), ctx.key, deadline);
 
     const UUID write_operation_id = generate_uuid();
     PendingWriteRecord record;
@@ -940,10 +897,10 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
     record.deadline = deadline;
     record.handle = handle;
     record.list_it = list_it;
-    shard.by_key.insert_or_assign(ctx.key, std::move(record));
+    pending_write_shard.by_key.insert_or_assign(ctx.key, std::move(record));
 
     PreWriteResult result;
-    result.remote_buffer = BuildRemoteBufferDesc(handle);
+    result.remote_buffer = std::move(remote_buffer_result.value());
     result.write_operation_id = write_operation_id;
     timer.LogResponse("error_code=", ErrorCode::OK);
     return result;
@@ -967,17 +924,19 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
     const auto now = std::chrono::steady_clock::now();
 
     std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
-    auto& shard = GetPendingWriteShard(ctx);
-    std::unique_lock shard_lock(shard.mutex);
+    auto& pending_write_shard = GetPendingWriteShard(ctx);
+    std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
 
-    auto record_it = shard.by_key.find(ctx.key);
-    if (record_it == shard.by_key.end()) {
-        timer.LogResponse("error_code=", ErrorCode::OK, "idempotent=", true);
-        return {};
+    auto record_it = pending_write_shard.by_key.find(ctx.key);
+    if (record_it == pending_write_shard.by_key.end()) {
+        LOG(ERROR) << "WriteCommit: no pending write record for key: "
+                   << ctx.key;
+        timer.LogResponse("error_code=", ErrorCode::OBJECT_NOT_FOUND);
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
     if (record_it->second.deadline <= now) {
-        shard.ordered_list.erase(record_it->second.list_it);
-        shard.by_key.erase(record_it);
+        pending_write_shard.ordered_list.erase(record_it->second.list_it);
+        pending_write_shard.by_key.erase(record_it);
         timer.LogResponse("error_code=", ErrorCode::LEASE_EXPIRED);
         return tl::make_unexpected(ErrorCode::LEASE_EXPIRED);
     }
@@ -995,11 +954,12 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
     // callback failure). The caller should restart a full write flow instead of
     // reusing a potentially stale prewrite context.
     //
-    // Note: after erasing the record, subsequent WriteCommit calls become
-    // idempotent no-ops (return OK) due to record absence.
+    // Note: after erasing the record, a duplicate WriteCommit without a new
+    // PreWrite returns OBJECT_NOT_FOUND (unlike UnPinKey, writes are not
+    // idempotent past commit).
     auto commit_result = tiered_backend_->Commit(ctx.key, handle);
-    shard.ordered_list.erase(record_it->second.list_it);
-    shard.by_key.erase(record_it);
+    pending_write_shard.ordered_list.erase(record_it->second.list_it);
+    pending_write_shard.by_key.erase(record_it);
 
     if (!commit_result) {
         timer.LogResponse("error_code=", commit_result.error(),
@@ -1030,34 +990,56 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     const auto deadline = now + lease_duration_;
 
     std::shared_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
-    auto& shard = GetPinnedKeyShard(ctx);
-    std::unique_lock shard_lock(shard.mutex);
+    auto& pin_shard = GetPinnedKeyShard(ctx);
+    std::unique_lock pin_shard_lock(pin_shard.mutex);
 
-    RemoveExpiredPinnedKeyLocked(shard, ctx.key, now);
-    auto record_it = shard.by_key.find(ctx.key);
-    if (record_it != shard.by_key.end()) {
-        record_it->second.ref_count++;
-        record_it->second.deadline = deadline;
-        TouchOrderedDeadlineNode(shard.ordered_list, record_it->second.list_it,
-                                 ctx.key, deadline);
+    auto record_it = pin_shard.by_key.find(ctx.key);
+    if (record_it != pin_shard.by_key.end()) {
+        if (record_it->second.deadline <= now) {
+            pin_shard.ordered_list.erase(record_it->second.list_it);
+            pin_shard.by_key.erase(record_it);
+        } else {
+            auto remote_buffer_result =
+                BuildRemoteBufferDesc(record_it->second.handle);
+            if (!remote_buffer_result) {
+                timer.LogResponse("error_code=", remote_buffer_result.error());
+                return tl::make_unexpected(remote_buffer_result.error());
+            }
+            record_it->second.ref_count++;
+            record_it->second.deadline = deadline;
+            auto list_it = record_it->second.list_it;
+            list_it->first.assign(ctx.key.data(), ctx.key.size());
+            list_it->second = deadline;
+            pin_shard.ordered_list.splice(pin_shard.ordered_list.end(),
+                                          pin_shard.ordered_list, list_it);
 
-        PinKeyResult result;
-        result.remote_buffer = BuildRemoteBufferDesc(record_it->second.handle);
-        result.read_operation_id = record_it->second.read_operation_id;
-        timer.LogResponse("error_code=", ErrorCode::OK,
-                          "ref_count=", record_it->second.ref_count);
-        return result;
+            PinKeyResult result;
+            result.remote_buffer = std::move(remote_buffer_result.value());
+            result.read_operation_id = record_it->second.read_operation_id;
+            timer.LogResponse("error_code=", ErrorCode::OK,
+                              "ref_count=", record_it->second.ref_count);
+            return result;
+        }
     }
 
     auto handle_result = tiered_backend_->Get(ctx.key, tier_id);
     if (!handle_result) {
+        LOG(ERROR) << "PinKey: Get failed"
+                   << ", key=" << ctx.key
+                   << ", error=" << toString(handle_result.error());
         timer.LogResponse("error_code=", handle_result.error());
         return tl::make_unexpected(handle_result.error());
     }
 
     auto handle = std::move(handle_result.value());
-    auto list_it = shard.ordered_list.emplace(shard.ordered_list.end(),
-                                              ctx.key, deadline);
+    auto remote_buffer_result = BuildRemoteBufferDesc(handle);
+    if (!remote_buffer_result) {
+        timer.LogResponse("error_code=", remote_buffer_result.error());
+        return tl::make_unexpected(remote_buffer_result.error());
+    }
+
+    auto list_it = pin_shard.ordered_list.emplace(pin_shard.ordered_list.end(),
+                                                  ctx.key, deadline);
 
     const UUID read_operation_id_value = generate_uuid();
     PinnedKeyRecord record;
@@ -1066,10 +1048,10 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     record.handle = handle;
     record.ref_count = 1;
     record.list_it = list_it;
-    shard.by_key.insert_or_assign(ctx.key, std::move(record));
+    pin_shard.by_key.insert_or_assign(ctx.key, std::move(record));
 
     PinKeyResult result;
-    result.remote_buffer = BuildRemoteBufferDesc(handle);
+    result.remote_buffer = std::move(remote_buffer_result.value());
     result.read_operation_id = read_operation_id_value;
     timer.LogResponse("error_code=", ErrorCode::OK);
     return result;
@@ -1093,17 +1075,18 @@ tl::expected<void, ErrorCode> DataManager::UnPinKeyInternal(
     const auto now = std::chrono::steady_clock::now();
 
     std::shared_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
-    auto& shard = GetPinnedKeyShard(ctx);
-    std::unique_lock shard_lock(shard.mutex);
+    auto& pin_shard = GetPinnedKeyShard(ctx);
+    std::unique_lock pin_shard_lock(pin_shard.mutex);
 
-    auto record_it = shard.by_key.find(ctx.key);
-    if (record_it == shard.by_key.end()) {
+    auto record_it = pin_shard.by_key.find(ctx.key);
+    if (record_it == pin_shard.by_key.end()) {
+        LOG(WARNING) << "UnPinKey: no pinned key record for key: " << ctx.key;
         timer.LogResponse("error_code=", ErrorCode::OK, "idempotent=", true);
         return {};
     }
     if (record_it->second.deadline <= now) {
-        shard.ordered_list.erase(record_it->second.list_it);
-        shard.by_key.erase(record_it);
+        pin_shard.ordered_list.erase(record_it->second.list_it);
+        pin_shard.by_key.erase(record_it);
         timer.LogResponse("error_code=", ErrorCode::LEASE_EXPIRED);
         return tl::make_unexpected(ErrorCode::LEASE_EXPIRED);
     }
@@ -1119,8 +1102,8 @@ tl::expected<void, ErrorCode> DataManager::UnPinKeyInternal(
         return {};
     }
 
-    shard.ordered_list.erase(record_it->second.list_it);
-    shard.by_key.erase(record_it);
+    pin_shard.ordered_list.erase(record_it->second.list_it);
+    pin_shard.by_key.erase(record_it);
     timer.LogResponse("error_code=", ErrorCode::OK, "ref_count=", 0);
     return {};
 }

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -265,10 +265,12 @@ size_t DataManager::ScanExpiredRecordShard(RecordShard<Record>& shard,
     return removed;
 }
 
-template size_t DataManager::ScanExpiredRecordShard<PendingWriteRecord>(
-    RecordShard<PendingWriteRecord>&, TimePoint);
-template size_t DataManager::ScanExpiredRecordShard<PinnedKeyRecord>(
-    RecordShard<PinnedKeyRecord>&, TimePoint);
+template size_t
+DataManager::ScanExpiredRecordShard<DataManager::PendingWriteRecord>(
+    RecordShard<DataManager::PendingWriteRecord>&, TimePoint);
+template size_t
+DataManager::ScanExpiredRecordShard<DataManager::PinnedKeyRecord>(
+    RecordShard<DataManager::PinnedKeyRecord>&, TimePoint);
 
 tl::expected<AllocationHandle, ErrorCode>
 DataManager::LookupPendingWriteHandleInternal(const KeyCtx& ctx,

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -154,7 +154,6 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
     lease_scan_interval_ = std::chrono::milliseconds(
         std::max<uint32_t>(1, GetEnvOr<uint32_t>("P2P_RPC_LEASE_SCAN_INTERVAL",
                                                  kDefaultLeaseScanIntervalMs)));
-    lease_scanner_thread_ = std::thread(&DataManager::LeaseScannerMain, this);
 
     LOG(INFO) << "DataManager initialized with " << lock_shard_count_
               << " lock shards, local_transfer_mode="
@@ -166,6 +165,9 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
               << local_transfer_config_.local_memcpy_async_worker_num
               << ", lease_duration_ms=" << lease_duration_.count()
               << ", lease_scan_interval_ms=" << lease_scan_interval_.count();
+
+    // Start background work only after synchronous initialization completes.
+    lease_scanner_thread_ = std::thread(&DataManager::LeaseScannerMain, this);
 }
 
 DataManager::~DataManager() { Stop(); }
@@ -229,31 +231,6 @@ DataManager::PendingWriteShard& DataManager::GetPendingWriteShard(
 DataManager::PinnedKeyShard& DataManager::GetPinnedKeyShard(
     std::string_view key) {
     return pinned_key_shards_[HashKey(key) % pinned_key_shards_.size()];
-}
-
-uint64_t DataManager::TimePointToDeadlineMs(TimePoint deadline) const {
-    const auto remaining =
-        std::max(std::chrono::milliseconds::zero(),
-                 std::chrono::duration_cast<std::chrono::milliseconds>(
-                     deadline - std::chrono::steady_clock::now()));
-    const auto system_deadline = std::chrono::system_clock::now() + remaining;
-    return static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            system_deadline.time_since_epoch())
-            .count());
-}
-
-DataManager::TimePoint DataManager::DeadlineMsToTimePoint(
-    uint64_t deadline_ms) const {
-    const auto system_deadline = std::chrono::system_clock::time_point(
-        std::chrono::milliseconds(static_cast<int64_t>(deadline_ms)));
-    const auto remaining =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            system_deadline - std::chrono::system_clock::now());
-    if (remaining <= std::chrono::milliseconds::zero()) {
-        return std::chrono::steady_clock::now();
-    }
-    return std::chrono::steady_clock::now() + remaining;
 }
 
 bool DataManager::IsExpired(TimePoint deadline) const {
@@ -976,10 +953,8 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
 
     PreWriteResult result;
     result.remote_buffer = BuildRemoteBufferDesc(handle);
-    result.deadline_ms = TimePointToDeadlineMs(deadline);
     result.pending_write_token = pending_write_token;
-    timer.LogResponse("error_code=", ErrorCode::OK,
-                      "deadline_ms=", result.deadline_ms);
+    timer.LogResponse("error_code=", ErrorCode::OK);
     return result;
 }
 
@@ -1077,7 +1052,6 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
 
         PinKeyResult result;
         result.remote_buffer = BuildRemoteBufferDesc(record_it->second.handle);
-        result.deadline_ms = TimePointToDeadlineMs(deadline);
         result.pin_token = record_it->second.pin_token;
         timer.LogResponse("error_code=", ErrorCode::OK,
                           "ref_count=", record_it->second.ref_count);
@@ -1105,10 +1079,8 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
 
     PinKeyResult result;
     result.remote_buffer = BuildRemoteBufferDesc(handle);
-    result.deadline_ms = TimePointToDeadlineMs(deadline);
     result.pin_token = pin_token_value;
-    timer.LogResponse("error_code=", ErrorCode::OK,
-                      "deadline_ms=", result.deadline_ms);
+    timer.LogResponse("error_code=", ErrorCode::OK);
     return result;
 }
 

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -173,11 +173,25 @@ DataManager::~DataManager() { Stop(); }
 
 void DataManager::Stop() {
     ShutdownLeaseScanner();
+    ClearLeaseRecords();
     if (async_memcpy_executor_) {
         async_memcpy_executor_->Shutdown();
     }
     if (tiered_backend_) {
         tiered_backend_->Stop();
+    }
+}
+
+void DataManager::ClearLeaseRecords() {
+    for (auto& shard : pending_write_shards_) {
+        std::unique_lock lock(shard.mutex);
+        shard.by_key.clear();
+        shard.ordered_list.clear();
+    }
+    for (auto& shard : pinned_key_shards_) {
+        std::unique_lock lock(shard.mutex);
+        shard.by_key.clear();
+        shard.ordered_list.clear();
     }
 }
 

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -314,7 +314,6 @@ DataManager::LookupPendingWriteHandleInternal(const KeyCtx& ctx,
 void DataManager::AbortPendingWriteInternal(const KeyCtx& ctx,
                                             const UUID& write_operation_id) {
     if (ctx.key.empty() || IsZeroUUID(write_operation_id)) return;
-    std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
     auto& pending_write_shard = GetPendingWriteShard(ctx);
     std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
     auto it = pending_write_shard.by_key.find(ctx.key);
@@ -849,25 +848,52 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
 
     const auto now = std::chrono::steady_clock::now();
     const auto deadline = now + lease_duration_;
+    const UUID write_operation_id = generate_uuid();
 
-    std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
     auto& pending_write_shard = GetPendingWriteShard(ctx);
-    std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
 
-    auto pending_it = pending_write_shard.by_key.find(ctx.key);
-    if (pending_it != pending_write_shard.by_key.end()) {
-        if (pending_it->second.deadline <= now) {
-            pending_write_shard.ordered_list.erase(pending_it->second.list_it);
-            pending_write_shard.by_key.erase(pending_it);
-        } else {
-            timer.LogResponse("error_code=", ErrorCode::OBJECT_HAS_LEASE);
-            return tl::make_unexpected(ErrorCode::OBJECT_HAS_LEASE);
+    const auto rollback_reservation = [&]() {
+        std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
+        auto it = pending_write_shard.by_key.find(ctx.key);
+        if (it != pending_write_shard.by_key.end() &&
+            it->second.write_operation_id == write_operation_id) {
+            pending_write_shard.ordered_list.erase(it->second.list_it);
+            pending_write_shard.by_key.erase(it);
         }
+    };
+
+    // Reserve a pending-write slot (handle filled after Allocate).
+    {
+        std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
+        auto pending_it = pending_write_shard.by_key.find(ctx.key);
+        if (pending_it != pending_write_shard.by_key.end()) {
+            if (pending_it->second.deadline <= now) {
+                pending_write_shard.ordered_list.erase(
+                    pending_it->second.list_it);
+                pending_write_shard.by_key.erase(pending_it);
+            } else {
+                LOG(ERROR) << "PreWrite: key has active pending write lease"
+                           << ", key=" << ctx.key
+                           << ", error=" << toString(ErrorCode::OBJECT_HAS_LEASE);
+                timer.LogResponse("error_code=", ErrorCode::OBJECT_HAS_LEASE);
+                return tl::make_unexpected(ErrorCode::OBJECT_HAS_LEASE);
+            }
+        }
+        auto list_it = pending_write_shard.ordered_list.emplace(
+            pending_write_shard.ordered_list.end(), ctx.key, deadline);
+        PendingWriteRecord record;
+        record.write_operation_id = write_operation_id;
+        record.deadline = deadline;
+        record.list_it = list_it;
+        pending_write_shard.by_key.insert_or_assign(ctx.key, std::move(record));
     }
+
+    // Slow path: no pending_write_shard_lock during tier allocation.
     if (tiered_backend_->Exist(ctx.key)) {
         LOG(ERROR) << "PreWrite: key already exists"
                    << ", key=" << ctx.key
                    << ", error=" << toString(ErrorCode::OBJECT_ALREADY_EXISTS);
+        rollback_reservation();
         timer.LogResponse("error_code=", ErrorCode::OBJECT_ALREADY_EXISTS);
         return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
     }
@@ -877,27 +903,38 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
         LOG(ERROR) << "PreWrite: Allocate failed"
                    << ", key=" << ctx.key
                    << ", error=" << toString(handle_result.error());
+        rollback_reservation();
         timer.LogResponse("error_code=", handle_result.error());
         return tl::make_unexpected(handle_result.error());
     }
 
     auto handle = std::move(handle_result.value());
+    {
+        std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
+        auto it = pending_write_shard.by_key.find(ctx.key);
+        if (it == pending_write_shard.by_key.end()) {
+            LOG(ERROR) << "PreWrite: reserved pending write record missing"
+                       << ", key=" << ctx.key
+                       << ", error=" << toString(ErrorCode::OBJECT_NOT_FOUND);
+            timer.LogResponse("error_code=", ErrorCode::OBJECT_NOT_FOUND);
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        if (it->second.write_operation_id != write_operation_id) {
+            LOG(ERROR) << "PreWrite: write_operation_id mismatch"
+                       << ", key=" << ctx.key
+                       << ", error=" << toString(ErrorCode::INVALID_WRITE);
+            timer.LogResponse("error_code=", ErrorCode::INVALID_WRITE);
+            return tl::make_unexpected(ErrorCode::INVALID_WRITE);
+        }
+        it->second.handle = handle;
+    }
+
     auto remote_buffer_result = BuildRemoteBufferDesc(handle);
     if (!remote_buffer_result) {
+        rollback_reservation();
         timer.LogResponse("error_code=", remote_buffer_result.error());
         return tl::make_unexpected(remote_buffer_result.error());
     }
-
-    auto list_it = pending_write_shard.ordered_list.emplace(
-        pending_write_shard.ordered_list.end(), ctx.key, deadline);
-
-    const UUID write_operation_id = generate_uuid();
-    PendingWriteRecord record;
-    record.write_operation_id = write_operation_id;
-    record.deadline = deadline;
-    record.handle = handle;
-    record.list_it = list_it;
-    pending_write_shard.by_key.insert_or_assign(ctx.key, std::move(record));
 
     PreWriteResult result;
     result.remote_buffer = std::move(remote_buffer_result.value());
@@ -923,45 +960,60 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
 
     const auto now = std::chrono::steady_clock::now();
 
-    std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
     auto& pending_write_shard = GetPendingWriteShard(ctx);
-    std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
+    AllocationHandle handle;
 
-    auto record_it = pending_write_shard.by_key.find(ctx.key);
-    if (record_it == pending_write_shard.by_key.end()) {
-        LOG(ERROR) << "WriteCommit: no pending write record for key: "
-                   << ctx.key;
-        timer.LogResponse("error_code=", ErrorCode::OBJECT_NOT_FOUND);
-        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
-    }
-    if (record_it->second.deadline <= now) {
+    // Pending: validate token, copy handle, remove lease (always, before Commit).
+    {
+        std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
+        auto record_it = pending_write_shard.by_key.find(ctx.key);
+        if (record_it == pending_write_shard.by_key.end()) {
+            LOG(ERROR) << "WriteCommit: no pending write record for key: "
+                       << ctx.key;
+            timer.LogResponse("error_code=", ErrorCode::OBJECT_NOT_FOUND);
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        if (record_it->second.deadline <= now) {
+            pending_write_shard.ordered_list.erase(record_it->second.list_it);
+            pending_write_shard.by_key.erase(record_it);
+            LOG(ERROR) << "WriteCommit: pending write lease expired"
+                       << ", key=" << ctx.key
+                       << ", error=" << toString(ErrorCode::LEASE_EXPIRED);
+            timer.LogResponse("error_code=", ErrorCode::LEASE_EXPIRED);
+            return tl::make_unexpected(ErrorCode::LEASE_EXPIRED);
+        }
+        if (record_it->second.write_operation_id != write_operation_id) {
+            LOG(ERROR) << "WriteCommit: write_operation_id mismatch"
+                       << ", key=" << ctx.key
+                       << ", error=" << toString(ErrorCode::INVALID_WRITE);
+            timer.LogResponse("error_code=", ErrorCode::INVALID_WRITE);
+            return tl::make_unexpected(ErrorCode::INVALID_WRITE);
+        }
+        if (!record_it->second.handle) {
+            LOG(ERROR) << "WriteCommit: pending write has no allocation handle"
+                       << ", key=" << ctx.key
+                       << ", error=" << toString(ErrorCode::INVALID_WRITE);
+            timer.LogResponse("error_code=", ErrorCode::INVALID_WRITE);
+            return tl::make_unexpected(ErrorCode::INVALID_WRITE);
+        }
+        handle = record_it->second.handle;
         pending_write_shard.ordered_list.erase(record_it->second.list_it);
         pending_write_shard.by_key.erase(record_it);
-        timer.LogResponse("error_code=", ErrorCode::LEASE_EXPIRED);
-        return tl::make_unexpected(ErrorCode::LEASE_EXPIRED);
-    }
-    if (record_it->second.write_operation_id != write_operation_id) {
-        timer.LogResponse("error_code=", ErrorCode::INVALID_WRITE);
-        return tl::make_unexpected(ErrorCode::INVALID_WRITE);
     }
 
-    auto handle = record_it->second.handle;
-    // Once we attempt the commit, always erase the pending record regardless of
-    // the commit result.
-    //
-    // Rationale: most commit failures are not transient and cannot be resolved
-    // by retrying WriteCommit alone (e.g. tier commit failure or master
-    // callback failure). The caller should restart a full write flow instead of
-    // reusing a potentially stale prewrite context.
-    //
-    // Note: after erasing the record, a duplicate WriteCommit without a new
-    // PreWrite returns OBJECT_NOT_FOUND (unlike UnPinKey, writes are not
-    // idempotent past commit).
-    auto commit_result = tiered_backend_->Commit(ctx.key, handle);
-    pending_write_shard.ordered_list.erase(record_it->second.list_it);
-    pending_write_shard.by_key.erase(record_it);
+    // Commit under key_lock to avoid concurrent Delete. Most commit failures
+    // are not recoverable by retrying WriteCommit alone; caller must restart
+    // PreWrite -> transfer -> WriteCommit. Duplicate WriteCommit -> OBJECT_NOT_FOUND.
+    tl::expected<void, ErrorCode> commit_result;
+    {
+        std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
+        commit_result = tiered_backend_->Commit(ctx.key, handle);
+    }
 
     if (!commit_result) {
+        LOG(ERROR) << "WriteCommit: tier commit failed"
+                   << ", key=" << ctx.key
+                   << ", error=" << toString(commit_result.error());
         timer.LogResponse("error_code=", commit_result.error(),
                           "record_erased=", true);
         return tl::make_unexpected(commit_result.error());
@@ -989,39 +1041,47 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     const auto now = std::chrono::steady_clock::now();
     const auto deadline = now + lease_duration_;
 
-    std::shared_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
     auto& pin_shard = GetPinnedKeyShard(ctx);
-    std::unique_lock pin_shard_lock(pin_shard.mutex);
 
-    auto record_it = pin_shard.by_key.find(ctx.key);
-    if (record_it != pin_shard.by_key.end()) {
-        if (record_it->second.deadline <= now) {
-            pin_shard.ordered_list.erase(record_it->second.list_it);
-            pin_shard.by_key.erase(record_it);
-        } else {
-            auto remote_buffer_result =
-                BuildRemoteBufferDesc(record_it->second.handle);
-            if (!remote_buffer_result) {
-                timer.LogResponse("error_code=", remote_buffer_result.error());
-                return tl::make_unexpected(remote_buffer_result.error());
+    // Active pin: bump ref_count / renew lease; no tiered_backend::Get.
+    const auto bump_existing_pin =
+        [&](auto it) -> tl::expected<PinKeyResult, ErrorCode> {
+        auto remote_buffer_result = BuildRemoteBufferDesc(it->second.handle);
+        if (!remote_buffer_result) {
+            timer.LogResponse("error_code=", remote_buffer_result.error());
+            return tl::make_unexpected(remote_buffer_result.error());
+        }
+        it->second.ref_count++;
+        it->second.deadline = deadline;
+        auto list_it = it->second.list_it;
+        list_it->first.assign(ctx.key.data(), ctx.key.size());
+        list_it->second = deadline;
+        pin_shard.ordered_list.splice(pin_shard.ordered_list.end(),
+                                      pin_shard.ordered_list, list_it);
+
+        PinKeyResult result;
+        result.remote_buffer = std::move(remote_buffer_result.value());
+        result.read_operation_id = it->second.read_operation_id;
+        timer.LogResponse("error_code=", ErrorCode::OK,
+                          "ref_count=", it->second.ref_count);
+        return result;
+    };
+
+    // Fast path: valid pin record -> return without tiered_backend::Get.
+    {
+        std::unique_lock pin_shard_lock(pin_shard.mutex);
+        auto record_it = pin_shard.by_key.find(ctx.key);
+        if (record_it != pin_shard.by_key.end()) {
+            if (record_it->second.deadline <= now) {
+                pin_shard.ordered_list.erase(record_it->second.list_it);
+                pin_shard.by_key.erase(record_it);
+            } else {
+                return bump_existing_pin(record_it);
             }
-            record_it->second.ref_count++;
-            record_it->second.deadline = deadline;
-            auto list_it = record_it->second.list_it;
-            list_it->first.assign(ctx.key.data(), ctx.key.size());
-            list_it->second = deadline;
-            pin_shard.ordered_list.splice(pin_shard.ordered_list.end(),
-                                          pin_shard.ordered_list, list_it);
-
-            PinKeyResult result;
-            result.remote_buffer = std::move(remote_buffer_result.value());
-            result.read_operation_id = record_it->second.read_operation_id;
-            timer.LogResponse("error_code=", ErrorCode::OK,
-                              "ref_count=", record_it->second.ref_count);
-            return result;
         }
     }
 
+    // Slow path: Get committed object (no pin_shard_lock).
     auto handle_result = tiered_backend_->Get(ctx.key, tier_id);
     if (!handle_result) {
         LOG(ERROR) << "PinKey: Get failed"
@@ -1036,6 +1096,18 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     if (!remote_buffer_result) {
         timer.LogResponse("error_code=", remote_buffer_result.error());
         return tl::make_unexpected(remote_buffer_result.error());
+    }
+
+    // Re-check after Get: concurrent pin -> bump; else insert new record.
+    std::unique_lock pin_shard_lock(pin_shard.mutex);
+    auto record_it = pin_shard.by_key.find(ctx.key);
+    if (record_it != pin_shard.by_key.end()) {
+        if (record_it->second.deadline <= now) {
+            pin_shard.ordered_list.erase(record_it->second.list_it);
+            pin_shard.by_key.erase(record_it);
+        } else {
+            return bump_existing_pin(record_it);
+        }
     }
 
     auto list_it = pin_shard.ordered_list.emplace(pin_shard.ordered_list.end(),
@@ -1074,7 +1146,6 @@ tl::expected<void, ErrorCode> DataManager::UnPinKeyInternal(
 
     const auto now = std::chrono::steady_clock::now();
 
-    std::shared_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
     auto& pin_shard = GetPinnedKeyShard(ctx);
     std::unique_lock pin_shard_lock(pin_shard.mutex);
 

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -157,8 +157,8 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
         local_transfer_config_.p2p_key_lease_scan_interval_ms > 0
             ? local_transfer_config_.p2p_key_lease_scan_interval_ms
             : kDefaultLeaseScanIntervalMs;
-    lease_scan_interval_ = std::chrono::milliseconds(
-        std::max<uint32_t>(1, scan_ms));
+    lease_scan_interval_ =
+        std::chrono::milliseconds(std::max<uint32_t>(1, scan_ms));
 
     LOG(INFO) << "DataManager initialized with " << lock_shard_count_
               << " lock shards, local_transfer_mode="
@@ -169,7 +169,8 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
               << ", async_memcpy_workers="
               << local_transfer_config_.local_memcpy_async_worker_num
               << ", p2p_key_lease_duration_ms=" << lease_duration_.count()
-              << ", p2p_key_lease_scan_interval_ms=" << lease_scan_interval_.count();
+              << ", p2p_key_lease_scan_interval_ms="
+              << lease_scan_interval_.count();
 
     // Start background work only after synchronous initialization completes.
     lease_scanner_thread_ = std::thread(&DataManager::LeaseScannerMain, this);
@@ -237,8 +238,7 @@ tl::expected<RemoteBufferDesc, ErrorCode> DataManager::BuildRemoteBufferDesc(
     }
     RemoteBufferDesc remote_buffer;
     remote_buffer.segment_endpoint = local_transfer_config_.te_endpoint;
-    remote_buffer.addr =
-        reinterpret_cast<uintptr_t>(loc_data.buffer->data());
+    remote_buffer.addr = reinterpret_cast<uintptr_t>(loc_data.buffer->data());
     remote_buffer.size = loc_data.buffer->size();
     return remote_buffer;
 }
@@ -858,8 +858,8 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
                 pending_write_shard.by_key.erase(pending_it);
             } else {
                 LOG(ERROR) << "PreWrite: key has active pending write lease"
-                           << ", key=" << ctx.key
-                           << ", error=" << toString(ErrorCode::OBJECT_HAS_LEASE);
+                           << ", key=" << ctx.key << ", error="
+                           << toString(ErrorCode::OBJECT_HAS_LEASE);
                 timer.LogResponse("error_code=", ErrorCode::OBJECT_HAS_LEASE);
                 return tl::make_unexpected(ErrorCode::OBJECT_HAS_LEASE);
             }
@@ -948,7 +948,8 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
     auto& pending_write_shard = GetPendingWriteShard(ctx);
     AllocationHandle handle;
 
-    // Pending: validate token, copy handle, remove lease (always, before Commit).
+    // Pending: validate token, copy handle, remove lease (always, before
+    // Commit).
     {
         std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
         auto record_it = pending_write_shard.by_key.find(ctx.key);
@@ -988,7 +989,8 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
 
     // Commit under key_lock to avoid concurrent Delete. Most commit failures
     // are not recoverable by retrying WriteCommit alone; caller must restart
-    // PreWrite -> transfer -> WriteCommit. Duplicate WriteCommit -> OBJECT_NOT_FOUND.
+    // PreWrite -> transfer -> WriteCommit. Duplicate WriteCommit ->
+    // OBJECT_NOT_FOUND.
     tl::expected<void, ErrorCode> commit_result;
     {
         std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
@@ -1114,8 +1116,8 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     return result;
 }
 
-tl::expected<void, ErrorCode> DataManager::UnPinKey(std::string_view key,
-                                                    const UUID& read_operation_id) {
+tl::expected<void, ErrorCode> DataManager::UnPinKey(
+    std::string_view key, const UUID& read_operation_id) {
     return UnPinKeyInternal(BuildKeyCtx(key), read_operation_id);
 }
 

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -251,9 +251,10 @@ size_t DataManager::ScanExpiredRecordShard(RecordShard<Record>& shard,
         }
         auto record_it = shard.existed_operation_key_map.find(list_it->first);
         if (record_it == shard.existed_operation_key_map.end()) {
-            LOG(WARNING) << "ScanExpiredRecordShard: expired ordered_list entry "
-                            "missing from existed_operation_key_map, key="
-                         << list_it->first;
+            LOG(WARNING)
+                << "ScanExpiredRecordShard: expired ordered_list entry "
+                   "missing from existed_operation_key_map, key="
+                << list_it->first;
             shard.ordered_list.erase(list_it);
             continue;
         }
@@ -301,12 +302,14 @@ void DataManager::AbortPendingWriteInternal(const KeyCtx& ctx,
     switch (ErasePendingWriteRecord(pending_write_shard, ctx.key,
                                     write_operation_id)) {
         case PendingWriteEraseResult::NotFound:
-            LOG(WARNING) << "AbortPendingWrite: no pending write record for key: "
-                         << ctx.key;
+            LOG(WARNING)
+                << "AbortPendingWrite: no pending write record for key: "
+                << ctx.key;
             break;
         case PendingWriteEraseResult::WriteOperationIdMismatch:
-            LOG(ERROR) << "AbortPendingWrite: write_operation_id mismatch for key: "
-                       << ctx.key;
+            LOG(ERROR)
+                << "AbortPendingWrite: write_operation_id mismatch for key: "
+                << ctx.key;
             break;
         case PendingWriteEraseResult::Erased:
             break;
@@ -596,10 +599,10 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
         return {};
     };
 
-    auto write_and_commit = [write_fn = std::move(write_fn),
-                             commit_fn = std::move(commit_fn),
-                             key_owned = std::string(key)]() mutable
-        -> tl::expected<void, ErrorCode> {
+    auto write_and_commit =
+        [write_fn = std::move(write_fn), commit_fn = std::move(commit_fn),
+         key_owned =
+             std::string(key)]() mutable -> tl::expected<void, ErrorCode> {
         ScopedVLogTimer timer(1, "DataManager::PutViaMemcpy");
         timer.LogRequest("key=", key_owned);
         auto write_result = write_fn();
@@ -921,11 +924,12 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
         return tl::make_unexpected(reserve_result.error());
     }
 
-    // Reserve holds unique_lock because it inserts into existed_operation_key_map
-    // and ordered_list. Allocate runs without shard lock so other keys in the
-    // shard are not blocked. Attach only fills handle on the reserved record
-    // under shared_lock (see AttachPendingWriteHandle); the record itself has no
-    // separate lock while the write lease excludes concurrent writers.
+    // Reserve holds unique_lock because it inserts into
+    // existed_operation_key_map and ordered_list. Allocate runs without shard
+    // lock so other keys in the shard are not blocked. Attach only fills handle
+    // on the reserved record under shared_lock (see AttachPendingWriteHandle);
+    // the record itself has no separate lock while the write lease excludes
+    // concurrent writers.
     if (tiered_backend_->Exist(ctx.key)) {
         LOG(ERROR) << "PreWrite: key already exists"
                    << ", key=" << ctx.key
@@ -948,8 +952,8 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
     }
 
     auto handle = std::move(handle_result.value());
-    auto attach_result = AttachPendingWriteHandle(
-        pending_write_shard, ctx.key, write_operation_id, handle);
+    auto attach_result = AttachPendingWriteHandle(pending_write_shard, ctx.key,
+                                                  write_operation_id, handle);
     if (!attach_result) {
         timer.LogResponse("error_code=", attach_result.error());
         return tl::make_unexpected(attach_result.error());
@@ -1000,8 +1004,9 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
             const auto erased = ErasePendingWriteRecord(
                 pending_write_shard, ctx.key, write_operation_id);
             if (erased == PendingWriteEraseResult::Erased) {
-                LOG(ERROR) << "WriteCommit: removed expired pending write record"
-                           << ", key=" << ctx.key;
+                LOG(ERROR)
+                    << "WriteCommit: removed expired pending write record"
+                    << ", key=" << ctx.key;
             } else {
                 LOG(WARNING) << "WriteCommit: expired pending write record not "
                                 "found for cleanup, key="
@@ -1019,8 +1024,8 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
     // metadata updates on this key via its internal shard lock.
     auto commit_result = tiered_backend_->Commit(ctx.key, handle);
 
-    const auto erased = ErasePendingWriteRecord(
-        pending_write_shard, ctx.key, write_operation_id);
+    const auto erased = ErasePendingWriteRecord(pending_write_shard, ctx.key,
+                                                write_operation_id);
     if (erased != PendingWriteEraseResult::Erased) {
         LOG(WARNING) << "WriteCommit: pending write record already removed"
                      << " during commit, key=" << ctx.key;
@@ -1030,9 +1035,9 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
         LOG(ERROR) << "WriteCommit: tier commit failed"
                    << ", key=" << ctx.key
                    << ", error=" << toString(commit_result.error());
-        timer.LogResponse("error_code=", commit_result.error(),
-                          "record_erased=",
-                          erased == PendingWriteEraseResult::Erased);
+        timer.LogResponse(
+            "error_code=", commit_result.error(),
+            "record_erased=", erased == PendingWriteEraseResult::Erased);
         return tl::make_unexpected(commit_result.error());
     }
 
@@ -1138,7 +1143,8 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     record.handle = handle;
     record.ref_count = 1;
     record.list_it = list_it;
-    pin_shard.existed_operation_key_map.insert_or_assign(ctx.key, std::move(record));
+    pin_shard.existed_operation_key_map.insert_or_assign(ctx.key,
+                                                         std::move(record));
 
     PinKeyResult result;
     result.remote_buffer = std::move(remote_buffer_result.value());

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -254,10 +254,13 @@ RemoteBufferDesc DataManager::BuildRemoteBufferDesc(
     const auto& loc_data = handle->loc.data;
     RemoteBufferDesc remote_buffer;
     remote_buffer.segment_endpoint = local_transfer_config_.te_endpoint;
-    remote_buffer.addr =
-        reinterpret_cast<uintptr_t>(loc_data.buffer ? loc_data.buffer->data()
-                                                    : nullptr);
-    remote_buffer.size = loc_data.buffer ? loc_data.buffer->size() : 0;
+    remote_buffer.addr = 0;
+    remote_buffer.size = 0;
+    if (loc_data.buffer) {
+        remote_buffer.addr =
+            reinterpret_cast<uintptr_t>(loc_data.buffer->data());
+        remote_buffer.size = loc_data.buffer->size();
+    }
     return remote_buffer;
 }
 

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -410,16 +410,17 @@ void DataManager::ShutdownLeaseScanner() {
 }
 
 void DataManager::LeaseScannerMain() {
-    std::unique_lock<std::mutex> wait_lock(lease_scanner_mutex_);
     while (!lease_scanner_stop_requested_.load()) {
-        lease_scanner_cv_.wait_for(wait_lock, lease_scan_interval_, [this]() {
-            return lease_scanner_stop_requested_.load();
-        });
+        {
+            std::unique_lock<std::mutex> wait_lock(lease_scanner_mutex_);
+            lease_scanner_cv_.wait_for(
+                wait_lock, lease_scan_interval_,
+                [this]() { return lease_scanner_stop_requested_.load(); });
+        }
         if (lease_scanner_stop_requested_.load()) {
             break;
         }
         const auto now = std::chrono::steady_clock::now();
-        wait_lock.unlock();
         for (auto& shard : pending_write_shards_) {
             std::unique_lock shard_lock(shard.mutex);
             ScanExpiredRecordShard(shard, now);
@@ -428,7 +429,6 @@ void DataManager::LeaseScannerMain() {
             std::unique_lock shard_lock(shard.mutex);
             ScanExpiredRecordShard(shard, now);
         }
-        wait_lock.lock();
     }
 }
 
@@ -501,10 +501,8 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
     }
 
     return CallableTaskHandle<void>::Create(
-        [this, ctx = std::move(*submit_result), alloc_handle,
-         key_owned = std::string(key),
+        [this, ctx = std::move(*submit_result), alloc_handle, kctx,
          write_operation_id]() mutable -> tl::expected<void, ErrorCode> {
-            const KeyCtx kctx = BuildKeyCtx(key_owned);
             ScopedVLogTimer timer(1, "DataManager::PutViaTe");
             timer.LogRequest("key=", kctx.key);
 
@@ -566,9 +564,8 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
     const UUID write_operation_id = prewrite_result->write_operation_id;
     AllocationHandle alloc_handle = prewrite_result->handle;
 
-    auto write_fn = [this, key_owned = std::string(key), slice, alloc_handle,
+    auto write_fn = [this, kctx, slice, alloc_handle,
                      write_operation_id]() -> tl::expected<void, ErrorCode> {
-        const KeyCtx kctx = BuildKeyCtx(key_owned);
         DataSource source;
         source.buffer = std::make_unique<RefBuffer>(slice.ptr, slice.size);
         source.type = MemoryType::DRAM;
@@ -583,9 +580,8 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
         return {};
     };
 
-    auto commit_fn = [this, key_owned = std::string(key),
+    auto commit_fn = [this, kctx,
                       write_operation_id]() -> tl::expected<void, ErrorCode> {
-        const KeyCtx kctx = BuildKeyCtx(key_owned);
         auto commit_result = WriteCommitInternal(kctx, write_operation_id);
         if (!commit_result) {
             LOG(ERROR) << "Failed to commit data for key: " << kctx.key
@@ -595,12 +591,11 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
         return {};
     };
 
-    auto write_and_commit =
-        [write_fn = std::move(write_fn), commit_fn = std::move(commit_fn),
-         key_owned =
-             std::string(key)]() mutable -> tl::expected<void, ErrorCode> {
+    auto write_and_commit = [write_fn = std::move(write_fn),
+                             commit_fn = std::move(commit_fn),
+                             kctx]() mutable -> tl::expected<void, ErrorCode> {
         ScopedVLogTimer timer(1, "DataManager::PutViaMemcpy");
-        timer.LogRequest("key=", key_owned);
+        timer.LogRequest("key=", kctx.key);
         auto write_result = write_fn();
         if (!write_result) {
             LOG(ERROR) << "Failed to write data, error: "
@@ -888,6 +883,9 @@ tl::expected<DataManager::PreWriteResult, ErrorCode> DataManager::PreWrite(
     auto internal_result =
         PreWriteInternal(BuildKeyCtx(key), size_bytes, tier_id);
     if (!internal_result) {
+        LOG(WARNING) << "PreWrite failed"
+                     << ", key=" << key
+                     << ", error=" << toString(internal_result.error());
         return tl::make_unexpected(internal_result.error());
     }
     PreWriteResult rpc_result;
@@ -1075,7 +1073,6 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
         it->second.ref_count++;
         it->second.deadline = deadline;
         auto list_it = it->second.list_it;
-        list_it->first.assign(ctx.key.data(), ctx.key.size());
         list_it->second = deadline;
         pin_shard.ordered_list.splice(pin_shard.ordered_list.end(),
                                       pin_shard.ordered_list, list_it);

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -149,9 +149,8 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
             local_transfer_config_.local_memcpy_async_worker_num);
     }
 
-    lease_duration_ = std::chrono::milliseconds(
-        GetEnvOr<uint32_t>("P2P_RPC_LEASE_DURATION_MS",
-                           kDefaultLeaseDurationMs));
+    lease_duration_ = std::chrono::milliseconds(GetEnvOr<uint32_t>(
+        "P2P_RPC_LEASE_DURATION_MS", kDefaultLeaseDurationMs));
     lease_scan_interval_ = std::chrono::milliseconds(
         std::max<uint32_t>(1, GetEnvOr<uint32_t>("P2P_RPC_LEASE_SCAN_INTERVAL",
                                                  kDefaultLeaseScanIntervalMs)));
@@ -237,8 +236,7 @@ uint64_t DataManager::TimePointToDeadlineMs(TimePoint deadline) const {
         std::max(std::chrono::milliseconds::zero(),
                  std::chrono::duration_cast<std::chrono::milliseconds>(
                      deadline - std::chrono::steady_clock::now()));
-    const auto system_deadline =
-        std::chrono::system_clock::now() + remaining;
+    const auto system_deadline = std::chrono::system_clock::now() + remaining;
     return static_cast<uint64_t>(
         std::chrono::duration_cast<std::chrono::milliseconds>(
             system_deadline.time_since_epoch())
@@ -247,9 +245,8 @@ uint64_t DataManager::TimePointToDeadlineMs(TimePoint deadline) const {
 
 DataManager::TimePoint DataManager::DeadlineMsToTimePoint(
     uint64_t deadline_ms) const {
-    const auto system_deadline =
-        std::chrono::system_clock::time_point(std::chrono::milliseconds(
-            static_cast<int64_t>(deadline_ms)));
+    const auto system_deadline = std::chrono::system_clock::time_point(
+        std::chrono::milliseconds(static_cast<int64_t>(deadline_ms)));
     const auto remaining =
         std::chrono::duration_cast<std::chrono::milliseconds>(
             system_deadline - std::chrono::system_clock::now());
@@ -354,7 +351,8 @@ size_t DataManager::ScanExpiredPendingWrites(PendingWriteShard& shard,
     return removed;
 }
 
-size_t DataManager::ScanExpiredPinnedKeys(PinnedKeyShard& shard, TimePoint now) {
+size_t DataManager::ScanExpiredPinnedKeys(PinnedKeyShard& shard,
+                                          TimePoint now) {
     size_t removed = 0;
     while (!shard.ordered_list.empty()) {
         auto list_it = shard.ordered_list.begin();
@@ -404,8 +402,9 @@ tl::expected<AllocationHandle, ErrorCode> DataManager::LookupPinnedKeyHandle(
     return LookupPinnedKeyHandleInternal(BuildKeyCtx(key), pin_token);
 }
 
-tl::expected<AllocationHandle, ErrorCode> DataManager::LookupPinnedKeyHandleInternal(
-    const KeyCtx& ctx, const UUID& pin_token) {
+tl::expected<AllocationHandle, ErrorCode>
+DataManager::LookupPinnedKeyHandleInternal(const KeyCtx& ctx,
+                                           const UUID& pin_token) {
     const auto now = std::chrono::steady_clock::now();
     auto& shard = GetPinnedKeyShard(ctx);
     std::shared_lock shard_lock(shard.mutex);
@@ -423,7 +422,7 @@ tl::expected<AllocationHandle, ErrorCode> DataManager::LookupPinnedKeyHandleInte
 }
 
 void DataManager::AbortPendingWrite(std::string_view key,
-                                   const UUID& pending_write_token) {
+                                    const UUID& pending_write_token) {
     AbortPendingWriteInternal(BuildKeyCtx(key), pending_write_token);
 }
 
@@ -626,14 +625,13 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
 
     auto commit_fn = [this, kctx,
                       pending_write_token]() -> tl::expected<void, ErrorCode> {
-            auto commit_result =
-                WriteCommitInternal(kctx, pending_write_token);
-            if (!commit_result) {
-                LOG(ERROR) << "Failed to commit data for key: " << kctx.key
-                           << ", error: " << commit_result.error();
-                return tl::make_unexpected(commit_result.error());
-            }
-            return {};
+        auto commit_result = WriteCommitInternal(kctx, pending_write_token);
+        if (!commit_result) {
+            LOG(ERROR) << "Failed to commit data for key: " << kctx.key
+                       << ", error: " << commit_result.error();
+            return tl::make_unexpected(commit_result.error());
+        }
+        return {};
     };
 
     auto write_and_commit = [write_fn = std::move(write_fn),
@@ -852,7 +850,8 @@ tl::expected<void, ErrorCode> DataManager::ReadRemoteData(
         return tl::make_unexpected(handle_result.error());
     }
 
-    auto transfer_result = TransferDataToRemote(handle_result.value(), dest_buffers);
+    auto transfer_result =
+        TransferDataToRemote(handle_result.value(), dest_buffers);
     auto unpin_result = UnPinKeyInternal(kctx, pin_token);
 
     if (!transfer_result) {
@@ -944,8 +943,9 @@ tl::expected<DataManager::PreWriteResult, ErrorCode> DataManager::PreWrite(
     return PreWriteInternal(BuildKeyCtx(key), size_bytes, tier_id);
 }
 
-tl::expected<DataManager::PreWriteResult, ErrorCode> DataManager::PreWriteInternal(
-    const KeyCtx& ctx, size_t size_bytes, std::optional<UUID> tier_id) {
+tl::expected<DataManager::PreWriteResult, ErrorCode>
+DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
+                              std::optional<UUID> tier_id) {
     ScopedVLogTimer timer(1, "DataManager::PreWrite");
     timer.LogRequest("key=", ctx.key, "size_bytes=", size_bytes);
 
@@ -978,8 +978,8 @@ tl::expected<DataManager::PreWriteResult, ErrorCode> DataManager::PreWriteIntern
     }
 
     auto handle = std::move(handle_result.value());
-    auto list_it =
-        shard.ordered_list.emplace(shard.ordered_list.end(), ctx.key_string, deadline);
+    auto list_it = shard.ordered_list.emplace(shard.ordered_list.end(),
+                                              ctx.key_string, deadline);
 
     const UUID pending_write_token = generate_uuid();
     PendingWriteRecord record;
@@ -1106,8 +1106,8 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     }
 
     auto handle = std::move(handle_result.value());
-    auto list_it =
-        shard.ordered_list.emplace(shard.ordered_list.end(), ctx.key_string, deadline);
+    auto list_it = shard.ordered_list.emplace(shard.ordered_list.end(),
+                                              ctx.key_string, deadline);
 
     const UUID pin_token_value = generate_uuid();
     PinnedKeyRecord record;
@@ -1692,10 +1692,10 @@ tl::expected<void, ErrorCode> DataManager::Delete(std::string_view key,
     timer.LogRequest("key=", key);
 
     // NOTE (weak delete semantics):
-    // TieredBackend::Delete only removes the metadata entry (or a replica entry)
-    // from the in-memory index. It does NOT directly free underlying memory.
-    // The actual buffer lifetime is still governed by AllocationHandle's RAII
-    // reference counting.
+    // TieredBackend::Delete only removes the metadata entry (or a replica
+    // entry) from the in-memory index. It does NOT directly free underlying
+    // memory. The actual buffer lifetime is still governed by
+    // AllocationHandle's RAII reference counting.
     //
     // We still guard Delete against in-flight 3-phase contexts:
     // - PendingWriteRecord holds a strong handle reference until WriteCommit or

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -201,15 +201,11 @@ void DataManager::ClearLeaseRecords() {
     }
 }
 
-size_t DataManager::HashKey(std::string_view key) const {
-    return std::hash<std::string_view>{}(key);
-}
-
 DataManager::KeyCtx DataManager::BuildKeyCtx(std::string_view key) const {
     KeyCtx ctx;
-    ctx.key = key;
-    ctx.key_string = std::string(key);
-    ctx.hash = HashKey(key);
+    // `key` may reference RPC/coro request storage; copy before returning.
+    ctx.key.assign(key.data(), key.size());
+    ctx.hash = StringHash{}(std::string_view(ctx.key));
     ctx.pending_write_shard_idx =
         pending_write_shards_.empty()
             ? 0
@@ -226,16 +222,6 @@ DataManager::PendingWriteShard& DataManager::GetPendingWriteShard(
 
 DataManager::PinnedKeyShard& DataManager::GetPinnedKeyShard(const KeyCtx& ctx) {
     return pinned_key_shards_[ctx.pinned_key_shard_idx];
-}
-
-DataManager::PendingWriteShard& DataManager::GetPendingWriteShard(
-    std::string_view key) {
-    return pending_write_shards_[HashKey(key) % pending_write_shards_.size()];
-}
-
-DataManager::PinnedKeyShard& DataManager::GetPinnedKeyShard(
-    std::string_view key) {
-    return pinned_key_shards_[HashKey(key) % pinned_key_shards_.size()];
 }
 
 bool DataManager::IsExpired(TimePoint deadline) const {
@@ -259,15 +245,15 @@ RemoteBufferDesc DataManager::BuildRemoteBufferDesc(
 
 void DataManager::TouchOrderedDeadlineNode(OrderedDeadlineList& ordered_list,
                                            OrderedDeadlineListIt it,
-                                           const std::string& key,
+                                           std::string_view key,
                                            TimePoint deadline) {
-    it->first = key;
+    it->first.assign(key.data(), key.size());
     it->second = deadline;
     ordered_list.splice(ordered_list.end(), ordered_list, it);
 }
 
 bool DataManager::ErasePendingWriteLocked(PendingWriteShard& shard,
-                                          const std::string& key) {
+                                         std::string_view key) {
     auto it = shard.by_key.find(key);
     if (it == shard.by_key.end()) {
         return false;
@@ -278,7 +264,7 @@ bool DataManager::ErasePendingWriteLocked(PendingWriteShard& shard,
 }
 
 bool DataManager::ErasePinnedKeyLocked(PinnedKeyShard& shard,
-                                       const std::string& key) {
+                                      std::string_view key) {
     auto it = shard.by_key.find(key);
     if (it == shard.by_key.end()) {
         return false;
@@ -289,8 +275,8 @@ bool DataManager::ErasePinnedKeyLocked(PinnedKeyShard& shard,
 }
 
 bool DataManager::RemoveExpiredPendingWriteLocked(PendingWriteShard& shard,
-                                                  const std::string& key,
-                                                  TimePoint now) {
+                                                 std::string_view key,
+                                                 TimePoint now) {
     auto it = shard.by_key.find(key);
     if (it == shard.by_key.end() || it->second.deadline > now) {
         return false;
@@ -366,7 +352,7 @@ DataManager::LookupPendingWriteHandleInternal(const KeyCtx& ctx,
     const auto now = std::chrono::steady_clock::now();
     auto& shard = GetPendingWriteShard(ctx);
     std::shared_lock shard_lock(shard.mutex);
-    auto it = shard.by_key.find(ctx.key_string);
+    auto it = shard.by_key.find(ctx.key);
     if (it == shard.by_key.end()) {
         return tl::unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -390,7 +376,7 @@ DataManager::LookupPinnedKeyHandleInternal(const KeyCtx& ctx,
     const auto now = std::chrono::steady_clock::now();
     auto& shard = GetPinnedKeyShard(ctx);
     std::shared_lock shard_lock(shard.mutex);
-    auto it = shard.by_key.find(ctx.key_string);
+    auto it = shard.by_key.find(ctx.key);
     if (it == shard.by_key.end()) {
         return tl::unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -414,7 +400,7 @@ void DataManager::AbortPendingWriteInternal(const KeyCtx& ctx,
     std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
     auto& shard = GetPendingWriteShard(ctx);
     std::unique_lock shard_lock(shard.mutex);
-    auto it = shard.by_key.find(ctx.key_string);
+    auto it = shard.by_key.find(ctx.key);
     if (it == shard.by_key.end()) return;
     if (it->second.write_operation_id != write_operation_id) return;
     shard.ordered_list.erase(it->second.list_it);
@@ -928,8 +914,8 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
     auto& shard = GetPendingWriteShard(ctx);
     std::unique_lock shard_lock(shard.mutex);
 
-    RemoveExpiredPendingWriteLocked(shard, ctx.key_string, now);
-    if (shard.by_key.find(ctx.key_string) != shard.by_key.end()) {
+    RemoveExpiredPendingWriteLocked(shard, ctx.key, now);
+    if (shard.by_key.find(ctx.key) != shard.by_key.end()) {
         timer.LogResponse("error_code=", ErrorCode::OBJECT_HAS_LEASE);
         return tl::make_unexpected(ErrorCode::OBJECT_HAS_LEASE);
     }
@@ -946,7 +932,7 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
 
     auto handle = std::move(handle_result.value());
     auto list_it = shard.ordered_list.emplace(shard.ordered_list.end(),
-                                              ctx.key_string, deadline);
+                                              ctx.key, deadline);
 
     const UUID write_operation_id = generate_uuid();
     PendingWriteRecord record;
@@ -954,7 +940,7 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
     record.deadline = deadline;
     record.handle = handle;
     record.list_it = list_it;
-    shard.by_key.insert_or_assign(ctx.key_string, std::move(record));
+    shard.by_key.insert_or_assign(ctx.key, std::move(record));
 
     PreWriteResult result;
     result.remote_buffer = BuildRemoteBufferDesc(handle);
@@ -984,7 +970,7 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
     auto& shard = GetPendingWriteShard(ctx);
     std::unique_lock shard_lock(shard.mutex);
 
-    auto record_it = shard.by_key.find(ctx.key_string);
+    auto record_it = shard.by_key.find(ctx.key);
     if (record_it == shard.by_key.end()) {
         timer.LogResponse("error_code=", ErrorCode::OK, "idempotent=", true);
         return {};
@@ -1047,13 +1033,13 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     auto& shard = GetPinnedKeyShard(ctx);
     std::unique_lock shard_lock(shard.mutex);
 
-    RemoveExpiredPinnedKeyLocked(shard, ctx.key_string, now);
-    auto record_it = shard.by_key.find(ctx.key_string);
+    RemoveExpiredPinnedKeyLocked(shard, ctx.key, now);
+    auto record_it = shard.by_key.find(ctx.key);
     if (record_it != shard.by_key.end()) {
         record_it->second.ref_count++;
         record_it->second.deadline = deadline;
         TouchOrderedDeadlineNode(shard.ordered_list, record_it->second.list_it,
-                                 ctx.key_string, deadline);
+                                 ctx.key, deadline);
 
         PinKeyResult result;
         result.remote_buffer = BuildRemoteBufferDesc(record_it->second.handle);
@@ -1071,7 +1057,7 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
 
     auto handle = std::move(handle_result.value());
     auto list_it = shard.ordered_list.emplace(shard.ordered_list.end(),
-                                              ctx.key_string, deadline);
+                                              ctx.key, deadline);
 
     const UUID read_operation_id_value = generate_uuid();
     PinnedKeyRecord record;
@@ -1080,7 +1066,7 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     record.handle = handle;
     record.ref_count = 1;
     record.list_it = list_it;
-    shard.by_key.insert_or_assign(ctx.key_string, std::move(record));
+    shard.by_key.insert_or_assign(ctx.key, std::move(record));
 
     PinKeyResult result;
     result.remote_buffer = BuildRemoteBufferDesc(handle);
@@ -1110,7 +1096,7 @@ tl::expected<void, ErrorCode> DataManager::UnPinKeyInternal(
     auto& shard = GetPinnedKeyShard(ctx);
     std::unique_lock shard_lock(shard.mutex);
 
-    auto record_it = shard.by_key.find(ctx.key_string);
+    auto record_it = shard.by_key.find(ctx.key);
     if (record_it == shard.by_key.end()) {
         timer.LogResponse("error_code=", ErrorCode::OK, "idempotent=", true);
         return {};

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -128,7 +128,8 @@ bool IsZeroUUID(const UUID& uuid) {
 DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
                          std::shared_ptr<TransferEngine> transfer_engine,
                          size_t lock_shard_count,
-                         const LocalTransferConfig& local_transfer_config)
+                         const LocalTransferConfig& local_transfer_config,
+                         const KeyLeaseConfig& key_lease_config)
     : tiered_backend_(std::move(tiered_backend)),
       transfer_engine_(transfer_engine),
       lock_shard_count_(lock_shard_count > 0 ? lock_shard_count : 1024),
@@ -150,13 +151,11 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
     }
 
     lease_duration_ = std::chrono::milliseconds(
-        local_transfer_config_.p2p_key_lease_duration_ms > 0
-            ? local_transfer_config_.p2p_key_lease_duration_ms
-            : kDefaultLeaseDurationMs);
-    const uint32_t scan_ms =
-        local_transfer_config_.p2p_key_lease_scan_interval_ms > 0
-            ? local_transfer_config_.p2p_key_lease_scan_interval_ms
-            : kDefaultLeaseScanIntervalMs;
+        key_lease_config.duration_ms > 0 ? key_lease_config.duration_ms
+                                         : kDefaultLeaseDurationMs);
+    const uint32_t scan_ms = key_lease_config.scan_interval_ms > 0
+                                 ? key_lease_config.scan_interval_ms
+                                 : kDefaultLeaseScanIntervalMs;
     lease_scan_interval_ =
         std::chrono::milliseconds(std::max<uint32_t>(1, scan_ms));
 
@@ -192,21 +191,20 @@ void DataManager::Stop() {
 void DataManager::ClearLeaseRecords() {
     for (auto& shard : pending_write_shards_) {
         std::unique_lock lock(shard.mutex);
-        shard.by_key.clear();
+        shard.existed_operation_key_map.clear();
         shard.ordered_list.clear();
     }
     for (auto& shard : pinned_key_shards_) {
         std::unique_lock lock(shard.mutex);
-        shard.by_key.clear();
+        shard.existed_operation_key_map.clear();
         shard.ordered_list.clear();
     }
 }
 
 DataManager::KeyCtx DataManager::BuildKeyCtx(std::string_view key) const {
     KeyCtx ctx;
-    // `key` may reference RPC/coro request storage; copy before returning.
-    ctx.key.assign(key.data(), key.size());
-    ctx.hash = StringHash{}(std::string_view(ctx.key));
+    ctx.key = key;
+    ctx.hash = StringHash{}(key);
     ctx.pending_write_shard_idx =
         pending_write_shards_.empty()
             ? 0
@@ -252,13 +250,22 @@ size_t DataManager::ScanExpiredRecordShard(RecordShard<Record>& shard,
         if (list_it->second > now) {
             break;
         }
-        auto record_it = shard.by_key.find(list_it->first);
-        if (record_it == shard.by_key.end() ||
-            record_it->second.list_it != list_it) {
+        auto record_it = shard.existed_operation_key_map.find(list_it->first);
+        if (record_it == shard.existed_operation_key_map.end()) {
+            LOG(WARNING) << "ScanExpiredRecordShard: expired ordered_list entry "
+                            "missing from existed_operation_key_map, key="
+                         << list_it->first;
             shard.ordered_list.erase(list_it);
             continue;
         }
-        shard.by_key.erase(record_it);
+        if (record_it->second.list_it != list_it) {
+            LOG(WARNING) << "ScanExpiredRecordShard: existed_operation_key_map "
+                            "list_it out of sync with ordered_list, key="
+                         << list_it->first;
+            shard.ordered_list.erase(list_it);
+            continue;
+        }
+        shard.existed_operation_key_map.erase(record_it);
         shard.ordered_list.erase(list_it);
         ++removed;
     }
@@ -278,8 +285,8 @@ DataManager::LookupPendingWriteHandleInternal(const KeyCtx& ctx,
     const auto now = std::chrono::steady_clock::now();
     auto& pending_write_shard = GetPendingWriteShard(ctx);
     std::shared_lock pending_write_shard_lock(pending_write_shard.mutex);
-    auto it = pending_write_shard.by_key.find(ctx.key);
-    if (it == pending_write_shard.by_key.end()) {
+    auto it = pending_write_shard.existed_operation_key_map.find(ctx.key);
+    if (it == pending_write_shard.existed_operation_key_map.end()) {
         LOG(ERROR) << "LookupPendingWriteHandle: no pending write for key: "
                    << ctx.key;
         return tl::unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -298,24 +305,123 @@ DataManager::LookupPendingWriteHandleInternal(const KeyCtx& ctx,
     return it->second.handle;
 }
 
+DataManager::PendingWriteEraseResult DataManager::ErasePendingWriteRecord(
+    PendingWriteShard& shard, std::string_view key,
+    const UUID& write_operation_id) {
+    std::unique_lock lock(shard.mutex);
+    auto it = shard.existed_operation_key_map.find(key);
+    if (it == shard.existed_operation_key_map.end()) {
+        return PendingWriteEraseResult::NotFound;
+    }
+    if (it->second.write_operation_id != write_operation_id) {
+        return PendingWriteEraseResult::WriteOperationIdMismatch;
+    }
+    shard.ordered_list.erase(it->second.list_it);
+    shard.existed_operation_key_map.erase(it);
+    return PendingWriteEraseResult::Erased;
+}
+
 void DataManager::AbortPendingWriteInternal(const KeyCtx& ctx,
                                             const UUID& write_operation_id) {
     if (ctx.key.empty() || IsZeroUUID(write_operation_id)) return;
     auto& pending_write_shard = GetPendingWriteShard(ctx);
-    std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
-    auto it = pending_write_shard.by_key.find(ctx.key);
-    if (it == pending_write_shard.by_key.end()) {
-        LOG(WARNING) << "AbortPendingWrite: no pending write record for key: "
-                     << ctx.key;
-        return;
+    switch (ErasePendingWriteRecord(pending_write_shard, ctx.key,
+                                    write_operation_id)) {
+        case PendingWriteEraseResult::NotFound:
+            LOG(WARNING) << "AbortPendingWrite: no pending write record for key: "
+                         << ctx.key;
+            break;
+        case PendingWriteEraseResult::WriteOperationIdMismatch:
+            LOG(ERROR) << "AbortPendingWrite: write_operation_id mismatch for key: "
+                       << ctx.key;
+            break;
+        case PendingWriteEraseResult::Erased:
+            break;
+    }
+}
+
+tl::expected<void, ErrorCode> DataManager::ReservePendingWriteSlot(
+    PendingWriteShard& shard, std::string_view key, TimePoint now,
+    TimePoint deadline, const UUID& write_operation_id) {
+    std::unique_lock lock(shard.mutex);
+    auto pending_it = shard.existed_operation_key_map.find(key);
+    if (pending_it != shard.existed_operation_key_map.end()) {
+        if (pending_it->second.deadline <= now) {
+            shard.ordered_list.erase(pending_it->second.list_it);
+            shard.existed_operation_key_map.erase(pending_it);
+        } else {
+            LOG(ERROR) << "PreWrite: replica is processing an in-flight write"
+                       << ", key=" << key << ", error="
+                       << toString(ErrorCode::REPLICA_IS_PROCESSING);
+            return tl::make_unexpected(ErrorCode::REPLICA_IS_PROCESSING);
+        }
+    }
+    auto list_it = shard.ordered_list.emplace(shard.ordered_list.end(),
+                                              std::string(key), deadline);
+    PendingWriteRecord record;
+    record.write_operation_id = write_operation_id;
+    record.deadline = deadline;
+    record.list_it = list_it;
+    shard.existed_operation_key_map.insert_or_assign(std::string(key),
+                                                     std::move(record));
+    return {};
+}
+
+tl::expected<void, ErrorCode> DataManager::AttachPendingWriteHandle(
+    PendingWriteShard& shard, std::string_view key,
+    const UUID& write_operation_id, const AllocationHandle& handle) {
+    std::unique_lock lock(shard.mutex);
+    auto it = shard.existed_operation_key_map.find(key);
+    if (it == shard.existed_operation_key_map.end()) {
+        LOG(ERROR) << "PreWrite: reserved pending write record missing"
+                   << ", key=" << key
+                   << ", error=" << toString(ErrorCode::OBJECT_NOT_FOUND);
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
     if (it->second.write_operation_id != write_operation_id) {
-        LOG(ERROR) << "AbortPendingWrite: write_operation_id mismatch for key: "
-                   << ctx.key;
-        return;
+        LOG(ERROR) << "PreWrite: write_operation_id mismatch"
+                   << ", key=" << key
+                   << ", error=" << toString(ErrorCode::INVALID_WRITE);
+        return tl::make_unexpected(ErrorCode::INVALID_WRITE);
     }
-    pending_write_shard.ordered_list.erase(it->second.list_it);
-    pending_write_shard.by_key.erase(it);
+    it->second.handle = handle;
+    return {};
+}
+
+tl::expected<AllocationHandle, ErrorCode>
+DataManager::TakePendingWriteForCommit(PendingWriteShard& shard,
+                                       std::string_view key, TimePoint now,
+                                       const UUID& write_operation_id) {
+    std::unique_lock lock(shard.mutex);
+    auto record_it = shard.existed_operation_key_map.find(key);
+    if (record_it == shard.existed_operation_key_map.end()) {
+        LOG(ERROR) << "WriteCommit: no pending write record for key: " << key;
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    if (record_it->second.deadline <= now) {
+        shard.ordered_list.erase(record_it->second.list_it);
+        shard.existed_operation_key_map.erase(record_it);
+        LOG(ERROR) << "WriteCommit: pending write lease expired"
+                   << ", key=" << key
+                   << ", error=" << toString(ErrorCode::LEASE_EXPIRED);
+        return tl::make_unexpected(ErrorCode::LEASE_EXPIRED);
+    }
+    if (record_it->second.write_operation_id != write_operation_id) {
+        LOG(ERROR) << "WriteCommit: write_operation_id mismatch"
+                   << ", key=" << key
+                   << ", error=" << toString(ErrorCode::INVALID_WRITE);
+        return tl::make_unexpected(ErrorCode::INVALID_WRITE);
+    }
+    if (!record_it->second.handle) {
+        LOG(ERROR) << "WriteCommit: pending write has no allocation handle"
+                   << ", key=" << key
+                   << ", error=" << toString(ErrorCode::INVALID_WRITE);
+        return tl::make_unexpected(ErrorCode::INVALID_WRITE);
+    }
+    AllocationHandle handle = record_it->second.handle;
+    shard.ordered_list.erase(record_it->second.list_it);
+    shard.existed_operation_key_map.erase(record_it);
+    return handle;
 }
 
 void DataManager::ShutdownLeaseScanner() {
@@ -425,8 +531,10 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
     }
 
     return CallableTaskHandle<void>::Create(
-        [this, ctx = std::move(*submit_result), alloc_handle, kctx,
+        [this, ctx = std::move(*submit_result), alloc_handle,
+         key_owned = std::string(key),
          write_operation_id]() mutable -> tl::expected<void, ErrorCode> {
+            const KeyCtx kctx = BuildKeyCtx(key_owned);
             ScopedVLogTimer timer(1, "DataManager::PutViaTe");
             timer.LogRequest("key=", kctx.key);
 
@@ -495,8 +603,9 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
     }
     AllocationHandle alloc_handle = handle_result.value();
 
-    auto write_fn = [this, kctx, slice, alloc_handle,
+    auto write_fn = [this, key_owned = std::string(key), slice, alloc_handle,
                      write_operation_id]() -> tl::expected<void, ErrorCode> {
+        const KeyCtx kctx = BuildKeyCtx(key_owned);
         DataSource source;
         source.buffer = std::make_unique<RefBuffer>(slice.ptr, slice.size);
         source.type = MemoryType::DRAM;
@@ -511,8 +620,9 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
         return {};
     };
 
-    auto commit_fn = [this, kctx,
+    auto commit_fn = [this, key_owned = std::string(key),
                       write_operation_id]() -> tl::expected<void, ErrorCode> {
+        const KeyCtx kctx = BuildKeyCtx(key_owned);
         auto commit_result = WriteCommitInternal(kctx, write_operation_id);
         if (!commit_result) {
             LOG(ERROR) << "Failed to commit data for key: " << kctx.key
@@ -524,9 +634,10 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
 
     auto write_and_commit = [write_fn = std::move(write_fn),
                              commit_fn = std::move(commit_fn),
-                             key]() mutable -> tl::expected<void, ErrorCode> {
+                             key_owned = std::string(key)]() mutable
+        -> tl::expected<void, ErrorCode> {
         ScopedVLogTimer timer(1, "DataManager::PutViaMemcpy");
-        timer.LogRequest("key=", key);
+        timer.LogRequest("key=", key_owned);
         auto write_result = write_fn();
         if (!write_result) {
             LOG(ERROR) << "Failed to write data, error: "
@@ -839,40 +950,11 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
 
     auto& pending_write_shard = GetPendingWriteShard(ctx);
 
-    const auto rollback_reservation = [&]() {
-        std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
-        auto it = pending_write_shard.by_key.find(ctx.key);
-        if (it != pending_write_shard.by_key.end() &&
-            it->second.write_operation_id == write_operation_id) {
-            pending_write_shard.ordered_list.erase(it->second.list_it);
-            pending_write_shard.by_key.erase(it);
-        }
-    };
-
-    // Reserve a pending-write slot (handle filled after Allocate).
-    {
-        std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
-        auto pending_it = pending_write_shard.by_key.find(ctx.key);
-        if (pending_it != pending_write_shard.by_key.end()) {
-            if (pending_it->second.deadline <= now) {
-                pending_write_shard.ordered_list.erase(
-                    pending_it->second.list_it);
-                pending_write_shard.by_key.erase(pending_it);
-            } else {
-                LOG(ERROR) << "PreWrite: key has active pending write lease"
-                           << ", key=" << ctx.key << ", error="
-                           << toString(ErrorCode::OBJECT_HAS_LEASE);
-                timer.LogResponse("error_code=", ErrorCode::OBJECT_HAS_LEASE);
-                return tl::make_unexpected(ErrorCode::OBJECT_HAS_LEASE);
-            }
-        }
-        auto list_it = pending_write_shard.ordered_list.emplace(
-            pending_write_shard.ordered_list.end(), ctx.key, deadline);
-        PendingWriteRecord record;
-        record.write_operation_id = write_operation_id;
-        record.deadline = deadline;
-        record.list_it = list_it;
-        pending_write_shard.by_key.insert_or_assign(ctx.key, std::move(record));
+    auto reserve_result = ReservePendingWriteSlot(
+        pending_write_shard, ctx.key, now, deadline, write_operation_id);
+    if (!reserve_result) {
+        timer.LogResponse("error_code=", reserve_result.error());
+        return tl::make_unexpected(reserve_result.error());
     }
 
     // Slow path: no pending_write_shard_lock during tier allocation.
@@ -880,7 +962,8 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
         LOG(ERROR) << "PreWrite: key already exists"
                    << ", key=" << ctx.key
                    << ", error=" << toString(ErrorCode::OBJECT_ALREADY_EXISTS);
-        rollback_reservation();
+        (void)ErasePendingWriteRecord(pending_write_shard, ctx.key,
+                                      write_operation_id);
         timer.LogResponse("error_code=", ErrorCode::OBJECT_ALREADY_EXISTS);
         return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
     }
@@ -890,35 +973,24 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
         LOG(ERROR) << "PreWrite: Allocate failed"
                    << ", key=" << ctx.key
                    << ", error=" << toString(handle_result.error());
-        rollback_reservation();
+        (void)ErasePendingWriteRecord(pending_write_shard, ctx.key,
+                                      write_operation_id);
         timer.LogResponse("error_code=", handle_result.error());
         return tl::make_unexpected(handle_result.error());
     }
 
     auto handle = std::move(handle_result.value());
-    {
-        std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
-        auto it = pending_write_shard.by_key.find(ctx.key);
-        if (it == pending_write_shard.by_key.end()) {
-            LOG(ERROR) << "PreWrite: reserved pending write record missing"
-                       << ", key=" << ctx.key
-                       << ", error=" << toString(ErrorCode::OBJECT_NOT_FOUND);
-            timer.LogResponse("error_code=", ErrorCode::OBJECT_NOT_FOUND);
-            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
-        }
-        if (it->second.write_operation_id != write_operation_id) {
-            LOG(ERROR) << "PreWrite: write_operation_id mismatch"
-                       << ", key=" << ctx.key
-                       << ", error=" << toString(ErrorCode::INVALID_WRITE);
-            timer.LogResponse("error_code=", ErrorCode::INVALID_WRITE);
-            return tl::make_unexpected(ErrorCode::INVALID_WRITE);
-        }
-        it->second.handle = handle;
+    auto attach_result = AttachPendingWriteHandle(
+        pending_write_shard, ctx.key, write_operation_id, handle);
+    if (!attach_result) {
+        timer.LogResponse("error_code=", attach_result.error());
+        return tl::make_unexpected(attach_result.error());
     }
 
     auto remote_buffer_result = BuildRemoteBufferDesc(handle);
     if (!remote_buffer_result) {
-        rollback_reservation();
+        (void)ErasePendingWriteRecord(pending_write_shard, ctx.key,
+                                      write_operation_id);
         timer.LogResponse("error_code=", remote_buffer_result.error());
         return tl::make_unexpected(remote_buffer_result.error());
     }
@@ -948,46 +1020,14 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
     const auto now = std::chrono::steady_clock::now();
 
     auto& pending_write_shard = GetPendingWriteShard(ctx);
-    AllocationHandle handle;
 
-    // Pending: validate token, copy handle, remove lease (always, before
-    // Commit).
-    {
-        std::unique_lock pending_write_shard_lock(pending_write_shard.mutex);
-        auto record_it = pending_write_shard.by_key.find(ctx.key);
-        if (record_it == pending_write_shard.by_key.end()) {
-            LOG(ERROR) << "WriteCommit: no pending write record for key: "
-                       << ctx.key;
-            timer.LogResponse("error_code=", ErrorCode::OBJECT_NOT_FOUND);
-            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
-        }
-        if (record_it->second.deadline <= now) {
-            pending_write_shard.ordered_list.erase(record_it->second.list_it);
-            pending_write_shard.by_key.erase(record_it);
-            LOG(ERROR) << "WriteCommit: pending write lease expired"
-                       << ", key=" << ctx.key
-                       << ", error=" << toString(ErrorCode::LEASE_EXPIRED);
-            timer.LogResponse("error_code=", ErrorCode::LEASE_EXPIRED);
-            return tl::make_unexpected(ErrorCode::LEASE_EXPIRED);
-        }
-        if (record_it->second.write_operation_id != write_operation_id) {
-            LOG(ERROR) << "WriteCommit: write_operation_id mismatch"
-                       << ", key=" << ctx.key
-                       << ", error=" << toString(ErrorCode::INVALID_WRITE);
-            timer.LogResponse("error_code=", ErrorCode::INVALID_WRITE);
-            return tl::make_unexpected(ErrorCode::INVALID_WRITE);
-        }
-        if (!record_it->second.handle) {
-            LOG(ERROR) << "WriteCommit: pending write has no allocation handle"
-                       << ", key=" << ctx.key
-                       << ", error=" << toString(ErrorCode::INVALID_WRITE);
-            timer.LogResponse("error_code=", ErrorCode::INVALID_WRITE);
-            return tl::make_unexpected(ErrorCode::INVALID_WRITE);
-        }
-        handle = record_it->second.handle;
-        pending_write_shard.ordered_list.erase(record_it->second.list_it);
-        pending_write_shard.by_key.erase(record_it);
+    auto handle_result = TakePendingWriteForCommit(
+        pending_write_shard, ctx.key, now, write_operation_id);
+    if (!handle_result) {
+        timer.LogResponse("error_code=", handle_result.error());
+        return tl::make_unexpected(handle_result.error());
     }
+    AllocationHandle handle = std::move(handle_result.value());
 
     // Commit under key_lock to avoid concurrent Delete. Most commit failures
     // are not recoverable by retrying WriteCommit alone; caller must restart
@@ -1059,11 +1099,11 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     // Fast path: valid pin record -> return without tiered_backend::Get.
     {
         std::unique_lock pin_shard_lock(pin_shard.mutex);
-        auto record_it = pin_shard.by_key.find(ctx.key);
-        if (record_it != pin_shard.by_key.end()) {
+        auto record_it = pin_shard.existed_operation_key_map.find(ctx.key);
+        if (record_it != pin_shard.existed_operation_key_map.end()) {
             if (record_it->second.deadline <= now) {
                 pin_shard.ordered_list.erase(record_it->second.list_it);
-                pin_shard.by_key.erase(record_it);
+                pin_shard.existed_operation_key_map.erase(record_it);
             } else {
                 return bump_existing_pin(record_it);
             }
@@ -1089,11 +1129,11 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
 
     // Re-check after Get: concurrent pin -> bump; else insert new record.
     std::unique_lock pin_shard_lock(pin_shard.mutex);
-    auto record_it = pin_shard.by_key.find(ctx.key);
-    if (record_it != pin_shard.by_key.end()) {
+    auto record_it = pin_shard.existed_operation_key_map.find(ctx.key);
+    if (record_it != pin_shard.existed_operation_key_map.end()) {
         if (record_it->second.deadline <= now) {
             pin_shard.ordered_list.erase(record_it->second.list_it);
-            pin_shard.by_key.erase(record_it);
+            pin_shard.existed_operation_key_map.erase(record_it);
         } else {
             return bump_existing_pin(record_it);
         }
@@ -1109,7 +1149,7 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     record.handle = handle;
     record.ref_count = 1;
     record.list_it = list_it;
-    pin_shard.by_key.insert_or_assign(ctx.key, std::move(record));
+    pin_shard.existed_operation_key_map.insert_or_assign(ctx.key, std::move(record));
 
     PinKeyResult result;
     result.remote_buffer = std::move(remote_buffer_result.value());
@@ -1138,15 +1178,15 @@ tl::expected<void, ErrorCode> DataManager::UnPinKeyInternal(
     auto& pin_shard = GetPinnedKeyShard(ctx);
     std::unique_lock pin_shard_lock(pin_shard.mutex);
 
-    auto record_it = pin_shard.by_key.find(ctx.key);
-    if (record_it == pin_shard.by_key.end()) {
+    auto record_it = pin_shard.existed_operation_key_map.find(ctx.key);
+    if (record_it == pin_shard.existed_operation_key_map.end()) {
         LOG(WARNING) << "UnPinKey: no pinned key record for key: " << ctx.key;
         timer.LogResponse("error_code=", ErrorCode::OK, "idempotent=", true);
         return {};
     }
     if (record_it->second.deadline <= now) {
         pin_shard.ordered_list.erase(record_it->second.list_it);
-        pin_shard.by_key.erase(record_it);
+        pin_shard.existed_operation_key_map.erase(record_it);
         timer.LogResponse("error_code=", ErrorCode::LEASE_EXPIRED);
         return tl::make_unexpected(ErrorCode::LEASE_EXPIRED);
     }
@@ -1163,7 +1203,7 @@ tl::expected<void, ErrorCode> DataManager::UnPinKeyInternal(
     }
 
     pin_shard.ordered_list.erase(record_it->second.list_it);
-    pin_shard.by_key.erase(record_it);
+    pin_shard.existed_operation_key_map.erase(record_it);
     timer.LogResponse("error_code=", ErrorCode::OK, "ref_count=", 0);
     return {};
 }

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -952,7 +952,7 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
                                                   write_operation_id, handle);
     if (!attach_result) {
         (void)ErasePendingWriteRecord(pending_write_shard, ctx.key,
-            write_operation_id);
+                                      write_operation_id);
         timer.LogResponse("error_code=", attach_result.error());
         return tl::make_unexpected(attach_result.error());
     }

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -222,10 +222,6 @@ DataManager::PinnedKeyShard& DataManager::GetPinnedKeyShard(const KeyCtx& ctx) {
     return pinned_key_shards_[ctx.pinned_key_shard_idx];
 }
 
-bool DataManager::IsExpired(TimePoint deadline) const {
-    return deadline <= std::chrono::steady_clock::now();
-}
-
 tl::expected<RemoteBufferDesc, ErrorCode> DataManager::BuildRemoteBufferDesc(
     const AllocationHandle& handle) const {
     const auto& loc_data = handle->loc.data;
@@ -955,6 +951,8 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
     auto attach_result = AttachPendingWriteHandle(pending_write_shard, ctx.key,
                                                   write_operation_id, handle);
     if (!attach_result) {
+        (void)ErasePendingWriteRecord(pending_write_shard, ctx.key,
+            write_operation_id);
         timer.LogResponse("error_code=", attach_result.error());
         return tl::make_unexpected(attach_result.error());
     }
@@ -1722,12 +1720,6 @@ tl::expected<void, ErrorCode> DataManager::Delete(std::string_view key,
     // entry) from the in-memory index. It does NOT directly free underlying
     // memory. The actual buffer lifetime is still governed by
     // AllocationHandle's RAII reference counting.
-    //
-    // We still guard Delete against in-flight 3-phase contexts:
-    // - PendingWriteRecord holds a strong handle reference until WriteCommit or
-    //   lease cleanup.
-    // - PinnedKeyRecord holds a strong handle reference until UnPinKey reaches
-    //   ref_count==0 or lease cleanup.
     auto result = tiered_backend_->Delete(key, tier_id, notify_master);
     if (!result.has_value()) {
         LOG(ERROR) << "Failed to delete key: " << key;

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -115,7 +115,7 @@ ErrorCode ExecuteLocalCopyPlan(const LocalCopyPlan& plan) {
     return ErrorCode::OK;
 }
 
-bool IsZeroUuid(const UUID& uuid) {
+bool IsZeroUUID(const UUID& uuid) {
     return uuid.first == 0 && uuid.second == 0;
 }
 
@@ -149,11 +149,16 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
             local_transfer_config_.local_memcpy_async_worker_num);
     }
 
-    lease_duration_ = std::chrono::milliseconds(GetEnvOr<uint32_t>(
-        "P2P_RPC_LEASE_DURATION_MS", kDefaultLeaseDurationMs));
+    lease_duration_ = std::chrono::milliseconds(
+        local_transfer_config_.p2p_key_lease_duration_ms > 0
+            ? local_transfer_config_.p2p_key_lease_duration_ms
+            : kDefaultLeaseDurationMs);
+    const uint32_t scan_ms =
+        local_transfer_config_.p2p_key_lease_scan_interval_ms > 0
+            ? local_transfer_config_.p2p_key_lease_scan_interval_ms
+            : kDefaultLeaseScanIntervalMs;
     lease_scan_interval_ = std::chrono::milliseconds(
-        std::max<uint32_t>(1, GetEnvOr<uint32_t>("P2P_RPC_LEASE_SCAN_INTERVAL",
-                                                 kDefaultLeaseScanIntervalMs)));
+        std::max<uint32_t>(1, scan_ms));
 
     LOG(INFO) << "DataManager initialized with " << lock_shard_count_
               << " lock shards, local_transfer_mode="
@@ -163,8 +168,8 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
               << ", te_endpoint=" << local_transfer_config_.te_endpoint
               << ", async_memcpy_workers="
               << local_transfer_config_.local_memcpy_async_worker_num
-              << ", lease_duration_ms=" << lease_duration_.count()
-              << ", lease_scan_interval_ms=" << lease_scan_interval_.count();
+              << ", p2p_key_lease_duration_ms=" << lease_duration_.count()
+              << ", p2p_key_lease_scan_interval_ms=" << lease_scan_interval_.count();
 
     // Start background work only after synchronous initialization completes.
     lease_scanner_thread_ = std::thread(&DataManager::LeaseScannerMain, this);
@@ -350,14 +355,14 @@ size_t DataManager::ScanExpiredPinnedKeys(PinnedKeyShard& shard,
 }
 
 tl::expected<AllocationHandle, ErrorCode> DataManager::LookupPendingWriteHandle(
-    std::string_view key, const UUID& pending_write_token) {
+    std::string_view key, const UUID& write_operation_id) {
     return LookupPendingWriteHandleInternal(BuildKeyCtx(key),
-                                            pending_write_token);
+                                            write_operation_id);
 }
 
 tl::expected<AllocationHandle, ErrorCode>
 DataManager::LookupPendingWriteHandleInternal(const KeyCtx& ctx,
-                                              const UUID& pending_write_token) {
+                                              const UUID& write_operation_id) {
     const auto now = std::chrono::steady_clock::now();
     auto& shard = GetPendingWriteShard(ctx);
     std::shared_lock shard_lock(shard.mutex);
@@ -368,20 +373,20 @@ DataManager::LookupPendingWriteHandleInternal(const KeyCtx& ctx,
     if (it->second.deadline <= now) {
         return tl::unexpected(ErrorCode::LEASE_EXPIRED);
     }
-    if (it->second.pending_write_token != pending_write_token) {
+    if (it->second.write_operation_id != write_operation_id) {
         return tl::unexpected(ErrorCode::INVALID_WRITE);
     }
     return it->second.handle;
 }
 
 tl::expected<AllocationHandle, ErrorCode> DataManager::LookupPinnedKeyHandle(
-    std::string_view key, const UUID& pin_token) {
-    return LookupPinnedKeyHandleInternal(BuildKeyCtx(key), pin_token);
+    std::string_view key, const UUID& read_operation_id) {
+    return LookupPinnedKeyHandleInternal(BuildKeyCtx(key), read_operation_id);
 }
 
 tl::expected<AllocationHandle, ErrorCode>
 DataManager::LookupPinnedKeyHandleInternal(const KeyCtx& ctx,
-                                           const UUID& pin_token) {
+                                           const UUID& read_operation_id) {
     const auto now = std::chrono::steady_clock::now();
     auto& shard = GetPinnedKeyShard(ctx);
     std::shared_lock shard_lock(shard.mutex);
@@ -392,26 +397,26 @@ DataManager::LookupPinnedKeyHandleInternal(const KeyCtx& ctx,
     if (it->second.deadline <= now) {
         return tl::unexpected(ErrorCode::LEASE_EXPIRED);
     }
-    if (it->second.pin_token != pin_token) {
+    if (it->second.read_operation_id != read_operation_id) {
         return tl::unexpected(ErrorCode::INVALID_READ);
     }
     return it->second.handle;
 }
 
 void DataManager::AbortPendingWrite(std::string_view key,
-                                    const UUID& pending_write_token) {
-    AbortPendingWriteInternal(BuildKeyCtx(key), pending_write_token);
+                                    const UUID& write_operation_id) {
+    AbortPendingWriteInternal(BuildKeyCtx(key), write_operation_id);
 }
 
 void DataManager::AbortPendingWriteInternal(const KeyCtx& ctx,
-                                            const UUID& pending_write_token) {
-    if (ctx.key.empty() || IsZeroUuid(pending_write_token)) return;
+                                            const UUID& write_operation_id) {
+    if (ctx.key.empty() || IsZeroUUID(write_operation_id)) return;
     std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
     auto& shard = GetPendingWriteShard(ctx);
     std::unique_lock shard_lock(shard.mutex);
     auto it = shard.by_key.find(ctx.key_string);
     if (it == shard.by_key.end()) return;
-    if (it->second.pending_write_token != pending_write_token) return;
+    if (it->second.write_operation_id != write_operation_id) return;
     shard.ordered_list.erase(it->second.list_it);
     shard.by_key.erase(it);
 }
@@ -499,12 +504,12 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
     if (!prewrite_result) {
         return tl::unexpected(prewrite_result.error());
     }
-    const UUID pending_write_token = prewrite_result->pending_write_token;
+    const UUID write_operation_id = prewrite_result->write_operation_id;
 
     auto handle_result =
-        LookupPendingWriteHandleInternal(kctx, pending_write_token);
+        LookupPendingWriteHandleInternal(kctx, write_operation_id);
     if (!handle_result) {
-        AbortPendingWriteInternal(kctx, pending_write_token);
+        AbortPendingWriteInternal(kctx, write_operation_id);
         return tl::unexpected(handle_result.error());
     }
     AllocationHandle alloc_handle = handle_result.value();
@@ -515,13 +520,13 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
         LOG(ERROR) << "SubmitTeTransferInternal failed"
                    << ", key=" << key
                    << ", error_code=" << toString(submit_result.error());
-        AbortPendingWriteInternal(kctx, pending_write_token);
+        AbortPendingWriteInternal(kctx, write_operation_id);
         return tl::unexpected(submit_result.error());
     }
 
     return CallableTaskHandle<void>::Create(
         [this, ctx = std::move(*submit_result), alloc_handle, kctx,
-         pending_write_token]() mutable -> tl::expected<void, ErrorCode> {
+         write_operation_id]() mutable -> tl::expected<void, ErrorCode> {
             ScopedVLogTimer timer(1, "DataManager::PutViaTe");
             timer.LogRequest("key=", kctx.key);
 
@@ -530,7 +535,7 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
                 LOG(ERROR) << "WaitAllTransferBatches failed"
                            << ", key=" << kctx.key
                            << ", error_code=" << toString(wait_result.error());
-                AbortPendingWriteInternal(kctx, pending_write_token);
+                AbortPendingWriteInternal(kctx, write_operation_id);
                 return tl::unexpected(wait_result.error());
             }
 
@@ -547,12 +552,12 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
                         << "CopyFromDRAMBuffer failed"
                         << ", key=" << kctx.key
                         << ", error_code=" << toString(copy_result.error());
-                    AbortPendingWriteInternal(kctx, pending_write_token);
+                    AbortPendingWriteInternal(kctx, write_operation_id);
                     return tl::unexpected(copy_result.error());
                 }
             }
 
-            auto commit_result = WriteCommitInternal(kctx, pending_write_token);
+            auto commit_result = WriteCommitInternal(kctx, write_operation_id);
             if (!commit_result) {
                 return tl::unexpected(commit_result.error());
             }
@@ -574,18 +579,18 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
     if (!prewrite_result) {
         return tl::unexpected(prewrite_result.error());
     }
-    const UUID pending_write_token = prewrite_result->pending_write_token;
+    const UUID write_operation_id = prewrite_result->write_operation_id;
 
     auto handle_result =
-        LookupPendingWriteHandleInternal(kctx, pending_write_token);
+        LookupPendingWriteHandleInternal(kctx, write_operation_id);
     if (!handle_result) {
-        AbortPendingWriteInternal(kctx, pending_write_token);
+        AbortPendingWriteInternal(kctx, write_operation_id);
         return tl::unexpected(handle_result.error());
     }
     AllocationHandle alloc_handle = handle_result.value();
 
     auto write_fn = [this, kctx, slice, alloc_handle,
-                     pending_write_token]() -> tl::expected<void, ErrorCode> {
+                     write_operation_id]() -> tl::expected<void, ErrorCode> {
         DataSource source;
         source.buffer = std::make_unique<RefBuffer>(slice.ptr, slice.size);
         source.type = MemoryType::DRAM;
@@ -594,15 +599,15 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
         if (!write_result.has_value()) {
             LOG(ERROR) << "Failed to write data for key: " << kctx.key
                        << ", error: " << write_result.error();
-            AbortPendingWriteInternal(kctx, pending_write_token);
+            AbortPendingWriteInternal(kctx, write_operation_id);
             return tl::make_unexpected(write_result.error());
         }
         return {};
     };
 
     auto commit_fn = [this, kctx,
-                      pending_write_token]() -> tl::expected<void, ErrorCode> {
-        auto commit_result = WriteCommitInternal(kctx, pending_write_token);
+                      write_operation_id]() -> tl::expected<void, ErrorCode> {
+        auto commit_result = WriteCommitInternal(kctx, write_operation_id);
         if (!commit_result) {
             LOG(ERROR) << "Failed to commit data for key: " << kctx.key
                        << ", error: " << commit_result.error();
@@ -869,12 +874,12 @@ tl::expected<UUID, ErrorCode> DataManager::WriteRemoteData(
         timer.LogResponse("error_code=", prewrite_result.error());
         return tl::make_unexpected(prewrite_result.error());
     }
-    const UUID pending_write_token = prewrite_result->pending_write_token;
+    const UUID write_operation_id = prewrite_result->write_operation_id;
 
     auto handle_result =
-        LookupPendingWriteHandleInternal(kctx, pending_write_token);
+        LookupPendingWriteHandleInternal(kctx, write_operation_id);
     if (!handle_result) {
-        AbortPendingWriteInternal(kctx, pending_write_token);
+        AbortPendingWriteInternal(kctx, write_operation_id);
         timer.LogResponse("error_code=", handle_result.error());
         return tl::make_unexpected(handle_result.error());
     }
@@ -884,12 +889,12 @@ tl::expected<UUID, ErrorCode> DataManager::WriteRemoteData(
     // Transfer phase — no long key lock held.
     auto transfer_result = TransferDataFromRemote(handle, src_buffers);
     if (!transfer_result) {
-        AbortPendingWriteInternal(kctx, pending_write_token);
+        AbortPendingWriteInternal(kctx, write_operation_id);
         timer.LogResponse("error_code=", transfer_result.error());
         return tl::make_unexpected(transfer_result.error());
     }
 
-    auto commit_result = WriteCommitInternal(kctx, pending_write_token);
+    auto commit_result = WriteCommitInternal(kctx, write_operation_id);
     if (!commit_result) {
         timer.LogResponse("error_code=", commit_result.error());
         return tl::make_unexpected(commit_result.error());
@@ -943,9 +948,9 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
     auto list_it = shard.ordered_list.emplace(shard.ordered_list.end(),
                                               ctx.key_string, deadline);
 
-    const UUID pending_write_token = generate_uuid();
+    const UUID write_operation_id = generate_uuid();
     PendingWriteRecord record;
-    record.pending_write_token = pending_write_token;
+    record.write_operation_id = write_operation_id;
     record.deadline = deadline;
     record.handle = handle;
     record.list_it = list_it;
@@ -953,22 +958,22 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
 
     PreWriteResult result;
     result.remote_buffer = BuildRemoteBufferDesc(handle);
-    result.pending_write_token = pending_write_token;
+    result.write_operation_id = write_operation_id;
     timer.LogResponse("error_code=", ErrorCode::OK);
     return result;
 }
 
 tl::expected<void, ErrorCode> DataManager::WriteCommit(
-    std::string_view key, const UUID& pending_write_token) {
-    return WriteCommitInternal(BuildKeyCtx(key), pending_write_token);
+    std::string_view key, const UUID& write_operation_id) {
+    return WriteCommitInternal(BuildKeyCtx(key), write_operation_id);
 }
 
 tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
-    const KeyCtx& ctx, const UUID& pending_write_token) {
+    const KeyCtx& ctx, const UUID& write_operation_id) {
     ScopedVLogTimer timer(1, "DataManager::WriteCommit");
     timer.LogRequest("key=", ctx.key);
 
-    if (ctx.key.empty() || IsZeroUuid(pending_write_token)) {
+    if (ctx.key.empty() || IsZeroUUID(write_operation_id)) {
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -990,7 +995,7 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
         timer.LogResponse("error_code=", ErrorCode::LEASE_EXPIRED);
         return tl::make_unexpected(ErrorCode::LEASE_EXPIRED);
     }
-    if (record_it->second.pending_write_token != pending_write_token) {
+    if (record_it->second.write_operation_id != write_operation_id) {
         timer.LogResponse("error_code=", ErrorCode::INVALID_WRITE);
         return tl::make_unexpected(ErrorCode::INVALID_WRITE);
     }
@@ -1052,7 +1057,7 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
 
         PinKeyResult result;
         result.remote_buffer = BuildRemoteBufferDesc(record_it->second.handle);
-        result.pin_token = record_it->second.pin_token;
+        result.read_operation_id = record_it->second.read_operation_id;
         timer.LogResponse("error_code=", ErrorCode::OK,
                           "ref_count=", record_it->second.ref_count);
         return result;
@@ -1068,9 +1073,9 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     auto list_it = shard.ordered_list.emplace(shard.ordered_list.end(),
                                               ctx.key_string, deadline);
 
-    const UUID pin_token_value = generate_uuid();
+    const UUID read_operation_id_value = generate_uuid();
     PinnedKeyRecord record;
-    record.pin_token = pin_token_value;
+    record.read_operation_id = read_operation_id_value;
     record.deadline = deadline;
     record.handle = handle;
     record.ref_count = 1;
@@ -1079,22 +1084,22 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
 
     PinKeyResult result;
     result.remote_buffer = BuildRemoteBufferDesc(handle);
-    result.pin_token = pin_token_value;
+    result.read_operation_id = read_operation_id_value;
     timer.LogResponse("error_code=", ErrorCode::OK);
     return result;
 }
 
 tl::expected<void, ErrorCode> DataManager::UnPinKey(std::string_view key,
-                                                    const UUID& pin_token) {
-    return UnPinKeyInternal(BuildKeyCtx(key), pin_token);
+                                                    const UUID& read_operation_id) {
+    return UnPinKeyInternal(BuildKeyCtx(key), read_operation_id);
 }
 
 tl::expected<void, ErrorCode> DataManager::UnPinKeyInternal(
-    const KeyCtx& ctx, const UUID& pin_token) {
+    const KeyCtx& ctx, const UUID& read_operation_id) {
     ScopedVLogTimer timer(1, "DataManager::UnPinKey");
     timer.LogRequest("key=", ctx.key);
 
-    if (ctx.key.empty() || IsZeroUuid(pin_token)) {
+    if (ctx.key.empty() || IsZeroUUID(read_operation_id)) {
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -1116,7 +1121,7 @@ tl::expected<void, ErrorCode> DataManager::UnPinKeyInternal(
         timer.LogResponse("error_code=", ErrorCode::LEASE_EXPIRED);
         return tl::make_unexpected(ErrorCode::LEASE_EXPIRED);
     }
-    if (record_it->second.pin_token != pin_token) {
+    if (record_it->second.read_operation_id != read_operation_id) {
         timer.LogResponse("error_code=", ErrorCode::INVALID_READ);
         return tl::make_unexpected(ErrorCode::INVALID_READ);
     }

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -22,6 +22,9 @@ namespace mooncake {
 
 namespace {
 
+constexpr uint32_t kDefaultLeaseDurationMs = 5000;
+constexpr uint32_t kDefaultLeaseScanIntervalMs = 1000;
+
 struct LocalCopyPlan {
     AllocationHandle source_handle;
     const char* source_ptr = nullptr;
@@ -112,6 +115,10 @@ ErrorCode ExecuteLocalCopyPlan(const LocalCopyPlan& plan) {
     return ErrorCode::OK;
 }
 
+bool IsZeroUuid(const UUID& uuid) {
+    return uuid.first == 0 && uuid.second == 0;
+}
+
 }  // namespace
 
 // ================================================================
@@ -126,6 +133,8 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
       transfer_engine_(transfer_engine),
       lock_shard_count_(lock_shard_count > 0 ? lock_shard_count : 1024),
       lock_shards_(lock_shard_count_),
+      pending_write_shards_(lock_shard_count_),
+      pinned_key_shards_(lock_shard_count_),
       local_transfer_config_(local_transfer_config) {
     if (!tiered_backend_) {
         LOG(FATAL) << "TieredBackend cannot be null";
@@ -140,6 +149,14 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
             local_transfer_config_.local_memcpy_async_worker_num);
     }
 
+    lease_duration_ = std::chrono::milliseconds(
+        GetEnvOr<uint32_t>("P2P_RPC_LEASE_DURATION_MS",
+                           kDefaultLeaseDurationMs));
+    lease_scan_interval_ = std::chrono::milliseconds(
+        std::max<uint32_t>(1, GetEnvOr<uint32_t>("P2P_RPC_LEASE_SCAN_INTERVAL",
+                                                 kDefaultLeaseScanIntervalMs)));
+    lease_scanner_thread_ = std::thread(&DataManager::LeaseScannerMain, this);
+
     LOG(INFO) << "DataManager initialized with " << lock_shard_count_
               << " lock shards, local_transfer_mode="
               << (local_transfer_config_.mode == LocalTransferMode::TE
@@ -147,7 +164,294 @@ DataManager::DataManager(std::unique_ptr<TieredBackend> tiered_backend,
                       : "MEMCPY")
               << ", te_endpoint=" << local_transfer_config_.te_endpoint
               << ", async_memcpy_workers="
-              << local_transfer_config_.local_memcpy_async_worker_num;
+              << local_transfer_config_.local_memcpy_async_worker_num
+              << ", lease_duration_ms=" << lease_duration_.count()
+              << ", lease_scan_interval_ms=" << lease_scan_interval_.count();
+}
+
+DataManager::~DataManager() { Stop(); }
+
+void DataManager::Stop() {
+    ShutdownLeaseScanner();
+    if (async_memcpy_executor_) {
+        async_memcpy_executor_->Shutdown();
+    }
+    if (tiered_backend_) {
+        tiered_backend_->Stop();
+    }
+}
+
+size_t DataManager::HashKey(std::string_view key) const {
+    return std::hash<std::string_view>{}(key);
+}
+
+DataManager::KeyCtx DataManager::BuildKeyCtx(std::string_view key) const {
+    KeyCtx ctx;
+    ctx.key = key;
+    ctx.key_string = std::string(key);
+    ctx.hash = HashKey(key);
+    ctx.pending_write_shard_idx =
+        pending_write_shards_.empty()
+            ? 0
+            : (ctx.hash % pending_write_shards_.size());
+    ctx.pinned_key_shard_idx =
+        pinned_key_shards_.empty() ? 0 : (ctx.hash % pinned_key_shards_.size());
+    return ctx;
+}
+
+DataManager::PendingWriteShard& DataManager::GetPendingWriteShard(
+    const KeyCtx& ctx) {
+    return pending_write_shards_[ctx.pending_write_shard_idx];
+}
+
+DataManager::PinnedKeyShard& DataManager::GetPinnedKeyShard(const KeyCtx& ctx) {
+    return pinned_key_shards_[ctx.pinned_key_shard_idx];
+}
+
+DataManager::PendingWriteShard& DataManager::GetPendingWriteShard(
+    std::string_view key) {
+    return pending_write_shards_[HashKey(key) % pending_write_shards_.size()];
+}
+
+DataManager::PinnedKeyShard& DataManager::GetPinnedKeyShard(
+    std::string_view key) {
+    return pinned_key_shards_[HashKey(key) % pinned_key_shards_.size()];
+}
+
+uint64_t DataManager::TimePointToDeadlineMs(TimePoint deadline) const {
+    const auto remaining =
+        std::max(std::chrono::milliseconds::zero(),
+                 std::chrono::duration_cast<std::chrono::milliseconds>(
+                     deadline - std::chrono::steady_clock::now()));
+    const auto system_deadline =
+        std::chrono::system_clock::now() + remaining;
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            system_deadline.time_since_epoch())
+            .count());
+}
+
+DataManager::TimePoint DataManager::DeadlineMsToTimePoint(
+    uint64_t deadline_ms) const {
+    const auto system_deadline =
+        std::chrono::system_clock::time_point(std::chrono::milliseconds(
+            static_cast<int64_t>(deadline_ms)));
+    const auto remaining =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            system_deadline - std::chrono::system_clock::now());
+    if (remaining <= std::chrono::milliseconds::zero()) {
+        return std::chrono::steady_clock::now();
+    }
+    return std::chrono::steady_clock::now() + remaining;
+}
+
+bool DataManager::IsExpired(TimePoint deadline) const {
+    return deadline <= std::chrono::steady_clock::now();
+}
+
+RemoteBufferDesc DataManager::BuildRemoteBufferDesc(
+    const AllocationHandle& handle) const {
+    const auto& loc_data = handle->loc.data;
+    RemoteBufferDesc remote_buffer;
+    remote_buffer.segment_endpoint = local_transfer_config_.te_endpoint;
+    remote_buffer.addr =
+        reinterpret_cast<uintptr_t>(loc_data.buffer ? loc_data.buffer->data()
+                                                    : nullptr);
+    remote_buffer.size = loc_data.buffer ? loc_data.buffer->size() : 0;
+    return remote_buffer;
+}
+
+void DataManager::TouchOrderedDeadlineNode(OrderedDeadlineList& ordered_list,
+                                           OrderedDeadlineListIt it,
+                                           const std::string& key,
+                                           TimePoint deadline) {
+    it->first = key;
+    it->second = deadline;
+    ordered_list.splice(ordered_list.end(), ordered_list, it);
+}
+
+bool DataManager::ErasePendingWriteLocked(PendingWriteShard& shard,
+                                          const std::string& key) {
+    auto it = shard.by_key.find(key);
+    if (it == shard.by_key.end()) {
+        return false;
+    }
+    shard.ordered_list.erase(it->second.list_it);
+    shard.by_key.erase(it);
+    return true;
+}
+
+bool DataManager::ErasePinnedKeyLocked(PinnedKeyShard& shard,
+                                       const std::string& key) {
+    auto it = shard.by_key.find(key);
+    if (it == shard.by_key.end()) {
+        return false;
+    }
+    shard.ordered_list.erase(it->second.list_it);
+    shard.by_key.erase(it);
+    return true;
+}
+
+bool DataManager::RemoveExpiredPendingWriteLocked(PendingWriteShard& shard,
+                                                  const std::string& key,
+                                                  TimePoint now) {
+    auto it = shard.by_key.find(key);
+    if (it == shard.by_key.end() || it->second.deadline > now) {
+        return false;
+    }
+    shard.ordered_list.erase(it->second.list_it);
+    shard.by_key.erase(it);
+    return true;
+}
+
+bool DataManager::RemoveExpiredPinnedKeyLocked(PinnedKeyShard& shard,
+                                               const std::string& key,
+                                               TimePoint now) {
+    auto it = shard.by_key.find(key);
+    if (it == shard.by_key.end() || it->second.deadline > now) {
+        return false;
+    }
+    shard.ordered_list.erase(it->second.list_it);
+    shard.by_key.erase(it);
+    return true;
+}
+
+size_t DataManager::ScanExpiredPendingWrites(PendingWriteShard& shard,
+                                             TimePoint now) {
+    size_t removed = 0;
+    while (!shard.ordered_list.empty()) {
+        auto list_it = shard.ordered_list.begin();
+        if (list_it->second > now) {
+            break;
+        }
+        auto record_it = shard.by_key.find(list_it->first);
+        if (record_it == shard.by_key.end() ||
+            record_it->second.list_it != list_it) {
+            shard.ordered_list.erase(list_it);
+            continue;
+        }
+        shard.by_key.erase(record_it);
+        shard.ordered_list.erase(list_it);
+        ++removed;
+    }
+    return removed;
+}
+
+size_t DataManager::ScanExpiredPinnedKeys(PinnedKeyShard& shard, TimePoint now) {
+    size_t removed = 0;
+    while (!shard.ordered_list.empty()) {
+        auto list_it = shard.ordered_list.begin();
+        if (list_it->second > now) {
+            break;
+        }
+        auto record_it = shard.by_key.find(list_it->first);
+        if (record_it == shard.by_key.end() ||
+            record_it->second.list_it != list_it) {
+            shard.ordered_list.erase(list_it);
+            continue;
+        }
+        shard.by_key.erase(record_it);
+        shard.ordered_list.erase(list_it);
+        ++removed;
+    }
+    return removed;
+}
+
+tl::expected<AllocationHandle, ErrorCode> DataManager::LookupPendingWriteHandle(
+    std::string_view key, const UUID& pending_write_token) {
+    return LookupPendingWriteHandleInternal(BuildKeyCtx(key),
+                                            pending_write_token);
+}
+
+tl::expected<AllocationHandle, ErrorCode>
+DataManager::LookupPendingWriteHandleInternal(const KeyCtx& ctx,
+                                              const UUID& pending_write_token) {
+    const auto now = std::chrono::steady_clock::now();
+    auto& shard = GetPendingWriteShard(ctx);
+    std::shared_lock shard_lock(shard.mutex);
+    auto it = shard.by_key.find(ctx.key_string);
+    if (it == shard.by_key.end()) {
+        return tl::unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    if (it->second.deadline <= now) {
+        return tl::unexpected(ErrorCode::LEASE_EXPIRED);
+    }
+    if (it->second.pending_write_token != pending_write_token) {
+        return tl::unexpected(ErrorCode::INVALID_WRITE);
+    }
+    return it->second.handle;
+}
+
+tl::expected<AllocationHandle, ErrorCode> DataManager::LookupPinnedKeyHandle(
+    std::string_view key, const UUID& pin_token) {
+    return LookupPinnedKeyHandleInternal(BuildKeyCtx(key), pin_token);
+}
+
+tl::expected<AllocationHandle, ErrorCode> DataManager::LookupPinnedKeyHandleInternal(
+    const KeyCtx& ctx, const UUID& pin_token) {
+    const auto now = std::chrono::steady_clock::now();
+    auto& shard = GetPinnedKeyShard(ctx);
+    std::shared_lock shard_lock(shard.mutex);
+    auto it = shard.by_key.find(ctx.key_string);
+    if (it == shard.by_key.end()) {
+        return tl::unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    if (it->second.deadline <= now) {
+        return tl::unexpected(ErrorCode::LEASE_EXPIRED);
+    }
+    if (it->second.pin_token != pin_token) {
+        return tl::unexpected(ErrorCode::INVALID_READ);
+    }
+    return it->second.handle;
+}
+
+void DataManager::AbortPendingWrite(std::string_view key,
+                                   const UUID& pending_write_token) {
+    AbortPendingWriteInternal(BuildKeyCtx(key), pending_write_token);
+}
+
+void DataManager::AbortPendingWriteInternal(const KeyCtx& ctx,
+                                            const UUID& pending_write_token) {
+    if (ctx.key.empty() || IsZeroUuid(pending_write_token)) return;
+    std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
+    auto& shard = GetPendingWriteShard(ctx);
+    std::unique_lock shard_lock(shard.mutex);
+    auto it = shard.by_key.find(ctx.key_string);
+    if (it == shard.by_key.end()) return;
+    if (it->second.pending_write_token != pending_write_token) return;
+    shard.ordered_list.erase(it->second.list_it);
+    shard.by_key.erase(it);
+}
+
+void DataManager::ShutdownLeaseScanner() {
+    lease_scanner_stop_requested_.store(true);
+    lease_scanner_cv_.notify_all();
+    if (lease_scanner_thread_.joinable()) {
+        lease_scanner_thread_.join();
+    }
+}
+
+void DataManager::LeaseScannerMain() {
+    std::unique_lock<std::mutex> wait_lock(lease_scanner_mutex_);
+    while (!lease_scanner_stop_requested_.load()) {
+        lease_scanner_cv_.wait_for(wait_lock, lease_scan_interval_, [this]() {
+            return lease_scanner_stop_requested_.load();
+        });
+        if (lease_scanner_stop_requested_.load()) {
+            break;
+        }
+        const auto now = std::chrono::steady_clock::now();
+        wait_lock.unlock();
+        for (auto& shard : pending_write_shards_) {
+            std::unique_lock shard_lock(shard.mutex);
+            ScanExpiredPendingWrites(shard, now);
+        }
+        for (auto& shard : pinned_key_shards_) {
+            std::unique_lock shard_lock(shard.mutex);
+            ScanExpiredPinnedKeys(shard, now);
+        }
+        wait_lock.lock();
+    }
 }
 
 // ================================================================
@@ -187,6 +491,7 @@ tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode> DataManager::Put(
 tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>
 DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
     // using Te, treat local memory as remote memory
+    const KeyCtx kctx = BuildKeyCtx(key);
     size_t total_size = 0;
     for (const auto& s : slices) total_size += s.size;
     auto src_buffers = SlicesToRemoteBufferDescs(slices);
@@ -197,28 +502,19 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
         return tl::unexpected(validate_result.error());
     }
 
-    AllocationHandle alloc_handle;
-    {
-        std::unique_lock<std::shared_mutex> lock(GetKeyLock(key));
-
-        if (tiered_backend_->Exist(key)) {
-            LOG(WARNING) << "key already exists: " << key;
-            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
-        }
-
-        auto alloc_result = tiered_backend_->Allocate(total_size);
-        if (!alloc_result) {
-            auto err = alloc_result.error();
-            if (err == ErrorCode::REPLICA_NUM_EXCEEDED ||
-                err == ErrorCode::OBJECT_ALREADY_EXISTS ||
-                err == ErrorCode::REPLICA_ALREADY_EXISTS) {
-                LOG(WARNING) << "object already exists for key: " << key
-                             << ", error code: " << err;
-            }
-            return tl::unexpected(err);
-        }
-        alloc_handle = alloc_result.value();
+    auto prewrite_result = PreWriteInternal(kctx, total_size, std::nullopt);
+    if (!prewrite_result) {
+        return tl::unexpected(prewrite_result.error());
     }
+    const UUID pending_write_token = prewrite_result->pending_write_token;
+
+    auto handle_result =
+        LookupPendingWriteHandleInternal(kctx, pending_write_token);
+    if (!handle_result) {
+        AbortPendingWriteInternal(kctx, pending_write_token);
+        return tl::unexpected(handle_result.error());
+    }
+    AllocationHandle alloc_handle = handle_result.value();
 
     auto submit_result = SubmitTeTransferInternal(
         alloc_handle, src_buffers, Transport::TransferRequest::READ);
@@ -226,20 +522,22 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
         LOG(ERROR) << "SubmitTeTransferInternal failed"
                    << ", key=" << key
                    << ", error_code=" << toString(submit_result.error());
+        AbortPendingWriteInternal(kctx, pending_write_token);
         return tl::unexpected(submit_result.error());
     }
 
     return CallableTaskHandle<void>::Create(
-        [this, ctx = std::move(*submit_result), alloc_handle,
-         key]() mutable -> tl::expected<void, ErrorCode> {
+        [this, ctx = std::move(*submit_result), alloc_handle, kctx,
+         pending_write_token]() mutable -> tl::expected<void, ErrorCode> {
             ScopedVLogTimer timer(1, "DataManager::PutViaTe");
-            timer.LogRequest("key=", key);
+            timer.LogRequest("key=", kctx.key);
 
             auto wait_result = WaitAllTransferBatches(ctx.transfer_batches);
             if (!wait_result) {
                 LOG(ERROR) << "WaitAllTransferBatches failed"
-                           << ", key=" << key
+                           << ", key=" << kctx.key
                            << ", error_code=" << toString(wait_result.error());
+                AbortPendingWriteInternal(kctx, pending_write_token);
                 return tl::unexpected(wait_result.error());
             }
 
@@ -254,16 +552,16 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
                 if (!copy_result) {
                     LOG(ERROR)
                         << "CopyFromDRAMBuffer failed"
-                        << ", key=" << key
+                        << ", key=" << kctx.key
                         << ", error_code=" << toString(copy_result.error());
+                    AbortPendingWriteInternal(kctx, pending_write_token);
                     return tl::unexpected(copy_result.error());
                 }
             }
 
-            std::unique_lock<std::shared_mutex> lock(GetKeyLock(key));
-            auto commit_result = tiered_backend_->Commit(key, alloc_handle);
+            auto commit_result = WriteCommitInternal(kctx, pending_write_token);
             if (!commit_result) {
-                LOG(WARNING) << "commit race for key: " << key;
+                return tl::unexpected(commit_result.error());
             }
             timer.LogResponse("error_code=", ErrorCode::OK);
             return {};
@@ -276,56 +574,49 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
         LOG(ERROR) << "PutLocal in memcpy mode only supports a single slice";
         return tl::unexpected(ErrorCode::NOT_IMPLEMENTED);
     }
+    const KeyCtx kctx = BuildKeyCtx(key);
     Slice slice = slices[0];
 
-    AllocationHandle alloc_handle;
-    {
-        std::unique_lock lock(GetKeyLock(key));
-
-        if (tiered_backend_->Exist(key)) {
-            LOG(WARNING) << "Key already exists: " << key;
-            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
-        }
-
-        auto handle = tiered_backend_->Allocate(slice.size);
-        if (!handle.has_value()) {
-            LOG(ERROR) << "Failed to allocate space for key: " << key
-                       << ", error: " << handle.error();
-            return tl::make_unexpected(handle.error());
-        }
-        alloc_handle = handle.value();
+    auto prewrite_result = PreWriteInternal(kctx, slice.size, std::nullopt);
+    if (!prewrite_result) {
+        return tl::unexpected(prewrite_result.error());
     }
+    const UUID pending_write_token = prewrite_result->pending_write_token;
 
-    auto write_fn = [this, key, slice,
-                     alloc_handle]() -> tl::expected<void, ErrorCode> {
+    auto handle_result =
+        LookupPendingWriteHandleInternal(kctx, pending_write_token);
+    if (!handle_result) {
+        AbortPendingWriteInternal(kctx, pending_write_token);
+        return tl::unexpected(handle_result.error());
+    }
+    AllocationHandle alloc_handle = handle_result.value();
+
+    auto write_fn = [this, kctx, slice, alloc_handle,
+                     pending_write_token]() -> tl::expected<void, ErrorCode> {
         DataSource source;
         source.buffer = std::make_unique<RefBuffer>(slice.ptr, slice.size);
         source.type = MemoryType::DRAM;
 
         auto write_result = tiered_backend_->Write(source, alloc_handle);
         if (!write_result.has_value()) {
-            LOG(ERROR) << "Failed to write data for key: " << key
+            LOG(ERROR) << "Failed to write data for key: " << kctx.key
                        << ", error: " << write_result.error();
+            AbortPendingWriteInternal(kctx, pending_write_token);
             return tl::make_unexpected(write_result.error());
         }
         return {};
     };
 
-    auto commit_fn = [this, key,
-                      alloc_handle]() -> tl::expected<void, ErrorCode> {
-        std::unique_lock lock(GetKeyLock(key));
-        auto commit_result = tiered_backend_->Commit(key, alloc_handle);
-        if (!commit_result.has_value()) {
-            auto err = commit_result.error();
-            if (err != ErrorCode::REPLICA_NUM_EXCEEDED &&
-                err != ErrorCode::OBJECT_ALREADY_EXISTS &&
-                err != ErrorCode::REPLICA_ALREADY_EXISTS) {
-                LOG(ERROR) << "Failed to commit data for key: " << key
+    auto commit_fn = [this, kctx,
+                      pending_write_token]() -> tl::expected<void, ErrorCode> {
+            auto commit_result =
+                WriteCommitInternal(kctx, pending_write_token);
+            if (!commit_result) {
+                LOG(ERROR) << "Failed to commit data for key: " << kctx.key
                            << ", error: " << commit_result.error();
                 return tl::make_unexpected(commit_result.error());
             }
-        }
-        return {};
+            return {};
     };
 
     auto write_and_commit = [write_fn = std::move(write_fn),
@@ -514,12 +805,11 @@ tl::expected<ReadTaskHandle, ErrorCode> DataManager::BuildDataCopierViaMemcpy(
 // Remote data transfer — called by RPC service layer
 // ================================================================
 
-// Attention!!!
-// This method runs without key lock.
 tl::expected<void, ErrorCode> DataManager::ReadRemoteData(
     std::string_view key, const std::vector<RemoteBufferDesc>& dest_buffers) {
     ScopedVLogTimer timer(1, "DataManager::ReadRemoteData");
     timer.LogRequest("key=", key, "buffer_count=", dest_buffers.size());
+    const KeyCtx kctx = BuildKeyCtx(key);
 
     auto validate_result = ValidateRemoteBuffers(dest_buffers);
     if (!validate_result) {
@@ -529,15 +819,35 @@ tl::expected<void, ErrorCode> DataManager::ReadRemoteData(
         return tl::make_unexpected(validate_result.error());
     }
 
-    auto handle_result = tiered_backend_->Get(key);
-    if (!handle_result.has_value()) {
-        LOG(ERROR) << "ReadRemoteData: Failed to get data for key: " << key
-                   << ", error: " << toString(handle_result.error());
+    // Reverse RDMA path: use the same 3-phase pin/unpin semantics even though
+    // the control plane is still a single RPC.
+    auto pin_result = PinKeyInternal(kctx, std::nullopt);
+    if (!pin_result) {
+        timer.LogResponse("error_code=", pin_result.error());
+        return tl::make_unexpected(pin_result.error());
+    }
+    const UUID pin_token = pin_result->pin_token;
+
+    auto handle_result = LookupPinnedKeyHandleInternal(kctx, pin_token);
+    if (!handle_result) {
+        (void)UnPinKeyInternal(kctx, pin_token);
         timer.LogResponse("error_code=", handle_result.error());
         return tl::make_unexpected(handle_result.error());
     }
 
-    return TransferDataToRemote(handle_result.value(), dest_buffers);
+    auto transfer_result = TransferDataToRemote(handle_result.value(), dest_buffers);
+    auto unpin_result = UnPinKeyInternal(kctx, pin_token);
+
+    if (!transfer_result) {
+        timer.LogResponse("error_code=", transfer_result.error());
+        return tl::make_unexpected(transfer_result.error());
+    }
+    if (!unpin_result) {
+        timer.LogResponse("error_code=", unpin_result.error());
+        return tl::make_unexpected(unpin_result.error());
+    }
+    timer.LogResponse("error_code=", ErrorCode::OK);
+    return {};
 }
 
 tl::expected<void, ErrorCode> DataManager::TransferDataToRemote(
@@ -561,6 +871,7 @@ tl::expected<UUID, ErrorCode> DataManager::WriteRemoteData(
     std::optional<UUID> tier_id) {
     ScopedVLogTimer timer(1, "DataManager::WriteRemoteData");
     timer.LogRequest("key=", key, "buffer_count=", src_buffers.size());
+    const KeyCtx kctx = BuildKeyCtx(key);
 
     auto validate_result = ValidateRemoteBuffers(src_buffers);
     if (!validate_result) {
@@ -573,52 +884,280 @@ tl::expected<UUID, ErrorCode> DataManager::WriteRemoteData(
     size_t total_size = 0;
     for (const auto& buf : src_buffers) total_size += buf.size;
 
-    AllocationHandle handle;
-    {
-        std::unique_lock lock(GetKeyLock(key));
-
-        if (tiered_backend_->Exist(key)) {
-            LOG(WARNING) << "Key already exists: " << key;
-            timer.LogResponse("error_code=", ErrorCode::OBJECT_ALREADY_EXISTS);
-            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
-        }
-
-        auto handle_result = tiered_backend_->Allocate(total_size, tier_id);
-        if (!handle_result.has_value()) {
-            LOG(ERROR) << "WriteRemoteData: Failed to allocate space for key: "
-                       << key;
-            timer.LogResponse("error_code=", handle_result.error());
-            return tl::make_unexpected(handle_result.error());
-        }
-        handle = handle_result.value();
+    // Reverse RDMA path: still one RPC, but internally use the 3-phase write
+    // model (PreWrite -> transfer -> WriteCommit).
+    auto prewrite_result = PreWriteInternal(kctx, total_size, tier_id);
+    if (!prewrite_result) {
+        timer.LogResponse("error_code=", prewrite_result.error());
+        return tl::make_unexpected(prewrite_result.error());
     }
+    const UUID pending_write_token = prewrite_result->pending_write_token;
 
-    // Transfer phase — no lock held, RDMA runs concurrently.
+    auto handle_result =
+        LookupPendingWriteHandleInternal(kctx, pending_write_token);
+    if (!handle_result) {
+        AbortPendingWriteInternal(kctx, pending_write_token);
+        timer.LogResponse("error_code=", handle_result.error());
+        return tl::make_unexpected(handle_result.error());
+    }
+    AllocationHandle handle = handle_result.value();
+    UUID result_tier_id = handle->loc.tier->GetTierId();
+
+    // Transfer phase — no long key lock held.
     auto transfer_result = TransferDataFromRemote(handle, src_buffers);
-    if (!transfer_result.has_value()) {
-        LOG(ERROR) << "WriteRemoteData: Transfer failed for key: " << key
-                   << ", error: " << toString(transfer_result.error());
+    if (!transfer_result) {
+        AbortPendingWriteInternal(kctx, pending_write_token);
         timer.LogResponse("error_code=", transfer_result.error());
         return tl::make_unexpected(transfer_result.error());
     }
 
-    // Commit phase: re-acquire lock, commit the handle.
-    UUID result_tier_id;
-    {
-        std::unique_lock lock(GetKeyLock(key));
-        auto commit_result = tiered_backend_->Commit(key, handle);
-        if (!commit_result.has_value()) {
-            LOG(ERROR) << "WriteRemoteData: Failed to commit data for key: "
-                       << key;
-            timer.LogResponse("error_code=", commit_result.error());
-            return tl::make_unexpected(commit_result.error());
-        }
-        result_tier_id = handle->loc.tier->GetTierId();
+    auto commit_result = WriteCommitInternal(kctx, pending_write_token);
+    if (!commit_result) {
+        timer.LogResponse("error_code=", commit_result.error());
+        return tl::make_unexpected(commit_result.error());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK,
                       "transferred_bytes=", total_size);
     return result_tier_id;
+}
+
+tl::expected<DataManager::PreWriteResult, ErrorCode> DataManager::PreWrite(
+    std::string_view key, size_t size_bytes, std::optional<UUID> tier_id) {
+    return PreWriteInternal(BuildKeyCtx(key), size_bytes, tier_id);
+}
+
+tl::expected<DataManager::PreWriteResult, ErrorCode> DataManager::PreWriteInternal(
+    const KeyCtx& ctx, size_t size_bytes, std::optional<UUID> tier_id) {
+    ScopedVLogTimer timer(1, "DataManager::PreWrite");
+    timer.LogRequest("key=", ctx.key, "size_bytes=", size_bytes);
+
+    if (ctx.key.empty() || size_bytes == 0) {
+        timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    const auto deadline = now + lease_duration_;
+
+    std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
+    auto& shard = GetPendingWriteShard(ctx);
+    std::unique_lock shard_lock(shard.mutex);
+
+    RemoveExpiredPendingWriteLocked(shard, ctx.key_string, now);
+    if (shard.by_key.find(ctx.key_string) != shard.by_key.end()) {
+        timer.LogResponse("error_code=", ErrorCode::OBJECT_HAS_LEASE);
+        return tl::make_unexpected(ErrorCode::OBJECT_HAS_LEASE);
+    }
+    if (tiered_backend_->Exist(ctx.key)) {
+        timer.LogResponse("error_code=", ErrorCode::OBJECT_ALREADY_EXISTS);
+        return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+    }
+
+    auto handle_result = tiered_backend_->Allocate(size_bytes, tier_id);
+    if (!handle_result) {
+        timer.LogResponse("error_code=", handle_result.error());
+        return tl::make_unexpected(handle_result.error());
+    }
+
+    auto handle = std::move(handle_result.value());
+    auto list_it =
+        shard.ordered_list.emplace(shard.ordered_list.end(), ctx.key_string, deadline);
+
+    const UUID pending_write_token = generate_uuid();
+    PendingWriteRecord record;
+    record.pending_write_token = pending_write_token;
+    record.deadline = deadline;
+    record.handle = handle;
+    record.list_it = list_it;
+    shard.by_key.insert_or_assign(ctx.key_string, std::move(record));
+
+    PreWriteResult result;
+    result.remote_buffer = BuildRemoteBufferDesc(handle);
+    result.deadline_ms = TimePointToDeadlineMs(deadline);
+    result.pending_write_token = pending_write_token;
+    timer.LogResponse("error_code=", ErrorCode::OK,
+                      "deadline_ms=", result.deadline_ms);
+    return result;
+}
+
+tl::expected<void, ErrorCode> DataManager::WriteCommit(
+    std::string_view key, const UUID& pending_write_token) {
+    return WriteCommitInternal(BuildKeyCtx(key), pending_write_token);
+}
+
+tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
+    const KeyCtx& ctx, const UUID& pending_write_token) {
+    ScopedVLogTimer timer(1, "DataManager::WriteCommit");
+    timer.LogRequest("key=", ctx.key);
+
+    if (ctx.key.empty() || IsZeroUuid(pending_write_token)) {
+        timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+
+    std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
+    auto& shard = GetPendingWriteShard(ctx);
+    std::unique_lock shard_lock(shard.mutex);
+
+    auto record_it = shard.by_key.find(ctx.key_string);
+    if (record_it == shard.by_key.end()) {
+        timer.LogResponse("error_code=", ErrorCode::OK, "idempotent=", true);
+        return {};
+    }
+    if (record_it->second.deadline <= now) {
+        shard.ordered_list.erase(record_it->second.list_it);
+        shard.by_key.erase(record_it);
+        timer.LogResponse("error_code=", ErrorCode::LEASE_EXPIRED);
+        return tl::make_unexpected(ErrorCode::LEASE_EXPIRED);
+    }
+    if (record_it->second.pending_write_token != pending_write_token) {
+        timer.LogResponse("error_code=", ErrorCode::INVALID_WRITE);
+        return tl::make_unexpected(ErrorCode::INVALID_WRITE);
+    }
+
+    auto handle = record_it->second.handle;
+    // Once we attempt the commit, always erase the pending record regardless of
+    // the commit result.
+    //
+    // Rationale: most commit failures are not transient and cannot be resolved
+    // by retrying WriteCommit alone (e.g. tier commit failure or master
+    // callback failure). The caller should restart a full write flow instead of
+    // reusing a potentially stale prewrite context.
+    //
+    // Note: after erasing the record, subsequent WriteCommit calls become
+    // idempotent no-ops (return OK) due to record absence.
+    auto commit_result = tiered_backend_->Commit(ctx.key, handle);
+    shard.ordered_list.erase(record_it->second.list_it);
+    shard.by_key.erase(record_it);
+
+    if (!commit_result) {
+        timer.LogResponse("error_code=", commit_result.error(),
+                          "record_erased=", true);
+        return tl::make_unexpected(commit_result.error());
+    }
+
+    timer.LogResponse("error_code=", ErrorCode::OK, "record_erased=", true);
+    return {};
+}
+
+tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKey(
+    std::string_view key, std::optional<UUID> tier_id) {
+    return PinKeyInternal(BuildKeyCtx(key), tier_id);
+}
+
+tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
+    const KeyCtx& ctx, std::optional<UUID> tier_id) {
+    ScopedVLogTimer timer(1, "DataManager::PinKey");
+    timer.LogRequest("key=", ctx.key);
+
+    if (ctx.key.empty()) {
+        timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    const auto deadline = now + lease_duration_;
+
+    std::shared_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
+    auto& shard = GetPinnedKeyShard(ctx);
+    std::unique_lock shard_lock(shard.mutex);
+
+    RemoveExpiredPinnedKeyLocked(shard, ctx.key_string, now);
+    auto record_it = shard.by_key.find(ctx.key_string);
+    if (record_it != shard.by_key.end()) {
+        record_it->second.ref_count++;
+        record_it->second.deadline = deadline;
+        TouchOrderedDeadlineNode(shard.ordered_list, record_it->second.list_it,
+                                 ctx.key_string, deadline);
+
+        PinKeyResult result;
+        result.remote_buffer = BuildRemoteBufferDesc(record_it->second.handle);
+        result.deadline_ms = TimePointToDeadlineMs(deadline);
+        result.pin_token = record_it->second.pin_token;
+        timer.LogResponse("error_code=", ErrorCode::OK,
+                          "ref_count=", record_it->second.ref_count);
+        return result;
+    }
+
+    auto handle_result = tiered_backend_->Get(ctx.key, tier_id);
+    if (!handle_result) {
+        timer.LogResponse("error_code=", handle_result.error());
+        return tl::make_unexpected(handle_result.error());
+    }
+
+    auto handle = std::move(handle_result.value());
+    auto list_it =
+        shard.ordered_list.emplace(shard.ordered_list.end(), ctx.key_string, deadline);
+
+    const UUID pin_token_value = generate_uuid();
+    PinnedKeyRecord record;
+    record.pin_token = pin_token_value;
+    record.deadline = deadline;
+    record.handle = handle;
+    record.ref_count = 1;
+    record.list_it = list_it;
+    shard.by_key.insert_or_assign(ctx.key_string, std::move(record));
+
+    PinKeyResult result;
+    result.remote_buffer = BuildRemoteBufferDesc(handle);
+    result.deadline_ms = TimePointToDeadlineMs(deadline);
+    result.pin_token = pin_token_value;
+    timer.LogResponse("error_code=", ErrorCode::OK,
+                      "deadline_ms=", result.deadline_ms);
+    return result;
+}
+
+tl::expected<void, ErrorCode> DataManager::UnPinKey(std::string_view key,
+                                                    const UUID& pin_token) {
+    return UnPinKeyInternal(BuildKeyCtx(key), pin_token);
+}
+
+tl::expected<void, ErrorCode> DataManager::UnPinKeyInternal(
+    const KeyCtx& ctx, const UUID& pin_token) {
+    ScopedVLogTimer timer(1, "DataManager::UnPinKey");
+    timer.LogRequest("key=", ctx.key);
+
+    if (ctx.key.empty() || IsZeroUuid(pin_token)) {
+        timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+
+    std::shared_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
+    auto& shard = GetPinnedKeyShard(ctx);
+    std::unique_lock shard_lock(shard.mutex);
+
+    auto record_it = shard.by_key.find(ctx.key_string);
+    if (record_it == shard.by_key.end()) {
+        timer.LogResponse("error_code=", ErrorCode::OK, "idempotent=", true);
+        return {};
+    }
+    if (record_it->second.deadline <= now) {
+        shard.ordered_list.erase(record_it->second.list_it);
+        shard.by_key.erase(record_it);
+        timer.LogResponse("error_code=", ErrorCode::LEASE_EXPIRED);
+        return tl::make_unexpected(ErrorCode::LEASE_EXPIRED);
+    }
+    if (record_it->second.pin_token != pin_token) {
+        timer.LogResponse("error_code=", ErrorCode::INVALID_READ);
+        return tl::make_unexpected(ErrorCode::INVALID_READ);
+    }
+
+    if (record_it->second.ref_count > 1) {
+        record_it->second.ref_count--;
+        timer.LogResponse("error_code=", ErrorCode::OK,
+                          "ref_count=", record_it->second.ref_count);
+        return {};
+    }
+
+    shard.ordered_list.erase(record_it->second.list_it);
+    shard.by_key.erase(record_it);
+    timer.LogResponse("error_code=", ErrorCode::OK, "ref_count=", 0);
+    return {};
 }
 
 tl::expected<void, ErrorCode> DataManager::TransferDataFromRemote(
@@ -1135,6 +1674,17 @@ tl::expected<void, ErrorCode> DataManager::Delete(std::string_view key,
     ScopedVLogTimer timer(1, "DataManager::Delete");
     timer.LogRequest("key=", key);
 
+    // NOTE (weak delete semantics):
+    // TieredBackend::Delete only removes the metadata entry (or a replica entry)
+    // from the in-memory index. It does NOT directly free underlying memory.
+    // The actual buffer lifetime is still governed by AllocationHandle's RAII
+    // reference counting.
+    //
+    // We still guard Delete against in-flight 3-phase contexts:
+    // - PendingWriteRecord holds a strong handle reference until WriteCommit or
+    //   lease cleanup.
+    // - PinnedKeyRecord holds a strong handle reference until UnPinKey reaches
+    //   ref_count==0 or lease cleanup.
     std::unique_lock lock(GetKeyLock(key));
 
     auto result = tiered_backend_->Delete(key, tier_id, notify_master);

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -279,32 +279,6 @@ template size_t
 DataManager::ScanExpiredRecordShard<DataManager::PinnedKeyRecord>(
     RecordShard<DataManager::PinnedKeyRecord>&, TimePoint);
 
-tl::expected<AllocationHandle, ErrorCode>
-DataManager::LookupPendingWriteHandleInternal(const KeyCtx& ctx,
-                                              const UUID& write_operation_id) {
-    const auto now = std::chrono::steady_clock::now();
-    auto& pending_write_shard = GetPendingWriteShard(ctx);
-    std::shared_lock pending_write_shard_lock(pending_write_shard.mutex);
-    auto it = pending_write_shard.existed_operation_key_map.find(ctx.key);
-    if (it == pending_write_shard.existed_operation_key_map.end()) {
-        LOG(ERROR) << "LookupPendingWriteHandle: no pending write for key: "
-                   << ctx.key;
-        return tl::unexpected(ErrorCode::OBJECT_NOT_FOUND);
-    }
-    if (it->second.deadline <= now) {
-        LOG(ERROR) << "LookupPendingWriteHandle: lease expired for key: "
-                   << ctx.key;
-        return tl::unexpected(ErrorCode::LEASE_EXPIRED);
-    }
-    if (it->second.write_operation_id != write_operation_id) {
-        LOG(ERROR) << "LookupPendingWriteHandle: write_operation_id mismatch "
-                      "for key: "
-                   << ctx.key;
-        return tl::unexpected(ErrorCode::INVALID_WRITE);
-    }
-    return it->second.handle;
-}
-
 DataManager::PendingWriteEraseResult DataManager::ErasePendingWriteRecord(
     PendingWriteShard& shard, std::string_view key,
     const UUID& write_operation_id) {
@@ -370,7 +344,15 @@ tl::expected<void, ErrorCode> DataManager::ReservePendingWriteSlot(
 tl::expected<void, ErrorCode> DataManager::AttachPendingWriteHandle(
     PendingWriteShard& shard, std::string_view key,
     const UUID& write_operation_id, const AllocationHandle& handle) {
-    std::unique_lock lock(shard.mutex);
+    // Shard shared_lock only: validates map lookup against concurrent shard
+    // readers (lease scan, WriteCommit). Does not change map/ordered_list
+    // topology—only PendingWriteRecord::handle on an existing entry.
+    //
+    // No per-record mutex today: a key under an active pending-write lease is
+    // not concurrently updated (second PreWrite gets REPLICA_IS_PROCESSING;
+    // WriteCommit matches write_operation_id). Fine-grained record locking can
+    // be added later if handle visibility needs stricter isolation.
+    std::shared_lock shard_lock(shard.mutex);
     auto it = shard.existed_operation_key_map.find(key);
     if (it == shard.existed_operation_key_map.end()) {
         LOG(ERROR) << "PreWrite: reserved pending write record missing"
@@ -389,18 +371,18 @@ tl::expected<void, ErrorCode> DataManager::AttachPendingWriteHandle(
 }
 
 tl::expected<AllocationHandle, ErrorCode>
-DataManager::TakePendingWriteForCommit(PendingWriteShard& shard,
-                                       std::string_view key, TimePoint now,
-                                       const UUID& write_operation_id) {
-    std::unique_lock lock(shard.mutex);
+DataManager::ValidatePendingWriteForCommit(PendingWriteShard& shard,
+                                           std::string_view key, TimePoint now,
+                                           const UUID& write_operation_id) {
+    // Hold the pending record through Commit so a new PreWrite cannot reserve
+    // the same key in the race window before tiered_backend_->Commit finishes.
+    std::shared_lock shard_lock(shard.mutex);
     auto record_it = shard.existed_operation_key_map.find(key);
     if (record_it == shard.existed_operation_key_map.end()) {
         LOG(ERROR) << "WriteCommit: no pending write record for key: " << key;
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
     if (record_it->second.deadline <= now) {
-        shard.ordered_list.erase(record_it->second.list_it);
-        shard.existed_operation_key_map.erase(record_it);
         LOG(ERROR) << "WriteCommit: pending write lease expired"
                    << ", key=" << key
                    << ", error=" << toString(ErrorCode::LEASE_EXPIRED);
@@ -418,10 +400,7 @@ DataManager::TakePendingWriteForCommit(PendingWriteShard& shard,
                    << ", error=" << toString(ErrorCode::INVALID_WRITE);
         return tl::make_unexpected(ErrorCode::INVALID_WRITE);
     }
-    AllocationHandle handle = record_it->second.handle;
-    shard.ordered_list.erase(record_it->second.list_it);
-    shard.existed_operation_key_map.erase(record_it);
-    return handle;
+    return record_it->second.handle;
 }
 
 void DataManager::ShutdownLeaseScanner() {
@@ -511,14 +490,7 @@ DataManager::PutViaTe(std::string_view key, std::vector<Slice>& slices) {
         return tl::unexpected(prewrite_result.error());
     }
     const UUID write_operation_id = prewrite_result->write_operation_id;
-
-    auto handle_result =
-        LookupPendingWriteHandleInternal(kctx, write_operation_id);
-    if (!handle_result) {
-        AbortPendingWriteInternal(kctx, write_operation_id);
-        return tl::unexpected(handle_result.error());
-    }
-    AllocationHandle alloc_handle = handle_result.value();
+    AllocationHandle alloc_handle = prewrite_result->handle;
 
     auto submit_result = SubmitTeTransferInternal(
         alloc_handle, src_buffers, Transport::TransferRequest::READ);
@@ -594,14 +566,7 @@ DataManager::PutViaMemcpy(std::string_view key, std::vector<Slice>& slices) {
         return tl::unexpected(prewrite_result.error());
     }
     const UUID write_operation_id = prewrite_result->write_operation_id;
-
-    auto handle_result =
-        LookupPendingWriteHandleInternal(kctx, write_operation_id);
-    if (!handle_result) {
-        AbortPendingWriteInternal(kctx, write_operation_id);
-        return tl::unexpected(handle_result.error());
-    }
-    AllocationHandle alloc_handle = handle_result.value();
+    AllocationHandle alloc_handle = prewrite_result->handle;
 
     auto write_fn = [this, key_owned = std::string(key), slice, alloc_handle,
                      write_operation_id]() -> tl::expected<void, ErrorCode> {
@@ -898,15 +863,7 @@ tl::expected<UUID, ErrorCode> DataManager::WriteRemoteData(
         return tl::make_unexpected(prewrite_result.error());
     }
     const UUID write_operation_id = prewrite_result->write_operation_id;
-
-    auto handle_result =
-        LookupPendingWriteHandleInternal(kctx, write_operation_id);
-    if (!handle_result) {
-        AbortPendingWriteInternal(kctx, write_operation_id);
-        timer.LogResponse("error_code=", handle_result.error());
-        return tl::make_unexpected(handle_result.error());
-    }
-    AllocationHandle handle = handle_result.value();
+    AllocationHandle handle = prewrite_result->handle;
     UUID result_tier_id = handle->loc.tier->GetTierId();
 
     // Transfer phase — no long key lock held.
@@ -930,7 +887,15 @@ tl::expected<UUID, ErrorCode> DataManager::WriteRemoteData(
 
 tl::expected<DataManager::PreWriteResult, ErrorCode> DataManager::PreWrite(
     std::string_view key, size_t size_bytes, std::optional<UUID> tier_id) {
-    return PreWriteInternal(BuildKeyCtx(key), size_bytes, tier_id);
+    auto internal_result =
+        PreWriteInternal(BuildKeyCtx(key), size_bytes, tier_id);
+    if (!internal_result) {
+        return tl::make_unexpected(internal_result.error());
+    }
+    PreWriteResult rpc_result;
+    rpc_result.remote_buffer = std::move(internal_result->remote_buffer);
+    rpc_result.write_operation_id = internal_result->write_operation_id;
+    return rpc_result;
 }
 
 tl::expected<DataManager::PreWriteResult, ErrorCode>
@@ -957,7 +922,11 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
         return tl::make_unexpected(reserve_result.error());
     }
 
-    // Slow path: no pending_write_shard_lock during tier allocation.
+    // Reserve holds unique_lock because it inserts into existed_operation_key_map
+    // and ordered_list. Allocate runs without shard lock so other keys in the
+    // shard are not blocked. Attach only fills handle on the reserved record
+    // under shared_lock (see AttachPendingWriteHandle); the record itself has no
+    // separate lock while the write lease excludes concurrent writers.
     if (tiered_backend_->Exist(ctx.key)) {
         LOG(ERROR) << "PreWrite: key already exists"
                    << ", key=" << ctx.key
@@ -998,6 +967,7 @@ DataManager::PreWriteInternal(const KeyCtx& ctx, size_t size_bytes,
     PreWriteResult result;
     result.remote_buffer = std::move(remote_buffer_result.value());
     result.write_operation_id = write_operation_id;
+    result.handle = handle;
     timer.LogResponse("error_code=", ErrorCode::OK);
     return result;
 }
@@ -1021,22 +991,44 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
 
     auto& pending_write_shard = GetPendingWriteShard(ctx);
 
-    auto handle_result = TakePendingWriteForCommit(
+    auto handle_result = ValidatePendingWriteForCommit(
         pending_write_shard, ctx.key, now, write_operation_id);
     if (!handle_result) {
-        timer.LogResponse("error_code=", handle_result.error());
-        return tl::make_unexpected(handle_result.error());
+        const ErrorCode err = handle_result.error();
+        LOG(ERROR) << "WriteCommit: pending write validation failed"
+                   << ", key=" << ctx.key << ", error=" << toString(err);
+        if (err == ErrorCode::LEASE_EXPIRED) {
+            const auto erased = ErasePendingWriteRecord(
+                pending_write_shard, ctx.key, write_operation_id);
+            if (erased == PendingWriteEraseResult::Erased) {
+                LOG(ERROR) << "WriteCommit: removed expired pending write record"
+                           << ", key=" << ctx.key;
+            } else {
+                LOG(WARNING) << "WriteCommit: expired pending write record not "
+                                "found for cleanup, key="
+                             << ctx.key;
+            }
+        }
+        timer.LogResponse("error_code=", err);
+        return tl::make_unexpected(err);
     }
     AllocationHandle handle = std::move(handle_result.value());
 
-    // Commit under key_lock to avoid concurrent Delete. Most commit failures
-    // are not recoverable by retrying WriteCommit alone; caller must restart
-    // PreWrite -> transfer -> WriteCommit. Duplicate WriteCommit ->
-    // OBJECT_NOT_FOUND.
+    // key_lock: serialize tiered_backend_->Commit vs Delete on this key.
+    // PendingWriteRecord is erased only after Commit (see Erase below); while
+    // it remains in existed_operation_key_map, another PreWrite on this key
+    // gets REPLICA_IS_PROCESSING at Reserve.
     tl::expected<void, ErrorCode> commit_result;
     {
         std::unique_lock<std::shared_mutex> key_lock(GetKeyLock(ctx.key));
         commit_result = tiered_backend_->Commit(ctx.key, handle);
+    }
+
+    const auto erased = ErasePendingWriteRecord(
+        pending_write_shard, ctx.key, write_operation_id);
+    if (erased != PendingWriteEraseResult::Erased) {
+        LOG(WARNING) << "WriteCommit: pending write record already removed"
+                     << " during commit, key=" << ctx.key;
     }
 
     if (!commit_result) {
@@ -1044,11 +1036,13 @@ tl::expected<void, ErrorCode> DataManager::WriteCommitInternal(
                    << ", key=" << ctx.key
                    << ", error=" << toString(commit_result.error());
         timer.LogResponse("error_code=", commit_result.error(),
-                          "record_erased=", true);
+                          "record_erased=",
+                          erased == PendingWriteEraseResult::Erased);
         return tl::make_unexpected(commit_result.error());
     }
 
-    timer.LogResponse("error_code=", ErrorCode::OK, "record_erased=", true);
+    timer.LogResponse("error_code=", ErrorCode::OK, "record_erased=",
+                      erased == PendingWriteEraseResult::Erased);
     return {};
 }
 

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -856,6 +856,11 @@ tl::expected<void, ErrorCode> DataManager::ReadRemoteData(
 
     if (!transfer_result) {
         timer.LogResponse("error_code=", transfer_result.error());
+        if (!unpin_result) {
+            LOG(ERROR) << "Also failed to unpin key " << kctx.key
+                       << " after transfer failure: "
+                       << toString(unpin_result.error());
+        }
         return tl::make_unexpected(transfer_result.error());
     }
     if (!unpin_result) {

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -1143,7 +1143,7 @@ tl::expected<DataManager::PinKeyResult, ErrorCode> DataManager::PinKeyInternal(
     record.handle = handle;
     record.ref_count = 1;
     record.list_it = list_it;
-    pin_shard.existed_operation_key_map.insert_or_assign(ctx.key,
+    pin_shard.existed_operation_key_map.insert_or_assign(std::string(ctx.key),
                                                          std::move(record));
 
     PinKeyResult result;

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -243,8 +243,9 @@ tl::expected<RemoteBufferDesc, ErrorCode> DataManager::BuildRemoteBufferDesc(
     return remote_buffer;
 }
 
-size_t DataManager::ScanExpiredPendingWrites(PendingWriteShard& shard,
-                                             TimePoint now) {
+template <typename Record>
+size_t DataManager::ScanExpiredRecordShard(RecordShard<Record>& shard,
+                                           TimePoint now) {
     size_t removed = 0;
     while (!shard.ordered_list.empty()) {
         auto list_it = shard.ordered_list.begin();
@@ -264,26 +265,10 @@ size_t DataManager::ScanExpiredPendingWrites(PendingWriteShard& shard,
     return removed;
 }
 
-size_t DataManager::ScanExpiredPinnedKeys(PinnedKeyShard& shard,
-                                          TimePoint now) {
-    size_t removed = 0;
-    while (!shard.ordered_list.empty()) {
-        auto list_it = shard.ordered_list.begin();
-        if (list_it->second > now) {
-            break;
-        }
-        auto record_it = shard.by_key.find(list_it->first);
-        if (record_it == shard.by_key.end() ||
-            record_it->second.list_it != list_it) {
-            shard.ordered_list.erase(list_it);
-            continue;
-        }
-        shard.by_key.erase(record_it);
-        shard.ordered_list.erase(list_it);
-        ++removed;
-    }
-    return removed;
-}
+template size_t DataManager::ScanExpiredRecordShard<PendingWriteRecord>(
+    RecordShard<PendingWriteRecord>&, TimePoint);
+template size_t DataManager::ScanExpiredRecordShard<PinnedKeyRecord>(
+    RecordShard<PinnedKeyRecord>&, TimePoint);
 
 tl::expected<AllocationHandle, ErrorCode>
 DataManager::LookupPendingWriteHandleInternal(const KeyCtx& ctx,
@@ -352,11 +337,11 @@ void DataManager::LeaseScannerMain() {
         wait_lock.unlock();
         for (auto& shard : pending_write_shards_) {
             std::unique_lock shard_lock(shard.mutex);
-            ScanExpiredPendingWrites(shard, now);
+            ScanExpiredRecordShard(shard, now);
         }
         for (auto& shard : pinned_key_shards_) {
             std::unique_lock shard_lock(shard.mutex);
-            ScanExpiredPinnedKeys(shard, now);
+            ScanExpiredRecordShard(shard, now);
         }
         wait_lock.lock();
     }

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -254,6 +254,10 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
         local_transfer_config.local_memcpy_async_worker_num =
             config.local_memcpy_async_worker_num;
     }
+    local_transfer_config.p2p_key_lease_duration_ms =
+        config.p2p_key_lease_duration_ms;
+    local_transfer_config.p2p_key_lease_scan_interval_ms =
+        config.p2p_key_lease_scan_interval_ms;
 
     data_manager_.emplace(std::move(tiered_backend), transfer_engine_,
                           config.lock_shard_count, local_transfer_config);

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -233,6 +233,7 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
 
 ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
     auto tiered_backend = std::make_unique<TieredBackend>();
+    tiered_backend->SetMetadataShardCount(config.lock_shard_count);
 
     auto add_replica_callback = BuildAddReplicaCallback();
     auto remove_replica_callback = BuildRemoveReplicaCallback();

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -255,8 +255,8 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
             config.local_memcpy_async_worker_num;
     }
 
-    data_manager_ = DataManager(std::move(tiered_backend), transfer_engine_,
-                                config.lock_shard_count, local_transfer_config);
+    data_manager_.emplace(std::move(tiered_backend), transfer_engine_,
+                          config.lock_shard_count, local_transfer_config);
     // Set rectify callback on DataManager to remove stale replicas from master
     data_manager_->SetRectifyCallback([this](std::string_view key,
                                              std::optional<UUID> tier_id) {

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -254,13 +254,13 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
         local_transfer_config.local_memcpy_async_worker_num =
             config.local_memcpy_async_worker_num;
     }
-    local_transfer_config.p2p_key_lease_duration_ms =
-        config.p2p_key_lease_duration_ms;
-    local_transfer_config.p2p_key_lease_scan_interval_ms =
-        config.p2p_key_lease_scan_interval_ms;
+    KeyLeaseConfig key_lease_config;
+    key_lease_config.duration_ms = config.p2p_key_lease_duration_ms;
+    key_lease_config.scan_interval_ms = config.p2p_key_lease_scan_interval_ms;
 
     data_manager_.emplace(std::move(tiered_backend), transfer_engine_,
-                          config.lock_shard_count, local_transfer_config);
+                          config.lock_shard_count, local_transfer_config,
+                          key_lease_config);
     // Set rectify callback on DataManager to remove stale replicas from master
     data_manager_->SetRectifyCallback([this](std::string_view key,
                                              std::optional<UUID> tier_id) {

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -232,8 +232,8 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
 }
 
 ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
-    auto tiered_backend = std::make_unique<TieredBackend>();
-    tiered_backend->SetMetadataShardCount(config.lock_shard_count);
+    auto tiered_backend =
+        std::make_unique<TieredBackend>(config.lock_shard_count);
 
     auto add_replica_callback = BuildAddReplicaCallback();
     auto remove_replica_callback = BuildRemoveReplicaCallback();

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -45,6 +45,14 @@ DEFINE_uint64(local_memcpy_async_worker_num, 32,
               "local memcpy executor (P2P), 0 means forbid async memcpy");
 DEFINE_uint32(metrics_port, 9003, "Port for HTTP metrics server");
 DEFINE_bool(enable_metrics_http, true, "Enable HTTP metrics endpoint");
+DEFINE_uint32(
+    p2p_key_lease_duration_ms, 0,
+    "Maximum time (ms) a key may remain in PreWrite or PinKey "
+    "lease-protected intermediate state. 0 uses the built-in default (5000).");
+DEFINE_uint32(
+    p2p_key_lease_scan_interval_ms, 0,
+    "Interval (ms) for background scanning of expired key leases (PreWrite / "
+    "PinKey). 0 uses the built-in default (1000).");
 
 namespace mooncake {
 void RegisterClientRpcService(coro_rpc::coro_rpc_server& server,
@@ -113,7 +121,8 @@ int main(int argc, char* argv[]) {
                 static_cast<uint16_t>(FLAGS_metrics_port),
                 FLAGS_enable_metrics_http, {},  // labels
                 FLAGS_async_sender_thread_count, FLAGS_async_max_batch_size,
-                FLAGS_async_route_queue_size);
+                FLAGS_async_route_queue_size, FLAGS_p2p_key_lease_duration_ms,
+                FLAGS_p2p_key_lease_scan_interval_ms);
         } else {
             if (FLAGS_deployment_mode != "Centralization") {
                 LOG(WARNING)

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -26,7 +26,8 @@ DEFINE_string(deployment_mode, "Centralization",
 DEFINE_uint32(client_rpc_port, 12345, "Client RPC service port (P2P mode)");
 DEFINE_uint32(rpc_thread_num, 16, "Number of threads for P2P RPC service");
 DEFINE_uint64(lock_shard_count, 1024,
-              "Number of key lock shards for DataManager");
+              "Number of metadata shards in TieredBackend (and matching "
+              "pending-write/pinned-key lease shards in DataManager)");
 DEFINE_string(route_cache_max_memory, "300 MB", "Max memory for RouteCache");
 DEFINE_uint64(route_cache_ttl_ms, 5 * 60 * 1000,
               "TTL for RouteCache entries in ms");

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -36,7 +36,10 @@ void TieredBackend::SetMetadataShardCount(size_t count) {
         LOG(FATAL) << "SetMetadataShardCount must be called before Init()";
     }
     metadata_shard_count_ = count > 0 ? count : kDefaultMetadataShardCount;
-    metadata_shards_.assign(metadata_shard_count_, MetadataShard{});
+    metadata_shards_.reserve(metadata_shard_count_);
+    for (size_t i = 0; i < metadata_shard_count_; ++i) {
+        metadata_shards_.push_back(std::make_unique<MetadataShard>());
+    }
 }
 
 bool TieredBackend::KeyExistsInShard(const MetadataShard& shard,
@@ -149,6 +152,14 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     } catch (const std::logic_error& e) {
         LOG(ERROR) << "Failed to build DataCopier: " << e.what();
         return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+
+    // Initialize metadata shards if not already set
+    if (metadata_shards_.empty()) {
+        metadata_shards_.reserve(metadata_shard_count_);
+        for (size_t i = 0; i < metadata_shard_count_; ++i) {
+            metadata_shards_.push_back(std::make_unique<MetadataShard>());
+        }
     }
 
     // Register callback for syncing metadata to Master
@@ -944,7 +955,7 @@ void TieredBackend::ForEachKeyBatch(
     const std::function<bool(std::vector<ReplicaLocation>&&)>& callback) const {
     // Iterate per-shard. Each shard is locked independently.
     for (size_t s = 0; s < metadata_shard_count_; ++s) {
-        auto& shard = metadata_shards_[s];
+        auto& shard = *metadata_shards_[s];
 
         // Copy entry pointers under shard shared lock
         std::vector<std::pair<std::string, std::shared_ptr<MetadataEntry>>>

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -31,6 +31,53 @@ AllocationEntry::~AllocationEntry() {
 
 TieredBackend::TieredBackend() = default;
 
+void TieredBackend::SetMetadataShardCount(size_t count) {
+    if (!tiers_.empty()) {
+        LOG(FATAL) << "SetMetadataShardCount must be called before Init()";
+    }
+    metadata_shard_count_ =
+        count > 0 ? count : kDefaultMetadataShardCount;
+    metadata_shards_.assign(metadata_shard_count_, MetadataShard{});
+}
+
+bool TieredBackend::KeyExistsInShard(const MetadataShard& shard,
+                                     std::string_view key,
+                                     std::optional<UUID> tier_id) {
+    auto it = shard.index.find(key);
+    if (it == shard.index.end()) {
+        return false;
+    }
+    if (!tier_id.has_value()) {
+        return true;
+    }
+    auto entry = it->second;
+    std::shared_lock<std::shared_mutex> entry_lock(entry->mutex);
+    for (const auto& replica : entry->replicas) {
+        if (replica.first == *tier_id) {
+            return true;
+        }
+    }
+    return false;
+}
+
+ConditionalExecuteResult<void> TieredBackend::conditionalExecute(
+    std::string_view key, std::optional<UUID> tier_id,
+    std::function<void()> on_exists, std::function<void()> on_not_exists)
+    const {
+    auto& shard = GetMetadataShard(key);
+    std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
+    const bool exists = KeyExistsInShard(shard, key, tier_id);
+
+    ConditionalExecuteResult<void> result;
+    result.key_exists = exists;
+    if (exists) {
+        on_exists();
+    } else {
+        on_not_exists();
+    }
+    return result;
+}
+
 TieredBackend::~TieredBackend() {
     Stop();
     Destroy();
@@ -638,22 +685,7 @@ bool TieredBackend::Exist(std::string_view key,
                           std::optional<UUID> tier_id) const {
     auto& shard = GetMetadataShard(key);
     std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
-    auto it = shard.index.find(key);
-    if (it == shard.index.end()) {
-        return false;  // Key not found
-    }
-    if (!tier_id.has_value()) {
-        return true;  // Key exists in backend
-    }
-    // Check specific tier
-    auto entry = it->second;
-    std::shared_lock<std::shared_mutex> entry_lock(entry->mutex);
-    for (const auto& replica : entry->replicas) {
-        if (replica.first == *tier_id) {
-            return true;  // Key exists in target tier
-        }
-    }
-    return false;  // Key does not exist in target tier
+    return KeyExistsInShard(shard, key, tier_id);
 }
 
 tl::expected<void, ErrorCode> TieredBackend::Delete(std::string_view key,
@@ -912,7 +944,7 @@ const DataCopier& TieredBackend::GetDataCopier() const {
 void TieredBackend::ForEachKeyBatch(
     const std::function<bool(std::vector<ReplicaLocation>&&)>& callback) const {
     // Iterate per-shard. Each shard is locked independently.
-    for (size_t s = 0; s < kMetadataShardCount; ++s) {
+    for (size_t s = 0; s < metadata_shard_count_; ++s) {
         auto& shard = metadata_shards_[s];
 
         // Copy entry pointers under shard shared lock

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -29,7 +29,12 @@ AllocationEntry::~AllocationEntry() {
     }
 }
 
-TieredBackend::TieredBackend() = default;
+TieredBackend::TieredBackend() {
+    metadata_shards_.reserve(metadata_shard_count_);
+    for (size_t i = 0; i < metadata_shard_count_; ++i) {
+        metadata_shards_.push_back(std::make_unique<MetadataShard>());
+    }
+}
 
 void TieredBackend::SetMetadataShardCount(size_t count) {
     if (!tiers_.empty()) {
@@ -152,14 +157,6 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     } catch (const std::logic_error& e) {
         LOG(ERROR) << "Failed to build DataCopier: " << e.what();
         return tl::unexpected(ErrorCode::INTERNAL_ERROR);
-    }
-
-    // Initialize metadata shards if not already set
-    if (metadata_shards_.empty()) {
-        metadata_shards_.reserve(metadata_shard_count_);
-        for (size_t i = 0; i < metadata_shard_count_; ++i) {
-            metadata_shards_.push_back(std::make_unique<MetadataShard>());
-        }
     }
 
     // Register callback for syncing metadata to Master

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -29,27 +29,18 @@ AllocationEntry::~AllocationEntry() {
     }
 }
 
-TieredBackend::TieredBackend() {
+TieredBackend::TieredBackend(size_t metadata_shard_count) {
+    metadata_shard_count_ = metadata_shard_count > 0
+                                ? metadata_shard_count
+                                : kDefaultMetadataShardCount;
     metadata_shards_.reserve(metadata_shard_count_);
     for (size_t i = 0; i < metadata_shard_count_; ++i) {
         metadata_shards_.push_back(std::make_unique<MetadataShard>());
     }
 }
 
-void TieredBackend::SetMetadataShardCount(size_t count) {
-    if (!tiers_.empty()) {
-        LOG(FATAL) << "SetMetadataShardCount must be called before Init()";
-    }
-    metadata_shard_count_ = count > 0 ? count : kDefaultMetadataShardCount;
-    metadata_shards_.reserve(metadata_shard_count_);
-    for (size_t i = 0; i < metadata_shard_count_; ++i) {
-        metadata_shards_.push_back(std::make_unique<MetadataShard>());
-    }
-}
-
-bool TieredBackend::KeyExistsInShard(const MetadataShard& shard,
-                                     std::string_view key,
-                                     std::optional<UUID> tier_id) {
+bool TieredBackend::InnerExist(const MetadataShard& shard, std::string_view key,
+                               std::optional<UUID> tier_id) {
     auto it = shard.index.find(key);
     if (it == shard.index.end()) {
         return false;
@@ -73,7 +64,7 @@ ConditionalExecuteResult<void> TieredBackend::conditionalExecute(
     std::function<void()> on_not_exists) const {
     auto& shard = GetMetadataShard(key);
     std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
-    const bool exists = KeyExistsInShard(shard, key, tier_id);
+    const bool exists = InnerExist(shard, key, tier_id);
 
     ConditionalExecuteResult<void> result;
     result.key_exists = exists;
@@ -692,7 +683,7 @@ bool TieredBackend::Exist(std::string_view key,
                           std::optional<UUID> tier_id) const {
     auto& shard = GetMetadataShard(key);
     std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
-    return KeyExistsInShard(shard, key, tier_id);
+    return InnerExist(shard, key, tier_id);
 }
 
 tl::expected<void, ErrorCode> TieredBackend::Delete(std::string_view key,

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -35,8 +35,7 @@ void TieredBackend::SetMetadataShardCount(size_t count) {
     if (!tiers_.empty()) {
         LOG(FATAL) << "SetMetadataShardCount must be called before Init()";
     }
-    metadata_shard_count_ =
-        count > 0 ? count : kDefaultMetadataShardCount;
+    metadata_shard_count_ = count > 0 ? count : kDefaultMetadataShardCount;
     metadata_shards_.assign(metadata_shard_count_, MetadataShard{});
 }
 
@@ -62,8 +61,8 @@ bool TieredBackend::KeyExistsInShard(const MetadataShard& shard,
 
 ConditionalExecuteResult<void> TieredBackend::conditionalExecute(
     std::string_view key, std::optional<UUID> tier_id,
-    std::function<void()> on_exists, std::function<void()> on_not_exists)
-    const {
+    std::function<void()> on_exists,
+    std::function<void()> on_not_exists) const {
     auto& shard = GetMetadataShard(key);
     std::shared_lock<std::shared_mutex> read_lock(shard.mutex);
     const bool exists = KeyExistsInShard(shard, key, tier_id);

--- a/mooncake-store/src/types.cpp
+++ b/mooncake-store/src/types.cpp
@@ -37,6 +37,7 @@ const std::string& toString(ErrorCode errorCode) noexcept {
         {ErrorCode::REPLICA_ALREADY_EXISTS, "REPLICA_ALREADY_EXISTS"},
         {ErrorCode::REPLICA_NOT_FOUND, "REPLICA_NOT_FOUND"},
         {ErrorCode::REPLICA_NUM_EXCEEDED, "REPLICA_NUM_EXCEEDED"},
+        {ErrorCode::REPLICA_IS_PROCESSING, "REPLICA_IS_PROCESSING"},
         {ErrorCode::TRANSFER_FAIL, "TRANSFER_FAIL"},
         {ErrorCode::RPC_FAIL, "RPC_FAIL"},
         {ErrorCode::ETCD_OPERATION_ERROR, "ETCD_OPERATION_ERROR"},

--- a/mooncake-store/tests/client_config_builder_test.cpp
+++ b/mooncake-store/tests/client_config_builder_test.cpp
@@ -38,8 +38,8 @@ TEST(ClientConfigBuilderTest, BuildP2PClientConfigKeyLeaseOverrides) {
     auto config = ClientConfigBuilder::build_p2p_real_client(
         "127.0.0.1:12345", "http://127.0.0.1:8080/metadata", "tcp",
         std::nullopt, "127.0.0.1:50051", kTieredConfigJson, 0, nullptr, "",
-        12345, 8, 2048, 512 * 1024 * 1024, 120000, "te", 32, 9003, true, {},
-        0, 2000, 0, 3333, 444);
+        12345, 8, 2048, 512 * 1024 * 1024, 120000, "te", 32, 9003, true, {}, 0,
+        2000, 0, 3333, 444);
 
     EXPECT_EQ(config.p2p_key_lease_duration_ms, 3333u);
     EXPECT_EQ(config.p2p_key_lease_scan_interval_ms, 444u);

--- a/mooncake-store/tests/client_config_builder_test.cpp
+++ b/mooncake-store/tests/client_config_builder_test.cpp
@@ -28,6 +28,21 @@ TEST(ClientConfigBuilderTest, BuildP2PClientConfigUsesDefaults) {
     EXPECT_EQ(config.tiered_backend_config["tiers"].size(), 1u);
     EXPECT_EQ(config.local_memcpy_async_worker_num, 32u);
     EXPECT_EQ(config.local_transfer_mode, LocalTransferMode::TE);
+    EXPECT_EQ(config.p2p_key_lease_duration_ms,
+              P2PClientConfig::kP2pDefaultKeyLeaseDurationMs);
+    EXPECT_EQ(config.p2p_key_lease_scan_interval_ms,
+              P2PClientConfig::kP2pDefaultKeyLeaseScanIntervalMs);
+}
+
+TEST(ClientConfigBuilderTest, BuildP2PClientConfigKeyLeaseOverrides) {
+    auto config = ClientConfigBuilder::build_p2p_real_client(
+        "127.0.0.1:12345", "http://127.0.0.1:8080/metadata", "tcp",
+        std::nullopt, "127.0.0.1:50051", kTieredConfigJson, 0, nullptr, "",
+        12345, 8, 2048, 512 * 1024 * 1024, 120000, "te", 32, 9003, true, {},
+        0, 2000, 0, 3333, 444);
+
+    EXPECT_EQ(config.p2p_key_lease_duration_ms, 3333u);
+    EXPECT_EQ(config.p2p_key_lease_scan_interval_ms, 444u);
 }
 
 TEST(ClientConfigBuilderTest,

--- a/mooncake-store/tests/data_manager_test.cpp
+++ b/mooncake-store/tests/data_manager_test.cpp
@@ -321,14 +321,14 @@ TEST_F(DataManagerTest, PreWriteRejectsConcurrentLease) {
 
     auto second_prewrite = data_manager_->PreWrite(key, 256, GetTierId());
     ASSERT_FALSE(second_prewrite.has_value());
-    EXPECT_EQ(second_prewrite.error(), ErrorCode::OBJECT_HAS_LEASE);
+    EXPECT_EQ(second_prewrite.error(), ErrorCode::REPLICA_IS_PROCESSING);
 
     const auto kctx = data_manager_->BuildKeyCtx(key);
     auto& shard = data_manager_->GetPendingWriteShard(kctx);
     {
         std::shared_lock shard_lock(shard.mutex);
-        auto it = shard.by_key.find(key);
-        ASSERT_NE(it, shard.by_key.end());
+        auto it = shard.existed_operation_key_map.find(key);
+        ASSERT_NE(it, shard.existed_operation_key_map.end());
         EXPECT_EQ(it->second.write_operation_id,
                   prewrite_result->write_operation_id);
     }
@@ -351,7 +351,7 @@ TEST_F(DataManagerTest, WriteCommitErasesPendingWriteRecord) {
     auto& shard = data_manager_->GetPendingWriteShard(kctx);
     {
         std::shared_lock shard_lock(shard.mutex);
-        EXPECT_EQ(shard.by_key.count(key), 0U);
+        EXPECT_EQ(shard.existed_operation_key_map.count(key), 0U);
     }
 }
 
@@ -388,8 +388,8 @@ TEST_F(DataManagerTest, WriteCommitTokenMismatchKeepsPendingWriteRecord) {
     auto& shard = data_manager_->GetPendingWriteShard(kctx);
     {
         std::shared_lock shard_lock(shard.mutex);
-        auto it = shard.by_key.find(key);
-        ASSERT_NE(it, shard.by_key.end());
+        auto it = shard.existed_operation_key_map.find(key);
+        ASSERT_NE(it, shard.existed_operation_key_map.end());
         EXPECT_EQ(it->second.write_operation_id,
                   prewrite_result->write_operation_id);
     }
@@ -417,8 +417,8 @@ TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
     auto& shard = data_manager_->GetPinnedKeyShard(kctx);
     {
         std::shared_lock shard_lock(shard.mutex);
-        auto it = shard.by_key.find(key);
-        ASSERT_NE(it, shard.by_key.end());
+        auto it = shard.existed_operation_key_map.find(key);
+        ASSERT_NE(it, shard.existed_operation_key_map.end());
         EXPECT_EQ(it->second.ref_count, 2U);
     }
 
@@ -428,8 +428,8 @@ TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
         << "First UnPinKey failed: " << toString(first_unpin.error());
     {
         std::shared_lock shard_lock(shard.mutex);
-        auto it = shard.by_key.find(key);
-        ASSERT_NE(it, shard.by_key.end());
+        auto it = shard.existed_operation_key_map.find(key);
+        ASSERT_NE(it, shard.existed_operation_key_map.end());
         EXPECT_EQ(it->second.ref_count, 1U);
     }
 
@@ -439,7 +439,7 @@ TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
         << "Second UnPinKey failed: " << toString(second_unpin.error());
     {
         std::shared_lock shard_lock(shard.mutex);
-        EXPECT_EQ(shard.by_key.count(key), 0U);
+        EXPECT_EQ(shard.existed_operation_key_map.count(key), 0U);
     }
 }
 
@@ -466,8 +466,8 @@ TEST_F(DataManagerTest, UnPinKeyTokenMismatchKeepsPinnedRecord) {
     auto& shard = data_manager_->GetPinnedKeyShard(kctx);
     {
         std::shared_lock shard_lock(shard.mutex);
-        auto it = shard.by_key.find(key);
-        ASSERT_NE(it, shard.by_key.end());
+        auto it = shard.existed_operation_key_map.find(key);
+        ASSERT_NE(it, shard.existed_operation_key_map.end());
         EXPECT_EQ(it->second.ref_count, 1U);
         EXPECT_EQ(it->second.read_operation_id, pin_result->read_operation_id);
     }
@@ -486,8 +486,8 @@ TEST_F(DataManagerTest,
     auto& shard = data_manager_->GetPendingWriteShard(kctx);
     {
         std::unique_lock shard_lock(shard.mutex);
-        auto it = shard.by_key.find(key);
-        ASSERT_NE(it, shard.by_key.end());
+        auto it = shard.existed_operation_key_map.find(key);
+        ASSERT_NE(it, shard.existed_operation_key_map.end());
         const auto expired_deadline =
             std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
         it->second.deadline = expired_deadline;
@@ -501,7 +501,7 @@ TEST_F(DataManagerTest,
 
     {
         std::shared_lock shard_lock(shard.mutex);
-        EXPECT_EQ(shard.by_key.count(key), 0U);
+        EXPECT_EQ(shard.existed_operation_key_map.count(key), 0U);
     }
 
     auto retry_prewrite = data_manager_->PreWrite(key, 512, GetTierId());
@@ -528,8 +528,8 @@ TEST_F(DataManagerTest,
     auto& shard = data_manager_->GetPinnedKeyShard(kctx);
     {
         std::unique_lock shard_lock(shard.mutex);
-        auto it = shard.by_key.find(key);
-        ASSERT_NE(it, shard.by_key.end());
+        auto it = shard.existed_operation_key_map.find(key);
+        ASSERT_NE(it, shard.existed_operation_key_map.end());
         const auto expired_deadline =
             std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
         it->second.deadline = expired_deadline;
@@ -543,7 +543,7 @@ TEST_F(DataManagerTest,
 
     {
         std::shared_lock shard_lock(shard.mutex);
-        EXPECT_EQ(shard.by_key.count(key), 0U);
+        EXPECT_EQ(shard.existed_operation_key_map.count(key), 0U);
     }
 }
 

--- a/mooncake-store/tests/data_manager_test.cpp
+++ b/mooncake-store/tests/data_manager_test.cpp
@@ -80,9 +80,17 @@ class DataManagerTest : public ::testing::Test {
         LocalTransferConfig transfer_config;
         transfer_config.mode = LocalTransferMode::MEMCPY;
         transfer_config.local_memcpy_async_worker_num = 32;
+
+        // Save raw pointer before move for tests that need direct backend
+        // access
+        TieredBackend* backend_raw_ptr = tiered_backend_.get();
         data_manager_ = std::make_unique<DataManager>(
             std::move(tiered_backend_), transfer_engine_, 1024,
             transfer_config);
+        // Keep the raw pointer accessible for tests that need direct backend
+        // access Note: The backend is now owned by DataManager, but tests can
+        // still use it
+        tiered_backend_raw_ptr_ = backend_raw_ptr;
     }
 
     void TearDown() override {
@@ -145,6 +153,8 @@ class DataManagerTest : public ::testing::Test {
 
     std::unique_ptr<DataManager> data_manager_;
     std::unique_ptr<TieredBackend> tiered_backend_;
+    TieredBackend* tiered_backend_raw_ptr_ =
+        nullptr;  // Raw pointer for tests that need direct backend access
     std::shared_ptr<TransferEngine> transfer_engine_;
     std::optional<UUID> saved_tier_id_;
 };
@@ -286,7 +296,7 @@ TEST_F(DataManagerTest, DeleteWithTierId) {
 
 // BuildRemoteBufferDesc: null allocation buffer is an internal error.
 TEST_F(DataManagerTest, BuildRemoteBufferDescRejectsNullBuffer) {
-    auto alloc_result = tiered_backend_->Allocate(64, GetTierId());
+    auto alloc_result = tiered_backend_raw_ptr_->Allocate(64, GetTierId());
     ASSERT_TRUE(alloc_result.has_value())
         << "Allocate failed: " << toString(alloc_result.error());
 

--- a/mooncake-store/tests/data_manager_test.cpp
+++ b/mooncake-store/tests/data_manager_test.cpp
@@ -63,10 +63,9 @@ class DataManagerTest : public ::testing::Test {
         Json::Value config;
         ASSERT_TRUE(parseJsonString(json_config_str, config));
 
-        tiered_backend_ = std::make_unique<TieredBackend>();
         const size_t metadata_shard_count =
             GetEnvOr<size_t>("MOONCAKE_DM_LOCK_SHARD_COUNT", 1024);
-        tiered_backend_->SetMetadataShardCount(metadata_shard_count);
+        tiered_backend_ = std::make_unique<TieredBackend>(metadata_shard_count);
         // transfer_engine_ is nullptr when initializing tiered_backend_
         // only for local access test
         auto init_result = InitTieredBackendForTest(*tiered_backend_, config);

--- a/mooncake-store/tests/data_manager_test.cpp
+++ b/mooncake-store/tests/data_manager_test.cpp
@@ -300,8 +300,8 @@ TEST_F(DataManagerTest, PreWriteRejectsConcurrentLease) {
         std::shared_lock shard_lock(shard.mutex);
         auto it = shard.by_key.find(key);
         ASSERT_NE(it, shard.by_key.end());
-        EXPECT_EQ(it->second.pending_write_token,
-                  prewrite_result->pending_write_token);
+        EXPECT_EQ(it->second.write_operation_id,
+                  prewrite_result->write_operation_id);
     }
 }
 
@@ -313,7 +313,7 @@ TEST_F(DataManagerTest, WriteCommitErasesPendingWriteRecord) {
         << "PreWrite failed: " << toString(prewrite_result.error());
 
     auto commit_result =
-        data_manager_->WriteCommit(key, prewrite_result->pending_write_token);
+        data_manager_->WriteCommit(key, prewrite_result->write_operation_id);
     ASSERT_TRUE(commit_result.has_value())
         << "WriteCommit failed: " << toString(commit_result.error());
     EXPECT_TRUE(data_manager_->Exist(key));
@@ -332,7 +332,7 @@ TEST_F(DataManagerTest, WriteCommitTokenMismatchKeepsPendingWriteRecord) {
     ASSERT_TRUE(prewrite_result.has_value())
         << "PreWrite failed: " << toString(prewrite_result.error());
 
-    UUID wrong_token = prewrite_result->pending_write_token;
+    UUID wrong_token = prewrite_result->write_operation_id;
     wrong_token.first += 1;
     auto wrong_commit = data_manager_->WriteCommit(key, wrong_token);
     ASSERT_FALSE(wrong_commit.has_value());
@@ -343,8 +343,8 @@ TEST_F(DataManagerTest, WriteCommitTokenMismatchKeepsPendingWriteRecord) {
         std::shared_lock shard_lock(shard.mutex);
         auto it = shard.by_key.find(key);
         ASSERT_NE(it, shard.by_key.end());
-        EXPECT_EQ(it->second.pending_write_token,
-                  prewrite_result->pending_write_token);
+        EXPECT_EQ(it->second.write_operation_id,
+                  prewrite_result->write_operation_id);
     }
 }
 
@@ -364,7 +364,7 @@ TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
     auto second_pin = data_manager_->PinKey(key, GetTierId());
     ASSERT_TRUE(second_pin.has_value())
         << "Second PinKey failed: " << toString(second_pin.error());
-    EXPECT_EQ(first_pin->pin_token, second_pin->pin_token);
+    EXPECT_EQ(first_pin->read_operation_id, second_pin->read_operation_id);
 
     auto& shard = data_manager_->GetPinnedKeyShard(key);
     {
@@ -374,7 +374,7 @@ TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
         EXPECT_EQ(it->second.ref_count, 2U);
     }
 
-    auto first_unpin = data_manager_->UnPinKey(key, first_pin->pin_token);
+    auto first_unpin = data_manager_->UnPinKey(key, first_pin->read_operation_id);
     ASSERT_TRUE(first_unpin.has_value())
         << "First UnPinKey failed: " << toString(first_unpin.error());
     {
@@ -384,7 +384,7 @@ TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
         EXPECT_EQ(it->second.ref_count, 1U);
     }
 
-    auto second_unpin = data_manager_->UnPinKey(key, second_pin->pin_token);
+    auto second_unpin = data_manager_->UnPinKey(key, second_pin->read_operation_id);
     ASSERT_TRUE(second_unpin.has_value())
         << "Second UnPinKey failed: " << toString(second_unpin.error());
     {
@@ -406,7 +406,7 @@ TEST_F(DataManagerTest, UnPinKeyTokenMismatchKeepsPinnedRecord) {
     ASSERT_TRUE(pin_result.has_value())
         << "PinKey failed: " << toString(pin_result.error());
 
-    UUID wrong_token = pin_result->pin_token;
+    UUID wrong_token = pin_result->read_operation_id;
     wrong_token.first += 1;
     auto wrong_unpin = data_manager_->UnPinKey(key, wrong_token);
     ASSERT_FALSE(wrong_unpin.has_value());
@@ -418,7 +418,7 @@ TEST_F(DataManagerTest, UnPinKeyTokenMismatchKeepsPinnedRecord) {
         auto it = shard.by_key.find(key);
         ASSERT_NE(it, shard.by_key.end());
         EXPECT_EQ(it->second.ref_count, 1U);
-        EXPECT_EQ(it->second.pin_token, pin_result->pin_token);
+        EXPECT_EQ(it->second.read_operation_id, pin_result->read_operation_id);
     }
 }
 
@@ -443,7 +443,7 @@ TEST_F(DataManagerTest,
     }
 
     auto commit_result =
-        data_manager_->WriteCommit(key, prewrite_result->pending_write_token);
+        data_manager_->WriteCommit(key, prewrite_result->write_operation_id);
     ASSERT_FALSE(commit_result.has_value());
     EXPECT_EQ(commit_result.error(), ErrorCode::LEASE_EXPIRED);
 
@@ -483,7 +483,7 @@ TEST_F(DataManagerTest,
         it->second.list_it->second = expired_deadline;
     }
 
-    auto unpin_result = data_manager_->UnPinKey(key, pin_result->pin_token);
+    auto unpin_result = data_manager_->UnPinKey(key, pin_result->read_operation_id);
     ASSERT_FALSE(unpin_result.has_value());
     EXPECT_EQ(unpin_result.error(), ErrorCode::LEASE_EXPIRED);
 

--- a/mooncake-store/tests/data_manager_test.cpp
+++ b/mooncake-store/tests/data_manager_test.cpp
@@ -284,6 +284,209 @@ TEST_F(DataManagerTest, DeleteWithTierId) {
     ASSERT_FALSE(data_manager_->Exist(key));
 }
 
+// Test PreWrite: concurrent PreWrite should be rejected by a pending lease.
+TEST_F(DataManagerTest, PreWriteRejectsConcurrentLease) {
+    const std::string key = "prewrite_lifecycle_key";
+    auto prewrite_result = data_manager_->PreWrite(key, 256, GetTierId());
+    ASSERT_TRUE(prewrite_result.has_value())
+        << "PreWrite failed: " << toString(prewrite_result.error());
+
+    auto second_prewrite = data_manager_->PreWrite(key, 256, GetTierId());
+    ASSERT_FALSE(second_prewrite.has_value());
+    EXPECT_EQ(second_prewrite.error(), ErrorCode::OBJECT_HAS_LEASE);
+
+    auto& shard = data_manager_->GetPendingWriteShard(key);
+    {
+        std::shared_lock shard_lock(shard.mutex);
+        auto it = shard.by_key.find(key);
+        ASSERT_NE(it, shard.by_key.end());
+        EXPECT_EQ(it->second.pending_write_token,
+                  prewrite_result->pending_write_token);
+    }
+}
+
+// Test WriteCommit: successful commit should erase the pending write record.
+TEST_F(DataManagerTest, WriteCommitErasesPendingWriteRecord) {
+    const std::string key = "write_commit_erases_record_key";
+    auto prewrite_result = data_manager_->PreWrite(key, 256, GetTierId());
+    ASSERT_TRUE(prewrite_result.has_value())
+        << "PreWrite failed: " << toString(prewrite_result.error());
+
+    auto commit_result =
+        data_manager_->WriteCommit(key, prewrite_result->pending_write_token);
+    ASSERT_TRUE(commit_result.has_value())
+        << "WriteCommit failed: " << toString(commit_result.error());
+    EXPECT_TRUE(data_manager_->Exist(key));
+
+    auto& shard = data_manager_->GetPendingWriteShard(key);
+    {
+        std::shared_lock shard_lock(shard.mutex);
+        EXPECT_EQ(shard.by_key.count(key), 0U);
+    }
+}
+
+// Test WriteCommit: token mismatch should fail without erasing the record.
+TEST_F(DataManagerTest, WriteCommitTokenMismatchKeepsPendingWriteRecord) {
+    const std::string key = "write_commit_token_mismatch_key";
+    auto prewrite_result = data_manager_->PreWrite(key, 256, GetTierId());
+    ASSERT_TRUE(prewrite_result.has_value())
+        << "PreWrite failed: " << toString(prewrite_result.error());
+
+    UUID wrong_token = prewrite_result->pending_write_token;
+    wrong_token.first += 1;
+    auto wrong_commit = data_manager_->WriteCommit(key, wrong_token);
+    ASSERT_FALSE(wrong_commit.has_value());
+    EXPECT_EQ(wrong_commit.error(), ErrorCode::INVALID_WRITE);
+
+    auto& shard = data_manager_->GetPendingWriteShard(key);
+    {
+        std::shared_lock shard_lock(shard.mutex);
+        auto it = shard.by_key.find(key);
+        ASSERT_NE(it, shard.by_key.end());
+        EXPECT_EQ(it->second.pending_write_token,
+                  prewrite_result->pending_write_token);
+    }
+}
+
+// Test Pin/Unpin: ref_count increments on PinKey and reaches zero on final UnPinKey.
+TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
+    const std::string key = "pin_ref_count_key";
+    const std::string test_data = "Pin key ref count payload";
+
+    auto buffer = StringToBuffer(test_data);
+    ASSERT_TRUE(DoPut(key, buffer.get(), test_data.size()).has_value());
+
+    auto first_pin = data_manager_->PinKey(key, GetTierId());
+    ASSERT_TRUE(first_pin.has_value())
+        << "First PinKey failed: " << toString(first_pin.error());
+
+    auto second_pin = data_manager_->PinKey(key, GetTierId());
+    ASSERT_TRUE(second_pin.has_value())
+        << "Second PinKey failed: " << toString(second_pin.error());
+    EXPECT_EQ(first_pin->pin_token, second_pin->pin_token);
+
+    auto& shard = data_manager_->GetPinnedKeyShard(key);
+    {
+        std::shared_lock shard_lock(shard.mutex);
+        auto it = shard.by_key.find(key);
+        ASSERT_NE(it, shard.by_key.end());
+        EXPECT_EQ(it->second.ref_count, 2U);
+    }
+
+    auto first_unpin = data_manager_->UnPinKey(key, first_pin->pin_token);
+    ASSERT_TRUE(first_unpin.has_value())
+        << "First UnPinKey failed: " << toString(first_unpin.error());
+    {
+        std::shared_lock shard_lock(shard.mutex);
+        auto it = shard.by_key.find(key);
+        ASSERT_NE(it, shard.by_key.end());
+        EXPECT_EQ(it->second.ref_count, 1U);
+    }
+
+    auto second_unpin = data_manager_->UnPinKey(key, second_pin->pin_token);
+    ASSERT_TRUE(second_unpin.has_value())
+        << "Second UnPinKey failed: " << toString(second_unpin.error());
+    {
+        std::shared_lock shard_lock(shard.mutex);
+        EXPECT_EQ(shard.by_key.count(key), 0U);
+    }
+}
+
+// Test UnPinKey: token mismatch should fail without erasing or decrementing the record.
+TEST_F(DataManagerTest, UnPinKeyTokenMismatchKeepsPinnedRecord) {
+    const std::string key = "unpin_token_mismatch_key";
+    const std::string test_data = "Unpin token mismatch payload";
+
+    auto buffer = StringToBuffer(test_data);
+    ASSERT_TRUE(DoPut(key, buffer.get(), test_data.size()).has_value());
+
+    auto pin_result = data_manager_->PinKey(key, GetTierId());
+    ASSERT_TRUE(pin_result.has_value())
+        << "PinKey failed: " << toString(pin_result.error());
+
+    UUID wrong_token = pin_result->pin_token;
+    wrong_token.first += 1;
+    auto wrong_unpin = data_manager_->UnPinKey(key, wrong_token);
+    ASSERT_FALSE(wrong_unpin.has_value());
+    EXPECT_EQ(wrong_unpin.error(), ErrorCode::INVALID_READ);
+
+    auto& shard = data_manager_->GetPinnedKeyShard(key);
+    {
+        std::shared_lock shard_lock(shard.mutex);
+        auto it = shard.by_key.find(key);
+        ASSERT_NE(it, shard.by_key.end());
+        EXPECT_EQ(it->second.ref_count, 1U);
+        EXPECT_EQ(it->second.pin_token, pin_result->pin_token);
+    }
+}
+
+// Test WriteCommit: lease expiry causes commit failure and allows subsequent PreWrite.
+TEST_F(DataManagerTest, WriteCommitFailsAfterLeaseExpiryAndAllowsRetryPreWrite) {
+    const std::string key = "expired_prewrite_key";
+    auto prewrite_result = data_manager_->PreWrite(key, 512, GetTierId());
+    ASSERT_TRUE(prewrite_result.has_value())
+        << "PreWrite failed: " << toString(prewrite_result.error());
+
+    auto& shard = data_manager_->GetPendingWriteShard(key);
+    {
+        std::unique_lock shard_lock(shard.mutex);
+        auto it = shard.by_key.find(key);
+        ASSERT_NE(it, shard.by_key.end());
+        const auto expired_deadline =
+            std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
+        it->second.deadline = expired_deadline;
+        it->second.list_it->second = expired_deadline;
+    }
+
+    auto commit_result =
+        data_manager_->WriteCommit(key, prewrite_result->pending_write_token);
+    ASSERT_FALSE(commit_result.has_value());
+    EXPECT_EQ(commit_result.error(), ErrorCode::LEASE_EXPIRED);
+
+    {
+        std::shared_lock shard_lock(shard.mutex);
+        EXPECT_EQ(shard.by_key.count(key), 0U);
+    }
+
+    auto retry_prewrite = data_manager_->PreWrite(key, 512, GetTierId());
+    ASSERT_TRUE(retry_prewrite.has_value())
+        << "PreWrite should succeed after expired record is cleaned: "
+        << toString(retry_prewrite.error());
+}
+
+// Test UnPinKey: lease expiry causes unpin failure and cleans up the pin record.
+TEST_F(DataManagerTest, ExpiredPinnedLeaseBlocksUnpinButDeleteCanProceedAfterCleanup) {
+    const std::string key = "expired_pin_key";
+    const std::string test_data = "Expired pin payload";
+
+    auto buffer = StringToBuffer(test_data);
+    ASSERT_TRUE(DoPut(key, buffer.get(), test_data.size()).has_value());
+
+    auto pin_result = data_manager_->PinKey(key, GetTierId());
+    ASSERT_TRUE(pin_result.has_value())
+        << "PinKey failed: " << toString(pin_result.error());
+
+    auto& shard = data_manager_->GetPinnedKeyShard(key);
+    {
+        std::unique_lock shard_lock(shard.mutex);
+        auto it = shard.by_key.find(key);
+        ASSERT_NE(it, shard.by_key.end());
+        const auto expired_deadline =
+            std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
+        it->second.deadline = expired_deadline;
+        it->second.list_it->second = expired_deadline;
+    }
+
+    auto unpin_result = data_manager_->UnPinKey(key, pin_result->pin_token);
+    ASSERT_FALSE(unpin_result.has_value());
+    EXPECT_EQ(unpin_result.error(), ErrorCode::LEASE_EXPIRED);
+
+    {
+        std::shared_lock shard_lock(shard.mutex);
+        EXPECT_EQ(shard.by_key.count(key), 0U);
+    }
+}
+
 // Test concurrent Put operations
 TEST_F(DataManagerTest, ConcurrentPut) {
     const int num_keys = 10;

--- a/mooncake-store/tests/data_manager_test.cpp
+++ b/mooncake-store/tests/data_manager_test.cpp
@@ -412,7 +412,8 @@ TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
         EXPECT_EQ(it->second.ref_count, 2U);
     }
 
-    auto first_unpin = data_manager_->UnPinKey(key, first_pin->read_operation_id);
+    auto first_unpin =
+        data_manager_->UnPinKey(key, first_pin->read_operation_id);
     ASSERT_TRUE(first_unpin.has_value())
         << "First UnPinKey failed: " << toString(first_unpin.error());
     {
@@ -422,7 +423,8 @@ TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
         EXPECT_EQ(it->second.ref_count, 1U);
     }
 
-    auto second_unpin = data_manager_->UnPinKey(key, second_pin->read_operation_id);
+    auto second_unpin =
+        data_manager_->UnPinKey(key, second_pin->read_operation_id);
     ASSERT_TRUE(second_unpin.has_value())
         << "Second UnPinKey failed: " << toString(second_unpin.error());
     {
@@ -524,7 +526,8 @@ TEST_F(DataManagerTest,
         it->second.list_it->second = expired_deadline;
     }
 
-    auto unpin_result = data_manager_->UnPinKey(key, pin_result->read_operation_id);
+    auto unpin_result =
+        data_manager_->UnPinKey(key, pin_result->read_operation_id);
     ASSERT_FALSE(unpin_result.has_value());
     EXPECT_EQ(unpin_result.error(), ErrorCode::LEASE_EXPIRED);
 

--- a/mooncake-store/tests/data_manager_test.cpp
+++ b/mooncake-store/tests/data_manager_test.cpp
@@ -295,7 +295,8 @@ TEST_F(DataManagerTest, PreWriteRejectsConcurrentLease) {
     ASSERT_FALSE(second_prewrite.has_value());
     EXPECT_EQ(second_prewrite.error(), ErrorCode::OBJECT_HAS_LEASE);
 
-    auto& shard = data_manager_->GetPendingWriteShard(key);
+    const auto kctx = data_manager_->BuildKeyCtx(key);
+    auto& shard = data_manager_->GetPendingWriteShard(kctx);
     {
         std::shared_lock shard_lock(shard.mutex);
         auto it = shard.by_key.find(key);
@@ -318,7 +319,8 @@ TEST_F(DataManagerTest, WriteCommitErasesPendingWriteRecord) {
         << "WriteCommit failed: " << toString(commit_result.error());
     EXPECT_TRUE(data_manager_->Exist(key));
 
-    auto& shard = data_manager_->GetPendingWriteShard(key);
+    const auto kctx = data_manager_->BuildKeyCtx(key);
+    auto& shard = data_manager_->GetPendingWriteShard(kctx);
     {
         std::shared_lock shard_lock(shard.mutex);
         EXPECT_EQ(shard.by_key.count(key), 0U);
@@ -338,7 +340,8 @@ TEST_F(DataManagerTest, WriteCommitTokenMismatchKeepsPendingWriteRecord) {
     ASSERT_FALSE(wrong_commit.has_value());
     EXPECT_EQ(wrong_commit.error(), ErrorCode::INVALID_WRITE);
 
-    auto& shard = data_manager_->GetPendingWriteShard(key);
+    const auto kctx = data_manager_->BuildKeyCtx(key);
+    auto& shard = data_manager_->GetPendingWriteShard(kctx);
     {
         std::shared_lock shard_lock(shard.mutex);
         auto it = shard.by_key.find(key);
@@ -366,7 +369,8 @@ TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
         << "Second PinKey failed: " << toString(second_pin.error());
     EXPECT_EQ(first_pin->read_operation_id, second_pin->read_operation_id);
 
-    auto& shard = data_manager_->GetPinnedKeyShard(key);
+    const auto kctx = data_manager_->BuildKeyCtx(key);
+    auto& shard = data_manager_->GetPinnedKeyShard(kctx);
     {
         std::shared_lock shard_lock(shard.mutex);
         auto it = shard.by_key.find(key);
@@ -412,7 +416,8 @@ TEST_F(DataManagerTest, UnPinKeyTokenMismatchKeepsPinnedRecord) {
     ASSERT_FALSE(wrong_unpin.has_value());
     EXPECT_EQ(wrong_unpin.error(), ErrorCode::INVALID_READ);
 
-    auto& shard = data_manager_->GetPinnedKeyShard(key);
+    const auto kctx = data_manager_->BuildKeyCtx(key);
+    auto& shard = data_manager_->GetPinnedKeyShard(kctx);
     {
         std::shared_lock shard_lock(shard.mutex);
         auto it = shard.by_key.find(key);
@@ -431,7 +436,8 @@ TEST_F(DataManagerTest,
     ASSERT_TRUE(prewrite_result.has_value())
         << "PreWrite failed: " << toString(prewrite_result.error());
 
-    auto& shard = data_manager_->GetPendingWriteShard(key);
+    const auto kctx = data_manager_->BuildKeyCtx(key);
+    auto& shard = data_manager_->GetPendingWriteShard(kctx);
     {
         std::unique_lock shard_lock(shard.mutex);
         auto it = shard.by_key.find(key);
@@ -472,7 +478,8 @@ TEST_F(DataManagerTest,
     ASSERT_TRUE(pin_result.has_value())
         << "PinKey failed: " << toString(pin_result.error());
 
-    auto& shard = data_manager_->GetPinnedKeyShard(key);
+    const auto kctx = data_manager_->BuildKeyCtx(key);
+    auto& shard = data_manager_->GetPinnedKeyShard(kctx);
     {
         std::unique_lock shard_lock(shard.mutex);
         auto it = shard.by_key.find(key);

--- a/mooncake-store/tests/data_manager_test.cpp
+++ b/mooncake-store/tests/data_manager_test.cpp
@@ -284,6 +284,24 @@ TEST_F(DataManagerTest, DeleteWithTierId) {
     ASSERT_FALSE(data_manager_->Exist(key));
 }
 
+// BuildRemoteBufferDesc: null allocation buffer is an internal error.
+TEST_F(DataManagerTest, BuildRemoteBufferDescRejectsNullBuffer) {
+    auto alloc_result = tiered_backend_->Allocate(64, GetTierId());
+    ASSERT_TRUE(alloc_result.has_value())
+        << "Allocate failed: " << toString(alloc_result.error());
+
+    AllocationHandle handle = alloc_result.value();
+    auto saved_buffer = std::move(handle->loc.data.buffer);
+    ASSERT_EQ(handle->loc.data.buffer, nullptr);
+
+    auto desc_result = data_manager_->BuildRemoteBufferDesc(handle);
+    ASSERT_FALSE(desc_result.has_value());
+    EXPECT_EQ(desc_result.error(), ErrorCode::INTERNAL_ERROR);
+
+    // Restore buffer so AllocationEntry destructor can release via tier.
+    handle->loc.data.buffer = std::move(saved_buffer);
+}
+
 // Test PreWrite: concurrent PreWrite should be rejected by a pending lease.
 TEST_F(DataManagerTest, PreWriteRejectsConcurrentLease) {
     const std::string key = "prewrite_lifecycle_key";
@@ -325,6 +343,22 @@ TEST_F(DataManagerTest, WriteCommitErasesPendingWriteRecord) {
         std::shared_lock shard_lock(shard.mutex);
         EXPECT_EQ(shard.by_key.count(key), 0U);
     }
+}
+
+// WriteCommit without a pending write (e.g. duplicate commit) is an error.
+TEST_F(DataManagerTest, WriteCommitWithoutPendingWriteFails) {
+    const std::string key = "write_commit_no_pending_key";
+    auto prewrite_result = data_manager_->PreWrite(key, 256, GetTierId());
+    ASSERT_TRUE(prewrite_result.has_value());
+
+    auto first_commit =
+        data_manager_->WriteCommit(key, prewrite_result->write_operation_id);
+    ASSERT_TRUE(first_commit.has_value());
+
+    auto second_commit =
+        data_manager_->WriteCommit(key, prewrite_result->write_operation_id);
+    ASSERT_FALSE(second_commit.has_value());
+    EXPECT_EQ(second_commit.error(), ErrorCode::OBJECT_NOT_FOUND);
 }
 
 // Test WriteCommit: token mismatch should fail without erasing the record.

--- a/mooncake-store/tests/data_manager_test.cpp
+++ b/mooncake-store/tests/data_manager_test.cpp
@@ -64,6 +64,9 @@ class DataManagerTest : public ::testing::Test {
         ASSERT_TRUE(parseJsonString(json_config_str, config));
 
         tiered_backend_ = std::make_unique<TieredBackend>();
+        const size_t metadata_shard_count =
+            GetEnvOr<size_t>("MOONCAKE_DM_LOCK_SHARD_COUNT", 1024);
+        tiered_backend_->SetMetadataShardCount(metadata_shard_count);
         // transfer_engine_ is nullptr when initializing tiered_backend_
         // only for local access test
         auto init_result = InitTieredBackendForTest(*tiered_backend_, config);
@@ -85,7 +88,7 @@ class DataManagerTest : public ::testing::Test {
         // access
         TieredBackend* backend_raw_ptr = tiered_backend_.get();
         data_manager_ = std::make_unique<DataManager>(
-            std::move(tiered_backend_), transfer_engine_, 1024,
+            std::move(tiered_backend_), transfer_engine_, metadata_shard_count,
             transfer_config);
         // Keep the raw pointer accessible for tests that need direct backend
         // access Note: The backend is now owned by DataManager, but tests can

--- a/mooncake-store/tests/data_manager_test.cpp
+++ b/mooncake-store/tests/data_manager_test.cpp
@@ -348,7 +348,8 @@ TEST_F(DataManagerTest, WriteCommitTokenMismatchKeepsPendingWriteRecord) {
     }
 }
 
-// Test Pin/Unpin: ref_count increments on PinKey and reaches zero on final UnPinKey.
+// Test Pin/Unpin: ref_count increments on PinKey and reaches zero on final
+// UnPinKey.
 TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
     const std::string key = "pin_ref_count_key";
     const std::string test_data = "Pin key ref count payload";
@@ -392,7 +393,8 @@ TEST_F(DataManagerTest, PinKeyTracksRefCountUntilFinalUnpin) {
     }
 }
 
-// Test UnPinKey: token mismatch should fail without erasing or decrementing the record.
+// Test UnPinKey: token mismatch should fail without erasing or decrementing the
+// record.
 TEST_F(DataManagerTest, UnPinKeyTokenMismatchKeepsPinnedRecord) {
     const std::string key = "unpin_token_mismatch_key";
     const std::string test_data = "Unpin token mismatch payload";
@@ -420,8 +422,10 @@ TEST_F(DataManagerTest, UnPinKeyTokenMismatchKeepsPinnedRecord) {
     }
 }
 
-// Test WriteCommit: lease expiry causes commit failure and allows subsequent PreWrite.
-TEST_F(DataManagerTest, WriteCommitFailsAfterLeaseExpiryAndAllowsRetryPreWrite) {
+// Test WriteCommit: lease expiry causes commit failure and allows subsequent
+// PreWrite.
+TEST_F(DataManagerTest,
+       WriteCommitFailsAfterLeaseExpiryAndAllowsRetryPreWrite) {
     const std::string key = "expired_prewrite_key";
     auto prewrite_result = data_manager_->PreWrite(key, 512, GetTierId());
     ASSERT_TRUE(prewrite_result.has_value())
@@ -454,8 +458,10 @@ TEST_F(DataManagerTest, WriteCommitFailsAfterLeaseExpiryAndAllowsRetryPreWrite) 
         << toString(retry_prewrite.error());
 }
 
-// Test UnPinKey: lease expiry causes unpin failure and cleans up the pin record.
-TEST_F(DataManagerTest, ExpiredPinnedLeaseBlocksUnpinButDeleteCanProceedAfterCleanup) {
+// Test UnPinKey: lease expiry causes unpin failure and cleans up the pin
+// record.
+TEST_F(DataManagerTest,
+       ExpiredPinnedLeaseBlocksUnpinButDeleteCanProceedAfterCleanup) {
     const std::string key = "expired_pin_key";
     const std::string test_data = "Expired pin payload";
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
This PR implements a 3‑phase read/write model in mooncake-store’s DataManager (metadata prepare → data transfer via TE → metadata finalize/cleanup), and wires the existing reverse‑RDMA single‑RPC paths and local read/write paths to consistently follow the same phase semantics. The goal is to keep long‑latency TE/transfer work out of long critical sections and establish a solid foundation for the follow‑up work.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->
Run unit tests in data_manager_test.cpp to check prewrite/writeCommit/pinKey/UnPinKey functions.

New/updated unit test coverage includes:
- PreWrite contention: a second PreWrite for the same key is rejected while a pending lease/record exists.
- WriteCommit record cleanup: successful commit removes the pending write record.
- WriteCommit token mismatch: returns INVALID_WRITE and does not erase the valid record.
- PinKey/UnPinKey ref_count: multiple pins increment ref_count; final unpin removes the record.
- UnPinKey token mismatch: returns INVALID_READ and does not modify/delete the record.
- Lease expiry path: WriteCommit/UnPinKey return LEASE_EXPIRED and clean up records so future operations can proceed.

## Following
PR2 : Make TE waiting coroutine-friendly (true co_await suspension point) and remove blocking TODOs in local TE paths.
PR3 : Add forward-RDMA control plane

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
