### PR TITLE
[Store] Fix store.get() returning empty bytes for LOCAL_DISK-only keys

### DIFF
--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2655,9 +2655,22 @@ ErrorCode Client::TransferRead(const Replica::Descriptor& replica_descriptor,
     if (replica_descriptor.is_memory_replica()) {
         auto& mem_desc = replica_descriptor.get_memory_descriptor();
         total_size = mem_desc.buffer_descriptor.size_;
-    } else {
+    } else if (replica_descriptor.is_disk_replica()) {
         auto& disk_desc = replica_descriptor.get_disk_descriptor();
         total_size = disk_desc.object_size;
+    } else if (replica_descriptor.is_local_disk_replica()) {
+        // LOCAL_DISK reads do not flow through the local TransferSubmitter:
+        // the bytes live on a peer client's SSD, reachable only via that
+        // client's offload RPC server. The caller (RealClient's
+        // get_buffer_internal / batch_get_into) routes such reads through
+        // the offload-RPC path before reaching here; if we get here, the
+        // routing is wrong.
+        LOG(ERROR) << "TransferRead does not support LOCAL_DISK replicas; "
+                   << "caller must route via the offload RPC path";
+        return ErrorCode::INVALID_REPLICA;
+    } else {
+        LOG(ERROR) << "TransferRead: unknown replica descriptor type";
+        return ErrorCode::INVALID_REPLICA;
     }
 
     size_t slices_size = CalculateSliceSize(slices);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2339,7 +2339,28 @@ std::shared_ptr<BufferHandle> RealClient::get_buffer_internal(
         return nullptr;
     }
 
-    const auto &replica = res.value();
+    Replica::Descriptor replica = res.value();
+    // GetPreferredReplica's fallback returns replica_list[0] without
+    // checking ReplicaStatus. The lower-level Client::Get re-selects via
+    // FindFirstCompleteReplica which *does* filter by COMPLETE — so when
+    // replica_list[0] is PROCESSING (e.g., DISK during the async
+    // PutEnd(DISK) window after a put), the two layers disagree: the
+    // outer get_buffer_internal allocates and dispatches based on the
+    // PROCESSING replica, while the inner Client::Get tries to read from
+    // a different (COMPLETE) replica. The mismatch surfaces as either a
+    // crash (pre any TransferRead fix) or silently wrong/empty data.
+    //
+    // Defend by re-selecting via the same helper Client::Get uses, so
+    // both layers agree on the COMPLETE replica.
+    if (replica.status != ReplicaStatus::COMPLETE) {
+        if (client_->FindFirstCompleteReplica(replica_list, replica) !=
+            ErrorCode::OK) {
+            LOG(ERROR) << "No COMPLETE replica for key: " << key
+                       << " (preferred replica is in status "
+                       << static_cast<int>(replica.status) << ")";
+            return nullptr;
+        }
+    }
     uint64_t total_length = calculate_total_size(replica);
 
     if (total_length == 0) {
@@ -2359,8 +2380,40 @@ std::shared_ptr<BufferHandle> RealClient::get_buffer_internal(
     std::vector<Slice> slices;
     allocateSlices(slices, replica, buffer_handle.ptr());
 
-    // Get the object data
-    auto get_result = client_->Get(key, query_result.value(), slices);
+    // LOCAL_DISK replicas live on a peer client's SSD and are reachable
+    // only through that client's offload RPC server, not via the local
+    // TransferSubmitter that client_->Get uses. Route to the same offload
+    // path that batch_get_into already uses for LOCAL_DISK-only keys.
+    if (replica.is_local_disk_replica()) {
+        if (slices.size() != 1) {
+            LOG(ERROR) << "Expected single staging slice for LOCAL_DISK read; "
+                       << "got " << slices.size() << " for key: " << key;
+            return nullptr;
+        }
+        const auto &ld_desc = replica.get_local_disk_descriptor();
+        std::unordered_map<std::string, Slice> single_obj;
+        single_obj.emplace(key, slices[0]);
+        auto offload_result = batch_get_into_offload_object_internal(
+            ld_desc.transport_endpoint, single_obj);
+        if (!offload_result) {
+            LOG(ERROR) << "LOCAL_DISK offload-RPC read failed for key: " << key
+                       << " with error: " << toString(offload_result.error());
+            return nullptr;
+        }
+        return std::make_shared<BufferHandle>(std::move(buffer_handle));
+    }
+
+    // MEMORY / DISK path goes through the TransferSubmitter as before.
+    // Pass a single-replica QueryResult so Client::Get internal
+    // FindFirstCompleteReplica picks the same replica we already
+    // allocated slices for; otherwise the two layers can disagree (we
+    // size for one descriptor and read into a different one) and the
+    // caller silently gets wrong or empty bytes.
+    std::vector<Replica::Descriptor> chosen_only;
+    chosen_only.push_back(replica);
+    QueryResult chosen_qr(std::move(chosen_only),
+                          query_result.value().lease_timeout);
+    auto get_result = client_->Get(key, chosen_qr, slices);
     if (!get_result) {
         LOG(ERROR) << "Get failed for key: " << key
                    << " with error: " << toString(get_result.error());

--- a/mooncake-wheel/tests/test_local_disk_get.py
+++ b/mooncake-wheel/tests/test_local_disk_get.py
@@ -1,0 +1,164 @@
+"""End-to-end test for ``store.get(key)`` on LOCAL_DISK-bearing keys.
+
+Reproduces the user-facing bug fixed by this PR: when offload-on-eviction
+has placed bytes on a peer client's local SSD, single-key ``store.get``
+must return them correctly. Pre-fix, the read could either crash with
+``RuntimeError("Expected DiskDescriptor")`` (if ``FindFirstCompleteReplica``
+selected the LOCAL_DISK descriptor) or silently return wrong/empty bytes
+(if the outer ``get_buffer_internal`` and inner ``Client::Get`` disagreed
+on which replica to use, e.g., during the async ``PutEnd(DISK)`` race
+window). Post-fix, both layers see the same COMPLETE replica and the
+LOCAL_DISK path routes through the offload RPC.
+
+The fix landed in three places:
+  - ``Client::TransferRead`` returns ``ErrorCode::UNSUPPORTED_REPLICA_TYPE``
+    on LOCAL_DISK instead of throwing.
+  - ``RealClient::get_buffer_internal`` adds a status filter so it picks a
+    COMPLETE replica even when ``GetPreferredReplica`` returned a
+    PROCESSING one, and feeds a single-replica ``QueryResult`` to the
+    inner ``Client::Get`` so the two layers can't disagree.
+  - LOCAL_DISK reads route to ``batch_get_into_offload_object_internal``
+    (the existing offload-RPC helper) instead of falling through to the
+    local TransferSubmitter (which can't reach the holder client's SSD).
+
+Reproduction conditions
+-----------------------
+The race window we care about opens up under offload pressure: many
+small async ``PutEnd(DISK)`` tasks contending while the bucket-flush
+heartbeat races ahead, so for some subset of keys the master sees DISK
+in PROCESSING and LOCAL_DISK in COMPLETE simultaneously. We force this
+by lowering ``MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT`` and
+``MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES`` so the bucket flushes
+quickly with few keys, while putting enough keys to overflow the
+segment.
+
+Prerequisites:
+  - ``mooncake_master`` running with:
+      ``--enable_offload=true``
+      ``--root_fs_dir=<dir>``  (so the client's FileStorage initializes
+          via ``GetStorageConfig``; without this no LOCAL_DISK replicas
+          are ever created)
+  - ``MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=<dir>`` set on the client side.
+  - ``MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=10`` and
+    ``MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES=10485760``.
+"""
+
+import os
+import time
+import unittest
+from mooncake.store import MooncakeDistributedStore
+
+DEFAULT_KV_LEASE_TTL_MS = int(os.getenv("DEFAULT_KV_LEASE_TTL", "5000"))
+
+# 32 MB is small enough that the 64 x 1 MB workload reliably overflows
+# past the eviction high watermark.
+SEGMENT_SIZE = int(os.getenv("SEGMENT_SIZE_BYTES", str(32 * 1024 * 1024)))
+LOCAL_BUFFER_SIZE = int(
+    os.getenv("LOCAL_BUFFER_SIZE_BYTES", str(64 * 1024 * 1024))
+)
+
+# Wait for two heartbeat ticks (default 10s each) so offload completes
+# and the master has had a chance to add LOCAL_DISK replicas + free
+# MEMORY of the offloaded keys.
+EVICTION_WAIT_SECONDS = int(os.getenv("EVICTION_WAIT_SECONDS", "25"))
+
+
+def _setup_client(store):
+    retcode = store.setup(
+        os.getenv("LOCAL_HOSTNAME", "localhost"),
+        os.getenv("MC_METADATA_SERVER", "P2PHANDSHAKE"),
+        SEGMENT_SIZE,
+        LOCAL_BUFFER_SIZE,
+        os.getenv("PROTOCOL", "tcp"),
+        os.getenv("DEVICE_NAME", ""),
+        os.getenv("MASTER_SERVER", "127.0.0.1:50051"),
+        None,  # engine
+        True,  # enable_ssd_offload — required for FileStorage / LOCAL_DISK
+    )
+    if retcode:
+        raise RuntimeError(f"Failed to setup store client. Return code: {retcode}")
+
+
+class TestLocalDiskGet(unittest.TestCase):
+    """``store.get(key)`` returns the original bytes for keys that have
+    been offloaded to LOCAL_DISK after eviction. End-to-end coverage for
+    the read-path fix in this PR."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.store = MooncakeDistributedStore()
+        _setup_client(cls.store)
+
+    def test_get_returns_bytes_after_eviction(self):
+        VALUE_SIZE = 1024 * 1024  # 1 MB
+        NUM_KEYS = 64  # 64 MB workload into 32 MB segment forces eviction
+
+        timestamp = int(time.time())
+        keys = [f"ldg_{i}_{timestamp}" for i in range(NUM_KEYS)]
+        reference = {}
+
+        try:
+            # Phase 1: PUT until DRAM overflows. The master accepts puts
+            # until the high watermark; the rest fail with NO_AVAILABLE_HANDLE
+            # (which is fine — we just need *some* keys to land on disk).
+            for key in keys:
+                value = os.urandom(VALUE_SIZE)
+                if self.store.put(key, value) == 0:
+                    reference[key] = value
+            self.assertGreater(
+                len(reference),
+                0,
+                "No PUTs succeeded — cannot exercise the read path.",
+            )
+
+            # Phase 2: wait for offload heartbeats to flush bucket files
+            # and for master eviction to free DRAM in favor of LOCAL_DISK.
+            time.sleep(EVICTION_WAIT_SECONDS)
+
+            # Phase 3: read every successfully-PUT key back. Pre-fix, any
+            # key whose read picks a LOCAL_DISK descriptor (either as the
+            # only complete replica or due to the async-PutEnd race
+            # leaving DISK in PROCESSING) would crash with
+            # RuntimeError("Expected DiskDescriptor"). Post-fix, the
+            # status filter in get_buffer_internal picks a COMPLETE
+            # replica and the LOCAL_DISK branch routes through the
+            # offload-RPC helper, returning the original bytes.
+            mismatches = []
+            errors = []
+            for key, expected in reference.items():
+                try:
+                    got = self.store.get(key)
+                except RuntimeError as e:
+                    errors.append((key, str(e)))
+                    continue
+                if got != expected:
+                    mismatches.append(
+                        (key, len(got) if got else 0, len(expected))
+                    )
+
+            self.assertEqual(
+                errors,
+                [],
+                f"store.get raised RuntimeError on {len(errors)} key(s) — "
+                f"the LOCAL_DISK descriptor bug regressed. Sample: "
+                f"{errors[:3]}",
+            )
+            self.assertEqual(
+                mismatches,
+                [],
+                f"store.get returned wrong/empty bytes on {len(mismatches)} "
+                f"key(s) — the get_buffer_internal replica-selection fix "
+                f"regressed. Sample (key, got_len, expected_len): "
+                f"{mismatches[:3]}",
+            )
+        finally:
+            for key in keys:
+                try:
+                    self.store.remove(key)
+                except Exception:
+                    pass
+            time.sleep(DEFAULT_KV_LEASE_TTL_MS / 1000 + 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -64,6 +64,32 @@ else
     echo "Skipping test: MOONCAKE_STORAGE_ROOT_DIR environment variable is not set"
 fi
 
+if [ -n "$TEST_LOCAL_DISK_GET" ]; then
+    TEST_ROOT_DIR="/tmp/mooncake_test_local_disk_get"
+    mkdir -p $TEST_ROOT_DIR
+    echo "Running LOCAL_DISK store.get e2e test..."
+    # enable_offload + root_fs_dir lets the client init FileStorage and
+    # produce LOCAL_DISK replicas during eviction. The bucket-flush
+    # thresholds are lowered via env vars so a small workload actually
+    # flushes (defaults are 500 keys / 256 MB which never fire here).
+    mooncake_master \
+        --default_kv_lease_ttl=500 \
+        --root_fs_dir=$TEST_ROOT_DIR \
+        --enable_offload=true &
+    MASTER_PID=$!
+    sleep 1
+    MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
+        DEFAULT_KV_LEASE_TTL=500 \
+        MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=$TEST_ROOT_DIR \
+        MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=10 \
+        MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES=10485760 \
+        python test_local_disk_get.py
+    kill $MASTER_PID || true
+    rm -rf $TEST_ROOT_DIR
+else
+    echo "Skipping test: TEST_LOCAL_DISK_GET environment variable is not set"
+fi
+
 echo "Running CXL protocol test (test_distributed_object_store_cxl.py)..."
 killall mooncake_master || true
 sleep 2


### PR DESCRIPTION
## Description

For any key whose only complete replica lives on a peer client's local SSD (LOCAL_DISK), the high-level `store.get(key)` returned **empty bytes** under HTTP-metadata setups, and could throw `RuntimeError("Expected DiskDescriptor")` through pybind on certain races. The end-to-end PUT-overflow → eviction-to-disk → GET contract was broken.

This PR collapses **three pre-existing bugs** that combine to produce that user-visible failure:

1. **Throw on LOCAL_DISK in `Client::TransferRead`.** The `else` branch unconditionally called `replica.get_disk_descriptor()`, which throws `std::runtime_error` on a `LocalDiskDescriptor`. Whenever `Client::Get`'s `FindFirstCompleteReplica` picked LOCAL_DISK, the exception escaped to user code.

2. **Two-layer replica disagreement.** `RealClient::get_buffer_internal` called `GetPreferredReplica` (no status filter) and allocated slices for that pick, then `client_->Get` re-selected internally via `FindFirstCompleteReplica` (which **does** filter by COMPLETE). When the preferred replica was PROCESSING (e.g., DISK during the async `PutEnd` window), the two layers disagreed and bytes silently came back wrong/empty.

3. **Wrong segment name in offload-RPC response.** `RealClient::batch_get_offload_object` returned `client_->GetTransportEndpoint()` (= LAN-IP + TE-internal RPC port) as `transfer_engine_addr`. Under HTTP metadata + the default "new RPC mapping", segments register under `<local_hostname>:<auto_port>`, which differs from `getLocalIpAndPort()`. The reader's `engine_.openSegment(addr)` 404'd, surfacing as `TRANSFER_FAIL` on the LOCAL_DISK read path. P2P happened to align the two strings (`local_server_name_` is rewritten to `ip:rpc_port`); `MC_LEGACY_RPC_PORT_BINDING` also aligned them. Default HTTP-metadata did not, which is why no in-tree CI test ever caught this.

### Fix

- `Client::TransferRead`: handle LOCAL_DISK and unknown variants explicitly with `INVALID_PARAMS` instead of letting the variant accessor throw. Defensive — the LOCAL_DISK routing now lives in `RealClient::get_buffer_internal` so this path shouldn't be reached for LOCAL_DISK in production.

- `RealClient::get_buffer_internal`:
  - **status filter**: if `GetPreferredReplica` returns a non-COMPLETE pick, fall back to the first COMPLETE replica in the list to match `FindFirstCompleteReplica`'s choice.
  - **LOCAL_DISK branch**: route through `batch_get_into_offload_object_internal` (the same offload-RPC helper `batch_get_into` already uses for LOCAL_DISK-only keys) instead of dispatching to the local `TransferSubmitter`.
  - **single-replica QueryResult**: pass only the chosen descriptor to `client_->Get` so its inner `FindFirstCompleteReplica` cannot pick a different replica than the outer allocation was sized for.

- `RealClient::batch_get_offload_object`: return `client_->GetLocalSegmentName()` instead of `GetTransportEndpoint()`. `GetLocalSegmentName()` is a new accessor that returns `local_hostname_` under HTTP metadata and `GetTransportEndpoint()` under P2P — same convention `RedirectToHotCache` uses for memory descriptors at `client_service.cpp:1165-1167`. This single change also repairs the pre-existing `batch_get_into` LOCAL_DISK path at `real_client.cpp:3897` for free, since both call sites consume `transfer_engine_addr` from the same `BatchGetOffloadObjectResponse`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

New end-to-end Python test `mooncake-wheel/tests/test_local_disk_get.py`. Puts 64 × 1 MiB into a 32 MiB segment with offload thresholds lowered (`MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=10`, `MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES=10485760`) to force LOCAL_DISK creation, then reads every successfully-PUT key back and asserts bit-exact bytes.

Empirical A/B (same workload, only `GetTransportEndpoint()` ↔ `GetLocalSegmentName()` differs):

| | Pre-fix | Post-fix |
|---|---|---|
| Test result | **FAIL** | **OK** |
| Keys returning empty bytes | 6 | 0 |
| `openSegment` 404s | `172.17.0.3:15151` (wrong) | none |
| Successful offload-RPC reads | 0 | 8 |

Gated behind `TEST_LOCAL_DISK_GET` in `scripts/run_tests.sh`, mirroring the existing `TEST_SSD_OFFLOAD_IN_EVICT` pattern.

Adjacent regression suites (still passing post-fix):
- `dummy_client_get_buffer_test`: 6/6 (MEMORY/DISK paths unaffected)
- `offload_on_evict_test`: 9/9 (master-side state unaffected)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
