### PR TITLE
[devcontainer] use build.dockerFile instead of dockerfile and add libxxhash-dev

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get install -y libibverbs-dev \
     libzstd-dev \
     libmsgpack-dev \
     libgflags-dev \
+    libxxhash-dev \
     pkg-config \
     patchelf
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "Mooncake Dev",
-  "dockerFile": "Dockerfile",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "runArgs": [
     "--cap-add=SYS_PTRACE",
     "--cap-add=NET_RAW",
@@ -18,7 +20,7 @@
     "vscode": {
       "settings": {
         "terminal.integrated.shell.linux": "/bin/bash",
-        "bazel.buildifierFixOnFormat": true,
+        "bazel.buildifierFixOnFormat": true
       }
     }
   }


### PR DESCRIPTION
## Description

As a newcomer setting up the dev environment, I hit two issues in `.devcontainer/`: the VS Code Dev Containers extension rejects the legacy top-level `dockerFile` field, and the build fails due to a missing `libxxhash-dev` system dependency. This PR migrates to `build.dockerfile` form and adds the missing package.

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [x] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other

## How Has This Been Tested?

Verified locally on macOS with VS Code + Dev Containers extension.

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
