### PR TITLE
[Bugfix][Store]Optimize async route sync

### DIFF
--- a/mooncake-store/include/data_manager.h
+++ b/mooncake-store/include/data_manager.h
@@ -131,7 +131,8 @@ class DataManager {
     tl::expected<size_t, ErrorCode> QueryObjectSize(std::string_view key);
 
     tl::expected<void, ErrorCode> Delete(
-        std::string_view key, std::optional<UUID> tier_id = std::nullopt);
+        std::string_view key, std::optional<UUID> tier_id = std::nullopt,
+        bool notify_master = true);
 
     /**
      * @brief Get tier views from underlying tiered storage

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -195,7 +195,8 @@ class TieredBackend {
      * If nullopt, removes ALL replicas for this key (and the key entry itself).
      */
     tl::expected<void, ErrorCode> Delete(
-        std::string_view key, std::optional<UUID> tier_id = std::nullopt);
+        std::string_view key, std::optional<UUID> tier_id = std::nullopt,
+        bool notify_master = true);
 
     // --- Composite Operations ---
 

--- a/mooncake-store/src/data_manager.cpp
+++ b/mooncake-store/src/data_manager.cpp
@@ -1130,13 +1130,14 @@ tl::expected<size_t, ErrorCode> DataManager::QueryObjectSize(
 }
 
 tl::expected<void, ErrorCode> DataManager::Delete(std::string_view key,
-                                                  std::optional<UUID> tier_id) {
+                                                  std::optional<UUID> tier_id,
+                                                  bool notify_master) {
     ScopedVLogTimer timer(1, "DataManager::Delete");
     timer.LogRequest("key=", key);
 
     std::unique_lock lock(GetKeyLock(key));
 
-    auto result = tiered_backend_->Delete(key, tier_id);
+    auto result = tiered_backend_->Delete(key, tier_id, notify_master);
     if (!result.has_value()) {
         LOG(ERROR) << "Failed to delete key: " << key;
         timer.LogResponse("error_code=", result.error());

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -171,7 +171,8 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
             LOG(WARNING) << "Async ADD rejected by Master, deleting local"
                          << ", key=" << key << ", error=" << error;
             if (data_manager_.has_value()) {
-                auto r = data_manager_->Delete(key, segment_id);
+                auto r = data_manager_->Delete(key, segment_id,
+                                               /*notify_master=*/false);
                 if (!r) {
                     LOG(ERROR) << "Failed to delete local replica"
                                << ", key=" << key << ", error=" << r.error();

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -204,14 +204,6 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
     auto it = shard.metadata.find(key);
     if (it != shard.metadata.end()) {
         auto& metadata = *it->second;
-        if (max_replicas_per_key_ > 0 &&
-            metadata.replicas_.size() >= max_replicas_per_key_) {
-            LOG(WARNING) << "replica num exceeded"
-                         << ", key: " << key << ", client_id: " << client_id
-                         << ", segment_id: " << segment_id
-                         << ", current replica num:" << max_replicas_per_key_;
-            return tl::make_unexpected(ErrorCode::REPLICA_NUM_EXCEEDED);
-        }
         for (const auto& replica : metadata.replicas_) {
             if (!replica.is_p2p_proxy_replica()) {
                 LOG(ERROR) << "unexpected replica type"
@@ -230,6 +222,14 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
                              << ", segment_id: " << segment_id;
                 return tl::make_unexpected(ErrorCode::REPLICA_ALREADY_EXISTS);
             }
+        }
+        if (max_replicas_per_key_ > 0 &&
+            metadata.replicas_.size() >= max_replicas_per_key_) {
+            LOG(WARNING) << "replica num exceeded"
+                         << ", key: " << key << ", client_id: " << client_id
+                         << ", segment_id: " << segment_id
+                         << ", current replica num:" << max_replicas_per_key_;
+            return tl::make_unexpected(ErrorCode::REPLICA_NUM_EXCEEDED);
         }
         AddReplicaToSegmentIndex(shard, it->first, new_replica);
         OnReplicaAdded(new_replica);

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -656,8 +656,9 @@ bool TieredBackend::Exist(std::string_view key,
     return false;  // Key does not exist in target tier
 }
 
-tl::expected<void, ErrorCode> TieredBackend::Delete(
-    std::string_view key, std::optional<UUID> tier_id, bool notify_master) {
+tl::expected<void, ErrorCode> TieredBackend::Delete(std::string_view key,
+                                                    std::optional<UUID> tier_id,
+                                                    bool notify_master) {
     if (is_shutting_down_.load(std::memory_order_acquire)) {
         LOG(ERROR) << "TieredBackend is shutting down";
         return tl::make_unexpected(ErrorCode::SHUTTING_DOWN);

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -657,7 +657,7 @@ bool TieredBackend::Exist(std::string_view key,
 }
 
 tl::expected<void, ErrorCode> TieredBackend::Delete(
-    std::string_view key, std::optional<UUID> tier_id) {
+    std::string_view key, std::optional<UUID> tier_id, bool notify_master) {
     if (is_shutting_down_.load(std::memory_order_acquire)) {
         LOG(ERROR) << "TieredBackend is shutting down";
         return tl::make_unexpected(ErrorCode::SHUTTING_DOWN);
@@ -695,7 +695,7 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
             }
 
             if (tier_it != entry->replicas.end()) {
-                if (remove_replica_callback_) {
+                if (notify_master && remove_replica_callback_) {
                     auto result = remove_replica_callback_(
                         key, tier_it->second->loc.tier->GetTierId(), DELETE);
                     if (!result.has_value()) {
@@ -759,7 +759,7 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(
             return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
         }
         UUID invalid_id{0, 0};
-        if (remove_replica_callback_) {
+        if (notify_master && remove_replica_callback_) {
             auto result = remove_replica_callback_(key, invalid_id, DELETE_ALL);
             if (!result.has_value()) {
                 LOG(ERROR) << "Failed to Delete key " << key


### PR DESCRIPTION
## Description

1. When the client fails to synchronize route with the master, remove the meaningless behavior of informing the master
2. If a client add a exist repica of it to master, rectify wrong errorcode of add_replica (From REPLICA_NUM_EXCEEDED to REPLICA_ALREADY_EXIST)
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
