### PR TITLE
[Doc] Fix the inconsistent param description

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -32,11 +32,11 @@ This page summarizes useful flags, environment variables, and HTTP endpoints to 
   - `--allow_evict_soft_pinned_objects` (bool, default `true`): Allow evicting soft-pinned objects.
   - `--eviction_ratio` (double, default `0.05`): Fraction evicted when hitting high watermark.
   - `--eviction_high_watermark_ratio` (double, default `0.95`): Usage ratio to trigger eviction.
+  - `--client_ttl` (int64, default `10` s): Seconds a client stays considered alive after the last heartbeat. If this TTL elapses without a refresh, the master treats the client as disconnected and may unmount its segments.
 
 - High Availability (optional)
   - `--enable_ha` (bool, default `false`): Enable HA (requires etcd).
   - `--etcd_endpoints` (str, default empty unless HA config): etcd endpoints, semicolon separated.
-  - `--client_ttl` (int64, default `10` s): Client alive TTL after last ping (HA mode).
   - `--cluster_id` (str, default `mooncake_cluster`): Cluster ID for persistence in HA mode.
 
 - Task Manager (optional)

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -122,8 +122,9 @@ DEFINE_string(
     etcd_endpoints, "",
     "Endpoints of ETCD server, separated by semicolon, required in HA mode");
 DEFINE_int64(client_ttl, mooncake::DEFAULT_CLIENT_LIVE_TTL_SEC,
-             "How long a client is considered alive after the last ping, only "
-             "used in HA mode");
+             "Seconds a client stays considered alive after the last heartbeat."
+             "If it expires without refresh, the master may unmount "
+             "that client's segments and mark it NEED_REMOUNT.");
 
 DEFINE_string(root_fs_dir, mooncake::DEFAULT_ROOT_FS_DIR,
               "Root directory for storage backend, used in HA mode");

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -123,8 +123,8 @@ DEFINE_string(
     "Endpoints of ETCD server, separated by semicolon, required in HA mode");
 DEFINE_int64(client_ttl, mooncake::DEFAULT_CLIENT_LIVE_TTL_SEC,
              "Seconds a client stays considered alive after the last heartbeat."
-             "If it expires without refresh, the master may unmount "
-             "that client's segments and mark it NEED_REMOUNT.");
+             "If this TTL elapses without a refresh, the master treats the "
+             "client as disconnected and may unmount its segments");
 
 DEFINE_string(root_fs_dir, mooncake::DEFAULT_ROOT_FS_DIR,
               "Root directory for storage backend, used in HA mode");


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Correct misleading documentation for client_ttl / client_live_ttl_sec: client liveness TTL applies in all master modes (driven by Ping and segment mount/remount), not only when HA is enabled. Updates include the --client_ttl gflag help text, the deployment guide (moved the flag under “Eviction and TTLs” with an accurate explanation and the client_live_ttl_sec config key).

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
