### PR TITLE
[Bugfix][Store] Optimize log print and fix a sigsegv bug

### DIFF
--- a/mooncake-store/src/p2p_client_manager.cpp
+++ b/mooncake-store/src/p2p_client_manager.cpp
@@ -12,21 +12,25 @@ class CapacityPriorityIterator : public ClientIterator {
                                  boost::hash<UUID>>& client_metas) {
         if (client_metas.empty()) return;
 
-        clients_.reserve(client_metas.size());
-        for (auto& client : client_metas) {
+        std::vector<std::pair<size_t, std::shared_ptr<ClientMeta>>>
+            client_with_caps;
+        client_with_caps.reserve(client_metas.size());
+        for (const auto& client : client_metas) {
             if (auto p2p_meta =
                     std::static_pointer_cast<P2PClientMeta>(client.second)) {
-                clients_.emplace_back(p2p_meta);
+                client_with_caps.emplace_back(p2p_meta->GetAvailableCapacity(),
+                                              p2p_meta);
             }
         }
 
-        std::sort(clients_.begin(), clients_.end(),
-                  [](const auto& a, const auto& b) {
-                      return std::static_pointer_cast<P2PClientMeta>(a)
-                                 ->GetAvailableCapacity() >
-                             std::static_pointer_cast<P2PClientMeta>(b)
-                                 ->GetAvailableCapacity();
-                  });
+        std::sort(
+            client_with_caps.begin(), client_with_caps.end(),
+            [](const auto& a, const auto& b) { return a.first > b.first; });
+
+        clients_.reserve(client_with_caps.size());
+        for (auto& [cap, client] : client_with_caps) {
+            clients_.emplace_back(std::move(client));
+        }
     }
 };
 

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -943,8 +943,8 @@ async_simple::coro::Lazy<void> P2PClientService::RunWriteWithRetry(
     std::unique_ptr<TaskHandle<void>> current_task, std::string current_route,
     std::vector<std::unique_ptr<WriteOp>> retry_op_list, std::string_view key) {
     size_t retry_cnt = 0;
+    tl::expected<void, ErrorCode> result;
     while (current_task) {
-        tl::expected<void, ErrorCode> result;
         try {
             result = co_await current_task->WaitAsync();
         } catch (const std::exception& e) {
@@ -984,10 +984,12 @@ async_simple::coro::Lazy<void> P2PClientService::RunWriteWithRetry(
             retry_cnt++;
         }
     }
-    LOG(ERROR) << "write failed with all retry list, key:" << key;
-    tl::expected<void, ErrorCode> exhausted =
-        tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
-    promise->setValue(std::move(exhausted));
+    if (result.has_value()) {
+        result = tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+    }
+    LOG(ERROR) << "write failed with all retry list"
+               << ", key:" << key << ", error: " << result.error();
+    promise->setValue(std::move(result));
 }
 
 // ============================================================================
@@ -1435,16 +1437,20 @@ async_simple::coro::Lazy<void> P2PClientService::RunReadWithRetry(
                     tl::expected<void, ErrorCode> ok;
                     promise->setValue(std::move(ok));
                     co_return;
-                } else if (result.error() != ErrorCode::OBJECT_NOT_FOUND) {
-                    LOG(ERROR) << "Failed to get from remote, key: " << req->key
-                               << ", error: " << result.error();
                 } else {
+                    if (result.error() != ErrorCode::OBJECT_NOT_FOUND) {
+                        LOG(ERROR)
+                            << "Failed to get from remote, key: " << req->key
+                            << ", error: " << result.error();
+                    }
                     final_result = result.error();
                 }
             } catch (const std::exception& e) {
+                final_result = ErrorCode::INTERNAL_ERROR;
                 LOG(ERROR) << "Failed to get from remote, key: " << req->key
                            << ", exception: " << e.what();
             } catch (...) {
+                final_result = ErrorCode::INTERNAL_ERROR;
                 LOG(ERROR) << "Failed to get from remote, key: " << req->key
                            << ", unknown exception";
             }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -744,22 +744,28 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
     auto& context = it->second;
     context.client_buffer_allocator.reset();
 
+    bool had_error = false;
     for (auto& shm : context.mapped_shms) {
-        if (shm.shm_buffer) {
+        if (!shm.shm_buffer) continue;
+        if (shm.shm_size > 0) {
             auto rc = client_service_->unregisterLocalMemory(shm.shm_buffer,
                                                              shm.shm_size);
             if (!rc) {
-                LOG(ERROR) << "Failed to unregister memory";
-                munmap(shm.shm_buffer, shm.shm_size);
-                context.mapped_shms.clear();
-                shm_contexts_.erase(it);
-                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+                LOG(WARNING)
+                    << "Failed to unregister memory for " << shm.shm_name
+                    << ", error=" << toString(rc.error())
+                    << ", proceeding with cleanup";
+                had_error = true;
             }
-            munmap(shm.shm_buffer, shm.shm_size);
+        }
+        if (munmap(shm.shm_buffer, shm.shm_size) != 0) {
+            LOG(WARNING) << "munmap failed for " << shm.shm_name << ": "
+                         << strerror(errno);
         }
     }
     context.mapped_shms.clear();
     shm_contexts_.erase(it);
+    if (had_error) return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     return {};
 }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -761,6 +761,7 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
         if (munmap(shm.shm_buffer, shm.shm_size) != 0) {
             LOG(WARNING) << "munmap failed for " << shm.shm_name << ": "
                          << strerror(errno);
+            had_error = true;
         }
     }
     context.mapped_shms.clear();

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -737,8 +737,8 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
     std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
     if (it == shm_contexts_.end()) {
-        LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        LOG(INFO) << "client_id=" << client_id << ", shm already unmapped";
+        return {};
     }
 
     auto& context = it->second;
@@ -774,8 +774,8 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
     std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
     if (it == shm_contexts_.end()) {
-        LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        LOG(INFO) << "client_id=" << client_id << ", shm already unmapped";
+        return {};
     }
     auto& context = it->second;
 


### PR DESCRIPTION
## Description

1. The real client will monitor the status of the dummy client based on its heartbeat. When the heartbeat times out, it will proactively uninstall the shm registered by the dummy client. Similarly, when the dummy client exits, it will also proactively uninstall the shm. The behaviors of the two are in competition for uninstalling shm, so when the duumy client exits, a false alarm will appear in the log: the shm to be uninstalled no longer exists. For now, temporarily change the log level of this log from error to info. In addition, currently when uninstalling a registered shm, if an error is encountered, it will exit directly, but it should be done as much as possible
2. in the constructor of CapacityPriorityIterator, the compare function of std::sort could not guarantee consistency in the sorting, resulting in sigsegv when writing is in high concurrency. 
3. in the RunReadWithRetry() and RunWriteWithRetry() of P2PClientService, the actual error code was not set, and the function mistakenly returned the default error code

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
