### PR TITLE
[TE] Expose sendProbe via Python binding

### DIFF
--- a/docs/source/python-api-reference/transfer-engine.md
+++ b/docs/source/python-api-reference/transfer-engine.md
@@ -588,6 +588,25 @@ Gets the list of pending transfer notifications received from other nodes.
 **Returns:**
 - `List[TransferNotify]`: List of notification objects containing name and message
 
+#### send_probe()
+
+```python
+send_probe(peer_server_name)
+```
+
+Sends a lightweight JSON-RPC probe to a peer to verify reachability. Used to
+test whether a previously-unreachable peer has recovered (e.g. SGLang's
+`MooncakeKVManager` uses this to clear entries from its `failed_sessions`
+blacklist).
+
+**Parameters:**
+- `peer_server_name` (str): Peer hostname in `host:port` form, as registered
+  with the metadata server.
+
+**Returns:**
+- `int`: 0 on success, non-zero on failure (peer unknown, unreachable, or
+  RPC error).
+
 ## Environment Variables
 
 The Transfer Engine respects the following environment variables:

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -993,6 +993,12 @@ std::vector<TransferEnginePy::TransferNotify> TransferEnginePy::getNotifies() {
     return result;
 }
 
+int TransferEnginePy::sendProbe(const std::string& peer_server_name) {
+    if (!engine_) return -1;
+    pybind11::gil_scoped_release release;
+    return engine_->getMetadata()->sendProbe(peer_server_name);
+}
+
 namespace py = pybind11;
 
 // Implementation of coro_rpc_interface binding function
@@ -1087,6 +1093,11 @@ PYBIND11_MODULE(engine, m) {
             .def("get_first_buffer_address",
                  &TransferEnginePy::getFirstBufferAddress)
             .def("get_notifies", &TransferEnginePy::getNotifies)
+            .def("send_probe", &TransferEnginePy::sendProbe,
+                 py::arg("peer_server_name"),
+                 "Send a JSON-RPC probe to peer to verify reachability. "
+                 "Returns 0 on success, non-zero on failure. Used by "
+                 "SGLang's failed-session blacklist recovery.")
             .def("get_engine", &TransferEnginePy::getEngine)
             .def("get_engine_ptr", &TransferEnginePy::getEnginePtr);
 

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -178,6 +178,8 @@ class TransferEnginePy {
 
     std::vector<TransferNotify> getNotifies();
 
+    int sendProbe(const std::string &peer_server_name);
+
     std::shared_ptr<TransferEngine> getEngine() const { return engine_; }
 
     uintptr_t getEnginePtr() const { return (uintptr_t)engine_.get(); }

--- a/mooncake-wheel/tests/transfer_engine_initiator_test.py
+++ b/mooncake-wheel/tests/transfer_engine_initiator_test.py
@@ -268,6 +268,26 @@ class TestVLLMAdaptorTransfer(unittest.TestCase):
             f"[✓] {circles} rounds of batch_write_async_read passed, batch size {batch_size}."
         )
 
+    def test_send_probe_reachable_peer(self):
+        """send_probe against a registered, reachable peer returns 0."""
+        rc = self.adaptor.send_probe(self.target_server_name)
+        self.assertEqual(
+            rc,
+            0,
+            f"send_probe to reachable peer {self.target_server_name} returned {rc}",
+        )
+
+    def test_send_probe_unknown_peer(self):
+        """send_probe against an unknown peer returns non-zero (does not crash)."""
+        # "unreachable_peer:9" is not registered with the metadata server, so the
+        # metadata lookup itself should fail and sendProbe returns ERR_METADATA.
+        rc = self.adaptor.send_probe("unreachable_peer:9")
+        self.assertNotEqual(
+            rc,
+            0,
+            "send_probe to unknown peer unexpectedly succeeded",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Exposes the existing TransferMetadata::sendProbe C++ method through the TransferEngine pybind module as engine.send_probe(peer_server_name). This enables SGLang's MooncakeKVManager to issue lightweight JSON-RPC probes against peers, used to test whether a previously-blacklisted mooncake_session_id has become reachable again so it can be removed from the failed_sessions set.

Returns 0 on success, non-zero on failure (matching the C++ contract). No behavior change for existing engine.* methods.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- New Python unit tests in transfer_engine_initiator_test.py covering both the reachable-peer and unknown-peer cases.
- Manually validated end-to-end against SGLang's MooncakeKVManager.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
