### PR TITLE
[Doc] Update EFA transport doc: SGLang section + vllm-router + p5.48xlarge bench

### DIFF
--- a/docs/source/design/transfer-engine/efa_transport.md
+++ b/docs/source/design/transfer-engine/efa_transport.md
@@ -215,28 +215,28 @@ address shown in the target's startup log (e.g., `ip-172-31-29-226:12345`).
 
 #### 1. p6-b300.48xlarge (B300, 16 EFA × 400 Gbps)
 
-Tested on two p6-b300.48xlarge instances (Intel Xeon Platinum 8559C, 8× B300, 16 EFA devices) in the same AWS placement group.
-
-> **Note:** numbers below predate the SRD shared-endpoint refactor (#1944) and current EFA tuning work. They are a lower bound for the current code; we will re-sweep and update when the hardware is available again.
+Tested on two p6-b300.48xlarge instances (Intel Xeon Platinum 8559C, 8× B300, 16 EFA devices) in the same AWS placement group. Numbers below are post-SRD-shared-endpoint (#1944) on a fresh `main` build with the DLAMI pytorch env (CUDA 13).
 
 **GPU-to-GPU** (build with `-DUSE_CUDA=ON`, `--gpu_id=-1` for all 8 GPUs, `--buffer_size=2147483648`):
 
 | Configuration | Write | Read |
 |---------------|-------|------|
-| block=1MB, threads=16, batch=128 | 701 GB/s | **697 GB/s** |
-| **block=1MB, threads=32, batch=64** | **752 GB/s** | 713 GB/s |
-| block=1MB, threads=32, batch=32 | 751 GB/s | - |
-| block=1MB, threads=64, batch=32 | 728 GB/s | - |
+| block=1MB, threads=16, batch=128 | 758.88 GB/s | 720.35 GB/s |
+| block=1MB, threads=32, batch=64 | 753.32 GB/s | **755.78 GB/s** |
+| **block=1MB, threads=32, batch=32** | **780.33 GB/s** | - |
+| block=1MB, threads=64, batch=32 | 780.23 GB/s | - |
 
-> **Peak: 752 GB/s write**, reaching ~94% of the 800 GB/s theoretical line rate (16×400 Gbps). GPUDirect RDMA bypasses DRAM entirely (HBM3e → PCIe switch → NIC), so performance is not bottlenecked by CPU memory bandwidth.
+> **Peak: 780 GB/s write**, reaching ~97.5% of the 800 GB/s theoretical line rate (16×400 Gbps). GPUDirect RDMA bypasses DRAM entirely (HBM3e → PCIe switch → NIC), so performance is not bottlenecked by CPU memory bandwidth.
 
-**CPU-to-CPU** (build with `-DUSE_CUDA=OFF`):
+**CPU-to-CPU** (build with `-DUSE_CUDA=OFF`, or `--use_vram=false` on a CUDA build, `--buffer_size=4294967296`):
 
 | Configuration | Write | Read |
 |---------------|-------|------|
-| **block=1MB, threads=32, batch=128, buf=4GB** | **230 GB/s** | 180 GB/s |
+| **block=1MB, threads=32, batch=128** | **282.93 GB/s** | **270.47 GB/s** |
+| block=1MB, threads=16, batch=128 | 282.04 GB/s | 249.67 GB/s |
+| block=1MB, threads=32, batch=64 | 282.84 GB/s | 256.26 GB/s |
 
-> CPU-to-CPU is bounded by DRAM bandwidth (~250 GB/s/socket on Xeon 8559C). Per-NIC sampling shows NUMA-0 NICs at 90 Gbps and NUMA-1 NICs at 53 Gbps, confirming DRAM controller saturation rather than NIC limit.
+> CPU-to-CPU is bounded by DRAM bandwidth on the Xeon 8559C — write throughput is essentially flat across thread/batch combinations (~282 GB/s), confirming DRAM controller saturation rather than a NIC or in-flight-WR limit.
 
 #### 2. p6-b200.48xlarge (B200, 8 EFA × 400 Gbps)
 

--- a/docs/source/design/transfer-engine/efa_transport.md
+++ b/docs/source/design/transfer-engine/efa_transport.md
@@ -311,11 +311,43 @@ Tested on two p5en.48xlarge instances (Intel Xeon 8488C, 8× H200 141GB, 16 EFA 
 
 > `buffer_size` only needs to satisfy `buffer_size ≥ block_size × batch_size × threads` (the bench auto-adjusts if smaller, but silently). Anything larger than that minimum does not change throughput — 2 GB vs 4 GB differs by ~3% on write, read is flat within noise. The example commands use 4 GB because it is safe for any reasonable threads/batch combination without having to recompute the minimum.
 
+#### 4. p5.48xlarge (H100, 32 EFA × 100 Gbps)
+
+Tested on two p5.48xlarge instances (AMD EPYC 7R13, 8× H100 80GB, 32 EFA devices) in the same AWS placement group. Per-NIC line rate is half of p5en's, but with twice the NIC count the aggregate ceiling is the same 400 GB/s. The shared-endpoint WR cap scales with NIC count: `32 NICs × 256 = 8192` in-flight slots, so `threads × batch_size ≤ 8192` (vs 4096 on p5en).
+
+**GPU-to-GPU** (build with `-DUSE_CUDA=ON`, `--gpu_id=-1` for all 8 GPUs, `--buffer_size=4294967296`):
+
+| Configuration | Write | Read |
+|---------------|-------|------|
+| block=1MB, threads=8, batch=128 | 335.11 GB/s | - |
+| block=1MB, threads=16, batch=128 | 388.52 GB/s | 379.10 GB/s |
+| block=1MB, threads=32, batch=64 | 388.83 GB/s | 379.78 GB/s |
+| **block=1MB, threads=32, batch=128** | **388.90 GB/s** | **381.64 GB/s** |
+| block=1MB, threads=16, batch=32 | - | 356.94 GB/s |
+| block=1MB, threads=32, batch=32 | - | 380.66 GB/s |
+
+> **Peak write: 389 GB/s** at `threads=32, batch=128` — ~97% of the 400 GB/s theoretical line rate (32×100 Gbps). The plateau is wide: any `(threads, batch)` between `(16, 128)` and `(32, 128)` lands within 0.1% of peak. **Peak read: 382 GB/s** at `threads=32, batch=128` — unlike p5en, reads on this host scale with batch size up to 128 because the wider 32-NIC fabric absorbs larger in-flight queues without backoff. `(32, 256)` and `(64, 128)` (both at the 8192 WR cap) fail with no headroom for retries.
+
+**CPU-to-CPU** (build with `-DUSE_CUDA=OFF`, or `--use_vram=false` on a CUDA build, `--buffer_size=4294967296`):
+
+| Configuration | Write | Read |
+|---------------|-------|------|
+| block=1MB, threads=16, batch=128 | 39.83 GB/s | 40.43 GB/s |
+| block=1MB, threads=32, batch=64 | 47.31 GB/s | 48.06 GB/s |
+| block=1MB, threads=32, batch=128 | 47.75 GB/s | 48.62 GB/s |
+| block=1MB, threads=32, batch=32 | 55.66 GB/s | 56.68 GB/s |
+| **block=1MB, threads=48, batch=16** | **63.60 GB/s** | 63.00 GB/s |
+| **block=1MB, threads=64, batch=16** | 63.39 GB/s | 63.05 GB/s |
+| block=1MB, threads=32, batch=16 | 63.21 GB/s | 60.82 GB/s |
+| block=1MB, threads=96, batch=32 | 57.61 GB/s | 59.63 GB/s |
+
+> **Peak: ~64 GB/s** on both write and read — far below the GPU-to-GPU number despite identical NIC count. The bottleneck is DDR4-3200 DRAM bandwidth on the EPYC 7R13 (Milan): `batch=16` consistently wins because larger in-flight queues only deepen DRAM contention without unlocking new NIC capacity. p5.48xlarge CPU-to-CPU runs around **3× slower than p5en** (DDR5 Xeon 8488C, ~213 GB/s) at the same NIC aggregate. For PD KV transfer, the GPU-to-GPU path is the relevant one.
+
 ### Tuning Tips
 
 - **Use `--block_size=1048576` (1MB)** — the single most important knob. The 64 KB default reaches only ~26% of peak. 1 MB is within a few percent of the 2 MB plateau while leaving headroom for `batch_size` under the shared-endpoint WR cap.
-- **Keep `threads × batch_size ≤ num_nics × max_wr`** — under the SRD shared endpoint each NIC carries one `fid_ep` with a 256 WR cap (`MC_MAX_WR`), giving `16 NICs × 256 = 4096` in-flight slots on a 16-NIC host. Exceeding this trips "timed out waiting for CQ drain". In practice `threads=16, batch=128` is a solid baseline; going higher rarely adds throughput and routinely hits the cap.
-- **Write vs read:** write benefits from larger batches (peak at `batch=128`); read prefers smaller in-flight queues (peak at `batch=32` on p5en).
+- **Keep `threads × batch_size ≤ num_nics × max_wr`** — under the SRD shared endpoint each NIC carries one `fid_ep` with a 256 WR cap (`MC_MAX_WR`), giving `16 NICs × 256 = 4096` in-flight slots on a 16-NIC host (b300, b200, p5en) and `32 NICs × 256 = 8192` on p5. Exceeding this trips "timed out waiting for CQ drain". `threads=16, batch=128` is a solid baseline on 16-NIC hosts; on 32-NIC p5, `threads=32, batch=128` works the same way.
+- **Write vs read:** write benefits from larger batches (peak at `batch=128`); on 16-NIC p5en read prefers smaller queues (peak at `batch=32`), but on 32-NIC p5 reads scale up to `batch=128` because the wider fabric absorbs larger in-flight queues.
 - For **GPU-to-GPU**: pass `--gpu_id=-1` on **both** sides so buffers fan out across every GPU. Pinning a single GPU halves throughput because half the NICs end up cross-NUMA.
 - For **CPU-to-CPU**: DRAM bandwidth is the ceiling. NUMA-split (separate initiator/target instances per NUMA node) can help reduce contention when one instance can't saturate both nodes.
 - `--buffer_size` only needs `≥ block × batch × threads`; larger
@@ -425,52 +457,96 @@ vllm serve <model_path> -tp 8 \
    --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"mooncake_protocol":"efa"}}'
 ```
 
+### 3. Router
+
+Front the prefill / decode pair with `vllm-router`. **`PREFILL_HOST` / `DECODE_HOST` must be each node's reachable private IP, not `127.0.0.1`** — the router forwards these addresses to the peer for the KV handshake; localhost will fail with `Connection refused` and stall traffic.
+
+```bash
+vllm-router --policy round_robin \
+  --vllm-pd-disaggregation \
+  --prefill http://<prefill_ip>:8010 \
+  --decode  http://<decode_ip>:8020 \
+  --kv-connector mooncake \
+  --host 0.0.0.0 --port 30000 \
+  --intra-node-data-parallel-size 8
+```
+
+`--intra-node-data-parallel-size` should match the per-node DP size of your prefill / decode instances (8 in this example, matching `-tp 8`).
+
 ## Usage with SGLang
 
-SGLang's Mooncake integration currently hardcodes the `"rdma"` protocol. To use EFA transport, apply the provided patch and set environment variables.
+SGLang's PD-disaggregation Mooncake integration reads the transport from `MOONCAKE_PROTOCOL`. Set it to `efa` and select the Mooncake backend with `--disaggregation-transfer-backend mooncake`.
 
-### 1. Apply EFA Patch
+### 1. Apply EFA Patch (only if SGLang version predates PR #25083)
 
-SGLang's transfer engine initialization needs to be patched to read the protocol from an environment variable instead of using hardcoded `"rdma"`. Use the [patch script](https://github.com/whn09/kimi-k2-sglang):
+Older SGLang releases hardcode `"rdma"` in the transfer engine init. Since [SGLang PR #25083](https://github.com/sgl-project/sglang/pull/25083) the protocol is read from `MOONCAKE_PROTOCOL`, so once that PR is in your build (or upstream `main`) **this step is unnecessary** — skip to step 2.
+
+If you are pinned to an older release, apply the [patch script](https://github.com/whn09/kimi-k2-sglang):
 
 ```bash
 bash patch_sglang_efa.sh
 ```
 
-This is idempotent and safe to rerun.
+The script is idempotent and safe to rerun.
 
 ### 2. Environment Variables
 
+Only one Mooncake-specific env is required:
+
 ```bash
 export MOONCAKE_PROTOCOL=efa
+```
+
+If your container does not already export libfabric/EFA paths in its `Dockerfile`, also set:
+
+```bash
 export FI_PROVIDER=efa
 export FI_EFA_USE_DEVICE_RDMA=1
-export GLOO_SOCKET_IFNAME=enp71s0  # adjust to your instance's primary interface
+export LD_LIBRARY_PATH=/opt/amazon/efa/lib:$LD_LIBRARY_PATH
 ```
 
-For multi-node expert parallelism (EP) deployments, also set:
+> **Note on additional `MC_*` knobs:** `MC_NUM_CQ_PER_CTX`, `MC_MAX_WR`, `MC_MAX_CQE_PER_CTX`, `MC_SLICE_SIZE`, and `MC_EFA_STRIPING_THRESHOLD` are **not** required at typical PD-disagg loads — the SRD shared-endpoint refactor (#1944) makes them redundant up to high concurrency on 1k/1k traffic. Treat them as emergency switches for CQ-overflow or long-running drift symptoms.
+
+### 3. Prefill Instance
 
 ```bash
-export NVSHMEM_REMOTE_TRANSPORT=libfabric
-export NVSHMEM_LIBFABRIC_PROVIDER=efa
+MOONCAKE_PROTOCOL=efa \
+sglang serve <model_path> \
+  --trust-remote-code \
+  --tp 8 --dp 2 --enable-dp-attention --enable-dp-lm-head \
+  --host 0.0.0.0 --port 8010 \
+  --disaggregation-mode prefill \
+  --disaggregation-transfer-backend mooncake \
+  --disaggregation-bootstrap-port 8998
 ```
 
-> **Warning:** Do **not** set NVSHMEM variables on single-node deployments — doing so causes segmentation faults.
-
-### 3. Docker Launch Example
+### 4. Decode Instance
 
 ```bash
-docker run -d --name sglang \
-  --runtime=nvidia --gpus all --network host \
-  --privileged --shm-size=600g \
-  --device=/dev/infiniband \
-  -e MOONCAKE_PROTOCOL=efa \
-  -e FI_PROVIDER=efa \
-  -e FI_EFA_USE_DEVICE_RDMA=1 \
-  <image> bash start.sh
+MOONCAKE_PROTOCOL=efa \
+sglang serve <model_path> \
+  --trust-remote-code \
+  --tp 8 --dp 2 --enable-dp-attention --enable-dp-lm-head \
+  --host 0.0.0.0 --port 8020 \
+  --disaggregation-mode decode \
+  --disaggregation-transfer-backend mooncake \
+  --disaggregation-bootstrap-port 8998
 ```
 
-> **Note:** Ensure the Docker image's libfabric version matches the host's EFA driver. If not, mount the host's EFA libraries into the container (see [Troubleshooting](#libfabric-version-mismatch-in-docker)).
+### 5. Router
+
+Front the pair with `sglang_router` from the prefill host. **`PREFILL_HOST` must be the prefill node's reachable IP, not `127.0.0.1`** — the router forwards this address to the decode node for the bootstrap_room handshake; localhost will fail with `Connection refused` and stall traffic at 0/N.
+
+```bash
+python3 -m sglang_router.launch_router \
+  --pd-disaggregation \
+  --prefill "http://<prefill_ip>:8010" 8998 \
+  --decode  "http://<decode_ip>:8020" \
+  --policy round_robin \
+  --host 0.0.0.0 --port 8000
+```
+
+The trailing `8998` after `--prefill` must match the prefill's `--disaggregation-bootstrap-port`.
 
 ## Technical Details
 


### PR DESCRIPTION
## Description

Documentation-only update to `docs/source/design/transfer-engine/efa_transport.md`:

- **Rewrite "Usage with SGLang"** to use the natively-supported `MOONCAKE_PROTOCOL=efa` env (sglang already plumbs this through to the Mooncake init path). The section now mirrors the structure of "Usage with vLLM" with explicit `Prefill` / `Decode` / `Router` subsections, and drops unrelated `GLOO_SOCKET_IFNAME` and NVSHMEM bits. Includes a note on the cross-host router trap: `PREFILL_HOST` must be reachable from the decode node — `127.0.0.1` silently produces `Connection refused`.
- **Add a Router subsection to "Usage with vLLM"** showing the `vllm-router` invocation with `--kv-connector mooncake`, mirroring the SGLang router subsection.
- **Drop the SGLang Docker subsection** (redundant with the prefill/decode commands).
- **Add benchmark section "4. p5.48xlarge (H100, 32 EFA × 100 Gbps)"** with both GPU-to-GPU and CPU-to-CPU sweeps. Peak GPU 389 GB/s write / 382 GB/s read (~97% of 400 GB/s line rate). CPU plateaus at ~64 GB/s, bounded by DDR4-3200 on EPYC 7R13.
- **Update Tuning Tips** to cover the 32-NIC WR cap (`32 × 256 = 8192` in-flight slots, vs `4096` on 16-NIC hosts) and the read-batch difference between p5en and p5.

No code changes.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

- **SGLang section**: validated end-to-end on two p5.48xlarge instances (P5EN-1 + P5EN-2 in our test fleet, despite the alias both are p5.48xlarge with H100×8 + 32 EFA NICs) running MiMo-V2.5 1P+1D. With only `MOONCAKE_PROTOCOL=efa` set, the disagg pair runs cleanly at 8927 tok/s with no `Libfabric provider has encountered an internal error` aborts. The cross-host `PREFILL_HOST` trap was reproduced (router started with `127.0.0.1` → decode connection refused → bench stalls at 0/N) and avoided by using the host's internal IP.
- **vLLM router subsection**: pattern lifted from a working DeepSeek-V4-Pro 1P+1D recipe on p6-b300 (`vllm-router --policy round_robin --vllm-pd-disaggregation --kv-connector mooncake --intra-node-data-parallel-size 8`).
- **p5.48xlarge benchmark numbers**: collected on two p5.48xlarge nodes built bare-metal from this fork (`feat/efa-stale-peer-eviction @ 2f490548`) using the DLAMI pytorch + cu13 recipe documented in this same file. GPU-to-GPU sweep at `block=1MB`, threads ∈ {8, 16, 32, 64}, batch ∈ {32, 64, 128, 256}, picking configs that respect `threads × batch ≤ 32 NICs × 256 max_wr = 8192`. CPU-to-CPU sweep at threads ∈ {16, 32, 48, 64, 96, 128}, batch ∈ {16, 32, 64, 128}.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting. (N/A — docs only)
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective. (N/A — docs only; numbers reproducible from the recipe in the doc)