### PR TITLE
[TE] Gate auto failover on status polling

### DIFF
--- a/mooncake-transfer-engine/tent/config/transfer-engine.json
+++ b/mooncake-transfer-engine/tent/config/transfer-engine.json
@@ -11,6 +11,7 @@
     },
     "log_level": "warning",
     "max_failover_attempts": 3,
+    "enable_auto_failover_on_poll": true,
     "metrics": {
         "enabled": true,
         "http_port": 9100,

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -186,6 +186,9 @@ class TransferEngineImpl {
 
     Status resubmitTransferTask(Batch* batch, size_t task_id);
 
+    void updateTaskStatusFromPoll(Batch* batch, size_t task_id,
+                                  TransferStatus& task_status);
+
     TransportType resolveTransport(const Request& req, int priority,
                                    bool invalidate_on_fail = true);
 
@@ -236,6 +239,7 @@ class TransferEngineImpl {
     std::unique_ptr<ProxyManager> staging_proxy_;
     bool merge_requests_;
     int max_failover_attempts_{3};
+    bool enable_auto_failover_on_poll_{true};
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -304,6 +304,8 @@ Status TransferEngineImpl::construct() {
     CHECK_STATUS(getRpcServerPortFromConfig(*conf_, 0, port_));
     merge_requests_ = conf_->get("merge_requests", true);
     max_failover_attempts_ = conf_->get("max_failover_attempts", 3);
+    enable_auto_failover_on_poll_ =
+        conf_->get("enable_auto_failover_on_poll", true);
     if (!hostname_.empty())
         CHECK_STATUS(checkLocalIpAddress(hostname_, ipv6_));
     else
@@ -1304,6 +1306,18 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
     return transport->submitTransferTasks(sub_batch, {task.request});
 }
 
+void TransferEngineImpl::updateTaskStatusFromPoll(Batch* batch, size_t task_id,
+                                                  TransferStatus& task_status) {
+    auto& task = batch->task_list[task_id];
+    task.status = task_status.s;
+    if (!enable_auto_failover_on_poll_ || task_status.s != FAILED) return;
+
+    if (resubmitTransferTask(batch, task_id).ok()) {
+        task_status.s = PENDING;
+        task.status = PENDING;
+    }
+}
+
 Status TransferEngineImpl::sendNotification(SegmentID target_id,
                                             const Notification& notifi) {
     for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
@@ -1368,12 +1382,7 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
         CHECK_STATUS(transport->getTransferStatus(sub_batch, task.sub_task_id,
                                                   task_status));
     }
-    batch->task_list[task_id].status = task_status.s;
-
-    if (task_status.s == FAILED && resubmitTransferTask(batch, task_id).ok()) {
-        task_status.s = PENDING;
-        batch->task_list[task_id].status = PENDING;
-    }
+    updateTaskStatusFromPoll(batch, task_id, task_status);
 
     // Record metrics when task transitions to terminal state
     recordTaskCompletionMetrics(batch->task_list[task_id], prev_status,
@@ -1448,17 +1457,8 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
             CHECK_STATUS(transport->getTransferStatus(
                 sub_batch, task.sub_task_id, task_status));
         }
-        // memorize task result
-        task.status = task_status.s;
-
-        // Attempt failover before status aggregation so that a
-        // successfully resubmitted task appears as PENDING and does not
-        // latch the batch to a terminal state while retries are in-flight.
-        if (task_status.s == FAILED &&
-            resubmitTransferTask(batch, task_id).ok()) {
-            task.status = PENDING;
-            task_status.s = PENDING;
-        }
+        // Preserve legacy auto-failover-on-poll before aggregating status.
+        updateTaskStatusFromPoll(batch, task_id, task_status);
 
         if (task_status.s == COMPLETED) {
             success_tasks++;

--- a/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
@@ -218,6 +218,47 @@ TransferStatus pollUntilDone(
     return ts;
 }
 
+struct CorruptedRdmaBatch {
+    std::shared_ptr<FakeTransport> fake_rdma;
+    std::shared_ptr<FakeTransport> fake_tcp;
+    std::vector<uint8_t> buf;
+    BatchID batch_id{0};
+};
+
+void submitCorruptedRdmaBatch(TransferEngineImpl& engine,
+                              CorruptedRdmaBatch& batch, uint8_t fill) {
+    batch.fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    batch.fake_tcp = std::make_shared<FakeTransport>(TCP);
+
+    FaultPolicy rdma_policy;
+    rdma_policy.status_corrupt_rate = 1.0;
+    auto proxied_rdma =
+        std::make_shared<FaultProxyTransport>(batch.fake_rdma, rdma_policy);
+
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(proxied_rdma->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(batch.fake_tcp->install(seg_name, nullptr, nullptr).ok());
+
+    engine.swapTransportForTest(RDMA, proxied_rdma);
+    engine.swapTransportForTest(TCP, batch.fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    batch.buf.assign(kBufLen, fill);
+    ASSERT_TRUE(engine.registerLocalMemory(batch.buf.data(), kBufLen).ok());
+
+    batch.batch_id = engine.allocateBatch(8);
+    ASSERT_NE(batch.batch_id, (BatchID)0);
+
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = batch.buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(batch.buf.data());
+    req.length = kBufLen;
+
+    ASSERT_TRUE(engine.submitTransfer(batch.batch_id, {req}).ok());
+}
+
 // ---------------------------------------------------------------------------
 // P0: Completion reports FAILED (simulates WC error / QP error / peer drop
 // mid-transfer). Engine must failover.
@@ -269,6 +310,67 @@ TEST(EngineFailoverE2E, StatusCorruptionTriggersFailoverToSecondary) {
 
     EXPECT_TRUE(engine.freeBatch(batch_id).ok());
     EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+TEST(EngineFailoverE2E, AutoFailoverOnPollDisabledLeavesTaskFailed) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    CorruptedRdmaBatch batch;
+    submitCorruptedRdmaBatch(engine, batch, 0xA1);
+
+    TransferStatus status{};
+    ASSERT_TRUE(engine.getTransferStatus(batch.batch_id, 0, status).ok());
+    EXPECT_EQ(status.s, TransferStatusEnum::FAILED);
+    EXPECT_EQ(batch.fake_rdma->submit_calls.load(), 1);
+    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(batch.batch_id).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(batch.buf.data(), batch.buf.size()).ok());
+}
+
+TEST(EngineFailoverE2E, AutoFailoverOnPollDisabledAppliesToVectorStatus) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    CorruptedRdmaBatch batch;
+    submitCorruptedRdmaBatch(engine, batch, 0xA2);
+
+    std::vector<TransferStatus> status_list;
+    ASSERT_TRUE(engine.getTransferStatus(batch.batch_id, status_list).ok());
+    ASSERT_EQ(status_list.size(), 1);
+    EXPECT_EQ(status_list[0].s, TransferStatusEnum::FAILED);
+    EXPECT_EQ(batch.fake_rdma->submit_calls.load(), 1);
+    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(batch.batch_id).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(batch.buf.data(), batch.buf.size()).ok());
+}
+
+TEST(EngineFailoverE2E, AutoFailoverOnPollDisabledAppliesToOverallStatus) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    CorruptedRdmaBatch batch;
+    submitCorruptedRdmaBatch(engine, batch, 0xA3);
+
+    TransferStatus overall_status{};
+    ASSERT_TRUE(engine.getTransferStatus(batch.batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::FAILED);
+    EXPECT_EQ(batch.fake_rdma->submit_calls.load(), 1);
+    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(batch.batch_id).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(batch.buf.data(), batch.buf.size()).ok());
 }
 
 // ---------------------------------------------------------------------------

--- a/mooncake-transfer-engine/tent/tests/failover_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/failover_test.cpp
@@ -111,6 +111,17 @@ TEST(FailoverConfigTest, ZeroDisablesFailover) {
     EXPECT_GT(task.failover_count, max_attempts);
 }
 
+TEST(FailoverConfigTest, AutoFailoverOnPollDefaultEnabled) {
+    auto conf = std::make_shared<Config>();
+    EXPECT_TRUE(conf->get("enable_auto_failover_on_poll", true));
+}
+
+TEST(FailoverConfigTest, AutoFailoverOnPollCanBeDisabled) {
+    auto conf = std::make_shared<Config>();
+    conf->set("enable_auto_failover_on_poll", false);
+    EXPECT_FALSE(conf->get("enable_auto_failover_on_poll", true));
+}
+
 // ---------------------------------------------------------------------------
 // TransportType name coverage (tests the static helper indirectly via
 // the enum values — the function itself is file-local in the .cpp, so we


### PR DESCRIPTION
## Description

Refs #2116.

This PR adds a TENT config option, `enable_auto_failover_on_poll`, to gate the existing automatic failover behavior during status polling.

The option defaults to `true` to preserve the current backward-compatible behavior. When set to `false`, `getTransferStatus()` reports the observed task or batch status without triggering `resubmitTransferTask()` from the polling path. The behavior is applied consistently to task-level, vector, and overall batch status queries through a shared helper.

The larger explicit progress API split discussed in #2116 is intentionally left out of this focused PR.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- `cmake --build build-tent-2116-system --target tent_failover_test tent_engine_failover_e2e_test`
- `ctest --test-dir build-tent-2116-system -R tent_.*failover.*test --output-on-failure`
- `git -c core.filemode=false diff --check upstream/main...HEAD`

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.