### PR TITLE
CI: refactor TENT build and add test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -622,16 +622,20 @@ jobs:
       run: |
         mkdir build-tent
         cd build-tent
-        cmake -G Ninja .. -DUSE_TENT=ON -DUSE_HTTP=ON -DUSE_CUDA=ON -DENABLE_SCCACHE=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs"
+        cmake -G Ninja .. -DUSE_TENT=ON -DUSE_HTTP=ON -DENABLE_SCCACHE=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON
       shell: bash
 
     - name: Build project with TENT
       run: |
-        export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-        export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
         cd build-tent
         cmake --build .
         sudo cmake --install .
+      shell: bash
+
+    - name: Test (TENT)
+      run: |
+        cd build-tent
+        ctest --test-dir mooncake-transfer-engine/tent/tests -j --output-on-failure
       shell: bash
 
     - name: Build nvlink_allocator.so


### PR DESCRIPTION
## Description

The current CI configures and builds the TENT backend with -DUSE_CUDA=ON, but never runs any Tent tests. This change:

  - Removes -DUSE_CUDA=ON from the Tent CMake configuration — all Tent unit tests use mock/fake objects and don't need GPU hardware
  - Removes the CUDA stubs workaround from the build step (no longer needed without CUDA)
  - Adds a Test (TENT) step that runs ctest --test-dir mooncake-transfer-engine/tent/tests to execute only TENT-specific tests

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

CI on fork staryxchen/Mooncake#4 (https://github.com/staryxchen/Mooncake/pull/4): all Tent tests (--test-dir mooncake-transfer-engine/tent/tests) pass on both Python 3.10 and 3.12 build-flags jobs.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
