### PR TITLE
[PG] support external TE

### DIFF
--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <pybind11/pybind11.h>
 #include <mooncake_worker.cuh>
 #include <connection_poller.h>
 #include <p2p_proxy.h>
@@ -158,12 +157,12 @@ class MooncakeBackend final : public ::c10d::ProcessGroup {
         engine_->setWhitelistFilters(std::move(filters));
     }
 
-    /// Set an external TransferEngine (from mooncake.engine.TransferEngine)
-    /// to be used by MooncakeBackend instead of creating its own.
-    /// Must be called before init_process_group(backend="mooncake").
-    /// The engine must already be initialized.
-    /// Pass None to reset to default (self-created) behavior.
-    static void setTransferEngine(pybind11::object engine_obj);
+    /// Set an external TransferEngine to be used by MooncakeBackend
+    /// instead of creating its own. Must be called before
+    /// init_process_group(backend="mooncake"). The engine must already
+    /// be initialized. The caller is responsible for ensuring the engine
+    /// outlives all MooncakeBackend instances. Pass nullptr to reset.
+    static void setExternalEngine(TransferEngine* engine);
 
     std::string getPreferredHca(std::string location) {
         static std::once_flag topo_once;
@@ -221,9 +220,9 @@ class MooncakeBackend final : public ::c10d::ProcessGroup {
     static int backendIndex_;
     // External engine injection: when set, MooncakeBackend uses this engine
     // instead of the default self-created one. Non-owning pointer.
+    // The caller is responsible for ensuring the engine outlives all
+    // MooncakeBackend instances.
     static TransferEngine* externalEngine_;
-    // Python reference to the external TransferEnginePy object to prevent GC.
-    static pybind11::object externalEngineRef_;
     const c10::intrusive_ptr<MooncakeBackendOptions> options_;
     bool isCpu_{false};
     static std::string hostIp_;

--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <pybind11/pybind11.h>
 #include <mooncake_worker.cuh>
 #include <connection_poller.h>
 #include <p2p_proxy.h>
@@ -157,6 +158,13 @@ class MooncakeBackend final : public ::c10d::ProcessGroup {
         engine_->setWhitelistFilters(std::move(filters));
     }
 
+    /// Set an external TransferEngine (from mooncake.engine.TransferEngine)
+    /// to be used by MooncakeBackend instead of creating its own.
+    /// Must be called before init_process_group(backend="mooncake").
+    /// The engine must already be initialized.
+    /// Pass None to reset to default (self-created) behavior.
+    static void setTransferEngine(pybind11::object engine_obj);
+
     std::string getPreferredHca(std::string location) {
         static std::once_flag topo_once;
         static std::shared_ptr<Topology> topology;
@@ -211,6 +219,11 @@ class MooncakeBackend final : public ::c10d::ProcessGroup {
     std::shared_ptr<MooncakeWorker> worker_;
     static bool engineInitialized_;
     static int backendIndex_;
+    // External engine injection: when set, MooncakeBackend uses this engine
+    // instead of the default self-created one. Non-owning pointer.
+    static TransferEngine* externalEngine_;
+    // Python reference to the external TransferEnginePy object to prevent GC.
+    static pybind11::object externalEngineRef_;
     const c10::intrusive_ptr<MooncakeBackendOptions> options_;
     bool isCpu_{false};
     static std::string hostIp_;

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -32,6 +32,8 @@ TransferEngine* MooncakeBackend::engine_ = new TransferEngine(true);
 // worker_ is now owned per backend instance via MooncakeWorkerManager.
 bool MooncakeBackend::engineInitialized_ = false;
 int MooncakeBackend::backendIndex_ = 0;
+TransferEngine* MooncakeBackend::externalEngine_ = nullptr;
+pybind11::object MooncakeBackend::externalEngineRef_;
 
 std::vector<uint8_t> serialize(const ExtensionState& state) {
     uint32_t rankCount = static_cast<uint32_t>(state.activeRanks.size());
@@ -206,7 +208,11 @@ MooncakeBackend::MooncakeBackend(
     }
 
     // Initialize transfer engine
-    if (!engineInitialized_) {
+    if (externalEngine_) {
+        // Use externally-provided engine (already initialized), skip init.
+        engine_ = externalEngine_;
+        engineInitialized_ = true;
+    } else if (!engineInitialized_) {
         engine_->init(P2PHANDSHAKE, hostIp_);
         engineInitialized_ = true;
     }
@@ -1247,5 +1253,20 @@ void MooncakeBackend::joinGroup() {
     }
     connection_ctx_->waitUntilAllConnected();
     waitForExtensionState();
+}
+
+void MooncakeBackend::setTransferEngine(pybind11::object engine_obj) {
+    if (engine_obj.is_none()) {
+        externalEngine_ = nullptr;
+        externalEngineRef_ = pybind11::object();
+        return;
+    }
+    // Extract raw TransferEngine* from the TransferEnginePy Python object.
+    auto get_engine_ptr = engine_obj.attr("get_engine_ptr");
+    uintptr_t ptr = get_engine_ptr().cast<uintptr_t>();
+    externalEngine_ = reinterpret_cast<TransferEngine*>(ptr);
+    externalEngineRef_ = engine_obj;  // prevent Python GC
+    LOG(INFO) << "MooncakeBackend: external TransferEngine set (ptr="
+              << externalEngine_ << ")";
 }
 }  // namespace mooncake

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -966,8 +966,10 @@ void MooncakeBackend::shutdown() {
 
     // When using an external engine, we must not call unregister on it
     // during shutdown because the external engine's lifetime is managed
-    // by the caller. Instead, just abandon resources and reset the
-    // static pointer back to a fresh default engine.
+    // by the caller. Only clean up per-instance resources (proxy,
+    // connection context, buffers). Do NOT modify static state
+    // (engine_, engineInitialized_, externalEngine_) because other PG
+    // instances may still be using the same external engine.
     if (externalEngine_) {
         p2p_device_worker_->removeProxy(p2p_proxy_);
         p2p_proxy_->abandonResources();
@@ -991,15 +993,6 @@ void MooncakeBackend::shutdown() {
             }
         }
 
-        // Reset the static engine pointer back to the original leaky
-        // singleton so that subsequent PG instances (if any) use the
-        // default engine.  Do NOT create a new TransferEngine here —
-        // the original leaky singleton still exists and will be
-        // reused once engineInitialized_ is cleared.
-        static TransferEngine* defaultEngine = new TransferEngine(true);
-        engine_ = defaultEngine;
-        engineInitialized_ = false;
-        externalEngine_ = nullptr;
         return;
     }
 

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -33,7 +33,6 @@ TransferEngine* MooncakeBackend::engine_ = new TransferEngine(true);
 bool MooncakeBackend::engineInitialized_ = false;
 int MooncakeBackend::backendIndex_ = 0;
 TransferEngine* MooncakeBackend::externalEngine_ = nullptr;
-pybind11::object MooncakeBackend::externalEngineRef_;
 
 std::vector<uint8_t> serialize(const ExtensionState& state) {
     uint32_t rankCount = static_cast<uint32_t>(state.activeRanks.size());
@@ -965,6 +964,45 @@ void MooncakeBackend::shutdown() {
     }
     isShutdown_ = true;
 
+    // When using an external engine, we must not call unregister on it
+    // during shutdown because the external engine's lifetime is managed
+    // by the caller. Instead, just abandon resources and reset the
+    // static pointer back to a fresh default engine.
+    if (externalEngine_) {
+        p2p_device_worker_->removeProxy(p2p_proxy_);
+        p2p_proxy_->abandonResources();
+        connection_ctx_->shutdown();
+        if (connectionPollerRegistered_) {
+            ConnectionPoller::GetInstance().removeContext(connection_ctx_);
+            connectionPollerRegistered_ = false;
+        }
+        connection_ctx_->abandonResources();
+
+        // Free CPU sync regions (not registered with external engine)
+        for (size_t i = 0; i < 2; i++) {
+            delete[] cpu_sync_send_region_[i];
+            delete[] cpu_sync_recv_region_[i];
+            if (isCpu_) {
+                free(send_buffer_[i]);
+                free(recv_buffer_[i]);
+            } else {
+                cudaFree(send_buffer_[i]);
+                cudaFree(recv_buffer_[i]);
+            }
+        }
+
+        // Reset the static engine pointer back to the original leaky
+        // singleton so that subsequent PG instances (if any) use the
+        // default engine.  Do NOT create a new TransferEngine here —
+        // the original leaky singleton still exists and will be
+        // reused once engineInitialized_ is cleared.
+        static TransferEngine* defaultEngine = new TransferEngine(true);
+        engine_ = defaultEngine;
+        engineInitialized_ = false;
+        externalEngine_ = nullptr;
+        return;
+    }
+
     // If we encounter any hung operations, don't release resources
     // to avoid potential crash. Instead, we allow those resources to leak
     // and rely on the OS to reclaim them later.
@@ -1255,18 +1293,11 @@ void MooncakeBackend::joinGroup() {
     waitForExtensionState();
 }
 
-void MooncakeBackend::setTransferEngine(pybind11::object engine_obj) {
-    if (engine_obj.is_none()) {
-        externalEngine_ = nullptr;
-        externalEngineRef_ = pybind11::object();
-        return;
+void MooncakeBackend::setExternalEngine(TransferEngine* engine) {
+    externalEngine_ = engine;
+    if (engine) {
+        LOG(INFO) << "MooncakeBackend: external TransferEngine set (ptr="
+                  << engine << ")";
     }
-    // Extract raw TransferEngine* from the TransferEnginePy Python object.
-    auto get_engine_ptr = engine_obj.attr("get_engine_ptr");
-    uintptr_t ptr = get_engine_ptr().cast<uintptr_t>();
-    externalEngine_ = reinterpret_cast<TransferEngine*>(ptr);
-    externalEngineRef_ = engine_obj;  // prevent Python GC
-    LOG(INFO) << "MooncakeBackend: external TransferEngine set (ptr="
-              << externalEngine_ << ")";
 }
 }  // namespace mooncake

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -964,38 +964,6 @@ void MooncakeBackend::shutdown() {
     }
     isShutdown_ = true;
 
-    // When using an external engine, we must not call unregister on it
-    // during shutdown because the external engine's lifetime is managed
-    // by the caller. Only clean up per-instance resources (proxy,
-    // connection context, buffers). Do NOT modify static state
-    // (engine_, engineInitialized_, externalEngine_) because other PG
-    // instances may still be using the same external engine.
-    if (externalEngine_) {
-        p2p_device_worker_->removeProxy(p2p_proxy_);
-        p2p_proxy_->abandonResources();
-        connection_ctx_->shutdown();
-        if (connectionPollerRegistered_) {
-            ConnectionPoller::GetInstance().removeContext(connection_ctx_);
-            connectionPollerRegistered_ = false;
-        }
-        connection_ctx_->abandonResources();
-
-        // Free CPU sync regions (not registered with external engine)
-        for (size_t i = 0; i < 2; i++) {
-            delete[] cpu_sync_send_region_[i];
-            delete[] cpu_sync_recv_region_[i];
-            if (isCpu_) {
-                free(send_buffer_[i]);
-                free(recv_buffer_[i]);
-            } else {
-                cudaFree(send_buffer_[i]);
-                cudaFree(recv_buffer_[i]);
-            }
-        }
-
-        return;
-    }
-
     // If we encounter any hung operations, don't release resources
     // to avoid potential crash. Instead, we allow those resources to leak
     // and rely on the OS to reclaim them later.

--- a/mooncake-pg/src/pg_py.cpp
+++ b/mooncake-pg/src/pg_py.cpp
@@ -90,6 +90,11 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("createMooncakeCpuBackend", &createMooncakeCpuBackend);
     m.def("set_host_ip", &MooncakeBackend::setHostIp);
     m.def("set_device_filter", &MooncakeBackend::setDeviceFilter);
+    m.def("set_transfer_engine", &MooncakeBackend::setTransferEngine,
+          py::arg("engine"),
+          "Set an external TransferEngine to be used by MooncakeBackend. "
+          "Must be called before init_process_group(). The engine must already "
+          "be initialized. Pass None to reset to default behavior.");
     m.def("get_preferred_hca", &getPreferredHca);
     m.def("get_active_ranks", &getActiveRanks);
     m.def("get_num_synced_ranks", &getNumSyncedRanks);

--- a/mooncake-pg/src/pg_py.cpp
+++ b/mooncake-pg/src/pg_py.cpp
@@ -105,8 +105,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("createMooncakeCpuBackend", &createMooncakeCpuBackend);
     m.def("set_host_ip", &MooncakeBackend::setHostIp);
     m.def("set_device_filter", &MooncakeBackend::setDeviceFilter);
-    m.def("set_transfer_engine", &setTransferEnginePy,
-          py::arg("engine"),
+    m.def("set_transfer_engine", &setTransferEnginePy, py::arg("engine"),
           "Set an external TransferEngine to be used by MooncakeBackend. "
           "Must be called before init_process_group(). The engine must already "
           "be initialized. Pass None to reset to default behavior. "

--- a/mooncake-pg/src/pg_py.cpp
+++ b/mooncake-pg/src/pg_py.cpp
@@ -85,16 +85,33 @@ void joinGroup(c10::intrusive_ptr<c10d::ProcessGroup> backend) {
     mooncakeBackend->joinGroup();
 }
 
+/// Python-facing wrapper that extracts the raw TransferEngine* from a
+/// mooncake.engine.TransferEngine Python object and passes it to
+/// MooncakeBackend::setExternalEngine().  The caller must ensure the
+/// TransferEnginePy object outlives all MooncakeBackend instances.
+void setTransferEnginePy(pybind11::object engine_obj) {
+    if (engine_obj.is_none()) {
+        MooncakeBackend::setExternalEngine(nullptr);
+        return;
+    }
+    auto get_engine_ptr = engine_obj.attr("get_engine_ptr");
+    uintptr_t ptr = get_engine_ptr().cast<uintptr_t>();
+    auto* engine = reinterpret_cast<TransferEngine*>(ptr);
+    MooncakeBackend::setExternalEngine(engine);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("createMooncakeBackend", &createMooncakeBackend);
     m.def("createMooncakeCpuBackend", &createMooncakeCpuBackend);
     m.def("set_host_ip", &MooncakeBackend::setHostIp);
     m.def("set_device_filter", &MooncakeBackend::setDeviceFilter);
-    m.def("set_transfer_engine", &MooncakeBackend::setTransferEngine,
+    m.def("set_transfer_engine", &setTransferEnginePy,
           py::arg("engine"),
           "Set an external TransferEngine to be used by MooncakeBackend. "
           "Must be called before init_process_group(). The engine must already "
-          "be initialized. Pass None to reset to default behavior.");
+          "be initialized. Pass None to reset to default behavior. "
+          "The caller must ensure the TransferEngine object outlives all "
+          "MooncakeBackend instances.");
     m.def("get_preferred_hca", &getPreferredHca);
     m.def("get_active_ranks", &getActiveRanks);
     m.def("get_num_synced_ranks", &getNumSyncedRanks);


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Allow users (like SGLang) to pass external TE instances, while keeping existing APIs compatible.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
