### PR TITLE
fix(ha): ensure /oplog/{cluster_id}/latest key is initialized on firs…

### DIFF
--- a/mooncake-store/src/ha/oplog/etcd_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/etcd_oplog_store.cpp
@@ -38,8 +38,10 @@ ErrorCode EtcdOpLogStore::Init() {
     // This avoids "key not found" errors when querying the latest sequence ID.
     // Important: Only initialize if the key doesn't exist to avoid overwriting
     // existing data.
-    // Skip for read-only instances to avoid unnecessary etcd writes.
-    if (enable_batch_write_ && !cluster_id_.empty()) {
+    // Note: We allow any instance (reader or writer) to ensure the key exists,
+    // because snapshot resolution depends on it regardless of the HA role.
+    // The Create call uses CAS semantics so concurrent initializers are safe.
+    if (!cluster_id_.empty()) {
         std::string latest_key = BuildLatestKey();
         std::string existing_value;
         EtcdRevisionId revision_id;


### PR DESCRIPTION
# PR: Fix `/oplog/{cluster_id}/latest` key never initialized in master process

## Problem

When `mooncake_master` is started with `-enable_ha=true -enable_snapshot=true -cluster_id=mooncake`, the snapshot logic calls `ResolveSnapshotSequenceId()` → `GetSnapshotBoundaryOpLogStore()` → `EtcdOpLogStore::GetLatestSequenceId()` to read the `/oplog/mooncake/latest` key from etcd.

However, this key is **never automatically created** by the master process, causing snapshot operations to fail with "key not found" errors on first deployment.

## Root Cause

In `GetSnapshotBoundaryOpLogStore()` (`master_service.cpp:2804`):

```cpp
auto oplog_store = std::make_unique<EtcdOpLogStore>(cluster_id_);
```

Only `cluster_id_` is passed. The constructor defaults are:
- `enable_latest_seq_batch_update = false`
- `enable_batch_write = false`

Then in `EtcdOpLogStore::Init()`, the `/latest` key initialization is gated by:

```cpp
if (enable_batch_write_ && !cluster_id_.empty()) {
    // ... create /latest key if not exist
}
```

Since `enable_batch_write_ = false`, this block is **always skipped** in the master's snapshot path.

Meanwhile, `OpLogStoreFactory::Create(..., OpLogStoreRole::WRITER, ...)` (which would set `enable_batch_write = true`) is **never called** anywhere in the master's production code — only in `HotStandbyService` with `READER` role, and in tests.

## Fix

Remove the `enable_batch_write_` guard from the `/latest` key initialization in `Init()`. The new condition is simply `!cluster_id_.empty()`.

**Rationale:**
- The `/latest` key initialization uses `EtcdHelper::Create` (CAS / create-if-not-exist), so it's safe for multiple instances to call concurrently — only the first one actually creates the key.
- Snapshot resolution depends on this key existing regardless of the HA write role.
- The overhead is one extra etcd Get on startup (returns immediately if key already exists).

## Changes

- `mooncake-store/src/ha/oplog/etcd_oplog_store.cpp`: Change `Init()` condition from `enable_batch_write_ && !cluster_id_.empty()` to `!cluster_id_.empty()`.

## Before / After

**Before:**
```
Master starts → GetSnapshotBoundaryOpLogStore() → EtcdOpLogStore(cluster_id_) 
→ Init() → enable_batch_write_=false → SKIP /latest init → snapshot reads fail
```

**After:**
```
Master starts → GetSnapshotBoundaryOpLogStore() → EtcdOpLogStore(cluster_id_) 
→ Init() → cluster_id_ not empty → check /latest → Create if not exist ✅
```

## Testing

1. Start `mooncake_master` with `-enable_ha=true -enable_snapshot=true -cluster_id=mooncake` on a fresh etcd cluster (no pre-existing keys).
2. Verify `/oplog/mooncake/latest` is automatically created with value `"0"`.
3. Verify snapshot operations succeed without manual `etcdctl put`.
4. Verify standby nodes still work correctly (they now also ensure the key exists on startup).
