### PR TITLE
[TENT] fallback to per-task cudaMemcpyAsync when driver lacks batch s…

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -176,7 +176,6 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
     err = cudaErrorCallRequiresNewerDriver;
 #endif
 
-    err = cudaErrorCallRequiresNewerDriver;
     if (err == cudaErrorCallRequiresNewerDriver) {
         cudaGetLastError();
         err = cudaSuccess;

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -164,7 +164,8 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
     err = cudaMemcpyBatchAsync(dsts.data(), srcs.data(), sizes.data(),
                                srcs.size(), &attr, &attrs_idx, 1, &fail_idx,
                                batch->async_stream.get());
-    if (err != cudaSuccess && err != cudaErrorCallRequiresNewerDriver && fail_idx < tasks.size()) {
+    if (err != cudaSuccess && err != cudaErrorCallRequiresNewerDriver &&
+        fail_idx < tasks.size()) {
         LOG(ERROR) << "NVLinkTransport::startTransfer internal error: "
                    << "cudaMemcpyBatchAsync failed at task index " << fail_idx
                    << " (src=" << srcs[fail_idx] << ", dst=" << dsts[fail_idx]
@@ -180,9 +181,9 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
         cudaGetLastError();
         err = cudaSuccess;
         for (size_t i = 0; i < tasks.size(); ++i) {
-            auto single_err = cudaMemcpyAsync(dsts[i], srcs[i], sizes[i],
-                                              cudaMemcpyDefault,
-                                              batch->async_stream.get());
+            auto single_err =
+                cudaMemcpyAsync(dsts[i], srcs[i], sizes[i], cudaMemcpyDefault,
+                                batch->async_stream.get());
             if (single_err != cudaSuccess) {
                 tasks[i]->status_word = TransferStatusEnum::FAILED;
                 err = single_err;

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -164,7 +164,7 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
     err = cudaMemcpyBatchAsync(dsts.data(), srcs.data(), sizes.data(),
                                srcs.size(), &attr, &attrs_idx, 1, &fail_idx,
                                batch->async_stream.get());
-    if (err != cudaSuccess && fail_idx < tasks.size()) {
+    if (err != cudaSuccess && err != cudaErrorCallRequiresNewerDriver && fail_idx < tasks.size()) {
         LOG(ERROR) << "NVLinkTransport::startTransfer internal error: "
                    << "cudaMemcpyBatchAsync failed at task index " << fail_idx
                    << " (src=" << srcs[fail_idx] << ", dst=" << dsts[fail_idx]
@@ -173,17 +173,23 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
         tasks[fail_idx]->status_word = TransferStatusEnum::FAILED;
     }
 #else
-    err = cudaSuccess;
-    for (size_t i = 0; i < tasks.size(); ++i) {
-        auto single_err =
-            cudaMemcpyAsync(dsts[i], srcs[i], sizes[i], cudaMemcpyDefault,
-                            batch->async_stream.get());
-        if (single_err != cudaSuccess) {
-            tasks[i]->status_word = TransferStatusEnum::FAILED;
-            err = single_err;
+    err = cudaErrorCallRequiresNewerDriver;
+#endif
+
+    err = cudaErrorCallRequiresNewerDriver;
+    if (err == cudaErrorCallRequiresNewerDriver) {
+        cudaGetLastError();
+        err = cudaSuccess;
+        for (size_t i = 0; i < tasks.size(); ++i) {
+            auto single_err = cudaMemcpyAsync(dsts[i], srcs[i], sizes[i],
+                                              cudaMemcpyDefault,
+                                              batch->async_stream.get());
+            if (single_err != cudaSuccess) {
+                tasks[i]->status_word = TransferStatusEnum::FAILED;
+                err = single_err;
+            }
         }
     }
-#endif
 
     if (err != cudaSuccess) {
         for (auto* task : tasks) {


### PR DESCRIPTION

Fixes the case where containers ship CUDA Toolkit 12.8 but the host driver only supports 12.2

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
