### PR TITLE
[TENT] Proxy manager bugfixes

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -53,7 +53,8 @@ struct ProxyManagerMetrics {
 
     double getThroughputGBps() const {
         uint64_t us = total_latency_us.load();
-        return us > 0 ? (total_bytes_transferred.load() / 1e9) / (us / 1e6) : 0.0;
+        return us > 0 ? (total_bytes_transferred.load() / 1e9) / (us / 1e6)
+                      : 0.0;
     }
 };
 
@@ -73,8 +74,7 @@ class ProxyManager {
    public:
     explicit ProxyManager(TransferEngineImpl* impl,
                           size_t chunk_size = 4 * 1024 * 1024,
-                          size_t chunk_count = 64,
-                          int max_retries = 3);
+                          size_t chunk_count = 64, int max_retries = 3);
 
     ~ProxyManager();
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -88,7 +88,7 @@ class ProxyManager {
 
     Status unpinStageBuffer(uint64_t addr);
 
-    ProxyManagerMetrics getMetrics() const { return metrics_; }
+    const ProxyManagerMetrics& getMetrics() const { return metrics_; }
 
     void resetMetrics() { metrics_.reset(); }
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -20,7 +20,6 @@
 #include "tent/common/concurrent/thread_pool.h"
 
 #include "tent/runtime/transport.h"
-#include <chrono>
 
 // Beta version -- use with own risk
 
@@ -29,58 +28,6 @@ namespace tent {
 class TransferEngineImpl;
 class TaskInfo;
 struct StageBufferCache;
-
-struct ProxyManagerMetrics {
-    std::atomic<uint64_t> total_transfers{0};
-    std::atomic<uint64_t> total_bytes_transferred{0};
-    std::atomic<uint64_t> total_latency_us{0};
-    std::atomic<uint64_t> remote_staging_count{0};
-    std::atomic<uint64_t> pipeline_parallel_chunks{0};
-    std::atomic<uint64_t> retry_count{0};
-    std::atomic<int64_t> start_time{0};
-    std::atomic<int64_t> end_time{0};
-
-    void reset() {
-        total_transfers = 0;
-        total_bytes_transferred = 0;
-        total_latency_us = 0;
-        remote_staging_count = 0;
-        pipeline_parallel_chunks = 0;
-        retry_count = 0;
-        start_time = 0;
-        end_time = 0;
-    }
-
-    void markStartTime() {
-        start_time.store(
-            std::chrono::steady_clock::now().time_since_epoch().count(),
-            std::memory_order_relaxed);
-    }
-
-    void markEndTime() {
-        end_time.store(
-            std::chrono::steady_clock::now().time_since_epoch().count(),
-            std::memory_order_relaxed);
-    }
-
-    double getAvgLatencyMs() const {
-        uint64_t count = total_transfers.load();
-        return count > 0 ? (total_latency_us.load() / 1000.0) / count : 0.0;
-    }
-
-    double getThroughputGBps() const {
-        auto start = start_time.load();
-        auto end = end_time.load();
-        if (start == 0 || end == 0) return 0.0;
-
-        auto duration_us = end - start;
-        if (duration_us <= 0) return 0.0;
-
-        double duration_s = duration_us / 1e6;
-        double bytes_gb = total_bytes_transferred.load() / 1e9;
-        return bytes_gb / duration_s;
-    }
-};
 
 struct StagingTask {
     TaskInfo* native{nullptr};
@@ -98,7 +45,7 @@ class ProxyManager {
    public:
     explicit ProxyManager(TransferEngineImpl* impl,
                           size_t chunk_size = 4 * 1024 * 1024,
-                          size_t chunk_count = 64, int max_retries = 3);
+                          size_t chunk_count = 64);
 
     ~ProxyManager();
 
@@ -111,13 +58,6 @@ class ProxyManager {
     Status pinStageBuffer(const std::string& location, uint64_t& addr);
 
     Status unpinStageBuffer(uint64_t addr);
-
-    const ProxyManagerMetrics& getMetrics() const { return metrics_; }
-
-    void resetMetrics() {
-        metrics_.reset();
-        metrics_.markStartTime();
-    }
 
    private:
     void runner(size_t id);
@@ -157,11 +97,9 @@ class ProxyManager {
    private:
     const size_t chunk_size_;
     const size_t chunk_count_;
-    const int max_retries_;
     TransferEngineImpl* impl_;
     std::unordered_map<std::string, StageBuffers> stage_buffers_;
     std::atomic<bool> running_;
-    ProxyManagerMetrics metrics_;
     struct WorkerShard {
         std::thread thread;
         std::mutex mu;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -52,13 +52,15 @@ struct ProxyManagerMetrics {
     }
 
     void markStartTime() {
-        start_time.store(std::chrono::steady_clock::now().time_since_epoch().count(),
-                        std::memory_order_relaxed);
+        start_time.store(
+            std::chrono::steady_clock::now().time_since_epoch().count(),
+            std::memory_order_relaxed);
     }
 
     void markEndTime() {
-        end_time.store(std::chrono::steady_clock::now().time_since_epoch().count(),
-                      std::memory_order_relaxed);
+        end_time.store(
+            std::chrono::steady_clock::now().time_since_epoch().count(),
+            std::memory_order_relaxed);
     }
 
     double getAvgLatencyMs() const {

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -20,6 +20,7 @@
 #include "tent/common/concurrent/thread_pool.h"
 
 #include "tent/runtime/transport.h"
+#include <chrono>
 
 // Beta version -- use with own risk
 
@@ -36,6 +37,8 @@ struct ProxyManagerMetrics {
     std::atomic<uint64_t> remote_staging_count{0};
     std::atomic<uint64_t> pipeline_parallel_chunks{0};
     std::atomic<uint64_t> retry_count{0};
+    std::atomic<int64_t> start_time{0};
+    std::atomic<int64_t> end_time{0};
 
     void reset() {
         total_transfers = 0;
@@ -44,6 +47,18 @@ struct ProxyManagerMetrics {
         remote_staging_count = 0;
         pipeline_parallel_chunks = 0;
         retry_count = 0;
+        start_time = 0;
+        end_time = 0;
+    }
+
+    void markStartTime() {
+        start_time.store(std::chrono::steady_clock::now().time_since_epoch().count(),
+                        std::memory_order_relaxed);
+    }
+
+    void markEndTime() {
+        end_time.store(std::chrono::steady_clock::now().time_since_epoch().count(),
+                      std::memory_order_relaxed);
     }
 
     double getAvgLatencyMs() const {
@@ -52,9 +67,16 @@ struct ProxyManagerMetrics {
     }
 
     double getThroughputGBps() const {
-        uint64_t us = total_latency_us.load();
-        return us > 0 ? (total_bytes_transferred.load() / 1e9) / (us / 1e6)
-                      : 0.0;
+        auto start = start_time.load();
+        auto end = end_time.load();
+        if (start == 0 || end == 0) return 0.0;
+
+        auto duration_us = end - start;
+        if (duration_us <= 0) return 0.0;
+
+        double duration_s = duration_us / 1e6;
+        double bytes_gb = total_bytes_transferred.load() / 1e9;
+        return bytes_gb / duration_s;
     }
 };
 
@@ -90,7 +112,10 @@ class ProxyManager {
 
     const ProxyManagerMetrics& getMetrics() const { return metrics_; }
 
-    void resetMetrics() { metrics_.reset(); }
+    void resetMetrics() {
+        metrics_.reset();
+        metrics_.markStartTime();
+    }
 
    private:
     void runner(size_t id);

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -29,6 +29,34 @@ class TransferEngineImpl;
 class TaskInfo;
 struct StageBufferCache;
 
+struct ProxyManagerMetrics {
+    std::atomic<uint64_t> total_transfers{0};
+    std::atomic<uint64_t> total_bytes_transferred{0};
+    std::atomic<uint64_t> total_latency_us{0};
+    std::atomic<uint64_t> remote_staging_count{0};
+    std::atomic<uint64_t> pipeline_parallel_chunks{0};
+    std::atomic<uint64_t> retry_count{0};
+
+    void reset() {
+        total_transfers = 0;
+        total_bytes_transferred = 0;
+        total_latency_us = 0;
+        remote_staging_count = 0;
+        pipeline_parallel_chunks = 0;
+        retry_count = 0;
+    }
+
+    double getAvgLatencyMs() const {
+        uint64_t count = total_transfers.load();
+        return count > 0 ? (total_latency_us.load() / 1000.0) / count : 0.0;
+    }
+
+    double getThroughputGBps() const {
+        uint64_t us = total_latency_us.load();
+        return us > 0 ? (total_bytes_transferred.load() / 1e9) / (us / 1e6) : 0.0;
+    }
+};
+
 struct StagingTask {
     TaskInfo* native{nullptr};
     std::vector<std::string> params;
@@ -44,8 +72,9 @@ class ProxyManager {
 
    public:
     explicit ProxyManager(TransferEngineImpl* impl,
-                          size_t chunk_size = 8 * 1024 * 1024,
-                          size_t chunk_count = 32);
+                          size_t chunk_size = 4 * 1024 * 1024,
+                          size_t chunk_count = 64,
+                          int max_retries = 3);
 
     ~ProxyManager();
 
@@ -58,6 +87,10 @@ class ProxyManager {
     Status pinStageBuffer(const std::string& location, uint64_t& addr);
 
     Status unpinStageBuffer(uint64_t addr);
+
+    ProxyManagerMetrics getMetrics() const { return metrics_; }
+
+    void resetMetrics() { metrics_.reset(); }
 
    private:
     void runner(size_t id);
@@ -97,9 +130,11 @@ class ProxyManager {
    private:
     const size_t chunk_size_;
     const size_t chunk_count_;
+    const int max_retries_;
     TransferEngineImpl* impl_;
     std::unordered_map<std::string, StageBuffers> stage_buffers_;
     std::atomic<bool> running_;
+    ProxyManagerMetrics metrics_;
     struct WorkerShard {
         std::thread thread;
         std::mutex mu;

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -319,6 +319,7 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                                                    chunk.length, chunk.offset);
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT;
+                    event_queue.push(id);
                 } else if (request.opcode == Request::READ && remote_staging) {
                     if (remote_locked.count(chunk.remote_buf)) {
                         event_queue.push(id);
@@ -330,10 +331,11 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                                       remote_futures[id]);
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT_REMOTE;
+                    event_queue.push(id);
                 } else {
                     chunk.state = StageState::CROSS;
+                    event_queue.push(id);
                 }
-                event_queue.push(id);
                 break;
             }
 
@@ -374,6 +376,9 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT;
                     event_queue.push(id);
+                } else {
+                    // No staging needed, mark as finished
+                    chunk.state = StageState::FINISH;
                 }
                 break;
             }
@@ -418,6 +423,10 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
             }
 
             case StageState::FAILED: {
+                // Drain the queue to avoid losing chunks
+                while (!event_queue.empty()) {
+                    event_queue.pop();
+                }
                 return Status::InternalError(
                     "Proxy event loop in failed state");
             }
@@ -426,6 +435,7 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                 auto& fut = remote_futures[id];
                 if (!fut.valid()) {
                     chunk.state = StageState::FAILED;
+                    event_queue.push(id);
                     break;
                 }
                 if (fut.wait_for(std::chrono::seconds(0)) ==
@@ -433,6 +443,7 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                     Status rs = fut.get();
                     if (!rs.ok()) {
                         chunk.state = StageState::FAILED;
+                        event_queue.push(id);
                         break;
                     }
                     if (chunk.prev_state == StageState::PRE) {
@@ -444,9 +455,11 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                             remote_staging) {
                             remote_locked.erase(chunk.remote_buf);
                         }
+                        event_queue.push(id);
                     }
+                } else {
+                    event_queue.push(id);
                 }
-                event_queue.push(id);
                 break;
             }
         }

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -22,13 +22,9 @@
 namespace mooncake {
 namespace tent {
 ProxyManager::ProxyManager(TransferEngineImpl* impl, size_t chunk_size,
-                           size_t chunk_count, int max_retries)
-    : chunk_size_(chunk_size),
-      chunk_count_(chunk_count),
-      max_retries_(max_retries),
-      impl_(impl) {
+                           size_t chunk_count)
+    : chunk_size_(chunk_size), chunk_count_(chunk_count), impl_(impl) {
     running_ = true;
-
     for (size_t i = 0; i < kShards; ++i) {
         shards_[i].thread = std::thread(&ProxyManager::runner, this, i);
     }
@@ -242,11 +238,10 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
     auto server_addr = task.params[0];
     bool local_staging = !task.params[1].empty();
     bool remote_staging = !task.params[2].empty();
-    const static size_t kStageBuffers = 4;
+    const size_t kStageBuffers =
+        std::min(chunk_count_, static_cast<size_t>(16));
     uint64_t local_stage_buffer[kStageBuffers],
         remote_stage_buffer[kStageBuffers];
-
-    auto start_time = std::chrono::steady_clock::now();
     if (local_staging) {
         for (size_t i = 0; i < kStageBuffers; ++i) {
             local_stage_buffer[i] =
@@ -284,7 +279,6 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
         StageState prev_state;
         StageState state;
         BatchID batch;
-        int retry_count = 0;
     };
 
     std::queue<size_t> event_queue;
@@ -336,8 +330,6 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                                       remote_futures[id]);
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT_REMOTE;
-                    metrics_.remote_staging_count.fetch_add(
-                        1, std::memory_order_relaxed);
                 } else {
                     chunk.state = StageState::CROSS;
                 }
@@ -375,8 +367,7 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                                       remote_futures[id]);
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT_REMOTE;
-                    metrics_.remote_staging_count.fetch_add(
-                        1, std::memory_order_relaxed);
+                    event_queue.push(id);
                 } else if (request.opcode == Request::READ && local_staging) {
                     chunk.batch = submitLocalStage(request, chunk.local_buf,
                                                    chunk.length, chunk.offset);
@@ -427,13 +418,6 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
             }
 
             case StageState::FAILED: {
-                // Free all in-flight batches before returning
-                for (auto& chunk : chunks) {
-                    if (chunk.batch != 0) {
-                        impl_->freeBatch(chunk.batch);
-                        chunk.batch = 0;
-                    }
-                }
                 return Status::InternalError(
                     "Proxy event loop in failed state");
             }
@@ -442,35 +426,14 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                 auto& fut = remote_futures[id];
                 if (!fut.valid()) {
                     chunk.state = StageState::FAILED;
-                    event_queue.push(id);
                     break;
                 }
                 if (fut.wait_for(std::chrono::seconds(0)) ==
                     std::future_status::ready) {
                     Status rs = fut.get();
                     if (!rs.ok()) {
-                        if (chunk.retry_count < max_retries_) {
-                            chunk.retry_count++;
-                            metrics_.retry_count.fetch_add(
-                                1, std::memory_order_relaxed);
-                            LOG(WARNING)
-                                << "Remote staging failed for chunk " << id
-                                << ", retrying (attempt " << chunk.retry_count
-                                << "/" << max_retries_
-                                << "): " << rs.ToString();
-                            submitRemoteStage(server_addr, request,
-                                              chunk.remote_buf, chunk.length,
-                                              chunk.offset, remote_futures[id]);
-                            event_queue.push(id);
-                            break;
-                        } else {
-                            LOG(ERROR) << "Remote staging failed for chunk "
-                                       << id << " after " << max_retries_
-                                       << " retries: " << rs.ToString();
-                            chunk.state = StageState::FAILED;
-                            event_queue.push(id);
-                            break;
-                        }
+                        chunk.state = StageState::FAILED;
+                        break;
                     }
                     if (chunk.prev_state == StageState::PRE) {
                         chunk.state = StageState::CROSS;
@@ -482,27 +445,12 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                             remote_locked.erase(chunk.remote_buf);
                         }
                     }
-                } else {
-                    event_queue.push(id);
                 }
+                event_queue.push(id);
                 break;
             }
         }
     }
-
-    auto end_time = std::chrono::steady_clock::now();
-    auto latency_us = std::chrono::duration_cast<std::chrono::microseconds>(
-                          end_time - start_time)
-                          .count();
-
-    // Update metrics only after successful completion
-    metrics_.total_transfers.fetch_add(1, std::memory_order_relaxed);
-    metrics_.total_bytes_transferred.fetch_add(request.length,
-                                               std::memory_order_relaxed);
-    metrics_.total_latency_us.fetch_add(latency_us, std::memory_order_relaxed);
-    metrics_.pipeline_parallel_chunks.fetch_add(chunks.size(),
-                                                std::memory_order_relaxed);
-    metrics_.markEndTime();
 
     return Status::OK();
 }

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -246,9 +246,6 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
         remote_stage_buffer[kStageBuffers];
 
     auto start_time = std::chrono::steady_clock::now();
