### PR TITLE
[CI] change dependency `libboost-all-dev` to `libboost-dev`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get install -y libibverbs-dev \
     libjsoncpp-dev \
     libnuma-dev \
     libpython3-dev \
-    libboost-all-dev \
+    libboost-dev \
     libssl-dev \
     libgrpc-dev \
     libgrpc++-dev \

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -112,7 +112,7 @@ SYSTEM_PACKAGES="build-essential \
                   libunwind-dev \
                   libnuma-dev \
                   libpython3-dev \
-                  libboost-all-dev \
+                  libboost-dev \
                   libssl-dev \
                   libgrpc-dev \
                   libgrpc++-dev \

--- a/docs/source/design/transfer-engine/kunpeng_ub_transport.md
+++ b/docs/source/design/transfer-engine/kunpeng_ub_transport.md
@@ -50,7 +50,7 @@ sudo apt-get install -y \
     libjsoncpp-dev \
     libnuma-dev \
     libibverbs-dev \
-    libboost-all-dev \
+    libboost-dev \
     libcurl4-openssl-dev \
     libgtest-dev \
     libmsgpack-dev \

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -70,7 +70,7 @@ pip install mooncake-transfer-engine-non-cuda
                        libnuma-dev \
                        libunwind-dev \
                        libpython3-dev \
-                       libboost-all-dev \
+                       libboost-dev \
                        libssl-dev \
                        pybind11-dev \
                        libcurl4-openssl-dev \

--- a/scripts/ascend/dependencies_ascend.sh
+++ b/scripts/ascend/dependencies_ascend.sh
@@ -60,7 +60,7 @@ if command -v apt-get &> /dev/null; then
             libunwind-dev \
             libnuma-dev \
             libpython3-dev \
-            libboost-all-dev \
+            libboost-dev \
             libssl-dev \
             libzstd-dev \
             libgrpc-dev \

--- a/scripts/ascend/dependencies_ascend_installation.sh
+++ b/scripts/ascend/dependencies_ascend_installation.sh
@@ -70,7 +70,7 @@ if command -v apt-get &> /dev/null; then
             libunwind-dev \
             libnuma-dev \
             libpython3-dev \
-            libboost-all-dev \
+            libboost-dev \
             libssl-dev \
             libgrpc-dev \
             libgrpc++-dev \


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Motivation

- Some distros may fail to install the full `libboost-all-dev`.
- Changing it to `libboost-dev` can make dependencies smaller and more efficient.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
