### PR TITLE
[TENT] replace cudaMemcpyAsync with cuMemcpy to avoid dead lock

### DIFF
--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -81,6 +81,5 @@ Status CudaPlatform::copy(void* dst, void* src, size_t length) {
     CHECK_CUDA(cudaStreamSynchronize(stream.get()));
     return Status::OK();
 }
-}
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -56,25 +56,13 @@ Status CudaPlatform::free(void* ptr, size_t size) {
     return Status::OK();
 }
 
-// Define USE_CU_MEMCPY to use direction-aware CUDA Driver API functions
-// (supports all directions: H2D, D2H, D2D, H2H, avoids stream deadlocks)
-// If not defined, uses the original cudaMemcpyAsync + stream approach
-#define USE_CU_MEMCPY
-
 Status CudaPlatform::copy(void* dst, void* src, size_t length) {
-#ifdef USE_CU_MEMCPY
-    // Use direction-aware CUDA Driver API functions to support all transfer
-    // directions (H2D, D2H, D2D, H2H) while avoiding deadlock issues.
-    // These synchronous functions avoid both:
-    // - cudaMemcpy() deadlock (legacy default stream dependency)
-    // - cudaMemcpyAsync + cudaStreamSynchronize deadlock
-    //
-    // Direction-aware functions:
-    // - cuMemcpyHtoD: Host to Device (synchronous, no stream dependency)
-    // - cuMemcpyDtoH: Device to Host (synchronous, no stream dependency)
-    // - cuMemcpyDtoD: Device to Device (synchronous, no stream dependency)
-    // - memcpy: Host to Host (standard CPU copy)
+    // Use a non-blocking stream to avoid unintended synchronization 
+    // or even deadlocks in downstream components (e.g. mooncake-pg).
+    CUDAStreamHandle stream;
+    CHECK_STATUS(getStreamFromPool(stream));
 
+#ifdef USE_CU_MEMCPY
     // Ensure CUDA Driver API is initialized (idempotent)
     static CUresult init_result = cuInit(0);
     if (init_result != CUDA_SUCCESS) {
@@ -83,59 +71,16 @@ Status CudaPlatform::copy(void* dst, void* src, size_t length) {
         return Status::InternalError(
             std::string("CUDA Driver API init failed: ") + error_str);
     }
-
-    // Detect pointer types to determine transfer direction
-    cudaPointerAttributes src_attr, dst_attr;
-    CUresult result;
-
-    // Get source pointer attributes
-    cudaError_t cuda_err = cudaPointerGetAttributes(&src_attr, src);
-    bool src_is_device =
-        (cuda_err == cudaSuccess) && (src_attr.type == cudaMemoryTypeDevice);
-
-    // Get destination pointer attributes
-    cuda_err = cudaPointerGetAttributes(&dst_attr, dst);
-    bool dst_is_device =
-        (cuda_err == cudaSuccess) && (dst_attr.type == cudaMemoryTypeDevice);
-
-    // Select appropriate transfer function based on direction
-    if (src_is_device && dst_is_device) {
-        // Device to Device
-        result = cuMemcpyDtoD((CUdeviceptr)dst, (CUdeviceptr)src, length);
-    } else if (src_is_device && !dst_is_device) {
-        // Device to Host
-        result = cuMemcpyDtoH(dst, (CUdeviceptr)src, length);
-    } else if (!src_is_device && dst_is_device) {
-        // Host to Device
-        result = cuMemcpyHtoD((CUdeviceptr)dst, src, length);
-    } else {
-        // Host to Host - use standard CPU memcpy
-        memcpy(dst, src, length);
-        return Status::OK();
-    }
-
-    if (result != CUDA_SUCCESS) {
-        const char* error_str = nullptr;
-        cuGetErrorString(result, &error_str);
-        return Status::InternalError(std::string("CUDA memcpy failed: ") +
-                                     error_str);
-    }
-
-    return Status::OK();
-
+    CHECK_CU(cuMemcpyAsync((CUdeviceptr)dst, (CUdeviceptr)src, length,
+                           (CUstream)stream.get()));
 #else  // Original implementation using cudaMemcpyAsync
-    // Use cudaMemcpyAsync with a non-blocking stream instead of cudaMemcpy(),
-    // as the latter relies on the legacy default stream and can introduce
-    // unintended synchronization or even deadlocks in downstream
-    // components (e.g. mooncake-pg).
-
-    CUDAStreamHandle stream;
-    CHECK_STATUS(getStreamFromPool(stream));
     CHECK_CUDA(
         cudaMemcpyAsync(dst, src, length, cudaMemcpyDefault, stream.get()));
+#endif
+
     CHECK_CUDA(cudaStreamSynchronize(stream.get()));
     return Status::OK();
-#endif
+}
 }
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -56,13 +56,24 @@ Status CudaPlatform::free(void* ptr, size_t size) {
     return Status::OK();
 }
 
