### PR TITLE
[TENT] Apply TE's changes of RDMA transport

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -114,6 +114,9 @@ class RdmaContext {
 
     RdmaParams &params() const { return *params_.get(); }
 
+    // PCIe Relaxed Ordering support
+    bool isRelaxedOrderingEnabled() const { return relaxed_ordering_enabled_; }
+
     // Notification CQ (dedicated for notification QPs)
     RdmaCQ *notifyCq() { return notify_cq_; }
 
@@ -148,6 +151,9 @@ class RdmaContext {
 
     // Dedicated CQ for notification QPs (one per device)
     RdmaCQ *notify_cq_ = nullptr;
+
+    // PCIe Relaxed Ordering support
+    bool relaxed_ordering_enabled_ = false;
 
     const IbvSymbols &verbs_;
 };

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -85,11 +85,11 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     // forward through states and never return. Failed or discarded endpoints
     // enter EP_DESTROYING and are reclaimed - they are never reset or reused.
     enum EndPointStatus {
-        EP_UNINIT,      // Initial state, not yet constructed
-        EP_HANDSHAKING, // Connection in progress
-        EP_READY,       // Connected and operational
-        EP_DESTROYING,  // Being destroyed (failed or discarded)
-        EP_DESTROYED,   // Fully destroyed
+        EP_UNINIT,       // Initial state, not yet constructed
+        EP_HANDSHAKING,  // Connection in progress
+        EP_READY,        // Connected and operational
+        EP_DESTROYING,   // Being destroyed (failed or discarded)
+        EP_DESTROYED,    // Fully destroyed
     };
 
     int reset();
@@ -116,7 +116,9 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
 
     Status accept(const BootstrapDesc& peer_desc, BootstrapDesc& local_desc);
 
-    EndPointStatus status() const { return status_.load(std::memory_order_relaxed); }
+    EndPointStatus status() const {
+        return status_.load(std::memory_order_relaxed);
+    }
 
     std::vector<uint32_t> qpNum();
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -81,7 +81,16 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     ~RdmaEndPoint();
 
    public:
-    enum EndPointStatus { EP_UNINIT, EP_HANDSHAKING, EP_READY, EP_RESET };
+    // Endpoint lifecycle is unidirectional: once created, endpoints move
+    // forward through states and never return. Failed or discarded endpoints
+    // enter EP_DESTROYING and are reclaimed - they are never reset or reused.
+    enum EndPointStatus {
+        EP_UNINIT,      // Initial state, not yet constructed
+        EP_HANDSHAKING, // Connection in progress
+        EP_READY,       // Connected and operational
+        EP_DESTROYING,  // Being destroyed (failed or discarded)
+        EP_DESTROYED,   // Fully destroyed
+    };
 
     int reset();
 
@@ -91,13 +100,23 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
 
     int deconstruct();
 
+    // Two-phase QP destruction to avoid use-after-free in concurrent
+    // submitPostSend. Phase 1 (beginDestroy): sets status_=EP_DESTROYING,
+    // transitions QPs to ERR state so hardware flushes inflight WRs to CQ.
+    // Does not block. Phase 2 (finishDestroy): called after all outstanding
+    // WRs have been drained, actually destroys QPs and frees resources.
+    // Returns true if destruction is complete, false if outstanding WRs remain.
+    void beginDestroy();
+    void beginDestroyNoLock();  // Internal version without locking
+    bool finishDestroy();
+
     Status connect(const std::string& peer_server_name,
                    const std::string& peer_nic_name,
                    const std::string& peer_rpc_server_addr = "");
 
     Status accept(const BootstrapDesc& peer_desc, BootstrapDesc& local_desc);
 
-    EndPointStatus status() const { return status_; }
+    EndPointStatus status() const { return status_.load(std::memory_order_relaxed); }
 
     std::vector<uint32_t> qpNum();
 
@@ -148,6 +167,7 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     }
 
    private:
+    int resetConnection(const std::string& reason);
     int setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
                     std::vector<uint32_t> peer_qp_num_list,
                     std::string* reply_msg = nullptr);
@@ -183,6 +203,9 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     uint32_t padding_[7];
     RWSpinlock lock_;
 
+    // Two-phase destruction: timestamp when EP entered EP_DESTROYING
+    volatile uint64_t destroy_start_time_;
+
     std::string peer_server_name_;
     std::string peer_nic_name_;
     std::vector<uint32_t> peer_qp_num_list_;
@@ -203,6 +226,11 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     int notify_pending_count_ = 0;    // Number of pending sends
     uint64_t notify_send_wr_id_ = 0;  // Circular counter for wr_id
     bool notify_connected_ = false;
+
+    // Two-phase destruction constants (matching TE)
+    static constexpr double kFinishDestroyTimeoutSec = 30.0;
+    static constexpr int kFinishDestroyMaxRetries = 3;
+    int finish_destroy_retries_ = 0;  // Retry counter for finishDestroy
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -92,13 +92,13 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
         EP_DESTROYED,    // Fully destroyed
     };
 
-    int reset();
-
     int construct(RdmaContext* context, EndPointParams* params,
                   const std::string& endpoint_name,
                   std::atomic<int>* endpoints_count = nullptr);
 
     int deconstruct();
+
+    int resetConnection(const std::string& reason);
 
     // Two-phase QP destruction to avoid use-after-free in concurrent
     // submitPostSend. Phase 1 (beginDestroy): sets status_=EP_DESTROYING,
@@ -156,8 +156,6 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
         bool failed;
     };
 
-    int resetUnlocked();
-
     int submitSlices(std::vector<RdmaSlice*>& slice_list, int qp_index);
 
     int submitRecvImmDataRequest(int qp_index, uint64_t id);
@@ -169,7 +167,6 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     }
 
    private:
-    int resetConnection(const std::string& reason);
     int setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
                     std::vector<uint32_t> peer_qp_num_list,
                     std::string* reply_msg = nullptr);

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -203,7 +203,7 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     RWSpinlock lock_;
 
     // Two-phase destruction: timestamp when EP entered EP_DESTROYING
-    volatile uint64_t destroy_start_time_;
+    std::atomic<uint64_t> destroy_start_time_;
 
     std::string peer_server_name_;
     std::string peer_nic_name_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -114,6 +114,8 @@ class RdmaTransport : public Transport {
    public:
     Status setupLocalSegment();
 
+    std::shared_ptr<Config> config() const { return conf_; }
+
    private:
     bool installed_;
     std::shared_ptr<Config> conf_;

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -84,9 +84,35 @@ Status ConfigHelper::loadFromEnv(Config& config) {
         }
     }
 
-    // Legacy keys for backward compatibility
+    // Legacy keys for backward compatibility (MC_* env vars)
+    setConfig(config, "MC_NUM_CQ_PER_CTX",
+              "transports/rdma/device/num_cq_list");
+    setConfig(config, "MC_NUM_COMP_CHANNELS_PER_CTX",
+              "transports/rdma/device/num_comp_channels");
     setConfig(config, "MC_IB_PORT", "transports/rdma/device/port");
     setConfig(config, "MC_GID_INDEX", "transports/rdma/device/gid_index");
+    setConfig(config, "NCCL_IB_GID_INDEX", "transports/rdma/device/gid_index");
+    setConfig(config, "MC_MAX_CQE_PER_CTX", "transports/rdma/device/max_cqe");
+    setConfig(config, "MC_MAX_EP_PER_CTX",
+              "transports/rdma/endpoint/endpoint_store_cap");
+    setConfig(config, "MC_NUM_QP_PER_EP",
+              "transports/rdma/endpoint/qp_mul_factor");
+    setConfig(config, "MC_MAX_SGE", "transports/rdma/endpoint/max_sge");
+    setConfig(config, "MC_MAX_WR", "transports/rdma/endpoint/max_qp_wr");
+    setConfig(config, "MC_MAX_INLINE",
+              "transports/rdma/endpoint/max_inline_bytes");
+    setConfig(config, "MC_PKEY_INDEX", "transports/rdma/endpoint/pkey_index");
+    setConfig(config, "MC_MTU", "transports/rdma/endpoint/path_mtu");
+    setConfig(config, "MC_IB_TC", "transports/rdma/endpoint/traffic_class");
+    setConfig(config, "MC_IB_PCI_RELAXED_ORDERING",
+              "transports/rdma/pci_relaxed_ordering");
+    setConfig(config, "MC_WORKERS_PER_CTX",
+              "transports/rdma/workers/num_workers");
+    setConfig(config, "MC_SLICE_SIZE", "transports/rdma/workers/block_size");
+    setConfig(config, "MC_RETRY_CNT",
+              "transports/rdma/workers/max_retry_count");
+    setConfig(config, "MC_DISABLE_GPU_DIRECT_RDMA",
+              "transports/rdma/disable_gpu_direct_rdma");
     return status;
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/buffers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/buffers.cpp
@@ -78,7 +78,8 @@ LocalBufferManager::LocalBufferManager() {}
 
 LocalBufferManager::~LocalBufferManager() { clear(); }
 
