### PR TITLE
[Store] Add comprehensive test suite for Python binding error handling

### DIFF
--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -1356,6 +1356,325 @@ TEST_F(RealClientTest, UpsertBatch) {
     }
 }
 
+// ===================== Batch Existence Tests =====================
+
+TEST_F(RealClientTest, BatchIsExistMixed) {
+    StartMasterAndSetupClient();
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    const std::string data = "batch_exist_data";
+    std::span<const char> data_span(data.data(), data.size());
+    ASSERT_EQ(py_client_->put("exist_key_1", data_span, config), 0);
+    ASSERT_EQ(py_client_->put("exist_key_2", data_span, config), 0);
+
+    std::vector<std::string> keys = {"exist_key_1", "missing_key",
+                                     "exist_key_2", "also_missing"};
+    auto results = py_client_->batchIsExist(keys);
+    ASSERT_EQ(results.size(), 4u);
+    EXPECT_EQ(results[0], 1) << "exist_key_1 should exist";
+    EXPECT_EQ(results[1], 0) << "missing_key should not exist";
+    EXPECT_EQ(results[2], 1) << "exist_key_2 should exist";
+    EXPECT_EQ(results[3], 0) << "also_missing should not exist";
+}
+
+TEST_F(RealClientTest, ErrBatchIsExistBeforeSetup) {
+    GLogMuter muter;
+    std::vector<std::string> keys = {"k1", "k2"};
+    auto results = py_client_->batchIsExist(keys);
+    ASSERT_EQ(results.size(), 2u);
+    for (size_t i = 0; i < results.size(); ++i) {
+        EXPECT_LT(results[i], 0)
+            << "batchIsExist[" << i << "] before setup should return negative";
+    }
+}
+
+// ===================== GetSize Tests =====================
+
+TEST_F(RealClientTest, GetSizeBasic) {
+    StartMasterAndSetupClient();
+
+    const std::string data = "getsize_payload_123";
+    const std::string key = "getsize_key";
+    std::span<const char> data_span(data.data(), data.size());
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    ASSERT_EQ(py_client_->put(key, data_span, config), 0);
+    int64_t size = py_client_->getSize(key);
+    EXPECT_EQ(size, static_cast<int64_t>(data.size()))
+        << "getSize should return exact data length";
+}
+
+TEST_F(RealClientTest, ErrGetSizeBeforeSetup) {
+    GLogMuter muter;
+    EXPECT_LT(py_client_->getSize("any_key"), 0)
+        << "getSize before setup should return negative";
+}
+
+// ===================== RemoveByRegex Tests =====================
+
+TEST_F(RealClientTest, RemoveByRegexBasic) {
+    StartMasterAndSetupClient();
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::string data = "regex_data";
+    std::span<const char> data_span(data.data(), data.size());
+
+    ASSERT_EQ(py_client_->put("prefix_alpha", data_span, config), 0);
+    ASSERT_EQ(py_client_->put("prefix_beta", data_span, config), 0);
+    ASSERT_EQ(py_client_->put("other_key", data_span, config), 0);
+
+    long removed = py_client_->removeByRegex("^prefix_.*");
+    EXPECT_EQ(removed, 2) << "Should remove exactly the two prefix_ keys";
+
+    EXPECT_EQ(py_client_->isExist("prefix_alpha"), 0);
+    EXPECT_EQ(py_client_->isExist("prefix_beta"), 0);
+    EXPECT_EQ(py_client_->isExist("other_key"), 1)
+        << "Non-matching key should survive";
+}
+
+TEST_F(RealClientTest, RemoveByRegexNoMatch) {
+    StartMasterAndSetupClient();
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::string data = "no_match_data";
+    std::span<const char> data_span(data.data(), data.size());
+    ASSERT_EQ(py_client_->put("some_key", data_span, config), 0);
+
+    long removed = py_client_->removeByRegex("^nonexistent_pattern_.*");
+    EXPECT_EQ(removed, 0) << "No keys should match";
+    EXPECT_EQ(py_client_->isExist("some_key"), 1)
+        << "Existing key should remain";
+}
+
+TEST_F(RealClientTest, ErrRemoveByRegexBeforeSetup) {
+    GLogMuter muter;
+    long result = py_client_->removeByRegex(".*");
+    EXPECT_LT(result, 0) << "removeByRegex before setup should return negative";
+}
+
+// ===================== RemoveAll Edge Cases =====================
+
+TEST_F(RealClientTest, RemoveAllOnEmptyStore) {
+    StartMasterAndSetupClient();
+    long removed = py_client_->removeAll();
+    EXPECT_EQ(removed, 0) << "removeAll on empty store should return 0";
+}
+
+// ===================== BatchRemove Tests =====================
+
+TEST_F(RealClientTest, BatchRemoveBasic) {
+    StartMasterAndSetupClient();
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::string data = "batch_rm_data";
+    std::span<const char> data_span(data.data(), data.size());
+
+    ASSERT_EQ(py_client_->put("brm_1", data_span, config), 0);
+    ASSERT_EQ(py_client_->put("brm_2", data_span, config), 0);
+    ASSERT_EQ(py_client_->put("brm_3", data_span, config), 0);
+
+    std::vector<std::string> keys_to_remove = {"brm_1", "brm_3"};
+    auto results = py_client_->batchRemove(keys_to_remove);
+    ASSERT_EQ(results.size(), 2u);
+    for (size_t i = 0; i < results.size(); ++i) {
+        EXPECT_EQ(results[i], 0) << "batchRemove[" << i << "] should succeed";
+    }
+
+    EXPECT_EQ(py_client_->isExist("brm_1"), 0);
+    EXPECT_EQ(py_client_->isExist("brm_2"), 1) << "brm_2 should survive";
+    EXPECT_EQ(py_client_->isExist("brm_3"), 0);
+}
+
+TEST_F(RealClientTest, BatchRemoveNonExistentKeys) {
+    StartMasterAndSetupClient();
+
+    GLogMuter muter;
+    std::vector<std::string> keys = {"never_existed_1", "never_existed_2"};
+    auto results = py_client_->batchRemove(keys);
+    ASSERT_EQ(results.size(), 2u);
+}
+
+TEST_F(RealClientTest, ErrBatchRemoveBeforeSetup) {
+    GLogMuter muter;
+    std::vector<std::string> keys = {"k1", "k2"};
+    auto results = py_client_->batchRemove(keys);
+    ASSERT_EQ(results.size(), 2u);
+    for (size_t i = 0; i < results.size(); ++i) {
+        EXPECT_NE(results[i], 0)
+            << "batchRemove[" << i << "] before setup should fail";
+    }
+}
+
+// ===================== PutParts Tests =====================
+
+TEST_F(RealClientTest, PutPartsBasic) {
+    StartMasterAndSetupClient();
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::string key = "put_parts_key";
+
+    const std::string part1 = "Hello, ";
+    const std::string part2 = "Parts!";
+    const std::string expected = part1 + part2;
+    std::vector<std::span<const char>> parts;
+    parts.emplace_back(part1.data(), part1.size());
+    parts.emplace_back(part2.data(), part2.size());
+
+    EXPECT_EQ(py_client_->put_parts(key, parts, config), 0);
+
+    auto buf = py_client_->get_buffer(key);
+    ASSERT_NE(buf, nullptr);
+    EXPECT_EQ(buf->size(), expected.size());
+    EXPECT_EQ(std::string(static_cast<const char*>(buf->ptr()), buf->size()),
+              expected);
+}
+
+TEST_F(RealClientTest, ErrPutPartsBeforeSetup) {
+    GLogMuter muter;
+    const std::string part = "data";
+    std::vector<std::span<const char>> parts;
+    parts.emplace_back(part.data(), part.size());
+    ReplicateConfig config;
+    config.replica_num = 1;
+    EXPECT_NE(py_client_->put_parts("key", parts, config), 0)
+        << "put_parts before setup should fail";
+}
+
+// ===================== PutBatch and GetBatch Tests =====================
+
+TEST_F(RealClientTest, PutBatchThenBatchGetBuffer) {
+    StartMasterAndSetupClient();
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    std::vector<std::string> keys = {"batch_kv_0", "batch_kv_1", "batch_kv_2"};
+    std::string val0 = "value_zero";
+    std::string val1 = "value_one!";
+    std::string val2 = "value_two!";
+    std::vector<std::span<const char>> values;
+    values.emplace_back(val0.data(), val0.size());
+    values.emplace_back(val1.data(), val1.size());
+    values.emplace_back(val2.data(), val2.size());
+
+    ASSERT_EQ(py_client_->put_batch(keys, values, config), 0);
+
+    auto handles = py_client_->batch_get_buffer(keys);
+    ASSERT_EQ(handles.size(), 3u);
+
+    std::vector<std::string*> expected = {&val0, &val1, &val2};
+    for (size_t i = 0; i < handles.size(); ++i) {
+        ASSERT_NE(handles[i], nullptr)
+            << "Handle " << i << " should not be null";
+        EXPECT_EQ(std::string(static_cast<const char*>(handles[i]->ptr()),
+                              handles[i]->size()),
+                  *expected[i])
+            << "Data mismatch for key " << keys[i];
+    }
+}
+
+// ===================== HealthCheck Tests =====================
+
+TEST_F(RealClientTest, HealthCheckAfterSetup) {
+    StartMasterAndSetupClient();
+    EXPECT_EQ(py_client_->health_check(), HC_HEALTHY)
+        << "health_check should return HEALTHY after setup";
+}
+
+TEST_F(RealClientTest, HealthCheckBeforeSetup) {
+    int result = py_client_->health_check();
+    EXPECT_EQ(result, HC_NOT_INITIALIZED)
+        << "health_check before setup should return NOT_INITIALIZED";
+}
+
+// ===================== GetHostname Tests =====================
+
+TEST_F(RealClientTest, GetHostnameAfterSetup) {
+    StartMasterAndSetupClient();
+    std::string hostname = py_client_->get_hostname();
+    EXPECT_FALSE(hostname.empty()) << "get_hostname should return non-empty";
+    EXPECT_EQ(hostname, "localhost:17813")
+        << "get_hostname should match the configured hostname";
+}
+
+// ===================== Double TearDown Tests =====================
+
+TEST_F(RealClientTest, DoubleTearDownIsIdempotent) {
+    StartMasterAndSetupClient();
+
+    EXPECT_EQ(py_client_->tearDownAll(), 0) << "First teardown should succeed";
+    EXPECT_EQ(py_client_->tearDownAll(), 0)
+        << "Second teardown should also succeed (idempotent)";
+}
+
+// ===================== Empty Batch Operations =====================
+
+TEST_F(RealClientTest, EmptyBatchOperations) {
+    StartMasterAndSetupClient();
+
+    std::vector<std::string> empty_keys;
+    std::vector<std::span<const char>> empty_values;
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    EXPECT_EQ(py_client_->put_batch(empty_keys, empty_values, config), 0)
+        << "put_batch with empty input should succeed";
+
+    auto handles = py_client_->batch_get_buffer(empty_keys);
+    EXPECT_TRUE(handles.empty())
+        << "batch_get_buffer with empty input should return empty";
+
+    auto exist_results = py_client_->batchIsExist(empty_keys);
+    EXPECT_TRUE(exist_results.empty())
+        << "batchIsExist with empty input should return empty";
+
+    auto remove_results = py_client_->batchRemove(empty_keys);
+    EXPECT_TRUE(remove_results.empty())
+        << "batchRemove with empty input should return empty";
+}
+
+// ===================== Mount Segment Edge Cases =====================
+
+TEST_F(RealClientTest, ErrMountNonExistentFile) {
+    StartMasterAndSetupClient();
+
+    GLogMuter muter;
+    std::vector<std::string> segment_ids;
+    int ret =
+        py_client_->mountSegment("/tmp/mooncake_nonexistent_file_12345", 0,
+                                 4096, FLAGS_protocol, "", segment_ids);
+    EXPECT_NE(ret, 0) << "Mounting non-existent file should fail";
+    EXPECT_TRUE(segment_ids.empty());
+}
+
+TEST_F(RealClientTest, ErrUnmountInvalidSegmentIds) {
+    StartMasterAndSetupClient();
+
+    GLogMuter muter;
+    std::vector<std::string> bogus_ids = {
+        "00000000-0000-0000-0000-000000000000"};
+    int ret = py_client_->unmountSegment(bogus_ids);
+    EXPECT_NE(ret, 0) << "Unmounting non-existent segment ids should fail";
+}
+
+TEST_F(RealClientTest, ErrUnmountAndFreeInvalidSegmentIds) {
+    StartMasterAndSetupClient();
+
+    GLogMuter muter;
+    std::vector<std::string> bogus_ids = {
+        "00000000-0000-0000-0000-000000000000"};
+    int ret = py_client_->unmountAndFreeSegment(bogus_ids);
+    EXPECT_NE(ret, 0)
+        << "Unmount-and-free of non-existent segment ids should fail";
+}
+
 }  // namespace testing
 
 }  // namespace mooncake

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 try:
-    from aiohttp import web as _unused_web
+    from aiohttp import web as _unused_web  # noqa: F401
 except ModuleNotFoundError:
     aiohttp_module = types.ModuleType("aiohttp")
     web_module = types.ModuleType("aiohttp.web")