+// Define USE_CU_MEMCPY to use direction-aware CUDA Driver API functions
+// (supports all directions: H2D, D2H, D2D, H2H, avoids stream deadlocks)
+// If not defined, uses the original cudaMemcpyAsync + stream approach
+#define USE_CU_MEMCPY
+
 Status CudaPlatform::copy(void* dst, void* src, size_t length) {
-    // Use cuMemcpy from CUDA Driver API instead of Runtime API.
-    // This avoids synchronization issues with the legacy default stream
-    // that can cause deadlocks in downstream components (e.g. mooncake-pg).
-    // cuMemcpy is synchronous but doesn't rely on the default stream,
-    // providing better performance than cudaMemcpy and avoiding the
-    // cudaStreamSynchronize deadlocks of cudaMemcpyAsync.
+#ifdef USE_CU_MEMCPY
+    // Use direction-aware CUDA Driver API functions to support all transfer
+    // directions (H2D, D2H, D2D, H2H) while avoiding deadlock issues.
+    // These synchronous functions avoid both:
+    // - cudaMemcpy() deadlock (legacy default stream dependency)
+    // - cudaMemcpyAsync + cudaStreamSynchronize deadlock
+    //
+    // Direction-aware functions:
+    // - cuMemcpyHtoD: Host to Device (synchronous, no stream dependency)
+    // - cuMemcpyDtoH: Device to Host (synchronous, no stream dependency)
+    // - cuMemcpyDtoD: Device to Device (synchronous, no stream dependency)
+    // - memcpy: Host to Host (standard CPU copy)
 
     // Ensure CUDA Driver API is initialized (idempotent)
     static CUresult init_result = cuInit(0);
@@ -73,14 +84,58 @@ Status CudaPlatform::copy(void* dst, void* src, size_t length) {
             std::string("CUDA Driver API init failed: ") + error_str);
     }
 
-    CUresult result = cuMemcpy((CUdeviceptr)dst, (CUdeviceptr)src, length);
+    // Detect pointer types to determine transfer direction
+    cudaPointerAttributes src_attr, dst_attr;
+    CUresult result;
+
+    // Get source pointer attributes
+    cudaError_t cuda_err = cudaPointerGetAttributes(&src_attr, src);
+    bool src_is_device =
+        (cuda_err == cudaSuccess) && (src_attr.type == cudaMemoryTypeDevice);
+
+    // Get destination pointer attributes
+    cuda_err = cudaPointerGetAttributes(&dst_attr, dst);
+    bool dst_is_device =
+        (cuda_err == cudaSuccess) && (dst_attr.type == cudaMemoryTypeDevice);
+
+    // Select appropriate transfer function based on direction
+    if (src_is_device && dst_is_device) {
+        // Device to Device
+        result = cuMemcpyDtoD((CUdeviceptr)dst, (CUdeviceptr)src, length);
+    } else if (src_is_device && !dst_is_device) {
+        // Device to Host
+        result = cuMemcpyDtoH(dst, (CUdeviceptr)src, length);
+    } else if (!src_is_device && dst_is_device) {
+        // Host to Device
+        result = cuMemcpyHtoD((CUdeviceptr)dst, src, length);
+    } else {
+        // Host to Host - use standard CPU memcpy
+        memcpy(dst, src, length);
+        return Status::OK();
+    }
+
     if (result != CUDA_SUCCESS) {
         const char* error_str = nullptr;
         cuGetErrorString(result, &error_str);
-        return Status::InternalError(
-            std::string("cuMemcpy failed: ") + error_str);
+        return Status::InternalError(std::string("CUDA memcpy failed: ") +
+                                     error_str);
     }
