### PR TITLE
[Store] correct GC interval default fallback in FromEnvironment

### DIFF
--- a/docs/source/deployment/ssd-offload.md
+++ b/docs/source/deployment/ssd-offload.md
@@ -93,7 +93,7 @@ store.setup(
 | `MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES` | `2199023255552` (2 TB) | Maximum disk usage |
 | `MOONCAKE_OFFLOAD_TOTAL_KEYS_LIMIT` | `10000000` | Maximum number of objects on disk |
 | `MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS` | `10` | Interval for offload heartbeat to master (seconds) |
-| `MOONCAKE_OFFLOAD_CLIENT_BUFFER_GC_INTERVAL_SECONDS` | `10` | Interval for reclaiming expired offload buffers; defaults to the heartbeat interval in the current implementation |
+| `MOONCAKE_OFFLOAD_CLIENT_BUFFER_GC_INTERVAL_SECONDS` | `1` | Interval for reclaiming expired offload buffers; defaults to the heartbeat interval in the current implementation |
 | `MOONCAKE_OFFLOAD_CLIENT_BUFFER_GC_TTL_MS` | `5000` | Lease time for buffers returned by `batch_get_offload_object` before GC reclaims them |
 | `MOONCAKE_OFFLOAD_USE_URING` | `false` | Enable io_uring for async file I/O |
 

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -58,7 +58,7 @@ FileStorageConfig FileStorageConfig::FromEnvironment() {
                            config.heartbeat_interval_seconds);
     config.client_buffer_gc_interval_seconds =
         GetEnvOr<uint32_t>("MOONCAKE_OFFLOAD_CLIENT_BUFFER_GC_INTERVAL_SECONDS",
-                           config.heartbeat_interval_seconds);
+                           config.client_buffer_gc_interval_seconds);
 
     config.client_buffer_gc_ttl_ms =
         GetEnvOr<uint64_t>("MOONCAKE_OFFLOAD_CLIENT_BUFFER_GC_TTL_MS",


### PR DESCRIPTION
 ## Description
Investigating why issue(bug) #2119 might happen, this is the most likely contributing factor — and a confirmed bug in its own right.

Fix a copy-paste bug in `FileStorageConfig::FromEnvironment()` (`file_storage.cpp:61-63`). The `GetEnvOr` fallback for `client_buffer_gc_interval_seconds` incorrectly uses `config.heartbeat_interval_seconds` (10s) instead of `config.client_buffer_gc_interval_seconds` (1s), causing the GC thread to run every 10 seconds instead of every 1 second when the env var is not set. This delays zombie buffer reclamation and leads to `BUFFER_OVERFLOW` under concurrent load.

```cpp
// Before
config.client_buffer_gc_interval_seconds =
    GetEnvOr<uint32_t>("MOONCAKE_OFFLOAD_CLIENT_BUFFER_GC_INTERVAL_SECONDS",
                       config.heartbeat_interval_seconds);

// After
config.client_buffer_gc_interval_seconds =
    GetEnvOr<uint32_t>("MOONCAKE_OFFLOAD_CLIENT_BUFFER_GC_INTERVAL_SECONDS",
                       config.client_buffer_gc_interval_seconds);
```



## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

