### PR TITLE
[Store] Expose is_local_disk_replica() to Python + enable offload RPC in standalone mooncake_client

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1616,6 +1616,9 @@ PYBIND11_MODULE(store, m) {
         .def("is_disk_replica",
              static_cast<bool (Replica::Descriptor::*)() const noexcept>(
                  &Replica::Descriptor::is_disk_replica))
+        .def("is_local_disk_replica",
+             static_cast<bool (Replica::Descriptor::*)() const noexcept>(
+                 &Replica::Descriptor::is_local_disk_replica))
         .def(
             "get_memory_descriptor",
             static_cast<const MemoryDescriptor &(Replica::Descriptor::*)()

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -19,6 +19,11 @@ DEFINE_int32(port, 50052, "Real Client service port");
 DEFINE_string(global_segment_size, "4 GB", "Size of global segment");
 DEFINE_int32(threads, 1, "Number of threads for client service");
 DEFINE_bool(enable_offload, false, "Enable offload availability");
+DEFINE_bool(start_offload_rpc_server, true,
+            "Expose TCP RPC for disk-tier reads "
+            "(batch_get_offload_object / release_offload_buffer). "
+            "Effective only when --enable_offload is true. "
+            "Disable for a write-only owner.");
 DECLARE_bool(enable_http_server);
 DECLARE_int32(http_port);
 
@@ -106,7 +111,7 @@ int main(int argc, char *argv[]) {
         FLAGS_host, FLAGS_metadata_server, global_segment_size, 0,
         FLAGS_protocol, FLAGS_device_names, FLAGS_master_server_address,
         nullptr, "@mooncake_client_" + std::to_string(FLAGS_port) + ".sock",
-        FLAGS_port, FLAGS_enable_offload);
+        FLAGS_port, FLAGS_enable_offload, FLAGS_start_offload_rpc_server);
     if (!res) {
         LOG(FATAL) << "Failed to setup client: " << toString(res.error());
         return -1;


### PR DESCRIPTION
## Summary

Two small follow-ups to #2004 (LOCAL_DISK read-path fix) and to #1857 (which introduced the `start_offload_rpc_server` switch) that complete end-to-end disk-tier readback when the Mooncake owner is launched via the standalone `mooncake_client` binary path (e.g. through `start_mooncake_owner.sh` in vLLM integrations).

Without these two, even with #2004 + #1857 already merged:
- writes succeed and `.bucket` files land on SSD, **but**
- every disk-tier read returns `-900 RPC_FAIL`
- replica descriptors round-trip to Python as `unknown` (neither `is_memory_replica()` nor `is_disk_replica()` matches a `LocalDiskDescriptor`)

These two commits were originally part of [ivanium/Mooncake#5](https://github.com/ivanium/Mooncake/pull/5) (the consolidated end-to-end disk-read fix for GB200 + Kimi-K2.5-NVFP4 testing). #2004 picked up the in-process read-path fixes (Bug B / D / E + replica selection). This PR upstreams the two remaining pieces.

## Bugs fixed

### Commit 1 — `is_local_disk_replica()` Python binding

`Replica::Descriptor` is a 3-way `std::variant {MemoryDescriptor, DiskDescriptor, LocalDiskDescriptor}` with one predicate per variant on the C++ side. The Python wrapper bound `is_memory_replica` and `is_disk_replica`, but not `is_local_disk_replica`.

Mooncake's offload pipeline (`NotifyOffloadSuccess`) constructs `LocalDiskDescriptor` exclusively. Without the third predicate, any Python caller iterating replicas returned from the master — e.g. `batch_get_replica_desc()` used by vLLM's `MooncakeStoreConnector` tier-classification logging — sees every offloaded replica fail both checks and gets classified as `unknown`.

Pure additive: 3-line `.def(...)` addition in `mooncake-integration/store/store_py.cpp`. No behavior change for existing callers.

### Commit 2 — `start_offload_rpc_server` default in standalone binary

#1857 added the `start_offload_rpc_server` parameter to `setup_internal()` and updated the Python-binding caller (`setup_real`) to pass `true`. The standalone `mooncake_client` binary's `main()` in `real_client_main.cpp` was missed, so it continued to use the default value (`false`).

Net effect: when an owner is launched via the binary path, `local_rpc_addr` (sent to master via `NotifyOffloadSuccess.transport_endpoint`) falls back to `<host>:<FLAGS_port>` — which only has the IPC abstract socket `@mooncake_client_<port>.sock`, no TCP listener. Worker disk-tier reads then see `RPC_FAIL (-900)` on every attempt.

Fix: add `DEFINE_bool(start_offload_rpc_server, true, ...)` to `real_client_main.cpp` and pass it to `setup_internal()`. Default `true` matches the Python-binding behavior; the flag is preserved as a seam for future write-only owner / test-isolation setups (per the #1857 design intent).

## Validation

Branch built on top of current `main` (`6caf4128`) and tested end-to-end on a single GB200 node (Ubuntu 24.04, glibc 2.39, CUDA 13, vLLM `dev674+gb896ec108` + `MooncakeStoreConnector`).

Workload: Qwen3-8B DP=4, 100 conversations × 3 turns × 32 concurrent, 16K input, `--gpu-memory-utilization 0.4 --num-gpu-blocks-override 1024` to force GPU prefix-cache eviction into Mooncake; owner configured with 4 GiB CPU pool + 1 TB SSD to force CPU→disk spillover.

| Signal | Pre-this-PR (just #2004) | Post-this-PR |
|---|---|---|
| writes succeed | yes — `NotifyOffloadSuccess` events fire | yes |
| `.bucket` files on disk | yes — 310 / 77 GB | yes |
| tier-log classification | every entry `unknown_keys=N` | `disk_keys=N` (correct tier) |
| per-key load result codes | every key `-900 RPC_FAIL` | `success_keys=N`, no `-900` |

Sample tier-log line, pre-this-PR (writes work, reads broken):
```
batch_keys=165 memory_keys=0 disk_keys=0 unknown_keys=165
success_keys=0 failed_keys=165 bytes_by_tier={'memory': 0, 'disk': 0, 'unknown': 0}
```

Sample tier-log line, post-this-PR (matches the format the vLLM consumer expects):
```
batch_keys=101 memory_keys=0 disk_keys=101 unknown_keys=0
success_keys=101 failed_keys=0 bytes_by_tier={'memory': 0, 'disk': 238288896, 'unknown': 0}
```

## Related

- #1857 — added `start_offload_rpc_server` to `setup_internal()` and enabled it on the Python `setup_real` path; this PR is the missed-companion for the standalone-binary path.
- #2004 — LOCAL_DISK read-path fix in `real_client.cpp` / replica selection (merged 2026-05-09); this PR is the small follow-up that makes the read path actually reachable when the owner is the standalone binary.
- ivanium/Mooncake#5 — the original consolidated patch series these two commits came from.
- ivanium/vllm#32 — the vLLM-side consumer (`VLLM_MOONCAKE_STORE_TIER_LOG=1` tier-summary logging) that exposes the success/failure signals quoted above.

## Files changed

| File | Change |
|---|---|
| `mooncake-integration/store/store_py.cpp` | Add `.def("is_local_disk_replica", ...)` |
| `mooncake-store/src/real_client_main.cpp` | Add `DEFINE_bool(start_offload_rpc_server, true, ...)`, pass to `setup_internal()` |

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix