### PR TITLE
[Store] introduce NVMe KV backend core 

### DIFF
--- a/docs/source/deployment/ssd/index.md
+++ b/docs/source/deployment/ssd/index.md
@@ -6,6 +6,7 @@ storage pools. Choose the guide that matches the storage tier in your deployment
 | Storage option | Description |
 |----------------|-------------|
 | [SSD Offload](ssd-offload) | Configure local SSD offload, eviction, and I/O behavior. |
+| [NVMe KV Local-Disk Backend](nvme-kv) | Configure a local NVMe KV namespace for SSD offload. |
 | [NVMe-oF SSD Pool](nvmf-ssd-deployment-guide) | Configure a shared NVMe-over-Fabrics storage tier. |
 
 :::{toctree}
@@ -13,5 +14,6 @@ storage pools. Choose the guide that matches the storage tier in your deployment
 :hidden:
 
 ssd-offload
+nvme-kv
 nvmf-ssd-deployment-guide
 :::

--- a/docs/source/deployment/ssd/nvme-kv.md
+++ b/docs/source/deployment/ssd/nvme-kv.md
@@ -1,0 +1,150 @@
+# NVMe KV Local-Disk Backend
+
+## Overview
+
+Mooncake Store can use a node-local NVMe Key-Value namespace as an SSD offload backend. The backend implements `StorageBackendInterface`, so the master tracks offloaded objects as `LOCAL_DISK` replicas and applications continue to use the normal Mooncake Store APIs.
+
+For implementation details, see [NVMe KV Backend Design](../../design/nvme-kv-backend.md).
+
+## Prerequisites
+
+- A Linux host with an NVMe KV namespace exposed as a device node.
+- Device support for NVMe KV Store, Retrieve, Delete, and store-if-not-exists semantics.
+- Read and write permission on the configured device for the Mooncake real client process.
+- An existing writable directory for `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`, as required by the common `FileStorage` configuration.
+- `liburing` headers and library when the io_uring executor is required.
+
+## Build Support
+
+The ioctl executor is built as part of Mooncake Store. NVMe uring command support is enabled automatically when CMake finds `liburing` and Linux headers that expose `nvme_uring_cmd`, `IORING_OP_URING_CMD`, SQE128, and CQE32 support.
+
+During configuration, check for:
+
+```text
+io_uring: NVMe uring command support enabled
+```
+
+If this support is unavailable, the backend can still use the ioctl executor.
+
+## Topology
+
+```mermaid
+flowchart TD
+    App["Application or requesting Mooncake client"]
+    Master["Mooncake master"]
+    Client["Mooncake real client"]
+    FileStorage["FileStorage"]
+    Backend["NvmeKvStorageBackend"]
+    Connector["NvmeKvConnector"]
+    Executor["io_uring or ioctl executor"]
+    Device["Local NVMe KV namespace"]
+
+    App <-->|"metadata and offload coordination"| Master
+    App <-->|"object RPC and data transfer"| Client
+    Client <-->|"LOCAL_DISK replica updates"| Master
+    Client --> FileStorage --> Backend --> Connector --> Executor --> Device
+```
+
+The master selects the real client that owns a `LOCAL_DISK` replica. Only that real client opens the local NVMe KV device and issues device commands.
+
+## Configuration
+
+Set the NVMe KV variables in the real client environment. They are not required by the master.
+
+```bash
+export MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR=nvme_kv_storage_backend
+export MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=/var/lib/mooncake/nvme-kv
+export MOONCAKE_NVME_KV_DEVICE_PATH=/dev/nvme1n1
+export MOONCAKE_NVME_KV_TRANSPORT=auto
+```
+
+The directory configured by `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` must already exist and be writable. NVMe KV object values are stored on the device selected by `MOONCAKE_NVME_KV_DEVICE_PATH`.
+
+### Required settings
+
+| Environment variable | Default | Description |
+|----------------------|---------|-------------|
+| `MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR` | `bucket_storage_backend` | Set to `nvme_kv_storage_backend`. |
+| `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` | `/data/file_storage` | Existing writable directory required by the common `FileStorage` configuration. |
+| `MOONCAKE_NVME_KV_DEVICE_PATH` | None | Namespace block-device path or NVMe generic character-device path. io_uring resolves namespace block paths to the matching `/dev/ng*` device. |
+
+### Transport and command settings
+
+| Environment variable | Default | Description |
+|----------------------|---------|-------------|
+| `MOONCAKE_NVME_KV_TRANSPORT` | `auto` | `auto`, `io_uring`, or `ioctl`. `auto` tries io_uring first and falls back to ioctl only when io_uring initialization fails. |
+| `MOONCAKE_NVME_KV_NSID` | `1` | Namespace ID encoded in NVMe KV commands. |
+| `MOONCAKE_NVME_KV_QUEUE_DEPTH` | `256` | io_uring queue depth and executor capability exposed to the backend. |
+| `MOONCAKE_NVME_KV_RUNTIME_TRANSFER_LIMIT` | `270336` | Runtime upper bound for one NVMe KV value transfer, in bytes. |
+| `MOONCAKE_NVME_KV_PROTOCOL_MAX_VALUE_SIZE` | `524288` | Protocol or device value-size ceiling. |
+| `MOONCAKE_NVME_KV_TRANSFER_ALIGNMENT_BYTES` | `4096` | DMA buffer and transfer-length alignment. |
+| `MOONCAKE_NVME_KV_VALUE_BLOCK_UNIT_BYTES` | `512` | Unit used to encode the NVMe KV value block count. |
+
+The effective maximum value size is the smaller of the runtime transfer limit and protocol maximum, rounded down to the configured transfer alignment.
+
+### Backend concurrency
+
+| Environment variable | Default | Description |
+|----------------------|---------|-------------|
+| `MOONCAKE_NVME_KV_IO_CONCURRENCY` | `18` | Total backend I/O concurrency. When unset, Mooncake uses the smaller of 18, queue depth, and the configured maximum. |
+| `MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY` | `256` | Upper bound for automatic or explicit backend I/O concurrency. |
+| `MOONCAKE_NVME_KV_PREPARE_CONCURRENCY` | `12` | Workers used for checksum and object-layout preparation. |
+| `MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY` | `6` | Independent chunk submission lanes. |
+| `MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY` | `1` | Root submission lanes. A chunked object's root is queued only after its chunks complete. |
+| `MOONCAKE_NVME_KV_READ_PLAN_BATCH_SIZE` | `8` | Logical objects grouped into one chunk-read planning task. |
+
+Preparation, chunk submission, and root submission use bounded worker pools. Explicit lane counts are capped by the effective I/O concurrency.
+
+## Transport Selection
+
+### `auto` (recommended)
+
+Configure a namespace block-device path such as `/dev/nvme1n1`. When NVMe uring command support is compiled in, Mooncake resolves the matching NVMe generic character device, such as `/dev/ng1n1`, and initializes io_uring. If initialization fails, Mooncake opens the original block-device path with ioctl. The selected transport remains fixed for the connector lifetime.
+
+### `io_uring`
+
+Use this mode to require io_uring. Mooncake accepts either a namespace block-device path with a matching `/dev/ng*` device or the generic character-device path directly. Initialization fails instead of falling back.
+
+### `ioctl`
+
+Use this mode to require Linux NVMe passthrough ioctl. Configure the namespace block-device path. Each command is synchronous within one backend worker, and the backend worker pool supplies parallelism.
+
+## Start Mooncake
+
+Start the master with SSD offload enabled:
+
+```bash
+mooncake_master \
+    --rpc_port=50051 \
+    --enable_offload=true
+```
+
+Start a real client on the host that owns the NVMe KV device:
+
+```bash
+mooncake_client \
+    --master_server_address=127.0.0.1:50051 \
+    --host=<machine-ip> \
+    --protocol=rdma \
+    --device_names=<rdma-device> \
+    --port=50052 \
+    --global_segment_size="4 GB" \
+    --enable_offload=true \
+    --metadata_server=P2PHANDSHAKE
+```
+
+Embedded real-client mode uses the same environment variables. Set `enable_ssd_offload=True` when calling `MooncakeDistributedStore.setup()`. See [SSD Offload](ssd-offload.md) for the complete client flows.
+
+## Troubleshooting
+
+### io_uring falls back to ioctl
+
+Check that the build enabled NVMe uring command support and that the matching generic character device exists. Set `MOONCAKE_NVME_KV_TRANSPORT=io_uring` to turn fallback into an initialization error while diagnosing the setup.
+
+### Backend initialization reports an empty device path
+
+Set `MOONCAKE_NVME_KV_DEVICE_PATH` in the real client environment.
+
+### Store or Retrieve reports invalid parameters
+
+Verify namespace ID, effective maximum value size, transfer alignment, and value block unit against the device implementation. The runtime transfer limit must be at least one transfer-alignment unit.

--- a/docs/source/design/index.md
+++ b/docs/source/design/index.md
@@ -24,6 +24,7 @@ distributed execution components.
 | [Engram](engram) | Distributed serving and cache architecture. |
 | [Unified Parallel Tensor I/O](unified-parallel-tensor-io) | Parallel tensor storage and transfer model. |
 | [SSD Offload](ssd-offload) | SSD-backed cache hierarchy design. |
+| [NVMe KV Backend](nvme-kv-backend) | Local NVMe KV object layout, executor, and I/O design. |
 | [SSD Free-Ratio-First Allocation](ssd-free-ratio-first-allocation) | Capacity-aware replica placement strategy. |
 
 ## Distributed Execution and Routing

