### PR TITLE
[Store] Fix: validate HA backend availability during config parsing

### DIFF
--- a/mooncake-store/include/ha/ha_types.h
+++ b/mooncake-store/include/ha/ha_types.h
@@ -52,6 +52,29 @@ inline std::optional<HABackendType> ParseHABackendType(std::string_view type) {
     return std::nullopt;
 }
 
+inline ErrorCode ValidateHABackendAvailability(HABackendType type) {
+    switch (type) {
+        case HABackendType::UNKNOWN:
+            return ErrorCode::INVALID_PARAMS;
+        case HABackendType::ETCD:
+#ifdef STORE_USE_ETCD
+            return ErrorCode::OK;
+#else
+            return ErrorCode::UNAVAILABLE_IN_CURRENT_MODE;
+#endif
+        case HABackendType::REDIS:
+#ifdef STORE_USE_REDIS
+            return ErrorCode::OK;
+#else
+            return ErrorCode::UNAVAILABLE_IN_CURRENT_MODE;
+#endif
+        case HABackendType::K8S:
+            return ErrorCode::UNAVAILABLE_IN_CURRENT_MODE;
+    }
+
+    return ErrorCode::INVALID_PARAMS;
+}
+
 struct HABackendSpec {
     HABackendType type = HABackendType::UNKNOWN;
     std::string connstring;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -241,6 +241,11 @@ tl::expected<std::optional<ha::HABackendSpec>, ErrorCode> ParseHABackendSpec(
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
+    auto availability = ha::ValidateHABackendAvailability(backend_type.value());
+    if (availability != ErrorCode::OK) {
+        return tl::make_unexpected(availability);
+    }
+
     return std::optional<ha::HABackendSpec>{ha::HABackendSpec{
         .type = backend_type.value(),
         .connstring = master_server_entry.substr(delimiter_pos + 3),

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -38,6 +38,11 @@ tl::expected<HABackendSpec, ErrorCode> BuildHABackendSpec(
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
+    auto availability = ValidateHABackendAvailability(backend_type.value());
+    if (availability != ErrorCode::OK) {
+        return tl::make_unexpected(availability);
+    }
+
     auto connstring = ResolveHABackendConnstring(config);
     if (connstring.empty()) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -143,6 +143,8 @@ endif()
 if(STORE_USE_ETCD OR STORE_USE_REDIS OR STORE_USE_K8S_LEASE)
   add_test(NAME high_availability_test COMMAND high_availability_test)
 endif()
+add_ha_test(ha_backend_availability_test
+            ha/leadership/ha_backend_availability_test.cpp)
 
 add_executable(stress_workload_test stress_workload_test.cpp)
 target_link_libraries(

--- a/mooncake-store/tests/ha/leadership/ha_backend_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/ha_backend_availability_test.cpp
@@ -1,8 +1,13 @@
 #include "ha/ha_types.h"
 
 #include <gtest/gtest.h>
+#include <ylt/util/tl/expected.hpp>
 
 namespace mooncake {
+
+tl::expected<std::optional<ha::HABackendSpec>, ErrorCode> ParseHABackendSpec(
+    const std::string& master_server_entry);
+
 namespace ha {
 namespace {
 
@@ -34,6 +39,13 @@ TEST(HABackendAvailabilityTest, RedisAvailabilityMatchesBuildFlag) {
 TEST(HABackendAvailabilityTest, K8sLeaseIsRejectedUntilCoordinatorExists) {
     EXPECT_EQ(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE,
               ValidateHABackendAvailability(HABackendType::K8S));
+}
+
+TEST(HABackendAvailabilityTest,
+     ClientSpecParsingRejectsUnavailableBackendBeforeCoordinatorCreation) {
+    auto spec = ParseHABackendSpec("k8s://default/master");
+    ASSERT_FALSE(spec.has_value());
+    EXPECT_EQ(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE, spec.error());
 }
 
 }  // namespace

--- a/mooncake-store/tests/ha/leadership/ha_backend_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/ha_backend_availability_test.cpp
@@ -1,0 +1,41 @@
+#include "ha/ha_types.h"
+
+#include <gtest/gtest.h>
+
+namespace mooncake {
+namespace ha {
+namespace {
+
+TEST(HABackendAvailabilityTest, UnknownBackendIsInvalid) {
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS,
+              ValidateHABackendAvailability(HABackendType::UNKNOWN));
+}
+
+TEST(HABackendAvailabilityTest, EtcdAvailabilityMatchesBuildFlag) {
+#ifdef STORE_USE_ETCD
+    EXPECT_EQ(ErrorCode::OK,
+              ValidateHABackendAvailability(HABackendType::ETCD));
+#else
+    EXPECT_EQ(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE,
+              ValidateHABackendAvailability(HABackendType::ETCD));
+#endif
+}
+
+TEST(HABackendAvailabilityTest, RedisAvailabilityMatchesBuildFlag) {
+#ifdef STORE_USE_REDIS
+    EXPECT_EQ(ErrorCode::OK,
+              ValidateHABackendAvailability(HABackendType::REDIS));
+#else
+    EXPECT_EQ(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE,
+              ValidateHABackendAvailability(HABackendType::REDIS));
+#endif
+}
+
+TEST(HABackendAvailabilityTest, K8sLeaseIsRejectedUntilCoordinatorExists) {
+    EXPECT_EQ(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE,
+              ValidateHABackendAvailability(HABackendType::K8S));
+}
+
+}  // namespace
+}  // namespace ha
+}  // namespace mooncake


### PR DESCRIPTION
## Description

Validate the configured HA backend against the backends compiled into the current binary before constructing the HA backend spec.

Previously, configuring `ha_backend_type=redis` in a build without `STORE_USE_REDIS` was accepted during config parsing and failed later when creating the Redis leader coordinator. This change moves the availability check earlier into `BuildHABackendSpec()`, returning `UNAVAILABLE_IN_CURRENT_MODE` during HA backend config validation.

Also updates the `--enable_ha` flag description to refer to the configured HA backend instead of etcd specifically.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- `cmake -S . -B build`
- `cmake --build build --target ha_backend_availability_test`
- `clang-format-20 -style=file --dry-run -Werror mooncake-store/src/master.cpp mooncake-store/include/ha/ha_types.h mooncake-store/src/ha/leadership/master_service_supervisor.cpp mooncake-store/tests/ha/leadership/ha_backend_availability_test.cpp`
- `ctest --test-dir build -R ha_backend_availability_test --output-on-failure`

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