@@ -27,7 +27,7 @@ except ModuleNotFoundError:
     sys.modules["aiohttp.web"] = web_module
 
 try:
-    from mooncake.store import MooncakeDistributedStore as _unused_store
+    from mooncake.store import MooncakeDistributedStore as _unused_store  # noqa: F401
 except ModuleNotFoundError:
     store_module = types.ModuleType("mooncake.store")
 
@@ -37,7 +37,7 @@ except ModuleNotFoundError:
     store_module.MooncakeDistributedStore = MooncakeDistributedStore
     sys.modules["mooncake.store"] = store_module
 
-from mooncake.mooncake_store_service import MooncakeStoreService
+from mooncake.mooncake_store_service import MooncakeStoreService, _shm_name_to_path
 
 
 class FakeStore:
@@ -201,8 +201,7 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
             ["00000000-0000-0000-0000-000000000002"],
         )
         self.assertEqual(mount_body["allocated_size"], 4096)
-        self.assertEqual(self.fake_store.allocated_mount_calls,
-                         [(1, "tcp", "cpu:0")])
+        self.assertEqual(self.fake_store.allocated_mount_calls, [(1, "tcp", "cpu:0")])
 
         unmount_resp = await self.service.handle_unmount(
             FakeRequest({"segment_ids": mount_body["segment_ids"]})
@@ -242,6 +241,414 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resp.status, 400)
         body = json.loads(resp.text)
         self.assertIn("Missing segment_ids", body["error"])