--- a/docs/source/design/nvme-kv-backend.md
+++ b/docs/source/design/nvme-kv-backend.md
@@ -1,0 +1,182 @@
+---
+orphan: true
+---
+
+# NVMe KV Backend Design
+
+## Overview
+
+The NVMe KV backend extends Mooncake Store's node-local SSD offload path with an NVMe Key-Value namespace. It preserves Mooncake's logical object API while translating variable-length logical keys and values into fixed-size NVMe KV keys and bounded device values.
+
+The implementation separates object semantics from command transport. `NvmeKvStorageBackend` owns logical object layout, integrity validation, key-conflict handling, and batched I/O orchestration. `NvmeKvConnector` binds one configured device to one executor. `NvmeKvCommandExecutor` submits Store, Retrieve, and Delete commands through io_uring or ioctl.
+
+## Design Goals
+
+- Integrate one node-local NVMe KV namespace with the existing SSD offload flow.
+- Preserve object identity and integrity with placement validation and checksums.
+- Support logical objects larger than one device value.
+- Use store-if-not-exists for idempotent writes and explicit hash-collision handling.
+- Overlap object preparation, chunk submission, and root submission with bounded concurrency.
+- Use io_uring when available and ioctl as an initialization fallback.
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph Control["Mooncake control plane"]
+        Master["Mooncake master\ntracks LOCAL_DISK replicas"]
+    end
+
+    subgraph Requester["Requesting node"]
+        App["Application"]
+        RequestClient["Mooncake client"]
+        App --> RequestClient
+    end
+
+    subgraph Owner["NVMe KV owner node"]
+        RealClient["Mooncake real client"]
+        FileStorage["FileStorage"]
+        Backend["NvmeKvStorageBackend"]
+        Connector["NvmeKvConnector"]
+        Executor["io_uring or ioctl executor"]
+        Device["Local NVMe KV namespace"]
+
+        RealClient --> FileStorage --> Backend --> Connector --> Executor --> Device
+    end
+
+    RequestClient <-->|"metadata query"| Master
+    RealClient <-->|"offload heartbeat and replica updates"| Master
+    RequestClient <-->|"object RPC and Transfer Engine data movement"| RealClient
+```
+
+The master records the object as a `LOCAL_DISK` replica owned by a real client. NVMe KV commands remain local to that client.
+
+## Layer Responsibilities
+
+| Layer | Responsibilities |
+|------|------------------|
+| `FileStorage` | Obtains memory slices, invokes the backend, reports successful replicas, and serves remote SSD reads. |
+| `NvmeKvStorageBackend` | Builds object layouts, applies key-conflict policy, coordinates bounded batch I/O, and verifies data returned by the device. |
+| `NvmeKvConnector` | Resolves the configured device, selects one executor during initialization, and forwards commands. |
+| `NvmeKvCommandExecutor` | Encodes and submits NVMe KV Store, Retrieve, and Delete commands while owning transport-specific buffers and completion handling. |
+| NVMe KV namespace | Executes commands submitted through the Linux device node. |
+
+## Physical Keys and Conflicts
+
+NVMe KV namespaces expose key/value limits through their KV format, including
+the maximum key length and maximum value length supported by the namespace.
+Command completion can also report invalid key or value sizes. Mooncake logical
+keys are variable-length strings, so they cannot be passed to the device
+unchanged.
+
+NVMe KV commands use a 16-byte physical key, while Mooncake logical keys can be longer. The key codec derives root and chunk keys from the complete logical key, object role, chunk index, and conflict slot. Two independently seeded XXH64 values form the physical key, and four independently seeded XXH64 values form the identity verification hash stored in the root header. No logical-key byte is reserved or discarded.
+
+The backend tries at most 64 conflict slots. Every Store uses store-if-not-exists. When a physical key already exists, the backend retrieves the value and compares it with the expected bytes. Identical bytes mean the same object and make the operation idempotently successful. Different bytes mean a physical-key collision, so the backend tries the next slot. Other device errors are returned to `FileStorage`.
+
+Reads derive the same root keys and probe conflict slots until the stored logical identity matches the requested key. Placement metadata in the root must agree with both the observed physical key and the selected slot.
+
+## Object Layout
+
+The value side has the same shape constraint. Mooncake objects can be larger
+than one NVMe KV value, while each Store or Retrieve must stay within the
+effective value limit derived from the protocol/device ceiling, runtime
+transfer limit, and transfer alignment. Chunking exists to adapt Mooncake's
+logical object size to that bounded value model.
+
+```mermaid
+flowchart LR
+    Logical["Mooncake logical object"]
+    Decision{"Fits in one device value?"}
+    Inline["Root value\nheader + identity + payload"]
+    Manifest["Root manifest\nheader + identity + chunk records"]
+    Chunks["Raw chunk values\nchunk0 ... chunkN"]
+
+    Logical --> Decision
+    Decision -->|"yes"| Inline
+    Decision -->|"no"| Manifest
+    Manifest --> Chunks
+```
+
+An inline root contains `NvmeKvObjectHeader`, stored identity metadata, and the logical payload. The header records object type, payload size, identity verification hash, payload checksum, header checksum, and identity metadata size.
+
+A larger object is split into raw chunk values followed by one root manifest. Each manifest record stores the physical chunk key, chunk size, and checksum. The root manifest is written only after all chunks for that object complete successfully, so the root acts as the visibility marker. The manifest itself must fit in one device value.
+
+## Write Path
+
+```mermaid
+sequenceDiagram
+    participant F as FileStorage
+    participant B as NvmeKvStorageBackend
+    participant E as Executor
+
+    F->>B: BatchOffload(key to slices)
+    B->>B: validate limits and prepare checksums/layout
+    alt inline object
+        B->>E: Store root if not exists
+    else chunked object
+        B->>E: StoreBatch chunks if not exists
+        E-->>B: all chunks for one object complete
+        B->>E: queue root on the root lane
+    end
+    alt physical key already exists
+        B->>E: Retrieve existing value
+        B->>B: accept identical object or try next slot
+    end
+    B-->>F: successful keys and object metadata
+```
+
+Preparation workers build payload views, checksums, chunks, and root manifests while independent submission lanes issue device commands. Chunk lanes feed completed objects to a dedicated root lane instead of waiting for every object in the batch. Worker counts and command batches are bounded by the configured concurrency budget and executor queue depth.
+
+On failure, the backend best-effort deletes only keys created by the current attempt. Pre-existing values accepted as the same object are never deleted.
+
+## Read Path
+
+For each requested logical key, the backend derives and validates its root object. Inline payloads are checksum-verified and copied directly to the destination. Manifest roots are validated and converted into chunk records and destination offsets for the current request.
+
+Chunk reads are grouped into bounded tasks. When the selected executor supports direct destination reads, aligned destinations use `RetrieveIntoBatch` so the device can read directly into the Mooncake buffer. Other destinations, and executors that use the default batch implementation, use executor-owned buffers through `RetrieveBufferBatch` followed by a validated copy. Header, identity, placement, manifest, payload, and every chunk checksum are verified before the operation returns.
+
+## Executor Design
+
+### Common command layer
+
+Common utilities own physical-key packing, NVMe KV opcodes, Store/Retrieve/Delete command construction, transfer rounding, aligned buffer allocation, status mapping, and capability calculation. The effective value limit is:
+
+```text
+round_down(min(protocol_max_value_size, runtime_transfer_limit),
+           transfer_alignment)
+```
+
+### io_uring
+
+The io_uring executor uses a thread-local ring and NVMe uring commands with 128-byte SQEs. It requests CQE32 for command results and retries initialization without CQE32 when the kernel does not support it.
+
+Batch submission maintains a bounded number of commands in flight, drains available CQEs, and refills released SQEs immediately. A generation token plus command index in `user_data` rejects stale, duplicate, and out-of-batch completions. Request buffers remain alive until all accepted commands complete. On partial submission failure, the executor drains commands already accepted by the kernel before resetting the ring.
+
+### ioctl
+
+The ioctl executor builds the same command fields in `nvme_passthru_cmd` and submits them through `NVME_IOCTL_IO_CMD`. Calls are synchronous within one backend worker, while the backend worker pool provides parallelism across requests.
+
+### Selection
+
+`auto` tries io_uring first when compiled in and falls back to ioctl only if io_uring initialization fails. Runtime command failures are returned without changing transports. Explicit `io_uring` and `ioctl` modes fail initialization when the requested executor cannot be created.
+
+## Concurrency and Ownership
+
+- Backend worker pools bound object preparation, chunk submission, root submission, and fallback I/O.
+- io_uring rings are thread-local, avoiding a shared hot-path ring lock.
+- Batch APIs are synchronous at their boundary, so request arrays and DMA buffers outlive all command completions.
+- Direct reads verify checksums in the destination buffer after completion.
+- Root submission for a chunked object occurs only after its chunks finish successfully.
+
+## Failure Semantics
+
+| Condition | Behavior |
+|----------|----------|
+| Key not found | Return `OBJECT_NOT_FOUND`. |
+| Store-if-not-exists finds identical bytes | Treat as idempotent success. |
+| Store-if-not-exists finds different bytes | Treat as a physical-key collision and try the next slot. |
+| Header, identity, placement, manifest, or checksum failure | Return `FILE_READ_FAIL`. |
+| Partial chunk write | Best-effort cleanup of keys created by the failed attempt. |
+| io_uring submission or completion anomaly | Drain accepted commands, reset the thread-local ring, and fail the operation. |
+| io_uring initialization failure in `auto` mode | Try ioctl. |
+| Runtime device I/O failure | Return the mapped error without transport fallback. |

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -128,6 +128,7 @@ design/transfer-engine/index
 design/reshard-manifest
 design/tent/overview
 design/store/mooncake-store
+design/nvme-kv-backend
 design/mooncake-backend-pg
 design/mooncake-ep
 design/p2p-store

--- a/mooncake-store/include/nvme_kv_backend.h
+++ b/mooncake-store/include/nvme_kv_backend.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "nvme_kv_connector.h"
+#include "nvme_kv_key_codec.h"
+#include "nvme_kv_key_conflict_policy.h"
+#include "nvme_kv_object_layout.h"
+#include "rpc_types.h"
+#include "storage_backend.h"
+#include "thread_pool.h"
+
+namespace mooncake {
+
+class NvmeKvStorageBackend : public StorageBackendInterface {
+   public:
+    explicit NvmeKvStorageBackend(
+        const FileStorageConfig &file_storage_config_);
+
+    tl::expected<void, ErrorCode> Init() override;
+
+    tl::expected<int64_t, ErrorCode> BatchOffload(
+        const std::unordered_map<std::string, std::vector<Slice>> &batch_object,
+        std::function<ErrorCode(const std::vector<std::string> &keys,
+                                std::vector<StorageObjectMetadata> &metadatas)>
+            complete_handler,
+        EvictionHandler eviction_handler = nullptr) override;
+
+    tl::expected<void, ErrorCode> BatchLoad(
+        std::unordered_map<std::string, Slice> &batched_slices) override;
+
+    tl::expected<bool, ErrorCode> IsExist(const std::string &key) override;
+    tl::expected<bool, ErrorCode> IsEnableOffloading() override;
+
+    tl::expected<void, ErrorCode> ScanMeta(
+        const std::function<ErrorCode(
+            const std::vector<std::string> &keys,
+            std::vector<StorageObjectMetadata> &metadatas)> &handler) override;
+
+   private:
+    using PhysicalKey = NvmeKvPhysicalKey;
+
+    struct OffloadResult {
+        bool stored = false;
+        bool inserted = false;
+    };
+
+    struct CachedManifest {
+        uint32_t resolved_slot = 0;
+        uint32_t payload_size = 0;
+        std::vector<NvmeKvManifestChunkRecord> chunk_records;
+        std::vector<size_t> chunk_offsets;
+    };
+
+    tl::expected<void, ErrorCode> InitDevice();
+    tl::expected<OffloadResult, ErrorCode> OffloadOne(
+        const std::string &key, const std::vector<Slice> &slices,
+        size_t payload_size);
+    void StoreBatchParallel(
+        std::vector<NvmeKvCommandExecutor::StoreRequest> &requests);
+    void RunParallelIo(size_t item_count,
+                       const std::function<void(size_t)> &task,
+                       size_t max_inflight = 0);
+    void RunPipelinedIo(size_t item_count,
+                        const std::function<void(size_t)> &io_task,
+                        const std::function<void(size_t)> &completion_task);
+    std::shared_ptr<const CachedManifest> FindCachedManifest(
+        const std::string &key, size_t payload_size) const;
+    std::shared_ptr<const CachedManifest> CacheManifest(
+        const std::string &key, size_t payload_size, uint32_t resolved_slot,
+        const std::vector<NvmeKvManifestChunkRecord> &chunk_records);
+    void CacheManifestAfterWrite(
+        const std::string &key, size_t payload_size, uint32_t resolved_slot,
+        const std::vector<NvmeKvManifestChunkRecord> &chunk_records) noexcept;
+    void InitIoWorkers();
+
+    std::atomic<bool> initialized_{false};
+    mutable std::shared_mutex manifest_cache_mutex_;
+    std::unordered_map<std::string, std::shared_ptr<const CachedManifest>>
+        manifest_cache_;
+    std::shared_ptr<NvmeKvConnector> connector_;
+    std::atomic<int64_t> total_size_{0};
+    std::atomic<int64_t> total_keys_{0};
+    size_t io_parallelism_ = 1;
+    size_t prepare_concurrency_ = 1;
+    size_t batch_submit_concurrency_ = 1;
+    size_t root_submit_concurrency_ = 1;
+    std::unique_ptr<ThreadPool> io_workers_;
+    std::unique_ptr<ThreadPool> submit_workers_;
+    std::unique_ptr<ThreadPool> root_submit_workers_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/nvme_kv_connector.h
+++ b/mooncake-store/include/nvme_kv_connector.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <ylt/util/tl/expected.hpp>
+
+#include "nvme_kv_executor.h"
+#include "types.h"
+
+namespace mooncake {
+
+struct FileStorageConfig;
+
+class NvmeKvConnector {
+   public:
+    using PhysicalKey = NvmeKvCommandExecutor::PhysicalKey;
+    using Capabilities = NvmeKvCommandExecutor::Capabilities;
+
+    explicit NvmeKvConnector(const FileStorageConfig &file_storage_config);
+
+    tl::expected<void, ErrorCode> Init();
+    tl::expected<void, ErrorCode> Store(const PhysicalKey &key,
+                                        std::string value);
+    void StoreBatch(std::vector<NvmeKvCommandExecutor::StoreRequest> &requests);
+    tl::expected<std::string, ErrorCode> Retrieve(const PhysicalKey &key,
+                                                  uint32_t size_hint = 0) const;
+    void RetrieveBufferBatch(
+        std::vector<NvmeKvCommandExecutor::RetrieveBufferRequest> &requests)
+        const;
+    void RetrieveIntoBatch(
+        std::vector<NvmeKvCommandExecutor::RetrieveIntoRequest> &requests)
+        const;
+    tl::expected<void, ErrorCode> Delete(const PhysicalKey &key);
+    const Capabilities &GetCapabilities() const;
+
+   private:
+    tl::expected<void, ErrorCode> InitRealExecutor();
+    std::string storage_path_;
+    std::unique_ptr<NvmeKvCommandExecutor> executor_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/nvme_kv_executor.h
+++ b/mooncake-store/include/nvme_kv_executor.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <ylt/util/tl/expected.hpp>
+
+#include "types.h"
+
+namespace mooncake {
+
+struct FileStorageConfig;
+
+class NvmeKvCommandExecutor {
+   public:
+    using PhysicalKey = std::array<uint8_t, 16>;
+
+    struct StoreRequest {
+        PhysicalKey key;
+        std::string_view value;
+        tl::expected<void, ErrorCode> result =
+            tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    };
+
+    struct RetrievedBuffer {
+        std::shared_ptr<void> owner;
+        const char *data = nullptr;
+        uint32_t size = 0;
+
+        std::string ToString() const {
+            return data == nullptr ? std::string()
+                                   : std::string(data, data + size);
+        }
+    };
+
+    struct RetrieveBufferRequest {
+        PhysicalKey key;
+        uint32_t size_hint = 0;
+        tl::expected<RetrievedBuffer, ErrorCode> result =
+            tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    };
+
+    struct RetrieveIntoRequest {
+        PhysicalKey key;
+        char *data = nullptr;
+        uint32_t size = 0;
+        tl::expected<uint32_t, ErrorCode> result =
+            tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    };
+
+    struct Capabilities {
+        uint32_t effective_max_value_size = UINT32_MAX;
+        uint32_t queue_depth = 1;
+    };
+
+    virtual ~NvmeKvCommandExecutor() = default;
+
+    virtual tl::expected<void, ErrorCode> Store(const PhysicalKey &key,
+                                                std::string value) = 0;
+    // Batch calls are synchronous: implementations must finish accessing all
+    // request-owned buffers and populate every result before returning.
+    virtual void StoreBatch(std::vector<StoreRequest> &requests) {
+        for (auto &request : requests) {
+            request.result = Store(request.key, std::string(request.value));
+        }
+    }
+    virtual tl::expected<std::string, ErrorCode> Retrieve(
+        const PhysicalKey &key, uint32_t size_hint = 0) const = 0;
+    virtual void RetrieveBufferBatch(
+        std::vector<RetrieveBufferRequest> &requests) const {
+        for (auto &request : requests) {
+            auto result = Retrieve(request.key, request.size_hint);
+            if (!result) {
+                request.result = tl::make_unexpected(result.error());
+                continue;
+            }
+            auto owner =
+                std::make_shared<std::string>(std::move(result.value()));
+            RetrievedBuffer buffer;
+            buffer.owner = owner;
+            buffer.data = owner->data();
+            buffer.size = static_cast<uint32_t>(owner->size());
+            request.result = std::move(buffer);
+        }
+    }
+    virtual void RetrieveIntoBatch(
+        std::vector<RetrieveIntoRequest> &requests) const {
+        std::vector<RetrieveBufferRequest> buffer_requests;
+        buffer_requests.reserve(requests.size());
+        for (const auto &request : requests) {
+            RetrieveBufferRequest buffer_request;
+            buffer_request.key = request.key;
+            buffer_request.size_hint = request.size;
+            buffer_requests.push_back(std::move(buffer_request));
+        }
+        RetrieveBufferBatch(buffer_requests);
+        for (size_t index = 0; index < requests.size(); ++index) {
+            const auto &buffer_result = buffer_requests[index].result;
+            if (!buffer_result) {
+                requests[index].result =
+                    tl::make_unexpected(buffer_result.error());
+                continue;
+            }
+            const auto &buffer = buffer_result.value();
+            if (requests[index].data == nullptr ||
+                buffer.size != requests[index].size) {
+                requests[index].result =
+                    tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                continue;
+            }
+            std::memcpy(requests[index].data, buffer.data, buffer.size);
+            requests[index].result = buffer.size;
+        }
+    }
+    virtual tl::expected<void, ErrorCode> Delete(const PhysicalKey &key) = 0;
+    virtual const Capabilities &GetCapabilities() const = 0;
+};
+
+using NvmeKvExecutorResult =
+    tl::expected<std::unique_ptr<NvmeKvCommandExecutor>, ErrorCode>;
+
+NvmeKvExecutorResult CreateNvmeKvIoUringExecutor(
+    std::string device_path, uint32_t nsid, uint32_t queue_depth,
+    uint32_t runtime_transfer_limit);
+
+NvmeKvExecutorResult CreateNvmeKvIoctlExecutor(std::string device_path,
+                                               uint32_t nsid,
+                                               uint32_t queue_depth,
+                                               uint32_t runtime_transfer_limit);
+
+}  // namespace mooncake

--- a/mooncake-store/include/nvme_kv_executor_util.h
+++ b/mooncake-store/include/nvme_kv_executor_util.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+#include "nvme_kv_executor.h"
+#include "types.h"
+
+namespace mooncake {
+
+struct NvmeKvPackedKeyFields {
+    uint32_t cdw2 = 0;
+    uint32_t cdw3 = 0;
+    uint32_t cdw14 = 0;
+    uint32_t cdw15 = 0;
+};
+
+constexpr uint32_t kDefaultNvmeKvQueueDepth = 256;
+constexpr uint32_t kDefaultNvmeKvRuntimeTransferLimit = 270336;
+constexpr uint32_t kDefaultNvmeKvProtocolMaxValueSize = 512 * 1024;
+constexpr uint32_t kDefaultNvmeKvTransferAlignmentBytes = 4096;
+constexpr uint32_t kDefaultNvmeKvValueBlockUnitBytes = 512;
+constexpr uint32_t kNvmeKvMaxKeySizeBytes = 16;
+constexpr uint32_t kNvmeKvCommandTimeoutMs = 30000;
+constexpr uint32_t kNvmeKvStoreIfNotExistsOption = 0x2;
+constexpr uint8_t kNvmeKvCommandSetIdentifier = 0x01;
+constexpr uint8_t kNvmeKvStoreOpcode = 0x01;
+constexpr uint8_t kNvmeKvRetrieveOpcode = 0x02;
+constexpr uint8_t kNvmeKvDeleteOpcode = 0x10;
+
+struct NvmeKvFreeDeleter {
+    void operator()(void *ptr) const { std::free(ptr); }
+};
+
+using NvmeKvAlignedBuffer = std::unique_ptr<char, NvmeKvFreeDeleter>;
+
+uint32_t ParseNvmeKvU32EnvOr(const char *name, uint32_t fallback);
+NvmeKvAlignedBuffer AllocateNvmeKvAlignedBuffer(size_t size);
+uint32_t NvmeKvTransferAlignmentBytes();
+uint32_t NvmeKvValueBlockUnitBytes();
+uint32_t RoundUpToNvmeKvTransferBytes(uint32_t bytes);
+uint32_t RoundDownToNvmeKvTransferBytes(uint32_t bytes);
+uint32_t ComputeNvmeKvValueBlockCountMinusOne(uint32_t bytes);
+uint32_t ResolveNvmeKvStoreSubmissionBytes(uint32_t logical_bytes);
+uint32_t ResolveNvmeKvInitialRetrieveBytes(uint32_t size_hint,
+                                           uint32_t effective_max_value_size);
+uint32_t ResolveNvmeKvRetrievedValueSize(const char *buffer,
+                                         uint32_t returned_size,
+                                         uint32_t max_size, uint32_t size_hint);
+bool ShouldRetryNvmeKvRetrieveWithMaxBuffer(ErrorCode error, uint32_t size_hint,
+                                            uint32_t request_bytes,
+                                            uint32_t effective_max_value_size);
+NvmeKvCommandExecutor::Capabilities BuildNvmeKvCapabilities(
+    uint32_t default_queue_depth, uint32_t queue_depth,
+    uint32_t runtime_transfer_limit);
+std::string NvmeKvPhysicalKeyToHex(
+    const NvmeKvCommandExecutor::PhysicalKey &key);
+NvmeKvPackedKeyFields PackNvmeKvPhysicalKey(
+    const NvmeKvCommandExecutor::PhysicalKey &key);
+ErrorCode MapNvmeKvStatus(uint32_t status, bool is_write);
+ErrorCode MapNvmeKvTransportError(int err, bool is_write);
+bool IsNvmeKvControlFlowError(ErrorCode error);
+
+inline uint32_t BuildNvmeKvKeyLengthField(size_t key_length) {
+    return static_cast<uint32_t>(key_length) & 0xFFu;
+}
+
+template <typename Command>
+void EncodeNvmeKvKey(const NvmeKvCommandExecutor::PhysicalKey &key,
+                     Command &cmd) {
+    const auto fields = PackNvmeKvPhysicalKey(key);
+    cmd.cdw2 = fields.cdw2;
+    cmd.cdw3 = fields.cdw3;
+    cmd.cdw14 = fields.cdw14;
+    cmd.cdw15 = fields.cdw15;
+}
+
+template <typename Command>
+void BuildNvmeKvStoreCommand(Command &cmd, uint32_t nsid,
+                             const NvmeKvCommandExecutor::PhysicalKey &key,
+                             const void *data, uint32_t transfer_bytes) {
+    cmd = {};
+    cmd.opcode = kNvmeKvStoreOpcode;
+    cmd.nsid = nsid;
+    cmd.addr = reinterpret_cast<uint64_t>(data);
+    cmd.data_len = transfer_bytes;
+    cmd.cdw10 = transfer_bytes;
+    cmd.cdw11 = (kNvmeKvStoreIfNotExistsOption << 8) |
+                BuildNvmeKvKeyLengthField(key.size());
+    cmd.cdw12 = ComputeNvmeKvValueBlockCountMinusOne(transfer_bytes);
+    cmd.timeout_ms = kNvmeKvCommandTimeoutMs;
+    EncodeNvmeKvKey(key, cmd);
+}
+
+template <typename Command>
+void BuildNvmeKvRetrieveCommand(Command &cmd, uint32_t nsid,
+                                const NvmeKvCommandExecutor::PhysicalKey &key,
+                                void *data, uint32_t transfer_bytes) {
+    cmd = {};
+    cmd.opcode = kNvmeKvRetrieveOpcode;
+    cmd.nsid = nsid;
+    cmd.addr = reinterpret_cast<uint64_t>(data);
+    cmd.data_len = transfer_bytes;
+    cmd.cdw10 = transfer_bytes;
+    cmd.cdw11 = BuildNvmeKvKeyLengthField(key.size());
+    cmd.cdw12 = ComputeNvmeKvValueBlockCountMinusOne(transfer_bytes);
+    cmd.timeout_ms = kNvmeKvCommandTimeoutMs;
+    EncodeNvmeKvKey(key, cmd);
+}
+
+template <typename Command>
+void BuildNvmeKvDeleteCommand(Command &cmd, uint32_t nsid,
+                              const NvmeKvCommandExecutor::PhysicalKey &key) {
+    cmd = {};
+    cmd.opcode = kNvmeKvDeleteOpcode;
+    cmd.nsid = nsid;
+    cmd.cdw11 = BuildNvmeKvKeyLengthField(key.size());
+    cmd.timeout_ms = kNvmeKvCommandTimeoutMs;
+    EncodeNvmeKvKey(key, cmd);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/include/nvme_kv_key_codec.h
+++ b/mooncake-store/include/nvme_kv_key_codec.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+
+namespace mooncake {
+
+using NvmeKvPhysicalKey = std::array<uint8_t, 16>;
+
+struct NvmeKvObjectIdentity {
+    std::string logical_key;
+};
+
+constexpr uint32_t kNvmeKvMaxPhysicalKeySlots = 64;
+
+uint32_t ComputeNvmeKvChecksum(std::span<const uint8_t> data);
+std::string SerializeNvmeKvCanonicalIdentity(
+    const NvmeKvObjectIdentity& identity);
+bool ParseNvmeKvCanonicalIdentity(std::string_view encoded_identity,
+                                  NvmeKvObjectIdentity& identity);
+std::array<uint8_t, 32> ComputeNvmeKvVerifyHash(
+    const NvmeKvObjectIdentity& identity);
+NvmeKvPhysicalKey EncodeNvmeKvPhysicalKey(const NvmeKvObjectIdentity& identity,
+                                          uint32_t slot = 0);
+NvmeKvPhysicalKey EncodeNvmeKvChunkPhysicalKey(
+    const NvmeKvObjectIdentity& identity, uint32_t chunk_index,
+    uint32_t slot = 0);
+
+}  // namespace mooncake

--- a/mooncake-store/include/nvme_kv_key_conflict_policy.h
+++ b/mooncake-store/include/nvme_kv_key_conflict_policy.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <ylt/util/tl/expected.hpp>
+
+#include "nvme_kv_connector.h"
+#include "nvme_kv_key_codec.h"
+#include "nvme_kv_object_layout.h"
+#include "types.h"
+
+namespace mooncake {
+
+class NvmeKvKeyConflictPolicy {
+   public:
+    using PhysicalKey = NvmeKvPhysicalKey;
+
+    enum class ExistingObjectDecision {
+        kNotFound,
+        kSameObject,
+        kDifferentObject,
+    };
+
+    struct WritePlan {
+        NvmeKvObjectIdentity identity;
+        PhysicalKey root_key{};
+        bool store_inline = false;
+        std::string root_blob;
+        std::vector<std::pair<PhysicalKey, std::string_view>> chunk_values;
+        std::vector<NvmeKvManifestChunkRecord> manifest_records;
+    };
+
+    static bool ValidateResolvedRootPlacement(
+        const NvmeKvObjectIdentity& identity,
+        const NvmeKvStoredIdentityView& stored_view,
+        const NvmeKvPhysicalKey& observed_physical_key);
+    static tl::expected<WritePlan, ErrorCode> BuildWritePlan(
+        const NvmeKvObjectIdentity& identity, std::string_view payload,
+        uint32_t slot, uint32_t max_value_size);
+    static tl::expected<ExistingObjectDecision, ErrorCode>
+    ResolveExistingObject(NvmeKvConnector& connector,
+                          const PhysicalKey& physical_key,
+                          std::string_view expected_blob);
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/nvme_kv_object_layout.h
+++ b/mooncake-store/include/nvme_kv_object_layout.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "nvme_kv_key_codec.h"
+
+namespace mooncake {
+
+enum class NvmeKvObjectType : uint32_t {
+    kInline = 1,
+    kManifest = 2,
+};
+
+struct NvmeKvObjectHeader {
+    uint32_t magic;
+    uint32_t object_type;
+    uint32_t payload_size;
+    std::array<uint8_t, 32> verify_hash;
+    uint32_t payload_checksum;
+    uint32_t header_checksum;
+    uint32_t identity_metadata_size;
+
+    static constexpr uint32_t kMagic = 0x4e564b56;
+};
+
+struct NvmeKvStoredIdentityMetadata {
+    NvmeKvPhysicalKey resolved_physical_key{};
+    uint32_t resolved_slot = 0;
+};
+
+struct NvmeKvStoredIdentityView {
+    std::string logical_key;
+    NvmeKvPhysicalKey resolved_physical_key{};
+    uint32_t resolved_slot = 0;
+};
+
+struct NvmeKvManifestMetadata {
+    uint32_t logical_payload_size;
+    uint32_t chunk_count;
+};
+
+struct NvmeKvManifestChunkRecord {
+    NvmeKvPhysicalKey physical_key;
+    uint32_t payload_size;
+    uint32_t payload_checksum;
+};
+
+uint32_t ComputeNvmeKvPayloadChecksum(std::string_view payload);
+uint32_t ComputeNvmeKvHeaderChecksum(const NvmeKvObjectHeader& header);
+uint32_t ComputeNvmeKvStoredIdentityMetadataSize(
+    const NvmeKvObjectIdentity& identity);
+NvmeKvStoredIdentityMetadata BuildNvmeKvStoredIdentityMetadata(
+    const NvmeKvPhysicalKey& physical_key, uint32_t slot);
+std::string SerializeNvmeKvStoredIdentity(
+    const NvmeKvObjectIdentity& identity,
+    const NvmeKvStoredIdentityMetadata& metadata);
+bool ParseNvmeKvStoredIdentity(std::string_view encoded_identity,
+                               NvmeKvStoredIdentityView& identity_view);
+bool ValidateNvmeKvHeader(const NvmeKvObjectHeader& header,
+                          const NvmeKvObjectIdentity& identity,
+                          uint32_t expected_identity_size,
+                          uint32_t expected_size,
+                          NvmeKvObjectType expected_type);
+std::string BuildNvmeKvObjectBlob(const NvmeKvObjectHeader& header,
+                                  std::string_view identity_metadata,
+                                  std::string_view payload);
+bool ParseNvmeKvObjectBlob(std::string_view object_blob,
+                           NvmeKvObjectHeader& header,
+                           std::string_view& identity_metadata_view,
+                           std::string_view& payload_view);
+uint32_t ResolveNvmeKvObjectBlobSizeFromPrefix(const char* buffer,
+                                               uint32_t prefix_size);
+uint32_t ResolveNvmeKvObjectBlobSize(const char* buffer, uint32_t returned_size,
+                                     uint32_t max_size);
+std::string SerializeNvmeKvManifest(
+    const NvmeKvManifestMetadata& metadata,
+    const std::vector<NvmeKvManifestChunkRecord>& chunk_records);
+bool ParseNvmeKvManifest(std::string_view manifest_payload,
+                         NvmeKvManifestMetadata& metadata,
+                         std::vector<NvmeKvManifestChunkRecord>& chunk_records);
+
+}  // namespace mooncake

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -163,7 +163,8 @@ enum class StorageBackendType {
     kFilePerKey,
     kBucket,
     kOffsetAllocator,
-    kDistributed
+    kDistributed,
+    kNvmeKv
 };
 
 static constexpr size_t kKB = 1024;

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -14,6 +14,14 @@ set(MOONCAKE_STORE_SOURCES
     mmap_arena.cpp
     master_metric_manager.cpp
     storage_backend.cpp
+    nvme_kv_backend.cpp
+    nvme_kv_connector.cpp
+    nvme_kv_executor_io_uring.cpp
+    nvme_kv_executor_ioctl.cpp
+    nvme_kv_executor_util.cpp
+    nvme_kv_key_codec.cpp
+    nvme_kv_key_conflict_policy.cpp
+    nvme_kv_object_layout.cpp
     thread_pool.cpp
     etcd_helper.cpp
     segment.cpp
@@ -76,6 +84,10 @@ set(MOONCAKE_STORE_SOURCES
     memory_alloc.cpp
     ssd_register_client.cpp
     engram/engram_store.cpp)
+
+if(BUILD_UNIT_TESTS)
+  list(APPEND MOONCAKE_STORE_SOURCES nvme_kv_executor_stub.cpp)
+endif()
 
 set(EXTRA_LIBS "")
 set(SPDK_STATIC_LIBS "")
@@ -173,10 +185,38 @@ endif()
 find_library(URING_LIB uring PATHS /usr/lib /usr/lib64 /usr/local/lib
                                    /usr/local/lib64)
 find_path(URING_INCLUDE liburing.h PATHS /usr/include /usr/local/include)
+set(MOONCAKE_HAVE_NVME_URING_CMD OFF)
 if(URING_LIB AND URING_INCLUDE)
   message(STATUS "io_uring: Enabled for mooncake_store")
   list(APPEND MOONCAKE_STORE_SOURCES uring_file.cpp)
   list(APPEND EXTRA_LIBS ${URING_LIB})
+
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_INCLUDES_SAVE ${CMAKE_REQUIRED_INCLUDES})
+  set(CMAKE_REQUIRED_INCLUDES ${URING_INCLUDE})
+  check_cxx_source_compiles(
+    "
+#include <liburing.h>
+#include <linux/nvme_ioctl.h>
+int main() {
+    struct nvme_uring_cmd cmd{};
+    io_uring_sqe sqe{};
+    sqe.cmd_op = NVME_URING_CMD_IO;
+    (void)sqe.cmd;
+    io_uring_cqe cqe{};
+    (void)cqe.big_cqe;
+    unsigned flags = IORING_OP_URING_CMD | IORING_SETUP_CQE32;
+    return static_cast<int>(flags) + cmd.opcode;
+}
+"
+    MOONCAKE_NVME_URING_CMD_COMPILES)
+  set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_SAVE})
+  if(MOONCAKE_NVME_URING_CMD_COMPILES)
+    set(MOONCAKE_HAVE_NVME_URING_CMD ON)
+    message(STATUS "io_uring: NVMe uring command support enabled")
+  else()
+    message(STATUS "io_uring: NVMe uring command support unavailable, NVMe KV io_uring executor disabled")
+  endif()
 else()
   message(STATUS "io_uring: Disabled (liburing not found)")
 endif()
@@ -277,6 +317,10 @@ endif()
 # The cache_allocator library
 include_directories(${Python3_INCLUDE_DIRS})
 add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
+if(BUILD_UNIT_TESTS)
+  target_compile_definitions(mooncake_store
+                             PRIVATE MOONCAKE_ENABLE_NVME_KV_TEST_STUB=1)
+endif()
 if(KV_EVENTS_ZMQ_FOUND)
   target_compile_definitions(mooncake_store PRIVATE MOONCAKE_ENABLE_KV_EVENTS=1)
 endif()
@@ -321,6 +365,9 @@ endif()
 if(URING_LIB AND URING_INCLUDE)
   target_compile_definitions(mooncake_store PUBLIC USE_URING)
   target_include_directories(mooncake_store PRIVATE ${URING_INCLUDE})
+  if(MOONCAKE_HAVE_NVME_URING_CMD)
+    target_compile_definitions(mooncake_store PRIVATE MOONCAKE_HAVE_NVME_URING_CMD=1)
+  endif()
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -14,6 +14,14 @@ set(MOONCAKE_STORE_SOURCES
     mmap_arena.cpp
     master_metric_manager.cpp
     storage_backend.cpp
+    nvme_kv_backend.cpp
+    nvme_kv_connector.cpp
+    nvme_kv_executor_io_uring.cpp
+    nvme_kv_executor_ioctl.cpp
+    nvme_kv_executor_util.cpp
+    nvme_kv_key_codec.cpp
+    nvme_kv_key_conflict_policy.cpp
+    nvme_kv_object_layout.cpp
     thread_pool.cpp
     etcd_helper.cpp
     segment.cpp
@@ -80,6 +88,10 @@ set(MOONCAKE_STORE_SOURCES
     memory_alloc.cpp
     ssd_register_client.cpp
     engram/engram_store.cpp)
+
+if(BUILD_UNIT_TESTS)
+  list(APPEND MOONCAKE_STORE_SOURCES nvme_kv_executor_stub.cpp)
+endif()
 
 set(EXTRA_LIBS "")
 set(SPDK_STATIC_LIBS "")
@@ -177,10 +189,38 @@ endif()
 find_library(URING_LIB uring PATHS /usr/lib /usr/lib64 /usr/local/lib
                                    /usr/local/lib64)
 find_path(URING_INCLUDE liburing.h PATHS /usr/include /usr/local/include)
+set(MOONCAKE_HAVE_NVME_URING_CMD OFF)
 if(URING_LIB AND URING_INCLUDE)
   message(STATUS "io_uring: Enabled for mooncake_store")
   list(APPEND MOONCAKE_STORE_SOURCES uring_file.cpp)
   list(APPEND EXTRA_LIBS ${URING_LIB})
+
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_INCLUDES_SAVE ${CMAKE_REQUIRED_INCLUDES})
+  set(CMAKE_REQUIRED_INCLUDES ${URING_INCLUDE})
+  check_cxx_source_compiles(
+    "
+#include <liburing.h>
+#include <linux/nvme_ioctl.h>
+int main() {
+    struct nvme_uring_cmd cmd{};
+    io_uring_sqe sqe{};
+    sqe.cmd_op = NVME_URING_CMD_IO;
+    (void)sqe.cmd;
+    io_uring_cqe cqe{};
+    (void)cqe.big_cqe;
+    unsigned flags = IORING_OP_URING_CMD | IORING_SETUP_CQE32;
+    return static_cast<int>(flags) + cmd.opcode;
+}
+"
+    MOONCAKE_NVME_URING_CMD_COMPILES)
+  set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_SAVE})
+  if(MOONCAKE_NVME_URING_CMD_COMPILES)
+    set(MOONCAKE_HAVE_NVME_URING_CMD ON)
+    message(STATUS "io_uring: NVMe uring command support enabled")
+  else()
+    message(STATUS "io_uring: NVMe uring command support unavailable, NVMe KV io_uring executor disabled")
+  endif()
 else()
   message(STATUS "io_uring: Disabled (liburing not found)")
 endif()
@@ -281,6 +321,10 @@ endif()
 # The cache_allocator library
 include_directories(${Python3_INCLUDE_DIRS})
 add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
+if(BUILD_UNIT_TESTS)
+  target_compile_definitions(mooncake_store
+                             PRIVATE MOONCAKE_ENABLE_NVME_KV_TEST_STUB=1)
+endif()
 if(KV_EVENTS_ZMQ_FOUND)
   target_compile_definitions(mooncake_store PRIVATE MOONCAKE_ENABLE_KV_EVENTS=1)
 endif()
@@ -325,6 +369,9 @@ endif()
 if(URING_LIB AND URING_INCLUDE)
   target_compile_definitions(mooncake_store PUBLIC USE_URING)
   target_include_directories(mooncake_store PRIVATE ${URING_INCLUDE})
+  if(MOONCAKE_HAVE_NVME_URING_CMD)
+    target_compile_definitions(mooncake_store PRIVATE MOONCAKE_HAVE_NVME_URING_CMD=1)
+  endif()
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -100,6 +100,8 @@ FileStorageConfig FileStorageConfig::FromEnvironment() {
     } else if (storage_backend_descriptor == "distributed_storage_backend") {
         config.storage_backend_type = StorageBackendType::kDistributed;
         config.enable_dfs = true;
+    } else if (storage_backend_descriptor == "nvme_kv_storage_backend") {
+        config.storage_backend_type = StorageBackendType::kNvmeKv;
     } else {
         LOG(ERROR) << "Unknown storage backend.";
     }

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -98,6 +98,8 @@ FileStorageConfig FileStorageConfig::FromEnvironment() {
         config.storage_backend_type = StorageBackendType::kOffsetAllocator;
     } else if (storage_backend_descriptor == "distributed_storage_backend") {
         config.storage_backend_type = StorageBackendType::kDistributed;
+    } else if (storage_backend_descriptor == "nvme_kv_storage_backend") {
+        config.storage_backend_type = StorageBackendType::kNvmeKv;
     } else {
         LOG(ERROR) << "Unknown storage backend.";
     }

--- a/mooncake-store/src/nvme_kv_backend.cpp
+++ b/mooncake-store/src/nvme_kv_backend.cpp
@@ -1,0 +1,1556 @@
+#include "nvme_kv_backend.h"
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <exception>
+#include <latch>
+#include <limits>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "nvme_kv_executor_util.h"
+#include "nvme_kv_key_codec.h"
+#include "nvme_kv_key_conflict_policy.h"
+#include "nvme_kv_object_layout.h"
+
+namespace mooncake {
+
+namespace {
+
+constexpr uint32_t kMinMaxValueSize = sizeof(NvmeKvObjectHeader) + 1;
+constexpr size_t kDefaultMaxIoConcurrency = 256;
+constexpr size_t kDefaultIoConcurrency = 18;
+constexpr size_t kDefaultPrepareConcurrency = 12;
+constexpr size_t kDefaultBatchSubmitConcurrency = 6;
+constexpr size_t kDefaultRootSubmitConcurrency = 1;
+constexpr size_t kDefaultReadPlanBatchSize = 8;
+
+size_t PositiveSizeEnvOr(const char *name, size_t fallback, size_t maximum) {
+    const uint32_t parsed = ParseNvmeKvU32EnvOr(name, 0);
+    return parsed == 0 ? fallback : std::min<size_t>(parsed, maximum);
+}
+
+size_t MaxIoConcurrency() {
+    return PositiveSizeEnvOr("MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY",
+                             kDefaultMaxIoConcurrency, UINT32_MAX);
+}
+
+std::optional<size_t> ConfiguredIoConcurrency(size_t max_io_concurrency) {
+    const char *configured = std::getenv("MOONCAKE_NVME_KV_IO_CONCURRENCY");
+    if (configured == nullptr || configured[0] == '\0') {
+        return std::nullopt;
+    }
+    const size_t parsed = PositiveSizeEnvOr("MOONCAKE_NVME_KV_IO_CONCURRENCY",
+                                            0, max_io_concurrency);
+    return parsed == 0 ? std::nullopt : std::optional<size_t>(parsed);
+}
+
+class IndexQueue {
+   public:
+    bool Push(size_t index) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (closed_) {
+            return false;
+        }
+        queue_.push_back(index);
+        not_empty_.notify_one();
+        return true;
+    }
+
+    bool Pop(size_t &index) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        not_empty_.wait(lock, [&]() { return closed_ || !queue_.empty(); });
+        if (queue_.empty()) {
+            return false;
+        }
+        index = queue_.front();
+        queue_.pop_front();
+        return true;
+    }
+
+    void Close() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        closed_ = true;
+        not_empty_.notify_all();
+    }
+
+   private:
+    std::mutex mutex_;
+    std::condition_variable not_empty_;
+    std::deque<size_t> queue_;
+    bool closed_ = false;
+};
+
+bool CanRetrieveDirectlyInto(const char *data, uint32_t size) {
+    if (data == nullptr || size == 0) {
+        return false;
+    }
+    const uint32_t alignment = NvmeKvTransferAlignmentBytes();
+    return alignment != 0 && size % alignment == 0 &&
+           reinterpret_cast<uintptr_t>(data) % alignment == 0;
+}
+
+std::string_view BuildPayloadView(const std::vector<Slice> &slices,
+                                  size_t payload_size, std::string &storage) {
+    if (slices.size() == 1) {
+        const auto &slice = slices.front();
+        return slice.size == 0
+                   ? std::string_view{}
+                   : std::string_view(reinterpret_cast<const char *>(slice.ptr),
+                                      slice.size);
+    }
+    storage.reserve(payload_size);
+    for (const auto &slice : slices) {
+        storage.append(reinterpret_cast<const char *>(slice.ptr), slice.size);
+    }
+    return storage;
+}
+
+size_t ReadPlanBatchSize() {
+    return PositiveSizeEnvOr("MOONCAKE_NVME_KV_READ_PLAN_BATCH_SIZE",
+                             kDefaultReadPlanBatchSize, 1024);
+}
+
+std::optional<std::vector<size_t>> ValidateChunkRecords(
+    const NvmeKvObjectIdentity &identity, uint32_t slot,
+    size_t expected_payload_size,
+    const std::vector<NvmeKvManifestChunkRecord> &records) {
+    if (records.empty()) {
+        return std::nullopt;
+    }
+    std::vector<size_t> offsets;
+    offsets.reserve(records.size());
+    size_t offset = 0;
+    for (size_t index = 0; index < records.size(); ++index) {
+        const auto &record = records[index];
+        if (record.payload_size == 0 || offset > expected_payload_size ||
+            record.payload_size > expected_payload_size - offset ||
+            record.physical_key !=
+                EncodeNvmeKvChunkPhysicalKey(
+                    identity, static_cast<uint32_t>(index), slot)) {
+            return std::nullopt;
+        }
+        offsets.push_back(offset);
+        offset += record.payload_size;
+    }
+    return offset == expected_payload_size
+               ? std::optional<std::vector<size_t>>(std::move(offsets))
+               : std::nullopt;
+}
+
+struct ResolvedRoot {
+    NvmeKvPhysicalKey physical_key{};
+    uint32_t slot = 0;
+    std::string object_blob;
+};
+
+tl::expected<std::optional<ResolvedRoot>, ErrorCode> ResolveRoot(
+    NvmeKvConnector &connector, const std::string &logical_key) {
+    const NvmeKvObjectIdentity identity{.logical_key = logical_key};
+    for (uint32_t slot = 0; slot < kNvmeKvMaxPhysicalKeySlots; ++slot) {
+        const auto physical_key = EncodeNvmeKvPhysicalKey(identity, slot);
+        auto object_res = connector.Retrieve(physical_key);
+        if (!object_res) {
+            if (object_res.error() == ErrorCode::OBJECT_NOT_FOUND) {
+                continue;
+            }
+            return tl::make_unexpected(object_res.error());
+        }
+
+        NvmeKvObjectHeader header{};
+        std::string_view identity_metadata;
+        std::string_view payload;
+        if (!ParseNvmeKvObjectBlob(object_res.value(), header,
+                                   identity_metadata, payload)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+
+        NvmeKvStoredIdentityView stored_identity{};
+        if (!ParseNvmeKvStoredIdentity(identity_metadata, stored_identity)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        if (stored_identity.logical_key != logical_key) {
+            continue;
+        }
+        if (stored_identity.resolved_slot != slot ||
+            !NvmeKvKeyConflictPolicy::ValidateResolvedRootPlacement(
+                identity, stored_identity, physical_key)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        return std::optional<ResolvedRoot>(
+            ResolvedRoot{physical_key, slot, std::move(object_res.value())});
+    }
+    return std::nullopt;
+}
+
+}  // namespace
+
+NvmeKvStorageBackend::NvmeKvStorageBackend(
+    const FileStorageConfig &file_storage_config_)
+    : StorageBackendInterface(file_storage_config_) {}
+
+void NvmeKvStorageBackend::InitIoWorkers() {
+    const size_t max_io_concurrency = MaxIoConcurrency();
+    if (auto configured = ConfiguredIoConcurrency(max_io_concurrency);
+        configured.has_value()) {
+        io_parallelism_ = *configured;
+    } else {
+        const size_t queue_depth =
+            std::max<size_t>(1, connector_->GetCapabilities().queue_depth);
+        io_parallelism_ = std::min(
+            queue_depth, std::min(kDefaultIoConcurrency, max_io_concurrency));
+    }
+    if (io_parallelism_ > 1) {
+        io_workers_ = std::make_unique<ThreadPool>(io_parallelism_);
+    }
+    const size_t max_submit_concurrency =
+        io_parallelism_ > 1 ? io_parallelism_ - 1 : 1;
+    batch_submit_concurrency_ = PositiveSizeEnvOr(
+        "MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY",
+        std::min(kDefaultBatchSubmitConcurrency, max_submit_concurrency),
+        max_submit_concurrency);
+    root_submit_concurrency_ = PositiveSizeEnvOr(
+        "MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY",
+        std::min(kDefaultRootSubmitConcurrency, max_submit_concurrency),
+        max_submit_concurrency);
+    const size_t max_prepare_concurrency =
+        io_parallelism_ > batch_submit_concurrency_
+            ? io_parallelism_ - batch_submit_concurrency_
+            : 1;
+    prepare_concurrency_ = PositiveSizeEnvOr(
+        "MOONCAKE_NVME_KV_PREPARE_CONCURRENCY",
+        std::min(kDefaultPrepareConcurrency, max_prepare_concurrency),
+        max_prepare_concurrency);
+    if (batch_submit_concurrency_ > 1) {
+        submit_workers_ =
+            std::make_unique<ThreadPool>(batch_submit_concurrency_);
+        root_submit_workers_ =
+            std::make_unique<ThreadPool>(root_submit_concurrency_);
+    }
+    LOG(INFO) << "NVMe KV backend I/O concurrency: " << io_parallelism_
+              << " (max " << max_io_concurrency
+              << "), batch submit concurrency: " << batch_submit_concurrency_
+              << ", root submit concurrency: " << root_submit_concurrency_
+              << ", prepare concurrency: " << prepare_concurrency_;
+}
+
+void NvmeKvStorageBackend::RunParallelIo(
+    size_t item_count, const std::function<void(size_t)> &task,
+    size_t max_inflight) {
+    if (item_count == 0) {
+        return;
+    }
+    const size_t concurrency_limit =
+        max_inflight == 0 ? io_parallelism_
+                          : std::min(io_parallelism_, max_inflight);
+    const size_t worker_count = std::min(item_count, concurrency_limit);
+    if (worker_count <= 1 || io_workers_ == nullptr) {
+        for (size_t i = 0; i < item_count; ++i) {
+            task(i);
+        }
+        return;
+    }
+
+    std::atomic<size_t> next_index{0};
+    std::latch completed(static_cast<std::ptrdiff_t>(worker_count));
+    std::mutex exception_mutex;
+    std::exception_ptr first_exception;
+    std::exception_ptr enqueue_exception;
+
+    size_t enqueued = 0;
+    try {
+        for (; enqueued < worker_count; ++enqueued) {
+            io_workers_->enqueue([&]() {
+                try {
+                    while (true) {
+                        const size_t index =
+                            next_index.fetch_add(1, std::memory_order_relaxed);
+                        if (index >= item_count) {
+                            break;
+                        }
+                        task(index);
+                    }
+                } catch (...) {
+                    std::lock_guard<std::mutex> lock(exception_mutex);
+                    if (first_exception == nullptr) {
+                        first_exception = std::current_exception();
+                    }
+                }
+                completed.count_down();
+            });
+        }
+    } catch (...) {
+        enqueue_exception = std::current_exception();
+        completed.count_down(
+            static_cast<std::ptrdiff_t>(worker_count - enqueued));
+    }
+
+    completed.wait();
+    if (enqueue_exception != nullptr) {
+        std::rethrow_exception(enqueue_exception);
+    }
+    if (first_exception != nullptr) {
+        std::rethrow_exception(first_exception);
+    }
+}
+
+void NvmeKvStorageBackend::RunPipelinedIo(
+    size_t item_count, const std::function<void(size_t)> &io_task,
+    const std::function<void(size_t)> &completion_task) {
+    if (item_count == 0) {
+        return;
+    }
+    const size_t worker_count = std::min(item_count, batch_submit_concurrency_);
+    if (worker_count <= 1 || submit_workers_ == nullptr ||
+        io_workers_ == nullptr) {
+        for (size_t index = 0; index < item_count; ++index) {
+            io_task(index);
+            completion_task(index);
+        }
+        return;
+    }
+
+    std::atomic<size_t> next_index{0};
+    std::vector<std::exception_ptr> item_exceptions(item_count);
+    std::latch items_completed(static_cast<std::ptrdiff_t>(item_count));
+    std::latch workers_completed(static_cast<std::ptrdiff_t>(worker_count));
+    std::exception_ptr enqueue_exception;
+    size_t enqueued_workers = 0;
+    try {
+        for (; enqueued_workers < worker_count; ++enqueued_workers) {
+            submit_workers_->enqueue([&]() {
+                while (true) {
+                    const size_t index =
+                        next_index.fetch_add(1, std::memory_order_relaxed);
+                    if (index >= item_count) {
+                        break;
+                    }
+                    try {
+                        io_task(index);
+                    } catch (...) {
+                        item_exceptions[index] = std::current_exception();
+                        items_completed.count_down();
+                        continue;
+                    }
+                    try {
+                        io_workers_->enqueue([&, index]() {
+                            try {
+                                completion_task(index);
+                            } catch (...) {
+                                item_exceptions[index] =
+                                    std::current_exception();
+                            }
+                            items_completed.count_down();
+                        });
+                    } catch (...) {
+                        item_exceptions[index] = std::current_exception();
+                        items_completed.count_down();
+                    }
+                }
+                workers_completed.count_down();
+            });
+        }
+    } catch (...) {
+        enqueue_exception = std::current_exception();
+        workers_completed.count_down(
+            static_cast<std::ptrdiff_t>(worker_count - enqueued_workers));
+    }
+
+    if (enqueued_workers == 0) {
+        std::rethrow_exception(enqueue_exception);
+    }
+
+    items_completed.wait();
+    workers_completed.wait();
+    if (enqueue_exception != nullptr) {
+        std::rethrow_exception(enqueue_exception);
+    }
+    for (const auto &item_exception : item_exceptions) {
+        if (item_exception != nullptr) {
+            std::rethrow_exception(item_exception);
+        }
+    }
+}
+
+std::shared_ptr<const NvmeKvStorageBackend::CachedManifest>
+NvmeKvStorageBackend::FindCachedManifest(const std::string &key,
+                                         size_t payload_size) const {
+    std::shared_lock<std::shared_mutex> lock(manifest_cache_mutex_);
+    const auto it = manifest_cache_.find(key);
+    if (it == manifest_cache_.end() ||
+        it->second->payload_size != payload_size) {
+        return nullptr;
+    }
+    return it->second;
+}
+
+std::shared_ptr<const NvmeKvStorageBackend::CachedManifest>
+NvmeKvStorageBackend::CacheManifest(
+    const std::string &key, size_t payload_size, uint32_t resolved_slot,
+    const std::vector<NvmeKvManifestChunkRecord> &chunk_records) {
+    if (payload_size > std::numeric_limits<uint32_t>::max()) {
+        return nullptr;
+    }
+    const NvmeKvObjectIdentity identity{.logical_key = key};
+    auto chunk_offsets = ValidateChunkRecords(identity, resolved_slot,
+                                              payload_size, chunk_records);
+    if (!chunk_offsets) {
+        return nullptr;
+    }
+    auto manifest = std::make_shared<const CachedManifest>(CachedManifest{
+        .resolved_slot = resolved_slot,
+        .payload_size = static_cast<uint32_t>(payload_size),
+        .chunk_records = chunk_records,
+        .chunk_offsets = std::move(*chunk_offsets),
+    });
+    std::unique_lock<std::shared_mutex> lock(manifest_cache_mutex_);
+    auto [it, inserted] = manifest_cache_.try_emplace(key, manifest);
+    if (!inserted) {
+        if (it->second->payload_size != payload_size ||
+            it->second->resolved_slot != resolved_slot) {
+            return nullptr;
+        }
+        return it->second;
+    }
+    return manifest;
+}
+
+void NvmeKvStorageBackend::CacheManifestAfterWrite(
+    const std::string &key, size_t payload_size, uint32_t resolved_slot,
+    const std::vector<NvmeKvManifestChunkRecord> &chunk_records) noexcept {
+    try {
+        (void)CacheManifest(key, payload_size, resolved_slot, chunk_records);
+    } catch (...) {
+        LOG(WARNING) << "NVMe KV could not cache manifest for " << key;
+    }
+}
+
+void NvmeKvStorageBackend::StoreBatchParallel(
+    std::vector<NvmeKvCommandExecutor::StoreRequest> &requests) {
+    if (requests.empty()) {
+        return;
+    }
+    auto connector = connector_;
+    if (connector == nullptr) {
+        for (auto &request : requests) {
+            request.result = tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        return;
+    }
+
+    const size_t worker_count =
+        std::min(batch_submit_concurrency_, requests.size());
+    RunParallelIo(
+        worker_count,
+        [&](size_t worker_index) {
+            std::vector<size_t> request_indices;
+            std::vector<NvmeKvCommandExecutor::StoreRequest> worker_requests;
+            const size_t worker_request_count =
+                (requests.size() + worker_count - 1 - worker_index) /
+                worker_count;
+            request_indices.reserve(worker_request_count);
+            worker_requests.reserve(worker_request_count);
+            for (size_t request_index = worker_index;
+                 request_index < requests.size();
+                 request_index += worker_count) {
+                request_indices.push_back(request_index);
+                worker_requests.push_back(requests[request_index]);
+            }
+            connector->StoreBatch(worker_requests);
+            for (size_t index = 0; index < worker_requests.size(); ++index) {
+                requests[request_indices[index]].result =
+                    std::move(worker_requests[index].result);
+            }
+        },
+        worker_count);
+}
+
+tl::expected<void, ErrorCode> NvmeKvStorageBackend::InitDevice() {
+    auto connector = std::make_shared<NvmeKvConnector>(file_storage_config_);
+    auto init_res = connector->Init();
+    if (!init_res) {
+        LOG(ERROR) << "Failed to initialize NVMe KV device: "
+                   << toString(init_res.error());
+        return init_res;
+    }
+    connector_ = std::move(connector);
+    return {};
+}
+
+tl::expected<void, ErrorCode> NvmeKvStorageBackend::Init() {
+    bool expected = false;
+    if (!initialized_.compare_exchange_strong(expected, true,
+                                              std::memory_order_acq_rel)) {
+        LOG(ERROR) << "NVMe KV backend already initialized";
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    auto init_res = InitDevice();
+    if (!init_res) {
+        initialized_.store(false, std::memory_order_release);
+        return init_res;
+    }
+    total_size_.store(0, std::memory_order_relaxed);
+    total_keys_.store(0, std::memory_order_relaxed);
+    InitIoWorkers();
+    return {};
+}
+
+tl::expected<int64_t, ErrorCode> NvmeKvStorageBackend::BatchOffload(
+    const std::unordered_map<std::string, std::vector<Slice>> &batch_object,
+    std::function<ErrorCode(const std::vector<std::string> &keys,
+                            std::vector<StorageObjectMetadata> &metadatas)>
+        complete_handler,
+    NvmeKvStorageBackend::EvictionHandler eviction_handler) {
+    (void)eviction_handler;
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    if (batch_object.empty()) {
+        return tl::make_unexpected(ErrorCode::INVALID_KEY);
+    }
+
+    struct OffloadPlan {
+        std::string key;
+        const std::vector<Slice> *slices = nullptr;
+        size_t payload_size = 0;
+    };
+    std::vector<OffloadPlan> plans;
+    plans.reserve(batch_object.size());
+    int64_t batch_total_size = 0;
+    for (const auto &[key, slices] : batch_object) {
+        if (slices.empty()) {
+            continue;
+        }
+        size_t payload_size = 0;
+        for (const auto &slice : slices) {
+            if (slice.size >
+                std::numeric_limits<size_t>::max() - payload_size) {
+                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+            }
+            payload_size += slice.size;
+        }
+        if (payload_size >
+                static_cast<size_t>(std::numeric_limits<int64_t>::max()) ||
+            batch_total_size > std::numeric_limits<int64_t>::max() -
+                                   static_cast<int64_t>(payload_size)) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        batch_total_size += static_cast<int64_t>(payload_size);
+        plans.push_back(OffloadPlan{key, &slices, payload_size});
+    }
+
+    if (plans.empty()) {
+        return 0;
+    }
+
+    if (total_keys_.load(std::memory_order_relaxed) +
+            static_cast<int64_t>(plans.size()) >
+        file_storage_config_.total_keys_limit) {
+        return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
+    }
+    if (total_size_.load(std::memory_order_relaxed) + batch_total_size >
+        file_storage_config_.total_size_limit) {
+        return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
+    }
+    auto enable_offloading_res = IsEnableOffloading();
+    if (!enable_offloading_res) {
+        return tl::make_unexpected(enable_offloading_res.error());
+    }
+    if (!enable_offloading_res.value()) {
+        return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
+    }
+
+    std::vector<tl::expected<OffloadResult, ErrorCode>> results;
+    results.reserve(plans.size());
+    for (size_t i = 0; i < plans.size(); ++i) {
+        results.emplace_back(OffloadResult{});
+    }
+
+    struct PreparedOffload {
+        std::string payload_storage;
+        std::string_view payload;
+        std::optional<NvmeKvKeyConflictPolicy::WritePlan> write_plan;
+        std::vector<PhysicalKey> written_chunk_keys;
+        bool root_written = false;
+        bool needs_fallback = false;
+    };
+    std::vector<PreparedOffload> prepared(plans.size());
+
+    const auto prepare_one = [&](size_t index) {
+        const auto &plan = plans[index];
+        auto &item = prepared[index];
+        item.payload = BuildPayloadView(*plan.slices, plan.payload_size,
+                                        item.payload_storage);
+        auto write_plan = NvmeKvKeyConflictPolicy::BuildWritePlan(
+            NvmeKvObjectIdentity{.logical_key = plan.key}, item.payload, 0,
+            std::max(connector_->GetCapabilities().effective_max_value_size,
+                     kMinMaxValueSize));
+        if (!write_plan) {
+            results[index] = tl::make_unexpected(write_plan.error());
+            return;
+        }
+        item.write_plan.emplace(std::move(write_plan.value()));
+    };
+
+    struct StoreContext {
+        size_t plan_index = 0;
+        size_t chunk_index = 0;
+    };
+    const auto apply_chunk_results =
+        [&prepared](std::vector<NvmeKvCommandExecutor::StoreRequest> &requests,
+                    const std::vector<StoreContext> &contexts) {
+            for (size_t request_index = 0; request_index < requests.size();
+                 ++request_index) {
+                const auto &context = contexts[request_index];
+                auto &item = prepared[context.plan_index];
+                if (requests[request_index].result) {
+                    item.written_chunk_keys.push_back(
+                        item.write_plan->chunk_values[context.chunk_index]
+                            .first);
+                } else {
+                    item.needs_fallback = true;
+                }
+            }
+        };
+
+    bool roots_pipelined = false;
+    const auto store_chunks = [&]() {
+        if (io_workers_ == nullptr || submit_workers_ == nullptr ||
+            root_submit_workers_ == nullptr || batch_submit_concurrency_ <= 1) {
+            RunParallelIo(plans.size(), prepare_one, prepare_concurrency_);
+            std::vector<NvmeKvCommandExecutor::StoreRequest> chunk_requests;
+            std::vector<StoreContext> chunk_contexts;
+            for (size_t plan_index = 0; plan_index < plans.size();
+                 ++plan_index) {
+                auto &item = prepared[plan_index];
+                if (!item.write_plan || item.write_plan->store_inline) {
+                    continue;
+                }
+                for (size_t chunk_index = 0;
+                     chunk_index < item.write_plan->chunk_values.size();
+                     ++chunk_index) {
+                    const auto &[chunk_key, chunk_value] =
+                        item.write_plan->chunk_values[chunk_index];
+                    NvmeKvCommandExecutor::StoreRequest request;
+                    request.key = chunk_key;
+                    request.value = chunk_value;
+                    chunk_requests.push_back(request);
+                    chunk_contexts.push_back(
+                        StoreContext{plan_index, chunk_index});
+                }
+            }
+            StoreBatchParallel(chunk_requests);
+            apply_chunk_results(chunk_requests, chunk_contexts);
+            return;
+        }
+
+        const size_t lane_count =
+            std::min(batch_submit_concurrency_, plans.size());
+        const size_t root_lane_count =
+            std::min(root_submit_concurrency_, plans.size());
+        roots_pipelined = true;
+        std::vector<std::unique_ptr<IndexQueue>> queues;
+        queues.reserve(lane_count);
+        for (size_t lane = 0; lane < lane_count; ++lane) {
+            queues.push_back(std::make_unique<IndexQueue>());
+        }
+
+        const auto close_queues = [&]() {
+            for (auto &queue : queues) {
+                queue->Close();
+            }
+        };
+        IndexQueue root_queue;
+        std::mutex consumer_error_mutex;
+        std::exception_ptr consumer_error;
+        const auto set_consumer_error = [&]() {
+            std::lock_guard<std::mutex> lock(consumer_error_mutex);
+            if (consumer_error == nullptr) {
+                consumer_error = std::current_exception();
+            }
+            close_queues();
+            root_queue.Close();
+        };
+        std::latch consumers_done(static_cast<std::ptrdiff_t>(lane_count));
+        std::latch root_consumers_done(
+            static_cast<std::ptrdiff_t>(root_lane_count));
+
+        size_t enqueued_root_consumers = 0;
+        try {
+            for (; enqueued_root_consumers < root_lane_count;
+                 ++enqueued_root_consumers) {
+                root_submit_workers_->enqueue([&]() {
+                    try {
+                        auto connector = connector_;
+                        if (connector == nullptr) {
+                            throw std::runtime_error(
+                                "NVMe KV connector is unavailable");
+                        }
+                        const size_t queue_depth = std::max<size_t>(
+                            1, connector->GetCapabilities().queue_depth);
+                        std::vector<NvmeKvCommandExecutor::StoreRequest>
+                            requests;
+                        std::vector<size_t> contexts;
+                        requests.reserve(queue_depth);
+                        contexts.reserve(queue_depth);
+                        const auto flush = [&]() {
+                            if (requests.empty()) {
+                                return;
+                            }
+                            connector->StoreBatch(requests);
+                            for (size_t index = 0; index < requests.size();
+                                 ++index) {
+                                auto &item = prepared[contexts[index]];
+                                if (requests[index].result) {
+                                    item.root_written = true;
+                                } else {
+                                    item.needs_fallback = true;
+                                }
+                            }
+                            requests.clear();
+                            contexts.clear();
+                        };
+
+                        size_t plan_index = 0;
+                        while (root_queue.Pop(plan_index)) {
+                            auto &item = prepared[plan_index];
+                            NvmeKvCommandExecutor::StoreRequest request;
+                            request.key = item.write_plan->root_key;
+                            request.value = item.write_plan->root_blob;
+                            requests.push_back(request);
+                            contexts.push_back(plan_index);
+                            if (requests.size() == queue_depth) {
+                                flush();
+                            }
+                        }
+                        flush();
+                    } catch (...) {
+                        set_consumer_error();
+                    }
+                    root_consumers_done.count_down();
+                });
+            }
+        } catch (...) {
+            close_queues();
+            root_queue.Close();
+            root_consumers_done.count_down(static_cast<std::ptrdiff_t>(
+                root_lane_count - enqueued_root_consumers));
+            root_consumers_done.wait();
+            throw;
+        }
+
+        size_t enqueued_consumers = 0;
+        try {
+            for (; enqueued_consumers < lane_count; ++enqueued_consumers) {
+                submit_workers_->enqueue([&, lane = enqueued_consumers]() {
+                    try {
+                        auto connector = connector_;
+                        if (connector == nullptr) {
+                            throw std::runtime_error(
+                                "NVMe KV connector is unavailable");
+                        }
+                        const size_t queue_depth = std::max<size_t>(
+                            1, connector->GetCapabilities().queue_depth);
+                        std::vector<NvmeKvCommandExecutor::StoreRequest>
+                            chunk_requests;
+                        std::vector<StoreContext> chunk_contexts;
+                        chunk_requests.reserve(queue_depth);
+                        chunk_contexts.reserve(queue_depth);
+                        const auto flush_chunks = [&]() {
+                            if (chunk_requests.empty()) {
+                                return;
+                            }
+                            connector->StoreBatch(chunk_requests);
+                            apply_chunk_results(chunk_requests, chunk_contexts);
+                            for (const auto &context : chunk_contexts) {
+                                auto &item = prepared[context.plan_index];
+                                if (context.chunk_index + 1 ==
+                                        item.write_plan->chunk_values.size() &&
+                                    !item.needs_fallback) {
+                                    if (!root_queue.Push(context.plan_index)) {
+                                        item.needs_fallback = true;
+                                    }
+                                }
+                            }
+                            chunk_requests.clear();
+                            chunk_contexts.clear();
+                        };
+
+                        size_t plan_index = 0;
+                        while (queues[lane]->Pop(plan_index)) {
+                            auto &item = prepared[plan_index];
+                            for (size_t chunk_index = 0;
+                                 chunk_index <
+                                 item.write_plan->chunk_values.size();
+                                 ++chunk_index) {
+                                const auto &[chunk_key, chunk_value] =
+                                    item.write_plan->chunk_values[chunk_index];
+                                NvmeKvCommandExecutor::StoreRequest request;
+                                request.key = chunk_key;
+                                request.value = chunk_value;
+                                chunk_requests.push_back(request);
+                                chunk_contexts.push_back(
+                                    StoreContext{plan_index, chunk_index});
+                                if (chunk_requests.size() == queue_depth) {
+                                    flush_chunks();
+                                }
+                            }
+                        }
+                        flush_chunks();
+                    } catch (...) {
+                        set_consumer_error();
+                    }
+                    consumers_done.count_down();
+                });
+            }
+        } catch (...) {
+            close_queues();
+            root_queue.Close();
+            consumers_done.count_down(
+                static_cast<std::ptrdiff_t>(lane_count - enqueued_consumers));
+            consumers_done.wait();
+            root_consumers_done.wait();
+            throw;
+        }
+
+        std::exception_ptr producer_error;
+        try {
+            RunParallelIo(
+                plans.size(),
+                [&](size_t index) {
+                    prepare_one(index);
+                    auto &item = prepared[index];
+                    if (!item.write_plan) {
+                        return;
+                    }
+                    const bool queued =
+                        item.write_plan->store_inline
+                            ? root_queue.Push(index)
+                            : queues[index % lane_count]->Push(index);
+                    if (!queued) {
+                        results[index] =
+                            tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+                    }
+                },
+                prepare_concurrency_);
+        } catch (...) {
+            producer_error = std::current_exception();
+        }
+        close_queues();
+        consumers_done.wait();
+        root_queue.Close();
+        root_consumers_done.wait();
+        if (producer_error != nullptr) {
+            std::rethrow_exception(producer_error);
+        }
+        if (consumer_error != nullptr) {
+            std::rethrow_exception(consumer_error);
+        }
+    };
+
+    const auto cleanup_new_writes = [&](size_t plan_index, bool delete_root) {
+        auto connector = connector_;
+        auto &item = prepared[plan_index];
+        if (connector == nullptr || !item.write_plan) {
+            return;
+        }
+        if (delete_root) {
+            auto result = connector->Delete(item.write_plan->root_key);
+            if (!result && result.error() != ErrorCode::OBJECT_NOT_FOUND) {
+                LOG(WARNING) << "NVMe KV failed to clean batched root for "
+                             << plans[plan_index].key
+                             << " error=" << toString(result.error());
+            }
+            item.root_written = false;
+        }
+        for (const auto &chunk_key : item.written_chunk_keys) {
+            auto result = connector->Delete(chunk_key);
+            if (!result && result.error() != ErrorCode::OBJECT_NOT_FOUND) {
+                LOG(WARNING) << "NVMe KV failed to clean batched chunk for "
+                             << plans[plan_index].key
+                             << " error=" << toString(result.error());
+            }
+        }
+        item.written_chunk_keys.clear();
+    };
+
+    ErrorCode worker_error = ErrorCode::OK;
+    try {
+        store_chunks();
+
+        for (size_t plan_index = 0; plan_index < plans.size(); ++plan_index) {
+            if (prepared[plan_index].needs_fallback) {
+                cleanup_new_writes(plan_index, false);
+            }
+        }
+
+        std::vector<NvmeKvCommandExecutor::StoreRequest> root_requests;
+        std::vector<size_t> root_contexts;
+        for (size_t plan_index = 0; plan_index < plans.size(); ++plan_index) {
+            auto &item = prepared[plan_index];
+            if (!item.write_plan || item.needs_fallback || roots_pipelined) {
+                continue;
+            }
+            NvmeKvCommandExecutor::StoreRequest request;
+            request.key = item.write_plan->root_key;
+            request.value = item.write_plan->root_blob;
+            root_requests.push_back(request);
+            root_contexts.push_back(plan_index);
+        }
+        StoreBatchParallel(root_requests);
+        for (size_t request_index = 0; request_index < root_requests.size();
+             ++request_index) {
+            const size_t plan_index = root_contexts[request_index];
+            auto &item = prepared[plan_index];
+            if (!root_requests[request_index].result) {
+                item.needs_fallback = true;
+                cleanup_new_writes(plan_index, false);
+                continue;
+            }
+            item.root_written = true;
+        }
+
+        for (size_t plan_index = 0; plan_index < plans.size(); ++plan_index) {
+            auto &item = prepared[plan_index];
+            if (!item.write_plan || item.needs_fallback || !item.root_written) {
+                continue;
+            }
+            item.root_written = false;
+            item.written_chunk_keys.clear();
+            results[plan_index] =
+                OffloadResult{.stored = true, .inserted = true};
+            if (!item.write_plan->store_inline) {
+                CacheManifestAfterWrite(plans[plan_index].key,
+                                        plans[plan_index].payload_size, 0,
+                                        item.write_plan->manifest_records);
+            }
+        }
+
+        RunParallelIo(plans.size(), [&](size_t index) {
+            if (!prepared[index].needs_fallback) {
+                return;
+            }
+            results[index] = OffloadOne(plans[index].key, *plans[index].slices,
+                                        plans[index].payload_size);
+        });
+    } catch (const std::exception &error) {
+        LOG(ERROR) << "NVMe KV batch offload worker failed: " << error.what();
+        worker_error = ErrorCode::INTERNAL_ERROR;
+    } catch (...) {
+        LOG(ERROR) << "NVMe KV batch offload worker failed";
+        worker_error = ErrorCode::INTERNAL_ERROR;
+    }
+    if (worker_error != ErrorCode::OK) {
+        for (size_t index = 0; index < prepared.size(); ++index) {
+            cleanup_new_writes(index, prepared[index].root_written);
+        }
+    }
+
+    std::vector<std::string> keys;
+    std::vector<StorageObjectMetadata> metadatas;
+    keys.reserve(plans.size());
+    metadatas.reserve(plans.size());
+    int64_t inserted_keys = 0;
+    int64_t inserted_size = 0;
+    ErrorCode first_error = worker_error;
+    for (size_t i = 0; i < plans.size(); ++i) {
+        if (!results[i]) {
+            if (first_error == ErrorCode::OK) {
+                first_error = results[i].error();
+            }
+            continue;
+        }
+        if (!results[i].value().stored) {
+            continue;
+        }
+        if (results[i].value().inserted) {
+            ++inserted_keys;
+            inserted_size += static_cast<int64_t>(plans[i].payload_size);
+        }
+        keys.push_back(plans[i].key);
+        metadatas.emplace_back(StorageObjectMetadata{
+            .bucket_id = 0,
+            .offset = 0,
+            .key_size = static_cast<int64_t>(plans[i].key.size()),
+            .data_size = static_cast<int64_t>(plans[i].payload_size),
+            .transport_endpoint = "",
+        });
+    }
+
+    total_keys_.fetch_add(inserted_keys, std::memory_order_relaxed);
+    total_size_.fetch_add(inserted_size, std::memory_order_relaxed);
+    if (complete_handler != nullptr && !keys.empty()) {
+        const auto error_code = complete_handler(keys, metadatas);
+        if (error_code != ErrorCode::OK) {
+            return tl::make_unexpected(error_code);
+        }
+    }
+    if (first_error != ErrorCode::OK) {
+        return tl::make_unexpected(first_error);
+    }
+    return static_cast<int64_t>(keys.size());
+}
+
+tl::expected<NvmeKvStorageBackend::OffloadResult, ErrorCode>
+NvmeKvStorageBackend::OffloadOne(const std::string &key,
+                                 const std::vector<Slice> &slices,
+                                 size_t payload_size) {
+    if (payload_size >
+        static_cast<size_t>(std::numeric_limits<uint32_t>::max())) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    std::string payload_storage;
+    const std::string_view payload =
+        BuildPayloadView(slices, payload_size, payload_storage);
+
+    auto connector = connector_;
+    if (connector == nullptr) {
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    const uint32_t effective_max_value_size =
+        std::max(connector->GetCapabilities().effective_max_value_size,
+                 kMinMaxValueSize);
+
+    for (uint32_t slot = 0; slot < kNvmeKvMaxPhysicalKeySlots; ++slot) {
+        auto write_plan_res = NvmeKvKeyConflictPolicy::BuildWritePlan(
+            NvmeKvObjectIdentity{.logical_key = key}, payload, slot,
+            effective_max_value_size);
+        if (!write_plan_res) {
+            return tl::make_unexpected(write_plan_res.error());
+        }
+        auto &write_plan = write_plan_res.value();
+        const bool store_inline = write_plan.store_inline;
+        const auto &physical_key = write_plan.root_key;
+        const auto &root_blob = write_plan.root_blob;
+        const auto &chunk_store_values = write_plan.chunk_values;
+
+        std::vector<PhysicalKey> written_chunk_keys;
+        bool root_written = false;
+        const auto cleanup_new_writes = [&]() {
+            if (root_written) {
+                auto delete_res = connector->Delete(physical_key);
+                if (!delete_res &&
+                    delete_res.error() != ErrorCode::OBJECT_NOT_FOUND) {
+                    LOG(WARNING)
+                        << "NVMe KV failed to clean orphan root for " << key
+                        << " key=" << NvmeKvPhysicalKeyToHex(physical_key)
+                        << " error=" << toString(delete_res.error());
+                }
+                root_written = false;
+            }
+            if (written_chunk_keys.empty()) {
+                return;
+            }
+            for (const auto &chunk_key : written_chunk_keys) {
+                auto delete_res = connector->Delete(chunk_key);
+                if (!delete_res &&
+                    delete_res.error() != ErrorCode::OBJECT_NOT_FOUND) {
+                    LOG(WARNING)
+                        << "NVMe KV failed to clean orphan chunk for " << key
+                        << " key=" << NvmeKvPhysicalKeyToHex(chunk_key)
+                        << " error=" << toString(delete_res.error());
+                }
+            }
+            written_chunk_keys.clear();
+        };
+        const auto resolve_existing_root =
+            [&]() -> tl::expected<OffloadResult, ErrorCode> {
+            auto decision_res = NvmeKvKeyConflictPolicy::ResolveExistingObject(
+                *connector, physical_key, root_blob);
+            if (!decision_res) {
+                return tl::make_unexpected(decision_res.error());
+            }
+            if (decision_res.value() ==
+                NvmeKvKeyConflictPolicy::ExistingObjectDecision::kNotFound) {
+                return OffloadResult{};
+            }
+            if (decision_res.value() ==
+                NvmeKvKeyConflictPolicy::ExistingObjectDecision::
+                    kDifferentObject) {
+                return OffloadResult{};
+            }
+            return OffloadResult{.stored = true, .inserted = false};
+        };
+
+        bool write_success = true;
+        bool slot_collision = false;
+        ErrorCode write_error = ErrorCode::OK;
+        if (store_inline) {
+            auto store_res = connector->Store(physical_key, root_blob);
+            if (!store_res) {
+                write_success = false;
+                write_error = store_res.error();
+            } else {
+                root_written = true;
+            }
+        } else {
+            const auto handle_chunk_store_error =
+                [&](const PhysicalKey &chunk_key, std::string_view chunk_blob,
+                    ErrorCode error) -> bool {
+                if (error == ErrorCode::OBJECT_ALREADY_EXISTS) {
+                    auto existing_chunk_res =
+                        NvmeKvKeyConflictPolicy::ResolveExistingObject(
+                            *connector, chunk_key, chunk_blob);
+                    if (existing_chunk_res &&
+                        existing_chunk_res.value() ==
+                            NvmeKvKeyConflictPolicy::ExistingObjectDecision::
+                                kSameObject) {
+                        return true;
+                    }
+                    if (!existing_chunk_res) {
+                        write_error = existing_chunk_res.error();
+                    } else {
+                        write_error = ErrorCode::OBJECT_ALREADY_EXISTS;
+                    }
+                    slot_collision = true;
+                } else {
+                    write_error = error;
+                }
+                write_success = false;
+                cleanup_new_writes();
+                return false;
+            };
+            std::vector<NvmeKvCommandExecutor::StoreRequest> chunk_requests;
+            chunk_requests.reserve(chunk_store_values.size());
+            for (const auto &[chunk_key, chunk_blob] : chunk_store_values) {
+                NvmeKvCommandExecutor::StoreRequest request;
+                request.key = chunk_key;
+                request.value = chunk_blob;
+                chunk_requests.push_back(request);
+            }
+            connector->StoreBatch(chunk_requests);
+
+            for (size_t chunk_index = 0;
+                 chunk_index < chunk_store_values.size(); ++chunk_index) {
+                const auto &[chunk_key, chunk_blob] =
+                    chunk_store_values[chunk_index];
+                const auto &chunk_res = chunk_requests[chunk_index].result;
+                if (!chunk_res) {
+                    if (!handle_chunk_store_error(chunk_key, chunk_blob,
+                                                  chunk_res.error())) {
+                        break;
+                    }
+                    continue;
+                }
+                written_chunk_keys.push_back(chunk_key);
+            }
+            if (write_success) {
+                auto store_res = connector->Store(physical_key, root_blob);
+                if (!store_res) {
+                    write_success = false;
+                    write_error = store_res.error();
+                    cleanup_new_writes();
+                } else {
+                    root_written = true;
+                }
+            }
+        }
+
+        if (!write_success && write_error == ErrorCode::OBJECT_ALREADY_EXISTS) {
+            auto existing_res = resolve_existing_root();
+            if (existing_res && existing_res.value().stored) {
+                if (!store_inline) {
+                    CacheManifestAfterWrite(key, payload_size, slot,
+                                            write_plan.manifest_records);
+                }
+                return existing_res;
+            }
+            if (!existing_res) {
+                write_error = existing_res.error();
+            } else {
+                slot_collision = true;
+                cleanup_new_writes();
+            }
+        }
+
+        if (!write_success) {
+            if (!slot_collision && !store_inline) {
+                cleanup_new_writes();
+            }
+            written_chunk_keys.clear();
+            if (slot_collision) {
+                continue;
+            }
+            return tl::make_unexpected(write_error);
+        }
+
+        if (!store_inline) {
+            CacheManifestAfterWrite(key, payload_size, slot,
+                                    write_plan.manifest_records);
+        }
+        return OffloadResult{.stored = true, .inserted = true};
+    }
+    return OffloadResult{};
+}
+
+tl::expected<void, ErrorCode> NvmeKvStorageBackend::BatchLoad(
+    std::unordered_map<std::string, Slice> &batched_slices) {
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+
+    const auto connector = connector_;
+    if (connector == nullptr) {
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+
+    struct ReadPlan {
+        std::string key;
+        Slice dest_slice;
+        std::shared_ptr<const CachedManifest> cached_manifest;
+    };
+    std::vector<ReadPlan> plans;
+    plans.reserve(batched_slices.size());
+
+    for (const auto &[key, dest_slice] : batched_slices) {
+        if (dest_slice.size > std::numeric_limits<uint32_t>::max()) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        plans.push_back(ReadPlan{key, dest_slice,
+                                 FindCachedManifest(key, dest_slice.size)});
+    }
+
+    struct PreparedRead {
+        std::shared_ptr<const CachedManifest> manifest;
+    };
+    std::vector<PreparedRead> prepared_reads(plans.size());
+    const auto prepare_one =
+        [&](size_t plan_index) -> tl::expected<void, ErrorCode> {
+        const auto &plan = plans[plan_index];
+        auto resolved_res = ResolveRoot(*connector, plan.key);
+        if (!resolved_res) {
+            return tl::make_unexpected(resolved_res.error());
+        }
+        if (!resolved_res.value()) {
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        const auto &resolved = *resolved_res.value();
+        const std::string &object_blob = resolved.object_blob;
+        NvmeKvObjectHeader header{};
+        std::string_view identity_metadata_view;
+        std::string_view payload_view;
+        if (!ParseNvmeKvObjectBlob(object_blob, header, identity_metadata_view,
+                                   payload_view)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+
+        NvmeKvStoredIdentityView stored_identity_view{};
+        if (!ParseNvmeKvStoredIdentity(identity_metadata_view,
+                                       stored_identity_view) ||
+            stored_identity_view.logical_key.empty() ||
+            stored_identity_view.logical_key != plan.key) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        NvmeKvObjectIdentity identity{.logical_key =
+                                          stored_identity_view.logical_key};
+        if (!NvmeKvKeyConflictPolicy::ValidateResolvedRootPlacement(
+                identity, stored_identity_view, resolved.physical_key) ||
+            stored_identity_view.resolved_slot != resolved.slot) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+
+        const auto object_type =
+            static_cast<NvmeKvObjectType>(header.object_type);
+        const uint32_t expected_identity_size =
+            ComputeNvmeKvStoredIdentityMetadataSize(identity);
+        if (object_type == NvmeKvObjectType::kInline) {
+            if (!ValidateNvmeKvHeader(
+                    header, identity, expected_identity_size,
+                    static_cast<uint32_t>(plan.dest_slice.size),
+                    NvmeKvObjectType::kInline) ||
+                header.payload_checksum !=
+                    ComputeNvmeKvPayloadChecksum(payload_view) ||
+                payload_view.size() != plan.dest_slice.size) {
+                return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+            }
+            std::memcpy(plan.dest_slice.ptr, payload_view.data(),
+                        payload_view.size());
+            return {};
+        }
+
+        if (object_type != NvmeKvObjectType::kManifest ||
+            !ValidateNvmeKvHeader(header, identity, expected_identity_size,
+                                  static_cast<uint32_t>(payload_view.size()),
+                                  NvmeKvObjectType::kManifest) ||
+            header.payload_checksum !=
+                ComputeNvmeKvPayloadChecksum(payload_view)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+
+        NvmeKvManifestMetadata metadata{};
+        std::vector<NvmeKvManifestChunkRecord> chunk_records;
+        if (!ParseNvmeKvManifest(payload_view, metadata, chunk_records) ||
+            metadata.logical_payload_size != plan.dest_slice.size ||
+            metadata.chunk_count != chunk_records.size()) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+
+        auto cached_manifest =
+            CacheManifest(plan.key, plan.dest_slice.size,
+                          stored_identity_view.resolved_slot, chunk_records);
+        if (cached_manifest == nullptr) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        prepared_reads[plan_index].manifest = std::move(cached_manifest);
+        return {};
+    };
+
+    const auto load_chunk_blob =
+        [&](size_t plan_index, size_t chunk_index,
+            std::string_view chunk_blob) -> tl::expected<void, ErrorCode> {
+        const auto &plan = plans[plan_index];
+        const auto &prepared = prepared_reads[plan_index];
+        const auto &chunk_record =
+            prepared.manifest->chunk_records[chunk_index];
+        if (chunk_blob.size() != chunk_record.payload_size ||
+            chunk_record.payload_checksum !=
+                ComputeNvmeKvPayloadChecksum(chunk_blob)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        std::memcpy(static_cast<char *>(plan.dest_slice.ptr) +
+                        prepared.manifest->chunk_offsets[chunk_index],
+                    chunk_blob.data(), chunk_blob.size());
+        return {};
+    };
+
+    std::vector<tl::expected<void, ErrorCode>> prepare_results(plans.size());
+    std::vector<size_t> prepare_misses;
+    prepare_misses.reserve(plans.size());
+    for (size_t plan_index = 0; plan_index < plans.size(); ++plan_index) {
+        if (plans[plan_index].cached_manifest == nullptr) {
+            prepare_misses.push_back(plan_index);
+            continue;
+        }
+        prepared_reads[plan_index].manifest = plans[plan_index].cached_manifest;
+        prepare_results[plan_index] = {};
+    }
+    try {
+        RunParallelIo(prepare_misses.size(), [&](size_t index) {
+            const size_t plan_index = prepare_misses[index];
+            prepare_results[plan_index] = prepare_one(plan_index);
+        });
+        for (const auto &result : prepare_results) {
+            if (!result) {
+                return tl::make_unexpected(result.error());
+            }
+        }
+
+        std::vector<tl::expected<void, ErrorCode>> chunk_results(plans.size());
+        const size_t read_plan_batch_size = ReadPlanBatchSize();
+        const size_t read_group_count =
+            (plans.size() + read_plan_batch_size - 1) / read_plan_batch_size;
+        struct ChunkContext {
+            size_t plan_index = 0;
+            size_t chunk_index = 0;
+        };
+        struct ReadBatch {
+            std::vector<NvmeKvCommandExecutor::RetrieveIntoRequest>
+                direct_requests;
+            std::vector<ChunkContext> direct_contexts;
+            std::vector<NvmeKvCommandExecutor::RetrieveBufferRequest>
+                buffer_requests;
+            std::vector<ChunkContext> buffer_contexts;
+        };
+
+        const auto read_group = [&](size_t group_index) {
+            const size_t plan_begin = group_index * read_plan_batch_size;
+            const size_t plan_end =
+                std::min(plans.size(), plan_begin + read_plan_batch_size);
+            ReadBatch batch;
+
+            for (size_t plan_index = plan_begin; plan_index < plan_end;
+                 ++plan_index) {
+                const auto &prepared = prepared_reads[plan_index];
+                const auto chunk_count =
+                    !prepared.manifest
+                        ? 0
+                        : prepared.manifest->chunk_records.size();
+                if (chunk_count == 0) {
+                    chunk_results[plan_index] = {};
+                    continue;
+                }
+                for (size_t chunk_index = 0; chunk_index < chunk_count;
+                     ++chunk_index) {
+                    const auto &chunk_record =
+                        prepared.manifest->chunk_records[chunk_index];
+                    char *dest =
+                        static_cast<char *>(plans[plan_index].dest_slice.ptr) +
+                        prepared.manifest->chunk_offsets[chunk_index];
+                    if (CanRetrieveDirectlyInto(dest,
+                                                chunk_record.payload_size)) {
+                        NvmeKvCommandExecutor::RetrieveIntoRequest request;
+                        request.key = chunk_record.physical_key;
+                        request.data = dest;
+                        request.size = chunk_record.payload_size;
+                        batch.direct_contexts.push_back(
+                            ChunkContext{plan_index, chunk_index});
+                        batch.direct_requests.push_back(std::move(request));
+                    } else {
+                        NvmeKvCommandExecutor::RetrieveBufferRequest request;
+                        request.key = chunk_record.physical_key;
+                        request.size_hint = chunk_record.payload_size;
+                        batch.buffer_contexts.push_back(
+                            ChunkContext{plan_index, chunk_index});
+                        batch.buffer_requests.push_back(std::move(request));
+                    }
+                }
+            }
+
+            if (!batch.direct_requests.empty()) {
+                connector->RetrieveIntoBatch(batch.direct_requests);
+                for (size_t i = 0; i < batch.direct_requests.size(); ++i) {
+                    const auto &context = batch.direct_contexts[i];
+                    const auto &direct_res = batch.direct_requests[i].result;
+                    if (!direct_res) {
+                        chunk_results[context.plan_index] =
+                            tl::make_unexpected(direct_res.error());
+                        continue;
+                    }
+                    const auto &chunk_record =
+                        prepared_reads[context.plan_index]
+                            .manifest->chunk_records[context.chunk_index];
+                    if (direct_res.value() != chunk_record.payload_size) {
+                        chunk_results[context.plan_index] =
+                            tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                        continue;
+                    }
+                }
+            }
+
+            if (!batch.buffer_requests.empty()) {
+                connector->RetrieveBufferBatch(batch.buffer_requests);
+                for (size_t i = 0; i < batch.buffer_requests.size(); ++i) {
+                    const auto &context = batch.buffer_contexts[i];
+                    if (!chunk_results[context.plan_index]) {
+                        continue;
+                    }
+                    const auto &chunk_res = batch.buffer_requests[i].result;
+                    if (!chunk_res) {
+                        chunk_results[context.plan_index] =
+                            tl::make_unexpected(chunk_res.error());
+                        continue;
+                    }
+                    const auto &chunk_buffer = chunk_res.value();
+                    auto loaded = load_chunk_blob(
+                        context.plan_index, context.chunk_index,
+                        std::string_view(chunk_buffer.data, chunk_buffer.size));
+                    if (!loaded) {
+                        chunk_results[context.plan_index] = loaded;
+                    }
+                }
+            }
+
+            for (size_t plan_index = plan_begin; plan_index < plan_end;
+                 ++plan_index) {
+                if (!chunk_results[plan_index]) {
+                    continue;
+                }
+                chunk_results[plan_index] = {};
+            }
+        };
+
+        const auto verify_read_group = [&](size_t group_index) {
+            const size_t plan_begin = group_index * read_plan_batch_size;
+            const size_t plan_end =
+                std::min(plans.size(), plan_begin + read_plan_batch_size);
+            for (size_t plan_index = plan_begin; plan_index < plan_end;
+                 ++plan_index) {
+                if (!chunk_results[plan_index]) {
+                    continue;
+                }
+                const auto &manifest = prepared_reads[plan_index].manifest;
+                if (manifest == nullptr) {
+                    continue;
+                }
+                for (size_t chunk_index = 0;
+                     chunk_index < manifest->chunk_records.size();
+                     ++chunk_index) {
+                    const auto &chunk_record =
+                        manifest->chunk_records[chunk_index];
+                    const char *dest = static_cast<const char *>(
+                                           plans[plan_index].dest_slice.ptr) +
+                                       manifest->chunk_offsets[chunk_index];
+                    if (!CanRetrieveDirectlyInto(dest,
+                                                 chunk_record.payload_size)) {
+                        continue;
+                    }
+                    if (chunk_record.payload_checksum !=
+                        ComputeNvmeKvPayloadChecksum(std::string_view(
+                            dest, chunk_record.payload_size))) {
+                        chunk_results[plan_index] =
+                            tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                        break;
+                    }
+                }
+            }
+        };
+
+        RunPipelinedIo(read_group_count, read_group, verify_read_group);
+        for (size_t plan_index = 0; plan_index < plans.size(); ++plan_index) {
+            if (!chunk_results[plan_index]) {
+                const auto error = chunk_results[plan_index].error();
+                return tl::make_unexpected(error);
+            }
+        }
+    } catch (const std::exception &error) {
+        LOG(ERROR) << "NVMe KV batch load worker failed: " << error.what();
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    } catch (...) {
+        LOG(ERROR) << "NVMe KV batch load worker failed";
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+
+    return {};
+}
+
+tl::expected<bool, ErrorCode> NvmeKvStorageBackend::IsExist(
+    const std::string &key) {
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    const auto connector = connector_;
+    if (connector == nullptr) {
+        return false;
+    }
+    auto resolved = ResolveRoot(*connector, key);
+    if (!resolved) {
+        return tl::make_unexpected(resolved.error());
+    }
+    return resolved.value().has_value();
+}
+
+tl::expected<bool, ErrorCode> NvmeKvStorageBackend::IsEnableOffloading() {
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    if (connector_ == nullptr) {
+        return false;
+    }
+    return total_keys_.load(std::memory_order_relaxed) <
+               file_storage_config_.total_keys_limit &&
+           total_size_.load(std::memory_order_relaxed) <
+               file_storage_config_.total_size_limit;
+}
+
+tl::expected<void, ErrorCode> NvmeKvStorageBackend::ScanMeta(
+    const std::function<
+        ErrorCode(const std::vector<std::string> &keys,
+                  std::vector<StorageObjectMetadata> &metadatas)> &handler) {
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    (void)handler;
+    return {};
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/nvme_kv_backend.cpp
+++ b/mooncake-store/src/nvme_kv_backend.cpp
@@ -1,0 +1,1574 @@
+#include "nvme_kv_backend.h"
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <exception>
+#include <latch>
+#include <limits>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "nvme_kv_executor_util.h"
+#include "nvme_kv_key_codec.h"
+#include "nvme_kv_key_conflict_policy.h"
+#include "nvme_kv_object_layout.h"
+
+namespace mooncake {
+
+namespace {
+
+constexpr uint32_t kMinMaxValueSize = sizeof(NvmeKvObjectHeader) + 1;
+constexpr size_t kDefaultMaxIoConcurrency = 256;
+constexpr size_t kDefaultIoConcurrency = 18;
+constexpr size_t kDefaultPrepareConcurrency = 12;
+constexpr size_t kDefaultBatchSubmitConcurrency = 6;
+constexpr size_t kDefaultRootSubmitConcurrency = 1;
+constexpr size_t kDefaultReadPlanBatchSize = 8;
+
+size_t PositiveSizeEnvOr(const char *name, size_t fallback, size_t maximum) {
+    const uint32_t parsed = ParseNvmeKvU32EnvOr(name, 0);
+    return parsed == 0 ? fallback : std::min<size_t>(parsed, maximum);
+}
+
+size_t MaxIoConcurrency() {
+    return PositiveSizeEnvOr("MOONCAKE_NVME_KV_MAX_IO_CONCURRENCY",
+                             kDefaultMaxIoConcurrency, UINT32_MAX);
+}
+
+std::optional<size_t> ConfiguredIoConcurrency(size_t max_io_concurrency) {
+    const char *configured = std::getenv("MOONCAKE_NVME_KV_IO_CONCURRENCY");
+    if (configured == nullptr || configured[0] == '\0') {
+        return std::nullopt;
+    }
+    const size_t parsed = PositiveSizeEnvOr("MOONCAKE_NVME_KV_IO_CONCURRENCY",
+                                            0, max_io_concurrency);
+    return parsed == 0 ? std::nullopt : std::optional<size_t>(parsed);
+}
+
+class IndexQueue {
+   public:
+    bool Push(size_t index) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (closed_) {
+            return false;
+        }
+        queue_.push_back(index);
+        not_empty_.notify_one();
+        return true;
+    }
+
+    bool Pop(size_t &index) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        not_empty_.wait(lock, [&]() { return closed_ || !queue_.empty(); });
+        if (queue_.empty()) {
+            return false;
+        }
+        index = queue_.front();
+        queue_.pop_front();
+        return true;
+    }
+
+    void Close() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        closed_ = true;
+        not_empty_.notify_all();
+    }
+
+   private:
+    std::mutex mutex_;
+    std::condition_variable not_empty_;
+    std::deque<size_t> queue_;
+    bool closed_ = false;
+};
+
+bool CanRetrieveDirectlyInto(const char *data, uint32_t size) {
+    if (data == nullptr || size == 0) {
+        return false;
+    }
+    const uint32_t alignment = NvmeKvTransferAlignmentBytes();
+    return alignment != 0 && size % alignment == 0 &&
+           reinterpret_cast<uintptr_t>(data) % alignment == 0;
+}
+
+std::string_view BuildPayloadView(const std::vector<Slice> &slices,
+                                  size_t payload_size, std::string &storage) {
+    if (slices.size() == 1) {
+        const auto &slice = slices.front();
+        return slice.size == 0
+                   ? std::string_view{}
+                   : std::string_view(reinterpret_cast<const char *>(slice.ptr),
+                                      slice.size);
+    }
+    storage.reserve(payload_size);
+    for (const auto &slice : slices) {
+        storage.append(reinterpret_cast<const char *>(slice.ptr), slice.size);
+    }
+    return storage;
+}
+
+size_t ReadPlanBatchSize() {
+    return PositiveSizeEnvOr("MOONCAKE_NVME_KV_READ_PLAN_BATCH_SIZE",
+                             kDefaultReadPlanBatchSize, 1024);
+}
+
+std::optional<std::vector<size_t>> ValidateChunkRecords(
+    const NvmeKvObjectIdentity &identity, uint32_t slot,
+    size_t expected_payload_size,
+    const std::vector<NvmeKvManifestChunkRecord> &records) {
+    if (records.empty()) {
+        return std::nullopt;
+    }
+    std::vector<size_t> offsets;
+    offsets.reserve(records.size());
+    size_t offset = 0;
+    for (size_t index = 0; index < records.size(); ++index) {
+        const auto &record = records[index];
+        if (record.payload_size == 0 || offset > expected_payload_size ||
+            record.payload_size > expected_payload_size - offset ||
+            record.physical_key !=
+                EncodeNvmeKvChunkPhysicalKey(
+                    identity, static_cast<uint32_t>(index), slot)) {
+            return std::nullopt;
+        }
+        offsets.push_back(offset);
+        offset += record.payload_size;
+    }
+    return offset == expected_payload_size
+               ? std::optional<std::vector<size_t>>(std::move(offsets))
+               : std::nullopt;
+}
+
+bool ManifestChunkRecordsEqual(
+    const std::vector<NvmeKvManifestChunkRecord> &lhs,
+    const std::vector<NvmeKvManifestChunkRecord> &rhs) {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    for (size_t index = 0; index < lhs.size(); ++index) {
+        if (lhs[index].physical_key != rhs[index].physical_key ||
+            lhs[index].payload_size != rhs[index].payload_size ||
+            lhs[index].payload_checksum != rhs[index].payload_checksum) {
+            return false;
+        }
+    }
+    return true;
+}
+
+struct ResolvedRoot {
+    NvmeKvPhysicalKey physical_key{};
+    uint32_t slot = 0;
+    std::string object_blob;
+};
+
+tl::expected<std::optional<ResolvedRoot>, ErrorCode> ResolveRoot(
+    NvmeKvConnector &connector, const std::string &logical_key) {
+    const NvmeKvObjectIdentity identity{.logical_key = logical_key};
+    for (uint32_t slot = 0; slot < kNvmeKvMaxPhysicalKeySlots; ++slot) {
+        const auto physical_key = EncodeNvmeKvPhysicalKey(identity, slot);
+        auto object_res = connector.Retrieve(physical_key);
+        if (!object_res) {
+            if (object_res.error() == ErrorCode::OBJECT_NOT_FOUND) {
+                continue;
+            }
+            return tl::make_unexpected(object_res.error());
+        }
+
+        NvmeKvObjectHeader header{};
+        std::string_view identity_metadata;
+        std::string_view payload;
+        if (!ParseNvmeKvObjectBlob(object_res.value(), header,
+                                   identity_metadata, payload)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+
+        NvmeKvStoredIdentityView stored_identity{};
+        if (!ParseNvmeKvStoredIdentity(identity_metadata, stored_identity)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        if (stored_identity.logical_key != logical_key) {
+            continue;
+        }
+        if (stored_identity.resolved_slot != slot ||
+            !NvmeKvKeyConflictPolicy::ValidateResolvedRootPlacement(
+                identity, stored_identity, physical_key)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        return std::optional<ResolvedRoot>(
+            ResolvedRoot{physical_key, slot, std::move(object_res.value())});
+    }
+    return std::nullopt;
+}
+
+}  // namespace
+
+NvmeKvStorageBackend::NvmeKvStorageBackend(
+    const FileStorageConfig &file_storage_config_)
+    : StorageBackendInterface(file_storage_config_) {}
+
+void NvmeKvStorageBackend::InitIoWorkers() {
+    const size_t max_io_concurrency = MaxIoConcurrency();
+    if (auto configured = ConfiguredIoConcurrency(max_io_concurrency);
+        configured.has_value()) {
+        io_parallelism_ = *configured;
+    } else {
+        const size_t queue_depth =
+            std::max<size_t>(1, connector_->GetCapabilities().queue_depth);
+        io_parallelism_ = std::min(
+            queue_depth, std::min(kDefaultIoConcurrency, max_io_concurrency));
+    }
+    if (io_parallelism_ > 1) {
+        io_workers_ = std::make_unique<ThreadPool>(io_parallelism_);
+    }
+    const size_t max_submit_concurrency =
+        io_parallelism_ > 1 ? io_parallelism_ - 1 : 1;
+    batch_submit_concurrency_ = PositiveSizeEnvOr(
+        "MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY",
+        std::min(kDefaultBatchSubmitConcurrency, max_submit_concurrency),
+        max_submit_concurrency);
+    root_submit_concurrency_ = PositiveSizeEnvOr(
+        "MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY",
+        std::min(kDefaultRootSubmitConcurrency, max_submit_concurrency),
+        max_submit_concurrency);
+    const size_t max_prepare_concurrency =
+        io_parallelism_ > batch_submit_concurrency_
+            ? io_parallelism_ - batch_submit_concurrency_
+            : 1;
+    prepare_concurrency_ = PositiveSizeEnvOr(
+        "MOONCAKE_NVME_KV_PREPARE_CONCURRENCY",
+        std::min(kDefaultPrepareConcurrency, max_prepare_concurrency),
+        max_prepare_concurrency);
+    if (batch_submit_concurrency_ > 1) {
+        submit_workers_ =
+            std::make_unique<ThreadPool>(batch_submit_concurrency_);
+        root_submit_workers_ =
+            std::make_unique<ThreadPool>(root_submit_concurrency_);
+    }
+    LOG(INFO) << "NVMe KV backend I/O concurrency: " << io_parallelism_
+              << " (max " << max_io_concurrency
+              << "), batch submit concurrency: " << batch_submit_concurrency_
+              << ", root submit concurrency: " << root_submit_concurrency_
+              << ", prepare concurrency: " << prepare_concurrency_;
+}
+
+void NvmeKvStorageBackend::RunParallelIo(
+    size_t item_count, const std::function<void(size_t)> &task,
+    size_t max_inflight) {
+    if (item_count == 0) {
+        return;
+    }
+    const size_t concurrency_limit =
+        max_inflight == 0 ? io_parallelism_
+                          : std::min(io_parallelism_, max_inflight);
+    const size_t worker_count = std::min(item_count, concurrency_limit);
+    if (worker_count <= 1 || io_workers_ == nullptr) {
+        for (size_t i = 0; i < item_count; ++i) {
+            task(i);
+        }
+        return;
+    }
+
+    std::atomic<size_t> next_index{0};
+    std::latch completed(static_cast<std::ptrdiff_t>(worker_count));
+    std::mutex exception_mutex;
+    std::exception_ptr first_exception;
+    std::exception_ptr enqueue_exception;
+
+    size_t enqueued = 0;
+    try {
+        for (; enqueued < worker_count; ++enqueued) {
+            io_workers_->enqueue([&]() {
+                try {
+                    while (true) {
+                        const size_t index =
+                            next_index.fetch_add(1, std::memory_order_relaxed);
+                        if (index >= item_count) {
+                            break;
+                        }
+                        task(index);
+                    }
+                } catch (...) {
+                    std::lock_guard<std::mutex> lock(exception_mutex);
+                    if (first_exception == nullptr) {
+                        first_exception = std::current_exception();
+                    }
+                }
+                completed.count_down();
+            });
+        }
+    } catch (...) {
+        enqueue_exception = std::current_exception();
+        completed.count_down(
+            static_cast<std::ptrdiff_t>(worker_count - enqueued));
+    }
+
+    completed.wait();
+    if (enqueue_exception != nullptr) {
+        std::rethrow_exception(enqueue_exception);
+    }
+    if (first_exception != nullptr) {
+        std::rethrow_exception(first_exception);
+    }
+}
+
+void NvmeKvStorageBackend::RunPipelinedIo(
+    size_t item_count, const std::function<void(size_t)> &io_task,
+    const std::function<void(size_t)> &completion_task) {
+    if (item_count == 0) {
+        return;
+    }
+    const size_t worker_count = std::min(item_count, batch_submit_concurrency_);
+    if (worker_count <= 1 || submit_workers_ == nullptr ||
+        io_workers_ == nullptr) {
+        for (size_t index = 0; index < item_count; ++index) {
+            io_task(index);
+            completion_task(index);
+        }
+        return;
+    }
+
+    std::atomic<size_t> next_index{0};
+    std::vector<std::exception_ptr> item_exceptions(item_count);
+    std::latch items_completed(static_cast<std::ptrdiff_t>(item_count));
+    std::latch workers_completed(static_cast<std::ptrdiff_t>(worker_count));
+    std::exception_ptr enqueue_exception;
+    size_t enqueued_workers = 0;
+    try {
+        for (; enqueued_workers < worker_count; ++enqueued_workers) {
+            submit_workers_->enqueue([&]() {
+                while (true) {
+                    const size_t index =
+                        next_index.fetch_add(1, std::memory_order_relaxed);
+                    if (index >= item_count) {
+                        break;
+                    }
+                    try {
+                        io_task(index);
+                    } catch (...) {
+                        item_exceptions[index] = std::current_exception();
+                        items_completed.count_down();
+                        continue;
+                    }
+                    try {
+                        io_workers_->enqueue([&, index]() {
+                            try {
+                                completion_task(index);
+                            } catch (...) {
+                                item_exceptions[index] =
+                                    std::current_exception();
+                            }
+                            items_completed.count_down();
+                        });
+                    } catch (...) {
+                        item_exceptions[index] = std::current_exception();
+                        items_completed.count_down();
+                    }
+                }
+                workers_completed.count_down();
+            });
+        }
+    } catch (...) {
+        enqueue_exception = std::current_exception();
+        workers_completed.count_down(
+            static_cast<std::ptrdiff_t>(worker_count - enqueued_workers));
+    }
+
+    if (enqueued_workers == 0) {
+        std::rethrow_exception(enqueue_exception);
+    }
+
+    items_completed.wait();
+    workers_completed.wait();
+    if (enqueue_exception != nullptr) {
+        std::rethrow_exception(enqueue_exception);
+    }
+    for (const auto &item_exception : item_exceptions) {
+        if (item_exception != nullptr) {
+            std::rethrow_exception(item_exception);
+        }
+    }
+}
+
+std::shared_ptr<const NvmeKvStorageBackend::CachedManifest>
+NvmeKvStorageBackend::FindCachedManifest(const std::string &key,
+                                         size_t payload_size) const {
+    std::shared_lock<std::shared_mutex> lock(manifest_cache_mutex_);
+    const auto it = manifest_cache_.find(key);
+    if (it == manifest_cache_.end() ||
+        it->second->payload_size != payload_size) {
+        return nullptr;
+    }
+    return it->second;
+}
+
+std::shared_ptr<const NvmeKvStorageBackend::CachedManifest>
+NvmeKvStorageBackend::CacheManifest(
+    const std::string &key, size_t payload_size, uint32_t resolved_slot,
+    const std::vector<NvmeKvManifestChunkRecord> &chunk_records) {
+    if (payload_size > std::numeric_limits<uint32_t>::max()) {
+        return nullptr;
+    }
+    const NvmeKvObjectIdentity identity{.logical_key = key};
+    auto chunk_offsets = ValidateChunkRecords(identity, resolved_slot,
+                                              payload_size, chunk_records);
+    if (!chunk_offsets) {
+        return nullptr;
+    }
+    auto manifest = std::make_shared<const CachedManifest>(CachedManifest{
+        .resolved_slot = resolved_slot,
+        .payload_size = static_cast<uint32_t>(payload_size),
+        .chunk_records = chunk_records,
+        .chunk_offsets = std::move(*chunk_offsets),
+    });
+    std::unique_lock<std::shared_mutex> lock(manifest_cache_mutex_);
+    auto [it, inserted] = manifest_cache_.try_emplace(key, manifest);
+    if (inserted) {
+        return manifest;
+    }
+    if (it->second->payload_size == payload_size &&
+        it->second->resolved_slot == resolved_slot &&
+        ManifestChunkRecordsEqual(it->second->chunk_records, chunk_records)) {
+        return it->second;
+    }
+    it->second = manifest;
+    return manifest;
+}
+
+void NvmeKvStorageBackend::CacheManifestAfterWrite(
+    const std::string &key, size_t payload_size, uint32_t resolved_slot,
+    const std::vector<NvmeKvManifestChunkRecord> &chunk_records) noexcept {
+    try {
+        (void)CacheManifest(key, payload_size, resolved_slot, chunk_records);
+    } catch (...) {
+        LOG(WARNING) << "NVMe KV could not cache manifest for " << key;
+    }
+}
+
+void NvmeKvStorageBackend::StoreBatchParallel(
+    std::vector<NvmeKvCommandExecutor::StoreRequest> &requests) {
+    if (requests.empty()) {
+        return;
+    }
+    auto connector = connector_;
+    if (connector == nullptr) {
+        for (auto &request : requests) {
+            request.result = tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        return;
+    }
+
+    const size_t worker_count =
+        std::min(batch_submit_concurrency_, requests.size());
+    RunParallelIo(
+        worker_count,
+        [&](size_t worker_index) {
+            std::vector<size_t> request_indices;
+            std::vector<NvmeKvCommandExecutor::StoreRequest> worker_requests;
+            const size_t worker_request_count =
+                (requests.size() + worker_count - 1 - worker_index) /
+                worker_count;
+            request_indices.reserve(worker_request_count);
+            worker_requests.reserve(worker_request_count);
+            for (size_t request_index = worker_index;
+                 request_index < requests.size();
+                 request_index += worker_count) {
+                request_indices.push_back(request_index);
+                worker_requests.push_back(requests[request_index]);
+            }
+            connector->StoreBatch(worker_requests);
+            for (size_t index = 0; index < worker_requests.size(); ++index) {
+                requests[request_indices[index]].result =
+                    std::move(worker_requests[index].result);
+            }
+        },
+        worker_count);
+}
+
+tl::expected<void, ErrorCode> NvmeKvStorageBackend::InitDevice() {
+    auto connector = std::make_shared<NvmeKvConnector>(file_storage_config_);
+    auto init_res = connector->Init();
+    if (!init_res) {
+        LOG(ERROR) << "Failed to initialize NVMe KV device: "
+                   << toString(init_res.error());
+        return init_res;
+    }
+    connector_ = std::move(connector);
+    return {};
+}
+
+tl::expected<void, ErrorCode> NvmeKvStorageBackend::Init() {
+    bool expected = false;
+    if (!initialized_.compare_exchange_strong(expected, true,
+                                              std::memory_order_acq_rel)) {
+        LOG(ERROR) << "NVMe KV backend already initialized";
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    auto init_res = InitDevice();
+    if (!init_res) {
+        initialized_.store(false, std::memory_order_release);
+        return init_res;
+    }
+    total_size_.store(0, std::memory_order_relaxed);
+    total_keys_.store(0, std::memory_order_relaxed);
+    InitIoWorkers();
+    return {};
+}
+
+tl::expected<int64_t, ErrorCode> NvmeKvStorageBackend::BatchOffload(
+    const std::unordered_map<std::string, std::vector<Slice>> &batch_object,
+    std::function<ErrorCode(const std::vector<std::string> &keys,
+                            std::vector<StorageObjectMetadata> &metadatas)>
+        complete_handler,
+    NvmeKvStorageBackend::EvictionHandler eviction_handler) {
+    (void)eviction_handler;
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    if (batch_object.empty()) {
+        return tl::make_unexpected(ErrorCode::INVALID_KEY);
+    }
+
+    struct OffloadPlan {
+        std::string key;
+        const std::vector<Slice> *slices = nullptr;
+        size_t payload_size = 0;
+    };
+    std::vector<OffloadPlan> plans;
+    plans.reserve(batch_object.size());
+    int64_t batch_total_size = 0;
+    for (const auto &[key, slices] : batch_object) {
+        if (slices.empty()) {
+            continue;
+        }
+        size_t payload_size = 0;
+        for (const auto &slice : slices) {
+            if (slice.size >
+                std::numeric_limits<size_t>::max() - payload_size) {
+                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+            }
+            payload_size += slice.size;
+        }
+        if (payload_size >
+                static_cast<size_t>(std::numeric_limits<int64_t>::max()) ||
+            batch_total_size > std::numeric_limits<int64_t>::max() -
+                                   static_cast<int64_t>(payload_size)) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        batch_total_size += static_cast<int64_t>(payload_size);
+        plans.push_back(OffloadPlan{key, &slices, payload_size});
+    }
+
+    if (plans.empty()) {
+        return 0;
+    }
+
+    if (total_keys_.load(std::memory_order_relaxed) +
+            static_cast<int64_t>(plans.size()) >
+        file_storage_config_.total_keys_limit) {
+        return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
+    }
+    if (total_size_.load(std::memory_order_relaxed) + batch_total_size >
+        file_storage_config_.total_size_limit) {
+        return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
+    }
+    auto enable_offloading_res = IsEnableOffloading();
+    if (!enable_offloading_res) {
+        return tl::make_unexpected(enable_offloading_res.error());
+    }
+    if (!enable_offloading_res.value()) {
+        return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
+    }
+
+    std::vector<tl::expected<OffloadResult, ErrorCode>> results;
+    results.reserve(plans.size());
+    for (size_t i = 0; i < plans.size(); ++i) {
+        results.emplace_back(OffloadResult{});
+    }
+
+    struct PreparedOffload {
+        std::string payload_storage;
+        std::string_view payload;
+        std::optional<NvmeKvKeyConflictPolicy::WritePlan> write_plan;
+        std::vector<PhysicalKey> written_chunk_keys;
+        bool root_written = false;
+        bool needs_fallback = false;
+    };
+    std::vector<PreparedOffload> prepared(plans.size());
+
+    const auto prepare_one = [&](size_t index) {
+        const auto &plan = plans[index];
+        auto &item = prepared[index];
+        item.payload = BuildPayloadView(*plan.slices, plan.payload_size,
+                                        item.payload_storage);
+        auto write_plan = NvmeKvKeyConflictPolicy::BuildWritePlan(
+            NvmeKvObjectIdentity{.logical_key = plan.key}, item.payload, 0,
+            std::max(connector_->GetCapabilities().effective_max_value_size,
+                     kMinMaxValueSize));
+        if (!write_plan) {
+            results[index] = tl::make_unexpected(write_plan.error());
+            return;
+        }
+        item.write_plan.emplace(std::move(write_plan.value()));
+    };
+
+    struct StoreContext {
+        size_t plan_index = 0;
+        size_t chunk_index = 0;
+    };
+    const auto apply_chunk_results =
+        [&prepared](std::vector<NvmeKvCommandExecutor::StoreRequest> &requests,
+                    const std::vector<StoreContext> &contexts) {
+            for (size_t request_index = 0; request_index < requests.size();
+                 ++request_index) {
+                const auto &context = contexts[request_index];
+                auto &item = prepared[context.plan_index];
+                if (requests[request_index].result) {
+                    item.written_chunk_keys.push_back(
+                        item.write_plan->chunk_values[context.chunk_index]
+                            .first);
+                } else {
+                    item.needs_fallback = true;
+                }
+            }
+        };
+
+    bool roots_pipelined = false;
+    const auto store_chunks = [&]() {
+        if (io_workers_ == nullptr || submit_workers_ == nullptr ||
+            root_submit_workers_ == nullptr || batch_submit_concurrency_ <= 1) {
+            RunParallelIo(plans.size(), prepare_one, prepare_concurrency_);
+            std::vector<NvmeKvCommandExecutor::StoreRequest> chunk_requests;
+            std::vector<StoreContext> chunk_contexts;
+            for (size_t plan_index = 0; plan_index < plans.size();
+                 ++plan_index) {
+                auto &item = prepared[plan_index];
+                if (!item.write_plan || item.write_plan->store_inline) {
+                    continue;
+                }
+                for (size_t chunk_index = 0;
+                     chunk_index < item.write_plan->chunk_values.size();
+                     ++chunk_index) {
+                    const auto &[chunk_key, chunk_value] =
+                        item.write_plan->chunk_values[chunk_index];
+                    NvmeKvCommandExecutor::StoreRequest request;
+                    request.key = chunk_key;
+                    request.value = chunk_value;
+                    chunk_requests.push_back(request);
+                    chunk_contexts.push_back(
+                        StoreContext{plan_index, chunk_index});
+                }
+            }
+            StoreBatchParallel(chunk_requests);
+            apply_chunk_results(chunk_requests, chunk_contexts);
+            return;
+        }
+
+        const size_t lane_count =
+            std::min(batch_submit_concurrency_, plans.size());
+        const size_t root_lane_count =
+            std::min(root_submit_concurrency_, plans.size());
+        roots_pipelined = true;
+        std::vector<std::unique_ptr<IndexQueue>> queues;
+        queues.reserve(lane_count);
+        for (size_t lane = 0; lane < lane_count; ++lane) {
+            queues.push_back(std::make_unique<IndexQueue>());
+        }
+
+        const auto close_queues = [&]() {
+            for (auto &queue : queues) {
+                queue->Close();
+            }
+        };
+        IndexQueue root_queue;
+        std::mutex consumer_error_mutex;
+        std::exception_ptr consumer_error;
+        const auto set_consumer_error = [&]() {
+            std::lock_guard<std::mutex> lock(consumer_error_mutex);
+            if (consumer_error == nullptr) {
+                consumer_error = std::current_exception();
+            }
+            close_queues();
+            root_queue.Close();
+        };
+        std::latch consumers_done(static_cast<std::ptrdiff_t>(lane_count));
+        std::latch root_consumers_done(
+            static_cast<std::ptrdiff_t>(root_lane_count));
+
+        size_t enqueued_root_consumers = 0;
+        try {
+            for (; enqueued_root_consumers < root_lane_count;
+                 ++enqueued_root_consumers) {
+                root_submit_workers_->enqueue([&]() {
+                    try {
+                        auto connector = connector_;
+                        if (connector == nullptr) {
+                            throw std::runtime_error(
+                                "NVMe KV connector is unavailable");
+                        }
+                        const size_t queue_depth = std::max<size_t>(
+                            1, connector->GetCapabilities().queue_depth);
+                        std::vector<NvmeKvCommandExecutor::StoreRequest>
+                            requests;
+                        std::vector<size_t> contexts;
+                        requests.reserve(queue_depth);
+                        contexts.reserve(queue_depth);
+                        const auto flush = [&]() {
+                            if (requests.empty()) {
+                                return;
+                            }
+                            connector->StoreBatch(requests);
+                            for (size_t index = 0; index < requests.size();
+                                 ++index) {
+                                auto &item = prepared[contexts[index]];
+                                if (requests[index].result) {
+                                    item.root_written = true;
+                                } else {
+                                    item.needs_fallback = true;
+                                }
+                            }
+                            requests.clear();
+                            contexts.clear();
+                        };
+
+                        size_t plan_index = 0;
+                        while (root_queue.Pop(plan_index)) {
+                            auto &item = prepared[plan_index];
+                            NvmeKvCommandExecutor::StoreRequest request;
+                            request.key = item.write_plan->root_key;
+                            request.value = item.write_plan->root_blob;
+                            requests.push_back(request);
+                            contexts.push_back(plan_index);
+                            if (requests.size() == queue_depth) {
+                                flush();
+                            }
+                        }
+                        flush();
+                    } catch (...) {
+                        set_consumer_error();
+                    }
+                    root_consumers_done.count_down();
+                });
+            }
+        } catch (...) {
+            close_queues();
+            root_queue.Close();
+            root_consumers_done.count_down(static_cast<std::ptrdiff_t>(
+                root_lane_count - enqueued_root_consumers));
+            root_consumers_done.wait();
+            throw;
+        }
+
+        size_t enqueued_consumers = 0;
+        try {
+            for (; enqueued_consumers < lane_count; ++enqueued_consumers) {
+                submit_workers_->enqueue([&, lane = enqueued_consumers]() {
+                    try {
+                        auto connector = connector_;
+                        if (connector == nullptr) {
+                            throw std::runtime_error(
+                                "NVMe KV connector is unavailable");
+                        }
+                        const size_t queue_depth = std::max<size_t>(
+                            1, connector->GetCapabilities().queue_depth);
+                        std::vector<NvmeKvCommandExecutor::StoreRequest>
+                            chunk_requests;
+                        std::vector<StoreContext> chunk_contexts;
+                        chunk_requests.reserve(queue_depth);
+                        chunk_contexts.reserve(queue_depth);
+                        const auto flush_chunks = [&]() {
+                            if (chunk_requests.empty()) {
+                                return;
+                            }
+                            connector->StoreBatch(chunk_requests);
+                            apply_chunk_results(chunk_requests, chunk_contexts);
+                            for (const auto &context : chunk_contexts) {
+                                auto &item = prepared[context.plan_index];
+                                if (context.chunk_index + 1 ==
+                                        item.write_plan->chunk_values.size() &&
+                                    !item.needs_fallback) {
+                                    if (!root_queue.Push(context.plan_index)) {
+                                        item.needs_fallback = true;
+                                    }
+                                }
+                            }
+                            chunk_requests.clear();
+                            chunk_contexts.clear();
+                        };
+
+                        size_t plan_index = 0;
+                        while (queues[lane]->Pop(plan_index)) {
+                            auto &item = prepared[plan_index];
+                            for (size_t chunk_index = 0;
+                                 chunk_index <
+                                 item.write_plan->chunk_values.size();
+                                 ++chunk_index) {
+                                const auto &[chunk_key, chunk_value] =
+                                    item.write_plan->chunk_values[chunk_index];
+                                NvmeKvCommandExecutor::StoreRequest request;
+                                request.key = chunk_key;
+                                request.value = chunk_value;
+                                chunk_requests.push_back(request);
+                                chunk_contexts.push_back(
+                                    StoreContext{plan_index, chunk_index});
+                                if (chunk_requests.size() == queue_depth) {
+                                    flush_chunks();
+                                }
+                            }
+                        }
+                        flush_chunks();
+                    } catch (...) {
+                        set_consumer_error();
+                    }
+                    consumers_done.count_down();
+                });
+            }
+        } catch (...) {
+            close_queues();
+            root_queue.Close();
+            consumers_done.count_down(
+                static_cast<std::ptrdiff_t>(lane_count - enqueued_consumers));
+            consumers_done.wait();
+            root_consumers_done.wait();
+            throw;
+        }
+
+        std::exception_ptr producer_error;
+        try {
+            RunParallelIo(
+                plans.size(),
+                [&](size_t index) {
+                    prepare_one(index);
+                    auto &item = prepared[index];
+                    if (!item.write_plan) {
+                        return;
+                    }
+                    const bool queued =
+                        item.write_plan->store_inline
+                            ? root_queue.Push(index)
+                            : queues[index % lane_count]->Push(index);
+                    if (!queued) {
+                        results[index] =
+                            tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+                    }
+                },
+                prepare_concurrency_);
+        } catch (...) {
+            producer_error = std::current_exception();
+        }
+        close_queues();
+        consumers_done.wait();
+        root_queue.Close();
+        root_consumers_done.wait();
+        if (producer_error != nullptr) {
+            std::rethrow_exception(producer_error);
+        }
+        if (consumer_error != nullptr) {
+            std::rethrow_exception(consumer_error);
+        }
+    };
+
+    const auto cleanup_new_writes = [&](size_t plan_index, bool delete_root) {
+        auto connector = connector_;
+        auto &item = prepared[plan_index];
+        if (connector == nullptr || !item.write_plan) {
+            return;
+        }
+        if (delete_root) {
+            auto result = connector->Delete(item.write_plan->root_key);
+            if (!result && result.error() != ErrorCode::OBJECT_NOT_FOUND) {
+                LOG(WARNING) << "NVMe KV failed to clean batched root for "
+                             << plans[plan_index].key
+                             << " error=" << toString(result.error());
+            }
+            item.root_written = false;
+        }
+        for (const auto &chunk_key : item.written_chunk_keys) {
+            auto result = connector->Delete(chunk_key);
+            if (!result && result.error() != ErrorCode::OBJECT_NOT_FOUND) {
+                LOG(WARNING) << "NVMe KV failed to clean batched chunk for "
+                             << plans[plan_index].key
+                             << " error=" << toString(result.error());
+            }
+        }
+        item.written_chunk_keys.clear();
+    };
+
+    ErrorCode worker_error = ErrorCode::OK;
+    try {
+        store_chunks();
+
+        for (size_t plan_index = 0; plan_index < plans.size(); ++plan_index) {
+            if (prepared[plan_index].needs_fallback) {
+                cleanup_new_writes(plan_index, false);
+            }
+        }
+
+        std::vector<NvmeKvCommandExecutor::StoreRequest> root_requests;
+        std::vector<size_t> root_contexts;
+        for (size_t plan_index = 0; plan_index < plans.size(); ++plan_index) {
+            auto &item = prepared[plan_index];
+            if (!item.write_plan || item.needs_fallback || roots_pipelined) {
+                continue;
+            }
+            NvmeKvCommandExecutor::StoreRequest request;
+            request.key = item.write_plan->root_key;
+            request.value = item.write_plan->root_blob;
+            root_requests.push_back(request);
+            root_contexts.push_back(plan_index);
+        }
+        StoreBatchParallel(root_requests);
+        for (size_t request_index = 0; request_index < root_requests.size();
+             ++request_index) {
+            const size_t plan_index = root_contexts[request_index];
+            auto &item = prepared[plan_index];
+            if (!root_requests[request_index].result) {
+                item.needs_fallback = true;
+                cleanup_new_writes(plan_index, false);
+                continue;
+            }
+            item.root_written = true;
+        }
+
+        for (size_t plan_index = 0; plan_index < plans.size(); ++plan_index) {
+            auto &item = prepared[plan_index];
+            if (!item.write_plan || item.needs_fallback || !item.root_written) {
+                continue;
+            }
+            item.root_written = false;
+            item.written_chunk_keys.clear();
+            results[plan_index] =
+                OffloadResult{.stored = true, .inserted = true};
+            if (!item.write_plan->store_inline) {
+                CacheManifestAfterWrite(plans[plan_index].key,
+                                        plans[plan_index].payload_size, 0,
+                                        item.write_plan->manifest_records);
+            }
+        }
+
+        RunParallelIo(plans.size(), [&](size_t index) {
+            if (!prepared[index].needs_fallback) {
+                return;
+            }
+            results[index] = OffloadOne(plans[index].key, *plans[index].slices,
+                                        plans[index].payload_size);
+        });
+    } catch (const std::exception &error) {
+        LOG(ERROR) << "NVMe KV batch offload worker failed: " << error.what();
+        worker_error = ErrorCode::INTERNAL_ERROR;
+    } catch (...) {
+        LOG(ERROR) << "NVMe KV batch offload worker failed";
+        worker_error = ErrorCode::INTERNAL_ERROR;
+    }
+    if (worker_error != ErrorCode::OK) {
+        for (size_t index = 0; index < prepared.size(); ++index) {
+            cleanup_new_writes(index, prepared[index].root_written);
+        }
+    }
+
+    std::vector<std::string> keys;
+    std::vector<StorageObjectMetadata> metadatas;
+    keys.reserve(plans.size());
+    metadatas.reserve(plans.size());
+    int64_t inserted_keys = 0;
+    int64_t inserted_size = 0;
+    ErrorCode first_error = worker_error;
+    for (size_t i = 0; i < plans.size(); ++i) {
+        if (!results[i]) {
+            if (first_error == ErrorCode::OK) {
+                first_error = results[i].error();
+            }
+            continue;
+        }
+        if (!results[i].value().stored) {
+            continue;
+        }
+        if (results[i].value().inserted) {
+            ++inserted_keys;
+            inserted_size += static_cast<int64_t>(plans[i].payload_size);
+        }
+        keys.push_back(plans[i].key);
+        metadatas.emplace_back(StorageObjectMetadata{
+            .bucket_id = 0,
+            .offset = 0,
+            .key_size = static_cast<int64_t>(plans[i].key.size()),
+            .data_size = static_cast<int64_t>(plans[i].payload_size),
+            .transport_endpoint = "",
+        });
+    }
+
+    total_keys_.fetch_add(inserted_keys, std::memory_order_relaxed);
+    total_size_.fetch_add(inserted_size, std::memory_order_relaxed);
+    if (complete_handler != nullptr && !keys.empty()) {
+        const auto error_code = complete_handler(keys, metadatas);
+        if (error_code != ErrorCode::OK) {
+            return tl::make_unexpected(error_code);
+        }
+    }
+    if (first_error != ErrorCode::OK) {
+        return tl::make_unexpected(first_error);
+    }
+    return static_cast<int64_t>(keys.size());
+}
+
+tl::expected<NvmeKvStorageBackend::OffloadResult, ErrorCode>
+NvmeKvStorageBackend::OffloadOne(const std::string &key,
+                                 const std::vector<Slice> &slices,
+                                 size_t payload_size) {
+    if (payload_size >
+        static_cast<size_t>(std::numeric_limits<uint32_t>::max())) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    std::string payload_storage;
+    const std::string_view payload =
+        BuildPayloadView(slices, payload_size, payload_storage);
+
+    auto connector = connector_;
+    if (connector == nullptr) {
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    const uint32_t effective_max_value_size =
+        std::max(connector->GetCapabilities().effective_max_value_size,
+                 kMinMaxValueSize);
+
+    for (uint32_t slot = 0; slot < kNvmeKvMaxPhysicalKeySlots; ++slot) {
+        auto write_plan_res = NvmeKvKeyConflictPolicy::BuildWritePlan(
+            NvmeKvObjectIdentity{.logical_key = key}, payload, slot,
+            effective_max_value_size);
+        if (!write_plan_res) {
+            return tl::make_unexpected(write_plan_res.error());
+        }
+        auto &write_plan = write_plan_res.value();
+        const bool store_inline = write_plan.store_inline;
+        const auto &physical_key = write_plan.root_key;
+        const auto &root_blob = write_plan.root_blob;
+        const auto &chunk_store_values = write_plan.chunk_values;
+
+        std::vector<PhysicalKey> written_chunk_keys;
+        bool root_written = false;
+        const auto cleanup_new_writes = [&]() {
+            if (root_written) {
+                auto delete_res = connector->Delete(physical_key);
+                if (!delete_res &&
+                    delete_res.error() != ErrorCode::OBJECT_NOT_FOUND) {
+                    LOG(WARNING)
+                        << "NVMe KV failed to clean orphan root for " << key
+                        << " key=" << NvmeKvPhysicalKeyToHex(physical_key)
+                        << " error=" << toString(delete_res.error());
+                }
+                root_written = false;
+            }
+            if (written_chunk_keys.empty()) {
+                return;
+            }
+            for (const auto &chunk_key : written_chunk_keys) {
+                auto delete_res = connector->Delete(chunk_key);
+                if (!delete_res &&
+                    delete_res.error() != ErrorCode::OBJECT_NOT_FOUND) {
+                    LOG(WARNING)
+                        << "NVMe KV failed to clean orphan chunk for " << key
+                        << " key=" << NvmeKvPhysicalKeyToHex(chunk_key)
+                        << " error=" << toString(delete_res.error());
+                }
+            }
+            written_chunk_keys.clear();
+        };
+        const auto resolve_existing_root =
+            [&]() -> tl::expected<OffloadResult, ErrorCode> {
+            auto decision_res = NvmeKvKeyConflictPolicy::ResolveExistingObject(
+                *connector, physical_key, root_blob);
+            if (!decision_res) {
+                return tl::make_unexpected(decision_res.error());
+            }
+            if (decision_res.value() ==
+                NvmeKvKeyConflictPolicy::ExistingObjectDecision::kNotFound) {
+                return OffloadResult{};
+            }
+            if (decision_res.value() ==
+                NvmeKvKeyConflictPolicy::ExistingObjectDecision::
+                    kDifferentObject) {
+                return OffloadResult{};
+            }
+            return OffloadResult{.stored = true, .inserted = false};
+        };
+
+        bool write_success = true;
+        bool slot_collision = false;
+        ErrorCode write_error = ErrorCode::OK;
+        if (store_inline) {
+            auto store_res = connector->Store(physical_key, root_blob);
+            if (!store_res) {
+                write_success = false;
+                write_error = store_res.error();
+            } else {
+                root_written = true;
+            }
+        } else {
+            const auto handle_chunk_store_error =
+                [&](const PhysicalKey &chunk_key, std::string_view chunk_blob,
+                    ErrorCode error) -> bool {
+                if (error == ErrorCode::OBJECT_ALREADY_EXISTS) {
+                    auto existing_chunk_res =
+                        NvmeKvKeyConflictPolicy::ResolveExistingObject(
+                            *connector, chunk_key, chunk_blob);
+                    if (existing_chunk_res &&
+                        existing_chunk_res.value() ==
+                            NvmeKvKeyConflictPolicy::ExistingObjectDecision::
+                                kSameObject) {
+                        return true;
+                    }
+                    if (!existing_chunk_res) {
+                        write_error = existing_chunk_res.error();
+                    } else {
+                        write_error = ErrorCode::OBJECT_ALREADY_EXISTS;
+                    }
+                    slot_collision = true;
+                } else {
+                    write_error = error;
+                }
+                write_success = false;
+                cleanup_new_writes();
+                return false;
+            };
+            std::vector<NvmeKvCommandExecutor::StoreRequest> chunk_requests;
+            chunk_requests.reserve(chunk_store_values.size());
+            for (const auto &[chunk_key, chunk_blob] : chunk_store_values) {
+                NvmeKvCommandExecutor::StoreRequest request;
+                request.key = chunk_key;
+                request.value = chunk_blob;
+                chunk_requests.push_back(request);
+            }
+            connector->StoreBatch(chunk_requests);
+
+            for (size_t chunk_index = 0;
+                 chunk_index < chunk_store_values.size(); ++chunk_index) {
+                const auto &[chunk_key, chunk_blob] =
+                    chunk_store_values[chunk_index];
+                const auto &chunk_res = chunk_requests[chunk_index].result;
+                if (!chunk_res) {
+                    if (!handle_chunk_store_error(chunk_key, chunk_blob,
+                                                  chunk_res.error())) {
+                        break;
+                    }
+                    continue;
+                }
+                written_chunk_keys.push_back(chunk_key);
+            }
+            if (write_success) {
+                auto store_res = connector->Store(physical_key, root_blob);
+                if (!store_res) {
+                    write_success = false;
+                    write_error = store_res.error();
+                    cleanup_new_writes();
+                } else {
+                    root_written = true;
+                }
+            }
+        }
+
+        if (!write_success && write_error == ErrorCode::OBJECT_ALREADY_EXISTS) {
+            auto existing_res = resolve_existing_root();
+            if (existing_res && existing_res.value().stored) {
+                if (!store_inline) {
+                    CacheManifestAfterWrite(key, payload_size, slot,
+                                            write_plan.manifest_records);
+                }
+                return existing_res;
+            }
+            if (!existing_res) {
+                write_error = existing_res.error();
+            } else {
+                slot_collision = true;
+                cleanup_new_writes();
+            }
+        }
+
+        if (!write_success) {
+            if (!slot_collision && !store_inline) {
+                cleanup_new_writes();
+            }
+            written_chunk_keys.clear();
+            if (slot_collision) {
+                continue;
+            }
+            return tl::make_unexpected(write_error);
+        }
+
+        if (!store_inline) {
+            CacheManifestAfterWrite(key, payload_size, slot,
+                                    write_plan.manifest_records);
+        }
+        return OffloadResult{.stored = true, .inserted = true};
+    }
+    return OffloadResult{};
+}
+
+tl::expected<void, ErrorCode> NvmeKvStorageBackend::BatchLoad(
+    std::unordered_map<std::string, Slice> &batched_slices) {
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+
+    const auto connector = connector_;
+    if (connector == nullptr) {
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+
+    struct ReadPlan {
+        std::string key;
+        Slice dest_slice;
+        std::shared_ptr<const CachedManifest> cached_manifest;
+    };
+    std::vector<ReadPlan> plans;
+    plans.reserve(batched_slices.size());
+
+    for (const auto &[key, dest_slice] : batched_slices) {
+        if (dest_slice.size > std::numeric_limits<uint32_t>::max()) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        plans.push_back(ReadPlan{key, dest_slice,
+                                 FindCachedManifest(key, dest_slice.size)});
+    }
+
+    struct PreparedRead {
+        std::shared_ptr<const CachedManifest> manifest;
+    };
+    std::vector<PreparedRead> prepared_reads(plans.size());
+    const auto prepare_one =
+        [&](size_t plan_index) -> tl::expected<void, ErrorCode> {
+        const auto &plan = plans[plan_index];
+        auto resolved_res = ResolveRoot(*connector, plan.key);
+        if (!resolved_res) {
+            return tl::make_unexpected(resolved_res.error());
+        }
+        if (!resolved_res.value()) {
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        const auto &resolved = *resolved_res.value();
+        const std::string &object_blob = resolved.object_blob;
+        NvmeKvObjectHeader header{};
+        std::string_view identity_metadata_view;
+        std::string_view payload_view;
+        if (!ParseNvmeKvObjectBlob(object_blob, header, identity_metadata_view,
+                                   payload_view)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+
+        NvmeKvStoredIdentityView stored_identity_view{};
+        if (!ParseNvmeKvStoredIdentity(identity_metadata_view,
+                                       stored_identity_view) ||
+            stored_identity_view.logical_key.empty() ||
+            stored_identity_view.logical_key != plan.key) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        NvmeKvObjectIdentity identity{.logical_key =
+                                          stored_identity_view.logical_key};
+        if (!NvmeKvKeyConflictPolicy::ValidateResolvedRootPlacement(
+                identity, stored_identity_view, resolved.physical_key) ||
+            stored_identity_view.resolved_slot != resolved.slot) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+
+        const auto object_type =
+            static_cast<NvmeKvObjectType>(header.object_type);
+        const uint32_t expected_identity_size =
+            ComputeNvmeKvStoredIdentityMetadataSize(identity);
+        if (object_type == NvmeKvObjectType::kInline) {
+            if (!ValidateNvmeKvHeader(
+                    header, identity, expected_identity_size,
+                    static_cast<uint32_t>(plan.dest_slice.size),
+                    NvmeKvObjectType::kInline) ||
+                header.payload_checksum !=
+                    ComputeNvmeKvPayloadChecksum(payload_view) ||
+                payload_view.size() != plan.dest_slice.size) {
+                return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+            }
+            std::memcpy(plan.dest_slice.ptr, payload_view.data(),
+                        payload_view.size());
+            return {};
+        }
+
+        if (object_type != NvmeKvObjectType::kManifest ||
+            !ValidateNvmeKvHeader(header, identity, expected_identity_size,
+                                  static_cast<uint32_t>(payload_view.size()),
+                                  NvmeKvObjectType::kManifest) ||
+            header.payload_checksum !=
+                ComputeNvmeKvPayloadChecksum(payload_view)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+
+        NvmeKvManifestMetadata metadata{};
+        std::vector<NvmeKvManifestChunkRecord> chunk_records;
+        if (!ParseNvmeKvManifest(payload_view, metadata, chunk_records) ||
+            metadata.logical_payload_size != plan.dest_slice.size ||
+            metadata.chunk_count != chunk_records.size()) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+
+        auto cached_manifest =
+            CacheManifest(plan.key, plan.dest_slice.size,
+                          stored_identity_view.resolved_slot, chunk_records);
+        if (cached_manifest == nullptr) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        prepared_reads[plan_index].manifest = std::move(cached_manifest);
+        return {};
+    };
+
+    const auto load_chunk_blob =
+        [&](size_t plan_index, size_t chunk_index,
+            std::string_view chunk_blob) -> tl::expected<void, ErrorCode> {
+        const auto &plan = plans[plan_index];
+        const auto &prepared = prepared_reads[plan_index];
+        const auto &chunk_record =
+            prepared.manifest->chunk_records[chunk_index];
+        if (chunk_blob.size() != chunk_record.payload_size ||
+            chunk_record.payload_checksum !=
+                ComputeNvmeKvPayloadChecksum(chunk_blob)) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        std::memcpy(static_cast<char *>(plan.dest_slice.ptr) +
+                        prepared.manifest->chunk_offsets[chunk_index],
+                    chunk_blob.data(), chunk_blob.size());
+        return {};
+    };
+
+    std::vector<tl::expected<void, ErrorCode>> prepare_results(plans.size());
+    std::vector<size_t> prepare_misses;
+    prepare_misses.reserve(plans.size());
+    for (size_t plan_index = 0; plan_index < plans.size(); ++plan_index) {
+        if (plans[plan_index].cached_manifest == nullptr) {
+            prepare_misses.push_back(plan_index);
+            continue;
+        }
+        prepared_reads[plan_index].manifest = plans[plan_index].cached_manifest;
+        prepare_results[plan_index] = {};
+    }
+    try {
+        RunParallelIo(prepare_misses.size(), [&](size_t index) {
+            const size_t plan_index = prepare_misses[index];
+            prepare_results[plan_index] = prepare_one(plan_index);
+        });
+        for (const auto &result : prepare_results) {
+            if (!result) {
+                return tl::make_unexpected(result.error());
+            }
+        }
+
+        std::vector<tl::expected<void, ErrorCode>> chunk_results(plans.size());
+        const size_t read_plan_batch_size = ReadPlanBatchSize();
+        const size_t read_group_count =
+            (plans.size() + read_plan_batch_size - 1) / read_plan_batch_size;
+        struct ChunkContext {
+            size_t plan_index = 0;
+            size_t chunk_index = 0;
+        };
+        struct ReadBatch {
+            std::vector<NvmeKvCommandExecutor::RetrieveIntoRequest>
+                direct_requests;
+            std::vector<ChunkContext> direct_contexts;
+            std::vector<NvmeKvCommandExecutor::RetrieveBufferRequest>
+                buffer_requests;
+            std::vector<ChunkContext> buffer_contexts;
+        };
+
+        const auto read_group = [&](size_t group_index) {
+            const size_t plan_begin = group_index * read_plan_batch_size;
+            const size_t plan_end =
+                std::min(plans.size(), plan_begin + read_plan_batch_size);
+            ReadBatch batch;
+
+            for (size_t plan_index = plan_begin; plan_index < plan_end;
+                 ++plan_index) {
+                const auto &prepared = prepared_reads[plan_index];
+                const auto chunk_count =
+                    !prepared.manifest
+                        ? 0
+                        : prepared.manifest->chunk_records.size();
+                if (chunk_count == 0) {
+                    chunk_results[plan_index] = {};
+                    continue;
+                }
+                for (size_t chunk_index = 0; chunk_index < chunk_count;
+                     ++chunk_index) {
+                    const auto &chunk_record =
+                        prepared.manifest->chunk_records[chunk_index];
+                    char *dest =
+                        static_cast<char *>(plans[plan_index].dest_slice.ptr) +
+                        prepared.manifest->chunk_offsets[chunk_index];
+                    if (CanRetrieveDirectlyInto(dest,
+                                                chunk_record.payload_size)) {
+                        NvmeKvCommandExecutor::RetrieveIntoRequest request;
+                        request.key = chunk_record.physical_key;
+                        request.data = dest;
+                        request.size = chunk_record.payload_size;
+                        batch.direct_contexts.push_back(
+                            ChunkContext{plan_index, chunk_index});
+                        batch.direct_requests.push_back(std::move(request));
+                    } else {
+                        NvmeKvCommandExecutor::RetrieveBufferRequest request;
+                        request.key = chunk_record.physical_key;
+                        request.size_hint = chunk_record.payload_size;
+                        batch.buffer_contexts.push_back(
+                            ChunkContext{plan_index, chunk_index});
+                        batch.buffer_requests.push_back(std::move(request));
+                    }
+                }
+            }
+
+            if (!batch.direct_requests.empty()) {
+                connector->RetrieveIntoBatch(batch.direct_requests);
+                for (size_t i = 0; i < batch.direct_requests.size(); ++i) {
+                    const auto &context = batch.direct_contexts[i];
+                    const auto &direct_res = batch.direct_requests[i].result;
+                    if (!direct_res) {
+                        chunk_results[context.plan_index] =
+                            tl::make_unexpected(direct_res.error());
+                        continue;
+                    }
+                    const auto &chunk_record =
+                        prepared_reads[context.plan_index]
+                            .manifest->chunk_records[context.chunk_index];
+                    if (direct_res.value() != chunk_record.payload_size) {
+                        chunk_results[context.plan_index] =
+                            tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                        continue;
+                    }
+                }
+            }
+
+            if (!batch.buffer_requests.empty()) {
+                connector->RetrieveBufferBatch(batch.buffer_requests);
+                for (size_t i = 0; i < batch.buffer_requests.size(); ++i) {
+                    const auto &context = batch.buffer_contexts[i];
+                    if (!chunk_results[context.plan_index]) {
+                        continue;
+                    }
+                    const auto &chunk_res = batch.buffer_requests[i].result;
+                    if (!chunk_res) {
+                        chunk_results[context.plan_index] =
+                            tl::make_unexpected(chunk_res.error());
+                        continue;
+                    }
+                    const auto &chunk_buffer = chunk_res.value();
+                    auto loaded = load_chunk_blob(
+                        context.plan_index, context.chunk_index,
+                        std::string_view(chunk_buffer.data, chunk_buffer.size));
+                    if (!loaded) {
+                        chunk_results[context.plan_index] = loaded;
+                    }
+                }
+            }
+
+            for (size_t plan_index = plan_begin; plan_index < plan_end;
+                 ++plan_index) {
+                if (!chunk_results[plan_index]) {
+                    continue;
+                }
+                chunk_results[plan_index] = {};
+            }
+        };
+
+        const auto verify_read_group = [&](size_t group_index) {
+            const size_t plan_begin = group_index * read_plan_batch_size;
+            const size_t plan_end =
+                std::min(plans.size(), plan_begin + read_plan_batch_size);
+            for (size_t plan_index = plan_begin; plan_index < plan_end;
+                 ++plan_index) {
+                if (!chunk_results[plan_index]) {
+                    continue;
+                }
+                const auto &manifest = prepared_reads[plan_index].manifest;
+                if (manifest == nullptr) {
+                    continue;
+                }
+                for (size_t chunk_index = 0;
+                     chunk_index < manifest->chunk_records.size();
+                     ++chunk_index) {
+                    const auto &chunk_record =
+                        manifest->chunk_records[chunk_index];
+                    const char *dest = static_cast<const char *>(
+                                           plans[plan_index].dest_slice.ptr) +
+                                       manifest->chunk_offsets[chunk_index];
+                    if (!CanRetrieveDirectlyInto(dest,
+                                                 chunk_record.payload_size)) {
+                        continue;
+                    }
+                    if (chunk_record.payload_checksum !=
+                        ComputeNvmeKvPayloadChecksum(std::string_view(
+                            dest, chunk_record.payload_size))) {
+                        chunk_results[plan_index] =
+                            tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                        break;
+                    }
+                }
+            }
+        };
+
+        RunPipelinedIo(read_group_count, read_group, verify_read_group);
+        for (size_t plan_index = 0; plan_index < plans.size(); ++plan_index) {
+            if (!chunk_results[plan_index]) {
+                const auto error = chunk_results[plan_index].error();
+                return tl::make_unexpected(error);
+            }
+        }
+    } catch (const std::exception &error) {
+        LOG(ERROR) << "NVMe KV batch load worker failed: " << error.what();
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    } catch (...) {
+        LOG(ERROR) << "NVMe KV batch load worker failed";
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+
+    return {};
+}
+
+tl::expected<bool, ErrorCode> NvmeKvStorageBackend::IsExist(
+    const std::string &key) {
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    const auto connector = connector_;
+    if (connector == nullptr) {
+        return false;
+    }
+    auto resolved = ResolveRoot(*connector, key);
+    if (!resolved) {
+        return tl::make_unexpected(resolved.error());
+    }
+    return resolved.value().has_value();
+}
+
+tl::expected<bool, ErrorCode> NvmeKvStorageBackend::IsEnableOffloading() {
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    if (connector_ == nullptr) {
+        return false;
+    }
+    return total_keys_.load(std::memory_order_relaxed) <
+               file_storage_config_.total_keys_limit &&
+           total_size_.load(std::memory_order_relaxed) <
+               file_storage_config_.total_size_limit;
+}
+
+tl::expected<void, ErrorCode> NvmeKvStorageBackend::ScanMeta(
+    const std::function<
+        ErrorCode(const std::vector<std::string> &keys,
+                  std::vector<StorageObjectMetadata> &metadatas)> &handler) {
+    if (!initialized_.load(std::memory_order_acquire)) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    (void)handler;
+    return {};
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/nvme_kv_connector.cpp
+++ b/mooncake-store/src/nvme_kv_connector.cpp
@@ -1,0 +1,208 @@
+#include "nvme_kv_connector.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <utility>
+
+#include <glog/logging.h>
+
+#include "nvme_kv_executor_util.h"
+#include "storage_backend.h"
+
+namespace mooncake {
+
+#ifdef MOONCAKE_ENABLE_NVME_KV_TEST_STUB
+std::unique_ptr<NvmeKvCommandExecutor> CreateNvmeKvStubExecutor(
+    std::filesystem::path storage_path);
+#endif
+
+namespace {
+
+std::string GetEnvString(const char *name) {
+    const char *value = std::getenv(name);
+    return value == nullptr ? std::string() : std::string(value);
+}
+
+enum class RuntimeTransport {
+    kAuto,
+    kIoUring,
+    kIoctl,
+};
+
+const char *RuntimeTransportName(RuntimeTransport transport) {
+    switch (transport) {
+        case RuntimeTransport::kAuto:
+            return "auto";
+        case RuntimeTransport::kIoUring:
+            return "io_uring";
+        case RuntimeTransport::kIoctl:
+            return "ioctl";
+    }
+    return "unknown";
+}
+
+tl::expected<RuntimeTransport, ErrorCode> ParseRuntimeTransport() {
+    const auto transport = GetEnvString("MOONCAKE_NVME_KV_TRANSPORT");
+    if (transport.empty() || transport == "auto") {
+        return RuntimeTransport::kAuto;
+    }
+    if (transport == "io_uring") {
+        return RuntimeTransport::kIoUring;
+    }
+    if (transport == "ioctl") {
+        return RuntimeTransport::kIoctl;
+    }
+    LOG(ERROR) << "Unknown MOONCAKE_NVME_KV_TRANSPORT: " << transport;
+    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+}
+
+}  // namespace
+
+NvmeKvConnector::NvmeKvConnector(const FileStorageConfig &config)
+    : storage_path_(
+          (std::filesystem::path(config.storage_filepath) / "nvme_kv_blobs")
+              .string()) {}
+
+tl::expected<void, ErrorCode> NvmeKvConnector::Init() {
+    if (executor_ != nullptr) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+#ifdef MOONCAKE_ENABLE_NVME_KV_TEST_STUB
+    if (GetEnvString("MOONCAKE_NVME_KV_DRIVER") == "stub") {
+        std::error_code ec;
+        std::filesystem::create_directories(storage_path_, ec);
+        if (ec) {
+            return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+        }
+        executor_ =
+            CreateNvmeKvStubExecutor(std::filesystem::path(storage_path_));
+        return {};
+    }
+#endif
+
+    return InitRealExecutor();
+}
+
+tl::expected<void, ErrorCode> NvmeKvConnector::InitRealExecutor() {
+    const auto device_path = GetEnvString("MOONCAKE_NVME_KV_DEVICE_PATH");
+    if (device_path.empty()) {
+        LOG(ERROR) << "MOONCAKE_NVME_KV_DEVICE_PATH must not be empty";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    const uint32_t nsid = ParseNvmeKvU32EnvOr("MOONCAKE_NVME_KV_NSID", 1);
+    const uint32_t queue_depth = ParseNvmeKvU32EnvOr(
+        "MOONCAKE_NVME_KV_QUEUE_DEPTH", kDefaultNvmeKvQueueDepth);
+    const uint32_t runtime_transfer_limit =
+        ParseNvmeKvU32EnvOr("MOONCAKE_NVME_KV_RUNTIME_TRANSFER_LIMIT",
+                            kDefaultNvmeKvRuntimeTransferLimit);
+    auto transport = ParseRuntimeTransport();
+    if (!transport) {
+        return tl::make_unexpected(transport.error());
+    }
+
+    const auto create_executor =
+        [&](RuntimeTransport selected_transport) -> NvmeKvExecutorResult {
+        switch (selected_transport) {
+            case RuntimeTransport::kIoUring:
+                return CreateNvmeKvIoUringExecutor(
+                    device_path, nsid, queue_depth, runtime_transfer_limit);
+            case RuntimeTransport::kIoctl:
+                return CreateNvmeKvIoctlExecutor(device_path, nsid, queue_depth,
+                                                 runtime_transfer_limit);
+            case RuntimeTransport::kAuto:
+                break;
+        }
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    };
+
+    NvmeKvExecutorResult executor_result =
+        tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    if (transport.value() == RuntimeTransport::kAuto) {
+#ifdef MOONCAKE_HAVE_NVME_URING_CMD
+        executor_result = create_executor(RuntimeTransport::kIoUring);
+        if (!executor_result) {
+            LOG(WARNING) << "NVMe KV io_uring init failed, falling back to "
+                            "ioctl: "
+                         << toString(executor_result.error());
+        }
+#endif
+        if (!executor_result) {
+            executor_result = create_executor(RuntimeTransport::kIoctl);
+        }
+    } else {
+        executor_result = create_executor(transport.value());
+    }
+
+    if (!executor_result) {
+        LOG(ERROR) << "Failed to initialize NVMe KV "
+                   << RuntimeTransportName(transport.value()) << " executor";
+        return tl::make_unexpected(executor_result.error());
+    }
+    executor_ = std::move(executor_result.value());
+    return {};
+}
+
+tl::expected<void, ErrorCode> NvmeKvConnector::Store(const PhysicalKey &key,
+                                                     std::string value) {
+    if (executor_ == nullptr) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    return executor_->Store(key, std::move(value));
+}
+
+void NvmeKvConnector::StoreBatch(
+    std::vector<NvmeKvCommandExecutor::StoreRequest> &requests) {
+    if (executor_ == nullptr) {
+        for (auto &request : requests) {
+            request.result = tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+        return;
+    }
+    executor_->StoreBatch(requests);
+}
+
+tl::expected<std::string, ErrorCode> NvmeKvConnector::Retrieve(
+    const PhysicalKey &key, uint32_t size_hint) const {
+    if (executor_ == nullptr) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    return executor_->Retrieve(key, size_hint);
+}
+
+void NvmeKvConnector::RetrieveBufferBatch(
+    std::vector<NvmeKvCommandExecutor::RetrieveBufferRequest> &requests) const {
+    if (executor_ == nullptr) {
+        for (auto &request : requests) {
+            request.result = tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+        return;
+    }
+    executor_->RetrieveBufferBatch(requests);
+}
+
+void NvmeKvConnector::RetrieveIntoBatch(
+    std::vector<NvmeKvCommandExecutor::RetrieveIntoRequest> &requests) const {
+    if (executor_ == nullptr) {
+        for (auto &request : requests) {
+            request.result = tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+        return;
+    }
+    executor_->RetrieveIntoBatch(requests);
+}
+
+tl::expected<void, ErrorCode> NvmeKvConnector::Delete(const PhysicalKey &key) {
+    if (executor_ == nullptr) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    return executor_->Delete(key);
+}
+
+const NvmeKvConnector::Capabilities &NvmeKvConnector::GetCapabilities() const {
+    static const Capabilities kDefaultCapabilities{};
+    return executor_ == nullptr ? kDefaultCapabilities
+                                : executor_->GetCapabilities();
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/nvme_kv_executor_io_uring.cpp
+++ b/mooncake-store/src/nvme_kv_executor_io_uring.cpp
@@ -1,0 +1,760 @@
+#include "nvme_kv_executor.h"
+
+#ifdef MOONCAKE_HAVE_NVME_URING_CMD
+
+#include "nvme_kv_executor_util.h"
+#include "nvme_kv_object_layout.h"
+
+#include <fcntl.h>
+#include <liburing.h>
+#include <linux/nvme_ioctl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+// IORING_SETUP_SQE128 was introduced in Linux 5.19.  Provide a fallback
+// definition so the file compiles against older kernel headers (the feature
+// is only usable at runtime on 5.19+ kernels).
+#ifndef IORING_SETUP_SQE128
+#define IORING_SETUP_SQE128 (1U << 10)
+#endif
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <glog/logging.h>
+
+namespace mooncake {
+namespace {
+
+bool CanSubmitCallerBufferDirectly(std::string_view value,
+                                   uint32_t submission_bytes) {
+    if (value.empty() || submission_bytes != value.size()) {
+        return false;
+    }
+    const size_t required_alignment = std::max<size_t>(
+        kDefaultNvmeKvTransferAlignmentBytes, NvmeKvTransferAlignmentBytes());
+    return reinterpret_cast<uintptr_t>(value.data()) % required_alignment == 0;
+}
+
+bool IsCharacterDevice(const std::filesystem::path& path) {
+    struct stat st{};
+    return ::stat(path.c_str(), &st) == 0 && S_ISCHR(st.st_mode);
+}
+
+std::string ResolveIoUringDevicePath(const std::string& device_path) {
+    const std::filesystem::path path(device_path);
+    if (IsCharacterDevice(path)) {
+        return device_path;
+    }
+
+    const std::string filename = path.filename().string();
+    if (filename.rfind("nvme", 0) != 0) {
+        return device_path;
+    }
+    const std::filesystem::path generic_path =
+        path.parent_path() / ("ng" + filename.substr(4));
+    if (IsCharacterDevice(generic_path)) {
+        LOG(INFO) << "[NvmeKvIoUringExecutor] using NVMe generic char device "
+                  << generic_path << " for namespace block device "
+                  << device_path;
+        return generic_path.string();
+    }
+    return device_path;
+}
+
+class SharedNvmeUringRing {
+   public:
+    struct BatchCommand {
+        struct nvme_uring_cmd cmd{};
+        bool is_write = false;
+        size_t context_index = 0;
+        uint32_t observed_result = 0;
+        bool has_observed_result = false;
+        ErrorCode mapped_error = ErrorCode::OK;
+        bool submitted = false;
+        bool completed = false;
+    };
+
+    static SharedNvmeUringRing& Instance(unsigned queue_depth) {
+        thread_local SharedNvmeUringRing ring(queue_depth);
+        return ring;
+    }
+
+    bool IsInitialized() const { return initialized_; }
+
+    tl::expected<void, ErrorCode> SubmitBatch(
+        int fd, std::vector<BatchCommand>& commands) {
+        if (commands.empty()) {
+            return {};
+        }
+        if (!initialized_) {
+            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+        if (commands.size() >= UINT32_MAX) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+
+        const uint32_t completion_token = NextCompletionToken();
+        size_t next_command = 0;
+        size_t completed_count = 0;
+        size_t inflight_ops = 0;
+        ErrorCode batch_error = ErrorCode::OK;
+
+        const auto drain_ready = [&]() -> tl::expected<size_t, ErrorCode> {
+            size_t drained = 0;
+            while (inflight_ops != 0) {
+                io_uring_cqe* cqe = nullptr;
+                const int peek_ret = io_uring_peek_cqe(&ring_, &cqe);
+                if (peek_ret == -EAGAIN) {
+                    break;
+                }
+                if (peek_ret < 0 || cqe == nullptr) {
+                    return tl::make_unexpected(
+                        MapNvmeKvTransportError(peek_ret < 0 ? -peek_ret : EIO,
+                                                commands.front().is_write));
+                }
+                const uint64_t user_data = cqe->user_data;
+                const int res = cqe->res;
+                const uint64_t cqe_extra_result =
+                    cqe32_enabled_ ? cqe->big_cqe[0] : static_cast<uint64_t>(0);
+                io_uring_cqe_seen(&ring_, cqe);
+
+                size_t command_index = 0;
+                if (!DecodeUserData(user_data, completion_token,
+                                    command_index) ||
+                    command_index >= commands.size() ||
+                    !commands[command_index].submitted ||
+                    commands[command_index].completed) {
+                    LOG(ERROR) << "[NvmeKvIoUringExecutor] invalid or stale "
+                                  "io_uring completion token";
+                    batch_error = ErrorCode::INTERNAL_ERROR;
+                    continue;
+                }
+                auto& command = commands[command_index];
+                if (res >= 0 && cqe32_enabled_ &&
+                    cqe_extra_result <= UINT32_MAX) {
+                    command.observed_result =
+                        static_cast<uint32_t>(cqe_extra_result);
+                    command.has_observed_result = true;
+                }
+                if (res > 0) {
+                    command.mapped_error = MapNvmeKvStatus(
+                        static_cast<uint32_t>(res), command.is_write);
+                } else if (res < 0) {
+                    command.mapped_error =
+                        MapNvmeKvTransportError(-res, command.is_write);
+                } else {
+                    command.mapped_error = ErrorCode::OK;
+                }
+                command.completed = true;
+                --inflight_ops;
+                ++completed_count;
+                ++drained;
+            }
+            return drained;
+        };
+
+        const auto wait_and_drain =
+            [&](unsigned wait_min) -> tl::expected<size_t, ErrorCode> {
+            io_uring_cqe* first_cqe = nullptr;
+            int wait_ret = 0;
+            do {
+                wait_ret = io_uring_wait_cqe_nr(&ring_, &first_cqe, wait_min);
+            } while (wait_ret == -EINTR);
+            if (wait_ret < 0 || first_cqe == nullptr) {
+                return tl::make_unexpected(MapNvmeKvTransportError(
+                    wait_ret < 0 ? -wait_ret : EIO, commands.front().is_write));
+            }
+            // wait_cqe_nr leaves first_cqe in the CQ; drain_ready consumes it
+            // together with any other completions that are already available.
+            return drain_ready();
+        };
+
+        while (completed_count < commands.size()) {
+            const size_t prepared_start = next_command;
+            size_t prepared_ops = 0;
+            while (next_command < commands.size() &&
+                   inflight_ops + prepared_ops < queue_depth_) {
+                auto& command = commands[next_command];
+                io_uring_sqe* sqe = io_uring_get_sqe(&ring_);
+                if (sqe == nullptr) {
+                    break;
+                }
+                PrepareSqe(sqe, fd, command.cmd,
+                           EncodeUserData(completion_token, next_command));
+                ++next_command;
+                ++prepared_ops;
+            }
+            if (prepared_ops == 0 && inflight_ops == 0) {
+                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+            }
+
+            ErrorCode submit_error = ErrorCode::OK;
+            size_t submitted_prepared = 0;
+            while (submitted_prepared < prepared_ops) {
+                int submit_ret = 0;
+                do {
+                    submit_ret = submitted_prepared == 0
+                                     ? io_uring_submit_and_wait(&ring_, 1)
+                                     : io_uring_submit(&ring_);
+                } while (submit_ret == -EINTR);
+                const size_t remaining = prepared_ops - submitted_prepared;
+                if (submit_ret <= 0 ||
+                    static_cast<size_t>(submit_ret) > remaining) {
+                    submit_error = MapNvmeKvTransportError(
+                        submit_ret < 0 ? -submit_ret : EIO,
+                        commands.front().is_write);
+                    break;
+                }
+                const size_t accepted = static_cast<size_t>(submit_ret);
+                for (size_t index = 0; index < accepted; ++index) {
+                    auto& command =
+                        commands[prepared_start + submitted_prepared + index];
+                    command.submitted = true;
+                    ++inflight_ops;
+                }
+                submitted_prepared += accepted;
+            }
+
+            if (submit_error != ErrorCode::OK) {
+                while (inflight_ops != 0) {
+                    auto drain_result = wait_and_drain(1);
+                    if (!drain_result || drain_result.value() == 0) {
+                        LOG(FATAL)
+                            << "[NvmeKvIoUringExecutor] cannot safely drain "
+                               "submitted commands after a submission error";
+                    }
+                }
+                ResetRing();
+                return tl::make_unexpected(submit_error);
+            }
+
+            auto drain_result = wait_and_drain(1);
+            if (!drain_result || drain_result.value() == 0) {
+                LOG(FATAL) << "[NvmeKvIoUringExecutor] cannot safely drain "
+                              "submitted commands";
+            }
+        }
+        if (batch_error != ErrorCode::OK) {
+            ResetRing();
+            return tl::make_unexpected(batch_error);
+        }
+        return {};
+    }
+
+   private:
+    explicit SharedNvmeUringRing(unsigned queue_depth)
+        : queue_depth_(queue_depth == 0 ? kDefaultNvmeKvQueueDepth
+                                        : queue_depth) {
+        InitializeRing();
+    }
+
+    void InitializeRing() {
+        io_uring_params params{};
+        // IORING_SETUP_SQE128 is required for NVMe uring_cmd passthrough
+        // because sizeof(struct nvme_uring_cmd) = 72 bytes, which exceeds the
+        // 16 bytes available in the cmd[] area of a standard 64-byte SQE.
+        params.flags = IORING_SETUP_SQE128 | IORING_SETUP_CQE32;
+        int ret = io_uring_queue_init_params(queue_depth_, &ring_, &params);
+        if (ret < 0 && (params.flags & IORING_SETUP_CQE32)) {
+            LOG(WARNING)
+                << "[NvmeKvIoUringExecutor] io_uring_queue_init_params with "
+                   "CQE32 failed: "
+                << strerror(-ret) << ", retrying with SQE128 only";
+            params.flags = IORING_SETUP_SQE128;
+            ret = io_uring_queue_init_params(queue_depth_, &ring_, &params);
+        }
+        if (ret < 0) {
+            LOG(ERROR) << "[NvmeKvIoUringExecutor] io_uring queue init failed: "
+                       << strerror(-ret);
+            return;
+        }
+        cqe32_enabled_ = (ring_.flags & IORING_SETUP_CQE32) != 0;
+        initialized_ = true;
+    }
+
+    void ResetRing() {
+        if (initialized_) {
+            io_uring_queue_exit(&ring_);
+        }
+        ring_ = {};
+        initialized_ = false;
+        cqe32_enabled_ = false;
+        InitializeRing();
+    }
+
+    static void PrepareSqe(io_uring_sqe* sqe, int fd,
+                           const struct nvme_uring_cmd& cmd,
+                           uint64_t user_data) {
+        static_assert(sizeof(cmd) <= 80,
+                      "nvme_uring_cmd must fit in SQE128 cmd area");
+        constexpr size_t kSqe128Bytes = sizeof(io_uring_sqe) * 2;
+        std::memset(sqe, 0, kSqe128Bytes);
+        sqe->opcode = IORING_OP_URING_CMD;
+        sqe->fd = fd;
+        sqe->cmd_op = NVME_URING_CMD_IO;
+        sqe->len = sizeof(struct nvme_uring_cmd);
+        sqe->user_data = user_data;
+        std::memcpy(sqe->cmd, &cmd, sizeof(cmd));
+    }
+
+    uint32_t NextCompletionToken() {
+        ++completion_token_;
+        if (completion_token_ == 0) {
+            ++completion_token_;
+        }
+        return completion_token_;
+    }
+
+    static uint64_t EncodeUserData(uint32_t token, size_t command_index) {
+        return (static_cast<uint64_t>(token) << 32) |
+               (static_cast<uint32_t>(command_index) + 1u);
+    }
+
+    static bool DecodeUserData(uint64_t user_data, uint32_t expected_token,
+                               size_t& command_index) {
+        const uint32_t token = static_cast<uint32_t>(user_data >> 32);
+        const uint32_t encoded_index = static_cast<uint32_t>(user_data);
+        if (token != expected_token || encoded_index == 0) {
+            return false;
+        }
+        command_index = static_cast<size_t>(encoded_index - 1u);
+        return true;
+    }
+
+    ~SharedNvmeUringRing() {
+        if (initialized_) {
+            io_uring_queue_exit(&ring_);
+        }
+    }
+
+    io_uring ring_{};
+    unsigned queue_depth_ = kDefaultNvmeKvQueueDepth;
+    uint32_t completion_token_ = 0;
+    bool initialized_ = false;
+    bool cqe32_enabled_ = false;
+};
+
+class NvmeKvIoUringExecutor : public NvmeKvCommandExecutor {
+   public:
+    NvmeKvIoUringExecutor(std::string device_path, uint32_t nsid,
+                          Capabilities capabilities)
+        : device_path_(std::move(device_path)),
+          nsid_(nsid),
+          capabilities_(capabilities) {}
+
+    tl::expected<void, ErrorCode> Init() {
+        const std::string io_uring_device_path =
+            ResolveIoUringDevicePath(device_path_);
+        if (!IsCharacterDevice(io_uring_device_path)) {
+            LOG(WARNING) << "[NvmeKvIoUringExecutor] io_uring requires an NVMe "
+                            "generic character device, configured path="
+                         << device_path_
+                         << " resolved path=" << io_uring_device_path;
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+
+        fd_ = ::open(io_uring_device_path.c_str(), O_RDWR | O_CLOEXEC);
+        if (fd_ < 0) {
+            LOG(ERROR) << "[NvmeKvIoUringExecutor] open failed for "
+                       << io_uring_device_path << " (configured "
+                       << device_path_ << "): " << strerror(errno);
+            return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+        }
+
+        auto& ring = CurrentThreadRing();
+        if (!ring.IsInitialized()) {
+            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+        return {};
+    }
+
+    ~NvmeKvIoUringExecutor() override {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+
+    tl::expected<void, ErrorCode> Store(const PhysicalKey& key,
+                                        std::string value) override {
+        StoreRequest request;
+        request.key = key;
+        request.value = value;
+        std::vector<StoreRequest> requests;
+        requests.push_back(std::move(request));
+        StoreBatch(requests);
+        return std::move(requests.front().result);
+    }
+
+    void StoreBatch(std::vector<StoreRequest>& requests) override {
+        std::vector<NvmeKvAlignedBuffer> dma_buffers;
+        dma_buffers.reserve(requests.size());
+        std::vector<SharedNvmeUringRing::BatchCommand> commands;
+        commands.reserve(requests.size());
+
+        for (size_t index = 0; index < requests.size(); ++index) {
+            auto& request = requests[index];
+            if (request.value.size() > capabilities_.effective_max_value_size) {
+                request.result = tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                continue;
+            }
+            const uint32_t value_size =
+                static_cast<uint32_t>(request.value.size());
+            const uint32_t submission_bytes =
+                ResolveNvmeKvStoreSubmissionBytes(value_size);
+            if (submission_bytes > capabilities_.effective_max_value_size) {
+                request.result = tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                continue;
+            }
+            const char* submission_data = request.value.data();
+            if (!CanSubmitCallerBufferDirectly(request.value,
+                                               submission_bytes)) {
+                auto dma_buffer = AllocateNvmeKvAlignedBuffer(submission_bytes);
+                if (dma_buffer == nullptr) {
+                    request.result =
+                        tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+                    continue;
+                }
+                std::memset(dma_buffer.get(), 0, submission_bytes);
+                if (!request.value.empty()) {
+                    std::memcpy(dma_buffer.get(), request.value.data(),
+                                request.value.size());
+                }
+                submission_data = dma_buffer.get();
+                dma_buffers.push_back(std::move(dma_buffer));
+            }
+
+            SharedNvmeUringRing::BatchCommand command;
+            command.is_write = true;
+            command.context_index = index;
+            BuildNvmeKvStoreCommand(command.cmd, nsid_, request.key,
+                                    submission_data, submission_bytes);
+
+            commands.push_back(std::move(command));
+        }
+
+        auto submit_result = CurrentThreadRing().SubmitBatch(fd_, commands);
+        const ErrorCode uncompleted_error =
+            submit_result ? ErrorCode::INTERNAL_ERROR : submit_result.error();
+        for (const auto& command : commands) {
+            if (command.completed && command.mapped_error == ErrorCode::OK) {
+                requests[command.context_index].result = {};
+            } else {
+                requests[command.context_index].result =
+                    tl::make_unexpected(command.completed ? command.mapped_error
+                                                          : uncompleted_error);
+            }
+        }
+    }
+
+    tl::expected<std::string, ErrorCode> Retrieve(
+        const PhysicalKey& key, uint32_t size_hint = 0) const override {
+        RetrieveBufferRequest request;
+        request.key = key;
+        request.size_hint = size_hint;
+        std::vector<RetrieveBufferRequest> requests;
+        requests.push_back(std::move(request));
+        RetrieveBufferBatch(requests);
+        if (!requests.front().result) {
+            return tl::make_unexpected(requests.front().result.error());
+        }
+        return requests.front().result->ToString();
+    }
+
+    void RetrieveBufferBatch(
+        std::vector<RetrieveBufferRequest>& requests) const override {
+        struct RetrieveAttempt {
+            size_t request_index = 0;
+            uint32_t request_bytes = 0;
+            NvmeKvAlignedBuffer dma_buffer;
+            uint32_t returned_size = 0;
+            ErrorCode error = ErrorCode::OK;
+            bool completed = false;
+        };
+        const auto make_attempt = [](size_t request_index,
+                                     uint32_t request_bytes) {
+            RetrieveAttempt attempt;
+            attempt.request_index = request_index;
+            attempt.request_bytes = request_bytes;
+            return attempt;
+        };
+
+        const auto submit_attempts = [&](std::vector<RetrieveAttempt>& attempts)
+            -> tl::expected<void, ErrorCode> {
+            std::vector<SharedNvmeUringRing::BatchCommand> commands;
+            commands.reserve(attempts.size());
+            for (size_t attempt_index = 0; attempt_index < attempts.size();
+                 ++attempt_index) {
+                auto& attempt = attempts[attempt_index];
+                const uint32_t transfer_bytes =
+                    RoundUpToNvmeKvTransferBytes(attempt.request_bytes);
+                if (transfer_bytes > capabilities_.effective_max_value_size) {
+                    attempt.error = ErrorCode::BUFFER_OVERFLOW;
+                    attempt.completed = true;
+                    continue;
+                }
+                attempt.dma_buffer =
+                    AllocateNvmeKvAlignedBuffer(transfer_bytes);
+                if (attempt.dma_buffer == nullptr) {
+                    attempt.error = ErrorCode::INTERNAL_ERROR;
+                    attempt.completed = true;
+                    continue;
+                }
+
+                const auto& request = requests[attempt.request_index];
+                SharedNvmeUringRing::BatchCommand command;
+                command.is_write = false;
+                command.context_index = attempt_index;
+                BuildNvmeKvRetrieveCommand(command.cmd, nsid_, request.key,
+                                           attempt.dma_buffer.get(),
+                                           transfer_bytes);
+                commands.push_back(std::move(command));
+            }
+
+            auto submit_result = CurrentThreadRing().SubmitBatch(fd_, commands);
+            const ErrorCode uncompleted_error = submit_result
+                                                    ? ErrorCode::INTERNAL_ERROR
+                                                    : submit_result.error();
+            for (const auto& command : commands) {
+                auto& attempt = attempts[command.context_index];
+                attempt.completed = command.completed;
+                attempt.error = command.completed ? command.mapped_error
+                                                  : uncompleted_error;
+                if (command.completed &&
+                    command.mapped_error == ErrorCode::OK) {
+                    attempt.returned_size = command.has_observed_result
+                                                ? command.observed_result
+                                                : 0;
+                }
+            }
+            if (!submit_result) {
+                return tl::make_unexpected(submit_result.error());
+            }
+            return {};
+        };
+
+        const auto finish_successful_attempt =
+            [&](RetrieveAttempt& attempt, uint32_t prefix_limit,
+                bool allow_retry,
+                std::vector<RetrieveAttempt>& retry_attempts) {
+                auto& request = requests[attempt.request_index];
+                if (attempt.error != ErrorCode::OK ||
+                    attempt.dma_buffer == nullptr) {
+                    request.result = tl::make_unexpected(attempt.error);
+                    return;
+                }
+
+                const uint32_t actual_size = ResolveNvmeKvRetrievedValueSize(
+                    attempt.dma_buffer.get(), attempt.returned_size,
+                    prefix_limit, request.size_hint);
+                if (actual_size != 0 && actual_size <= prefix_limit) {
+                    char* data = attempt.dma_buffer.get();
+                    std::shared_ptr<void> owner(attempt.dma_buffer.release(),
+                                                NvmeKvFreeDeleter());
+                    request.result = RetrievedBuffer{
+                        .owner = std::move(owner),
+                        .data = data,
+                        .size = actual_size,
+                    };
+                    return;
+                }
+
+                uint32_t required_size = attempt.returned_size;
+                if (required_size <= prefix_limit) {
+                    required_size = ResolveNvmeKvObjectBlobSizeFromPrefix(
+                        attempt.dma_buffer.get(), prefix_limit);
+                }
+                if (allow_retry && required_size > prefix_limit &&
+                    required_size <= capabilities_.effective_max_value_size) {
+                    retry_attempts.push_back(
+                        make_attempt(attempt.request_index, required_size));
+                    return;
+                }
+                request.result = tl::make_unexpected(
+                    required_size > capabilities_.effective_max_value_size
+                        ? ErrorCode::BUFFER_OVERFLOW
+                        : ErrorCode::FILE_READ_FAIL);
+            };
+
+        std::vector<RetrieveAttempt> initial_attempts;
+        initial_attempts.reserve(requests.size());
+        std::vector<uint32_t> initial_request_bytes(requests.size(), 0);
+        for (size_t index = 0; index < requests.size(); ++index) {
+            const uint32_t request_bytes = ResolveNvmeKvInitialRetrieveBytes(
+                requests[index].size_hint,
+                capabilities_.effective_max_value_size);
+            initial_request_bytes[index] = request_bytes;
+            initial_attempts.push_back(make_attempt(index, request_bytes));
+        }
+
+        (void)submit_attempts(initial_attempts);
+
+        std::vector<RetrieveAttempt> fallback_attempts;
+        std::vector<RetrieveAttempt> retry_attempts;
+        for (auto& attempt : initial_attempts) {
+            const auto& request = requests[attempt.request_index];
+            const uint32_t initial_bytes =
+                initial_request_bytes[attempt.request_index];
+            if (attempt.error != ErrorCode::OK) {
+                if (ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+                        attempt.error, request.size_hint, initial_bytes,
+                        capabilities_.effective_max_value_size)) {
+                    fallback_attempts.push_back(
+                        make_attempt(attempt.request_index,
+                                     capabilities_.effective_max_value_size));
+                } else {
+                    requests[attempt.request_index].result =
+                        tl::make_unexpected(attempt.error);
+                }
+                continue;
+            }
+            finish_successful_attempt(attempt, initial_bytes, true,
+                                      retry_attempts);
+        }
+
+        if (!fallback_attempts.empty()) {
+            (void)submit_attempts(fallback_attempts);
+            for (auto& attempt : fallback_attempts) {
+                finish_successful_attempt(
+                    attempt, capabilities_.effective_max_value_size, false,
+                    retry_attempts);
+            }
+        }
+
+        if (!retry_attempts.empty()) {
+            (void)submit_attempts(retry_attempts);
+            std::vector<RetrieveAttempt> ignored_retries;
+            for (auto& attempt : retry_attempts) {
+                finish_successful_attempt(attempt, attempt.request_bytes, false,
+                                          ignored_retries);
+            }
+        }
+    }
+
+    void RetrieveIntoBatch(
+        std::vector<RetrieveIntoRequest>& requests) const override {
+        std::vector<SharedNvmeUringRing::BatchCommand> commands;
+        commands.reserve(requests.size());
+        for (size_t index = 0; index < requests.size(); ++index) {
+            auto& request = requests[index];
+            const uint32_t transfer_bytes =
+                RoundUpToNvmeKvTransferBytes(request.size);
+            const auto address = reinterpret_cast<uintptr_t>(request.data);
+            if (request.data == nullptr || request.size == 0 ||
+                transfer_bytes != request.size ||
+                transfer_bytes > capabilities_.effective_max_value_size ||
+                address % NvmeKvTransferAlignmentBytes() != 0) {
+                request.result = tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                continue;
+            }
+
+            SharedNvmeUringRing::BatchCommand command;
+            command.is_write = false;
+            command.context_index = index;
+            BuildNvmeKvRetrieveCommand(command.cmd, nsid_, request.key,
+                                       request.data, transfer_bytes);
+            commands.push_back(std::move(command));
+        }
+
+        auto submit_result = CurrentThreadRing().SubmitBatch(fd_, commands);
+        for (const auto& command : commands) {
+            auto& request = requests[command.context_index];
+            if (!command.completed) {
+                request.result = tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+                continue;
+            }
+            if (command.mapped_error != ErrorCode::OK) {
+                request.result = tl::make_unexpected(command.mapped_error);
+                continue;
+            }
+            const uint32_t actual_size = command.has_observed_result
+                                             ? command.observed_result
+                                             : request.size;
+            if (actual_size != request.size) {
+                request.result = tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                continue;
+            }
+            request.result = actual_size;
+        }
+        if (!submit_result) {
+            for (auto& request : requests) {
+                if (!request.result &&
+                    request.result.error() == ErrorCode::INTERNAL_ERROR) {
+                    request.result = tl::make_unexpected(submit_result.error());
+                }
+            }
+        }
+    }
+
+    tl::expected<void, ErrorCode> Delete(const PhysicalKey& key) override {
+        SharedNvmeUringRing::BatchCommand command;
+        command.is_write = true;
+        BuildNvmeKvDeleteCommand(command.cmd, nsid_, key);
+        std::vector<SharedNvmeUringRing::BatchCommand> commands;
+        commands.push_back(std::move(command));
+        auto submit_result = CurrentThreadRing().SubmitBatch(fd_, commands);
+        const auto& completed = commands.front();
+        if (!completed.completed) {
+            return tl::make_unexpected(submit_result ? ErrorCode::INTERNAL_ERROR
+                                                     : submit_result.error());
+        }
+        if (completed.mapped_error != ErrorCode::OK) {
+            return tl::make_unexpected(completed.mapped_error);
+        }
+        return {};
+    }
+
+    const Capabilities& GetCapabilities() const override {
+        return capabilities_;
+    }
+
+   private:
+    SharedNvmeUringRing& CurrentThreadRing() const {
+        return SharedNvmeUringRing::Instance(capabilities_.queue_depth);
+    }
+
+    std::string device_path_;
+    uint32_t nsid_ = 1;
+    Capabilities capabilities_;
+    int fd_ = -1;
+};
+
+}  // namespace
+
+NvmeKvExecutorResult CreateNvmeKvIoUringExecutor(
+    std::string device_path, uint32_t nsid, uint32_t queue_depth,
+    uint32_t runtime_transfer_limit) {
+    auto caps = BuildNvmeKvCapabilities(kDefaultNvmeKvQueueDepth, queue_depth,
+                                        runtime_transfer_limit);
+
+    auto executor = std::make_unique<NvmeKvIoUringExecutor>(
+        std::move(device_path), nsid, caps);
+    auto init_res = executor->Init();
+    if (!init_res) {
+        return tl::make_unexpected(init_res.error());
+    }
+    return std::unique_ptr<NvmeKvCommandExecutor>(std::move(executor));
+}
+
+}  // namespace mooncake
+
+#else
+
+namespace mooncake {
+
+NvmeKvExecutorResult CreateNvmeKvIoUringExecutor(
+    std::string /*device_path*/, uint32_t /*nsid*/, uint32_t /*queue_depth*/,
+    uint32_t /*runtime_transfer_limit*/) {
+    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+}
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_HAVE_NVME_URING_CMD

--- a/mooncake-store/src/nvme_kv_executor_io_uring.cpp
+++ b/mooncake-store/src/nvme_kv_executor_io_uring.cpp
@@ -1,0 +1,792 @@
+#include "nvme_kv_executor.h"
+
+#ifdef MOONCAKE_HAVE_NVME_URING_CMD
+
+#include "nvme_kv_executor_util.h"
+#include "nvme_kv_object_layout.h"
+
+#include <fcntl.h>
+#include <liburing.h>
+#include <linux/nvme_ioctl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+// IORING_SETUP_SQE128 was introduced in Linux 5.19.  Provide a fallback
+// definition so the file compiles against older kernel headers (the feature
+// is only usable at runtime on 5.19+ kernels).
+#ifndef IORING_SETUP_SQE128
+#define IORING_SETUP_SQE128 (1U << 10)
+#endif
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <glog/logging.h>
+
+namespace mooncake {
+namespace {
+
+bool CanSubmitCallerBufferDirectly(std::string_view value,
+                                   uint32_t submission_bytes) {
+    if (value.empty() || submission_bytes != value.size()) {
+        return false;
+    }
+    const size_t required_alignment = std::max<size_t>(
+        kDefaultNvmeKvTransferAlignmentBytes, NvmeKvTransferAlignmentBytes());
+    return reinterpret_cast<uintptr_t>(value.data()) % required_alignment == 0;
+}
+
+bool IsCharacterDevice(const std::filesystem::path& path) {
+    struct stat st{};
+    return ::stat(path.c_str(), &st) == 0 && S_ISCHR(st.st_mode);
+}
+
+std::string ResolveIoUringDevicePath(const std::string& device_path) {
+    const std::filesystem::path path(device_path);
+    if (IsCharacterDevice(path)) {
+        return device_path;
+    }
+
+    const std::string filename = path.filename().string();
+    if (filename.rfind("nvme", 0) != 0) {
+        return device_path;
+    }
+    const std::filesystem::path generic_path =
+        path.parent_path() / ("ng" + filename.substr(4));
+    if (IsCharacterDevice(generic_path)) {
+        LOG(INFO) << "[NvmeKvIoUringExecutor] using NVMe generic char device "
+                  << generic_path << " for namespace block device "
+                  << device_path;
+        return generic_path.string();
+    }
+    return device_path;
+}
+
+class SharedNvmeUringRing {
+   public:
+    struct BatchCommand {
+        struct nvme_uring_cmd cmd{};
+        bool is_write = false;
+        size_t context_index = 0;
+        uint32_t observed_result = 0;
+        bool has_observed_result = false;
+        ErrorCode mapped_error = ErrorCode::OK;
+        bool submitted = false;
+        bool completed = false;
+    };
+
+    static SharedNvmeUringRing& Instance(unsigned queue_depth) {
+        const unsigned normalized_queue_depth =
+            queue_depth == 0 ? kDefaultNvmeKvQueueDepth : queue_depth;
+        thread_local std::unique_ptr<SharedNvmeUringRing> ring;
+        if (ring == nullptr || ring->QueueDepth() != normalized_queue_depth) {
+            ring.reset(new SharedNvmeUringRing(normalized_queue_depth));
+        }
+        return *ring;
+    }
+
+    bool IsInitialized() const { return initialized_; }
+
+    tl::expected<void, ErrorCode> SubmitBatch(
+        int fd, std::vector<BatchCommand>& commands) {
+        if (commands.empty()) {
+            return {};
+        }
+        if (!initialized_) {
+            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+        if (commands.size() >= UINT32_MAX) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+
+        const uint32_t completion_token = NextCompletionToken();
+        size_t next_command = 0;
+        size_t completed_count = 0;
+        size_t inflight_ops = 0;
+        ErrorCode batch_error = ErrorCode::OK;
+
+        const auto drain_ready = [&]() -> tl::expected<size_t, ErrorCode> {
+            size_t drained = 0;
+            while (inflight_ops != 0) {
+                io_uring_cqe* cqe = nullptr;
+                const int peek_ret = io_uring_peek_cqe(&ring_, &cqe);
+                if (peek_ret == -EAGAIN) {
+                    break;
+                }
+                if (peek_ret < 0 || cqe == nullptr) {
+                    return tl::make_unexpected(
+                        MapNvmeKvTransportError(peek_ret < 0 ? -peek_ret : EIO,
+                                                commands.front().is_write));
+                }
+                const uint64_t user_data = cqe->user_data;
+                const int res = cqe->res;
+                const uint64_t cqe_extra_result =
+                    cqe32_enabled_ ? cqe->big_cqe[0] : static_cast<uint64_t>(0);
+                io_uring_cqe_seen(&ring_, cqe);
+
+                const auto complete_unknown_inflight = [&]() -> bool {
+                    for (auto& command : commands) {
+                        if (!command.submitted || command.completed) {
+                            continue;
+                        }
+                        command.mapped_error = ErrorCode::INTERNAL_ERROR;
+                        command.completed = true;
+                        --inflight_ops;
+                        ++completed_count;
+                        ++drained;
+                        return true;
+                    }
+                    return false;
+                };
+
+                size_t command_index = 0;
+                if (!DecodeUserData(user_data, completion_token,
+                                    command_index) ||
+                    command_index >= commands.size() ||
+                    !commands[command_index].submitted ||
+                    commands[command_index].completed) {
+                    LOG(ERROR) << "[NvmeKvIoUringExecutor] invalid or stale "
+                                  "io_uring completion token";
+                    batch_error = ErrorCode::INTERNAL_ERROR;
+                    if (!complete_unknown_inflight()) {
+                        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+                    }
+                    continue;
+                }
+                auto& command = commands[command_index];
+                if (res >= 0 && cqe32_enabled_ &&
+                    cqe_extra_result <= UINT32_MAX) {
+                    command.observed_result =
+                        static_cast<uint32_t>(cqe_extra_result);
+                    command.has_observed_result = true;
+                }
+                if (res > 0) {
+                    command.mapped_error = MapNvmeKvStatus(
+                        static_cast<uint32_t>(res), command.is_write);
+                } else if (res < 0) {
+                    command.mapped_error =
+                        MapNvmeKvTransportError(-res, command.is_write);
+                } else {
+                    command.mapped_error = ErrorCode::OK;
+                }
+                command.completed = true;
+                --inflight_ops;
+                ++completed_count;
+                ++drained;
+            }
+            return drained;
+        };
+
+        const auto wait_and_drain =
+            [&](unsigned wait_min) -> tl::expected<size_t, ErrorCode> {
+            io_uring_cqe* first_cqe = nullptr;
+            int wait_ret = 0;
+            do {
+                wait_ret = io_uring_wait_cqe_nr(&ring_, &first_cqe, wait_min);
+            } while (wait_ret == -EINTR);
+            if (wait_ret < 0 || first_cqe == nullptr) {
+                return tl::make_unexpected(MapNvmeKvTransportError(
+                    wait_ret < 0 ? -wait_ret : EIO, commands.front().is_write));
+            }
+            // wait_cqe_nr leaves first_cqe in the CQ; drain_ready consumes it
+            // together with any other completions that are already available.
+            return drain_ready();
+        };
+
+        while (completed_count < commands.size()) {
+            const size_t prepared_start = next_command;
+            size_t prepared_ops = 0;
+            while (next_command < commands.size() &&
+                   inflight_ops + prepared_ops < queue_depth_) {
+                auto& command = commands[next_command];
+                io_uring_sqe* sqe = io_uring_get_sqe(&ring_);
+                if (sqe == nullptr) {
+                    break;
+                }
+                PrepareSqe(sqe, fd, command.cmd,
+                           EncodeUserData(completion_token, next_command));
+                ++next_command;
+                ++prepared_ops;
+            }
+            if (prepared_ops == 0 && inflight_ops == 0) {
+                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+            }
+
+            ErrorCode submit_error = ErrorCode::OK;
+            size_t submitted_prepared = 0;
+            while (submitted_prepared < prepared_ops) {
+                int submit_ret = 0;
+                do {
+                    submit_ret = submitted_prepared == 0
+                                     ? io_uring_submit_and_wait(&ring_, 1)
+                                     : io_uring_submit(&ring_);
+                } while (submit_ret == -EINTR);
+                const size_t remaining = prepared_ops - submitted_prepared;
+                if (submit_ret <= 0 ||
+                    static_cast<size_t>(submit_ret) > remaining) {
+                    submit_error = MapNvmeKvTransportError(
+                        submit_ret < 0 ? -submit_ret : EIO,
+                        commands.front().is_write);
+                    break;
+                }
+                const size_t accepted = static_cast<size_t>(submit_ret);
+                for (size_t index = 0; index < accepted; ++index) {
+                    auto& command =
+                        commands[prepared_start + submitted_prepared + index];
+                    command.submitted = true;
+                    ++inflight_ops;
+                }
+                submitted_prepared += accepted;
+            }
+
+            if (submit_error != ErrorCode::OK) {
+                while (inflight_ops != 0) {
+                    auto drain_result = wait_and_drain(1);
+                    if (!drain_result || drain_result.value() == 0) {
+                        const ErrorCode drain_error =
+                            drain_result ? ErrorCode::INTERNAL_ERROR
+                                         : drain_result.error();
+                        ResetRing();
+                        return tl::make_unexpected(drain_error);
+                    }
+                }
+                ResetRing();
+                return tl::make_unexpected(submit_error);
+            }
+
+            auto drain_result = wait_and_drain(1);
+            if (!drain_result || drain_result.value() == 0) {
+                const ErrorCode drain_error = drain_result
+                                                  ? ErrorCode::INTERNAL_ERROR
+                                                  : drain_result.error();
+                ResetRing();
+                return tl::make_unexpected(drain_error);
+            }
+        }
+        if (batch_error != ErrorCode::OK) {
+            ResetRing();
+            return tl::make_unexpected(batch_error);
+        }
+        return {};
+    }
+
+   private:
+    explicit SharedNvmeUringRing(unsigned queue_depth)
+        : queue_depth_(queue_depth == 0 ? kDefaultNvmeKvQueueDepth
+                                        : queue_depth) {
+        InitializeRing();
+    }
+
+    void InitializeRing() {
+        io_uring_params params{};
+        // IORING_SETUP_SQE128 is required for NVMe uring_cmd passthrough
+        // because sizeof(struct nvme_uring_cmd) = 72 bytes, which exceeds the
+        // 16 bytes available in the cmd[] area of a standard 64-byte SQE.
+        params.flags = IORING_SETUP_SQE128 | IORING_SETUP_CQE32;
+        int ret = io_uring_queue_init_params(queue_depth_, &ring_, &params);
+        if (ret < 0 && (params.flags & IORING_SETUP_CQE32)) {
+            LOG(WARNING)
+                << "[NvmeKvIoUringExecutor] io_uring_queue_init_params with "
+                   "CQE32 failed: "
+                << strerror(-ret) << ", retrying with SQE128 only";
+            params.flags = IORING_SETUP_SQE128;
+            ret = io_uring_queue_init_params(queue_depth_, &ring_, &params);
+        }
+        if (ret < 0) {
+            LOG(ERROR) << "[NvmeKvIoUringExecutor] io_uring queue init failed: "
+                       << strerror(-ret);
+            return;
+        }
+        cqe32_enabled_ = (ring_.flags & IORING_SETUP_CQE32) != 0;
+        initialized_ = true;
+    }
+
+    void ResetRing() {
+        if (initialized_) {
+            io_uring_queue_exit(&ring_);
+        }
+        ring_ = {};
+        initialized_ = false;
+        cqe32_enabled_ = false;
+        InitializeRing();
+    }
+
+    unsigned QueueDepth() const { return queue_depth_; }
+
+    static void PrepareSqe(io_uring_sqe* sqe, int fd,
+                           const struct nvme_uring_cmd& cmd,
+                           uint64_t user_data) {
+        static_assert(sizeof(cmd) <= 80,
+                      "nvme_uring_cmd must fit in SQE128 cmd area");
+        constexpr size_t kSqe128Bytes = sizeof(io_uring_sqe) * 2;
+        std::memset(sqe, 0, kSqe128Bytes);
+        sqe->opcode = IORING_OP_URING_CMD;
+        sqe->fd = fd;
+        sqe->cmd_op = NVME_URING_CMD_IO;
+        sqe->len = sizeof(struct nvme_uring_cmd);
+        sqe->user_data = user_data;
+        std::memcpy(sqe->cmd, &cmd, sizeof(cmd));
+    }
+
+    uint32_t NextCompletionToken() {
+        ++completion_token_;
+        if (completion_token_ == 0) {
+            ++completion_token_;
+        }
+        return completion_token_;
+    }
+
+    static uint64_t EncodeUserData(uint32_t token, size_t command_index) {
+        return (static_cast<uint64_t>(token) << 32) |
+               (static_cast<uint32_t>(command_index) + 1u);
+    }
+
+    static bool DecodeUserData(uint64_t user_data, uint32_t expected_token,
+                               size_t& command_index) {
+        const uint32_t token = static_cast<uint32_t>(user_data >> 32);
+        const uint32_t encoded_index = static_cast<uint32_t>(user_data);
+        if (token != expected_token || encoded_index == 0) {
+            return false;
+        }
+        command_index = static_cast<size_t>(encoded_index - 1u);
+        return true;
+    }
+
+   public:
+    ~SharedNvmeUringRing() {
+        if (initialized_) {
+            io_uring_queue_exit(&ring_);
+        }
+    }
+
+   private:
+    io_uring ring_{};
+    unsigned queue_depth_ = kDefaultNvmeKvQueueDepth;
+    uint32_t completion_token_ = 0;
+    bool initialized_ = false;
+    bool cqe32_enabled_ = false;
+};
+
+class NvmeKvIoUringExecutor : public NvmeKvCommandExecutor {
+   public:
+    NvmeKvIoUringExecutor(std::string device_path, uint32_t nsid,
+                          Capabilities capabilities)
+        : device_path_(std::move(device_path)),
+          nsid_(nsid),
+          capabilities_(capabilities) {}
+
+    tl::expected<void, ErrorCode> Init() {
+        const std::string io_uring_device_path =
+            ResolveIoUringDevicePath(device_path_);
+        if (!IsCharacterDevice(io_uring_device_path)) {
+            LOG(WARNING) << "[NvmeKvIoUringExecutor] io_uring requires an NVMe "
+                            "generic character device, configured path="
+                         << device_path_
+                         << " resolved path=" << io_uring_device_path;
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+
+        fd_ = ::open(io_uring_device_path.c_str(), O_RDWR | O_CLOEXEC);
+        if (fd_ < 0) {
+            LOG(ERROR) << "[NvmeKvIoUringExecutor] open failed for "
+                       << io_uring_device_path << " (configured "
+                       << device_path_ << "): " << strerror(errno);
+            return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+        }
+
+        auto& ring = CurrentThreadRing();
+        if (!ring.IsInitialized()) {
+            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+        return {};
+    }
+
+    ~NvmeKvIoUringExecutor() override {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+
+    tl::expected<void, ErrorCode> Store(const PhysicalKey& key,
+                                        std::string value) override {
+        StoreRequest request;
+        request.key = key;
+        request.value = value;
+        std::vector<StoreRequest> requests;
+        requests.push_back(std::move(request));
+        StoreBatch(requests);
+        return std::move(requests.front().result);
+    }
+
+    void StoreBatch(std::vector<StoreRequest>& requests) override {
+        std::vector<NvmeKvAlignedBuffer> dma_buffers;
+        dma_buffers.reserve(requests.size());
+        std::vector<SharedNvmeUringRing::BatchCommand> commands;
+        commands.reserve(requests.size());
+
+        for (size_t index = 0; index < requests.size(); ++index) {
+            auto& request = requests[index];
+            if (request.value.size() > capabilities_.effective_max_value_size) {
+                request.result = tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                continue;
+            }
+            const uint32_t value_size =
+                static_cast<uint32_t>(request.value.size());
+            const uint32_t submission_bytes =
+                ResolveNvmeKvStoreSubmissionBytes(value_size);
+            if (submission_bytes > capabilities_.effective_max_value_size) {
+                request.result = tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                continue;
+            }
+            const char* submission_data = request.value.data();
+            if (!CanSubmitCallerBufferDirectly(request.value,
+                                               submission_bytes)) {
+                auto dma_buffer = AllocateNvmeKvAlignedBuffer(submission_bytes);
+                if (dma_buffer == nullptr) {
+                    request.result =
+                        tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+                    continue;
+                }
+                std::memset(dma_buffer.get(), 0, submission_bytes);
+                if (!request.value.empty()) {
+                    std::memcpy(dma_buffer.get(), request.value.data(),
+                                request.value.size());
+                }
+                submission_data = dma_buffer.get();
+                dma_buffers.push_back(std::move(dma_buffer));
+            }
+
+            SharedNvmeUringRing::BatchCommand command;
+            command.is_write = true;
+            command.context_index = index;
+            BuildNvmeKvStoreCommand(command.cmd, nsid_, request.key,
+                                    submission_data, submission_bytes);
+
+            commands.push_back(std::move(command));
+        }
+
+        auto submit_result = CurrentThreadRing().SubmitBatch(fd_, commands);
+        const ErrorCode uncompleted_error =
+            submit_result ? ErrorCode::INTERNAL_ERROR : submit_result.error();
+        for (const auto& command : commands) {
+            if (command.completed && command.mapped_error == ErrorCode::OK) {
+                requests[command.context_index].result = {};
+            } else {
+                requests[command.context_index].result =
+                    tl::make_unexpected(command.completed ? command.mapped_error
+                                                          : uncompleted_error);
+            }
+        }
+    }
+
+    tl::expected<std::string, ErrorCode> Retrieve(
+        const PhysicalKey& key, uint32_t size_hint = 0) const override {
+        RetrieveBufferRequest request;
+        request.key = key;
+        request.size_hint = size_hint;
+        std::vector<RetrieveBufferRequest> requests;
+        requests.push_back(std::move(request));
+        RetrieveBufferBatch(requests);
+        if (!requests.front().result) {
+            return tl::make_unexpected(requests.front().result.error());
+        }
+        return requests.front().result->ToString();
+    }
+
+    void RetrieveBufferBatch(
+        std::vector<RetrieveBufferRequest>& requests) const override {
+        struct RetrieveAttempt {
+            size_t request_index = 0;
+            uint32_t request_bytes = 0;
+            NvmeKvAlignedBuffer dma_buffer;
+            uint32_t returned_size = 0;
+            ErrorCode error = ErrorCode::OK;
+            bool completed = false;
+        };
+        const auto make_attempt = [](size_t request_index,
+                                     uint32_t request_bytes) {
+            RetrieveAttempt attempt;
+            attempt.request_index = request_index;
+            attempt.request_bytes = request_bytes;
+            return attempt;
+        };
+
+        const auto submit_attempts = [&](std::vector<RetrieveAttempt>& attempts)
+            -> tl::expected<void, ErrorCode> {
+            std::vector<SharedNvmeUringRing::BatchCommand> commands;
+            commands.reserve(attempts.size());
+            for (size_t attempt_index = 0; attempt_index < attempts.size();
+                 ++attempt_index) {
+                auto& attempt = attempts[attempt_index];
+                const uint32_t transfer_bytes =
+                    RoundUpToNvmeKvTransferBytes(attempt.request_bytes);
+                if (transfer_bytes > capabilities_.effective_max_value_size) {
+                    attempt.error = ErrorCode::BUFFER_OVERFLOW;
+                    attempt.completed = true;
+                    continue;
+                }
+                attempt.dma_buffer =
+                    AllocateNvmeKvAlignedBuffer(transfer_bytes);
+                if (attempt.dma_buffer == nullptr) {
+                    attempt.error = ErrorCode::INTERNAL_ERROR;
+                    attempt.completed = true;
+                    continue;
+                }
+
+                const auto& request = requests[attempt.request_index];
+                SharedNvmeUringRing::BatchCommand command;
+                command.is_write = false;
+                command.context_index = attempt_index;
+                BuildNvmeKvRetrieveCommand(command.cmd, nsid_, request.key,
+                                           attempt.dma_buffer.get(),
+                                           transfer_bytes);
+                commands.push_back(std::move(command));
+            }
+
+            auto submit_result = CurrentThreadRing().SubmitBatch(fd_, commands);
+            const ErrorCode uncompleted_error = submit_result
+                                                    ? ErrorCode::INTERNAL_ERROR
+                                                    : submit_result.error();
+            for (const auto& command : commands) {
+                auto& attempt = attempts[command.context_index];
+                attempt.completed = command.completed;
+                attempt.error = command.completed ? command.mapped_error
+                                                  : uncompleted_error;
+                if (command.completed &&
+                    command.mapped_error == ErrorCode::OK) {
+                    attempt.returned_size = command.has_observed_result
+                                                ? command.observed_result
+                                                : 0;
+                }
+            }
+            if (!submit_result) {
+                return tl::make_unexpected(submit_result.error());
+            }
+            return {};
+        };
+
+        const auto finish_successful_attempt =
+            [&](RetrieveAttempt& attempt, uint32_t prefix_limit,
+                bool allow_retry,
+                std::vector<RetrieveAttempt>& retry_attempts) {
+                auto& request = requests[attempt.request_index];
+                if (attempt.error != ErrorCode::OK ||
+                    attempt.dma_buffer == nullptr) {
+                    request.result = tl::make_unexpected(attempt.error);
+                    return;
+                }
+
+                const uint32_t actual_size = ResolveNvmeKvRetrievedValueSize(
+                    attempt.dma_buffer.get(), attempt.returned_size,
+                    prefix_limit, request.size_hint);
+                if (actual_size != 0 && actual_size <= prefix_limit) {
+                    char* data = attempt.dma_buffer.get();
+                    std::shared_ptr<void> owner(attempt.dma_buffer.release(),
+                                                NvmeKvFreeDeleter());
+                    request.result = RetrievedBuffer{
+                        .owner = std::move(owner),
+                        .data = data,
+                        .size = actual_size,
+                    };
+                    return;
+                }
+
+                uint32_t required_size = attempt.returned_size;
+                if (required_size <= prefix_limit) {
+                    required_size = ResolveNvmeKvObjectBlobSizeFromPrefix(
+                        attempt.dma_buffer.get(), prefix_limit);
+                }
+                if (allow_retry && required_size > prefix_limit &&
+                    required_size <= capabilities_.effective_max_value_size) {
+                    retry_attempts.push_back(
+                        make_attempt(attempt.request_index, required_size));
+                    return;
+                }
+                request.result = tl::make_unexpected(
+                    required_size > capabilities_.effective_max_value_size
+                        ? ErrorCode::BUFFER_OVERFLOW
+                        : ErrorCode::FILE_READ_FAIL);
+            };
+
+        std::vector<RetrieveAttempt> initial_attempts;
+        initial_attempts.reserve(requests.size());
+        std::vector<uint32_t> initial_request_bytes(requests.size(), 0);
+        for (size_t index = 0; index < requests.size(); ++index) {
+            const uint32_t request_bytes = ResolveNvmeKvInitialRetrieveBytes(
+                requests[index].size_hint,
+                capabilities_.effective_max_value_size);
+            initial_request_bytes[index] = request_bytes;
+            initial_attempts.push_back(make_attempt(index, request_bytes));
+        }
+
+        (void)submit_attempts(initial_attempts);
+
+        std::vector<RetrieveAttempt> fallback_attempts;
+        std::vector<RetrieveAttempt> retry_attempts;
+        for (auto& attempt : initial_attempts) {
+            const auto& request = requests[attempt.request_index];
+            const uint32_t initial_bytes =
+                initial_request_bytes[attempt.request_index];
+            if (attempt.error != ErrorCode::OK) {
+                if (ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+                        attempt.error, request.size_hint, initial_bytes,
+                        capabilities_.effective_max_value_size)) {
+                    fallback_attempts.push_back(
+                        make_attempt(attempt.request_index,
+                                     capabilities_.effective_max_value_size));
+                } else {
+                    requests[attempt.request_index].result =
+                        tl::make_unexpected(attempt.error);
+                }
+                continue;
+            }
+            finish_successful_attempt(attempt, initial_bytes, true,
+                                      retry_attempts);
+        }
+
+        if (!fallback_attempts.empty()) {
+            (void)submit_attempts(fallback_attempts);
+            for (auto& attempt : fallback_attempts) {
+                finish_successful_attempt(
+                    attempt, capabilities_.effective_max_value_size, false,
+                    retry_attempts);
+            }
+        }
+
+        if (!retry_attempts.empty()) {
+            (void)submit_attempts(retry_attempts);
+            std::vector<RetrieveAttempt> ignored_retries;
+            for (auto& attempt : retry_attempts) {
+                finish_successful_attempt(attempt, attempt.request_bytes, false,
+                                          ignored_retries);
+            }
+        }
+    }
+
+    void RetrieveIntoBatch(
+        std::vector<RetrieveIntoRequest>& requests) const override {
+        std::vector<SharedNvmeUringRing::BatchCommand> commands;
+        commands.reserve(requests.size());
+        for (size_t index = 0; index < requests.size(); ++index) {
+            auto& request = requests[index];
+            const uint32_t transfer_bytes =
+                RoundUpToNvmeKvTransferBytes(request.size);
+            const auto address = reinterpret_cast<uintptr_t>(request.data);
+            if (request.data == nullptr || request.size == 0 ||
+                transfer_bytes != request.size ||
+                transfer_bytes > capabilities_.effective_max_value_size ||
+                address % NvmeKvTransferAlignmentBytes() != 0) {
+                request.result = tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                continue;
+            }
+
+            SharedNvmeUringRing::BatchCommand command;
+            command.is_write = false;
+            command.context_index = index;
+            BuildNvmeKvRetrieveCommand(command.cmd, nsid_, request.key,
+                                       request.data, transfer_bytes);
+            commands.push_back(std::move(command));
+        }
+
+        auto submit_result = CurrentThreadRing().SubmitBatch(fd_, commands);
+        for (const auto& command : commands) {
+            auto& request = requests[command.context_index];
+            if (!command.completed) {
+                request.result = tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+                continue;
+            }
+            if (command.mapped_error != ErrorCode::OK) {
+                request.result = tl::make_unexpected(command.mapped_error);
+                continue;
+            }
+            const uint32_t actual_size = command.has_observed_result
+                                             ? command.observed_result
+                                             : request.size;
+            if (actual_size != request.size) {
+                request.result = tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                continue;
+            }
+            request.result = actual_size;
+        }
+        if (!submit_result) {
+            for (auto& request : requests) {
+                if (!request.result &&
+                    request.result.error() == ErrorCode::INTERNAL_ERROR) {
+                    request.result = tl::make_unexpected(submit_result.error());
+                }
+            }
+        }
+    }
+
+    tl::expected<void, ErrorCode> Delete(const PhysicalKey& key) override {
+        SharedNvmeUringRing::BatchCommand command;
+        command.is_write = true;
+        BuildNvmeKvDeleteCommand(command.cmd, nsid_, key);
+        std::vector<SharedNvmeUringRing::BatchCommand> commands;
+        commands.push_back(std::move(command));
+        auto submit_result = CurrentThreadRing().SubmitBatch(fd_, commands);
+        const auto& completed = commands.front();
+        if (!completed.completed) {
+            return tl::make_unexpected(submit_result ? ErrorCode::INTERNAL_ERROR
+                                                     : submit_result.error());
+        }
+        if (completed.mapped_error != ErrorCode::OK) {
+            return tl::make_unexpected(completed.mapped_error);
+        }
+        return {};
+    }
+
+    const Capabilities& GetCapabilities() const override {
+        return capabilities_;
+    }
+
+   private:
+    SharedNvmeUringRing& CurrentThreadRing() const {
+        return SharedNvmeUringRing::Instance(capabilities_.queue_depth);
+    }
+
+    std::string device_path_;
+    uint32_t nsid_ = 1;
+    Capabilities capabilities_;
+    int fd_ = -1;
+};
+
+}  // namespace
+
+NvmeKvExecutorResult CreateNvmeKvIoUringExecutor(
+    std::string device_path, uint32_t nsid, uint32_t queue_depth,
+    uint32_t runtime_transfer_limit) {
+    auto caps = BuildNvmeKvCapabilities(kDefaultNvmeKvQueueDepth, queue_depth,
+                                        runtime_transfer_limit);
+
+    auto executor = std::make_unique<NvmeKvIoUringExecutor>(
+        std::move(device_path), nsid, caps);
+    auto init_res = executor->Init();
+    if (!init_res) {
+        return tl::make_unexpected(init_res.error());
+    }
+    return std::unique_ptr<NvmeKvCommandExecutor>(std::move(executor));
+}
+
+}  // namespace mooncake
+
+#else
+
+namespace mooncake {
+
+NvmeKvExecutorResult CreateNvmeKvIoUringExecutor(
+    std::string /*device_path*/, uint32_t /*nsid*/, uint32_t /*queue_depth*/,
+    uint32_t /*runtime_transfer_limit*/) {
+    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+}
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_HAVE_NVME_URING_CMD

--- a/mooncake-store/src/nvme_kv_executor_ioctl.cpp
+++ b/mooncake-store/src/nvme_kv_executor_ioctl.cpp
@@ -1,0 +1,230 @@
+#include "nvme_kv_executor.h"
+#include "nvme_kv_executor_util.h"
+#include "nvme_kv_object_layout.h"
+
+#include <fcntl.h>
+#include <linux/nvme_ioctl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <utility>
+
+#include <glog/logging.h>
+
+namespace mooncake {
+namespace {
+
+class NvmeKvIoctlExecutor : public NvmeKvCommandExecutor {
+   public:
+    NvmeKvIoctlExecutor(std::string device_path, uint32_t nsid,
+                        Capabilities capabilities)
+        : device_path_(std::move(device_path)),
+          nsid_(nsid),
+          capabilities_(capabilities) {}
+
+    tl::expected<void, ErrorCode> Init() {
+        fd_ = ::open(device_path_.c_str(), O_RDWR | O_CLOEXEC);
+        if (fd_ < 0) {
+            LOG(ERROR) << "[NvmeKvIoctlExecutor] open failed for "
+                       << device_path_ << ": " << strerror(errno);
+            return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+        }
+        return {};
+    }
+
+    ~NvmeKvIoctlExecutor() override {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+
+    tl::expected<void, ErrorCode> Store(const PhysicalKey &key,
+                                        std::string value) override {
+        if (value.size() > capabilities_.effective_max_value_size) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+
+        const uint32_t value_size = static_cast<uint32_t>(value.size());
+        const uint32_t submission_bytes =
+            ResolveNvmeKvStoreSubmissionBytes(value_size);
+        if (submission_bytes > capabilities_.effective_max_value_size) {
+            LOG(WARNING) << "[NvmeKvIoctlExecutor] store submission exceeds "
+                            "effective_max_value_size"
+                         << " logical_bytes=" << value_size
+                         << " submission_bytes=" << submission_bytes
+                         << " effective_max_value_size="
+                         << capabilities_.effective_max_value_size;
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        auto dma_buffer = AllocateNvmeKvAlignedBuffer(submission_bytes);
+        if (dma_buffer == nullptr) {
+            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+        std::memset(dma_buffer.get(), 0, submission_bytes);
+        std::memcpy(dma_buffer.get(), value.data(), value.size());
+
+        nvme_passthru_cmd cmd{};
+        BuildNvmeKvStoreCommand(cmd, nsid_, key, dma_buffer.get(),
+                                submission_bytes);
+
+        auto result = Submit(cmd, true, "store-if-not-exists");
+        if (!result) {
+            return tl::make_unexpected(result.error());
+        }
+        return {};
+    }
+
+    tl::expected<std::string, ErrorCode> Retrieve(
+        const PhysicalKey &key, uint32_t size_hint = 0) const override {
+        const auto submit_retrieve = [&](uint32_t request_bytes,
+                                         const char *op_name)
+            -> tl::expected<std::pair<NvmeKvAlignedBuffer, uint32_t>,
+                            ErrorCode> {
+            const uint32_t transfer_bytes =
+                RoundUpToNvmeKvTransferBytes(request_bytes);
+            auto dma_buffer = AllocateNvmeKvAlignedBuffer(transfer_bytes);
+            if (dma_buffer == nullptr) {
+                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+            }
+            nvme_passthru_cmd cmd{};
+            BuildNvmeKvRetrieveCommand(cmd, nsid_, key, dma_buffer.get(),
+                                       transfer_bytes);
+
+            auto result = Submit(cmd, false, op_name);
+            if (!result) {
+                return tl::make_unexpected(result.error());
+            }
+            return std::make_pair(std::move(dma_buffer), result.value());
+        };
+
+        const uint32_t initial_request_bytes =
+            ResolveNvmeKvInitialRetrieveBytes(
+                size_hint, capabilities_.effective_max_value_size);
+        auto retrieve_res = submit_retrieve(initial_request_bytes, "retrieve");
+        bool used_fallback_request = false;
+        if (!retrieve_res) {
+            if (!ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+                    retrieve_res.error(), size_hint, initial_request_bytes,
+                    capabilities_.effective_max_value_size)) {
+                return tl::make_unexpected(retrieve_res.error());
+            }
+            retrieve_res = submit_retrieve(
+                capabilities_.effective_max_value_size, "retrieve-fallback");
+            if (!retrieve_res) {
+                return tl::make_unexpected(retrieve_res.error());
+            }
+            used_fallback_request = true;
+        }
+
+        auto [dma_buffer, reported_size] = std::move(retrieve_res.value());
+        const uint32_t prefix_limit =
+            used_fallback_request ? capabilities_.effective_max_value_size
+                                  : initial_request_bytes;
+        const uint32_t actual_size = ResolveNvmeKvRetrievedValueSize(
+            dma_buffer.get(), reported_size, prefix_limit, size_hint);
+        if (actual_size != 0 && actual_size <= prefix_limit) {
+            return std::string(dma_buffer.get(),
+                               dma_buffer.get() + actual_size);
+        }
+
+        uint32_t required_size = reported_size;
+        if (required_size <= prefix_limit) {
+            required_size = ResolveNvmeKvObjectBlobSizeFromPrefix(
+                dma_buffer.get(), prefix_limit);
+        }
+        if (required_size > prefix_limit &&
+            required_size <= capabilities_.effective_max_value_size) {
+            auto retry_res = submit_retrieve(required_size, "retrieve-retry");
+            if (!retry_res) {
+                return tl::make_unexpected(retry_res.error());
+            }
+            auto [retry_buffer, retry_reported_size] =
+                std::move(retry_res.value());
+            const uint32_t retry_actual_size = ResolveNvmeKvRetrievedValueSize(
+                retry_buffer.get(), retry_reported_size, required_size,
+                size_hint);
+            if (retry_actual_size != 0 && retry_actual_size <= required_size) {
+                return std::string(retry_buffer.get(),
+                                   retry_buffer.get() + retry_actual_size);
+            }
+        }
+
+        return tl::make_unexpected(
+            required_size > capabilities_.effective_max_value_size
+                ? ErrorCode::BUFFER_OVERFLOW
+                : ErrorCode::FILE_READ_FAIL);
+    }
+
+    tl::expected<void, ErrorCode> Delete(const PhysicalKey &key) override {
+        nvme_passthru_cmd cmd{};
+        BuildNvmeKvDeleteCommand(cmd, nsid_, key);
+
+        auto result = Submit(cmd, true, "delete");
+        if (!result) {
+            return tl::make_unexpected(result.error());
+        }
+        return {};
+    }
+
+    const Capabilities &GetCapabilities() const override {
+        return capabilities_;
+    }
+
+   private:
+    tl::expected<uint32_t, ErrorCode> Submit(nvme_passthru_cmd &cmd,
+                                             bool is_write,
+                                             const char *op_name) const {
+        errno = 0;
+        const int ret = ::ioctl(fd_, NVME_IOCTL_IO_CMD, &cmd);
+        const int err = errno;
+        if (ret < 0) {
+            const ErrorCode mapped = MapNvmeKvTransportError(err, is_write);
+            LOG(ERROR) << "[NvmeKvIoctlExecutor] ioctl failed"
+                       << " op=" << op_name << " device=" << device_path_
+                       << " errno=" << err << " strerror=" << strerror(err)
+                       << " mapped_error=" << toString(mapped);
+            return tl::make_unexpected(mapped);
+        }
+        if (ret > 0) {
+            const ErrorCode mapped =
+                MapNvmeKvStatus(static_cast<uint32_t>(ret), is_write);
+            if (!IsNvmeKvControlFlowError(mapped)) {
+                LOG(ERROR) << "[NvmeKvIoctlExecutor] ioctl returned NVMe status"
+                           << " op=" << op_name << " device=" << device_path_
+                           << " status=" << ret
+                           << " mapped_error=" << toString(mapped);
+            }
+            return tl::make_unexpected(mapped);
+        }
+        return static_cast<uint32_t>(cmd.result);
+    }
+
+    std::string device_path_;
+    uint32_t nsid_ = 1;
+    Capabilities capabilities_;
+    int fd_ = -1;
+};
+
+}  // namespace
+
+NvmeKvExecutorResult CreateNvmeKvIoctlExecutor(
+    std::string device_path, uint32_t nsid, uint32_t queue_depth,
+    uint32_t runtime_transfer_limit) {
+    auto caps = BuildNvmeKvCapabilities(kDefaultNvmeKvQueueDepth, queue_depth,
+                                        runtime_transfer_limit);
+
+    auto executor = std::make_unique<NvmeKvIoctlExecutor>(
+        std::move(device_path), nsid, caps);
+    auto init_res = executor->Init();
+    if (!init_res) {
+        return tl::make_unexpected(init_res.error());
+    }
+    return std::unique_ptr<NvmeKvCommandExecutor>(std::move(executor));
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/nvme_kv_executor_stub.cpp
+++ b/mooncake-store/src/nvme_kv_executor_stub.cpp
@@ -1,0 +1,123 @@
+#include "nvme_kv_executor.h"
+#include "nvme_kv_executor_util.h"
+
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+#include <utility>
+
+#include "mutex.h"
+
+namespace mooncake {
+namespace {
+
+class NvmeKvStubExecutor : public NvmeKvCommandExecutor {
+   public:
+    explicit NvmeKvStubExecutor(std::filesystem::path storage_path)
+        : storage_path_(std::move(storage_path)) {}
+
+    tl::expected<void, ErrorCode> Store(const PhysicalKey &key,
+                                        std::string value) override {
+        const auto blob_path = BlobPath(key);
+        {
+            SharedMutexLocker lock(&mutex_, shared_lock);
+            if (objects_.find(key) != objects_.end()) {
+                return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+            }
+        }
+        if (std::filesystem::exists(blob_path)) {
+            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+        }
+        std::ofstream out(blob_path, std::ios::binary | std::ios::trunc);
+        if (!out) {
+            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        }
+        out.write(value.data(), static_cast<std::streamsize>(value.size()));
+        if (!out.good()) {
+            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        }
+        SharedMutexLocker lock(&mutex_);
+        objects_[key] = std::move(value);
+        return {};
+    }
+
+    tl::expected<std::string, ErrorCode> Retrieve(
+        const PhysicalKey &key, uint32_t /*size_hint*/ = 0) const override {
+        {
+            SharedMutexLocker lock(&mutex_, shared_lock);
+            auto it = objects_.find(key);
+            if (it != objects_.end()) {
+                return it->second;
+            }
+        }
+        const auto blob_path = BlobPath(key);
+        std::ifstream in(blob_path, std::ios::binary);
+        if (!in) {
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        std::string value((std::istreambuf_iterator<char>(in)),
+                          std::istreambuf_iterator<char>());
+        if (!in.good() && !in.eof()) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        {
+            SharedMutexLocker lock(&mutex_);
+            objects_[key] = value;
+        }
+        return value;
+    }
+
+    tl::expected<void, ErrorCode> Delete(const PhysicalKey &key) override {
+        const auto blob_path = BlobPath(key);
+        {
+            SharedMutexLocker lock(&mutex_);
+            objects_.erase(key);
+        }
+        std::error_code ec;
+        const bool removed = std::filesystem::remove(blob_path, ec);
+        if (ec) {
+            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        }
+        if (!removed) {
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        return {};
+    }
+
+    const Capabilities &GetCapabilities() const override {
+        return capabilities_;
+    }
+
+   private:
+    struct PhysicalKeyHash {
+        size_t operator()(const PhysicalKey &key) const {
+            size_t seed = 0;
+            for (uint8_t b : key) {
+                seed = (seed * 131) ^ b;
+            }
+            return seed;
+        }
+    };
+
+    std::filesystem::path BlobPath(const PhysicalKey &key) const {
+        return storage_path_ / (NvmeKvPhysicalKeyToHex(key) + ".blob");
+    }
+
+    std::filesystem::path storage_path_;
+    mutable SharedMutex mutex_;
+    mutable std::unordered_map<PhysicalKey, std::string, PhysicalKeyHash>
+        objects_ GUARDED_BY(mutex_);
+    Capabilities capabilities_{
+        .effective_max_value_size = 128 * 1024,
+        .queue_depth = 1,
+    };
+};
+
+}  // namespace
+
+std::unique_ptr<NvmeKvCommandExecutor> CreateNvmeKvStubExecutor(
+    std::filesystem::path storage_path) {
+    return std::make_unique<NvmeKvStubExecutor>(std::move(storage_path));
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/nvme_kv_executor_stub.cpp
+++ b/mooncake-store/src/nvme_kv_executor_stub.cpp
@@ -1,0 +1,124 @@
+#include "nvme_kv_executor.h"
+#include "nvme_kv_executor_util.h"
+
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+#include <utility>
+
+#include "mutex.h"
+
+namespace mooncake {
+namespace {
+
+class NvmeKvStubExecutor : public NvmeKvCommandExecutor {
+   public:
+    explicit NvmeKvStubExecutor(std::filesystem::path storage_path)
+        : storage_path_(std::move(storage_path)),
+          capabilities_(BuildNvmeKvCapabilities(
+              1, ParseNvmeKvU32EnvOr("MOONCAKE_NVME_KV_QUEUE_DEPTH", 1),
+              ParseNvmeKvU32EnvOr("MOONCAKE_NVME_KV_RUNTIME_TRANSFER_LIMIT",
+                                  128 * 1024))) {}
+
+    tl::expected<void, ErrorCode> Store(const PhysicalKey &key,
+                                        std::string value) override {
+        const auto blob_path = BlobPath(key);
+        {
+            SharedMutexLocker lock(&mutex_, shared_lock);
+            if (objects_.find(key) != objects_.end()) {
+                return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+            }
+        }
+        if (std::filesystem::exists(blob_path)) {
+            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+        }
+        std::ofstream out(blob_path, std::ios::binary | std::ios::trunc);
+        if (!out) {
+            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        }
+        out.write(value.data(), static_cast<std::streamsize>(value.size()));
+        if (!out.good()) {
+            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        }
+        SharedMutexLocker lock(&mutex_);
+        objects_[key] = std::move(value);
+        return {};
+    }
+
+    tl::expected<std::string, ErrorCode> Retrieve(
+        const PhysicalKey &key, uint32_t /*size_hint*/ = 0) const override {
+        {
+            SharedMutexLocker lock(&mutex_, shared_lock);
+            auto it = objects_.find(key);
+            if (it != objects_.end()) {
+                return it->second;
+            }
+        }
+        const auto blob_path = BlobPath(key);
+        std::ifstream in(blob_path, std::ios::binary);
+        if (!in) {
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        std::string value((std::istreambuf_iterator<char>(in)),
+                          std::istreambuf_iterator<char>());
+        if (!in.good() && !in.eof()) {
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        {
+            SharedMutexLocker lock(&mutex_);
+            objects_[key] = value;
+        }
+        return value;
+    }
+
+    tl::expected<void, ErrorCode> Delete(const PhysicalKey &key) override {
+        const auto blob_path = BlobPath(key);
+        {
+            SharedMutexLocker lock(&mutex_);
+            objects_.erase(key);
+        }
+        std::error_code ec;
+        const bool removed = std::filesystem::remove(blob_path, ec);
+        if (ec) {
+            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        }
+        if (!removed) {
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        return {};
+    }
+
+    const Capabilities &GetCapabilities() const override {
+        return capabilities_;
+    }
+
+   private:
+    struct PhysicalKeyHash {
+        size_t operator()(const PhysicalKey &key) const {
+            size_t seed = 0;
+            for (uint8_t b : key) {
+                seed = (seed * 131) ^ b;
+            }
+            return seed;
+        }
+    };
+
+    std::filesystem::path BlobPath(const PhysicalKey &key) const {
+        return storage_path_ / (NvmeKvPhysicalKeyToHex(key) + ".blob");
+    }
+
+    std::filesystem::path storage_path_;
+    mutable SharedMutex mutex_;
+    mutable std::unordered_map<PhysicalKey, std::string, PhysicalKeyHash>
+        objects_ GUARDED_BY(mutex_);
+    Capabilities capabilities_;
+};
+
+}  // namespace
+
+std::unique_ptr<NvmeKvCommandExecutor> CreateNvmeKvStubExecutor(
+    std::filesystem::path storage_path) {
+    return std::make_unique<NvmeKvStubExecutor>(std::move(storage_path));
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/nvme_kv_executor_util.cpp
+++ b/mooncake-store/src/nvme_kv_executor_util.cpp
@@ -1,0 +1,217 @@
+#include "nvme_kv_executor_util.h"
+#include "nvme_kv_object_layout.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdlib>
+#include <iomanip>
+#include <limits>
+
+namespace mooncake {
+namespace {
+
+constexpr uint32_t kNvmeStatusCodeMask = 0xFFu;
+constexpr char kNvmeKvTransferAlignmentEnv[] =
+    "MOONCAKE_NVME_KV_TRANSFER_ALIGNMENT_BYTES";
+constexpr uint32_t kNvmeKvStatusCapacityExceeded = 0x81;
+constexpr uint32_t kNvmeKvStatusInvalidValueSize = 0x85;
+constexpr uint32_t kNvmeKvStatusInvalidKeySize = 0x86;
+constexpr uint32_t kNvmeKvStatusKeyNotFound = 0x87;
+constexpr uint32_t kNvmeKvStatusUnrecoveredRead = 0x88;
+constexpr uint32_t kNvmeKvStatusKeyExists = 0x89;
+
+uint32_t ReadLe32(const uint8_t *p) {
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) |
+           (static_cast<uint32_t>(p[3]) << 24);
+}
+
+}  // namespace
+
+uint32_t ParseNvmeKvU32EnvOr(const char *name, uint32_t fallback) {
+    const char *value = std::getenv(name);
+    if (value == nullptr || value[0] == '\0') {
+        return fallback;
+    }
+    char *end = nullptr;
+    errno = 0;
+    unsigned long parsed = std::strtoul(value, &end, 0);
+    if (errno != 0 || end == value || *end != '\0' ||
+        parsed > std::numeric_limits<uint32_t>::max()) {
+        return fallback;
+    }
+    return static_cast<uint32_t>(parsed);
+}
+
+NvmeKvAlignedBuffer AllocateNvmeKvAlignedBuffer(size_t size) {
+    void *ptr = nullptr;
+    const size_t alignment = std::max<size_t>(
+        kDefaultNvmeKvTransferAlignmentBytes, NvmeKvTransferAlignmentBytes());
+    if (posix_memalign(&ptr, alignment, size) != 0) {
+        return nullptr;
+    }
+    return NvmeKvAlignedBuffer(static_cast<char *>(ptr));
+}
+
+uint32_t RoundUpToNvmeKvTransferBytes(uint32_t bytes) {
+    if (bytes == 0) {
+        return 0;
+    }
+    const uint32_t alignment = NvmeKvTransferAlignmentBytes();
+    const uint64_t rounded =
+        ((static_cast<uint64_t>(bytes) + alignment - 1) / alignment) *
+        alignment;
+    if (rounded > std::numeric_limits<uint32_t>::max()) {
+        return std::numeric_limits<uint32_t>::max();
+    }
+    return static_cast<uint32_t>(rounded);
+}
+
+uint32_t RoundDownToNvmeKvTransferBytes(uint32_t bytes) {
+    const uint32_t alignment = NvmeKvTransferAlignmentBytes();
+    return (bytes / alignment) * alignment;
+}
+
+uint32_t NvmeKvTransferAlignmentBytes() {
+    const uint32_t configured = ParseNvmeKvU32EnvOr(
+        kNvmeKvTransferAlignmentEnv, kDefaultNvmeKvTransferAlignmentBytes);
+    return configured == 0 ? kDefaultNvmeKvTransferAlignmentBytes : configured;
+}
+
+uint32_t NvmeKvValueBlockUnitBytes() {
+    const uint32_t configured =
+        ParseNvmeKvU32EnvOr("MOONCAKE_NVME_KV_VALUE_BLOCK_UNIT_BYTES",
+                            kDefaultNvmeKvValueBlockUnitBytes);
+    return configured == 0 ? kDefaultNvmeKvValueBlockUnitBytes : configured;
+}
+
+uint32_t ResolveNvmeKvStoreSubmissionBytes(uint32_t logical_bytes) {
+    return RoundUpToNvmeKvTransferBytes(logical_bytes);
+}
+
+uint32_t ResolveNvmeKvInitialRetrieveBytes(uint32_t size_hint,
+                                           uint32_t effective_max_value_size) {
+    const uint32_t requested_bytes =
+        size_hint == 0 ? std::max<uint32_t>(sizeof(NvmeKvObjectHeader),
+                                            NvmeKvTransferAlignmentBytes())
+                       : size_hint;
+    return std::min(effective_max_value_size,
+                    RoundUpToNvmeKvTransferBytes(requested_bytes));
+}
+
+uint32_t ResolveNvmeKvRetrievedValueSize(const char *buffer,
+                                         uint32_t returned_size,
+                                         uint32_t max_size,
+                                         uint32_t size_hint) {
+    const uint32_t resolved_size =
+        ResolveNvmeKvObjectBlobSize(buffer, returned_size, max_size);
+    if (resolved_size != 0) {
+        return resolved_size;
+    }
+    if (returned_size == 0 && size_hint != 0 && size_hint <= max_size) {
+        return size_hint;
+    }
+    return 0;
+}
+
+bool ShouldRetryNvmeKvRetrieveWithMaxBuffer(ErrorCode error, uint32_t size_hint,
+                                            uint32_t request_bytes,
+                                            uint32_t effective_max_value_size) {
+    return error == ErrorCode::INVALID_PARAMS && size_hint == 0 &&
+           request_bytes < effective_max_value_size;
+}
+
+NvmeKvCommandExecutor::Capabilities BuildNvmeKvCapabilities(
+    uint32_t default_queue_depth, uint32_t queue_depth,
+    uint32_t runtime_transfer_limit) {
+    NvmeKvCommandExecutor::Capabilities caps;
+    const uint32_t protocol_max_value_size =
+        ParseNvmeKvU32EnvOr("MOONCAKE_NVME_KV_PROTOCOL_MAX_VALUE_SIZE",
+                            kDefaultNvmeKvProtocolMaxValueSize);
+    const uint32_t effective_runtime_limit =
+        runtime_transfer_limit == 0 ? kDefaultNvmeKvRuntimeTransferLimit
+                                    : runtime_transfer_limit;
+    caps.effective_max_value_size = RoundDownToNvmeKvTransferBytes(
+        std::min(protocol_max_value_size, effective_runtime_limit));
+    caps.queue_depth = queue_depth == 0 ? default_queue_depth : queue_depth;
+    return caps;
+}
+
+uint32_t ComputeNvmeKvValueBlockCountMinusOne(uint32_t bytes) {
+    if (bytes == 0) {
+        return 0;
+    }
+    const uint32_t rounded_bytes = RoundUpToNvmeKvTransferBytes(bytes);
+    const uint32_t block_unit = NvmeKvValueBlockUnitBytes();
+    const uint64_t block_count =
+        (static_cast<uint64_t>(rounded_bytes) + block_unit - 1) / block_unit;
+    return block_count == 0 ? 0 : block_count - 1;
+}
+
+NvmeKvPackedKeyFields PackNvmeKvPhysicalKey(
+    const NvmeKvCommandExecutor::PhysicalKey &key) {
+    NvmeKvPackedKeyFields fields;
+    fields.cdw2 = ReadLe32(key.data());
+    fields.cdw3 = ReadLe32(key.data() + 4);
+    fields.cdw14 = (static_cast<uint32_t>(kNvmeKvCommandSetIdentifier) << 24) |
+                   (ReadLe32(key.data() + 8) & 0x00FFFFFFu);
+    fields.cdw15 = ReadLe32(key.data() + 12);
+    return fields;
+}
+
+std::string NvmeKvPhysicalKeyToHex(
+    const NvmeKvCommandExecutor::PhysicalKey &key) {
+    std::ostringstream oss;
+    oss << std::hex << std::setfill('0');
+    for (uint8_t byte : key) {
+        oss << std::setw(2) << static_cast<int>(byte);
+    }
+    return oss.str();
+}
+
+ErrorCode MapNvmeKvStatus(uint32_t status, bool is_write) {
+    const uint32_t status_code = status & kNvmeStatusCodeMask;
+    switch (status_code) {
+        case kNvmeKvStatusCapacityExceeded:
+            return ErrorCode::KEYS_ULTRA_LIMIT;
+        case kNvmeKvStatusInvalidValueSize:
+        case kNvmeKvStatusInvalidKeySize:
+            return ErrorCode::INVALID_PARAMS;
+        case kNvmeKvStatusKeyNotFound:
+            return ErrorCode::OBJECT_NOT_FOUND;
+        case kNvmeKvStatusUnrecoveredRead:
+            return ErrorCode::FILE_READ_FAIL;
+        case kNvmeKvStatusKeyExists:
+            return ErrorCode::OBJECT_ALREADY_EXISTS;
+        default:
+            return is_write ? ErrorCode::FILE_WRITE_FAIL
+                            : ErrorCode::FILE_READ_FAIL;
+    }
+}
+
+ErrorCode MapNvmeKvTransportError(int err, bool is_write) {
+    switch (err) {
+        case ENOENT:
+            return ErrorCode::OBJECT_NOT_FOUND;
+        case ENOSPC:
+            return ErrorCode::KEYS_ULTRA_LIMIT;
+        case EINVAL:
+            return ErrorCode::INVALID_PARAMS;
+        case ENOMEM:
+            return ErrorCode::BUFFER_OVERFLOW;
+        default:
+            return MapNvmeKvStatus(static_cast<uint32_t>(err), is_write);
+    }
+}
+
+bool IsNvmeKvControlFlowError(ErrorCode error) {
+    switch (error) {
+        case ErrorCode::OBJECT_NOT_FOUND:
+        case ErrorCode::OBJECT_ALREADY_EXISTS:
+            return true;
+        default:
+            return false;
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/nvme_kv_key_codec.cpp
+++ b/mooncake-store/src/nvme_kv_key_codec.cpp
@@ -1,0 +1,105 @@
+#include "nvme_kv_key_codec.h"
+
+#include <cstring>
+
+#include <xxhash.h>
+
+namespace mooncake {
+namespace {
+
+constexpr uint8_t kIdentityEncodingVersion = 1;
+constexpr uint8_t kRootKeyRole = 1;
+constexpr uint8_t kChunkKeyRole = 2;
+
+void AppendU32(std::string& encoded, uint32_t value) {
+    const size_t offset = encoded.size();
+    encoded.resize(offset + sizeof(value));
+    std::memcpy(encoded.data() + offset, &value, sizeof(value));
+}
+
+bool ReadU32(std::string_view encoded, size_t& offset, uint32_t& value) {
+    if (offset + sizeof(value) > encoded.size()) {
+        return false;
+    }
+    std::memcpy(&value, encoded.data() + offset, sizeof(value));
+    offset += sizeof(value);
+    return true;
+}
+
+std::string BuildDerivationInput(const NvmeKvObjectIdentity& identity,
+                                 uint8_t role, uint32_t slot,
+                                 std::optional<uint32_t> chunk_index) {
+    std::string encoded = SerializeNvmeKvCanonicalIdentity(identity);
+    encoded.push_back(static_cast<char>(role));
+    AppendU32(encoded, slot);
+    encoded.push_back(chunk_index.has_value() ? 1 : 0);
+    if (chunk_index) {
+        AppendU32(encoded, *chunk_index);
+    }
+    return encoded;
+}
+
+NvmeKvPhysicalKey DerivePhysicalKey(std::string_view encoded) {
+    NvmeKvPhysicalKey physical_key{};
+    const uint64_t low = XXH64(encoded.data(), encoded.size(), 0);
+    const uint64_t high = XXH64(encoded.data(), encoded.size(), 1);
+    std::memcpy(physical_key.data(), &low, sizeof(low));
+    std::memcpy(physical_key.data() + sizeof(low), &high, sizeof(high));
+    return physical_key;
+}
+
+}  // namespace
+
+uint32_t ComputeNvmeKvChecksum(std::span<const uint8_t> data) {
+    return static_cast<uint32_t>(XXH32(data.data(), data.size(), 0));
+}
+
+std::string SerializeNvmeKvCanonicalIdentity(
+    const NvmeKvObjectIdentity& identity) {
+    std::string encoded(1, static_cast<char>(kIdentityEncodingVersion));
+    AppendU32(encoded, static_cast<uint32_t>(identity.logical_key.size()));
+    encoded.append(identity.logical_key);
+    return encoded;
+}
+
+bool ParseNvmeKvCanonicalIdentity(std::string_view encoded,
+                                  NvmeKvObjectIdentity& identity) {
+    identity = {};
+    if (encoded.empty() ||
+        static_cast<uint8_t>(encoded.front()) != kIdentityEncodingVersion) {
+        return false;
+    }
+    size_t offset = 1;
+    uint32_t key_size = 0;
+    if (!ReadU32(encoded, offset, key_size) ||
+        key_size != encoded.size() - offset) {
+        return false;
+    }
+    identity.logical_key = std::string(encoded.substr(offset));
+    return true;
+}
+
+std::array<uint8_t, 32> ComputeNvmeKvVerifyHash(
+    const NvmeKvObjectIdentity& identity) {
+    const std::string encoded = SerializeNvmeKvCanonicalIdentity(identity);
+    std::array<uint8_t, 32> hash{};
+    for (uint64_t seed = 0; seed < 4; ++seed) {
+        const uint64_t value = XXH64(encoded.data(), encoded.size(), seed);
+        std::memcpy(hash.data() + seed * sizeof(value), &value, sizeof(value));
+    }
+    return hash;
+}
+
+NvmeKvPhysicalKey EncodeNvmeKvPhysicalKey(const NvmeKvObjectIdentity& identity,
+                                          uint32_t slot) {
+    return DerivePhysicalKey(
+        BuildDerivationInput(identity, kRootKeyRole, slot, std::nullopt));
+}
+
+NvmeKvPhysicalKey EncodeNvmeKvChunkPhysicalKey(
+    const NvmeKvObjectIdentity& identity, uint32_t chunk_index, uint32_t slot) {
+    return DerivePhysicalKey(
+        BuildDerivationInput(identity, kChunkKeyRole, slot, chunk_index));
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/nvme_kv_key_conflict_policy.cpp
+++ b/mooncake-store/src/nvme_kv_key_conflict_policy.cpp
@@ -1,0 +1,145 @@
+#include "nvme_kv_key_conflict_policy.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
+namespace mooncake {
+namespace {
+
+uint32_t PayloadLimitForIdentityMetadata(uint32_t max_value_size,
+                                         uint32_t identity_metadata_size) {
+    const uint64_t fixed_overhead =
+        static_cast<uint64_t>(sizeof(NvmeKvObjectHeader)) +
+        identity_metadata_size;
+    if (max_value_size <= fixed_overhead) {
+        return 0;
+    }
+    return static_cast<uint32_t>(max_value_size - fixed_overhead);
+}
+
+}  // namespace
+
+bool NvmeKvKeyConflictPolicy::ValidateResolvedRootPlacement(
+    const NvmeKvObjectIdentity& identity,
+    const NvmeKvStoredIdentityView& stored_view,
+    const NvmeKvPhysicalKey& observed_physical_key) {
+    return stored_view.resolved_physical_key == observed_physical_key &&
+           EncodeNvmeKvPhysicalKey(identity, stored_view.resolved_slot) ==
+               stored_view.resolved_physical_key;
+}
+
+tl::expected<NvmeKvKeyConflictPolicy::WritePlan, ErrorCode>
+NvmeKvKeyConflictPolicy::BuildWritePlan(const NvmeKvObjectIdentity& identity,
+                                        std::string_view payload, uint32_t slot,
+                                        uint32_t max_value_size) {
+    if (payload.size() >
+        static_cast<size_t>(std::numeric_limits<uint32_t>::max())) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    WritePlan plan;
+    plan.identity = identity;
+    plan.root_key = EncodeNvmeKvPhysicalKey(identity, slot);
+
+    const auto root_identity_metadata = SerializeNvmeKvStoredIdentity(
+        identity, BuildNvmeKvStoredIdentityMetadata(plan.root_key, slot));
+    const uint32_t inline_payload_limit = PayloadLimitForIdentityMetadata(
+        max_value_size, static_cast<uint32_t>(root_identity_metadata.size()));
+    plan.store_inline = payload.size() <= inline_payload_limit;
+
+    const auto verify_hash = ComputeNvmeKvVerifyHash(identity);
+    if (plan.store_inline) {
+        NvmeKvObjectHeader header{
+            .magic = NvmeKvObjectHeader::kMagic,
+            .object_type = static_cast<uint32_t>(NvmeKvObjectType::kInline),
+            .payload_size = static_cast<uint32_t>(payload.size()),
+            .verify_hash = verify_hash,
+            .payload_checksum = ComputeNvmeKvPayloadChecksum(payload),
+            .header_checksum = 0,
+            .identity_metadata_size =
+                static_cast<uint32_t>(root_identity_metadata.size()),
+        };
+        header.header_checksum = ComputeNvmeKvHeaderChecksum(header);
+        plan.root_blob =
+            BuildNvmeKvObjectBlob(header, root_identity_metadata, payload);
+        return plan;
+    }
+
+    const uint32_t chunk_payload_limit = max_value_size;
+    if (chunk_payload_limit == 0) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    const size_t chunk_count =
+        (payload.size() + chunk_payload_limit - 1) / chunk_payload_limit;
+    if (chunk_count == 0 ||
+        chunk_count >
+            static_cast<size_t>(std::numeric_limits<uint32_t>::max())) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    plan.manifest_records.reserve(chunk_count);
+    plan.chunk_values.reserve(chunk_count);
+    for (size_t chunk_index = 0; chunk_index < chunk_count; ++chunk_index) {
+        const size_t offset = chunk_index * chunk_payload_limit;
+        const size_t chunk_size = std::min(
+            static_cast<size_t>(chunk_payload_limit), payload.size() - offset);
+        std::string_view chunk_payload(payload.data() + offset, chunk_size);
+        const auto chunk_key = EncodeNvmeKvChunkPhysicalKey(
+            identity, static_cast<uint32_t>(chunk_index), slot);
+        const uint32_t chunk_checksum =
+            ComputeNvmeKvPayloadChecksum(chunk_payload);
+        plan.chunk_values.emplace_back(chunk_key, chunk_payload);
+        plan.manifest_records.push_back(NvmeKvManifestChunkRecord{
+            chunk_key, static_cast<uint32_t>(chunk_size), chunk_checksum});
+    }
+
+    const NvmeKvManifestMetadata metadata{
+        .logical_payload_size = static_cast<uint32_t>(payload.size()),
+        .chunk_count = static_cast<uint32_t>(plan.manifest_records.size()),
+    };
+    const std::string manifest_payload =
+        SerializeNvmeKvManifest(metadata, plan.manifest_records);
+    if (manifest_payload.size() + sizeof(NvmeKvObjectHeader) +
+            root_identity_metadata.size() >
+        max_value_size) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    NvmeKvObjectHeader header{
+        .magic = NvmeKvObjectHeader::kMagic,
+        .object_type = static_cast<uint32_t>(NvmeKvObjectType::kManifest),
+        .payload_size = static_cast<uint32_t>(manifest_payload.size()),
+        .verify_hash = verify_hash,
+        .payload_checksum = ComputeNvmeKvPayloadChecksum(manifest_payload),
+        .header_checksum = 0,
+        .identity_metadata_size =
+            static_cast<uint32_t>(root_identity_metadata.size()),
+    };
+    header.header_checksum = ComputeNvmeKvHeaderChecksum(header);
+    plan.root_blob =
+        BuildNvmeKvObjectBlob(header, root_identity_metadata, manifest_payload);
+    return plan;
+}
+
+tl::expected<NvmeKvKeyConflictPolicy::ExistingObjectDecision, ErrorCode>
+NvmeKvKeyConflictPolicy::ResolveExistingObject(NvmeKvConnector& connector,
+                                               const PhysicalKey& physical_key,
+                                               std::string_view expected_blob) {
+    auto existing_value_res = connector.Retrieve(physical_key);
+    if (!existing_value_res) {
+        if (existing_value_res.error() == ErrorCode::OBJECT_NOT_FOUND) {
+            return ExistingObjectDecision::kNotFound;
+        }
+        return tl::make_unexpected(existing_value_res.error());
+    }
+    const auto& existing = existing_value_res.value();
+    if (existing.size() == expected_blob.size() &&
+        std::memcmp(existing.data(), expected_blob.data(),
+                    expected_blob.size()) == 0) {
+        return ExistingObjectDecision::kSameObject;
+    }
+    return ExistingObjectDecision::kDifferentObject;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/nvme_kv_object_layout.cpp
+++ b/mooncake-store/src/nvme_kv_object_layout.cpp
@@ -1,0 +1,204 @@
+#include "nvme_kv_object_layout.h"
+
+#include <cstring>
+
+namespace mooncake {
+namespace {
+
+uint32_t ResolveNvmeKvObjectBlobSizeFromHeader(const char* buffer,
+                                               uint32_t prefix_size,
+                                               bool enforce_prefix_limit) {
+    if (prefix_size < sizeof(NvmeKvObjectHeader)) {
+        return 0;
+    }
+
+    NvmeKvObjectHeader header{};
+    std::memcpy(&header, buffer, sizeof(header));
+    if (header.magic != NvmeKvObjectHeader::kMagic) {
+        return 0;
+    }
+
+    const uint64_t object_size = static_cast<uint64_t>(sizeof(header)) +
+                                 header.identity_metadata_size +
+                                 header.payload_size;
+    if (object_size > UINT32_MAX) {
+        return 0;
+    }
+    if (enforce_prefix_limit && object_size > prefix_size) {
+        return 0;
+    }
+    return static_cast<uint32_t>(object_size);
+}
+
+}  // namespace
+
+uint32_t ComputeNvmeKvPayloadChecksum(std::string_view payload) {
+    return ComputeNvmeKvChecksum(std::span<const uint8_t>(
+        reinterpret_cast<const uint8_t*>(payload.data()), payload.size()));
+}
+
+uint32_t ComputeNvmeKvHeaderChecksum(const NvmeKvObjectHeader& header) {
+    NvmeKvObjectHeader temp = header;
+    temp.header_checksum = 0;
+    return ComputeNvmeKvChecksum(std::span<const uint8_t>(
+        reinterpret_cast<const uint8_t*>(&temp), sizeof(temp)));
+}
+
+uint32_t ComputeNvmeKvStoredIdentityMetadataSize(
+    const NvmeKvObjectIdentity& identity) {
+    return static_cast<uint32_t>(
+        sizeof(NvmeKvStoredIdentityMetadata) +
+        SerializeNvmeKvCanonicalIdentity(identity).size());
+}
+
+NvmeKvStoredIdentityMetadata BuildNvmeKvStoredIdentityMetadata(
+    const NvmeKvPhysicalKey& physical_key, uint32_t slot) {
+    return NvmeKvStoredIdentityMetadata{
+        .resolved_physical_key = physical_key,
+        .resolved_slot = slot,
+    };
+}
+
+std::string SerializeNvmeKvStoredIdentity(
+    const NvmeKvObjectIdentity& identity,
+    const NvmeKvStoredIdentityMetadata& metadata) {
+    const std::string canonical_identity =
+        SerializeNvmeKvCanonicalIdentity(identity);
+    std::string encoded(reinterpret_cast<const char*>(&metadata),
+                        sizeof(metadata));
+    encoded.append(canonical_identity);
+    return encoded;
+}
+
+bool ParseNvmeKvStoredIdentity(std::string_view encoded_identity,
+                               NvmeKvStoredIdentityView& identity_view) {
+    identity_view = {};
+    if (encoded_identity.size() < sizeof(NvmeKvStoredIdentityMetadata)) {
+        return false;
+    }
+
+    NvmeKvStoredIdentityMetadata metadata{};
+    std::memcpy(&metadata, encoded_identity.data(), sizeof(metadata));
+    NvmeKvObjectIdentity identity{};
+    if (!ParseNvmeKvCanonicalIdentity(
+            encoded_identity.substr(sizeof(NvmeKvStoredIdentityMetadata)),
+            identity)) {
+        return false;
+    }
+
+    identity_view.logical_key = std::move(identity.logical_key);
+    identity_view.resolved_physical_key = metadata.resolved_physical_key;
+    identity_view.resolved_slot = metadata.resolved_slot;
+    return true;
+}
+
+bool ValidateNvmeKvHeader(const NvmeKvObjectHeader& header,
+                          const NvmeKvObjectIdentity& identity,
+                          uint32_t expected_identity_size,
+                          uint32_t expected_size,
+                          NvmeKvObjectType expected_type) {
+    if (header.magic != NvmeKvObjectHeader::kMagic) {
+        return false;
+    }
+    if (header.object_type != static_cast<uint32_t>(expected_type)) {
+        return false;
+    }
+    if (header.payload_size != expected_size) {
+        return false;
+    }
+    if (header.identity_metadata_size != expected_identity_size) {
+        return false;
+    }
+    if (header.header_checksum != ComputeNvmeKvHeaderChecksum(header)) {
+        return false;
+    }
+    if (header.verify_hash != ComputeNvmeKvVerifyHash(identity)) {
+        return false;
+    }
+    return true;
+}
+
+std::string BuildNvmeKvObjectBlob(const NvmeKvObjectHeader& header,
+                                  std::string_view identity_metadata,
+                                  std::string_view payload) {
+    std::string object_blob(reinterpret_cast<const char*>(&header),
+                            sizeof(header));
+    object_blob.append(identity_metadata);
+    object_blob.append(payload);
+    return object_blob;
+}
+
+bool ParseNvmeKvObjectBlob(std::string_view object_blob,
+                           NvmeKvObjectHeader& header,
+                           std::string_view& identity_metadata_view,
+                           std::string_view& payload_view) {
+    if (object_blob.size() < sizeof(NvmeKvObjectHeader)) {
+        return false;
+    }
+
+    std::memcpy(&header, object_blob.data(), sizeof(header));
+    if (header.magic != NvmeKvObjectHeader::kMagic) {
+        return false;
+    }
+    const size_t total_header_bytes =
+        sizeof(NvmeKvObjectHeader) + header.identity_metadata_size;
+    const size_t expected_size = total_header_bytes + header.payload_size;
+    if (object_blob.size() != expected_size) {
+        return false;
+    }
+    identity_metadata_view = object_blob.substr(sizeof(NvmeKvObjectHeader),
+                                                header.identity_metadata_size);
+    payload_view = object_blob.substr(total_header_bytes, header.payload_size);
+    return true;
+}
+
+uint32_t ResolveNvmeKvObjectBlobSizeFromPrefix(const char* buffer,
+                                               uint32_t prefix_size) {
+    return ResolveNvmeKvObjectBlobSizeFromHeader(buffer, prefix_size, false);
+}
+
+uint32_t ResolveNvmeKvObjectBlobSize(const char* buffer, uint32_t returned_size,
+                                     uint32_t max_size) {
+    const uint32_t header_size =
+        ResolveNvmeKvObjectBlobSizeFromHeader(buffer, max_size, true);
+    if (header_size != 0) {
+        return header_size;
+    }
+    if (returned_size > max_size) {
+        return 0;
+    }
+    return returned_size;
+}
+
+std::string SerializeNvmeKvManifest(
+    const NvmeKvManifestMetadata& metadata,
+    const std::vector<NvmeKvManifestChunkRecord>& chunk_records) {
+    std::string manifest(reinterpret_cast<const char*>(&metadata),
+                         sizeof(metadata));
+    for (const auto& record : chunk_records) {
+        manifest.append(reinterpret_cast<const char*>(&record), sizeof(record));
+    }
+    return manifest;
+}
+
+bool ParseNvmeKvManifest(
+    std::string_view manifest_payload, NvmeKvManifestMetadata& metadata,
+    std::vector<NvmeKvManifestChunkRecord>& chunk_records) {
+    if (manifest_payload.size() < sizeof(NvmeKvManifestMetadata)) {
+        return false;
+    }
+    std::memcpy(&metadata, manifest_payload.data(), sizeof(metadata));
+    const size_t records_bytes = manifest_payload.size() - sizeof(metadata);
+    if (records_bytes !=
+        metadata.chunk_count * sizeof(NvmeKvManifestChunkRecord)) {
+        return false;
+    }
+    chunk_records.resize(metadata.chunk_count);
+    if (!chunk_records.empty()) {
+        std::memcpy(chunk_records.data(),
+                    manifest_payload.data() + sizeof(metadata), records_bytes);
+    }
+    return true;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -24,6 +24,7 @@
 #include <ylt/struct_pb.hpp>
 
 #include "mutex.h"
+#include "nvme_kv_backend.h"
 #include "utils.h"
 #include "crc32c.h"
 #include "ascii_string.h"
@@ -5547,6 +5548,9 @@ CreateStorageBackend(const FileStorageConfig& config) {
             return std::make_shared<OffsetAllocatorStorageBackend>(
                 config, offset_backend_config);
         }
+        case StorageBackendType::kNvmeKv:
+            return std::make_shared<NvmeKvStorageBackend>(config);
+
         case StorageBackendType::kDistributed: {
             auto distributed_config =
                 DistributedStorageConfig::FromEnvironment();

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -24,6 +24,7 @@
 #include <ylt/struct_pb.hpp>
 
 #include "mutex.h"
+#include "nvme_kv_backend.h"
 #include "utils.h"
 #include "crc32c.h"
 #include "ascii_string.h"
@@ -5530,6 +5531,9 @@ CreateStorageBackend(const FileStorageConfig& config) {
             return std::make_shared<OffsetAllocatorStorageBackend>(
                 config, offset_backend_config);
         }
+        case StorageBackendType::kNvmeKv:
+            return std::make_shared<NvmeKvStorageBackend>(config);
+
         case StorageBackendType::kDistributed: {
             auto distributed_config =
                 DistributedStorageConfig::FromEnvironment();

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -174,6 +174,7 @@ add_ha_test(batch_oplog_snapshot_types_test
 add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
+add_store_test(nvme_kv_storage_backend_test nvme_kv_storage_backend_test.cpp)
 add_store_test(storage_backend_test storage_backend_test.cpp)
 add_store_test(client_storage_backend_test client_storage_backend_test.cpp)
 add_store_test(mutex_test mutex_test.cpp)

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -145,6 +145,7 @@ add_store_test(master_snapshot_codec_test
 add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
+add_store_test(nvme_kv_storage_backend_test nvme_kv_storage_backend_test.cpp)
 add_store_test(storage_backend_test storage_backend_test.cpp)
 add_store_test(client_storage_backend_test client_storage_backend_test.cpp)
 add_store_test(mutex_test mutex_test.cpp)

--- a/mooncake-store/tests/nvme_kv_storage_backend_test.cpp
+++ b/mooncake-store/tests/nvme_kv_storage_backend_test.cpp
@@ -1,0 +1,188 @@
+#include "nvme_kv_backend.h"
+#include "nvme_kv_executor_util.h"
+#include "storage_backend.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace mooncake::test {
+
+namespace {
+
+class EnvVarGuard {
+   public:
+    EnvVarGuard(const char *name, const char *value) : name_(name) {
+        if (const char *old_value = getenv(name)) {
+            old_value_ = old_value;
+        }
+        setenv(name, value, 1);
+    }
+
+    ~EnvVarGuard() {
+        if (old_value_.has_value()) {
+            setenv(name_.c_str(), old_value_->c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+   private:
+    std::string name_;
+    std::optional<std::string> old_value_;
+};
+
+class NvmeKvStorageBackendTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        data_path_ = (fs::current_path() / "nvme_kv_test_data").string();
+        std::error_code ec;
+        fs::remove_all(data_path_, ec);
+        ASSERT_FALSE(ec) << ec.message();
+        fs::create_directories(data_path_, ec);
+        ASSERT_FALSE(ec) << ec.message();
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        fs::remove_all(data_path_, ec);
+    }
+
+    std::string data_path_;
+};
+
+}  // namespace
+
+TEST_F(NvmeKvStorageBackendTest, PhysicalKeyPackingEncodesCommandSet) {
+    NvmeKvCommandExecutor::PhysicalKey key{};
+    for (size_t i = 0; i < key.size(); ++i) {
+        key[i] = static_cast<uint8_t>(0x10 + i);
+    }
+
+    const auto fields = PackNvmeKvPhysicalKey(key);
+    uint32_t expected_cdw14 = 0;
+    std::memcpy(&expected_cdw14, key.data() + 8, sizeof(expected_cdw14));
+    expected_cdw14 &= 0x00FFFFFFu;
+    expected_cdw14 |= static_cast<uint32_t>(kNvmeKvCommandSetIdentifier) << 24;
+
+    EXPECT_EQ(fields.cdw14, expected_cdw14);
+    EXPECT_EQ(static_cast<uint8_t>(fields.cdw14 >> 24),
+              kNvmeKvCommandSetIdentifier);
+}
+
+TEST_F(NvmeKvStorageBackendTest, StatusMappingHandlesKvSpecificStatusCodes) {
+    EXPECT_EQ(MapNvmeKvStatus(0x81, true), ErrorCode::KEYS_ULTRA_LIMIT);
+    EXPECT_EQ(MapNvmeKvStatus(0x85, true), ErrorCode::INVALID_PARAMS);
+    EXPECT_EQ(MapNvmeKvStatus(0x86, false), ErrorCode::INVALID_PARAMS);
+    EXPECT_EQ(MapNvmeKvStatus(0x87, false), ErrorCode::OBJECT_NOT_FOUND);
+    EXPECT_EQ(MapNvmeKvStatus(0x89, true), ErrorCode::OBJECT_ALREADY_EXISTS);
+
+    EXPECT_EQ(MapNvmeKvTransportError(ENOENT, false),
+              ErrorCode::OBJECT_NOT_FOUND);
+    EXPECT_EQ(MapNvmeKvTransportError(ENOSPC, true),
+              ErrorCode::KEYS_ULTRA_LIMIT);
+    EXPECT_EQ(MapNvmeKvTransportError(ENOMEM, false),
+              ErrorCode::BUFFER_OVERFLOW);
+    EXPECT_EQ(MapNvmeKvTransportError(0x4087, false),
+              ErrorCode::OBJECT_NOT_FOUND);
+
+    constexpr uint32_t kRawValueSize = 1234;
+    std::array<char, 4096> raw_value{};
+    EXPECT_EQ(
+        ResolveNvmeKvInitialRetrieveBytes(kRawValueSize, raw_value.size()),
+        RoundUpToNvmeKvTransferBytes(kRawValueSize));
+    EXPECT_EQ(ResolveNvmeKvRetrievedValueSize(raw_value.data(), 0,
+                                              raw_value.size(), kRawValueSize),
+              kRawValueSize);
+    EXPECT_EQ(ResolveNvmeKvRetrievedValueSize(raw_value.data(), 0, 1024,
+                                              kRawValueSize),
+              0);
+
+    EXPECT_TRUE(ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+        ErrorCode::INVALID_PARAMS, 0, kDefaultNvmeKvTransferAlignmentBytes,
+        kDefaultNvmeKvRuntimeTransferLimit));
+    EXPECT_FALSE(ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+        ErrorCode::INVALID_PARAMS, kDefaultNvmeKvTransferAlignmentBytes,
+        kDefaultNvmeKvTransferAlignmentBytes,
+        kDefaultNvmeKvRuntimeTransferLimit));
+    EXPECT_FALSE(ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+        ErrorCode::OBJECT_NOT_FOUND, 0, kDefaultNvmeKvTransferAlignmentBytes,
+        kDefaultNvmeKvRuntimeTransferLimit));
+    EXPECT_FALSE(ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+        ErrorCode::INTERNAL_ERROR, 0, kDefaultNvmeKvTransferAlignmentBytes,
+        kDefaultNvmeKvRuntimeTransferLimit));
+    EXPECT_FALSE(ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+        ErrorCode::INVALID_PARAMS, 0, kDefaultNvmeKvRuntimeTransferLimit,
+        kDefaultNvmeKvRuntimeTransferLimit));
+}
+
+TEST_F(NvmeKvStorageBackendTest, BackendLoadsKnownObjectsFromDevice) {
+    EnvVarGuard driver_guard("MOONCAKE_NVME_KV_DRIVER", "stub");
+
+    FileStorageConfig config;
+    config.storage_filepath = data_path_ + "/known_objects";
+    config.storage_backend_type = StorageBackendType::kNvmeKv;
+
+    constexpr int kObjectCount = 9;
+    std::vector<std::string> keys;
+    std::vector<std::string> values;
+    keys.reserve(kObjectCount);
+    values.reserve(kObjectCount);
+    std::unordered_map<std::string, std::vector<Slice>> batch;
+    for (int i = 0; i < kObjectCount; ++i) {
+        keys.emplace_back("nvme_kv_known_key_" + std::to_string(i));
+        const size_t value_size = i == 0 ? 4096 : 128 * 1024 + 4096 + i * 17;
+        values.emplace_back(value_size, static_cast<char>('a' + (i % 26)));
+        batch.emplace(keys.back(),
+                      std::vector<Slice>{
+                          Slice{values.back().data(), values.back().size()}});
+    }
+
+    {
+        NvmeKvStorageBackend backend(config);
+        ASSERT_TRUE(backend.Init().has_value());
+        auto offload_result = backend.BatchOffload(
+            batch,
+            [](const std::vector<std::string> &,
+               std::vector<StorageObjectMetadata> &) { return ErrorCode::OK; });
+        ASSERT_TRUE(offload_result.has_value());
+        ASSERT_EQ(offload_result.value(), kObjectCount);
+    }
+
+    NvmeKvStorageBackend reader(config);
+    ASSERT_TRUE(reader.Init().has_value());
+    for (const auto &key : keys) {
+        EXPECT_TRUE(reader.IsExist(key).value_or(false));
+    }
+    EXPECT_FALSE(reader.IsExist("nvme_kv_missing_key").value_or(true));
+
+    auto duplicate_result = reader.BatchOffload(
+        batch,
+        [](const std::vector<std::string> &,
+           std::vector<StorageObjectMetadata> &) { return ErrorCode::OK; });
+    ASSERT_TRUE(duplicate_result.has_value());
+    EXPECT_EQ(duplicate_result.value(), kObjectCount);
+
+    std::vector<std::string> loaded_values;
+    loaded_values.reserve(kObjectCount);
+    std::unordered_map<std::string, Slice> load_batch;
+    for (int i = 0; i < kObjectCount; ++i) {
+        loaded_values.emplace_back(values[i].size(), '\0');
+        load_batch.emplace(keys[i], Slice{loaded_values.back().data(),
+                                          loaded_values.back().size()});
+    }
+    ASSERT_TRUE(reader.BatchLoad(load_batch).has_value());
+    EXPECT_EQ(loaded_values, values);
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/nvme_kv_storage_backend_test.cpp
+++ b/mooncake-store/tests/nvme_kv_storage_backend_test.cpp
@@ -1,0 +1,281 @@
+#include "nvme_kv_backend.h"
+#include "nvme_kv_executor_util.h"
+#include "storage_backend.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace mooncake::test {
+
+namespace {
+
+class EnvVarGuard {
+   public:
+    EnvVarGuard(const char *name, const char *value) : name_(name) {
+        if (const char *old_value = getenv(name)) {
+            old_value_ = old_value;
+        }
+        setenv(name, value, 1);
+    }
+
+    ~EnvVarGuard() {
+        if (old_value_.has_value()) {
+            setenv(name_.c_str(), old_value_->c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+   private:
+    std::string name_;
+    std::optional<std::string> old_value_;
+};
+
+class NvmeKvStorageBackendTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        data_path_ = (fs::current_path() / "nvme_kv_test_data").string();
+        std::error_code ec;
+        fs::remove_all(data_path_, ec);
+        ASSERT_FALSE(ec) << ec.message();
+        fs::create_directories(data_path_, ec);
+        ASSERT_FALSE(ec) << ec.message();
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        fs::remove_all(data_path_, ec);
+    }
+
+    std::string data_path_;
+};
+
+}  // namespace
+
+TEST_F(NvmeKvStorageBackendTest, PhysicalKeyPackingEncodesCommandSet) {
+    NvmeKvCommandExecutor::PhysicalKey key{};
+    for (size_t i = 0; i < key.size(); ++i) {
+        key[i] = static_cast<uint8_t>(0x10 + i);
+    }
+
+    const auto fields = PackNvmeKvPhysicalKey(key);
+    uint32_t expected_cdw14 = 0;
+    std::memcpy(&expected_cdw14, key.data() + 8, sizeof(expected_cdw14));
+    expected_cdw14 &= 0x00FFFFFFu;
+    expected_cdw14 |= static_cast<uint32_t>(kNvmeKvCommandSetIdentifier) << 24;
+
+    EXPECT_EQ(fields.cdw14, expected_cdw14);
+    EXPECT_EQ(static_cast<uint8_t>(fields.cdw14 >> 24),
+              kNvmeKvCommandSetIdentifier);
+}
+
+TEST_F(NvmeKvStorageBackendTest, StatusMappingHandlesKvSpecificStatusCodes) {
+    EXPECT_EQ(MapNvmeKvStatus(0x81, true), ErrorCode::KEYS_ULTRA_LIMIT);
+    EXPECT_EQ(MapNvmeKvStatus(0x85, true), ErrorCode::INVALID_PARAMS);
+    EXPECT_EQ(MapNvmeKvStatus(0x86, false), ErrorCode::INVALID_PARAMS);
+    EXPECT_EQ(MapNvmeKvStatus(0x87, false), ErrorCode::OBJECT_NOT_FOUND);
+    EXPECT_EQ(MapNvmeKvStatus(0x89, true), ErrorCode::OBJECT_ALREADY_EXISTS);
+
+    EXPECT_EQ(MapNvmeKvTransportError(ENOENT, false),
+              ErrorCode::OBJECT_NOT_FOUND);
+    EXPECT_EQ(MapNvmeKvTransportError(ENOSPC, true),
+              ErrorCode::KEYS_ULTRA_LIMIT);
+    EXPECT_EQ(MapNvmeKvTransportError(ENOMEM, false),
+              ErrorCode::BUFFER_OVERFLOW);
+    EXPECT_EQ(MapNvmeKvTransportError(0x4087, false),
+              ErrorCode::OBJECT_NOT_FOUND);
+
+    constexpr uint32_t kRawValueSize = 1234;
+    std::array<char, 4096> raw_value{};
+    EXPECT_EQ(
+        ResolveNvmeKvInitialRetrieveBytes(kRawValueSize, raw_value.size()),
+        RoundUpToNvmeKvTransferBytes(kRawValueSize));
+    EXPECT_EQ(ResolveNvmeKvRetrievedValueSize(raw_value.data(), 0,
+                                              raw_value.size(), kRawValueSize),
+              kRawValueSize);
+    EXPECT_EQ(ResolveNvmeKvRetrievedValueSize(raw_value.data(), 0, 1024,
+                                              kRawValueSize),
+              0);
+
+    EXPECT_TRUE(ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+        ErrorCode::INVALID_PARAMS, 0, kDefaultNvmeKvTransferAlignmentBytes,
+        kDefaultNvmeKvRuntimeTransferLimit));
+    EXPECT_FALSE(ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+        ErrorCode::INVALID_PARAMS, kDefaultNvmeKvTransferAlignmentBytes,
+        kDefaultNvmeKvTransferAlignmentBytes,
+        kDefaultNvmeKvRuntimeTransferLimit));
+    EXPECT_FALSE(ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+        ErrorCode::OBJECT_NOT_FOUND, 0, kDefaultNvmeKvTransferAlignmentBytes,
+        kDefaultNvmeKvRuntimeTransferLimit));
+    EXPECT_FALSE(ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+        ErrorCode::INTERNAL_ERROR, 0, kDefaultNvmeKvTransferAlignmentBytes,
+        kDefaultNvmeKvRuntimeTransferLimit));
+    EXPECT_FALSE(ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+        ErrorCode::INVALID_PARAMS, 0, kDefaultNvmeKvRuntimeTransferLimit,
+        kDefaultNvmeKvRuntimeTransferLimit));
+}
+
+TEST_F(NvmeKvStorageBackendTest, BackendLoadsKnownObjectsFromDevice) {
+    EnvVarGuard driver_guard("MOONCAKE_NVME_KV_DRIVER", "stub");
+
+    FileStorageConfig config;
+    config.storage_filepath = data_path_ + "/known_objects";
+    config.storage_backend_type = StorageBackendType::kNvmeKv;
+
+    constexpr int kObjectCount = 9;
+    std::vector<std::string> keys;
+    std::vector<std::string> values;
+    keys.reserve(kObjectCount);
+    values.reserve(kObjectCount);
+    std::unordered_map<std::string, std::vector<Slice>> batch;
+    for (int i = 0; i < kObjectCount; ++i) {
+        keys.emplace_back("nvme_kv_known_key_" + std::to_string(i));
+        const size_t value_size = i == 0 ? 4096 : 128 * 1024 + 4096 + i * 17;
+        values.emplace_back(value_size, static_cast<char>('a' + (i % 26)));
+        batch.emplace(keys.back(),
+                      std::vector<Slice>{
+                          Slice{values.back().data(), values.back().size()}});
+    }
+
+    {
+        NvmeKvStorageBackend backend(config);
+        ASSERT_TRUE(backend.Init().has_value());
+        auto offload_result = backend.BatchOffload(
+            batch,
+            [](const std::vector<std::string> &,
+               std::vector<StorageObjectMetadata> &) { return ErrorCode::OK; });
+        ASSERT_TRUE(offload_result.has_value());
+        ASSERT_EQ(offload_result.value(), kObjectCount);
+    }
+
+    NvmeKvStorageBackend reader(config);
+    ASSERT_TRUE(reader.Init().has_value());
+    for (const auto &key : keys) {
+        EXPECT_TRUE(reader.IsExist(key).value_or(false));
+    }
+    EXPECT_FALSE(reader.IsExist("nvme_kv_missing_key").value_or(true));
+
+    auto duplicate_result = reader.BatchOffload(
+        batch,
+        [](const std::vector<std::string> &,
+           std::vector<StorageObjectMetadata> &) { return ErrorCode::OK; });
+    ASSERT_TRUE(duplicate_result.has_value());
+    EXPECT_EQ(duplicate_result.value(), kObjectCount);
+
+    std::vector<std::string> loaded_values;
+    loaded_values.reserve(kObjectCount);
+    std::unordered_map<std::string, Slice> load_batch;
+    for (int i = 0; i < kObjectCount; ++i) {
+        loaded_values.emplace_back(values[i].size(), '\0');
+        load_batch.emplace(keys[i], Slice{loaded_values.back().data(),
+                                          loaded_values.back().size()});
+    }
+    ASSERT_TRUE(reader.BatchLoad(load_batch).has_value());
+    EXPECT_EQ(loaded_values, values);
+}
+
+TEST_F(NvmeKvStorageBackendTest, PipelinedStubRoundTripChunkedObjects) {
+    EnvVarGuard driver_guard("MOONCAKE_NVME_KV_DRIVER", "stub");
+    EnvVarGuard queue_depth_guard("MOONCAKE_NVME_KV_QUEUE_DEPTH", "8");
+    EnvVarGuard runtime_limit_guard("MOONCAKE_NVME_KV_RUNTIME_TRANSFER_LIMIT",
+                                    "65536");
+    EnvVarGuard io_concurrency_guard("MOONCAKE_NVME_KV_IO_CONCURRENCY", "8");
+    EnvVarGuard batch_submit_guard("MOONCAKE_NVME_KV_BATCH_SUBMIT_CONCURRENCY",
+                                   "3");
+    EnvVarGuard root_submit_guard("MOONCAKE_NVME_KV_ROOT_SUBMIT_CONCURRENCY",
+                                  "2");
+
+    FileStorageConfig config;
+    config.storage_filepath = data_path_ + "/pipelined";
+    config.storage_backend_type = StorageBackendType::kNvmeKv;
+
+    NvmeKvStorageBackend backend(config);
+    ASSERT_TRUE(backend.Init().has_value());
+
+    constexpr int kObjectCount = 24;
+    std::vector<std::string> keys;
+    std::vector<std::string> values;
+    keys.reserve(kObjectCount);
+    values.reserve(kObjectCount);
+    std::unordered_map<std::string, std::vector<Slice>> batch;
+    for (int i = 0; i < kObjectCount; ++i) {
+        keys.emplace_back("nvme_kv_pipelined_key_" + std::to_string(i));
+        values.emplace_back(180 * 1024 + i * 4096,
+                            static_cast<char>('A' + (i % 26)));
+        batch.emplace(keys.back(),
+                      std::vector<Slice>{
+                          Slice{values.back().data(), values.back().size()}});
+    }
+
+    auto offload_result = backend.BatchOffload(
+        batch,
+        [](const std::vector<std::string> &,
+           std::vector<StorageObjectMetadata> &) { return ErrorCode::OK; });
+    ASSERT_TRUE(offload_result.has_value());
+    EXPECT_EQ(offload_result.value(), kObjectCount);
+
+    std::vector<std::string> loaded_values;
+    loaded_values.reserve(kObjectCount);
+    std::unordered_map<std::string, Slice> load_batch;
+    for (int i = 0; i < kObjectCount; ++i) {
+        loaded_values.emplace_back(values[i].size(), '\0');
+        load_batch.emplace(keys[i], Slice{loaded_values.back().data(),
+                                          loaded_values.back().size()});
+    }
+    ASSERT_TRUE(backend.BatchLoad(load_batch).has_value());
+    EXPECT_EQ(loaded_values, values);
+}
+
+TEST_F(NvmeKvStorageBackendTest, ManifestCacheUpdatesAfterSameKeyRewrite) {
+    EnvVarGuard driver_guard("MOONCAKE_NVME_KV_DRIVER", "stub");
+    EnvVarGuard runtime_limit_guard("MOONCAKE_NVME_KV_RUNTIME_TRANSFER_LIMIT",
+                                    "65536");
+
+    FileStorageConfig config;
+    config.storage_filepath = data_path_ + "/manifest_cache";
+    config.storage_backend_type = StorageBackendType::kNvmeKv;
+
+    NvmeKvStorageBackend backend(config);
+    ASSERT_TRUE(backend.Init().has_value());
+
+    const std::string key = "nvme_kv_manifest_cache_rewrite";
+    std::string first_value(192 * 1024, 'x');
+    std::string second_value(first_value.size(), 'y');
+
+    auto store_value = [&](std::string &value) {
+        std::unordered_map<std::string, std::vector<Slice>> batch;
+        batch.emplace(key,
+                      std::vector<Slice>{Slice{value.data(), value.size()}});
+        auto offload_result = backend.BatchOffload(
+            batch,
+            [](const std::vector<std::string> &,
+               std::vector<StorageObjectMetadata> &) { return ErrorCode::OK; });
+        ASSERT_TRUE(offload_result.has_value());
+        EXPECT_EQ(offload_result.value(), 1);
+    };
+
+    store_value(first_value);
+    std::string loaded(first_value.size(), '\0');
+    std::unordered_map<std::string, Slice> load_batch{
+        {key, Slice{loaded.data(), loaded.size()}}};
+    ASSERT_TRUE(backend.BatchLoad(load_batch).has_value());
+    EXPECT_EQ(loaded, first_value);
+
+    store_value(second_value);
+    std::fill(loaded.begin(), loaded.end(), '\0');
+    ASSERT_TRUE(backend.BatchLoad(load_batch).has_value());
+    EXPECT_EQ(loaded, second_value);
+}
+
+}  // namespace mooncake::test


### PR DESCRIPTION
## Description

This PR introduces a scoped NVMe Key-Value backend for Mooncake Store SSD offload.

The backend lets a Mooncake real client store `LOCAL_DISK` replicas on one node-local NVMe KV namespace while preserving the existing Mooncake object API. Mooncake logical objects are mapped into NVMe KV Store/Retrieve/Delete commands through a small set of focused layers:

- `NvmeKvStorageBackend` owns object layout, identity validation, checksums, physical-key conflict handling, and batched I/O orchestration.
- `NvmeKvConnector` owns one configured device and one selected executor.
- `NvmeKvCommandExecutor` owns transport-specific command encoding and submission.

The object layout is driven by the NVMe KV command model. NVMe KV namespaces expose bounded key and value sizes, so Mooncake cannot pass arbitrary logical keys and object payloads directly to the device. The backend therefore derives fixed-width physical keys from the full logical key, object role, conflict slot, and chunk index. Small objects are stored inline in one root value; larger objects are split into raw chunk values plus a root manifest that records chunk keys, sizes, and checksums.

Writes use store-if-not-exists by default. The normal new-object path does not perform a separate existence query before writing; the device returns `KEY_EXISTS` only on the conflict/idempotency path, where the backend retrieves the existing value to distinguish the same object from a physical-key collision.

The current implementation supports:

- `nvme_kv_storage_backend` registration and selection through the existing `FileStorage` path.
- Single node-local NVMe KV namespace configuration via `MOONCAKE_NVME_KV_DEVICE_PATH`.
- Deterministic logical-key to physical-key encoding with conflict slots.
- Inline root values and chunked root-manifest layout for larger objects.
- Header, identity, placement, manifest, payload, and chunk checksum validation.
- Store, Retrieve, and Delete command submission through ioctl.
- NVMe uring command submission through io_uring when build and kernel support are available.
- `auto` transport selection that tries io_uring first and falls back to ioctl only if io_uring initialization fails.
- Runtime transfer sizing and alignment knobs for devices with stricter value transfer requirements.
- Bounded backend concurrency for preparation, chunk submission, root submission, and read planning.

This PR intentionally does not add Mooncake-level SSD pool management, rebuild/drain/cleanup flows, admin device maintenance, HiCache benchmark adapters, or internal packaging/test scripts.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
# Unit and configuration coverage
storage_backend_test --gtest_filter="*NvmeKv*"
storage_backend_test --gtest_filter="*FileStorage*"
ssd_metrics_test

# Formatting
./scripts/code_format.sh
git diff --check
```

**Hardware validation:**

- Validated real NVMe KV Store/Retrieve/Delete behavior on a local NVMe KV namespace.
- Validated ioctl and io_uring transports.
- Validated io_uring namespace block-device to NVMe generic character-device resolution.
- Validated positive NVMe KV completion statuses such as key-not-found, invalid value size, and key-exists are mapped as KV errors rather than successful byte counts.
- Validated the backend can reach the device/channel bandwidth range observed by direct NVMe KV command baselines under the tuned batch and concurrency settings.

**Test results:**

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (real-device NVMe KV validation)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (Codex was used to help implement, review, document, and validate the change; the submitter is responsible for the final content.)
