### PR TITLE
[Store] L2->L1 promotion-on-hit: observability metrics + max_per_heartbeat knob

### DIFF
--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -109,6 +109,12 @@ struct MasterConfig {
     bool promotion_on_hit = false;
     uint32_t promotion_admission_threshold = 2;
     uint32_t promotion_queue_limit = 50000;
+    // Max promotion tasks PromotionObjectHeartbeat returns to a single
+    // client per call. Each task is a synchronous SSD-read + RDMA-write
+    // on the client; serializing them avoids blocking past the client-
+    // liveness window. Default 1 is conservative; small-object or RDMA-
+    // rich clusters may safely raise it.
+    uint32_t promotion_max_per_heartbeat = 1;
 };
 
 class MasterServiceSupervisorConfig {
@@ -182,6 +188,7 @@ class MasterServiceSupervisorConfig {
     bool promotion_on_hit = false;
     uint32_t promotion_admission_threshold = 2;
     uint32_t promotion_queue_limit = 50000;
+    uint32_t promotion_max_per_heartbeat = 1;
     MasterServiceSupervisorConfig() = default;
 
     // From MasterConfig
@@ -209,6 +216,7 @@ class MasterServiceSupervisorConfig {
         promotion_on_hit = config.promotion_on_hit;
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
+        promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
         rpc_port = static_cast<int>(config.rpc_port);
         rpc_thread_num = static_cast<size_t>(config.rpc_thread_num);
 
@@ -350,6 +358,7 @@ class WrappedMasterServiceConfig {
     bool promotion_on_hit = false;
     uint32_t promotion_admission_threshold = 2;
     uint32_t promotion_queue_limit = 50000;
+    uint32_t promotion_max_per_heartbeat = 1;
     std::string ha_backend_type = "etcd";
     std::string ha_backend_connstring;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
@@ -417,6 +426,7 @@ class WrappedMasterServiceConfig {
         promotion_on_hit = config.promotion_on_hit;
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
+        promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = ResolveConfiguredHABackendConnstring(
             ha_backend_type, config.ha_backend_connstring,
@@ -502,6 +512,7 @@ class WrappedMasterServiceConfig {
         promotion_on_hit = config.promotion_on_hit;
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
+        promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = ResolveConfiguredHABackendConnstring(
             ha_backend_type, config.ha_backend_connstring,
@@ -886,6 +897,7 @@ class MasterServiceConfig {
     bool promotion_on_hit = false;
     uint32_t promotion_admission_threshold = 2;
     uint32_t promotion_queue_limit = 50000;
+    uint32_t promotion_max_per_heartbeat = 1;
     std::string ha_backend_type = "etcd";
     std::string ha_backend_connstring;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
@@ -949,6 +961,7 @@ class MasterServiceConfig {
         promotion_on_hit = config.promotion_on_hit;
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
+        promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = config.ha_backend_connstring;
         cluster_id = config.cluster_id;

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -295,6 +295,31 @@ class MasterMetricManager {
     int64_t get_put_start_release_cnt();
     int64_t get_put_start_discarded_staging_size();
 
+    // Promotion-on-hit Metrics
+    void inc_promotion_in_flight(int64_t val = 1);
+    void dec_promotion_in_flight(int64_t val = 1);
+    void inc_promotion_admitted(int64_t val = 1);
+    void inc_promotion_completed(int64_t val = 1);
+    void inc_promotion_completed_bytes(int64_t bytes);
+    void inc_promotion_expired(int64_t val = 1);
+    void inc_promotion_failed(int64_t val = 1);
+    void inc_promotion_cancelled(int64_t val = 1);
+    void inc_promotion_rejected_frequency(int64_t val = 1);
+    void inc_promotion_rejected_watermark(int64_t val = 1);
+    void inc_promotion_rejected_cap(int64_t val = 1);
+
+    // Promotion-on-hit Metrics Getters
+    int64_t get_promotion_in_flight();
+    int64_t get_promotion_admitted();
+    int64_t get_promotion_completed();
+    int64_t get_promotion_completed_bytes();
+    int64_t get_promotion_expired();
+    int64_t get_promotion_failed();
+    int64_t get_promotion_cancelled();
+    int64_t get_promotion_rejected_frequency();
+    int64_t get_promotion_rejected_watermark();
+    int64_t get_promotion_rejected_cap();
+
     // CopyStart, CopyEnd, CopyRevoke, MoveStart, MoveEnd, MoveRevoke Metrics
     void inc_copy_start_requests(int64_t val = 1);
     void inc_copy_start_failures(int64_t val = 1);
@@ -631,6 +656,18 @@ class MasterMetricManager {
     ylt::metric::counter_t put_start_discard_cnt_;
     ylt::metric::counter_t put_start_release_cnt_;
     ylt::metric::gauge_t put_start_discarded_staging_size_;
+
+    // Promotion-on-hit Metrics
+    ylt::metric::gauge_t promotion_in_flight_metric_;
+    ylt::metric::counter_t promotion_admitted_;
+    ylt::metric::counter_t promotion_completed_;
+    ylt::metric::counter_t promotion_completed_bytes_;
+    ylt::metric::counter_t promotion_expired_;
+    ylt::metric::counter_t promotion_failed_;
+    ylt::metric::counter_t promotion_cancelled_;
+    ylt::metric::counter_t promotion_rejected_frequency_;
+    ylt::metric::counter_t promotion_rejected_watermark_;
+    ylt::metric::counter_t promotion_rejected_cap_;
 
     // Snapshot Metrics
     ylt::metric::histogram_t snapshot_duration_ms_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1337,6 +1337,8 @@ class MasterService {
         NO_THREAD_SAFETY_ANALYSIS {
         if (tenant_state.promotion_tasks.erase(key) > 0) {
             promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+            MasterMetricManager::instance().dec_promotion_in_flight();
+            MasterMetricManager::instance().inc_promotion_cancelled();
         }
     }
 
@@ -1713,6 +1715,7 @@ class MasterService {
     bool promotion_on_hit_{false};
     uint32_t promotion_admission_threshold_{2};
     uint32_t promotion_queue_limit_{50000};
+    uint32_t promotion_max_per_heartbeat_{1};
     // Global in-flight task counter, checked against promotion_queue_limit_
     // as the gate cap. Promotion specifically targets skewed
     // access (hot keys re-accessed after eviction), so the global counter

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -134,6 +134,12 @@ DEFINE_uint32(promotion_admission_threshold, 2,
               "(set 1 to disable second-touch gating)");
 DEFINE_uint32(promotion_queue_limit, 50000,
               "Max in-flight promotion tasks across all shards");
+DEFINE_uint32(promotion_max_per_heartbeat, 1,
+              "Max promotion tasks returned to a single client per "
+              "PromotionObjectHeartbeat call. Each task is a synchronous "
+              "SSD-read + RDMA-write on the client; serializing them avoids "
+              "blocking past the client-liveness window. Default 1 is "
+              "conservative.");
 DEFINE_string(ha_backend_type, "etcd",
               "HA backend type, e.g. etcd | redis | k8s");
 DEFINE_string(ha_backend_connstring, "",
@@ -358,6 +364,9 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetUInt32("promotion_queue_limit",
                              &master_config.promotion_queue_limit,
                              FLAGS_promotion_queue_limit);
+    default_config.GetUInt32("promotion_max_per_heartbeat",
+                             &master_config.promotion_max_per_heartbeat,
+                             FLAGS_promotion_max_per_heartbeat);
     default_config.GetString("ha_backend_type", &master_config.ha_backend_type,
                              FLAGS_ha_backend_type);
     default_config.GetString("ha_backend_connstring",
@@ -637,6 +646,12 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
          !info.is_default) ||
         !conf_set) {
         master_config.promotion_queue_limit = FLAGS_promotion_queue_limit;
+    }
+    if ((google::GetCommandLineFlagInfo("promotion_max_per_heartbeat", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.promotion_max_per_heartbeat =
+            FLAGS_promotion_max_per_heartbeat;
     }
     // Clamp promotion_admission_threshold into the sketch counter's
     // representable range. The CountMinSketch uses 8-bit saturating

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -329,6 +329,46 @@ MasterMetricManager::MasterMetricManager()
           "master_put_start_discarded_staging_size",
           "Total size of memory replicas in discarded but not yet released "
           "PutStart operations"),
+
+      // Promotion-on-hit Metrics
+      promotion_in_flight_metric_(
+          "master_promotion_in_flight",
+          "Current number of in-flight L2->L1 promotion tasks"),
+      promotion_admitted_(
+          "master_promotion_admitted_total",
+          "Total promotion tasks admitted past all gates and enqueued"),
+      promotion_completed_(
+          "master_promotion_completed_total",
+          "Total promotion tasks committed via NotifyPromotionSuccess"),
+      promotion_completed_bytes_(
+          "master_promotion_completed_bytes_total",
+          "Total bytes promoted from LOCAL_DISK to MEMORY"),
+      promotion_expired_("master_promotion_expired_total",
+                         "Total promotion tasks expired via the reaper "
+                         "(put_start_release_timeout_sec)"),
+      promotion_failed_(
+          "master_promotion_failed_total",
+          "Total promotion tasks aborted by holder via "
+          "NotifyPromotionFailure (holder reported a downstream failure)"),
+      promotion_cancelled_(
+          "master_promotion_cancelled_total",
+          "Total promotion tasks removed because the prerequisite went "
+          "away: object removal mid-flight (Remove / UpsertStart / etc.), "
+          "holder-client expiry (ClearInvalidHandles), or staged replica "
+          "lost (NotifyPromotionSuccess committed=false)"),
+      promotion_rejected_frequency_(
+          "master_promotion_rejected_frequency_total",
+          "Promotion attempts rejected because CountMinSketch frequency "
+          "was below promotion_admission_threshold"),
+      promotion_rejected_watermark_(
+          "master_promotion_rejected_watermark_total",
+          "Promotion attempts rejected because DRAM was at or above the "
+          "eviction high watermark"),
+      promotion_rejected_cap_(
+          "master_promotion_rejected_cap_total",
+          "Promotion attempts rejected because promotion_in_flight was at "
+          "promotion_queue_limit"),
+
       // Snapshot Metrics
       snapshot_duration_ms_(
           "master_snapshot_duration_ms",
@@ -417,8 +457,18 @@ void MasterMetricManager::update_metrics_for_zero_output() {
     mem_cache_nums_.update(0);
     file_cache_nums_.update(0);
     put_start_discarded_staging_size_.update(0);
+    promotion_in_flight_metric_.update(0);
 
     // Update Counters (use inc(0) to mark as changed)
+    promotion_admitted_.inc(0);
+    promotion_completed_.inc(0);
+    promotion_completed_bytes_.inc(0);
+    promotion_expired_.inc(0);
+    promotion_failed_.inc(0);
+    promotion_cancelled_.inc(0);
+    promotion_rejected_frequency_.inc(0);
+    promotion_rejected_watermark_.inc(0);
+    promotion_rejected_cap_.inc(0);
     put_start_requests_.inc(0);
     put_start_failures_.inc(0);
     put_start_alloc_failures_.inc(0);
@@ -1024,6 +1074,41 @@ void MasterMetricManager::inc_put_start_release_cnt(int64_t count,
     put_start_discarded_staging_size_.dec(size);
 }
 
+// --- Promotion-on-hit Metrics ---
+void MasterMetricManager::inc_promotion_in_flight(int64_t val) {
+    promotion_in_flight_metric_.inc(val);
+}
+void MasterMetricManager::dec_promotion_in_flight(int64_t val) {
+    promotion_in_flight_metric_.dec(val);
+}
+void MasterMetricManager::inc_promotion_admitted(int64_t val) {
+    promotion_admitted_.inc(val);
+}
+void MasterMetricManager::inc_promotion_completed(int64_t val) {
+    promotion_completed_.inc(val);
+}
+void MasterMetricManager::inc_promotion_completed_bytes(int64_t bytes) {
+    promotion_completed_bytes_.inc(bytes);
+}
+void MasterMetricManager::inc_promotion_expired(int64_t val) {
+    promotion_expired_.inc(val);
+}
+void MasterMetricManager::inc_promotion_failed(int64_t val) {
+    promotion_failed_.inc(val);
+}
+void MasterMetricManager::inc_promotion_cancelled(int64_t val) {
+    promotion_cancelled_.inc(val);
+}
+void MasterMetricManager::inc_promotion_rejected_frequency(int64_t val) {
+    promotion_rejected_frequency_.inc(val);
+}
+void MasterMetricManager::inc_promotion_rejected_watermark(int64_t val) {
+    promotion_rejected_watermark_.inc(val);
+}
+void MasterMetricManager::inc_promotion_rejected_cap(int64_t val) {
+    promotion_rejected_cap_.inc(val);
+}
+
 void MasterMetricManager::set_snapshot_duration_ms(int64_t size) {
     snapshot_duration_ms_.observe(size);
 }
@@ -1376,6 +1461,38 @@ int64_t MasterMetricManager::get_put_start_discarded_staging_size() {
     return put_start_discarded_staging_size_.value();
 }
 
+// --- Promotion-on-hit Metrics Getters ---
+int64_t MasterMetricManager::get_promotion_in_flight() {
+    return promotion_in_flight_metric_.value();
+}
+int64_t MasterMetricManager::get_promotion_admitted() {
+    return promotion_admitted_.value();
+}
+int64_t MasterMetricManager::get_promotion_completed() {
+    return promotion_completed_.value();
+}
+int64_t MasterMetricManager::get_promotion_completed_bytes() {
+    return promotion_completed_bytes_.value();
+}
+int64_t MasterMetricManager::get_promotion_expired() {
+    return promotion_expired_.value();
+}
+int64_t MasterMetricManager::get_promotion_failed() {
+    return promotion_failed_.value();
+}
+int64_t MasterMetricManager::get_promotion_cancelled() {
+    return promotion_cancelled_.value();
+}
+int64_t MasterMetricManager::get_promotion_rejected_frequency() {
+    return promotion_rejected_frequency_.value();
+}
+int64_t MasterMetricManager::get_promotion_rejected_watermark() {
+    return promotion_rejected_watermark_.value();
+}
+int64_t MasterMetricManager::get_promotion_rejected_cap() {
+    return promotion_rejected_cap_.value();
+}
+
 // CopyStart, CopyEnd, CopyRevoke, MoveStart, MoveEnd, MoveRevoke Metrics
 void MasterMetricManager::inc_copy_start_requests(int64_t val) {
     copy_start_requests_.inc(val);
@@ -1647,6 +1764,18 @@ std::string MasterMetricManager::serialize_metrics() {
     serialize_metric(put_start_discard_cnt_);
     serialize_metric(put_start_release_cnt_);
     serialize_metric(put_start_discarded_staging_size_);
+
+    // Serialize Promotion-on-hit Metrics
+    serialize_metric(promotion_in_flight_metric_);
+    serialize_metric(promotion_admitted_);
+    serialize_metric(promotion_completed_);
+    serialize_metric(promotion_completed_bytes_);
+    serialize_metric(promotion_expired_);
+    serialize_metric(promotion_failed_);
+    serialize_metric(promotion_cancelled_);
+    serialize_metric(promotion_rejected_frequency_);
+    serialize_metric(promotion_rejected_watermark_);
+    serialize_metric(promotion_rejected_cap_);
 
     // Serialize Snapshot Metrics
     serialize_metric(snapshot_duration_ms_);
@@ -2280,6 +2409,21 @@ std::string MasterMetricManager::get_summary_string(
        << "Released/Total=" << put_start_release_cnt << "/"
        << put_start_discard_cnt << ", StagingSize="
        << byte_size_to_string(put_start_discarded_staging_size);
+
+    // Promotion-on-hit summary (counters are cumulative, not deltas; the
+    // gauge is current-state).
+    ss << " | Promotion: "
+       << "in_flight=" << promotion_in_flight_metric_.value() << ", "
+       << "admitted=" << promotion_admitted_.value() << ", "
+       << "completed=" << promotion_completed_.value() << ", "
+       << "failed=" << promotion_failed_.value() << ", "
+       << "cancelled=" << promotion_cancelled_.value() << ", "
+       << "expired=" << promotion_expired_.value() << ", "
+       << "bytes=" << byte_size_to_string(promotion_completed_bytes_.value())
+       << ", "
+       << "rejected(freq/wm/cap)=" << promotion_rejected_frequency_.value()
+       << "/" << promotion_rejected_watermark_.value() << "/"
+       << promotion_rejected_cap_.value();
 
     // Snapshot summary
     ss << " | Snapshots: "

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -258,6 +258,12 @@ MasterService::MasterService(const MasterServiceConfig& config)
     promotion_on_hit_ = enable_offload_ && config.promotion_on_hit;
     promotion_admission_threshold_ = config.promotion_admission_threshold;
     promotion_queue_limit_ = config.promotion_queue_limit;
+    promotion_max_per_heartbeat_ = config.promotion_max_per_heartbeat;
+    // Clamp to >=1: 0 would make PromotionObjectHeartbeat return an empty
+    // batch every call, silently disabling promotion delivery.
+    if (promotion_max_per_heartbeat_ == 0) {
+        promotion_max_per_heartbeat_ = 1;
+    }
     // Defense-in-depth clamp: master.cpp clamps threshold into [1, 255]
     // at flag-parse time, but direct MasterServiceConfig construction
     // (tests, embedded users) bypasses that. Without the clamp here,
@@ -280,7 +286,9 @@ MasterService::MasterService(const MasterServiceConfig& config)
         LOG(INFO) << "Promotion-on-hit mode enabled: LOCAL_DISK-only Gets "
                      "will queue async promotion to MEMORY (threshold="
                   << promotion_admission_threshold_
-                  << ", queue_limit=" << promotion_queue_limit_ << ")";
+                  << ", queue_limit=" << promotion_queue_limit_
+                  << ", max_per_heartbeat=" << promotion_max_per_heartbeat_
+                  << ")";
     }
 
     eviction_running_ = true;
@@ -767,10 +775,7 @@ void MasterService::ClearInvalidHandles(
                     tenant_state.processing_keys.erase(it->first);
                     tenant_state.replication_tasks.erase(it->first);
                     tenant_state.offloading_tasks.erase(it->first);
-                    if (tenant_state.promotion_tasks.erase(it->first) > 0) {
-                        promotion_in_flight_.fetch_sub(
-                            1, std::memory_order_relaxed);
-                    }
+                    ErasePromotionTaskIfPresent(tenant_state, it->first);
                     it = EraseMetadata(tenant_state, it, tenant_it->first);
                 } else {
                     ++it;
@@ -3269,6 +3274,7 @@ void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
     // bypass the gate entirely since freq is uint8_t) cannot reach here.
     const uint8_t freq = promotion_sketch_->increment(key);
     if (freq < promotion_admission_threshold_) {
+        MasterMetricManager::instance().inc_promotion_rejected_frequency();
         return;
     }
 
@@ -3278,6 +3284,7 @@ void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
     const double used_ratio =
         MasterMetricManager::instance().get_global_mem_used_ratio();
     if (used_ratio >= eviction_high_watermark_ratio_) {
+        MasterMetricManager::instance().inc_promotion_rejected_watermark();
         return;
     }
 
@@ -3309,6 +3316,7 @@ void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
     // relaxed because the value is purely advisory.
     if (promotion_in_flight_.load(std::memory_order_relaxed) >=
         promotion_queue_limit_) {
+        MasterMetricManager::instance().inc_promotion_rejected_cap();
         return;
     }
 
@@ -3350,6 +3358,8 @@ void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
                            .start_time = std::chrono::system_clock::now(),
                            .holder_id = holder_id});
     promotion_in_flight_.fetch_add(1, std::memory_order_relaxed);
+    MasterMetricManager::instance().inc_promotion_in_flight();
+    MasterMetricManager::instance().inc_promotion_admitted();
     VLOG(1) << "promotion_queued key=" << key << " size=" << object_size;
 }
 
@@ -3365,17 +3375,16 @@ auto MasterService::PromotionObjectHeartbeat(const UUID& client_id)
         return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
     }
     MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
-    // Return at most kMaxPerHeartbeat tasks. Each task does a
-    // synchronous SSD read + RDMA write on the client side; allowing
+    // Return at most promotion_max_per_heartbeat_ tasks. Each task does
+    // a synchronous SSD read + RDMA write on the client side; allowing
     // more than one per heartbeat risks blocking past the client-
     // liveness window and the master marking the client dead. The rest
     // stay queued in promotion_objects for subsequent heartbeats. The
     // cap must live here (server side) rather than on the client so
     // leftover work isn't silently dropped.
-    constexpr size_t kMaxPerHeartbeat = 1;
     auto& src = local_disk_segment_it->second->promotion_objects;
     std::unordered_map<std::string, int64_t> result;
-    while (result.size() < kMaxPerHeartbeat && !src.empty()) {
+    while (result.size() < promotion_max_per_heartbeat_ && !src.empty()) {
         auto node = src.extract(src.begin());
         result.insert(std::move(node));
     }
@@ -3515,8 +3524,17 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
     if (source != nullptr) {
         source->dec_refcnt();
     }
+    const uint64_t completed_bytes = task_it->second.object_size;
     tenant_state.promotion_tasks.erase(task_it);
     promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+    MasterMetricManager::instance().dec_promotion_in_flight();
+    if (committed) {
+        MasterMetricManager::instance().inc_promotion_completed();
+        MasterMetricManager::instance().inc_promotion_completed_bytes(
+            static_cast<int64_t>(completed_bytes));
+    } else {
+        MasterMetricManager::instance().inc_promotion_cancelled();
+    }
 
     // Erase the per-client promotion_objects entry (best-effort; the
     // heartbeat may have already drained it).
@@ -3574,6 +3592,8 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
     }
     tenant_state.promotion_tasks.erase(task_it);
     promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+    MasterMetricManager::instance().dec_promotion_in_flight();
+    MasterMetricManager::instance().inc_promotion_failed();
 
     // Clear the holder's per-client promotion_objects entry. Same
     // best-effort cleanup pattern as NotifyPromotionSuccess — the
@@ -3784,6 +3804,8 @@ void MasterService::DiscardExpiredProcessingReplicas(
                          << task_it->first;
             task_it = tenant_state.promotion_tasks.erase(task_it);
             promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+            MasterMetricManager::instance().dec_promotion_in_flight();
+            MasterMetricManager::instance().inc_promotion_expired();
         }
 
         if (tenant_state.Empty()) {

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -331,10 +331,13 @@ TEST_F(PromotionOnHitTest, StalePromotionReaper) {
             << "Dedup gate should block re-enqueue while task is in flight";
     }
 
-    // Wait past the staleness window; the eviction thread reaps the task.
-    // Eviction loop sleeps for kEvictionThreadSleepMs (10 ms), so 2s wall
-    // clock gives ~200 attempts — plenty.
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    // Wait past the staleness window. The eviction thread reaps every
+    // kEvictionThreadSleepMs (10 ms) but gated by
+    // `now - last_discard_time > put_start_release_timeout_sec_` (strict).
+    // With release=1s a 2s sleep leaves only ~1s margin between reaper
+    // firing and the wake-up, which has flaked under CI load. 3s gives
+    // ~2s of margin and matches the schedule's strict-greater comparison.
+    std::this_thread::sleep_for(std::chrono::seconds(3));
 
     // Trigger #3: with the task reaped, dedup is unblocked and a fresh
     // GetReplicaList must enqueue again.
@@ -401,8 +404,9 @@ TEST_F(PromotionOnHitTest, RemoveDuringPromotion) {
     EXPECT_EQ(notify.error(), ErrorCode::OBJECT_NOT_FOUND);
 
     // Wait for the reaper; it must tolerate the missing metadata entry
-    // (the source replica it would dec_refcnt is already gone).
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    // (the source replica it would dec_refcnt is already gone). 3s for
+    // CI-safe margin over the 1s release timeout.
+    std::this_thread::sleep_for(std::chrono::seconds(3));
 
     // Re-injecting the key and re-triggering must work end-to-end, proving
     // the per-shard PromotionTask was reaped (not stuck).
@@ -1025,9 +1029,9 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsReapedTask) {
     // removed. We can't easily poll for reap externally (the only
     // user-facing observable would be re-admitting through the gate,
     // which would create a fresh task and defeat the test), so use a
-    // fixed sleep with margin. Matches the StalePromotionReaper pattern
-    // (TTL=1s, sleep=2s).
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    // fixed sleep with margin. 3s sleep over 1s release timeout matches
+    // StalePromotionReaper's CI-safe margin.
+    std::this_thread::sleep_for(std::chrono::seconds(3));
 
     // AllocStart on a reaped task must reject without allocating.
     // Allocating would leave an orphaned PROCESSING MEMORY replica

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -1736,6 +1736,33 @@ TEST_F(PromotionOnHitTest, MetricsRejectionCountersIncrementOnGateMiss) {
     EXPECT_EQ(mm.get_promotion_rejected_cap() - cap_pre, 1);
 
     service->RemoveAll();
+
+    // Watermark gate uses a fresh service configured with
+    // eviction_high_watermark_ratio = 0.0 so any non-negative DRAM
+    // usage trips it. threshold = 1 makes the first Get clear the
+    // frequency gate and reach the watermark check.
+    MasterServiceConfig wm_config;
+    wm_config.enable_offload = true;
+    wm_config.promotion_on_hit = true;
+    wm_config.promotion_admission_threshold = 1;
+    wm_config.promotion_queue_limit = 50;
+    wm_config.eviction_high_watermark_ratio = 0.0;
+    wm_config.default_kv_lease_ttl = 2000;
+    auto wm_service = std::make_unique<MasterService>(wm_config);
+
+    auto wm_seg =
+        PrepareSegment(*wm_service, "wm_seg", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*wm_service, wm_seg.client_id, "k_w",
+                                       1024, wm_seg.segment_name));
+
+    const int64_t wm_pre = mm.get_promotion_rejected_watermark();
+    {
+        auto r = wm_service->GetReplicaList("k_w");
+        ASSERT_TRUE(r.has_value());
+    }
+    EXPECT_EQ(mm.get_promotion_rejected_watermark() - wm_pre, 1);
+
+    wm_service->RemoveAll();
 }
 
 // promotion_max_per_heartbeat controls how many tasks

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -306,6 +306,9 @@ TEST_F(PromotionOnHitTest, StalePromotionReaper) {
     ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_cold", 1024,
                                        ctx.segment_name));
 
+    auto& mm = MasterMetricManager::instance();
+    const int64_t expired_pre = mm.get_promotion_expired();
+
     // Trigger #1: enqueue, then drain the per-segment queue. Drain leaves
     // the per-shard PromotionTask intact (the heartbeat is best-effort GC,
     // not the authoritative state).
@@ -344,6 +347,9 @@ TEST_F(PromotionOnHitTest, StalePromotionReaper) {
             << "After reap, a fresh read must re-enqueue the same key";
     }
 
+    EXPECT_EQ(mm.get_promotion_expired() - expired_pre, 1)
+        << "Reaper expiry must bump promotion_expired";
+
     service->RemoveAll();
 }
 
@@ -368,6 +374,9 @@ TEST_F(PromotionOnHitTest, RemoveDuringPromotion) {
     ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_cold", 1024,
                                        ctx.segment_name));
 
+    auto& mm = MasterMetricManager::instance();
+    const int64_t cancelled_pre = mm.get_promotion_cancelled();
+
     // Queue a promotion task.
     {
         auto r = service->GetReplicaList("k_cold");
@@ -381,6 +390,9 @@ TEST_F(PromotionOnHitTest, RemoveDuringPromotion) {
     ASSERT_TRUE(rm.has_value())
         << "Remove on a LOCAL_DISK-only key with a queued promotion should "
         << "succeed (all replicas COMPLETE); error=" << rm.error();
+    EXPECT_EQ(mm.get_promotion_cancelled() - cancelled_pre, 1)
+        << "Remove of a key with an in-flight promotion task must bump "
+        << "promotion_cancelled";
 
     // NotifyPromotionSuccess on the now-removed key must surface the missing
     // metadata cleanly, not crash.
@@ -547,6 +559,9 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
     ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, k2, 1024,
                                        seg.segment_name));
 
+    auto& mm = MasterMetricManager::instance();
+    const int64_t cap_rej_pre = mm.get_promotion_rejected_cap();
+
     // First read on k1 enqueues a task in shard S.
     auto r1 = service->GetReplicaList(k1);
     ASSERT_TRUE(r1.has_value());
@@ -568,6 +583,8 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
         << "k1 was read first and should be the surviving task";
     EXPECT_EQ(heartbeat->count(k2), 0u)
         << "k2 was rejected by the cap gate; should not appear";
+    EXPECT_EQ(mm.get_promotion_rejected_cap() - cap_rej_pre, 1)
+        << "k2's rejection must increment promotion_rejected_cap";
 
     service->RemoveAll();
 }
@@ -1133,6 +1150,9 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
     ASSERT_TRUE(seg_baseline.has_value());
     const size_t used_baseline = seg_baseline->first;
 
+    auto& mm = MasterMetricManager::instance();
+    const int64_t failed_pre = mm.get_promotion_failed();
+
     // Admit + stage k_a. promotion_in_flight_ goes 0 -> 1.
     {
         auto r = service->GetReplicaList("k_a");
@@ -1154,6 +1174,8 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
     ASSERT_TRUE(failure.has_value())
         << "NotifyPromotionFailure on a valid in-flight task from the "
         << "legitimate holder must succeed; error=" << failure.error();
+    EXPECT_EQ(mm.get_promotion_failed() - failed_pre, 1)
+        << "holder-reported failure must bump promotion_failed";
 
     // The staged buffer must be freed back to the DRAM allocator. If
     // this fires, NotifyPromotionFailure did not pop the staged replica
@@ -1387,6 +1409,9 @@ TEST_F(PromotionOnHitTest, ClientExpiryClearsPromotionTask) {
     ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_cold",
                                        1024, holder.segment_name));
 
+    auto& mm = MasterMetricManager::instance();
+    const int64_t cancelled_pre = mm.get_promotion_cancelled();
+
     // Admit the promotion. promotion_in_flight_ goes 0 -> 1.
     {
         auto r = service->GetReplicaList("k_cold");
@@ -1464,6 +1489,9 @@ TEST_F(PromotionOnHitTest, ClientExpiryClearsPromotionTask) {
         << "saturated by the dead holder's task for "
         << "put_start_release_timeout_sec_ seconds, and this admission "
         << "is dropped.";
+    EXPECT_EQ(mm.get_promotion_cancelled() - cancelled_pre, 1)
+        << "Holder-client expiry mid-promotion must bump "
+        << "promotion_cancelled";
 
     service->RemoveAll();
 }
@@ -1608,6 +1636,218 @@ TEST_F(PromotionOnHitTest, RemoveByRegexErasesPromotionTask) {
         << "other_k2 must be admittable after RemoveByRegex of regex_k1 "
         << "— RemoveByRegex must erase the in-flight promotion_tasks "
         << "entry. Otherwise queue_limit=1 stays saturated.";
+
+    service->RemoveAll();
+}
+
+// The funnel metrics (admitted, completed, completed_bytes, in_flight)
+// track a successful promotion lifecycle end-to-end: a single
+// admission bumps admitted+1 and in_flight+1; NotifyPromotionSuccess
+// bumps completed+1 and completed_bytes+object_size and brings
+// in_flight back to 0.
+TEST_F(PromotionOnHitTest, MetricsFunnelTracksSuccessfulPromotion) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    constexpr int64_t kObjBytes = 4096;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_hot",
+                                       kObjBytes, seg.segment_name));
+
+    auto& mm = MasterMetricManager::instance();
+    const int64_t admitted_pre = mm.get_promotion_admitted();
+    const int64_t completed_pre = mm.get_promotion_completed();
+    const int64_t bytes_pre = mm.get_promotion_completed_bytes();
+    const int64_t in_flight_pre = mm.get_promotion_in_flight();
+
+    // Admit.
+    {
+        auto r = service->GetReplicaList("k_hot");
+        ASSERT_TRUE(r.has_value());
+    }
+    EXPECT_EQ(mm.get_promotion_admitted() - admitted_pre, 1);
+    EXPECT_EQ(mm.get_promotion_in_flight() - in_flight_pre, 1);
+
+    // Drive AllocStart + NotifyPromotionSuccess.
+    auto alloc =
+        service->PromotionAllocStart(seg.client_id, "k_hot", kObjBytes, {});
+    ASSERT_TRUE(alloc.has_value());
+    auto notify = service->NotifyPromotionSuccess(seg.client_id, "k_hot");
+    ASSERT_TRUE(notify.has_value());
+
+    EXPECT_EQ(mm.get_promotion_completed() - completed_pre, 1);
+    EXPECT_EQ(mm.get_promotion_completed_bytes() - bytes_pre, kObjBytes);
+    EXPECT_EQ(mm.get_promotion_in_flight() - in_flight_pre, 0);
+
+    service->RemoveAll();
+}
+
+// Each rejection gate (frequency / watermark / cap) increments its
+// own counter when its branch fires.
+TEST_F(PromotionOnHitTest, MetricsRejectionCountersIncrementOnGateMiss) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    // Threshold > 1 so the first Get is rejected on frequency.
+    config.promotion_admission_threshold = 2;
+    config.promotion_queue_limit = 1;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_a", 1024,
+                                       seg.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_b", 1024,
+                                       seg.segment_name));
+
+    auto& mm = MasterMetricManager::instance();
+    const int64_t freq_pre = mm.get_promotion_rejected_frequency();
+    const int64_t cap_pre = mm.get_promotion_rejected_cap();
+
+    // 1st Get on k_a: freq=1, threshold=2 → rejected on frequency.
+    {
+        auto r = service->GetReplicaList("k_a");
+        ASSERT_TRUE(r.has_value());
+    }
+    EXPECT_EQ(mm.get_promotion_rejected_frequency() - freq_pre, 1);
+
+    // 2nd Get on k_a: freq=2, admits. Now in-flight = 1 == limit.
+    {
+        auto r = service->GetReplicaList("k_a");
+        ASSERT_TRUE(r.has_value());
+    }
+    // Get on k_b: freq=1, threshold=2 → rejected on frequency.
+    {
+        auto r = service->GetReplicaList("k_b");
+        ASSERT_TRUE(r.has_value());
+    }
+    // Get on k_b again: freq=2, gets past frequency, but cap=1
+    // saturated → rejected on cap.
+    {
+        auto r = service->GetReplicaList("k_b");
+        ASSERT_TRUE(r.has_value());
+    }
+    EXPECT_EQ(mm.get_promotion_rejected_cap() - cap_pre, 1);
+
+    service->RemoveAll();
+}
+
+// promotion_max_per_heartbeat controls how many tasks
+// PromotionObjectHeartbeat returns per call. Set the knob to 3 and
+// verify the master returns up to 3 tasks per heartbeat.
+TEST_F(PromotionOnHitTest, MaxPerHeartbeatKnobControlsBatchSize) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_max_per_heartbeat = 3;  // raise from default 1
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+
+    // Admit 5 tasks on the same holder.
+    for (int i = 0; i < 5; ++i) {
+        const auto key = "k_" + std::to_string(i);
+        ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, key, 1024,
+                                           seg.segment_name));
+        auto r = service->GetReplicaList(key);
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // First heartbeat: cap=3.
+    auto first = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(first.has_value());
+    EXPECT_EQ(first->size(), 3u)
+        << "expected promotion_max_per_heartbeat=3 keys, got " << first->size();
+
+    // Second heartbeat: 2 leftover.
+    auto second = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(second.has_value());
+    EXPECT_EQ(second->size(), 2u);
+
+    // Third heartbeat: empty.
+    auto third = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(third.has_value());
+    EXPECT_EQ(third->size(), 0u);
+
+    service->RemoveAll();
+}
+
+// promotion_max_per_heartbeat = 0 must be clamped to 1 by the
+// MasterService constructor; otherwise PromotionObjectHeartbeat would
+// return an empty batch every call and silently disable promotion
+// delivery.
+TEST_F(PromotionOnHitTest, MaxPerHeartbeatZeroClampsToOne) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_max_per_heartbeat = 0;  // pathological
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k1", 1024,
+                                       seg.segment_name));
+    {
+        auto r = service->GetReplicaList("k1");
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // If max_per_heartbeat=0 weren't clamped, this would return empty.
+    auto hb = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(hb.has_value());
+    EXPECT_EQ(hb->size(), 1u)
+        << "max_per_heartbeat=0 must clamp to 1 so promotion delivery "
+        << "isn't silently disabled";
+
+    service->RemoveAll();
+}
+
+// Remove on a key mid-promotion must bump promotion_cancelled so the
+// funnel invariant
+// admitted = completed + failed + expired + cancelled + in_flight
+// holds. Exercises the ErasePromotionTaskIfPresent path.
+TEST_F(PromotionOnHitTest, MetricsRemoveMidPromotionCountsAsCancelled) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_drop", 1024,
+                                       seg.segment_name));
+
+    auto& mm = MasterMetricManager::instance();
+    const int64_t admitted_pre = mm.get_promotion_admitted();
+    const int64_t cancelled_pre = mm.get_promotion_cancelled();
+    const int64_t in_flight_pre = mm.get_promotion_in_flight();
+
+    // Admit a promotion. in_flight goes from 0 to 1.
+    {
+        auto r = service->GetReplicaList("k_drop");
+        ASSERT_TRUE(r.has_value());
+    }
+    ASSERT_EQ(mm.get_promotion_admitted() - admitted_pre, 1);
+    ASSERT_EQ(mm.get_promotion_in_flight() - in_flight_pre, 1);
+
+    auto rm = service->Remove("k_drop", /*force=*/true);
+    ASSERT_TRUE(rm.has_value()) << "error=" << rm.error();
+
+    EXPECT_EQ(mm.get_promotion_in_flight() - in_flight_pre, 0);
+    EXPECT_EQ(mm.get_promotion_cancelled() - cancelled_pre, 1);
 
     service->RemoveAll();
 }

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -1640,6 +1640,198 @@ TEST_F(PromotionOnHitTest, RemoveByRegexErasesPromotionTask) {
     service->RemoveAll();
 }
 
+// RemoveAll on a key with an in-flight PromotionTask must drop the
+// task entry alongside the metadata. Same shape as
+// RemoveErasesPromotionTask but exercises the bulk-erase loop in
+// MasterService::RemoveAll, which iterates every shard and erases
+// metadata entries directly.
+TEST_F(PromotionOnHitTest, RemoveAllErasesPromotionTask) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;
+    config.default_kv_lease_ttl = 5000;
+    config.put_start_release_timeout_sec = 300;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder =
+        PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_first",
+                                       1024, holder.segment_name));
+
+    auto& mm = MasterMetricManager::instance();
+    const int64_t cancelled_pre = mm.get_promotion_cancelled();
+
+    {
+        auto r = service->GetReplicaList("k_first");
+        ASSERT_TRUE(r.has_value());
+    }
+    {
+        auto pending = service->PromotionObjectHeartbeat(holder.client_id);
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(pending->count("k_first"), 1u);
+    }
+
+    auto removed = service->RemoveAll(/*force=*/true);
+    EXPECT_GE(removed, 1) << "RemoveAll should erase k_first";
+
+    EXPECT_EQ(mm.get_promotion_cancelled() - cancelled_pre, 1)
+        << "RemoveAll on a key with an in-flight promotion must route "
+        << "through EraseMetadataEntry and bump promotion_cancelled_total.";
+
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_second",
+                                       1024, holder.segment_name));
+    {
+        auto r = service->GetReplicaList("k_second");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
+    ASSERT_TRUE(pending_post.has_value());
+    EXPECT_EQ(pending_post->count("k_second"), 1u)
+        << "k_second must be admittable after RemoveAll of k_first — "
+        << "otherwise queue_limit=1 stays saturated until reaper TTL.";
+
+    service->RemoveAll(/*force=*/true);
+}
+
+// BatchRemove normal-completion path on a key with an in-flight
+// PromotionTask must drop the task entry. ReMountSegment registers the
+// holder in ok_client_ so CleanupStaleHandles returns false and
+// BatchRemove takes the non-stale branch.
+TEST_F(PromotionOnHitTest, BatchRemoveErasesPromotionTask) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;
+    config.default_kv_lease_ttl = 5000;
+    config.put_start_release_timeout_sec = 300;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder =
+        PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    {
+        Segment seg_a = MakeSegment("seg_a", kDefaultSegmentBase, seg_size);
+        seg_a.id = holder.segment_id;
+        std::vector<Segment> segs{seg_a};
+        auto remount = service->ReMountSegment(segs, holder.client_id);
+        ASSERT_TRUE(remount.has_value()) << "ReMount failed";
+    }
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_first",
+                                       1024, holder.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_second",
+                                       1024, holder.segment_name));
+
+    auto& mm = MasterMetricManager::instance();
+    const int64_t cancelled_pre = mm.get_promotion_cancelled();
+
+    {
+        auto r = service->GetReplicaList("k_first");
+        ASSERT_TRUE(r.has_value());
+    }
+    {
+        auto pending = service->PromotionObjectHeartbeat(holder.client_id);
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(pending->count("k_first"), 1u);
+    }
+
+    auto results = service->BatchRemove({"k_first"}, /*force=*/true);
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_TRUE(results[0].has_value())
+        << "BatchRemove should succeed; error=" << results[0].error();
+
+    EXPECT_EQ(mm.get_promotion_cancelled() - cancelled_pre, 1)
+        << "BatchRemove normal path on a key with an in-flight promotion "
+        << "must bump promotion_cancelled_total.";
+
+    {
+        auto r = service->GetReplicaList("k_second");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
+    ASSERT_TRUE(pending_post.has_value());
+    EXPECT_EQ(pending_post->count("k_second"), 1u)
+        << "k_second must be admittable after BatchRemove of k_first — "
+        << "otherwise queue_limit=1 stays saturated until reaper TTL.";
+
+    service->RemoveAll(/*force=*/true);
+}
+
+// BatchRemove stale-handle path on a key with an in-flight
+// PromotionTask must drop the task entry. The holder is mounted via
+// PrepareSegment only (no ReMount), so its client is absent from
+// ok_client_; BatchRemove's CleanupStaleHandles then erases the
+// LOCAL_DISK replica and the stale-handle branch fires.
+TEST_F(PromotionOnHitTest, BatchRemoveStaleHandleErasesPromotionTask) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;
+    config.default_kv_lease_ttl = 5000;
+    config.put_start_release_timeout_sec = 300;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder =
+        PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_first",
+                                       1024, holder.segment_name));
+
+    auto& mm = MasterMetricManager::instance();
+    const int64_t cancelled_pre = mm.get_promotion_cancelled();
+
+    {
+        auto r = service->GetReplicaList("k_first");
+        ASSERT_TRUE(r.has_value());
+    }
+    {
+        auto pending = service->PromotionObjectHeartbeat(holder.client_id);
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(pending->count("k_first"), 1u);
+    }
+
+    auto results = service->BatchRemove({"k_first"}, /*force=*/true);
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_FALSE(results[0].has_value())
+        << "stale-handle path should report OBJECT_NOT_FOUND once the "
+        << "LOCAL_DISK replica is wiped.";
+
+    EXPECT_EQ(mm.get_promotion_cancelled() - cancelled_pre, 1)
+        << "BatchRemove stale-handle path must also bump "
+        << "promotion_cancelled_total.";
+
+    auto second_holder = PrepareSegment(
+        *service, "seg_b", kDefaultSegmentBase + seg_size, seg_size);
+    {
+        Segment seg_b =
+            MakeSegment("seg_b", kDefaultSegmentBase + seg_size, seg_size);
+        seg_b.id = second_holder.segment_id;
+        std::vector<Segment> segs{seg_b};
+        auto remount = service->ReMountSegment(segs, second_holder.client_id);
+        ASSERT_TRUE(remount.has_value()) << "ReMount failed";
+    }
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, second_holder.client_id,
+                                       "k_second", 1024,
+                                       second_holder.segment_name));
+    {
+        auto r = service->GetReplicaList("k_second");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto pending_post =
+        service->PromotionObjectHeartbeat(second_holder.client_id);
+    ASSERT_TRUE(pending_post.has_value());
+    EXPECT_EQ(pending_post->count("k_second"), 1u)
+        << "k_second must be admittable after the stale-handle "
+        << "BatchRemove — otherwise queue_limit=1 stays saturated until "
+        << "reaper TTL.";
+
+    service->RemoveAll(/*force=*/true);
+}
+
 // The funnel metrics (admitted, completed, completed_bytes, in_flight)
 // track a successful promotion lifecycle end-to-end: a single
 // admission bumps admitted+1 and in_flight+1; NotifyPromotionSuccess
