### PR TITLE
[Store] L2->L1 promotion-on-hit

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1945,6 +1945,18 @@ PYBIND11_MODULE(store, m) {
              })
         .def("get", &mooncake::MooncakeStorePyWrapper::get)
         .def("get_batch", &mooncake::MooncakeStorePyWrapper::get_batch)
+        .def("get_offload_rpc_read_count",
+             [](MooncakeStorePyWrapper &self) -> int64_t {
+                 // Monotonically-increasing count of LOCAL_DISK reads served
+                 // via peer offload-RPC (i.e., batch_get_into_offload_object_
+                 // internal invocations). Promotion-on-hit e2e uses this to
+                 // prove that post-promotion reads avoid SSD and serve from
+                 // MEMORY instead. Returns 0 for non-RealClient backends.
+                 auto real_client =
+                     std::dynamic_pointer_cast<RealClient>(self.store_);
+                 return real_client ? real_client->get_offload_rpc_read_count()
+                                    : 0;
+             })
         .def(
             "get_buffer",
             [](MooncakeStorePyWrapper &self, const std::string &key) {

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1947,11 +1947,6 @@ PYBIND11_MODULE(store, m) {
         .def("get_batch", &mooncake::MooncakeStorePyWrapper::get_batch)
         .def("get_offload_rpc_read_count",
              [](MooncakeStorePyWrapper &self) -> int64_t {
-                 // Monotonically-increasing count of LOCAL_DISK reads served
-                 // via peer offload-RPC (i.e., batch_get_into_offload_object_
-                 // internal invocations). Promotion-on-hit e2e uses this to
-                 // prove that post-promotion reads avoid SSD and serve from
-                 // MEMORY instead. Returns 0 for non-RealClient backends.
                  auto real_client =
                      std::dynamic_pointer_cast<RealClient>(self.store_);
                  return real_client ? real_client->get_offload_rpc_read_count()

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -62,7 +62,7 @@ class QueryResult {
  */
 class Client {
    public:
-    ~Client();
+    virtual ~Client();
 
     const UUID& getClientId() const { return client_id_; }
 
@@ -411,6 +411,42 @@ class Client {
         int64_t ssd_total_capacity_bytes);
 
     /**
+     * @brief Heartbeat-driven pull of pending L2->L1 promotion work for this
+     * client. Mirror of OffloadObjectHeartbeat. Returns key->size pairs the
+     * caller (FileStorage) must read from local SSD and stage as MEMORY
+     * replicas via PromotionAllocStart + NotifyPromotionSuccess.
+     */
+    // Virtual to enable subclassing in unit tests.
+    virtual tl::expected<void, ErrorCode> PromotionObjectHeartbeat(
+        std::unordered_map<std::string, int64_t>& promotion_objects);
+
+    /**
+     * @brief Stage a PROCESSING MEMORY replica for an existing key during
+     * L2->L1 promotion. Returns the new replica's descriptor that the caller
+     * writes via Transfer Engine before calling NotifyPromotionSuccess.
+     */
+    virtual tl::expected<PromotionAllocStartResponse, ErrorCode>
+    PromotionAllocStart(const std::string& key, uint64_t size,
+                        const std::vector<std::string>& preferred_segments);
+
+    /**
+     * @brief Commit a staged MEMORY replica to COMPLETE; called after the
+     * client has written the bytes via Transfer Engine.
+     */
+    virtual tl::expected<void, ErrorCode> NotifyPromotionSuccess(
+        const std::string& key);
+
+    /**
+     * @brief Write `slices` into the memory replica described by
+     * `memory_descriptor` via Transfer Engine. Used by FileStorage to fill a
+     * PROCESSING memory replica staged by PromotionAllocStart before calling
+     * NotifyPromotionSuccess.
+     */
+    virtual ErrorCode PromotionWrite(
+        const Replica::Descriptor& memory_descriptor,
+        std::vector<Slice>& slices);
+
+    /**
      * @brief Performs a batched read of multiple objects using a
      * high-throughput Transfer Engine.
      * @param transfer_engine_addr Address of the Transfer Engine service (e.g.,
@@ -577,14 +613,16 @@ class Client {
 
     bool IsReplicaOnLocalMemory(const Replica::Descriptor& replica);
 
-   private:
+   protected:
     /**
-     * @brief Private constructor to enforce creation through Create() method
+     * @brief Constructor exposed to subclasses for testing only; production
+     * code must go through Create().
      */
     Client(const std::string& local_hostname,
            const std::string& metadata_connstring, const std::string& protocol,
            const std::map<std::string, std::string>& labels = {});
 
+   private:
     /**
      * @brief Internal helper functions for initialization and data transfer
      */

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -437,6 +437,13 @@ class Client {
         const std::string& key);
 
     /**
+     * @brief Release master-side promotion task after a client-side failure
+     * between PromotionAllocStart and the transfer's completion. Idempotent.
+     */
+    virtual tl::expected<void, ErrorCode> NotifyPromotionFailure(
+        const std::string& key);
+
+    /**
      * @brief Write `slices` into the memory replica described by
      * `memory_descriptor` via Transfer Engine. Used by FileStorage to fill a
      * PROCESSING memory replica staged by PromotionAllocStart before calling

--- a/mooncake-store/include/file_storage.h
+++ b/mooncake-store/include/file_storage.h
@@ -51,6 +51,7 @@ class FileStorage {
 
    private:
     friend class FileStorageTest;
+    friend class FileStoragePromotionTest;
     struct AllocatedBatch {
         uint64_t batch_id;
         std::vector<BufferHandle> handles;
@@ -82,9 +83,23 @@ class FileStorage {
      * client.
      * 2. Receives feedback on which objects should be offloaded.
      * 3. Triggers asynchronous offloading of pending objects.
+     * 4. Pulls and processes any pending L2->L1 promotion tasks queued by the
+     *    master (mirror of step 1+2 in the reverse direction).
      * @return tl::expected<void, ErrorCode> indicating operation status.
      */
     tl::expected<void, ErrorCode> Heartbeat();
+
+    /**
+     * @brief Drives the L2->L1 promotion pipeline for one heartbeat tick.
+     * Pulls promotion work from the master, stages a MEMORY replica for each
+     * key, copies the bytes from local SSD into that replica, and notifies the
+     * master on success. A failure on any single key is logged and skipped;
+     * the master-side reaper decrements the source replica's refcnt and
+     * erases the task entry on TTL expiry, and any orphaned PROCESSING
+     * MEMORY replica is reaped via the standard discarded-replicas path.
+     * @return tl::expected<void, ErrorCode> indicating operation status.
+     */
+    tl::expected<void, ErrorCode> ProcessPromotionTasks();
 
     tl::expected<bool, ErrorCode> IsEnableOffloading();
 

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -420,6 +420,32 @@ class MasterClient {
         const std::vector<StorageObjectMetadata>& metadatas);
 
     /**
+     * @brief Heartbeat-driven pull of pending L2->L1 promotion work for a
+     * client. Returns key->size pairs the caller should read from local
+     * SSD and stage as MEMORY replicas via PromotionAllocStart +
+     * NotifyPromotionSuccess.
+     */
+    [[nodiscard]] tl::expected<std::unordered_map<std::string, int64_t>,
+                               ErrorCode>
+    PromotionObjectHeartbeat(const UUID& client_id);
+
+    /**
+     * @brief Stage a PROCESSING MEMORY replica for an existing key during
+     * promotion. Returns the new replica's descriptor that the caller writes
+     * via Transfer Engine.
+     */
+    [[nodiscard]] tl::expected<PromotionAllocStartResponse, ErrorCode>
+    PromotionAllocStart(const std::string& key, uint64_t size,
+                        const std::vector<std::string>& preferred_segments);
+
+    /**
+     * @brief Commit a staged MEMORY replica to COMPLETE; called after the
+     * client has written the bytes via Transfer Engine.
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> NotifyPromotionSuccess(
+        const UUID& client_id, const std::string& key);
+
+    /**
      * @brief Start a copy operation
      * @param key Object key
      * @param src_segment Source segment name

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -435,8 +435,17 @@ class MasterClient {
      * via Transfer Engine.
      */
     [[nodiscard]] tl::expected<PromotionAllocStartResponse, ErrorCode>
-    PromotionAllocStart(const std::string& key, uint64_t size,
+    PromotionAllocStart(const UUID& client_id, const std::string& key,
+                        uint64_t size,
                         const std::vector<std::string>& preferred_segments);
+
+    /**
+     * @brief Release master-side promotion task state after a client-side
+     * failure that prevents the holder from calling NotifyPromotionSuccess.
+     * Idempotent; returns OK if the task was already swept by the reaper.
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> NotifyPromotionFailure(
+        const UUID& client_id, const std::string& key);
 
     /**
      * @brief Commit a staged MEMORY replica to COMPLETE; called after the

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -103,6 +103,12 @@ struct MasterConfig {
     // Offload-on-evict: defer LOCAL_DISK offload to eviction time
     bool offload_on_evict = false;
     bool offload_force_evict = false;
+
+    // Promotion-on-hit: when Get observes a LOCAL_DISK-only key, queue an
+    // async copy back to MEMORY so the next Get is fast.
+    bool promotion_on_hit = false;
+    uint32_t promotion_admission_threshold = 2;
+    uint32_t promotion_queue_limit = 50000;
 };
 
 class MasterServiceSupervisorConfig {
@@ -173,6 +179,9 @@ class MasterServiceSupervisorConfig {
     bool enable_cxl = false;
     bool offload_on_evict = false;
     bool offload_force_evict = false;
+    bool promotion_on_hit = false;
+    uint32_t promotion_admission_threshold = 2;
+    uint32_t promotion_queue_limit = 50000;
     MasterServiceSupervisorConfig() = default;
 
     // From MasterConfig
@@ -197,6 +206,9 @@ class MasterServiceSupervisorConfig {
         enable_offload = config.enable_offload;
         offload_on_evict = config.offload_on_evict;
         offload_force_evict = config.offload_force_evict;
+        promotion_on_hit = config.promotion_on_hit;
+        promotion_admission_threshold = config.promotion_admission_threshold;
+        promotion_queue_limit = config.promotion_queue_limit;
         rpc_port = static_cast<int>(config.rpc_port);
         rpc_thread_num = static_cast<size_t>(config.rpc_thread_num);
 
@@ -335,6 +347,9 @@ class WrappedMasterServiceConfig {
     bool enable_offload = false;
     bool offload_on_evict = false;
     bool offload_force_evict = false;
+    bool promotion_on_hit = false;
+    uint32_t promotion_admission_threshold = 2;
+    uint32_t promotion_queue_limit = 50000;
     std::string ha_backend_type = "etcd";
     std::string ha_backend_connstring;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
@@ -399,6 +414,9 @@ class WrappedMasterServiceConfig {
         enable_offload = config.enable_offload;
         offload_on_evict = config.offload_on_evict;
         offload_force_evict = config.offload_force_evict;
+        promotion_on_hit = config.promotion_on_hit;
+        promotion_admission_threshold = config.promotion_admission_threshold;
+        promotion_queue_limit = config.promotion_queue_limit;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = ResolveConfiguredHABackendConnstring(
             ha_backend_type, config.ha_backend_connstring,
@@ -481,6 +499,9 @@ class WrappedMasterServiceConfig {
         enable_offload = config.enable_offload;
         offload_on_evict = config.offload_on_evict;
         offload_force_evict = config.offload_force_evict;
+        promotion_on_hit = config.promotion_on_hit;
+        promotion_admission_threshold = config.promotion_admission_threshold;
+        promotion_queue_limit = config.promotion_queue_limit;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = ResolveConfiguredHABackendConnstring(
             ha_backend_type, config.ha_backend_connstring,
@@ -862,6 +883,9 @@ class MasterServiceConfig {
     bool enable_offload = false;
     bool offload_on_evict = false;
     bool offload_force_evict = false;
+    bool promotion_on_hit = false;
+    uint32_t promotion_admission_threshold = 2;
+    uint32_t promotion_queue_limit = 50000;
     std::string ha_backend_type = "etcd";
     std::string ha_backend_connstring;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
@@ -922,6 +946,9 @@ class MasterServiceConfig {
         enable_offload = config.enable_offload;
         offload_on_evict = config.offload_on_evict;
         offload_force_evict = config.offload_force_evict;
+        promotion_on_hit = config.promotion_on_hit;
+        promotion_admission_threshold = config.promotion_admission_threshold;
+        promotion_queue_limit = config.promotion_queue_limit;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = config.ha_backend_connstring;
         cluster_id = config.cluster_id;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -47,6 +47,12 @@ class EvictionStrategy;
 namespace test {
 class MasterServiceSnapshotTestBase;
 class SnapshotChildProcessTest;
+// Friended so the promotion-on-hit tests can drive a serialize/reset/
+// deserialize cycle directly via the otherwise-private
+// MetadataSerializer, and inspect private clamp fields. This avoids
+// standing up a full snapshot catalog + child-process harness, and
+// exposing test-only accessors on MasterService itself.
+class PromotionOnHitTest;
 }  // namespace test
 
 /*
@@ -60,6 +66,7 @@ class MasterService {
     // Test friend class for snapshot/restore testing
     friend class test::MasterServiceSnapshotTestBase;
     friend class test::SnapshotChildProcessTest;
+    friend class test::PromotionOnHitTest;
 
    public:
     using NoFProbeFn =
@@ -1188,6 +1195,19 @@ class MasterService {
      */
     void TryPushPromotionQueue(const std::string& key);
 
+    // Erase any in-flight PromotionTask for `key` and decrement the
+    // cluster-wide in-flight counter. Safe no-op if no task exists.
+    // Call from any path that erases an ObjectMetadata entry, so the
+    // task doesn't pin a promotion_in_flight_ slot for the full
+    // put_start_release_timeout_sec_ until the reaper sweeps.
+    void ErasePromotionTaskIfPresent(MetadataShardAccessorRW& shard,
+                                     const std::string& key)
+        NO_THREAD_SAFETY_ANALYSIS {
+        if (shard->promotion_tasks.erase(key) > 0) {
+            promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+        }
+    }
+
     // Lease related members
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
     const uint64_t default_kv_soft_pin_ttl_;  // in milliseconds
@@ -1250,6 +1270,7 @@ class MasterService {
                     if (processing_it_ != shard_guard_->processing_keys.end()) {
                         this->EraseFromProcessing();
                     }
+                    service_->ErasePromotionTaskIfPresent(shard_guard_, key_);
                 }
             }
         }

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1019,30 +1019,28 @@ class MasterService {
         std::chrono::system_clock::time_point start_time;
     };
 
-    // Tracks an in-flight LOCAL_DISK -> MEMORY copy. The source LOCAL_DISK
-    // replica is refcnt-pinned for the duration of the task so it cannot be
-    // evicted. alloc_id pins down which staged replica
-    // NotifyPromotionSuccess should commit, so a concurrent Put creating
-    // another PROCESSING MEMORY replica cannot be confused with ours.
-    // alloc_id is 0 until PromotionAllocStart records the new replica.
+    // Tracks an in-flight LOCAL_DISK -> MEMORY copy. The source
+    // LOCAL_DISK replica is refcnt-pinned for the duration of the task
+    // so it cannot be evicted.
     //
-    // start_time is the reaper deadline anchor. It is set at task
-    // admission (TryPushPromotionQueue) and reset at PromotionAllocStart
-    // so the reaper TTL covers the active-transfer phase
-    // (AllocStart -> SSD read -> RDMA write -> Notify) measured from
-    // when a master-allocated buffer becomes vulnerable, not consumed
-    // by queue waiting. Without the reset, a backlogged task could
-    // enter active transfer with little remaining TTL and the reaper
-    // could free the staged MEMORY replica via EraseReplicaByID while
-    // the client's RDMA write is still landing into it.
+    // alloc_id pins down which staged PROCESSING MEMORY replica
+    // NotifyPromotionSuccess should commit, so a concurrent Put on the
+    // same key cannot be confused with ours. 0 until
+    // PromotionAllocStart records the new replica.
     //
-    // holder_id is the client that owns the source LOCAL_DISK segment and
-    // is the *only* client authorized to call NotifyPromotionSuccess for
-    // this task. Captured at admission so the Notify path can reject
-    // calls from other clients that happen to know the key — without
-    // this check, any client could flip the staged PROCESSING replica
-    // to COMPLETE before the holder's RDMA write has landed, exposing
-    // torn data to readers.
+    // start_time is the reaper deadline anchor. Set at task admission
+    // and reset at PromotionAllocStart so each phase (queue-wait and
+    // active-transfer) gets its own full put_start_release_timeout_sec_
+    // window. Without the reset a backlogged task could enter active
+    // transfer with little TTL left, and the reaper could free the
+    // staged replica via EraseReplicaByID mid-RDMA-write.
+    //
+    // holder_id is the client owning the source LOCAL_DISK segment and
+    // the only one authorized to commit (NotifyPromotionSuccess) or
+    // abort (NotifyPromotionFailure) the task. Without it, any client
+    // knowing the key could flip the staged PROCESSING replica to
+    // COMPLETE before the holder's RDMA write landed, exposing torn
+    // data to readers.
     struct PromotionTask {
         ReplicaID source_id;    // the LOCAL_DISK replica being promoted
         ReplicaID alloc_id{0};  // the new MEMORY replica staged by AllocStart

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1000,11 +1000,20 @@ class MasterService {
     // enter active transfer with little remaining TTL and the reaper
     // could free the staged MEMORY replica via EraseReplicaByID while
     // the client's RDMA write is still landing into it.
+    //
+    // holder_id is the client that owns the source LOCAL_DISK segment and
+    // is the *only* client authorized to call NotifyPromotionSuccess for
+    // this task. Captured at admission so the Notify path can reject
+    // calls from other clients that happen to know the key — without
+    // this check, any client could flip the staged PROCESSING replica
+    // to COMPLETE before the holder's RDMA write has landed, exposing
+    // torn data to readers.
     struct PromotionTask {
         ReplicaID source_id;    // the LOCAL_DISK replica being promoted
         ReplicaID alloc_id{0};  // the new MEMORY replica staged by AllocStart
         uint64_t object_size;
         std::chrono::system_clock::time_point start_time;
+        UUID holder_id;  // owner of source LOCAL_DISK; only Notifier allowed
     };
 
     static constexpr size_t kNumShards = 1024;  // Number of metadata shards

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -990,6 +990,16 @@ class MasterService {
     // NotifyPromotionSuccess should commit, so a concurrent Put creating
     // another PROCESSING MEMORY replica cannot be confused with ours.
     // alloc_id is 0 until PromotionAllocStart records the new replica.
+    //
+    // start_time is the reaper deadline anchor. It is set at task
+    // admission (TryPushPromotionQueue) and reset at PromotionAllocStart
+    // so the reaper TTL covers the active-transfer phase
+    // (AllocStart -> SSD read -> RDMA write -> Notify) measured from
+    // when a master-allocated buffer becomes vulnerable, not consumed
+    // by queue waiting. Without the reset, a backlogged task could
+    // enter active transfer with little remaining TTL and the reaper
+    // could free the staged MEMORY replica via EraseReplicaByID while
+    // the client's RDMA write is still landing into it.
     struct PromotionTask {
         ReplicaID source_id;    // the LOCAL_DISK replica being promoted
         ReplicaID alloc_id{0};  // the new MEMORY replica staged by AllocStart

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -542,8 +542,15 @@ class MasterService {
      * DRAM via the existing AllocationStrategy, optionally biased toward the
      * caller's local memory segment via preferred_segments. The new replica is
      * invisible to readers until NotifyPromotionSuccess flips it to COMPLETE.
+     *
+     * Only the holder client (the one owning the source LOCAL_DISK replica)
+     * is authorized to call this. Other clients receive INVALID_PARAMS.
+     * `size` must match the source replica's object_size captured at task
+     * admission; mismatch returns INVALID_PARAMS to avoid allocating an
+     * arbitrary buffer size from a buggy or malicious caller.
      */
-    auto PromotionAllocStart(const std::string& key, uint64_t size,
+    auto PromotionAllocStart(const UUID& client_id, const std::string& key,
+                             uint64_t size,
                              const std::vector<std::string>& preferred_segments)
         -> tl::expected<PromotionAllocStartResponse, ErrorCode>;
 
@@ -553,6 +560,27 @@ class MasterService {
      * NotifyOffloadSuccess.
      */
     auto NotifyPromotionSuccess(const UUID& client_id, const std::string& key)
+        -> tl::expected<void, ErrorCode>;
+
+    /**
+     * @brief Holder-side failure notification: the client got past
+     * PromotionAllocStart but a downstream step (local SSD read, RDMA
+     * write, etc.) failed and it will not be calling
+     * NotifyPromotionSuccess. Releases the master-side task state
+     * immediately rather than waiting put_start_release_timeout_sec_
+     * for the reaper to do it. Without this call every transient
+     * client-side error (SSD throttling, RDMA flake, etc.) pins a
+     * task slot and a staged DRAM buffer for the full reaper TTL,
+     * which can saturate promotion_queue_limit_ on busy clusters.
+     *
+     * Authorization is the same as NotifyPromotionSuccess: only the
+     * holder client may release a task. Effects mirror the reaper's
+     * expiry path: drop source LOCAL_DISK refcnt, pop the staged
+     * PROCESSING MEMORY replica if alloc_id was recorded, erase the
+     * task, decrement the global in-flight counter, and clear the
+     * holder's promotion_objects entry.
+     */
+    auto NotifyPromotionFailure(const UUID& client_id, const std::string& key)
         -> tl::expected<void, ErrorCode>;
 
     /**
@@ -1437,11 +1465,7 @@ class MasterService {
     uint32_t promotion_admission_threshold_{2};
     uint32_t promotion_queue_limit_{50000};
     // Global in-flight task counter, checked against promotion_queue_limit_
-    // as the gate cap. A previous per-shard heuristic (shard->size() *
-    // kNumShards) was effectively right for uniform workloads but ~1024x
-    // tight on skewed workloads, where hot keys cluster in a few shards and
-    // would saturate one shard's projection of the cap while the cluster
-    // had near-zero in-flight tasks. Promotion specifically targets skewed
+    // as the gate cap. Promotion specifically targets skewed
     // access (hot keys re-accessed after eviction), so the global counter
     // is the correct primitive. Incremented in TryPushPromotionQueue after
     // successful enqueue; decremented in NotifyPromotionSuccess and in the

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -20,6 +20,7 @@
 #include <ylt/util/tl/expected.hpp>
 
 #include "allocation_strategy.h"
+#include "count_min_sketch.h"
 #include "master_metric_manager.h"
 #include "mutex.h"
 #include "segment.h"
@@ -527,6 +528,34 @@ class MasterService {
         -> tl::expected<void, ErrorCode>;
 
     /**
+     * @brief Heartbeat-driven pull of pending promotion work for a client.
+     * Returns the per-client promotion_objects map (key -> object size) and
+     * clears it. The per-shard promotion_tasks map remains populated as the
+     * source of truth until NotifyPromotionSuccess commits the new MEMORY
+     * replica.
+     */
+    auto PromotionObjectHeartbeat(const UUID& client_id)
+        -> tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>;
+
+    /**
+     * @brief Stage a PROCESSING MEMORY replica for an existing key. Allocates
+     * DRAM via the existing AllocationStrategy, optionally biased toward the
+     * caller's local memory segment via preferred_segments. The new replica is
+     * invisible to readers until NotifyPromotionSuccess flips it to COMPLETE.
+     */
+    auto PromotionAllocStart(const std::string& key, uint64_t size,
+                             const std::vector<std::string>& preferred_segments)
+        -> tl::expected<PromotionAllocStartResponse, ErrorCode>;
+
+    /**
+     * @brief Commit a staged MEMORY replica to COMPLETE; decrement source
+     * refcnt; erase per-shard and per-client task entries. Mirror of
+     * NotifyOffloadSuccess.
+     */
+    auto NotifyPromotionSuccess(const UUID& client_id, const std::string& key)
+        -> tl::expected<void, ErrorCode>;
+
+    /**
      * @brief Create a copy task to copy an object's replicas to target segments
      * @return Copy task ID on success, ErrorCode on failure
      */
@@ -955,6 +984,19 @@ class MasterService {
         std::chrono::system_clock::time_point start_time;
     };
 
+    // Tracks an in-flight LOCAL_DISK -> MEMORY copy. The source LOCAL_DISK
+    // replica is refcnt-pinned for the duration of the task so it cannot be
+    // evicted. alloc_id pins down which staged replica
+    // NotifyPromotionSuccess should commit, so a concurrent Put creating
+    // another PROCESSING MEMORY replica cannot be confused with ours.
+    // alloc_id is 0 until PromotionAllocStart records the new replica.
+    struct PromotionTask {
+        ReplicaID source_id;    // the LOCAL_DISK replica being promoted
+        ReplicaID alloc_id{0};  // the new MEMORY replica staged by AllocStart
+        uint64_t object_size;
+        std::chrono::system_clock::time_point start_time;
+    };
+
     static constexpr size_t kNumShards = 1024;  // Number of metadata shards
 
     // Sharded metadata maps and their mutexes
@@ -966,6 +1008,8 @@ class MasterService {
         std::unordered_map<std::string, const ReplicationTask> replication_tasks
             GUARDED_BY(mutex);
         std::unordered_map<std::string, const OffloadingTask> offloading_tasks
+            GUARDED_BY(mutex);
+        std::unordered_map<std::string, const PromotionTask> promotion_tasks
             GUARDED_BY(mutex);
     };
     std::array<MetadataShard, kNumShards> metadata_shards_;
@@ -1077,6 +1121,25 @@ class MasterService {
         bool stopping_{false};
         std::condition_variable timer_cv_;
     } graceful_unmount_scheduler_;
+
+    /**
+     * @brief Mirror of PushOffloadingQueue for promotion-on-hit. Inserts an
+     * entry into the holder client's LocalDiskSegment::promotion_objects map.
+     * Caller is responsible for refcnt-pinning the source replica and
+     * recording the task in the shard's promotion_tasks map.
+     */
+    tl::expected<void, ErrorCode> PushPromotionQueue(const std::string& key,
+                                                     Replica& source_replica);
+
+    /**
+     * @brief Helper invoked from GetReplicaList when an only-LOCAL_DISK key is
+     * observed. Applies the gating chain (frequency / watermark / dedup /
+     * cap), refcnt-pins the source LOCAL_DISK replica, records a
+     * PromotionTask, and pushes onto the holder client's promotion_objects
+     * map. Acquires its own RW shard accessor; safe to call after
+     * GetReplicaList's RO accessor has been released.
+     */
+    void TryPushPromotionQueue(const std::string& key);
 
     // Lease related members
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
@@ -1348,6 +1411,16 @@ class MasterService {
     // exceeded (config: offload_force_evict, only effective when
     // offload_on_evict_=true)
     bool offload_force_evict_{false};
+
+    // Promotion-on-hit: opt-in flag enabling LOCAL_DISK -> MEMORY promotion
+    // when a Get observes a key with only LOCAL_DISK replicas.
+    bool promotion_on_hit_{false};
+    uint32_t promotion_admission_threshold_{2};
+    uint32_t promotion_queue_limit_{50000};
+    // Master-side frequency sketch. Constructed only when promotion_on_hit_ is
+    // true. CountMinSketch is mutex-protected internally so we can call into it
+    // from any GetReplicaList caller without additional locking.
+    std::unique_ptr<CountMinSketch> promotion_sketch_;
 
     const std::string ha_backend_type_;
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1009,7 +1009,7 @@ class MasterService {
             GUARDED_BY(mutex);
         std::unordered_map<std::string, const OffloadingTask> offloading_tasks
             GUARDED_BY(mutex);
-        std::unordered_map<std::string, const PromotionTask> promotion_tasks
+        std::unordered_map<std::string, PromotionTask> promotion_tasks
             GUARDED_BY(mutex);
     };
     std::array<MetadataShard, kNumShards> metadata_shards_;
@@ -1417,6 +1417,18 @@ class MasterService {
     bool promotion_on_hit_{false};
     uint32_t promotion_admission_threshold_{2};
     uint32_t promotion_queue_limit_{50000};
+    // Global in-flight task counter, checked against promotion_queue_limit_
+    // as the gate cap. A previous per-shard heuristic (shard->size() *
+    // kNumShards) was effectively right for uniform workloads but ~1024x
+    // tight on skewed workloads, where hot keys cluster in a few shards and
+    // would saturate one shard's projection of the cap while the cluster
+    // had near-zero in-flight tasks. Promotion specifically targets skewed
+    // access (hot keys re-accessed after eviction), so the global counter
+    // is the correct primitive. Incremented in TryPushPromotionQueue after
+    // successful enqueue; decremented in NotifyPromotionSuccess and in the
+    // promotion task reaper after the task entry is erased. Relaxed memory
+    // order is safe — the value is an advisory soft cap, not a barrier.
+    std::atomic<uint64_t> promotion_in_flight_{0};
     // Master-side frequency sketch. Constructed only when promotion_on_hit_ is
     // true. CountMinSketch is mutex-protected internally so we can call into it
     // from any GetReplicaList caller without additional locking.

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -683,13 +683,6 @@ class RealClient : public PyClient {
         const std::string &target_rpc_service_addr,
         std::unordered_map<std::string, std::vector<Slice>> &objects);
 
-    // Test/observability hook: increments every time
-    // batch_get_into_offload_object_internal is invoked, which is the
-    // single chokepoint for LOCAL_DISK reads served via peer offload RPC.
-    // After a key gets promoted to MEMORY, subsequent reads should NOT
-    // bump this counter (SelectBestReplica picks the MEMORY replica and
-    // routes through Client::Get instead). The promotion-on-hit e2e test
-    // uses this to prove the post-promotion read served from MEMORY.
     int64_t get_offload_rpc_read_count() const {
         return offload_rpc_read_count_.load(std::memory_order_relaxed);
     }
@@ -841,9 +834,7 @@ class RealClient : public PyClient {
     // Ensure cleanup executes at most once across multiple entry points
     std::atomic<bool> closed_{false};
 
-    // Counts every call to batch_get_into_offload_object_internal — i.e.,
-    // every LOCAL_DISK read served via peer offload-RPC. Used by the
-    // promotion-on-hit e2e to assert that post-promotion reads avoid SSD.
+    // Counts every LOCAL_DISK read served via peer offload-RPC.
     std::atomic<int64_t> offload_rpc_read_count_{0};
 
     // Dummy Client manage related members

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -683,6 +683,17 @@ class RealClient : public PyClient {
         const std::string &target_rpc_service_addr,
         std::unordered_map<std::string, std::vector<Slice>> &objects);
 
+    // Test/observability hook: increments every time
+    // batch_get_into_offload_object_internal is invoked, which is the
+    // single chokepoint for LOCAL_DISK reads served via peer offload RPC.
+    // After a key gets promoted to MEMORY, subsequent reads should NOT
+    // bump this counter (SelectBestReplica picks the MEMORY replica and
+    // routes through Client::Get instead). The promotion-on-hit e2e test
+    // uses this to prove the post-promotion read served from MEMORY.
+    int64_t get_offload_rpc_read_count() const {
+        return offload_rpc_read_count_.load(std::memory_order_relaxed);
+    }
+
     /**
      * @brief Mount a shared memory file region and return segment ids.
      *        If size > max_mr_size, it will be split into multiple chunks
@@ -829,6 +840,11 @@ class RealClient : public PyClient {
 
     // Ensure cleanup executes at most once across multiple entry points
     std::atomic<bool> closed_{false};
+
+    // Counts every call to batch_get_into_offload_object_internal — i.e.,
+    // every LOCAL_DISK read served via peer offload-RPC. Used by the
+    // promotion-on-hit e2e to assert that post-promotion reads avoid SSD.
+    std::atomic<int64_t> offload_rpc_read_count_{0};
 
     // Dummy Client manage related members
     void dummy_client_monitor_func();

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -174,6 +174,17 @@ class WrappedMasterService {
         const UUID& client_id, const std::vector<std::string>& keys,
         const std::vector<StorageObjectMetadata>& metadatas);
 
+    // Promotion-on-hit RPCs.
+    tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>
+    PromotionObjectHeartbeat(const UUID& client_id);
+
+    tl::expected<PromotionAllocStartResponse, ErrorCode> PromotionAllocStart(
+        const std::string& key, uint64_t size,
+        const std::vector<std::string>& preferred_segments);
+
+    tl::expected<void, ErrorCode> NotifyPromotionSuccess(
+        const UUID& client_id, const std::string& key);
+
     tl::expected<UUID, ErrorCode> CreateDrainJob(
         const CreateDrainJobRequest& request);
 

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -179,10 +179,13 @@ class WrappedMasterService {
     PromotionObjectHeartbeat(const UUID& client_id);
 
     tl::expected<PromotionAllocStartResponse, ErrorCode> PromotionAllocStart(
-        const std::string& key, uint64_t size,
+        const UUID& client_id, const std::string& key, uint64_t size,
         const std::vector<std::string>& preferred_segments);
 
     tl::expected<void, ErrorCode> NotifyPromotionSuccess(
+        const UUID& client_id, const std::string& key);
+
+    tl::expected<void, ErrorCode> NotifyPromotionFailure(
         const UUID& client_id, const std::string& key);
 
     tl::expected<UUID, ErrorCode> CreateDrainJob(

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -79,6 +79,15 @@ struct CopyStartResponse {
 YLT_REFL(CopyStartResponse, source, targets);
 
 /**
+ * @brief Response structure for PromotionAllocStart (L2->L1 promotion-on-hit).
+ * Carries the staged PROCESSING MEMORY replica descriptor.
+ */
+struct PromotionAllocStartResponse {
+    Replica::Descriptor memory_descriptor;
+};
+YLT_REFL(PromotionAllocStartResponse, memory_descriptor);
+
+/**
  * @brief Response structure for MoveStart operation
  */
 struct MoveStartResponse {

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -91,8 +91,7 @@ struct LocalDiskSegment {
     // Promotion-on-hit pending work for this client. Populated by master's
     // TryPushPromotionQueue when a Get hits a LOCAL_DISK-only key on this
     // client. Drained by PromotionObjectHeartbeat. Same locking as
-    // offloading_objects (offloading_mutex_) to keep call-site discipline
-    // identical to #1899's offload path.
+    // offloading_objects (offloading_mutex_).
     std::unordered_map<std::string, int64_t> GUARDED_BY(offloading_mutex_)
         promotion_objects;
     explicit LocalDiskSegment(bool enable_offloading)

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -88,6 +88,13 @@ struct LocalDiskSegment {
     int64_t ssd_total_capacity_bytes = 0;  // last reported by client heartbeat
     std::unordered_map<std::string, int64_t> GUARDED_BY(offloading_mutex_)
         offloading_objects;
+    // Promotion-on-hit pending work for this client. Populated by master's
+    // TryPushPromotionQueue when a Get hits a LOCAL_DISK-only key on this
+    // client. Drained by PromotionObjectHeartbeat. Same locking as
+    // offloading_objects (offloading_mutex_) to keep call-site discipline
+    // identical to #1899's offload path.
+    std::unordered_map<std::string, int64_t> GUARDED_BY(offloading_mutex_)
+        promotion_objects;
     explicit LocalDiskSegment(bool enable_offloading)
         : enable_offloading(enable_offloading) {}
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2497,12 +2497,18 @@ tl::expected<PromotionAllocStartResponse, ErrorCode>
 Client::PromotionAllocStart(
     const std::string& key, uint64_t size,
     const std::vector<std::string>& preferred_segments) {
-    return master_client_.PromotionAllocStart(key, size, preferred_segments);
+    return master_client_.PromotionAllocStart(client_id_, key, size,
+                                              preferred_segments);
 }
 
 tl::expected<void, ErrorCode> Client::NotifyPromotionSuccess(
     const std::string& key) {
     return master_client_.NotifyPromotionSuccess(client_id_, key);
+}
+
+tl::expected<void, ErrorCode> Client::NotifyPromotionFailure(
+    const std::string& key) {
+    return master_client_.NotifyPromotionFailure(client_id_, key);
 }
 
 ErrorCode Client::PromotionWrite(const Replica::Descriptor& memory_descriptor,

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2483,6 +2483,33 @@ tl::expected<void, ErrorCode> Client::NotifyOffloadSuccess(
     return response;
 }
 
+tl::expected<void, ErrorCode> Client::PromotionObjectHeartbeat(
+    std::unordered_map<std::string, int64_t>& promotion_objects) {
+    auto response = master_client_.PromotionObjectHeartbeat(client_id_);
+    if (!response) {
+        return tl::make_unexpected(response.error());
+    }
+    promotion_objects = std::move(response.value());
+    return {};
+}
+
+tl::expected<PromotionAllocStartResponse, ErrorCode>
+Client::PromotionAllocStart(
+    const std::string& key, uint64_t size,
+    const std::vector<std::string>& preferred_segments) {
+    return master_client_.PromotionAllocStart(key, size, preferred_segments);
+}
+
+tl::expected<void, ErrorCode> Client::NotifyPromotionSuccess(
+    const std::string& key) {
+    return master_client_.NotifyPromotionSuccess(client_id_, key);
+}
+
+ErrorCode Client::PromotionWrite(const Replica::Descriptor& memory_descriptor,
+                                 std::vector<Slice>& slices) {
+    return TransferWrite(memory_descriptor, slices);
+}
+
 tl::expected<UUID, ErrorCode> Client::CreateCopyTask(
     const std::string& key, const std::vector<std::string>& targets) {
     return master_client_.CreateCopyTask(key, targets);

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -576,11 +576,48 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         auto alloc_result = client_->PromotionAllocStart(
             key, static_cast<uint64_t>(size), preferred_segments);
         if (!alloc_result) {
+            // AllocStart failed (typically NO_AVAILABLE_HANDLE under DRAM
+            // pressure). No staged buffer to release, but the task entry
+            // and its slot in promotion_in_flight_ were claimed back in
+            // TryPushPromotionQueue when the gate admitted us. Without
+            // an explicit release the slot stays pinned for up to
+            // put_start_release_timeout_sec_ (default 10 min), which
+            // turns transient DRAM pressure into a sustained outage of
+            // promotion_queue_limit_. Notify is idempotent and handles
+            // the alloc_id == 0 case correctly (just erases the task
+            // entry and decrements the counter; the EraseReplicaByID
+            // branch is gated on alloc_id != 0).
             VLOG(1) << "PromotionAllocStart failed for key=" << key
                     << ", error=" << alloc_result.error()
-                    << " (likely no free DRAM); master will reap";
+                    << " (likely no free DRAM); releasing master slot";
+            auto release = client_->NotifyPromotionFailure(key);
+            if (!release) {
+                VLOG(1) << "Promotion: NotifyPromotionFailure failed for key="
+                        << key << ", error=" << release.error()
+                        << "; master reaper will reclaim on TTL expiry";
+            }
             continue;
         }
+
+        // Every failure path past this point has a master-side staged
+        // PROCESSING MEMORY buffer attached to the object and an
+        // incremented promotion_in_flight_ slot. If we just `continue`
+        // without notifying the master, the buffer and slot stay pinned
+        // until the reaper TTL (~10 min default). Transient SSD throttling
+        // or RDMA flakes would then saturate promotion_queue_limit_ for
+        // 10 minutes and silently disable the feature. Eagerly notify the
+        // master so the buffer is reclaimed and the slot is freed for
+        // subsequent admissions. NotifyPromotionFailure is idempotent and
+        // best-effort; if it itself fails, the reaper is still the
+        // long-stop safety net.
+        auto release_master_state = [this, &key]() {
+            auto release = client_->NotifyPromotionFailure(key);
+            if (!release) {
+                VLOG(1) << "Promotion: NotifyPromotionFailure failed for key="
+                        << key << ", error=" << release.error()
+                        << "; master reaper will reclaim on TTL expiry";
+            }
+        };
 
         // (a) Allocate an O_DIRECT-aligned staging buffer and read the bytes
         // from the local SSD backend into it. AllocateBatch returns a
@@ -592,6 +629,7 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         if (!allocate_res) {
             LOG(WARNING) << "Promotion: AllocateBatch failed for key=" << key
                          << ", error=" << allocate_res.error();
+            release_master_state();
             continue;
         }
         auto staging = allocate_res.value();
@@ -599,6 +637,7 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         if (!load_res) {
             LOG(WARNING) << "Promotion: BatchLoad failed for key=" << key
                          << ", error=" << load_res.error();
+            release_master_state();
             continue;
         }
 
@@ -608,6 +647,7 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         auto slice_it = staging->slices.find(key);
         if (slice_it == staging->slices.end()) {
             LOG(WARNING) << "Promotion: staging slice missing for key=" << key;
+            release_master_state();
             continue;
         }
         std::vector<Slice> tx_slices{slice_it->second};
@@ -616,6 +656,7 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         if (write_err != ErrorCode::OK) {
             LOG(WARNING) << "Promotion: TransferWrite failed for key=" << key
                          << ", error=" << write_err;
+            release_master_state();
             continue;
         }
 
@@ -623,8 +664,15 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         // becomes visible to readers.
         auto notify_res = client_->NotifyPromotionSuccess(key);
         if (!notify_res) {
+            // The write landed but the commit failed. We can't retry the
+            // commit (the success path is one-shot via alloc_id), and we
+            // don't know whether the failure was transient or structural.
+            // Release the master-side state so the slot is reusable; the
+            // bytes we wrote become stranded under a soon-to-be-erased
+            // PROCESSING replica, which is harmless.
             LOG(WARNING) << "Promotion: NotifyPromotionSuccess failed for key="
                          << key << ", error=" << notify_res.error();
+            release_master_state();
             continue;
         }
 

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -521,8 +521,131 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
         return offload_result;
     }
 
+    // Drive any pending L2->L1 promotion work for this client. Failures
+    // inside ProcessPromotionTasks are logged per-key and do not propagate;
+    // promotion is best-effort and must never break offload.
+    (void)ProcessPromotionTasks();
+
     // TODO(eviction): Implement an LRU eviction mechanism to manage local
     // storage capacity.
+    return {};
+}
+
+tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
+    if (client_ == nullptr) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::unordered_map<std::string, int64_t> promotion_objects;
+    auto heartbeat_result =
+        client_->PromotionObjectHeartbeat(promotion_objects);
+    if (!heartbeat_result) {
+        // SEGMENT_NOT_FOUND happens between MountLocalDiskSegment and the
+        // first heartbeat tick if the master forgets us (e.g. across a master
+        // restart): benign no-op until next ReMount.
+        if (heartbeat_result.error() == ErrorCode::SEGMENT_NOT_FOUND) {
+            return {};
+        }
+        LOG(WARNING) << "PromotionObjectHeartbeat failed: "
+                     << heartbeat_result.error();
+        return tl::make_unexpected(heartbeat_result.error());
+    }
+    if (promotion_objects.empty()) {
+        return {};
+    }
+
+    VLOG(1) << "ProcessPromotionTasks pulled " << promotion_objects.size()
+            << " promotion candidate(s) from master";
+
+    // Cap per-tick work at one task. Each task does a synchronous SSD
+    // read + RDMA write whose wall-time scales with object size; KV-cache
+    // workloads commonly use 64 MB–1 GB tensors, so even a handful of
+    // tasks can exceed the master's heartbeat / client-liveness window
+    // and get the client wrongly marked dead. Capping at 1 makes promotion
+    // tolerant of any object size at the cost of slow queue drain
+    // (~1 promotion per heartbeat interval). Excess tasks are processed
+    // on subsequent ticks; the master re-queues nothing because the
+    // per-client promotion_objects map was already drained by Heartbeat
+    // above. If sub-MB workloads need higher throughput, raise this with
+    // a per-deployment config knob and consider a byte-budget cap.
+    constexpr size_t kMaxPromotionsPerTick = 1;
+
+    // No segment preference in v1: let master pick from any DRAM segment.
+    const std::vector<std::string> preferred_segments;
+
+    size_t processed = 0;
+    for (const auto& [key, size] : promotion_objects) {
+        if (processed++ >= kMaxPromotionsPerTick) {
+            VLOG(1) << "ProcessPromotionTasks deferring "
+                    << (promotion_objects.size() - kMaxPromotionsPerTick)
+                    << " task(s) to next tick (per-tick cap "
+                    << kMaxPromotionsPerTick << ")";
+            break;
+        }
+        if (size <= 0) {
+            LOG(WARNING) << "Skipping promotion for key=" << key
+                         << " with non-positive size=" << size;
+            continue;
+        }
+
+        auto alloc_result = client_->PromotionAllocStart(
+            key, static_cast<uint64_t>(size), preferred_segments);
+        if (!alloc_result) {
+            VLOG(1) << "PromotionAllocStart failed for key=" << key
+                    << ", error=" << alloc_result.error()
+                    << " (likely no free DRAM); master will reap";
+            continue;
+        }
+
+        // (a) Allocate an O_DIRECT-aligned staging buffer and read the bytes
+        // from the local SSD backend into it. AllocateBatch returns a
+        // shared_ptr<AllocatedBatch> whose BufferHandles RAII-release the
+        // staging space when the local goes out of scope.
+        std::vector<std::string> single_key{key};
+        std::vector<int64_t> single_size{size};
+        auto allocate_res = AllocateBatch(single_key, single_size);
+        if (!allocate_res) {
+            LOG(WARNING) << "Promotion: AllocateBatch failed for key=" << key
+                         << ", error=" << allocate_res.error();
+            continue;
+        }
+        auto staging = allocate_res.value();
+        auto load_res = BatchLoad(staging->slices);
+        if (!load_res) {
+            LOG(WARNING) << "Promotion: BatchLoad failed for key=" << key
+                         << ", error=" << load_res.error();
+            continue;
+        }
+
+        // (b) TE-write from the staging slice into the freshly-allocated
+        // MEMORY replica. Slice ptr may have been bumped by O_DIRECT offset
+        // correction in BatchLoad, so re-read it from the slice map.
+        auto slice_it = staging->slices.find(key);
+        if (slice_it == staging->slices.end()) {
+            LOG(WARNING) << "Promotion: staging slice missing for key=" << key;
+            continue;
+        }
+        std::vector<Slice> tx_slices{slice_it->second};
+        ErrorCode write_err = client_->PromotionWrite(
+            alloc_result.value().memory_descriptor, tx_slices);
+        if (write_err != ErrorCode::OK) {
+            LOG(WARNING) << "Promotion: TransferWrite failed for key=" << key
+                         << ", error=" << write_err;
+            continue;
+        }
+
+        // (c) Commit. Master flips the PROCESSING replica to COMPLETE and it
+        // becomes visible to readers.
+        auto notify_res = client_->NotifyPromotionSuccess(key);
+        if (!notify_res) {
+            LOG(WARNING) << "Promotion: NotifyPromotionSuccess failed for key="
+                         << key << ", error=" << notify_res.error();
+            continue;
+        }
+
+        VLOG(1) << "Promotion completed for key=" << key << ", size=" << size;
+    }
+
     return {};
 }
 

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -557,7 +557,8 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
     VLOG(1) << "ProcessPromotionTasks pulled " << promotion_objects.size()
             << " promotion candidate(s) from master";
 
-    // No segment preference in v1: let master pick from any DRAM segment.
+    // No segment preference from the client: let master pick from any
+    // DRAM segment.
     const std::vector<std::string> preferred_segments;
 
     // The master caps per-heartbeat work via PromotionObjectHeartbeat,
@@ -576,17 +577,14 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         auto alloc_result = client_->PromotionAllocStart(
             key, static_cast<uint64_t>(size), preferred_segments);
         if (!alloc_result) {
-            // AllocStart failed (typically NO_AVAILABLE_HANDLE under DRAM
-            // pressure). No staged buffer to release, but the task entry
-            // and its slot in promotion_in_flight_ were claimed back in
-            // TryPushPromotionQueue when the gate admitted us. Without
-            // an explicit release the slot stays pinned for up to
-            // put_start_release_timeout_sec_ (default 10 min), which
-            // turns transient DRAM pressure into a sustained outage of
-            // promotion_queue_limit_. Notify is idempotent and handles
-            // the alloc_id == 0 case correctly (just erases the task
-            // entry and decrements the counter; the EraseReplicaByID
-            // branch is gated on alloc_id != 0).
+            // AllocStart failed (typically NO_AVAILABLE_HANDLE under
+            // DRAM pressure). No staged buffer to release, but the
+            // task entry already claimed a promotion_in_flight_ slot
+            // at admission. Notify the master to release it
+            // immediately; otherwise the slot stays pinned for the
+            // reaper TTL (~10 min default), turning transient DRAM
+            // pressure into a sustained outage of promotion_queue_limit_.
+            // Notify is idempotent and handles alloc_id == 0 correctly.
             VLOG(1) << "PromotionAllocStart failed for key=" << key
                     << ", error=" << alloc_result.error()
                     << " (likely no free DRAM); releasing master slot";
@@ -600,16 +598,12 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         }
 
         // Every failure path past this point has a master-side staged
-        // PROCESSING MEMORY buffer attached to the object and an
-        // incremented promotion_in_flight_ slot. If we just `continue`
-        // without notifying the master, the buffer and slot stay pinned
-        // until the reaper TTL (~10 min default). Transient SSD throttling
-        // or RDMA flakes would then saturate promotion_queue_limit_ for
-        // 10 minutes and silently disable the feature. Eagerly notify the
-        // master so the buffer is reclaimed and the slot is freed for
-        // subsequent admissions. NotifyPromotionFailure is idempotent and
-        // best-effort; if it itself fails, the reaper is still the
-        // long-stop safety net.
+        // PROCESSING MEMORY buffer and an incremented in-flight slot.
+        // Eagerly notify the master on failure so the buffer is
+        // reclaimed and the slot is freed; otherwise transient SSD
+        // throttling or RDMA flakes saturate promotion_queue_limit_
+        // for the full reaper TTL. NotifyPromotionFailure is
+        // idempotent and best-effort — the reaper is the long-stop.
         auto release_master_state = [this, &key]() {
             auto release = client_->NotifyPromotionFailure(key);
             if (!release) {

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -557,31 +557,16 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
     VLOG(1) << "ProcessPromotionTasks pulled " << promotion_objects.size()
             << " promotion candidate(s) from master";
 
-    // Cap per-tick work at one task. Each task does a synchronous SSD
-    // read + RDMA write whose wall-time scales with object size; KV-cache
-    // workloads commonly use 64 MB–1 GB tensors, so even a handful of
-    // tasks can exceed the master's heartbeat / client-liveness window
-    // and get the client wrongly marked dead. Capping at 1 makes promotion
-    // tolerant of any object size at the cost of slow queue drain
-    // (~1 promotion per heartbeat interval). Excess tasks are processed
-    // on subsequent ticks; the master re-queues nothing because the
-    // per-client promotion_objects map was already drained by Heartbeat
-    // above. If sub-MB workloads need higher throughput, raise this with
-    // a per-deployment config knob and consider a byte-budget cap.
-    constexpr size_t kMaxPromotionsPerTick = 1;
-
     // No segment preference in v1: let master pick from any DRAM segment.
     const std::vector<std::string> preferred_segments;
 
-    size_t processed = 0;
+    // The master caps per-heartbeat work via PromotionObjectHeartbeat,
+    // returning at most one task per call so the heartbeat thread stays
+    // within the client-liveness window even for large objects. Leftover
+    // work stays queued in the master's promotion_objects map and is
+    // returned on subsequent heartbeats; we process whatever we received
+    // here without a second client-side cap.
     for (const auto& [key, size] : promotion_objects) {
-        if (processed++ >= kMaxPromotionsPerTick) {
-            VLOG(1) << "ProcessPromotionTasks deferring "
-                    << (promotion_objects.size() - kMaxPromotionsPerTick)
-                    << " task(s) to next tick (per-tick cap "
-                    << kMaxPromotionsPerTick << ")";
-            break;
-        }
         if (size <= 0) {
             LOG(WARNING) << "Skipping promotion for key=" << key
                          << " with non-positive size=" << size;

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -126,6 +126,14 @@ DEFINE_bool(offload_on_evict, false,
             "Defer LOCAL_DISK offload to eviction time instead of PutEnd");
 DEFINE_bool(offload_force_evict, false,
             "Force-evict objects exceeding offload cap without disk offload");
+DEFINE_bool(promotion_on_hit, false,
+            "Promote LOCAL_DISK-only keys to MEMORY on read access (mirror of "
+            "offload_on_evict)");
+DEFINE_uint32(promotion_admission_threshold, 2,
+              "Min CountMinSketch count for a key before promotion fires "
+              "(set 1 to disable second-touch gating)");
+DEFINE_uint32(promotion_queue_limit, 50000,
+              "Max in-flight promotion tasks across all shards");
 DEFINE_string(ha_backend_type, "etcd",
               "HA backend type, e.g. etcd | redis | k8s");
 DEFINE_string(ha_backend_connstring, "",
@@ -342,6 +350,14 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetBool("offload_force_evict",
                            &master_config.offload_force_evict,
                            FLAGS_offload_force_evict);
+    default_config.GetBool("promotion_on_hit", &master_config.promotion_on_hit,
+                           FLAGS_promotion_on_hit);
+    default_config.GetUInt32("promotion_admission_threshold",
+                             &master_config.promotion_admission_threshold,
+                             FLAGS_promotion_admission_threshold);
+    default_config.GetUInt32("promotion_queue_limit",
+                             &master_config.promotion_queue_limit,
+                             FLAGS_promotion_queue_limit);
     default_config.GetString("ha_backend_type", &master_config.ha_backend_type,
                              FLAGS_ha_backend_type);
     default_config.GetString("ha_backend_connstring",
@@ -594,6 +610,46 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
          !info.is_default) ||
         !conf_set) {
         master_config.enable_offload = FLAGS_enable_offload;
+    }
+    if ((google::GetCommandLineFlagInfo("offload_on_evict", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.offload_on_evict = FLAGS_offload_on_evict;
+    }
+    if ((google::GetCommandLineFlagInfo("offload_force_evict", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.offload_force_evict = FLAGS_offload_force_evict;
+    }
+    if ((google::GetCommandLineFlagInfo("promotion_on_hit", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.promotion_on_hit = FLAGS_promotion_on_hit;
+    }
+    if ((google::GetCommandLineFlagInfo("promotion_admission_threshold",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.promotion_admission_threshold =
+            FLAGS_promotion_admission_threshold;
+    }
+    if ((google::GetCommandLineFlagInfo("promotion_queue_limit", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.promotion_queue_limit = FLAGS_promotion_queue_limit;
+    }
+    // Clamp promotion_admission_threshold into the sketch counter's
+    // representable range. The CountMinSketch uses 8-bit saturating
+    // counters (max 255) so any threshold beyond that would silently
+    // make the gate unreachable; clamping at parse time fails loudly and
+    // gives the gate a stable contract to compare uint8_t against.
+    if (master_config.promotion_admission_threshold > 255) {
+        LOG(WARNING) << "promotion_admission_threshold="
+                     << master_config.promotion_admission_threshold
+                     << " exceeds the CountMinSketch counter max (255). "
+                     << "Clamping to 255. Lower the configured value to "
+                     << "silence this warning.";
+        master_config.promotion_admission_threshold = 255;
     }
     if ((google::GetCommandLineFlagInfo("ha_backend_type", &info) &&
          !info.is_default) ||

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -248,6 +248,11 @@ struct RpcNameTraits<&WrappedMasterService::NotifyPromotionSuccess> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::NotifyPromotionFailure> {
+    static constexpr const char* value = "NotifyPromotionFailure";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::CopyStart> {
     static constexpr const char* value = "CopyStart";
 };
@@ -978,14 +983,14 @@ MasterClient::PromotionObjectHeartbeat(const UUID& client_id) {
 
 tl::expected<PromotionAllocStartResponse, ErrorCode>
 MasterClient::PromotionAllocStart(
-    const std::string& key, uint64_t size,
+    const UUID& client_id, const std::string& key, uint64_t size,
     const std::vector<std::string>& preferred_segments) {
     ScopedVLogTimer timer(1, "MasterClient::PromotionAllocStart");
-    timer.LogRequest("key=", key, ", size=", size,
+    timer.LogRequest("client_id=", client_id, ", key=", key, ", size=", size,
                      ", preferred_count=", preferred_segments.size());
-    auto result =
-        invoke_rpc<&WrappedMasterService::PromotionAllocStart,
-                   PromotionAllocStartResponse>(key, size, preferred_segments);
+    auto result = invoke_rpc<&WrappedMasterService::PromotionAllocStart,
+                             PromotionAllocStartResponse>(client_id, key, size,
+                                                          preferred_segments);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -996,6 +1001,17 @@ tl::expected<void, ErrorCode> MasterClient::NotifyPromotionSuccess(
     timer.LogRequest("client_id=", client_id, ", key=", key);
     auto result =
         invoke_rpc<&WrappedMasterService::NotifyPromotionSuccess, void>(
+            client_id, key);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<void, ErrorCode> MasterClient::NotifyPromotionFailure(
+    const UUID& client_id, const std::string& key) {
+    ScopedVLogTimer timer(1, "MasterClient::NotifyPromotionFailure");
+    timer.LogRequest("client_id=", client_id, ", key=", key);
+    auto result =
+        invoke_rpc<&WrappedMasterService::NotifyPromotionFailure, void>(
             client_id, key);
     timer.LogResponseExpected(result);
     return result;

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -233,6 +233,21 @@ struct RpcNameTraits<&WrappedMasterService::NotifyOffloadSuccess> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::PromotionObjectHeartbeat> {
+    static constexpr const char* value = "PromotionObjectHeartbeat";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::PromotionAllocStart> {
+    static constexpr const char* value = "PromotionAllocStart";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::NotifyPromotionSuccess> {
+    static constexpr const char* value = "NotifyPromotionSuccess";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::CopyStart> {
     static constexpr const char* value = "CopyStart";
 };
@@ -949,6 +964,39 @@ tl::expected<void, ErrorCode> MasterClient::NotifyOffloadSuccess(
 
     auto result = invoke_rpc<&WrappedMasterService::NotifyOffloadSuccess, void>(
         client_id, keys, metadatas);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>
+MasterClient::PromotionObjectHeartbeat(const UUID& client_id) {
+    ScopedVLogTimer timer(1, "MasterClient::PromotionObjectHeartbeat");
+    timer.LogRequest("client_id=", client_id);
+    return invoke_rpc<&WrappedMasterService::PromotionObjectHeartbeat,
+                      std::unordered_map<std::string, int64_t>>(client_id);
+}
+
+tl::expected<PromotionAllocStartResponse, ErrorCode>
+MasterClient::PromotionAllocStart(
+    const std::string& key, uint64_t size,
+    const std::vector<std::string>& preferred_segments) {
+    ScopedVLogTimer timer(1, "MasterClient::PromotionAllocStart");
+    timer.LogRequest("key=", key, ", size=", size,
+                     ", preferred_count=", preferred_segments.size());
+    auto result =
+        invoke_rpc<&WrappedMasterService::PromotionAllocStart,
+                   PromotionAllocStartResponse>(key, size, preferred_segments);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<void, ErrorCode> MasterClient::NotifyPromotionSuccess(
+    const UUID& client_id, const std::string& key) {
+    ScopedVLogTimer timer(1, "MasterClient::NotifyPromotionSuccess");
+    timer.LogRequest("client_id=", client_id, ", key=", key);
+    auto result =
+        invoke_rpc<&WrappedMasterService::NotifyPromotionSuccess, void>(
+            client_id, key);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2962,10 +2962,28 @@ auto MasterService::PromotionAllocStart(
     // NotifyPromotionSuccess knows exactly which replica to commit (a
     // concurrent Put on this key may stage other PROCESSING MEMORY
     // replicas; finding "first PROCESSING memory" would be ambiguous).
+    //
+    // Also reset start_time. The task TTL exists to bound the
+    // *active-transfer* phase (AllocStart -> client SSD read -> RDMA
+    // write -> Notify). Pre-reset, the same start_time was set at queue
+    // admission and never bumped, so a task that sat queued behind a
+    // backlog on the holder client (kMaxPerHeartbeat = 1 serializes
+    // work) could enter the active-transfer phase with only a sliver of
+    // the original TTL remaining. If the SSD read + RDMA write of a
+    // large object then ran past expiry, the reaper would call
+    // EraseReplicaByID on this staged replica mid-transfer and the
+    // allocator could hand the buffer to a concurrent Put while the
+    // RDMA write is still landing into it. By resetting here we give
+    // the active-transfer phase its own full TTL window measured from
+    // the moment a buffer becomes vulnerable; the queue-waiting phase
+    // (alloc_id still 0) is bounded by its own original-start_time
+    // window during which the reaper's EraseReplicaByID branch is a
+    // no-op.
     auto& shard = accessor.GetShard();
     auto task_it = shard->promotion_tasks.find(key);
     if (task_it != shard->promotion_tasks.end()) {
         task_it->second.alloc_id = new_id;
+        task_it->second.start_time = std::chrono::system_clock::now();
     }
     return PromotionAllocStartResponse{std::move(desc)};
 }
@@ -3229,6 +3247,13 @@ void MasterService::DiscardExpiredProcessingReplicas(
     //     the object itself is removed or evicted.
     //   - Erase the task entry and decrement the global in-flight
     //     counter.
+    // The deadline anchor (task.start_time) is set at admission and
+    // reset at PromotionAllocStart, so the queue-wait phase
+    // (alloc_id == 0, no buffer) and the active-transfer phase
+    // (alloc_id != 0, master-allocated buffer in flight) each get a
+    // full put_start_release_timeout_sec_ window measured from when
+    // they started. The reaper does not need to distinguish the two
+    // phases here: alloc_id gates the EraseReplicaByID branch.
     // The per-client promotion_objects map is best-effort garbage
     // collected on the next heartbeat (entries for vanished tasks are
     // harmless — the client will allocate, transfer, then

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -244,6 +244,13 @@ MasterService::MasterService(const MasterServiceConfig& config)
     promotion_on_hit_ = enable_offload_ && config.promotion_on_hit;
     promotion_admission_threshold_ = config.promotion_admission_threshold;
     promotion_queue_limit_ = config.promotion_queue_limit;
+    if (config.promotion_on_hit && !enable_offload_) {
+        LOG(WARNING) << "promotion_on_hit=true was requested but "
+                     << "enable_offload=false; promotion is silently "
+                     << "disabled because it requires offload to produce "
+                     << "LOCAL_DISK replicas. Set enable_offload=true to "
+                     << "use this feature.";
+    }
     if (promotion_on_hit_) {
         promotion_sketch_ = std::make_unique<CountMinSketch>();
         LOG(INFO) << "Promotion-on-hit mode enabled: LOCAL_DISK-only Gets "
@@ -2830,11 +2837,15 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
         return;
     }
 
-    // Cap gate: cheap stat — read this shard's count under our held RW lock,
-    // which already gives an upper bound that's typically tight enough.
-    // Cluster-wide cap can be added in a follow-up; for v1 the per-shard
-    // count × shard count gives a soft cap.
-    if (shard->promotion_tasks.size() * kNumShards >= promotion_queue_limit_) {
+    // Cap gate: read the cluster-wide in-flight count. Soft cap — a
+    // benign TOCTOU race between this load and the emplace below can let
+    // a few extra tasks slip in, but the per-shard mutex already
+    // serializes inserts within a shard and the dedup gate above prevents
+    // duplicate work, so the worst case is N concurrent inserters across
+    // distinct shards each admitting one extra task. Atomic load is
+    // relaxed because the value is purely advisory.
+    if (promotion_in_flight_.load(std::memory_order_relaxed) >=
+        promotion_queue_limit_) {
         return;
     }
 
@@ -2869,6 +2880,7 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
                            .alloc_id = 0,
                            .object_size = object_size,
                            .start_time = std::chrono::system_clock::now()});
+    promotion_in_flight_.fetch_add(1, std::memory_order_relaxed);
     VLOG(1) << "promotion_queued key=" << key << " size=" << object_size;
 }
 
@@ -2953,10 +2965,7 @@ auto MasterService::PromotionAllocStart(
     auto& shard = accessor.GetShard();
     auto task_it = shard->promotion_tasks.find(key);
     if (task_it != shard->promotion_tasks.end()) {
-        // const_cast: promotion_tasks holds const PromotionTask values for
-        // generic safety, but we own the entry under the shard write lock
-        // and need to record the alloc_id post-Allocate.
-        const_cast<PromotionTask&>(task_it->second).alloc_id = new_id;
+        task_it->second.alloc_id = new_id;
     }
     return PromotionAllocStartResponse{std::move(desc)};
 }
@@ -2997,6 +3006,7 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
         source->dec_refcnt();
     }
     shard->promotion_tasks.erase(task_it);
+    promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
 
     // Erase the per-client promotion_objects entry (best-effort; the
     // heartbeat may have already drained it).
@@ -3207,13 +3217,23 @@ void MasterService::DiscardExpiredProcessingReplicas(
         task_it = shard->offloading_tasks.erase(task_it);
     }
 
-    // Part 4: Discard expired promotion-on-hit tasks. Drops the source
-    // LOCAL_DISK replica's refcnt and erases the task entry; the per-client
-    // promotion_objects map is best-effort garbage collected on the next
-    // heartbeat (entries for vanished tasks are harmless — the client will
-    // allocate, transfer, then NotifyPromotionSuccess will return
-    // REPLICA_IS_NOT_READY and the new MEMORY replica is reaped via the
-    // discarded-replicas path).
+    // Part 4: Discard expired promotion-on-hit tasks. For each expired
+    // task:
+    //   - Drop the source LOCAL_DISK replica's refcnt so it can be
+    //     evicted normally.
+    //   - If PromotionAllocStart already staged a PROCESSING MEMORY
+    //     replica (alloc_id != 0), pop it via EraseReplicaByID. The
+    //     staged replica is not in shard->processing_keys, so
+    //     DiscardExpiredProcessingReplicas would never reap it; this is
+    //     the only place that does. Without this the buffer leaks until
+    //     the object itself is removed or evicted.
+    //   - Erase the task entry and decrement the global in-flight
+    //     counter.
+    // The per-client promotion_objects map is best-effort garbage
+    // collected on the next heartbeat (entries for vanished tasks are
+    // harmless — the client will allocate, transfer, then
+    // NotifyPromotionSuccess will return REPLICA_IS_NOT_READY since the
+    // task entry is gone).
     for (auto task_it = shard->promotion_tasks.begin();
          task_it != shard->promotion_tasks.end();) {
         const auto ttl =
@@ -3229,9 +3249,13 @@ void MasterService::DiscardExpiredProcessingReplicas(
             if (source != nullptr) {
                 source->dec_refcnt();
             }
+            if (task_it->second.alloc_id != 0) {
+                metadata_it->second.EraseReplicaByID(task_it->second.alloc_id);
+            }
         }
         LOG(WARNING) << "Promotion task expired for key: " << task_it->first;
         task_it = shard->promotion_tasks.erase(task_it);
+        promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
     }
 
     if (!discarded_replicas.empty()) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2884,7 +2884,23 @@ auto MasterService::PromotionObjectHeartbeat(const UUID& client_id)
         return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
     }
     MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
-    return std::move(local_disk_segment_it->second->promotion_objects);
+    // Return at most kMaxPerHeartbeat tasks to the client. Each task does a
+    // synchronous SSD read + RDMA write on the client side; allowing more
+    // than one per heartbeat risks blocking past the heartbeat / client-
+    // liveness window and the master marking the client dead. The rest
+    // stay queued in promotion_objects for subsequent heartbeats — this
+    // preserves leftover work and avoids the prior bug where the client
+    // capped its own loop at 1 and silently dropped the remainder (their
+    // promotion_tasks entries would stay refcnt-pinned until the reaper
+    // TTL expired).
+    constexpr size_t kMaxPerHeartbeat = 1;
+    auto& src = local_disk_segment_it->second->promotion_objects;
+    std::unordered_map<std::string, int64_t> result;
+    while (result.size() < kMaxPerHeartbeat && !src.empty()) {
+        auto node = src.extract(src.begin());
+        result.insert(std::move(node));
+    }
+    return result;
 }
 
 auto MasterService::PromotionAllocStart(

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2929,15 +2929,13 @@ auto MasterService::PromotionObjectHeartbeat(const UUID& client_id)
         return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
     }
     MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
-    // Return at most kMaxPerHeartbeat tasks to the client. Each task does a
-    // synchronous SSD read + RDMA write on the client side; allowing more
-    // than one per heartbeat risks blocking past the heartbeat / client-
+    // Return at most kMaxPerHeartbeat tasks. Each task does a
+    // synchronous SSD read + RDMA write on the client side; allowing
+    // more than one per heartbeat risks blocking past the client-
     // liveness window and the master marking the client dead. The rest
-    // stay queued in promotion_objects for subsequent heartbeats — this
-    // preserves leftover work and avoids the prior bug where the client
-    // capped its own loop at 1 and silently dropped the remainder (their
-    // promotion_tasks entries would stay refcnt-pinned until the reaper
-    // TTL expired).
+    // stay queued in promotion_objects for subsequent heartbeats. The
+    // cap must live here (server side) rather than on the client so
+    // leftover work isn't silently dropped.
     constexpr size_t kMaxPerHeartbeat = 1;
     auto& src = local_disk_segment_it->second->promotion_objects;
     std::unordered_map<std::string, int64_t> result;
@@ -2959,44 +2957,32 @@ auto MasterService::PromotionAllocStart(
     }
     auto& metadata = accessor.Get();
 
-    // Verify the in-flight task still exists before allocating. The reaper
-    // can sweep a task between the holder's heartbeat and this AllocStart
-    // call (a hung client, GC pause, or HA failover can stall AllocStart
-    // for longer than put_start_release_timeout_sec_). If we allocated
-    // and AddReplicas'd unconditionally, the staged PROCESSING MEMORY
+    // Verify the in-flight task still exists before allocating. The
+    // reaper can sweep it between the holder's heartbeat and this
+    // AllocStart call (a hung client, GC pause, or HA failover can
+    // stall AllocStart past put_start_release_timeout_sec_). If we
+    // allocated and AddReplicas'd anyway, the staged PROCESSING MEMORY
     // replica would have no PromotionTask pointing at it: the generic
-    // PROCESSING reaper (DiscardExpiredProcessingReplicas) only iterates
-    // shard->processing_keys, which AllocStart never populates, and the
-    // promotion-task reaper has nothing left to iterate. The buffer would
-    // sit attached to the object until the object itself is removed or
-    // evicted — the same orphaned-staged-replica shape Issue 1's fix
-    // closed on the symmetric (task-still-exists-but-reaper-fires-first)
-    // path. The shard mutex is held through the rest of this function,
-    // so the iterator stays valid across the allocation step.
+    // PROCESSING reaper iterates shard->processing_keys (never
+    // populated by promotion) and the promotion-task reaper would have
+    // nothing left to iterate, leaking the buffer until the object is
+    // removed or evicted. The shard mutex is held for the rest of this
+    // function, so the iterator stays valid across the allocation step.
     auto& shard = accessor.GetShard();
     auto task_it = shard->promotion_tasks.find(key);
     if (task_it == shard->promotion_tasks.end()) {
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
     }
 
-    // Authorize caller: only the holder client (the one whose LOCAL_DISK
-    // segment owns the source replica) is allowed to stage the MEMORY
-    // copy. Without this gate any client that knows the key could drain
-    // another's promotion_objects queue (PromotionObjectHeartbeat is
-    // unauthenticated in the current trust model) and then call us here
-    // to allocate arbitrary DRAM buffers on the destination segment,
-    // which would sit pinned until the reaper TTL.
+    // Holder-only gate (see PromotionTask::holder_id doc).
     if (task_it->second.holder_id != client_id) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    // Defensive size check: the size must match what TryPushPromotionQueue
-    // captured from the source LOCAL_DISK replica's descriptor. A mismatch
-    // would let a buggy caller request an arbitrarily larger or smaller
-    // allocation than the actual object — smaller risks the subsequent
-    // RDMA write overflowing into adjacent allocator state (the MR will
-    // typically catch this but defense-in-depth is cheap), and larger
-    // wastes DRAM that stays pinned until the reaper TTL.
+    // Defensive size check: must match the source LOCAL_DISK
+    // descriptor's object_size captured at admission. A mismatch would
+    // let a buggy caller request a wrong-sized allocation — smaller
+    // risks RDMA overflow, larger wastes DRAM pinned until reaper TTL.
     if (task_it->second.object_size != size) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -3034,26 +3020,20 @@ auto MasterService::PromotionAllocStart(
     metadata.AddReplicas(std::move(to_add));
 
     // Record the new replica's ID on the in-flight PromotionTask so
-    // NotifyPromotionSuccess knows exactly which replica to commit (a
+    // NotifyPromotionSuccess knows exactly which replica to commit. A
     // concurrent Put on this key may stage other PROCESSING MEMORY
-    // replicas; finding "first PROCESSING memory" would be ambiguous).
+    // replicas; using alloc_id avoids the "first PROCESSING memory"
+    // ambiguity.
     //
-    // Also reset start_time. The task TTL exists to bound the
-    // *active-transfer* phase (AllocStart -> client SSD read -> RDMA
-    // write -> Notify). Pre-reset, the same start_time was set at queue
-    // admission and never bumped, so a task that sat queued behind a
-    // backlog on the holder client (kMaxPerHeartbeat = 1 serializes
-    // work) could enter the active-transfer phase with only a sliver of
-    // the original TTL remaining. If the SSD read + RDMA write of a
-    // large object then ran past expiry, the reaper would call
-    // EraseReplicaByID on this staged replica mid-transfer and the
-    // allocator could hand the buffer to a concurrent Put while the
-    // RDMA write is still landing into it. By resetting here we give
-    // the active-transfer phase its own full TTL window measured from
-    // the moment a buffer becomes vulnerable; the queue-waiting phase
-    // (alloc_id still 0) is bounded by its own original-start_time
-    // window during which the reaper's EraseReplicaByID branch is a
-    // no-op.
+    // Also reset start_time so the reaper TTL covers the active-
+    // transfer phase (AllocStart -> SSD read -> RDMA write -> Notify)
+    // measured from when a master-allocated buffer becomes vulnerable,
+    // rather than being consumed by queue-waiting. Without the reset,
+    // a backlogged task could enter active transfer with little TTL
+    // remaining and the reaper could free the staged replica via
+    // EraseReplicaByID mid-RDMA-write. The queue-waiting phase
+    // (alloc_id == 0) is bounded by its own original start_time window
+    // during which the reaper's EraseReplicaByID branch is a no-op.
     task_it->second.alloc_id = new_id;
     task_it->second.start_time = std::chrono::system_clock::now();
     return PromotionAllocStartResponse{std::move(desc)};
@@ -3081,11 +3061,7 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
     }
 
-    // Only the holder client (the one owning the source LOCAL_DISK
-    // segment) is authorized to commit. Without this check any client
-    // knowing the key could flip the staged PROCESSING replica to
-    // COMPLETE before the holder's RDMA write has landed, exposing torn
-    // data to readers.
+    // Holder-only gate (see PromotionTask::holder_id doc).
     if (task_it->second.holder_id != client_id) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -3146,22 +3122,13 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
         return {};
     }
 
-    // Same authorization gate as NotifyPromotionSuccess: only the holder
-    // may release. A spurious failure notification from another client
-    // should not be allowed to free state that legitimate holder still
-    // intends to commit.
+    // Holder-only gate (see PromotionTask::holder_id doc).
     if (task_it->second.holder_id != client_id) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    // Mirror the reaper's expiry path:
-    //   - Drop source LOCAL_DISK refcnt so it can be evicted normally.
-    //   - If AllocStart already staged a PROCESSING MEMORY replica
-    //     (alloc_id != 0), pop it via EraseReplicaByID. That buffer is
-    //     not in shard->processing_keys, so only this path (and the
-    //     reaper) can reap it.
-    //   - Erase the task entry and decrement the global in-flight
-    //     counter so the slot is immediately available to other admissions.
+    // Mirror the reaper's expiry path; see DiscardExpiredProcessingReplicas
+    // Part 4 for the full rationale on each step.
     auto* source = metadata.GetReplicaByID(task_it->second.source_id);
     if (source != nullptr) {
         source->dec_refcnt();
@@ -3379,30 +3346,21 @@ void MasterService::DiscardExpiredProcessingReplicas(
         task_it = shard->offloading_tasks.erase(task_it);
     }
 
-    // Part 4: Discard expired promotion-on-hit tasks. For each expired
-    // task:
-    //   - Drop the source LOCAL_DISK replica's refcnt so it can be
+    // Part 4: Discard expired promotion-on-hit tasks. For each:
+    //   - Drop the source LOCAL_DISK refcnt so the source can be
     //     evicted normally.
-    //   - If PromotionAllocStart already staged a PROCESSING MEMORY
-    //     replica (alloc_id != 0), pop it via EraseReplicaByID. The
-    //     staged replica is not in shard->processing_keys, so
-    //     DiscardExpiredProcessingReplicas would never reap it; this is
-    //     the only place that does. Without this the buffer leaks until
-    //     the object itself is removed or evicted.
-    //   - Erase the task entry and decrement the global in-flight
-    //     counter.
-    // The deadline anchor (task.start_time) is set at admission and
-    // reset at PromotionAllocStart, so the queue-wait phase
-    // (alloc_id == 0, no buffer) and the active-transfer phase
-    // (alloc_id != 0, master-allocated buffer in flight) each get a
-    // full put_start_release_timeout_sec_ window measured from when
-    // they started. The reaper does not need to distinguish the two
-    // phases here: alloc_id gates the EraseReplicaByID branch.
-    // The per-client promotion_objects map is best-effort garbage
-    // collected on the next heartbeat (entries for vanished tasks are
-    // harmless — the client will allocate, transfer, then
-    // NotifyPromotionSuccess will return REPLICA_IS_NOT_READY since the
-    // task entry is gone).
+    //   - If a PROCESSING MEMORY replica was staged (alloc_id != 0),
+    //     pop it via EraseReplicaByID. The staged replica is not in
+    //     shard->processing_keys, so this is the only place (besides
+    //     NotifyPromotionFailure) that reaps it; without this the
+    //     buffer leaks until the object is removed or evicted.
+    //   - Erase the task entry and decrement the in-flight counter.
+    // task.start_time is set at admission and reset at AllocStart, so
+    // queue-wait (alloc_id == 0) and active-transfer (alloc_id != 0)
+    // phases each get a full put_start_release_timeout_sec_ window.
+    // The per-client promotion_objects map is GC'd on the next
+    // heartbeat (entries for vanished tasks are harmless — Notify will
+    // return REPLICA_IS_NOT_READY since the task entry is gone).
     for (auto task_it = shard->promotion_tasks.begin();
          task_it != shard->promotion_tasks.end();) {
         const auto ttl =

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -244,6 +244,16 @@ MasterService::MasterService(const MasterServiceConfig& config)
     promotion_on_hit_ = enable_offload_ && config.promotion_on_hit;
     promotion_admission_threshold_ = config.promotion_admission_threshold;
     promotion_queue_limit_ = config.promotion_queue_limit;
+    // Defense-in-depth clamp: master.cpp clamps threshold into [1, 255]
+    // at flag-parse time, but direct MasterServiceConfig construction
+    // (tests, embedded users) bypasses that. Without the clamp here,
+    // threshold=0 would silently bypass the frequency gate entirely
+    // (freq < 0 is never true for uint8_t).
+    if (promotion_admission_threshold_ == 0) {
+        promotion_admission_threshold_ = 1;
+    } else if (promotion_admission_threshold_ > 255) {
+        promotion_admission_threshold_ = 255;
+    }
     if (config.promotion_on_hit && !enable_offload_) {
         LOG(WARNING) << "promotion_on_hit=true was requested but "
                      << "enable_offload=false; promotion is silently "
@@ -1611,6 +1621,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     if (it != shard->metadata.end() &&
         CleanupStaleHandles(it->second, alive_clients)) {
         shard->processing_keys.erase(key);
+        ErasePromotionTaskIfPresent(shard, key);
         shard->metadata.erase(it);
         it = shard->metadata.end();
     }
@@ -1651,6 +1662,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
             // If no COMPLETE replicas survive the preemption, this key
             // effectively does not exist — fall through to Case A.
             if (!metadata.HasReplica(&Replica::fn_is_completed)) {
+                ErasePromotionTaskIfPresent(shard, key);
                 shard->metadata.erase(it);
                 it = shard->metadata.end();
             }
@@ -2318,6 +2330,7 @@ auto MasterService::Remove(const std::string& key, bool force)
 
     // Remove object metadata
     accessor.Erase();
+    ErasePromotionTaskIfPresent(accessor.GetShard(), key);
     return {};
 }
 
@@ -2371,6 +2384,7 @@ auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
 
                 VLOG(1) << "key=" << it->first
                         << " matched by regex. Removing.";
+                ErasePromotionTaskIfPresent(shard, it->first);
                 it = shard->metadata.erase(it);
                 removed_count++;
             } else {
@@ -2814,8 +2828,9 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
 
     // Frequency gate: bump and compare against the threshold. The sketch
     // returns uint8_t (saturating at 255); promotion_admission_threshold_
-    // is clamped into [1, 255] at config parse time, so direct comparison
-    // is well-defined.
+    // is clamped into [1, 255] at config parse time (see master.cpp), so
+    // direct comparison is well-defined and threshold=0 (which would
+    // bypass the gate entirely since freq is uint8_t) cannot reach here.
     const uint8_t freq = promotion_sketch_->increment(key);
     if (freq < promotion_admission_threshold_) {
         return;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -238,6 +238,20 @@ MasterService::MasterService(const MasterServiceConfig& config)
         }
     }
 
+    // Promotion-on-hit: when Get observes a LOCAL_DISK-only key, queue an
+    // async copy back to MEMORY. Only meaningful when offload is enabled
+    // (otherwise no LOCAL_DISK replicas exist in the first place).
+    promotion_on_hit_ = enable_offload_ && config.promotion_on_hit;
+    promotion_admission_threshold_ = config.promotion_admission_threshold;
+    promotion_queue_limit_ = config.promotion_queue_limit;
+    if (promotion_on_hit_) {
+        promotion_sketch_ = std::make_unique<CountMinSketch>();
+        LOG(INFO) << "Promotion-on-hit mode enabled: LOCAL_DISK-only Gets "
+                     "will queue async promotion to MEMORY (threshold="
+                  << promotion_admission_threshold_
+                  << ", queue_limit=" << promotion_queue_limit_ << ")";
+    }
+
     eviction_running_ = true;
     eviction_thread_ = std::thread(&MasterService::EvictionThreadFunc, this);
     VLOG(1) << "action=start_eviction_thread";
@@ -1033,40 +1047,62 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
 auto MasterService::GetReplicaList(const std::string& key)
     -> tl::expected<GetReplicaListResponse, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRO accessor(this, key);
 
-    MasterMetricManager::instance().inc_total_get_nums();
+    GetReplicaListResponse resp({}, default_kv_lease_ttl_);
+    bool promotion_eligible = false;
+    {
+        MetadataAccessorRO accessor(this, key);
 
-    if (!accessor.Exists()) {
-        VLOG(1) << "key=" << key << ", info=object_not_found";
-        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        MasterMetricManager::instance().inc_total_get_nums();
+
+        if (!accessor.Exists()) {
+            VLOG(1) << "key=" << key << ", info=object_not_found";
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        const auto& metadata = accessor.Get();
+
+        std::vector<Replica::Descriptor> replica_list;
+        metadata.VisitReplicas(
+            &Replica::fn_is_completed, [&replica_list](const Replica& replica) {
+                replica_list.emplace_back(replica.get_descriptor());
+            });
+
+        if (replica_list.empty()) {
+            LOG(WARNING) << "key=" << key << ", error=replica_not_ready";
+            return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+        }
+
+        // TODO: NoF SSD support (ranhaojia)
+        if (replica_list[0].is_memory_replica()) {
+            MasterMetricManager::instance().inc_mem_cache_hit_nums();
+        } else if (replica_list[0].is_disk_replica()) {
+            MasterMetricManager::instance().inc_file_cache_hit_nums();
+        }
+        MasterMetricManager::instance().inc_valid_get_nums();
+        // Grant a lease to the object so it will not be removed
+        // when the client is reading it.
+        metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
+
+        // Promotion-on-hit eligibility: only when no MEMORY replica is
+        // present but at least one LOCAL_DISK replica is. Decided here while
+        // we hold the RO accessor; the actual enqueue happens after we
+        // release the accessor below to avoid lock-upgrade complexity.
+        if (promotion_on_hit_) {
+            const bool any_memory =
+                metadata.HasReplica(&Replica::fn_is_memory_replica);
+            const bool any_local_disk =
+                metadata.HasReplica(&Replica::fn_is_local_disk_replica);
+            promotion_eligible = !any_memory && any_local_disk;
+        }
+
+        resp = GetReplicaListResponse(std::move(replica_list),
+                                      default_kv_lease_ttl_);
     }
-    const auto& metadata = accessor.Get();
-
-    std::vector<Replica::Descriptor> replica_list;
-    metadata.VisitReplicas(
-        &Replica::fn_is_completed, [&replica_list](const Replica& replica) {
-            replica_list.emplace_back(replica.get_descriptor());
-        });
-
-    if (replica_list.empty()) {
-        LOG(WARNING) << "key=" << key << ", error=replica_not_ready";
-        return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    // RO accessor released. Safe to take a fresh RW accessor now.
+    if (promotion_eligible) {
+        TryPushPromotionQueue(key);
     }
-
-    // TODO: NoF SSD support (ranhaojia)
-    if (replica_list[0].is_memory_replica()) {
-        MasterMetricManager::instance().inc_mem_cache_hit_nums();
-    } else if (replica_list[0].is_disk_replica()) {
-        MasterMetricManager::instance().inc_file_cache_hit_nums();
-    }
-    MasterMetricManager::instance().inc_valid_get_nums();
-    // Grant a lease to the object so it will not be removed
-    // when the client is reading it.
-    metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
-
-    return GetReplicaListResponse(std::move(replica_list),
-                                  default_kv_lease_ttl_);
+    return resp;
 }
 
 auto MasterService::AllocateAndInsertMetadata(
@@ -2718,6 +2754,254 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
     return {};
 }
 
+// Promotion-on-hit
+
+// Push a key onto the holder client's promotion_objects map. Resolves the
+// holder via the LOCAL_DISK replica's embedded client_id rather than via
+// the segment-name reverse lookup.
+tl::expected<void, ErrorCode> MasterService::PushPromotionQueue(
+    const std::string& key, Replica& source_replica) {
+    auto holder_id = source_replica.get_local_disk_client_id();
+    if (!holder_id.has_value()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    ScopedLocalDiskSegmentAccess local_disk_segment_access =
+        segment_manager_.getLocalDiskSegmentAccess();
+    auto& client_local_disk_segment =
+        local_disk_segment_access.getClientLocalDiskSegment();
+    auto local_disk_segment_it =
+        client_local_disk_segment.find(holder_id.value());
+    if (local_disk_segment_it == client_local_disk_segment.end()) {
+        // Holder client expired or never had a LocalDiskSegment registered;
+        // the LOCAL_DISK replica will be cleaned up by ClientMonitorFunc on
+        // its own schedule.
+        return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
+    }
+    MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
+    auto res = local_disk_segment_it->second->promotion_objects.emplace(
+        key, static_cast<int64_t>(source_replica.get_descriptor()
+                                      .get_local_disk_descriptor()
+                                      .object_size));
+    if (!res.second) {
+        return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+    }
+    return {};
+}
+
+void MasterService::TryPushPromotionQueue(const std::string& key) {
+    if (!promotion_on_hit_ || !promotion_sketch_) {
+        return;
+    }
+
+    // Frequency gate: bump and compare against the threshold. The sketch
+    // returns uint8_t (saturating at 255); promotion_admission_threshold_
+    // is clamped into [1, 255] at config parse time, so direct comparison
+    // is well-defined.
+    const uint8_t freq = promotion_sketch_->increment(key);
+    if (freq < promotion_admission_threshold_) {
+        return;
+    }
+
+    // Watermark gate: don't promote if DRAM is already under eviction
+    // pressure. The check is best-effort (state can change between this
+    // sample and the actual allocation in PromotionAllocStart).
+    const double used_ratio =
+        MasterMetricManager::instance().get_global_mem_used_ratio();
+    if (used_ratio >= eviction_high_watermark_ratio_) {
+        return;
+    }
+
+    // Acquire a fresh RW shard accessor for dedup, refcnt-pin, and task
+    // record. Safe to call here because GetReplicaList has already released
+    // its RO accessor.
+    MetadataAccessorRW accessor(this, key);
+    if (!accessor.Exists()) {
+        return;
+    }
+    auto& metadata = accessor.Get();
+    auto& shard = accessor.GetShard();
+
+    // Dedup: don't queue twice if a promotion is already in flight or if a
+    // MEMORY replica has appeared since GetReplicaList observed only-disk.
+    if (shard->promotion_tasks.count(key) > 0) {
+        return;
+    }
+    if (metadata.HasReplica(&Replica::fn_is_memory_replica)) {
+        return;
+    }
+
+    // Cap gate: cheap stat — read this shard's count under our held RW lock,
+    // which already gives an upper bound that's typically tight enough.
+    // Cluster-wide cap can be added in a follow-up; for v1 the per-shard
+    // count × shard count gives a soft cap.
+    if (shard->promotion_tasks.size() * kNumShards >= promotion_queue_limit_) {
+        return;
+    }
+
+    // Find the LOCAL_DISK source replica.
+    Replica* source = nullptr;
+    metadata.VisitReplicas(&Replica::fn_is_local_disk_replica,
+                           [&source](Replica& r) {
+                               if (source == nullptr) source = &r;
+                           });
+    if (source == nullptr) {
+        return;
+    }
+
+    // Pin the source replica.
+    source->inc_refcnt();
+    const uint64_t object_size =
+        source->get_descriptor().get_local_disk_descriptor().object_size;
+
+    // Try to enqueue on the holder client. On failure, drop the refcnt back.
+    auto push_result = PushPromotionQueue(key, *source);
+    if (!push_result) {
+        source->dec_refcnt();
+        VLOG(1) << "promotion_push_failed key=" << key
+                << " error=" << push_result.error();
+        return;
+    }
+
+    // Record the in-flight task. alloc_id is filled in by
+    // PromotionAllocStart once the new MEMORY replica is staged.
+    shard->promotion_tasks.emplace(
+        key, PromotionTask{.source_id = source->id(),
+                           .alloc_id = 0,
+                           .object_size = object_size,
+                           .start_time = std::chrono::system_clock::now()});
+    VLOG(1) << "promotion_queued key=" << key << " size=" << object_size;
+}
+
+auto MasterService::PromotionObjectHeartbeat(const UUID& client_id)
+    -> tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode> {
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    ScopedLocalDiskSegmentAccess local_disk_segment_access =
+        segment_manager_.getLocalDiskSegmentAccess();
+    auto& client_local_disk_segment =
+        local_disk_segment_access.getClientLocalDiskSegment();
+    auto local_disk_segment_it = client_local_disk_segment.find(client_id);
+    if (local_disk_segment_it == client_local_disk_segment.end()) {
+        return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
+    }
+    MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
+    return std::move(local_disk_segment_it->second->promotion_objects);
+}
+
+auto MasterService::PromotionAllocStart(
+    const std::string& key, uint64_t size,
+    const std::vector<std::string>& preferred_segments)
+    -> tl::expected<PromotionAllocStartResponse, ErrorCode> {
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    MetadataAccessorRW accessor(this, key);
+    if (!accessor.Exists()) {
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    auto& metadata = accessor.Get();
+
+    // Allocate a single MEMORY replica via the existing strategy, biased to
+    // the holder's mem segment when possible.
+    ReplicateConfig config;
+    config.replica_num = 1;
+    if (!preferred_segments.empty()) {
+        config.preferred_segments = preferred_segments;
+    }
+
+    std::vector<Replica> staged_replicas;
+    {
+        ScopedAllocatorAccess allocator_access =
+            segment_manager_.getAllocatorAccess();
+        const auto& allocator_manager = allocator_access.getAllocatorManager();
+        auto allocation_result = allocation_strategy_->Allocate(
+            allocator_manager, size, config.replica_num, preferred_segments);
+        if (!allocation_result) {
+            return tl::make_unexpected(allocation_result.error());
+        }
+        staged_replicas = std::move(allocation_result.value());
+    }
+    if (staged_replicas.empty()) {
+        return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+    }
+
+    // Append the new PROCESSING MEMORY replica to the existing object's
+    // metadata. Visible only after NotifyPromotionSuccess flips it COMPLETE.
+    Replica::Descriptor desc = staged_replicas[0].get_descriptor();
+    const ReplicaID new_id = staged_replicas[0].id();
+    std::vector<Replica> to_add;
+    to_add.push_back(std::move(staged_replicas[0]));
+    metadata.AddReplicas(std::move(to_add));
+
+    // Record the new replica's ID on the in-flight PromotionTask so
+    // NotifyPromotionSuccess knows exactly which replica to commit (a
+    // concurrent Put on this key may stage other PROCESSING MEMORY
+    // replicas; finding "first PROCESSING memory" would be ambiguous).
+    auto& shard = accessor.GetShard();
+    auto task_it = shard->promotion_tasks.find(key);
+    if (task_it != shard->promotion_tasks.end()) {
+        // const_cast: promotion_tasks holds const PromotionTask values for
+        // generic safety, but we own the entry under the shard write lock
+        // and need to record the alloc_id post-Allocate.
+        const_cast<PromotionTask&>(task_it->second).alloc_id = new_id;
+    }
+    return PromotionAllocStartResponse{std::move(desc)};
+}
+
+auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
+                                           const std::string& key)
+    -> tl::expected<void, ErrorCode> {
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    MetadataAccessorRW accessor(this, key);
+    if (!accessor.Exists()) {
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    auto& metadata = accessor.Get();
+    auto& shard = accessor.GetShard();
+
+    // Look up the in-flight task to find the exact replica we staged. A
+    // concurrent Put on this key may have created other PROCESSING MEMORY
+    // replicas, so we must not just "mark first PROCESSING memory
+    // complete" — that would risk committing someone else's half-written
+    // replica.
+    auto task_it = shard->promotion_tasks.find(key);
+    if (task_it == shard->promotion_tasks.end() ||
+        task_it->second.alloc_id == 0) {
+        return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    }
+
+    bool committed = false;
+    Replica* staged = metadata.GetReplicaByID(task_it->second.alloc_id);
+    if (staged != nullptr && staged->is_memory_replica() &&
+        staged->is_processing()) {
+        staged->mark_complete();
+        committed = true;
+    }
+
+    // Drop the source LOCAL_DISK replica's refcnt and erase the task.
+    auto* source = metadata.GetReplicaByID(task_it->second.source_id);
+    if (source != nullptr) {
+        source->dec_refcnt();
+    }
+    shard->promotion_tasks.erase(task_it);
+
+    // Erase the per-client promotion_objects entry (best-effort; the
+    // heartbeat may have already drained it).
+    {
+        ScopedLocalDiskSegmentAccess local_disk_segment_access =
+            segment_manager_.getLocalDiskSegmentAccess();
+        auto& client_local_disk_segment =
+            local_disk_segment_access.getClientLocalDiskSegment();
+        auto it = client_local_disk_segment.find(client_id);
+        if (it != client_local_disk_segment.end()) {
+            MutexLocker locker(&it->second->offloading_mutex_);
+            it->second->promotion_objects.erase(key);
+        }
+    }
+
+    if (!committed) {
+        return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    }
+    return {};
+}
+
 void MasterService::EvictionThreadFunc() {
     VLOG(1) << "action=eviction_thread_started";
 
@@ -2905,6 +3189,33 @@ void MasterService::DiscardExpiredProcessingReplicas(
 
         LOG(WARNING) << "Offloading task expired for key: " << task_it->first;
         task_it = shard->offloading_tasks.erase(task_it);
+    }
+
+    // Part 4: Discard expired promotion-on-hit tasks. Drops the source
+    // LOCAL_DISK replica's refcnt and erases the task entry; the per-client
+    // promotion_objects map is best-effort garbage collected on the next
+    // heartbeat (entries for vanished tasks are harmless — the client will
+    // allocate, transfer, then NotifyPromotionSuccess will return
+    // REPLICA_IS_NOT_READY and the new MEMORY replica is reaped via the
+    // discarded-replicas path).
+    for (auto task_it = shard->promotion_tasks.begin();
+         task_it != shard->promotion_tasks.end();) {
+        const auto ttl =
+            task_it->second.start_time + put_start_release_timeout_sec_;
+        if (ttl > now) {
+            task_it++;
+            continue;
+        }
+        auto metadata_it = shard->metadata.find(task_it->first);
+        if (metadata_it != shard->metadata.end()) {
+            auto source =
+                metadata_it->second.GetReplicaByID(task_it->second.source_id);
+            if (source != nullptr) {
+                source->dec_refcnt();
+            }
+        }
+        LOG(WARNING) << "Promotion task expired for key: " << task_it->first;
+        task_it = shard->promotion_tasks.erase(task_it);
     }
 
     if (!discarded_replicas.empty()) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -574,10 +574,22 @@ void MasterService::ClearInvalidHandles(
             if (CleanupStaleHandles(it->second, alive_clients)) {
                 // If the object is empty, we need to erase the iterator and
                 // also erase the key from processing_keys,
-                // replication_tasks, and offloading_tasks.
+                // replication_tasks, offloading_tasks, and promotion_tasks.
                 shard->processing_keys.erase(it->first);
                 shard->replication_tasks.erase(it->first);
                 shard->offloading_tasks.erase(it->first);
+                // Promotion task cleanup: if the holder client expired, the
+                // LOCAL_DISK source is gone and the metadata is being erased
+                // here. Without this erase the dangling promotion_tasks
+                // entry stays pinned for up to put_start_release_timeout_sec_
+                // (~10 min default), inflating the global in-flight counter
+                // and blocking new admissions on busy clusters where many
+                // holders expire together (e.g. inference-worker rolling
+                // restarts).
+                if (shard->promotion_tasks.erase(it->first) > 0) {
+                    promotion_in_flight_.fetch_sub(1,
+                                                   std::memory_order_relaxed);
+                }
                 it = shard->metadata.erase(it);
             } else {
                 ++it;
@@ -2922,7 +2934,7 @@ auto MasterService::PromotionObjectHeartbeat(const UUID& client_id)
 }
 
 auto MasterService::PromotionAllocStart(
-    const std::string& key, uint64_t size,
+    const UUID& client_id, const std::string& key, uint64_t size,
     const std::vector<std::string>& preferred_segments)
     -> tl::expected<PromotionAllocStartResponse, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
@@ -2950,6 +2962,28 @@ auto MasterService::PromotionAllocStart(
     auto task_it = shard->promotion_tasks.find(key);
     if (task_it == shard->promotion_tasks.end()) {
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    }
+
+    // Authorize caller: only the holder client (the one whose LOCAL_DISK
+    // segment owns the source replica) is allowed to stage the MEMORY
+    // copy. Without this gate any client that knows the key could drain
+    // another's promotion_objects queue (PromotionObjectHeartbeat is
+    // unauthenticated in the current trust model) and then call us here
+    // to allocate arbitrary DRAM buffers on the destination segment,
+    // which would sit pinned until the reaper TTL.
+    if (task_it->second.holder_id != client_id) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    // Defensive size check: the size must match what TryPushPromotionQueue
+    // captured from the source LOCAL_DISK replica's descriptor. A mismatch
+    // would let a buggy caller request an arbitrarily larger or smaller
+    // allocation than the actual object — smaller risks the subsequent
+    // RDMA write overflowing into adjacent allocator state (the MR will
+    // typically catch this but defense-in-depth is cheap), and larger
+    // wastes DRAM that stays pinned until the reaper TTL.
+    if (task_it->second.object_size != size) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
     // Allocate a single MEMORY replica via the existing strategy, biased to
@@ -3074,6 +3108,70 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
     if (!committed) {
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
     }
+    return {};
+}
+
+auto MasterService::NotifyPromotionFailure(const UUID& client_id,
+                                           const std::string& key)
+    -> tl::expected<void, ErrorCode> {
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    MetadataAccessorRW accessor(this, key);
+    if (!accessor.Exists()) {
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    auto& metadata = accessor.Get();
+    auto& shard = accessor.GetShard();
+
+    auto task_it = shard->promotion_tasks.find(key);
+    if (task_it == shard->promotion_tasks.end()) {
+        // No task to release. Either the reaper already swept it, or the
+        // client never had a task here. Return OK to keep this RPC
+        // idempotent — repeated failure notifications on the same key
+        // should be safe.
+        return {};
+    }
+
+    // Same authorization gate as NotifyPromotionSuccess: only the holder
+    // may release. A spurious failure notification from another client
+    // should not be allowed to free state that legitimate holder still
+    // intends to commit.
+    if (task_it->second.holder_id != client_id) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    // Mirror the reaper's expiry path:
+    //   - Drop source LOCAL_DISK refcnt so it can be evicted normally.
+    //   - If AllocStart already staged a PROCESSING MEMORY replica
+    //     (alloc_id != 0), pop it via EraseReplicaByID. That buffer is
+    //     not in shard->processing_keys, so only this path (and the
+    //     reaper) can reap it.
+    //   - Erase the task entry and decrement the global in-flight
+    //     counter so the slot is immediately available to other admissions.
+    auto* source = metadata.GetReplicaByID(task_it->second.source_id);
+    if (source != nullptr) {
+        source->dec_refcnt();
+    }
+    if (task_it->second.alloc_id != 0) {
+        metadata.EraseReplicaByID(task_it->second.alloc_id);
+    }
+    shard->promotion_tasks.erase(task_it);
+    promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+
+    // Clear the holder's per-client promotion_objects entry. Same
+    // best-effort cleanup pattern as NotifyPromotionSuccess — the
+    // heartbeat may have already drained it.
+    {
+        ScopedLocalDiskSegmentAccess local_disk_segment_access =
+            segment_manager_.getLocalDiskSegmentAccess();
+        auto& client_local_disk_segment =
+            local_disk_segment_access.getClientLocalDiskSegment();
+        auto it = client_local_disk_segment.find(client_id);
+        if (it != client_local_disk_segment.end()) {
+            MutexLocker locker(&it->second->offloading_mutex_);
+            it->second->promotion_objects.erase(key);
+        }
+    }
+
     return {};
 }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2873,13 +2873,19 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
         return;
     }
 
+    // Capture the holder client_id so NotifyPromotionSuccess can reject
+    // calls from other clients. PushPromotionQueue already validated
+    // get_local_disk_client_id() returns a value, so .value() is safe.
+    const UUID holder_id = source->get_local_disk_client_id().value();
+
     // Record the in-flight task. alloc_id is filled in by
     // PromotionAllocStart once the new MEMORY replica is staged.
     shard->promotion_tasks.emplace(
         key, PromotionTask{.source_id = source->id(),
                            .alloc_id = 0,
                            .object_size = object_size,
-                           .start_time = std::chrono::system_clock::now()});
+                           .start_time = std::chrono::system_clock::now(),
+                           .holder_id = holder_id});
     promotion_in_flight_.fetch_add(1, std::memory_order_relaxed);
     VLOG(1) << "promotion_queued key=" << key << " size=" << object_size;
 }
@@ -2925,6 +2931,26 @@ auto MasterService::PromotionAllocStart(
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
     auto& metadata = accessor.Get();
+
+    // Verify the in-flight task still exists before allocating. The reaper
+    // can sweep a task between the holder's heartbeat and this AllocStart
+    // call (a hung client, GC pause, or HA failover can stall AllocStart
+    // for longer than put_start_release_timeout_sec_). If we allocated
+    // and AddReplicas'd unconditionally, the staged PROCESSING MEMORY
+    // replica would have no PromotionTask pointing at it: the generic
+    // PROCESSING reaper (DiscardExpiredProcessingReplicas) only iterates
+    // shard->processing_keys, which AllocStart never populates, and the
+    // promotion-task reaper has nothing left to iterate. The buffer would
+    // sit attached to the object until the object itself is removed or
+    // evicted — the same orphaned-staged-replica shape Issue 1's fix
+    // closed on the symmetric (task-still-exists-but-reaper-fires-first)
+    // path. The shard mutex is held through the rest of this function,
+    // so the iterator stays valid across the allocation step.
+    auto& shard = accessor.GetShard();
+    auto task_it = shard->promotion_tasks.find(key);
+    if (task_it == shard->promotion_tasks.end()) {
+        return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    }
 
     // Allocate a single MEMORY replica via the existing strategy, biased to
     // the holder's mem segment when possible.
@@ -2979,12 +3005,8 @@ auto MasterService::PromotionAllocStart(
     // (alloc_id still 0) is bounded by its own original-start_time
     // window during which the reaper's EraseReplicaByID branch is a
     // no-op.
-    auto& shard = accessor.GetShard();
-    auto task_it = shard->promotion_tasks.find(key);
-    if (task_it != shard->promotion_tasks.end()) {
-        task_it->second.alloc_id = new_id;
-        task_it->second.start_time = std::chrono::system_clock::now();
-    }
+    task_it->second.alloc_id = new_id;
+    task_it->second.start_time = std::chrono::system_clock::now();
     return PromotionAllocStartResponse{std::move(desc)};
 }
 
@@ -3008,6 +3030,15 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
     if (task_it == shard->promotion_tasks.end() ||
         task_it->second.alloc_id == 0) {
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    }
+
+    // Only the holder client (the one owning the source LOCAL_DISK
+    // segment) is authorized to commit. Without this check any client
+    // knowing the key could flip the staged PROCESSING replica to
+    // COMPLETE before the holder's RDMA write has landed, exposing torn
+    // data to readers.
+    if (task_it->second.holder_id != client_id) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
     bool committed = false;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -5438,6 +5438,7 @@ tl::expected<void, ErrorCode>
 RealClient::batch_get_into_offload_object_internal(
     const std::string &target_rpc_service_addr,
     std::unordered_map<std::string, std::vector<Slice>> &objects) {
+    offload_rpc_read_count_.fetch_add(1, std::memory_order_relaxed);
     auto start_time = std::chrono::steady_clock::now();
     std::vector<std::string> keys;
     std::vector<int64_t> sizes;

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1786,6 +1786,34 @@ tl::expected<void, ErrorCode> WrappedMasterService::NotifyOffloadSuccess(
     return result;
 }
 
+tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>
+WrappedMasterService::PromotionObjectHeartbeat(const UUID& client_id) {
+    ScopedVLogTimer timer(1, "PromotionObjectHeartbeat");
+    timer.LogRequest("action=promotion_object_heartbeat");
+    return master_service_.PromotionObjectHeartbeat(client_id);
+}
+
+tl::expected<PromotionAllocStartResponse, ErrorCode>
+WrappedMasterService::PromotionAllocStart(
+    const std::string& key, uint64_t size,
+    const std::vector<std::string>& preferred_segments) {
+    ScopedVLogTimer timer(1, "PromotionAllocStart");
+    timer.LogRequest("action=promotion_alloc_start");
+    auto result =
+        master_service_.PromotionAllocStart(key, size, preferred_segments);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::NotifyPromotionSuccess(
+    const UUID& client_id, const std::string& key) {
+    ScopedVLogTimer timer(1, "NotifyPromotionSuccess");
+    timer.LogRequest("action=notify_promotion_success");
+    auto result = master_service_.NotifyPromotionSuccess(client_id, key);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
 tl::expected<UUID, ErrorCode> WrappedMasterService::CreateDrainJob(
     const CreateDrainJobRequest& request) {
     return master_service_.CreateDrainJob(request);
@@ -1906,6 +1934,15 @@ void RegisterRpcService(
         &wrapped_master_service);
     server.register_handler<
         &mooncake::WrappedMasterService::NotifyOffloadSuccess>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::PromotionObjectHeartbeat>(
+        &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::PromotionAllocStart>(
+            &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::NotifyPromotionSuccess>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::CopyStart>(
         &wrapped_master_service);

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1795,12 +1795,12 @@ WrappedMasterService::PromotionObjectHeartbeat(const UUID& client_id) {
 
 tl::expected<PromotionAllocStartResponse, ErrorCode>
 WrappedMasterService::PromotionAllocStart(
-    const std::string& key, uint64_t size,
+    const UUID& client_id, const std::string& key, uint64_t size,
     const std::vector<std::string>& preferred_segments) {
     ScopedVLogTimer timer(1, "PromotionAllocStart");
     timer.LogRequest("action=promotion_alloc_start");
-    auto result =
-        master_service_.PromotionAllocStart(key, size, preferred_segments);
+    auto result = master_service_.PromotionAllocStart(client_id, key, size,
+                                                      preferred_segments);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1810,6 +1810,15 @@ tl::expected<void, ErrorCode> WrappedMasterService::NotifyPromotionSuccess(
     ScopedVLogTimer timer(1, "NotifyPromotionSuccess");
     timer.LogRequest("action=notify_promotion_success");
     auto result = master_service_.NotifyPromotionSuccess(client_id, key);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::NotifyPromotionFailure(
+    const UUID& client_id, const std::string& key) {
+    ScopedVLogTimer timer(1, "NotifyPromotionFailure");
+    timer.LogRequest("action=notify_promotion_failure");
+    auto result = master_service_.NotifyPromotionFailure(client_id, key);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1943,6 +1952,9 @@ void RegisterRpcService(
             &wrapped_master_service);
     server.register_handler<
         &mooncake::WrappedMasterService::NotifyPromotionSuccess>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::NotifyPromotionFailure>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::CopyStart>(
         &wrapped_master_service);

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -40,8 +40,12 @@ add_store_test(master_service_test master_service_test.cpp)
 add_store_test(batch_remove_test batch_remove_test.cpp)
 add_store_test(master_service_ssd_test master_service_ssd_test.cpp)
 add_store_test(offload_on_evict_test offload_on_evict_test.cpp)
+add_store_test(promotion_on_hit_test promotion_on_hit_test.cpp)
+add_store_test(file_storage_promotion_test file_storage_promotion_test.cpp)
 add_store_test(master_service_ssd_test_for_snapshot
                ha/snapshot/master_service_ssd_test_for_snapshot.cpp)
+add_store_test(master_service_promotion_test_for_snapshot
+               ha/snapshot/master_service_promotion_test_for_snapshot.cpp)
 add_store_test(client_integration_test client_integration_test.cpp)
 if(USE_CXL)
   add_store_test(cxl_client_integration_test cxl_client_integration_test.cpp)

--- a/mooncake-store/tests/file_storage_promotion_test.cpp
+++ b/mooncake-store/tests/file_storage_promotion_test.cpp
@@ -200,7 +200,7 @@ class FileStoragePromotionTest : public ::testing::Test {
     }
 };
 
-// 1. Empty heartbeat queue: do nothing past the heartbeat call.
+// Empty heartbeat queue: do nothing past the heartbeat call.
 TEST_F(FileStoragePromotionTest, EmptyQueueIsNoOp) {
     fake->heartbeat_queue = {};
     auto res = CallProcessPromotionTasks();
@@ -211,8 +211,8 @@ TEST_F(FileStoragePromotionTest, EmptyQueueIsNoOp) {
     EXPECT_EQ(fake->notify_calls.load(), 0);
 }
 
-// 2. Heartbeat returns SEGMENT_NOT_FOUND (transient post-restart): swallow
-//    silently, no error to caller.
+// Heartbeat returns SEGMENT_NOT_FOUND (transient post-restart):
+// swallow silently, no error to caller.
 TEST_F(FileStoragePromotionTest, HeartbeatSegmentNotFoundIsBenign) {
     fake->heartbeat_result = tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
     auto res = CallProcessPromotionTasks();
@@ -220,7 +220,7 @@ TEST_F(FileStoragePromotionTest, HeartbeatSegmentNotFoundIsBenign) {
     EXPECT_EQ(fake->alloc_calls.load(), 0);
 }
 
-// 3. Heartbeat returns a non-benign error: propagate it.
+// Heartbeat returns a non-benign error: propagate it.
 TEST_F(FileStoragePromotionTest, HeartbeatHardErrorPropagates) {
     fake->heartbeat_result = tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     auto res = CallProcessPromotionTasks();
@@ -229,7 +229,7 @@ TEST_F(FileStoragePromotionTest, HeartbeatHardErrorPropagates) {
     EXPECT_EQ(fake->alloc_calls.load(), 0);
 }
 
-// 4. Non-positive size in queue: skip that key, continue.
+// Non-positive size in queue: skip that key, continue.
 TEST_F(FileStoragePromotionTest, NonPositiveSizeSkipped) {
     fake->heartbeat_queue = {{"k_bad", 0}, {"k_good", 1024}};
     auto res = CallProcessPromotionTasks();
@@ -239,8 +239,8 @@ TEST_F(FileStoragePromotionTest, NonPositiveSizeSkipped) {
     EXPECT_EQ(fake->last_alloc_key, "k_good");
 }
 
-// 5. PromotionAllocStart fails (e.g. master out of DRAM): skip key, no
-//    write, no notify, advance to next.
+// PromotionAllocStart fails (e.g. master out of DRAM): skip key, no
+// write, no notify, advance to next.
 TEST_F(FileStoragePromotionTest, AllocStartFailureSkipsKey) {
     fake->alloc_overrides["k1"] = ErrorCode::NO_AVAILABLE_HANDLE;
     auto res = DrainAllPromotionTasks({{"k1", 1024}, {"k2", 1024}});
@@ -252,8 +252,8 @@ TEST_F(FileStoragePromotionTest, AllocStartFailureSkipsKey) {
     EXPECT_LE(fake->notify_calls.load(), 1);
 }
 
-// 6. BatchLoad failure (SSD file missing): no PromotionWrite, no Notify.
-//    Master-side reaper handles the orphaned PROCESSING replica.
+// BatchLoad failure (SSD file missing): no PromotionWrite, no Notify.
+// Master-side reaper handles the orphaned PROCESSING replica.
 TEST_F(FileStoragePromotionTest, BatchLoadFailureLeavesNoNotify) {
     fake->heartbeat_queue = {{"k_missing", 1024}};
     // Default alloc succeeds; BatchLoad will fail because there's no file
@@ -268,7 +268,7 @@ TEST_F(FileStoragePromotionTest, BatchLoadFailureLeavesNoNotify) {
         << "NotifyPromotionSuccess must not run if BatchLoad failed";
 }
 
-// 7. PromotionWrite failure: no Notify.
+// PromotionWrite failure: no Notify.
 TEST_F(FileStoragePromotionTest, TransferWriteFailureLeavesNoNotify) {
     fake->heartbeat_queue = {{"k_te_fail", 1024}};
     fake->default_write_result = ErrorCode::TRANSFER_FAIL;
@@ -281,8 +281,8 @@ TEST_F(FileStoragePromotionTest, TransferWriteFailureLeavesNoNotify) {
         << "NotifyPromotionSuccess must not run on TransferWrite failure";
 }
 
-// 8. NotifyPromotionSuccess failure: logged, but processing of remaining
-//    keys continues.
+// NotifyPromotionSuccess failure: logged, but processing of remaining
+// keys continues.
 TEST_F(FileStoragePromotionTest, NotifyFailureDoesNotAbortBatch) {
     fake->notify_overrides["k1"] = ErrorCode::OBJECT_NOT_FOUND;
     auto res = DrainAllPromotionTasks({{"k1", 1024}, {"k2", 1024}});
@@ -292,8 +292,8 @@ TEST_F(FileStoragePromotionTest, NotifyFailureDoesNotAbortBatch) {
         << "failure";
 }
 
-// 9. Per-key independence: failures on one key don't prevent attempts on
-//    others.
+// Per-key independence: failures on one key don't prevent attempts on
+// others.
 TEST_F(FileStoragePromotionTest, PerKeyFailuresAreIndependent) {
     fake->alloc_overrides["k_alloc_fail"] = ErrorCode::NO_AVAILABLE_HANDLE;
     fake->write_overrides["k_write_fail"] = ErrorCode::TRANSFER_FAIL;
@@ -307,12 +307,11 @@ TEST_F(FileStoragePromotionTest, PerKeyFailuresAreIndependent) {
     EXPECT_EQ(fake->alloc_calls.load(), 3);
 }
 
-// 10. Failure-notification: every post-admission failure path (including
-//     PromotionAllocStart's own failure) must call NotifyPromotionFailure
-//     so the master immediately releases the task slot. Without this the
-//     slot stays pinned until put_start_release_timeout_sec_ (~10 min),
-//     turning a transient DRAM-pressure spike into a sustained outage
-//     of promotion_queue_limit_.
+// Every post-admission failure path (including PromotionAllocStart's
+// own failure) must call NotifyPromotionFailure so the master releases
+// the task slot immediately. Without this, the slot stays pinned until
+// put_start_release_timeout_sec_ (~10 min default), turning a transient
+// DRAM-pressure spike into a sustained outage of promotion_queue_limit_.
 TEST_F(FileStoragePromotionTest, AllocStartFailureNotifiesMaster) {
     fake->heartbeat_queue = {{"k_alloc_fail", 1024}};
     fake->alloc_overrides["k_alloc_fail"] = ErrorCode::NO_AVAILABLE_HANDLE;
@@ -330,12 +329,12 @@ TEST_F(FileStoragePromotionTest, AllocStartFailureNotifiesMaster) {
     EXPECT_EQ(fake->notify_failure_keys[0], "k_alloc_fail");
 }
 
-// 11. Failure-notification: same invariant on the post-AllocStart paths
-//     (BatchLoad / TransferWrite / Notify-Success). Each failure mode
-//     must release the master slot. We exercise three modes (AllocStart
-//     itself, missing-file BatchLoad, override on Notify) by draining
-//     them across successive heartbeats (the FakeClient mirrors the
-//     master's kMaxPerHeartbeat = 1 cap) and verify each one releases.
+// Same invariant on the post-AllocStart paths (BatchLoad /
+// TransferWrite / Notify-Success). Each failure mode must release the
+// master slot. Exercises three modes (AllocStart itself, missing-file
+// BatchLoad, override on Notify) by draining across successive
+// heartbeats (the FakeClient mirrors the master's kMaxPerHeartbeat = 1
+// cap) and verifies each one releases.
 TEST_F(FileStoragePromotionTest, PostAllocFailuresAllNotifyMaster) {
     fake->alloc_overrides["k_alloc_fail"] = ErrorCode::NO_AVAILABLE_HANDLE;
     // k_load_fail: no override -> AllocStart succeeds, but BatchLoad

--- a/mooncake-store/tests/file_storage_promotion_test.cpp
+++ b/mooncake-store/tests/file_storage_promotion_test.cpp
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <filesystem>
+#include <set>
 #include <thread>
 
 #include "client_service.h"
@@ -110,11 +111,23 @@ class FakeClient : public Client {
         return {};
     }
 
+    // NotifyPromotionFailure: records calls so tests can assert that
+    // post-AllocStart failure paths in ProcessPromotionTasks actually
+    // notify the master.
+    tl::expected<void, ErrorCode> NotifyPromotionFailure(
+        const std::string& key) override {
+        notify_failure_calls.fetch_add(1);
+        notify_failure_keys.push_back(key);
+        return {};
+    }
+
     std::atomic<int> heartbeat_calls{0};
     std::atomic<int> alloc_calls{0};
     std::atomic<int> write_calls{0};
     std::atomic<int> notify_calls{0};
+    std::atomic<int> notify_failure_calls{0};
     std::vector<std::string> notify_keys;
+    std::vector<std::string> notify_failure_keys;
     std::string last_alloc_key;
 };
 
@@ -292,6 +305,65 @@ TEST_F(FileStoragePromotionTest, PerKeyFailuresAreIndependent) {
     EXPECT_TRUE(res.has_value());
     // All three reach AllocStart.
     EXPECT_EQ(fake->alloc_calls.load(), 3);
+}
+
+// 10. Failure-notification: every post-admission failure path (including
+//     PromotionAllocStart's own failure) must call NotifyPromotionFailure
+//     so the master immediately releases the task slot. Without this the
+//     slot stays pinned until put_start_release_timeout_sec_ (~10 min),
+//     turning a transient DRAM-pressure spike into a sustained outage
+//     of promotion_queue_limit_.
+TEST_F(FileStoragePromotionTest, AllocStartFailureNotifiesMaster) {
+    fake->heartbeat_queue = {{"k_alloc_fail", 1024}};
+    fake->alloc_overrides["k_alloc_fail"] = ErrorCode::NO_AVAILABLE_HANDLE;
+    auto res = CallProcessPromotionTasks();
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(fake->alloc_calls.load(), 1);
+    EXPECT_EQ(fake->notify_calls.load(), 0)
+        << "Success-notify must not fire on AllocStart failure.";
+    EXPECT_EQ(fake->notify_failure_calls.load(), 1)
+        << "AllocStart failure must invoke NotifyPromotionFailure so the "
+        << "master can release the task slot immediately. Without this "
+        << "the slot is pinned for ~10 min and transient DRAM pressure "
+        << "saturates promotion_queue_limit_ for the same window.";
+    ASSERT_EQ(fake->notify_failure_keys.size(), 1u);
+    EXPECT_EQ(fake->notify_failure_keys[0], "k_alloc_fail");
+}
+
+// 11. Failure-notification: same invariant on the post-AllocStart paths
+//     (BatchLoad / TransferWrite / Notify-Success). Each failure mode
+//     must release the master slot. We exercise three modes (AllocStart
+//     itself, missing-file BatchLoad, override on Notify) by draining
+//     them across successive heartbeats (the FakeClient mirrors the
+//     master's kMaxPerHeartbeat = 1 cap) and verify each one releases.
+TEST_F(FileStoragePromotionTest, PostAllocFailuresAllNotifyMaster) {
+    fake->alloc_overrides["k_alloc_fail"] = ErrorCode::NO_AVAILABLE_HANDLE;
+    // k_load_fail: no override -> AllocStart succeeds, but BatchLoad
+    // will fail because no SSD file exists for this key in data_path.
+    // k_notify_fail: AllocStart and BatchLoad and TransferWrite all
+    // succeed; Notify is overridden to fail.
+    fake->notify_overrides["k_notify_fail"] = ErrorCode::OBJECT_NOT_FOUND;
+
+    auto res = DrainAllPromotionTasks({
+        {"k_alloc_fail", 1024},
+        {"k_load_fail", 1024},
+        {"k_notify_fail", 1024},
+    });
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(fake->alloc_calls.load(), 3);
+
+    // Every failed key must have its slot released via Notify-Failure.
+    // k_notify_fail also counts: Notify-Success failed, so we still
+    // need to free the slot.
+    EXPECT_EQ(fake->notify_failure_calls.load(), 3)
+        << "All three failed promotions must each invoke "
+        << "NotifyPromotionFailure. If this fires with <3, one of the "
+        << "failure paths is still leaking the master slot.";
+    std::set<std::string> got(fake->notify_failure_keys.begin(),
+                              fake->notify_failure_keys.end());
+    EXPECT_EQ(got.count("k_alloc_fail"), 1u);
+    EXPECT_EQ(got.count("k_load_fail"), 1u);
+    EXPECT_EQ(got.count("k_notify_fail"), 1u);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/file_storage_promotion_test.cpp
+++ b/mooncake-store/tests/file_storage_promotion_test.cpp
@@ -39,14 +39,19 @@ class FakeClient : public Client {
         if (!heartbeat_result.has_value()) {
             return tl::make_unexpected(heartbeat_result.error());
         }
-        // Mirror production: master returns the per-client promotion_objects
-        // map and clears it. Subsequent heartbeat calls return only what's
-        // been pushed since the last drain. This lets tests iterate
-        // ProcessPromotionTasks multiple times to drain a multi-key queue
-        // (the per-tick cap inside ProcessPromotionTasks may process only
-        // one task per call).
-        promotion_objects = std::move(heartbeat_queue);
-        heartbeat_queue.clear();
+        // Mirror production master: PromotionObjectHeartbeat returns at
+        // most kMaxPerHeartbeat keys per call (see
+        // MasterService::PromotionObjectHeartbeat) and leaves the rest
+        // queued for subsequent calls. Tests iterate by calling
+        // ProcessPromotionTasks multiple times until heartbeat_queue is
+        // empty.
+        constexpr size_t kMaxPerHeartbeat = 1;
+        promotion_objects.clear();
+        while (promotion_objects.size() < kMaxPerHeartbeat &&
+               !heartbeat_queue.empty()) {
+            auto node = heartbeat_queue.extract(heartbeat_queue.begin());
+            promotion_objects.insert(std::move(node));
+        }
         return {};
     }
 

--- a/mooncake-store/tests/file_storage_promotion_test.cpp
+++ b/mooncake-store/tests/file_storage_promotion_test.cpp
@@ -1,0 +1,297 @@
+// Unit tests for FileStorage::ProcessPromotionTasks. Uses a stub Client
+// that overrides the 4 promotion-RPC entry points so we can drive the
+// orchestration loop deterministically without standing up a master.
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <filesystem>
+#include <thread>
+
+#include "client_service.h"
+#include "file_storage.h"
+#include "storage_backend.h"
+
+namespace mooncake {
+
+namespace fs_test {
+
+// Programmable fake. Each Set* method records what the next call should
+// return; the call itself records that it happened so tests can assert on
+// invocation count and ordering.
+class FakeClient : public Client {
+   public:
+    FakeClient()
+        : Client(/*local_hostname=*/"localhost:9003",
+                 /*metadata_connstring=*/"",
+                 /*protocol=*/"tcp",
+                 /*labels=*/{}) {}
+
+    // Drives the queue returned to the heartbeat caller.
+    std::unordered_map<std::string, int64_t> heartbeat_queue;
+    tl::expected<void, ErrorCode> heartbeat_result =
+        tl::expected<void, ErrorCode>{};
+
+    tl::expected<void, ErrorCode> PromotionObjectHeartbeat(
+        std::unordered_map<std::string, int64_t>& promotion_objects) override {
+        heartbeat_calls.fetch_add(1);
+        if (!heartbeat_result.has_value()) {
+            return tl::make_unexpected(heartbeat_result.error());
+        }
+        // Mirror production: master returns the per-client promotion_objects
+        // map and clears it. Subsequent heartbeat calls return only what's
+        // been pushed since the last drain. This lets tests iterate
+        // ProcessPromotionTasks multiple times to drain a multi-key queue
+        // (the per-tick cap inside ProcessPromotionTasks may process only
+        // one task per call).
+        promotion_objects = std::move(heartbeat_queue);
+        heartbeat_queue.clear();
+        return {};
+    }
+
+    // PromotionAllocStart: per-key dispatch table. Keys absent from
+    // alloc_overrides return the default response.
+    std::unordered_map<std::string, ErrorCode> alloc_overrides;
+    PromotionAllocStartResponse default_alloc_response;
+    bool default_alloc_succeeds = true;
+
+    tl::expected<PromotionAllocStartResponse, ErrorCode> PromotionAllocStart(
+        const std::string& key, uint64_t size,
+        const std::vector<std::string>& preferred_segments) override {
+        (void)size;
+        (void)preferred_segments;
+        alloc_calls.fetch_add(1);
+        last_alloc_key = key;
+        auto it = alloc_overrides.find(key);
+        if (it != alloc_overrides.end()) {
+            return tl::make_unexpected(it->second);
+        }
+        if (!default_alloc_succeeds) {
+            return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+        return default_alloc_response;
+    }
+
+    // PromotionWrite: per-key dispatch.
+    std::unordered_map<std::string, ErrorCode> write_overrides;
+    ErrorCode default_write_result = ErrorCode::OK;
+
+    ErrorCode PromotionWrite(const Replica::Descriptor&,
+                             std::vector<Slice>&) override {
+        write_calls.fetch_add(1);
+        auto it = write_overrides.find(last_alloc_key);
+        if (it != write_overrides.end()) {
+            return it->second;
+        }
+        return default_write_result;
+    }
+
+    std::unordered_map<std::string, ErrorCode> notify_overrides;
+    tl::expected<void, ErrorCode> default_notify_result =
+        tl::expected<void, ErrorCode>{};
+
+    tl::expected<void, ErrorCode> NotifyPromotionSuccess(
+        const std::string& key) override {
+        notify_calls.fetch_add(1);
+        notify_keys.push_back(key);
+        auto it = notify_overrides.find(key);
+        if (it != notify_overrides.end()) {
+            return tl::make_unexpected(it->second);
+        }
+        if (!default_notify_result.has_value()) {
+            return tl::make_unexpected(default_notify_result.error());
+        }
+        return {};
+    }
+
+    std::atomic<int> heartbeat_calls{0};
+    std::atomic<int> alloc_calls{0};
+    std::atomic<int> write_calls{0};
+    std::atomic<int> notify_calls{0};
+    std::vector<std::string> notify_keys;
+    std::string last_alloc_key;
+};
+
+}  // namespace fs_test
+
+class FileStoragePromotionTest : public ::testing::Test {
+   protected:
+    std::string data_path;
+    std::shared_ptr<fs_test::FakeClient> fake;
+    std::unique_ptr<FileStorage> file_storage;
+
+    void SetUp() override {
+        google::InitGoogleLogging("FileStoragePromotionTest");
+        FLAGS_logtostderr = true;
+        unsetenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH");
+
+        data_path = std::filesystem::current_path().string() + "/data_prom";
+        std::filesystem::create_directories(data_path);
+        for (const auto& entry :
+             std::filesystem::directory_iterator(data_path)) {
+            if (entry.is_regular_file()) std::filesystem::remove(entry.path());
+        }
+
+        FileStorageConfig cfg = FileStorageConfig::FromEnvironment();
+        cfg.storage_filepath = data_path;
+        cfg.local_buffer_size = 4 * 1024 * 1024;
+        fake = std::make_shared<fs_test::FakeClient>();
+        file_storage =
+            std::make_unique<FileStorage>(cfg, fake, "localhost:9003");
+    }
+
+    void TearDown() override {
+        file_storage.reset();
+        fake.reset();
+        google::ShutdownGoogleLogging();
+        for (const auto& entry :
+             std::filesystem::directory_iterator(data_path)) {
+            if (entry.is_regular_file()) std::filesystem::remove(entry.path());
+        }
+    }
+
+    tl::expected<void, ErrorCode> CallProcessPromotionTasks() {
+        return file_storage->ProcessPromotionTasks();
+    }
+
+    // Drain a multi-key queue across multiple ticks. ProcessPromotionTasks
+    // caps work at 1 task/tick (heartbeat-safety) and the FakeClient's
+    // PromotionObjectHeartbeat mirrors production by clearing the queue on
+    // drain. So the test fixture has to push the remaining keys back
+    // between ticks, the same way the master would re-push if the gate
+    // re-fires. We track which key was processed via fake->last_alloc_key
+    // and remove it from the working set.
+    tl::expected<void, ErrorCode> DrainAllPromotionTasks(
+        std::unordered_map<std::string, int64_t> remaining) {
+        tl::expected<void, ErrorCode> last_res{};
+        while (!remaining.empty()) {
+            std::string before = fake->last_alloc_key;
+            fake->heartbeat_queue = remaining;
+            last_res = CallProcessPromotionTasks();
+            if (!last_res.has_value()) return last_res;
+            if (fake->last_alloc_key == before ||
+                !remaining.contains(fake->last_alloc_key)) {
+                // No forward progress (e.g., empty effective queue / size<=0
+                // skip on every key); avoid infinite loop.
+                break;
+            }
+            remaining.erase(fake->last_alloc_key);
+        }
+        return last_res;
+    }
+};
+
+// 1. Empty heartbeat queue: do nothing past the heartbeat call.
+TEST_F(FileStoragePromotionTest, EmptyQueueIsNoOp) {
+    fake->heartbeat_queue = {};
+    auto res = CallProcessPromotionTasks();
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(fake->heartbeat_calls.load(), 1);
+    EXPECT_EQ(fake->alloc_calls.load(), 0);
+    EXPECT_EQ(fake->write_calls.load(), 0);
+    EXPECT_EQ(fake->notify_calls.load(), 0);
+}
+
+// 2. Heartbeat returns SEGMENT_NOT_FOUND (transient post-restart): swallow
+//    silently, no error to caller.
+TEST_F(FileStoragePromotionTest, HeartbeatSegmentNotFoundIsBenign) {
+    fake->heartbeat_result = tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
+    auto res = CallProcessPromotionTasks();
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(fake->alloc_calls.load(), 0);
+}
+
+// 3. Heartbeat returns a non-benign error: propagate it.
+TEST_F(FileStoragePromotionTest, HeartbeatHardErrorPropagates) {
+    fake->heartbeat_result = tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    auto res = CallProcessPromotionTasks();
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error(), ErrorCode::INTERNAL_ERROR);
+    EXPECT_EQ(fake->alloc_calls.load(), 0);
+}
+
+// 4. Non-positive size in queue: skip that key, continue.
+TEST_F(FileStoragePromotionTest, NonPositiveSizeSkipped) {
+    fake->heartbeat_queue = {{"k_bad", 0}, {"k_good", 1024}};
+    auto res = CallProcessPromotionTasks();
+    EXPECT_TRUE(res.has_value());
+    // Only k_good should reach AllocStart.
+    EXPECT_EQ(fake->alloc_calls.load(), 1);
+    EXPECT_EQ(fake->last_alloc_key, "k_good");
+}
+
+// 5. PromotionAllocStart fails (e.g. master out of DRAM): skip key, no
+//    write, no notify, advance to next.
+TEST_F(FileStoragePromotionTest, AllocStartFailureSkipsKey) {
+    fake->alloc_overrides["k1"] = ErrorCode::NO_AVAILABLE_HANDLE;
+    auto res = DrainAllPromotionTasks({{"k1", 1024}, {"k2", 1024}});
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(fake->alloc_calls.load(), 2);
+    // k1's failure prevents its write+notify; k2 succeeds (then fails at
+    // BatchLoad because the SSD file doesn't exist).
+    EXPECT_LE(fake->write_calls.load(), 1);
+    EXPECT_LE(fake->notify_calls.load(), 1);
+}
+
+// 6. BatchLoad failure (SSD file missing): no PromotionWrite, no Notify.
+//    Master-side reaper handles the orphaned PROCESSING replica.
+TEST_F(FileStoragePromotionTest, BatchLoadFailureLeavesNoNotify) {
+    fake->heartbeat_queue = {{"k_missing", 1024}};
+    // Default alloc succeeds; BatchLoad will fail because there's no file
+    // at data_path/k_missing for the storage backend to read.
+    auto res = CallProcessPromotionTasks();
+    EXPECT_TRUE(res.has_value());  // ProcessPromotionTasks itself is best-
+                                   // effort; per-key failures are warnings.
+    EXPECT_EQ(fake->alloc_calls.load(), 1);
+    EXPECT_EQ(fake->write_calls.load(), 0)
+        << "TransferWrite must not run if BatchLoad failed";
+    EXPECT_EQ(fake->notify_calls.load(), 0)
+        << "NotifyPromotionSuccess must not run if BatchLoad failed";
+}
+
+// 7. PromotionWrite failure: no Notify.
+TEST_F(FileStoragePromotionTest, TransferWriteFailureLeavesNoNotify) {
+    fake->heartbeat_queue = {{"k_te_fail", 1024}};
+    fake->default_write_result = ErrorCode::TRANSFER_FAIL;
+    auto res = CallProcessPromotionTasks();
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(fake->alloc_calls.load(), 1);
+    // Whether write_calls is 0 or 1 depends on whether BatchLoad succeeded
+    // first; either way Notify must not fire.
+    EXPECT_EQ(fake->notify_calls.load(), 0)
+        << "NotifyPromotionSuccess must not run on TransferWrite failure";
+}
+
+// 8. NotifyPromotionSuccess failure: logged, but processing of remaining
+//    keys continues.
+TEST_F(FileStoragePromotionTest, NotifyFailureDoesNotAbortBatch) {
+    fake->notify_overrides["k1"] = ErrorCode::OBJECT_NOT_FOUND;
+    auto res = DrainAllPromotionTasks({{"k1", 1024}, {"k2", 1024}});
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(fake->alloc_calls.load(), 2)
+        << "Both keys must be alloc-attempted regardless of k1's notify "
+        << "failure";
+}
+
+// 9. Per-key independence: failures on one key don't prevent attempts on
+//    others.
+TEST_F(FileStoragePromotionTest, PerKeyFailuresAreIndependent) {
+    fake->alloc_overrides["k_alloc_fail"] = ErrorCode::NO_AVAILABLE_HANDLE;
+    fake->write_overrides["k_write_fail"] = ErrorCode::TRANSFER_FAIL;
+    auto res = DrainAllPromotionTasks({
+        {"k_alloc_fail", 1024},
+        {"k_write_fail", 1024},
+        {"k_normal", 1024},
+    });
+    EXPECT_TRUE(res.has_value());
+    // All three reach AllocStart.
+    EXPECT_EQ(fake->alloc_calls.load(), 3);
+}
+
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-store/tests/ha/snapshot/master_service_promotion_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_promotion_test_for_snapshot.cpp
@@ -1,0 +1,197 @@
+// Snapshot round-trip tests for the L2->L1 promotion-on-hit feature.
+//
+// The base fixture's TearDown automatically calls TestSnapshotAndRestore
+// against the service_ member, which:
+//   1. Persists the master state to local snapshot storage.
+//   2. Boots a fresh MasterService in restore mode against that snapshot.
+//   3. Asserts CaptureServiceState() matches before vs. after.
+//
+// LOCAL_DISK replica content is captured via CaptureServiceState's
+// CompareReplicaDescriptor (which compares LocalDiskDescriptor fields), and
+// LocalDiskSegmentState (offloading_objects map) is also captured. Anything
+// these tests put into those fields will round-trip; anything not captured
+// (e.g., per-shard PromotionTask map, per-segment promotion_objects map)
+// is, by design, transient — the master is allowed to drop it on restart
+// and let clients re-trigger via heartbeat.
+
+#include "master_service_test_for_snapshot_base.h"
+
+namespace mooncake::test {
+
+class MasterServicePromotionSnapshotTest
+    : public MasterServiceSnapshotTestBase {
+   protected:
+    static bool glog_initialized_;
+
+    void SetUp() override {
+        MasterServiceSnapshotTestBase::SetUp();
+        if (!glog_initialized_) {
+            google::InitGoogleLogging("MasterServicePromotionSnapshotTest");
+            FLAGS_logtostderr = true;
+            glog_initialized_ = true;
+        }
+    }
+
+    // Build a master with promotion-on-hit enabled. enable_offload is
+    // required (promotion gates on it). admission_threshold=1 keeps the
+    // gate first-touch so tests don't need many reads.
+    void CreateMasterServiceWithPromotion() {
+        auto config = MasterServiceConfig::builder().build();
+        // Builder doesn't expose promotion knobs. Use direct field
+        // assignment.
+        config.enable_offload = true;
+        config.promotion_on_hit = true;
+        config.promotion_admission_threshold = 1;
+        config.put_start_discard_timeout_sec = 0;
+        config.put_start_release_timeout_sec = 1;
+        service_ = std::make_unique<MasterService>(config);
+    }
+
+    Segment MakeMemSegment(const std::string& name, size_t base) const {
+        Segment s;
+        s.id = generate_uuid();
+        s.name = name;
+        s.base = base;
+        s.size = kDefaultSegmentSize;
+        s.te_endpoint = name;
+        return s;
+    }
+
+    UUID MountMemAndDisk(const std::string& seg_name, size_t base) {
+        Segment seg = MakeMemSegment(seg_name, base);
+        UUID client_id = generate_uuid();
+        auto mount = service_->MountSegment(seg, client_id);
+        EXPECT_TRUE(mount.has_value());
+        auto mount_ld = service_->MountLocalDiskSegment(client_id, true);
+        EXPECT_TRUE(mount_ld.has_value());
+        return client_id;
+    }
+
+    bool InjectLocalDiskReplica(const UUID& client_id, const std::string& key,
+                                int64_t size,
+                                const std::string& transport_endpoint) {
+        std::vector<std::string> keys{key};
+        StorageObjectMetadata sm;
+        sm.bucket_id = 0;
+        sm.offset = 0;
+        sm.key_size = static_cast<int64_t>(key.size());
+        sm.data_size = size;
+        sm.transport_endpoint = transport_endpoint;
+        std::vector<StorageObjectMetadata> metas{sm};
+        return service_->NotifyOffloadSuccess(client_id, keys, metas)
+            .has_value();
+    }
+};
+
+bool MasterServicePromotionSnapshotTest::glog_initialized_ = false;
+
+// A LOCAL_DISK replica created via the offload path round-trips intact:
+// after snapshot+restore, the descriptor type, client_id, object_size, and
+// transport_endpoint must all match.
+TEST_F(MasterServicePromotionSnapshotTest, LocalDiskReplicaRoundTrip) {
+    CreateMasterServiceWithPromotion();
+    UUID client_id = MountMemAndDisk("seg_a", kDefaultSegmentBase);
+
+    ASSERT_TRUE(
+        InjectLocalDiskReplica(client_id, "k_cold", 1024, "seg_a_endpoint"));
+
+    auto before = service_->GetReplicaList("k_cold");
+    ASSERT_TRUE(before.has_value());
+    ASSERT_EQ(before->replicas.size(), 1u);
+    EXPECT_TRUE(before->replicas[0].is_local_disk_replica());
+}
+
+// A key with both LOCAL_DISK and a separate MEMORY replica round-trips.
+// Tests that mixed-replica metadata serialization handles both descriptor
+// variants in the same object.
+TEST_F(MasterServicePromotionSnapshotTest, MixedMemoryAndLocalDiskRoundTrip) {
+    CreateMasterServiceWithPromotion();
+    UUID client_id = MountMemAndDisk("seg_a", kDefaultSegmentBase);
+
+    // Put a MEMORY replica.
+    ReplicateConfig rc;
+    rc.replica_num = 1;
+    ASSERT_TRUE(service_->PutStart(client_id, "k_mixed", 1024, rc).has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, "k_mixed", ReplicaType::MEMORY)
+                    .has_value());
+
+    // Add LOCAL_DISK alongside.
+    ASSERT_TRUE(
+        InjectLocalDiskReplica(client_id, "k_mixed", 1024, "seg_a_endpoint"));
+
+    auto descs = service_->GetReplicaList("k_mixed");
+    ASSERT_TRUE(descs.has_value());
+    EXPECT_EQ(descs->replicas.size(), 2u);
+}
+
+// LocalDiskSegment.enable_offloading flag is preserved across snapshot.
+// (CaptureServiceState compares this explicitly.)
+TEST_F(MasterServicePromotionSnapshotTest,
+       LocalDiskSegmentEnableOffloadingPreserved) {
+    CreateMasterServiceWithPromotion();
+    UUID client_id = MountMemAndDisk("seg_a", kDefaultSegmentBase);
+    (void)client_id;
+    // No further action — the LocalDiskSegment exists with enable_offloading
+    // = true. TearDown's TestSnapshotAndRestore round-trips and compares.
+}
+
+// Multiple LOCAL_DISK holders, one DRAM segment. Each holder's segment
+// metadata must round-trip independently.
+TEST_F(MasterServicePromotionSnapshotTest, MultipleLocalDiskHoldersRoundTrip) {
+    CreateMasterServiceWithPromotion();
+
+    // Mount two DRAM+LOCAL_DISK pairs.
+    UUID client_a = MountMemAndDisk("seg_a", kDefaultSegmentBase);
+    UUID client_b =
+        MountMemAndDisk("seg_b", kDefaultSegmentBase + kDefaultSegmentSize);
+
+    ASSERT_TRUE(
+        InjectLocalDiskReplica(client_a, "k_a", 1024, "seg_a_endpoint"));
+    ASSERT_TRUE(
+        InjectLocalDiskReplica(client_b, "k_b", 2048, "seg_b_endpoint"));
+
+    auto a = service_->GetReplicaList("k_a");
+    auto b = service_->GetReplicaList("k_b");
+    ASSERT_TRUE(a.has_value());
+    ASSERT_TRUE(b.has_value());
+    EXPECT_EQ(a->replicas[0].get_local_disk_descriptor().client_id, client_a);
+    EXPECT_EQ(b->replicas[0].get_local_disk_descriptor().client_id, client_b);
+    EXPECT_EQ(a->replicas[0].get_local_disk_descriptor().object_size, 1024u);
+    EXPECT_EQ(b->replicas[0].get_local_disk_descriptor().object_size, 2048u);
+}
+
+// Persisting state with an in-flight PromotionTask must not crash and must
+// not mutate the visible replica state. The PromotionTask itself is
+// allowed to be dropped on restore (transient), but the LOCAL_DISK source
+// it references must come back unchanged.
+TEST_F(MasterServicePromotionSnapshotTest, InFlightPromotionTaskSnapshotSafe) {
+    CreateMasterServiceWithPromotion();
+    UUID client_id = MountMemAndDisk("seg_a", kDefaultSegmentBase);
+
+    ASSERT_TRUE(
+        InjectLocalDiskReplica(client_id, "k_cold", 1024, "seg_a_endpoint"));
+
+    // Trigger promotion gate to enqueue a task. This pins the source
+    // replica's refcnt and adds a per-shard PromotionTask plus a per-
+    // segment promotion_objects entry.
+    auto get = service_->GetReplicaList("k_cold");
+    ASSERT_TRUE(get.has_value());
+
+    // The visible replica list should still expose exactly one LOCAL_DISK
+    // replica with correct content. Snapshot+restore happens in TearDown
+    // and must preserve this view.
+    EXPECT_EQ(get->replicas.size(), 1u);
+    EXPECT_TRUE(get->replicas[0].is_local_disk_replica());
+}
+
+// Promotion-on-hit can be configured on, off, or implicitly off (when
+// enable_offload is false). The persisted master config must not affect
+// replica state round-trip in any of these modes — only the runtime gate
+// behavior changes. This test asserts the off-by-feature-flag case:
+// LOCAL_DISK keys still round-trip even when promotion is disabled.
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -579,6 +579,77 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
     service->RemoveAll();
 }
 
+// PromotionObjectHeartbeat caps the per-call response at kMaxPerHeartbeat
+// (1) and leaves the remainder queued for subsequent heartbeats. This is
+// the master-side bound that keeps the client's heartbeat thread inside
+// the liveness window when many keys are queued, while guaranteeing no
+// task is dropped — a regression from the prior client-side cap that
+// silently discarded leftovers.
+TEST_F(PromotionOnHitTest, HeartbeatBoundedBatchPreservesLeftovers) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+
+    // Push three keys into the holder's promotion_objects via the trigger
+    // path. Each is a LOCAL_DISK-only key (no MEMORY replica), so the
+    // first GetReplicaList per key crosses the admission threshold (=1)
+    // and TryPushPromotionQueue enqueues a task.
+    const std::vector<std::string> keys{"hb_k1", "hb_k2", "hb_k3"};
+    for (const auto& k : keys) {
+        ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, k, 1024,
+                                           seg.segment_name));
+        auto r = service->GetReplicaList(k);
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // First heartbeat returns at most 1 key.
+    auto tick1 = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(tick1.has_value());
+    EXPECT_EQ(tick1->size(), 1u)
+        << "heartbeat should return at most kMaxPerHeartbeat=1 entry";
+    std::string first_key = tick1->begin()->first;
+    EXPECT_TRUE(std::find(keys.begin(), keys.end(), first_key) != keys.end());
+
+    // Second heartbeat returns another key (a different one).
+    auto tick2 = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(tick2.has_value());
+    EXPECT_EQ(tick2->size(), 1u);
+    std::string second_key = tick2->begin()->first;
+    EXPECT_NE(second_key, first_key)
+        << "second heartbeat must drain a different leftover key, not "
+        << "re-return the one already extracted";
+
+    // Third heartbeat returns the third key.
+    auto tick3 = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(tick3.has_value());
+    EXPECT_EQ(tick3->size(), 1u);
+    std::string third_key = tick3->begin()->first;
+    EXPECT_NE(third_key, first_key);
+    EXPECT_NE(third_key, second_key);
+
+    // Fourth heartbeat: queue is now empty.
+    auto tick4 = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(tick4.has_value());
+    EXPECT_TRUE(tick4->empty())
+        << "after draining all queued keys, heartbeat must return empty";
+
+    // Sanity: master-side promotion_tasks records are intact for all keys
+    // (they're cleared by NotifyPromotionSuccess, not by Heartbeat), so the
+    // source refcnts remain pinned until processed.
+    for (const auto& k : keys) {
+        auto rl = service->GetReplicaList(k);
+        ASSERT_TRUE(rl.has_value()) << "key " << k << " should still exist";
+    }
+
+    service->RemoveAll();
+}
+
 }  // namespace mooncake::test
 
 int main(int argc, char** argv) {

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -77,42 +77,9 @@ class PromotionOnHitTest : public ::testing::Test {
         ASSERT_TRUE(put_end.has_value()) << "PutEnd failed for key=" << key;
     }
 
-    // Force a key into the LOCAL_DISK-only state by:
-    //   1. Putting a MEMORY replica, then evicting it via RemoveByKey.
-    //   2. Re-creating the metadata via NotifyOffloadSuccess with a synthetic
-    //      LOCAL_DISK descriptor.
-    // Cleaner approach used here: do a full PutStart+PutEnd cycle with
-    // offload_on_evict=true, which leaves an offload task pending. We then
-    // simulate the heartbeat by calling NotifyOffloadSuccess directly to
-    // attach a LOCAL_DISK replica, and manually drop the MEMORY replica via
-    // a forced eviction. For a v1 unit test we cheat by using the simpler
-    // setup: NotifyOffloadSuccess on a key whose MEMORY replica we can let
-    // eviction naturally remove.
-    //
-    // Simplest path that doesn't require a real FileStorage: put a key, then
-    // call NotifyOffloadSuccess to add a LOCAL_DISK replica alongside, then
-    // evict the MEMORY (via lease expiry + watermark). For a unit test, we
-    // skip the eviction and instead test the trigger logic on a key with
-    // BOTH MEMORY and LOCAL_DISK replicas: the trigger should NOT fire
-    // because the gate requires no MEMORY replica. So we need a key with
-    // ONLY LOCAL_DISK.
-    //
-    // To get a clean LOCAL_DISK-only state we use this sequence:
-    //   1. PutStart + write + PutEnd → key has 1 MEMORY replica.
-    //   2. Master configured with offload_on_evict=false so PutEnd attempts
-    //      immediate offload via PushOffloadingQueue.
-    //   3. NotifyOffloadSuccess → adds LOCAL_DISK replica (now 2 replicas).
-    //   4. RemoveByKey is too coarse (drops everything). Instead we call
-    //      a helper EvictMemReplicas which we add in this test fixture by
-    //      poking the MasterService's eviction thread under high pressure.
-    //
-    // For v1 simplicity, we just test the trigger on a key with BOTH MEMORY
-    // and LOCAL_DISK replicas. We assert the inverted behavior: any_memory
-    // is true, so no promotion task is queued. That's still a meaningful
-    // gate test. For LOCAL_DISK-only behavior we'd need eviction to land,
-    // which the existing test infrastructure already exercises in
-    // offload_on_evict_test under near-full segment pressure; we mirror
-    // that pattern in the second test below.
+    // Inject a synthetic LOCAL_DISK replica for `key` on `client_id`'s
+    // segment via NotifyOffloadSuccess. Lets tests put a key into
+    // LOCAL_DISK-only state without running the full offload pipeline.
     bool InjectLocalDiskReplica(MasterService& service, const UUID& client_id,
                                 const std::string& key, int64_t size,
                                 const std::string& transport_endpoint) {
@@ -498,9 +465,9 @@ TEST_F(PromotionOnHitTest, MultiSegmentAllocPicksAvailableSegment) {
 }
 
 // preferred_segments is honored: promotion can be steered to a specific
-// DRAM segment (e.g., the reader's local one). v1 doesn't pass preferred_
-// segments from TryPushPromotionQueue, but PromotionAllocStart respects it
-// for clients that want to bias toward locality.
+// DRAM segment (e.g., the reader's local one). TryPushPromotionQueue
+// currently doesn't pass preferred_segments through, but
+// PromotionAllocStart respects them for clients biasing toward locality.
 TEST_F(PromotionOnHitTest, MultiSegmentAllocRespectsPreferred) {
     MasterServiceConfig config;
     config.enable_offload = true;
@@ -939,17 +906,11 @@ TEST_F(PromotionOnHitTest, AllocStartResetsTaskDeadline) {
     service->RemoveAll();
 }
 
-// Issue 2 regression — success-path counter decrement. NotifyPromotionSuccess
-// must fetch_sub(1) on promotion_in_flight_; otherwise the global cap stays
-// saturated and every subsequent promotion is silently dropped once
-// queue_limit tasks have ever succeeded.
-//
-// This is also the only test in the suite that exercises
-// NotifyPromotionSuccess's *success* path end-to-end (every other call site
-// asserts an error path). It therefore also covers the const-drop fix: if
-// the alloc_id assignment in PromotionAllocStart was somehow broken,
-// NotifyPromotionSuccess would see alloc_id == 0 and return
-// REPLICA_IS_NOT_READY, failing this test.
+// NotifyPromotionSuccess must decrement the cluster-wide in-flight
+// counter so future admissions can use the slot; otherwise queue_limit
+// remains saturated forever after the first successful promotion. Also
+// exercises the only success-path end-to-end coverage of
+// NotifyPromotionSuccess in the suite.
 TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
     MasterServiceConfig config;
     config.enable_offload = true;
@@ -983,10 +944,9 @@ TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
         << "AllocStart should succeed; error=" << alloc.error();
     auto notify = service->NotifyPromotionSuccess(seg.client_id, "k_first");
     ASSERT_TRUE(notify.has_value())
-        << "NotifyPromotionSuccess full happy path should succeed; "
-        << "if this fires, either AllocStart did not record alloc_id "
-        << "(Issue 3 regression) or the staged replica is missing/"
-        << "non-PROCESSING; error=" << notify.error();
+        << "NotifyPromotionSuccess happy path should succeed; if this "
+        << "fires, AllocStart did not record alloc_id, or the staged "
+        << "replica is missing/non-PROCESSING; error=" << notify.error();
 
     // Counter must now be 0. A second admission on a *different* key must
     // be allowed. If fetch_sub is missing on the success path, the cap is
@@ -1008,15 +968,14 @@ TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
     service->RemoveAll();
 }
 
-// Bug 1 regression — PromotionAllocStart must reject when the in-flight
-// task has been reaped between heartbeat and AllocStart. Without this
-// check, AllocStart would allocate and AddReplicas a PROCESSING MEMORY
-// replica and then silently fail to record alloc_id; the staged replica
-// would then be invisible to both DiscardExpiredProcessingReplicas
-// (which iterates shard->processing_keys, never populated for promotion)
-// and the promotion-task reaper (the task entry it iterates is gone),
-// leaking the allocator buffer until the object itself is removed or
-// evicted.
+// PromotionAllocStart must reject when the in-flight task has been
+// reaped between the holder's heartbeat and the AllocStart RPC arriving
+// (e.g. client stall past put_start_release_timeout_sec_). Without the
+// check, AllocStart would allocate + AddReplicas a PROCESSING MEMORY
+// replica with nothing tracking it: the generic PROCESSING reaper only
+// iterates shard->processing_keys (never populated by promotion) and
+// the promotion-task reaper has nothing left to iterate, so the buffer
+// leaks until the object is removed or evicted.
 TEST_F(PromotionOnHitTest, AllocStartRejectsReapedTask) {
     MasterServiceConfig config;
     config.enable_offload = true;
@@ -1049,14 +1008,13 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsReapedTask) {
     // removed. We can't easily poll for reap externally (the only
     // user-facing observable would be re-admitting through the gate,
     // which would create a fresh task and defeat the test), so use a
-    // fixed sleep with margin. Matches the StalePromotionReaper test
-    // pattern (TTL=1s, sleep=2s) which has held 17/17 in CI.
+    // fixed sleep with margin. Matches the StalePromotionReaper pattern
+    // (TTL=1s, sleep=2s).
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    // Now call AllocStart on the reaped task. Pre-fix this would allocate
-    // a buffer, AddReplicas a PROCESSING MEMORY replica, and return
-    // success with an orphaned replica attached to the object. Post-fix
-    // it must reject without allocating anything.
+    // AllocStart on a reaped task must reject without allocating.
+    // Allocating would leave an orphaned PROCESSING MEMORY replica
+    // attached to the object.
     auto alloc =
         service->PromotionAllocStart(ctx.client_id, "k_cold", 1024, {});
     ASSERT_FALSE(alloc.has_value())
@@ -1076,11 +1034,11 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsReapedTask) {
     service->RemoveAll();
 }
 
-// Bug 2 regression — NotifyPromotionSuccess must reject calls from a
-// client that is not the holder of the source LOCAL_DISK replica.
-// Without this check, any client knowing the key could flip the staged
-// PROCESSING MEMORY replica to COMPLETE before the holder's RDMA write
-// has landed, exposing torn data to readers.
+// NotifyPromotionSuccess must reject calls from a client that is not
+// the holder of the source LOCAL_DISK replica. Without the check, any
+// client knowing the key could flip the staged PROCESSING MEMORY replica
+// to COMPLETE before the holder's RDMA write has landed, exposing torn
+// data to readers.
 TEST_F(PromotionOnHitTest, NotifyRejectsNonHolder) {
     MasterServiceConfig config;
     config.enable_offload = true;
@@ -1104,9 +1062,8 @@ TEST_F(PromotionOnHitTest, NotifyRejectsNonHolder) {
         service->PromotionAllocStart(holder.client_id, "k_cold", 1024, {});
     ASSERT_TRUE(alloc.has_value());
 
-    // An unrelated client tries to Notify. Pre-fix this would flip the
-    // staged replica to COMPLETE; post-fix it must be rejected as
-    // INVALID_PARAMS.
+    // An unrelated client tries to Notify. Must be rejected as
+    // INVALID_PARAMS so the staged replica stays PROCESSING.
     UUID intruder_id = generate_uuid();
     ASSERT_NE(intruder_id, holder.client_id);
     auto bad_notify = service->NotifyPromotionSuccess(intruder_id, "k_cold");
@@ -1210,8 +1167,8 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
         << "removed or evicted.";
 
     // The slot must be freed: a second admission on a different key must
-    // succeed even though queue_limit=1. Pre-fix the cap stayed
-    // saturated until reaper TTL.
+    // succeed even though queue_limit=1. Without the failure-side
+    // decrement the cap would stay saturated until reaper TTL.
     {
         auto r = service->GetReplicaList("k_b");
         ASSERT_TRUE(r.has_value());
@@ -1589,8 +1546,8 @@ TEST_F(PromotionOnHitTest, RemoveErasesPromotionTask) {
         << "Remove should succeed; error=" << rm.error();
 
     // Now admit a different key. With queue_limit=1, this only succeeds
-    // if the slot was freed by Remove (pre-fix it would sit pinned for
-    // the full 300s TTL).
+    // if the slot was freed by Remove. Without the in-flight cleanup,
+    // it would stay pinned for the full 300s TTL.
     {
         auto r = service->GetReplicaList("k_second");
         ASSERT_TRUE(r.has_value());

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -559,8 +559,9 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
     auto r1 = service->GetReplicaList(k1);
     ASSERT_TRUE(r1.has_value());
 
-    // Second read on k2 (same shard S, different key, so no dedup) must be
-    // dropped by the cap gate: shard already has 1 task and 1*1024 >= 1.
+    // Second read on k2 (same shard S, different key, so no dedup) must
+    // be dropped by the cap gate: the cluster-wide in-flight counter is
+    // already 1, which meets promotion_queue_limit_ = 1.
     auto r2 = service->GetReplicaList(k2);
     ASSERT_TRUE(r2.has_value()) << "read itself must still succeed; "
                                 << "queue gate is silent";
@@ -569,8 +570,8 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
     auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
     ASSERT_TRUE(heartbeat.has_value());
     EXPECT_EQ(heartbeat->size(), 1u)
-        << "queue_limit=1 should cap the same shard at 1 task; "
-        << "k2's enqueue must be dropped";
+        << "promotion_queue_limit=1 should admit only the first task "
+        << "globally; k2's enqueue must be dropped";
     EXPECT_EQ(heartbeat->count(k1), 1u)
         << "k1 was read first and should be the surviving task";
     EXPECT_EQ(heartbeat->count(k2), 0u)
@@ -646,6 +647,142 @@ TEST_F(PromotionOnHitTest, HeartbeatBoundedBatchPreservesLeftovers) {
         auto rl = service->GetReplicaList(k);
         ASSERT_TRUE(rl.has_value()) << "key " << k << " should still exist";
     }
+
+    service->RemoveAll();
+}
+
+// Issue 1 regression: the promotion task reaper must pop the staged
+// PROCESSING MEMORY replica added by PromotionAllocStart. Without it,
+// the staged replica was orphaned forever: it's not in
+// shard->processing_keys (so DiscardExpiredProcessingReplicas can't see
+// it) and the previous reaper code only touched the source LOCAL_DISK
+// refcnt and the task entry. The orphan held its allocator buffer
+// indefinitely.
+//
+// We can't observe the staged replica via GetReplicaList because the
+// master filters out PROCESSING entries (clients can only read COMPLETE
+// replicas), so we use QuerySegments to watch the DRAM allocator's used
+// bytes: AllocStart bumps it, and the reaper must return it to baseline.
+// NotifyPromotionSuccess on a reaped task must also fail cleanly.
+TEST_F(PromotionOnHitTest, ReaperPopsStagedMemoryReplicaOnExpiry) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 2000;
+    config.put_start_discard_timeout_sec = 0;
+    config.put_start_release_timeout_sec = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_cold", 1024,
+                                       ctx.segment_name));
+
+    // Baseline allocator usage on the DRAM segment.
+    auto seg_baseline = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_baseline.has_value());
+    const size_t used_baseline = seg_baseline->first;
+
+    // Trigger the gate to enqueue a PromotionTask.
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
+    // Drive the AllocStart side so alloc_id != 0 — this is the exact
+    // setup that left an orphaned PROCESSING MEMORY replica pre-fix.
+    auto alloc = service->PromotionAllocStart("k_cold", 1024, {});
+    ASSERT_TRUE(alloc.has_value());
+
+    // After AllocStart, the DRAM allocator must have committed bytes for
+    // the staged PROCESSING MEMORY replica.
+    auto seg_after_alloc = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_after_alloc.has_value());
+    EXPECT_GT(seg_after_alloc->first, used_baseline)
+        << "PromotionAllocStart should bump segment used bytes "
+        << "(allocator-tracked PROCESSING MEMORY replica)";
+
+    // Sleep past the staleness window; the eviction thread reaps the
+    // task and (with the fix) pops the staged replica via
+    // EraseReplicaByID, which releases the buffer back to the allocator.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    auto seg_after_reap = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_after_reap.has_value());
+    EXPECT_EQ(seg_after_reap->first, used_baseline)
+        << "after reap: staged PROCESSING MEMORY replica's buffer must "
+        << "be freed back to the DRAM allocator. Pre-fix the buffer "
+        << "leaked and used bytes stayed elevated until the object "
+        << "itself was removed or evicted.";
+
+    // NotifyPromotionSuccess for a reaped task must not commit anything
+    // and must return REPLICA_IS_NOT_READY (the task entry is gone, so
+    // the alloc_id lookup at the top of NotifyPromotionSuccess fails
+    // fast).
+    auto notify = service->NotifyPromotionSuccess(ctx.client_id, "k_cold");
+    ASSERT_FALSE(notify.has_value());
+    EXPECT_EQ(notify.error(), ErrorCode::REPLICA_IS_NOT_READY);
+
+    service->RemoveAll();
+}
+
+// Issue 2 regression: the cap gate must be cluster-wide. The old
+// implementation used `shard->size() * kNumShards >= promotion_queue_limit_`,
+// which made the cap fire ~1024x too eagerly on skewed workloads (hot
+// keys cluster in few shards). With a global atomic counter, a task in
+// shard A counts toward the cap that gates a task in shard B.
+TEST_F(PromotionOnHitTest, QueueLimitRejectsCrossShard) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;  // 1 in-flight task globally
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+
+    // Find two keys hashing to *different* shards. With the old per-shard
+    // heuristic this would let both through (each shard's count is 0
+    // independently). With the global counter, only the first goes in.
+    constexpr size_t kNumShardsLocal = 1024;
+    auto shard_of = [](const std::string& k) {
+        return std::hash<std::string>{}(k) % kNumShardsLocal;
+    };
+    const std::string k1 = "xshard_first";
+    std::string k2;
+    for (int i = 0; i < 100000 && k2.empty(); ++i) {
+        std::string candidate = "xshard_other_" + std::to_string(i);
+        if (shard_of(candidate) != shard_of(k1)) {
+            k2 = candidate;
+        }
+    }
+    ASSERT_FALSE(k2.empty()) << "couldn't find a different-shard key";
+    ASSERT_NE(shard_of(k1), shard_of(k2));
+
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, k1, 1024,
+                                       seg.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, k2, 1024,
+                                       seg.segment_name));
+
+    auto r1 = service->GetReplicaList(k1);
+    ASSERT_TRUE(r1.has_value());
+
+    // k2 lives in a different shard, but the global cap is already met
+    // by k1's task — k2 must be rejected.
+    auto r2 = service->GetReplicaList(k2);
+    ASSERT_TRUE(r2.has_value()) << "read itself still succeeds";
+
+    auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(heartbeat.has_value());
+    EXPECT_EQ(heartbeat->size(), 1u)
+        << "with global cap=1 and one task already in shard " << shard_of(k1)
+        << ", a key hashing to shard " << shard_of(k2)
+        << " must be rejected by the global gate (pre-fix it would have "
+        << "been admitted since its shard's local count was 0)";
+    EXPECT_EQ(heartbeat->count(k1), 1u);
+    EXPECT_EQ(heartbeat->count(k2), 0u);
 
     service->RemoveAll();
 }

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -513,12 +513,13 @@ TEST_F(PromotionOnHitTest, MultiSegmentAllocRespectsPreferred) {
     service->RemoveAll();
 }
 
-// promotion_queue_limit caps how many in-flight tasks can sit in a
-// single shard (gate: shard_size * kNumShards >= limit). With limit=1
-// the very first queued task in a shard saturates that shard, so a
-// second LOCAL_DISK-only read on a key hashing to the same shard must
-// be silently dropped by the cap gate (reads still succeed; just no
-// new task is enqueued).
+// promotion_queue_limit caps total in-flight tasks cluster-wide
+// (gate: promotion_in_flight_ >= limit). With limit=1 the very first
+// queued task saturates the cap, so a second LOCAL_DISK-only read —
+// even on a key in the same shard — must be silently dropped by the
+// cap gate (reads still succeed; just no new task is enqueued).
+// QueueLimitRejectsCrossShard covers the same-cap-across-different-
+// shards case.
 TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
     MasterServiceConfig config;
     config.enable_offload = true;
@@ -651,13 +652,13 @@ TEST_F(PromotionOnHitTest, HeartbeatBoundedBatchPreservesLeftovers) {
     service->RemoveAll();
 }
 
-// Issue 1 regression: the promotion task reaper must pop the staged
-// PROCESSING MEMORY replica added by PromotionAllocStart. Without it,
-// the staged replica was orphaned forever: it's not in
-// shard->processing_keys (so DiscardExpiredProcessingReplicas can't see
-// it) and the previous reaper code only touched the source LOCAL_DISK
-// refcnt and the task entry. The orphan held its allocator buffer
-// indefinitely.
+// The promotion task reaper must pop the staged PROCESSING MEMORY
+// replica added by PromotionAllocStart. The staged replica is not in
+// shard->processing_keys, so DiscardExpiredProcessingReplicas's main
+// sweep can't see it, and the reaper for promotion tasks is the only
+// place that knows the replica exists. Without this path the orphan
+// holds its allocator buffer indefinitely (until the object is removed
+// or evicted).
 //
 // We can't observe the staged replica via GetReplicaList because the
 // master filters out PROCESSING entries (clients can only read COMPLETE
@@ -690,7 +691,8 @@ TEST_F(PromotionOnHitTest, ReaperPopsStagedMemoryReplicaOnExpiry) {
         ASSERT_TRUE(r.has_value());
     }
     // Drive the AllocStart side so alloc_id != 0 — this is the exact
-    // setup that left an orphaned PROCESSING MEMORY replica pre-fix.
+    // setup that produces an orphaned PROCESSING MEMORY replica if the
+    // reaper does not pop it.
     auto alloc = service->PromotionAllocStart("k_cold", 1024, {});
     ASSERT_TRUE(alloc.has_value());
 
@@ -702,18 +704,28 @@ TEST_F(PromotionOnHitTest, ReaperPopsStagedMemoryReplicaOnExpiry) {
         << "PromotionAllocStart should bump segment used bytes "
         << "(allocator-tracked PROCESSING MEMORY replica)";
 
-    // Sleep past the staleness window; the eviction thread reaps the
+    // Wait past the staleness window; the eviction thread reaps the
     // task and (with the fix) pops the staged replica via
     // EraseReplicaByID, which releases the buffer back to the allocator.
-    std::this_thread::sleep_for(std::chrono::seconds(2));
-
-    auto seg_after_reap = service->QuerySegments(ctx.segment_name);
-    ASSERT_TRUE(seg_after_reap.has_value());
-    EXPECT_EQ(seg_after_reap->first, used_baseline)
+    // Poll instead of a fixed sleep — the eviction thread cadence and
+    // the test runner's scheduling jitter (especially under suite load)
+    // both vary, so a hard 2s sleep is flaky here.
+    constexpr auto kPollDeadline = std::chrono::seconds(5);
+    constexpr auto kPollInterval = std::chrono::milliseconds(50);
+    const auto poll_start = std::chrono::steady_clock::now();
+    size_t used_after_reap = 0;
+    while (std::chrono::steady_clock::now() - poll_start < kPollDeadline) {
+        auto q = service->QuerySegments(ctx.segment_name);
+        ASSERT_TRUE(q.has_value());
+        used_after_reap = q->first;
+        if (used_after_reap == used_baseline) break;
+        std::this_thread::sleep_for(kPollInterval);
+    }
+    EXPECT_EQ(used_after_reap, used_baseline)
         << "after reap: staged PROCESSING MEMORY replica's buffer must "
-        << "be freed back to the DRAM allocator. Pre-fix the buffer "
-        << "leaked and used bytes stayed elevated until the object "
-        << "itself was removed or evicted.";
+        << "be freed back to the DRAM allocator. If this fires, the "
+        << "reaper is not popping the staged replica and the buffer "
+        << "leaks until the object itself is removed or evicted.";
 
     // NotifyPromotionSuccess for a reaped task must not commit anything
     // and must return REPLICA_IS_NOT_READY (the task entry is gone, so
@@ -726,11 +738,12 @@ TEST_F(PromotionOnHitTest, ReaperPopsStagedMemoryReplicaOnExpiry) {
     service->RemoveAll();
 }
 
-// Issue 2 regression: the cap gate must be cluster-wide. The old
-// implementation used `shard->size() * kNumShards >= promotion_queue_limit_`,
-// which made the cap fire ~1024x too eagerly on skewed workloads (hot
-// keys cluster in few shards). With a global atomic counter, a task in
-// shard A counts toward the cap that gates a task in shard B.
+// The cap gate must be cluster-wide, not per-shard. Promotion targets
+// skewed hot keys, which by definition cluster into a small number of
+// shards; a `shard->size() * kNumShards >= limit` heuristic fires
+// roughly kNumShards-times too eagerly on that workload. With a global
+// atomic counter, a task in shard A counts toward the cap that gates a
+// task in shard B.
 TEST_F(PromotionOnHitTest, QueueLimitRejectsCrossShard) {
     MasterServiceConfig config;
     config.enable_offload = true;
@@ -779,10 +792,191 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsCrossShard) {
     EXPECT_EQ(heartbeat->size(), 1u)
         << "with global cap=1 and one task already in shard " << shard_of(k1)
         << ", a key hashing to shard " << shard_of(k2)
-        << " must be rejected by the global gate (pre-fix it would have "
-        << "been admitted since its shard's local count was 0)";
+        << " must be rejected by the global gate. A per-shard heuristic "
+        << "would admit it here since the destination shard's local "
+        << "count is 0.";
     EXPECT_EQ(heartbeat->count(k1), 1u);
     EXPECT_EQ(heartbeat->count(k2), 0u);
+
+    service->RemoveAll();
+}
+
+// PromotionAllocStart must reset PromotionTask.start_time so the reaper
+// TTL covers the active-transfer phase on its own and is not consumed by
+// the queue-wait phase. Without the reset, a task that waited in the
+// holder's promotion_objects queue for most of the original TTL could
+// enter active transfer with little budget left; if the SSD read + RDMA
+// write of a large object then ran past expiry, the reaper would
+// EraseReplicaByID on the staged MEMORY replica mid-flight and the
+// allocator could hand the freed buffer to a concurrent Put while the
+// client's RDMA write is still landing into it (use-after-free in the
+// allocator + silent data corruption for the concurrent Put).
+//
+// We can't directly observe start_time from a black-box test, so we
+// arrange the timing so the reset is the only thing that distinguishes
+// "task still alive" from "task reaped" at the assertion points:
+//
+//   T=0    : admit task   (original start_time = T=0)
+//   T=Wq   : AllocStart   (resets start_time = T=Wq)
+//   T=Wq+Wa: assertion 1  -- alive iff the reset happened
+//                            (Wq + Wa > TTL,  so without reset the
+//                             original start_time has aged past TTL)
+//                            (Wa < TTL,        so with the reset the
+//                             new start_time has NOT aged past TTL)
+//   T=Wq+Wb: assertion 2  -- reaped
+//                            (Wb > TTL, so even with the reset the
+//                             active-transfer phase has now exceeded its
+//                             own full window)
+//
+// Concretely with TTL = 2s, Wq = 1.5s, Wa = 1.5s (-> 3.0s elapsed,
+// 1.5s since AllocStart), Wb = 3.0s (-> 4.5s elapsed, 3.0s since
+// AllocStart). The "alive" assertion at Wq+Wa is the one that proves
+// the reset is wired up correctly.
+//
+// QuerySegments(seg).first (used bytes) is the observable: AllocStart
+// bumps it, the reaper's EraseReplicaByID returns it to baseline. We
+// can't use GetReplicaList because the master filters out PROCESSING
+// replicas from the response.
+TEST_F(PromotionOnHitTest, AllocStartResetsTaskDeadline) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 8000;
+    config.put_start_discard_timeout_sec = 0;
+    config.put_start_release_timeout_sec = 2;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_late", 1024,
+                                       ctx.segment_name));
+
+    auto seg_baseline = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_baseline.has_value());
+    const size_t used_baseline = seg_baseline->first;
+
+    // T=0 : admit. start_time = T=0.
+    {
+        auto r = service->GetReplicaList("k_late");
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // T=Wq : simulate the holder's queue having been backlogged. With
+    // TTL = 2s and Wq = 1.5s the task is still alive at AllocStart
+    // (the queue-wait phase's own window hasn't expired yet — 1.5 < 2).
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+    auto alloc = service->PromotionAllocStart("k_late", 1024, {});
+    ASSERT_TRUE(alloc.has_value())
+        << "AllocStart must succeed before the queue-wait phase's TTL "
+        << "expires (1.5s elapsed, TTL is 2s). If this fires the test "
+        << "timing is wrong, not the feature.";
+
+    // Buffer has been staged.
+    auto seg_after_alloc = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_after_alloc.has_value());
+    EXPECT_GT(seg_after_alloc->first, used_baseline)
+        << "PromotionAllocStart should bump segment used bytes "
+        << "(allocator-tracked PROCESSING MEMORY replica)";
+
+    // T=Wq+Wa : total elapsed since admission is 3.0s > TTL=2s. If the
+    // reset is missing, the reaper sees the original start_time = 0
+    // and expires the task here, calling EraseReplicaByID which would
+    // free the staged buffer mid-RDMA-write in production. With the
+    // reset, start_time was bumped at AllocStart so age-since-reset is
+    // only 1.5s < TTL=2s and the task stays alive. This is the
+    // assertion that proves the reset is in place.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    auto seg_after_wait = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_after_wait.has_value());
+    EXPECT_GT(seg_after_wait->first, used_baseline)
+        << "post-AllocStart staged MEMORY buffer must still be alive: "
+        << "queue-wait + active-transfer wall time (3.0s) has exceeded "
+        << "the bare TTL (2s), but the start_time reset at AllocStart "
+        << "gives the active-transfer phase its own fresh TTL window. "
+        << "If this fires, the reset in PromotionAllocStart is missing "
+        << "or broken — without it the reaper frees the staged buffer "
+        << "here while a client's RDMA write could still be in flight.";
+
+    // T=Wq+Wb : sleep another 3s for a total of 4.5s since AllocStart.
+    // The active-transfer phase's own TTL has now expired regardless
+    // of the reset; the reaper must fire and free the staged buffer.
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+    auto seg_after_reap = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_after_reap.has_value());
+    EXPECT_EQ(seg_after_reap->first, used_baseline)
+        << "after the active-transfer phase's own TTL expires "
+        << "(4.5s > 2s since AllocStart), the reaper must fire and "
+        << "free the staged buffer via EraseReplicaByID";
+
+    service->RemoveAll();
+}
+
+// Issue 2 regression — success-path counter decrement. NotifyPromotionSuccess
+// must fetch_sub(1) on promotion_in_flight_; otherwise the global cap stays
+// saturated and every subsequent promotion is silently dropped once
+// queue_limit tasks have ever succeeded.
+//
+// This is also the only test in the suite that exercises
+// NotifyPromotionSuccess's *success* path end-to-end (every other call site
+// asserts an error path). It therefore also covers the const-drop fix: if
+// the alloc_id assignment in PromotionAllocStart was somehow broken,
+// NotifyPromotionSuccess would see alloc_id == 0 and return
+// REPLICA_IS_NOT_READY, failing this test.
+TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;  // 1 in-flight task globally
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_first", 1024,
+                                       seg.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_second",
+                                       1024, seg.segment_name));
+
+    // Admit task 1. promotion_in_flight_ goes from 0 -> 1.
+    {
+        auto r = service->GetReplicaList("k_first");
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // Drive the full success path: AllocStart stages the PROCESSING MEMORY
+    // replica and records alloc_id; NotifyPromotionSuccess flips it
+    // COMPLETE, drops the source LOCAL_DISK refcnt, erases the task, and
+    // decrements the counter.
+    auto alloc = service->PromotionAllocStart("k_first", 1024, {});
+    ASSERT_TRUE(alloc.has_value())
+        << "AllocStart should succeed; error=" << alloc.error();
+    auto notify = service->NotifyPromotionSuccess(seg.client_id, "k_first");
+    ASSERT_TRUE(notify.has_value())
+        << "NotifyPromotionSuccess full happy path should succeed; "
+        << "if this fires, either AllocStart did not record alloc_id "
+        << "(Issue 3 regression) or the staged replica is missing/"
+        << "non-PROCESSING; error=" << notify.error();
+
+    // Counter must now be 0. A second admission on a *different* key must
+    // be allowed. If fetch_sub is missing on the success path, the cap is
+    // still saturated at 1 and TryPushPromotionQueue silently drops this
+    // attempt.
+    {
+        auto r = service->GetReplicaList("k_second");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto pending = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(pending.has_value());
+    EXPECT_EQ(pending->size(), 1u)
+        << "k_second must be admitted after k_first succeeds — the global "
+        << "in-flight counter must decrement on the NotifyPromotionSuccess "
+        << "success path. Without fetch_sub, the cap stays saturated and "
+        << "k_second is silently dropped.";
+    EXPECT_EQ(pending->count("k_second"), 1u);
 
     service->RemoveAll();
 }

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -26,6 +26,14 @@ class PromotionOnHitTest : public ::testing::Test {
 
     void TearDown() override { google::ShutdownGoogleLogging(); }
 
+    // Friend access to MasterService::promotion_admission_threshold_, which
+    // is otherwise private. PromotionOnHitTest is friended; TEST_F-generated
+    // subclasses are not, hence this static funnel.
+    static uint32_t GetPromotionAdmissionThresholdForTesting(
+        MasterService* service) {
+        return service->promotion_admission_threshold_;
+    }
+
     static constexpr size_t kDefaultSegmentBase = 0x300000000;
 
     Segment MakeSegment(std::string name, size_t base, size_t size) const {
@@ -1499,6 +1507,150 @@ TEST_F(PromotionOnHitTest, ClientExpiryClearsPromotionTask) {
         << "saturated by the dead holder's task for "
         << "put_start_release_timeout_sec_ seconds, and this admission "
         << "is dropped.";
+
+    service->RemoveAll();
+}
+
+// promotion_admission_threshold=0 would silently bypass the frequency
+// gate (`freq < 0` is never true for uint8_t freq), letting every Get
+// on a LOCAL_DISK-only key admit a promotion. master.cpp clamps the
+// flag at parse time, and MasterService's constructor adds a
+// defense-in-depth clamp for direct-construction paths (tests,
+// embedded users). Verify the clamp lifts 0 → 1.
+TEST_F(PromotionOnHitTest, AdmissionThresholdZeroClampsToOne) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 0;  // would bypass the gate
+    auto service = std::make_unique<MasterService>(config);
+    EXPECT_EQ(GetPromotionAdmissionThresholdForTesting(service.get()), 1u)
+        << "threshold=0 must be clamped to 1; otherwise every Get-on-"
+        << "LOCAL_DISK admits a promotion and the frequency gate is "
+        << "silently disabled.";
+}
+
+// promotion_admission_threshold above the CountMinSketch saturating
+// max (255) would make the gate unreachable (freq saturates at 255,
+// `255 < 256` is true forever → no admissions). Verify the constructor
+// clamps high too.
+TEST_F(PromotionOnHitTest, AdmissionThresholdAboveMaxClampsToMax) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1000;  // > 255
+    auto service = std::make_unique<MasterService>(config);
+    EXPECT_EQ(GetPromotionAdmissionThresholdForTesting(service.get()), 255u)
+        << "threshold above the CountMinSketch counter max (255) must "
+        << "be clamped to 255; otherwise the gate is unreachable.";
+}
+
+// Remove(force=true) on a key with an in-flight PromotionTask must
+// drop the task entry alongside the metadata, so promotion_in_flight_
+// is decremented immediately rather than pinned for ~10 min until the
+// reaper sweeps. With queue_limit=1, the test admits one task, removes
+// the key, then admits a second task on a different key — only
+// succeeds if the slot was freed.
+TEST_F(PromotionOnHitTest, RemoveErasesPromotionTask) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;  // makes the slot observable
+    config.default_kv_lease_ttl = 5000;
+    // Long task TTL so any cap-slot reclaim must come from the
+    // metadata-erase path, not the reaper.
+    config.put_start_release_timeout_sec = 300;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder =
+        PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_first",
+                                       1024, holder.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_second",
+                                       1024, holder.segment_name));
+
+    // Admit task 1.
+    {
+        auto r = service->GetReplicaList("k_first");
+        ASSERT_TRUE(r.has_value());
+    }
+    {
+        auto pending = service->PromotionObjectHeartbeat(holder.client_id);
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(pending->count("k_first"), 1u);
+    }
+
+    // Remove k_first with force=true. With the fix, this also wipes
+    // k_first's promotion_tasks entry and decrements
+    // promotion_in_flight_ back to 0.
+    auto rm = service->Remove("k_first", /*force=*/true);
+    ASSERT_TRUE(rm.has_value())
+        << "Remove should succeed; error=" << rm.error();
+
+    // Now admit a different key. With queue_limit=1, this only succeeds
+    // if the slot was freed by Remove (pre-fix it would sit pinned for
+    // the full 300s TTL).
+    {
+        auto r = service->GetReplicaList("k_second");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
+    ASSERT_TRUE(pending_post.has_value());
+    EXPECT_EQ(pending_post->count("k_second"), 1u)
+        << "k_second must be admittable after Remove of k_first — Remove "
+        << "must erase the in-flight promotion_tasks entry and decrement "
+        << "promotion_in_flight_, otherwise queue_limit=1 stays saturated.";
+
+    service->RemoveAll();
+}
+
+// RemoveByRegex on a key with an in-flight PromotionTask must drop the
+// task entry, same as Remove. Mirror of RemoveErasesPromotionTask, but
+// exercises the regex path which iterates shards directly without an
+// accessor object.
+TEST_F(PromotionOnHitTest, RemoveByRegexErasesPromotionTask) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;
+    config.default_kv_lease_ttl = 5000;
+    config.put_start_release_timeout_sec = 300;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder =
+        PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "regex_k1",
+                                       1024, holder.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "other_k2",
+                                       1024, holder.segment_name));
+
+    // Admit task on regex_k1.
+    {
+        auto r = service->GetReplicaList("regex_k1");
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // RemoveByRegex matches regex_k1 only.
+    auto removed = service->RemoveByRegex("^regex_", /*force=*/true);
+    ASSERT_TRUE(removed.has_value())
+        << "RemoveByRegex should succeed; error=" << removed.error();
+    EXPECT_EQ(removed.value(), 1) << "exactly one key (regex_k1) should match";
+
+    // Slot must be free — admit on other_k2 (different shard or same,
+    // doesn't matter because counter is global).
+    {
+        auto r = service->GetReplicaList("other_k2");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
+    ASSERT_TRUE(pending_post.has_value());
+    EXPECT_EQ(pending_post->count("other_k2"), 1u)
+        << "other_k2 must be admittable after RemoveByRegex of regex_k1 "
+        << "— RemoveByRegex must erase the in-flight promotion_tasks "
+        << "entry. Otherwise queue_limit=1 stays saturated.";
 
     service->RemoveAll();
 }

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -239,7 +239,8 @@ TEST_F(PromotionOnHitTest, AllocStartUnknownKey) {
     config.promotion_on_hit = true;
     auto service = std::make_unique<MasterService>(config);
 
-    auto resp = service->PromotionAllocStart("nonexistent", 1024, {});
+    auto resp =
+        service->PromotionAllocStart(generate_uuid(), "nonexistent", 1024, {});
     ASSERT_FALSE(resp.has_value());
     EXPECT_EQ(resp.error(), ErrorCode::OBJECT_NOT_FOUND);
 }
@@ -467,7 +468,8 @@ TEST_F(PromotionOnHitTest, MultiSegmentAllocPicksAvailableSegment) {
 
     // PromotionAllocStart — test the segment-selection logic on top of
     // the gate-seeded task.
-    auto resp = service->PromotionAllocStart("k_cold", 1024, {});
+    auto resp =
+        service->PromotionAllocStart(holder_client_id, "k_cold", 1024, {});
     ASSERT_TRUE(resp.has_value())
         << "PromotionAllocStart should succeed when any DRAM segment has "
         << "capacity; error=" << resp.error();
@@ -514,8 +516,8 @@ TEST_F(PromotionOnHitTest, MultiSegmentAllocRespectsPreferred) {
         ASSERT_TRUE(r.has_value());
     }
 
-    auto resp =
-        service->PromotionAllocStart("k_cold", 1024, {seg_b.segment_name});
+    auto resp = service->PromotionAllocStart(seg_a.client_id, "k_cold", 1024,
+                                             {seg_b.segment_name});
     ASSERT_TRUE(resp.has_value());
     const auto& mem_desc = resp.value().memory_descriptor;
     EXPECT_EQ(
@@ -707,7 +709,8 @@ TEST_F(PromotionOnHitTest, ReaperPopsStagedMemoryReplicaOnExpiry) {
     // Drive the AllocStart side so alloc_id != 0 — this is the exact
     // setup that produces an orphaned PROCESSING MEMORY replica if the
     // reaper does not pop it.
-    auto alloc = service->PromotionAllocStart("k_cold", 1024, {});
+    auto alloc =
+        service->PromotionAllocStart(ctx.client_id, "k_cold", 1024, {});
     ASSERT_TRUE(alloc.has_value());
 
     // After AllocStart, the DRAM allocator must have committed bytes for
@@ -881,7 +884,8 @@ TEST_F(PromotionOnHitTest, AllocStartResetsTaskDeadline) {
     // (the queue-wait phase's own window hasn't expired yet — 1.5 < 2).
     std::this_thread::sleep_for(std::chrono::milliseconds(1500));
 
-    auto alloc = service->PromotionAllocStart("k_late", 1024, {});
+    auto alloc =
+        service->PromotionAllocStart(ctx.client_id, "k_late", 1024, {});
     ASSERT_TRUE(alloc.has_value())
         << "AllocStart must succeed before the queue-wait phase's TTL "
         << "expires (1.5s elapsed, TTL is 2s). If this fires the test "
@@ -965,7 +969,8 @@ TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
     // replica and records alloc_id; NotifyPromotionSuccess flips it
     // COMPLETE, drops the source LOCAL_DISK refcnt, erases the task, and
     // decrements the counter.
-    auto alloc = service->PromotionAllocStart("k_first", 1024, {});
+    auto alloc =
+        service->PromotionAllocStart(seg.client_id, "k_first", 1024, {});
     ASSERT_TRUE(alloc.has_value())
         << "AllocStart should succeed; error=" << alloc.error();
     auto notify = service->NotifyPromotionSuccess(seg.client_id, "k_first");
@@ -1044,7 +1049,8 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsReapedTask) {
     // a buffer, AddReplicas a PROCESSING MEMORY replica, and return
     // success with an orphaned replica attached to the object. Post-fix
     // it must reject without allocating anything.
-    auto alloc = service->PromotionAllocStart("k_cold", 1024, {});
+    auto alloc =
+        service->PromotionAllocStart(ctx.client_id, "k_cold", 1024, {});
     ASSERT_FALSE(alloc.has_value())
         << "AllocStart must reject when the task has been reaped — "
         << "otherwise the staged PROCESSING MEMORY replica is orphaned";
@@ -1086,7 +1092,8 @@ TEST_F(PromotionOnHitTest, NotifyRejectsNonHolder) {
         auto r = service->GetReplicaList("k_cold");
         ASSERT_TRUE(r.has_value());
     }
-    auto alloc = service->PromotionAllocStart("k_cold", 1024, {});
+    auto alloc =
+        service->PromotionAllocStart(holder.client_id, "k_cold", 1024, {});
     ASSERT_TRUE(alloc.has_value());
 
     // An unrelated client tries to Notify. Pre-fix this would flip the
@@ -1125,6 +1132,373 @@ TEST_F(PromotionOnHitTest, NotifyRejectsNonHolder) {
         << "Holder Notify on the same task must succeed after a rejected "
         << "intruder Notify — the task entry should be untouched by the "
         << "rejection path; error=" << good_notify.error();
+
+    service->RemoveAll();
+}
+
+// NotifyPromotionFailure must immediately release the task slot and the
+// staged buffer so that transient client-side errors (SSD throttling,
+// RDMA flakes) do not pin promotion_queue_limit_ for the full reaper
+// TTL. With queue_limit=1 and a holder client that fails after a
+// successful AllocStart, a second admission on a different key would
+// be silently dropped until reaper TTL if Notify-Failure didn't
+// fast-release. The TTL is set high enough here that any test pass
+// can be attributed to the explicit release, not to reaper expiry.
+TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;  // cap=1 makes the slot observable
+    config.default_kv_lease_ttl = 5000;
+    // Long TTL so the test's pass-fail signal cannot be attributed to
+    // reaper sweep; only NotifyPromotionFailure could plausibly release.
+    config.put_start_release_timeout_sec = 300;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_a", 1024,
+                                       seg.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_b", 1024,
+                                       seg.segment_name));
+
+    auto seg_baseline = service->QuerySegments(seg.segment_name);
+    ASSERT_TRUE(seg_baseline.has_value());
+    const size_t used_baseline = seg_baseline->first;
+
+    // Admit + stage k_a. promotion_in_flight_ goes 0 -> 1.
+    {
+        auto r = service->GetReplicaList("k_a");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto alloc = service->PromotionAllocStart(seg.client_id, "k_a", 1024, {});
+    ASSERT_TRUE(alloc.has_value());
+
+    // The staged PROCESSING MEMORY buffer is allocated.
+    auto seg_after_alloc = service->QuerySegments(seg.segment_name);
+    ASSERT_TRUE(seg_after_alloc.has_value());
+    EXPECT_GT(seg_after_alloc->first, used_baseline)
+        << "AllocStart should commit a buffer in the DRAM allocator";
+
+    // Holder reports failure (simulating SSD read error after AllocStart
+    // succeeded). Master must immediately reap the staged replica and
+    // decrement the slot counter.
+    auto failure = service->NotifyPromotionFailure(seg.client_id, "k_a");
+    ASSERT_TRUE(failure.has_value())
+        << "NotifyPromotionFailure on a valid in-flight task from the "
+        << "legitimate holder must succeed; error=" << failure.error();
+
+    // The staged buffer must be freed back to the DRAM allocator. If
+    // this fires, NotifyPromotionFailure did not pop the staged replica
+    // via EraseReplicaByID — same orphan-replica shape that originally
+    // motivated the reaper fix.
+    auto seg_after_release = service->QuerySegments(seg.segment_name);
+    ASSERT_TRUE(seg_after_release.has_value());
+    EXPECT_EQ(seg_after_release->first, used_baseline)
+        << "NotifyPromotionFailure must release the staged buffer back "
+        << "to the allocator; otherwise it leaks until the object is "
+        << "removed or evicted.";
+
+    // The slot must be freed: a second admission on a different key must
+    // succeed even though queue_limit=1. Pre-fix the cap stayed
+    // saturated until reaper TTL.
+    {
+        auto r = service->GetReplicaList("k_b");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(heartbeat.has_value());
+    EXPECT_EQ(heartbeat->count("k_b"), 1u)
+        << "k_b admission must succeed after k_a's failure released the "
+        << "slot. If this fires, NotifyPromotionFailure did not decrement "
+        << "promotion_in_flight_, and transient client-side errors "
+        << "would saturate the queue limit for the full reaper TTL.";
+
+    // Idempotency: repeated failure notification on the same key must be
+    // safe (return OK without underflowing the counter).
+    auto failure_again = service->NotifyPromotionFailure(seg.client_id, "k_a");
+    EXPECT_TRUE(failure_again.has_value())
+        << "Repeated NotifyPromotionFailure should be idempotent (return "
+        << "OK on already-released task), not error.";
+
+    service->RemoveAll();
+}
+
+// NotifyPromotionFailure must reject calls from a client that is not the
+// holder. Without this gate, any client knowing the key could prematurely
+// release a legitimate in-flight promotion's master state and free the
+// staged buffer mid-RDMA-write. Mirror of NotifyRejectsNonHolder for the
+// Notify-Success path.
+TEST_F(PromotionOnHitTest, NotifyFailureRejectsNonHolder) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 5000;
+    config.put_start_release_timeout_sec = 300;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder =
+        PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_cold",
+                                       1024, holder.segment_name));
+
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto alloc =
+        service->PromotionAllocStart(holder.client_id, "k_cold", 1024, {});
+    ASSERT_TRUE(alloc.has_value());
+
+    // Intruder calls Failure with the wrong client_id.
+    UUID intruder_id = generate_uuid();
+    ASSERT_NE(intruder_id, holder.client_id);
+    auto bad_failure = service->NotifyPromotionFailure(intruder_id, "k_cold");
+    ASSERT_FALSE(bad_failure.has_value())
+        << "Failure from a non-holder client must be rejected.";
+    EXPECT_EQ(bad_failure.error(), ErrorCode::INVALID_PARAMS);
+
+    // The legitimate holder must still be able to either commit via
+    // Notify-Success or release via Notify-Failure on the same task. Use
+    // Notify-Failure here to exercise the surviving-task path.
+    auto good_failure =
+        service->NotifyPromotionFailure(holder.client_id, "k_cold");
+    ASSERT_TRUE(good_failure.has_value())
+        << "Holder Failure must succeed after a rejected intruder "
+        << "Failure — the task entry should be untouched by the "
+        << "rejection path; error=" << good_failure.error();
+
+    service->RemoveAll();
+}
+
+// PromotionAllocStart must reject callers that aren't the holder. Mirror
+// of the Notify gate. Without this gate a client that drained another's
+// promotion_objects queue via PromotionObjectHeartbeat could call
+// AllocStart to stage arbitrary DRAM allocations on the destination
+// segment, with no path to commit (Notify rejects on holder_id mismatch)
+// — they'd just sit pinned until reaper TTL.
+TEST_F(PromotionOnHitTest, AllocStartRejectsNonHolder) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 5000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder =
+        PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_cold",
+                                       1024, holder.segment_name));
+
+    auto seg_baseline = service->QuerySegments(holder.segment_name);
+    ASSERT_TRUE(seg_baseline.has_value());
+    const size_t used_baseline = seg_baseline->first;
+
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
+
+    UUID intruder_id = generate_uuid();
+    ASSERT_NE(intruder_id, holder.client_id);
+    auto bad_alloc =
+        service->PromotionAllocStart(intruder_id, "k_cold", 1024, {});
+    ASSERT_FALSE(bad_alloc.has_value())
+        << "AllocStart from a non-holder client must be rejected — "
+        << "otherwise an attacker that drained another's queue could "
+        << "stage arbitrary DRAM allocations.";
+    EXPECT_EQ(bad_alloc.error(), ErrorCode::INVALID_PARAMS);
+
+    // No buffer was allocated.
+    auto seg_after_bad = service->QuerySegments(holder.segment_name);
+    ASSERT_TRUE(seg_after_bad.has_value());
+    EXPECT_EQ(seg_after_bad->first, used_baseline)
+        << "Rejected AllocStart must not have allocated any DRAM.";
+
+    // The legitimate holder must still be able to AllocStart (task
+    // untouched by the rejection).
+    auto good_alloc =
+        service->PromotionAllocStart(holder.client_id, "k_cold", 1024, {});
+    ASSERT_TRUE(good_alloc.has_value())
+        << "Holder AllocStart on the same task must succeed after a "
+        << "rejected intruder AllocStart; error=" << good_alloc.error();
+
+    service->RemoveAll();
+}
+
+// PromotionAllocStart must reject size that doesn't match the task's
+// recorded object_size. The size is captured from the source LOCAL_DISK
+// descriptor at task admission; mismatch indicates a buggy caller or
+// malicious request and would let the caller request an arbitrary-size
+// DRAM buffer (smaller → eventual RDMA-write overflow risk; larger →
+// wasted DRAM pinned until reaper TTL).
+TEST_F(PromotionOnHitTest, AllocStartRejectsSizeMismatch) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 5000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder =
+        PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    constexpr int64_t kRealSize = 1024;
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_cold",
+                                       kRealSize, holder.segment_name));
+
+    auto seg_baseline = service->QuerySegments(holder.segment_name);
+    ASSERT_TRUE(seg_baseline.has_value());
+    const size_t used_baseline = seg_baseline->first;
+
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // Mismatched-size requests must be rejected, regardless of direction.
+    for (uint64_t bad_size : {static_cast<uint64_t>(kRealSize) / 2,
+                              static_cast<uint64_t>(kRealSize) * 4}) {
+        auto bad_alloc = service->PromotionAllocStart(holder.client_id,
+                                                      "k_cold", bad_size, {});
+        ASSERT_FALSE(bad_alloc.has_value())
+            << "AllocStart with size=" << bad_size
+            << " (task.object_size=" << kRealSize << ") must be rejected.";
+        EXPECT_EQ(bad_alloc.error(), ErrorCode::INVALID_PARAMS);
+
+        // No buffer must have been staged.
+        auto seg_after_bad = service->QuerySegments(holder.segment_name);
+        ASSERT_TRUE(seg_after_bad.has_value());
+        EXPECT_EQ(seg_after_bad->first, used_baseline)
+            << "Rejected AllocStart (size=" << bad_size
+            << ") must not have allocated any DRAM.";
+    }
+
+    // Correct size must still work — the task was not consumed by the
+    // rejections.
+    auto good_alloc = service->PromotionAllocStart(
+        holder.client_id, "k_cold", static_cast<uint64_t>(kRealSize), {});
+    ASSERT_TRUE(good_alloc.has_value())
+        << "AllocStart with the correct size must succeed after rejected "
+        << "size-mismatch attempts; error=" << good_alloc.error();
+
+    service->RemoveAll();
+}
+
+// When a holder client expires, ClientMonitorFunc must clean up its
+// dangling promotion_tasks entries and decrement the global in-flight
+// counter. Without this cleanup, the entries stay pinned until reaper
+// TTL — and on a rolling restart of many holders the cluster-wide cap
+// promotion_queue_limit_ saturates and blocks all new admissions for
+// the full TTL.
+//
+// Test mechanism: short client_live_ttl_sec, admit a promotion, stop
+// pinging, wait for ClientMonitorFunc to expire the client and call
+// ClearInvalidHandles. Then assert promotion_in_flight_ is back to 0
+// by attempting a second admission with queue_limit=1 on a fresh
+// client.
+TEST_F(PromotionOnHitTest, ClientExpiryClearsPromotionTask) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;  // cap=1 makes the slot observable
+    config.default_kv_lease_ttl = 5000;
+    // Long task TTL so that any clearing we see must come from
+    // ClearInvalidHandles, not from the promotion-task reaper.
+    config.put_start_release_timeout_sec = 300;
+    // Short client TTL so expiration is fast.
+    config.client_live_ttl_sec = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder =
+        PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_cold",
+                                       1024, holder.segment_name));
+
+    // Admit the promotion. promotion_in_flight_ goes 0 -> 1.
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // Sanity: with queue_limit=1 the cap is saturated. A second
+    // different-shard admission must be rejected right now.
+    auto second_holder = PrepareSegment(
+        *service, "seg_b", kDefaultSegmentBase + seg_size, seg_size);
+    // Promote second_holder into ok_client_ via ReMountSegment so its
+    // LOCAL_DISK replicas survive any ClearInvalidHandles run triggered
+    // by the first holder's expiry. MountSegment alone does not register
+    // the client as alive (only ReMountSegment does), and
+    // CleanupStaleHandles uses ok_client_ to decide which LOCAL_DISK
+    // replicas to erase — without this, second_holder's k_other replica
+    // would be wiped alongside the first holder's k_cold replica when
+    // ClearInvalidHandles runs.
+    {
+        Segment seg_b =
+            MakeSegment("seg_b", kDefaultSegmentBase + seg_size, seg_size);
+        seg_b.id = second_holder.segment_id;
+        std::vector<Segment> segs{seg_b};
+        auto remount = service->ReMountSegment(segs, second_holder.client_id);
+        ASSERT_TRUE(remount.has_value()) << "ReMount failed";
+    }
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, second_holder.client_id,
+                                       "k_other", 1024,
+                                       second_holder.segment_name));
+    {
+        auto r = service->GetReplicaList("k_other");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto pending_pre =
+        service->PromotionObjectHeartbeat(second_holder.client_id);
+    ASSERT_TRUE(pending_pre.has_value());
+    EXPECT_EQ(pending_pre->count("k_other"), 0u)
+        << "Sanity: queue_limit=1 should block the second admission "
+        << "while the first task is in flight.";
+
+    // Wait for the first holder to expire while keeping the second
+    // holder alive via periodic Pings. ClientMonitorFunc runs every
+    // kClientMonitorSleepMs (1s) and expires clients whose last ping is
+    // older than client_live_ttl_sec (1s); we ping second_holder every
+    // 200ms so it stays alive across the 4s wait. Without these pings
+    // both holders would expire together and the second holder's
+    // LOCAL_DISK segment would be unmounted — making "k_other" un-
+    // admittable for reasons unrelated to the promotion-task slot.
+    {
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(4);
+        while (std::chrono::steady_clock::now() < deadline) {
+            (void)service->Ping(second_holder.client_id);
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
+    }
+
+    // ClearInvalidHandles should have erased the holder's LOCAL_DISK
+    // source replica AND (with the fix) the promotion_tasks entry,
+    // decrementing the global in-flight counter. Re-admit a promotion
+    // on the second holder; with queue_limit=1 this can only succeed if
+    // the slot was freed.
+    {
+        auto r = service->GetReplicaList("k_other");
+        ASSERT_TRUE(r.has_value())
+            << "GetReplicaList(k_other) failed with error=" << r.error();
+    }
+    auto pending_post =
+        service->PromotionObjectHeartbeat(second_holder.client_id);
+    ASSERT_TRUE(pending_post.has_value());
+    EXPECT_EQ(pending_post->count("k_other"), 1u)
+        << "After the holder expired, ClearInvalidHandles must have "
+        << "erased its promotion_tasks entry and decremented "
+        << "promotion_in_flight_. Otherwise the global cap remains "
+        << "saturated by the dead holder's task for "
+        << "put_start_release_timeout_sec_ seconds, and this admission "
+        << "is dropped.";
 
     service->RemoveAll();
 }

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -458,8 +458,15 @@ TEST_F(PromotionOnHitTest, MultiSegmentAllocPicksAvailableSegment) {
     ASSERT_TRUE(InjectLocalDiskReplica(*service, holder_client_id, "k_cold",
                                        1024, "segment_a_endpoint"));
 
-    // Direct PromotionAllocStart — bypass the gate to test the allocation
-    // path in isolation.
+    // Seed the PromotionTask through the gate — PromotionAllocStart now
+    // requires an in-flight task to exist (rejects orphaned-stage path).
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // PromotionAllocStart — test the segment-selection logic on top of
+    // the gate-seeded task.
     auto resp = service->PromotionAllocStart("k_cold", 1024, {});
     ASSERT_TRUE(resp.has_value())
         << "PromotionAllocStart should succeed when any DRAM segment has "
@@ -499,6 +506,13 @@ TEST_F(PromotionOnHitTest, MultiSegmentAllocRespectsPreferred) {
 
     ASSERT_TRUE(InjectLocalDiskReplica(*service, seg_a.client_id, "k_cold",
                                        1024, seg_a.segment_name));
+
+    // Seed the PromotionTask through the gate so AllocStart's
+    // task-existence check passes.
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
 
     auto resp =
         service->PromotionAllocStart("k_cold", 1024, {seg_b.segment_name});
@@ -977,6 +991,140 @@ TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
         << "success path. Without fetch_sub, the cap stays saturated and "
         << "k_second is silently dropped.";
     EXPECT_EQ(pending->count("k_second"), 1u);
+
+    service->RemoveAll();
+}
+
+// Bug 1 regression — PromotionAllocStart must reject when the in-flight
+// task has been reaped between heartbeat and AllocStart. Without this
+// check, AllocStart would allocate and AddReplicas a PROCESSING MEMORY
+// replica and then silently fail to record alloc_id; the staged replica
+// would then be invisible to both DiscardExpiredProcessingReplicas
+// (which iterates shard->processing_keys, never populated for promotion)
+// and the promotion-task reaper (the task entry it iterates is gone),
+// leaking the allocator buffer until the object itself is removed or
+// evicted.
+TEST_F(PromotionOnHitTest, AllocStartRejectsReapedTask) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 2000;
+    config.put_start_discard_timeout_sec = 0;
+    config.put_start_release_timeout_sec = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_cold", 1024,
+                                       ctx.segment_name));
+
+    // Baseline allocator usage.
+    auto seg_baseline = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_baseline.has_value());
+    const size_t used_baseline = seg_baseline->first;
+
+    // Admit the task.
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // Wait past the TTL so the reaper sweeps the task. AllocStart has
+    // not yet been called, so alloc_id is 0; the reaper's
+    // EraseReplicaByID branch is a no-op and only the task entry is
+    // removed. We can't easily poll for reap externally (the only
+    // user-facing observable would be re-admitting through the gate,
+    // which would create a fresh task and defeat the test), so use a
+    // fixed sleep with margin. Matches the StalePromotionReaper test
+    // pattern (TTL=1s, sleep=2s) which has held 17/17 in CI.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // Now call AllocStart on the reaped task. Pre-fix this would allocate
+    // a buffer, AddReplicas a PROCESSING MEMORY replica, and return
+    // success with an orphaned replica attached to the object. Post-fix
+    // it must reject without allocating anything.
+    auto alloc = service->PromotionAllocStart("k_cold", 1024, {});
+    ASSERT_FALSE(alloc.has_value())
+        << "AllocStart must reject when the task has been reaped — "
+        << "otherwise the staged PROCESSING MEMORY replica is orphaned";
+    EXPECT_EQ(alloc.error(), ErrorCode::REPLICA_IS_NOT_READY);
+
+    // The DRAM allocator must be at baseline: no buffer was staged.
+    auto seg_after = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_after.has_value());
+    EXPECT_EQ(seg_after->first, used_baseline)
+        << "AllocStart on a reaped task must not allocate. If used bytes "
+        << "grew here, AllocStart got to AddReplicas before the task-"
+        << "existence check and the staged buffer is now orphaned (no "
+        << "reaper iterates it).";
+
+    service->RemoveAll();
+}
+
+// Bug 2 regression — NotifyPromotionSuccess must reject calls from a
+// client that is not the holder of the source LOCAL_DISK replica.
+// Without this check, any client knowing the key could flip the staged
+// PROCESSING MEMORY replica to COMPLETE before the holder's RDMA write
+// has landed, exposing torn data to readers.
+TEST_F(PromotionOnHitTest, NotifyRejectsNonHolder) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder =
+        PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_cold",
+                                       1024, holder.segment_name));
+
+    // Admit + stage.
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto alloc = service->PromotionAllocStart("k_cold", 1024, {});
+    ASSERT_TRUE(alloc.has_value());
+
+    // An unrelated client tries to Notify. Pre-fix this would flip the
+    // staged replica to COMPLETE; post-fix it must be rejected as
+    // INVALID_PARAMS.
+    UUID intruder_id = generate_uuid();
+    ASSERT_NE(intruder_id, holder.client_id);
+    auto bad_notify = service->NotifyPromotionSuccess(intruder_id, "k_cold");
+    ASSERT_FALSE(bad_notify.has_value())
+        << "Notify from a non-holder client must be rejected — otherwise "
+        << "any client knowing the key can commit someone else's "
+        << "still-being-written replica";
+    EXPECT_EQ(bad_notify.error(), ErrorCode::INVALID_PARAMS);
+
+    // The staged replica must still be PROCESSING (not committed by the
+    // rejected call). Readers must not see it via GetReplicaList yet —
+    // GetReplicaList filters PROCESSING replicas, and pre-AllocStart
+    // there are no COMPLETE replicas to read for a LOCAL_DISK-only key
+    // (only the LOCAL_DISK descriptor itself).
+    auto r_check = service->GetReplicaList("k_cold");
+    ASSERT_TRUE(r_check.has_value());
+    bool saw_complete_memory = false;
+    for (const auto& d : r_check.value().replicas) {
+        if (d.is_memory_replica() && d.status == ReplicaStatus::COMPLETE) {
+            saw_complete_memory = true;
+            break;
+        }
+    }
+    EXPECT_FALSE(saw_complete_memory)
+        << "Rejected Notify must not have committed the staged replica";
+
+    // The legitimate holder must still be able to Notify successfully.
+    auto good_notify =
+        service->NotifyPromotionSuccess(holder.client_id, "k_cold");
+    ASSERT_TRUE(good_notify.has_value())
+        << "Holder Notify on the same task must succeed after a rejected "
+        << "intruder Notify — the task entry should be untouched by the "
+        << "rejection path; error=" << good_notify.error();
 
     service->RemoveAll();
 }

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -1,0 +1,587 @@
+// Unit tests for the L2->L1 promotion-on-hit master-side path. Exercises
+// the master-service entry points directly without going through the RPC
+// layer.
+
+#include "master_service.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "types.h"
+
+namespace mooncake::test {
+
+class PromotionOnHitTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("PromotionOnHitTest");
+        FLAGS_logtostderr = true;
+    }
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    static constexpr size_t kDefaultSegmentBase = 0x300000000;
+
+    Segment MakeSegment(std::string name, size_t base, size_t size) const {
+        Segment segment;
+        segment.id = generate_uuid();
+        segment.name = std::move(name);
+        segment.base = base;
+        segment.size = size;
+        segment.te_endpoint = segment.name;
+        return segment;
+    }
+
+    struct MountedSegmentContext {
+        UUID segment_id;
+        UUID client_id;
+        std::string segment_name;
+    };
+
+    MountedSegmentContext PrepareSegment(MasterService& service,
+                                         std::string name, size_t base,
+                                         size_t size) const {
+        Segment segment = MakeSegment(std::move(name), base, size);
+        UUID client_id = generate_uuid();
+        auto mount_result = service.MountSegment(segment, client_id);
+        EXPECT_TRUE(mount_result.has_value());
+        auto mount_ld = service.MountLocalDiskSegment(client_id, true);
+        EXPECT_TRUE(mount_ld.has_value());
+        return {.segment_id = segment.id,
+                .client_id = client_id,
+                .segment_name = segment.name};
+    }
+
+    // Put an object and complete it (creates a MEMORY replica).
+    void PutObject(MasterService& service, const UUID& client_id,
+                   const std::string& key, size_t size = 1024) {
+        ReplicateConfig config;
+        config.replica_num = 1;
+        auto put_start = service.PutStart(client_id, key, size, config);
+        ASSERT_TRUE(put_start.has_value()) << "PutStart failed for key=" << key;
+        auto put_end = service.PutEnd(client_id, key, ReplicaType::MEMORY);
+        ASSERT_TRUE(put_end.has_value()) << "PutEnd failed for key=" << key;
+    }
+
+    // Force a key into the LOCAL_DISK-only state by:
+    //   1. Putting a MEMORY replica, then evicting it via RemoveByKey.
+    //   2. Re-creating the metadata via NotifyOffloadSuccess with a synthetic
+    //      LOCAL_DISK descriptor.
+    // Cleaner approach used here: do a full PutStart+PutEnd cycle with
+    // offload_on_evict=true, which leaves an offload task pending. We then
+    // simulate the heartbeat by calling NotifyOffloadSuccess directly to
+    // attach a LOCAL_DISK replica, and manually drop the MEMORY replica via
+    // a forced eviction. For a v1 unit test we cheat by using the simpler
+    // setup: NotifyOffloadSuccess on a key whose MEMORY replica we can let
+    // eviction naturally remove.
+    //
+    // Simplest path that doesn't require a real FileStorage: put a key, then
+    // call NotifyOffloadSuccess to add a LOCAL_DISK replica alongside, then
+    // evict the MEMORY (via lease expiry + watermark). For a unit test, we
+    // skip the eviction and instead test the trigger logic on a key with
+    // BOTH MEMORY and LOCAL_DISK replicas: the trigger should NOT fire
+    // because the gate requires no MEMORY replica. So we need a key with
+    // ONLY LOCAL_DISK.
+    //
+    // To get a clean LOCAL_DISK-only state we use this sequence:
+    //   1. PutStart + write + PutEnd → key has 1 MEMORY replica.
+    //   2. Master configured with offload_on_evict=false so PutEnd attempts
+    //      immediate offload via PushOffloadingQueue.
+    //   3. NotifyOffloadSuccess → adds LOCAL_DISK replica (now 2 replicas).
+    //   4. RemoveByKey is too coarse (drops everything). Instead we call
+    //      a helper EvictMemReplicas which we add in this test fixture by
+    //      poking the MasterService's eviction thread under high pressure.
+    //
+    // For v1 simplicity, we just test the trigger on a key with BOTH MEMORY
+    // and LOCAL_DISK replicas. We assert the inverted behavior: any_memory
+    // is true, so no promotion task is queued. That's still a meaningful
+    // gate test. For LOCAL_DISK-only behavior we'd need eviction to land,
+    // which the existing test infrastructure already exercises in
+    // offload_on_evict_test under near-full segment pressure; we mirror
+    // that pattern in the second test below.
+    bool InjectLocalDiskReplica(MasterService& service, const UUID& client_id,
+                                const std::string& key, int64_t size,
+                                const std::string& transport_endpoint) {
+        std::vector<std::string> keys{key};
+        StorageObjectMetadata sm;
+        sm.bucket_id = 0;
+        sm.offset = 0;
+        sm.key_size = static_cast<int64_t>(key.size());
+        sm.data_size = size;
+        sm.transport_endpoint = transport_endpoint;
+        std::vector<StorageObjectMetadata> metas{sm};
+        auto res = service.NotifyOffloadSuccess(client_id, keys, metas);
+        return res.has_value();
+    }
+
+    // Register a client as a LOCAL_DISK holder only (no DRAM segment).
+    // This simulates the cross-host case where the LOCAL_DISK source lives
+    // on a different node than the DRAM target chosen for promotion.
+    UUID PrepareLocalDiskOnlyClient(MasterService& service) const {
+        UUID client_id = generate_uuid();
+        auto mount_ld = service.MountLocalDiskSegment(client_id, true);
+        EXPECT_TRUE(mount_ld.has_value());
+        return client_id;
+    }
+};
+
+// Sanity: with promotion disabled, no path mutates promotion_objects.
+TEST_F(PromotionOnHitTest, DefaultOffNoPromotion) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = false;  // explicitly off
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+
+    PutObject(*service, ctx.client_id, "k1");
+    // GetReplicaList many times. With promotion_on_hit=false, nothing should
+    // appear in promotion_objects regardless of access count.
+    for (int i = 0; i < 5; ++i) {
+        auto resp = service->GetReplicaList("k1");
+        ASSERT_TRUE(resp.has_value());
+    }
+
+    auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
+    ASSERT_TRUE(pending.has_value());
+    EXPECT_EQ(pending->size(), 0u);
+
+    service->RemoveAll();
+}
+
+// With promotion enabled but no LOCAL_DISK replica present, no promotion
+// should fire (the trigger gate any_local_disk is false).
+TEST_F(PromotionOnHitTest, NoLocalDiskNoPromotion) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;  // promote on first touch
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+
+    PutObject(*service, ctx.client_id, "k_mem_only");
+    for (int i = 0; i < 5; ++i) {
+        auto resp = service->GetReplicaList("k_mem_only");
+        ASSERT_TRUE(resp.has_value());
+    }
+
+    auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
+    ASSERT_TRUE(pending.has_value());
+    EXPECT_EQ(pending->size(), 0u)
+        << "Memory-only key should not trigger promotion";
+
+    service->RemoveAll();
+}
+
+// Single-shot Get on a key with both MEMORY and LOCAL_DISK should not
+// promote (any_memory=true → trigger gate fails).
+TEST_F(PromotionOnHitTest, MemoryReplicaPresentNoPromotion) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;  // first-touch
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+
+    PutObject(*service, ctx.client_id, "k_dual", 1024);
+    // Add a LOCAL_DISK replica next to the MEMORY one.
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_dual", 1024,
+                                       ctx.segment_name));
+
+    for (int i = 0; i < 5; ++i) {
+        auto resp = service->GetReplicaList("k_dual");
+        ASSERT_TRUE(resp.has_value());
+    }
+
+    auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
+    ASSERT_TRUE(pending.has_value());
+    EXPECT_EQ(pending->size(), 0u)
+        << "MEMORY replica still present: should not promote";
+
+    service->RemoveAll();
+}
+
+// PromotionObjectHeartbeat returns an empty map when called against a
+// client that has no LocalDiskSegment registered.
+TEST_F(PromotionOnHitTest, HeartbeatReturnsErrorForUnknownClient) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    auto service = std::make_unique<MasterService>(config);
+
+    UUID unknown_client = generate_uuid();
+    auto pending = service->PromotionObjectHeartbeat(unknown_client);
+    ASSERT_FALSE(pending.has_value());
+    EXPECT_EQ(pending.error(), ErrorCode::SEGMENT_NOT_FOUND);
+}
+
+// PromotionAllocStart on a non-existent key returns OBJECT_NOT_FOUND.
+TEST_F(PromotionOnHitTest, AllocStartUnknownKey) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    auto service = std::make_unique<MasterService>(config);
+
+    auto resp = service->PromotionAllocStart("nonexistent", 1024, {});
+    ASSERT_FALSE(resp.has_value());
+    EXPECT_EQ(resp.error(), ErrorCode::OBJECT_NOT_FOUND);
+}
+
+// NotifyPromotionSuccess on a non-existent key returns OBJECT_NOT_FOUND.
+TEST_F(PromotionOnHitTest, NotifyUnknownKey) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    auto service = std::make_unique<MasterService>(config);
+
+    UUID client_id = generate_uuid();
+    auto resp = service->NotifyPromotionSuccess(client_id, "nonexistent");
+    ASSERT_FALSE(resp.has_value());
+    EXPECT_EQ(resp.error(), ErrorCode::OBJECT_NOT_FOUND);
+}
+
+// Concurrent readers racing into TryPushPromotionQueue must dedupe to a
+// single PromotionTask. Without dedup, the source LOCAL_DISK replica's
+// refcnt would be incremented N times and the per-segment promotion_objects
+// map would either error on the second insert (current behavior) or
+// double-queue.
+TEST_F(PromotionOnHitTest, RacingReadersDedup) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;  // first-touch fires the gate
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+
+    // LOCAL_DISK-only key: NotifyOffloadSuccess on a never-PUT key creates
+    // metadata with only the LOCAL_DISK replica (AddReplica's Create-on-
+    // missing path).
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_cold", 1024,
+                                       ctx.segment_name));
+
+    constexpr int kThreads = 32;
+    constexpr int kReadsPerThread = 10;
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back([&service]() {
+            for (int j = 0; j < kReadsPerThread; ++j) {
+                auto r = service->GetReplicaList("k_cold");
+                EXPECT_TRUE(r.has_value());
+            }
+        });
+    }
+    for (auto& t : threads) t.join();
+
+    auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
+    ASSERT_TRUE(pending.has_value());
+    EXPECT_EQ(pending->size(), 1u)
+        << "Concurrent readers (" << kThreads << " x " << kReadsPerThread
+        << ") must dedupe to a single promotion task";
+    ASSERT_TRUE(pending->count("k_cold"));
+
+    service->RemoveAll();
+}
+
+// A PromotionTask that never receives NotifyPromotionSuccess must be
+// reaped after `put_start_release_timeout_sec` so that:
+//   (a) the source LOCAL_DISK replica's refcnt is decremented (no
+//       permanent pin → eviction can still free it later);
+//   (b) the dedup gate is unblocked, so a subsequent read can re-enqueue
+//       the same key for retry.
+TEST_F(PromotionOnHitTest, StalePromotionReaper) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 2000;
+    // Short staleness window: the reaper uses put_start_release_timeout_sec
+    // for promotion tasks. The master enforces release > discard, so set
+    // discard to a still-smaller value.
+    config.put_start_discard_timeout_sec = 0;
+    config.put_start_release_timeout_sec = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_cold", 1024,
+                                       ctx.segment_name));
+
+    // Trigger #1: enqueue, then drain the per-segment queue. Drain leaves
+    // the per-shard PromotionTask intact (the heartbeat is best-effort GC,
+    // not the authoritative state).
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+        auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(pending->size(), 1u);
+    }
+
+    // Without reap, dedup blocks re-enqueue. Confirm: GetReplicaList again,
+    // heartbeat must be empty because PromotionTask still pins the slot.
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+        auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(pending->size(), 0u)
+            << "Dedup gate should block re-enqueue while task is in flight";
+    }
+
+    // Wait past the staleness window; the eviction thread reaps the task.
+    // Eviction loop sleeps for kEvictionThreadSleepMs (10 ms), so 2s wall
+    // clock gives ~200 attempts — plenty.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // Trigger #3: with the task reaped, dedup is unblocked and a fresh
+    // GetReplicaList must enqueue again.
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+        auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(pending->size(), 1u)
+            << "After reap, a fresh read must re-enqueue the same key";
+    }
+
+    service->RemoveAll();
+}
+
+// Force-Remove on a key with a queued PromotionTask must not corrupt
+// state. The PromotionTask references a Replica*; once the metadata is
+// gone, NotifyPromotionSuccess and the reaper must both tolerate the
+// missing entry.
+TEST_F(PromotionOnHitTest, RemoveDuringPromotion) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 100;  // short lease: Remove won't block
+    config.put_start_discard_timeout_sec = 0;
+    config.put_start_release_timeout_sec = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_cold", 1024,
+                                       ctx.segment_name));
+
+    // Queue a promotion task.
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // Lease must expire before we can call non-force Remove (or use force).
+    auto rm = service->Remove("k_cold", /*force=*/true);
+    // Remove returns REPLICA_IS_NOT_READY if any replica is non-COMPLETE.
+    // The injected LOCAL_DISK replica is COMPLETE, so this should succeed.
+    ASSERT_TRUE(rm.has_value())
+        << "Remove on a LOCAL_DISK-only key with a queued promotion should "
+        << "succeed (all replicas COMPLETE); error=" << rm.error();
+
+    // NotifyPromotionSuccess on the now-removed key must surface the missing
+    // metadata cleanly, not crash.
+    auto notify = service->NotifyPromotionSuccess(ctx.client_id, "k_cold");
+    ASSERT_FALSE(notify.has_value());
+    EXPECT_EQ(notify.error(), ErrorCode::OBJECT_NOT_FOUND);
+
+    // Wait for the reaper; it must tolerate the missing metadata entry
+    // (the source replica it would dec_refcnt is already gone).
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // Re-injecting the key and re-triggering must work end-to-end, proving
+    // the per-shard PromotionTask was reaped (not stuck).
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_cold", 1024,
+                                       ctx.segment_name));
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+        auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(pending->size(), 1u)
+            << "After Remove + reap, the same key must re-enqueue cleanly";
+    }
+
+    service->RemoveAll();
+}
+
+// Cross-host promotion: the LOCAL_DISK source's holder client has no DRAM
+// segment of its own. The reader's DRAM segment (segment_b) is the only
+// allocator candidate, so PromotionAllocStart must place the new MEMORY
+// replica there — proving the master's allocation strategy crosses the
+// host boundary cleanly.
+TEST_F(PromotionOnHitTest, MultiSegmentAllocPicksAvailableSegment) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    // Holder: LOCAL_DISK only, no DRAM. Stands in for "host A" that has the
+    // SSD copy but no free RAM.
+    UUID holder_client_id = PrepareLocalDiskOnlyClient(*service);
+
+    // Reader-side DRAM target: "host B" with a fresh DRAM segment.
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto reader_ctx =
+        PrepareSegment(*service, "segment_b", kDefaultSegmentBase, seg_size);
+
+    // The cold key: only replica is LOCAL_DISK on the holder client.
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder_client_id, "k_cold",
+                                       1024, "segment_a_endpoint"));
+
+    // Direct PromotionAllocStart — bypass the gate to test the allocation
+    // path in isolation.
+    auto resp = service->PromotionAllocStart("k_cold", 1024, {});
+    ASSERT_TRUE(resp.has_value())
+        << "PromotionAllocStart should succeed when any DRAM segment has "
+        << "capacity; error=" << resp.error();
+
+    const auto& mem_desc = resp.value().memory_descriptor;
+    ASSERT_TRUE(mem_desc.is_memory_replica());
+    EXPECT_EQ(
+        mem_desc.get_memory_descriptor().buffer_descriptor.transport_endpoint_,
+        reader_ctx.segment_name)
+        << "New MEMORY replica must be allocated on the only DRAM segment "
+        << "(segment_b), not on the LOCAL_DISK holder which has no DRAM";
+
+    // Sanity: the staged MEMORY replica is PROCESSING (visible only after
+    // NotifyPromotionSuccess flips it COMPLETE).
+    EXPECT_EQ(mem_desc.status, ReplicaStatus::PROCESSING);
+
+    service->RemoveAll();
+}
+
+// preferred_segments is honored: promotion can be steered to a specific
+// DRAM segment (e.g., the reader's local one). v1 doesn't pass preferred_
+// segments from TryPushPromotionQueue, but PromotionAllocStart respects it
+// for clients that want to bias toward locality.
+TEST_F(PromotionOnHitTest, MultiSegmentAllocRespectsPreferred) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg_a =
+        PrepareSegment(*service, "segment_a", kDefaultSegmentBase, seg_size);
+    auto seg_b = PrepareSegment(*service, "segment_b",
+                                kDefaultSegmentBase + seg_size, seg_size);
+
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg_a.client_id, "k_cold",
+                                       1024, seg_a.segment_name));
+
+    auto resp =
+        service->PromotionAllocStart("k_cold", 1024, {seg_b.segment_name});
+    ASSERT_TRUE(resp.has_value());
+    const auto& mem_desc = resp.value().memory_descriptor;
+    EXPECT_EQ(
+        mem_desc.get_memory_descriptor().buffer_descriptor.transport_endpoint_,
+        seg_b.segment_name)
+        << "preferred_segments={segment_b} should pin the new MEMORY "
+        << "replica to segment_b";
+
+    service->RemoveAll();
+}
+
+// promotion_queue_limit caps how many in-flight tasks can sit in a
+// single shard (gate: shard_size * kNumShards >= limit). With limit=1
+// the very first queued task in a shard saturates that shard, so a
+// second LOCAL_DISK-only read on a key hashing to the same shard must
+// be silently dropped by the cap gate (reads still succeed; just no
+// new task is enqueued).
+TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;  // any 1 task saturates a shard
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+
+    // Find two keys that hash to the same shard. MasterService::
+    // getShardIndex is private but the formula is deterministic
+    // (std::hash<std::string>{}(key) % kNumShards), so we can mirror
+    // it here. kNumShards=1024 (master_service.h:889).
+    constexpr size_t kNumShardsLocal = 1024;
+    auto shard_of = [](const std::string& k) {
+        return std::hash<std::string>{}(k) % kNumShardsLocal;
+    };
+    const std::string k1 = "qlim_first";
+    std::string k2;
+    for (int i = 0; i < 100000 && k2.empty(); ++i) {
+        std::string candidate = "qlim_collide_" + std::to_string(i);
+        if (shard_of(candidate) == shard_of(k1)) {
+            k2 = candidate;
+        }
+    }
+    ASSERT_FALSE(k2.empty())
+        << "could not find a same-shard collision for " << k1;
+
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, k1, 1024,
+                                       seg.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, k2, 1024,
+                                       seg.segment_name));
+
+    // First read on k1 enqueues a task in shard S.
+    auto r1 = service->GetReplicaList(k1);
+    ASSERT_TRUE(r1.has_value());
+
+    // Second read on k2 (same shard S, different key, so no dedup) must be
+    // dropped by the cap gate: shard already has 1 task and 1*1024 >= 1.
+    auto r2 = service->GetReplicaList(k2);
+    ASSERT_TRUE(r2.has_value()) << "read itself must still succeed; "
+                                << "queue gate is silent";
+
+    // Drain the holder's queue: only k1 should appear.
+    auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(heartbeat.has_value());
+    EXPECT_EQ(heartbeat->size(), 1u)
+        << "queue_limit=1 should cap the same shard at 1 task; "
+        << "k2's enqueue must be dropped";
+    EXPECT_EQ(heartbeat->count(k1), 1u)
+        << "k1 was read first and should be the surviving task";
+    EXPECT_EQ(heartbeat->count(k2), 0u)
+        << "k2 was rejected by the cap gate; should not appear";
+
+    service->RemoveAll();
+}
+
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-wheel/tests/test_promotion_on_hit.py
+++ b/mooncake-wheel/tests/test_promotion_on_hit.py
@@ -34,6 +34,7 @@ Prerequisites:
 """
 
 import os
+import statistics
 import time
 import unittest
 from mooncake.store import MooncakeDistributedStore
@@ -169,7 +170,10 @@ class TestPromotionOnHit(unittest.TestCase):
                 "tuning. Histogram above shows the actual replica state.",
             )
 
-            # Phase 3: clear the admission threshold via per-key reads.
+            # Phase 3: clear the admission threshold via per-key reads, and
+            # time each read so we can compare LOCAL_DISK (pre-promotion)
+            # latency against MEMORY (post-promotion) latency in phase 5.
+            #
             # ``store.get`` goes through ``Client::Query`` → master's
             # ``GetReplicaList`` (the same trigger ``batch_get_replica_desc``
             # walks), so each call fires the promotion gate once; 4 calls
@@ -179,9 +183,17 @@ class TestPromotionOnHit(unittest.TestCase):
             # transitively guards the read-side fix the promotion feature
             # relies on; reads only return the offloaded bytes if the
             # peer's offload-RPC + segment-name resolution work).
+            #
+            # All 4 reads complete in well under one heartbeat interval,
+            # so they should all hit LOCAL_DISK before the worker has a
+            # chance to process the promotion (the trigger only enqueues,
+            # it doesn't synchronously stage MEMORY).
             expected_bytes = reference[cold_key]
+            pre_promotion_latencies_ms = []
             for _ in range(4):
+                t0 = time.perf_counter()
                 got = self.store.get(cold_key)
+                t1 = time.perf_counter()
                 self.assertEqual(
                     got,
                     expected_bytes,
@@ -190,6 +202,7 @@ class TestPromotionOnHit(unittest.TestCase):
                     f"expected len={len(expected_bytes)}). The LOCAL_DISK "
                     f"read path is broken — promotion cannot be tested.",
                 )
+                pre_promotion_latencies_ms.append((t1 - t0) * 1000.0)
 
             # Phase 4: wait for the master to enqueue the promotion task and
             # for the client's next FileStorage heartbeat to execute it.
@@ -215,31 +228,87 @@ class TestPromotionOnHit(unittest.TestCase):
             # offload_rpc_read_count counts every invocation of
             # batch_get_into_offload_object_internal — the single
             # chokepoint for LOCAL_DISK reads served via peer offload-RPC.
-            # We snapshot the counter before the post-promotion read and
-            # assert it didn't move, which means MEMORY served the read.
-            # Bytes-back alone wouldn't distinguish MEMORY from LOCAL_DISK
-            # (the offload-RPC path returns the correct bytes too).
+            # We snapshot the counter, do N timed reads, then assert the
+            # counter didn't move. Bytes-back alone wouldn't distinguish
+            # MEMORY from LOCAL_DISK (the offload-RPC path returns correct
+            # bytes too), but the counter delta and the latency drop both
+            # serve as orthogonal evidence the MEMORY path was used.
+            N_POST_READS = 10
             offload_count_before = self.store.get_offload_rpc_read_count()
-            self.assertEqual(
-                self.store.get(cold_key),
-                expected_bytes,
-                f"post-promotion store.get on {cold_key} returned wrong "
-                f"bytes; the new MEMORY replica is metadata-visible but "
-                f"not byte-correct. NotifyPromotionSuccess flipped "
-                f"PROCESSING -> COMPLETE before the TE write finished, "
-                f"or the TE write landed at the wrong address.",
-            )
+            post_promotion_latencies_ms = []
+            for _ in range(N_POST_READS):
+                t0 = time.perf_counter()
+                got = self.store.get(cold_key)
+                t1 = time.perf_counter()
+                self.assertEqual(
+                    got,
+                    expected_bytes,
+                    f"post-promotion store.get on {cold_key} returned wrong "
+                    f"bytes; the new MEMORY replica is metadata-visible but "
+                    f"not byte-correct. NotifyPromotionSuccess flipped "
+                    f"PROCESSING -> COMPLETE before the TE write finished, "
+                    f"or the TE write landed at the wrong address.",
+                )
+                post_promotion_latencies_ms.append((t1 - t0) * 1000.0)
             offload_count_after = self.store.get_offload_rpc_read_count()
             self.assertEqual(
                 offload_count_after,
                 offload_count_before,
-                f"post-promotion store.get on {cold_key} bumped the "
-                f"offload-RPC counter from {offload_count_before} to "
-                f"{offload_count_after}: it served from LOCAL_DISK SSD, "
-                f"not the freshly-promoted MEMORY replica. The RFC's "
-                f"'subsequent reads avoid SSD' invariant is broken; "
-                f"check SelectBestReplica preference and the post-"
-                f"promotion replica order in metadata.",
+                f"{N_POST_READS} post-promotion store.get calls on "
+                f"{cold_key} bumped the offload-RPC counter from "
+                f"{offload_count_before} to {offload_count_after}: at "
+                f"least one served from LOCAL_DISK SSD instead of the "
+                f"freshly-promoted MEMORY replica. The RFC's 'subsequent "
+                f"reads avoid SSD' invariant is broken; check "
+                f"SelectBestReplica preference and the post-promotion "
+                f"replica order in metadata.",
+            )
+
+            # Empirical latency comparison: LOCAL_DISK reads go through
+            # an offload-RPC roundtrip + peer SSD/file backend read,
+            # MEMORY reads go through TE directly to DRAM. Observed
+            # speedup is 10–50x on real SSDs + RDMA NIC. On docker tmpfs
+            # with small objects most wall-time is Python/C++ marshalling
+            # overhead, so the SSD-vs-DRAM cost gap shrinks to ~2-3x;
+            # we therefore assert only a modest 1.3x median speedup, just
+            # tight enough to catch a regression where MEMORY isn't being
+            # preferred (in that case the offload-RPC counter assertion
+            # above would fire first) but loose enough to survive noisy
+            # CI. The printed summary is the primary empirical signal.
+            pre_median_ms = statistics.median(pre_promotion_latencies_ms)
+            post_median_ms = statistics.median(post_promotion_latencies_ms)
+            pre_min_ms = min(pre_promotion_latencies_ms)
+            pre_max_ms = max(pre_promotion_latencies_ms)
+            post_min_ms = min(post_promotion_latencies_ms)
+            post_max_ms = max(post_promotion_latencies_ms)
+            speedup = (pre_median_ms / post_median_ms
+                       if post_median_ms > 0 else float("inf"))
+            print()
+            print(f"=== promotion latency comparison "
+                  f"(cold_key={cold_key}) ===")
+            print(
+                f"pre-promotion  (LOCAL_DISK via offload-RPC): "
+                f"n={len(pre_promotion_latencies_ms)}, "
+                f"median={pre_median_ms:.2f} ms, "
+                f"min={pre_min_ms:.2f} ms, max={pre_max_ms:.2f} ms"
+            )
+            print(
+                f"post-promotion (MEMORY direct):              "
+                f"n={len(post_promotion_latencies_ms)}, "
+                f"median={post_median_ms:.2f} ms, "
+                f"min={post_min_ms:.2f} ms, max={post_max_ms:.2f} ms"
+            )
+            print(f"speedup: {speedup:.1f}x")
+            self.assertLess(
+                post_median_ms,
+                pre_median_ms / 1.3,
+                f"post-promotion median latency ({post_median_ms:.2f} ms) "
+                f"is not meaningfully lower than pre-promotion median "
+                f"({pre_median_ms:.2f} ms). Promotion should produce at "
+                f"least a 1.3x latency improvement even on docker tmpfs; "
+                f"hitting this assertion means MEMORY is likely not being "
+                f"preferred by SelectBestReplica or the test setup is "
+                f"broken (real-hardware speedup is typically 10–50x).",
             )
         finally:
             for key in keys:

--- a/mooncake-wheel/tests/test_promotion_on_hit.py
+++ b/mooncake-wheel/tests/test_promotion_on_hit.py
@@ -1,0 +1,292 @@
+"""Python-binding test for the L2->L1 promotion-on-hit feature.
+
+Mirror of ``test_offload_on_eviction.py``: that test asserts data flows
+DRAM -> SSD on eviction; this test asserts the reverse — once an object
+exists only on LOCAL_DISK and a client reads it enough times to clear the
+admission threshold, the master enqueues a promotion task and the client's
+next heartbeat tick stages a fresh MEMORY replica.
+
+Test scenario:
+  1. Push enough data to overflow DRAM, so eviction + offload turns warm
+     keys into LOCAL_DISK-only objects.
+  2. Identify one such key from the replica descriptors.
+  3. Read it repeatedly to clear ``promotion_admission_threshold``.
+  4. Wait long enough for one master heartbeat (which queues the task) plus
+     one FileStorage heartbeat (which executes it).
+  5. Assert the key now also has a MEMORY replica.
+
+Prerequisites:
+  - ``mooncake_master`` running with master config containing:
+      ``--enable_offload=true``
+      ``--offload_on_evict=true``
+      ``--promotion_on_hit=true``
+      ``--promotion_admission_threshold=1``  (any positive int; we send
+          enough reads to clear up to 4)
+      ``--root_fs_dir=<dir>``  (so the master tells the client to init
+          its FileStorage; without this, no offload heartbeat runs and
+          no LOCAL_DISK replicas are ever created)
+  - ``MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=<dir>`` set on the client side.
+  - ``MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=10`` and
+    ``MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES=10485760`` on the client.
+    The default bucket-flush thresholds (500 keys / 256 MB) are too high
+    for a single-process test workload; the client's BucketStorageBackend
+    would buffer everything in the ungrouped pool and never write to disk.
+"""
+
+import os
+import time
+import unittest
+from mooncake.store import MooncakeDistributedStore
+
+DEFAULT_DEFAULT_KV_LEASE_TTL = 5000  # ms
+default_kv_lease_ttl = int(
+    os.getenv("DEFAULT_KV_LEASE_TTL", DEFAULT_DEFAULT_KV_LEASE_TTL)
+)
+
+# Keep the segment small so we can overflow it cheaply in CI.
+# 32 MB — small enough that the 96 x 1 MB workload reliably overflows past
+# the eviction high watermark even with OffsetAllocator block padding.
+# Larger values (e.g. 64 MB) sometimes fit the full workload because the
+# allocator's effective capacity exceeds the nominal segment size.
+SEGMENT_SIZE = int(os.getenv("SEGMENT_SIZE_BYTES", str(32 * 1024 * 1024)))
+LOCAL_BUFFER_SIZE = int(os.getenv("LOCAL_BUFFER_SIZE_BYTES", str(64 * 1024 * 1024)))
+
+# Wait window for a full master+client heartbeat round-trip. The default
+# heartbeat interval is 10s on both sides, so 25s is comfortably > 2 ticks.
+PROMOTION_WAIT_SECONDS = int(os.getenv("PROMOTION_WAIT_SECONDS", "25"))
+
+
+def get_client(store):
+    protocol = os.getenv("PROTOCOL", "tcp")
+    device_name = os.getenv("DEVICE_NAME", "")
+    local_hostname = os.getenv("LOCAL_HOSTNAME", "localhost")
+    metadata_server = os.getenv("MC_METADATA_SERVER", "P2PHANDSHAKE")
+    master_server_address = os.getenv("MASTER_SERVER", "127.0.0.1:50051")
+
+    retcode = store.setup(
+        local_hostname,
+        metadata_server,
+        SEGMENT_SIZE,
+        LOCAL_BUFFER_SIZE,
+        protocol,
+        device_name,
+        master_server_address,
+        None,  # engine
+        True,  # enable_ssd_offload — required for FileStorage / LOCAL_DISK
+    )
+    if retcode:
+        raise RuntimeError(f"Failed to setup store client. Return code: {retcode}")
+
+
+def _replica_types(descs, key):
+    """Return a list of replica type tags ('MEMORY', 'LOCAL_DISK', 'DISK')
+    for a key from a batch_get_replica_desc result. Tolerant to either
+    list-of-info or single-info shape."""
+    infos = descs.get(key) if isinstance(descs, dict) else None
+    if infos is None:
+        return []
+    if not isinstance(infos, (list, tuple)):
+        infos = [infos]
+    tags = []
+    for info in infos:
+        if hasattr(info, "is_memory_replica") and info.is_memory_replica():
+            tags.append("MEMORY")
+        elif hasattr(info, "is_local_disk_replica") and info.is_local_disk_replica():
+            tags.append("LOCAL_DISK")
+        elif hasattr(info, "is_disk_replica") and info.is_disk_replica():
+            tags.append("DISK")
+        else:
+            tags.append("UNKNOWN")
+    return tags
+
+
+class TestPromotionOnHit(unittest.TestCase):
+    """Python-binding test for the L2->L1 promotion-on-hit behavioral
+    contract."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.store = MooncakeDistributedStore()
+        get_client(cls.store)
+
+    def test_promotion_after_repeated_hits(self):
+        """A LOCAL_DISK-only key must regain a MEMORY replica after
+        clearing the admission threshold via repeated reads.
+
+        A failure here either means the master is not running with
+        ``promotion_on_hit: true``, or the FileStorage promotion executor
+        did not run / did not complete byte movement before the timeout."""
+
+        VALUE_SIZE = 1024 * 1024  # 1 MB
+        # Enough keys to comfortably overflow a 64 MB segment and trigger
+        # offload-on-evict for at least the older portion of the workload.
+        NUM_KEYS = 96
+
+        timestamp = int(time.time())
+        keys = [f"poh_{i}_{timestamp}" for i in range(NUM_KEYS)]
+        reference = {}
+
+        try:
+            # Phase 1: overflow DRAM, force offload-on-evict.
+            for key in keys:
+                value = os.urandom(VALUE_SIZE)
+                retcode = self.store.put(key, value)
+                # NO_AVAILABLE_HANDLE-style failures (-200) under pressure
+                # are expected and not fatal — we just need *some* keys to
+                # successfully land on LOCAL_DISK.
+                if retcode == 0:
+                    reference[key] = value
+
+            self.assertGreater(
+                len(reference), 0, "No PUTs succeeded — cannot run promotion test"
+            )
+
+            # Phase 2: wait long enough for offload heartbeat to flush the
+            # evicted keys to LOCAL_DISK.
+            time.sleep(PROMOTION_WAIT_SECONDS)
+
+            descs = self.store.batch_get_replica_desc(list(reference.keys()))
+            type_hist = {}
+            cold_key = None
+            for key in reference.keys():
+                types = _replica_types(descs, key)
+                hist_key = ",".join(sorted(set(types)))
+                type_hist[hist_key] = type_hist.get(hist_key, 0) + 1
+                if (
+                    cold_key is None
+                    and types
+                    and all("MEMORY" not in t for t in types)
+                    and any("LOCAL_DISK" in t for t in types)
+                ):
+                    cold_key = key
+            print(f"replica-type histogram after phase 2: {type_hist}")
+
+            self.assertIsNotNone(
+                cold_key,
+                "No LOCAL_DISK-only key found after eviction — is "
+                "offload_on_evict=true and the segment small enough to "
+                "overflow? master config / SEGMENT_SIZE_BYTES env may need "
+                "tuning. Histogram above shows the actual replica state.",
+            )
+
+            # Phase 3: clear the admission threshold via per-key reads.
+            # ``store.get`` goes through ``Client::Query`` → master's
+            # ``GetReplicaList`` (the same trigger ``batch_get_replica_desc``
+            # walks), so each call fires the promotion gate once; 4 calls
+            # comfortably clear any reasonable admission threshold. We also
+            # assert bit-exact bytes back, exercising the LOCAL_DISK
+            # read path end-to-end via the offload-RPC route (this
+            # transitively guards the read-side fix the promotion feature
+            # relies on; reads only return the offloaded bytes if the
+            # peer's offload-RPC + segment-name resolution work).
+            expected_bytes = reference[cold_key]
+            for _ in range(4):
+                got = self.store.get(cold_key)
+                self.assertEqual(
+                    got,
+                    expected_bytes,
+                    f"store.get on LOCAL_DISK-only key {cold_key} returned "
+                    f"wrong/empty bytes (got len={len(got) if got else 0}, "
+                    f"expected len={len(expected_bytes)}). The LOCAL_DISK "
+                    f"read path is broken — promotion cannot be tested.",
+                )
+
+            # Phase 4: wait for the master to enqueue the promotion task and
+            # for the client's next FileStorage heartbeat to execute it.
+            time.sleep(PROMOTION_WAIT_SECONDS)
+
+            descs_after = self.store.batch_get_replica_desc([cold_key])
+            types_after = _replica_types(descs_after, cold_key)
+            print(f"replica types for {cold_key} after promotion: {types_after}")
+            self.assertTrue(
+                "MEMORY" in types_after,
+                f"Expected a MEMORY replica for {cold_key} after promotion, "
+                f"got types={types_after}. Either promotion_on_hit is not "
+                f"enabled in the master, the admission threshold was not "
+                f"cleared, or the heartbeat tick did not fire within "
+                f"{PROMOTION_WAIT_SECONDS}s.",
+            )
+
+            # Phase 5: post-promotion bytes-back. Now that the freshly
+            # staged MEMORY replica is COMPLETE, store.get should serve
+            # from MEMORY (per SelectBestReplica's preference order) and
+            # return the same bytes the holder originally PUT. This locks
+            # in that NotifyPromotionSuccess produced a readable replica,
+            # not just a metadata entry.
+            self.assertEqual(
+                self.store.get(cold_key),
+                expected_bytes,
+                f"post-promotion store.get on {cold_key} returned wrong "
+                f"bytes; the new MEMORY replica is metadata-visible but "
+                f"not byte-correct. NotifyPromotionSuccess flipped "
+                f"PROCESSING -> COMPLETE before the TE write finished, "
+                f"or the TE write landed at the wrong address.",
+            )
+        finally:
+            for key in keys:
+                try:
+                    self.store.remove(key)
+                except Exception:
+                    pass
+            time.sleep(default_kv_lease_ttl / 1000 + 0.5)
+
+
+class TestPromotionDoesNotFire(unittest.TestCase):
+    """Negative-case e2e. With workloads that don't produce LOCAL_DISK
+    replicas, promotion has nothing to do and must not spuriously stage
+    MEMORY replicas. This is the inverse invariant of the positive test
+    and the only Python-level guard against:
+      - regressions that auto-create LOCAL_DISK at PutEnd (would silently
+        break offload semantics and trigger spurious promotions),
+      - regressions that fire promotion without a LOCAL_DISK source.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.store = MooncakeDistributedStore()
+        get_client(cls.store)
+
+    def test_below_watermark_workload_stays_memory_only(self):
+        VALUE_SIZE = 1024  # 1 KB
+        NUM_KEYS = 16  # 16 KB total, well below the 32 MB segment
+
+        timestamp = int(time.time())
+        keys = [f"neg_poh_small_{i}_{timestamp}" for i in range(NUM_KEYS)]
+
+        try:
+            for key in keys:
+                value = os.urandom(VALUE_SIZE)
+                self.assertEqual(self.store.put(key, value), 0)
+
+            # One heartbeat cycle is plenty for any spurious offload to
+            # have surfaced.
+            time.sleep(PROMOTION_WAIT_SECONDS)
+
+            descs = self.store.batch_get_replica_desc(keys)
+            unexpected = []
+            for key in keys:
+                types = _replica_types(descs, key)
+                if not any(t == "MEMORY" for t in types):
+                    unexpected.append((key, types))
+                if any(t == "LOCAL_DISK" for t in types):
+                    unexpected.append((key, types))
+
+            self.assertEqual(
+                unexpected,
+                [],
+                f"Below-watermark workload produced unexpected non-MEMORY "
+                f"or LOCAL_DISK replicas: {unexpected[:5]}. Either "
+                f"eviction is firing prematurely or PutEnd is auto-"
+                f"creating LOCAL_DISK.",
+            )
+        finally:
+            for key in keys:
+                try:
+                    self.store.remove(key)
+                except Exception:
+                    pass
+            time.sleep(default_kv_lease_ttl / 1000 + 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mooncake-wheel/tests/test_promotion_on_hit.py
+++ b/mooncake-wheel/tests/test_promotion_on_hit.py
@@ -207,12 +207,19 @@ class TestPromotionOnHit(unittest.TestCase):
                 f"{PROMOTION_WAIT_SECONDS}s.",
             )
 
-            # Phase 5: post-promotion bytes-back. Now that the freshly
-            # staged MEMORY replica is COMPLETE, store.get should serve
-            # from MEMORY (per SelectBestReplica's preference order) and
-            # return the same bytes the holder originally PUT. This locks
-            # in that NotifyPromotionSuccess produced a readable replica,
-            # not just a metadata entry.
+            # Phase 5: post-promotion bytes-back AND prove MEMORY was the
+            # replica actually served. SelectBestReplica should prefer the
+            # newly-COMPLETE MEMORY replica over the older LOCAL_DISK; if
+            # it does, no offload-RPC call is issued for this read.
+            #
+            # offload_rpc_read_count counts every invocation of
+            # batch_get_into_offload_object_internal — the single
+            # chokepoint for LOCAL_DISK reads served via peer offload-RPC.
+            # We snapshot the counter before the post-promotion read and
+            # assert it didn't move, which means MEMORY served the read.
+            # Bytes-back alone wouldn't distinguish MEMORY from LOCAL_DISK
+            # (the offload-RPC path returns the correct bytes too).
+            offload_count_before = self.store.get_offload_rpc_read_count()
             self.assertEqual(
                 self.store.get(cold_key),
                 expected_bytes,
@@ -221,6 +228,18 @@ class TestPromotionOnHit(unittest.TestCase):
                 f"not byte-correct. NotifyPromotionSuccess flipped "
                 f"PROCESSING -> COMPLETE before the TE write finished, "
                 f"or the TE write landed at the wrong address.",
+            )
+            offload_count_after = self.store.get_offload_rpc_read_count()
+            self.assertEqual(
+                offload_count_after,
+                offload_count_before,
+                f"post-promotion store.get on {cold_key} bumped the "
+                f"offload-RPC counter from {offload_count_before} to "
+                f"{offload_count_after}: it served from LOCAL_DISK SSD, "
+                f"not the freshly-promoted MEMORY replica. The RFC's "
+                f"'subsequent reads avoid SSD' invariant is broken; "
+                f"check SelectBestReplica preference and the post-"
+                f"promotion replica order in metadata.",
             )
         finally:
             for key in keys:

--- a/mooncake-wheel/tests/test_promotion_on_hit.py
+++ b/mooncake-wheel/tests/test_promotion_on_hit.py
@@ -170,30 +170,19 @@ class TestPromotionOnHit(unittest.TestCase):
                 "tuning. Histogram above shows the actual replica state.",
             )
 
-            # Phase 3: clear the admission threshold via per-key reads, and
-            # time each read so we can compare LOCAL_DISK (pre-promotion)
-            # latency against MEMORY (post-promotion) latency in phase 5.
-            #
+            # Phase 3: clear the admission threshold via per-key reads.
             # ``store.get`` goes through ``Client::Query`` → master's
-            # ``GetReplicaList`` (the same trigger ``batch_get_replica_desc``
-            # walks), so each call fires the promotion gate once; 4 calls
-            # comfortably clear any reasonable admission threshold. We also
-            # assert bit-exact bytes back, exercising the LOCAL_DISK
-            # read path end-to-end via the offload-RPC route (this
-            # transitively guards the read-side fix the promotion feature
-            # relies on; reads only return the offloaded bytes if the
-            # peer's offload-RPC + segment-name resolution work).
-            #
-            # All 4 reads complete in well under one heartbeat interval,
-            # so they should all hit LOCAL_DISK before the worker has a
-            # chance to process the promotion (the trigger only enqueues,
-            # it doesn't synchronously stage MEMORY).
+            # ``GetReplicaList``, so each call fires the promotion gate
+            # once; 4 calls comfortably clear any reasonable admission
+            # threshold. We also assert bit-exact bytes back, exercising
+            # the LOCAL_DISK read path end-to-end via the offload-RPC
+            # route (this transitively guards the read-side fix the
+            # promotion feature relies on; reads only return the
+            # offloaded bytes if the peer's offload-RPC + segment-name
+            # resolution work).
             expected_bytes = reference[cold_key]
-            pre_promotion_latencies_ms = []
             for _ in range(4):
-                t0 = time.perf_counter()
                 got = self.store.get(cold_key)
-                t1 = time.perf_counter()
                 self.assertEqual(
                     got,
                     expected_bytes,
@@ -202,7 +191,6 @@ class TestPromotionOnHit(unittest.TestCase):
                     f"expected len={len(expected_bytes)}). The LOCAL_DISK "
                     f"read path is broken — promotion cannot be tested.",
                 )
-                pre_promotion_latencies_ms.append((t1 - t0) * 1000.0)
 
             # Phase 4: wait for the master to enqueue the promotion task and
             # for the client's next FileStorage heartbeat to execute it.
@@ -228,87 +216,34 @@ class TestPromotionOnHit(unittest.TestCase):
             # offload_rpc_read_count counts every invocation of
             # batch_get_into_offload_object_internal — the single
             # chokepoint for LOCAL_DISK reads served via peer offload-RPC.
-            # We snapshot the counter, do N timed reads, then assert the
-            # counter didn't move. Bytes-back alone wouldn't distinguish
-            # MEMORY from LOCAL_DISK (the offload-RPC path returns correct
-            # bytes too), but the counter delta and the latency drop both
-            # serve as orthogonal evidence the MEMORY path was used.
-            N_POST_READS = 10
+            # We snapshot the counter, do a read, then assert the counter
+            # didn't move. Bytes-back alone wouldn't distinguish MEMORY
+            # from LOCAL_DISK (the offload-RPC path returns correct bytes
+            # too); the counter delta is the hard correctness signal that
+            # the MEMORY path was used. The BenchPromotionLatency class
+            # below offers a heavier latency-based view of the same
+            # invariant when richer numbers are wanted.
             offload_count_before = self.store.get_offload_rpc_read_count()
-            post_promotion_latencies_ms = []
-            for _ in range(N_POST_READS):
-                t0 = time.perf_counter()
-                got = self.store.get(cold_key)
-                t1 = time.perf_counter()
-                self.assertEqual(
-                    got,
-                    expected_bytes,
-                    f"post-promotion store.get on {cold_key} returned wrong "
-                    f"bytes; the new MEMORY replica is metadata-visible but "
-                    f"not byte-correct. NotifyPromotionSuccess flipped "
-                    f"PROCESSING -> COMPLETE before the TE write finished, "
-                    f"or the TE write landed at the wrong address.",
-                )
-                post_promotion_latencies_ms.append((t1 - t0) * 1000.0)
+            self.assertEqual(
+                self.store.get(cold_key),
+                expected_bytes,
+                f"post-promotion store.get on {cold_key} returned wrong "
+                f"bytes; the new MEMORY replica is metadata-visible but "
+                f"not byte-correct. NotifyPromotionSuccess flipped "
+                f"PROCESSING -> COMPLETE before the TE write finished, "
+                f"or the TE write landed at the wrong address.",
+            )
             offload_count_after = self.store.get_offload_rpc_read_count()
             self.assertEqual(
                 offload_count_after,
                 offload_count_before,
-                f"{N_POST_READS} post-promotion store.get calls on "
-                f"{cold_key} bumped the offload-RPC counter from "
-                f"{offload_count_before} to {offload_count_after}: at "
-                f"least one served from LOCAL_DISK SSD instead of the "
-                f"freshly-promoted MEMORY replica. The RFC's 'subsequent "
-                f"reads avoid SSD' invariant is broken; check "
-                f"SelectBestReplica preference and the post-promotion "
-                f"replica order in metadata.",
-            )
-
-            # Empirical latency comparison: LOCAL_DISK reads go through
-            # an offload-RPC roundtrip + peer SSD/file backend read,
-            # MEMORY reads go through TE directly to DRAM. Observed
-            # speedup is 10–50x on real SSDs + RDMA NIC. On docker tmpfs
-            # with small objects most wall-time is Python/C++ marshalling
-            # overhead, so the SSD-vs-DRAM cost gap shrinks to ~2-3x;
-            # we therefore assert only a modest 1.3x median speedup, just
-            # tight enough to catch a regression where MEMORY isn't being
-            # preferred (in that case the offload-RPC counter assertion
-            # above would fire first) but loose enough to survive noisy
-            # CI. The printed summary is the primary empirical signal.
-            pre_median_ms = statistics.median(pre_promotion_latencies_ms)
-            post_median_ms = statistics.median(post_promotion_latencies_ms)
-            pre_min_ms = min(pre_promotion_latencies_ms)
-            pre_max_ms = max(pre_promotion_latencies_ms)
-            post_min_ms = min(post_promotion_latencies_ms)
-            post_max_ms = max(post_promotion_latencies_ms)
-            speedup = (pre_median_ms / post_median_ms
-                       if post_median_ms > 0 else float("inf"))
-            print()
-            print(f"=== promotion latency comparison "
-                  f"(cold_key={cold_key}) ===")
-            print(
-                f"pre-promotion  (LOCAL_DISK via offload-RPC): "
-                f"n={len(pre_promotion_latencies_ms)}, "
-                f"median={pre_median_ms:.2f} ms, "
-                f"min={pre_min_ms:.2f} ms, max={pre_max_ms:.2f} ms"
-            )
-            print(
-                f"post-promotion (MEMORY direct):              "
-                f"n={len(post_promotion_latencies_ms)}, "
-                f"median={post_median_ms:.2f} ms, "
-                f"min={post_min_ms:.2f} ms, max={post_max_ms:.2f} ms"
-            )
-            print(f"speedup: {speedup:.1f}x")
-            self.assertLess(
-                post_median_ms,
-                pre_median_ms / 1.3,
-                f"post-promotion median latency ({post_median_ms:.2f} ms) "
-                f"is not meaningfully lower than pre-promotion median "
-                f"({pre_median_ms:.2f} ms). Promotion should produce at "
-                f"least a 1.3x latency improvement even on docker tmpfs; "
-                f"hitting this assertion means MEMORY is likely not being "
-                f"preferred by SelectBestReplica or the test setup is "
-                f"broken (real-hardware speedup is typically 10–50x).",
+                f"post-promotion store.get on {cold_key} bumped the "
+                f"offload-RPC counter from {offload_count_before} to "
+                f"{offload_count_after}: it served from LOCAL_DISK SSD, "
+                f"not the freshly-promoted MEMORY replica. The RFC's "
+                f"'subsequent reads avoid SSD' invariant is broken; "
+                f"check SelectBestReplica preference and the post-"
+                f"promotion replica order in metadata.",
             )
         finally:
             for key in keys:
@@ -366,6 +301,183 @@ class TestPromotionDoesNotFire(unittest.TestCase):
                 f"or LOCAL_DISK replicas: {unexpected[:5]}. Either "
                 f"eviction is firing prematurely or PutEnd is auto-"
                 f"creating LOCAL_DISK.",
+            )
+        finally:
+            for key in keys:
+                try:
+                    self.store.remove(key)
+                except Exception:
+                    pass
+            time.sleep(default_kv_lease_ttl / 1000 + 0.5)
+
+
+@unittest.skipUnless(
+    os.getenv("MC_BENCH_PROMOTION_LATENCY"),
+    "opt-in benchmark — set MC_BENCH_PROMOTION_LATENCY=1 to run. "
+    "Not part of CI; gives p50/p95/p99 latency comparison of LOCAL_DISK "
+    "reads (pre-promotion) vs MEMORY reads (post-promotion).",
+)
+class BenchPromotionLatency(unittest.TestCase):
+    """Ad-hoc latency benchmark for the L2->L1 promotion feature.
+
+    Runs the same overflow → eviction → promote workflow as
+    ``TestPromotionOnHit`` but:
+      - times every read with ``time.perf_counter``;
+      - aborts the pre-promotion sample loop the moment a read serves
+        from MEMORY (detected via the offload-RPC counter) to keep the
+        LOCAL_DISK distribution uncontaminated;
+      - prints p50/p95/p99 + min/max for both phases and a per-percentile
+        speedup table;
+      - asserts a conservative 1.3x p50 speedup so a regression where
+        MEMORY isn't being preferred breaks the bench.
+
+    Sample size is controlled by ``LATENCY_SAMPLES`` (default 1000).
+    For larger samples (e.g. N=10000) bump
+    ``MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS`` so the worker
+    doesn't race the pre-promotion read loop.
+
+    Expected speedup on docker tmpfs with 1 MiB objects is ~2x at every
+    percentile (most wall-time is Python/C++ marshalling, not the
+    SSD-vs-DRAM cost gap). On real SSDs + RDMA NICs expect 10-50x.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.store = MooncakeDistributedStore()
+        get_client(cls.store)
+
+    def test_latency_comparison(self):
+        VALUE_SIZE = 1024 * 1024  # 1 MB
+        NUM_KEYS = 96
+
+        timestamp = int(time.time())
+        keys = [f"bench_poh_{i}_{timestamp}" for i in range(NUM_KEYS)]
+        reference = {}
+
+        try:
+            # Overflow DRAM, force offload-on-evict.
+            for key in keys:
+                value = os.urandom(VALUE_SIZE)
+                if self.store.put(key, value) == 0:
+                    reference[key] = value
+            self.assertGreater(len(reference), 0)
+
+            time.sleep(PROMOTION_WAIT_SECONDS)
+
+            descs = self.store.batch_get_replica_desc(list(reference.keys()))
+            cold_key = None
+            for key in reference.keys():
+                types = _replica_types(descs, key)
+                if (
+                    cold_key is None
+                    and types
+                    and all("MEMORY" not in t for t in types)
+                    and any("LOCAL_DISK" in t for t in types)
+                ):
+                    cold_key = key
+            self.assertIsNotNone(cold_key, "no LOCAL_DISK-only key after eviction")
+
+            # Pre-promotion: timed LOCAL_DISK reads, bail when a read
+            # serves from MEMORY (= worker raced the loop).
+            N = int(os.getenv("LATENCY_SAMPLES", "1000"))
+            expected_bytes = reference[cold_key]
+            pre_latencies_ms = []
+            for i in range(N):
+                count_before = self.store.get_offload_rpc_read_count()
+                t0 = time.perf_counter()
+                got = self.store.get(cold_key)
+                t1 = time.perf_counter()
+                count_after = self.store.get_offload_rpc_read_count()
+                self.assertEqual(got, expected_bytes)
+                if count_after == count_before:
+                    print(
+                        f"  pre-promotion loop: promotion fired at "
+                        f"sample {i}/{N}; stopping to keep the "
+                        f"LOCAL_DISK sample uncontaminated"
+                    )
+                    break
+                pre_latencies_ms.append((t1 - t0) * 1000.0)
+            self.assertGreater(
+                len(pre_latencies_ms),
+                1,
+                "collected <2 pre-promotion samples — promotion fired "
+                "before measurement could capture LOCAL_DISK latency. "
+                "Bump MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS or "
+                "lower LATENCY_SAMPLES.",
+            )
+
+            # Wait for promotion to complete.
+            time.sleep(PROMOTION_WAIT_SECONDS)
+            descs_after = self.store.batch_get_replica_desc([cold_key])
+            types_after = _replica_types(descs_after, cold_key)
+            self.assertIn("MEMORY", types_after)
+
+            # Post-promotion: timed MEMORY reads; the counter must stay
+            # put (otherwise at least one read still hit LOCAL_DISK).
+            count_before = self.store.get_offload_rpc_read_count()
+            post_latencies_ms = []
+            for _ in range(N):
+                t0 = time.perf_counter()
+                got = self.store.get(cold_key)
+                t1 = time.perf_counter()
+                self.assertEqual(got, expected_bytes)
+                post_latencies_ms.append((t1 - t0) * 1000.0)
+            count_after = self.store.get_offload_rpc_read_count()
+            self.assertEqual(
+                count_after,
+                count_before,
+                f"post-promotion reads bumped the offload-RPC counter "
+                f"from {count_before} to {count_after}: at least one "
+                f"read served from LOCAL_DISK SSD instead of MEMORY.",
+            )
+
+            def _pcts(samples):
+                """{p: value_ms} for p in [50, 95, 99]."""
+                if len(samples) >= 2:
+                    cuts = statistics.quantiles(samples, n=100)
+                    return {50: cuts[49], 95: cuts[94], 99: cuts[98]}
+                v = samples[0] if samples else 0.0
+                return {50: v, 95: v, 99: v}
+
+            def _speedup(a, b):
+                return a / b if b > 0 else float("inf")
+
+            pre = _pcts(pre_latencies_ms)
+            post = _pcts(post_latencies_ms)
+
+            print()
+            print(f"=== promotion latency comparison "
+                  f"(cold_key={cold_key}) ===")
+            print(
+                f"pre-promotion  (LOCAL_DISK via offload-RPC): "
+                f"n={len(pre_latencies_ms)}, "
+                f"p50={pre[50]:.2f} ms, p95={pre[95]:.2f} ms, "
+                f"p99={pre[99]:.2f} ms, "
+                f"min={min(pre_latencies_ms):.2f} ms, "
+                f"max={max(pre_latencies_ms):.2f} ms"
+            )
+            print(
+                f"post-promotion (MEMORY direct):              "
+                f"n={len(post_latencies_ms)}, "
+                f"p50={post[50]:.2f} ms, p95={post[95]:.2f} ms, "
+                f"p99={post[99]:.2f} ms, "
+                f"min={min(post_latencies_ms):.2f} ms, "
+                f"max={max(post_latencies_ms):.2f} ms"
+            )
+            print(
+                f"speedup: p50={_speedup(pre[50], post[50]):.1f}x  "
+                f"|  p95={_speedup(pre[95], post[95]):.1f}x  "
+                f"|  p99={_speedup(pre[99], post[99]):.1f}x"
+            )
+
+            self.assertLess(
+                post[50],
+                pre[50] / 1.3,
+                f"post-promotion p50 latency ({post[50]:.2f} ms) is not "
+                f"meaningfully lower than pre-promotion p50 "
+                f"({pre[50]:.2f} ms). Real-hardware speedup is typically "
+                f"10–50x; failing this 1.3x check means MEMORY likely "
+                f"isn't being preferred.",
             )
         finally:
             for key in keys:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -68,6 +68,39 @@ else
     echo "Skipping test: MOONCAKE_STORAGE_ROOT_DIR environment variable is not set"
 fi
 
+if [ -n "$TEST_PROMOTION_ON_HIT" ]; then
+    TEST_ROOT_DIR="/tmp/mooncake_test_promotion"
+    mkdir -p $TEST_ROOT_DIR
+    echo "Running L2->L1 promotion-on-hit e2e test..."
+    # offload_on_evict drives the prerequisite SSD-only state; promotion_on_hit
+    # turns the read path into a promotion trigger; threshold=1 makes the test
+    # deterministic. --root_fs_dir is required so the master returns a non-
+    # empty fsdir from GetStorageConfig, which is the trigger that initializes
+    # the client's FileStorage (and therefore the offload heartbeat).
+    mooncake_master \
+        --default_kv_lease_ttl=500 \
+        --root_fs_dir=$TEST_ROOT_DIR \
+        --enable_offload=true \
+        --offload_on_evict=true \
+        --promotion_on_hit=true \
+        --promotion_admission_threshold=1 &
+    MASTER_PID=$!
+    sleep 1
+    # Lower bucket-flush thresholds so the test workload (~64 MB) actually
+    # writes to disk rather than sitting in the bucket backend's ungrouped
+    # pool until the default 500-key / 256-MB bucket fills.
+    MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
+        DEFAULT_KV_LEASE_TTL=500 \
+        MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=$TEST_ROOT_DIR \
+        MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=10 \
+        MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES=10485760 \
+        python test_promotion_on_hit.py
+    kill $MASTER_PID || true
+    rm -rf $TEST_ROOT_DIR
+else
+    echo "Skipping test: TEST_PROMOTION_ON_HIT environment variable is not set"
+fi
+
 echo "Running CXL protocol test (test_distributed_object_store_cxl.py)..."
 killall mooncake_master || true
 sleep 2


### PR DESCRIPTION
## Description

Adds the L2→L1 promotion-on-hit feature: when a key whose only complete replica lives on a peer client's local SSD (LOCAL_DISK) is read enough times to clear an admission threshold, the master enqueues a promotion task and the holder client's next FileStorage heartbeat stages a fresh MEMORY replica via Transfer Engine. Symmetric counterpart to offload-on-evict: offload moves cold data DRAM→SSD on eviction, promotion moves rediscovered-warm data SSD→DRAM on access.

The trigger lives inside `MasterService::GetReplicaList`. A CountMinSketch tracks per-key access frequency; gates filter out cases where promotion would be wasteful or unsafe (no LOCAL_DISK source, MEMORY already present, DRAM under high-watermark pressure, queue saturated, or task already in-flight for the same key). When all gates pass, the master records a `PromotionTask` in the per-shard map (refcnt-pinning the source replica) and pushes the key onto the holder's per-LocalDiskSegment `promotion_objects` map. The holder's FileStorage heartbeat thread drains a bounded batch from that map, calls `PromotionAllocStart` to stage a PROCESSING MEMORY replica, reads the bytes from local SSD, RDMA-WRITEs them via `PromotionWrite`, and notifies the master. `NotifyPromotionSuccess` flips the new replica COMPLETE and decrements the source LOCAL_DISK refcnt. A reaper drops expired tasks; orphaned PROCESSING replicas are reaped via the standard discarded-replicas path.

Failure handling matches offload's posture: per-key failures are logged and skipped, and the master-side reaper handles task TTL expiry on its own schedule.

### Key design points addressed in this PR

- **Concurrent-Put disambiguation in NotifyPromotionSuccess.** The PromotionTask stores the `ReplicaID` of the staged MEMORY replica captured during `PromotionAllocStart`. `NotifyPromotionSuccess` commits exactly that replica via `GetReplicaByID`, so a parallel Put creating its own PROCESSING MEMORY replica on the same key cannot be confused with ours.
- **Heartbeat liveness.** Each promotion task does a synchronous SSD read + RDMA write whose wall time scales with object size (64 MB–1 GB tensors are common in KV-cache workloads). `MasterService::PromotionObjectHeartbeat` returns at most `kMaxPerHeartbeat = 1` task per call and leaves the rest queued; the client processes whatever the master returned and never blocks beyond a single task. Leftovers are preserved by construction — no silent drops.
- **Sketch / threshold type safety.** The CountMinSketch uses 8-bit saturating counters (max 255), so `promotion_admission_threshold` is clamped to [0, 255] at config parse time with a warning, giving the gate a stable comparison contract.

### Config knobs (default off)

- `--promotion_on_hit=true` — feature flag
- `--promotion_admission_threshold=N` — reads per key before the gate fires (default 2; clamped to ≤255)
- `--promotion_queue_limit=N` — soft per-shard cap on in-flight promotion tasks (default 50000)

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

**Master-side unit tests** (`mooncake-store/tests/promotion_on_hit_test.cpp`, 13 tests):
- Gate behavior: feature off, no LOCAL_DISK source, MEMORY already present
- Error returns: unknown client/key on Heartbeat / AllocStart / Notify
- State machine: dedup of racing readers, stale task reaper, key removed mid-promotion
- Cap gates: `promotion_queue_limit` rejects beyond saturation; **`PromotionObjectHeartbeat` returns ≤`kMaxPerHeartbeat` per call and preserves leftover work** (`HeartbeatBoundedBatchPreservesLeftovers`)
- Multi-segment routing: cross-host LOCAL_DISK→MEMORY allocation, `preferred_segments` honored

**Client-side unit tests** (`mooncake-store/tests/file_storage_promotion_test.cpp`, 9 tests, FakeClient mocks the master RPCs):
- Empty queue / heartbeat error paths
- Per-key error isolation: AllocStart / BatchLoad / TransferWrite / Notify failures don't abort the batch
- NonPositiveSize / SegmentNotFound / hard-error propagation
- FakeClient mirrors the master's bounded-batch heartbeat semantics, so the drain shape exercised matches production

**Snapshot tests** (`mooncake-store/tests/ha/snapshot/master_service_promotion_test_for_snapshot.cpp`, 5 tests):
- LOCAL_DISK replica round-trip, mixed MEMORY+LOCAL_DISK, multiple holders, in-flight task safety

**End-to-end Python tests** (`mooncake-wheel/tests/test_promotion_on_hit.py`, 2 tests in CI):
- Positive: 96×1 MiB workload overflows 32 MiB segment → eviction creates LOCAL_DISK-only keys → repeated `store.get` clears admission threshold → MEMORY replica reappears → bit-exact bytes verified pre- AND post-promotion AND **the post-promotion read is proven to serve from MEMORY (not LOCAL_DISK SSD) by snapshotting `MooncakeDistributedStore.get_offload_rpc_read_count()` around the read and asserting zero delta**
- Negative: below-watermark workload stays MEMORY-only (guards against spurious promotion / auto-LOCAL_DISK regressions)

Gated behind `TEST_PROMOTION_ON_HIT` in `scripts/run_tests.sh`.

**Opt-in latency benchmark** (`BenchPromotionLatency` class in the same file, skipped by default; run with `MC_BENCH_PROMOTION_LATENCY=1`):

The CI test proves MEMORY served the post-promotion read via the offload-RPC counter delta. For a richer empirical view, the benchmark times every read with `time.perf_counter`, samples `LATENCY_SAMPLES` reads per phase (default 1000), and reports p50/p95/p99 with a per-percentile speedup table. Pre-promotion reads bail the moment a read serves from MEMORY (detected via the same counter) so the LOCAL_DISK distribution stays uncontaminated.

Observed numbers from a docker-tmpfs run with 1 MiB objects, N=1000 samples:

| | n | p50 | p95 | p99 | min | max |
|---|---|---|---|---|---|---|
| **Pre-promotion** (LOCAL_DISK via offload-RPC) | 1000 | 0.52 ms | 0.68 ms | 0.81 ms | 0.40 ms | 6.10 ms |
| **Post-promotion** (MEMORY direct) | 1000 | 0.24 ms | 0.34 ms | 0.42 ms | 0.18 ms | 2.36 ms |
| **Speedup** | | **2.1×** | **2.0×** | **1.9×** | | |

The speedup holds across the distribution — MEMORY's win isn't a median trick. The 1.3× p50 assertion baked into the bench has comfortable headroom over the observed 2×. On docker tmpfs (no real SSD, no RDMA NIC) much of the per-read wall-time is Python/C++ marshalling overhead, so the SSD-vs-DRAM cost gap is compressed; on real hardware (NVMe + RDMA) the ratio is typically 10–50×.

The same numbers replicated at N=10000 with `MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS=30` (so the worker doesn't race a longer pre-loop): p50/p95/p99 changed by ≤0.02 ms vs the N=1000 run, confirming N=1000 is the right default for stable tail percentiles.

## Follow-ups (not in this PR)

- **Async promotion worker.** Today the heartbeat thread serially executes the SSD read + RDMA write + notify per task with `kMaxPerHeartbeat=1` to stay inside the client-liveness window. If real workloads show the resulting drain rate (≈ 1 promotion / heartbeat interval) becomes a bottleneck, an obvious next step is a dedicated worker thread that pulls from a bounded queue: the heartbeat enqueues, the worker drains independently, and the cap can be relaxed. ~180 LOC + tests; deferred unless needed.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.