### PR TITLE
[TE] Add explicit progressBatch API

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -150,6 +150,8 @@ class TransferEngineImpl {
 
     Status getTransferStatus(BatchID batch_id, TransferStatus& overall_status);
 
+    Status progressBatch(BatchID batch_id, TransferStatus& overall_status);
+
     Status waitTransferCompletion(BatchID batch_id);
 
     Status transferSync(const std::vector<Request>& request_list);
@@ -186,8 +188,15 @@ class TransferEngineImpl {
 
     Status resubmitTransferTask(Batch* batch, size_t task_id);
 
-    void updateTaskStatusFromPoll(Batch* batch, size_t task_id,
-                                  TransferStatus& task_status);
+    Status pollTaskStatus(Batch* batch, size_t task_id,
+                          TransferStatus& task_status);
+
+    void updateTaskStatusAfterPoll(Batch* batch, size_t task_id,
+                                   TransferStatus& task_status,
+                                   bool allow_failover);
+
+    Status getBatchStatus(BatchID batch_id, TransferStatus& overall_status,
+                          bool allow_failover);
 
     TransportType resolveTransport(const Request& req, int priority,
                                    bool invalidate_on_fail = true);

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -54,6 +54,7 @@ struct TaskInfo {
     Request request;
     bool staging{false};
     TransferStatusEnum status{TransferStatusEnum::PENDING};
+    bool failover_pending{false};
     volatile TransferStatusEnum staging_status{TransferStatusEnum::PENDING};
     std::chrono::steady_clock::time_point start_time{};  // For latency tracking
     int failover_count{0};  // Number of cross-transport failover attempts

--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -307,6 +307,14 @@ class TransferEngine {
 
     Status getTransferStatus(BatchID batch_id, TransferStatus& overall_status);
 
+    // Drive one progress step on a batch and return its aggregated status.
+    // Unlike getTransferStatus, this always allows internal failover/resubmit
+    // regardless of enable_auto_failover_on_poll. The call is non-blocking and
+    // performs at most one state-machine step per task; callers that want to
+    // wait for completion must invoke it in a loop. PENDING means "make
+    // progress later"; terminal states (COMPLETED/FAILED) will not be revived.
+    Status progressBatch(BatchID batch_id, TransferStatus& overall_status);
+
    private:
     std::unique_ptr<TransferEngineImpl> impl_;
 };

--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -312,7 +312,8 @@ class TransferEngine {
     // regardless of enable_auto_failover_on_poll. The call is non-blocking and
     // performs at most one state-machine step per task; callers that want to
     // wait for completion must invoke it in a loop. PENDING means "make
-    // progress later"; terminal states (COMPLETED/FAILED) will not be revived.
+    // progress later"; internally latched terminal states (COMPLETED/FAILED)
+    // will not be revived.
     Status progressBatch(BatchID batch_id, TransferStatus& overall_status);
 
    private:

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -385,8 +385,7 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
 
             case StageState::INFLIGHT: {
                 TransferStatus xfer_status;
-                CHECK_STATUS(
-                    impl_->getTransferStatus(chunk.batch, xfer_status));
+                CHECK_STATUS(impl_->progressBatch(chunk.batch, xfer_status));
                 if (xfer_status.s == PENDING) {
                     event_queue.push(id);
                     break;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1306,11 +1306,35 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
     return transport->submitTransferTasks(sub_batch, {task.request});
 }
 
-void TransferEngineImpl::updateTaskStatusFromPoll(Batch* batch, size_t task_id,
-                                                  TransferStatus& task_status) {
+Status TransferEngineImpl::pollTaskStatus(Batch* batch, size_t task_id,
+                                          TransferStatus& task_status) {
+    auto& task = batch->task_list[task_id];
+    if (task.staging) {
+        return staging_proxy_->getStatus(&task, task_status);
+    }
+
+    if (task.type == UNSPEC) {
+        task_status.s = FAILED;
+        task_status.transferred_bytes = 0;
+        return Status::OK();
+    }
+
+    auto& transport = transport_list_[task.type];
+    auto& sub_batch = batch->sub_batch[task.type];
+    if (!transport || !sub_batch) {
+        return Status::InvalidArgument("Transport not available" LOC_MARK);
+    }
+    return transport->getTransferStatus(sub_batch, task.sub_task_id,
+                                        task_status);
+}
+
+void TransferEngineImpl::updateTaskStatusAfterPoll(Batch* batch, size_t task_id,
+                                                   TransferStatus& task_status,
+                                                   bool allow_failover) {
     auto& task = batch->task_list[task_id];
     task.status = task_status.s;
-    if (!enable_auto_failover_on_poll_ || task_status.s != FAILED) return;
+    if (!allow_failover || task_status.s != FAILED || task.type == UNSPEC)
+        return;
 
     if (resubmitTransferTask(batch, task_id).ok()) {
         task_status.s = PENDING;
@@ -1365,24 +1389,9 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
         return Status::InvalidArgument("Invalid task ID" LOC_MARK);
     auto& task = batch->task_list[task_id];
     auto prev_status = task.status;
-    if (task.staging) {
-        CHECK_STATUS(staging_proxy_->getStatus(&task, task_status));
-    } else {
-        if (task.type == UNSPEC) {
-            task_status.s = FAILED;
-            task_status.transferred_bytes = 0;
-            batch->task_list[task_id].status = task_status.s;
-            return Status::OK();
-        }
-        auto& transport = transport_list_[task.type];
-        auto& sub_batch = batch->sub_batch[task.type];
-        if (!transport || !sub_batch) {
-            return Status::InvalidArgument("Transport not available" LOC_MARK);
-        }
-        CHECK_STATUS(transport->getTransferStatus(sub_batch, task.sub_task_id,
-                                                  task_status));
-    }
-    updateTaskStatusFromPoll(batch, task_id, task_status);
+    CHECK_STATUS(pollTaskStatus(batch, task_id, task_status));
+    updateTaskStatusAfterPoll(batch, task_id, task_status,
+                              enable_auto_failover_on_poll_);
 
     // Record metrics when task transitions to terminal state
     recordTaskCompletionMetrics(batch->task_list[task_id], prev_status,
@@ -1405,8 +1414,9 @@ Status TransferEngineImpl::getTransferStatus(
     return Status::OK();
 }
 
-Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
-                                             TransferStatus& overall_status) {
+Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
+                                          TransferStatus& overall_status,
+                                          bool allow_failover) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
     Batch* batch = (Batch*)(batch_id);
     overall_status.s = PENDING;
@@ -1439,26 +1449,8 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
             continue;
         }
         auto prev_status = task.status;
-        if (task.staging) {
-            CHECK_STATUS(staging_proxy_->getStatus(&task, task_status));
-        } else {
-            if (task.type == UNSPEC) {
-                task.status = FAILED;
-                failed_tasks++;
-                if (isWorse(FAILED, worst_failure)) worst_failure = FAILED;
-                continue;
-            }
-            auto& transport = transport_list_[task.type];
-            auto& sub_batch = batch->sub_batch[task.type];
-            if (!transport || !sub_batch) {
-                return Status::InvalidArgument(
-                    "Transport not available" LOC_MARK);
-            }
-            CHECK_STATUS(transport->getTransferStatus(
-                sub_batch, task.sub_task_id, task_status));
-        }
-        // Preserve legacy auto-failover-on-poll before aggregating status.
-        updateTaskStatusFromPoll(batch, task_id, task_status);
+        CHECK_STATUS(pollTaskStatus(batch, task_id, task_status));
+        updateTaskStatusAfterPoll(batch, task_id, task_status, allow_failover);
 
         if (task_status.s == COMPLETED) {
             success_tasks++;
@@ -1486,10 +1478,21 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
     return Status::OK();
 }
 
+Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
+                                             TransferStatus& overall_status) {
+    return getBatchStatus(batch_id, overall_status,
+                          enable_auto_failover_on_poll_);
+}
+
+Status TransferEngineImpl::progressBatch(BatchID batch_id,
+                                         TransferStatus& overall_status) {
+    return getBatchStatus(batch_id, overall_status, true);
+}
+
 Status TransferEngineImpl::waitTransferCompletion(BatchID batch_id) {
     TransferStatus xfer_status;
     while (true) {
-        CHECK_STATUS(getTransferStatus(batch_id, xfer_status));
+        CHECK_STATUS(progressBatch(batch_id, xfer_status));
         if (xfer_status.s != PENDING) {
             freeBatch(batch_id);
             return xfer_status.s == COMPLETED
@@ -1507,7 +1510,7 @@ Status TransferEngineImpl::transferSync(
     CHECK_STATUS(submitTransfer(batch_id, request_list));
     while (true) {
         TransferStatus xfer_status;
-        CHECK_STATUS(getTransferStatus(batch_id, xfer_status));
+        CHECK_STATUS(progressBatch(batch_id, xfer_status));
         if (xfer_status.s == COMPLETED) break;
         if (xfer_status.s != PENDING) {
             CHECK_STATUS(freeBatch(batch_id));

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1414,9 +1414,9 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
                               enable_auto_failover_on_poll_);
 
     // Record metrics when task transitions to terminal state
-    recordTaskCompletionMetrics(batch->task_list[task_id], prev_status,
-                                task.failover_pending ? PENDING
-                                                      : task.status);
+    recordTaskCompletionMetrics(
+        batch->task_list[task_id], prev_status,
+        task.failover_pending ? PENDING : task.status);
 
     if (task_status.s == COMPLETED) CHECK_STATUS(maybeFireSubmitHooks(batch));
     return Status::OK();
@@ -1487,9 +1487,9 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
         }
 
         // Record metrics when task transitions to terminal state
-        recordTaskCompletionMetrics(batch->task_list[task_id], prev_status,
-                                    task.failover_pending ? PENDING
-                                                          : task.status);
+        recordTaskCompletionMetrics(
+            batch->task_list[task_id], prev_status,
+            task.failover_pending ? PENDING : task.status);
     }
     // Determine overall status: COMPLETED only when all succeed; FAILED only
     // when all tasks are terminal (no in-flight work) and at least one failed;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1332,13 +1332,33 @@ void TransferEngineImpl::updateTaskStatusAfterPoll(Batch* batch, size_t task_id,
                                                    TransferStatus& task_status,
                                                    bool allow_failover) {
     auto& task = batch->task_list[task_id];
-    task.status = task_status.s;
-    if (!allow_failover || task_status.s != FAILED || task.type == UNSPEC)
-        return;
 
+    if (task_status.s != FAILED) {
+        task.status = task_status.s;
+        task.failover_pending = false;
+        return;
+    }
+
+    if (task.type == UNSPEC) {
+        task.status = FAILED;
+        task.failover_pending = false;
+        return;
+    }
+
+    // Observation-only polling records that this task has seen a failure, but
+    // leaves the failover decision to the progress-driving path.
+    if (!allow_failover) {
+        task.status = FAILED;
+        task.failover_pending = true;
+        return;
+    }
+
+    task.status = FAILED;
+    task.failover_pending = false;
     if (resubmitTransferTask(batch, task_id).ok()) {
         task_status.s = PENDING;
         task.status = PENDING;
+        task.failover_pending = false;
     }
 }
 
@@ -1388,14 +1408,15 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
     if (task_id >= batch->task_list.size())
         return Status::InvalidArgument("Invalid task ID" LOC_MARK);
     auto& task = batch->task_list[task_id];
-    auto prev_status = task.status;
+    auto prev_status = task.failover_pending ? PENDING : task.status;
     CHECK_STATUS(pollTaskStatus(batch, task_id, task_status));
     updateTaskStatusAfterPoll(batch, task_id, task_status,
                               enable_auto_failover_on_poll_);
 
     // Record metrics when task transitions to terminal state
     recordTaskCompletionMetrics(batch->task_list[task_id], prev_status,
-                                task_status.s);
+                                task.failover_pending ? PENDING
+                                                      : task.status);
 
     if (task_status.s == COMPLETED) CHECK_STATUS(maybeFireSubmitHooks(batch));
     return Status::OK();
@@ -1437,7 +1458,10 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
         if (task.derived) continue;  // This task is performed by other tasks
         total_tasks++;
         TransferStatus task_status;
-        if (task.status != PENDING) {
+        if (allow_failover && task.status == FAILED && task.failover_pending) {
+            task_status.s = FAILED;
+            task_status.transferred_bytes = 0;
+        } else if (task.status != PENDING) {
             if (task.status == COMPLETED) {
                 success_tasks++;
                 overall_status.transferred_bytes += task.request.length;
@@ -1447,9 +1471,10 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
                     worst_failure = task.status;
             }
             continue;
+        } else {
+            CHECK_STATUS(pollTaskStatus(batch, task_id, task_status));
         }
-        auto prev_status = task.status;
-        CHECK_STATUS(pollTaskStatus(batch, task_id, task_status));
+        auto prev_status = task.failover_pending ? PENDING : task.status;
         updateTaskStatusAfterPoll(batch, task_id, task_status, allow_failover);
 
         if (task_status.s == COMPLETED) {
@@ -1463,7 +1488,8 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
 
         // Record metrics when task transitions to terminal state
         recordTaskCompletionMetrics(batch->task_list[task_id], prev_status,
-                                    task_status.s);
+                                    task.failover_pending ? PENDING
+                                                          : task.status);
     }
     // Determine overall status: COMPLETED only when all succeed; FAILED only
     // when all tasks are terminal (no in-flight work) and at least one failed;

--- a/mooncake-transfer-engine/tent/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/tent/src/transfer_engine.cpp
@@ -169,5 +169,10 @@ Status TransferEngine::getTransferStatus(BatchID batch_id,
     return impl_->getTransferStatus(batch_id, overall_status);
 }
 
+Status TransferEngine::progressBatch(BatchID batch_id,
+                                     TransferStatus& overall_status) {
+    return impl_->progressBatch(batch_id, overall_status);
+}
+
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
@@ -434,7 +434,7 @@ TEST(EngineFailoverE2E, ProgressBatchRetriesWhenPollAutoFailoverDisabled) {
         engine.unregisterLocalMemory(batch.buf.data(), batch.buf.size()).ok());
 }
 
-TEST(EngineFailoverE2E, ProgressBatchDoesNotReviveObservedFailedTask) {
+TEST(EngineFailoverE2E, ProgressBatchRecoversAfterObservationOnlyFailedStatus) {
     auto cfg = makeMinimalP2PConfig();
     cfg->set("enable_auto_failover_on_poll", false);
     TransferEngineImpl engine(cfg);
@@ -449,8 +449,15 @@ TEST(EngineFailoverE2E, ProgressBatchDoesNotReviveObservedFailedTask) {
     EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 0);
 
     ASSERT_TRUE(engine.progressBatch(batch.batch_id, overall_status).ok());
-    EXPECT_EQ(overall_status.s, TransferStatusEnum::FAILED);
-    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 0);
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::PENDING);
+    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 1);
+    EXPECT_EQ(batch.fake_tcp->status_calls.load(), 0)
+        << "progressBatch should resubmit but not poll the fallback in the "
+           "same progress step";
+
+    ASSERT_TRUE(engine.progressBatch(batch.batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(batch.fake_tcp->status_calls.load(), 1);
 
     EXPECT_TRUE(engine.freeBatch(batch.batch_id).ok());
     EXPECT_TRUE(
@@ -468,9 +475,20 @@ TEST(EngineFailoverE2E, ProgressBatchHonorsMaxFailoverAttemptsZero) {
     submitCorruptedRdmaBatch(engine, batch, 0xA6);
 
     TransferStatus overall_status{};
+    ASSERT_TRUE(engine.getTransferStatus(batch.batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::FAILED);
+    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 0);
+
     ASSERT_TRUE(engine.progressBatch(batch.batch_id, overall_status).ok());
     EXPECT_EQ(overall_status.s, TransferStatusEnum::FAILED);
     EXPECT_EQ(batch.fake_rdma->submit_calls.load(), 1);
+    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 0);
+
+    const auto rdma_status_calls = batch.fake_rdma->status_calls.load();
+    ASSERT_TRUE(engine.progressBatch(batch.batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::FAILED);
+    EXPECT_EQ(batch.fake_rdma->status_calls.load(), rdma_status_calls)
+        << "terminal FAILED should be cached and not revived";
     EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 0);
 
     EXPECT_TRUE(engine.freeBatch(batch.batch_id).ok());

--- a/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
@@ -65,12 +65,23 @@ class FakeSubBatch : public Transport::SubBatch {
    public:
     size_t size() const override { return task_count; }
     size_t task_count = 0;
+    std::vector<Request> requests;
     std::vector<TransferStatus> statuses;
+    std::vector<int> poll_counts;
 };
 
 class FakeTransport : public Transport {
    public:
-    explicit FakeTransport(TransportType self_type) : self_type_(self_type) {
+    using StatusFactory = std::function<TransferStatus(const Request&)>;
+    using PollStatusFactory =
+        std::function<TransferStatus(const Request&, int)>;
+
+    explicit FakeTransport(TransportType self_type,
+                           StatusFactory status_factory = {},
+                           PollStatusFactory poll_status_factory = {})
+        : self_type_(self_type),
+          status_factory_(std::move(status_factory)),
+          poll_status_factory_(std::move(poll_status_factory)) {
         caps.dram_to_dram = true;  // so checkAvailability returns true
     }
 
@@ -103,7 +114,14 @@ class FakeTransport : public Transport {
         ++submit_calls;
         auto* fb = static_cast<FakeSubBatch*>(batch);
         for (const auto& req : request_list) {
-            fb->statuses.push_back({TransferStatusEnum::COMPLETED, req.length});
+            if (status_factory_) {
+                fb->statuses.push_back(status_factory_(req));
+            } else {
+                fb->statuses.push_back(
+                    {TransferStatusEnum::COMPLETED, req.length});
+            }
+            fb->requests.push_back(req);
+            fb->poll_counts.push_back(0);
             fb->task_count++;
         }
         return Status::OK();
@@ -116,7 +134,13 @@ class FakeTransport : public Transport {
         if (task_id < 0 || task_id >= (int)fb->statuses.size()) {
             return Status::InvalidArgument("bad task_id" LOC_MARK);
         }
-        status = fb->statuses[task_id];
+        ++fb->poll_counts[task_id];
+        if (poll_status_factory_) {
+            status = poll_status_factory_(fb->requests[task_id],
+                                          fb->poll_counts[task_id]);
+        } else {
+            status = fb->statuses[task_id];
+        }
         return Status::OK();
     }
 
@@ -163,6 +187,8 @@ class FakeTransport : public Transport {
 
    private:
     TransportType self_type_;
+    StatusFactory status_factory_;
+    PollStatusFactory poll_status_factory_;
 };
 
 // ---------------------------------------------------------------------------
@@ -371,6 +397,266 @@ TEST(EngineFailoverE2E, AutoFailoverOnPollDisabledAppliesToOverallStatus) {
     EXPECT_TRUE(engine.freeBatch(batch.batch_id).ok());
     EXPECT_TRUE(
         engine.unregisterLocalMemory(batch.buf.data(), batch.buf.size()).ok());
+}
+
+// ---------------------------------------------------------------------------
+// P0c: Explicit progressBatch() drives one progress step and always allows
+// failover/resubmit, regardless of enable_auto_failover_on_poll. Internal
+// sync paths (waitTransferCompletion, transferSync) and the proxy event loop
+// are wired through it so observation-only callers stay decoupled from
+// progress-driving callers.
+// ---------------------------------------------------------------------------
+
+TEST(EngineFailoverE2E, ProgressBatchRetriesWhenPollAutoFailoverDisabled) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    CorruptedRdmaBatch batch;
+    submitCorruptedRdmaBatch(engine, batch, 0xA4);
+
+    TransferStatus overall_status{};
+    ASSERT_TRUE(engine.progressBatch(batch.batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::PENDING);
+    EXPECT_EQ(batch.fake_rdma->submit_calls.load(), 1);
+    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 1);
+    EXPECT_EQ(batch.fake_tcp->status_calls.load(), 0)
+        << "progressBatch should perform one progress step, not poll the "
+           "fallback submission immediately";
+
+    ASSERT_TRUE(engine.progressBatch(batch.batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(batch.fake_tcp->status_calls.load(), 1);
+
+    EXPECT_TRUE(engine.freeBatch(batch.batch_id).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(batch.buf.data(), batch.buf.size()).ok());
+}
+
+TEST(EngineFailoverE2E, ProgressBatchDoesNotReviveObservedFailedTask) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    CorruptedRdmaBatch batch;
+    submitCorruptedRdmaBatch(engine, batch, 0xA5);
+
+    TransferStatus overall_status{};
+    ASSERT_TRUE(engine.getTransferStatus(batch.batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::FAILED);
+    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 0);
+
+    ASSERT_TRUE(engine.progressBatch(batch.batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::FAILED);
+    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(batch.batch_id).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(batch.buf.data(), batch.buf.size()).ok());
+}
+
+TEST(EngineFailoverE2E, ProgressBatchHonorsMaxFailoverAttemptsZero) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    cfg->set("max_failover_attempts", 0);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    CorruptedRdmaBatch batch;
+    submitCorruptedRdmaBatch(engine, batch, 0xA6);
+
+    TransferStatus overall_status{};
+    ASSERT_TRUE(engine.progressBatch(batch.batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::FAILED);
+    EXPECT_EQ(batch.fake_rdma->submit_calls.load(), 1);
+    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(batch.batch_id).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(batch.buf.data(), batch.buf.size()).ok());
+}
+
+TEST(EngineFailoverE2E, ProgressBatchKeepsOverallPendingWithMixedOutcomes) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    cfg->set("max_failover_attempts", 0);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> failing_buf(kBufLen, 0xA7);
+    std::vector<uint8_t> pending_buf(kBufLen, 0xA8);
+    const uint64_t failing_addr =
+        reinterpret_cast<uint64_t>(failing_buf.data());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, FakeTransport::StatusFactory{},
+        [failing_addr](const Request& req, int poll_count) {
+            if (req.target_offset == failing_addr) {
+                return TransferStatus{TransferStatusEnum::FAILED, 0};
+            }
+            if (poll_count == 1) {
+                return TransferStatus{TransferStatusEnum::PENDING, 0};
+            }
+            return TransferStatus{TransferStatusEnum::COMPLETED, req.length};
+        });
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    ASSERT_TRUE(engine.registerLocalMemory(failing_buf.data(), kBufLen).ok());
+    ASSERT_TRUE(engine.registerLocalMemory(pending_buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(2);
+    ASSERT_NE(batch_id, (BatchID)0);
+
+    Request failing_req;
+    failing_req.opcode = Request::WRITE;
+    failing_req.source = failing_buf.data();
+    failing_req.target_id = LOCAL_SEGMENT_ID;
+    failing_req.target_offset = failing_addr;
+    failing_req.length = kBufLen;
+
+    Request pending_req;
+    pending_req.opcode = Request::WRITE;
+    pending_req.source = pending_buf.data();
+    pending_req.target_id = LOCAL_SEGMENT_ID;
+    pending_req.target_offset = reinterpret_cast<uint64_t>(pending_buf.data());
+    pending_req.length = kBufLen;
+
+    ASSERT_TRUE(
+        engine.submitTransfer(batch_id, {failing_req, pending_req}).ok());
+
+    TransferStatus overall_status{};
+    ASSERT_TRUE(engine.progressBatch(batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::PENDING);
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 0);
+
+    ASSERT_TRUE(engine.progressBatch(batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::FAILED);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(failing_buf.data(), kBufLen).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(pending_buf.data(), kBufLen).ok());
+}
+
+TEST(EngineFailoverE2E,
+     WaitTransferCompletionUsesProgressBatchWhenPollDisabled) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    CorruptedRdmaBatch batch;
+    submitCorruptedRdmaBatch(engine, batch, 0xA9);
+
+    EXPECT_TRUE(engine.waitTransferCompletion(batch.batch_id).ok());
+    EXPECT_EQ(batch.fake_tcp->submit_calls.load(), 1);
+
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(batch.buf.data(), batch.buf.size()).ok());
+}
+
+TEST(EngineFailoverE2E, TransferSyncUsesProgressBatchWhenPollDisabled) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+
+    FaultPolicy rdma_policy;
+    rdma_policy.status_corrupt_rate = 1.0;
+    auto proxied_rdma =
+        std::make_shared<FaultProxyTransport>(fake_rdma, rdma_policy);
+
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(proxied_rdma->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, proxied_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0xB0);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+    req.length = kBufLen;
+
+    EXPECT_TRUE(engine.transferSync({req}).ok());
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 1);
+
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+TEST(EngineFailoverE2E, ProgressBatchAdvancesExactlyOneStepPerCall) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    // Reach COMPLETED only on the third poll; earlier polls stay PENDING.
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, FakeTransport::StatusFactory{},
+        [](const Request& req, int poll_count) {
+            if (poll_count < 3) {
+                return TransferStatus{TransferStatusEnum::PENDING, 0};
+            }
+            return TransferStatus{TransferStatusEnum::COMPLETED, req.length};
+        });
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0xC0);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(1);
+    ASSERT_NE(batch_id, (BatchID)0);
+
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+    req.length = kBufLen;
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {req}).ok());
+
+    // Each progressBatch call must perform exactly one poll on the underlying
+    // transport — no internal loop until completion.
+    TransferStatus overall_status{};
+    ASSERT_TRUE(engine.progressBatch(batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::PENDING);
+    EXPECT_EQ(fake_rdma->status_calls.load(), 1);
+
+    ASSERT_TRUE(engine.progressBatch(batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::PENDING);
+    EXPECT_EQ(fake_rdma->status_calls.load(), 2);
+
+    ASSERT_TRUE(engine.progressBatch(batch_id, overall_status).ok());
+    EXPECT_EQ(overall_status.s, TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(fake_rdma->status_calls.load(), 3);
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add the C++ `progressBatch(BatchID, TransferStatus&)` API on `TransferEngine` and `TransferEngineImpl`.
- Split polling from status update/failover so `getTransferStatus()` preserves `enable_auto_failover_on_poll` compatibility while `progressBatch()` performs explicit failover progress.
- Move internal blocking/sync and staging progress paths to `progressBatch()`.
- Add TENT failover e2e coverage for explicit progress with poll auto-failover disabled, one-step progress behavior, max attempts, no terminal revive, mixed pending/failed aggregation, and wait/sync migration.

## Not in scope
- C API or Python binding changes.
- Callback/event-driven worker behavior.
- Changing `freeBatch()` / `lazyFreeBatch()` cleanup semantics.
- Changing the default `getTransferStatus()` compatibility behavior.

## Validation
- `cmake --build build-tent-progress-verify --target tent_failover_test tent_engine_failover_e2e_test -j1`
- `ctest --test-dir build-tent-progress-verify -R 'tent_.*failover.*test' --output-on-failure`
- `git diff --check upstream/main...HEAD -- mooncake-transfer-engine/tent/include/tent/transfer_engine.h mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h mooncake-transfer-engine/tent/src/transfer_engine.cpp mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp`

Refs #2116
Build note: local verification used the existing WSL dependency overrides for yalantinglibs and system glog include/library selection.