### PR TITLE
[Store] Fix std::terminate crash on mooncake client shutdown (Issue#2115)

### DIFF
--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -833,6 +833,7 @@ class RealClient : public PyClient {
     // Dummy Client manage related members
     void dummy_client_monitor_func();
     int start_dummy_client_monitor();
+    void stop_dummy_client_monitor();
     std::thread dummy_client_monitor_thread_;
     std::atomic<bool> dummy_client_monitor_running_{false};
     static constexpr uint64_t kDummyClientMonitorSleepMs =

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1057,6 +1057,7 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
     }
 
     stop_ipc_server();
+    stop_dummy_client_monitor();
     stop_http_server();
 
     if (!client_) {
@@ -5145,6 +5146,13 @@ int RealClient::start_dummy_client_monitor() {
     return 0;
 }
 
+void RealClient::stop_dummy_client_monitor() {
+    dummy_client_monitor_running_ = false;
+    if (dummy_client_monitor_thread_.joinable()) {
+        dummy_client_monitor_thread_.join();
+    }
+    LOG(INFO) << "dummy_client_monitor_thread stopped";
+}
 int RealClient::start_ipc_server() {
     ipc_running_ = true;
     ipc_thread_ = std::jthread(&RealClient::ipc_server_func, this);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -5150,8 +5150,8 @@ void RealClient::stop_dummy_client_monitor() {
     dummy_client_monitor_running_ = false;
     if (dummy_client_monitor_thread_.joinable()) {
         dummy_client_monitor_thread_.join();
+        LOG(INFO) << "dummy_client_monitor_thread stopped";
     }
-    LOG(INFO) << "dummy_client_monitor_thread stopped";
 }
 int RealClient::start_ipc_server() {
     ipc_running_ = true;


### PR DESCRIPTION
## Description

Fix `std::terminate` crash in standalone `mooncake_client` on shutdown. The `dummy_client_monitor_thread_` (`std::thread`) is started in `start_dummy_client_monitor()` but never joined or detached, so `~RealClient()` triggers `std::terminate()` per the C++ spec.

Add `stop_dummy_client_monitor()` following the same pattern as `stop_ipc_server()`: set the running flag to false, then join the thread. The call is placed in `tearDownAll_internal()` before `stop_http_server()` and before the `dummy_client_mutex_` lock acquisition, avoiding both the early-return skip and the lock-then-join deadlock.

Fixes #2115

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other


