### PR TITLE
[CP][Store]: Use SharedMutex in MetadataShard for better performance (#1343)

### DIFF
--- a/mooncake-store/include/centralized_master_service.h
+++ b/mooncake-store/include/centralized_master_service.h
@@ -264,7 +264,7 @@ class CentralizedMasterService final : public MasterService {
         const ObjectMetadata& metadata) override;
 
     // Hooks implementation
-    void OnObjectAccessed(ObjectMetadata& metadata) override;
+    void OnObjectAccessed(const ObjectMetadata& metadata) override;
     void OnObjectHit(const ObjectMetadata& metadata) override;
     void OnReplicaRemoved(const Replica& replica) override;
     void OnReplicaAdded(const Replica& replica) override;
@@ -357,7 +357,7 @@ class CentralizedMasterService final : public MasterService {
 
         // Grant a lease with timeout as now() + ttl, only update if the new
         // timeout is larger
-        void GrantLease(const uint64_t ttl, const uint64_t soft_ttl);
+        void GrantLease(const uint64_t ttl, const uint64_t soft_ttl) const;
 
         // Check if the lease has expired
         bool IsLeaseExpired() const;
@@ -372,6 +372,14 @@ class CentralizedMasterService final : public MasterService {
         // Check if is in soft pin status
         bool IsSoftPinned(
             const std::chrono::steady_clock::time_point& now) const;
+
+        virtual bool IsValid() const override {
+            return ObjectMetadata::IsValid() &&
+                   HasReplica([](const Replica& replica) {
+                       return !replica.is_memory_replica() ||
+                              !replica.has_invalid_mem_handle();
+                   });
+        }
 
         // Return names of all segments referenced by replicas
         std::vector<std::string> GetReplicaSegmentNames() const {
@@ -395,8 +403,11 @@ class CentralizedMasterService final : public MasterService {
         // The client that created this object (via PutStart).
         const UUID owner_client_id_;
         const std::chrono::steady_clock::time_point put_start_time_;
-        std::chrono::steady_clock::time_point lease_timeout_;
-        std::optional<std::chrono::steady_clock::time_point> soft_pin_timeout_;
+        mutable SpinLock lock_;
+        mutable std::chrono::steady_clock::time_point lease_timeout_
+            GUARDED_BY(lock_);
+        mutable std::optional<std::chrono::steady_clock::time_point>
+            soft_pin_timeout_ GUARDED_BY(lock_);
         int32_t replication_task_cnt_;
     };
 
@@ -437,14 +448,18 @@ class CentralizedMasterService final : public MasterService {
 
    private:
     class CentralizedMetadataAccessor final
-        : public MasterService::MetadataAccessor {
+        : public MasterService::MetadataAccessorRW {
        public:
         CentralizedMetadataAccessor(CentralizedMasterService* service,
                                     std::string_view key)
-            : MasterService::MetadataAccessor(service, key),
-              c_shard_(static_cast<CentralizedMetadataShard&>(shard_)),
-              processing_it_(c_shard_.processing_keys.find(key)),
-              replication_task_it_(c_shard_.replication_tasks.find(key)) {}
+            : MasterService::MetadataAccessorRW(service, key),
+              c_shard_(static_cast<CentralizedMetadataShard&>(
+                  shard_guard_.GetRef())),
+              processing_it_(c_shard_.processing_keys.end()),
+              replication_task_it_(c_shard_.replication_tasks.end()) {
+            processing_it_ = c_shard_.processing_keys.find(key);
+            replication_task_it_ = c_shard_.replication_tasks.find(key);
+        }
 
         bool InProcessing() const NO_THREAD_SAFETY_ANALYSIS {
             return processing_it_ != c_shard_.processing_keys.end();
@@ -454,13 +469,14 @@ class CentralizedMasterService final : public MasterService {
             return replication_task_it_ != c_shard_.replication_tasks.end();
         }
 
-        CentralizedMetadataShard& GetShard() NO_THREAD_SAFETY_ANALYSIS {
+        CentralizedMetadataShard& GetCentralizedShard()
+            NO_THREAD_SAFETY_ANALYSIS {
             return c_shard_;
         }
 
         CentralizedObjectMetadata& Get() NO_THREAD_SAFETY_ANALYSIS {
             return static_cast<CentralizedObjectMetadata&>(
-                MasterService::MetadataAccessor::Get());
+                MasterService::MetadataAccessorRW::Get());
         }
 
         const ReplicationTask& GetReplicationTask() NO_THREAD_SAFETY_ANALYSIS {
@@ -472,14 +488,12 @@ class CentralizedMasterService final : public MasterService {
             processing_it_ = c_shard_.processing_keys.end();
         }
 
-        // Access the extended shard directly (for inserting processing keys)
-        CentralizedMetadataShard& GetCentralizedShard() { return c_shard_; }
-
         void EraseReplicationTask() NO_THREAD_SAFETY_ANALYSIS {
             c_shard_.replication_tasks.erase(replication_task_it_);
             replication_task_it_ = c_shard_.replication_tasks.end();
             Get().replication_task_cnt_--;
         }
+
         void AddReplicationTask(
             const UUID& client_id, ReplicationTask::Type type, ReplicaID id,
             std::vector<ReplicaID> replica_ids) NO_THREAD_SAFETY_ANALYSIS {
@@ -498,11 +512,6 @@ class CentralizedMasterService final : public MasterService {
         std::unordered_map<std::string, const ReplicationTask, StringHash,
                            std::equal_to<>>::iterator replication_task_it_;
     };
-
-    std::unique_ptr<MetadataAccessor> GetMetadataAccessor(
-        std::string_view key) override {
-        return std::make_unique<CentralizedMetadataAccessor>(this, key);
-    }
 
    private:
     class DiscardedReplicas {

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -210,7 +210,9 @@ class MasterService {
 
         // Check if the metadata is valid
         // Valid means it has at least one replica and size is greater than 0
-        bool IsValid() const { return CountReplicas() > 0 && size_ > 0; }
+        virtual bool IsValid() const {
+            return CountReplicas() > 0 && size_ > 0;
+        }
 
         void AddReplicas(std::vector<Replica>&& replicas) {
             replicas_.insert(replicas_.end(),
@@ -380,7 +382,7 @@ class MasterService {
     //    from `metadata`, when removing an entry from `metadata`, you MUST
     //    first remove the corresponding key from `segment_key_index`.
     struct MetadataShard {
-        mutable Mutex mutex;
+        mutable SharedMutex mutex;
         std::unordered_map<std::string, std::unique_ptr<ObjectMetadata>,
                            StringHash, std::equal_to<>>
             metadata GUARDED_BY(mutex);
@@ -390,6 +392,39 @@ class MasterService {
                            boost::hash<UUID>>
             segment_key_index GUARDED_BY(mutex);
     };
+
+    // For accessing a metadata shard with exclusive (read-write) lock
+    class MetadataShardAccessorRW {
+       public:
+        MetadataShardAccessorRW(MasterService* master_service,
+                                size_t shard_index)
+            : shard_(master_service->GetShard(shard_index)),
+              lock_(&shard_.mutex) {}
+
+        MetadataShard* operator->() { return &shard_; }
+        const MetadataShard* operator->() const { return &shard_; }
+        MetadataShard& GetRef() NO_THREAD_SAFETY_ANALYSIS { return shard_; }
+
+       private:
+        MetadataShard& shard_;
+        SharedMutexLocker lock_;
+    };
+
+    // For accessing a metadata shard with shared (read-only) lock
+    class MetadataShardAccessorRO {
+       public:
+        MetadataShardAccessorRO(const MasterService* master_service,
+                                size_t shard_index)
+            : shard_(master_service->GetShard(shard_index)),
+              lock_(&shard_.mutex, shared_lock) {}
+
+        const MetadataShard* operator->() const { return &shard_; }
+
+       private:
+        const MetadataShard& shard_;
+        SharedMutexLocker lock_;
+    };
+
     // Virtual function to access shards
     virtual MetadataShard& GetShard(size_t idx) = 0;
     virtual const MetadataShard& GetShard(size_t idx) const = 0;
@@ -412,23 +447,21 @@ class MasterService {
 
    protected:
     // Helper class for accessing metadata with automatic locking
-    class MetadataAccessor {
+    class MetadataAccessorRW {
        public:
-        MetadataAccessor(MasterService* service, std::string_view key)
+        MetadataAccessorRW(MasterService* service, std::string_view key)
             : service_(service),
               shard_idx_(service_->GetShardIndex(key)),
-              shard_(service_->GetShard(shard_idx_)),
-              lock_(&shard_.mutex),
-              it_(shard_.metadata.find(key)) {}
+              shard_guard_(service_, shard_idx_),
+              it_(shard_guard_->metadata.find(key)) {}
 
-        virtual ~MetadataAccessor() = default;
+        virtual ~MetadataAccessorRW() = default;
 
         // Check if metadata exists
         bool Exists() const NO_THREAD_SAFETY_ANALYSIS {
-            return it_ != shard_.metadata.end();
+            return it_ != shard_guard_->metadata.end() &&
+                   it_->second->IsValid();
         }
-
-        MetadataShard& GetShard() NO_THREAD_SAFETY_ANALYSIS { return shard_; }
 
         const std::string& GetKey() const NO_THREAD_SAFETY_ANALYSIS {
             return it_->first;
@@ -437,33 +470,65 @@ class MasterService {
         // Get metadata (only call when Exists() is true)
         ObjectMetadata& Get() NO_THREAD_SAFETY_ANALYSIS { return *it_->second; }
 
+        MetadataShardAccessorRW& GetShard() NO_THREAD_SAFETY_ANALYSIS {
+            return shard_guard_;
+        }
+
         // Delete current metadata.
         // To prevent dangling string_views in segment_key_index, segment index
         // should be cleaned up before erasing the metadata entry.
         void Erase() NO_THREAD_SAFETY_ANALYSIS {
-            if (it_ != shard_.metadata.end()) {
-                service_->RemoveReplicaFromSegmentIndex(shard_, it_->first,
-                                                        it_->second->replicas_);
-                shard_.metadata.erase(it_);
-                it_ = shard_.metadata.end();
+            if (it_ != shard_guard_->metadata.end()) {
+                service_->RemoveReplicaFromSegmentIndex(
+                    shard_guard_.GetRef(), it_->first, it_->second->replicas_);
+                shard_guard_->metadata.erase(it_);
+                it_ = shard_guard_->metadata.end();
             }
         }
 
        protected:
         MasterService* service_;
         size_t shard_idx_;
-        MetadataShard& shard_;
-        MutexLocker lock_;
+        MetadataShardAccessorRW shard_guard_;
         using MetadataMap =
             std::unordered_map<std::string, std::unique_ptr<ObjectMetadata>,
                                StringHash, std::equal_to<>>;
         MetadataMap::iterator it_;
     };
 
-    virtual std::unique_ptr<MetadataAccessor> GetMetadataAccessor(
-        std::string_view key) {
-        return std::make_unique<MetadataAccessor>(this, key);
-    }
+    // Key-level read-only accessor
+    class MetadataAccessorRO {
+       public:
+        MetadataAccessorRO(const MasterService* service, std::string_view key)
+            : service_(service),
+              shard_idx_(service_->GetShardIndex(key)),
+              shard_guard_(service_, shard_idx_),
+              it_(shard_guard_->metadata.find(key)) {}
+
+        // Check if metadata exists
+        bool Exists() const NO_THREAD_SAFETY_ANALYSIS {
+            return it_ != shard_guard_->metadata.end() &&
+                   it_->second->IsValid();
+        }
+
+        // Get metadata (only call when Exists() is true)
+        const ObjectMetadata& Get() const NO_THREAD_SAFETY_ANALYSIS {
+            return *it_->second;
+        }
+
+        const std::string& GetKey() const NO_THREAD_SAFETY_ANALYSIS {
+            return it_->first;
+        }
+
+       private:
+        const MasterService* service_;
+        const size_t shard_idx_;
+        MetadataShardAccessorRO shard_guard_;
+        using MetadataMap =
+            std::unordered_map<std::string, std::unique_ptr<ObjectMetadata>,
+                               StringHash, std::equal_to<>>;
+        MetadataMap::const_iterator it_;
+    };
 
    protected:
     virtual ClientManager& GetClientManager() = 0;
@@ -477,7 +542,7 @@ class MasterService {
     // The following methods are hooks function to handle special events
 
     // Triggered when the metadata of an object is accessed (e.g. Get or Exist)
-    virtual void OnObjectAccessed(ObjectMetadata& metadata) = 0;
+    virtual void OnObjectAccessed(const ObjectMetadata& metadata) = 0;
 
     // Triggered when the object is removed
     virtual void OnObjectRemoved(ObjectMetadata& metadata);
@@ -500,7 +565,8 @@ class MasterService {
     const bool enable_ha_;
     ViewVersionId view_version_;
 
-    friend class MetadataAccessor;
+    friend class MetadataAccessorRW;
+    friend class MetadataAccessorRO;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/mutex.h
+++ b/mooncake-store/include/mutex.h
@@ -1,9 +1,19 @@
 #ifndef THREAD_SAFETY_ANALYSIS_MUTEX_H
 #define THREAD_SAFETY_ANALYSIS_MUTEX_H
 
+#include <atomic>
 #include <mutex>
 #include <shared_mutex>
 #include <atomic>
+
+#if defined(__x86_64__)
+#include <immintrin.h>
+#define PAUSE() _mm_pause()
+#elif defined(__aarch64__) || defined(__arm__)
+#define PAUSE() __asm__ __volatile__("yield")
+#else
+#define PAUSE()
+#endif
 
 // Enable thread safety attributes only with clang.
 // The attributes can be safely erased when compiling with other compilers.
@@ -116,27 +126,33 @@ class CAPABILITY("shared_mutex") SharedMutex {
     const SharedMutex& operator!() const { return *this; }
 };
 
-// Simple spinlock implementation using std::atomic<bool>.
+// Simple spin lock implementation using std::atomic_flag for exclusive locking
+// only.
 class CAPABILITY("mutex") SpinLock {
    private:
-    std::atomic<bool> flag_{false};
+    std::atomic_flag flag = ATOMIC_FLAG_INIT;
 
    public:
+    // Acquire/lock the spinlock.
     void lock() ACQUIRE() {
-        while (flag_.exchange(true, std::memory_order_acquire)) {
-            while (flag_.load(std::memory_order_relaxed)) {
-                MOONCAKE_CPU_RELAX();
+        do {
+            while (flag.test(std::memory_order_relaxed)) {
+                PAUSE();
             }
-        }
+        } while (flag.test_and_set(std::memory_order_acquire));
     }
 
-    void unlock() RELEASE() { flag_.store(false, std::memory_order_release); }
-
+    // Try to acquire the spinlock. Returns true on success, and false on
+    // failure.
     bool try_lock() TRY_ACQUIRE(true) {
-        return !flag_.exchange(true, std::memory_order_acquire);
+        return !flag.test_and_set(std::memory_order_acquire);
     }
 
-    const SpinLock& operator!() const { return *this; }
+    // Release the spinlock.
+    void unlock() RELEASE() { flag.clear(std::memory_order_release); }
+
+    // Check whether the spinlock is locked.
+    bool is_locked() const { return flag.test(std::memory_order_relaxed); }
 };
 
 // Simple spin-read-write lock implementation.
@@ -324,29 +340,22 @@ class SCOPED_CAPABILITY SharedMutexLocker {
     }
 };
 
-// RAII class for SpinLock
-class SCOPED_CAPABILITY SpinLockLocker {
+class SCOPED_CAPABILITY SpinLocker {
    private:
-    SpinLock* mut;
-    bool locked;
+    SpinLock* lock_;
 
    public:
-    explicit SpinLockLocker(SpinLock* mu) ACQUIRE(mu) : mut(mu), locked(true) {
-        mu->lock();
-    }
-    ~SpinLockLocker() RELEASE() {
-        if (locked) mut->unlock();
+    // Acquire lock.
+    explicit SpinLocker(SpinLock* lock) ACQUIRE(lock) : lock_(lock) {
+        lock->lock();
     }
 
     // Prevent copying and assignment
-    SpinLockLocker(const SpinLockLocker&) = delete;
-    SpinLockLocker& operator=(const SpinLockLocker&) = delete;
+    SpinLocker(const SpinLocker&) = delete;
+    SpinLocker& operator=(const SpinLocker&) = delete;
 
-    void unlock() RELEASE() {
-        if (!locked) return;
-        mut->unlock();
-        locked = false;
-    }
+    // Release lock.
+    ~SpinLocker() RELEASE() { lock_->unlock(); }
 };
 
 // RAII class for SpinRWLock

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -84,7 +84,7 @@ class P2PMasterService : public MasterService {
 
    protected:
     // Hooks
-    void OnObjectAccessed(ObjectMetadata& metadata) override;
+    void OnObjectAccessed(const ObjectMetadata& metadata) override;
     void OnObjectHit(const ObjectMetadata& metadata) override;
     void OnReplicaRemoved(const Replica& replica) override;
     void OnReplicaAdded(const Replica& replica) override;

--- a/mooncake-store/src/centralized_master_service.cpp
+++ b/mooncake-store/src/centralized_master_service.cpp
@@ -6,6 +6,7 @@
 #include <ylt/util/tl/expected.hpp>
 
 #include "master_metric_manager.h"
+#include "mutex.h"
 #include "types.h"
 
 namespace mooncake {
@@ -46,7 +47,8 @@ CentralizedMasterService::CentralizedObjectMetadata::HasDiffRepStatus(
 }
 
 void CentralizedMasterService::CentralizedObjectMetadata::GrantLease(
-    const uint64_t ttl, const uint64_t soft_ttl) {
+    const uint64_t ttl, const uint64_t soft_ttl) const {
+    SpinLocker locker(&lock_);
     std::chrono::steady_clock::time_point now =
         std::chrono::steady_clock::now();
     lease_timeout_ =
@@ -59,21 +61,25 @@ void CentralizedMasterService::CentralizedObjectMetadata::GrantLease(
 
 bool CentralizedMasterService::CentralizedObjectMetadata::IsLeaseExpired()
     const {
+    SpinLocker locker(&lock_);
     return std::chrono::steady_clock::now() >= lease_timeout_;
 }
 
 bool CentralizedMasterService::CentralizedObjectMetadata::IsLeaseExpired(
     const std::chrono::steady_clock::time_point& now) const {
+    SpinLocker locker(&lock_);
     return now >= lease_timeout_;
 }
 
 bool CentralizedMasterService::CentralizedObjectMetadata::IsSoftPinned() const {
+    SpinLocker locker(&lock_);
     return soft_pin_timeout_ &&
            std::chrono::steady_clock::now() < *soft_pin_timeout_;
 }
 
 bool CentralizedMasterService::CentralizedObjectMetadata::IsSoftPinned(
     const std::chrono::steady_clock::time_point& now) const {
+    SpinLocker locker(&lock_);
     return soft_pin_timeout_ && now < *soft_pin_timeout_;
 }
 
@@ -266,7 +272,7 @@ auto CentralizedMasterService::BatchReplicaClear(
                 return false;
             };
 
-            auto& shard = accessor.GetShard();
+            auto& shard = accessor.GetShard().GetRef();
             metadata.VisitReplicas(
                 match_replica_on_segment, [&](Replica& replica) {
                     has_replica_on_segment = true;
@@ -298,8 +304,10 @@ auto CentralizedMasterService::BatchReplicaClear(
     return cleared_keys;
 }
 
-void CentralizedMasterService::OnObjectAccessed(ObjectMetadata& metadata) {
-    auto& c_metadata = static_cast<CentralizedObjectMetadata&>(metadata);
+void CentralizedMasterService::OnObjectAccessed(
+    const ObjectMetadata& metadata) {
+    const auto& c_metadata =
+        static_cast<const CentralizedObjectMetadata&>(metadata);
     c_metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
 }
 
@@ -414,9 +422,8 @@ auto CentralizedMasterService::PutStart(const UUID& client_id,
             << ", action=put_start_begin";
 
     // Lock the shard and check if object already exists
-    size_t shard_idx = GetShardIndex(key);
-    auto& shard = GetCentralizedShard(shard_idx);
-    MutexLocker lock(&shard.mutex);
+    MetadataShardAccessorRW shard_rw(this, GetShardIndex(key));
+    auto& shard = static_cast<CentralizedMetadataShard&>(shard_rw.GetRef());
 
     const auto now = std::chrono::steady_clock::now();
     auto it = shard.metadata.find(key);
@@ -518,8 +525,8 @@ auto CentralizedMasterService::PutEnd(const UUID& client_id,
         },
         [&](Replica& replica) {
             replica.mark_complete();
-            AddReplicaToSegmentIndex(accessor.GetShard(), accessor.GetKey(),
-                                     replica);
+            AddReplicaToSegmentIndex(accessor.GetShard().GetRef(),
+                                     accessor.GetKey(), replica);
             OnReplicaAdded(replica);
         });
 
@@ -780,8 +787,9 @@ void CentralizedMasterService::EvictionThreadFunc() {
             // Try discarding expired processing keys and ongoing replication
             // tasks if we have not done this for a long time.
             for (size_t i = 0; i < kNumShards; ++i) {
-                auto& shard = GetCentralizedShard(i);
-                MutexLocker lock(&shard.mutex);
+                MetadataShardAccessorRW shard_rw(this, i);
+                auto& shard =
+                    static_cast<CentralizedMetadataShard&>(shard_rw.GetRef());
                 DiscardExpiredProcessingReplicas(shard, now);
             }
             ReleaseExpiredDiscardedReplicas(now);
@@ -1015,8 +1023,8 @@ void CentralizedMasterService::BatchEvict(double evict_ratio_target,
     // First pass: evict objects without soft pin and lease expired
     for (size_t i = 0; i < GetShardCount(); i++) {
         size_t current_idx = (start_idx + i) % GetShardCount();
-        auto& shard = GetCentralizedShard(current_idx);
-        MutexLocker lock(&shard.mutex);
+        MetadataShardAccessorRW shard_rw(this, current_idx);
+        auto& shard = static_cast<CentralizedMetadataShard&>(shard_rw.GetRef());
 
         // Discard expired processing keys first so that they won't be counted
         // in later evictions.
@@ -1134,8 +1142,9 @@ void CentralizedMasterService::BatchEvict(double evict_ratio_target,
             for (size_t i = 0; i < GetShardCount() && target_evict_num > 0;
                  i++) {
                 size_t current_idx = (start_idx + i) % GetShardCount();
-                auto& shard = GetCentralizedShard(current_idx);
-                MutexLocker lock(&shard.mutex);
+                MetadataShardAccessorRW shard_rw(this, current_idx);
+                auto& shard =
+                    static_cast<CentralizedMetadataShard&>(shard_rw.GetRef());
                 auto it = shard.metadata.begin();
                 while (it != shard.metadata.end() && target_evict_num > 0) {
                     auto* metadata = static_cast<CentralizedObjectMetadata*>(
@@ -1179,8 +1188,9 @@ void CentralizedMasterService::BatchEvict(double evict_ratio_target,
             for (size_t i = 0; i < GetShardCount() && target_evict_num > 0;
                  i++) {
                 size_t current_idx = (start_idx + i) % GetShardCount();
-                auto& shard = GetCentralizedShard(current_idx);
-                MutexLocker lock(&shard.mutex);
+                MetadataShardAccessorRW shard_rw(this, current_idx);
+                auto& shard =
+                    static_cast<CentralizedMetadataShard&>(shard_rw.GetRef());
 
                 auto it = shard.metadata.begin();
                 while (it != shard.metadata.end() && target_evict_num > 0) {
@@ -1248,9 +1258,9 @@ void CentralizedMasterService::OnSegmentRemoved(const UUID& segment_id) {
     MasterService::OnSegmentRemoved(segment_id);
 
     for (size_t i = 0; i < kNumShards; ++i) {
-        auto& shard = GetShard(i);
-        auto& c_shard = static_cast<CentralizedMetadataShard&>(shard);
-        MutexLocker lock(&c_shard.mutex);
+        MetadataShardAccessorRW shard_rw(this, i);
+        auto& c_shard =
+            static_cast<CentralizedMetadataShard&>(shard_rw.GetRef());
 
         // 2. Clean up dangling replication tasks
         for (auto task_it = c_shard.replication_tasks.begin();
@@ -1568,8 +1578,8 @@ tl::expected<void, ErrorCode> CentralizedMasterService::CopyEnd(
             all_complete = false;
         } else {
             replica->mark_complete();
-            AddReplicaToSegmentIndex(accessor.GetShard(), accessor.GetKey(),
-                                     *replica);
+            AddReplicaToSegmentIndex(accessor.GetShard().GetRef(),
+                                     accessor.GetKey(), *replica);
             OnReplicaAdded(*replica);
         }
     }
@@ -1761,14 +1771,14 @@ tl::expected<void, ErrorCode> CentralizedMasterService::MoveEnd(
             return tl::make_unexpected(ErrorCode::REPLICA_IS_GONE);
         }
         replica->mark_complete();
-        AddReplicaToSegmentIndex(accessor.GetShard(), accessor.GetKey(),
-                                 *replica);
+        AddReplicaToSegmentIndex(accessor.GetShard().GetRef(),
+                                 accessor.GetKey(), *replica);
         OnReplicaAdded(*replica);
     }
 
     // Remove source replica: remove from segment index first, then erase.
-    RemoveReplicaFromSegmentIndex(accessor.GetShard(), accessor.GetKey(),
-                                  *source);
+    RemoveReplicaFromSegmentIndex(accessor.GetShard().GetRef(),
+                                  accessor.GetKey(), *source);
     OnReplicaRemoved(*source);
     auto source_replica =
         metadata.PopReplicas([&source_id](const Replica& replica) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -80,8 +80,8 @@ void MasterService::OnObjectRemoved(ObjectMetadata& metadata) {
 // 2. remove the replica in metadata about the segment
 void MasterService::OnSegmentRemoved(const UUID& segment_id) {
     for (size_t i = 0; i < GetShardCount(); ++i) {
-        auto& shard = GetShard(i);
-        MutexLocker lock(&shard.mutex);
+        MetadataShardAccessorRW shard_rw(this, i);
+        auto& shard = shard_rw.GetRef();
 
         auto idx_it = shard.segment_key_index.find(segment_id);
         if (idx_it == shard.segment_key_index.end()) {
@@ -195,13 +195,13 @@ auto MasterService::QueryClientStatus(const QueryClientStatusRequest& req)
 
 auto MasterService::ExistKey(std::string_view key)
     -> tl::expected<bool, ErrorCode> {
-    auto accessor = GetMetadataAccessor(key);
-    if (!accessor->Exists()) {
+    MetadataAccessorRO accessor(this, key);
+    if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";
         return false;
     }
 
-    auto& metadata = accessor->Get();
+    const auto& metadata = accessor.Get();
     if (metadata.IsObjectAccessible()) {
         OnObjectAccessed(metadata);
         return true;
@@ -224,9 +224,8 @@ auto MasterService::GetAllKeys()
     -> tl::expected<std::vector<std::string>, ErrorCode> {
     std::vector<std::string> all_keys;
     for (size_t i = 0; i < GetShardCount(); i++) {
-        auto& shard = GetShard(i);
-        MutexLocker lock(&shard.mutex);
-        for (const auto& item : shard.metadata) {
+        MetadataShardAccessorRO shard(this, i);
+        for (const auto& item : shard->metadata) {
             all_keys.push_back(item.first);
         }
     }
@@ -309,10 +308,9 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
     }
 
     for (size_t i = 0; i < GetShardCount(); ++i) {
-        auto& shard = GetShard(i);
-        MutexLocker lock(&shard.mutex);
+        MetadataShardAccessorRO shard(this, i);
 
-        for (auto& [key, metadata] : shard.metadata) {
+        for (const auto& [key, metadata] : shard->metadata) {
             if (std::regex_search(key, pattern)) {
                 std::vector<Replica::Descriptor> replica_list;
                 replica_list.reserve(metadata->replicas_.size());
@@ -341,15 +339,15 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
 auto MasterService::GetReplicaList(std::string_view key,
                                    const GetReplicaListRequestConfig& config)
     -> tl::expected<GetReplicaListResponse, ErrorCode> {
-    auto accessor = GetMetadataAccessor(key);
+    MetadataAccessorRO accessor(this, key);
 
     MasterMetricManager::instance().inc_total_get_nums();
 
-    if (!accessor->Exists()) {
+    if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
-    auto& metadata = accessor->Get();
+    const auto& metadata = accessor.Get();
 
     std::vector<Replica::Descriptor> replica_list =
         FilterReplicas(config, metadata);
@@ -375,13 +373,13 @@ auto MasterService::GetReplicaList(std::string_view key,
 
 auto MasterService::Remove(std::string_view key)
     -> tl::expected<void, ErrorCode> {
-    auto accessor = GetMetadataAccessor(key);
-    if (!accessor->Exists()) {
+    MetadataAccessorRW accessor(this, key);
+    if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
 
-    auto& metadata = accessor->Get();
+    auto& metadata = accessor.Get();
 
     if (auto res = metadata.IsObjectRemovable(); !res) {
         VLOG(1) << "key=" << key << ", error=" << res.error();
@@ -390,7 +388,7 @@ auto MasterService::Remove(std::string_view key)
 
     // Remove object metadata
     OnObjectRemoved(metadata);
-    accessor->Erase();
+    accessor.Erase();
     return {};
 }
 
@@ -410,10 +408,9 @@ auto MasterService::RemoveByRegex(std::string_view regex_pattern)
     }
 
     for (size_t i = 0; i < GetShardCount(); ++i) {
-        auto& shard = GetShard(i);
-        MutexLocker lock(&shard.mutex);
+        MetadataShardAccessorRW shard(this, i);
 
-        for (auto it = shard.metadata.begin(); it != shard.metadata.end();) {
+        for (auto it = shard->metadata.begin(); it != shard->metadata.end();) {
             if (std::regex_search(it->first, pattern)) {
                 if (!it->second->IsObjectRemovable()) {
                     VLOG(1) << "key=" << it->first
@@ -425,9 +422,9 @@ auto MasterService::RemoveByRegex(std::string_view regex_pattern)
                 VLOG(1) << "key=" << it->first
                         << " matched by regex. Removing.";
                 OnObjectRemoved(*it->second);
-                RemoveReplicaFromSegmentIndex(shard, it->first,
+                RemoveReplicaFromSegmentIndex(shard.GetRef(), it->first,
                                               it->second->replicas_);
-                it = shard.metadata.erase(it);
+                it = shard->metadata.erase(it);
                 removed_count++;
             } else {
                 ++it;
@@ -445,18 +442,17 @@ long MasterService::RemoveAll() {
     uint64_t total_freed_size = 0;
 
     for (size_t i = 0; i < GetShardCount(); ++i) {
-        auto& shard = GetShard(i);
-        MutexLocker lock(&shard.mutex);
-        auto it = shard.metadata.begin();
-        while (it != shard.metadata.end()) {
+        MetadataShardAccessorRW shard(this, i);
+        auto it = shard->metadata.begin();
+        while (it != shard->metadata.end()) {
             if (it->second->IsObjectRemovable()) {
                 auto mem_rep_count =
                     it->second->CountReplicas(&Replica::fn_is_memory_replica);
                 total_freed_size += it->second->size_ * mem_rep_count;
                 OnObjectRemoved(*it->second);
-                RemoveReplicaFromSegmentIndex(shard, it->first,
+                RemoveReplicaFromSegmentIndex(shard.GetRef(), it->first,
                                               it->second->replicas_);
-                it = shard.metadata.erase(it);
+                it = shard->metadata.erase(it);
                 removed_count++;
             } else {
                 ++it;
@@ -473,9 +469,8 @@ long MasterService::RemoveAll() {
 size_t MasterService::GetKeyCount() const {
     size_t total = 0;
     for (size_t i = 0; i < GetShardCount(); ++i) {
-        const auto& shard = GetShard(i);
-        MutexLocker lock(&shard.mutex);
-        total += shard.metadata.size();
+        MetadataShardAccessorRO shard(this, i);
+        total += shard->metadata.size();
     }
     return total;
 }

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -94,9 +94,9 @@ auto P2PMasterService::GetWriteRoute(const WriteRouteRequest& req)
     // it might happen that concurrent write for same key.
     // for this case, we will finally check it when add route replica.
     if (!req.key.empty() && max_replicas_per_key_ > 0) {
-        auto accessor = GetMetadataAccessor(req.key);
-        if (accessor->Exists()) {
-            auto& metadata = accessor->Get();
+        MetadataAccessorRO accessor(this, req.key);
+        if (accessor.Exists()) {
+            auto& metadata = accessor.Get();
             if (metadata.replicas_.size() >= max_replicas_per_key_) {
                 LOG(WARNING)
                     << "replica num exceeded"
@@ -174,7 +174,7 @@ auto P2PMasterService::BatchGetWriteRoute(const BatchGetWriteRouteRequest& req)
 
 auto P2PMasterService::AddReplica(const AddReplicaRequest& req)
     -> tl::expected<void, ErrorCode> {
-    auto accessor = GetMetadataAccessor(req.key);
+    MetadataAccessorRW accessor(this, req.key);
     auto client = std::static_pointer_cast<P2PClientMeta>(
         client_manager_->GetClient(req.client_id));
     if (!client) {
@@ -182,7 +182,7 @@ auto P2PMasterService::AddReplica(const AddReplicaRequest& req)
                    << ", client_id: " << req.client_id;
         return tl::make_unexpected(ErrorCode::CLIENT_NOT_FOUND);
     }
-    return InnerAddReplica(accessor->GetShard(), req.key, req.client_id,
+    return InnerAddReplica(accessor.GetShard().GetRef(), req.key, req.client_id,
                            req.segment_id, req.size, client);
 }
 
@@ -250,9 +250,9 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
 
 auto P2PMasterService::RemoveReplica(const RemoveReplicaRequest& req)
     -> tl::expected<void, ErrorCode> {
-    auto accessor = GetMetadataAccessor(req.key);
-    return InnerRemoveReplica(accessor->GetShard(), req.key, req.client_id,
-                              req.segment_id);
+    MetadataAccessorRW accessor(this, req.key);
+    return InnerRemoveReplica(accessor.GetShard().GetRef(), req.key,
+                              req.client_id, req.segment_id);
 }
 
 tl::expected<void, ErrorCode> P2PMasterService::InnerRemoveReplica(
@@ -390,8 +390,8 @@ auto P2PMasterService::BatchSyncReplica(const BatchSyncReplicaRequest& req)
 
     // Process each shard group with one lock acquisition
     for (auto& [shard_idx, ops] : shard_groups) {
-        auto& shard = GetShard(shard_idx);
-        MutexLocker lock(&shard.mutex);
+        MetadataShardAccessorRW shard_rw(this, shard_idx);
+        auto& shard = shard_rw.GetRef();
 
         for (auto& [idx, is_add] : ops) {
             if (is_add) {
@@ -436,7 +436,7 @@ auto P2PMasterService::SetSyncCompleted(UUID client_id)
     return {};
 }
 
-void P2PMasterService::OnObjectAccessed(ObjectMetadata& metadata) {
+void P2PMasterService::OnObjectAccessed(const ObjectMetadata& metadata) {
     // do nothing
 }
 


### PR DESCRIPTION
* [Store]: Use 'const std::string&' as param for MasterService::GetReplicaList

* [Store]: Use SharedMutex in MetadataShard for better performance

* [Store]: Address code review problems

* [Store]: Address code review problems

* Fix typo

* Simplify ObjectMetadata::IsValid

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