+
     return Status::OK();
+
+#else  // Original implementation using cudaMemcpyAsync
+    // Use cudaMemcpyAsync with a non-blocking stream instead of cudaMemcpy(),
+    // as the latter relies on the legacy default stream and can introduce
+    // unintended synchronization or even deadlocks in downstream
+    // components (e.g. mooncake-pg).
+
+    CUDAStreamHandle stream;
+    CHECK_STATUS(getStreamFromPool(stream));
+    CHECK_CUDA(
+        cudaMemcpyAsync(dst, src, length, cudaMemcpyDefault, stream.get()));
+    CHECK_CUDA(cudaStreamSynchronize(stream.get()));
+    return Status::OK();
+#endif
 }
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -15,7 +15,8 @@
 #include "tent/platform/cuda.h"
 #include "tent/common/status.h"
 
-#include <bits/stdint-uintn.h>
+#include <bits/stduint-uintn.h>
+#include <cuda.h>
 #include <cuda_runtime.h>
 #include <numa.h>
 #include <glog/logging.h>
@@ -56,15 +57,29 @@ Status CudaPlatform::free(void* ptr, size_t size) {
 }
 
 Status CudaPlatform::copy(void* dst, void* src, size_t length) {
-    // Use cudaMemcpyAsync with a non-blocking stream instead of cudaMemcpy(),
-    // as the latter relies on the legacy default stream and can introduce
-    // unintended synchronization or even deadlocks in downstream
-    // components (e.g. mooncake-pg).
-    CUDAStreamHandle stream;
-    CHECK_STATUS(getStreamFromPool(stream));
-    CHECK_CUDA(
-        cudaMemcpyAsync(dst, src, length, cudaMemcpyDefault, stream.get()));
-    CHECK_CUDA(cudaStreamSynchronize(stream.get()));
+    // Use cuMemcpy from CUDA Driver API instead of Runtime API.
+    // This avoids synchronization issues with the legacy default stream
+    // that can cause deadlocks in downstream components (e.g. mooncake-pg).
+    // cuMemcpy is synchronous but doesn't rely on the default stream,
+    // providing better performance than cudaMemcpy and avoiding the
+    // cudaStreamSynchronize deadlocks of cudaMemcpyAsync.
+
+    // Ensure CUDA Driver API is initialized (idempotent)
+    static CUresult init_result = cuInit(0);
+    if (init_result != CUDA_SUCCESS) {
+        const char* error_str = nullptr;
+        cuGetErrorString(init_result, &error_str);
+        return Status::InternalError(
+            std::string("CUDA Driver API init failed: ") + error_str);
+    }
+
+    CUresult result = cuMemcpy((CUdeviceptr)dst, (CUdeviceptr)src, length);
+    if (result != CUDA_SUCCESS) {
+        const char* error_str = nullptr;
+        cuGetErrorString(result, &error_str);
+        return Status::InternalError(
+            std::string("cuMemcpy failed: ") + error_str);
+    }
     return Status::OK();
 }
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -73,12 +73,12 @@ Status CudaPlatform::copy(void* dst, void* src, size_t length) {
     }
     CHECK_CU(cuMemcpyAsync((CUdeviceptr)dst, (CUdeviceptr)src, length,
                            (CUstream)stream.get()));
