### PR TITLE
[Store] Optimize SpinLock via adding a fast-path check

### DIFF
--- a/mooncake-store/include/mutex.h
+++ b/mooncake-store/include/mutex.h
@@ -125,6 +125,10 @@ class CAPABILITY("mutex") SpinLock {
    public:
     // Acquire/lock the spinlock.
     void lock() ACQUIRE() {
+        // Fast path: try to acquire directly
+        if (!flag.test_and_set(std::memory_order_acquire)) return;
+
+        // Slow path: spin wait with relaxed loads, acquire on success
         do {
             while (flag.test(std::memory_order_relaxed)) {
                 PAUSE();


### PR DESCRIPTION
## Description
 PR(#1343) introduced SpinLock in mutex.h to optimize locking in MetadataShard.                                                                                                         This PR adds an uncontended fast path to avoid the inner spin loop when the lock is already free, reducing latency in the common case.                                                                                                                               
                                                                                                                                                                                           
The original TTAS pattern (relaxed inner spin + acquire test_and_set) is                                                                                                               correctly synchronized — the `test_and_set(acquire)` establishes the                                                                                                                     happens-before relationship with `unlock()`'s `clear(release)`. This PR                                                                                                                  preserves that pattern while adding a single `test_and_set` fast path                                                                                                                    before entering the spin loop.                                      

> `test_and_set` is an atomic read-modify-write operation that checks the current value and sets it to true, returning the previous state — used here to atomically test if the lock is free and acquire it in one indivisible step.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other


