### PR TITLE
[Store] remove invalid kMaxSliceSize assertion in AllocateBatch

### DIFF
--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -614,8 +614,6 @@ FileStorage::AllocateBatch(const std::vector<std::string>& keys,
     u_int64_t total_size = 0;
     bool gc_triggered = false;
     for (size_t i = 0; i < keys.size(); ++i) {
-        assert(sizes[i] <= kMaxSliceSize);
-
         // Allocate oversized buffer for O_DIRECT alignment:
         //   +4096 for aligning the ptr to 4096 boundary
         //   +4096 for aligned read tail padding (actual_offset may not be

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -603,6 +603,11 @@ tl::expected<void, ErrorCode> FileStorage::RegisterLocalMemory() {
 tl::expected<std::shared_ptr<FileStorage::AllocatedBatch>, ErrorCode>
 FileStorage::AllocateBatch(const std::vector<std::string>& keys,
                            const std::vector<int64_t>& sizes) {
+    if (keys.size() != sizes.size()) {
+        LOG(ERROR) << "Mismatched keys and sizes count: keys=" << keys.size()
+                   << ", sizes=" << sizes.size();
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
     auto result = std::make_shared<AllocatedBatch>();
     result->batch_id = next_batch_id_.fetch_add(1, std::memory_order_relaxed);
     std::chrono::steady_clock::time_point now =
@@ -614,6 +619,12 @@ FileStorage::AllocateBatch(const std::vector<std::string>& keys,
     u_int64_t total_size = 0;
     bool gc_triggered = false;
     for (size_t i = 0; i < keys.size(); ++i) {
+        if (sizes[i] < 0 || sizes[i] > config_.local_buffer_size) {
+            LOG(ERROR) << "Invalid size for key " << keys[i] << ": " << sizes[i]
+                       << " (limit: " << config_.local_buffer_size << ")";
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+
         // Allocate oversized buffer for O_DIRECT alignment:
         //   +4096 for aligning the ptr to 4096 boundary
         //   +4096 for aligned read tail padding (actual_offset may not be


### PR DESCRIPTION
## Description

- Fix a size limit inconsistency bug in Mooncake Store's SSD offloading path that causes `mooncake_client` to crash when reading large offloaded objects back from SSD.
- Fixes #2156

**Problem**

`FileStorage::AllocateBatch` (`file_storage.cpp:617`) has an unconditional assertion:

```cpp
assert(sizes[i] <= kMaxSliceSize);  // kMaxSliceSize ≈ 4MB
```

However, the master-side validation (`master_service.cpp:917-923`) only enforces this limit for the CACHELIB allocator:

```cpp
if ((memory_allocator_type_ == BufferAllocatorType::CACHELIB) &&
    (slice_length > kMaxSliceSize)) {
    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
}
```

Other allocators (e.g., OffsetAllocator) are allowed to put slices larger than 4MB. This creates an inconsistency:

1. **Put path**: master accepts objects > 4MB when using non-CACHELIB allocators
2. **Offload to SSD**: large objects are written to SSD successfully
3. **Read from SSD**: `AllocateBatch` hits the assertion and aborts the process

When running a large model (e.g., Qwen3.6-35B-A3B with `--page-size=64`), a single KV cache page can exceed 4MB. Once memory is full and objects are evicted to SSD, reading them back triggers this crash.

**Fix**

Replace the unconditional `assert(sizes[i] <= kMaxSliceSize)` with a runtime validation that rejects negative sizes or sizes exceeding the global storage limit (`config_.total_size_limit`). This prevents the client from crashing on large offloaded objects while still guarding against truly invalid inputs.


## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

