### PR TITLE
[Store] feat: add graceful segment unmount APIs

### DIFF
--- a/docs/source/http-api-reference/http-service.md
+++ b/docs/source/http-api-reference/http-service.md
@@ -241,11 +241,16 @@ Unmount one or more segment ids previously returned by `/api/mount_shm`.
 **Request Body**:
 ```json
 {
-  "segment_ids": ["00000000-0000-0000-0000-000000000001"]
+  "segment_ids": ["00000000-0000-0000-0000-000000000001"],
+  "grace_period_seconds": 0
 }
 ```
 
 `segment_ids` may also be provided as a single string for one segment.
+`grace_period_seconds` is optional and defaults to `0`, which keeps the
+existing immediate unmount behavior. When set to a positive value, the master
+keeps the segment readable for that grace period while preventing new
+allocations, then completes the unmount.
 
 **Success Response**:
 ```json
@@ -258,7 +263,8 @@ Unmount one or more segment ids previously returned by `/api/mount_shm`.
 ```bash
 curl -X POST http://localhost:8080/api/unmount_shm \
   -H "Content-Type: application/json" \
-  -d '{"segment_ids": ["00000000-0000-0000-0000-000000000001"]}'
+  -d '{"segment_ids": ["00000000-0000-0000-0000-000000000001"],
+       "grace_period_seconds": 30}'
 ```
 
 ### `/api/mount`
@@ -312,11 +318,16 @@ the memory allocated by the store process.
 **Request Body**:
 ```json
 {
-  "segment_ids": ["00000000-0000-0000-0000-000000000002"]
+  "segment_ids": ["00000000-0000-0000-0000-000000000002"],
+  "grace_period_seconds": 0
 }
 ```
 
 `segment_ids` may also be provided as a single string for one segment.
+`grace_period_seconds` is optional and defaults to `0`, which keeps the
+existing immediate unmount-and-free behavior. When set to a positive value, the
+master keeps the segment readable for that grace period while preventing new
+allocations, then the store releases the local allocated memory after cleanup.
 
 **Success Response**:
 ```json
@@ -329,5 +340,6 @@ the memory allocated by the store process.
 ```bash
 curl -X POST http://localhost:8080/api/unmount \
   -H "Content-Type: application/json" \
-  -d '{"segment_ids": ["00000000-0000-0000-0000-000000000002"]}'
+  -d '{"segment_ids": ["00000000-0000-0000-0000-000000000002"],
+       "grace_period_seconds": 30}'
 ```

--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -1484,18 +1484,26 @@ named shared memory object name instead of an arbitrary path.
 Unmount one or more file or shared-memory segments by segment id.
 
 ```python
-def unmount_segment(self, segment_ids: List[str]) -> int
+def unmount_segment(
+    self,
+    segment_ids: List[str],
+    grace_period_seconds: int = 0,
+) -> int
 ```
 
 **Parameters:**
 - `segment_ids` (List[str]): Segment ids returned by `mount_segment()`.
+- `grace_period_seconds` (int, optional): Grace period before the segment is
+  fully unmounted. Defaults to `0`, which keeps the existing immediate unmount
+  behavior. During a positive grace period, the segment remains readable but no
+  longer accepts new allocations.
 
 **Returns:**
 - `int`: Status code (0 = success, non-zero = error code)
 
 **Example:**
 ```python
-ret = store.unmount_segment(segment_ids)
+ret = store.unmount_segment(segment_ids, grace_period_seconds=30)
 if ret != 0:
     print("Unmount failed:", ret)
 ```
@@ -1550,19 +1558,28 @@ Unmount one or more internally allocated segments by segment id and free their
 local memory.
 
 ```python
-def unmount_and_free_segment(self, segment_ids: List[str]) -> int
+def unmount_and_free_segment(
+    self,
+    segment_ids: List[str],
+    grace_period_seconds: int = 0,
+) -> int
 ```
 
 **Parameters:**
 - `segment_ids` (List[str]): Segment ids returned by
   `allocate_and_mount_segment()`.
+- `grace_period_seconds` (int, optional): Grace period before the segment is
+  fully unmounted and its local allocated memory is released. Defaults to `0`,
+  which keeps the existing immediate unmount-and-free behavior. During a
+  positive grace period, the segment remains readable but no longer accepts new
+  allocations.
 
 **Returns:**
 - `int`: Status code (0 = success, non-zero = error code)
 
 **Example:**
 ```python
-ret = store.unmount_and_free_segment(segment_ids)
+ret = store.unmount_and_free_segment(segment_ids, grace_period_seconds=30)
 if ret != 0:
     print("Unmount and free failed:", ret)
 ```

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -340,14 +340,15 @@ class MooncakeStorePyWrapper {
         return result;
     }
 
