### PR TITLE
ci: add test step for TENT in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -634,6 +634,14 @@ jobs:
         sudo cmake --install .
       shell: bash
 
+    - name: Test (TENT)
+      run: |
+        cd build-tent
+        export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
+        export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
+        ctest -j --output-on-failure
+      shell: bash
+
     - name: Build nvlink_allocator.so
       run: |
         mkdir -p build/mooncake-transfer-engine/nvlink-allocator


### PR DESCRIPTION
## Summary
- Add a `Test (TENT)` step after the Tent build in `ci.yml`
- Runs `ctest -j --output-on-failure` in the `build-tent` directory

## Test plan
- [ ] CI `build-ubuntu` job passes the new `Test (TENT)` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)