### PR TITLE
[CI] Upgrade `actions/upload-artifact` to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
       shell: bash
 
     - name: Upload wheel for ZMQ test job
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: wheel-build-py${{ steps.generate_tag_build.outputs.python_version_tag }}
         path: mooncake-wheel/dist-py${{ steps.generate_tag_build.outputs.python_version_tag }}/*.whl
@@ -668,9 +668,9 @@ jobs:
       shell: bash
 
     - name: Upload Python wheel artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
-        name: mooncake-wheel-ubuntu-py${{ steps.generate_tag_flags.outputs.python_version_tag }}
+        archive: false
         path: mooncake-wheel/dist-py${{ steps.generate_tag_flags.outputs.python_version_tag }}/*.whl
 
   build-docker:

--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -355,7 +355,7 @@ jobs:
 
     - name: Upload Test Logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-logs-${{ github.run_number }}
         path: |

--- a/.github/workflows/ci_cu13.yml
+++ b/.github/workflows/ci_cu13.yml
@@ -118,7 +118,7 @@ jobs:
       shell: bash
 
     - name: Upload Python wheel artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
-        name: mooncake-wheel-cu130-ubuntu-py${{ steps.generate_tag.outputs.python_version_tag }}
+        archive: false
         path: mooncake-wheel/dist-py${{ steps.generate_tag.outputs.python_version_tag }}/*.whl

--- a/.github/workflows/release-cuda13.yaml
+++ b/.github/workflows/release-cuda13.yaml
@@ -101,9 +101,9 @@ jobs:
           VERSION: ${{ env.VERSION }}
 
       - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: mooncake-wheel-cuda13-py${{ steps.generate_tag_release.outputs.python_version_tag }}
+          archive: false
           path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
 
   publish-release:

--- a/.github/workflows/release-non-cuda.yaml
+++ b/.github/workflows/release-non-cuda.yaml
@@ -78,9 +78,9 @@ jobs:
           VERSION: ${{ env.VERSION }}
 
       - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: mooncake-wheel-non-cuda-py${{ steps.generate_tag_release.outputs.python_version_tag }}
+          archive: false
           path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
 
   publish-release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,9 +100,9 @@ jobs:
           VERSION: ${{ env.VERSION }}
 
       - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: mooncake-wheel-py${{ steps.generate_tag_release.outputs.python_version_tag }}
+          archive: false
           path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
 
   publish-release:


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Upgrade `actions/upload-artifact` to v7 to unlock the single-file artifact feature

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
