### PR TITLE
[TE] Enable TTL for RPC Meta Cache

### DIFF
--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -289,6 +289,7 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_RETRY_CNT` The maximum number of retries in Transfer Engine
 - `MC_LOG_LEVEL` This option can be set as `TRACE`/`INFO`/`WARNING`/`ERROR` (see [glog doc](https://github.com/google/glog/blob/master/docs/logging.md)), and more detailed logs will be output during runtime
 - `MC_DISABLE_METACACHE` Disable local meta cache to prevent transfer failure due to dynamic memory registrations, which may downgrades the performance
+- `MC_RPC_META_CACHE_TTL_SEC` Set the Time-To-Live (TTL) for RPC metadata cache in seconds. Default value is 60 seconds. When a replica's port changes (e.g., due to port conflicts or restarts), other clients will use the stale cached port until the TTL expires. Setting a shorter TTL (e.g., 5-10 seconds) can help recover faster from such scenarios, but may increase metadata service load. Setting to 0 disables caching completely, forcing every RPC to query the metadata service
 - `MC_HANDSHAKE_LISTEN_BACKLOG` The backlog size of socket listening for handshaking, default value is 128
 - `MC_HANDSHAKE_MAX_LENGTH` The maximum handshake message length in bytes for P2P mode. Valid range: 1MB to 128MB. Default value is 1MB (1048576 bytes). Increase this value when using a single RDMA instance with many registered memory buffers (>10,000) to avoid handshake failures. Example: set to 10485760 for 10MB
 - `MC_LOG_DIR` Specify the directory path for log redirection files. If invalid, log to stderr instead.

--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -289,7 +289,11 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_RETRY_CNT` The maximum number of retries in Transfer Engine
 - `MC_LOG_LEVEL` This option can be set as `TRACE`/`INFO`/`WARNING`/`ERROR` (see [glog doc](https://github.com/google/glog/blob/master/docs/logging.md)), and more detailed logs will be output during runtime
 - `MC_DISABLE_METACACHE` Disable local meta cache to prevent transfer failure due to dynamic memory registrations, which may downgrades the performance
-- `MC_RPC_META_CACHE_TTL_SEC` Set the Time-To-Live (TTL) for RPC metadata cache in seconds. Default value is 60 seconds. When a replica's port changes (e.g., due to port conflicts or restarts), other clients will use the stale cached port until the TTL expires. Setting a shorter TTL (e.g., 5-10 seconds) can help recover faster from such scenarios, but may increase metadata service load. Setting to 0 disables caching completely, forcing every RPC to query the metadata service
+- `MC_RPC_META_CACHE_TTL_SEC` Set the Time-To-Live (TTL) for RPC metadata cache in seconds. Valid range: -1 to 86400 (24 hours). Default value is 60 seconds.
+  - **TTL > 0**: Cache entries expire after the specified seconds
+  - **TTL = 0**: Caching disabled, every RPC queries the metadata service
+  - **TTL = -1**: Permanent cache (no expiration)
+  When a replica's port changes (e.g., due to port conflicts or restarts), other clients will use the stale cached port until the TTL expires. Setting a shorter TTL (e.g., 5-10 seconds) can help recover faster from such scenarios, but may increase metadata service load
 - `MC_HANDSHAKE_LISTEN_BACKLOG` The backlog size of socket listening for handshaking, default value is 128
 - `MC_HANDSHAKE_MAX_LENGTH` The maximum handshake message length in bytes for P2P mode. Valid range: 1MB to 128MB. Default value is 1MB (1048576 bytes). Increase this value when using a single RDMA instance with many registered memory buffers (>10,000) to avoid handshake failures. Example: set to 10485760 for 10MB
 - `MC_LOG_DIR` Specify the directory path for log redirection files. If invalid, log to stderr instead.

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -51,7 +51,8 @@ struct GlobalConfig {
     int retry_cnt = 9;
     int handshake_listen_backlog = 128;
     bool metacache = true;
-    int64_t rpc_meta_cache_ttl_us = 60000000;  // RPC metadata cache TTL in microseconds (default: 60s)
+    int64_t rpc_meta_cache_ttl_us =
+        60000000;  // RPC metadata cache TTL in microseconds (default: 60s)
     int log_level = google::INFO;
     bool trace = false;
     int64_t slice_timeout = -1;

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -51,6 +51,7 @@ struct GlobalConfig {
     int retry_cnt = 9;
     int handshake_listen_backlog = 128;
     bool metacache = true;
+    int64_t rpc_meta_cache_ttl_us = 60000000;  // RPC metadata cache TTL in microseconds (default: 60s)
     int log_level = google::INFO;
     bool trace = false;
     int64_t slice_timeout = -1;

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -114,6 +114,7 @@ class TransferMetadata {
         uint16_t barex_port;
 #endif
         int sockfd;  // local cache
+        int64_t cached_timestamp_us = 0;  // Cache timestamp in microseconds (for TTL)
     };
 
     struct HandShakeDesc {

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -114,7 +114,8 @@ class TransferMetadata {
         uint16_t barex_port;
 #endif
         int sockfd;  // local cache
-        int64_t cached_timestamp_us = 0;  // Cache timestamp in microseconds (for TTL)
+        int64_t cached_timestamp_us =
+            0;  // Cache timestamp in microseconds (for TTL)
     };
 
     struct HandShakeDesc {

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -232,14 +232,15 @@ void loadGlobalConfig(GlobalConfig& config) {
         std::getenv("MC_RPC_META_CACHE_TTL_SEC");
     if (rpc_meta_cache_ttl_env) {
         int val = atoi(rpc_meta_cache_ttl_env);
-        if (val >= 0 && val < 3600) {
+        if (val >= -1 && val <= 86400) {
             config.rpc_meta_cache_ttl_us =
                 val * 1000000LL;  // Convert sec to us
             LOG(INFO) << "RPC metadata cache TTL set to " << val << " seconds";
         } else {
             LOG(WARNING) << "Ignore value from environment variable "
                             "MC_RPC_META_CACHE_TTL_SEC"
-                         << ", it should be between 0 and 3600 seconds";
+                         << ", it should be between -1 and 86400 seconds "
+                            "(0=disable cache, -1=permanent cache)";
         }
     }
 

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -228,16 +228,18 @@ void loadGlobalConfig(GlobalConfig& config) {
         config.metacache = false;
     }
 
-    const char* rpc_meta_cache_ttl_env = std::getenv("MC_RPC_META_CACHE_TTL_SEC");
+    const char* rpc_meta_cache_ttl_env =
+        std::getenv("MC_RPC_META_CACHE_TTL_SEC");
     if (rpc_meta_cache_ttl_env) {
         int val = atoi(rpc_meta_cache_ttl_env);
         if (val >= 0 && val < 3600) {
-            config.rpc_meta_cache_ttl_us = val * 1000000LL;  // Convert sec to us
+            config.rpc_meta_cache_ttl_us =
+                val * 1000000LL;  // Convert sec to us
             LOG(INFO) << "RPC metadata cache TTL set to " << val << " seconds";
         } else {
-            LOG(WARNING)
-                << "Ignore value from environment variable MC_RPC_META_CACHE_TTL_SEC"
-                << ", it should be between 0 and 3600 seconds";
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RPC_META_CACHE_TTL_SEC"
+                         << ", it should be between 0 and 3600 seconds";
         }
     }
 
@@ -433,8 +435,8 @@ void dumpGlobalConfig() {
     LOG(INFO) << "max_inline = " << config.max_inline;
     LOG(INFO) << "mtu_length = " << mtuLengthToString(config.mtu_length);
     LOG(INFO) << "metacache = " << (config.metacache ? "enabled" : "disabled");
-    LOG(INFO) << "rpc_meta_cache_ttl = " << (config.rpc_meta_cache_ttl_us / 1000000.0)
-              << " seconds";
+    LOG(INFO) << "rpc_meta_cache_ttl = "
+              << (config.rpc_meta_cache_ttl_us / 1000000.0) << " seconds";
     LOG(INFO) << "parallel_reg_mr = " << config.parallel_reg_mr;
     LOG(INFO) << "ib_traffic_class = " << config.ib_traffic_class;
 }

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -228,6 +228,19 @@ void loadGlobalConfig(GlobalConfig& config) {
         config.metacache = false;
     }
 
+    const char* rpc_meta_cache_ttl_env = std::getenv("MC_RPC_META_CACHE_TTL_SEC");
+    if (rpc_meta_cache_ttl_env) {
+        int val = atoi(rpc_meta_cache_ttl_env);
+        if (val >= 0 && val < 3600) {
+            config.rpc_meta_cache_ttl_us = val * 1000000LL;  // Convert sec to us
+            LOG(INFO) << "RPC metadata cache TTL set to " << val << " seconds";
+        } else {
+            LOG(WARNING)
+                << "Ignore value from environment variable MC_RPC_META_CACHE_TTL_SEC"
+                << ", it should be between 0 and 3600 seconds";
+        }
+    }
+
     const char* handshake_listen_backlog =
         std::getenv("MC_HANDSHAKE_LISTEN_BACKLOG");
     if (handshake_listen_backlog) {
@@ -419,6 +432,9 @@ void dumpGlobalConfig() {
     LOG(INFO) << "max_wr = " << config.max_wr;
     LOG(INFO) << "max_inline = " << config.max_inline;
     LOG(INFO) << "mtu_length = " << mtuLengthToString(config.mtu_length);
+    LOG(INFO) << "metacache = " << (config.metacache ? "enabled" : "disabled");
+    LOG(INFO) << "rpc_meta_cache_ttl = " << (config.rpc_meta_cache_ttl_us / 1000000.0)
+              << " seconds";
     LOG(INFO) << "parallel_reg_mr = " << config.parallel_reg_mr;
     LOG(INFO) << "ib_traffic_class = " << config.ib_traffic_class;
 }

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -1151,27 +1151,26 @@ int TransferMetadata::getRpcMetaEntry(const std::string &server_name,
                                       RpcMetaDesc &desc) {
     {
         RWSpinlock::ReadGuard guard(rpc_meta_lock_);
-        if (rpc_meta_map_.count(server_name)) {
-            const auto &cached = rpc_meta_map_[server_name];
-            // Check if cache entry has expired
+        auto it = rpc_meta_map_.find(server_name);
+        if (it != rpc_meta_map_.end()) {
             int64_t ttl_us = globalConfig().rpc_meta_cache_ttl_us;
             if (ttl_us > 0) {
+                // Positive TTL: use cache with expiration
                 int64_t current_us = getCurrentTimeInNano() / 1000;
-                int64_t age_us = current_us - cached.cached_timestamp_us;
+                int64_t age_us = current_us - it->second.cached_timestamp_us;
                 if (age_us < ttl_us) {
                     // Cache entry is still valid
-                    desc = cached;
+                    desc = it->second;
                     return 0;
                 }
                 // Cache entry expired, fall through to refresh below
-            } else if (ttl_us == 0) {
-                // TTL disabled, always use cache
-                desc = cached;
+            } else if (ttl_us < 0) {
+                // Negative TTL: permanent cache (no expiration)
+                desc = it->second;
                 return 0;
-            } else {
-                // Negative TTL means cache disabled, but this shouldn't happen
-                // Fall through to refresh
             }
+            // If ttl_us == 0, caching is disabled per documentation,
+            // so we fall through to refresh without using cached value.
         }
     }
     RWSpinlock::WriteGuard guard(rpc_meta_lock_);

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -1152,8 +1152,26 @@ int TransferMetadata::getRpcMetaEntry(const std::string &server_name,
     {
         RWSpinlock::ReadGuard guard(rpc_meta_lock_);
         if (rpc_meta_map_.count(server_name)) {
-            desc = rpc_meta_map_[server_name];
-            return 0;
+            const auto &cached = rpc_meta_map_[server_name];
+            // Check if cache entry has expired
+            int64_t ttl_us = globalConfig().rpc_meta_cache_ttl_us;
+            if (ttl_us > 0) {
+                int64_t current_us = getCurrentTimeInNano() / 1000;
+                int64_t age_us = current_us - cached.cached_timestamp_us;
+                if (age_us < ttl_us) {
+                    // Cache entry is still valid
+                    desc = cached;
+                    return 0;
+                }
+                // Cache entry expired, fall through to refresh below
+            } else if (ttl_us == 0) {
+                // TTL disabled, always use cache
+                desc = cached;
+                return 0;
+            } else {
+                // Negative TTL means cache disabled, but this shouldn't happen
+                // Fall through to refresh
+            }
         }
     }
     RWSpinlock::WriteGuard guard(rpc_meta_lock_);
@@ -1171,6 +1189,8 @@ int TransferMetadata::getRpcMetaEntry(const std::string &server_name,
         desc.ip_or_host_name = rpcMetaJSON["ip_or_host_name"].asString();
         desc.rpc_port = (uint16_t)rpcMetaJSON["rpc_port"].asUInt();
     }
+    // Set timestamp when caching
+    desc.cached_timestamp_us = getCurrentTimeInNano() / 1000;
     rpc_meta_map_[server_name] = desc;
     return 0;
 }


### PR DESCRIPTION
## Description

We add an option to enable TTL for RPC Meta Cache. This could mitigate problems from the massive unstable cluster (e.g., reported by #2039)

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [X] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
