### PR TITLE
[EFA] Add MC_EFA_CQ_THREADS env var to cap CQ poller threads

### DIFF
--- a/docs/source/design/transfer-engine/efa_transport.md
+++ b/docs/source/design/transfer-engine/efa_transport.md
@@ -507,10 +507,11 @@ export LD_LIBRARY_PATH=/opt/amazon/efa/lib:$LD_LIBRARY_PATH
 
 > **Note on additional `MC_*` knobs:** `MC_NUM_CQ_PER_CTX`, `MC_MAX_WR`, `MC_MAX_CQE_PER_CTX`, `MC_SLICE_SIZE`, and `MC_EFA_STRIPING_THRESHOLD` are **not** required at typical PD-disagg loads — the SRD shared-endpoint refactor (#1944) makes them redundant up to high concurrency on 1k/1k traffic. Treat them as emergency switches for CQ-overflow or long-running drift symptoms.
 
-> **`MC_EFA_CQ_THREADS`** — caps the number of CQ polling threads spawned by the EFA transport. By default (unset or `0`), Mooncake creates one CQ poller thread per EFA context. When multiple EFA consumers coexist in the same process (e.g., Mooncake KV cache transfer + DeepEP/UCCL-EP MoE all-to-all), these pollers compete for CPU and can degrade the other consumer's latency. Set `MC_EFA_CQ_THREADS=1` to limit Mooncake to a single CQ poller, freeing CPU for other EFA consumers with no measurable impact on Mooncake transfer throughput.
+> **`MC_EFA_CQ_THREADS`** — caps the number of CQ polling threads spawned by the EFA transport. Default is `1`, which reaches 99.93% of peak GPU-to-GPU throughput while saving CPU for other workloads. Set to `0` to disable the cap (one poller per EFA context — the legacy behavior). Higher values (e.g., `MC_EFA_CQ_THREADS=4`) are available as an escape hatch for throughput tuning but rarely help in practice.
 >
 > ```bash
-> export MC_EFA_CQ_THREADS=1   # use 1 CQ poller (recommended when co-located with DeepEP/UCCL-EP)
+> export MC_EFA_CQ_THREADS=1   # default: single CQ poller (recommended)
+> export MC_EFA_CQ_THREADS=0   # disable cap: one poller per EFA context (legacy)
 > ```
 >
 > If the value exceeds the number of EFA contexts, it is safely ignored (no excess threads are created).

--- a/docs/source/design/transfer-engine/efa_transport.md
+++ b/docs/source/design/transfer-engine/efa_transport.md
@@ -507,6 +507,14 @@ export LD_LIBRARY_PATH=/opt/amazon/efa/lib:$LD_LIBRARY_PATH
 
 > **Note on additional `MC_*` knobs:** `MC_NUM_CQ_PER_CTX`, `MC_MAX_WR`, `MC_MAX_CQE_PER_CTX`, `MC_SLICE_SIZE`, and `MC_EFA_STRIPING_THRESHOLD` are **not** required at typical PD-disagg loads — the SRD shared-endpoint refactor (#1944) makes them redundant up to high concurrency on 1k/1k traffic. Treat them as emergency switches for CQ-overflow or long-running drift symptoms.
 
+> **`MC_EFA_CQ_THREADS`** — caps the number of CQ polling threads spawned by the EFA transport. By default (unset or `0`), Mooncake creates one CQ poller thread per EFA context. When multiple EFA consumers coexist in the same process (e.g., Mooncake KV cache transfer + DeepEP/UCCL-EP MoE all-to-all), these pollers compete for CPU and can degrade the other consumer's latency. Set `MC_EFA_CQ_THREADS=1` to limit Mooncake to a single CQ poller, freeing CPU for other EFA consumers with no measurable impact on Mooncake transfer throughput.
+>
+> ```bash
+> export MC_EFA_CQ_THREADS=1   # use 1 CQ poller (recommended when co-located with DeepEP/UCCL-EP)
+> ```
+>
+> If the value exceeds the number of EFA contexts, it is safely ignored (no excess threads are created).
+
 ### 3. Prefill Instance
 
 ```bash

--- a/mooncake-common/include/environ.h
+++ b/mooncake-common/include/environ.h
@@ -50,6 +50,7 @@ class Environ {
     bool GetIntraNvlink() const { return intra_nvlink_; }
     bool GetPathRoundrobin() const { return path_roundrobin_; }
     bool GetWithNvidiaPeermem() const { return with_nvidia_peermem_; }
+    int GetEfaCqThreads() const { return efa_cq_threads_; }
 
    private:
     Environ();
@@ -101,6 +102,7 @@ class Environ {
     bool intra_nvlink_;
     bool path_roundrobin_;
     bool with_nvidia_peermem_;
+    int efa_cq_threads_;
 };
 
 }  // namespace mooncake

--- a/mooncake-common/src/environ.cpp
+++ b/mooncake-common/src/environ.cpp
@@ -82,6 +82,7 @@ Environ::Environ() {
     intra_nvlink_ = GetBool("MC_INTRA_NVLINK", false);
     path_roundrobin_ = GetBool("MC_PATH_ROUNDROBIN", false);
     with_nvidia_peermem_ = GetBool("WITH_NVIDIA_PEERMEM", true);
+    efa_cq_threads_ = GetInt("MC_EFA_CQ_THREADS", 0);
 }
 
 }  // namespace mooncake

--- a/mooncake-common/src/environ.cpp
+++ b/mooncake-common/src/environ.cpp
@@ -82,7 +82,7 @@ Environ::Environ() {
     intra_nvlink_ = GetBool("MC_INTRA_NVLINK", false);
     path_roundrobin_ = GetBool("MC_PATH_ROUNDROBIN", false);
     with_nvidia_peermem_ = GetBool("WITH_NVIDIA_PEERMEM", true);
-    efa_cq_threads_ = GetInt("MC_EFA_CQ_THREADS", 0);
+    efa_cq_threads_ = GetInt("MC_EFA_CQ_THREADS", 1);
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -107,8 +107,7 @@ void EfaTransport::startWorkerThreads() {
     if (worker_running_) return;
 
     worker_running_ = true;
-    // Default: one poller thread per context. MC_EFA_CQ_THREADS caps this when
-    // multiple EFA consumers coexist (e.g., Mooncake KV transfer + DeepEP).
+    // MC_EFA_CQ_THREADS caps CQ poller count (default 1). Set 0 to disable cap.
     size_t num_threads = context_list_.size();
     int cq_cap = Environ::Get().GetEfaCqThreads();
     if (cq_cap > 0 && static_cast<size_t>(cq_cap) < num_threads) {

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -33,6 +33,7 @@
 
 #include "common.h"
 #include "config.h"
+#include "environ.h"
 #include "memory_location.h"
 #include "topology.h"
 #include "transport/efa_transport/efa_context.h"
@@ -106,12 +107,12 @@ void EfaTransport::startWorkerThreads() {
     if (worker_running_) return;
 
     worker_running_ = true;
-    // One poller thread per context for responsive CQ draining under load
+    // Default: one poller thread per context. MC_EFA_CQ_THREADS caps this when
+    // multiple EFA consumers coexist (e.g., Mooncake KV transfer + DeepEP).
     size_t num_threads = context_list_.size();
-    const char* cq_env = std::getenv("MC_EFA_CQ_THREADS");
-    if (cq_env) {
-        size_t cq_val = std::stoull(cq_env);
-        if (cq_val > 0 && cq_val < num_threads) num_threads = cq_val;
+    int cq_cap = Environ::Get().GetEfaCqThreads();
+    if (cq_cap > 0 && static_cast<size_t>(cq_cap) < num_threads) {
+        num_threads = static_cast<size_t>(cq_cap);
     }
     for (size_t i = 0; i < num_threads; i++) {
         worker_threads_.emplace_back(&EfaTransport::workerThreadFunc, this, i);
@@ -160,7 +161,7 @@ void EfaTransport::workerThreadFunc(int thread_id) {
 
         // If no work was done, yield CPU briefly
         if (!did_work) {
-            std::this_thread::sleep_for(std::chrono::microseconds(10));
+            std::this_thread::yield();
         }
     }
 }

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -23,6 +23,7 @@
 #include <cassert>
 #include <chrono>
 #include <cstddef>
+#include <cstdlib>
 #include <fstream>
 #include <future>
 #include <set>
@@ -107,6 +108,11 @@ void EfaTransport::startWorkerThreads() {
     worker_running_ = true;
     // One poller thread per context for responsive CQ draining under load
     size_t num_threads = context_list_.size();
+    const char* cq_env = std::getenv("MC_EFA_CQ_THREADS");
+    if (cq_env) {
+        size_t cq_val = std::stoull(cq_env);
+        if (cq_val > 0 && cq_val < num_threads) num_threads = cq_val;
+    }
     for (size_t i = 0; i < num_threads; i++) {
         worker_threads_.emplace_back(&EfaTransport::workerThreadFunc, this, i);
     }
@@ -154,7 +160,7 @@ void EfaTransport::workerThreadFunc(int thread_id) {
 
         // If no work was done, yield CPU briefly
         if (!did_work) {
-            std::this_thread::yield();
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
         }
     }
 }


### PR DESCRIPTION
## Description

**Problem**: `EfaTransport` starts one CQ poller per EFA context (`N_ctx` = 8/16/32 depending on instance). Each poller runs a `while (running) { pollCq(); if (!work) yield(); }` loop, which on Linux pegs the CPU at ~100% per thread because `std::this_thread::yield()` returns immediately when no same-priority threads are ready. When other latency-sensitive workloads share the process (e.g., UCCL-EP / DeepEP a2a proxy threads, vLLM scheduler), the OS scheduler delays them, causing tail-latency blowups.

**Fix**: Add `MC_EFA_CQ_THREADS` to cap the poller count, with a sensible default (1) for typical PD-disagg workloads. Benchmarks on p5.48xlarge show cap=1 reaches 99.93% of peak GPU-to-GPU throughput (386.22 vs 386.48 GB/s) while freeing 31 cores. The env var preserves the escape hatch for high-throughput tuning (set `MC_EFA_CQ_THREADS=0` to disable the cap).

**Follow-up**: replace busy-spin with event-driven idle (cond_var or `FI_WAIT_FD` epoll). RDMA transport already does this via `submitted/processed` counters and `cond_var_.wait_for()`. Tracking separately.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] New feature

## How Has This Been Tested?

- Tested on 2-node p5.48xlarge (32 EFA × 100 Gbps) cluster, `cmake -DUSE_EFA=ON -DUSE_CUDA=ON`, libfabric-aws 1.30.0, DLAMI Ubuntu 24.04
- `MC_EFA_CQ_THREADS=1`: 386.22 GB/s GPU write (99.93% of uncapped default)
- `MC_EFA_CQ_THREADS` unset (default=1): single poller thread confirmed via logs and `ps -T`
- `MC_EFA_CQ_THREADS=0`: legacy behavior preserved (one thread per context, 386.48 GB/s)
- `MC_EFA_CQ_THREADS` > context count: safely ignored (no excess threads)
- SGLang PD disaggregated serving (DeepSeek-V4-Pro-FP8, 2P+2D, DP=16): 200/200 requests at 0.7-1.0 req/s, DeepEP all-to-all latency returns to baseline with capped CQ threads

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.