-    int unmount_segment(const std::vector<std::string> &segment_ids) {
+    int unmount_segment(const std::vector<std::string> &segment_ids,
+                        uint64_t grace_period_seconds = 0) {
         auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
         if (!real_client) {
             LOG(ERROR) << "unmount_segment requires RealClient";
             return -1;
         }
         py::gil_scoped_release release;
-        return real_client->unmountSegment(segment_ids);
+        return real_client->unmountSegment(segment_ids, grace_period_seconds);
     }
 
     py::dict allocate_and_mount_segment(size_t size,
@@ -377,14 +378,16 @@ class MooncakeStorePyWrapper {
         return result;
     }
 
-    int unmount_and_free_segment(const std::vector<std::string> &segment_ids) {
+    int unmount_and_free_segment(const std::vector<std::string> &segment_ids,
+                                 uint64_t grace_period_seconds = 0) {
         auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
         if (!real_client) {
             LOG(ERROR) << "unmount_and_free_segment requires RealClient";
             return -1;
         }
         py::gil_scoped_release release;
-        return real_client->unmountAndFreeSegment(segment_ids);
+        return real_client->unmountAndFreeSegment(segment_ids,
+                                                  grace_period_seconds);
     }
 
     std::string get_tp_key_name(const std::string &base_key, int rank) const {
@@ -1909,14 +1912,14 @@ PYBIND11_MODULE(store, m) {
              py::arg("path"), py::arg("size"), py::arg("offset") = 0,
              py::arg("protocol") = "tcp", py::arg("location") = "")
         .def("unmount_segment", &MooncakeStorePyWrapper::unmount_segment,
-             py::arg("segment_ids"))
+             py::arg("segment_ids"), py::arg("grace_period_seconds") = 0)
         .def("allocate_and_mount_segment",
              &MooncakeStorePyWrapper::allocate_and_mount_segment,
              py::arg("size"), py::arg("protocol") = "tcp",
              py::arg("location") = "")
         .def("unmount_and_free_segment",
              &MooncakeStorePyWrapper::unmount_and_free_segment,
-             py::arg("segment_ids"))
+             py::arg("segment_ids"), py::arg("grace_period_seconds") = 0)
         .def("alloc_from_mem_pool",
              [](MooncakeStorePyWrapper &self, size_t size) {
                  py::gil_scoped_release release;

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -2,6 +2,8 @@
 
 #include <atomic>
 #include <boost/functional/hash.hpp>
+#include <condition_variable>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -306,8 +308,11 @@ class Client {
     /**
      * @brief Unmounts a segment by its UUID.
      *        Logic is identical to UnmountSegment, but looks up by id.
+     * @param grace_period_ms 0 = immediate unmount (legacy behavior).
      */
-    tl::expected<void, ErrorCode> UnmountSegmentById(const UUID& segment_id);
+    tl::expected<void, ErrorCode> UnmountSegmentById(
+        const UUID& segment_id, uint64_t grace_period_ms = 0,
+        std::function<void(const UUID&)> cleanup_callback = {});
 
     /**
      * @brief Registers memory buffer with TransferEngine for data transfer
@@ -705,12 +710,28 @@ class Client {
     mutable std::mutex mounted_segments_mutex_;
     std::unordered_map<UUID, Segment, boost::hash<UUID>> mounted_segments_;
 
+    // Segments in graceful unmount: readable by remote peers, not allocatable
+    // locally. TE MR remains registered until master confirms removal.
+    std::unordered_map<UUID, Segment, boost::hash<UUID>>
+        gracefully_unmounting_segments_;
+    std::unordered_map<UUID, std::function<void(const UUID&)>,
+                       boost::hash<UUID>>
+        graceful_unmount_cleanup_callbacks_;
+
     /**
      * @brief Internal helper to unmount a segment by iterator.
      *        Caller must hold mounted_segments_mutex_.
      */
     tl::expected<void, ErrorCode> UnmountSegmentImpl(
         std::unordered_map<UUID, Segment, boost::hash<UUID>>::iterator it);
+
+    void StartGracefulUnmountTimer(const UUID& segment_id,
+                                   uint64_t grace_period_ms);
+    void OnGracefulUnmountTimer(const UUID& segment_id, int retry_left);
+    bool WaitForGracefulUnmountDelay(std::chrono::milliseconds delay);
+    std::mutex graceful_unmount_timer_mutex_;
+    std::condition_variable graceful_unmount_timer_cv_;
+    bool graceful_unmount_timer_stopping_{false};
 
     // Configuration
     const std::string local_hostname_;

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -14,6 +14,7 @@
 
 #include "client_metric.h"
 #include "replica.h"
+#include "segment.h"
 #include "types.h"
 #include "rpc_types.h"
 #include "master_metric_manager.h"
@@ -315,12 +316,18 @@ class MasterClient {
     [[nodiscard]] tl::expected<void, ErrorCode> UnmountSegment(
         const UUID& segment_id);
 
+    [[nodiscard]] tl::expected<void, ErrorCode> GracefulUnmountSegment(
+        const UUID& segment_id, uint64_t grace_period_ms);
+
     /**
      * @brief Gets the cluster ID for the current client to use as subdirectory
      * name
      * @return GetClusterIdResponse containing the cluster ID
      */
     [[nodiscard]] tl::expected<std::string, ErrorCode> GetFsdir();
+
+    [[nodiscard]] tl::expected<SegmentStatus, ErrorCode> QuerySegmentStatus(
+        const std::string& segment_name);
 
     [[nodiscard]] tl::expected<GetStorageConfigResponse, ErrorCode>
     GetStorageConfig();

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -329,6 +329,9 @@ class MasterClient {
     [[nodiscard]] tl::expected<SegmentStatus, ErrorCode> QuerySegmentStatus(
         const std::string& segment_name);
 
+    [[nodiscard]] tl::expected<SegmentStatus, ErrorCode> QuerySegmentStatusById(
+        const UUID& segment_id);
+
     [[nodiscard]] tl::expected<GetStorageConfigResponse, ErrorCode>
     GetStorageConfig();
 

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -326,9 +326,6 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<std::string, ErrorCode> GetFsdir();
 
-    [[nodiscard]] tl::expected<SegmentStatus, ErrorCode> QuerySegmentStatus(
-        const std::string& segment_name);
-
     [[nodiscard]] tl::expected<SegmentStatus, ErrorCode> QuerySegmentStatusById(
         const UUID& segment_id);
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -499,6 +499,12 @@ class MasterService {
         const std::string& segment_name);
 
     /**
+     * @brief Query current segment lifecycle state by segment id.
+     */
+    tl::expected<SegmentStatus, ErrorCode> QuerySegmentStatusById(
+        const UUID& segment_id);
+
+    /**
      * @brief Query the status of a task
      * @return Task basic info
      */

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -960,6 +960,7 @@ class MasterService {
         struct Record {
             UUID segment_id;
             UUID client_id;
+            uint64_t client_generation;
             std::chrono::steady_clock::time_point expire_time;
             bool operator>(const Record& other) const {
                 return expire_time > other.expire_time;
@@ -969,8 +970,11 @@ class MasterService {
         std::mutex mutex_;
         std::priority_queue<Record, std::vector<Record>, std::greater<Record>>
             queue_;
+        std::unordered_map<UUID, uint64_t, boost::hash<UUID>>
+            client_generations_;
         std::thread timer_thread_;
         std::atomic<bool> timer_running_{false};
+        bool stopping_{false};
         std::condition_variable timer_cv_;
     } graceful_unmount_scheduler_;
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -99,6 +99,10 @@ class MasterService {
     auto UnmountSegment(const UUID& segment_id, const UUID& client_id)
         -> tl::expected<void, ErrorCode>;
 
+    auto GracefulUnmountSegment(const UUID& segment_id, const UUID& client_id,
+                                uint64_t grace_period_ms)
+        -> tl::expected<void, ErrorCode>;
+
     /**
      * @brief Check if an object exists
      * @return ErrorCode::OK if exists, otherwise return other ErrorCode
@@ -934,6 +938,35 @@ class MasterService {
 
     tl::expected<void, ErrorCode> PushOffloadingQueue(const std::string& key,
                                                       Replica& replica);
+
+    // Graceful unmount scheduler
+    class GracefulUnmountScheduler {
+       public:
+        explicit GracefulUnmountScheduler(MasterService* service);
+        ~GracefulUnmountScheduler();
+        void Schedule(const UUID& segment_id, const UUID& client_id,
+                      std::chrono::steady_clock::time_point expire_time);
+        void RemoveClientRecords(const UUID& client_id);
+        void Stop();
+
+       private:
+        void TimerLoop();
+        struct Record {
+            UUID segment_id;
+            UUID client_id;
+            std::chrono::steady_clock::time_point expire_time;
+            bool operator>(const Record& other) const {
+                return expire_time > other.expire_time;
+            }
+        };
+        MasterService* service_;
+        std::mutex mutex_;
+        std::priority_queue<Record, std::vector<Record>, std::greater<Record>>
+            queue_;
+        std::thread timer_thread_;
+        std::atomic<bool> timer_running_{false};
+        std::condition_variable timer_cv_;
+    } graceful_unmount_scheduler_;
 
     // Lease related members
     const uint64_t default_kv_lease_ttl_;     // in milliseconds

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -960,7 +960,6 @@ class MasterService {
         struct Record {
             UUID segment_id;
             UUID client_id;
-            uint64_t client_generation;
             std::chrono::steady_clock::time_point expire_time;
             bool operator>(const Record& other) const {
                 return expire_time > other.expire_time;
@@ -970,8 +969,6 @@ class MasterService {
         std::mutex mutex_;
         std::priority_queue<Record, std::vector<Record>, std::greater<Record>>
             queue_;
-        std::unordered_map<UUID, uint64_t, boost::hash<UUID>>
-            client_generations_;
         std::thread timer_thread_;
         std::atomic<bool> timer_running_{false};
         bool stopping_{false};

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -695,8 +695,10 @@ class RealClient : public PyClient {
 
     /**
      * @brief Unmount segments by their ids and clean up local mmap/fd.
+     * @param grace_period_seconds 0 = immediate unmount (legacy behavior).
      */
-    int unmountSegment(const std::vector<std::string> &segment_ids);
+    int unmountSegment(const std::vector<std::string> &segment_ids,
+                       uint64_t grace_period_seconds = 0);
 
     /**
      * @brief Allocate memory internally and mount segments to master.
@@ -712,8 +714,10 @@ class RealClient : public PyClient {
 
     /**
      * @brief Unmount segments by their ids and free locally allocated memory.
+     * @param grace_period_seconds 0 = immediate unmount (legacy behavior).
      */
-    int unmountAndFreeSegment(const std::vector<std::string> &segment_ids);
+    int unmountAndFreeSegment(const std::vector<std::string> &segment_ids,
+                              uint64_t grace_period_seconds = 0);
 
     struct MountedSegmentRecord {
         void *mmap_base = nullptr;
@@ -872,6 +876,11 @@ class RealClient : public PyClient {
     std::unordered_map<std::string, AllocatedSegmentRecord>
         allocated_segment_records_;
     std::mutex allocated_segment_records_mutex_;
+
+    void ReleaseMountedSegmentRecord(const std::string &segment_id);
+    void ReleaseAllMountedSegmentRecords();
+    void ReleaseAllocatedSegmentRecord(const std::string &segment_id);
+    void ReleaseAllAllocatedSegmentRecords();
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -124,6 +124,10 @@ class WrappedMasterService {
     tl::expected<void, ErrorCode> UnmountSegment(const UUID& segment_id,
                                                  const UUID& client_id);
 
+    tl::expected<void, ErrorCode> GracefulUnmountSegment(
+        const UUID& segment_id, const UUID& client_id,
+        uint64_t grace_period_ms);
+
     tl::expected<std::string, ErrorCode> GetFsdir();
 
     tl::expected<GetStorageConfigResponse, ErrorCode> GetStorageConfig();

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -165,6 +165,8 @@ class WrappedMasterService {
 
     tl::expected<SegmentStatus, ErrorCode> QuerySegmentStatus(
         const std::string& segment_name);
+    tl::expected<SegmentStatus, ErrorCode> QuerySegmentStatusById(
+        const UUID& segment_id);
     tl::expected<UUID, ErrorCode> CreateCopyTask(
         const std::string& key, const std::vector<std::string>& targets);
 

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -175,6 +175,12 @@ class ScopedSegmentAccess {
                                      SegmentStatus& status) const;
 
     /**
+     * @brief Query the lifecycle status of a segment by id.
+     */
+    ErrorCode GetSegmentStatusById(const UUID& segment_id,
+                                   SegmentStatus& status) const;
+
+    /**
      * @brief Update the lifecycle status of a segment by name.
      */
     ErrorCode SetSegmentStatusByName(const std::string& segment_name,

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -21,7 +21,8 @@ enum class SegmentStatus {
     OK,             // Segment is mounted and available for allocation
     DRAINING,       // Segment remains readable but accepts no new allocations
     DRAINED,        // Segment has been drained and awaits unmount
-    UNMOUNTING,     // Segment is under unmounting
+    GRACEFULLY_UNMOUNTING,  // Readable, no new allocations, timer running
+    UNMOUNTING,             // Segment is under unmounting
 };
 
 /**
@@ -30,11 +31,13 @@ enum class SegmentStatus {
 inline std::ostream& operator<<(std::ostream& os,
                                 const SegmentStatus& status) noexcept {
     static const std::unordered_map<SegmentStatus, std::string_view>
-        status_strings{{SegmentStatus::UNDEFINED, "UNDEFINED"},
-                       {SegmentStatus::OK, "OK"},
-                       {SegmentStatus::DRAINING, "DRAINING"},
-                       {SegmentStatus::DRAINED, "DRAINED"},
-                       {SegmentStatus::UNMOUNTING, "UNMOUNTING"}};
+        status_strings{
+            {SegmentStatus::UNDEFINED, "UNDEFINED"},
+            {SegmentStatus::OK, "OK"},
+            {SegmentStatus::DRAINING, "DRAINING"},
+            {SegmentStatus::DRAINED, "DRAINED"},
+            {SegmentStatus::GRACEFULLY_UNMOUNTING, "GRACEFULLY_UNMOUNTING"},
+            {SegmentStatus::UNMOUNTING, "UNMOUNTING"}};
 
     os << (status_strings.count(status) ? status_strings.at(status)
                                         : "UNKNOWN");
@@ -101,6 +104,12 @@ class ScopedSegmentAccess {
      */
     ErrorCode PrepareUnmountSegment(const UUID& segment_id,
                                     size_t& metrics_dec_capacity);
+
+    /**
+     * @brief Prepare a segment for graceful unmount: remove allocator but keep
+     *        segment metadata. Status becomes GRACEFULLY_UNMOUNTING.
+     */
+    ErrorCode PrepareGracefulUnmountSegment(const UUID& segment_id);
 
     /**
      * @brief Deleting the segment to complete the unmounting operation

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2,6 +2,8 @@
 
 #include <glog/logging.h>
 
+#include "segment.h"
+
 #include <csignal>
 #include <algorithm>
 #include <cassert>
@@ -98,22 +100,37 @@ Client::~Client() {
         leader_monitor_thread_.join();
     }
 
-    // Make a copy of mounted_segments_ to avoid modifying while iterating
-    std::vector<Segment> segments_to_unmount;
+    // Make copies to avoid modifying while iterating
+    std::vector<Segment> mounted_segments_copy;
+    std::vector<Segment> gracefully_unmounting_segments_copy;
     {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
-        segments_to_unmount.reserve(mounted_segments_.size());
+        mounted_segments_copy.reserve(mounted_segments_.size());
         for (auto& entry : mounted_segments_) {
-            segments_to_unmount.emplace_back(entry.second);
+            mounted_segments_copy.emplace_back(entry.second);
+        }
+        for (auto& entry : gracefully_unmounting_segments_) {
+            gracefully_unmounting_segments_copy.emplace_back(entry.second);
         }
     }
 
-    for (auto& segment : segments_to_unmount) {
+    // Unmount mounted segments: notify master + local cleanup
+    for (auto& segment : mounted_segments_copy) {
         auto result =
             UnmountSegment(reinterpret_cast<void*>(segment.base), segment.size);
         if (!result) {
-            LOG(ERROR) << "Failed to unmount segment: "
+            LOG(ERROR) << "Failed to unmount segment in destructor: "
                        << toString(result.error());
+        }
+    }
+
+    // Unregister gracefully unmounting segments: master already has timer
+    for (auto& segment : gracefully_unmounting_segments_copy) {
+        int rc = transfer_engine_->unregisterLocalMemory(
+            reinterpret_cast<void*>(segment.base));
+        if (rc != 0 && rc != ERR_ADDRESS_NOT_REGISTERED) {
+            LOG(ERROR) << "Failed to unregister transfer buffer in destructor: "
+                       << rc;
         }
     }
 
@@ -121,7 +138,14 @@ Client::~Client() {
     {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
         mounted_segments_.clear();
+        gracefully_unmounting_segments_.clear();
+        graceful_unmount_cleanup_callbacks_.clear();
     }
+    {
+        std::lock_guard<std::mutex> lock(graceful_unmount_timer_mutex_);
+        graceful_unmount_timer_stopping_ = true;
+    }
+    graceful_unmount_timer_cv_.notify_all();
 
     // Stop hot cache handler and hot cache
     hot_cache_handler_.reset();
@@ -2203,7 +2227,8 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
 }
 
 tl::expected<void, ErrorCode> Client::UnmountSegmentById(
-    const UUID& segment_id) {
+    const UUID& segment_id, uint64_t grace_period_ms,
+    std::function<void(const UUID&)> cleanup_callback) {
     std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
     auto segment = mounted_segments_.find(segment_id);
     if (segment == mounted_segments_.end()) {
@@ -2211,7 +2236,117 @@ tl::expected<void, ErrorCode> Client::UnmountSegmentById(
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    return UnmountSegmentImpl(segment);
+    if (grace_period_ms == 0) {
+        return UnmountSegmentImpl(segment);
+    }
+
+    auto result =
+        master_client_.GracefulUnmountSegment(segment_id, grace_period_ms);
+    if (!result) {
+        ErrorCode err = result.error();
+        LOG(ERROR) << "Failed to graceful unmount segment from master: "
+                   << toString(err);
+        return tl::unexpected(err);
+    }
+
+    gracefully_unmounting_segments_.emplace(segment->first, segment->second);
+    if (cleanup_callback) {
+        graceful_unmount_cleanup_callbacks_[segment->first] =
+            std::move(cleanup_callback);
+    }
+    mounted_segments_.erase(segment);
+    StartGracefulUnmountTimer(segment_id, grace_period_ms);
+    return {};
+}
+
+bool Client::WaitForGracefulUnmountDelay(std::chrono::milliseconds delay) {
+    std::unique_lock<std::mutex> lock(graceful_unmount_timer_mutex_);
+    return graceful_unmount_timer_cv_.wait_for(
+        lock, delay, [this]() { return graceful_unmount_timer_stopping_; });
+}
+
+void Client::StartGracefulUnmountTimer(const UUID& segment_id,
+                                       uint64_t grace_period_ms) {
+    auto delay =
+        std::chrono::milliseconds(grace_period_ms) + std::chrono::seconds(10);
+    task_thread_pool_.enqueue([this, segment_id, delay]() {
+        if (this->WaitForGracefulUnmountDelay(delay)) {
+            return;
+        }
+        this->OnGracefulUnmountTimer(segment_id, /*retry_left=*/3);
+    });
+}
+
+void Client::OnGracefulUnmountTimer(const UUID& segment_id, int retry_left) {
+    // Query master to confirm the segment has been removed
+    std::string segment_name;
+    {
+        std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+        auto it = gracefully_unmounting_segments_.find(segment_id);
+        if (it == gracefully_unmounting_segments_.end()) {
+            // Already cleaned up (e.g. by destructor)
+            return;
+        }
+        segment_name = it->second.name;
+    }
+
+    auto status = master_client_.QuerySegmentStatus(segment_name);
+    bool removed = false;
+    if (!status) {
+        if (status.error() == ErrorCode::SEGMENT_NOT_FOUND) {
+            removed = true;
+        } else {
+            LOG(WARNING) << "Failed to query graceful unmount segment status: "
+                         << toString(status.error());
+        }
+    } else if (status.value() == SegmentStatus::UNDEFINED) {
+        removed = true;
+    }
+
+    if (removed) {
+        std::function<void(const UUID&)> cleanup_callback;
+        {
+            std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+            auto it = gracefully_unmounting_segments_.find(segment_id);
+            if (it != gracefully_unmounting_segments_.end()) {
+                int rc = transfer_engine_->unregisterLocalMemory(
+                    reinterpret_cast<void*>(it->second.base));
+                if (rc != 0 && rc != ERR_ADDRESS_NOT_REGISTERED) {
+                    LOG(ERROR)
+                        << "Failed to unregister TE MR for graceful unmount: "
+                        << rc;
+                }
+                gracefully_unmounting_segments_.erase(it);
+            }
+            auto callback_it =
+                graceful_unmount_cleanup_callbacks_.find(segment_id);
+            if (callback_it != graceful_unmount_cleanup_callbacks_.end()) {
+                cleanup_callback = std::move(callback_it->second);
+                graceful_unmount_cleanup_callbacks_.erase(callback_it);
+            }
+        }
+        if (cleanup_callback) {
+            cleanup_callback(segment_id);
+        }
+        return;
+    }
+
+    if (retry_left > 0) {
+        try {
+            task_thread_pool_.enqueue([this, segment_id, retry_left]() {
+                if (this->WaitForGracefulUnmountDelay(
+                        std::chrono::seconds(10))) {
+                    return;
+                }
+                this->OnGracefulUnmountTimer(segment_id, retry_left - 1);
+            });
+        } catch (const std::runtime_error& e) {
+            VLOG(1) << "Skip graceful unmount retry enqueue: " << e.what();
+        }
+    } else {
+        LOG(WARNING) << "Graceful unmount cleanup timeout for segment "
+                     << segment_name;
+    }
 }
 
 tl::expected<void, ErrorCode> Client::RegisterLocalMemory(

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -100,9 +100,21 @@ Client::~Client() {
         leader_monitor_thread_.join();
     }
 
+    {
+        std::lock_guard<std::mutex> lock(graceful_unmount_timer_mutex_);
+        graceful_unmount_timer_stopping_ = true;
+    }
+    graceful_unmount_timer_cv_.notify_all();
+
+    // Stop queued timer/task callbacks before tearing down segment state.
+    task_running_ = false;
+    task_thread_pool_.stop();
+
     // Make copies to avoid modifying while iterating
     std::vector<Segment> mounted_segments_copy;
     std::vector<Segment> gracefully_unmounting_segments_copy;
+    std::vector<std::pair<UUID, std::function<void(const UUID&)>>>
+        graceful_cleanup_callbacks;
     {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
         mounted_segments_copy.reserve(mounted_segments_.size());
@@ -112,6 +124,13 @@ Client::~Client() {
         for (auto& entry : gracefully_unmounting_segments_) {
             gracefully_unmounting_segments_copy.emplace_back(entry.second);
         }
+        graceful_cleanup_callbacks.reserve(
+            graceful_unmount_cleanup_callbacks_.size());
+        for (auto& entry : graceful_unmount_cleanup_callbacks_) {
+            graceful_cleanup_callbacks.emplace_back(entry.first,
+                                                    std::move(entry.second));
+        }
+        graceful_unmount_cleanup_callbacks_.clear();
     }
 
     // Unmount mounted segments: notify master + local cleanup
@@ -139,21 +158,17 @@ Client::~Client() {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
         mounted_segments_.clear();
         gracefully_unmounting_segments_.clear();
-        graceful_unmount_cleanup_callbacks_.clear();
     }
-    {
-        std::lock_guard<std::mutex> lock(graceful_unmount_timer_mutex_);
-        graceful_unmount_timer_stopping_ = true;
+
+    for (auto& entry : graceful_cleanup_callbacks) {
+        if (entry.second) {
+            entry.second(entry.first);
+        }
     }
-    graceful_unmount_timer_cv_.notify_all();
 
     // Stop hot cache handler and hot cache
     hot_cache_handler_.reset();
     hot_cache_.reset();
-
-    // Stop task thread pool after task polling has stopped.
-    task_running_ = false;
-    task_thread_pool_.stop();
 }
 
 static std::optional<bool> get_auto_discover() {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2279,7 +2279,6 @@ void Client::StartGracefulUnmountTimer(const UUID& segment_id,
 
 void Client::OnGracefulUnmountTimer(const UUID& segment_id, int retry_left) {
     // Query master to confirm the segment has been removed
-    std::string segment_name;
     {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
         auto it = gracefully_unmounting_segments_.find(segment_id);
@@ -2287,10 +2286,9 @@ void Client::OnGracefulUnmountTimer(const UUID& segment_id, int retry_left) {
             // Already cleaned up (e.g. by destructor)
             return;
         }
-        segment_name = it->second.name;
     }
 
-    auto status = master_client_.QuerySegmentStatus(segment_name);
+    auto status = master_client_.QuerySegmentStatusById(segment_id);
     bool removed = false;
     if (!status) {
         if (status.error() == ErrorCode::SEGMENT_NOT_FOUND) {
@@ -2345,7 +2343,7 @@ void Client::OnGracefulUnmountTimer(const UUID& segment_id, int retry_left) {
         }
     } else {
         LOG(WARNING) << "Graceful unmount cleanup timeout for segment "
-                     << segment_name;
+                     << UuidToString(segment_id);
     }
 }
 

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -178,6 +178,11 @@ struct RpcNameTraits<&WrappedMasterService::QuerySegmentStatus> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::QuerySegmentStatusById> {
+    static constexpr const char* value = "QuerySegmentStatusById";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::GetStorageConfig> {
     static constexpr const char* value = "GetStorageConfig";
 };
@@ -784,6 +789,17 @@ tl::expected<SegmentStatus, ErrorCode> MasterClient::QuerySegmentStatus(
     auto result =
         invoke_rpc<&WrappedMasterService::QuerySegmentStatus, SegmentStatus>(
             segment_name);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<SegmentStatus, ErrorCode> MasterClient::QuerySegmentStatusById(
+    const UUID& segment_id) {
+    ScopedVLogTimer timer(1, "MasterClient::QuerySegmentStatusById");
+    timer.LogRequest("segment_id=", segment_id);
+
+    auto result = invoke_rpc<&WrappedMasterService::QuerySegmentStatusById,
+                             SegmentStatus>(segment_id);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -173,11 +173,6 @@ struct RpcNameTraits<&WrappedMasterService::GetFsdir> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::QuerySegmentStatus> {
-    static constexpr const char* value = "QuerySegmentStatus";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::QuerySegmentStatusById> {
     static constexpr const char* value = "QuerySegmentStatusById";
 };
@@ -777,18 +772,6 @@ tl::expected<std::string, ErrorCode> MasterClient::GetFsdir() {
     timer.LogRequest("action=get_fsdir");
 
     auto result = invoke_rpc<&WrappedMasterService::GetFsdir, std::string>();
-    timer.LogResponseExpected(result);
-    return result;
-}
-
-tl::expected<SegmentStatus, ErrorCode> MasterClient::QuerySegmentStatus(
-    const std::string& segment_name) {
-    ScopedVLogTimer timer(1, "MasterClient::QuerySegmentStatus");
-    timer.LogRequest("segment_name=", segment_name);
-
-    auto result =
-        invoke_rpc<&WrappedMasterService::QuerySegmentStatus, SegmentStatus>(
-            segment_name);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -158,6 +158,11 @@ struct RpcNameTraits<&WrappedMasterService::UnmountSegment> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::GracefulUnmountSegment> {
+    static constexpr const char* value = "GracefulUnmountSegment";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::Ping> {
     static constexpr const char* value = "Ping";
 };
@@ -165,6 +170,11 @@ struct RpcNameTraits<&WrappedMasterService::Ping> {
 template <>
 struct RpcNameTraits<&WrappedMasterService::GetFsdir> {
     static constexpr const char* value = "GetFsdir";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::QuerySegmentStatus> {
+    static constexpr const char* value = "QuerySegmentStatus";
 };
 
 template <>
@@ -734,6 +744,19 @@ tl::expected<void, ErrorCode> MasterClient::UnmountSegment(
     return result;
 }
 
+tl::expected<void, ErrorCode> MasterClient::GracefulUnmountSegment(
+    const UUID& segment_id, uint64_t grace_period_ms) {
+    ScopedVLogTimer timer(1, "MasterClient::GracefulUnmountSegment");
+    timer.LogRequest("segment_id=", segment_id, ", client_id=", client_id_,
+                     ", grace_period_ms=", grace_period_ms);
+
+    auto result =
+        invoke_rpc<&WrappedMasterService::GracefulUnmountSegment, void>(
+            segment_id, client_id_, grace_period_ms);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
 tl::expected<PingResponse, ErrorCode> MasterClient::Ping() {
     ScopedVLogTimer timer(1, "MasterClient::Ping");
     timer.LogRequest("client_id=", client_id_);
@@ -749,6 +772,18 @@ tl::expected<std::string, ErrorCode> MasterClient::GetFsdir() {
     timer.LogRequest("action=get_fsdir");
 
     auto result = invoke_rpc<&WrappedMasterService::GetFsdir, std::string>();
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<SegmentStatus, ErrorCode> MasterClient::QuerySegmentStatus(
+    const std::string& segment_name) {
+    ScopedVLogTimer timer(1, "MasterClient::QuerySegmentStatus");
+    timer.LogRequest("segment_name=", segment_name);
+
+    auto result =
+        invoke_rpc<&WrappedMasterService::QuerySegmentStatus, SegmentStatus>(
+            segment_name);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -575,6 +575,17 @@ auto MasterService::QuerySegmentStatus(const std::string& segment_name)
     return status;
 }
 
+auto MasterService::QuerySegmentStatusById(const UUID& segment_id)
+    -> tl::expected<SegmentStatus, ErrorCode> {
+    ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
+    SegmentStatus status = SegmentStatus::UNDEFINED;
+    auto err = segment_access.GetSegmentStatusById(segment_id, status);
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+    return status;
+}
+
 auto MasterService::QueryIp(const UUID& client_id)
     -> tl::expected<std::vector<std::string>, ErrorCode> {
     ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -466,7 +466,7 @@ auto MasterService::GracefulUnmountSegment(const UUID& segment_id,
                                            const UUID& client_id,
                                            uint64_t grace_period_ms)
     -> tl::expected<void, ErrorCode> {
-    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    std::unique_lock<std::shared_mutex> lock(snapshot_mutex_);
     ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
 
     // Verify ownership: the segment must belong to the calling client
@@ -5301,7 +5301,11 @@ void MasterService::GracefulUnmountScheduler::Schedule(
     std::chrono::steady_clock::time_point expire_time) {
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        queue_.push(Record{segment_id, client_id, expire_time});
+        if (stopping_) {
+            return;
+        }
+        auto generation = client_generations_[client_id];
+        queue_.push(Record{segment_id, client_id, generation, expire_time});
         if (!timer_running_.load()) {
             timer_running_.store(true);
             timer_thread_ = std::thread([this]() { this->TimerLoop(); });
@@ -5313,23 +5317,14 @@ void MasterService::GracefulUnmountScheduler::Schedule(
 void MasterService::GracefulUnmountScheduler::RemoveClientRecords(
     const UUID& client_id) {
     std::lock_guard<std::mutex> lock(mutex_);
-    std::vector<Record> remaining;
-    remaining.reserve(queue_.size());
-    while (!queue_.empty()) {
-        auto rec = queue_.top();
-        queue_.pop();
-        if (rec.client_id != client_id) {
-            remaining.push_back(rec);
-        }
-    }
-    for (auto& rec : remaining) {
-        queue_.push(rec);
-    }
+    ++client_generations_[client_id];
+    timer_cv_.notify_one();
 }
 
 void MasterService::GracefulUnmountScheduler::Stop() {
     {
         std::lock_guard<std::mutex> lock(mutex_);
+        stopping_ = true;
         timer_running_.store(false);
     }
     timer_cv_.notify_all();
@@ -5369,6 +5364,14 @@ void MasterService::GracefulUnmountScheduler::TimerLoop() {
         lock.unlock();
 
         for (auto& rec : expired) {
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                auto generation_it = client_generations_.find(rec.client_id);
+                if (generation_it != client_generations_.end() &&
+                    generation_it->second != rec.client_generation) {
+                    continue;
+                }
+            }
             if (service_) {
                 service_->UnmountSegment(rec.segment_id, rec.client_id);
             }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -5304,8 +5304,7 @@ void MasterService::GracefulUnmountScheduler::Schedule(
         if (stopping_) {
             return;
         }
-        auto generation = client_generations_[client_id];
-        queue_.push(Record{segment_id, client_id, generation, expire_time});
+        queue_.push(Record{segment_id, client_id, expire_time});
         if (!timer_running_.load()) {
             timer_running_.store(true);
             timer_thread_ = std::thread([this]() { this->TimerLoop(); });
@@ -5317,7 +5316,18 @@ void MasterService::GracefulUnmountScheduler::Schedule(
 void MasterService::GracefulUnmountScheduler::RemoveClientRecords(
     const UUID& client_id) {
     std::lock_guard<std::mutex> lock(mutex_);
-    ++client_generations_[client_id];
+    std::vector<Record> remaining;
+    remaining.reserve(queue_.size());
+    while (!queue_.empty()) {
+        auto rec = queue_.top();
+        queue_.pop();
+        if (rec.client_id != client_id) {
+            remaining.push_back(rec);
+        }
+    }
+    for (auto& rec : remaining) {
+        queue_.push(rec);
+    }
     timer_cv_.notify_one();
 }
 
@@ -5361,19 +5371,17 @@ void MasterService::GracefulUnmountScheduler::TimerLoop() {
             expired.push_back(queue_.top());
             queue_.pop();
         }
-        lock.unlock();
 
         for (auto& rec : expired) {
-            {
-                std::lock_guard<std::mutex> lock(mutex_);
-                auto generation_it = client_generations_.find(rec.client_id);
-                if (generation_it != client_generations_.end() &&
-                    generation_it->second != rec.client_generation) {
-                    continue;
-                }
-            }
             if (service_) {
-                service_->UnmountSegment(rec.segment_id, rec.client_id);
+                auto result =
+                    service_->UnmountSegment(rec.segment_id, rec.client_id);
+                if (!result.has_value()) {
+                    LOG(WARNING)
+                        << "Failed to complete graceful unmount, segment_id="
+                        << rec.segment_id << ", client_id=" << rec.client_id
+                        << ", error=" << toString(result.error());
+                }
             }
         }
     }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -84,7 +84,8 @@ int64_t CurrentTimeMs() {
 MasterService::MasterService() : MasterService(MasterServiceConfig()) {}
 
 MasterService::MasterService(const MasterServiceConfig& config)
-    : default_kv_lease_ttl_(config.default_kv_lease_ttl),
+    : graceful_unmount_scheduler_(this),
+      default_kv_lease_ttl_(config.default_kv_lease_ttl),
       default_kv_soft_pin_ttl_(config.default_kv_soft_pin_ttl),
       allow_evict_soft_pinned_objects_(config.allow_evict_soft_pinned_objects),
       eviction_ratio_(config.eviction_ratio),
@@ -264,6 +265,7 @@ MasterService::~MasterService() {
     snapshot_running_ = false;
     task_cleanup_running_ = false;
     job_dispatch_running_ = false;
+    graceful_unmount_scheduler_.Stop();
 
     // Wake sleepers so join() doesn't block for long sleep intervals.
     task_cleanup_cv_.notify_all();
@@ -457,6 +459,44 @@ auto MasterService::UnmountSegment(const UUID& segment_id,
     if (err != ErrorCode::OK) {
         return tl::make_unexpected(err);
     }
+    return {};
+}
+
+auto MasterService::GracefulUnmountSegment(const UUID& segment_id,
+                                           const UUID& client_id,
+                                           uint64_t grace_period_ms)
+    -> tl::expected<void, ErrorCode> {
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
+
+    // Verify ownership: the segment must belong to the calling client
+    std::vector<Segment> client_segments;
+    auto err = segment_access.GetClientSegments(client_id, client_segments);
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+    bool owned = false;
+    for (auto& seg : client_segments) {
+        if (seg.id == segment_id) {
+            owned = true;
+            break;
+        }
+    }
+    if (!owned) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    err = segment_access.PrepareGracefulUnmountSegment(segment_id);
+    if (err == ErrorCode::SEGMENT_NOT_FOUND) {
+        return {};
+    }
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+
+    auto expire_time = std::chrono::steady_clock::now() +
+                       std::chrono::milliseconds(grace_period_ms);
+    graceful_unmount_scheduler_.Schedule(segment_id, client_id, expire_time);
     return {};
 }
 
@@ -3938,6 +3978,12 @@ void MasterService::ClientMonitorFunc() {
 
         // Update the client status to NEED_REMOUNT
         if (!expired_clients.empty()) {
+            // Notify graceful unmount scheduler to drop pending records
+            // for expired clients. The actual unmount is handled below.
+            for (auto& cid : expired_clients) {
+                graceful_unmount_scheduler_.RemoveClientRecords(cid);
+            }
+
             // Record which segments are unmounted, will be used in the commit
             // phase.
             std::vector<UUID> unmount_segments;
@@ -5227,6 +5273,96 @@ MasterService::MetadataSerializer::DeserializeDiscardedReplicas(
     }
 
     return {};
+}
+
+// ---------------------------------------------------------------------------
+// GracefulUnmountScheduler implementation
+// ---------------------------------------------------------------------------
+
+MasterService::GracefulUnmountScheduler::GracefulUnmountScheduler(
+    MasterService* service)
+    : service_(service) {}
+
+MasterService::GracefulUnmountScheduler::~GracefulUnmountScheduler() { Stop(); }
+
+void MasterService::GracefulUnmountScheduler::Schedule(
+    const UUID& segment_id, const UUID& client_id,
+    std::chrono::steady_clock::time_point expire_time) {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        queue_.push(Record{segment_id, client_id, expire_time});
+        if (!timer_running_.load()) {
+            timer_running_.store(true);
+            timer_thread_ = std::thread([this]() { this->TimerLoop(); });
+        }
+    }
+    timer_cv_.notify_one();
+}
+
+void MasterService::GracefulUnmountScheduler::RemoveClientRecords(
+    const UUID& client_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<Record> remaining;
+    remaining.reserve(queue_.size());
+    while (!queue_.empty()) {
+        auto rec = queue_.top();
+        queue_.pop();
+        if (rec.client_id != client_id) {
+            remaining.push_back(rec);
+        }
+    }
+    for (auto& rec : remaining) {
+        queue_.push(rec);
+    }
+}
+
+void MasterService::GracefulUnmountScheduler::Stop() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        timer_running_.store(false);
+    }
+    timer_cv_.notify_all();
+    if (timer_thread_.joinable()) {
+        timer_thread_.join();
+    }
+}
+
+void MasterService::GracefulUnmountScheduler::TimerLoop() {
+    while (timer_running_.load()) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (queue_.empty()) {
+            timer_cv_.wait(lock, [this]() {
+                return !timer_running_.load() || !queue_.empty();
+            });
+            if (!timer_running_.load()) break;
+            continue;
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        auto next_expire = queue_.top().expire_time;
+        if (next_expire > now) {
+            timer_cv_.wait_until(lock, next_expire, [this, next_expire]() {
+                return !timer_running_.load() || queue_.empty() ||
+                       queue_.top().expire_time < next_expire;
+            });
+            if (!timer_running_.load()) break;
+            continue;
+        }
+
+        // Collect all expired records
+        std::vector<Record> expired;
+        while (!queue_.empty() && queue_.top().expire_time <= now) {
+            expired.push_back(queue_.top());
+            queue_.pop();
+        }
+        lock.unlock();
+
+        for (auto& rec : expired) {
+            if (service_) {
+                service_->UnmountSegment(rec.segment_id, rec.client_id);
+            }
+        }
+    }
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1295,6 +1295,11 @@ int RealClient::unmountSegment(const std::vector<std::string> &segment_ids,
 
     uint64_t grace_period_ms = grace_period_seconds * 1000;
     int first_error = 0;
+    struct SegmentToUnmount {
+        std::string segment_id;
+        UUID id;
+    };
+    std::vector<SegmentToUnmount> to_unmount;
     std::vector<std::pair<std::string, MountedSegmentRecord>> to_cleanup;
     {
         std::lock_guard<std::mutex> lock(mounted_segment_records_mutex_);
@@ -1314,27 +1319,35 @@ int RealClient::unmountSegment(const std::vector<std::string> &segment_ids,
                 continue;
             }
 
-            std::function<void(const UUID &)> cleanup_callback;
-            if (grace_period_ms != 0) {
-                cleanup_callback = [this](const UUID &cleanup_id) {
-                    ReleaseMountedSegmentRecord(UuidToString(cleanup_id));
-                };
-            }
-            auto result = client_->UnmountSegmentById(
-                id, grace_period_ms, std::move(cleanup_callback));
-            if (!result.has_value()) {
-                LOG(ERROR) << "UnmountSegmentById failed for " << segment_id;
-                if (first_error == 0) {
-                    first_error = static_cast<int>(result.error());
-                }
-                continue;  // Don't release local resources on failure
-            }
+            to_unmount.push_back({segment_id, id});
+        }
+    }
 
-            // For immediate unmount, clean up local mmap/fd right away.
-            // For graceful unmount, local mmap/fd is kept until the segment
-            // is actually removed or the client destructor runs.
-            if (grace_period_ms == 0) {
-                to_cleanup.emplace_back(segment_id, it->second);
+    for (auto &entry : to_unmount) {
+        std::function<void(const UUID &)> cleanup_callback;
+        if (grace_period_ms != 0) {
+            cleanup_callback = [this](const UUID &cleanup_id) {
+                ReleaseMountedSegmentRecord(UuidToString(cleanup_id));
+            };
+        }
+        auto result = client_->UnmountSegmentById(entry.id, grace_period_ms,
+                                                  std::move(cleanup_callback));
+        if (!result.has_value()) {
+            LOG(ERROR) << "UnmountSegmentById failed for " << entry.segment_id;
+            if (first_error == 0) {
+                first_error = static_cast<int>(result.error());
+            }
+            continue;  // Don't release local resources on failure
+        }
+
+        // For immediate unmount, clean up local mmap/fd right away.
+        // For graceful unmount, local mmap/fd is kept until the segment
+        // is actually removed or the client destructor runs.
+        if (grace_period_ms == 0) {
+            std::lock_guard<std::mutex> lock(mounted_segment_records_mutex_);
+            auto it = mounted_segment_records_.find(entry.segment_id);
+            if (it != mounted_segment_records_.end()) {
+                to_cleanup.emplace_back(entry.segment_id, it->second);
                 mounted_segment_records_.erase(it);
             }
         }
@@ -1462,6 +1475,11 @@ int RealClient::unmountAndFreeSegment(
 
     uint64_t grace_period_ms = grace_period_seconds * 1000;
     int first_error = 0;
+    struct SegmentToUnmount {
+        std::string segment_id;
+        UUID id;
+    };
+    std::vector<SegmentToUnmount> to_unmount;
     std::vector<std::pair<std::string, AllocatedSegmentRecord>> to_cleanup;
     {
         std::lock_guard<std::mutex> lock(allocated_segment_records_mutex_);
@@ -1481,24 +1499,32 @@ int RealClient::unmountAndFreeSegment(
                 continue;
             }
 
-            std::function<void(const UUID &)> cleanup_callback;
-            if (grace_period_ms != 0) {
-                cleanup_callback = [this](const UUID &cleanup_id) {
-                    ReleaseAllocatedSegmentRecord(UuidToString(cleanup_id));
-                };
-            }
-            auto result = client_->UnmountSegmentById(
-                id, grace_period_ms, std::move(cleanup_callback));
-            if (!result.has_value()) {
-                LOG(ERROR) << "UnmountSegmentById failed for " << segment_id;
-                if (first_error == 0) {
-                    first_error = static_cast<int>(result.error());
-                }
-                continue;  // Don't release local resources on failure
-            }
+            to_unmount.push_back({segment_id, id});
+        }
+    }
 
-            if (grace_period_ms == 0) {
-                to_cleanup.emplace_back(segment_id, it->second);
+    for (auto &entry : to_unmount) {
+        std::function<void(const UUID &)> cleanup_callback;
+        if (grace_period_ms != 0) {
+            cleanup_callback = [this](const UUID &cleanup_id) {
+                ReleaseAllocatedSegmentRecord(UuidToString(cleanup_id));
+            };
+        }
+        auto result = client_->UnmountSegmentById(entry.id, grace_period_ms,
+                                                  std::move(cleanup_callback));
+        if (!result.has_value()) {
+            LOG(ERROR) << "UnmountSegmentById failed for " << entry.segment_id;
+            if (first_error == 0) {
+                first_error = static_cast<int>(result.error());
+            }
+            continue;  // Don't release local resources on failure
+        }
+
+        if (grace_period_ms == 0) {
+            std::lock_guard<std::mutex> lock(allocated_segment_records_mutex_);
+            auto it = allocated_segment_records_.find(entry.segment_id);
+            if (it != allocated_segment_records_.end()) {
+                to_cleanup.emplace_back(entry.segment_id, it->second);
                 allocated_segment_records_.erase(it);
             }
         }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -15,6 +15,7 @@
 #include <cstdlib>  // for atexit
 #include <algorithm>
 #include <cctype>
+#include <functional>
 #include <limits>
 #include <optional>
 #include <vector>
@@ -1073,19 +1074,10 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
         }
     }
 
-    std::unordered_map<std::string, AllocatedSegmentRecord> records_to_free;
-    {
-        std::lock_guard<std::mutex> lock(allocated_segment_records_mutex_);
-        records_to_free.swap(allocated_segment_records_);
-    }
-    for (const auto &entry : records_to_free) {
-        if (entry.second.base) {
-            free_memory(entry.second.protocol, entry.second.base);
-        }
-    }
-
     // Reset all resources
     client_.reset();
+    ReleaseAllMountedSegmentRecords();
+    ReleaseAllAllocatedSegmentRecords();
     client_buffer_allocator_.reset();
     port_binder_.reset();
     hugepage_segment_ptrs_.clear();
@@ -1230,12 +1222,78 @@ int RealClient::mountSegment(const std::string &path, size_t offset,
     return 0;
 }
 
-int RealClient::unmountSegment(const std::vector<std::string> &segment_ids) {
+void RealClient::ReleaseMountedSegmentRecord(const std::string &segment_id) {
+    MountedSegmentRecord record;
+    bool found = false;
+    {
+        std::lock_guard<std::mutex> lock(mounted_segment_records_mutex_);
+        auto it = mounted_segment_records_.find(segment_id);
+        if (it != mounted_segment_records_.end()) {
+            record = it->second;
+            mounted_segment_records_.erase(it);
+            found = true;
+        }
+    }
+    if (found && record.mmap_base) {
+        munmap(record.mmap_base, record.size);
+    }
+}
+
+void RealClient::ReleaseAllMountedSegmentRecords() {
+    std::vector<MountedSegmentRecord> records;
+    {
+        std::lock_guard<std::mutex> lock(mounted_segment_records_mutex_);
+        records.reserve(mounted_segment_records_.size());
+        for (auto &entry : mounted_segment_records_) {
+            records.push_back(entry.second);
+        }
+        mounted_segment_records_.clear();
+    }
+    for (auto &record : records) {
+        if (record.mmap_base) {
+            munmap(record.mmap_base, record.size);
+        }
+    }
+}
+
+void RealClient::ReleaseAllocatedSegmentRecord(const std::string &segment_id) {
+    AllocatedSegmentRecord record;
+    bool found = false;
+    {
+        std::lock_guard<std::mutex> lock(allocated_segment_records_mutex_);
+        auto it = allocated_segment_records_.find(segment_id);
+        if (it != allocated_segment_records_.end()) {
+            record = it->second;
+            allocated_segment_records_.erase(it);
+            found = true;
+        }
+    }
+    if (found && record.base) {
+        free_memory(record.protocol, record.base);
+    }
+}
+
+void RealClient::ReleaseAllAllocatedSegmentRecords() {
+    std::unordered_map<std::string, AllocatedSegmentRecord> records;
+    {
+        std::lock_guard<std::mutex> lock(allocated_segment_records_mutex_);
+        records.swap(allocated_segment_records_);
+    }
+    for (auto &entry : records) {
+        if (entry.second.base) {
+            free_memory(entry.second.protocol, entry.second.base);
+        }
+    }
+}
+
+int RealClient::unmountSegment(const std::vector<std::string> &segment_ids,
+                               uint64_t grace_period_seconds) {
     if (!client_) {
         LOG(ERROR) << "Client not initialized";
         return -1;
     }
 
+    uint64_t grace_period_ms = grace_period_seconds * 1000;
     int first_error = 0;
     std::vector<std::pair<std::string, MountedSegmentRecord>> to_cleanup;
     {
@@ -1256,7 +1314,14 @@ int RealClient::unmountSegment(const std::vector<std::string> &segment_ids) {
                 continue;
             }
 
-            auto result = client_->UnmountSegmentById(id);
+            std::function<void(const UUID &)> cleanup_callback;
+            if (grace_period_ms != 0) {
+                cleanup_callback = [this](const UUID &cleanup_id) {
+                    ReleaseMountedSegmentRecord(UuidToString(cleanup_id));
+                };
+            }
+            auto result = client_->UnmountSegmentById(
+                id, grace_period_ms, std::move(cleanup_callback));
             if (!result.has_value()) {
                 LOG(ERROR) << "UnmountSegmentById failed for " << segment_id;
                 if (first_error == 0) {
@@ -1265,8 +1330,13 @@ int RealClient::unmountSegment(const std::vector<std::string> &segment_ids) {
                 continue;  // Don't release local resources on failure
             }
 
-            to_cleanup.emplace_back(segment_id, it->second);
-            mounted_segment_records_.erase(it);
+            // For immediate unmount, clean up local mmap/fd right away.
+            // For graceful unmount, local mmap/fd is kept until the segment
+            // is actually removed or the client destructor runs.
+            if (grace_period_ms == 0) {
+                to_cleanup.emplace_back(segment_id, it->second);
+                mounted_segment_records_.erase(it);
+            }
         }
     }
 
@@ -1383,12 +1453,14 @@ int RealClient::allocateAndMountSegment(
 }
 
 int RealClient::unmountAndFreeSegment(
-    const std::vector<std::string> &segment_ids) {
+    const std::vector<std::string> &segment_ids,
+    uint64_t grace_period_seconds) {
     if (!client_) {
         LOG(ERROR) << "Client not initialized";
         return -1;
     }
 
+    uint64_t grace_period_ms = grace_period_seconds * 1000;
     int first_error = 0;
     std::vector<std::pair<std::string, AllocatedSegmentRecord>> to_cleanup;
     {
@@ -1409,7 +1481,14 @@ int RealClient::unmountAndFreeSegment(
                 continue;
             }
 
-            auto result = client_->UnmountSegmentById(id);
+            std::function<void(const UUID &)> cleanup_callback;
+            if (grace_period_ms != 0) {
+                cleanup_callback = [this](const UUID &cleanup_id) {
+                    ReleaseAllocatedSegmentRecord(UuidToString(cleanup_id));
+                };
+            }
+            auto result = client_->UnmountSegmentById(
+                id, grace_period_ms, std::move(cleanup_callback));
             if (!result.has_value()) {
                 LOG(ERROR) << "UnmountSegmentById failed for " << segment_id;
                 if (first_error == 0) {
@@ -1418,8 +1497,10 @@ int RealClient::unmountAndFreeSegment(
                 continue;  // Don't release local resources on failure
             }
 
-            to_cleanup.emplace_back(segment_id, it->second);
-            allocated_segment_records_.erase(it);
+            if (grace_period_ms == 0) {
+                to_cleanup.emplace_back(segment_id, it->second);
+                allocated_segment_records_.erase(it);
+            }
         }
     }
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1715,6 +1715,11 @@ tl::expected<SegmentStatus, ErrorCode> WrappedMasterService::QuerySegmentStatus(
     return master_service_.QuerySegmentStatus(segment_name);
 }
 
+tl::expected<SegmentStatus, ErrorCode>
+WrappedMasterService::QuerySegmentStatusById(const UUID& segment_id) {
+    return master_service_.QuerySegmentStatusById(segment_id);
+}
+
 void RegisterRpcService(
     coro_rpc::coro_rpc_server& server,
     mooncake::WrappedMasterService& wrapped_master_service) {
@@ -1776,6 +1781,12 @@ void RegisterRpcService(
     server.register_handler<&mooncake::WrappedMasterService::Ping>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::GetFsdir>(
+        &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::QuerySegmentStatus>(
+            &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::QuerySegmentStatusById>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::GetStorageConfig>(
         &wrapped_master_service);

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1375,6 +1375,29 @@ tl::expected<void, ErrorCode> WrappedMasterService::UnmountSegment(
         [] { MasterMetricManager::instance().inc_unmount_segment_failures(); });
 }
 
+tl::expected<void, ErrorCode> WrappedMasterService::GracefulUnmountSegment(
+    const UUID& segment_id, const UUID& client_id, uint64_t grace_period_ms) {
+    return execute_rpc(
+        "GracefulUnmountSegment",
+        [&] {
+            return master_service_.GracefulUnmountSegment(segment_id, client_id,
+                                                          grace_period_ms);
+        },
+        [&](auto& timer) {
+            timer.LogRequest("segment_id=", segment_id,
+                             ", client_id=", client_id,
+                             ", grace_period_ms=", grace_period_ms);
+        },
+        [] {
+            MasterMetricManager::instance()
+                .inc_unmount_segment_requests();  // reuse metric or add new
+        },
+        [] {
+            MasterMetricManager::instance()
+                .inc_unmount_segment_failures();  // reuse metric or add new
+        });
+}
+
 tl::expected<CopyStartResponse, ErrorCode> WrappedMasterService::CopyStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment,
@@ -1746,6 +1769,9 @@ void RegisterRpcService(
     server.register_handler<&mooncake::WrappedMasterService::ReMountSegment>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::UnmountSegment>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::GracefulUnmountSegment>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::Ping>(
         &wrapped_master_service);

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -211,6 +211,49 @@ ErrorCode ScopedSegmentAccess::PrepareUnmountSegment(
     return ErrorCode::OK;
 }
 
+ErrorCode ScopedSegmentAccess::PrepareGracefulUnmountSegment(
+    const UUID& segment_id) {
+    auto it = segment_manager_->mounted_segments_.find(segment_id);
+    if (it == segment_manager_->mounted_segments_.end()) {
+        LOG(WARNING) << "segment_id=" << segment_id
+                     << ", warn=segment_not_found";
+        return ErrorCode::SEGMENT_NOT_FOUND;
+    }
+    auto status = it->second.status;
+    if (status == SegmentStatus::UNMOUNTING) {
+        LOG(ERROR) << "segment_id=" << segment_id
+                   << ", error=segment_is_unmounting";
+        return ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS;
+    }
+    if (status == SegmentStatus::GRACEFULLY_UNMOUNTING) {
+        // Idempotent: already in graceful unmount state
+        return ErrorCode::OK;
+    }
+    if (status != SegmentStatus::OK && status != SegmentStatus::DRAINING) {
+        LOG(ERROR) << "segment_id=" << segment_id
+                   << ", error=unavailable_in_current_status, status="
+                   << status;
+        return ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS;
+    }
+
+    auto& mounted_segment = it->second;
+    auto& segment = mounted_segment.segment;
+
+    // Remove the allocator from the segment manager
+    std::shared_ptr<BufferAllocatorBase> allocator =
+        mounted_segment.buf_allocator;
+    if (HasAllocator(segment_manager_->allocator_manager_, segment.name,
+                     allocator)) {
+        segment_manager_->allocator_manager_.removeAllocator(segment.name,
+                                                             allocator);
+    }
+    mounted_segment.buf_allocator.reset();
+
+    // Set the segment status to GRACEFULLY_UNMOUNTING
+    mounted_segment.status = SegmentStatus::GRACEFULLY_UNMOUNTING;
+    return ErrorCode::OK;
+}
+
 ErrorCode ScopedSegmentAccess::CommitUnmountSegment(
     const UUID& segment_id, const UUID& client_id,
     const size_t& metrics_dec_capacity) {

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -247,8 +247,6 @@ ErrorCode ScopedSegmentAccess::PrepareGracefulUnmountSegment(
         segment_manager_->allocator_manager_.removeAllocator(segment.name,
                                                              allocator);
     }
-    mounted_segment.buf_allocator.reset();
-
     // Set the segment status to GRACEFULLY_UNMOUNTING
     mounted_segment.status = SegmentStatus::GRACEFULLY_UNMOUNTING;
     return ErrorCode::OK;

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -283,9 +283,14 @@ ErrorCode ScopedSegmentAccess::CommitUnmountSegment(
     auto&& segment = segment_manager_->mounted_segments_.find(segment_id);
     if (segment != segment_manager_->mounted_segments_.end()) {
         segment_name = segment->second.segment.name;
-        // Also remove from segment_name_client_id_map_
-        segment_manager_->client_by_name_.erase(segment_name);
-        segment_manager_->segment_id_by_name_.erase(segment_name);
+        auto segment_id_by_name_it =
+            segment_manager_->segment_id_by_name_.find(segment_name);
+        if (segment_id_by_name_it !=
+                segment_manager_->segment_id_by_name_.end() &&
+            segment_id_by_name_it->second == segment_id) {
+            segment_manager_->segment_id_by_name_.erase(segment_id_by_name_it);
+            segment_manager_->client_by_name_.erase(segment_name);
+        }
         is_cxl = (segment->second.segment.protocol == "cxl");
     }
     // Remove from mounted_segments_

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -997,6 +997,17 @@ ErrorCode ScopedSegmentAccess::GetSegmentStatusByName(
     return ErrorCode::OK;
 }
 
+ErrorCode ScopedSegmentAccess::GetSegmentStatusById(
+    const UUID& segment_id, SegmentStatus& status) const {
+    auto mounted_segment_it =
+        segment_manager_->mounted_segments_.find(segment_id);
+    if (mounted_segment_it == segment_manager_->mounted_segments_.end()) {
+        return ErrorCode::SEGMENT_NOT_FOUND;
+    }
+    status = mounted_segment_it->second.status;
+    return ErrorCode::OK;
+}
+
 ErrorCode ScopedSegmentAccess::SetSegmentStatusByName(
     const std::string& segment_name, SegmentStatus status) {
     auto segment_id_it =

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -5159,6 +5159,194 @@ TEST_F(MasterServiceTest, HardPinDefaultIsFalse) {
     service_->RemoveAll();
 }
 
+// ===================== Graceful Unmount Tests =====================
+
+TEST_F(MasterServiceTest, GracefulUnmountSegment_SetsCorrectStatus) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    auto segment = MakeSegment("graceful_test_segment");
+    UUID client_id = generate_uuid();
+
+    // Mount segment
+    ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
+
+    // Verify initial status
+    auto status_before = service_->QuerySegmentStatus(segment.name);
+    ASSERT_TRUE(status_before.has_value());
+    EXPECT_EQ(status_before.value(), SegmentStatus::OK);
+
+    // Graceful unmount with 1 second grace period
+    auto graceful_result = service_->GracefulUnmountSegment(
+        segment.id, client_id, /*grace_period_ms=*/1000);
+    ASSERT_TRUE(graceful_result.has_value())
+        << "Graceful unmount should succeed: "
+        << toString(graceful_result.error());
+
+    // Verify status is GRACEFULLY_UNMOUNTING
+    auto status_after = service_->QuerySegmentStatus(segment.name);
+    ASSERT_TRUE(status_after.has_value());
+    EXPECT_EQ(status_after.value(), SegmentStatus::GRACEFULLY_UNMOUNTING);
+
+    // Wait for timer to expire and clean up
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+}
+
+TEST_F(MasterServiceTest, GracefulUnmountSegment_RejectWrongClient) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    auto segment = MakeSegment("graceful_owner_segment");
+    UUID owner_client = generate_uuid();
+    UUID wrong_client = generate_uuid();
+
+    ASSERT_TRUE(service_->MountSegment(segment, owner_client).has_value());
+
+    // Wrong client trying to graceful unmount should fail
+    auto graceful_result = service_->GracefulUnmountSegment(
+        segment.id, wrong_client, /*grace_period_ms=*/1000);
+    ASSERT_FALSE(graceful_result.has_value());
+    EXPECT_EQ(graceful_result.error(), ErrorCode::SEGMENT_NOT_FOUND);
+
+    // Owner should still be able to unmount
+    auto owner_result = service_->GracefulUnmountSegment(
+        segment.id, owner_client, /*grace_period_ms=*/1000);
+    EXPECT_TRUE(owner_result.has_value());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+}
+
+TEST_F(MasterServiceTest, GracefulUnmountSegment_Idempotent) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    auto segment = MakeSegment("graceful_idempotent_segment");
+    UUID client_id = generate_uuid();
+
+    ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
+
+    // First graceful unmount should succeed
+    auto result1 = service_->GracefulUnmountSegment(segment.id, client_id,
+                                                    /*grace_period_ms=*/1000);
+    ASSERT_TRUE(result1.has_value());
+
+    // Second graceful unmount on the same segment should also succeed
+    // (idempotent)
+    auto result2 = service_->GracefulUnmountSegment(segment.id, client_id,
+                                                    /*grace_period_ms=*/1000);
+    EXPECT_TRUE(result2.has_value()) << "Graceful unmount should be idempotent";
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+}
+
+TEST_F(MasterServiceTest, GracefulUnmountSegment_TimerExpiresAndUnmounts) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    auto segment = MakeSegment("graceful_timer_segment");
+    UUID client_id = generate_uuid();
+
+    ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
+
+    // Graceful unmount with a short grace period (50ms)
+    auto graceful_result = service_->GracefulUnmountSegment(
+        segment.id, client_id, /*grace_period_ms=*/50);
+    ASSERT_TRUE(graceful_result.has_value());
+
+    // Immediately after graceful unmount, segment should still exist
+    auto status_immediate = service_->QuerySegmentStatus(segment.name);
+    ASSERT_TRUE(status_immediate.has_value());
+    EXPECT_EQ(status_immediate.value(), SegmentStatus::GRACEFULLY_UNMOUNTING);
+
+    // Wait for timer to expire and unmount (give some margin)
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    // After timer expires, segment should be fully unmounted (UNDEFINED or
+    // error)
+    auto status_after = service_->QuerySegmentStatus(segment.name);
+    // Segment may be UNDEFINED (not found) or return an error
+    EXPECT_TRUE(!status_after.has_value() ||
+                status_after.value() == SegmentStatus::UNDEFINED)
+        << "Segment should be unmounted after timer expires, got status="
+        << (status_after.has_value() ? static_cast<int>(status_after.value())
+                                     : -1);
+}
+
+TEST_F(MasterServiceTest, GracefulUnmountSegment_EarlierTimerPreemptsWait) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    auto long_segment = MakeSegment("graceful_long_timer_segment");
+    auto short_segment =
+        MakeSegment("graceful_short_timer_segment", /*base=*/0x400000000);
+    UUID client_id = generate_uuid();
+
+    ASSERT_TRUE(service_->MountSegment(long_segment, client_id).has_value());
+    ASSERT_TRUE(service_->MountSegment(short_segment, client_id).has_value());
+
+    ASSERT_TRUE(service_
+                    ->GracefulUnmountSegment(long_segment.id, client_id,
+                                             /*grace_period_ms=*/1000)
+                    .has_value());
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    ASSERT_TRUE(service_
+                    ->GracefulUnmountSegment(short_segment.id, client_id,
+                                             /*grace_period_ms=*/50)
+                    .has_value());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    auto short_status = service_->QuerySegmentStatus(short_segment.name);
+    EXPECT_TRUE(!short_status.has_value() ||
+                short_status.value() == SegmentStatus::UNDEFINED);
+
+    auto long_status = service_->QuerySegmentStatus(long_segment.name);
+    ASSERT_TRUE(long_status.has_value());
+    EXPECT_EQ(long_status.value(), SegmentStatus::GRACEFULLY_UNMOUNTING);
+}
+
+TEST_F(MasterServiceTest, GracefulUnmountSegment_PreventAllocation) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    auto segment1 = MakeSegment("graceful_seg1");
+    auto segment2 = MakeSegment("graceful_seg2", /*base=*/0x400000000);
+    UUID client_id = generate_uuid();
+
+    ASSERT_TRUE(service_->MountSegment(segment1, client_id).has_value());
+    ASSERT_TRUE(service_->MountSegment(segment2, client_id).has_value());
+
+    // Put an object on segment1
+    std::string key = "test_key_prevent_alloc";
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.preferred_segment = segment1.name;
+
+    auto put_start = service_->PutStart(client_id, key, 1024, config);
+    ASSERT_TRUE(put_start.has_value());
+    ASSERT_TRUE(
+        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+
+    // Graceful unmount segment1
+    ASSERT_TRUE(service_->GracefulUnmountSegment(segment1.id, client_id, 1000)
+                    .has_value());
+
+    // Segment1 status should be GRACEFULLY_UNMOUNTING
+    auto status1 = service_->QuerySegmentStatus(segment1.name);
+    ASSERT_TRUE(status1.has_value());
+    EXPECT_EQ(status1.value(), SegmentStatus::GRACEFULLY_UNMOUNTING);
+
+    // Segment2 status should still be OK
+    auto status2 = service_->QuerySegmentStatus(segment2.name);
+    ASSERT_TRUE(status2.has_value());
+    EXPECT_EQ(status2.value(), SegmentStatus::OK);
+
+    // New put without preferred_segment should succeed on segment2
+    std::string key2 = "test_key_after_graceful";
+    ReplicateConfig config2;
+    config2.replica_num = 1;
+
+    auto put_start2 = service_->PutStart(client_id, key2, 1024, config2);
+    ASSERT_TRUE(put_start2.has_value());
+    auto replicas = put_start2.value();
+    ASSERT_EQ(replicas.size(), 1u);
+    // Should be placed on segment2, not segment1
+    EXPECT_EQ(replicas[0]
+                  .get_memory_descriptor()
+                  .buffer_descriptor.transport_endpoint_,
+              segment2.name);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+}
+
 }  // namespace mooncake::test
 
 int main(int argc, char** argv) {

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -5264,6 +5264,34 @@ TEST_F(MasterServiceTest, GracefulUnmountSegment_TimerExpiresAndUnmounts) {
                                      : -1);
 }
 
+TEST_F(MasterServiceTest,
+       GracefulUnmountSegment_QueryStatusByIdWithReusedName) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    auto old_segment = MakeSegment("graceful_reused_name_segment");
+    auto new_segment = MakeSegment(old_segment.name, /*base=*/0x400000000);
+    UUID client_id = generate_uuid();
+
+    ASSERT_TRUE(service_->MountSegment(old_segment, client_id).has_value());
+    ASSERT_TRUE(service_
+                    ->GracefulUnmountSegment(old_segment.id, client_id,
+                                             /*grace_period_ms=*/50)
+                    .has_value());
+    ASSERT_TRUE(service_->MountSegment(new_segment, client_id).has_value());
+
+    auto old_status = service_->QuerySegmentStatusById(old_segment.id);
+    ASSERT_TRUE(old_status.has_value());
+    EXPECT_EQ(old_status.value(), SegmentStatus::GRACEFULLY_UNMOUNTING);
+
+    auto new_status = service_->QuerySegmentStatusById(new_segment.id);
+    ASSERT_TRUE(new_status.has_value());
+    EXPECT_EQ(new_status.value(), SegmentStatus::OK);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    EXPECT_FALSE(service_->QuerySegmentStatusById(old_segment.id).has_value());
+    ASSERT_TRUE(service_->QuerySegmentStatusById(new_segment.id).has_value());
+}
+
 TEST_F(MasterServiceTest, GracefulUnmountSegment_EarlierTimerPreemptsWait) {
     std::unique_ptr<MasterService> service_(new MasterService());
     auto long_segment = MakeSegment("graceful_long_timer_segment");

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -5356,6 +5356,16 @@ TEST_F(MasterServiceTest, GracefulUnmountSegment_PreventAllocation) {
     ASSERT_TRUE(status1.has_value());
     EXPECT_EQ(status1.value(), SegmentStatus::GRACEFULLY_UNMOUNTING);
 
+    // Existing replicas on the graceful segment should remain readable during
+    // the grace window.
+    auto existing_replicas = service_->GetReplicaList(key);
+    ASSERT_TRUE(existing_replicas.has_value());
+    ASSERT_EQ(existing_replicas->replicas.size(), 1u);
+    EXPECT_EQ(existing_replicas->replicas[0]
+                  .get_memory_descriptor()
+                  .buffer_descriptor.transport_endpoint_,
+              segment1.name);
+
     // Segment2 status should still be OK
     auto status2 = service_->QuerySegmentStatus(segment2.name);
     ASSERT_TRUE(status2.has_value());

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -5290,6 +5290,10 @@ TEST_F(MasterServiceTest,
 
     EXPECT_FALSE(service_->QuerySegmentStatusById(old_segment.id).has_value());
     ASSERT_TRUE(service_->QuerySegmentStatusById(new_segment.id).has_value());
+
+    auto status_by_name = service_->QuerySegmentStatus(new_segment.name);
+    ASSERT_TRUE(status_by_name.has_value());
+    EXPECT_EQ(status_by_name.value(), SegmentStatus::OK);
 }
 
 TEST_F(MasterServiceTest, GracefulUnmountSegment_EarlierTimerPreemptsWait) {

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -184,6 +184,33 @@ TEST_F(RealClientTest, MountAndAllocateUnmountApisRejectForeignSegments) {
     EXPECT_EQ(std::remove(path.c_str()), 0);
 }
 
+TEST_F(RealClientTest, MountAndAllocateUnmountApisAcceptGracePeriod) {
+    StartMasterAndSetupClient();
+
+    const size_t slab_size = facebook::cachelib::Slab::kSize;
+    std::vector<std::string> allocated_segment_ids;
+    size_t allocated_size = 0;
+    ASSERT_EQ(
+        py_client_->allocateAndMountSegment(
+            1, FLAGS_protocol, "", allocated_segment_ids, &allocated_size),
+        0);
+    ASSERT_FALSE(allocated_segment_ids.empty());
+    EXPECT_EQ(py_client_->unmountAndFreeSegment(allocated_segment_ids, 1), 0);
+
+    std::string path = CreateTempSegmentFile(slab_size);
+    ASSERT_FALSE(path.empty());
+
+    std::vector<std::string> mounted_segment_ids;
+    ASSERT_EQ(py_client_->mountSegment(path, 0, slab_size, FLAGS_protocol, "",
+                                       mounted_segment_ids),
+              0);
+    ASSERT_FALSE(mounted_segment_ids.empty());
+    EXPECT_EQ(py_client_->unmountSegment(mounted_segment_ids, 1), 0);
+
+    EXPECT_EQ(py_client_->tearDownAll(), 0);
+    EXPECT_EQ(std::remove(path.c_str()), 0);
+}
+
 // Test basic Put and Get operations
 TEST_F(RealClientTest, BasicPutGetOperations) {
     // Start in-proc master

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -336,10 +336,11 @@ class MooncakeStoreService:
                     content_type="application/json",
                 )
 
+            grace_period_seconds = data.get("grace_period_seconds", 0)
             failed_segment_ids = []
             async with self._state_lock:
                 for sid in segment_ids:
-                    ret = self.store.unmount_segment([sid])
+                    ret = self.store.unmount_segment([sid], grace_period_seconds)
                     if ret != 0:
                         failed_segment_ids.append(sid)
                         continue
@@ -427,7 +428,10 @@ class MooncakeStoreService:
                     content_type="application/json",
                 )
 
-            ret = self.store.unmount_and_free_segment(segment_ids)
+            grace_period_seconds = data.get("grace_period_seconds", 0)
+            ret = self.store.unmount_and_free_segment(
+                segment_ids, grace_period_seconds
+            )
             if ret != 0:
                 return web.Response(
                     status=500,

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -64,8 +64,8 @@ class FakeStore:
         }
         return {"ret": 0, "segment_ids": [segment_id]}
 
-    def unmount_segment(self, segment_ids):
-        self.unmount_calls.append(list(segment_ids))
+    def unmount_segment(self, segment_ids, grace_period_seconds=0):
+        self.unmount_calls.append((list(segment_ids), grace_period_seconds))
         for segment_id in segment_ids:
             if segment_id in self.unmount_failures:
                 return -1
@@ -82,8 +82,8 @@ class FakeStore:
             "allocated_size": 4096,
         }
 
-    def unmount_and_free_segment(self, segment_ids):
-        self.free_unmount_calls.append(list(segment_ids))
+    def unmount_and_free_segment(self, segment_ids, grace_period_seconds=0):
+        self.free_unmount_calls.append((list(segment_ids), grace_period_seconds))
         return 0
 
 
@@ -138,8 +138,22 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(unmount_body["status"], "success")
         self.assertEqual(
             self.fake_store.unmount_calls,
-            [["00000000-0000-0000-0000-000000000001"]],
+            [(["00000000-0000-0000-0000-000000000001"], 0)],
         )
+        self.assertEqual(self.service.current_mode, "prefill")
+
+    async def test_unmount_shm_passes_grace_period(self):
+        segment_id = "00000000-0000-0000-0000-000000000001"
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = [segment_id]
+
+        resp = await self.service.handle_unmount_shm(
+            FakeRequest({"segment_ids": [segment_id], "grace_period_seconds": 3})
+        )
+
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(self.fake_store.unmount_calls, [([segment_id], 3)])
+        self.assertEqual(self.service.mounted_segment_ids, [])
         self.assertEqual(self.service.current_mode, "prefill")
 
     async def test_unmount_shm_updates_state_for_partial_success(self):
@@ -158,7 +172,7 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(body["failed_segment_ids"], [failed_id])
         self.assertEqual(
             self.fake_store.unmount_calls,
-            [[succeeded_id], [failed_id]],
+            [([succeeded_id], 0), ([failed_id], 0)],
         )
         self.assertEqual(self.service.mounted_segment_ids, [failed_id])
         self.assertEqual(self.service.current_mode, "decode")
@@ -184,7 +198,7 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         body = json.loads(resp.text)
         self.assertEqual(body["mode"], "prefill")
         self.assertIn("rolled back to prefill", body["error"])
-        self.assertEqual(self.fake_store.unmount_calls, [[old_id]])
+        self.assertEqual(self.fake_store.unmount_calls, [([old_id], 0)])
         self.assertEqual(self.service.mounted_segment_ids, [])
         self.assertEqual(self.service.current_mode, "prefill")
         self.assertEqual(self.service.last_mount_info, {})
@@ -212,8 +226,18 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(unmount_body["status"], "success")
         self.assertEqual(
             self.fake_store.free_unmount_calls,
-            [["00000000-0000-0000-0000-000000000002"]],
+            [(["00000000-0000-0000-0000-000000000002"], 0)],
         )
+
+    async def test_unmount_allocated_passes_grace_period(self):
+        segment_id = "00000000-0000-0000-0000-000000000002"
+
+        resp = await self.service.handle_unmount(
+            FakeRequest({"segment_ids": [segment_id], "grace_period_seconds": 4})
+        )
+
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(self.fake_store.free_unmount_calls, [([segment_id], 4)])
 
     async def test_mount_shm_requires_name_and_size(self):
         resp = await self.service.handle_mount_shm(


### PR DESCRIPTION
## Description

This PR adds graceful segment unmount support to Mooncake Store.

The change allows callers to request a grace period when unmounting mounted segments so the master first marks the segment as `GRACEFULLY_UNMOUNTING`, removes it from allocation, and only completes the unmount after the grace period expires. This lets existing readers continue using the segment during the grace window while preventing new allocations from targeting it.

The feature is exposed through both C++/pybind APIs and the Python HTTP service:

- `unmount_segment(segment_ids, grace_period_seconds=0)` for mounted shm/file-backed segments.
- `unmount_and_free_segment(segment_ids, grace_period_seconds=0)` for allocate-backed segments.
- `/api/unmount_shm` with `grace_period_seconds`.
- `/api/unmount` with `grace_period_seconds`.

The implementation also hardens cleanup behavior by polling graceful unmount completion by `segment_id` rather than reusable segment names, so local memory registrations and backing resources are released correctly even if a client remounts another segment with the same name during the cleanup window.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

The following tests/checks were run locally and passed:

```bash
cmake --build build --target master_service_test pybind_client_test -j

build/mooncake-store/tests/master_service_test \
  --gtest_filter='MasterServiceTest.GracefulUnmountSegment*'

build/mooncake-store/tests/pybind_client_test \
  --gtest_filter='RealClientTest.MountAndAllocateUnmountApisAcceptGracePeriod:RealClientTest.MountAndAllocateUnmountApisRejectForeignSegments:RealClientTest.AllocateAndMountSegmentFreesOnTearDown'

python3 -m unittest mooncake-wheel.tests.test_mooncake_store_service_api
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