@@ -1843,7 +2035,7 @@ TEST_F(PromotionOnHitTest, MaxPerHeartbeatZeroClampsToOne) {
 // Remove on a key mid-promotion must bump promotion_cancelled so the
 // funnel invariant
 // admitted = completed + failed + expired + cancelled + in_flight
-// holds. Exercises the ErasePromotionTaskIfPresent path.
+// holds. Exercises the EraseMetadataEntry path.
 TEST_F(PromotionOnHitTest, MetricsRemoveMidPromotionCountsAsCancelled) {
     MasterServiceConfig config;
     config.enable_offload = true;


### PR DESCRIPTION
## Description

Ref #2031

Follow-up to #2071 (L2->L1 promotion-on-hit, merged as da70ac9f). Adds Prometheus metrics for the promotion funnel and exposes the previously-hardcoded `kMaxPerHeartbeat` as a config knob.

### Metrics (Prometheus, `master_promotion_*` prefix)

**Funnel** — answers "is the feature firing, and where does work get lost?":

| Metric | Type | Description |
|---|---|---|
| `master_promotion_in_flight` | gauge | Current in-flight tasks |
| `master_promotion_admitted_total` | counter | Tasks past all gates, enqueued |
| `master_promotion_completed_total` | counter | `NotifyPromotionSuccess` success |
| `master_promotion_completed_bytes_total` | counter | Bytes promoted (sum of source `object_size`) |
| `master_promotion_failed_total` | counter | `NotifyPromotionFailure` accepted (holder-reported failure) |
| `master_promotion_cancelled_total` | counter | Task erased because its prerequisite went away (object `Remove`/`Upsert`, holder client expired, or `NotifyPromotionSuccess` could not commit the staged replica) |
| `master_promotion_expired_total` | counter | Reaper sweep — task exceeded `put_start_release_timeout_sec` |

Invariant: `admitted = completed + failed + cancelled + expired + in_flight`.

`failed` vs `cancelled` are intentionally separate so dashboards can distinguish holder-side failures (network/IO/transfer error reported via `NotifyPromotionFailure`) from upstream-side cancellation (the thing being promoted no longer exists).

**Rejection** — answers "why aren't we admitting?":

| Metric | Type | Description |
|---|---|---|
| `master_promotion_rejected_frequency_total` | counter | Below `promotion_admission_threshold` |
| `master_promotion_rejected_watermark_total` | counter | DRAM at or above eviction high watermark |
| `master_promotion_rejected_cap_total` | counter | `promotion_in_flight` at `promotion_queue_limit` |

Enough to build a working Grafana panel: `rate(admitted)` vs `rate(completed)` shows yield; `rate(rejected_*)` breaks down where work is dropping; `in_flight / promotion_queue_limit` shows saturation.

### `promotion_max_per_heartbeat` knob

Was a compile-time `constexpr kMaxPerHeartbeat = 1` in `PromotionObjectHeartbeat`. With the default 10s client heartbeat, this capped per-client throughput at ~6 promotions/min and made `promotion_queue_limit = 50000` mostly theoretical.

Exposed as `MasterServiceConfig::promotion_max_per_heartbeat` (default 1, no behavior change). Wired through:

- `DEFINE_uint32(promotion_max_per_heartbeat, ...)` flag in `master.cpp`
- `default_config.GetUInt32(...)` parse from JSON
- `MasterServiceSupervisorConfig` plumbing
- `MasterService` constructor stores into `promotion_max_per_heartbeat_`, used in `PromotionObjectHeartbeat`
- Constructor clamps `0 → 1` (defense-in-depth — `0` would silently halt promotion delivery)
- Startup log now includes `max_per_heartbeat=` alongside `threshold=` / `queue_limit=`

Operators with small objects and RDMA-rich clusters can safely raise it; the new `MaxPerHeartbeatKnobControlsBatchSize` test exercises `=3`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

`promotion_on_hit_test`: **33/33 pass** (was 28; +5 new), 5 consecutive clean runs.

New tests:

- `MetricsFunnelTracksSuccessfulPromotion` — single full lifecycle bumps `admitted`/`completed`/`completed_bytes` correctly and returns `in_flight` to baseline.
- `MetricsRejectionCountersIncrementOnGateMiss` — verifies all three rejection counters (`rejected_frequency`, `rejected_watermark`, `rejected_cap`) increment when their respective branches fire. Watermark sub-case uses `eviction_high_watermark_ratio = 0.0` to force the gate.
- `MetricsRemoveMidPromotionCountsAsCancelled` — verifies that erasing a key with an in-flight promotion (via `Remove`) routes the task to `promotion_cancelled_total` rather than `promotion_failed_total`.
- `MaxPerHeartbeatKnobControlsBatchSize` — sets knob to 3, admits 5 tasks, asserts heartbeats drain as 3 + 2 + 0.
- `MaxPerHeartbeatZeroClampsToOne` — pathological `=0` config gets clamped to 1 by the constructor; promotion delivery is not silently disabled.

Existing tests enhanced with metric assertions:

- `StalePromotionReaper` — asserts `promotion_expired` increments.
- `RemoveDuringPromotion` — asserts `promotion_cancelled` increments.
- `QueueLimitRejectsBeyondCap` — asserts `promotion_rejected_cap` increments.
- `NotifyFailureReleasesStateImmediately` — asserts `promotion_failed` increments.
- `ClientExpiryClearsPromotionTask` — asserts `promotion_cancelled` increments.

Regression check:

- `file_storage_promotion_test`: 11/11 pass
- `master_service_promotion_test_for_snapshot`: 5/5 pass
- `offload_on_evict_test`: 9/9 pass

`scripts/code_format.sh --check --base upstream/main` (clang-format-20 in CI image): clean.

Default `promotion_max_per_heartbeat = 1` means existing deployments see no behavior change; all metrics zero-emit on cold start so dashboards built against them work immediately.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
