### PR TITLE
feat(ci): update EP/PG torch versions — drop 2.9.0, add 2.12.0; switch CUDA 12.8→12.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,7 +606,7 @@ jobs:
       run: |
         cd build
         rm -r */tests
-        cmake -G Ninja .. -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF -DUSE_HTTP=ON -DENABLE_SCCACHE=ON -DUSE_CXL=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.9.0;2.9.1;2.10.0;2.11.0"
+        cmake -G Ninja .. -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF -DUSE_HTTP=ON -DENABLE_SCCACHE=ON -DUSE_CXL=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.9.1;2.10.0;2.11.0;2.12.0"
       shell: bash
 
     - name: Build project

--- a/.github/workflows/ci_cu13.yml
+++ b/.github/workflows/ci_cu13.yml
@@ -75,7 +75,7 @@ jobs:
           -DWITH_STORE=ON \
           -DWITH_P2P_STORE=ON \
           -DWITH_EP=ON \
-          -DEP_TORCH_VERSIONS="2.9.0;2.9.1;2.10.0;2.11.0" \
+          -DEP_TORCH_VERSIONS="2.9.1;2.10.0;2.11.0;2.12.0" \
           -DWITH_METRICS=ON \
           -DBUILD_UNIT_TESTS=OFF \
           -DBUILD_EXAMPLES=ON \

--- a/.github/workflows/release-cuda13.yaml
+++ b/.github/workflows/release-cuda13.yaml
@@ -65,7 +65,7 @@ jobs:
           sudo bash -x dependencies.sh -y
           mkdir build
           cd build
-          cmake .. -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.9.0;2.9.1;2.10.0;2.11.0" -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.9.1;2.10.0;2.11.0;2.12.0" -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
         shell: bash
 
       - name: Build project

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
           sudo bash -x dependencies.sh -y
           mkdir build
           cd build
-          cmake .. -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.9.0;2.9.1;2.10.0;2.11.0" -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.9.1;2.10.0;2.11.0;2.12.0" -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
         shell: bash
 
       - name: Build project

--- a/mooncake-common/SetupPyTorchEnv.cmake
+++ b/mooncake-common/SetupPyTorchEnv.cmake
@@ -23,6 +23,18 @@ function(install_pytorch_wheel _version _cuda_major _cuda_minor _module_prefix)
     # TODO: Fix when we need to support more CUDA 13 versions or when the CI env is fixed.
     set(_cu_tag "cu130")
 
+  elseif(_cuda_major EQUAL 12 AND _version VERSION_GREATER_EQUAL "2.12.0")
+    # PyTorch 2.12.0+ no longer publishes cu128 wheels.
+    # Use cu126 for all CUDA 12 builds.
+    if(_cuda_minor GREATER_EQUAL 6)
+      set(_cu_tag "cu126")
+    else()
+      message(FATAL_ERROR
+        "${_module_prefix} Can't find a matching PyTorch wheel for version ${_version} "
+        "with CUDA ${_cuda_major}.${_cuda_minor}"
+      )
+    endif()
+
   elseif(_cuda_major EQUAL 12 AND _version VERSION_GREATER_EQUAL "2.11.0")
     # PyTorch 2.11.0+ defaults to CUDA 13.
     # We must explicitly point to CUDA 12 wheels for these newer versions.


### PR DESCRIPTION
## Description

Update the EP/PG torch version matrix to include PyTorch 2.12.0 and add cmake logic for its cu126 wheel routing.

**PyTorch 2.12.0** (released 2026-05-13) no longer publishes cu128 wheels — only cu130 (default) and cu126 (legacy hardware). This means the existing CUDA 12.8 + torch 2.12.0 combination has no cu128 wheel to download. The cmake logic now handles this by routing torch 2.12.0+ on CUDA 12 hosts to the cu126 index.

### Changes

1. **EP_TORCH_VERSIONS**: `2.9.0;2.9.1;2.10.0;2.11.0` → `2.9.1;2.10.0;2.11.0;2.12.0`
   - Drop 2.9.0 (superseded by 2.9.1 patch release)
   - Add 2.12.0 (latest stable)

2. **SetupPyTorchEnv.cmake**: Add a `version >= 2.12.0` branch that routes CUDA 12 builds to the cu126 wheel index, preserving the existing cu128 path for 2.11.0 on CUDA 12.8+ hosts.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [x] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [x] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- Verified that `pip install torch==2.12.0 --index-url https://download.pytorch.org/whl/cu126` resolves successfully (cu126 wheel exists for 2.12.0).
- Verified that `pip install torch==2.12.0 --index-url https://download.pytorch.org/whl/cu128` fails (no cu128 wheel for 2.12.0).
- CI will validate the full build matrix on this PR.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.