### PR TITLE
[Store] Add structured object store helper

### DIFF
--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -169,7 +169,7 @@ transfer = MooncakeBundleTransfer(store, key_prefix="demo/structured")
 payload = StructuredObjectPayload(
     metadata={"step": 7, "layout": "rollout"},
     buffers={
-        "tokens": np.arange(24, dtype=np.int32).reshape(6, 4),
+        "tokens": np.array(range(24), dtype=np.int32).reshape(6, 4),
         "mask": np.ones((6, 4), dtype=np.int8),
         "prompt_ids": b"sample-ids",
     },

--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -130,6 +130,111 @@ store.close()
 
 </details>
 
+## Structured Object Store Helper
+
+`mooncake.structured_object_store` provides a higher-level helper for one logical object that contains multiple named members.
+It is designed for cases such as rollout / batch transfer where callers want to keep their own object semantics locally while using Mooncake for fast payload movement.
+
+The helper separates two concepts:
+
+- **structured object path**: named members with metadata-aware materialization;
+- **generic bundle path**: manifest + named payloads when the caller only needs raw grouped objects.
+
+### Main types
+
+```python
+from mooncake.structured_object_store import (
+    MooncakeBundleTransfer,
+    StructuredMemberSlice,
+    StructuredObjectPayload,
+)
+```
+
+- `MooncakeBundleTransfer`: public helper facade built on a `MooncakeDistributedStore`.
+- `StructuredObjectPayload`: structured object to write. Members are passed in `buffers`, and optional object metadata is passed in `metadata`.
+- `StructuredMemberSlice`: slice selection for one structured member during reads.
+
+### Structured object write and full read
+
+Use `put_structured_object()` to write one structured object. The default read path is `read_spec(ref)`, and full-object materialization is just the default case of the partial-read API.
+
+```python
+import numpy as np
+from mooncake.store import MooncakeDistributedStore
+from mooncake.structured_object_store import MooncakeBundleTransfer, StructuredObjectPayload
+
+store = MooncakeDistributedStore()
+transfer = MooncakeBundleTransfer(store, key_prefix="demo/structured")
+
+payload = StructuredObjectPayload(
+    metadata={"step": 7, "layout": "rollout"},
+    buffers={
+        "tokens": np.arange(24, dtype=np.int32).reshape(6, 4),
+        "mask": np.ones((6, 4), dtype=np.int8),
+        "prompt_ids": b"sample-ids",
+    },
+)
+
+ref = transfer.put_structured_object(payload)
+result = transfer.materialize(transfer.read_spec(ref))
+
+tokens = result.objects["tokens"]
+prompt_ids = result.objects["prompt_ids"]
+metadata = result.metadata
+```
+
+### Partial reads
+
+Read narrowing happens on top of `read_spec(ref)`:
+
+- `select_members([...])` keeps only selected members;
+- `slice_member(name, axis=0, start=..., end=...)` slices one ndarray member;
+- `materialize(spec)` returns newly materialized objects.
+
+```python
+spec = (
+    transfer.read_spec(ref)
+    .select_members(["tokens"])
+    .slice_member("tokens", axis=0, start=2, end=5)
+)
+result = transfer.materialize(spec)
+
+selected_tokens = result.objects["tokens"]
+```
+
+Current scope:
+
+- byte members support full-member reads;
+- ndarray members support full reads and sliced reads;
+- full read is the default `read_spec(ref)` case.
+
+### Reusing caller-owned destinations
+
+Use `materialize_into()` when the caller already owns the destination ndarray buffers and wants Mooncake to fill them directly.
+
+```python
+destination = np.empty((3, 4), dtype=np.int32)
+spec = (
+    transfer.read_spec(ref)
+    .select_members(["tokens"])
+    .slice_member("tokens", axis=0, start=2, end=5)
+)
+result = transfer.materialize_into(spec, {"tokens": destination})
+
+assert result.objects["tokens"] is destination
+```
+
+`materialize_into()` is only for members whose destination layout is already known to the caller. For byte members or default object reconstruction, use `materialize()`.
+
+### Generic bundle fallback
+
+If the caller does not need structured member semantics, the same helper also supports raw named bundles:
+
+- `put_bundle(...)`
+- `remove_bundle(...)`
+
+Use the bundle path when the object is just a manifest plus named payloads, and use the structured object path when callers want member selection, slicing, and ndarray-aware materialization.
+
 ## Zero-Copy API (Advanced Performance)
 
 For maximum performance, especially with RDMA networks, use the zero-copy API. This allows direct memory access without intermediate copies.

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1,0 +1,1172 @@
+from __future__ import annotations
+
+import ctypes
+import json
+import uuid
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Iterator, Literal, Mapping, Optional, Protocol, Sequence
+
+import numpy as np
+
+DEFAULT_BUNDLE_CHUNK_BYTES = 512 * 1024**2
+AUTO_PARALLEL_MIN_BYTES = 4 * 1024**3
+AUTO_PARALLEL_MIN_CHUNKS = 8
+MISSING_OBJECT_ERROR = -704  # Mooncake remove returns -704 for an already-missing object.
+STRUCTURED_FIELD_SPECS_KEY = "__mooncake_structured_fields__"
+
+
+class BundleStore(Protocol):
+    def put(self, key: str, value: Any) -> int: ...
+
+    def get(self, key: str) -> bytes: ...
+
+    def remove(self, key: str, force: bool = False) -> int: ...
+
+
+@dataclass(frozen=True)
+class BundleTransferPolicy:
+    """Controls generic bundle transfer parallelism."""
+
+    max_inflight_put: int = 1
+    put_mode: Literal["auto", "batch", "parallel"] = "auto"
+
+
+@dataclass
+class RemoteBundleRef:
+    """Reference to a generic named-buffer bundle stored in Mooncake."""
+
+    manifest_key: str
+    manifest: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class StructuredObjectPayload:
+    """Structured object encoded as metadata plus named buffers."""
+
+    metadata: Mapping[str, Any]
+    buffers: Mapping[str, Any]
+
+
+@dataclass
+class StructuredObjectResult:
+    """Materialized structured object data fetched from Mooncake."""
+
+    metadata: dict[str, Any]
+    objects: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class StructuredMemberSlice:
+    """Slice description for one structured member."""
+
+    axis: int
+    start: int
+    end: int
+    step: int = 1
+
+
+@dataclass(frozen=True)
+class StructuredObjectReadSpec:
+    """Lazy read plan for structured object materialization."""
+
+    ref: RemoteBundleRef | Mapping[str, Any]
+    member_names: tuple[str, ...] | None = None
+    member_slices: tuple[tuple[str, StructuredMemberSlice], ...] = ()
+
+    def select_members(self, names: Optional[Sequence[str]]) -> "StructuredObjectReadSpec":
+        """Return a new spec that materializes only the selected members."""
+        return StructuredObjectReadSpec(
+            ref=self.ref,
+            member_names=None if names is None else tuple(names),
+            member_slices=self.member_slices,
+        )
+
+    def slice_member(
+        self,
+        name: str,
+        axis: int,
+        start: int,
+        end: int,
+        step: int = 1,
+    ) -> "StructuredObjectReadSpec":
+        """Return a new spec with a slice applied to one member."""
+        slice_spec = StructuredMemberSlice(axis=axis, start=start, end=end, step=step)
+        member_slices = dict(self.member_slices)
+        member_slices[name] = slice_spec
+        return StructuredObjectReadSpec(
+            ref=self.ref,
+            member_names=self.member_names,
+            member_slices=tuple(member_slices.items()),
+        )
+
+    def member_slice(self, name: str) -> StructuredMemberSlice | None:
+        """Return the configured slice for a member, if any."""
+        return dict(self.member_slices).get(name)
+
+
+@dataclass(frozen=True)
+class _NdarrayReadPlan:
+    dtype: np.dtype[Any]
+    full_shape: tuple[int, ...]
+    output_shape: tuple[int, ...]
+    byte_offset: int
+    byte_length: int
+    step: int
+    cover_row_count: int
+
+
+class MooncakeBundleTransfer:
+    """Transfer structured objects through Mooncake, with a low-level bundle fallback."""
+
+    def __init__(
+        self,
+        store: BundleStore,
+        key_prefix: str = "bundle",
+        default_chunk_bytes: int = DEFAULT_BUNDLE_CHUNK_BYTES,
+    ) -> None:
+        """Initialize a bundle transfer helper with a configurable default chunk size."""
+        self.store = store
+        self.key_prefix = _normalize_key_prefix(key_prefix)
+        self.default_chunk_bytes = _validate_chunk_bytes(default_chunk_bytes)
+        self._transport = _MooncakePayloadTransport(store)
+        self._bundle_store = _BundleManifestStore(
+            store=store,
+            transport=self._transport,
+            key_prefix=self.key_prefix,
+            default_chunk_bytes=self.default_chunk_bytes,
+        )
+        self._structured_store = _StructuredObjectLayer(self._bundle_store)
+
+    def put_bundle(
+        self,
+        meta: bytes | bytearray | memoryview,
+        buffers: Mapping[str, Any],
+        partition: str = "default",
+        chunk_bytes: Optional[int] = None,
+        policy: Optional[BundleTransferPolicy] = None,
+        max_inflight_put: Optional[int] = None,
+        pre_registered_buffers: Optional[Mapping[str, bool]] = None,
+    ) -> RemoteBundleRef:
+        """Store raw metadata bytes plus named buffers as a low-level bundle."""
+        return self._bundle_store.put_bundle(
+            meta=meta,
+            buffers=buffers,
+            partition=partition,
+            chunk_bytes=chunk_bytes,
+            policy=policy,
+            max_inflight_put=max_inflight_put,
+            pre_registered_buffers=pre_registered_buffers,
+        )
+
+    def remove_bundle(self, ref: RemoteBundleRef | Mapping[str, Any]) -> None:
+        """Remove all Mooncake objects that belong to a stored bundle."""
+        self._bundle_store.remove_bundle(ref)
+
+    def put_structured_object(
+        self,
+        payload: StructuredObjectPayload,
+        partition: str = "default",
+        chunk_bytes: Optional[int] = None,
+        policy: Optional[BundleTransferPolicy] = None,
+        max_inflight_put: Optional[int] = None,
+    ) -> RemoteBundleRef:
+        """Store a structured object described by JSON metadata plus named members."""
+        return self._structured_store.put_structured_object(
+            payload=payload,
+            partition=partition,
+            chunk_bytes=chunk_bytes,
+            policy=policy,
+            max_inflight_put=max_inflight_put,
+        )
+
+    def read_spec(self, ref: RemoteBundleRef | Mapping[str, Any]) -> StructuredObjectReadSpec:
+        """Create a lazy read spec for a structured object reference."""
+        return self._structured_store.read_spec(ref)
+
+    def materialize(self, spec: StructuredObjectReadSpec) -> StructuredObjectResult:
+        """Materialize a structured object read spec."""
+        return self._structured_store.materialize(spec)
+
+    def materialize_into(
+        self,
+        spec: StructuredObjectReadSpec,
+        destinations: Optional[Mapping[str, Any]],
+    ) -> StructuredObjectResult:
+        """Materialize a structured object read spec into caller-provided destinations when possible."""
+        return self._structured_store.materialize_into(spec, destinations)
+
+
+class _StructuredObjectLayer:
+    def __init__(self, bundle_store: "_BundleManifestStore") -> None:
+        self._bundle_store = bundle_store
+
+    def put_structured_object(
+        self,
+        payload: StructuredObjectPayload,
+        partition: str,
+        chunk_bytes: Optional[int],
+        policy: Optional[BundleTransferPolicy],
+        max_inflight_put: Optional[int],
+    ) -> RemoteBundleRef:
+        metadata, buffers = _encode_structured_fields(payload.metadata, payload.buffers)
+        return self._bundle_store.put_bundle(
+            meta=_encode_structured_metadata(metadata),
+            buffers=buffers,
+            partition=partition,
+            chunk_bytes=chunk_bytes,
+            policy=policy,
+            max_inflight_put=max_inflight_put,
+        )
+
+    def read_spec(self, ref: RemoteBundleRef | Mapping[str, Any]) -> StructuredObjectReadSpec:
+        return StructuredObjectReadSpec(ref=ref)
+
+    def materialize(self, spec: StructuredObjectReadSpec) -> StructuredObjectResult:
+        return self.materialize_into(spec, destinations=None)
+
+    def materialize_into(
+        self,
+        spec: StructuredObjectReadSpec,
+        destinations: Optional[Mapping[str, Any]],
+    ) -> StructuredObjectResult:
+        metadata, buffers, selected = self._resolve_structured_read(spec)
+        field_specs = _structured_field_specs(metadata)
+        destination_map = destinations or {}
+        member_slices = dict(spec.member_slices)
+        objects = {
+            name: self._read_structured_member(
+                name=name,
+                payload_spec=buffers[name],
+                field_spec=field_specs.get(name, {"encoding": "bytes"}),
+                member_slice=member_slices.get(name),
+                destination=destination_map.get(name),
+            )
+            for name in selected
+        }
+        return StructuredObjectResult(metadata=dict(metadata), objects=objects)
+
+    def _resolve_structured_read(
+        self,
+        spec: StructuredObjectReadSpec,
+    ) -> tuple[dict[str, Any], Mapping[str, Any], list[str]]:
+        if spec.member_names is not None and not spec.member_names:
+            raise ValueError("structured read spec selected no members")
+        manifest = self._bundle_store.resolve_manifest(spec.ref)
+        metadata = _decode_structured_metadata(self._bundle_store.read_payload(manifest["meta"]))
+        buffers = manifest["buffers"]
+        selected = list(buffers) if spec.member_names is None else list(spec.member_names)
+        missing = [name for name in selected if name not in buffers]
+        if missing:
+            raise KeyError(f"unknown bundle buffers: {missing}")
+        return metadata, buffers, selected
+
+    def _read_structured_member(
+        self,
+        name: str,
+        payload_spec: Mapping[str, Any],
+        field_spec: Mapping[str, Any],
+        member_slice: StructuredMemberSlice | None,
+        destination: Any,
+    ) -> Any:
+        encoding = field_spec.get("encoding", "bytes")
+        if encoding == "bytes":
+            return self._read_bytes_member(name, payload_spec, member_slice, destination)
+        if encoding != "ndarray":
+            raise ValueError(f"unsupported structured field encoding: {encoding}")
+        return self._read_ndarray_member(name, payload_spec, field_spec, member_slice, destination)
+
+    def _read_bytes_member(
+        self,
+        name: str,
+        payload_spec: Mapping[str, Any],
+        member_slice: StructuredMemberSlice | None,
+        destination: Any,
+    ) -> bytes:
+        if member_slice is not None:
+            raise ValueError(f"structured bytes member {name} does not support slicing")
+        if destination is not None:
+            raise ValueError(f"structured bytes member {name} does not support materialize_into")
+        return self._bundle_store.read_payload(payload_spec)
+
+    def _read_ndarray_member(
+        self,
+        name: str,
+        payload_spec: Mapping[str, Any],
+        field_spec: Mapping[str, Any],
+        member_slice: StructuredMemberSlice | None,
+        destination: Any,
+    ) -> np.ndarray:
+        dtype = field_spec.get("dtype")
+        shape = field_spec.get("shape")
+        if not isinstance(dtype, str) or not isinstance(shape, list):
+            raise ValueError(f"structured ndarray field {name} is missing dtype or shape")
+        read_plan = _resolve_ndarray_read_plan(tuple(int(dim) for dim in shape), np.dtype(dtype), member_slice)
+        target = _resolve_ndarray_destination(name, destination, read_plan.dtype, read_plan.output_shape)
+        destination_view = target.view(np.uint8).reshape(-1)
+        if read_plan.byte_length == 0:
+            return target
+        if read_plan.step == 1:
+            self._bundle_store.read_payload_range_into_destination(
+                payload_spec,
+                destination_view,
+                read_plan.byte_offset,
+            )
+            return target
+        temp_shape = (read_plan.cover_row_count, *read_plan.full_shape[1:])
+        temp = np.empty(temp_shape, dtype=read_plan.dtype)
+        temp_view = temp.view(np.uint8).reshape(-1)
+        self._bundle_store.read_payload_range_into_destination(payload_spec, temp_view, read_plan.byte_offset)
+        target[...] = temp[:: read_plan.step]
+        return target
+
+class _BundleManifestStore:
+    def __init__(
+        self,
+        store: BundleStore,
+        transport: "_MooncakePayloadTransport",
+        key_prefix: str,
+        default_chunk_bytes: int,
+    ) -> None:
+        self._store = store
+        self._transport = transport
+        self._key_prefix = key_prefix
+        self._default_chunk_bytes = default_chunk_bytes
+
+    def put_bundle(
+        self,
+        meta: bytes | bytearray | memoryview,
+        buffers: Mapping[str, Any],
+        partition: str,
+        chunk_bytes: Optional[int],
+        policy: Optional[BundleTransferPolicy],
+        max_inflight_put: Optional[int],
+        pre_registered_buffers: Optional[Mapping[str, bool]] = None,
+    ) -> RemoteBundleRef:
+        _validate_key_segment(partition, "partition")
+        meta_view = _bytes_view(meta, "meta")
+        target_chunk_bytes = _validate_chunk_bytes(
+            self._default_chunk_bytes if chunk_bytes is None else chunk_bytes
+        )
+        transfer_policy = self._policy(policy, max_inflight_put=max_inflight_put)
+        object_id = f"{partition}/{uuid.uuid4().hex}"
+        base_key = f"{self._key_prefix}/{object_id}"
+        manifest_key = f"{base_key}/manifest"
+        written_keys: list[str] = []
+        buffer_specs: dict[str, Any] = {}
+        pre_registered_map = dict(pre_registered_buffers or {})
+        try:
+            meta_spec, meta_keys = self._put_payload(
+                f"{base_key}/meta",
+                meta_view,
+                target_chunk_bytes,
+                transfer_policy,
+                pre_registered=False,
+            )
+            written_keys.extend(meta_keys)
+            for name, value in buffers.items():
+                _validate_key_segment(name, "buffer name")
+                payload_view = _bytes_view(value, name)
+                payload_spec, payload_keys = self._put_payload(
+                    f"{base_key}/buffer/{name}",
+                    payload_view,
+                    target_chunk_bytes,
+                    transfer_policy,
+                    pre_registered=bool(pre_registered_map.get(name, False)),
+                )
+                buffer_specs[name] = payload_spec
+                written_keys.extend(payload_keys)
+            manifest = {
+                "version": 1,
+                "layout": "bundle",
+                "object_id": object_id,
+                "meta": meta_spec,
+                "buffers": buffer_specs,
+            }
+            manifest_blob = _encode_manifest(manifest)
+            _check_status(self._store.put(manifest_key, manifest_blob), "put", manifest_key)
+            written_keys.append(manifest_key)
+        except Exception:
+            _cleanup_keys(self._store, written_keys, strict=False)
+            raise
+        return RemoteBundleRef(manifest_key=manifest_key, manifest=manifest)
+
+    def remove_bundle(self, ref: RemoteBundleRef | Mapping[str, Any]) -> None:
+        manifest = self.resolve_manifest(ref)
+        keys = self._payload_keys(manifest)
+        keys.append(self._manifest_key(ref, manifest))
+        _cleanup_keys(self._store, keys, strict=True)
+
+    def resolve_manifest(self, ref: RemoteBundleRef | Mapping[str, Any]) -> dict[str, Any]:
+        if isinstance(ref, RemoteBundleRef):
+            manifest = ref.manifest
+        else:
+            manifest = ref.get("manifest")
+            if manifest is None:
+                manifest_key = ref.get("manifest_key")
+                if not isinstance(manifest_key, str):
+                    raise ValueError("bundle ref must include manifest_key")
+                manifest = _decode_manifest(self._store.get(manifest_key))
+        self._validate_manifest(manifest)
+        return manifest
+
+    def read_payload(self, payload_spec: Mapping[str, Any]) -> bytes:
+        return self._transport.read_payload(payload_spec)
+
+    def read_payload_range_into_destination(
+        self,
+        payload_spec: Mapping[str, Any],
+        destination: np.ndarray,
+        byte_offset: int,
+        destination_pre_registered: bool = False,
+    ) -> None:
+        self._transport.read_payload_range_into_destination(
+            payload_spec,
+            destination,
+            byte_offset,
+            destination_pre_registered=destination_pre_registered,
+        )
+
+    def _put_payload(
+        self,
+        key: str,
+        value: memoryview,
+        chunk_bytes: int,
+        transfer_policy: BundleTransferPolicy,
+        pre_registered: bool,
+    ) -> tuple[dict[str, Any], list[str]]:
+        chunks = _split_view(value, chunk_bytes)
+        chunk_keys = [key if len(chunks) == 1 else f"{key}/chunk/{index}" for index in range(len(chunks))]
+        written_keys = self._transport.put_payload_chunks(
+            chunk_keys,
+            chunks,
+            transfer_policy,
+            pre_registered=pre_registered,
+        )
+        payload_spec = {
+            "key": key,
+            "bytes": len(value),
+            "chunks": [
+                {"key": chunk_key, "bytes": len(chunk)}
+                for chunk_key, chunk in zip(chunk_keys, chunks)
+            ],
+        }
+        return payload_spec, written_keys
+
+    def _policy(
+        self,
+        policy: Optional[BundleTransferPolicy],
+        max_inflight_put: Optional[int] = None,
+    ) -> BundleTransferPolicy:
+        result = policy or BundleTransferPolicy()
+        if max_inflight_put is not None:
+            result = BundleTransferPolicy(max_inflight_put=max_inflight_put, put_mode=result.put_mode)
+        if result.max_inflight_put < 1:
+            raise ValueError("max_inflight_put must be positive")
+        if result.put_mode not in {"auto", "batch", "parallel"}:
+            raise ValueError(f"unsupported put_mode: {result.put_mode}")
+        return result
+
+    def _validate_manifest(self, manifest: Mapping[str, Any]) -> None:
+        if manifest.get("version") != 1 or manifest.get("layout") != "bundle":
+            raise ValueError("invalid bundle manifest")
+        object_id = manifest.get("object_id")
+        if not isinstance(object_id, str):
+            raise ValueError("bundle manifest object_id must be a string")
+        base_key = f"{self._key_prefix}/{object_id}"
+        self._validate_payload_spec(manifest.get("meta"), base_key)
+        buffers = manifest.get("buffers")
+        if not isinstance(buffers, dict):
+            raise ValueError("bundle manifest buffers must be a dict")
+        for name, payload_spec in buffers.items():
+            _validate_key_segment(name, "buffer name")
+            self._validate_payload_spec(payload_spec, base_key)
+
+    def _validate_payload_spec(self, payload_spec: Any, base_key: str) -> None:
+        if not isinstance(payload_spec, dict):
+            raise ValueError("bundle payload spec must be a dict")
+        payload_key = payload_spec.get("key")
+        if not isinstance(payload_key, str) or not payload_key.startswith(f"{base_key}/"):
+            raise ValueError("bundle payload key is outside the bundle namespace")
+        expected_bytes = int(payload_spec.get("bytes", -1))
+        if expected_bytes < 0:
+            raise ValueError("bundle payload bytes must be non-negative")
+        chunks = payload_spec.get("chunks")
+        if not isinstance(chunks, list) or (expected_bytes and not chunks):
+            raise ValueError("bundle payload chunks are invalid")
+        seen_keys = set()
+        total_bytes = 0
+        for chunk in chunks:
+            if not isinstance(chunk, dict):
+                raise ValueError("bundle chunk must be a dict")
+            key = chunk.get("key")
+            chunk_bytes = int(chunk.get("bytes", -1))
+            if not isinstance(key, str) or (key != payload_key and not key.startswith(f"{payload_key}/")):
+                raise ValueError("bundle chunk key is outside the payload namespace")
+            if key in seen_keys:
+                raise ValueError("bundle chunk keys must be unique")
+            if chunk_bytes < 0:
+                raise ValueError("bundle chunk bytes must be non-negative")
+            seen_keys.add(key)
+            total_bytes += chunk_bytes
+        if total_bytes != expected_bytes:
+            raise ValueError(f"bundle payload chunks total {total_bytes} bytes, expected {expected_bytes}")
+
+    def _manifest_key(self, ref: RemoteBundleRef | Mapping[str, Any], manifest: Mapping[str, Any]) -> str:
+        expected = f"{self._key_prefix}/{manifest['object_id']}/manifest"
+        manifest_key = ref.manifest_key if isinstance(ref, RemoteBundleRef) else ref.get("manifest_key")
+        if manifest_key is None:
+            return expected
+        if manifest_key != expected:
+            raise ValueError("bundle manifest_key does not match manifest object_id")
+        return manifest_key
+
+    def _payload_keys(self, manifest: Mapping[str, Any]) -> list[str]:
+        return [
+            chunk["key"]
+            for payload_spec in [manifest["meta"], *manifest["buffers"].values()]
+            for chunk in payload_spec["chunks"]
+        ]
+
+
+class _MooncakePayloadTransport:
+    """Move payload bytes through Mooncake, preferring fast-path APIs and falling back to generic store calls."""
+    def __init__(self, store: BundleStore) -> None:
+        self._store = store
+        self._batch_put_from = getattr(store, "batch_put_from", None)
+        self._batch_get_into = getattr(store, "batch_get_into", None)
+        self._get_into = getattr(store, "get_into", None)
+        self._get_into_ranges = getattr(store, "get_into_ranges", None)
+        self._register_buffer = getattr(store, "register_buffer", None)
+        self._unregister_buffer = getattr(store, "unregister_buffer", None)
+
+    def put_payload_chunks(
+        self,
+        chunk_keys: Sequence[str],
+        chunks: Sequence[memoryview],
+        transfer_policy: BundleTransferPolicy,
+        pre_registered: bool,
+    ) -> list[str]:
+        if not self._has_batch_put_support():
+            return self._put_chunks_direct(chunk_keys, chunks)
+        put_mode = self._resolve_put_mode(chunks, transfer_policy)
+        if put_mode == "batch":
+            self.batch_put_chunks_from(chunk_keys, chunks, pre_registered=pre_registered)
+            return list(chunk_keys)
+        return self._put_chunks_parallel(
+            list(chunk_keys),
+            list(chunks),
+            transfer_policy.max_inflight_put,
+            pre_registered=pre_registered,
+        )
+
+    def read_payload(self, payload_spec: Mapping[str, Any]) -> bytes:
+        expected_bytes = int(payload_spec["bytes"])
+        if expected_bytes == 0:
+            return b""
+        data = bytearray(expected_bytes)
+        self.read_payload_into(payload_spec, data)
+        return bytes(data)
+
+    def read_payload_into(self, payload_spec: Mapping[str, Any], destination: bytearray | np.ndarray) -> None:
+        chunks = payload_spec["chunks"]
+        offsets = _chunk_offsets(chunks)
+        if self._read_chunks_with_batch_get_into(chunks, offsets, destination):
+            return
+        for offset, chunk in zip(offsets, chunks):
+            self._read_chunk_with_get(chunk, destination, offset)
+
+    def read_payload_range_into_destination(
+        self,
+        payload_spec: Mapping[str, Any],
+        destination: np.ndarray,
+        byte_offset: int,
+        destination_pre_registered: bool,
+    ) -> None:
+        chunks = payload_spec["chunks"]
+        byte_length = int(destination.size)
+        if not self._read_payload_range_into_registered_destination(
+            chunks,
+            destination,
+            byte_offset,
+            byte_length,
+            destination_pre_registered=destination_pre_registered,
+        ):
+            self._copy_payload_range_into_destination(chunks, destination, byte_offset, byte_length)
+
+    def batch_put_chunks_from(
+        self,
+        chunk_keys: Sequence[str],
+        chunks: Sequence[memoryview],
+        pre_registered: bool,
+    ) -> None:
+        batch_put_from = self._batch_put_from
+        if not callable(batch_put_from):
+            raise RuntimeError("batch_put_from is unavailable")
+        if not chunk_keys:
+            return
+        prepared_chunks = [_prepare_chunk_source_buffer(chunk) for chunk in chunks]
+        buffer_ptrs = [ptr for _owner, ptr, _size in prepared_chunks]
+        sizes = [size for _owner, _ptr, size in prepared_chunks]
+        registered_ptrs = self._register_buffers(buffer_ptrs, sizes, pre_registered, "bundle source payload")
+        try:
+            results = batch_put_from(list(chunk_keys), buffer_ptrs, sizes)
+            if len(results) != len(chunk_keys):
+                raise RuntimeError(
+                    f"batch_put_from returned {len(results)} results for {len(chunk_keys)} chunks"
+                )
+            for chunk_key, status in zip(chunk_keys, results):
+                _check_status(status, "batch_put_from", chunk_key)
+        except Exception:
+            _cleanup_keys(self._store, chunk_keys, strict=False)
+            raise
+        finally:
+            self._unregister_buffers(registered_ptrs, "bundle source payload")
+
+    def _put_chunks_direct(
+        self,
+        chunk_keys: Sequence[str],
+        chunks: Sequence[memoryview],
+    ) -> list[str]:
+        written_keys: list[str] = []
+        try:
+            for chunk_key, chunk in zip(chunk_keys, chunks):
+                _check_status(self._store.put(chunk_key, chunk), "put", chunk_key)
+                written_keys.append(chunk_key)
+        except Exception:
+            _cleanup_keys(self._store, written_keys, strict=False)
+            raise
+        return list(chunk_keys)
+
+    def _put_chunks_parallel(
+        self,
+        chunk_keys: list[str],
+        chunks: list[memoryview],
+        max_inflight_put: int,
+        pre_registered: bool,
+    ) -> list[str]:
+        groups = self._group_chunk_ranges(chunk_keys, chunks, max_inflight_put)
+        futures: list[Future[bool]] = []
+        try:
+            with ThreadPoolExecutor(max_workers=min(max_inflight_put, len(groups))) as executor:
+                futures = [
+                    executor.submit(self.batch_put_chunks_from, group_keys, group_chunks, pre_registered)
+                    for group_keys, group_chunks in groups
+                ]
+                for future in as_completed(futures):
+                    future.result()
+        except Exception:
+            for future in futures:
+                future.cancel()
+            for future in futures:
+                if future.done() and not future.cancelled():
+                    try:
+                        future.result()
+                    except Exception:
+                        pass
+            _cleanup_keys(self._store, chunk_keys, strict=False)
+            raise
+        return chunk_keys
+
+    def _group_chunk_ranges(
+        self,
+        chunk_keys: Sequence[str],
+        chunks: Sequence[memoryview],
+        max_inflight_put: int,
+    ) -> list[tuple[list[str], list[memoryview]]]:
+        if not chunk_keys:
+            return []
+        group_count = max(1, min(max_inflight_put, len(chunks)))
+        group_size = (len(chunks) + group_count - 1) // group_count
+        return [
+            (list(chunk_keys[start : start + group_size]), list(chunks[start : start + group_size]))
+            for start in range(0, len(chunks), group_size)
+        ]
+
+    def _read_chunks_with_batch_get_into(
+        self,
+        chunks: Sequence[Mapping[str, Any]],
+        offsets: Sequence[int],
+        destination: bytearray | np.ndarray,
+    ) -> bool:
+        batch_get_into = self._batch_get_into
+        if not callable(batch_get_into) or not self._has_buffer_registration_support():
+            return False
+        with self._registered_buffer(destination, "bundle payload") as base_ptr:
+            keys = [chunk["key"] for chunk in chunks]
+            ptrs = [base_ptr + offset for offset in offsets]
+            sizes = [int(chunk["bytes"]) for chunk in chunks]
+            read_sizes = batch_get_into(keys, ptrs, sizes)
+            if len(read_sizes) != len(keys):
+                raise RuntimeError(f"batch_get_into returned {len(read_sizes)} results for {len(keys)} chunks")
+            for key, expected_size, actual_size in zip(keys, sizes, read_sizes):
+                if actual_size != expected_size:
+                    raise RuntimeError(
+                        f"batch_get_into failed for {key}: expected {expected_size}, got {actual_size}"
+                    )
+        return True
+
+    def _read_chunk_with_get(
+        self,
+        chunk: Mapping[str, Any],
+        destination: bytearray | np.ndarray,
+        offset: int,
+    ) -> None:
+        chunk_bytes = int(chunk["bytes"])
+        if chunk_bytes == 0:
+            return
+        data = self._store.get(chunk["key"])
+        if len(data) != chunk_bytes:
+            raise RuntimeError(
+                f"get failed for {chunk['key']}: expected {chunk_bytes} bytes, got {len(data)}"
+            )
+        destination[offset : offset + chunk_bytes] = data
+
+    def _read_payload_range_into_registered_destination(
+        self,
+        chunks: Sequence[Mapping[str, Any]],
+        destination: np.ndarray,
+        byte_offset: int,
+        byte_length: int,
+        destination_pre_registered: bool,
+    ) -> bool:
+        get_into = self._get_into
+        can_use_get_into = len(chunks) == 1 and byte_offset == 0 and callable(get_into)
+        get_into_ranges = self._get_into_ranges
+        can_use_get_into_ranges = callable(get_into_ranges)
+        if not self._has_buffer_registration_support():
+            return False
+        if not can_use_get_into and not can_use_get_into_ranges:
+            return False
+        with self._registered_buffer(
+            destination,
+            "structured ndarray payload",
+            pre_registered=destination_pre_registered,
+        ) as base_ptr:
+            if can_use_get_into and int(chunks[0]["bytes"]) == byte_length:
+                expected_size = int(chunks[0]["bytes"])
+                read_size = get_into(chunks[0]["key"], base_ptr, expected_size)
+                if read_size != expected_size:
+                    raise RuntimeError(
+                        f"get_into failed for {chunks[0]['key']}: expected {expected_size}, got {read_size}"
+                    )
+                return True
+            if not can_use_get_into_ranges:
+                return False
+            fragments = _payload_range_fragments(chunks, byte_offset, byte_length)
+            if not fragments:
+                return True
+            keys = [key for key, _chunk_size, _destination_offset, _source_offset, _size in fragments]
+            dst_offsets = [
+                [destination_offset] for _key, _chunk_size, destination_offset, _source_offset, _size in fragments
+            ]
+            src_offsets = [[source_offset] for _key, _chunk_size, _destination_offset, source_offset, _size in fragments]
+            sizes = [[size] for _key, _chunk_size, _destination_offset, _source_offset, size in fragments]
+            results = get_into_ranges([base_ptr], [keys], [dst_offsets], [src_offsets], [sizes])
+            if len(results) != 1 or len(results[0]) != len(keys):
+                raise RuntimeError(f"get_into_ranges returned invalid ranged result shape for {len(keys)} chunks")
+            for key, expected_sizes, actual_sizes in zip(keys, sizes, results[0]):
+                if len(actual_sizes) != len(expected_sizes):
+                    raise RuntimeError(f"get_into_ranges returned invalid ranged fragment count for {key}")
+                for expected_size, actual_size in zip(expected_sizes, actual_sizes):
+                    if actual_size != expected_size:
+                        raise RuntimeError(
+                            f"get_into_ranges failed for {key}: expected {expected_size}, got {actual_size}"
+                        )
+            return True
+
+    def _copy_payload_range_into_destination(
+        self,
+        chunks: Sequence[Mapping[str, Any]],
+        destination: np.ndarray,
+        byte_offset: int,
+        byte_length: int,
+    ) -> None:
+        for key, chunk_size, destination_offset, source_offset, size in _payload_range_fragments(
+            chunks,
+            byte_offset,
+            byte_length,
+        ):
+            data = self._store.get(key)
+            if len(data) != chunk_size:
+                raise RuntimeError(f"get failed for {key}: expected {chunk_size} bytes, got {len(data)}")
+            fragment = memoryview(data)[source_offset : source_offset + size]
+            target_end = destination_offset + size
+            destination[destination_offset:target_end] = np.frombuffer(fragment, dtype=np.uint8)
+
+    def _register_buffers(
+        self,
+        buffer_ptrs: Sequence[int],
+        sizes: Sequence[int],
+        pre_registered: bool,
+        label: str,
+    ) -> list[int]:
+        register_buffer = self._register_buffer
+        unregister_buffer = self._unregister_buffer
+        if pre_registered:
+            return []
+        if not (callable(register_buffer) and callable(unregister_buffer)):
+            raise RuntimeError(f"register_buffer APIs are unavailable for {label}")
+        registered_ptrs: list[int] = []
+        try:
+            for ptr, size in zip(buffer_ptrs, sizes):
+                register_status = register_buffer(ptr, size)
+                if register_status == 0:
+                    registered_ptrs.append(ptr)
+                    continue
+                if not _is_duplicate_buffer_registration(register_status):
+                    _check_status(register_status, "register_buffer", label)
+        except Exception:
+            self._unregister_buffers(registered_ptrs, label)
+            raise
+        return registered_ptrs
+
+    def _unregister_buffers(self, registered_ptrs: Sequence[int], label: str) -> None:
+        unregister_buffer = self._unregister_buffer
+        if not callable(unregister_buffer):
+            raise RuntimeError(f"unregister_buffer APIs are unavailable for {label}")
+        for ptr in reversed(registered_ptrs):
+            _check_status(unregister_buffer(ptr), "unregister_buffer", label)
+
+    @contextmanager
+    def _registered_buffer(
+        self,
+        destination: bytearray | np.ndarray,
+        label: str,
+        pre_registered: bool = False,
+    ) -> Iterator[int]:
+        base_ptr = _buffer_ptr(destination)
+        if pre_registered:
+            yield base_ptr
+            return
+        registered_ptrs = self._register_buffers([base_ptr], [_buffer_nbytes(destination)], False, label)
+        if not registered_ptrs:
+            yield base_ptr
+            return
+        succeeded = False
+        try:
+            yield base_ptr
+            succeeded = True
+        finally:
+            try:
+                self._unregister_buffers(registered_ptrs, label)
+            except Exception:
+                if succeeded:
+                    raise
+
+    def _resolve_put_mode(
+        self,
+        chunks: Sequence[memoryview],
+        transfer_policy: BundleTransferPolicy,
+    ) -> Literal["batch", "parallel"]:
+        if transfer_policy.put_mode == "parallel":
+            return "parallel"
+        if transfer_policy.put_mode == "batch":
+            return "batch"
+        if transfer_policy.max_inflight_put <= 1:
+            return "batch"
+        if len(chunks) < AUTO_PARALLEL_MIN_CHUNKS:
+            return "batch"
+        if sum(len(chunk) for chunk in chunks) < AUTO_PARALLEL_MIN_BYTES:
+            return "batch"
+        if min(transfer_policy.max_inflight_put, len(chunks)) < 2:
+            return "batch"
+        return "parallel"
+
+    def _has_batch_put_support(self) -> bool:
+        return callable(self._batch_put_from) and self._has_buffer_registration_support()
+
+    def _has_buffer_registration_support(self) -> bool:
+        return callable(self._register_buffer) and callable(self._unregister_buffer)
+
+
+def _resolve_ndarray_destination(
+    name: str,
+    destination: Any,
+    dtype: np.dtype[Any],
+    shape: tuple[int, ...],
+) -> np.ndarray:
+    if destination is None:
+        return np.empty(shape, dtype=dtype)
+    if not isinstance(destination, np.ndarray):
+        raise TypeError(f"structured ndarray field {name} destination must be a numpy.ndarray")
+    if destination.dtype != dtype:
+        raise ValueError(
+            f"structured ndarray field {name} destination dtype mismatch: expected {dtype.str}, got {destination.dtype.str}"
+        )
+    if tuple(destination.shape) != shape:
+        raise ValueError(
+            f"structured ndarray field {name} destination shape mismatch: expected {shape}, got {tuple(destination.shape)}"
+        )
+    if not destination.flags["C_CONTIGUOUS"]:
+        raise ValueError(f"structured ndarray field {name} destination must be C-contiguous")
+    return destination
+
+
+def _resolve_ndarray_read_plan(
+    shape: tuple[int, ...],
+    dtype: np.dtype[Any],
+    member_slice: StructuredMemberSlice | None,
+) -> _NdarrayReadPlan:
+    if member_slice is None:
+        return _NdarrayReadPlan(
+            dtype=dtype,
+            full_shape=shape,
+            output_shape=shape,
+            byte_offset=0,
+            byte_length=int(np.prod(shape, dtype=np.int64)) * dtype.itemsize if shape else dtype.itemsize,
+            step=1,
+            cover_row_count=shape[0] if shape else 1,
+        )
+    if member_slice.axis != 0:
+        raise ValueError("structured ndarray slicing currently supports axis=0 only")
+    if not shape:
+        raise ValueError("structured ndarray slicing requires at least one dimension")
+    total_rows = shape[0]
+    start, end, step = _normalized_member_slice(member_slice, total_rows)
+    row_width = dtype.itemsize * int(np.prod(shape[1:], dtype=np.int64))
+    if start >= end:
+        return _NdarrayReadPlan(
+            dtype=dtype,
+            full_shape=shape,
+            output_shape=(0, *shape[1:]),
+            byte_offset=start * row_width,
+            byte_length=0,
+            step=step,
+            cover_row_count=0,
+        )
+    selected_count = 1 + (end - 1 - start) // step
+    cover_start = start
+    cover_end = start + (selected_count - 1) * step + 1
+    return _NdarrayReadPlan(
+        dtype=dtype,
+        full_shape=shape,
+        output_shape=(selected_count, *shape[1:]),
+        byte_offset=cover_start * row_width,
+        byte_length=(cover_end - cover_start) * row_width,
+        step=step,
+        cover_row_count=cover_end - cover_start,
+    )
+
+def _normalized_member_slice(member_slice: StructuredMemberSlice, total_rows: int) -> tuple[int, int, int]:
+    if member_slice.step <= 0:
+        raise ValueError("structured ndarray slicing step must be positive")
+    return slice(member_slice.start, member_slice.end, member_slice.step).indices(total_rows)
+
+
+def _bytes_view(value: Any, name: str) -> memoryview:
+    try:
+        view = memoryview(value)
+    except TypeError as error:
+        raise TypeError(f"{name} must be bytes-like, got {type(value).__name__}") from error
+    if not view.contiguous:
+        view = memoryview(bytes(view))
+    return view.cast("B")
+
+
+def _prepare_chunk_source_buffer(chunk: memoryview) -> tuple[Any, int, int]:
+    if chunk.c_contiguous and not chunk.readonly:
+        return chunk, ctypes.addressof(ctypes.c_char.from_buffer(chunk)), len(chunk)
+    copied = ctypes.create_string_buffer(bytes(chunk))
+    return copied, ctypes.addressof(copied), len(chunk)
+
+
+def _buffer_ptr(value: bytearray | np.ndarray) -> int:
+    return ctypes.addressof(ctypes.c_char.from_buffer(value))
+
+
+def _buffer_nbytes(value: bytearray | np.ndarray) -> int:
+    if isinstance(value, np.ndarray):
+        return int(value.nbytes)
+    return len(value)
+
+
+def _split_view(view: memoryview, chunk_bytes: int) -> list[memoryview]:
+    if len(view) == 0:
+        return [view]
+    return [view[start : start + chunk_bytes] for start in range(0, len(view), chunk_bytes)]
+
+
+def _chunk_offsets(chunks: Sequence[Mapping[str, Any]]) -> list[int]:
+    offsets = [0]
+    for chunk in chunks[:-1]:
+        offsets.append(offsets[-1] + int(chunk["bytes"]))
+    return offsets
+
+
+def _payload_range_fragments(
+    chunks: Sequence[Mapping[str, Any]],
+    byte_offset: int,
+    byte_length: int,
+) -> list[tuple[str, int, int, int, int]]:
+    fragments: list[tuple[str, int, int, int, int]] = []
+    read_end = byte_offset + byte_length
+    chunk_offset = 0
+    for chunk in chunks:
+        chunk_size = int(chunk["bytes"])
+        chunk_end = chunk_offset + chunk_size
+        overlap_start = max(byte_offset, chunk_offset)
+        overlap_end = min(read_end, chunk_end)
+        if overlap_start < overlap_end:
+            fragments.append(
+                (
+                    chunk["key"],
+                    chunk_size,
+                    overlap_start - byte_offset,
+                    overlap_start - chunk_offset,
+                    overlap_end - overlap_start,
+                )
+            )
+        chunk_offset = chunk_end
+    return fragments
+
+
+def _validate_chunk_bytes(chunk_bytes: int) -> int:
+    if chunk_bytes <= 0:
+        raise ValueError("chunk_bytes must be positive")
+    return chunk_bytes
+
+
+def _normalize_key_prefix(key_prefix: str) -> str:
+    prefix = key_prefix.strip("/")
+    if not prefix or any(ord(char) < 32 for char in prefix):
+        raise ValueError("key_prefix must be a non-empty key prefix")
+    return prefix
+
+
+def _validate_key_segment(value: str, name: str) -> None:
+    if not isinstance(value, str) or not value or "/" in value or any(ord(char) < 32 for char in value):
+        raise ValueError(f"invalid bundle {name}: {value!r}")
+
+
+def _encode_manifest(manifest: Mapping[str, Any]) -> bytes:
+    return _encode_json_dict(manifest, "bundle manifest")
+
+
+def _decode_manifest(payload: bytes) -> dict[str, Any]:
+    return _decode_json_dict(payload, "bundle manifest")
+
+
+def _normalize_structured_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(metadata, Mapping):
+        raise TypeError("structured metadata must be a mapping")
+    normalized = dict(metadata)
+    if STRUCTURED_FIELD_SPECS_KEY in normalized:
+        raise ValueError(f"structured metadata key {STRUCTURED_FIELD_SPECS_KEY!r} is reserved")
+    if not isinstance(normalized.get("layout", "structured"), str):
+        raise ValueError("structured metadata layout must be a string")
+    normalized.setdefault("layout", "structured")
+    return normalized
+
+
+def _encode_structured_fields(
+    metadata: Mapping[str, Any],
+    fields: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    normalized_metadata = _normalize_structured_metadata(metadata)
+    field_specs: dict[str, Any] = {}
+    encoded_fields: dict[str, Any] = {}
+    for name, value in fields.items():
+        _validate_key_segment(name, "buffer name")
+        spec, encoded_value = _encode_structured_field(value)
+        field_specs[name] = spec
+        encoded_fields[name] = encoded_value
+    if field_specs:
+        normalized_metadata[STRUCTURED_FIELD_SPECS_KEY] = field_specs
+    return normalized_metadata, encoded_fields
+
+
+def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
+    if isinstance(value, np.ndarray):
+        array = np.ascontiguousarray(value)
+        return {
+            "encoding": "ndarray",
+            "dtype": array.dtype.str,
+            "shape": list(array.shape),
+        }, array.view(np.uint8).reshape(-1)
+    return {"encoding": "bytes"}, value
+
+
+def _structured_field_specs(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    field_specs = metadata.get(STRUCTURED_FIELD_SPECS_KEY, {})
+    if not isinstance(field_specs, dict):
+        raise ValueError("structured field specs must be a dict")
+    return field_specs
+
+
+def _encode_structured_metadata(metadata: Mapping[str, Any]) -> bytes:
+    return _encode_json_dict(metadata, "structured metadata")
+
+
+def _decode_structured_metadata(payload: bytes) -> dict[str, Any]:
+    return _decode_json_dict(payload, "structured metadata")
+
+
+def _encode_json_dict(value: Mapping[str, Any], label: str) -> bytes:
+    try:
+        return json.dumps(value, separators=(",", ":")).encode("utf-8")
+    except TypeError as error:
+        raise TypeError(f"{label} must be JSON-serializable") from error
+
+
+def _decode_json_dict(payload: bytes, label: str) -> dict[str, Any]:
+    value = json.loads(payload.decode("utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must decode to a dict")
+    return value
+
+
+def _check_status(status: Any, operation: str, key: str) -> None:
+    if status not in (None, 0):
+        raise RuntimeError(f"{operation} failed for {key}: {status}")
+
+
+def _is_duplicate_buffer_registration(status: Any) -> bool:
+    # Mooncake returns -600 when a caller-owned buffer is already registered.
+    return status == -600
+
+
+def _cleanup_keys(store: BundleStore, keys: Sequence[str], strict: bool) -> None:
+    errors = []
+    pending_keys = list(dict.fromkeys(keys))
+    batch_remove = getattr(store, "batch_remove", None)
+    if callable(batch_remove) and pending_keys:
+        try:
+            try:
+                results = batch_remove(pending_keys, True)
+            except TypeError:
+                results = batch_remove(pending_keys)
+            if len(results) != len(pending_keys):
+                raise RuntimeError(
+                    f"batch_remove returned {len(results)} results for {len(pending_keys)} keys"
+                )
+            failed_results = [
+                (key, status)
+                for key, status in zip(pending_keys, results)
+                if status not in (None, 0, MISSING_OBJECT_ERROR)
+            ]
+            if not failed_results:
+                return
+            errors.extend(failed_results)
+            pending_keys = [key for key, _status in failed_results]
+        except Exception:
+            if strict:
+                raise
+
+    retry_errors = []
+    for key in pending_keys:
+        try:
+            status = store.remove(key, True)
+        except KeyError:
+            continue
+        except Exception:
+            if strict:
+                raise
+            continue
+        if status not in (None, 0, MISSING_OBJECT_ERROR):
+            retry_errors.append((key, status))
+    if retry_errors:
+        errors = retry_errors
+    if errors and strict:
+        raise RuntimeError(f"failed to remove {len(errors)} Mooncake keys: {errors[:3]}")

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -13,7 +13,9 @@ import numpy as np
 DEFAULT_BUNDLE_CHUNK_BYTES = 512 * 1024**2
 AUTO_PARALLEL_MIN_BYTES = 4 * 1024**3
 AUTO_PARALLEL_MIN_CHUNKS = 8
-MISSING_OBJECT_ERROR = -704  # Mooncake remove returns -704 for an already-missing object.
+MISSING_OBJECT_ERROR = (
+    -704
+)  # Mooncake remove returns -704 for an already-missing object.
 STRUCTURED_FIELD_SPECS_KEY = "__mooncake_structured_fields__"
 
 
@@ -41,12 +43,22 @@ class RemoteBundleRef:
     manifest: dict[str, Any]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class StructuredObjectPayload:
     """Structured object encoded as metadata plus named buffers."""
 
     metadata: Mapping[str, Any]
     buffers: Mapping[str, Any]
+
+    def __init__(
+        self,
+        metadata: Optional[Mapping[str, Any]] = None,
+        buffers: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        if buffers is None:
+            raise TypeError("StructuredObjectPayload requires buffers")
+        object.__setattr__(self, "metadata", {} if metadata is None else metadata)
+        object.__setattr__(self, "buffers", buffers)
 
 
 @dataclass
@@ -75,7 +87,9 @@ class StructuredObjectReadSpec:
     member_names: tuple[str, ...] | None = None
     member_slices: tuple[tuple[str, StructuredMemberSlice], ...] = ()
 
-    def select_members(self, names: Optional[Sequence[str]]) -> "StructuredObjectReadSpec":
+    def select_members(
+        self, names: Optional[Sequence[str]]
+    ) -> "StructuredObjectReadSpec":
         """Return a new spec that materializes only the selected members."""
         return StructuredObjectReadSpec(
             ref=self.ref,
@@ -181,7 +195,9 @@ class MooncakeBundleTransfer:
             max_inflight_put=max_inflight_put,
         )
 
-    def read_spec(self, ref: RemoteBundleRef | Mapping[str, Any]) -> StructuredObjectReadSpec:
+    def read_spec(
+        self, ref: RemoteBundleRef | Mapping[str, Any]
+    ) -> StructuredObjectReadSpec:
         """Create a lazy read spec for a structured object reference."""
         return self._structured_store.read_spec(ref)
 
@@ -220,7 +236,9 @@ class _StructuredObjectLayer:
             max_inflight_put=max_inflight_put,
         )
 
-    def read_spec(self, ref: RemoteBundleRef | Mapping[str, Any]) -> StructuredObjectReadSpec:
+    def read_spec(
+        self, ref: RemoteBundleRef | Mapping[str, Any]
+    ) -> StructuredObjectReadSpec:
         return StructuredObjectReadSpec(ref=ref)
 
     def materialize(self, spec: StructuredObjectReadSpec) -> StructuredObjectResult:
@@ -254,9 +272,13 @@ class _StructuredObjectLayer:
         if spec.member_names is not None and not spec.member_names:
             raise ValueError("structured read spec selected no members")
         manifest = self._bundle_store.resolve_manifest(spec.ref)
-        metadata = _decode_structured_metadata(self._bundle_store.read_payload(manifest["meta"]))
+        metadata = _decode_structured_metadata(
+            self._bundle_store.read_payload(manifest["meta"])
+        )
         buffers = manifest["buffers"]
-        selected = list(buffers) if spec.member_names is None else list(spec.member_names)
+        selected = (
+            list(buffers) if spec.member_names is None else list(spec.member_names)
+        )
         missing = [name for name in selected if name not in buffers]
         if missing:
             raise KeyError(f"unknown bundle buffers: {missing}")
@@ -272,10 +294,14 @@ class _StructuredObjectLayer:
     ) -> Any:
         encoding = field_spec.get("encoding", "bytes")
         if encoding == "bytes":
-            return self._read_bytes_member(name, payload_spec, member_slice, destination)
+            return self._read_bytes_member(
+                name, payload_spec, member_slice, destination
+            )
         if encoding != "ndarray":
             raise ValueError(f"unsupported structured field encoding: {encoding}")
-        return self._read_ndarray_member(name, payload_spec, field_spec, member_slice, destination)
+        return self._read_ndarray_member(
+            name, payload_spec, field_spec, member_slice, destination
+        )
 
     def _read_bytes_member(
         self,
@@ -287,7 +313,9 @@ class _StructuredObjectLayer:
         if member_slice is not None:
             raise ValueError(f"structured bytes member {name} does not support slicing")
         if destination is not None:
-            raise ValueError(f"structured bytes member {name} does not support materialize_into")
+            raise ValueError(
+                f"structured bytes member {name} does not support materialize_into"
+            )
         return self._bundle_store.read_payload(payload_spec)
 
     def _read_ndarray_member(
@@ -301,9 +329,15 @@ class _StructuredObjectLayer:
         dtype = field_spec.get("dtype")
         shape = field_spec.get("shape")
         if not isinstance(dtype, str) or not isinstance(shape, list):
-            raise ValueError(f"structured ndarray field {name} is missing dtype or shape")
-        read_plan = _resolve_ndarray_read_plan(tuple(int(dim) for dim in shape), np.dtype(dtype), member_slice)
-        target = _resolve_ndarray_destination(name, destination, read_plan.dtype, read_plan.output_shape)
+            raise ValueError(
+                f"structured ndarray field {name} is missing dtype or shape"
+            )
+        read_plan = _resolve_ndarray_read_plan(
+            tuple(int(dim) for dim in shape), np.dtype(dtype), member_slice
+        )
+        target = _resolve_ndarray_destination(
+            name, destination, read_plan.dtype, read_plan.output_shape
+        )
         destination_view = target.view(np.uint8).reshape(-1)
         if read_plan.byte_length == 0:
             return target
@@ -317,9 +351,12 @@ class _StructuredObjectLayer:
         temp_shape = (read_plan.cover_row_count, *read_plan.full_shape[1:])
         temp = np.empty(temp_shape, dtype=read_plan.dtype)
         temp_view = temp.view(np.uint8).reshape(-1)
-        self._bundle_store.read_payload_range_into_destination(payload_spec, temp_view, read_plan.byte_offset)
+        self._bundle_store.read_payload_range_into_destination(
+            payload_spec, temp_view, read_plan.byte_offset
+        )
         target[...] = temp[:: read_plan.step]
         return target
+
 
 class _BundleManifestStore:
     def __init__(
@@ -385,7 +422,9 @@ class _BundleManifestStore:
                 "buffers": buffer_specs,
             }
             manifest_blob = _encode_manifest(manifest)
-            _check_status(self._store.put(manifest_key, manifest_blob), "put", manifest_key)
+            _check_status(
+                self._store.put(manifest_key, manifest_blob), "put", manifest_key
+            )
             written_keys.append(manifest_key)
         except Exception:
             _cleanup_keys(self._store, written_keys, strict=False)
@@ -398,7 +437,9 @@ class _BundleManifestStore:
         keys.append(self._manifest_key(ref, manifest))
         _cleanup_keys(self._store, keys, strict=True)
 
-    def resolve_manifest(self, ref: RemoteBundleRef | Mapping[str, Any]) -> dict[str, Any]:
+    def resolve_manifest(
+        self, ref: RemoteBundleRef | Mapping[str, Any]
+    ) -> dict[str, Any]:
         if isinstance(ref, RemoteBundleRef):
             manifest = ref.manifest
         else:
@@ -437,7 +478,10 @@ class _BundleManifestStore:
         pre_registered: bool,
     ) -> tuple[dict[str, Any], list[str]]:
         chunks = _split_view(value, chunk_bytes)
-        chunk_keys = [key if len(chunks) == 1 else f"{key}/chunk/{index}" for index in range(len(chunks))]
+        chunk_keys = [
+            key if len(chunks) == 1 else f"{key}/chunk/{index}"
+            for index in range(len(chunks))
+        ]
         written_keys = self._transport.put_payload_chunks(
             chunk_keys,
             chunks,
@@ -461,7 +505,9 @@ class _BundleManifestStore:
     ) -> BundleTransferPolicy:
         result = policy or BundleTransferPolicy()
         if max_inflight_put is not None:
-            result = BundleTransferPolicy(max_inflight_put=max_inflight_put, put_mode=result.put_mode)
+            result = BundleTransferPolicy(
+                max_inflight_put=max_inflight_put, put_mode=result.put_mode
+            )
         if result.max_inflight_put < 1:
             raise ValueError("max_inflight_put must be positive")
         if result.put_mode not in {"auto", "batch", "parallel"}:
@@ -487,7 +533,9 @@ class _BundleManifestStore:
         if not isinstance(payload_spec, dict):
             raise ValueError("bundle payload spec must be a dict")
         payload_key = payload_spec.get("key")
-        if not isinstance(payload_key, str) or not payload_key.startswith(f"{base_key}/"):
+        if not isinstance(payload_key, str) or not payload_key.startswith(
+            f"{base_key}/"
+        ):
             raise ValueError("bundle payload key is outside the bundle namespace")
         expected_bytes = int(payload_spec.get("bytes", -1))
         if expected_bytes < 0:
@@ -502,7 +550,9 @@ class _BundleManifestStore:
                 raise ValueError("bundle chunk must be a dict")
             key = chunk.get("key")
             chunk_bytes = int(chunk.get("bytes", -1))
-            if not isinstance(key, str) or (key != payload_key and not key.startswith(f"{payload_key}/")):
+            if not isinstance(key, str) or (
+                key != payload_key and not key.startswith(f"{payload_key}/")
+            ):
                 raise ValueError("bundle chunk key is outside the payload namespace")
             if key in seen_keys:
                 raise ValueError("bundle chunk keys must be unique")
@@ -511,11 +561,19 @@ class _BundleManifestStore:
             seen_keys.add(key)
             total_bytes += chunk_bytes
         if total_bytes != expected_bytes:
-            raise ValueError(f"bundle payload chunks total {total_bytes} bytes, expected {expected_bytes}")
+            raise ValueError(
+                f"bundle payload chunks total {total_bytes} bytes, expected {expected_bytes}"
+            )
 
-    def _manifest_key(self, ref: RemoteBundleRef | Mapping[str, Any], manifest: Mapping[str, Any]) -> str:
+    def _manifest_key(
+        self, ref: RemoteBundleRef | Mapping[str, Any], manifest: Mapping[str, Any]
+    ) -> str:
         expected = f"{self._key_prefix}/{manifest['object_id']}/manifest"
-        manifest_key = ref.manifest_key if isinstance(ref, RemoteBundleRef) else ref.get("manifest_key")
+        manifest_key = (
+            ref.manifest_key
+            if isinstance(ref, RemoteBundleRef)
+            else ref.get("manifest_key")
+        )
         if manifest_key is None:
             return expected
         if manifest_key != expected:
@@ -532,6 +590,7 @@ class _BundleManifestStore:
 
 class _MooncakePayloadTransport:
     """Move payload bytes through Mooncake, preferring fast-path APIs and falling back to generic store calls."""
+
     def __init__(self, store: BundleStore) -> None:
         self._store = store
         self._batch_put_from = getattr(store, "batch_put_from", None)
@@ -552,7 +611,9 @@ class _MooncakePayloadTransport:
             return self._put_chunks_direct(chunk_keys, chunks)
         put_mode = self._resolve_put_mode(chunks, transfer_policy)
         if put_mode == "batch":
-            self.batch_put_chunks_from(chunk_keys, chunks, pre_registered=pre_registered)
+            self.batch_put_chunks_from(
+                chunk_keys, chunks, pre_registered=pre_registered
+            )
             return list(chunk_keys)
         return self._put_chunks_parallel(
             list(chunk_keys),
@@ -569,7 +630,9 @@ class _MooncakePayloadTransport:
         self.read_payload_into(payload_spec, data)
         return bytes(data)
 
-    def read_payload_into(self, payload_spec: Mapping[str, Any], destination: bytearray | np.ndarray) -> None:
+    def read_payload_into(
+        self, payload_spec: Mapping[str, Any], destination: bytearray | np.ndarray
+    ) -> None:
         chunks = payload_spec["chunks"]
         offsets = _chunk_offsets(chunks)
         if self._read_chunks_with_batch_get_into(chunks, offsets, destination):
@@ -585,7 +648,7 @@ class _MooncakePayloadTransport:
         destination_pre_registered: bool,
     ) -> None:
         chunks = payload_spec["chunks"]
-        byte_length = int(destination.size)
+        byte_length = _buffer_nbytes(destination)
         if not self._read_payload_range_into_registered_destination(
             chunks,
             destination,
@@ -593,7 +656,9 @@ class _MooncakePayloadTransport:
             byte_length,
             destination_pre_registered=destination_pre_registered,
         ):
-            self._copy_payload_range_into_destination(chunks, destination, byte_offset, byte_length)
+            self._copy_payload_range_into_destination(
+                chunks, destination, byte_offset, byte_length
+            )
 
     def batch_put_chunks_from(
         self,
@@ -609,7 +674,9 @@ class _MooncakePayloadTransport:
         prepared_chunks = [_prepare_chunk_source_buffer(chunk) for chunk in chunks]
         buffer_ptrs = [ptr for _owner, ptr, _size in prepared_chunks]
         sizes = [size for _owner, _ptr, size in prepared_chunks]
-        registered_ptrs = self._register_buffers(buffer_ptrs, sizes, pre_registered, "bundle source payload")
+        registered_ptrs = self._register_buffers(
+            buffer_ptrs, sizes, pre_registered, "bundle source payload"
+        )
         try:
             results = batch_put_from(list(chunk_keys), buffer_ptrs, sizes)
             if len(results) != len(chunk_keys):
@@ -647,11 +714,18 @@ class _MooncakePayloadTransport:
         pre_registered: bool,
     ) -> list[str]:
         groups = self._group_chunk_ranges(chunk_keys, chunks, max_inflight_put)
-        futures: list[Future[bool]] = []
+        futures: list[Future[None]] = []
         try:
-            with ThreadPoolExecutor(max_workers=min(max_inflight_put, len(groups))) as executor:
+            with ThreadPoolExecutor(
+                max_workers=min(max_inflight_put, len(groups))
+            ) as executor:
                 futures = [
-                    executor.submit(self.batch_put_chunks_from, group_keys, group_chunks, pre_registered)
+                    executor.submit(
+                        self.batch_put_chunks_from,
+                        group_keys,
+                        group_chunks,
+                        pre_registered,
+                    )
                     for group_keys, group_chunks in groups
                 ]
                 for future in as_completed(futures):
@@ -680,7 +754,10 @@ class _MooncakePayloadTransport:
         group_count = max(1, min(max_inflight_put, len(chunks)))
         group_size = (len(chunks) + group_count - 1) // group_count
         return [
-            (list(chunk_keys[start : start + group_size]), list(chunks[start : start + group_size]))
+            (
+                list(chunk_keys[start : start + group_size]),
+                list(chunks[start : start + group_size]),
+            )
             for start in range(0, len(chunks), group_size)
         ]
 
@@ -699,7 +776,9 @@ class _MooncakePayloadTransport:
             sizes = [int(chunk["bytes"]) for chunk in chunks]
             read_sizes = batch_get_into(keys, ptrs, sizes)
             if len(read_sizes) != len(keys):
-                raise RuntimeError(f"batch_get_into returned {len(read_sizes)} results for {len(keys)} chunks")
+                raise RuntimeError(
+                    f"batch_get_into returned {len(read_sizes)} results for {len(keys)} chunks"
+                )
             for key, expected_size, actual_size in zip(keys, sizes, read_sizes):
                 if actual_size != expected_size:
                     raise RuntimeError(
@@ -757,18 +836,34 @@ class _MooncakePayloadTransport:
             fragments = _payload_range_fragments(chunks, byte_offset, byte_length)
             if not fragments:
                 return True
-            keys = [key for key, _chunk_size, _destination_offset, _source_offset, _size in fragments]
-            dst_offsets = [
-                [destination_offset] for _key, _chunk_size, destination_offset, _source_offset, _size in fragments
+            keys = [
+                key
+                for key, _chunk_size, _destination_offset, _source_offset, _size in fragments
             ]
-            src_offsets = [[source_offset] for _key, _chunk_size, _destination_offset, source_offset, _size in fragments]
-            sizes = [[size] for _key, _chunk_size, _destination_offset, _source_offset, size in fragments]
-            results = get_into_ranges([base_ptr], [keys], [dst_offsets], [src_offsets], [sizes])
+            dst_offsets = [
+                [destination_offset]
+                for _key, _chunk_size, destination_offset, _source_offset, _size in fragments
+            ]
+            src_offsets = [
+                [source_offset]
+                for _key, _chunk_size, _destination_offset, source_offset, _size in fragments
+            ]
+            sizes = [
+                [size]
+                for _key, _chunk_size, _destination_offset, _source_offset, size in fragments
+            ]
+            results = get_into_ranges(
+                [base_ptr], [keys], [dst_offsets], [src_offsets], [sizes]
+            )
             if len(results) != 1 or len(results[0]) != len(keys):
-                raise RuntimeError(f"get_into_ranges returned invalid ranged result shape for {len(keys)} chunks")
+                raise RuntimeError(
+                    f"get_into_ranges returned invalid ranged result shape for {len(keys)} chunks"
+                )
             for key, expected_sizes, actual_sizes in zip(keys, sizes, results[0]):
                 if len(actual_sizes) != len(expected_sizes):
-                    raise RuntimeError(f"get_into_ranges returned invalid ranged fragment count for {key}")
+                    raise RuntimeError(
+                        f"get_into_ranges returned invalid ranged fragment count for {key}"
+                    )
                 for expected_size, actual_size in zip(expected_sizes, actual_sizes):
                     if actual_size != expected_size:
                         raise RuntimeError(
@@ -783,17 +878,27 @@ class _MooncakePayloadTransport:
         byte_offset: int,
         byte_length: int,
     ) -> None:
-        for key, chunk_size, destination_offset, source_offset, size in _payload_range_fragments(
+        for (
+            key,
+            chunk_size,
+            destination_offset,
+            source_offset,
+            size,
+        ) in _payload_range_fragments(
             chunks,
             byte_offset,
             byte_length,
         ):
             data = self._store.get(key)
             if len(data) != chunk_size:
-                raise RuntimeError(f"get failed for {key}: expected {chunk_size} bytes, got {len(data)}")
+                raise RuntimeError(
+                    f"get failed for {key}: expected {chunk_size} bytes, got {len(data)}"
+                )
             fragment = memoryview(data)[source_offset : source_offset + size]
             target_end = destination_offset + size
-            destination[destination_offset:target_end] = np.frombuffer(fragment, dtype=np.uint8)
+            destination[destination_offset:target_end] = np.frombuffer(
+                fragment, dtype=np.uint8
+            )
 
     def _register_buffers(
         self,
@@ -840,7 +945,9 @@ class _MooncakePayloadTransport:
         if pre_registered:
             yield base_ptr
             return
-        registered_ptrs = self._register_buffers([base_ptr], [_buffer_nbytes(destination)], False, label)
+        registered_ptrs = self._register_buffers(
+            [base_ptr], [_buffer_nbytes(destination)], False, label
+        )
         if not registered_ptrs:
             yield base_ptr
             return
@@ -875,7 +982,9 @@ class _MooncakePayloadTransport:
         return "parallel"
 
     def _has_batch_put_support(self) -> bool:
-        return callable(self._batch_put_from) and self._has_buffer_registration_support()
+        return (
+            callable(self._batch_put_from) and self._has_buffer_registration_support()
+        )
 
     def _has_buffer_registration_support(self) -> bool:
         return callable(self._register_buffer) and callable(self._unregister_buffer)
@@ -890,7 +999,9 @@ def _resolve_ndarray_destination(
     if destination is None:
         return np.empty(shape, dtype=dtype)
     if not isinstance(destination, np.ndarray):
-        raise TypeError(f"structured ndarray field {name} destination must be a numpy.ndarray")
+        raise TypeError(
+            f"structured ndarray field {name} destination must be a numpy.ndarray"
+        )
     if destination.dtype != dtype:
         raise ValueError(
             f"structured ndarray field {name} destination dtype mismatch: expected {dtype.str}, got {destination.dtype.str}"
@@ -900,7 +1011,13 @@ def _resolve_ndarray_destination(
             f"structured ndarray field {name} destination shape mismatch: expected {shape}, got {tuple(destination.shape)}"
         )
     if not destination.flags["C_CONTIGUOUS"]:
-        raise ValueError(f"structured ndarray field {name} destination must be C-contiguous")
+        raise ValueError(
+            f"structured ndarray field {name} destination must be C-contiguous"
+        )
+    if not destination.flags["WRITEABLE"]:
+        raise ValueError(
+            f"structured ndarray field {name} destination must be writeable"
+        )
     return destination
 
 
@@ -915,7 +1032,9 @@ def _resolve_ndarray_read_plan(
             full_shape=shape,
             output_shape=shape,
             byte_offset=0,
-            byte_length=int(np.prod(shape, dtype=np.int64)) * dtype.itemsize if shape else dtype.itemsize,
+            byte_length=int(np.prod(shape, dtype=np.int64)) * dtype.itemsize
+            if shape
+            else dtype.itemsize,
             step=1,
             cover_row_count=shape[0] if shape else 1,
         )
@@ -949,17 +1068,24 @@ def _resolve_ndarray_read_plan(
         cover_row_count=cover_end - cover_start,
     )
 
-def _normalized_member_slice(member_slice: StructuredMemberSlice, total_rows: int) -> tuple[int, int, int]:
+
+def _normalized_member_slice(
+    member_slice: StructuredMemberSlice, total_rows: int
+) -> tuple[int, int, int]:
     if member_slice.step <= 0:
         raise ValueError("structured ndarray slicing step must be positive")
-    return slice(member_slice.start, member_slice.end, member_slice.step).indices(total_rows)
+    return slice(member_slice.start, member_slice.end, member_slice.step).indices(
+        total_rows
+    )
 
 
 def _bytes_view(value: Any, name: str) -> memoryview:
     try:
         view = memoryview(value)
     except TypeError as error:
-        raise TypeError(f"{name} must be bytes-like, got {type(value).__name__}") from error
+        raise TypeError(
+            f"{name} must be bytes-like, got {type(value).__name__}"
+        ) from error
     if not view.contiguous:
         view = memoryview(bytes(view))
     return view.cast("B")
@@ -985,7 +1111,9 @@ def _buffer_nbytes(value: bytearray | np.ndarray) -> int:
 def _split_view(view: memoryview, chunk_bytes: int) -> list[memoryview]:
     if len(view) == 0:
         return [view]
-    return [view[start : start + chunk_bytes] for start in range(0, len(view), chunk_bytes)]
+    return [
+        view[start : start + chunk_bytes] for start in range(0, len(view), chunk_bytes)
+    ]
 
 
 def _chunk_offsets(chunks: Sequence[Mapping[str, Any]]) -> list[int]:
@@ -1036,7 +1164,12 @@ def _normalize_key_prefix(key_prefix: str) -> str:
 
 
 def _validate_key_segment(value: str, name: str) -> None:
-    if not isinstance(value, str) or not value or "/" in value or any(ord(char) < 32 for char in value):
+    if (
+        not isinstance(value, str)
+        or not value
+        or "/" in value
+        or any(ord(char) < 32 for char in value)
+    ):
         raise ValueError(f"invalid bundle {name}: {value!r}")
 
 
@@ -1053,7 +1186,9 @@ def _normalize_structured_metadata(metadata: Mapping[str, Any]) -> dict[str, Any
         raise TypeError("structured metadata must be a mapping")
     normalized = dict(metadata)
     if STRUCTURED_FIELD_SPECS_KEY in normalized:
-        raise ValueError(f"structured metadata key {STRUCTURED_FIELD_SPECS_KEY!r} is reserved")
+        raise ValueError(
+            f"structured metadata key {STRUCTURED_FIELD_SPECS_KEY!r} is reserved"
+        )
     if not isinstance(normalized.get("layout", "structured"), str):
         raise ValueError("structured metadata layout must be a string")
     normalized.setdefault("layout", "structured")
@@ -1169,4 +1304,6 @@ def _cleanup_keys(store: BundleStore, keys: Sequence[str], strict: bool) -> None
     if retry_errors:
         errors = retry_errors
     if errors and strict:
-        raise RuntimeError(f"failed to remove {len(errors)} Mooncake keys: {errors[:3]}")
+        raise RuntimeError(
+            f"failed to remove {len(errors)} Mooncake keys: {errors[:3]}"
+        )

--- a/mooncake-wheel/tests/conftest.py
+++ b/mooncake-wheel/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/mooncake-wheel/tests/conftest.py
+++ b/mooncake-wheel/tests/conftest.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+SOURCE_PACKAGE = ROOT / "mooncake"
+
+try:
+    import mooncake
+except ModuleNotFoundError:
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+else:
+    if importlib.util.find_spec("mooncake.structured_object_store") is None:
+        mooncake_path = getattr(mooncake, "__path__", None)
+        if mooncake_path is not None and str(SOURCE_PACKAGE) not in mooncake_path:
+            mooncake_path.append(str(SOURCE_PACKAGE))

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -79,7 +79,9 @@ class InMemoryStore:
             self.remove(key, force)
         return [0 for _key in keys]
 
-    def batch_put_from(self, keys: list[str], buffer_ptrs: list[int], sizes: list[int]) -> list[int]:
+    def batch_put_from(
+        self, keys: list[str], buffer_ptrs: list[int], sizes: list[int]
+    ) -> list[int]:
         results: list[int] = []
         for key, ptr, size in zip(keys, buffer_ptrs, sizes):
             data = ctypes.string_at(ptr, size)
@@ -126,16 +128,22 @@ class InMemoryStore:
                 buffer_ptrs, all_keys, all_dst_offsets, all_src_offsets, all_sizes
             ):
                 buffer_results: list[list[int]] = []
-                for key, dst_offsets, src_offsets, sizes in zip(keys, dst_groups, src_groups, size_groups):
+                for key, dst_offsets, src_offsets, sizes in zip(
+                    keys, dst_groups, src_groups, size_groups
+                ):
                     with self.lock:
                         data = self.objects[key]
                     key_results: list[int] = []
-                    for dst_offset, src_offset, size in zip(dst_offsets, src_offsets, sizes):
+                    for dst_offset, src_offset, size in zip(
+                        dst_offsets, src_offsets, sizes
+                    ):
                         end = src_offset + size
                         if end > len(data):
                             key_results.append(-1)
                             continue
-                        ctypes.memmove(base_ptr + dst_offset, data[src_offset:end], size)
+                        ctypes.memmove(
+                            base_ptr + dst_offset, data[src_offset:end], size
+                        )
                         key_results.append(size)
                     buffer_results.append(key_results)
                 results.append(buffer_results)
@@ -261,18 +269,24 @@ def make_transfer(
     return current_store, MooncakeBundleTransfer(current_store, **kwargs)
 
 
-def structured_payload(metadata: dict[str, object] | None = None, **buffers: object) -> StructuredObjectPayload:
-    return StructuredObjectPayload(metadata=metadata or {"type": "example"}, buffers=buffers)
+def structured_payload(
+    metadata: dict[str, object] | None = None, **buffers: object
+) -> StructuredObjectPayload:
+    return StructuredObjectPayload(metadata=metadata, buffers=buffers)
 
 
-def write_manifest(store: InMemoryStore, manifest_key: str, manifest: dict[str, object]) -> None:
-    store.objects[manifest_key] = json.dumps(manifest, separators=(",", ":")).encode("utf-8")
+def write_manifest(
+    store: InMemoryStore, manifest_key: str, manifest: dict[str, object]
+) -> None:
+    store.objects[manifest_key] = json.dumps(manifest, separators=(",", ":")).encode(
+        "utf-8"
+    )
 
 
 def test_bundle_read_spec_full_read_is_partial_special_case() -> None:
     store, transfer = make_transfer()
     array = np.arange(16, dtype=np.int32).reshape(4, 4)
-    payload = structured_payload(array=array, raw=b"abc")
+    payload = structured_payload({"type": "example"}, array=array, raw=b"abc")
 
     ref = transfer.put_structured_object(payload)
     result = transfer.materialize(transfer.read_spec(ref))
@@ -281,6 +295,18 @@ def test_bundle_read_spec_full_read_is_partial_special_case() -> None:
     assert result.objects["raw"] == b"abc"
     assert store.batch_get_into_calls > 0
     assert store.registered == set()
+
+
+def test_structured_object_payload_metadata_defaults_empty() -> None:
+    store, transfer = make_transfer()
+    array = np.arange(8, dtype=np.int32).reshape(2, 4)
+
+    ref = transfer.put_structured_object(
+        StructuredObjectPayload(buffers={"array": array})
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert np.array_equal(result.objects["array"], array)
 
 
 def test_bundle_chunked_full_read_via_read_spec() -> None:
@@ -301,7 +327,9 @@ def test_bundle_put_falls_back_to_store_put_without_batch_put_support() -> None:
     store, transfer = make_transfer(MinimalStore())
     payload = bytes(range(128))
 
-    ref = transfer.put_structured_object(structured_payload(payload=payload), chunk_bytes=17)
+    ref = transfer.put_structured_object(
+        structured_payload(payload=payload), chunk_bytes=17
+    )
     result = transfer.materialize(transfer.read_spec(ref))
 
     assert result.objects["payload"] == payload
@@ -387,7 +415,11 @@ def test_structured_object_slice_member_uses_partial_range_reads() -> None:
     payload = structured_payload(weights=array, raw=b"payload")
 
     ref = transfer.put_structured_object(payload, chunk_bytes=20)
-    spec = transfer.read_spec(ref).select_members(["weights"]).slice_member("weights", axis=0, start=3, end=9)
+    spec = (
+        transfer.read_spec(ref)
+        .select_members(["weights"])
+        .slice_member("weights", axis=0, start=3, end=9)
+    )
     before_range_reads = store.get_into_ranges_calls
     result = transfer.materialize(spec)
 
@@ -402,7 +434,11 @@ def test_structured_object_slice_member_falls_back_to_plain_get_reads() -> None:
     payload = structured_payload(weights=array, raw=b"payload")
 
     ref = transfer.put_structured_object(payload, chunk_bytes=20)
-    spec = transfer.read_spec(ref).select_members(["weights"]).slice_member("weights", axis=0, start=3, end=9)
+    spec = (
+        transfer.read_spec(ref)
+        .select_members(["weights"])
+        .slice_member("weights", axis=0, start=3, end=9)
+    )
     result = transfer.materialize(spec)
 
     assert np.array_equal(result.objects["weights"], array[3:9])
@@ -433,7 +469,11 @@ def test_structured_object_duplicate_destination_registration_is_tolerated() -> 
     payload = structured_payload(weights=array)
 
     ref = transfer.put_structured_object(payload, chunk_bytes=40)
-    spec = transfer.read_spec(ref).select_members(["weights"]).slice_member("weights", axis=0, start=2, end=10)
+    spec = (
+        transfer.read_spec(ref)
+        .select_members(["weights"])
+        .slice_member("weights", axis=0, start=2, end=10)
+    )
     destination = np.empty((8, 8), dtype=np.float32)
     destination_ptr = ctypes.addressof(ctypes.c_char.from_buffer(destination))
     assert store.register_buffer(destination_ptr, int(destination.nbytes)) == 0
@@ -453,7 +493,9 @@ def test_structured_object_slice_member_step_copy() -> None:
     payload = structured_payload(weights=array)
 
     ref = transfer.put_structured_object(payload, chunk_bytes=24)
-    spec = transfer.read_spec(ref).slice_member("weights", axis=0, start=1, end=12, step=3)
+    spec = transfer.read_spec(ref).slice_member(
+        "weights", axis=0, start=1, end=12, step=3
+    )
     result = transfer.materialize(spec)
 
     assert np.array_equal(result.objects["weights"], array[1:12:3])
@@ -470,15 +512,30 @@ def test_structured_object_invalid_slice_and_destination_raise() -> None:
     )
 
     with pytest.raises(ValueError, match="axis=0"):
-        transfer.materialize(transfer.read_spec(ref).slice_member("weights", axis=1, start=0, end=2))
+        transfer.materialize(
+            transfer.read_spec(ref).slice_member("weights", axis=1, start=0, end=2)
+        )
     with pytest.raises(ValueError, match="step must be positive"):
-        transfer.materialize(transfer.read_spec(ref).slice_member("weights", axis=0, start=0, end=2, step=0))
+        transfer.materialize(
+            transfer.read_spec(ref).slice_member(
+                "weights", axis=0, start=0, end=2, step=0
+            )
+        )
     with pytest.raises(ValueError, match="does not support slicing"):
-        transfer.materialize(transfer.read_spec(ref).slice_member("raw", axis=0, start=0, end=1))
+        transfer.materialize(
+            transfer.read_spec(ref).slice_member("raw", axis=0, start=0, end=1)
+        )
     with pytest.raises(ValueError, match="shape mismatch"):
         transfer.materialize_into(
             transfer.read_spec(ref).slice_member("weights", axis=0, start=1, end=3),
             destinations={"weights": np.empty((3, 4), dtype=np.int16)},
+        )
+    readonly_destination = np.empty((2, 4), dtype=np.int16)
+    readonly_destination.flags.writeable = False
+    with pytest.raises(ValueError, match="writeable"):
+        transfer.materialize_into(
+            transfer.read_spec(ref).slice_member("weights", axis=0, start=1, end=3),
+            destinations={"weights": readonly_destination},
         )
 
 
@@ -557,7 +614,9 @@ def test_bundle_partial_register_failure_unwinds_registered_buffers() -> None:
     payload = bytes(range(64))
 
     with pytest.raises(RuntimeError, match="register_buffer"):
-        transfer.put_structured_object(structured_payload(payload=payload), chunk_bytes=32)
+        transfer.put_structured_object(
+            structured_payload(payload=payload), chunk_bytes=32
+        )
 
     assert store.registered == set()
     assert store.objects == {}
@@ -611,7 +670,11 @@ def test_bundle_invalid_policy_and_chunk_size_raise() -> None:
     with pytest.raises(ValueError, match="max_inflight_put"):
         transfer.put_bundle(b"meta", {"payload": b"data"}, max_inflight_put=0)
     with pytest.raises(ValueError, match="selected no members"):
-        transfer.materialize(transfer.read_spec({"manifest_key": "test/default/example/manifest"}).select_members([]))
+        transfer.materialize(
+            transfer.read_spec(
+                {"manifest_key": "test/default/example/manifest"}
+            ).select_members([])
+        )
     with pytest.raises(ValueError, match="chunk_bytes"):
         transfer.put_bundle(b"meta", {"payload": b"data"}, chunk_bytes=0)
 
@@ -633,12 +696,19 @@ def test_structured_object_invalid_metadata_raises() -> None:
     store, transfer = make_transfer()
 
     with pytest.raises(TypeError, match="mapping"):
-        transfer.put_structured_object(StructuredObjectPayload(metadata=["not", "a", "mapping"], buffers={}))
+        transfer.put_structured_object(
+            StructuredObjectPayload(metadata=["not", "a", "mapping"], buffers={})
+        )
     with pytest.raises(TypeError, match="JSON-serializable"):
-        transfer.put_structured_object(StructuredObjectPayload(metadata={"bad": object()}, buffers={}))
+        transfer.put_structured_object(
+            StructuredObjectPayload(metadata={"bad": object()}, buffers={})
+        )
     with pytest.raises(ValueError, match="reserved"):
         transfer.put_structured_object(
-            StructuredObjectPayload(metadata={"__mooncake_structured_fields__": {}}, buffers={"payload": b"abc"})
+            StructuredObjectPayload(
+                metadata={"__mooncake_structured_fields__": {}},
+                buffers={"payload": b"abc"},
+            )
         )
 
 
@@ -697,4 +767,3 @@ def test_bundle_rejects_tampered_manifest() -> None:
         transfer.remove_bundle(
             RemoteBundleRef(manifest_key="test/other/manifest", manifest=ref.manifest)
         )
-

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1,0 +1,700 @@
+from __future__ import annotations
+
+import ctypes
+import json
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from mooncake.structured_object_store import (
+    BundleTransferPolicy,
+    MooncakeBundleTransfer,
+    RemoteBundleRef,
+    StructuredObjectPayload,
+    StructuredObjectReadSpec,
+)
+
+
+class InMemoryStore:
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.lock = threading.Lock()
+        self.registered: set[int] = set()
+        self.max_active_puts = 0
+        self.max_active_gets = 0
+        self.active_puts = 0
+        self.active_gets = 0
+        self.get_into_calls = 0
+        self.get_into_ranges_calls = 0
+        self.batch_get_into_calls = 0
+        self.batch_remove_calls = 0
+
+    def _enter_put(self) -> None:
+        with self.lock:
+            self.active_puts += 1
+            self.max_active_puts = max(self.max_active_puts, self.active_puts)
+
+    def _exit_put(self) -> None:
+        with self.lock:
+            self.active_puts -= 1
+
+    def _enter_get(self, count: int = 1) -> None:
+        with self.lock:
+            self.active_gets += count
+            self.max_active_gets = max(self.max_active_gets, self.active_gets)
+
+    def _exit_get(self, count: int = 1) -> None:
+        with self.lock:
+            self.active_gets -= count
+
+    def put(self, key: str, value) -> int:
+        self._enter_put()
+        try:
+            time.sleep(0.01)
+            with self.lock:
+                self.objects[key] = bytes(value)
+            return 0
+        finally:
+            self._exit_put()
+
+    def get(self, key: str) -> bytes:
+        self._enter_get()
+        try:
+            time.sleep(0.01)
+            with self.lock:
+                return self.objects[key]
+        finally:
+            self._exit_get()
+
+    def remove(self, key: str, force: bool = False) -> int:
+        with self.lock:
+            self.objects.pop(key, None)
+        return 0
+
+    def batch_remove(self, keys: list[str], force: bool = False) -> list[int]:
+        self.batch_remove_calls += 1
+        for key in keys:
+            self.remove(key, force)
+        return [0 for _key in keys]
+
+    def batch_put_from(self, keys: list[str], buffer_ptrs: list[int], sizes: list[int]) -> list[int]:
+        results: list[int] = []
+        for key, ptr, size in zip(keys, buffer_ptrs, sizes):
+            data = ctypes.string_at(ptr, size)
+            results.append(self.put(key, data))
+        return results
+
+    def register_buffer(self, buffer_ptr: int, size: int) -> int:
+        self.registered.add(buffer_ptr)
+        return 0
+
+    def unregister_buffer(self, buffer_ptr: int) -> int:
+        self.registered.remove(buffer_ptr)
+        return 0
+
+    def get_into(self, key: str, ptr: int, size: int) -> int:
+        self.get_into_calls += 1
+        self._enter_get()
+        try:
+            time.sleep(0.01)
+            with self.lock:
+                data = self.objects[key]
+            if len(data) > size:
+                return -1
+            ctypes.memmove(ptr, data, len(data))
+            return len(data)
+        finally:
+            self._exit_get()
+
+    def get_into_ranges(
+        self,
+        buffer_ptrs: list[int],
+        all_keys: list[list[str]],
+        all_dst_offsets: list[list[list[int]]],
+        all_src_offsets: list[list[list[int]]],
+        all_sizes: list[list[list[int]]],
+    ) -> list[list[list[int]]]:
+        self.get_into_ranges_calls += 1
+        total_keys = sum(len(keys) for keys in all_keys)
+        self._enter_get(total_keys)
+        try:
+            time.sleep(0.01)
+            results: list[list[list[int]]] = []
+            for base_ptr, keys, dst_groups, src_groups, size_groups in zip(
+                buffer_ptrs, all_keys, all_dst_offsets, all_src_offsets, all_sizes
+            ):
+                buffer_results: list[list[int]] = []
+                for key, dst_offsets, src_offsets, sizes in zip(keys, dst_groups, src_groups, size_groups):
+                    with self.lock:
+                        data = self.objects[key]
+                    key_results: list[int] = []
+                    for dst_offset, src_offset, size in zip(dst_offsets, src_offsets, sizes):
+                        end = src_offset + size
+                        if end > len(data):
+                            key_results.append(-1)
+                            continue
+                        ctypes.memmove(base_ptr + dst_offset, data[src_offset:end], size)
+                        key_results.append(size)
+                    buffer_results.append(key_results)
+                results.append(buffer_results)
+            return results
+        finally:
+            self._exit_get(total_keys)
+
+    def batch_get_into(
+        self, keys: list[str], ptrs: list[int], sizes: list[int]
+    ) -> list[int]:
+        self.batch_get_into_calls += 1
+        self._enter_get(len(keys))
+        try:
+            time.sleep(0.01)
+            results = []
+            for key, ptr, size in zip(keys, ptrs, sizes):
+                with self.lock:
+                    data = self.objects[key]
+                if len(data) > size:
+                    results.append(-1)
+                    continue
+                ctypes.memmove(ptr, data, len(data))
+                results.append(len(data))
+            return results
+        finally:
+            self._exit_get(len(keys))
+
+
+class GetOnlyStore(InMemoryStore):
+    batch_get_into = None
+
+
+class MinimalStore(GetOnlyStore):
+    batch_put_from = None
+    register_buffer = None
+    unregister_buffer = None
+
+
+class ReadFastPathWithoutRegisterStore(MinimalStore):
+    batch_get_into = InMemoryStore.batch_get_into
+    get_into = InMemoryStore.get_into
+    get_into_ranges = InMemoryStore.get_into_ranges
+
+
+class PlainStore(MinimalStore):
+    get_into = None
+    get_into_ranges = None
+
+
+class FailingPutStore(InMemoryStore):
+    def __init__(self, fail_on_put: int) -> None:
+        super().__init__()
+        self.put_count = 0
+        self.fail_on_put = fail_on_put
+
+    def put(self, key: str, value) -> int:
+        self.put_count += 1
+        if self.put_count == self.fail_on_put:
+            raise RuntimeError("injected put failure")
+        return super().put(key, value)
+
+
+class FailingBatchGetStore(InMemoryStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_key = ""
+
+    def batch_get_into(
+        self, keys: list[str], ptrs: list[int], sizes: list[int]
+    ) -> list[int]:
+        if self.fail_key in keys:
+            raise RuntimeError("injected get failure")
+        return super().batch_get_into(keys, ptrs, sizes)
+
+
+class FailingRemoveStore(FailingPutStore):
+    def remove(self, key: str, force: bool = False) -> int:
+        raise RuntimeError("injected remove failure")
+
+    batch_remove = None
+
+
+class ForceTrackingStore(InMemoryStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.batch_remove_forces: list[bool] = []
+
+    def batch_remove(self, keys: list[str], force: bool = False) -> list[int]:
+        self.batch_remove_forces.append(force)
+        return super().batch_remove(keys, force)
+
+
+class StrictRegisterStore(InMemoryStore):
+    def register_buffer(self, buffer_ptr: int, size: int) -> int:
+        if buffer_ptr in self.registered:
+            return -600
+        return super().register_buffer(buffer_ptr, size)
+
+
+class FailingRegisterStore(InMemoryStore):
+    def __init__(self, fail_on_register: int) -> None:
+        super().__init__()
+        self.register_count = 0
+        self.fail_on_register = fail_on_register
+
+    def register_buffer(self, buffer_ptr: int, size: int) -> int:
+        self.register_count += 1
+        if self.register_count == self.fail_on_register:
+            return -1
+        return super().register_buffer(buffer_ptr, size)
+
+
+def make_transfer(
+    store: InMemoryStore | None = None,
+    *,
+    key_prefix: str = "test",
+    default_chunk_bytes: int | None = None,
+) -> tuple[InMemoryStore, MooncakeBundleTransfer]:
+    current_store = store or InMemoryStore()
+    kwargs = {"key_prefix": key_prefix}
+    if default_chunk_bytes is not None:
+        kwargs["default_chunk_bytes"] = default_chunk_bytes
+    return current_store, MooncakeBundleTransfer(current_store, **kwargs)
+
+
+def structured_payload(metadata: dict[str, object] | None = None, **buffers: object) -> StructuredObjectPayload:
+    return StructuredObjectPayload(metadata=metadata or {"type": "example"}, buffers=buffers)
+
+
+def write_manifest(store: InMemoryStore, manifest_key: str, manifest: dict[str, object]) -> None:
+    store.objects[manifest_key] = json.dumps(manifest, separators=(",", ":")).encode("utf-8")
+
+
+def test_bundle_read_spec_full_read_is_partial_special_case() -> None:
+    store, transfer = make_transfer()
+    array = np.arange(16, dtype=np.int32).reshape(4, 4)
+    payload = structured_payload(array=array, raw=b"abc")
+
+    ref = transfer.put_structured_object(payload)
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert np.array_equal(result.objects["array"], array)
+    assert result.objects["raw"] == b"abc"
+    assert store.batch_get_into_calls > 0
+    assert store.registered == set()
+
+
+def test_bundle_chunked_full_read_via_read_spec() -> None:
+    store, transfer = make_transfer()
+    payload = bytes(range(128))
+
+    ref = transfer.put_structured_object(
+        structured_payload(payload=payload),
+        chunk_bytes=17,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["payload"] == payload
+    assert len(ref.manifest["buffers"]["payload"]["chunks"]) > 1
+
+
+def test_bundle_put_falls_back_to_store_put_without_batch_put_support() -> None:
+    store, transfer = make_transfer(MinimalStore())
+    payload = bytes(range(128))
+
+    ref = transfer.put_structured_object(structured_payload(payload=payload), chunk_bytes=17)
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["payload"] == payload
+    assert len(ref.manifest["buffers"]["payload"]["chunks"]) > 1
+    assert store.registered == set()
+
+
+def test_bundle_uses_configurable_default_chunk_size() -> None:
+    store, transfer = make_transfer(default_chunk_bytes=17)
+    payload = bytes(range(128))
+
+    ref = transfer.put_bundle(b"meta", {"payload": payload})
+
+    assert len(ref.manifest["buffers"]["payload"]["chunks"]) > 1
+    assert ref.manifest["buffers"]["payload"]["chunks"][0]["bytes"] == 17
+
+
+def test_structured_object_roundtrip() -> None:
+    store, transfer = make_transfer()
+    array = np.arange(12, dtype=np.int16).reshape(3, 4)
+    payload = structured_payload(
+        {"type": "example", "fields": ["weights", "tokens"]},
+        weights=array,
+        tokens=b"abc",
+    )
+
+    ref = transfer.put_structured_object(payload)
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.metadata == {
+        "layout": "structured",
+        "type": "example",
+        "fields": ["weights", "tokens"],
+        "__mooncake_structured_fields__": {
+            "weights": {
+                "encoding": "ndarray",
+                "dtype": array.dtype.str,
+                "shape": [3, 4],
+            },
+            "tokens": {"encoding": "bytes"},
+        },
+    }
+    assert np.array_equal(result.objects["weights"], array)
+    assert result.objects["weights"].flags["C_CONTIGUOUS"]
+    assert result.objects["tokens"] == b"abc"
+
+
+def test_structured_object_read_spec_select_members() -> None:
+    store, transfer = make_transfer()
+    array = np.arange(10, dtype=np.float32).reshape(2, 5)
+    payload = structured_payload(weights=array, raw=b"payload")
+
+    ref = transfer.put_structured_object(payload)
+    spec = transfer.read_spec(ref).select_members(["weights"])
+    assert isinstance(spec, StructuredObjectReadSpec)
+    batch_get_into_calls = store.batch_get_into_calls
+    result = transfer.materialize(spec)
+
+    assert list(result.objects) == ["weights"]
+    assert np.array_equal(result.objects["weights"], array)
+    assert store.get_into_calls > 0
+    assert store.get_into_ranges_calls == 0
+    assert store.batch_get_into_calls == batch_get_into_calls + 1
+
+
+def test_structured_object_multichunk_ndarray_uses_range_gather() -> None:
+    store, transfer = make_transfer()
+    array = np.arange(64, dtype=np.int16).reshape(8, 8)
+    payload = structured_payload(weights=array)
+
+    ref = transfer.put_structured_object(payload, chunk_bytes=32)
+    batch_get_into_calls = store.batch_get_into_calls
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert np.array_equal(result.objects["weights"], array)
+    assert store.get_into_ranges_calls > 0
+    assert store.batch_get_into_calls == batch_get_into_calls + 1
+
+
+def test_structured_object_slice_member_uses_partial_range_reads() -> None:
+    store, transfer = make_transfer()
+    array = np.arange(96, dtype=np.int16).reshape(12, 8)
+    payload = structured_payload(weights=array, raw=b"payload")
+
+    ref = transfer.put_structured_object(payload, chunk_bytes=20)
+    spec = transfer.read_spec(ref).select_members(["weights"]).slice_member("weights", axis=0, start=3, end=9)
+    before_range_reads = store.get_into_ranges_calls
+    result = transfer.materialize(spec)
+
+    assert np.array_equal(result.objects["weights"], array[3:9])
+    assert result.objects["weights"].shape == (6, 8)
+    assert store.get_into_ranges_calls == before_range_reads + 1
+
+
+def test_structured_object_slice_member_falls_back_to_plain_get_reads() -> None:
+    store, transfer = make_transfer(PlainStore())
+    array = np.arange(96, dtype=np.int16).reshape(12, 8)
+    payload = structured_payload(weights=array, raw=b"payload")
+
+    ref = transfer.put_structured_object(payload, chunk_bytes=20)
+    spec = transfer.read_spec(ref).select_members(["weights"]).slice_member("weights", axis=0, start=3, end=9)
+    result = transfer.materialize(spec)
+
+    assert np.array_equal(result.objects["weights"], array[3:9])
+    assert result.objects["weights"].shape == (6, 8)
+    assert store.get_into_calls == 0
+    assert store.get_into_ranges_calls == 0
+    assert store.batch_get_into_calls == 0
+
+
+def test_structured_object_materialize_into_reuses_destination() -> None:
+    store, transfer = make_transfer()
+    array = np.arange(96, dtype=np.float32).reshape(12, 8)
+    payload = structured_payload(weights=array)
+
+    ref = transfer.put_structured_object(payload, chunk_bytes=40)
+    spec = transfer.read_spec(ref).slice_member("weights", axis=0, start=2, end=10)
+    destination = np.empty((8, 8), dtype=np.float32)
+    result = transfer.materialize_into(spec, destinations={"weights": destination})
+
+    assert result.objects["weights"] is destination
+    assert np.array_equal(destination, array[2:10])
+    assert store.get_into_ranges_calls > 0
+
+
+def test_structured_object_duplicate_destination_registration_is_tolerated() -> None:
+    store, transfer = make_transfer(StrictRegisterStore())
+    array = np.arange(96, dtype=np.float32).reshape(12, 8)
+    payload = structured_payload(weights=array)
+
+    ref = transfer.put_structured_object(payload, chunk_bytes=40)
+    spec = transfer.read_spec(ref).select_members(["weights"]).slice_member("weights", axis=0, start=2, end=10)
+    destination = np.empty((8, 8), dtype=np.float32)
+    destination_ptr = ctypes.addressof(ctypes.c_char.from_buffer(destination))
+    assert store.register_buffer(destination_ptr, int(destination.nbytes)) == 0
+
+    result = transfer.materialize_into(spec, destinations={"weights": destination})
+
+    assert result.objects["weights"] is destination
+    assert np.array_equal(destination, array[2:10])
+    assert store.get_into_ranges_calls > 0
+    assert destination_ptr in store.registered
+    store.unregister_buffer(destination_ptr)
+
+
+def test_structured_object_slice_member_step_copy() -> None:
+    store, transfer = make_transfer()
+    array = np.arange(120, dtype=np.int32).reshape(15, 8)
+    payload = structured_payload(weights=array)
+
+    ref = transfer.put_structured_object(payload, chunk_bytes=24)
+    spec = transfer.read_spec(ref).slice_member("weights", axis=0, start=1, end=12, step=3)
+    result = transfer.materialize(spec)
+
+    assert np.array_equal(result.objects["weights"], array[1:12:3])
+    assert result.objects["weights"].shape == array[1:12:3].shape
+    assert store.get_into_ranges_calls > 0
+
+
+def test_structured_object_invalid_slice_and_destination_raise() -> None:
+    store, transfer = make_transfer()
+    array = np.arange(24, dtype=np.int16).reshape(6, 4)
+    ref = transfer.put_structured_object(
+        structured_payload(weights=array, raw=b"abc"),
+        chunk_bytes=8,
+    )
+
+    with pytest.raises(ValueError, match="axis=0"):
+        transfer.materialize(transfer.read_spec(ref).slice_member("weights", axis=1, start=0, end=2))
+    with pytest.raises(ValueError, match="step must be positive"):
+        transfer.materialize(transfer.read_spec(ref).slice_member("weights", axis=0, start=0, end=2, step=0))
+    with pytest.raises(ValueError, match="does not support slicing"):
+        transfer.materialize(transfer.read_spec(ref).slice_member("raw", axis=0, start=0, end=1))
+    with pytest.raises(ValueError, match="shape mismatch"):
+        transfer.materialize_into(
+            transfer.read_spec(ref).slice_member("weights", axis=0, start=1, end=3),
+            destinations={"weights": np.empty((3, 4), dtype=np.int16)},
+        )
+
+
+def test_bundle_remove_deletes_payload_and_manifest() -> None:
+    store, transfer = make_transfer()
+
+    ref = transfer.put_bundle(b"meta", {"payload": b"data"})
+    assert store.objects
+    transfer.remove_bundle(ref)
+
+    assert store.objects == {}
+    assert store.batch_remove_calls == 1
+
+
+def test_bundle_partial_put_failure_cleans_payloads() -> None:
+    store, transfer = make_transfer(FailingPutStore(fail_on_put=2))
+
+    with pytest.raises(RuntimeError, match="injected put failure"):
+        transfer.put_bundle(b"meta", {"payload": b"data"}, chunk_bytes=2)
+
+    assert store.objects == {}
+
+
+def test_bundle_cleanup_failure_preserves_put_error() -> None:
+    _store, transfer = make_transfer(FailingRemoveStore(fail_on_put=2))
+
+    with pytest.raises(RuntimeError, match="injected put failure"):
+        transfer.put_bundle(b"meta", {"payload": b"data"}, chunk_bytes=2)
+
+
+def test_bundle_remove_uses_force_batch_remove_when_available() -> None:
+    store, transfer = make_transfer(ForceTrackingStore())
+
+    ref = transfer.put_structured_object(
+        structured_payload(payload=bytes(range(64))),
+        chunk_bytes=8,
+    )
+    transfer.materialize(transfer.read_spec(ref))
+    transfer.remove_bundle(ref)
+
+    assert store.batch_remove_forces == [True]
+    assert store.objects == {}
+
+
+def test_bundle_concurrent_put_and_read_spec_full_read() -> None:
+    store, transfer = make_transfer(GetOnlyStore())
+    payload = bytes(range(128))
+
+    ref = transfer.put_structured_object(
+        structured_payload(payload=payload),
+        chunk_bytes=8,
+        policy=BundleTransferPolicy(max_inflight_put=4, put_mode="parallel"),
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["payload"] == payload
+    assert store.max_active_puts > 1
+    assert store.max_active_gets >= 1
+
+
+def test_bundle_duplicate_source_registration_is_tolerated() -> None:
+    store, transfer = make_transfer(StrictRegisterStore())
+    payload = np.arange(64, dtype=np.uint8).reshape(8, 8)
+    payload_ptr = ctypes.addressof(ctypes.c_char.from_buffer(payload))
+    assert store.register_buffer(payload_ptr, int(payload.nbytes)) == 0
+
+    ref = transfer.put_structured_object(structured_payload(payload=payload))
+
+    assert ref.manifest["buffers"]["payload"]["bytes"] == int(payload.nbytes)
+    assert payload_ptr in store.registered
+    store.unregister_buffer(payload_ptr)
+
+
+def test_bundle_partial_register_failure_unwinds_registered_buffers() -> None:
+    store, transfer = make_transfer(FailingRegisterStore(fail_on_register=2))
+    payload = bytes(range(64))
+
+    with pytest.raises(RuntimeError, match="register_buffer"):
+        transfer.put_structured_object(structured_payload(payload=payload), chunk_bytes=32)
+
+    assert store.registered == set()
+    assert store.objects == {}
+
+
+def test_bundle_batch_get_failure_unregisters_buffer() -> None:
+    store, transfer = make_transfer(FailingBatchGetStore())
+    ref = transfer.put_structured_object(
+        structured_payload(payload=bytes(range(64))),
+        chunk_bytes=8,
+    )
+    store.fail_key = ref.manifest["buffers"]["payload"]["chunks"][2]["key"]
+
+    with pytest.raises(RuntimeError, match="injected get failure"):
+        transfer.materialize(transfer.read_spec(ref))
+
+    assert store.registered == set()
+
+
+def test_bundle_falls_back_to_get_without_batch_get_into() -> None:
+    store, transfer = make_transfer(GetOnlyStore())
+
+    ref = transfer.put_structured_object(
+        structured_payload(payload=b"abcdef"),
+        chunk_bytes=2,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["payload"] == b"abcdef"
+    assert store.max_active_gets >= 1
+
+
+def test_bundle_read_fast_paths_require_registration_support() -> None:
+    store, transfer = make_transfer(ReadFastPathWithoutRegisterStore())
+
+    ref = transfer.put_structured_object(
+        structured_payload(payload=bytes(range(64))),
+        chunk_bytes=8,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["payload"] == bytes(range(64))
+    assert store.batch_get_into_calls == 0
+    assert store.get_into_calls == 0
+    assert store.get_into_ranges_calls == 0
+
+
+def test_bundle_invalid_policy_and_chunk_size_raise() -> None:
+    store, transfer = make_transfer()
+
+    with pytest.raises(ValueError, match="max_inflight_put"):
+        transfer.put_bundle(b"meta", {"payload": b"data"}, max_inflight_put=0)
+    with pytest.raises(ValueError, match="selected no members"):
+        transfer.materialize(transfer.read_spec({"manifest_key": "test/default/example/manifest"}).select_members([]))
+    with pytest.raises(ValueError, match="chunk_bytes"):
+        transfer.put_bundle(b"meta", {"payload": b"data"}, chunk_bytes=0)
+
+
+def test_bundle_invalid_name_and_prefix_raise() -> None:
+    store, transfer = make_transfer()
+
+    with pytest.raises(ValueError, match="buffer name"):
+        transfer.put_bundle(b"meta", {"bad/name": b"data"})
+    with pytest.raises(ValueError, match="partition"):
+        transfer.put_bundle(b"meta", {"payload": b"data"}, partition="bad/name")
+    with pytest.raises(ValueError, match="key_prefix"):
+        MooncakeBundleTransfer(store, key_prefix="")
+    with pytest.raises(ValueError, match="chunk_bytes"):
+        MooncakeBundleTransfer(store, default_chunk_bytes=0)
+
+
+def test_structured_object_invalid_metadata_raises() -> None:
+    store, transfer = make_transfer()
+
+    with pytest.raises(TypeError, match="mapping"):
+        transfer.put_structured_object(StructuredObjectPayload(metadata=["not", "a", "mapping"], buffers={}))
+    with pytest.raises(TypeError, match="JSON-serializable"):
+        transfer.put_structured_object(StructuredObjectPayload(metadata={"bad": object()}, buffers={}))
+    with pytest.raises(ValueError, match="reserved"):
+        transfer.put_structured_object(
+            StructuredObjectPayload(metadata={"__mooncake_structured_fields__": {}}, buffers={"payload": b"abc"})
+        )
+
+
+def test_structured_object_rejects_invalid_field_spec() -> None:
+    store, transfer = make_transfer()
+    manifest_key = "test/default/example/manifest"
+    meta_key = "test/default/example/meta"
+    payload_key = "test/default/example/buffer/payload"
+    metadata_blob = (
+        b'{"layout":"structured","__mooncake_structured_fields__":'
+        b'{"payload":{"encoding":"unknown"}}}'
+    )
+    store.objects[meta_key] = metadata_blob
+    store.objects[payload_key] = b"abc"
+    write_manifest(
+        store,
+        manifest_key,
+        {
+            "version": 1,
+            "layout": "bundle",
+            "object_id": "default/example",
+            "meta": {
+                "key": meta_key,
+                "bytes": len(metadata_blob),
+                "chunks": [{"key": meta_key, "bytes": len(metadata_blob)}],
+            },
+            "buffers": {
+                "payload": {
+                    "key": payload_key,
+                    "bytes": 3,
+                    "chunks": [{"key": payload_key, "bytes": 3}],
+                }
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="unsupported structured field encoding"):
+        transfer.materialize(transfer.read_spec({"manifest_key": manifest_key}))
+
+
+def test_bundle_rejects_tampered_manifest() -> None:
+    store, transfer = make_transfer()
+    ref = transfer.put_bundle(b"meta", {"payload": b"abcdef"}, chunk_bytes=2)
+    tampered = dict(ref.manifest)
+    tampered["buffers"] = dict(ref.manifest["buffers"])
+    tampered["buffers"]["payload"] = dict(ref.manifest["buffers"]["payload"])
+    tampered["buffers"]["payload"]["chunks"] = [
+        {"key": "other/object", "bytes": 6},
+    ]
+    write_manifest(store, ref.manifest_key, tampered)
+
+    with pytest.raises(ValueError, match="namespace"):
+        transfer.materialize(transfer.read_spec({"manifest_key": ref.manifest_key}))
+
+    with pytest.raises(ValueError, match="manifest_key"):
+        transfer.remove_bundle(
+            RemoteBundleRef(manifest_key="test/other/manifest", manifest=ref.manifest)
+        )
+


### PR DESCRIPTION
  ## Motivation                                                                                                                                                                      
                                                                                                                                                                                     
  Higher-level training frameworks often need to move one logical structured object through Mooncake rather than a single opaque byte payload. In the rollout-style scenario we care about, the object usually contains:                                                                                                                                                
                                                                                                                                                                                     
  - dense ndarray members that dominate transfer cost;                                                                                                                               
  - non-ndarray byte members that should still move with the same object lifecycle;                                                                                                  
  - lightweight metadata used to describe the object structure.                                                                                                                      
                                                                                                                                                                                     
  The old generic bundle helper could already move named payloads, but from a maintainer and downstream-framework perspective it mixed too many concerns in one surface: generic manifest handling, chunked Mooncake transport, structured ndarray semantics, and internal optimization details.                                                                    
                                                                                                                                                                                     
  This PR introduces a clearer structured-object helper in Mooncake so downstream frameworks can keep their own container semantics locally while using Mooncake for:

  - structured object put/get lifecycle;                                                                                                                                             
  - full-read and partial-read materialization;                                                                                                                                      
  - ndarray member slicing and destination reuse;                                                                                                                                    
  - low-level raw bundle fallback when needed.                                                                                                                                       
                                                                                                                                                                                     
  ## Scenario                                                                                                                                                                        
                                                                                                                                                                                     
  This targets structured remote object transfer where the consumer may need either the whole object or only selected members:                                                       
                                                                                                                                                                                     
  1. A producer stores one structured object as metadata plus named members.                                                                                                         
  2. Dense ndarray members are stored as Mooncake payloads with shape/dtype metadata.                                                                                                
  3. A consumer materializes:                                                                                                                                                        
     - the full object by default;                                                                                                                                                   
     - only selected members when needed;                                                                                                                                            
     - selected axis-0 ndarray slices for partial reads.                                                                                                                             
  4. Caller-owned ndarray destinations can be reused for materialization.                                                                                                            
  5. The helper still supports a lower-level raw bundle path when structured semantics are not needed.                                                                               
                                                                                                                                                                                     
  This matches the rollout/data-transfer scenario more directly than a purely bundle-oriented helper while keeping framework-specific schema logic outside Mooncake.                 
                                                                                                                                                                                     
  ## Description                                                                                                                                                                     
                                                                                                                                                                                     
  This PR adds a Python structured object store helper centered on `MooncakeBundleTransfer`, `StructuredObjectPayload`, and `StructuredObjectReadSpec`.                              
                                                                                                                                                                                     
  ### Structured object APIs                                                                                                                                                         
                                                                                                                                                                                     
  - `StructuredObjectPayload`                                                                                                                                                        
  - `StructuredObjectResult`                                                                                                                                                         
  - `StructuredMemberSlice`                                                                                                                                                          
  - `StructuredObjectReadSpec`                                                                                                                                                       
  - `MooncakeBundleTransfer.put_structured_object(...)`                                                                                                                              
  - `MooncakeBundleTransfer.read_spec(...)`                                                                                                                                          
  - `MooncakeBundleTransfer.materialize(...)`                                                                                                                                        
  - `MooncakeBundleTransfer.materialize_into(...)`                                                                                                                                   
                                                                                                                                                                                     
  The structured helper supports:                                                                                                                                                    
                                                                                                                                                                                     
  - full structured reads through `read_spec(ref)`;                                                                                                                                  
  - member subset reads through `select_members(...)`;                                                                                                                               
  - axis-0 ndarray slice reads through `slice_member(...)`;                                                                                                                          
  - caller-owned ndarray destination reuse through `materialize_into(...)`.                                                                                                          
                                                                                                                                                                                     
  ### Generic bundle fallback                                                                                                                                                        
                                                                                                                                                                                     
  The helper still exposes a lower-level bundle API:                                                                                                                                 
                                                                                                                                                                                     
  - `put_bundle(...)`                                                                                                                                                                
  - `remove_bundle(...)`                                                                                                                                                             
  - `RemoteBundleRef`                                                                                                                                                                
                                                                                                                                                                                     
  This path stores one logical object as:                                                                                                                                            
                                                                                                                                                                                     
  - manifest metadata;                                                                                                                                                               
  - one metadata payload;                                                                                                                                                            
  - one or more named member payloads.                                                                                                                                               
                                                                                                                                                                                     
  ### Transfer behavior                                                                                                                                                              
                                                                                                                                                                                     
  The implementation keeps the transport policy inside Mooncake and prefers the fastest available store path while preserving generic fallbacks:                                     
                                                                                                                                                                                     
  - write path:                                                                                                                                                                  
    - direct `store.put(...)` fallback when batch registration APIs are unavailable;
    - `batch_put_from(...)` when supported;    
    - grouped parallel batch put when policy selects it;
  - read path:                                                                                                                                                                       
    - `batch_get_into(...)` when read fast-path APIs and buffer registration are both available;                                                                                     
    - `get_into(...)` / `get_into_ranges(...)` for ndarray reads when supported;                                                                                                     
    - plain `get(...)` copy fallback for full and partial reads.                                                                                                                     
                                                                                                                                                                                     
  The structured public API does not expose registered-buffer optimization hints directly; those remain internal transport behavior.                                                 
                                                                                                                                                                                     
  ## Basic Usage                                                                                                                                                                     
                                                                                                                                                                                     
  ```python                                                                                                                                                                          
  import numpy as np                                                                                                                                                                 
                                                                                                                                                                                     
  from mooncake.structured_object_store import MooncakeBundleTransfer, StructuredObjectPayload                                                                                       
  from mooncake.store import MooncakeDistributedStore                                                                                                                                
                                                                                                                                                                                     
  store = MooncakeDistributedStore()                                                                                                                                                 
  transfer = MooncakeBundleTransfer(store, key_prefix="bundle")                                                                                                                      
                                                                                                                                                                                     
  payload = StructuredObjectPayload(                                                                                                                                                 
      metadata={"type": "example", "fields": ["tokens", "scores"]},                                                                                                                  
      buffers={                                                                                                                                                                  
          "tokens": np.arange(16, dtype=np.int32).reshape(4, 4),
          "scores": b"score-bytes",            
      },                                       
  )                                                                                                                                                                                  
                                                                                                                                                                                     
  ref = transfer.put_structured_object(                                                                                                                                              
      payload,                                                                                                                                                                       
      partition="worker-0",                                                                                                                                                      
      chunk_bytes=64 * 1024 * 1024,            
  )                                                                                                                                                                                  
                                                                                                                                                                                     
  spec = transfer.read_spec(ref).select_members(["tokens"])                                                                                                                          
  result = transfer.materialize(spec)                                                                                                                                                
                                                                                                                                                                                     
  destination = np.empty((4, 4), dtype=np.int32)                                                                                                                                     
  transfer.materialize_into(                                                                                                                                                         
      spec,                                                                                                                                                                          
      destinations={"tokens": destination},                                                                                                                                      
  )                             
                                        
  transfer.remove_bundle(ref)                  
                                                                                                                                                                                     
  Selected slice materialization:                                                                                                                                                    
                                                                                                                                                                                     
  spec = (                                                                                                                                                                           
      transfer.read_spec(ref)                                                                                                                                                    
      .select_members(["tokens"])              
      .slice_member("tokens", axis=0, start=1, end=3)
  )                                                                                                                                                                                  
  result = transfer.materialize(spec)                                                                                                                                                
   ```                                                                                                                                                                                  
  Architecture                                                                                                                                                                       
                                                                                                                                                                                 
  The implementation is organized as three logical layers:
                                        
  1. Structured object layer                   
    - structured payload/result/read-spec types;
    - structured metadata encode/decode;       
    - member selection and slicing;                                                                                                                                                  
    - ndarray destination validation and materialization.                                                                                                                            
  2. Bundle + manifest layer                                                                                                                                                         
    - one logical object as manifest + named payloads;                                                                                                                               
    - manifest validation;                                                                                                                                                           
    - payload spec construction;                                                                                                                                                     
    - bundle lifecycle cleanup.                                                                                                                                                      
  3. Mooncake transport layer                                                                                                                                                        
    - chunk splitting/grouping;                                                                                                                                                      
    - batch/direct/parallel put routing;                                                                                                                                             
    - full-payload reads;                                                                                                                                                            
    - ranged ndarray reads;                                                                                                                                                          
    - buffer registration lifecycle;                                                                                                                                                 
    - cleanup/fallback behavior.                                                                                                                                                 
                                               
  This keeps framework semantics outside Mooncake while making the structured-object flow easier for maintainers to review top-down.
                                                                                                                                                                                     
  Robustness and Safety                                                                                                                                                              
                                                                                                                                                                                     
  - validates bundle names, partition names, chunk sizes, and key prefixes;                                                                                                          
  - validates ndarray destination dtype/shape/contiguity before materialization;                                                                                                 
  - rejects invalid slice definitions and unsupported structured encodings;                                                                                                          
  - rejects user metadata collisions with the reserved internal structured-field key;                                                                                                
  - cleans up partial writes on put failures;                                                                                                                                        
  - tolerates duplicate buffer registration status from Mooncake;                                                                                                                    
  - unwinds partially completed buffer registrations on failure;                                                                                                                     
  - gates read/write fast paths on the full capability set they require, and falls back cleanly otherwise;                                                                           
  - treats missing-object remove status as non-fatal during cleanup.                                                                                                                 
                                                                                                                                                                                     
  Performance                                                                                                                                                                        
                                                                                                                                                                                 
  The helper preserves the fast-path behavior needed for structured rollout-style transfer while keeping the public API simpler:                                                     
                                                                                                                                                                                     
  - full reads are expressed as the default read_spec(ref) case;                                                                                                                     
  - partial reads narrow from that default through member selection and slicing;                                                                                                     
  - ndarray materialization uses ranged reads when the store supports them;                                                                                                      
  - full-payload reads still prefer batch zero-copy paths when available;                                                                                                            
  - fallback behavior remains available for stores with fewer capabilities.                                                                                                          
                                                                                                                                                                                     
  No benchmark script is included in this PR.                                                                                                                                        
                                                                                                                                                                                     
  Module                                                                                                                                                                             
                                                                                                                                                                                     
  - Python Wheel (mooncake-wheel)                                                                                                                                                    
  - Docs                                                                                                                                                                         
                                                                                                                                                                                     
  Type of Change                                                                                                                                                                     
                                                                                                                                                                                     
  - New feature                                                                                                                                                                      
  - Refactor                                                                                                                                                                     
  - Documentation update                                                                                                                                                             
                                                                                                                                                                                     
  How Has This Been Tested?                                                                                                                                                          
                                                                                                                                                                                     
  - python -m py_compile mooncake-wheel/mooncake/structured_object_store.py                                                                                                      
  - pytest -q mooncake-wheel/tests/test_structured_object_store.py
                                     
  The test coverage includes:           
                                        
  - structured object roundtrip;    
  - full read via read_spec(ref);    
  - member subset reads;                       
  - ndarray slice reads;                                                                                                                                                             
  - destination reuse via materialize_into(...);                                                                                                                                     
  - raw bundle fallback behavior;                                                                                                                                                    
  - direct put fallback when batch-put support is unavailable;                                                                                                                       
  - plain get(...) read fallback when read fast-path APIs are unavailable;                                                                                                           
  - cleanup on partial write failure;                                                                                                                                                
  - cleanup on batch get failure;                                                                                                                                                    
  - duplicate registration tolerance;                                                                                                                                                
  - partial registration unwind on failure;                                                                                                                                      
  - manifest tamper rejection.          

 ## Benchmark Results                                                                                                                                                               
                                                                                                                                                                                     
  ### Setup                                                                                                                                                                          
  - Payload: rollout-style tensor dict                                                                                                                                               
  - Chunk size: 2 MiB                                                                                                                                                                
  - Baseline: regular serialize/deserialize of the whole tensor dict as one blob                                                                                                     
  - Experiment 1: new structured object API, single-thread write                                                                                                                     
  - Experiment 2: new structured object API, parallel write (`max_inflight_put=8`)                                                                                                   
  - Backend used for this microbenchmark: in-memory benchmark store                                                                                                                  
                                                                                                                                                                                     
  ### Results                                                                                                                                                                        
                                                                                                                                                                                     
  | Payload | Chunks | Case | Write Time (s) | Write Throughput (MB/s) | Read Time (s) | Read Throughput (MB/s) |                                                                    
  |---|---:|---|---:|---:|---:|---:|                                                                                                                                                 
  | 80.01 MiB | 41 | Baseline: serialized blob | 0.117936 | 678.40 | 0.097240 | 822.79 |                                                                                             
  | 80.01 MiB | 42 | Structured API, single-thread write | 0.038912 | 2056.10 | 0.026462 | 3023.46 |                                                                                 
  | 80.01 MiB | 42 | Structured API, parallel write (8) | 0.031986 | 2501.34 | 0.027301 | 2930.53 |                                                                                  
  | 156.02 MiB | 79 | Baseline: serialized blob | 0.234368 | 665.69 | 0.186516 | 836.47 |                                                                                            
  | 156.02 MiB | 80 | Structured API, single-thread write | 0.073553 | 2121.12 | 0.048126 | 3241.83 |                                                                                
  | 156.02 MiB | 80 | Structured API, parallel write (8) | 0.059511 | 2621.64 | 0.049258 | 3167.34 |                                                                                 
                                                                                                                                                                                     
  ### Summary                                                                                                                                                                         
                                                                                                                                                                                     
  I ran a rollout-style tensor-dict microbenchmark with a relatively large payload and many chunks (2 MiB chunk size), comparing three paths:                                        
                                                                                                                                                                                     
  1. **Baseline**: serialize/deserialize the whole tensor dict as a regular blob                                                                                                     
  2. **Structured object API, single-thread write**                                                                                                                                  
  3. **Structured object API, parallel write** (`max_inflight_put=8`)                                                                                                                
                                                                                                                                                                                     
  Across both tested payload sizes (~80 MiB and ~156 MiB), the new structured object API significantly outperformed the blob serialization baseline.                                 
                                                                                                                                                                                     
  - For writes, the structured API with **single-thread write** improved throughput by about **3.1x–3.2x** over the baseline.                                                        
  - The **parallel write** path improved throughput further, reaching about **3.8x–3.9x** over the baseline and about **18%–24%** better than structured single-thread write.        
  - Read performance also improved substantially, with the structured API delivering roughly **3x+** higher throughput than the blob baseline in these tests.                        
                                                                                                                                                                                     
  > Note: this is an **in-memory microbenchmark**, so it primarily measures serialization/materialization overhead and chunked transfer behavior, rather than full end-to-end        
  performance against a real Mooncake deployment. 

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
