### PR TITLE
feat: add Hygon DCU/DTK and Iluvatar CoreX platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Mooncake supports heterogeneous accelerators, NICs, and specialized transport pa
 | T-Head | PPU / Barex | Supported | T-Head PPU deployments are represented here through Barex-based transport support |
 | NVIDIA | CUDA GPUs / NVLink | Supported | `-DUSE_CUDA=ON`, `-DUSE_INTRA_NVLINK=ON`, `-DUSE_MNNVL=ON`; covers CUDA memory, GPUDirect RDMA, GPUDirect Storage, intra-node NVLink, and multi-node NVLink |
 | AMD | ROCm / HIP GPUs | Supported | `-DUSE_HIP=ON`; HIP transport for AMD GPU communication |
+| Hygon | DCU / DTK | Supported | `-DUSE_HYGON=ON`; CUDA-compatible runtime via Hygon DTK SDK |
+| Iluvatar | CoreX | Supported | `-DUSE_COREX=ON`; CUDA-compatible runtime via Iluvatar CoreX SDK |
 
 #### Network and fabric support
 
@@ -236,6 +238,8 @@ The following need to be installed before running any component of Mooncake:
 - Python 3.10, virtual environment is recommended.
 - CUDA 12.1 and above, including NVIDIA GPUDirect Storage Support, if the package is built with `-DUSE_CUDA` (disabled by default). *You may install them from [here](https://developer.nvidia.com/cuda-downloads)*.
 - Cambricon Neuware, if the package is built with `-DUSE_MLU`. By default Mooncake looks for Neuware under `NEUWARE_HOME` or `/usr/local/neuware`.
+- Hygon DTK SDK, if the package is built with `-DUSE_HYGON`. By default Mooncake looks for DTK under `DTK_HOME` or `/opt/dtk`.
+- Iluvatar CoreX SDK, if the package is built with `-DUSE_COREX`. By default Mooncake looks for CoreX under `COREX_HOME` or `/usr/local/corex`.
 
 ### Use Python package
 The simplest way to use Mooncake Transfer Engine is using `pip`:
@@ -310,6 +314,8 @@ The following are additional dependencies for building Mooncake:
 - Go 1.20+, if you want to build with `-DWITH_P2P_STORE`, `-DUSE_ETCD` (enabled by default to use etcd as metadata servers), or `-DSTORE_USE_ETCD` (use etcd for the failover of the store master).
 - CUDA 12.1 and above, including NVIDIA GPUDirect Storage Support, if the package is built with `-DUSE_CUDA`. *This is NOT included in the `dependencies.sh` script. You may install them from [here](https://developer.nvidia.com/cuda-downloads)*.
 - Cambricon Neuware, if you want to build with `-DUSE_MLU`. *This is NOT included in the `dependencies.sh` script.* Mooncake resolves it from `NEUWARE_HOME` or `/usr/local/neuware` by default, and also supports overriding `MLU_INCLUDE_DIR` / `MLU_LIB_DIR` during CMake configure.
+- Hygon DTK SDK, if you want to build with `-DUSE_HYGON`. *This is NOT included in the `dependencies.sh` script.* Mooncake resolves it from `DTK_HOME` or `/opt/dtk` by default, and also supports overriding `DTK_INCLUDE_DIR` / `DTK_LIB_DIR` during CMake configure.
+- Iluvatar CoreX SDK, if you want to build with `-DUSE_COREX`. *This is NOT included in the `dependencies.sh` script.* Mooncake resolves it from `COREX_HOME` or `/usr/local/corex` by default, and also supports overriding `COREX_INCLUDE_DIR` / `COREX_LIB_DIR` during CMake configure.
 - [Optional] Rust Toolchain and libclang, if you want to build Transfer Engine Rust examples with `-DWITH_RUST_EXAMPLE=ON` or Mooncake Store Rust bindings with `-DWITH_STORE_RUST=ON`. *This is NOT included in the `dependencies.sh` script.*
 - [Optional] `hiredis`, if you want to build with `-DUSE_REDIS` to use Redis instead of etcd as metadata servers.
 - [Optional] `curl`, if you want to build with `-DUSE_HTTP` to use HTTP instead of etcd as metadata servers.

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -228,6 +228,14 @@ The following options can be used during `cmake ..` to specify whether to compil
 - `-DMACA_LIB_DIR=/path/to/lib64`: Override MACA library directory when `-DUSE_MACA=ON`.
 - `-DMACA_RUNTIME_LIBS="mcruntime;mxc-runtime64;rt"`: Override MACA runtime libraries linked by `transfer_engine`.
 - `-DUSE_HIP=[ON|OFF]`: Enable AMD GPU support via HIP/ROCm
+- `-DUSE_HYGON=[ON|OFF]`: Enable Hygon DCU support via DTK SDK. **Default: OFF.** Uses CUDA-compatible runtime.
+- `-DDTK_ROOT=/path/to/dtk`: Override the default DTK SDK root used when `-DUSE_HYGON=ON`. If unset, Mooncake uses `DTK_HOME` or `/opt/dtk`.
+- `-DDTK_INCLUDE_DIR=/path/to/include`: Override the DTK include directory when `-DUSE_HYGON=ON`.
+- `-DDTK_LIB_DIR=/path/to/lib64`: Override the DTK library directory when `-DUSE_HYGON=ON`.
+- `-DUSE_COREX=[ON|OFF]`: Enable Iluvatar CoreX GPU support. **Default: OFF.** Uses CUDA-compatible runtime.
+- `-DCOREX_ROOT=/path/to/corex`: Override the default CoreX SDK root used when `-DUSE_COREX=ON`. If unset, Mooncake uses `COREX_HOME` or `/usr/local/corex`.
+- `-DCOREX_INCLUDE_DIR=/path/to/include`: Override the CoreX include directory when `-DUSE_COREX=ON`.
+- `-DCOREX_LIB_DIR=/path/to/lib`: Override the CoreX library directory when `-DUSE_COREX=ON`.
 - `-DUSE_MLU=[ON|OFF]`: Enable Cambricon MLU memory support via Neuware. **Default: OFF.** Supports MLU memory detection, topology discovery, and RDMA registration for Transfer Engine.
 - `-DNEUWARE_ROOT=/path/to/neuware`: Override the default Neuware SDK root used when `-DUSE_MLU=ON`. If unset, Mooncake uses `NEUWARE_HOME` or `/usr/local/neuware`.
 - `-DMLU_INCLUDE_DIR=/path/to/include`: Override the Neuware include directory when `-DUSE_MLU=ON`.

--- a/docs/source/zh_archive/build.md
+++ b/docs/source/zh_archive/build.md
@@ -180,6 +180,12 @@
 - `-DNEUWARE_ROOT=/path/to/neuware`: 在 `-DUSE_MLU=ON` 时覆盖默认 Neuware SDK 根路径；未设置时使用 `NEUWARE_HOME` 或 `/usr/local/neuware`。
 - `-DMLU_INCLUDE_DIR=/path/to/include` / `-DMLU_LIB_DIR=/path/to/lib64`: 在 `-DUSE_MLU=ON` 时覆盖 Neuware 头文件与库目录。
 - `-DUSE_HIP=[ON|OFF]`: 通过 HIP/ROCm 启用对 AMD GPU 的支持
+- `-DUSE_HYGON=[ON|OFF]`: 通过 DTK SDK 启用对海光 DCU 的支持。默认 OFF；使用 CUDA 兼容运行时。
+- `-DDTK_ROOT=/path/to/dtk`: 在 `-DUSE_HYGON=ON` 时覆盖默认 DTK SDK 根路径；未设置时使用 `DTK_HOME` 或 `/opt/dtk`。
+- `-DDTK_INCLUDE_DIR=/path/to/include` / `-DDTK_LIB_DIR=/path/to/lib64`: 在 `-DUSE_HYGON=ON` 时覆盖 DTK 头文件与库目录。
+- `-DUSE_COREX=[ON|OFF]`: 启用对天数智芯 CoreX GPU 的支持。默认 OFF；使用 CUDA 兼容运行时。
+- `-DCOREX_ROOT=/path/to/corex`: 在 `-DUSE_COREX=ON` 时覆盖默认 CoreX SDK 根路径；未设置时使用 `COREX_HOME` 或 `/usr/local/corex`。
+- `-DCOREX_INCLUDE_DIR=/path/to/include` / `-DCOREX_LIB_DIR=/path/to/lib`: 在 `-DUSE_COREX=ON` 时覆盖 CoreX 头文件与库目录。
 - `-DUSE_CXL=[ON|OFF]`: 启用 CXL 支持
 - `-DWITH_STORE=[ON|OFF]`: 编译 Mooncake Store 组件
 - `-DWITH_P2P_STORE=[ON|OFF]`: 启用 Golang 支持并编译 P2P Store 组件，需要 go 1.23+

--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -226,21 +226,53 @@ if (USE_MUSA)
 endif()
 
 if (USE_HYGON)
+  if (NOT DEFINED DTK_ROOT OR DTK_ROOT STREQUAL "")
+    if (DEFINED ENV{DTK_HOME} AND NOT "$ENV{DTK_HOME}" STREQUAL "")
+      set(DTK_ROOT "$ENV{DTK_HOME}" CACHE PATH "Path to Hygon DTK SDK" FORCE)
+    else()
+      set(DTK_ROOT "/opt/dtk" CACHE PATH "Path to Hygon DTK SDK" FORCE)
+    endif()
+  endif()
+
+  if (NOT DEFINED DTK_INCLUDE_DIR OR DTK_INCLUDE_DIR STREQUAL "")
+    set(DTK_INCLUDE_DIR "${DTK_ROOT}/cuda/cuda-11/include")
+  endif()
+
+  if (NOT DEFINED DTK_LIB_DIR OR DTK_LIB_DIR STREQUAL "")
+    set(DTK_LIB_DIR "${DTK_ROOT}/cuda/cuda-11/lib64")
+  endif()
+
   add_compile_definitions(USE_HYGON)
   message(STATUS "Hygon DCU/DTK support is enabled")
-  include_directories(/opt/dtk/cuda/cuda-11/include)
-  link_directories(
-    /opt/dtk/cuda/cuda-11/lib64
-  )
+  include_directories(${DTK_INCLUDE_DIR})
+  if (EXISTS "${DTK_LIB_DIR}")
+    link_directories(${DTK_LIB_DIR})
+  endif()
 endif()
 
 if (USE_COREX)
+  if (NOT DEFINED COREX_ROOT OR COREX_ROOT STREQUAL "")
+    if (DEFINED ENV{COREX_HOME} AND NOT "$ENV{COREX_HOME}" STREQUAL "")
+      set(COREX_ROOT "$ENV{COREX_HOME}" CACHE PATH "Path to Iluvatar CoreX SDK" FORCE)
+    else()
+      set(COREX_ROOT "/usr/local/corex" CACHE PATH "Path to Iluvatar CoreX SDK" FORCE)
+    endif()
+  endif()
+
+  if (NOT DEFINED COREX_INCLUDE_DIR OR COREX_INCLUDE_DIR STREQUAL "")
+    set(COREX_INCLUDE_DIR "${COREX_ROOT}/include")
+  endif()
+
+  if (NOT DEFINED COREX_LIB_DIR OR COREX_LIB_DIR STREQUAL "")
+    set(COREX_LIB_DIR "${COREX_ROOT}/lib")
+  endif()
+
   add_compile_definitions(USE_COREX)
   message(STATUS "Iluvatar CoreX support is enabled")
-  include_directories(/usr/local/corex/include)
-  link_directories(
-    /usr/local/corex/lib
-  )
+  include_directories(${COREX_INCLUDE_DIR})
+  if (EXISTS "${COREX_LIB_DIR}")
+    link_directories(${COREX_LIB_DIR})
+  endif()
 endif()
 
 if (USE_HIP)

--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -65,6 +65,8 @@ option(USE_MLU "option for enabling Cambricon MLU features" OFF)
 option(USE_MUSA "option for enabling gpu features for MTHREADS GPU" OFF)
 option(USE_MACA "option for enabling gpu features for MUXI GPU with MACA" OFF)
 option(USE_HIP "option for enabling gpu features for AMD GPU" OFF)
+option(USE_HYGON "option for enabling gpu features for Hygon DCU with DTK" OFF)
+option(USE_COREX "option for enabling gpu features for Iluvatar CoreX" OFF)
 option(USE_NVMEOF "option for using NVMe over Fabric" OFF)
 option(USE_TCP "option for using TCP transport" ON)
 option(USE_BAREX "option for using accl-barex transport" OFF)
@@ -220,6 +222,24 @@ if (USE_MUSA)
   include_directories(/usr/local/musa/include)
   link_directories(
     /usr/local/musa/lib
+  )
+endif()
+
+if (USE_HYGON)
+  add_compile_definitions(USE_HYGON)
+  message(STATUS "Hygon DCU/DTK support is enabled")
+  include_directories(/opt/dtk/cuda/cuda-11/include)
+  link_directories(
+    /opt/dtk/cuda/cuda-11/lib64
+  )
+endif()
+
+if (USE_COREX)
+  add_compile_definitions(USE_COREX)
+  message(STATUS "Iluvatar CoreX support is enabled")
+  include_directories(/usr/local/corex/include)
+  link_directories(
+    /usr/local/corex/lib
   )
 endif()
 

--- a/mooncake-store/include/gpu_staging_utils.h
+++ b/mooncake-store/include/gpu_staging_utils.h
@@ -15,7 +15,8 @@ namespace gpu_staging {
 // Detect whether ptr resides in accelerator device memory.
 // If so, writes the device ID to *out_device_id for subsequent SetDevice.
 inline bool IsDevicePointer(const void* ptr, int* out_device_id) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA) || \
+    defined(USE_HYGON) || defined(USE_COREX)
     cudaPointerAttributes attr{};
     if (cudaPointerGetAttributes(&attr, ptr) == cudaSuccess &&
         attr.type == cudaMemoryTypeDevice) {
@@ -45,7 +46,8 @@ inline bool IsDevicePointer(const void* ptr, int* out_device_id) {
 
 // Copy device memory to host. Caller must have called SetDevice first.
 inline bool CopyDeviceToHost(void* dst, const void* src, size_t size) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA) || \
+    defined(USE_HYGON) || defined(USE_COREX)
     return cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost) == cudaSuccess;
 #elif defined(USE_HIP)
     return hipMemcpy(dst, src, size, hipMemcpyDeviceToHost) == hipSuccess;
@@ -64,7 +66,8 @@ inline bool CopyDeviceToHost(void* dst, const void* src, size_t size) {
 // attributes (cudaMemcpyDefault). Works for H2H, H2D, D2H, and D2D.
 // Caller must have called SetDevice first when device memory is involved.
 inline bool CopyAuto(void* dst, const void* src, size_t size) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA) || \
+    defined(USE_HYGON) || defined(USE_COREX)
     return cudaMemcpy(dst, src, size, cudaMemcpyDefault) == cudaSuccess;
 #elif defined(USE_HIP)
     return hipMemcpy(dst, src, size, hipMemcpyDefault) == hipSuccess;
@@ -94,7 +97,8 @@ inline bool CopyAuto(void* dst, const void* src, size_t size) {
 // Bind the calling thread to the given device context.
 inline void SetDevice(int device_id) {
     if (device_id < 0) return;
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA) || \
+    defined(USE_HYGON) || defined(USE_COREX)
     cudaSetDevice(device_id);
 #elif defined(USE_HIP)
     hipSetDevice(device_id);
@@ -105,7 +109,8 @@ inline void SetDevice(int device_id) {
 
 // Copy host memory to device. Caller must have called SetDevice first.
 inline bool CopyHostToDevice(void* dst, const void* src, size_t size) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA) || \
+    defined(USE_HYGON) || defined(USE_COREX)
     return cudaMemcpy(dst, src, size, cudaMemcpyHostToDevice) == cudaSuccess;
 #elif defined(USE_HIP)
     return hipMemcpy(dst, src, size, hipMemcpyHostToDevice) == hipSuccess;
@@ -128,7 +133,8 @@ inline bool CopyHostToDevice(void* dst, const void* src, size_t size) {
 //
 // Pageable host memory (not tracked by CUDA runtime) is treated as host.
 inline bool IsHostPointer(const void* ptr) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA) || \
+    defined(USE_HYGON) || defined(USE_COREX)
     cudaPointerAttributes attr{};
     if (cudaPointerGetAttributes(&attr, ptr) != cudaSuccess) {
         // Query failed: pageable host memory not tracked by the runtime.

--- a/mooncake-store/include/pinned_buffer_pool.h
+++ b/mooncake-store/include/pinned_buffer_pool.h
@@ -83,7 +83,8 @@ class PinnedBufferPool {
         buf.capacity = size;
         buf.is_pinned = false;
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA) || \
+    defined(USE_HYGON) || defined(USE_COREX)
         if (cudaMallocHost(reinterpret_cast<void**>(&buf.data), size) ==
             cudaSuccess) {
             buf.is_pinned = true;
@@ -119,7 +120,8 @@ class PinnedBufferPool {
             delete[] buf.data;
             return;
         }
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA) || \
+    defined(USE_HYGON) || defined(USE_COREX)
         cudaFreeHost(buf.data);
 #elif defined(USE_HIP)
         hipHostFree(buf.data);

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -43,7 +43,7 @@
 #endif
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
 #include <cassert>
 
 #if defined(USE_MNNVL) || defined(USE_UBSHMEM)
@@ -108,7 +108,7 @@ DEFINE_uint32(report_precision, 2, "Report precision");
 DEFINE_string(backend, "classic", "Backend to use: classic|tent");
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
 DEFINE_bool(use_vram, true, "Allocate memory from GPU/NPU VRAM");
 DEFINE_bool(init_mem, true, "Initialize allocated memory");
 DEFINE_int32(gpu_id, 0,
@@ -120,7 +120,7 @@ using namespace mooncake;
 static void* allocateMemoryPool(size_t size, int buffer_id,
                                 bool from_vram = false) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
     if (from_vram) {
         int gpu_id;
         if (FLAGS_gpu_id == -1) {
@@ -191,7 +191,7 @@ static void* allocateMemoryPool(size_t size, int buffer_id,
 
 static void freeMemoryPool(void* addr, size_t size) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
     if (FLAGS_protocol == "nvlink" || FLAGS_protocol == "hip") {
 #ifdef USE_MNNVL
         if (FLAGS_use_vram) {
@@ -291,7 +291,7 @@ std::atomic<size_t> total_batch_count(0);
 // Ensure each worker thread has a valid GPU context before issuing transfers.
 static inline void setWorkerDeviceIfNeeded() {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_SUNRISE)
     if (FLAGS_use_vram && FLAGS_gpu_id >= 0) {
         checkCudaError(cudaSetDevice(FLAGS_gpu_id),
                        "Failed to set device in worker");
@@ -302,7 +302,7 @@ static inline void setWorkerDeviceIfNeeded() {
 // Common helper to determine buffer count based on GPU/NUMA configuration
 static int determineBufferCount() {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_SUNRISE)
     if (FLAGS_use_vram) {
         int gpu_num;
         LOG(INFO) << "VRAM is used";
@@ -333,7 +333,7 @@ static std::vector<void*> allocateBuffers() {
     buffer_num = determineBufferCount();
     std::vector<void*> addr(buffer_num);
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
     }
@@ -356,7 +356,7 @@ static void freeBuffers(std::vector<void*>& addr) {
 // Helper to get location name for classic backend
 static std::string getLocationName(int buffer_id) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
     if (FLAGS_use_vram) {
         int name_suffix = (FLAGS_gpu_id == -1) ? buffer_id : FLAGS_gpu_id;
         return std::string(GPU_PREFIX) + std::to_string(name_suffix);

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -42,10 +42,9 @@
 #endif
 #endif
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX) || defined(USE_UBSHMEM) || \
-    defined(USE_SUNRISE)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
+    defined(USE_UBSHMEM) || defined(USE_SUNRISE)
 #include <cassert>
 
 #if defined(USE_MNNVL) || defined(USE_UBSHMEM)
@@ -109,10 +108,9 @@ DEFINE_string(report_unit, "GB", "Report unit: GB|GiB|Gb|MB|MiB|Mb|KB|KiB|Kb");
 DEFINE_uint32(report_precision, 2, "Report precision");
 DEFINE_string(backend, "classic", "Backend to use: classic|tent");
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX) || defined(USE_UBSHMEM) || \
-    defined(USE_SUNRISE)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
+    defined(USE_UBSHMEM) || defined(USE_SUNRISE)
 DEFINE_bool(use_vram, true, "Allocate memory from GPU/NPU VRAM");
 DEFINE_bool(init_mem, true, "Initialize allocated memory");
 DEFINE_int32(gpu_id, 0,
@@ -123,10 +121,9 @@ using namespace mooncake;
 
 static void* allocateMemoryPool(size_t size, int buffer_id,
                                 bool from_vram = false) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX) || defined(USE_UBSHMEM) || \
-    defined(USE_SUNRISE)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
+    defined(USE_UBSHMEM) || defined(USE_SUNRISE)
     if (from_vram) {
         int gpu_id;
         if (FLAGS_gpu_id == -1) {
@@ -196,10 +193,9 @@ static void* allocateMemoryPool(size_t size, int buffer_id,
 }
 
 static void freeMemoryPool(void* addr, size_t size) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX) || defined(USE_UBSHMEM) || \
-    defined(USE_SUNRISE)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
+    defined(USE_UBSHMEM) || defined(USE_SUNRISE)
     if (FLAGS_protocol == "nvlink" || FLAGS_protocol == "hip") {
 #ifdef USE_MNNVL
         if (FLAGS_use_vram) {
@@ -298,9 +294,9 @@ std::atomic<size_t> total_batch_count(0);
 
 // Ensure each worker thread has a valid GPU context before issuing transfers.
 static inline void setWorkerDeviceIfNeeded() {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX) || defined(USE_SUNRISE)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
+    defined(USE_SUNRISE)
     if (FLAGS_use_vram && FLAGS_gpu_id >= 0) {
         checkCudaError(cudaSetDevice(FLAGS_gpu_id),
                        "Failed to set device in worker");
@@ -310,9 +306,9 @@ static inline void setWorkerDeviceIfNeeded() {
 
 // Common helper to determine buffer count based on GPU/NUMA configuration
 static int determineBufferCount() {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX) || defined(USE_SUNRISE)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
+    defined(USE_SUNRISE)
     if (FLAGS_use_vram) {
         int gpu_num;
         LOG(INFO) << "VRAM is used";
@@ -342,10 +338,9 @@ static int determineBufferCount() {
 static std::vector<void*> allocateBuffers() {
     buffer_num = determineBufferCount();
     std::vector<void*> addr(buffer_num);
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX) || defined(USE_UBSHMEM) || \
-    defined(USE_SUNRISE)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
+    defined(USE_UBSHMEM) || defined(USE_SUNRISE)
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
     }
@@ -367,10 +362,9 @@ static void freeBuffers(std::vector<void*>& addr) {
 
 // Helper to get location name for classic backend
 static std::string getLocationName(int buffer_id) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX) || defined(USE_UBSHMEM) || \
-    defined(USE_SUNRISE)
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||    \
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || \
+    defined(USE_UBSHMEM) || defined(USE_SUNRISE)
     if (FLAGS_use_vram) {
         int name_suffix = (FLAGS_gpu_id == -1) ? buffer_id : FLAGS_gpu_id;
         return std::string(GPU_PREFIX) + std::to_string(name_suffix);

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -43,7 +43,9 @@
 #endif
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX) || defined(USE_UBSHMEM) || \
+    defined(USE_SUNRISE)
 #include <cassert>
 
 #if defined(USE_MNNVL) || defined(USE_UBSHMEM)
@@ -108,7 +110,9 @@ DEFINE_uint32(report_precision, 2, "Report precision");
 DEFINE_string(backend, "classic", "Backend to use: classic|tent");
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX) || defined(USE_UBSHMEM) || \
+    defined(USE_SUNRISE)
 DEFINE_bool(use_vram, true, "Allocate memory from GPU/NPU VRAM");
 DEFINE_bool(init_mem, true, "Initialize allocated memory");
 DEFINE_int32(gpu_id, 0,
@@ -120,7 +124,9 @@ using namespace mooncake;
 static void* allocateMemoryPool(size_t size, int buffer_id,
                                 bool from_vram = false) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX) || defined(USE_UBSHMEM) || \
+    defined(USE_SUNRISE)
     if (from_vram) {
         int gpu_id;
         if (FLAGS_gpu_id == -1) {
@@ -191,7 +197,9 @@ static void* allocateMemoryPool(size_t size, int buffer_id,
 
 static void freeMemoryPool(void* addr, size_t size) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX) || defined(USE_UBSHMEM) || \
+    defined(USE_SUNRISE)
     if (FLAGS_protocol == "nvlink" || FLAGS_protocol == "hip") {
 #ifdef USE_MNNVL
         if (FLAGS_use_vram) {
@@ -291,7 +299,8 @@ std::atomic<size_t> total_batch_count(0);
 // Ensure each worker thread has a valid GPU context before issuing transfers.
 static inline void setWorkerDeviceIfNeeded() {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX) || defined(USE_SUNRISE)
     if (FLAGS_use_vram && FLAGS_gpu_id >= 0) {
         checkCudaError(cudaSetDevice(FLAGS_gpu_id),
                        "Failed to set device in worker");
@@ -302,7 +311,8 @@ static inline void setWorkerDeviceIfNeeded() {
 // Common helper to determine buffer count based on GPU/NUMA configuration
 static int determineBufferCount() {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX) || defined(USE_SUNRISE)
     if (FLAGS_use_vram) {
         int gpu_num;
         LOG(INFO) << "VRAM is used";
@@ -333,7 +343,9 @@ static std::vector<void*> allocateBuffers() {
     buffer_num = determineBufferCount();
     std::vector<void*> addr(buffer_num);
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX) || defined(USE_UBSHMEM) || \
+    defined(USE_SUNRISE)
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
     }
@@ -356,7 +368,9 @@ static void freeBuffers(std::vector<void*>& addr) {
 // Helper to get location name for classic backend
 static std::string getLocationName(int buffer_id) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX) || defined(USE_UBSHMEM) || defined(USE_SUNRISE)
+    defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX) || defined(USE_UBSHMEM) || \
+    defined(USE_SUNRISE)
     if (FLAGS_use_vram) {
         int name_suffix = (FLAGS_gpu_id == -1) ? buffer_id : FLAGS_gpu_id;
         return std::string(GPU_PREFIX) + std::to_string(name_suffix);

--- a/mooncake-transfer-engine/example/transfer_engine_bench_with_notify.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench_with_notify.cpp
@@ -38,7 +38,7 @@
 #endif
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 #include <cassert>
 
 #ifdef USE_MNNVL
@@ -59,7 +59,7 @@ static void checkCudaError(cudaError_t result, const char *message) {
 #endif
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 const static int NR_SOCKETS = 4;
 #else
 const static int NR_SOCKETS =
@@ -92,7 +92,7 @@ DEFINE_string(report_unit, "GB", "Report unit: GB|GiB|Gb|MB|MiB|Mb|KB|KiB|Kb");
 DEFINE_uint32(report_precision, 2, "Report precision");
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 DEFINE_bool(use_vram, true, "Allocate memory from GPU VRAM");
 DEFINE_bool(init_mem, true, "Initialize allocated memory");
 DEFINE_int32(gpu_id, 0, "GPU ID to use");
@@ -103,7 +103,7 @@ using namespace mooncake;
 static void *allocateMemoryPool(size_t size, int socket_id,
                                 bool from_vram = false) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     if (from_vram) {
         int gpu_id = FLAGS_gpu_id;
         void *d_buf;
@@ -129,7 +129,7 @@ static void *allocateMemoryPool(size_t size, int socket_id,
 
 static void freeMemoryPool(void *addr, size_t size) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 #ifdef USE_MNNVL
     if (FLAGS_use_vram) {
         freeFabricMemory(addr);
@@ -342,7 +342,7 @@ int initiator() {
     int buffer_num = NR_SOCKETS;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     if (FLAGS_use_vram) LOG(INFO) << "VRAM is used";
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);
@@ -442,7 +442,7 @@ int target() {
     int buffer_num = NR_SOCKETS;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     if (FLAGS_use_vram) LOG(INFO) << "VRAM is used";
     for (int i = 0; i < buffer_num; ++i) {
         addr[i] = allocateMemoryPool(FLAGS_buffer_size, i, FLAGS_use_vram);

--- a/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
@@ -36,7 +36,7 @@
 #endif
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 #include <cassert>
 
 static void checkCudaError(cudaError_t result, const char *message) {
@@ -77,7 +77,7 @@ DEFINE_string(report_unit, "GB", "Report unit: GB|GiB|Gb|MB|MiB|Mb|KB|KiB|Kb");
 DEFINE_uint32(report_precision, 2, "Report precision");
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 DEFINE_bool(use_vram, true, "Allocate memory from GPU VRAM");
 DEFINE_bool(init_mem, true, "Initialize allocated memory");
 DEFINE_int32(gpu_id, 0, "GPU ID to use");
@@ -88,7 +88,7 @@ using namespace mooncake;
 static void *allocateMemoryPool(size_t size, int socket_id,
                                 bool from_vram = false) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     if (from_vram) {
         int gpu_id = FLAGS_gpu_id;
         void *d_buf;
@@ -111,7 +111,7 @@ static void *allocateMemoryPool(size_t size, int socket_id,
 
 static void freeMemoryPool(void *addr, size_t size) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     // check pointer on GPU
     cudaPointerAttributes attributes;
     checkCudaError(cudaPointerGetAttributes(&attributes, addr),
@@ -304,7 +304,7 @@ int initiator() {
     int buffer_num = NR_SOCKETS;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     buffer_num = FLAGS_use_vram ? 1 : NR_SOCKETS;
     if (FLAGS_use_vram) LOG(INFO) << "VRAM is used";
     for (int i = 0; i < buffer_num; ++i) {

--- a/mooncake-transfer-engine/example/transfer_engine_validator.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_validator.cpp
@@ -38,7 +38,7 @@
 #endif
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 #include <cassert>
 
 #ifdef USE_MNNVL
@@ -88,7 +88,7 @@ DEFINE_string(report_unit, "GB", "Report unit: GB|GiB|Gb|MB|MiB|Mb|KB|KiB|Kb");
 DEFINE_uint32(report_precision, 2, "Report precision");
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 DEFINE_bool(use_vram, true, "Allocate memory from GPU VRAM");
 DEFINE_int32(gpu_id, 0, "GPU ID to use, -1 for all GPUs");
 #endif
@@ -98,7 +98,7 @@ using namespace mooncake;
 static void *allocateMemoryPool(size_t size, int buffer_id,
                                 bool from_vram = false) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     if (from_vram) {
         int gpu_id;
         if (FLAGS_gpu_id == -1) {
@@ -123,7 +123,7 @@ static void *allocateMemoryPool(size_t size, int buffer_id,
 
 static void freeMemoryPool(void *addr, size_t size) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 #ifdef USE_MNNVL
     if (FLAGS_use_vram) {
         freeFabricMemory(addr);
@@ -224,7 +224,7 @@ Status submitRequestSync(TransferEngine *engine, SegmentID handle,
 }
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 class PinnedBuffer {
    public:
     explicit PinnedBuffer(size_t size) : size_(size), ptr_(nullptr) {
@@ -260,7 +260,7 @@ thread_local std::vector<uint8_t> user_buf(FLAGS_block_size);
 
 void fillData(int thread_id, void *addr, uint8_t seed) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     memset(ref_buf.data(), seed, FLAGS_block_size);
     cudaStream_t s;
     cudaStreamCreate(&s);
@@ -290,7 +290,7 @@ void checkData(int thread_id, void *addr, uint8_t seed) {
             (uint8_t *)(addr) +
             FLAGS_block_size * (i * FLAGS_threads + thread_id);
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
         cudaStream_t s;
         cudaStreamCreate(&s);
         cudaMemcpyAsync(user_buf.data(), local_addr, FLAGS_block_size,
@@ -425,7 +425,7 @@ int initiator() {
 
     std::vector<void *> addr;
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     if (FLAGS_use_vram) {
         int gpu_num;
         LOG(INFO) << "VRAM is used";
@@ -549,7 +549,7 @@ int target() {
 
     std::vector<void *> addr;
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     if (FLAGS_use_vram) {
         int gpu_num;
         LOG(INFO) << "VRAM is used";

--- a/mooncake-transfer-engine/include/cuda_alike.h
+++ b/mooncake-transfer-engine/include/cuda_alike.h
@@ -15,10 +15,17 @@
 #include "gpu_vendor/maca.h"
 #elif defined(USE_SUNRISE)
 #include "gpu_vendor/sunrise.h"
+#elif defined(USE_HYGON)
+#include <cuda.h>
+#include <cuda_runtime.h>
+#elif defined(USE_COREX)
+#include <cuda.h>
+#include <cuda_runtime.h>
 #endif
 
 #if !defined(USE_HIP) && !defined(USE_MUSA) && !defined(USE_MLU) && \
-    !defined(USE_UBSHMEM) && !defined(USE_MACA) && !defined(USE_SUNRISE)
+    !defined(USE_UBSHMEM) && !defined(USE_MACA) && !defined(USE_SUNRISE) && \
+    !defined(USE_HYGON) && !defined(USE_COREX)
 #include <string>
 const static std::string GPU_PREFIX = "cuda:";
 #endif

--- a/mooncake-transfer-engine/include/cuda_alike.h
+++ b/mooncake-transfer-engine/include/cuda_alike.h
@@ -24,8 +24,7 @@
 #endif
 
 #if !defined(USE_HIP) && !defined(USE_MUSA) && !defined(USE_MLU) && \
-    !defined(USE_UBSHMEM) && !defined(USE_MACA) && !defined(USE_SUNRISE) && \
-    !defined(USE_HYGON) && !defined(USE_COREX)
+    !defined(USE_UBSHMEM) && !defined(USE_MACA) && !defined(USE_SUNRISE)
 #include <string>
 const static std::string GPU_PREFIX = "cuda:";
 #endif

--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -83,12 +83,12 @@ if(USE_MUSA)
 endif()
 
 if(USE_HYGON)
-  target_include_directories(transfer_engine PRIVATE /opt/dtk/cuda/cuda-11/include)
+  target_include_directories(transfer_engine PRIVATE ${DTK_INCLUDE_DIR})
   target_link_libraries(transfer_engine PUBLIC cuda cudart rt)
 endif()
 
 if(USE_COREX)
-  target_include_directories(transfer_engine PRIVATE /usr/local/corex/include)
+  target_include_directories(transfer_engine PRIVATE ${COREX_INCLUDE_DIR})
   target_link_libraries(transfer_engine PUBLIC cuda cudart rt)
 endif()
 

--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -82,6 +82,16 @@ if(USE_MUSA)
   target_link_libraries(transfer_engine PUBLIC musa musart rt)
 endif()
 
+if(USE_HYGON)
+  target_include_directories(transfer_engine PRIVATE /opt/dtk/cuda/cuda-11/include)
+  target_link_libraries(transfer_engine PUBLIC cuda cudart rt)
+endif()
+
+if(USE_COREX)
+  target_include_directories(transfer_engine PRIVATE /usr/local/corex/include)
+  target_link_libraries(transfer_engine PUBLIC cuda cudart rt)
+endif()
+
 if(USE_HIP)
   target_include_directories(transfer_engine PRIVATE ${HIP_INCLUDE_DIRS})
   target_link_libraries(transfer_engine PUBLIC hip::host rt)

--- a/mooncake-transfer-engine/src/memory_location.cpp
+++ b/mooncake-transfer-engine/src/memory_location.cpp
@@ -36,7 +36,8 @@ const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
     std::vector<MemoryLocationEntry> entries;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
     cudaPointerAttributes attributes;
     cudaError_t result = cudaPointerGetAttributes(&attributes, start);
     if (result != cudaSuccess) {

--- a/mooncake-transfer-engine/src/memory_location.cpp
+++ b/mooncake-transfer-engine/src/memory_location.cpp
@@ -35,7 +35,7 @@ const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
                                                          bool only_first_page) {
     std::vector<MemoryLocationEntry> entries;
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
     cudaPointerAttributes attributes;

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -395,8 +395,7 @@ static std::vector<TopologyEntry> discoverCudaTopology(
             cudaSuccess) {
             continue;
         }
-        for (char *ch = pci_bus_id; (*ch = tolower(*ch)); ch++)
-            ;
+        for (char *ch = pci_bus_id; (*ch = tolower(*ch)); ch++);
 
         std::vector<std::string> preferred_hca;
         std::vector<std::string> avail_hca;

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -338,7 +338,8 @@ static std::vector<TopologyEntry> discoverCpuTopology(
 }
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
 
 static int getPciDistance(const char *bus1, const char *bus2) {
     char buf[PATH_MAX];
@@ -477,7 +478,8 @@ int Topology::discover(const std::vector<std::string> &filter) {
         matrix_[ent.name] = ent;
     }
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
     for (auto &ent : discoverCudaTopology(all_hca)) {
         matrix_[ent.name] = ent;
     }

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -337,7 +337,7 @@ static std::vector<TopologyEntry> discoverCpuTopology(
     return topology;
 }
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
 
@@ -395,7 +395,8 @@ static std::vector<TopologyEntry> discoverCudaTopology(
             cudaSuccess) {
             continue;
         }
-        for (char *ch = pci_bus_id; (*ch = tolower(*ch)); ch++);
+        for (char *ch = pci_bus_id; (*ch = tolower(*ch)); ch++)
+            ;
 
         std::vector<std::string> preferred_hca;
         std::vector<std::string> avail_hca;
@@ -477,7 +478,7 @@ int Topology::discover(const std::vector<std::string> &filter) {
     for (auto &ent : discoverCpuTopology(all_hca)) {
         matrix_[ent.name] = ent;
     }
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
     for (auto &ent : discoverCudaTopology(all_hca)) {

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -44,7 +44,7 @@ struct SessionHeader {
     uint8_t opcode;
 };
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
 static bool isCudaMemory(void* addr) {
@@ -120,7 +120,7 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
 
         char* dram_buffer = addr + total_transferred_bytes_;
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
         if (isCudaMemory(addr)) {
@@ -143,7 +143,7 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
             *socket_, asio::buffer(dram_buffer, buffer_size),
             [this, addr, dram_buffer, self](const asio::error_code& ec,
                                             std::size_t transferred_bytes) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
                 if (isCudaMemory(addr)) {
@@ -181,7 +181,7 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
 
         char* dram_buffer = addr + total_transferred_bytes_;
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
         bool is_cuda_memory = isCudaMemory(addr);
@@ -209,7 +209,7 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                             << " (value: " << ec.value() << ")";
                     }
                     session_mutex_.unlock();
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
                     if (is_cuda_memory) delete[] dram_buffer;
@@ -217,7 +217,7 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                     return;  // Connection will be closed
                 }
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
                 if (is_cuda_memory) {
@@ -274,9 +274,10 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
             *socket_, asio::buffer(&header_, sizeof(SessionHeader)),
             [this, self](const asio::error_code& ec, std::size_t len) {
                 if (ec || len != sizeof(SessionHeader)) {
-                    LOG(ERROR) << "ClientSession::writeHeader failed. Error: "
-                               << ec.message() << " (value: " << ec.value()
-                               << ")" << ", bytes written: " << len;
+                    LOG(ERROR)
+                        << "ClientSession::writeHeader failed. Error: "
+                        << ec.message() << " (value: " << ec.value() << ")"
+                        << ", bytes written: " << len;
                     if (on_finalize_) on_finalize_(TransferStatusEnum::FAILED);
                     session_mutex_.unlock();
                     if (on_complete_) on_complete_();
@@ -305,7 +306,7 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
 
         char* dram_buffer = addr + total_transferred_bytes_;
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
         bool is_cuda_memory = isCudaMemory(addr);
@@ -329,7 +330,7 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                         << " (value: " << ec.value() << ")";
                     if (on_finalize_) on_finalize_(TransferStatusEnum::FAILED);
                     if (on_complete_) on_complete_();
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
                     if (is_cuda_memory) delete[] dram_buffer;
@@ -338,7 +339,7 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                     return;
                 }
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
                 if (is_cuda_memory) {
@@ -381,7 +382,7 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
 
         char* dram_buffer = addr + total_transferred_bytes_;
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
         if (isCudaMemory(addr)) {
@@ -406,7 +407,7 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
             *socket_, asio::buffer(dram_buffer, buffer_size),
             [this, addr, dram_buffer, self](const asio::error_code& ec,
                                             std::size_t transferred_bytes) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
                 if (isCudaMemory(addr)) {

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -45,7 +45,8 @@ struct SessionHeader {
 };
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
 static bool isCudaMemory(void* addr) {
     cudaPointerAttributes attributes;
     auto status = cudaPointerGetAttributes(&attributes, addr);
@@ -120,7 +121,8 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
         char* dram_buffer = addr + total_transferred_bytes_;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
         if (isCudaMemory(addr)) {
             dram_buffer = new char[buffer_size];
             cudaError_t cuda_status =
@@ -142,7 +144,8 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
             [this, addr, dram_buffer, self](const asio::error_code& ec,
                                             std::size_t transferred_bytes) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
                 if (isCudaMemory(addr)) {
                     delete[] dram_buffer;
                 }
@@ -179,7 +182,8 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
         char* dram_buffer = addr + total_transferred_bytes_;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
         bool is_cuda_memory = isCudaMemory(addr);
         if (is_cuda_memory) {
             dram_buffer = new char[buffer_size];
@@ -206,14 +210,16 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                     }
                     session_mutex_.unlock();
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
                     if (is_cuda_memory) delete[] dram_buffer;
 #endif
                     return;  // Connection will be closed
                 }
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
                 if (is_cuda_memory) {
                     cudaError_t cuda_status =
                         cudaMemcpy(addr + total_transferred_bytes_, dram_buffer,
@@ -300,7 +306,8 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
         char* dram_buffer = addr + total_transferred_bytes_;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
         bool is_cuda_memory = isCudaMemory(addr);
         if (is_cuda_memory) {
             dram_buffer = new char[buffer_size];
@@ -323,7 +330,8 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                     if (on_finalize_) on_finalize_(TransferStatusEnum::FAILED);
                     if (on_complete_) on_complete_();
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
                     if (is_cuda_memory) delete[] dram_buffer;
 #endif
                     session_mutex_.unlock();
@@ -331,7 +339,8 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                 }
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
                 if (is_cuda_memory) {
                     cudaError_t cuda_status =
                         cudaMemcpy(addr + total_transferred_bytes_, dram_buffer,
@@ -373,7 +382,8 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
         char* dram_buffer = addr + total_transferred_bytes_;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
         if (isCudaMemory(addr)) {
             dram_buffer = new char[buffer_size];
             cudaError_t cuda_status =
@@ -397,7 +407,8 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
             [this, addr, dram_buffer, self](const asio::error_code& ec,
                                             std::size_t transferred_bytes) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
                 if (isCudaMemory(addr)) {
                     delete[] dram_buffer;
                 }

--- a/mooncake-transfer-engine/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test.cpp
@@ -48,7 +48,7 @@
 #include <cufile.h>
 #endif
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
 
@@ -175,7 +175,7 @@ void setBackendDevice(const std::string &backend) {
     if (!usesDeviceMemory(backend)) {
         return;
     }
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
     checkCudaError(cudaSetDevice(pickDevId(backend)), "Failed to set device");
@@ -187,7 +187,7 @@ void setBackendDevice(const std::string &backend) {
 void *allocateMemoryPool(size_t size, int socket_id,
                          const std::string &backend) {
     if (usesDeviceMemory(backend)) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
         setBackendDevice(backend);
@@ -205,7 +205,7 @@ void *allocateMemoryPool(size_t size, int socket_id,
 
 void freeMemoryPool(void *addr, size_t size, const std::string &backend) {
     if (usesDeviceMemory(backend)) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
         cudaFree(addr);
@@ -220,7 +220,7 @@ void freeMemoryPool(void *addr, size_t size, const std::string &backend) {
 void copyFromHost(void *dst, const void *src, size_t size,
                   const std::string &backend) {
     if (usesDeviceMemory(backend)) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
         checkCudaError(cudaMemcpy(dst, src, size, cudaMemcpyHostToDevice),
@@ -236,7 +236,7 @@ void copyFromHost(void *dst, const void *src, size_t size,
 void copyToHost(void *dst, const void *src, size_t size,
                 const std::string &backend) {
     if (usesDeviceMemory(backend)) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
         checkCudaError(cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost),

--- a/mooncake-transfer-engine/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test.cpp
@@ -49,7 +49,8 @@
 #endif
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
 
 #include <cassert>
 
@@ -100,7 +101,7 @@ std::string pickBackend() {
 #if defined(USE_MLU)
     return "mlu";
 #elif defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     return FLAGS_use_vram ? "gpu" : "cpu";
 #else
     return "cpu";
@@ -112,7 +113,7 @@ int pickDevId(const std::string &backend) {
         return FLAGS_device_id;
     }
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     if (backend == "gpu") {
         return FLAGS_gpu_id;
     }
@@ -127,7 +128,7 @@ void validateBackend(const std::string &backend) {
         return;
     }
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
     if (backend == "gpu") {
         return;
     }
@@ -175,7 +176,8 @@ void setBackendDevice(const std::string &backend) {
         return;
     }
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
     checkCudaError(cudaSetDevice(pickDevId(backend)), "Failed to set device");
 #else
     LOG(FATAL) << "Device memory backend is not available in this build";
@@ -186,7 +188,8 @@ void *allocateMemoryPool(size_t size, int socket_id,
                          const std::string &backend) {
     if (usesDeviceMemory(backend)) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
         setBackendDevice(backend);
         void *d_buf = nullptr;
         checkCudaError(cudaMalloc(&d_buf, size),
@@ -203,7 +206,8 @@ void *allocateMemoryPool(size_t size, int socket_id,
 void freeMemoryPool(void *addr, size_t size, const std::string &backend) {
     if (usesDeviceMemory(backend)) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
         cudaFree(addr);
         return;
 #else
@@ -217,7 +221,8 @@ void copyFromHost(void *dst, const void *src, size_t size,
                   const std::string &backend) {
     if (usesDeviceMemory(backend)) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
         checkCudaError(cudaMemcpy(dst, src, size, cudaMemcpyHostToDevice),
                        "Failed to copy host data to device");
         return;
@@ -232,7 +237,8 @@ void copyToHost(void *dst, const void *src, size_t size,
                 const std::string &backend) {
     if (usesDeviceMemory(backend)) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MLU) || defined(USE_MACA)
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
         checkCudaError(cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost),
                        "Failed to copy device data to host");
         return;

--- a/mooncake-transfer-engine/tests/tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_transport_test.cpp
@@ -28,7 +28,7 @@
 #endif
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 #include <cassert>
 #include "common/base/status.h"
 
@@ -45,7 +45,7 @@ static void checkCudaError(cudaError_t result, const char *message) {
 #include "transport/transport.h"
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) || \
-    defined(USE_MACA)
+    defined(USE_MACA) || defined(USE_HYGON) || defined(USE_COREX)
 DEFINE_int32(gpu_id, 0, "GPU ID to use");
 #endif
 


### PR DESCRIPTION
## Description

Add build system and runtime support for two CUDA-compatible domestic accelerator platforms:

- **Hygon DCU with DTK SDK** (`USE_HYGON`) — SDK path resolved from `DTK_HOME` env var or `/opt/dtk` default
- **Iluvatar CoreX SDK** (`USE_COREX`) — SDK path resolved from `COREX_HOME` env var or `/usr/local/corex` default

Both platforms expose CUDA-compatible APIs, so the integration follows the same pattern as existing CUDA-like platforms (MUSA, MACA): add the new macros to all platform guard chains and register SDK paths in CMake.

## Module

- [x] Transfer Engine (mooncake-transfer-engine)
- [x] Mooncake Store (mooncake-store)
- [x] Docs

## Type of Change

- [x] New feature

## How Has This Been Tested?

Build configuration tested with cmake -DUSE_HYGON=ON and cmake -DUSE_COREX=ON (CMake configure succeeds; full compilation requires the respective SDKs installed).

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have updated the documentation.

Co-authored-by: KarmaD7 <KarmaD7@users.noreply.github.com>