### PR TITLE
[Doc] Fix autodoc2 package path in docs config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/source/api/
 
 # PyBuilder
 .pybuilder/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,7 +55,7 @@ myst_enable_extensions = [
 myst_fence_as_directive = ["mermaid"]
 autodoc2_packages = [
     {
-        "path": "../../Mooncake",
+        "path": "../../mooncake-wheel/mooncake",
         "exclude_dirs": ["__pycache__", "third_party"],
     },
 ]


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
The `autodoc2_packages` path in `docs/source/conf.py` pointed to `../../Mooncake` (the repo root), which is not a Python package. This caused the docs build to fail with Item Mooncake does not exist. The correct path is `../../mooncake-wheel/mooncake`. Also adds the auto-generated docs/source/api/ directory to .gitignore.
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

`make clean && make html` passes now

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