+
+    # ==================== /api/put tests ====================
+
+    async def test_handle_put_success(self):
+        self.fake_store.put = lambda key, value: 0
+        resp = await self.service.handle_put(
+            FakeRequest({"key": "test_key", "value": "test_value"})
+        )
+        self.assertEqual(resp.status, 200)
+        body = json.loads(resp.text)
+        self.assertEqual(body["status"], "success")
+
+    async def test_handle_put_missing_key(self):
+        self.fake_store.put = lambda key, value: 0
+        resp = await self.service.handle_put(FakeRequest({"value": "test_value"}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Missing key or value", body["error"])
+
+    async def test_handle_put_missing_value(self):
+        self.fake_store.put = lambda key, value: 0
+        resp = await self.service.handle_put(FakeRequest({"key": "k"}))
+        self.assertEqual(resp.status, 500)
+
+    async def test_handle_put_store_failure(self):
+        self.fake_store.put = lambda key, value: -1
+        resp = await self.service.handle_put(FakeRequest({"key": "k", "value": "v"}))
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("PUT operation failed", body["error"])
+
+    async def test_handle_put_empty_key(self):
+        self.fake_store.put = lambda key, value: 0
+        resp = await self.service.handle_put(FakeRequest({"key": "", "value": "v"}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Missing key or value", body["error"])
+
+    # ==================== /api/get/{key} tests ====================
+
+    async def test_handle_get_success(self):
+        self.fake_store.get = lambda key: b"payload_bytes"
+        request = FakeRequest({})
+        request.match_info = {"key": "my_key"}
+        resp = await self.service.handle_get(request)
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.body, b"payload_bytes")
+
+    async def test_handle_get_not_found(self):
+        self.fake_store.get = lambda key: None
+        request = FakeRequest({})
+        request.match_info = {"key": "missing_key"}
+        resp = await self.service.handle_get(request)
+        self.assertEqual(resp.status, 404)
+        body = json.loads(resp.text)
+        self.assertIn("Key not found", body["error"])
+
+    async def test_handle_get_empty_bytes(self):
+        self.fake_store.get = lambda key: b""
+        request = FakeRequest({})
+        request.match_info = {"key": "empty_value_key"}
+        resp = await self.service.handle_get(request)
+        self.assertEqual(resp.status, 404)
+        body = json.loads(resp.text)
+        self.assertIn("Key not found", body["error"])
+
+    async def test_handle_get_store_exception(self):
+        def raise_error(key):
+            raise RuntimeError("store crashed")
+
+        self.fake_store.get = raise_error
+        request = FakeRequest({})
+        request.match_info = {"key": "crash_key"}
+        resp = await self.service.handle_get(request)
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("store crashed", body["error"])
+
+    # ==================== /api/exist/{key} tests ====================
+
+    async def test_handle_exist_true(self):
+        self.fake_store.is_exist = lambda key: True
+        request = FakeRequest({})
+        request.match_info = {"key": "existing_key"}
+        resp = await self.service.handle_exist(request)
+        self.assertEqual(resp.status, 200)
+        body = json.loads(resp.text)
+        self.assertTrue(body["exists"])
+
+    async def test_handle_exist_false(self):
+        self.fake_store.is_exist = lambda key: False
+        request = FakeRequest({})
+        request.match_info = {"key": "missing_key"}
+        resp = await self.service.handle_exist(request)
+        self.assertEqual(resp.status, 200)
+        body = json.loads(resp.text)
+        self.assertFalse(body["exists"])
+
+    async def test_handle_exist_store_exception(self):
+        def raise_error(key):
+            raise RuntimeError("exist check crashed")
+
+        self.fake_store.is_exist = raise_error
+        request = FakeRequest({})
+        request.match_info = {"key": "crash_key"}
+        resp = await self.service.handle_exist(request)
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("exist check crashed", body["error"])
+
+    # ==================== /api/remove/{key} tests ====================
+
+    async def test_handle_remove_success(self):
+        self.fake_store.remove = lambda key: 0
+        request = FakeRequest({})
+        request.match_info = {"key": "removable_key"}
+        resp = await self.service.handle_remove(request)
+        self.assertEqual(resp.status, 200)
+        body = json.loads(resp.text)
+        self.assertEqual(body["status"], "success")
+
+    async def test_handle_remove_failure(self):
+        self.fake_store.remove = lambda key: -1
+        request = FakeRequest({})
+        request.match_info = {"key": "stuck_key"}
+        resp = await self.service.handle_remove(request)
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("Remove operation failed", body["error"])
+
+    async def test_handle_remove_store_exception(self):
+        def raise_error(key):
+            raise RuntimeError("remove crashed")
+
+        self.fake_store.remove = raise_error
+        request = FakeRequest({})
+        request.match_info = {"key": "crash_key"}
+        resp = await self.service.handle_remove(request)
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("remove crashed", body["error"])
+
+    # ==================== /api/remove_all tests ====================
+
+    async def test_handle_remove_all_success(self):
+        self.fake_store.remove_all = lambda: 5
+        resp = await self.service.handle_remove_all(FakeRequest({}))
+        self.assertEqual(resp.status, 200)
+        body = json.loads(resp.text)
+        self.assertIn("5", body["status"])
+
+    async def test_handle_remove_all_zero_keys(self):
+        self.fake_store.remove_all = lambda: 0
+        resp = await self.service.handle_remove_all(FakeRequest({}))
+        self.assertEqual(resp.status, 200)
+        body = json.loads(resp.text)
+        self.assertIn("0", body["status"])
+
+    async def test_handle_remove_all_failure(self):
+        self.fake_store.remove_all = lambda: -1
+        resp = await self.service.handle_remove_all(FakeRequest({}))
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("RemoveAll operation failed", body["error"])
+
+    async def test_handle_remove_all_store_exception(self):
+        def raise_error():
+            raise RuntimeError("remove_all crashed")
+
+        self.fake_store.remove_all = raise_error
+        resp = await self.service.handle_remove_all(FakeRequest({}))
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("remove_all crashed", body["error"])
+
+    # ==================== /api/reconfigure tests ====================
+
+    async def test_reconfigure_decode_success(self):
+        self.fake_store.fail_mount = False
+        resp = await self.service.handle_reconfigure(
+            FakeRequest(
+                {
+                    "mode": "decode",
+                    "path": "/dev/shm/test",
+                    "size": 4096,
+                }
+            )
+        )
+        self.assertEqual(resp.status, 200)
+        body = json.loads(resp.text)
+        self.assertEqual(body["mode"], "decode")
+        self.assertEqual(body["status"], "success")
+        self.assertIn("segment_ids", body)
+        self.assertEqual(self.service.current_mode, "decode")
+
+    async def test_reconfigure_decode_missing_path(self):
+        resp = await self.service.handle_reconfigure(
+            FakeRequest({"mode": "decode", "size": 4096})
+        )
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Missing path or size", body["error"])
+
+    async def test_reconfigure_decode_missing_size(self):
+        resp = await self.service.handle_reconfigure(
+            FakeRequest({"mode": "decode", "path": "/dev/shm/test"})
+        )
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Missing path or size", body["error"])
+
+    async def test_reconfigure_prefill_success(self):
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = []
+        resp = await self.service.handle_reconfigure(FakeRequest({"mode": "prefill"}))
+        self.assertEqual(resp.status, 200)
+        body = json.loads(resp.text)
+        self.assertEqual(body["mode"], "prefill")
+        self.assertEqual(self.service.current_mode, "prefill")
+
+    async def test_reconfigure_prefill_unmounts_segments(self):
+        sid = "00000000-0000-0000-0000-000000000001"
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = [sid]
+        resp = await self.service.handle_reconfigure(FakeRequest({"mode": "prefill"}))
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(self.fake_store.unmount_calls, [[sid]])
+        self.assertEqual(self.service.mounted_segment_ids, [])
+        self.assertEqual(self.service.current_mode, "prefill")
+
+    async def test_reconfigure_prefill_unmount_failure(self):
+        sid = "00000000-0000-0000-0000-000000000002"
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = [sid]
+        self.fake_store.unmount_failures = {sid}
+        resp = await self.service.handle_reconfigure(FakeRequest({"mode": "prefill"}))
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("Unmount failed", body["error"])
+
+    async def test_reconfigure_invalid_mode(self):
+        resp = await self.service.handle_reconfigure(FakeRequest({"mode": "invalid"}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Invalid mode", body["error"])
+
+    async def test_reconfigure_empty_mode(self):
+        resp = await self.service.handle_reconfigure(FakeRequest({}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Invalid mode", body["error"])
+
+    async def test_reconfigure_decode_remount_unmounts_previous(self):
+        old_id = "00000000-0000-0000-0000-000000000001"
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = [old_id]
+        self.fake_store.fail_mount = False
+        resp = await self.service.handle_reconfigure(
+            FakeRequest(
+                {
+                    "mode": "decode",
+                    "path": "/dev/shm/new",
+                    "size": 8192,
+                }
+            )
+        )
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(self.fake_store.unmount_calls, [[old_id]])
+        self.assertEqual(self.service.current_mode, "decode")
+
+    # ==================== /api/mount edge cases ====================
+
+    async def test_mount_negative_size(self):
+        resp = await self.service.handle_mount(FakeRequest({"size": -1}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Invalid size", body["error"])
+
+    async def test_mount_float_size(self):
+        resp = await self.service.handle_mount(FakeRequest({"size": 1.5}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Invalid size", body["error"])
+
+    async def test_mount_string_size(self):
+        resp = await self.service.handle_mount(FakeRequest({"size": "1024"}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Invalid size", body["error"])
+
+    async def test_mount_missing_size(self):
+        resp = await self.service.handle_mount(FakeRequest({}))
+        self.assertEqual(resp.status, 400)
+
+    # ==================== /api/unmount edge cases ====================
+
+    async def test_unmount_requires_segment_ids(self):
+        resp = await self.service.handle_unmount(FakeRequest({}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Missing segment_ids", body["error"])
+
+    async def test_unmount_empty_list(self):
+        resp = await self.service.handle_unmount(FakeRequest({"segment_ids": []}))
+        self.assertEqual(resp.status, 400)
+        body = json.loads(resp.text)
+        self.assertIn("Missing segment_ids", body["error"])
+
+    async def test_unmount_success(self):
+        resp = await self.service.handle_unmount(
+            FakeRequest({"segment_ids": ["00000000-0000-0000-0000-000000000002"]})
+        )
+        self.assertEqual(resp.status, 200)
+        body = json.loads(resp.text)
+        self.assertEqual(body["status"], "success")
+
+    # ==================== /api/mount_shm edge cases ====================
+
+    async def test_mount_shm_store_failure(self):
+        self.fake_store.fail_mount = True
+        resp = await self.service.handle_mount_shm(
+            FakeRequest({"name": "test-seg", "size": 4096})
+        )
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("Mount failed", body["error"])
+
+    async def test_mount_shm_with_defaults(self):
+        resp = await self.service.handle_mount_shm(
+            FakeRequest({"name": "minimal-seg", "size": 2048})
+        )
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(
+            self.fake_store.mount_calls,
+            [("/dev/shm/minimal-seg", 2048, 0, "tcp", "")],
+        )
+
+    async def test_mount_shm_empty_name(self):
+        resp = await self.service.handle_mount_shm(
+            FakeRequest({"name": "", "size": 4096})
+        )
+        self.assertEqual(resp.status, 400)
+
+    async def test_mount_shm_dot_name(self):
+        resp = await self.service.handle_mount_shm(
+            FakeRequest({"name": ".", "size": 4096})
+        )
+        self.assertEqual(resp.status, 400)
+
+    async def test_mount_shm_dotdot_name(self):
+        resp = await self.service.handle_mount_shm(
+            FakeRequest({"name": "..", "size": 4096})
+        )
+        self.assertEqual(resp.status, 400)
+
+    # ==================== /api/unmount_shm edge cases ====================
+
+    async def test_unmount_shm_string_segment_id_coercion(self):
+        resp = await self.service.handle_unmount_shm(
+            FakeRequest({"segment_ids": "00000000-0000-0000-0000-000000000001"})
+        )
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(
+            self.fake_store.unmount_calls,
+            [["00000000-0000-0000-0000-000000000001"]],
+        )
+
+    async def test_unmount_shm_empty_list(self):
+        resp = await self.service.handle_unmount_shm(FakeRequest({"segment_ids": []}))
+        self.assertEqual(resp.status, 400)
+
+
+class ShmNameToPathTest(unittest.TestCase):
+    def test_valid_simple_name(self):
+        self.assertEqual(_shm_name_to_path("my-segment"), "/dev/shm/my-segment")
+
+    def test_valid_leading_slash(self):
+        self.assertEqual(_shm_name_to_path("/my-segment"), "/dev/shm/my-segment")
+
+    def test_rejects_empty(self):
+        self.assertIsNone(_shm_name_to_path(""))
+
+    def test_rejects_none(self):
+        self.assertIsNone(_shm_name_to_path(None))
+
+    def test_rejects_non_string(self):
+        self.assertIsNone(_shm_name_to_path(123))
+
+    def test_rejects_dot(self):
+        self.assertIsNone(_shm_name_to_path("."))
+
+    def test_rejects_dotdot(self):
+        self.assertIsNone(_shm_name_to_path(".."))
+
+    def test_rejects_path_traversal(self):
+        self.assertIsNone(_shm_name_to_path("../etc/passwd"))
+
+    def test_rejects_nested_path(self):
+        self.assertIsNone(_shm_name_to_path("subdir/file"))
+
+    def test_rejects_slash_only(self):
+        self.assertIsNone(_shm_name_to_path("/"))
+
+    def test_rejects_slash_dot(self):
+        self.assertIsNone(_shm_name_to_path("/."))
+
+    def test_rejects_slash_dotdot(self):
+        self.assertIsNone(_shm_name_to_path("/.."))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Addresses #654 — adds comprehensive error handling and corner case tests for the mooncake-store Python binding layer.

**What changed:**
- **20+ new C++ tests** in `pybind_client_test.cpp` covering previously untested `RealClient` methods and error paths
- **42 new Python tests** in `test_mooncake_store_service_api.py` covering all 6 previously untested REST API endpoints plus edge cases
- **11 new unit tests** for the `_shm_name_to_path` utility function (path traversal, invalid inputs)
- Fixed pre-existing ruff F401 lint warnings with `noqa` comments

**Test coverage before → after:**
- Python REST API tests: 10 → 62 (6.2x increase)
- C++ pybind client tests: 17 → 37+ (2.2x increase)
- Previously untested endpoints now covered: `/api/put`, `/api/get/{key}`, `/api/exist/{key}`, `/api/remove/{key}`, `/api/remove_all`, `/api/reconfigure`

### C++ Tests Added (`pybind_client_test.cpp`)

| Category | Tests |
|----------|-------|
| `batchIsExist` | Mixed existing/missing keys, before setup |
| `getSize` | Existing key returns exact size, before setup |
| `removeByRegex` | Matching keys, no match, before setup |
| `removeAll` | Empty store returns 0 |
| `batchRemove` | Valid keys, non-existent keys, before setup |
| `put_parts` | Multi-part put roundtrip, before setup |
| `put_batch` / `batch_get_buffer` | Batch put then batch get roundtrip |
| `health_check` | After setup (HEALTHY), before setup (NOT_INITIALIZED) |
| `get_hostname` | Returns configured hostname |
| Idempotency | Double `tearDownAll` is safe |
| Empty batches | All batch ops with empty input vectors |
| Mount errors | Non-existent file, invalid segment IDs, invalid free |

### Python Tests Added (`test_mooncake_store_service_api.py`)

| Endpoint | Tests |
|----------|-------|
| `/api/put` | Success, missing key, missing value, empty key, store failure |
| `/api/get/{key}` | Success, not found, empty bytes, store exception |
| `/api/exist/{key}` | True, false, store exception |
| `/api/remove/{key}` | Success, failure, store exception |
| `/api/remove_all` | Success, zero keys, failure, store exception |
| `/api/reconfigure` | Decode success, missing path/size, prefill success, unmount failure, invalid/empty mode, remount |
| `/api/mount` | Negative/float/string/missing size |
| `/api/unmount` | Missing segment_ids, empty list, success |
| `/api/mount_shm` | Store failure, default params, empty/dot/dotdot names |
| `/api/unmount_shm` | String coercion, empty list |
| `_shm_name_to_path` | 11 edge cases (traversal, dot, slash, None, non-string) |

## Test plan

- [x] All 62 Python tests pass locally (`pytest -v`)
- [x] Pre-commit hooks pass (ruff, ruff-format, clang-format, codespell)
- [ ] C++ tests compile and pass in CI (requires Linux + gtest + in-proc master)