### PR TITLE
[Store] Fix Ascend dummy reconnect shm replay

### DIFF
--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -484,6 +484,9 @@ class RealClient : public PyClient {
     tl::expected<void, ErrorCode> ascend_unmap_shm_internal(
         const UUID &client_id);
 
+    tl::expected<bool, ErrorCode> is_shm_mapped_internal(
+        uint64_t dummy_base_addr, const UUID &client_id);
+
     tl::expected<void, ErrorCode> unregister_shm_buffer_internal(
         uint64_t dummy_base_addr, const UUID &client_id);
 

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -117,17 +117,30 @@ std::vector<std::vector<uint64_t>> void_ptr_rows_to_u64_nested(
 
 namespace mooncake {
 
+template <auto ServiceMethod>
+constexpr bool can_invoke_when_disconnected() {
+    using Method = std::remove_reference_t<decltype(ServiceMethod)>;
+    return std::is_same_v<
+               Method, std::remove_reference_t<decltype(&RealClient::ping)>> ||
+           std::is_same_v<Method,
+                          std::remove_reference_t<
+                              decltype(&RealClient::service_ready_internal)>> ||
+           std::is_same_v<Method,
+                          std::remove_reference_t<
+                              decltype(&RealClient::is_shm_mapped_internal)>> ||
+           std::is_same_v<Method,
+                          std::remove_reference_t<
+                              decltype(&RealClient::ascend_shm_internal)>> ||
+           std::is_same_v<Method,
+                          std::remove_reference_t<
+                              decltype(&RealClient::ascend_ipc_shm_internal)>>;
+}
+
 template <auto ServiceMethod, typename ReturnType, typename... Args>
 tl::expected<ReturnType, ErrorCode> DummyClient::invoke_rpc(Args&&... args) {
     auto pool = client_accessor_.GetClientPool();
 
-    if constexpr (!std::is_same_v<
-                      std::remove_reference_t<decltype(ServiceMethod)>,
-                      std::remove_reference_t<decltype(&RealClient::ping)>> &&
-                  !std::is_same_v<
-                      std::remove_reference_t<decltype(ServiceMethod)>,
-                      std::remove_reference_t<
-                          decltype(&RealClient::service_ready_internal)>>) {
+    if constexpr (!can_invoke_when_disconnected<ServiceMethod>()) {
         if (!connected_.load()) {
             LOG(ERROR) << "Dummy Client not connected";
             return tl::make_unexpected(ErrorCode::RPC_FAIL);
@@ -266,6 +279,20 @@ ErrorCode DummyClient::connect(const std::string& server_address) {
 int DummyClient::register_ascend_shm(const ShmHelper::ShmSegment* shm,
                                      bool is_local) {
 #ifdef USE_ASCEND_DIRECT
+    const auto dummy_base_addr = reinterpret_cast<uint64_t>(shm->base_addr);
+    auto mapped_result = invoke_rpc<&RealClient::is_shm_mapped_internal, bool>(
+        dummy_base_addr, client_id_);
+    if (!mapped_result.has_value()) {
+        LOG(WARNING) << "Failed to query real-side shared memory mapping, addr="
+                     << shm->base_addr;
+        return -1;
+    }
+    if (mapped_result.value()) {
+        LOG(INFO) << "Real-side shared memory mapping already exists, addr="
+                  << shm->base_addr << ", size=" << shm->size;
+        return 0;
+    }
+
     // Detect memory type: device memory uses IPC sharing
     aclrtPtrAttributes attributes;
     auto ret = aclrtPointerGetAttributes(shm->base_addr, &attributes);
@@ -288,8 +315,8 @@ int DummyClient::register_ascend_shm(const ShmHelper::ShmSegment* shm,
 
         std::string ipc_key_bytes(ipc_key, kIPCKeyLen);
         auto map_ret = invoke_rpc<&RealClient::ascend_ipc_shm_internal, void>(
-            reinterpret_cast<uint64_t>(shm->base_addr), shm->size, is_local,
-            ipc_key_bytes, device_id_, client_id_);
+            dummy_base_addr, shm->size, is_local, ipc_key_bytes, device_id_,
+            client_id_);
         if (!map_ret.has_value()) {
             LOG(ERROR) << "Failed to map IPC buffer on real side";
             return -1;
@@ -331,8 +358,8 @@ int DummyClient::register_ascend_shm(const ShmHelper::ShmSegment* shm,
     std::string handle_bytes(reinterpret_cast<char*>(&export_handle),
                              sizeof(export_handle));
     auto map_ret = invoke_rpc<&RealClient::ascend_shm_internal, void>(
-        reinterpret_cast<uint64_t>(shm->base_addr), shm->size, is_local,
-        handle_bytes, device_id_, client_id_);
+        dummy_base_addr, shm->size, is_local, handle_bytes, device_id_,
+        client_id_);
     if (!map_ret.has_value()) {
         LOG(ERROR) << "Failed to map VMM buffer on real side";
         return -1;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2408,6 +2408,22 @@ tl::expected<void, ErrorCode> RealClient::ascend_unmap_shm_internal(
     return {};
 }
 
+tl::expected<bool, ErrorCode> RealClient::is_shm_mapped_internal(
+    uint64_t dummy_base_addr, const UUID &client_id) {
+    std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
+    auto context_it = shm_contexts_.find(client_id);
+    if (context_it == shm_contexts_.end()) {
+        return false;
+    }
+
+    const auto target_addr = static_cast<uintptr_t>(dummy_base_addr);
+    const auto &mapped_shms = context_it->second.mapped_shms;
+    return std::any_of(mapped_shms.begin(), mapped_shms.end(),
+                       [target_addr](const MappedShm &shm) {
+                           return shm.dummy_base_addr == target_addr;
+                       });
+}
+
 tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
     uint64_t dummy_base_addr, const UUID &client_id) {
     std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -66,6 +66,7 @@ void RegisterClientRpcService(coro_rpc::coro_rpc_server &server,
     server.register_handler<&RealClient::ascend_ipc_shm_internal>(&real_client);
     server.register_handler<&RealClient::ascend_unmap_shm_internal>(
         &real_client);
+    server.register_handler<&RealClient::is_shm_mapped_internal>(&real_client);
     server.register_handler<&RealClient::unmap_shm_internal>(&real_client);
     server.register_handler<&RealClient::unregister_shm_buffer_internal>(
         &real_client);


### PR DESCRIPTION
## Description

Fix Ascend dummy-real reconnect handling after ping failures.

This change lets the dummy client replay the Ascend shared-memory registration RPCs while it is in the disconnected reconnect state. It also adds a real-client query for existing dummy shared-memory mappings, so a transient ping failure can skip repeated ACL export when the real side already has the mapping.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Constructed relevant test cases passed.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
