### PR TITLE
[Bugfix][Store] Fix snapshot failure when OpLog has never been written

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2816,7 +2816,7 @@ MasterService::ResolveSnapshotSequenceId() const {
 
     uint64_t sequence_id = 0;
     auto err = oplog_store.value()->GetLatestSequenceId(sequence_id);
-    if (err == ErrorCode::ETCD_KEY_NOT_EXIST) {
+    if (err == ErrorCode::OPLOG_ENTRY_NOT_FOUND) {
         return ha::OpLogSequenceId{0};
     }
     if (err != ErrorCode::OK) {


### PR DESCRIPTION
ResolveSnapshotSequenceId() only checks for ETCD_KEY_NOT_EXIST, but
EtcdOpLogStore::GetLatestSequenceId() translates that error code into
OPLOG_ENTRY_NOT_FOUND before returning. Add the missing error code to
the sentinel check so that an uninitialized OpLog is correctly treated
as sequence_id=0.

## Description

When HA is enabled and the master runs as **leader**, no OpLog entries are written
to etcd. The key `/oplog/<cluster_id>/latest` never exists. During snapshot,
`GetLatestSequenceId()` returns `OPLOG_ENTRY_NOT_FOUND`, but
`ResolveSnapshotSequenceId()` only handles `ETCD_KEY_NOT_EXIST`, causing snapshot
to fail with `UNKNOWN_ERROR`.

This PR adds `OPLOG_ENTRY_NOT_FOUND` to the sentinel check, treating it the same
as `ETCD_KEY_NOT_EXIST` (return sequence_id=0).

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Reproduced and verified on a production-like environment:
- 3-node etcd cluster with HA-enabled Mooncake master in leader mode
- `enable_snapshot=true`, `snapshot_interval_seconds=60`
- Before fix: snapshot fails every cycle with `UNKNOWN_ERROR`
- After fix: snapshots generate successfully and persist to object store continuously

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