-static inline int getAccessFlags(Permission perm, bool relaxed_ordering = false) {
+static inline int getAccessFlags(Permission perm,
+                                 bool relaxed_ordering = false) {
     int access = IBV_ACCESS_LOCAL_WRITE;
     if (perm == kGlobalReadWrite) {
         access |= IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
@@ -211,8 +212,8 @@ Status LocalBufferManager::addDevice(RdmaContext* context) {
     for (auto& buffer : buffer_list_) {
         auto range = buffer.first;
         auto& options = buffer.second.options;
-        auto access = getAccessFlags(options.perm,
-                                     context->isRelaxedOrderingEnabled());
+        auto access =
+            getAccessFlags(options.perm, context->isRelaxedOrderingEnabled());
         if (buffer.second.mem_reg_map.count(context)) continue;
         auto mem_reg =
             context->registerMemReg(range.addr, range.length, access);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/buffers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/buffers.cpp
@@ -78,12 +78,15 @@ LocalBufferManager::LocalBufferManager() {}
 
 LocalBufferManager::~LocalBufferManager() { clear(); }
 
-static inline int getAccessFlags(Permission perm) {
+static inline int getAccessFlags(Permission perm, bool relaxed_ordering = false) {
     int access = IBV_ACCESS_LOCAL_WRITE;
     if (perm == kGlobalReadWrite) {
         access |= IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
     } else if (perm == kGlobalReadOnly) {
         access |= IBV_ACCESS_REMOTE_READ;
+    }
+    if (relaxed_ordering) {
+        access |= IBV_ACCESS_RELAXED_ORDERING;
     }
     return access;
 }
@@ -98,7 +101,6 @@ Status LocalBufferManager::addBufferInternal(BufferDesc& desc,
                                              bool force_sequential) {
     AddressRange range((void*)desc.addr, desc.length);
     BufferEntryForRdma staging;
-    auto access = getAccessFlags(options.perm);
     assert(desc.rkey.empty());
     size_t context_count = 0;
     for (auto* context : context_list_) {
@@ -116,6 +118,9 @@ Status LocalBufferManager::addBufferInternal(BufferDesc& desc,
         for (size_t id = 0; id < context_list_.size(); ++id) {
             auto* context = context_list_[id];
             if (!context) continue;
+            // Calculate access flags per context (for relaxed ordering support)
+            int access = getAccessFlags(options.perm,
+                                        context->isRelaxedOrderingEnabled());
             tasks.emplace_back(std::async(
                 std::launch::async,
                 [context, &mem_reg_list, id, addr, length, access]() {
@@ -128,6 +133,9 @@ Status LocalBufferManager::addBufferInternal(BufferDesc& desc,
         for (size_t id = 0; id < context_list_.size(); ++id) {
             auto* context = context_list_[id];
             if (!context) continue;
+            // Calculate access flags per context (for relaxed ordering support)
+            int access = getAccessFlags(options.perm,
+                                        context->isRelaxedOrderingEnabled());
             mem_reg_list[id] =
                 context->registerMemReg((void*)desc.addr, desc.length, access);
         }
@@ -203,7 +211,8 @@ Status LocalBufferManager::addDevice(RdmaContext* context) {
     for (auto& buffer : buffer_list_) {
         auto range = buffer.first;
         auto& options = buffer.second.options;
-        auto access = getAccessFlags(options.perm);
+        auto access = getAccessFlags(options.perm,
+                                     context->isRelaxedOrderingEnabled());
         if (buffer.second.mem_reg_map.count(context)) continue;
         auto mem_reg =
             context->registerMemReg(range.addr, range.length, access);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -516,13 +516,33 @@ RdmaContext::MemReg RdmaContext::registerMemReg(void* addr, size_t length,
     if (result == CUDA_SUCCESS && memType == CU_MEMORYTYPE_DEVICE) {
         // Get device ordinal and set primary context current
         unsigned int devOrd = 0;
-        cuPointerGetAttribute(&devOrd, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
-                              (CUdeviceptr)addr);
+        result = cuPointerGetAttribute(
+            &devOrd, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL, (CUdeviceptr)addr);
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR) << "Failed to get CUDA device ordinal: " << result;
+            return nullptr;
+        }
+
         CUdevice cuDev;
+        result = cuDeviceGet(&cuDev, devOrd);
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR) << "Failed to get CUDA device: " << result;
+            return nullptr;
+        }
+
         CUcontext cuCtx;
-        cuDeviceGet(&cuDev, devOrd);
-        cuDevicePrimaryCtxRetain(&cuCtx, cuDev);
-        cuCtxSetCurrent(cuCtx);
+        result = cuDevicePrimaryCtxRetain(&cuCtx, cuDev);
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR) << "Failed to retain CUDA primary context: " << result;
+            return nullptr;
+        }
+
+        result = cuCtxSetCurrent(cuCtx);
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR) << "Failed to set CUDA context current: " << result;
+            cuDevicePrimaryCtxRelease(cuDev);
+            return nullptr;
+        }
 
         // Register GPU memory
         ibv_mr* entry =

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -390,7 +390,8 @@ int RdmaContext::enable() {
 
     // Check PCIe Relaxed Ordering support from config
     // Mode: 0 = disabled, 1 = enabled if supported, 2 = auto (default)
-    auto mode = transport_.config()->get("transports/rdma/pci_relaxed_ordering", 1);
+    auto mode =
+        transport_.config()->get("transports/rdma/pci_relaxed_ordering", 1);
     if (mode != 0) {
         // Check if ibv_reg_mr_iova2 symbol is available (IBVERBS_1.8+)
         void* sym = dlsym(RTLD_DEFAULT, "ibv_reg_mr_iova2");
@@ -401,8 +402,8 @@ int RdmaContext::enable() {
         } else {
             if (mode == 1) {
                 LOG(WARNING) << "[RDMA] Relaxed ordering requested but NOT "
-                              << "supported (ibv_reg_mr_iova2 missing). "
-                              << "Falling back to strict ordering.";
+                             << "supported (ibv_reg_mr_iova2 missing). "
+                             << "Falling back to strict ordering.";
             }
             relaxed_ordering_enabled_ = false;
         }
@@ -563,8 +564,7 @@ int RdmaContext::warmupMrRegistration(void* addr, size_t length) {
         return -1;
     }
     int access_flags = IBV_ACCESS_LOCAL_WRITE;
-    if (relaxed_ordering_enabled_) 
-        access_flags |= IBV_ACCESS_RELAXED_ORDERING;
+    if (relaxed_ordering_enabled_) access_flags |= IBV_ACCESS_RELAXED_ORDERING;
     ibv_mr* entry =
         verbs_.ibv_reg_mr_default(native_pd_, addr, length, access_flags);
     if (!entry) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -26,6 +26,13 @@
 #include <fstream>
 #include <memory>
 #include <thread>
+#include <cstdlib>
+#include <dlfcn.h>
+
+#ifdef USE_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
 
 #include "tent/common/status.h"
 #include "tent/transport/rdma/endpoint_store.h"
@@ -381,6 +388,30 @@ int RdmaContext::enable() {
         return notify_ret;
     }
 
+    // Check PCIe Relaxed Ordering support from config
+    // Mode: 0 = disabled, 1 = enabled if supported, 2 = auto (default)
+    auto mode = transport_.config()->get("transports/rdma/pci_relaxed_ordering", 1);
+    if (mode != 0) {
+        // Check if ibv_reg_mr_iova2 symbol is available (IBVERBS_1.8+)
+        void* sym = dlsym(RTLD_DEFAULT, "ibv_reg_mr_iova2");
+        if (sym) {
+            relaxed_ordering_enabled_ = true;
+            LOG(INFO) << "[RDMA] Relaxed ordering is supported and enabled for "
+                      << device_name_;
+        } else {
+            if (mode == 1) {
+                LOG(WARNING) << "[RDMA] Relaxed ordering requested but NOT "
+                              << "supported (ibv_reg_mr_iova2 missing). "
+                              << "Falling back to strict ordering.";
+            }
+            relaxed_ordering_enabled_ = false;
+        }
+    } else {
+        LOG(INFO) << "[RDMA] Relaxed ordering disabled via config for "
+                  << device_name_;
+        relaxed_ordering_enabled_ = false;
+    }
+
     ibv_port_attr port_attr;
     int ret = verbs_.ibv_query_port_default(native_context_,
                                             params_->device.port, &port_attr);
@@ -473,6 +504,46 @@ RdmaContext::MemReg RdmaContext::registerMemReg(void* addr, size_t length,
         LOG(FATAL) << "RDMA context " << name() << " not constructed";
         return nullptr;
     }
+
+#ifdef USE_CUDA
+    // Ensure CUDA context is current for GPU memory registration
+    // This is needed for worker threads or callers from non-CUDA threads
+    CUmemorytype memType;
+    CUresult result = cuPointerGetAttribute(
+        &memType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, (CUdeviceptr)addr);
+
+    if (result == CUDA_SUCCESS && memType == CU_MEMORYTYPE_DEVICE) {
+        // Get device ordinal and set primary context current
+        unsigned int devOrd = 0;
+        cuPointerGetAttribute(&devOrd, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
+                              (CUdeviceptr)addr);
+        CUdevice cuDev;
+        CUcontext cuCtx;
+        cuDeviceGet(&cuDev, devOrd);
+        cuDevicePrimaryCtxRetain(&cuCtx, cuDev);
+        cuCtxSetCurrent(cuCtx);
+
+        // Register GPU memory
+        ibv_mr* entry =
+            verbs_.ibv_reg_mr_default(native_pd_, addr, length, access);
+
+        // Release primary context reference
+        cuDevicePrimaryCtxRelease(cuDev);
+
+        if (!entry) {
+            const void* end = static_cast<const char*>(addr) + length;
+            PLOG(ERROR) << "Failed to register GPU memory from " << addr
+                        << " to " << end << " in RDMA device " << device_name_;
+            return nullptr;
+        }
+        mr_set_mutex_.lock();
+        mr_set_.insert(entry);
+        mr_set_mutex_.unlock();
+        return entry;
+    }
+#endif
+
+    // Standard CPU memory registration
     ibv_mr* entry = verbs_.ibv_reg_mr_default(native_pd_, addr, length, access);
     if (!entry) {
         const void* end = static_cast<const char*>(addr) + length;
@@ -491,8 +562,11 @@ int RdmaContext::warmupMrRegistration(void* addr, size_t length) {
         LOG(FATAL) << "RDMA context " << name() << " not constructed";
         return -1;
     }
-    ibv_mr* entry = verbs_.ibv_reg_mr_default(native_pd_, addr, length,
-                                              IBV_ACCESS_LOCAL_WRITE);
+    int access_flags = IBV_ACCESS_LOCAL_WRITE;
+    if (relaxed_ordering_enabled_) 
+        access_flags |= IBV_ACCESS_RELAXED_ORDERING;
+    ibv_mr* entry =
+        verbs_.ibv_reg_mr_default(native_pd_, addr, length, access_flags);
     if (!entry) {
         PLOG(WARNING) << "ibv_reg_mr warm-up failed on " << device_name_
                       << " for [" << addr << ", " << length << " bytes]";

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -532,15 +532,6 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     return mooncake::tent::Status::OK();
 }
 
-int RdmaEndPoint::reset() {
-    // Endpoints have unidirectional lifecycle and are never reset.
-    // This function is deprecated and always returns error.
-    // Use resetConnection() to mark an endpoint for destruction instead.
-    LOG(WARNING) << "reset() called on endpoint with unidirectional lifecycle, "
-                 << "use resetConnection() instead";
-    return -1;
-}
-
 int RdmaEndPoint::resetConnection(const std::string& reason) {
     // Mark endpoint for destruction due to failure or error.
     // Endpoints have unidirectional lifecycle - once marked for destruction,

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -33,7 +33,8 @@
 
 namespace mooncake {
 namespace tent {
-static inline const std::string statusToString(RdmaEndPoint::EndPointStatus status) {
+static inline const std::string statusToString(
+    RdmaEndPoint::EndPointStatus status) {
     switch (status) {
         case RdmaEndPoint::EP_UNINIT:
             return "EP_UNINIT";
@@ -55,8 +56,7 @@ static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
                                    uint16_t peer_lid, uint32_t peer_qp_num,
                                    uint16_t pkey_index);
 
-RdmaEndPoint::RdmaEndPoint()
-    : status_(EP_UNINIT) {}
+RdmaEndPoint::RdmaEndPoint() : status_(EP_UNINIT) {}
 
 RdmaEndPoint::~RdmaEndPoint() {
     if (status_.load(std::memory_order_relaxed) != EP_UNINIT) deconstruct();
@@ -231,7 +231,8 @@ void RdmaEndPoint::beginDestroy() {
 
 void RdmaEndPoint::beginDestroyNoLock() {
     auto current_status = status_.load(std::memory_order_relaxed);
-    if (current_status == EP_DESTROYING || current_status == EP_DESTROYED) return;
+    if (current_status == EP_DESTROYING || current_status == EP_DESTROYED)
+        return;
 
     destroy_start_time_ = getCurrentTimeInNano();
     status_.store(EP_DESTROYING, std::memory_order_release);
@@ -282,7 +283,8 @@ bool RdmaEndPoint::finishDestroy() {
             }
         }
         if (has_outstanding) {
-            double elapsed = (getCurrentTimeInNano() - destroy_start_time_) / 1e9;
+            double elapsed =
+                (getCurrentTimeInNano() - destroy_start_time_) / 1e9;
             if (elapsed < kFinishDestroyTimeoutSec) {
                 return false;  // Still waiting for WRs to drain
             }
@@ -472,9 +474,10 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
         // Endpoint already connected to a different peer - reject the request
         // instead of resetting. Endpoints have unidirectional lifecycle and
         // are never reset or reused. The caller should create a new endpoint.
-        LOG(ERROR) << "Endpoint already established with " << peer_nic_name_
-                   << " of " << peer_server_name_
-                   << ", cannot accept new connection (unidirectional lifecycle)";
+        LOG(ERROR)
+            << "Endpoint already established with " << peer_nic_name_ << " of "
+            << peer_server_name_
+            << ", cannot accept new connection (unidirectional lifecycle)";
         return mooncake::tent::Status::InternalError(
             "Endpoint already connected to different peer" LOC_MARK);
     }
@@ -548,7 +551,8 @@ int RdmaEndPoint::resetConnection(const std::string& reason) {
     {
         RWSpinlock::WriteGuard guard(lock_);
         auto curr_status = status_.load(std::memory_order_acquire);
-        if (curr_status == EP_DESTROYING || curr_status == EP_DESTROYED) return 0;
+        if (curr_status == EP_DESTROYING || curr_status == EP_DESTROYED)
+            return 0;
         if (curr_status != EP_HANDSHAKING && curr_status != EP_READY) return 0;
 
         destroy_start_time_ = getCurrentTimeInNano();
@@ -614,8 +618,7 @@ int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
     if (qp_index < 0) qp_index = 0;
     qp_index %= qp_list_.size();
     // Check endpoint status before submitting
-    if (status_.load(std::memory_order_relaxed) != EP_READY)
-        return 0;
+    if (status_.load(std::memory_order_relaxed) != EP_READY) return 0;
     auto cq = context_->cq(qp_index % context_->cqCount());
     int wr_count =
         std::min(cq->maxCqe() - cq->getQuota(),
@@ -682,8 +685,7 @@ int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
 int RdmaEndPoint::submitRecvImmDataRequest(int qp_index, uint64_t id) {
     RWSpinlock::ReadGuard guard(lock_);
     // Check endpoint status before submitting
-    if (status_.load(std::memory_order_relaxed) != EP_READY)
-        return 0;
+    if (status_.load(std::memory_order_relaxed) != EP_READY) return 0;
     if (qp_index < 0 || qp_index >= (int)qp_list_.size()) return 0;
     ibv_recv_wr wr, *bad_wr;
     memset(&wr, 0, sizeof(ibv_recv_wr));

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -26,14 +26,14 @@
 #include "tent/common/status.h"
 #include "tent/common/types.h"
 #include "tent/transport/rdma/context.h"
+#include "tent/transport/rdma/endpoint_store.h"
 #include "tent/common/utils/os.h"
 #include "tent/common/utils/string_builder.h"
 #include "tent/thirdparty/nlohmann/json.h"
 
 namespace mooncake {
 namespace tent {
-static inline const std::string statusToString(
-    RdmaEndPoint::EndPointStatus status) {
+static inline const std::string statusToString(RdmaEndPoint::EndPointStatus status) {
     switch (status) {
         case RdmaEndPoint::EP_UNINIT:
             return "EP_UNINIT";
@@ -41,8 +41,10 @@ static inline const std::string statusToString(
             return "EP_HANDSHAKING";
         case RdmaEndPoint::EP_READY:
             return "EP_READY";
-        case RdmaEndPoint::EP_RESET:
-            return "EP_RESET";
+        case RdmaEndPoint::EP_DESTROYING:
+            return "EP_DESTROYING";
+        case RdmaEndPoint::EP_DESTROYED:
+            return "EP_DESTROYED";
     }
     return "UNKNOWN";
 }
@@ -50,12 +52,14 @@ static inline const std::string statusToString(
 // Forward declaration for notification QP setup
 static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
                                    const std::string& peer_gid_str,
-                                   uint16_t peer_lid, uint32_t peer_qp_num);
+                                   uint16_t peer_lid, uint32_t peer_qp_num,
+                                   uint16_t pkey_index);
 
-RdmaEndPoint::RdmaEndPoint() : status_(EP_UNINIT) {}
+RdmaEndPoint::RdmaEndPoint()
+    : status_(EP_UNINIT) {}
 
 RdmaEndPoint::~RdmaEndPoint() {
-    if (status_ != EP_UNINIT) deconstruct();
+    if (status_.load(std::memory_order_relaxed) != EP_UNINIT) deconstruct();
     if (endpoints_count_)
         endpoints_count_->fetch_sub(1, std::memory_order_relaxed);
 }
@@ -118,7 +122,7 @@ int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
     ibv_qp_attr qp_attr;
     memset(&qp_attr, 0, sizeof(qp_attr));
     qp_attr.qp_state = IBV_QPS_INIT;
-    qp_attr.pkey_index = 0;
+    qp_attr.pkey_index = params_->pkey_index;
     qp_attr.port_num = context_->portNum();
     qp_attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE;
 
@@ -160,7 +164,7 @@ int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
         }
     }
 
-    status_ = EP_HANDSHAKING;
+    status_.store(EP_HANDSHAKING, std::memory_order_relaxed);
     return 0;
 }
 
@@ -170,8 +174,10 @@ int RdmaEndPoint::deconstruct() {
 }
 
 int RdmaEndPoint::deconstructUnlocked() {
-    if (status_ == EP_UNINIT) return 0;
-    status_ = EP_RESET;
+    auto current_status = status_.load(std::memory_order_relaxed);
+    // Idempotent: if already destroyed or never initialized, skip cleanup
+    if (current_status == EP_DESTROYED || current_status == EP_UNINIT) return 0;
+    status_.store(EP_DESTROYED, std::memory_order_relaxed);
     resetInflightSlices();
     peer_qp_num_list_.clear();
 
@@ -214,8 +220,94 @@ int RdmaEndPoint::deconstructUnlocked() {
     wr_depth_list_ = nullptr;
     peer_server_name_.clear();
     peer_nic_name_.clear();
-    status_ = EP_UNINIT;
+    // Status remains EP_DESTROYED (unidirectional lifecycle)
     return 0;
+}
+
+void RdmaEndPoint::beginDestroy() {
+    RWSpinlock::WriteGuard guard(lock_);
+    beginDestroyNoLock();
+}
+
+void RdmaEndPoint::beginDestroyNoLock() {
+    auto current_status = status_.load(std::memory_order_relaxed);
+    if (current_status == EP_DESTROYING || current_status == EP_DESTROYED) return;
+
+    destroy_start_time_ = getCurrentTimeInNano();
+    status_.store(EP_DESTROYING, std::memory_order_release);
+
+    // Transition QPs to ERR state so hardware flushes inflight WRs to CQ
+    ibv_qp_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_ERR;
+
+    for (size_t i = 0; i < qp_list_.size(); ++i) {
+        int ret =
+            context_->verbs_.ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE);
+        if (ret) {
+            PLOG(ERROR) << "Failed to modify QP to ERR in beginDestroy";
+        }
+    }
+}
+
+bool RdmaEndPoint::finishDestroy() {
+    RWSpinlock::WriteGuard guard(lock_);
+    auto current_status = status_.load(std::memory_order_relaxed);
+
+    // Gate 1: already done
+    if (current_status == EP_DESTROYED) return true;
+
+    // Gate 2: non-two-phase path. Endpoint reached waiting_list_ without
+    // going through beginDestroy(). This handles edge cases and serves as
+    // a safety net. Endpoints that never reached construct() own no RDMA
+    // resources; drop them directly.
+    if (current_status != EP_DESTROYING) {
+        if (qp_list_.empty()) {
+            status_.store(EP_DESTROYED, std::memory_order_relaxed);
+            return true;
+        }
+        LOG(WARNING) << "finishDestroy called in unexpected state: "
+                     << statusToString(current_status)
+                     << ", forcing destruction to avoid waiting_list_ leak";
+        // Fall through to the unified destroy path
+    } else {
+        // Gate 3: two-phase path. Wait for inflight WRs to drain via CQ
+        // polling. If ibv_modify_qp-to-ERR failed in beginDestroy, WRs may
+        // never be flushed; enforce a timeout to avoid leaking forever.
+        bool has_outstanding = false;
+        for (size_t i = 0; i < qp_list_.size(); ++i) {
+            if (wr_depth_list_[i].value != 0) {
+                has_outstanding = true;
+                break;
+            }
+        }
+        if (has_outstanding) {
+            double elapsed = (getCurrentTimeInNano() - destroy_start_time_) / 1e9;
+            if (elapsed < kFinishDestroyTimeoutSec) {
+                return false;  // Still waiting for WRs to drain
+            }
+            LOG(WARNING) << "finishDestroy timed out after " << elapsed
+                         << "s with outstanding WRs, forcing destruction";
+        }
+    }
+
+    // Unified destroy: tear down QPs and bound retries to avoid
+    // log flooding when ibv_destroy_qp fails permanently.
+    int ret = deconstructUnlocked();
+    if (ret) {
+        finish_destroy_retries_++;
+        LOG(ERROR) << "Failed to finish destroying endpoint (attempt "
+                   << finish_destroy_retries_ << "/" << kFinishDestroyMaxRetries
+                   << "): " << ret;
+        if (finish_destroy_retries_ < kFinishDestroyMaxRetries) {
+            return false;  // Retry later
+        }
+        LOG(ERROR) << "Giving up after " << finish_destroy_retries_
+                   << " retries (possible resource leak)";
+    }
+
+    status_.store(EP_DESTROYED, std::memory_order_relaxed);
+    return true;
 }
 
 Status RdmaEndPoint::connect(const std::string& peer_server_name,
@@ -234,13 +326,14 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
     {
         RWSpinlock::WriteGuard guard(lock_);
         if (peer_server_name.empty() || peer_nic_name.empty()) {
-            return Status::InvalidArgument("Invalid peer path" LOC_MARK);
+            return mooncake::tent::Status::InvalidArgument(
+                "Invalid peer path" LOC_MARK);
         }
-        if (status_ == EP_READY) {
-            return Status::OK();
+        if (status_.load(std::memory_order_relaxed) == EP_READY) {
+            return mooncake::tent::Status::OK();
         }
-        if (status_ != EP_HANDSHAKING) {
-            return Status::InvalidArgument(
+        if (status_.load(std::memory_order_relaxed) != EP_HANDSHAKING) {
+            return mooncake::tent::Status::InvalidArgument(
                 "Endpoint not in handshaking state" LOC_MARK);
         }
 
@@ -270,7 +363,7 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         // Same server, different NIC: call handler directly, bypass RPC
         int rc = transport.onSetupRdmaConnections(local_desc, peer_desc);
         if (rc != 0) {
-            return Status::InternalError(
+            return mooncake::tent::Status::InternalError(
                 "Local bootstrap failed: " + peer_desc.reply_msg + LOC_MARK);
         }
         qp_num = peer_desc.qp_num;
@@ -282,22 +375,24 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         if (rpc_server_addr.empty()) {
             SegmentDescRef segment_desc;
             auto& manager = transport.metadata_->segmentManager();
-            CHECK_STATUS(manager.getRemote(segment_desc, peer_server_name));
+            auto status = manager.getRemote(segment_desc, peer_server_name);
+            if (!status.ok()) return status;
             rpc_server_addr = segment_desc->rpc_server_addr;
         }
         if (rpc_server_addr.empty()) {
-            return Status::InvalidArgument(
+            return mooncake::tent::Status::InvalidArgument(
                 "Missing peer RPC server address" LOC_MARK);
         }
-        CHECK_STATUS(
-            ControlClient::bootstrap(rpc_server_addr, local_desc, peer_desc));
+        auto bootstrap_status =
+            ControlClient::bootstrap(rpc_server_addr, local_desc, peer_desc);
+        if (!bootstrap_status.ok()) return bootstrap_status;
         qp_num = peer_desc.qp_num;
         peer_gid = peer_desc.local_gid;
         peer_lid = peer_desc.local_lid;
     }
 
     if (peer_gid.empty()) {
-        return Status::InvalidArgument(
+        return mooncake::tent::Status::InvalidArgument(
             "Missing peer GID in bootstrap" LOC_MARK);
     }
 
@@ -306,11 +401,11 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
     // connection while we were doing bootstrap without the lock.
     {
         RWSpinlock::WriteGuard guard(lock_);
-        if (status_ == EP_READY) {
-            return Status::OK();
+        if (status_.load(std::memory_order_relaxed) == EP_READY) {
+            return mooncake::tent::Status::OK();
         }
-        if (status_ != EP_HANDSHAKING) {
-            return Status::InvalidArgument(
+        if (status_.load(std::memory_order_relaxed) != EP_HANDSHAKING) {
+            return mooncake::tent::Status::InvalidArgument(
                 "Endpoint state changed during bootstrap" LOC_MARK);
         }
 
@@ -319,7 +414,7 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         peer_nic_name_ = peer_nic_name;
         int rc = setupAllQPs(peer_gid, peer_lid, qp_num);
         if (rc) {
-            return Status::InternalError(
+            return mooncake::tent::Status::InternalError(
                 "Failed to configure RDMA endpoint" LOC_MARK);
         }
         peer_qp_num_list_ = qp_num;
@@ -327,7 +422,8 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         // Setup notification QP connection if peer supports it
         if (peer_desc.notify_qp_num != 0 && notify_qp_) {
             rc = setupNotifyQpConnection(notify_qp_, context_, peer_gid,
-                                         peer_lid, peer_desc.notify_qp_num);
+                                         peer_lid, peer_desc.notify_qp_num,
+                                         params_->pkey_index);
             if (rc) {
                 LOG(WARNING)
                     << "Failed to setup notification QP, notification disabled";
@@ -340,13 +436,13 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         }
     }
 
-    return Status::OK();
+    return mooncake::tent::Status::OK();
 }
 
 Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
                             BootstrapDesc& local_desc) {
     RWSpinlock::WriteGuard guard(lock_);
-    if (status_ == EP_READY) {
+    if (status_.load(std::memory_order_relaxed) == EP_READY) {
         // Idempotency check: if the incoming bootstrap is from the same peer
         // and carries the same peer QP list as the established connection,
         // this is a duplicate request (e.g. from a concurrent connect() on
@@ -371,19 +467,21 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
             local_desc.local_lid = context_->lid();
             local_desc.local_gid = context_->gid();
             local_desc.notify_qp_num = notifyQpNum();
-            return Status::OK();
+            return mooncake::tent::Status::OK();
         }
-        LOG(WARNING) << "Endpoint is established with " << peer_nic_name_
-                     << " of " << peer_server_name_ << ", resetting first";
-        resetUnlocked();
-        status_ = EP_HANDSHAKING;
-    } else if (status_ == EP_RESET) {
-        resetUnlocked();
-        status_ = EP_HANDSHAKING;
-    } else if (status_ != EP_HANDSHAKING) {
+        // Endpoint already connected to a different peer - reject the request
+        // instead of resetting. Endpoints have unidirectional lifecycle and
+        // are never reset or reused. The caller should create a new endpoint.
+        LOG(ERROR) << "Endpoint already established with " << peer_nic_name_
+                   << " of " << peer_server_name_
+                   << ", cannot accept new connection (unidirectional lifecycle)";
+        return mooncake::tent::Status::InternalError(
+            "Endpoint already connected to different peer" LOC_MARK);
+    }
+    if (status_.load(std::memory_order_relaxed) != EP_HANDSHAKING) {
         LOG(ERROR) << "Endpoint not in handshaking state: "
-                   << statusToString(status_);
-        return Status::InvalidArgument(
+                   << statusToString(status_.load(std::memory_order_relaxed));
+        return mooncake::tent::Status::InvalidArgument(
             "Endpoint not in handshaking state" LOC_MARK);
     }
     auto& transport = context_->transport_;
@@ -391,7 +489,8 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     auto peer_server_name = getServerNameFromNicPath(peer_nic_path);
     auto peer_nic_name = getNicNameFromNicPath(peer_nic_path);
     if (peer_server_name.empty() || peer_nic_name.empty())
-        return Status::InvalidArgument("Invalid peer path" LOC_MARK);
+        return mooncake::tent::Status::InvalidArgument(
+            "Invalid peer path" LOC_MARK);
     local_desc.local_nic_path =
         MakeNicPath(transport.local_segment_name_, context_->name());
     local_desc.peer_nic_path = peer_nic_path;
@@ -400,7 +499,7 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     local_desc.local_gid = context_->gid();
     local_desc.notify_qp_num = notifyQpNum();  // Pass notification QP number
     if (peer_desc.local_gid.empty()) {
-        return Status::InvalidArgument(
+        return mooncake::tent::Status::InvalidArgument(
             "Missing peer GID in bootstrap" LOC_MARK);
     }
     peer_server_name_ = peer_server_name;
@@ -408,16 +507,16 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     int rc =
         setupAllQPs(peer_desc.local_gid, peer_desc.local_lid, peer_desc.qp_num);
     if (rc) {
-        return Status::InternalError(
+        return mooncake::tent::Status::InternalError(
             "Failed to configure RDMA endpoint" LOC_MARK);
     }
     peer_qp_num_list_ = peer_desc.qp_num;
 
     // Setup notification QP connection if peer supports it
     if (peer_desc.notify_qp_num != 0 && notify_qp_) {
-        rc = setupNotifyQpConnection(notify_qp_, context_, peer_desc.local_gid,
-                                     peer_desc.local_lid,
-                                     peer_desc.notify_qp_num);
+        rc = setupNotifyQpConnection(
+            notify_qp_, context_, peer_desc.local_gid, peer_desc.local_lid,
+            peer_desc.notify_qp_num, params_->pkey_index);
         if (rc) {
             notify_connected_ = false;
         } else {
@@ -427,54 +526,48 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
         }
     }
 
-    return Status::OK();
+    return mooncake::tent::Status::OK();
 }
 
 int RdmaEndPoint::reset() {
-    RWSpinlock::WriteGuard guard(lock_);
-    return resetUnlocked();
+    // Endpoints have unidirectional lifecycle and are never reset.
+    // This function is deprecated and always returns error.
+    // Use resetConnection() to mark an endpoint for destruction instead.
+    LOG(WARNING) << "reset() called on endpoint with unidirectional lifecycle, "
+                 << "use resetConnection() instead";
+    return -1;
 }
 
-int RdmaEndPoint::resetUnlocked() {
-    if (status_ != EP_READY) return 0;
-    status_ = EP_RESET;
-    peer_qp_num_list_.clear();
-    resetInflightSlices();
+int RdmaEndPoint::resetConnection(const std::string& reason) {
+    // Mark endpoint for destruction due to failure or error.
+    // Endpoints have unidirectional lifecycle - once marked for destruction,
+    // they are never reused. The endpoint store will create a new endpoint
+    // for future connections.
+    RdmaEndPoint* endpoint_ptr = this;
 
-    if (notify_qp_) {
-        // Keep the QP registered in the transport map — the qp_num doesn't
-        // change across resets, and the notify worker may still poll
-        // completions (flush errors) from the CQ between reset and reconnect.
-        // Unregistering here would cause "unknown QP" warnings.
-        notify_connected_ = false;
-        {
-            std::lock_guard<std::mutex> lock(notify_send_mutex_);
-            notify_pending_count_ = 0;
-        }
-        notify_send_cv_.notify_all();
+    {
+        RWSpinlock::WriteGuard guard(lock_);
+        auto curr_status = status_.load(std::memory_order_acquire);
+        if (curr_status == EP_DESTROYING || curr_status == EP_DESTROYED) return 0;
+        if (curr_status != EP_HANDSHAKING && curr_status != EP_READY) return 0;
+
+        destroy_start_time_ = getCurrentTimeInNano();
+        status_.store(EP_DESTROYING, std::memory_order_release);
+        LOG(INFO) << "Endpoint marked for destruction: " << reason;
     }
 
-    ibv_qp_attr attr;
-    memset(&attr, 0, sizeof(attr));
-    attr.qp_state = IBV_QPS_RESET;
-    for (size_t i = 0; i < qp_list_.size(); ++i) {
-        int ret =
-            context_->verbs_.ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE);
-        if (ret) {
-            PLOG(ERROR) << "ibv_modify_qp(RESET)";
-            deconstructUnlocked();
-            return -1;
-        }
-        cancelQuota(i, wr_depth_list_[i].value);
-    }
+    // Delete from endpoint store so endpoint() won't return this endpoint.
+    // remove() calls beginDestroyNoLock() to avoid deadlocking when
+    // caller already holds lock_.
+    context_->endpointStore()->remove(endpoint_ptr);
     return 0;
 }
 
 int RdmaEndPoint::setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
                               std::vector<uint32_t> peer_qp_num_list,
                               std::string* reply_msg) {
-    if (status_ == EP_READY) {
-        status_ = EP_RESET;
+    if (status_.load(std::memory_order_relaxed) == EP_READY) {
+        status_.store(EP_DESTROYING, std::memory_order_relaxed);
         return -1;
     }
 
@@ -485,7 +578,7 @@ int RdmaEndPoint::setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
            << peer_nic_name_ << " of " << peer_server_name_;
         LOG(ERROR) << ss.str();
         if (reply_msg) *reply_msg = ss.str();
-        status_ = EP_RESET;
+        status_.store(EP_DESTROYING, std::memory_order_relaxed);
         return -1;
     }
 
@@ -493,12 +586,12 @@ int RdmaEndPoint::setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
         int ret = setupOneQP(qp_index, peer_gid, peer_lid,
                              peer_qp_num_list[qp_index], reply_msg);
         if (ret) {
-            status_ = EP_RESET;
+            status_.store(EP_DESTROYING, std::memory_order_relaxed);
             return ret;
         }
     }
 
-    status_ = EP_READY;
+    status_.store(EP_READY, std::memory_order_relaxed);
     return 0;
 }
 
@@ -520,7 +613,9 @@ int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
     if (qp_list_.empty()) return 0;
     if (qp_index < 0) qp_index = 0;
     qp_index %= qp_list_.size();
-    if (status_ != EP_READY) return 0;
+    // Check endpoint status before submitting
+    if (status_.load(std::memory_order_relaxed) != EP_READY)
+        return 0;
     auto cq = context_->cq(qp_index % context_->cqCount());
     int wr_count =
         std::min(cq->maxCqe() - cq->getQuota(),
@@ -586,7 +681,9 @@ int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
 
 int RdmaEndPoint::submitRecvImmDataRequest(int qp_index, uint64_t id) {
     RWSpinlock::ReadGuard guard(lock_);
-    if (status_ != EP_READY) return 0;
+    // Check endpoint status before submitting
+    if (status_.load(std::memory_order_relaxed) != EP_READY)
+        return 0;
     if (qp_index < 0 || qp_index >= (int)qp_list_.size()) return 0;
     ibv_recv_wr wr, *bad_wr;
     memset(&wr, 0, sizeof(ibv_recv_wr));
@@ -788,7 +885,8 @@ void RdmaEndPoint::repostAllNotifyRecvs() {
 
 static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
                                    const std::string& peer_gid_str,
-                                   uint16_t peer_lid, uint32_t peer_qp_num) {
+                                   uint16_t peer_lid, uint32_t peer_qp_num,
+                                   uint16_t pkey_index) {
     // Reconnect path may call this when QP is already in RTS; force a clean
     // state machine: RESET -> INIT -> RTR -> RTS.
     ibv_qp_attr qp_attr = {};
@@ -801,7 +899,7 @@ static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
 
     memset(&qp_attr, 0, sizeof(qp_attr));
     qp_attr.qp_state = IBV_QPS_INIT;
-    qp_attr.pkey_index = 0;
+    qp_attr.pkey_index = pkey_index;
     qp_attr.port_num = ctx->portNum();
     qp_attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE;
     ret = ibv_modify_qp(

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
@@ -28,7 +28,7 @@
 
 namespace mooncake {
 namespace tent {
-std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::get(const std::string &key) {
+std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::get(const std::string& key) {
     RWSpinlock::ReadGuard guard(endpoint_map_lock_);
     auto iter = endpoint_map_.find(key);
     if (iter != endpoint_map_.end()) return iter->second;
@@ -36,12 +36,38 @@ std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::get(const std::string &key) {
 }
 
 std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::getOrInsert(
-    const std::string &key) {
+    const std::string& key) {
     auto endpoint = get(key);
-    if (endpoint) return endpoint;
+    // Endpoints have unidirectional lifecycle - if existing endpoint is
+    // in terminal state (destroying/destroyed), remove it and create new.
+    if (endpoint) {
+        auto status = endpoint->status();
+        if (status == RdmaEndPoint::EP_DESTROYING ||
+            status == RdmaEndPoint::EP_DESTROYED) {
+            remove(endpoint.get());
+            endpoint = nullptr;
+        } else {
+            return endpoint;
+        }
+    }
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
-    if (endpoint_map_.find(key) != endpoint_map_.end())
-        return endpoint_map_[key];
+    // Double-check after acquiring write lock
+    auto iter = endpoint_map_.find(key);
+    if (iter != endpoint_map_.end()) {
+        auto ep = iter->second;
+        auto status = ep->status();
+        if (status == RdmaEndPoint::EP_DESTROYING ||
+            status == RdmaEndPoint::EP_DESTROYED) {
+            waiting_list_.insert(ep);
+            endpoint_map_.erase(iter);
+            auto fifo_iter = fifo_map_[key];
+            fifo_list_.erase(fifo_iter);
+            fifo_map_.erase(key);
+            // Fall through to create new endpoint
+        } else {
+            return ep;
+        }
+    }
     endpoint = std::make_shared<RdmaEndPoint>();
     int ret = endpoint->construct(&context_, &context_.params().endpoint, key);
     if (ret) {
@@ -56,18 +82,29 @@ std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::getOrInsert(
     return endpoint;
 }
 
-int FIFOEndpointStore::remove(RdmaEndPoint *ep) {
+int FIFOEndpointStore::remove(RdmaEndPoint* ep) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
-    auto key = ep->name();
-    auto iter = endpoint_map_.find(key);
-    if (iter != endpoint_map_.end() && iter->second.get() == ep) {
-        waiting_list_.insert(iter->second);
-        endpoint_map_.erase(iter);
-        auto fifo_iter = fifo_map_[key];
-        fifo_list_.erase(fifo_iter);
-        fifo_map_.erase(key);
+    // Search for and remove the endpoint by pointer comparison
+    for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end();
+         ++iter) {
+        if (iter->second.get() == ep) {
+            waiting_list_.insert(iter->second);
+            iter->second->beginDestroy();
+            auto fifo_iter = fifo_map_[iter->first];
+            fifo_list_.erase(fifo_iter);
+            fifo_map_.erase(iter->first);
+            endpoint_map_.erase(iter);
+            return 0;
+        }
     }
-    return 0;
+    // If not found in endpoint_map, check if it's in waiting_list
+    for (const auto& waiting_ep : waiting_list_) {
+        if (waiting_ep.get() == ep) {
+            // Already in waiting list, no action needed
+            return 0;
+        }
+    }
+    return -1;  // Endpoint not found
 }
 
 void FIFOEndpointStore::evictOne() {
@@ -75,17 +112,20 @@ void FIFOEndpointStore::evictOne() {
     std::string victim = fifo_list_.front();
     fifo_list_.pop_front();
     fifo_map_.erase(victim);
-    waiting_list_.insert(endpoint_map_[victim]);
+    auto victim_endpoint = endpoint_map_[victim];
+    victim_endpoint->beginDestroy();
+    waiting_list_.insert(victim_endpoint);
     endpoint_map_.erase(victim);
+    LOG(INFO) << victim << " evicted from FIFOEndpointStore";
 }
 
 void FIFOEndpointStore::reclaim() {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     std::vector<std::shared_ptr<RdmaEndPoint>> to_delete;
-    for (auto &endpoint : waiting_list_) {
-        if (!endpoint->getInflightSlices()) to_delete.push_back(endpoint);
+    for (auto& endpoint : waiting_list_) {
+        if (endpoint->finishDestroy()) to_delete.push_back(endpoint);
     }
-    for (auto &endpoint : to_delete) waiting_list_.erase(endpoint);
+    for (auto& endpoint : to_delete) waiting_list_.erase(endpoint);
 }
 
 size_t FIFOEndpointStore::size() { return endpoint_map_.size(); }
@@ -93,8 +133,8 @@ size_t FIFOEndpointStore::size() { return endpoint_map_.size(); }
 void FIFOEndpointStore::clear() {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     std::vector<std::string> to_delete;
-    for (auto &entry : endpoint_map_) to_delete.push_back(entry.first);
-    for (auto &key : to_delete) {
+    for (auto& entry : endpoint_map_) to_delete.push_back(entry.first);
+    for (auto& key : to_delete) {
         endpoint_map_.erase(key);
         auto fifo_iter = fifo_map_[key];
         fifo_list_.erase(fifo_iter);
@@ -102,7 +142,7 @@ void FIFOEndpointStore::clear() {
     }
 }
 
-std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::get(const std::string &key) {
+std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::get(const std::string& key) {
     RWSpinlock::ReadGuard guard(endpoint_map_lock_);
     auto iter = endpoint_map_.find(key);
     if (iter != endpoint_map_.end()) {
@@ -113,12 +153,42 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::get(const std::string &key) {
 }
 
 std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::getOrInsert(
-    const std::string &key) {
+    const std::string& key) {
     auto endpoint = get(key);
-    if (endpoint) return endpoint;
+    // Endpoints have unidirectional lifecycle - if existing endpoint is
+    // in terminal state (destroying/destroyed), remove it and create new.
+    if (endpoint) {
+        auto status = endpoint->status();
+        if (status == RdmaEndPoint::EP_DESTROYING ||
+            status == RdmaEndPoint::EP_DESTROYED) {
+            remove(endpoint.get());
+            endpoint = nullptr;
+        } else {
+            return endpoint;
+        }
+    }
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
-    if (endpoint_map_.find(key) != endpoint_map_.end()) {
-        return endpoint_map_[key].first;
+    // Double-check after acquiring write lock
+    auto iter = endpoint_map_.find(key);
+    if (iter != endpoint_map_.end()) {
+        auto ep = iter->second.first;
+        auto status = ep->status();
+        if (status == RdmaEndPoint::EP_DESTROYING ||
+            status == RdmaEndPoint::EP_DESTROYED) {
+            waiting_list_len_++;
+            waiting_list_.insert(ep);
+            auto fifo_iter = fifo_map_[key];
+            if (hand_.has_value() && hand_.value() == fifo_iter) {
+                fifo_iter == fifo_list_.begin() ? hand_ = std::nullopt
+                                                : hand_ = std::prev(fifo_iter);
+            }
+            fifo_list_.erase(fifo_iter);
+            fifo_map_.erase(key);
+            endpoint_map_.erase(iter);
+            // Fall through to create new endpoint
+        } else {
+            return ep;
+        }
     }
     endpoint = std::make_shared<RdmaEndPoint>();
     int ret = endpoint->construct(&context_, &context_.params().endpoint, key,
@@ -135,23 +205,34 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::getOrInsert(
     return endpoint;
 }
 
-int SIEVEEndpointStore::remove(RdmaEndPoint *ep) {
+int SIEVEEndpointStore::remove(RdmaEndPoint* ep) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
-    auto key = ep->name();
-    auto iter = endpoint_map_.find(key);
-    if (iter != endpoint_map_.end() && iter->second.first.get() == ep) {
-        waiting_list_len_++;
-        waiting_list_.insert(iter->second.first);
-        endpoint_map_.erase(iter);
-        auto fifo_iter = fifo_map_[key];
-        if (hand_.has_value() && hand_.value() == fifo_iter) {
-            fifo_iter == fifo_list_.begin() ? hand_ = std::nullopt
-                                            : hand_ = std::prev(fifo_iter);
+    // Search for and remove the endpoint by pointer comparison
+    for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end();
+         ++iter) {
+        if (iter->second.first.get() == ep) {
+            waiting_list_len_++;
+            waiting_list_.insert(iter->second.first);
+            iter->second.first->beginDestroy();
+            auto fifo_iter = fifo_map_[iter->first];
+            if (hand_.has_value() && hand_.value() == fifo_iter) {
+                fifo_iter == fifo_list_.begin() ? hand_ = std::nullopt
+                                                : hand_ = std::prev(fifo_iter);
+            }
+            fifo_list_.erase(fifo_iter);
+            fifo_map_.erase(iter->first);
+            endpoint_map_.erase(iter);
+            return 0;
         }
-        fifo_list_.erase(fifo_iter);
-        fifo_map_.erase(key);
     }
-    return 0;
+    // If not found in endpoint_map, check if it's in waiting_list
+    for (const auto& waiting_ep : waiting_list_) {
+        if (waiting_ep.get() == ep) {
+            // Already in waiting list, no action needed
+            return 0;
+        }
+    }
+    return -1;  // Endpoint not found
 }
 
 void SIEVEEndpointStore::evictOne() {
@@ -174,6 +255,7 @@ void SIEVEEndpointStore::evictOne() {
     fifo_list_.erase(o);
     fifo_map_.erase(victim);
     auto victim_instance = endpoint_map_[victim].first;
+    victim_instance->beginDestroy();
     waiting_list_len_++;
     waiting_list_.insert(victim_instance);
     endpoint_map_.erase(victim);
@@ -185,10 +267,10 @@ void SIEVEEndpointStore::reclaim() {
     if (waiting_list_len_.load(std::memory_order_relaxed) == 0) return;
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     std::vector<std::shared_ptr<RdmaEndPoint>> to_delete;
-    for (auto &endpoint : waiting_list_) {
-        if (!endpoint->getInflightSlices()) to_delete.push_back(endpoint);
+    for (auto& endpoint : waiting_list_) {
+        if (endpoint->finishDestroy()) to_delete.push_back(endpoint);
     }
-    for (auto &endpoint : to_delete) waiting_list_.erase(endpoint);
+    for (auto& endpoint : to_delete) waiting_list_.erase(endpoint);
     waiting_list_len_ -= to_delete.size();
 }
 
@@ -197,8 +279,8 @@ size_t SIEVEEndpointStore::size() { return endpoint_map_.size(); }
 void SIEVEEndpointStore::clear() {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     std::vector<std::string> to_delete;
-    for (auto &entry : endpoint_map_) to_delete.push_back(entry.first);
-    for (auto &key : to_delete) {
+    for (auto& entry : endpoint_map_) to_delete.push_back(entry.first);
+    for (auto& key : to_delete) {
         endpoint_map_.erase(key);
         auto fifo_iter = fifo_map_[key];
         if (hand_.has_value() && hand_.value() == fifo_iter) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
@@ -89,7 +89,7 @@ int FIFOEndpointStore::remove(RdmaEndPoint* ep) {
          ++iter) {
         if (iter->second.get() == ep) {
             waiting_list_.insert(iter->second);
-            iter->second->beginDestroy();
+            iter->second->beginDestroyNoLock();
             auto fifo_iter = fifo_map_[iter->first];
             fifo_list_.erase(fifo_iter);
             fifo_map_.erase(iter->first);
@@ -213,7 +213,7 @@ int SIEVEEndpointStore::remove(RdmaEndPoint* ep) {
         if (iter->second.first.get() == ep) {
             waiting_list_len_++;
             waiting_list_.insert(iter->second.first);
-            iter->second.first->beginDestroy();
+            iter->second.first->beginDestroyNoLock();
             auto fifo_iter = fifo_map_[iter->first];
             if (hand_.has_value() && hand_.value() == fifo_iter) {
                 fifo_iter == fifo_list_.begin() ? hand_ = std::nullopt

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
@@ -17,9 +17,9 @@
 namespace mooncake {
 namespace tent {
 
-Status RailMonitor::load(const Topology *local, const Topology *remote,
-                         const std::string &rail_topo_json,
-                         const Config *conf) {
+Status RailMonitor::load(const Topology* local, const Topology* remote,
+                         const std::string& rail_topo_json,
+                         const Config* conf) {
     local_ = local;
     remote_ = remote;
     if (conf) {
@@ -43,7 +43,7 @@ Status RailMonitor::load(const Topology *local, const Topology *remote,
 bool RailMonitor::available(int local_nic, int remote_nic) {
     auto it = rail_states_.find(std::make_pair(local_nic, remote_nic));
     if (it == rail_states_.end()) return false;
-    auto &st = it->second;
+    auto& st = it->second;
     if (!st.paused()) return true;
     if (std::chrono::steady_clock::now() < st.resume_time) return false;
     // Cooldown expired: clear all exponential-backoff memory so a fresh
@@ -60,7 +60,7 @@ bool RailMonitor::available(int local_nic, int remote_nic) {
 void RailMonitor::markFailed(int local_nic, int remote_nic) {
     auto it = rail_states_.find(std::make_pair(local_nic, remote_nic));
     if (it == rail_states_.end()) return;
-    auto &st = it->second;
+    auto& st = it->second;
     auto now = std::chrono::steady_clock::now();
     if (st.error_count == 0 || now - st.last_error > error_window_) {
         st.error_count = 1;
@@ -83,7 +83,7 @@ void RailMonitor::markFailed(int local_nic, int remote_nic) {
 void RailMonitor::markRecovered(int local_nic, int remote_nic) {
     auto it = rail_states_.find(std::make_pair(local_nic, remote_nic));
     if (it == rail_states_.end()) return;
-    auto &st = it->second;
+    auto& st = it->second;
     // Fast path: a healthy rail stays healthy. 99%+ of completions land
     // here, so we must not touch best_mapping_ or write any field.
     if (!st.paused() && st.error_count == 0 && st.cooldown.count() == 0) return;
@@ -129,7 +129,7 @@ int RailMonitor::findBestRemoteDevice(int local_nic, int remote_numa) {
  *   ]
  * }
  */
-Status RailMonitor::loadFromJson(const std::string &rail_topo_json) {
+Status RailMonitor::loadFromJson(const std::string& rail_topo_json) {
     try {
         auto root = json::parse(rail_topo_json);
 
@@ -137,7 +137,7 @@ Status RailMonitor::loadFromJson(const std::string &rail_topo_json) {
         direct_rails_.clear();
 
         if (root.contains("all")) {
-            for (const auto &path_entry : root["all"]) {
+            for (const auto& path_entry : root["all"]) {
                 std::string local_nic_name = path_entry.value("local", "");
                 std::string remote_nic_name = path_entry.value("remote", "");
                 int local_nic_id = local_->getNicId(local_nic_name);
@@ -153,7 +153,7 @@ Status RailMonitor::loadFromJson(const std::string &rail_topo_json) {
         }
 
         if (root.contains("direct")) {
-            for (const auto &path_entry : root["direct"]) {
+            for (const auto& path_entry : root["direct"]) {
                 std::string local_nic_name = path_entry.value("local", "");
                 std::string remote_nic_name = path_entry.value("remote", "");
                 int local_nic_id = local_->getNicId(local_nic_name);
@@ -167,7 +167,7 @@ Status RailMonitor::loadFromJson(const std::string &rail_topo_json) {
                 }
             }
         }
-    } catch (const std::exception &ex) {
+    } catch (const std::exception& ex) {
         LOG(ERROR) << "Failed to parse rail_topo_json: " << ex.what();
         return Status::InvalidArgument("Failed to parse JSON" LOC_MARK);
     }
@@ -177,12 +177,12 @@ Status RailMonitor::loadFromJson(const std::string &rail_topo_json) {
     return Status::OK();
 }
 
-static int matchRemoteNicId(const Topology *local, const Topology *remote,
+static int matchRemoteNicId(const Topology* local, const Topology* remote,
                             int local_nic) {
     std::string mem_name;
     for (size_t i = 0; i < local->getMemCount(); ++i) {
         auto entry = local->getMemEntry(i);
-        auto &prior_devices = entry->device_list[0];
+        auto& prior_devices = entry->device_list[0];
         if (entry->type == Topology::MEM_CUDA && !prior_devices.empty() &&
             prior_devices[0] == local_nic) {
             mem_name = entry->name;
@@ -193,7 +193,7 @@ static int matchRemoteNicId(const Topology *local, const Topology *remote,
     auto mem_id = remote->getMemId(mem_name);
     if (mem_id < 0) return -1;
     auto entry = remote->getMemEntry(mem_id);
-    auto &prior_devices = entry->device_list[0];
+    auto& prior_devices = entry->device_list[0];
     if (entry->type == Topology::MEM_CUDA && !prior_devices.empty())
         return prior_devices[0];
     return -1;
@@ -214,6 +214,23 @@ Status RailMonitor::loadDefault() {
         auto local_entry = local_->getNicEntry(local_nic);
         if (local_entry->type != Topology::NIC_RDMA) continue;
         int numa_id = local_entry->numa_node;
+
+        // Priority 1: Same-name device matching (mlx5_0 -> mlx5_0)
+        bool matched = false;
+        auto local_nic_name = local_entry->name;
+        for (int remote_nic = 0; remote_nic < remote_nic_count; ++remote_nic) {
+            auto remote_entry = remote_->getNicEntry(remote_nic);
+            if (remote_entry && remote_entry->type == Topology::NIC_RDMA &&
+                remote_entry->name == local_nic_name) {
+                remote_load[remote_nic]++;
+                direct_rails_[local_nic] = remote_nic;
+                matched = true;
+                break;
+            }
+        }
+        if (matched) continue;
+
+        // Priority 2: CUDA memory topology matching (GPU-direct NIC)
         int remote_nic = matchRemoteNicId(local_, remote_, local_nic);
         if (remote_nic >= 0) {
             remote_load[remote_nic]++;
@@ -299,7 +316,7 @@ void RailMonitor::updateBestMapping() {
 
     for (size_t local_numa = 0; local_numa < kMaxNuma; ++local_numa) {
         for (size_t remote_numa = 0; remote_numa < kMaxNuma; ++remote_numa) {
-            auto &mapping = best_mapping_[remote_numa];
+            auto& mapping = best_mapping_[remote_numa];
             size_t local_cnt = local_devices[local_numa].size();
             size_t remote_cnt = remote_devices[remote_numa].size();
             if (!local_cnt || !remote_cnt) continue;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -164,7 +164,8 @@ static Status convertConfToRdmaParams(std::shared_ptr<Config> conf,
 }
 
 static bool isGpuDirectRdmaSupported(std::shared_ptr<Config> conf) {
-    auto disable_gpu_direct = conf->get("transports/rdma/disable_gpu_direct_rdma", false);
+    auto disable_gpu_direct =
+        conf->get("transports/rdma/disable_gpu_direct_rdma", false);
     if (disable_gpu_direct) {
         return false;
     }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -163,8 +163,9 @@ static Status convertConfToRdmaParams(std::shared_ptr<Config> conf,
     return Status::OK();
 }
 
-static bool isGpuDirectRdmaSupported() {
-    if (getenv("MC_DISABLE_GPU_DIRECT_RDMA")) {
+static bool isGpuDirectRdmaSupported(std::shared_ptr<Config> conf) {
+    auto disable_gpu_direct = conf->get("transports/rdma/disable_gpu_direct_rdma", false);
+    if (disable_gpu_direct) {
         return false;
     }
     std::ifstream modules("/proc/modules");
@@ -252,7 +253,7 @@ Status RdmaTransport::install(std::string& local_segment_name,
 
     installed_ = true;
     caps.dram_to_dram = true;
-    if (isGpuDirectRdmaSupported()) {
+    if (isGpuDirectRdmaSupported(conf_)) {
         caps.dram_to_gpu = true;
         caps.gpu_to_dram = true;
         caps.gpu_to_gpu = true;
@@ -558,10 +559,6 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
     std::shared_ptr<RdmaEndPoint> endpoint;
     std::string peer_name = MakeNicPath(segment_desc->name, target_dev_name);
     endpoint = context->endpointStore()->getOrInsert(peer_name);
-    if (endpoint && endpoint->status() == RdmaEndPoint::EP_RESET) {
-        context->endpointStore()->remove(endpoint.get());
-        endpoint = context->endpointStore()->getOrInsert(peer_name);
-    }
     if (!endpoint) {
         LOG(ERROR) << "Cannot allocate endpoint " << peer_name;
         return nullptr;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -178,10 +178,6 @@ std::shared_ptr<RdmaEndPoint> Workers::getEndpoint(Workers::PostPath path) {
     std::shared_ptr<RdmaEndPoint> endpoint;
     auto peer_name = MakeNicPath(target_seg_name, target_dev_name);
     endpoint = context->endpointStore()->getOrInsert(peer_name);
-    if (endpoint && endpoint->status() == RdmaEndPoint::EP_RESET) {
-        context->endpointStore()->remove(endpoint.get());
-        endpoint = context->endpointStore()->getOrInsert(peer_name);
-    }
     if (!endpoint) {
         LOG(ERROR) << "Cannot allocate endpoint " << peer_name;
         return nullptr;
@@ -462,7 +458,25 @@ int Workers::handleContextEvents(std::shared_ptr<RdmaContext>& context) {
 }
 
 void Workers::monitorThread() {
+    // Track time for periodic endpoint reclaim (1 Hz heartbeat)
+    auto last_reclaim_time = std::chrono::steady_clock::now();
+
     while (running_) {
+        // Periodic endpoint reclaim: runs every 1 second to drain waiting_list_
+        // Under failure load, insertions stall but endpoints still need cleanup
+        auto current_time = std::chrono::steady_clock::now();
+        auto time_since_last_reclaim =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                current_time - last_reclaim_time)
+                .count();
+
+        if (time_since_last_reclaim >= 1000) {  // 1 second = 1000 ms
+            for (auto& context : transport_->context_set_) {
+                context->endpointStore()->reclaim();
+            }
+            last_reclaim_time = current_time;
+        }
+
         for (auto& context : transport_->context_set_) {
             struct epoll_event event;
             if (context->eventFd() < 0) continue;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -205,7 +205,7 @@ void Workers::disableEndpoint(RdmaSlice* slice) {
     }
     if (auto ep = slice->ep_weak_ptr.lock()) {
         ep->acknowledge(slice, FAILED);
-        ep->reset();
+        ep->resetConnection("Endpoint failed");
     }
 }
 


### PR DESCRIPTION
## Description

This PR delivers comprehensive RDMA functionality improvements and bugfixes to TENT based on current's TE implementation. 

- Two-phase QP destruction: Implements safe destruction of Queue Pairs to avoid use-after-free in concurrent submitPostSend. Phase 1 (beginDestroy) transitions QPs to ERR state so hardware flushes inflight WRs to CQ; Phase 2 (finishDestroy) waits for outstanding WRs to drain before actually destroying QPs and freeing resources.
- Unidirectional endpoint lifecycle: Endpoints now progress monotonically through states (EP_UNINIT → EP_HANDSHAKING → EP_READY → EP_DESTROYING → EP_DESTROYED) and are never reset or reused. Failed endpoints are destroyed and new ones created for reconnection.
- PCIe Relaxed Ordering support: Adds detection and configuration support for PCIe Relaxed Ordering (requires ibv_reg_mr_iova2 symbol, IBVERBS_1.8+). Controlled via transports/rdma/pci_relaxed_ordering config.
- GPU Direct RDMA improvements: Adds CUDA context management in registerMemReg() for proper GPU memory registration from worker threads or non-CUDA threads.
- Rail monitoring improvements: Prioritizes same-name device matching (mlx5_0 → mlx5_0) over CUDA topology matching for rail selection.
- Periodic endpoint reclaim: Adds 1 Hz heartbeat in monitor thread to periodically call reclaim() and clean up endpoints in the waiting list.
- Legacy environment variable support: Maps MC_* environment variables to hierarchical config paths for backward compatibility.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?


## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
