### PR TITLE
Add release-npu workflow

### DIFF
--- a/.github/workflows/release-npu.yaml
+++ b/.github/workflows/release-npu.yaml
@@ -1,0 +1,230 @@
+name: Release Ascend NPU
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    if: github.repository == 'kvcache-ai/Mooncake'
+
+    runs-on: self-hosted
+
+    permissions:
+      contents: write
+
+    strategy:
+      max-parallel: 1
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
+    env:
+      BUILD_WITH_EP: "0"
+      NPU_BUILD: "1"
+
+    container:
+      image: localhost:5000/mooncake-hixl-ci:v6-release
+
+      options: --privileged --user 0:0 --device /dev/davinci0 --device /dev/davinci1 --device /dev/davinci2 --device /dev/davinci3
+                    --device /dev/davinci4 --device /dev/davinci5 --device /dev/davinci6 --device /dev/davinci7
+                    --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc --ulimit nproc=65535:65535
+
+      volumes:
+        - /usr/local/dcmi:/usr/local/dcmi:ro
+        - /usr/local/Ascend/driver/:/usr/local/Ascend/driver/:ro
+        - /etc/ascend_install.info:/etc/ascend_install.info:ro
+        - /etc/hccn.conf:/etc/hccn.conf:ro
+
+    steps:
+      - name: Configure GitHub fetch defaults
+        shell: bash
+        run: |
+          git config --global protocol.version 2
+          git config --global http.version HTTP/1.1
+          git config --global http.lowSpeedLimit 1024
+          git config --global http.lowSpeedTime 30
+
+      - name: Checkout code
+        id: checkout_code
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Retry checkout via GitHub mirror
+        if: steps.checkout_code.outcome == 'failure'
+        shell: bash
+        env:
+          ASCEND_GITHUB_MIRROR_URLS: 'https://ghfast.top/'
+        run: |
+          set -euo pipefail
+
+          if [ -z "${ASCEND_GITHUB_MIRROR_URLS:-}" ]; then
+            echo "Checkout from GitHub failed and ASCEND_GITHUB_MIRROR_URLS is not set"
+            exit 1
+          fi
+
+          normalize_base() {
+            local base="$1"
+            base="${base#${base%%[![:space:]]*}}"
+            base="${base%${base##*[![:space:]]}}"
+            [ -n "$base" ] || return 1
+            [ "$base" != "https://github.com/" ] && base="${base%/}/"
+            printf '%s\n' "$base"
+          }
+
+          candidates=()
+          while IFS= read -r raw; do
+            base="$(normalize_base "$raw" || true)"
+            [ -n "$base" ] || continue
+            [ "$base" = "https://github.com/" ] && continue
+            candidates+=("$base")
+          done < <(printf '%s\n' "$ASCEND_GITHUB_MIRROR_URLS" | tr ',;' '\n')
+
+          if [ ${#candidates[@]} -eq 0 ]; then
+            echo "Checkout from GitHub failed and no valid mirror candidates were configured"
+            exit 1
+          fi
+
+          workdir="${GITHUB_WORKSPACE}"
+          git config --global --add safe.directory "$workdir"
+
+          for base in "${candidates[@]}"; do
+            mirror_url="${base}https://github.com/${GITHUB_REPOSITORY}.git"
+            echo "Retrying checkout with ${mirror_url}"
+
+            find "$workdir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+            git init "$workdir"
+            git -C "$workdir" remote add origin "$mirror_url"
+
+            if git -C "$workdir" fetch --depth=1 origin "${{ github.sha }}" && \
+               git -C "$workdir" checkout --force --detach FETCH_HEAD; then
+              echo "Mirror checkout succeeded via ${base}"
+              exit 0
+            fi
+
+            echo "Mirror checkout failed via ${base}"
+            rm -rf "$workdir/.git"
+          done
+
+          echo "Direct GitHub checkout failed and all mirror retries failed"
+          exit 1
+
+      - name: Use container Python ${{ matrix.python-version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHON_BIN="$(command -v python${{ matrix.python-version }})"
+          "$PYTHON_BIN" --version
+          "$PYTHON_BIN" -m pip --version
+          echo "PYTHON_BIN=${PYTHON_BIN}" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        shell: bash
+        env:
+          ASCEND_GITHUB_MIRROR_URLS: 'https://ghfast.top/'
+        run: |
+          set -euo pipefail
+          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          if command -v apt-get >/dev/null 2>&1; then
+            bash -x dependencies.sh -y
+          else
+            bash -x scripts/ascend/dependencies_openeuler.sh -y
+          fi
+          bash scripts/ascend/dependencies_ascend_installation.sh
+          echo "PATH=/usr/local/go/bin:${PATH}" >> "$GITHUB_ENV"
+          echo "GOPROXY=https://goproxy.io|https://mirrors.aliyun.com/goproxy/|https://goproxy.cn|direct" >> "$GITHUB_ENV"
+          echo "GOSUMDB=sum.golang.google.cn" >> "$GITHUB_ENV"
+          /usr/local/go/bin/go env -w GOPROXY="https://goproxy.io|https://mirrors.aliyun.com/goproxy/|https://goproxy.cn|direct"
+          /usr/local/go/bin/go env -w GOSUMDB=sum.golang.google.cn
+
+      - name: Configure project
+        shell: bash
+        run: |
+          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          rm -rf build
+          mkdir build
+          cd build
+          cmake_args=(
+            -DUSE_ASCEND_DIRECT=ON
+            -DUSE_CUDA=OFF
+            -DWITH_EP=OFF
+            -DUSE_HTTP=ON
+            -DUSE_ETCD=ON
+            -DSTORE_USE_ETCD=ON
+            -DBUILD_UNIT_TESTS=OFF
+            -DBUILD_EXAMPLES=ON
+            -DCMAKE_BUILD_TYPE=Release
+            -DPython3_EXECUTABLE="${PYTHON_BIN}"
+          )
+          cmake .. "${cmake_args[@]}"
+
+      - name: Build project
+        shell: bash
+        env:
+          GOPROXY: 'https://goproxy.io|https://mirrors.aliyun.com/goproxy/|https://goproxy.cn|direct'
+          GOSUMDB: sum.golang.google.cn
+        run: |
+          set -euo pipefail
+          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          export PATH="/usr/local/go/bin:${PATH}"
+          cd build
+          cmake --build . -j"$(nproc)"
+          cmake --install .
+
+      - name: Generate Python version tag
+        id: generate_tag_release
+        shell: bash
+        run: |
+          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
+
+      - name: Build Python wheel
+        shell: bash
+        run: |
+          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+          NPU_BUILD=1 PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-npu-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
+
+      - name: Upload Python wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mooncake-wheel-npu-py${{ steps.generate_tag_release.outputs.python_version_tag }}
+          path: mooncake-wheel/dist-npu-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
+
+  publish-release:
+    needs: build
+    runs-on: ubuntu-22.04
+    environment: pypi
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: mooncake-wheel/dist-all
+          pattern: mooncake-wheel-npu-py*
+
+      - name: Prepare wheels for release
+        run: |
+          mkdir -p mooncake-wheel/dist-release
+          find mooncake-wheel/dist-all -name "*.whl" -exec cp {} mooncake-wheel/dist-release/ \;
+          echo "Collected wheels for release:"
+          ls -la mooncake-wheel/dist-release/
+
+      - name: Upload wheels to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: mooncake-wheel/dist-release/*.whl
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: mooncake-wheel/dist-release/

--- a/scripts/ascend/dependencies_openeuler.sh
+++ b/scripts/ascend/dependencies_openeuler.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+# Copyright 2024-2026 KVCache.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+GREEN="\033[0;32m"
+BLUE="\033[0;34m"
+YELLOW="\033[0;33m"
+RED="\033[0;31m"
+NC="\033[0m"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DEPS_BUILD_DIR="${REPO_ROOT}/.mooncake-openeuler-deps"
+GOVER=1.25.9
+ASCEND_GITHUB_MIRROR_URLS="${ASCEND_GITHUB_MIRROR_URLS:-https://ghfast.top/}"
+
+print_section() {
+    echo -e "\n${BLUE}=== $1 ===${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ ERROR: $1${NC}"
+    exit 1
+}
+
+print_warn() {
+    echo -e "${YELLOW}! $1${NC}"
+}
+
+check_success() {
+    if [ $? -ne 0 ]; then
+        print_error "$1"
+    fi
+}
+
+SKIP_CONFIRM=false
+for arg in "$@"; do
+    case $arg in
+        -y|--yes)
+            SKIP_CONFIRM=true
+            ;;
+        -h|--help)
+            echo -e "${YELLOW}Mooncake openEuler Dependencies Installer${NC}"
+            echo "Usage: bash scripts/ascend/dependencies_openeuler.sh [-y]"
+            exit 0
+            ;;
+    esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+    print_error "Require root permission, try: sudo bash scripts/ascend/dependencies_openeuler.sh -y"
+fi
+
+echo -e "${YELLOW}Mooncake openEuler Dependencies Installer${NC}"
+echo "Repository root: ${REPO_ROOT}"
+echo "This script installs (same scope as root dependencies.sh):"
+echo "  - openEuler/RHEL system packages (dnf/yum)"
+echo "  - Git submodules (pybind11, yalantinglibs, ...)"
+echo "  - yalantinglibs (from extern/ submodule)"
+echo "  - Go ${GOVER} (for USE_ETCD / libetcd_wrapper.so)"
+echo "Run scripts/ascend/dependencies_ascend_installation.sh afterward for Ascend extras."
+echo
+
+if [ "$SKIP_CONFIRM" = false ]; then
+    read -p "Do you want to continue? [Y/n] " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]] && [[ ! $REPLY = "" ]]; then
+        echo -e "${YELLOW}Installation cancelled.${NC}"
+        exit 0
+    fi
+fi
+
+detect_pkg_manager() {
+    if command -v dnf >/dev/null 2>&1; then
+        echo dnf
+    elif command -v yum >/dev/null 2>&1; then
+        echo yum
+    else
+        print_error "Neither dnf nor yum found. This script is for openEuler/RHEL only."
+    fi
+}
+
+git_with_github_mirror_fallback() {
+    local repo_dir="$1"
+    local repo_url="$2"
+    shift 2
+
+    if git clone "$repo_url" "$repo_dir" "$@"; then
+        return 0
+    fi
+
+    print_warn "Direct clone failed, retrying with mirror https://ghfast.top/"
+    rm -rf "$repo_dir"
+    git clone "https://ghfast.top/${repo_url}" "$repo_dir" "$@"
+}
+
+clone_repo_if_not_exists() {
+    local repo_dir="$1"
+    local repo_url="$2"
+    shift 2
+
+    if [ -d "$repo_dir" ]; then
+        echo "Directory $repo_dir already exists, skipping clone."
+        return 0
+    fi
+    git_with_github_mirror_fallback "$repo_dir" "$repo_url" "$@"
+}
+
+install_rpm_packages() {
+    local pkg_mgr="$1"
+    shift
+    local packages=("$@")
+    local missing=()
+
+    print_section "Installing system packages via ${pkg_mgr}"
+    ${pkg_mgr} makecache -y || ${pkg_mgr} makecache
+    check_success "Failed to refresh ${pkg_mgr} metadata"
+
+    for pkg in "${packages[@]}"; do
+        if ! ${pkg_mgr} install -y "$pkg"; then
+            missing+=("$pkg")
+        fi
+    done
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        print_warn "Some packages were not installed (may be optional on this openEuler release):"
+        printf '  - %s\n' "${missing[@]}"
+    fi
+}
+
+PKG_MGR="$(detect_pkg_manager)"
+
+# Core build dependencies aligned with root dependencies.sh (Debian names mapped to RHEL/openEuler).
+CORE_PACKAGES=(
+    gcc gcc-c++ make cmake ninja-build git wget unzip
+    gflags-devel glog-devel libibverbs-devel numactl-devel
+    gtest gtest-devel boost-devel openssl-devel hiredis-devel
+    libcurl-devel jsoncpp-devel libunwind-devel python3-devel
+    zstd-devel xxhash-devel pkgconf pkgconf-pkg-config patchelf
+    mpich mpich-devel glibc glibc-common
+)
+
+# Often provided by repos on openEuler; install best-effort.
+OPTIONAL_PACKAGES=(
+    grpc-devel grpc-plugins protobuf-devel protobuf-compiler
+    liburing-devel jemalloc-devel
+)
+
+install_rpm_packages "$PKG_MGR" "${CORE_PACKAGES[@]}"
+install_rpm_packages "$PKG_MGR" "${OPTIONAL_PACKAGES[@]}" || true
+
+# openEuler images may ship MPICH; remove OpenMPI if present to avoid conflicts.
+${PKG_MGR} remove -y openmpi openmpi-devel 2>/dev/null || true
+
+print_success "System package installation finished"
+
+export CPLUS_INCLUDE_PATH="$(
+    echo "${CPLUS_INCLUDE_PATH:-}" | tr ':' '\n' | grep -v "/usr/local/Ascend" | paste -sd: -
+)"
+
+print_section "Initializing Git submodules"
+cd "${REPO_ROOT}"
+if [ ! -f "${REPO_ROOT}/.gitmodules" ]; then
+    print_error "No .gitmodules found under ${REPO_ROOT}"
+fi
+
+submodule_updated=false
+if git submodule sync --recursive && git submodule update --init --recursive; then
+    submodule_updated=true
+elif [ -n "${ASCEND_GITHUB_MIRROR_URLS:-}" ]; then
+  while IFS= read -r raw; do
+    base="${raw#"${raw%%[![:space:]]*}"}"
+    base="${base%"${base##*[![:space:]]}"}"
+    [ -n "$base" ] || continue
+    [ "$base" = "https://github.com/" ] && continue
+    [ "$base" != "https://github.com/" ] && base="${base%/}/"
+    echo "Retrying submodule update with mirror ${base}"
+    if git -c url."${base}https://github.com/".insteadOf=https://github.com/ \
+        submodule sync --recursive && \
+       git -c url."${base}https://github.com/".insteadOf=https://github.com/ \
+        submodule update --init --recursive; then
+        submodule_updated=true
+        break
+    fi
+  done < <(printf '%s\n' "$ASCEND_GITHUB_MIRROR_URLS" | tr ',;' '\n')
+fi
+
+if [ "$submodule_updated" != true ]; then
+    print_error "git submodule update failed (direct GitHub and mirrors exhausted)"
+fi
+print_success "Git submodules initialized"
+
+print_section "Installing yalantinglibs from extern/ submodule"
+if [ -d "${REPO_ROOT}/extern/yalantinglibs" ]; then
+    cd "${REPO_ROOT}/extern/yalantinglibs"
+    rm -rf build
+    mkdir -p build && cd build
+    cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DBUILD_UNIT_TESTS=OFF
+    check_success "Failed to configure yalantinglibs"
+    cmake --build . -j"$(nproc)"
+    check_success "Failed to build yalantinglibs"
+    cmake --install .
+    check_success "Failed to install yalantinglibs"
+    print_success "yalantinglibs installed from submodule"
+    cd "${REPO_ROOT}"
+else
+    print_warn "extern/yalantinglibs missing, building from upstream clone"
+    mkdir -p "${DEPS_BUILD_DIR}"
+    cd "${DEPS_BUILD_DIR}"
+    clone_repo_if_not_exists "yalantinglibs" "https://github.com/alibaba/yalantinglibs.git"
+    cd yalantinglibs
+    git checkout 0.5.5
+    rm -rf build && mkdir -p build && cd build
+    cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DBUILD_UNIT_TESTS=OFF
+    cmake --build . -j"$(nproc)"
+    cmake --install .
+    cd "${REPO_ROOT}"
+    print_success "yalantinglibs installed from git clone"
+fi
+
+print_section "Verifying essential build tools"
+for tool in getconf ldd patchelf cmake git; do
+    command -v "$tool" >/dev/null || print_error "${tool} not found after dependency installation"
+    print_success "${tool} found: $(command -v "$tool")"
+done
+
+print_section "Installing Go ${GOVER}"
+USED_CN_MIRROR=false
+
+install_go() {
+    local arch
+    arch="$(uname -m)"
+    case "$arch" in
+        aarch64) arch=arm64 ;;
+        x86_64) arch=amd64 ;;
+        *) print_error "Unsupported architecture: $arch" ;;
+    esac
+
+    local tarball="go${GOVER}.linux-${arch}.tar.gz"
+    local urls=(
+        "https://go.dev/dl/${tarball}"
+        "https://golang.google.cn/dl/${tarball}"
+        "https://mirrors.aliyun.com/golang/${tarball}"
+    )
+
+    local url downloaded=false
+    for url in "${urls[@]}"; do
+        echo "Downloading Go ${GOVER} from ${url}..."
+        if wget -q --show-progress --timeout=30 --tries=2 -O "${tarball}" "${url}"; then
+            downloaded=true
+            [[ "$url" != "https://go.dev/dl/${tarball}" ]] && USED_CN_MIRROR=true
+            break
+        fi
+        rm -f "${tarball}"
+    done
+
+    [ "$downloaded" = true ] || print_error "Failed to download Go ${GOVER}"
+
+    rm -rf /usr/local/go
+    tar -C /usr/local -xzf "${tarball}"
+    rm -f "${tarball}"
+    export PATH="/usr/local/go/bin:${PATH}"
+    print_success "Go ${GOVER} installed to /usr/local/go"
+}
+
+if command -v go >/dev/null 2>&1; then
+    current_go="$(go version | awk '{print $3}')"
+    if [[ "$current_go" == "go${GOVER}" ]]; then
+        print_success "Go ${GOVER} already installed (${current_go})"
+    else
+        print_warn "Found ${current_go}, installing Go ${GOVER}"
+        install_go
+    fi
+else
+    install_go
+fi
+
+export PATH="/usr/local/go/bin:${PATH}"
+if [ "$USED_CN_MIRROR" = true ] && [ -z "${GOPROXY:-}" ]; then
+    export GOPROXY=https://goproxy.cn,https://goproxy.io,direct
+    print_warn "GOPROXY set to ${GOPROXY} (restricted network detected)"
+fi
+
+go version
+print_success "Go is available: $(command -v go)"
+
+print_section "Installation complete"
+echo -e "${GREEN}openEuler dependencies are ready.${NC}"
+echo "Next steps (example NPU release build):"
+echo "  source /usr/local/Ascend/cann-9.0.0/set_env.sh"
+echo "  mkdir -p build && cd build"
+echo "  cmake .. -DUSE_ASCEND_DIRECT=ON -DUSE_CUDA=OFF -DWITH_EP=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON"
+echo "  cmake --build . -j\$(nproc) && cmake --install ."

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -140,7 +140,19 @@ echo "Building wheel package..."
 # Build the wheel package
 cd mooncake-wheel
 
-# Handle package name modification for non-CUDA builds
+BUILD_VARIANTS="NON_CUDA_BUILD CU13_BUILD NPU_BUILD"
+BUILD_VARIANT_COUNT=0
+for build_variant in $BUILD_VARIANTS; do
+    if [ "${!build_variant}" = "1" ]; then
+        BUILD_VARIANT_COUNT=$((BUILD_VARIANT_COUNT + 1))
+    fi
+done
+if [ "$BUILD_VARIANT_COUNT" -gt 1 ]; then
+    echo "Error: only one of $BUILD_VARIANTS can be set"
+    exit 1
+fi
+
+# Handle package name modification for release build variants
 if [ "$NON_CUDA_BUILD" = "1" ]; then
     echo "Modifying package name for non-CUDA build"
     # Backup original pyproject.toml
@@ -150,12 +162,7 @@ if [ "$NON_CUDA_BUILD" = "1" ]; then
     sed -i 's/description = "Python binding of a Mooncake library using pybind11"/description = "Python binding of a Mooncake library using pybind11 (Non-CUDA version)"/' pyproject.toml
     sed -i 's/keywords = \["mooncake", "data transfer", "kv cache", "llm inference"\]/keywords = ["mooncake", "data transfer", "kv cache", "llm inference", "non-cuda"]/' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-non-cuda"
-else
-    echo "Using standard package name: mooncake-transfer-engine"
-fi
-
-# Handle package name modification for CU13 builds
-if [ "$CU13_BUILD" = "1" ]; then
+elif [ "$CU13_BUILD" = "1" ]; then
     echo "Modifying package name for CU13 build"
     # Backup original pyproject.toml
     cp pyproject.toml pyproject.toml.backup
@@ -164,6 +171,15 @@ if [ "$CU13_BUILD" = "1" ]; then
     sed -i 's/description = "Python binding of a Mooncake library using pybind11"/description = "Python binding of a Mooncake library using pybind11 (CUDA 13 version)"/' pyproject.toml
     sed -i 's/keywords = \["mooncake", "data transfer", "kv cache", "llm inference"\]/keywords = ["mooncake", "data transfer", "kv cache", "llm inference", "cuda13"]/' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-cuda13"
+elif [ "$NPU_BUILD" = "1" ]; then
+    echo "Modifying package name for Ascend NPU build"
+    # Backup original pyproject.toml
+    cp pyproject.toml pyproject.toml.backup
+    # Replace package name and description
+    sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-npu"/' pyproject.toml
+    sed -i 's/description = "Python binding of a Mooncake library using pybind11"/description = "Python binding of a Mooncake library using pybind11 (Ascend NPU version)"/' pyproject.toml
+    sed -i 's/keywords = \["mooncake", "data transfer", "kv cache", "llm inference"\]/keywords = ["mooncake", "data transfer", "kv cache", "llm inference", "ascend", "npu"]/' pyproject.toml
+    echo "Package name modified to: mooncake-transfer-engine-npu"
 else
     echo "Using standard package name: mooncake-transfer-engine"
 fi
@@ -173,7 +189,14 @@ rm -rf ${OUTPUT_DIR}/
 mkdir -p ${OUTPUT_DIR}
 
 echo "Installing required build packages"
-if command -v pip &>/dev/null; then
+if [ "$NPU_BUILD" = "1" ]; then
+    PYTHON_CMD="python${PYTHON_VERSION}"
+    if ! command -v "$PYTHON_CMD" &>/dev/null; then
+        echo "Error: $PYTHON_CMD not found for NPU wheel build"
+        exit 1
+    fi
+    "$PYTHON_CMD" -m pip install --upgrade pip build setuptools wheel auditwheel
+elif command -v pip &>/dev/null; then
     python${PYTHON_VERSION} -m pip install --upgrade pip build setuptools wheel auditwheel
 elif command -v uv &>/dev/null; then
     uv pip install --upgrade pip
@@ -242,8 +265,14 @@ echo "Detected glibc version: $GLIBC_VERSION"
 echo "Using platform tag: $PLATFORM_TAG"
 
 echo "Repairing wheel with auditwheel for platform: $PLATFORM_TAG"
-python${PYTHON_VERSION} -m build --wheel --outdir ${OUTPUT_DIR}
-auditwheel repair ${OUTPUT_DIR}/*.whl \
+if [ "$NPU_BUILD" = "1" ]; then
+    python${PYTHON_VERSION} -m build --wheel --no-isolation --outdir ${OUTPUT_DIR}
+    AUDITWHEEL_CMD="python${PYTHON_VERSION} -m auditwheel"
+else
+    python${PYTHON_VERSION} -m build --wheel --outdir ${OUTPUT_DIR}
+    AUDITWHEEL_CMD="auditwheel"
+fi
+${AUDITWHEEL_CMD} repair ${OUTPUT_DIR}/*.whl \
     --exclude libcurl.so* \
     --exclude libibverbs.so* \
     --exclude libmlx5.so* \
@@ -364,5 +393,7 @@ rm -f ${OUTPUT_DIR}/*.whl
 mv ${REPAIRED_DIR}/*.whl ${OUTPUT_DIR}/
 
 cd ..
+
+[[ -f mooncake-wheel/pyproject.toml.backup ]] && mv mooncake-wheel/pyproject.toml.backup mooncake-wheel/pyproject.toml
 
 echo "Wheel package built and repaired successfully!"


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
Add CI/CD workflow for building and publishing Ascend NPU wheel packages. This includes:
- New GitHub Actions workflow (release-npu.yaml) for building NPU wheels across Python 3.10/3.11/3.12/3.13 and publishing to PyPI via tag trigger
- New openEuler/RHEL dependency installer (scripts/ascend/dependencies_openeuler.sh) for NPU build environments
- Extended scripts/build_wheel.sh to support NPU build variant (NPU_BUILD=1)

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->
- Tested full build pipeline on self-hosted NPU runner with Python 3.10/3.11/3.12/3.13
- Verified wheel package can be installed and imported
- Verified TestPyPI publishing via OIDC Trusted Publisher with tag trigger
- Tested GitHub mirror fallback for checkout on restricted network
- Tested Go dependency download with multi-proxy fallback (goproxy.io | aliyun | goproxy.cn)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