+    CHECK_CU(cuStreamSynchronize((CUstream)stream.get()));
 #else  // Original implementation using cudaMemcpyAsync
     CHECK_CUDA(
         cudaMemcpyAsync(dst, src, length, cudaMemcpyDefault, stream.get()));
-#endif
-
     CHECK_CUDA(cudaStreamSynchronize(stream.get()));
+#endif
     return Status::OK();
 }
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -57,7 +57,7 @@ Status CudaPlatform::free(void* ptr, size_t size) {
 }
 
 Status CudaPlatform::copy(void* dst, void* src, size_t length) {
-    // Use a non-blocking stream to avoid unintended synchronization 
+    // Use a non-blocking stream to avoid unintended synchronization
     // or even deadlocks in downstream components (e.g. mooncake-pg).
     CUDAStreamHandle stream;
     CHECK_STATUS(getStreamFromPool(stream));

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -15,7 +15,7 @@
 #include "tent/platform/cuda.h"
 #include "tent/common/status.h"
 
-#include <bits/stduint-uintn.h>
+#include <bits/stdint-uintn.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <numa.h>

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_stream_pool.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_stream_pool.cpp
@@ -14,6 +14,10 @@
 
 #include "tent/platform/cuda.h"
 
+#ifdef USE_CU_MEMCPY
+#include <cuda.h>
+#endif
+
 namespace mooncake {
 namespace tent {
 
@@ -67,6 +71,29 @@ Status CUDAStreamPool::DevicePool::acquire(cudaStream_t& outStream) {
 
     // Lazy creation: avoid holding the lock so we don't block other threads
     // checking out streams.
+#ifdef USE_CU_MEMCPY
+    // Use CUDA Driver API to avoid runtime lock contention with PyTorch
+    CUcontext currentCtx = nullptr;
+    CUdevice currentDevice = 0;
+    CHECK_CU(cuCtxGetCurrent(&currentCtx));
+    if (currentCtx) {
+        CHECK_CU(cuCtxGetDevice(&currentDevice));
+    }
+
+    // Set the device for stream creation
+    CUdevice targetDevice;
+    CHECK_CU(cuDeviceGet(&targetDevice, deviceId_));
+    CUcontext targetCtx = nullptr;
+    CHECK_CU(cuDevicePrimaryCtxRetain(&targetCtx, targetDevice));
+    CHECK_CU(cuCtxSetCurrent(targetCtx));
+
+    CHECK_CU(cuStreamCreate(&outStream, CU_STREAM_NON_BLOCKING));
+
+    // Restore previous context
+    if (currentCtx) {
+        CHECK_CU(cuCtxSetCurrent(currentCtx));
+    }
+#else
     int currentDevice;
     CHECK_CUDA(cudaGetDevice(&currentDevice));
 
@@ -80,6 +107,7 @@ Status CUDAStreamPool::DevicePool::acquire(cudaStream_t& outStream) {
     if (currentDevice != deviceId_) {
         CHECK_CUDA(cudaSetDevice(currentDevice));
     }
+#endif
 
     return Status::OK();
 }
@@ -91,9 +119,23 @@ void CUDAStreamPool::DevicePool::release(cudaStream_t stream) {
 
 Status CUDAStreamPool::acquire(CUDAStreamHandle& outHandle, int deviceId) {
     if (deviceId == kCurrentDevice) {
+#ifdef USE_CU_MEMCPY
+        CUcontext currentCtx = nullptr;
+        CUresult result = cuCtxGetCurrent(&currentCtx);
+        if (result != CUDA_SUCCESS || !currentCtx) {
+            return Status::InternalError("No CUDA context current");
+        }
+        CUdevice device;
+        result = cuCtxGetDevice(&device);
+        if (result != CUDA_SUCCESS) {
+            return Status::InternalError("Failed to get current device ID");
+        }
+        deviceId = static_cast<int>(device);
+#else
         if (cudaGetDevice(&deviceId) != cudaSuccess) {
             return Status::InternalError("Failed to get current device ID");
         }
+#endif
     } else if (deviceId < 0) {
         return Status::InternalError("Invalid device ID");
     }
@@ -138,8 +180,13 @@ CUDAStreamPool::DevicePool* CUDAStreamPool::getDevicePool(int deviceId) {
 
     // consistency check on deviceId
     int actualDeviceCount = 0;
+#ifdef USE_CU_MEMCPY
+    CUresult result = cuDeviceGetCount(&actualDeviceCount);
+    if (result != CUDA_SUCCESS || deviceId >= actualDeviceCount) {
+#else
     if (cudaGetDeviceCount(&actualDeviceCount) != cudaSuccess ||
         deviceId >= actualDeviceCount) {
+#endif
         LOG(ERROR) << "Invalid cuda device id " << deviceId;
         return nullptr;
     }


### PR DESCRIPTION
## Description

When integrating Mooncake PG (Process Group) with TENT, we encountered deadlocks with TcpTransport and NvlinkTransport.

```
Main Thread:                         Worker Thread:
────────────────────────────────────────────────────────────
PyTorch: dist.all_gather()
  → PG launches enqueueTaskKernel (GPU spin-wait)
  → Returns

PyTorch: .cpu()
  → Waits for GPU data
  → Holds CUDA Runtime global lock while waiting
                                       Polls task queue
                                         → TENT::submitTransfer()
                                           → CudaPlatform::copy()
                                             → cudaMemcpyAsync
                                               → Tries to acquire Runtime lock ← Blocked ✓
                                             
  → Kernel cannot complete (waits for TENT)
  → TENT cannot start (waits for lock)
  → Deadlock
```

### Root Cause

CUDA Runtime API maintains a global mutex (runtime mutex) that all `cudaXxx` calls must acquire. When PyTorch's `.cpu()` holds this lock while waiting for GPU operations, TENT's worker thread cannot acquire it for `cudaMemcpyAsync`, causing a deadlock.

### Verification

Replacing `cudaMemcpyAsync` in TENT with the Driver API equivalent `cuMemcpyAsync` eliminates the deadlock. This is because the Driver API bypasses the CUDA Runtime global lock.

## Solution

Replace CUDA Runtime API with CUDA Driver API on the critical path (where worker threads call TENT for transfers):

| Function | Runtime API | Driver API |
|----------|-------------|------------|
| `CudaPlatform::copy()` | `cudaMemcpyAsync`, `cudaStreamSynchronize` | `cuMemcpyAsync`, `cuStreamSynchronize` |
| `CUDAStreamPool::DevicePool::acquire()` | `cudaGetDevice`, `cudaSetDevice`, `cudaStreamCreateWithFlags` | `cuCtxGetCurrent`, `cuCtxSetCurrent`, `cuStreamCreate` |
| `CUDAStreamPool::acquire()` | `cudaGetDevice` | `cuCtxGetCurrent`, `cuCtxGetDevice` |
| `CUDAStreamPool::getDevicePool()` | `cudaGetDeviceCount` | `cuDeviceGetCount` |

## Changes

### `tent/src/platform/cuda/cuda_allocator.cpp`

- Moved synchronization operations in `copy()` inside `#ifdef USE_CU_MEMCPY`
- Replaced `cudaStreamSynchronize` with `cuStreamSynchronize`

### `tent/src/platform/cuda/cuda_stream_pool.cpp`

- Added `#ifdef USE_CU_MEMCPY` macro support
- Implemented complete Driver API path in critical functions

## Build

Enable with `-DUSE_CU_MEMCPY=ON`:

```bash
cmake -DUSE_CU_MEMCPY=ON ..
make
```

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
