### PR TITLE
[TransferEngine] Add maca_transport for Metax MACA C500 intra-node P2P

### DIFF
--- a/mooncake-transfer-engine/example/transfer_engine_validator.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_validator.cpp
@@ -413,6 +413,8 @@ int initiator() {
             xport = engine->installTransport("nvlink", nullptr);
         } else if (FLAGS_protocol == "nvlink_intra") {
             xport = engine->installTransport("nvlink_intra", nullptr);
+        } else if (FLAGS_protocol == "maca") {
+            xport = engine->installTransport("maca", nullptr);
         } else if (FLAGS_protocol == "hip") {
             xport = engine->installTransport("hip", nullptr);
         } else {
@@ -536,6 +538,8 @@ int target() {
             engine->installTransport("tcp", nullptr);
         } else if (FLAGS_protocol == "nvlink") {
             engine->installTransport("nvlink", nullptr);
+        } else if (FLAGS_protocol == "maca") {
+            engine->installTransport("maca", nullptr);
         } else if (FLAGS_protocol == "hip") {
             engine->installTransport("hip", nullptr);
         } else {

--- a/mooncake-transfer-engine/include/gpu_vendor/maca.h
+++ b/mooncake-transfer-engine/include/gpu_vendor/maca.h
@@ -9,7 +9,7 @@
 const static std::string GPU_PREFIX = "maca:";
 
 #define CUdevice MCdevice
-#define CUdeviceptr MCdeviceptr
+#define CUdeviceptr mcDeviceptr_t
 #define CUmemorytype MCmemorytype
 #define CUresult mcError_t
 #define cuDeviceGet mcDeviceGet
@@ -33,6 +33,36 @@ const static std::string GPU_PREFIX = "maca:";
 #define CUDA_SUCCESS mcSuccess
 #define CUDA_ERROR_NOT_PERMITTED mcErrorNotPermitted
 #define CUDA_ERROR_NOT_SUPPORTED mcErrorNotSupported
+
+#define CUmemFabricHandle mcMemFabricHandle_t
+#define CUmemGenericAllocationHandle mcMemGenericAllocationHandle
+#define CUmemAllocationProp mcMemAllocationProp
+#define CUmemAccessDesc mcMemAccessDesc
+#define CUmemAllocationType mcMemAllocationType
+#define CU_MEM_ALLOCATION_TYPE_PINNED mcMemAllocationTypePinned
+#define CU_MEM_LOCATION_TYPE_DEVICE mcMemLocationTypeDevice
+#define CU_MEM_HANDLE_TYPE_FABRIC mcMemHandleTypeFabric
+#define CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED \
+    mcDeviceAttributeHandleTypeFabricSupported
+#define CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED \
+    mcDeviceAttributeHandleTypePosixFileDescriptorSupported
+#define CU_MEM_ACCESS_FLAGS_PROT_READWRITE mcMemAccessFlagsProtReadWrite
+#define CU_MEM_ALLOC_GRANULARITY_MINIMUM MC_MEM_ALLOC_GRANULARITY_MINIMUM
+
+#define CU_MEMORYTYPE_HOST mcMemoryTypeHost
+#define CU_MEMORYTYPE_DEVICE mcMemoryTypeDevice
+#define CU_POINTER_ATTRIBUTE_MEMORY_TYPE mcPointerAttributeMemoryType
+#define CU_POINTER_ATTRIBUTE_RANGE_START_ADDR mcPointerAttributeRangeStartAddr
+#define CU_POINTER_ATTRIBUTE_RANGE_SIZE mcPointerAttributeRangeSize
+#define CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD mcMemHandleTypePosixFileDescriptor
+#define CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED \
+    mcDeviceAttributeHandleTypePosixFileDescriptorSupported
+static inline CUresult cuGetErrorString(CUresult error, const char **err_str) {
+    if (err_str) {
+        *err_str = mcGetErrorString(error);
+    }
+    return CUDA_SUCCESS;
+}
 
 #define cudaDeviceCanAccessPeer mcDeviceCanAccessPeer
 #define cudaDeviceEnablePeerAccess mcDeviceEnablePeerAccess

--- a/mooncake-transfer-engine/include/transport/maca_transport/maca_transport.h
+++ b/mooncake-transfer-engine/include/transport/maca_transport/maca_transport.h
@@ -1,0 +1,97 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MACA_TRANSPORT_H_
+#define MACA_TRANSPORT_H_
+
+#include "cuda_alike.h"
+
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+#include <vector>
+#include <utility>
+
+#include "common/hash_utils.h"
+#include "topology.h"
+#include "transfer_metadata.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+
+class TransferMetadata;
+
+class MacaTransport : public Transport {
+   public:
+    MacaTransport();
+
+    ~MacaTransport();
+
+    Status submitTransfer(BatchID batch_id,
+                          const std::vector<TransferRequest>& entries) override;
+
+    Status submitTransferTask(
+        const std::vector<TransferTask*>& task_list) override;
+
+    Status getTransferStatus(BatchID batch_id, size_t task_id,
+                             TransferStatus& status) override;
+
+    static void* allocatePinnedLocalMemory(size_t length);
+
+    static void freePinnedLocalMemory(void* addr);
+
+   protected:
+    int install(std::string& local_server_name,
+                std::shared_ptr<TransferMetadata> meta,
+                std::shared_ptr<Topology> topo) override;
+
+    int registerLocalMemory(void* addr, size_t length,
+                            const std::string& location, bool remote_accessible,
+                            bool update_metadata = true) override;
+
+    int unregisterLocalMemory(void* addr, bool update_metadata = true) override;
+
+    int registerLocalMemoryBatch(const std::vector<BufferEntry>& buffer_list,
+                                 const std::string& location) override;
+
+    int unregisterLocalMemoryBatch(
+        const std::vector<void*>& addr_list) override;
+
+    int relocateSharedMemoryAddress(uint64_t& dest_addr, uint64_t length,
+                                    uint64_t target_id);
+
+    const char* getName() const override { return "maca"; }
+
+   private:
+    std::atomic_bool running_;
+
+    struct OpenedShmEntry {
+        void* shm_addr;
+        uint64_t length;
+    };
+
+    std::unordered_map<std::pair<uint64_t, uint64_t>, OpenedShmEntry, PairHash>
+        remap_entries_;
+    RWSpinlock remap_lock_;
+
+    std::mutex register_mutex_;
+    std::unordered_set<uint64_t> registered_base_addrs_;
+};
+
+}  // namespace mooncake
+
+#endif  // MACA_TRANSPORT_H_

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -44,6 +44,9 @@
 #ifdef USE_HIP
 #include "transport/hip_transport/hip_transport.h"
 #endif
+#ifdef USE_MACA
+#include "transport/maca_transport/maca_transport.h"
+#endif
 #ifdef USE_MNNVL
 #include "transport/nvlink_transport/nvlink_transport.h"
 #endif
@@ -320,6 +323,11 @@ Transport* MultiTransport::installTransport(const std::string& proto,
 #ifdef USE_HIP
     else if (std::string(proto) == "hip") {
         transport = new HipTransport();
+    }
+#endif
+#ifdef USE_MACA
+    else if (std::string(proto) == "maca") {
+        transport = new MacaTransport();
     }
 #endif
 #ifdef USE_MNNVL

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -268,6 +268,15 @@ int TransferEngineImpl::init(const std::string& metadata_conn_string,
             LOG(ERROR) << "Failed to install Ascend transport";
             return -1;
         }
+#elif defined(USE_MACA)
+
+        Transport* t = multi_transports_->installTransport("maca", nullptr);
+        if (!t) {
+            LOG(ERROR) << "Failed to install MACA transport";
+            return -1;
+        }
+        LOG(INFO) << "Using MACA transport";
+
 #elif defined(USE_MNNVL) || defined(USE_INTRA_NVLINK)
 
         const char* force_mnnvl = getenv("MC_FORCE_MNNVL");

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -423,6 +423,7 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
     } else if (segmentJSON["protocol"] == "nvlink" ||
                segmentJSON["protocol"] == "nvlink_intra" ||
                segmentJSON["protocol"] == "hip" ||
+               segmentJSON["protocol"] == "maca" ||
                segmentJSON["protocol"] == "ubshmem") {
         Json::Value buffersJSON(Json::arrayValue);
         for (const auto &buffer : desc.buffers) {
@@ -744,7 +745,8 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
             desc->buffers.push_back(buffer);
         }
     } else if (desc->protocol == "nvlink" || desc->protocol == "nvlink_intra" ||
-               desc->protocol == "hip" || desc->protocol == "ubshmem") {
+               desc->protocol == "hip" || desc->protocol == "maca" ||
+               desc->protocol == "ubshmem") {
         for (const auto &bufferJSON : segmentJSON["buffers"]) {
             BufferDesc buffer;
             buffer.name = bufferJSON["name"].asString();

--- a/mooncake-transfer-engine/src/transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/CMakeLists.txt
@@ -47,6 +47,11 @@ if (USE_HIP)
   target_sources(transport PUBLIC $<TARGET_OBJECTS:hip_transport>)
 endif()
 
+if (USE_MACA)
+  add_subdirectory(maca_transport)
+  target_sources(transport PUBLIC $<TARGET_OBJECTS:maca_transport>)
+endif()
+
 if (USE_MNNVL AND NOT USE_HIP)
   add_subdirectory(nvlink_transport)
   target_sources(transport PUBLIC $<TARGET_OBJECTS:nvlink_transport>)

--- a/mooncake-transfer-engine/src/transport/maca_transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/maca_transport/CMakeLists.txt
@@ -1,0 +1,5 @@
+file(GLOB MACA_TRANSPORT_SOURCES "*.cpp")
+
+add_library(maca_transport OBJECT ${MACA_TRANSPORT_SOURCES})
+
+target_include_directories(maca_transport PUBLIC ${MACA_INCLUDE_DIR})

--- a/mooncake-transfer-engine/src/transport/maca_transport/maca_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/maca_transport/maca_transport.cpp
@@ -1,0 +1,482 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/maca_transport/maca_transport.h"
+
+#include <bits/stdint-uintn.h>
+#include "cuda_alike.h"
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <memory>
+
+#include "common.h"
+#include "common/serialization.h"
+#include "config.h"
+#include "transfer_engine.h"
+#include "transfer_metadata.h"
+#include "transport/transport.h"
+
+static bool checkCudaErrorReturn(cudaError_t result, const char *message) {
+    if (result != cudaSuccess) {
+        LOG(ERROR) << message << " (Error code: " << result << " - "
+                   << cudaGetErrorString(result) << ")" << std::endl;
+        return false;
+    }
+    return true;
+}
+
+namespace mooncake {
+static int getNumDevices() {
+    static int cached_num_devices = -1;
+    if (cached_num_devices == -1) {
+        if (!checkCudaErrorReturn(cudaGetDeviceCount(&cached_num_devices),
+                                  "MacaTransport: cudaGetDeviceCount failed")) {
+            return 0;
+        }
+    }
+    return cached_num_devices;
+}
+
+static bool enableP2PAccess(int src_device_id, int dst_device_id) {
+    int original_device;
+    cudaGetDevice(&original_device);
+
+    int canAccessPeer = 0;
+    if (!checkCudaErrorReturn(cudaDeviceCanAccessPeer(
+                                  &canAccessPeer, src_device_id, dst_device_id),
+                              "MacaTransport: failed to query peer access")) {
+        cudaSetDevice(original_device);
+        return false;
+    }
+
+    if (!canAccessPeer) {
+        LOG(ERROR) << "MacaTransport: device " << src_device_id
+                   << " cannot p2p access device " << dst_device_id;
+        cudaSetDevice(original_device);
+        return false;
+    }
+
+    // enable src->dst p2p access
+    if (!checkCudaErrorReturn(cudaSetDevice(src_device_id),
+                              "MacaTransport: failed to set device")) {
+        cudaSetDevice(original_device);
+        return false;
+    }
+    cudaError_t result = cudaDeviceEnablePeerAccess(dst_device_id, 0);
+
+    if (result != cudaSuccess && result != cudaErrorPeerAccessAlreadyEnabled) {
+        LOG(ERROR) << "MacaTransport: failed to enable p2p access (Error code: "
+                   << result << " - " << cudaGetErrorString(result) << ")"
+                   << std::endl;
+        cudaSetDevice(original_device);
+        return false;
+    }
+
+    // enable dst->src p2p access
+    if (!checkCudaErrorReturn(cudaSetDevice(dst_device_id),
+                              "MacaTransport: failed to set device")) {
+        cudaSetDevice(original_device);
+        return false;
+    }
+    result = cudaDeviceEnablePeerAccess(src_device_id, 0);
+
+    if (result != cudaSuccess && result != cudaErrorPeerAccessAlreadyEnabled) {
+        LOG(ERROR) << "MacaTransport: failed to enable p2p access (Error code: "
+                   << result << " - " << cudaGetErrorString(result) << ")"
+                   << std::endl;
+        cudaSetDevice(original_device);
+        return false;
+    }
+
+    cudaSetDevice(original_device);
+    return true;
+}
+
+static int getDeviceFromPointer(void *ptr) {
+    if (!ptr) return -1;
+
+    cudaPointerAttributes attr;
+    cudaError_t err = cudaPointerGetAttributes(&attr, ptr);
+    if (err != cudaSuccess) {
+        LOG(ERROR) << "MacaTransport: cudaPointerGetAttributes failed for "
+                   << ptr;
+        return -1;
+    }
+
+    if (attr.type == cudaMemoryTypeDevice) {
+        return attr.device;
+    }
+    return -1;
+}
+
+MacaTransport::MacaTransport() {
+    int num_devices = getNumDevices();
+    if (globalConfig().trace) {
+        LOG(INFO) << "MacaTransport: num_devices: " << num_devices;
+    }
+
+    for (int src_device_id = 0; src_device_id < num_devices; ++src_device_id) {
+        for (int dst_device_id = src_device_id + 1; dst_device_id < num_devices;
+             ++dst_device_id) {
+            if (enableP2PAccess(src_device_id, dst_device_id)) {
+                if (globalConfig().trace) {
+                    LOG(INFO)
+                        << "MacaTransport: enabled p2p access between device "
+                        << src_device_id << " and " << dst_device_id;
+                }
+            } else {
+                LOG(ERROR)
+                    << "MacaTransport: failed to enable p2p access between "
+                       "device "
+                    << src_device_id << " and " << dst_device_id;
+            }
+        }
+    }
+}
+
+MacaTransport::~MacaTransport() {
+    for (auto &entry : remap_entries_) {
+        cudaIpcCloseMemHandle(entry.second.shm_addr);
+    }
+    remap_entries_.clear();
+}
+
+int MacaTransport::install(std::string &local_server_name,
+                           std::shared_ptr<TransferMetadata> metadata,
+                           std::shared_ptr<Topology> topology) {
+    metadata_ = metadata;
+    local_server_name_ = local_server_name;
+
+    auto desc = std::make_shared<SegmentDesc>();
+    if (!desc) return ERR_MEMORY;
+    desc->name = local_server_name_;
+    desc->protocol = "maca";
+    metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
+                               std::move(desc));
+    return 0;
+}
+
+Status MacaTransport::submitTransfer(
+    BatchID batch_id, const std::vector<TransferRequest> &entries) {
+    auto &batch_desc = *((BatchDesc *)(batch_id));
+    if (batch_desc.task_list.size() + entries.size() > batch_desc.batch_size) {
+        LOG(ERROR) << "MacaTransport: Exceed the limitation of current batch's "
+                      "capacity";
+        return Status::InvalidArgument(
+            "MacaTransport: Exceed the limitation of capacity, batch id: " +
+            std::to_string(batch_id));
+    }
+
+    size_t task_id = batch_desc.task_list.size();
+    batch_desc.task_list.resize(task_id + entries.size());
+
+    for (auto &request : entries) {
+        TransferTask &task = batch_desc.task_list[task_id];
+        ++task_id;
+        uint64_t dest_addr = request.target_offset;
+        if (request.target_id != LOCAL_SEGMENT_ID) {
+            int rc = relocateSharedMemoryAddress(dest_addr, request.length,
+                                                 request.target_id);
+            if (rc) return Status::Memory("device memory not registered");
+        }
+        task.total_bytes = request.length;
+        Slice *slice = getSliceCache().allocate();
+        slice->source_addr = (char *)request.source;
+        slice->local.dest_addr = (char *)dest_addr;
+        slice->length = request.length;
+        slice->opcode = request.opcode;
+        slice->task = &task;
+        slice->target_id = request.target_id;
+        slice->status = Slice::PENDING;
+        __sync_fetch_and_add(&task.slice_count, 1);
+
+        // Set correct device context before memcpy
+        int original_device = -1;
+        cudaGetDevice(&original_device);
+        int target_device = getDeviceFromPointer(request.source);
+        if (target_device < 0)
+            target_device = getDeviceFromPointer((void *)dest_addr);
+        if (target_device >= 0) cudaSetDevice(target_device);
+
+        cudaError_t err;
+        if (slice->opcode == TransferRequest::READ)
+            err = cudaMemcpy(slice->source_addr, (void *)slice->local.dest_addr,
+                             slice->length, cudaMemcpyDefault);
+        else
+            err = cudaMemcpy((void *)slice->local.dest_addr, slice->source_addr,
+                             slice->length, cudaMemcpyDefault);
+        if (err != cudaSuccess)
+            slice->markFailed();
+        else
+            slice->markSuccess();
+
+        if (original_device >= 0) cudaSetDevice(original_device);
+    }
+
+    return Status::OK();
+}
+
+Status MacaTransport::getTransferStatus(BatchID batch_id, size_t task_id,
+                                        TransferStatus &status) {
+    auto &batch_desc = *((BatchDesc *)(batch_id));
+    const size_t task_count = batch_desc.task_list.size();
+    if (task_id >= task_count) {
+        return Status::InvalidArgument(
+            "MacaTransport::getTransportStatus invalid argument, batch id: " +
+            std::to_string(batch_id));
+    }
+    auto &task = batch_desc.task_list[task_id];
+    status.transferred_bytes = task.transferred_bytes;
+    uint64_t success_slice_count = task.success_slice_count;
+    uint64_t failed_slice_count = task.failed_slice_count;
+    if (success_slice_count + failed_slice_count == task.slice_count) {
+        if (failed_slice_count) {
+            status.s = TransferStatusEnum::FAILED;
+        } else {
+            status.s = TransferStatusEnum::COMPLETED;
+        }
+        task.is_finished = true;
+    } else {
+        status.s = TransferStatusEnum::WAITING;
+    }
+    return Status::OK();
+}
+
+Status MacaTransport::submitTransferTask(
+    const std::vector<TransferTask *> &task_list) {
+    for (size_t index = 0; index < task_list.size(); ++index) {
+        assert(task_list[index]);
+        auto &task = *task_list[index];
+        assert(task.request);
+        auto &request = *task.request;
+        uint64_t dest_addr = request.target_offset;
+        if (request.target_id != LOCAL_SEGMENT_ID) {
+            int rc = relocateSharedMemoryAddress(dest_addr, request.length,
+                                                 request.target_id);
+            if (rc) return Status::Memory("device memory not registered");
+        }
+        task.total_bytes = request.length;
+        Slice *slice = getSliceCache().allocate();
+        slice->source_addr = (char *)request.source;
+        slice->local.dest_addr = (char *)dest_addr;
+        slice->length = request.length;
+        slice->opcode = request.opcode;
+        slice->task = &task;
+        slice->target_id = request.target_id;
+        slice->status = Slice::PENDING;
+        task.slice_list.push_back(slice);
+        __sync_fetch_and_add(&task.slice_count, 1);
+
+        // Set correct device context before memcpy
+        int original_device = -1;
+        cudaGetDevice(&original_device);
+        int target_device = getDeviceFromPointer(request.source);
+        if (target_device < 0)
+            target_device = getDeviceFromPointer((void *)dest_addr);
+        if (target_device >= 0) cudaSetDevice(target_device);
+
+        cudaError_t err;
+        if (slice->opcode == TransferRequest::READ)
+            err = cudaMemcpy(slice->source_addr, (void *)slice->local.dest_addr,
+                             slice->length, cudaMemcpyDefault);
+        else
+            err = cudaMemcpy((void *)slice->local.dest_addr, slice->source_addr,
+                             slice->length, cudaMemcpyDefault);
+        if (err != cudaSuccess)
+            slice->markFailed();
+        else
+            slice->markSuccess();
+
+        if (original_device >= 0) cudaSetDevice(original_device);
+    }
+    return Status::OK();
+}
+
+int MacaTransport::registerLocalMemory(void *addr, size_t length,
+                                       const std::string &location,
+                                       bool remote_accessible,
+                                       bool update_metadata) {
+    std::lock_guard<std::mutex> lock(register_mutex_);
+    if (globalConfig().trace) {
+        LOG(INFO) << "register memory: addr " << addr << ", length " << length;
+    }
+    cudaPointerAttributes attr;
+    cudaError_t err = cudaPointerGetAttributes(&attr, addr);
+    if (err != cudaSuccess) {
+        LOG(ERROR) << "MacaTransport: cudaPointerGetAttributes failed";
+        return -1;
+    }
+
+    if (attr.type != cudaMemoryTypeDevice) {
+        LOG(ERROR) << "Unsupported memory type, " << addr << " " << attr.type;
+        return -1;
+    }
+
+    // Resolve the true cudaMalloc base address. Framework caching allocators
+    // (PyTorch, etc.) sub-allocate tensors within larger cudaMalloc segments.
+    // cudaIpcGetMemHandle always returns a handle for the entire segment, so
+    // we must register at segment granularity for correct IPC relocation.
+    CUdeviceptr base_ptr = 0;
+    size_t alloc_size = 0;
+    CUresult cu_err =
+        cuMemGetAddressRange(&base_ptr, &alloc_size, (CUdeviceptr)addr);
+    if (cu_err != CUDA_SUCCESS) {
+        LOG(ERROR) << "MacaTransport: cuMemGetAddressRange failed "
+                   << "for addr " << addr << " (error " << cu_err << ")";
+        return -1;
+    }
+
+    // Skip if this cudaMalloc block is already registered
+    if (registered_base_addrs_.count((uint64_t)base_ptr)) {
+        return 0;
+    }
+
+    cudaIpcMemHandle_t handle;
+    err = cudaIpcGetMemHandle(&handle, (void *)base_ptr);
+    if (err != cudaSuccess) {
+        LOG(ERROR) << "MacaTransport: cudaIpcGetMemHandle failed";
+        return -1;
+    }
+
+    (void)remote_accessible;
+    BufferDesc desc;
+    desc.addr = (uint64_t)base_ptr;
+    desc.length = alloc_size;
+    desc.name = location;
+    desc.shm_name = serializeBinaryData(&handle, sizeof(cudaIpcMemHandle_t));
+    int rc = metadata_->addLocalMemoryBuffer(desc, true);
+    if (rc == 0) {
+        registered_base_addrs_.insert((uint64_t)base_ptr);
+    }
+    return rc;
+}
+
+int MacaTransport::unregisterLocalMemory(void *addr, bool update_metadata) {
+    CUdeviceptr base_ptr = 0;
+    size_t alloc_size = 0;
+    CUresult cu_err =
+        cuMemGetAddressRange(&base_ptr, &alloc_size, (CUdeviceptr)addr);
+
+    void *key_ptr = addr;
+    if (cu_err == CUDA_SUCCESS) {
+        key_ptr = (void *)base_ptr;
+    } else {
+        LOG(WARNING)
+            << "MacaTransport: cuMemGetAddressRange failed for "
+            << "addr " << addr << " during unregister (error " << cu_err
+            << "). Memory may already be freed, using provided address.";
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(register_mutex_);
+        registered_base_addrs_.erase((uint64_t)key_ptr);
+    }
+    return metadata_->removeLocalMemoryBuffer(key_ptr, update_metadata);
+}
+
+int MacaTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
+                                               uint64_t length,
+                                               uint64_t target_id) {
+    auto desc = metadata_->getSegmentDescByID(target_id);
+    int index = 0;
+    for (auto &entry : desc->buffers) {
+        if (!entry.shm_name.empty() && entry.addr <= dest_addr &&
+            dest_addr + length <= entry.addr + entry.length) {
+            remap_lock_.lockShared();
+            if (remap_entries_.count(std::make_pair(target_id, entry.addr))) {
+                auto shm_addr =
+                    remap_entries_[std::make_pair(target_id, entry.addr)]
+                        .shm_addr;
+                remap_lock_.unlockShared();
+                dest_addr = dest_addr - entry.addr + ((uint64_t)shm_addr);
+                return 0;
+            }
+            remap_lock_.unlockShared();
+            RWSpinlock::WriteGuard lock_guard(remap_lock_);
+            if (!remap_entries_.count(std::make_pair(target_id, entry.addr))) {
+                std::vector<unsigned char> output_buffer;
+                deserializeBinaryData(entry.shm_name, output_buffer);
+                if (output_buffer.size() == sizeof(cudaIpcMemHandle_t)) {
+                    cudaIpcMemHandle_t handle;
+                    memcpy(&handle, output_buffer.data(), sizeof(handle));
+                    void *shm_addr = nullptr;
+                    cudaError_t err = cudaIpcOpenMemHandle(
+                        &shm_addr, handle, cudaIpcMemLazyEnablePeerAccess);
+                    if (err != cudaSuccess) {
+                        LOG(ERROR) << "MacaTransport: "
+                                      "cudaIpcOpenMemHandle failed: "
+                                   << cudaGetErrorString(err);
+                        return -1;
+                    }
+                    OpenedShmEntry shm_entry;
+                    shm_entry.shm_addr = shm_addr;
+                    shm_entry.length = entry.length;
+                    remap_entries_[std::make_pair(target_id, entry.addr)] =
+                        shm_entry;
+                } else {
+                    LOG(ERROR) << "Mismatched MACA data transfer method";
+                    return -1;
+                }
+            }
+            auto shm_addr =
+                remap_entries_[std::make_pair(target_id, entry.addr)].shm_addr;
+            dest_addr = dest_addr - entry.addr + ((uint64_t)shm_addr);
+            return 0;
+        }
+        index++;
+    }
+    LOG(ERROR) << "Requested address " << (void *)dest_addr << " to "
+               << (void *)(dest_addr + length) << " not found!";
+    return ERR_INVALID_ARGUMENT;
+}
+
+int MacaTransport::registerLocalMemoryBatch(
+    const std::vector<Transport::BufferEntry> &buffer_list,
+    const std::string &location) {
+    for (auto &buffer : buffer_list)
+        registerLocalMemory(buffer.addr, buffer.length, location, true, false);
+    return metadata_->updateLocalSegmentDesc();
+}
+
+int MacaTransport::unregisterLocalMemoryBatch(
+    const std::vector<void *> &addr_list) {
+    for (auto &addr : addr_list) unregisterLocalMemory(addr, false);
+    return metadata_->updateLocalSegmentDesc();
+}
+
+void *MacaTransport::allocatePinnedLocalMemory(size_t size) {
+    void *ptr = nullptr;
+    cudaError_t res = cudaMalloc(&ptr, size);
+    if (res == cudaSuccess) {
+        LOG(INFO) << "MacaTransport: allocated device memory " << size
+                  << " bytes";
+        return ptr;
+    } else {
+        LOG(ERROR) << "MacaTransport: cudaMalloc failed: "
+                   << cudaGetErrorString(res);
+        return nullptr;
+    }
+}
+
+void MacaTransport::freePinnedLocalMemory(void *ptr) {
+    cudaFree(ptr);
+    return;
+}
+
+}  // namespace mooncake


### PR DESCRIPTION
This commit introduces a standalone maca_transport following the same pattern as hip_transport, instead of polluting nvlink_transport with MACA-specific workarounds.

Key points:
- Sync mcMemcpy with device-context guard (save/restore device before each copy to avoid mcErrorContextIsDestroyed / SIGSEGV).
- Base-pointer registration via cuMemGetAddressRange for correct IPC handle semantics with framework caching allocators.
- IPC-only path; fabric memory is not reliably supported on MACA 3.5.3.
- P2P access enabled in constructor with original device restoration.

Glue changes:
- multi_transport.cpp: register "maca" protocol
- transfer_engine_impl.cpp: auto-install maca transport under USE_MACA
- transfer_metadata.cpp: add "maca" to encode/decode protocol whitelist
- transfer_engine_validator.cpp: support --protocol=maca
- maca.h: add missing CU_POINTER_ATTRIBUTE_*, cuGetErrorString macros

Verified on Metax C500 (2-GPU) with transfer_engine_validator:
  Data validation passed, throughput ~6.9 GB/s

Closes #2058

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