-    metrics_.total_transfers.fetch_add(1, std::memory_order_relaxed);
-    metrics_.total_bytes_transferred.fetch_add(request.length,
-                                               std::memory_order_relaxed);
     if (local_staging) {
         for (size_t i = 0; i < kStageBuffers; ++i) {
             local_stage_buffer[i] =
@@ -429,6 +426,13 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
             }
 
             case StageState::FAILED: {
+                // Free all in-flight batches before returning
+                for (auto& chunk : chunks) {
+                    if (chunk.batch != 0) {
+                        impl_->freeBatch(chunk.batch);
+                        chunk.batch = 0;
+                    }
+                }
                 return Status::InternalError(
                     "Proxy event loop in failed state");
             }
@@ -489,9 +493,15 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
     auto latency_us = std::chrono::duration_cast<std::chrono::microseconds>(
                           end_time - start_time)
                           .count();
+
+    // Update metrics only after successful completion
+    metrics_.total_transfers.fetch_add(1, std::memory_order_relaxed);
+    metrics_.total_bytes_transferred.fetch_add(request.length,
+                                               std::memory_order_relaxed);
     metrics_.total_latency_us.fetch_add(latency_us, std::memory_order_relaxed);
-    metrics_.pipeline_parallel_chunks.fetch_add(kStageBuffers,
+    metrics_.pipeline_parallel_chunks.fetch_add(chunks.size(),
                                                 std::memory_order_relaxed);
+    metrics_.markEndTime();
 
     return Status::OK();
 }

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -28,6 +28,7 @@ ProxyManager::ProxyManager(TransferEngineImpl* impl, size_t chunk_size,
       max_retries_(max_retries),
       impl_(impl) {
     running_ = true;
+
     for (size_t i = 0; i < kShards; ++i) {
         shards_[i].thread = std::thread(&ProxyManager::runner, this, i);
     }

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -22,8 +22,11 @@
 namespace mooncake {
 namespace tent {
 ProxyManager::ProxyManager(TransferEngineImpl* impl, size_t chunk_size,
-                           size_t chunk_count)
-    : chunk_size_(chunk_size), chunk_count_(chunk_count), impl_(impl) {
+                           size_t chunk_count, int max_retries)
+    : chunk_size_(chunk_size),
+      chunk_count_(chunk_count),
+      max_retries_(max_retries),
+      impl_(impl) {
     running_ = true;
     for (size_t i = 0; i < kShards; ++i) {
         shards_[i].thread = std::thread(&ProxyManager::runner, this, i);
@@ -241,6 +244,10 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
     const static size_t kStageBuffers = 4;
     uint64_t local_stage_buffer[kStageBuffers],
         remote_stage_buffer[kStageBuffers];
+
+    auto start_time = std::chrono::steady_clock::now();
+    metrics_.total_transfers.fetch_add(1, std::memory_order_relaxed);
+    metrics_.total_bytes_transferred.fetch_add(request.length, std::memory_order_relaxed);
     if (local_staging) {
         for (size_t i = 0; i < kStageBuffers; ++i) {
             local_stage_buffer[i] =
@@ -278,6 +285,7 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
         StageState prev_state;
         StageState state;
         BatchID batch;
+        int retry_count = 0;
     };
 
     std::queue<size_t> event_queue;
@@ -329,6 +337,7 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                                       remote_futures[id]);
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT_REMOTE;
+                    metrics_.remote_staging_count.fetch_add(1, std::memory_order_relaxed);
                 } else {
                     chunk.state = StageState::CROSS;
                 }
@@ -366,6 +375,7 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                                       remote_futures[id]);
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT_REMOTE;
+                    metrics_.remote_staging_count.fetch_add(1, std::memory_order_relaxed);
                 } else if (request.opcode == Request::READ && local_staging) {
                     chunk.batch = submitLocalStage(request, chunk.local_buf,
                                                    chunk.length, chunk.offset);
@@ -424,14 +434,32 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                 auto& fut = remote_futures[id];
                 if (!fut.valid()) {
                     chunk.state = StageState::FAILED;
+                    event_queue.push(id);
                     break;
                 }
                 if (fut.wait_for(std::chrono::seconds(0)) ==
                     std::future_status::ready) {
                     Status rs = fut.get();
                     if (!rs.ok()) {
-                        chunk.state = StageState::FAILED;
-                        break;
+                        if (chunk.retry_count < max_retries_) {
+                            chunk.retry_count++;
+                            metrics_.retry_count.fetch_add(1, std::memory_order_relaxed);
+                            LOG(WARNING) << "Remote staging failed for chunk " << id
+                                         << ", retrying (attempt " << chunk.retry_count
+                                         << "/" << max_retries_ << "): " << rs.ToString();
+                            submitRemoteStage(server_addr, request, chunk.remote_buf,
+                                              chunk.length, chunk.offset,
+                                              remote_futures[id]);
+                            event_queue.push(id);
+                            break;
+                        } else {
+                            LOG(ERROR) << "Remote staging failed for chunk " << id
+                                      << " after " << max_retries_ << " retries: "
+                                      << rs.ToString();
+                            chunk.state = StageState::FAILED;
+                            event_queue.push(id);
+                            break;
+                        }
                     }
                     if (chunk.prev_state == StageState::PRE) {
                         chunk.state = StageState::CROSS;
@@ -450,6 +478,13 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
             }
         }
     }
+
+    auto end_time = std::chrono::steady_clock::now();
+    auto latency_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                          end_time - start_time)
+                          .count();
+    metrics_.total_latency_us.fetch_add(latency_us, std::memory_order_relaxed);
+    metrics_.pipeline_parallel_chunks.fetch_add(kStageBuffers, std::memory_order_relaxed);
 
     return Status::OK();
 }

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -247,7 +247,8 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
 
     auto start_time = std::chrono::steady_clock::now();
     metrics_.total_transfers.fetch_add(1, std::memory_order_relaxed);
-    metrics_.total_bytes_transferred.fetch_add(request.length, std::memory_order_relaxed);
+    metrics_.total_bytes_transferred.fetch_add(request.length,
+                                               std::memory_order_relaxed);
     if (local_staging) {
         for (size_t i = 0; i < kStageBuffers; ++i) {
             local_stage_buffer[i] =
@@ -337,7 +338,8 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                                       remote_futures[id]);
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT_REMOTE;
-                    metrics_.remote_staging_count.fetch_add(1, std::memory_order_relaxed);
+                    metrics_.remote_staging_count.fetch_add(
+                        1, std::memory_order_relaxed);
                 } else {
                     chunk.state = StageState::CROSS;
                 }
@@ -375,7 +377,8 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                                       remote_futures[id]);
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT_REMOTE;
-                    metrics_.remote_staging_count.fetch_add(1, std::memory_order_relaxed);
+                    metrics_.remote_staging_count.fetch_add(
+                        1, std::memory_order_relaxed);
                 } else if (request.opcode == Request::READ && local_staging) {
                     chunk.batch = submitLocalStage(request, chunk.local_buf,
                                                    chunk.length, chunk.offset);
@@ -443,19 +446,22 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                     if (!rs.ok()) {
                         if (chunk.retry_count < max_retries_) {
                             chunk.retry_count++;
-                            metrics_.retry_count.fetch_add(1, std::memory_order_relaxed);
-                            LOG(WARNING) << "Remote staging failed for chunk " << id
-                                         << ", retrying (attempt " << chunk.retry_count
-                                         << "/" << max_retries_ << "): " << rs.ToString();
-                            submitRemoteStage(server_addr, request, chunk.remote_buf,
-                                              chunk.length, chunk.offset,
-                                              remote_futures[id]);
+                            metrics_.retry_count.fetch_add(
+                                1, std::memory_order_relaxed);
+                            LOG(WARNING)
+                                << "Remote staging failed for chunk " << id
+                                << ", retrying (attempt " << chunk.retry_count
+                                << "/" << max_retries_
+                                << "): " << rs.ToString();
+                            submitRemoteStage(server_addr, request,
+                                              chunk.remote_buf, chunk.length,
+                                              chunk.offset, remote_futures[id]);
                             event_queue.push(id);
                             break;
                         } else {
-                            LOG(ERROR) << "Remote staging failed for chunk " << id
-                                      << " after " << max_retries_ << " retries: "
-                                      << rs.ToString();
+                            LOG(ERROR) << "Remote staging failed for chunk "
+                                       << id << " after " << max_retries_
+                                       << " retries: " << rs.ToString();
                             chunk.state = StageState::FAILED;
                             event_queue.push(id);
                             break;
@@ -484,7 +490,8 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                           end_time - start_time)
                           .count();
     metrics_.total_latency_us.fetch_add(latency_us, std::memory_order_relaxed);
-    metrics_.pipeline_parallel_chunks.fetch_add(kStageBuffers, std::memory_order_relaxed);
+    metrics_.pipeline_parallel_chunks.fetch_add(kStageBuffers,
+                                                std::memory_order_relaxed);
 
     return Status::OK();
 }

--- a/mooncake-transfer-engine/tent/src/transport/bufio/bufio_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/bufio/bufio_transport.cpp
@@ -80,7 +80,7 @@ Status BufIoTransport::install(std::string& local_segment_name,
 
     installed_ = true;
     caps.dram_to_file = true;
-    if (Platform::getLoader().type() == "cuda") {
+    if (Platform::getLoader().type() != "cpu") {
         caps.gpu_to_file = true;
     }
 

--- a/mooncake-transfer-engine/tent/src/transport/io_uring/io_uring_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/io_uring/io_uring_transport.cpp
@@ -87,7 +87,7 @@ Status IOUringTransport::install(std::string& local_segment_name,
     async_memcpy_threshold_ =
         conf_->get("transports/nvlink/async_memcpy_threshold", 1024) * 1024;
     caps.dram_to_file = true;
-    if (Platform::getLoader().type() == "cuda") {
+    if (Platform::getLoader().type() != "cpu") {
         caps.gpu_to_file = true;
     }
     return Status::OK();

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -114,7 +114,7 @@ Status MnnvlTransport::install(std::string &local_segment_name,
         128;
 
     caps.dram_to_gpu = true;
-    if (Platform::getLoader().type() == "cuda") caps.gpu_to_gpu = true;
+    if (Platform::getLoader().type() != "cpu") caps.gpu_to_gpu = true;
 
     installed_ = true;
     supported_ = true;

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -95,8 +95,7 @@ Status TcpTransport::install(std::string &local_segment_name,
         return 0;
     });
     caps.dram_to_dram = true;
-    if (Platform::getLoader().type() == "cuda" ||
-        Platform::getLoader().type() == "cann") {
+    if (Platform::getLoader().type() != "cpu") {
         caps.dram_to_gpu = true;
         caps.gpu_to_dram = true;
         caps.gpu_to_gpu = true;


### PR DESCRIPTION
## Description

This PR fixes two critical bugs in the event loop state machine:
1. Added missing event_queue.push(id) in POST state to prevent task stalls
2. Fixed INFLIGHT_REMOTE state handling to ensure proper event scheduling

Also, we made unified platform detection across all transport layers (TCP, RDMA, NVLink, Bufio, MNNVL) by changing from explicit platform checks (== "cuda" || == "cann") to a more extensible approach (!= "cpu"), improving compatibility with future GPU/NPU platforms.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

We have tested in H20 machines by manually disable GPUDirect (`MC_DISABLE_GPU_DIRECT_RDMA=1`). And the throughput between two GPU devices are shown below:

- RDMA: GPU→GPU (H20, w/ GPUDirect RDMA) 45.7 GB/s 
- RDMA: GPU→GPU (Target Staging) 46.2  GB/s
- RDMA: GPU→GPU (Initiator Staging) 33.6  GB/s
- RDMA: GPU→GPU (Dual Staging) 33.2 GB/s

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
