### PR TITLE
[Store] Add opt-in grouped object routing semantics

### DIFF
--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -481,8 +481,36 @@ config.preferred_segment = self.get_hostname()
 
 ```python
 config = ReplicateConfig()
-config.prefer_alloc_in_same_node = "True
+config.prefer_alloc_in_same_node = "True"
 ```
+
+#### group_ids
+**Type:** `List[str] | None`
+**Default:** `None`
+**Description:** Optionally assigns object metadata to routing groups during writes. When this field is unset, Mooncake Store preserves the default ungrouped behavior. When it is set, each group ID maps to the object at the same position in the write request. Empty string (`""`) explicitly stores that object as ungrouped.
+
+For batch write APIs, the number of group IDs must match the number of keys:
+
+```python
+config = ReplicateConfig()
+config.group_ids = ["session-a", "", "session-b"]
+
+store.put_batch(
+    ["key-a", "key-b", "key-c"],
+    [b"value-a", b"value-b", b"value-c"],
+    config,
+)
+```
+
+For a single-object write, provide one group ID:
+
+```python
+config = ReplicateConfig()
+config.group_ids = ["session-a"]
+
+store.put("key-a", b"value-a", config)
+```
+
 ---
 
 ## Unified Parallel Tensor IO API

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -677,6 +677,66 @@ class MooncakeStorePyWrapper {
                                ReplicateConfig{});  // Default config
     }
 
+    ReplicateConfig MakeSingleKeyConfig(const ReplicateConfig &config,
+                                        size_t key_index) const {
+        ReplicateConfig key_config = config;
+        if (config.group_ids.has_value()) {
+            key_config.group_ids =
+                std::vector<std::string>{config.group_ids->at(key_index)};
+        }
+        return key_config;
+    }
+
+    ReplicateConfig MakeIndexedConfig(
+        const ReplicateConfig &config,
+        const std::vector<size_t> &original_indices) const {
+        if (!config.group_ids.has_value()) {
+            return config;
+        }
+
+        ReplicateConfig indexed_config = config;
+        std::vector<std::string> group_ids;
+        group_ids.reserve(original_indices.size());
+        for (size_t index : original_indices) {
+            group_ids.push_back(config.group_ids->at(index));
+        }
+        indexed_config.group_ids = std::move(group_ids);
+        return indexed_config;
+    }
+
+    ReplicateConfig MakeRepeatedIndexedConfig(
+        const ReplicateConfig &config,
+        const std::vector<size_t> &original_indices, int repeat_count) const {
+        if (!config.group_ids.has_value()) {
+            return config;
+        }
+
+        ReplicateConfig indexed_config = config;
+        std::vector<std::string> group_ids;
+        group_ids.reserve(original_indices.size() *
+                          static_cast<size_t>(repeat_count));
+        for (size_t index : original_indices) {
+            for (int i = 0; i < repeat_count; ++i) {
+                group_ids.push_back(config.group_ids->at(index));
+            }
+        }
+        indexed_config.group_ids = std::move(group_ids);
+        return indexed_config;
+    }
+
+    std::vector<int> ValidateGroupIdsForBatchConfig(
+        const ReplicateConfig &config, size_t key_count,
+        const char *operation_name) const {
+        if (config.group_ids.has_value() &&
+            config.group_ids->size() != key_count) {
+            LOG(ERROR) << operation_name
+                       << ": group_ids size must match keys size";
+            return std::vector<int>(key_count,
+                                    to_py_ret(ErrorCode::INVALID_PARAMS));
+        }
+        return {};
+    }
+
     int put_tensor_with_tp_impl(
         const std::string &key, pybind11::object tensor,
         const ReplicateConfig &config = ReplicateConfig{}, int tp_rank = 0,
@@ -725,11 +785,12 @@ class MooncakeStorePyWrapper {
         const ReplicateConfig &config = ReplicateConfig{}) {
         return batch_write_tensor_impl(
             keys, infos, config, "put",
-            [this, &config](const std::vector<std::string> &write_keys,
-                            const std::vector<void *> &buffer_ptrs,
-                            const std::vector<size_t> &buffer_sizes) {
+            [this](const std::vector<std::string> &write_keys,
+                   const std::vector<void *> &buffer_ptrs,
+                   const std::vector<size_t> &buffer_sizes,
+                   const ReplicateConfig &write_config) {
                 return store_->batch_put_from(write_keys, buffer_ptrs,
-                                              buffer_sizes, config);
+                                              buffer_sizes, write_config);
             });
     }
 
@@ -769,6 +830,11 @@ class MooncakeStorePyWrapper {
         std::vector<size_t> processed_indices;
         std::vector<int> final_results(base_keys.size(),
                                        to_py_ret(ErrorCode::INVALID_PARAMS));
+        auto group_ids_error = ValidateGroupIdsForBatchConfig(
+            config, base_keys.size(), "batch_put_tensor_with_tp");
+        if (!group_ids_error.empty()) {
+            return group_ids_error;
+        }
         try {
             // Chunking phase (GIL Held)
             for (size_t i = 0; i < base_keys.size(); ++i) {
@@ -799,8 +865,10 @@ class MooncakeStorePyWrapper {
             if (all_chunk_keys.empty()) return final_results;
 
             // Reuse the standard batch_put implementation
-            std::vector<int> chunk_results =
-                batch_put_tensor_impl(all_chunk_keys, all_chunks_list, config);
+            ReplicateConfig chunk_config =
+                MakeRepeatedIndexedConfig(config, processed_indices, tp_size);
+            std::vector<int> chunk_results = batch_put_tensor_impl(
+                all_chunk_keys, all_chunks_list, chunk_config);
 
             // Aggregate results
             for (size_t i = 0; i < processed_indices.size(); ++i) {
@@ -1234,6 +1302,12 @@ class MooncakeStorePyWrapper {
         const std::vector<std::string> &keys,
         const pybind11::list &tensors_list,
         const ReplicateConfig &config = ReplicateConfig{}) {
+        auto group_ids_error = ValidateGroupIdsForBatchConfig(
+            config, keys.size(), "batch_upsert_tensor");
+        if (!group_ids_error.empty()) {
+            return group_ids_error;
+        }
+
         std::vector<PyTensorInfo> infos(keys.size());
         std::vector<int> results(keys.size(), 0);
 
@@ -1287,8 +1361,10 @@ class MooncakeStorePyWrapper {
             }
 
             if (!valid_keys.empty()) {
+                ReplicateConfig write_config =
+                    MakeIndexedConfig(config, original_indices);
                 std::vector<int> op_results = store_->batch_upsert_from(
-                    valid_keys, buffer_ptrs, buffer_sizes, config);
+                    valid_keys, buffer_ptrs, buffer_sizes, write_config);
                 for (size_t i = 0; i < op_results.size(); ++i) {
                     results[original_indices[i]] = op_results[i];
                 }
@@ -1603,6 +1679,7 @@ PYBIND11_MODULE(store, m) {
         .def_readwrite("prefer_alloc_in_same_node",
                        &ReplicateConfig::prefer_alloc_in_same_node)
         .def_readwrite("data_type", &ReplicateConfig::data_type)
+        .def_readwrite("group_ids", &ReplicateConfig::group_ids)
         .def("__str__", [](const ReplicateConfig &config) {
             std::ostringstream oss;
             oss << config;

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -677,16 +677,6 @@ class MooncakeStorePyWrapper {
                                ReplicateConfig{});  // Default config
     }
 
-    ReplicateConfig MakeSingleKeyConfig(const ReplicateConfig &config,
-                                        size_t key_index) const {
-        ReplicateConfig key_config = config;
-        if (config.group_ids.has_value()) {
-            key_config.group_ids =
-                std::vector<std::string>{config.group_ids->at(key_index)};
-        }
-        return key_config;
-    }
-
     ReplicateConfig MakeIndexedConfig(
         const ReplicateConfig &config,
         const std::vector<size_t> &original_indices) const {

--- a/mooncake-integration/store/store_py_internal.h
+++ b/mooncake-integration/store/store_py_internal.h
@@ -848,7 +848,7 @@ bool is_default_replicate_config(const ReplicateConfig &config) {
     return config.replica_num == 1 && !config.with_soft_pin &&
            !config.with_hard_pin && config.preferred_segments.empty() &&
            config.preferred_segment.empty() &&
-           !config.prefer_alloc_in_same_node;
+           !config.prefer_alloc_in_same_node && !config.group_ids.has_value();
 }
 
 std::optional<ParallelAxisSpec> parse_parallel_axis_spec(

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -935,14 +935,14 @@ std::vector<int> batch_put_tensor_with_parallelism(
         },
         [this, &keys, &tensors_list, &config](size_t i,
                                               const py::handle &parallelism) {
-            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
+            ReplicateConfig key_config = config.ForSingleKey(i);
             return put_tensor_with_parallelism(
                 keys[i], tensors_list[i],
                 py::reinterpret_borrow<py::object>(parallelism), key_config);
         },
         [this, &keys, &tensors_list, &config](
             size_t i, const py::handle &writer_partition) {
-            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
+            ReplicateConfig key_config = config.ForSingleKey(i);
             return put_tensor_with_parallelism(
                 keys[i], tensors_list[i], py::none(), key_config,
                 py::reinterpret_borrow<py::object>(writer_partition));
@@ -1092,14 +1092,14 @@ std::vector<int> batch_put_tensor_with_parallelism_from(
         },
         [this, &keys, &buffer_ptrs, &sizes, &config](
             size_t i, const py::handle &parallelism) {
-            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
+            ReplicateConfig key_config = config.ForSingleKey(i);
             return put_tensor_with_parallelism_from(
                 keys[i], buffer_ptrs[i], sizes[i],
                 py::reinterpret_borrow<py::object>(parallelism), key_config);
         },
         [this, &keys, &buffer_ptrs, &sizes, &config](
             size_t i, const py::handle &writer_partition) {
-            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
+            ReplicateConfig key_config = config.ForSingleKey(i);
             return put_tensor_with_parallelism_from(
                 keys[i], buffer_ptrs[i], sizes[i], py::none(), key_config,
                 py::reinterpret_borrow<py::object>(writer_partition));
@@ -1391,14 +1391,14 @@ std::vector<int> batch_upsert_tensor_with_parallelism(
         },
         [this, &keys, &tensors_list, &config](size_t i,
                                               const py::handle &parallelism) {
-            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
+            ReplicateConfig key_config = config.ForSingleKey(i);
             return upsert_tensor_with_parallelism(
                 keys[i], tensors_list[i],
                 py::reinterpret_borrow<py::object>(parallelism), key_config);
         },
         [this, &keys, &tensors_list, &config](
             size_t i, const py::handle &writer_partition) {
-            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
+            ReplicateConfig key_config = config.ForSingleKey(i);
             return upsert_tensor_with_parallelism(
                 keys[i], tensors_list[i], py::none(), key_config,
                 py::reinterpret_borrow<py::object>(writer_partition));
@@ -1468,14 +1468,14 @@ std::vector<int> batch_upsert_tensor_with_parallelism_from(
         },
         [this, &keys, &buffer_ptrs, &sizes, &config](
             size_t i, const py::handle &parallelism) {
-            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
+            ReplicateConfig key_config = config.ForSingleKey(i);
             return upsert_tensor_with_parallelism_from(
                 keys[i], buffer_ptrs[i], sizes[i],
                 py::reinterpret_borrow<py::object>(parallelism), key_config);
         },
         [this, &keys, &buffer_ptrs, &sizes, &config](
             size_t i, const py::handle &writer_partition) {
-            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
+            ReplicateConfig key_config = config.ForSingleKey(i);
             return upsert_tensor_with_parallelism_from(
                 keys[i], buffer_ptrs[i], sizes[i], py::none(), key_config,
                 py::reinterpret_borrow<py::object>(writer_partition));

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -20,6 +20,12 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
                                          const ReplicateConfig &config,
                                          const char *operation_name,
                                          BatchWriteFromFn &&batch_write_from) {
+    auto group_ids_error =
+        ValidateGroupIdsForBatchConfig(config, keys.size(), operation_name);
+    if (!group_ids_error.empty()) {
+        return group_ids_error;
+    }
+
     std::vector<int> results(keys.size(), 0);
 
     {
@@ -65,8 +71,10 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
         }
 
         if (!valid_keys.empty()) {
-            std::vector<int> op_results =
-                batch_write_from(valid_keys, buffer_ptrs, buffer_sizes);
+            ReplicateConfig write_config =
+                MakeIndexedConfig(config, original_indices);
+            std::vector<int> op_results = batch_write_from(
+                valid_keys, buffer_ptrs, buffer_sizes, write_config);
             for (size_t i = 0; i < op_results.size(); ++i) {
                 results[original_indices[i]] = op_results[i];
             }
@@ -905,6 +913,12 @@ std::vector<int> batch_put_tensor_with_parallelism(
     const py::object &parallelisms = py::none(),
     const ReplicateConfig &config = ReplicateConfig{},
     const py::object &writer_partitions = py::none()) {
+    auto group_ids_error = ValidateGroupIdsForBatchConfig(
+        config, keys.size(), "batch_put_tensor_with_parallelism");
+    if (!group_ids_error.empty()) {
+        return group_ids_error;
+    }
+
     return execute_batch_parallelism_write_requests(
         keys, tensors_list.size(), parallelisms, writer_partitions,
         "batch_put_tensor_with_parallelism",
@@ -921,14 +935,16 @@ std::vector<int> batch_put_tensor_with_parallelism(
         },
         [this, &keys, &tensors_list, &config](size_t i,
                                               const py::handle &parallelism) {
+            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
             return put_tensor_with_parallelism(
                 keys[i], tensors_list[i],
-                py::reinterpret_borrow<py::object>(parallelism), config);
+                py::reinterpret_borrow<py::object>(parallelism), key_config);
         },
         [this, &keys, &tensors_list, &config](
             size_t i, const py::handle &writer_partition) {
+            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
             return put_tensor_with_parallelism(
-                keys[i], tensors_list[i], py::none(), config,
+                keys[i], tensors_list[i], py::none(), key_config,
                 py::reinterpret_borrow<py::object>(writer_partition));
         });
 }
@@ -1029,6 +1045,12 @@ std::vector<int> batch_put_tensor_with_parallelism_from(
     const py::object &parallelisms = py::none(),
     const ReplicateConfig &config = ReplicateConfig{},
     const py::object &writer_partitions = py::none()) {
+    auto group_ids_error = ValidateGroupIdsForBatchConfig(
+        config, keys.size(), "batch_put_tensor_with_parallelism_from");
+    if (!group_ids_error.empty()) {
+        return group_ids_error;
+    }
+
     return execute_batch_parallelism_write_requests(
         keys, buffer_ptrs.size(), parallelisms, writer_partitions,
         "batch_put_tensor_with_parallelism_from",
@@ -1070,14 +1092,16 @@ std::vector<int> batch_put_tensor_with_parallelism_from(
         },
         [this, &keys, &buffer_ptrs, &sizes, &config](
             size_t i, const py::handle &parallelism) {
+            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
             return put_tensor_with_parallelism_from(
                 keys[i], buffer_ptrs[i], sizes[i],
-                py::reinterpret_borrow<py::object>(parallelism), config);
+                py::reinterpret_borrow<py::object>(parallelism), key_config);
         },
         [this, &keys, &buffer_ptrs, &sizes, &config](
             size_t i, const py::handle &writer_partition) {
+            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
             return put_tensor_with_parallelism_from(
-                keys[i], buffer_ptrs[i], sizes[i], py::none(), config,
+                keys[i], buffer_ptrs[i], sizes[i], py::none(), key_config,
                 py::reinterpret_borrow<py::object>(writer_partition));
         });
 }
@@ -1345,6 +1369,12 @@ std::vector<int> batch_upsert_tensor_with_parallelism(
     const py::object &parallelisms = py::none(),
     const ReplicateConfig &config = ReplicateConfig{},
     const py::object &writer_partitions = py::none()) {
+    auto group_ids_error = ValidateGroupIdsForBatchConfig(
+        config, keys.size(), "batch_upsert_tensor_with_parallelism");
+    if (!group_ids_error.empty()) {
+        return group_ids_error;
+    }
+
     return execute_batch_parallelism_write_requests(
         keys, tensors_list.size(), parallelisms, writer_partitions,
         "batch_upsert_tensor_with_parallelism",
@@ -1361,14 +1391,16 @@ std::vector<int> batch_upsert_tensor_with_parallelism(
         },
         [this, &keys, &tensors_list, &config](size_t i,
                                               const py::handle &parallelism) {
+            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
             return upsert_tensor_with_parallelism(
                 keys[i], tensors_list[i],
-                py::reinterpret_borrow<py::object>(parallelism), config);
+                py::reinterpret_borrow<py::object>(parallelism), key_config);
         },
         [this, &keys, &tensors_list, &config](
             size_t i, const py::handle &writer_partition) {
+            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
             return upsert_tensor_with_parallelism(
-                keys[i], tensors_list[i], py::none(), config,
+                keys[i], tensors_list[i], py::none(), key_config,
                 py::reinterpret_borrow<py::object>(writer_partition));
         });
 }
@@ -1379,6 +1411,12 @@ std::vector<int> batch_upsert_tensor_with_parallelism_from(
     const py::object &parallelisms = py::none(),
     const ReplicateConfig &config = ReplicateConfig{},
     const py::object &writer_partitions = py::none()) {
+    auto group_ids_error = ValidateGroupIdsForBatchConfig(
+        config, keys.size(), "batch_upsert_tensor_with_parallelism_from");
+    if (!group_ids_error.empty()) {
+        return group_ids_error;
+    }
+
     return execute_batch_parallelism_write_requests(
         keys, buffer_ptrs.size(), parallelisms, writer_partitions,
         "batch_upsert_tensor_with_parallelism_from",
@@ -1430,14 +1468,16 @@ std::vector<int> batch_upsert_tensor_with_parallelism_from(
         },
         [this, &keys, &buffer_ptrs, &sizes, &config](
             size_t i, const py::handle &parallelism) {
+            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
             return upsert_tensor_with_parallelism_from(
                 keys[i], buffer_ptrs[i], sizes[i],
-                py::reinterpret_borrow<py::object>(parallelism), config);
+                py::reinterpret_borrow<py::object>(parallelism), key_config);
         },
         [this, &keys, &buffer_ptrs, &sizes, &config](
             size_t i, const py::handle &writer_partition) {
+            ReplicateConfig key_config = MakeSingleKeyConfig(config, i);
             return upsert_tensor_with_parallelism_from(
-                keys[i], buffer_ptrs[i], sizes[i], py::none(), config,
+                keys[i], buffer_ptrs[i], sizes[i], py::none(), key_config,
                 py::reinterpret_borrow<py::object>(writer_partition));
         });
 }

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -952,6 +952,18 @@ class MasterService {
             }
         }
 
+        bool NeedsLeaseRefresh(const uint64_t ttl,
+                               const uint64_t soft_ttl) const {
+            SpinLocker locker(&lock);
+            const auto now = std::chrono::system_clock::now();
+            if (lease_timeout <= now + std::chrono::milliseconds(ttl / 2)) {
+                return true;
+            }
+            return soft_pin_timeout &&
+                   *soft_pin_timeout <=
+                       now + std::chrono::milliseconds(soft_ttl / 2);
+        }
+
         // Check if the lease has expired
         bool IsLeaseExpired() const {
             SpinLocker locker(&lock);
@@ -1075,6 +1087,8 @@ class MasterService {
     std::array<MetadataShard, kNumShards> metadata_shards_;
 
     std::unordered_map<std::string, std::string> object_group_ids_
+        GUARDED_BY(group_routing_mutex_);
+    mutable std::unordered_set<std::string> groups_needing_lease_refresh_
         GUARDED_BY(group_routing_mutex_);
     mutable std::shared_mutex group_routing_mutex_;
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -741,11 +742,13 @@ class MasterService {
             const std::chrono::system_clock::time_point put_start_time_,
             size_t value_length, std::vector<Replica>&& reps,
             bool enable_soft_pin, bool enable_hard_pin = false,
-            ObjectDataType data_type_ = ObjectDataType::UNKNOWN)
+            ObjectDataType data_type_ = ObjectDataType::UNKNOWN,
+            std::string group_id_ = "")
             : client_id(client_id_),
               put_start_time(put_start_time_),
               size(value_length),
               data_type(data_type_),
+              group_id(std::move(group_id_)),
               lease_timeout(),
               soft_pin_timeout(std::nullopt),
               hard_pinned(enable_hard_pin),
@@ -769,6 +772,7 @@ class MasterService {
         std::chrono::system_clock::time_point put_start_time;
         const size_t size;
         const ObjectDataType data_type{ObjectDataType::UNKNOWN};
+        const std::string group_id;
 
         mutable SpinLock lock;
         // Default constructor, creates a time_point representing
@@ -975,6 +979,8 @@ class MasterService {
 
         bool IsHardPinned() const { return hard_pinned; }
 
+        bool IsGrouped() const { return !group_id.empty(); }
+
         // Check if the metadata is valid
         // Valid means it has at least one valid replica and size is greater
         // than 0
@@ -1063,8 +1069,14 @@ class MasterService {
             GUARDED_BY(mutex);
         std::unordered_map<std::string, PromotionTask> promotion_tasks
             GUARDED_BY(mutex);
+        std::unordered_map<std::string, std::unordered_set<std::string>>
+            group_members GUARDED_BY(mutex);
     };
     std::array<MetadataShard, kNumShards> metadata_shards_;
+
+    std::unordered_map<std::string, std::string> object_group_ids_
+        GUARDED_BY(group_routing_mutex_);
+    mutable std::shared_mutex group_routing_mutex_;
 
     // For accessing a metadata shard with read-write permission
     class MetadataShardAccessorRW {
@@ -1077,6 +1089,10 @@ class MasterService {
         MetadataShard* operator->() { return &shard_; }
 
         const MetadataShard* operator->() const { return &shard_; }
+
+        MetadataShard& get() { return shard_; }
+
+        const MetadataShard& get() const { return shard_; }
 
        private:
         MetadataShard& shard_;
@@ -1093,6 +1109,8 @@ class MasterService {
 
         const MetadataShard* operator->() const { return &shard_; }
 
+        const MetadataShard& get() const { return shard_; }
+
        private:
         const MetadataShard& shard_;
         SharedMutexLocker lock_;
@@ -1102,6 +1120,19 @@ class MasterService {
     size_t getShardIndex(const std::string& key) const {
         return std::hash<std::string>{}(key) % kNumShards;
     }
+
+    size_t getMetadataShardIndex(const std::string& key) const;
+    void RegisterGroupMember(MetadataShard& shard, const std::string& key,
+                             const std::string& group_id);
+    void UnregisterGroupMember(MetadataShard& shard, const std::string& key,
+                               const std::string& group_id);
+    std::unordered_map<std::string, ObjectMetadata>::iterator
+    EraseMetadataEntry(
+        MetadataShard& shard,
+        std::unordered_map<std::string, ObjectMetadata>::iterator it);
+    void RebuildGroupRoutingIndex();
+    void GrantLeaseForGroup(const MetadataShard& shard, const std::string& key,
+                            const ObjectMetadata& metadata) const;
 
     // Helper to clean up stale handles pointing to unmounted segments
     // or local_disk replicas whose owner client is no longer alive.
@@ -1114,7 +1145,7 @@ class MasterService {
     auto AllocateAndInsertMetadata(
         MetadataShardAccessorRW& shard, const UUID& client_id,
         const std::string& key, uint64_t value_length,
-        const ReplicateConfig& config,
+        const ReplicateConfig& config, const std::string& group_id,
         const std::chrono::system_clock::time_point& now)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
 
@@ -1193,19 +1224,6 @@ class MasterService {
      */
     void TryPushPromotionQueue(const std::string& key);
 
-    // Erase any in-flight PromotionTask for `key` and decrement the
-    // cluster-wide in-flight counter. Safe no-op if no task exists.
-    // Call from any path that erases an ObjectMetadata entry, so the
-    // task doesn't pin a promotion_in_flight_ slot for the full
-    // put_start_release_timeout_sec_ until the reaper sweeps.
-    void ErasePromotionTaskIfPresent(MetadataShardAccessorRW& shard,
-                                     const std::string& key)
-        NO_THREAD_SAFETY_ANALYSIS {
-        if (shard->promotion_tasks.erase(key) > 0) {
-            promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
-        }
-    }
-
     // Lease related members
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
     const uint64_t default_kv_soft_pin_ttl_;  // in milliseconds
@@ -1245,7 +1263,7 @@ class MasterService {
         MetadataAccessorRW(MasterService* service, const std::string& key)
             : service_(service),
               key_(key),
-              shard_idx_(service_->getShardIndex(key)),
+              shard_idx_(service_->getMetadataShardIndex(key)),
               shard_guard_(service_, shard_idx_),
               it_(shard_guard_->metadata.find(key)),
               processing_it_(shard_guard_->processing_keys.find(key)),
@@ -1268,7 +1286,6 @@ class MasterService {
                     if (processing_it_ != shard_guard_->processing_keys.end()) {
                         this->EraseFromProcessing();
                     }
-                    service_->ErasePromotionTaskIfPresent(shard_guard_, key_);
                 }
             }
         }
@@ -1300,8 +1317,7 @@ class MasterService {
 
         // Delete current metadata (for PutRevoke or Remove operations)
         void Erase() NO_THREAD_SAFETY_ANALYSIS {
-            shard_guard_->metadata.erase(it_);
-            it_ = shard_guard_->metadata.end();
+            it_ = service_->EraseMetadataEntry(shard_guard_.get(), it_);
         }
 
         void EraseFromProcessing() NO_THREAD_SAFETY_ANALYSIS {
@@ -1388,7 +1404,7 @@ class MasterService {
         MetadataAccessorRO(const MasterService* service, const std::string& key)
             : service_(service),
               key_(key),
-              shard_idx_(service_->getShardIndex(key)),
+              shard_idx_(service_->getMetadataShardIndex(key)),
               shard_guard_(service_, shard_idx_),
               it_(shard_guard_->metadata.find(key)),
               processing_it_(shard_guard_->processing_keys.find(key)) {}

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -91,7 +91,19 @@ struct ReplicateConfig {
         preferred_nof_segments{};  // Preferred NoF segments for allocation
     bool prefer_alloc_in_same_node{false};
     ObjectDataType data_type{ObjectDataType::UNKNOWN};
+    // Optional per-key routing group IDs. Empty string keeps that key
+    // ungrouped. Grouped keys share metadata routing, coalesced lease refresh,
+    // and memory eviction behavior.
     std::optional<std::vector<std::string>> group_ids{};
+
+    ReplicateConfig ForSingleKey(size_t key_index) const {
+        ReplicateConfig key_config = *this;
+        if (group_ids.has_value()) {
+            key_config.group_ids =
+                std::vector<std::string>{group_ids->at(key_index)};
+        }
+        return key_config;
+    }
 
     friend std::ostream& operator<<(std::ostream& os,
                                     const ReplicateConfig& config) noexcept {

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -91,6 +91,7 @@ struct ReplicateConfig {
         preferred_nof_segments{};  // Preferred NoF segments for allocation
     bool prefer_alloc_in_same_node{false};
     ObjectDataType data_type{ObjectDataType::UNKNOWN};
+    std::optional<std::vector<std::string>> group_ids{};
 
     friend std::ostream& operator<<(std::ostream& os,
                                     const ReplicateConfig& config) noexcept {
@@ -116,7 +117,16 @@ struct ReplicateConfig {
         os << "]";
         os << ", prefer_alloc_in_same_node: "
            << config.prefer_alloc_in_same_node
-           << ", data_type: " << config.data_type << " }";
+           << ", data_type: " << config.data_type;
+        if (config.group_ids.has_value()) {
+            os << ", group_ids: [";
+            for (size_t i = 0; i < config.group_ids->size(); ++i) {
+                os << config.group_ids->at(i);
+                if (i + 1 < config.group_ids->size()) os << ", ";
+            }
+            os << "]";
+        }
+        os << " }";
         return os;
     }
 };

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -118,17 +118,6 @@ tl::expected<std::string, ErrorCode> GetGroupIdForKey(
     return config.group_ids->at(key_index);
 }
 
-ReplicateConfig MakeSingleKeyConfig(const ReplicateConfig& config,
-                                    size_t key_index) {
-    ReplicateConfig key_config = config;
-    if (config.group_ids.has_value()) {
-        key_config.group_ids = std::vector<std::string>{
-            config.group_ids->at(key_index),
-        };
-    }
-    return key_config;
-}
-
 }  // namespace
 
 MasterService::MasterService() : MasterService(MasterServiceConfig()) {}
@@ -613,6 +602,7 @@ void MasterService::RegisterGroupMember(MetadataShard& shard,
     }
     std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
     object_group_ids_[key] = group_id;
+    groups_needing_lease_refresh_.insert(group_id);
     shard.group_members[group_id].insert(key);
 }
 
@@ -622,17 +612,22 @@ void MasterService::UnregisterGroupMember(MetadataShard& shard,
     if (group_id.empty()) {
         return;
     }
+    bool group_empty = false;
     auto group_it = shard.group_members.find(group_id);
     if (group_it != shard.group_members.end()) {
         group_it->second.erase(key);
         if (group_it->second.empty()) {
             shard.group_members.erase(group_it);
+            group_empty = true;
         }
     }
     std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
     auto route_it = object_group_ids_.find(key);
     if (route_it != object_group_ids_.end() && route_it->second == group_id) {
         object_group_ids_.erase(route_it);
+    }
+    if (group_empty) {
+        groups_needing_lease_refresh_.erase(group_id);
     }
 }
 
@@ -658,6 +653,7 @@ MasterService::EraseMetadataEntry(
 
 void MasterService::RebuildGroupRoutingIndex() {
     std::unordered_map<std::string, std::string> rebuilt_group_ids;
+    std::unordered_set<std::string> groups_needing_refresh;
     // Snapshot restore rebuilds this derived index after all metadata shards
     // have been deserialized. Take shard locks here so the helper does not
     // depend on callers touching guarded shard state directly.
@@ -670,12 +666,14 @@ void MasterService::RebuildGroupRoutingIndex() {
             }
             shard->group_members[metadata.group_id].insert(key);
             rebuilt_group_ids[key] = metadata.group_id;
+            groups_needing_refresh.insert(metadata.group_id);
         }
     }
 
     {
         std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
         object_group_ids_ = std::move(rebuilt_group_ids);
+        groups_needing_lease_refresh_ = std::move(groups_needing_refresh);
     }
 }
 
@@ -684,6 +682,17 @@ void MasterService::GrantLeaseForGroup(const MetadataShard& shard,
                                        const ObjectMetadata& metadata) const {
     if (!metadata.IsGrouped()) {
         metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
+        return;
+    }
+
+    bool needs_refresh = metadata.NeedsLeaseRefresh(default_kv_lease_ttl_,
+                                                    default_kv_soft_pin_ttl_);
+    if (!needs_refresh) {
+        std::shared_lock<std::shared_mutex> lock(group_routing_mutex_);
+        needs_refresh = groups_needing_lease_refresh_.find(metadata.group_id) !=
+                        groups_needing_lease_refresh_.end();
+    }
+    if (!needs_refresh) {
         return;
     }
 
@@ -700,8 +709,12 @@ void MasterService::GrantLeaseForGroup(const MetadataShard& shard,
                                          default_kv_soft_pin_ttl_);
         }
     }
-    if (!group_it->second.contains(key)) {
+    if (group_it->second.find(key) == group_it->second.end()) {
         metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
+    }
+    {
+        std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
+        groups_needing_lease_refresh_.erase(metadata.group_id);
     }
 }
 
@@ -2070,7 +2083,7 @@ MasterService::BatchUpsertStart(const UUID& client_id,
         results;
     results.reserve(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
-        auto key_config = MakeSingleKeyConfig(config, i);
+        auto key_config = config.ForSingleKey(i);
         results.emplace_back(
             UpsertStart(client_id, keys[i], slice_lengths[i], key_config));
     }
@@ -5811,6 +5824,7 @@ void MasterService::MetadataSerializer::Reset() {
         std::unique_lock<std::shared_mutex> lock(
             service_->group_routing_mutex_);
         service_->object_group_ids_.clear();
+        service_->groups_needing_lease_refresh_.clear();
     }
     {
         std::lock_guard lock(service_->discarded_replicas_mutex_);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -104,6 +104,31 @@ bool HasExpectedReplicaAllocation(const ReplicateConfig& config,
            allocated_nof_replicas == config.nof_replica_num;
 }
 
+tl::expected<std::string, ErrorCode> GetGroupIdForKey(
+    const ReplicateConfig& config, size_t key_count, size_t key_index) {
+    if (!config.group_ids.has_value()) {
+        return "";
+    }
+    if (config.group_ids->size() != key_count || key_index >= key_count) {
+        LOG(ERROR) << "group_ids.size()=" << config.group_ids->size()
+                   << ", key_count=" << key_count
+                   << ", error=invalid_group_ids";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    return config.group_ids->at(key_index);
+}
+
+ReplicateConfig MakeSingleKeyConfig(const ReplicateConfig& config,
+                                    size_t key_index) {
+    ReplicateConfig key_config = config;
+    if (config.group_ids.has_value()) {
+        key_config.group_ids = std::vector<std::string>{
+            config.group_ids->at(key_index),
+        };
+    }
+    return key_config;
+}
+
 }  // namespace
 
 MasterService::MasterService() : MasterService(MasterServiceConfig()) {}
@@ -571,6 +596,115 @@ MasterService::getAliveClientsSnapshot() const {
     return ok_client_;
 }
 
+size_t MasterService::getMetadataShardIndex(const std::string& key) const {
+    std::shared_lock<std::shared_mutex> lock(group_routing_mutex_);
+    auto it = object_group_ids_.find(key);
+    if (it == object_group_ids_.end()) {
+        return getShardIndex(key);
+    }
+    return getShardIndex(it->second);
+}
+
+void MasterService::RegisterGroupMember(MetadataShard& shard,
+                                        const std::string& key,
+                                        const std::string& group_id) {
+    if (group_id.empty()) {
+        return;
+    }
+    std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
+    object_group_ids_[key] = group_id;
+    shard.group_members[group_id].insert(key);
+}
+
+void MasterService::UnregisterGroupMember(MetadataShard& shard,
+                                          const std::string& key,
+                                          const std::string& group_id) {
+    if (group_id.empty()) {
+        return;
+    }
+    auto group_it = shard.group_members.find(group_id);
+    if (group_it != shard.group_members.end()) {
+        group_it->second.erase(key);
+        if (group_it->second.empty()) {
+            shard.group_members.erase(group_it);
+        }
+    }
+    std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
+    auto route_it = object_group_ids_.find(key);
+    if (route_it != object_group_ids_.end() && route_it->second == group_id) {
+        object_group_ids_.erase(route_it);
+    }
+}
+
+std::unordered_map<std::string, MasterService::ObjectMetadata>::iterator
+MasterService::EraseMetadataEntry(
+    MetadataShard& shard,
+    std::unordered_map<std::string, ObjectMetadata>::iterator it) {
+    if (it == shard.metadata.end()) {
+        return it;
+    }
+    const std::string key = it->first;
+    const std::string group_id = it->second.group_id;
+    // Keep the route visible until metadata is gone. Concurrent writers that
+    // saw the old route will either serialize on this shard or retry after the
+    // route changes, instead of creating a second copy on the key shard.
+    auto next = shard.metadata.erase(it);
+    if (shard.promotion_tasks.erase(key) > 0) {
+        promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+    }
+    UnregisterGroupMember(shard, key, group_id);
+    return next;
+}
+
+void MasterService::RebuildGroupRoutingIndex() {
+    std::unordered_map<std::string, std::string> rebuilt_group_ids;
+    // Snapshot restore rebuilds this derived index after all metadata shards
+    // have been deserialized. Take shard locks here so the helper does not
+    // depend on callers touching guarded shard state directly.
+    for (size_t shard_idx = 0; shard_idx < kNumShards; ++shard_idx) {
+        MetadataShardAccessorRW shard(this, shard_idx);
+        shard->group_members.clear();
+        for (const auto& [key, metadata] : shard->metadata) {
+            if (!metadata.IsGrouped()) {
+                continue;
+            }
+            shard->group_members[metadata.group_id].insert(key);
+            rebuilt_group_ids[key] = metadata.group_id;
+        }
+    }
+
+    {
+        std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
+        object_group_ids_ = std::move(rebuilt_group_ids);
+    }
+}
+
+void MasterService::GrantLeaseForGroup(const MetadataShard& shard,
+                                       const std::string& key,
+                                       const ObjectMetadata& metadata) const {
+    if (!metadata.IsGrouped()) {
+        metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
+        return;
+    }
+
+    auto group_it = shard.group_members.find(metadata.group_id);
+    if (group_it == shard.group_members.end()) {
+        metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
+        return;
+    }
+
+    for (const auto& member_key : group_it->second) {
+        auto member_it = shard.metadata.find(member_key);
+        if (member_it != shard.metadata.end()) {
+            member_it->second.GrantLease(default_kv_lease_ttl_,
+                                         default_kv_soft_pin_ttl_);
+        }
+    }
+    if (!group_it->second.contains(key)) {
+        metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
+    }
+}
+
 void MasterService::ClearInvalidHandles() {
     ClearInvalidHandles(getAliveClientsSnapshot());
 }
@@ -588,19 +722,7 @@ void MasterService::ClearInvalidHandles(
                 shard->processing_keys.erase(it->first);
                 shard->replication_tasks.erase(it->first);
                 shard->offloading_tasks.erase(it->first);
-                // Promotion task cleanup: if the holder client expired, the
-                // LOCAL_DISK source is gone and the metadata is being erased
-                // here. Without this erase the dangling promotion_tasks
-                // entry stays pinned for up to put_start_release_timeout_sec_
-                // (~10 min default), inflating the global in-flight counter
-                // and blocking new admissions on busy clusters where many
-                // holders expire together (e.g. inference-worker rolling
-                // restarts).
-                if (shard->promotion_tasks.erase(it->first) > 0) {
-                    promotion_in_flight_.fetch_sub(1,
-                                                   std::memory_order_relaxed);
-                }
-                it = shard->metadata.erase(it);
+                it = EraseMetadataEntry(shard.get(), it);
             } else {
                 ++it;
             }
@@ -762,7 +884,7 @@ auto MasterService::ExistKey(const std::string& key)
     if (metadata.HasReplica(&Replica::fn_is_completed)) {
         // Grant a lease to the object as it may be further used by the
         // client.
-        metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
+        GrantLeaseForGroup(accessor.GetShard().get(), key, metadata);
         return true;
     }
 
@@ -1064,8 +1186,7 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
                 }
 
                 results.emplace(key, std::move(replica_list));
-                metadata.GrantLease(default_kv_lease_ttl_,
-                                    default_kv_soft_pin_ttl_);
+                GrantLeaseForGroup(shard.get(), key, metadata);
             }
         }
     }
@@ -1110,7 +1231,7 @@ auto MasterService::GetReplicaList(const std::string& key)
         MasterMetricManager::instance().inc_valid_get_nums();
         // Grant a lease to the object so it will not be removed
         // when the client is reading it.
-        metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
+        GrantLeaseForGroup(accessor.GetShard().get(), key, metadata);
 
         // Promotion-on-hit eligibility: only when no MEMORY replica is
         // present but at least one LOCAL_DISK replica is. Decided here while
@@ -1137,7 +1258,7 @@ auto MasterService::GetReplicaList(const std::string& key)
 auto MasterService::AllocateAndInsertMetadata(
     MetadataShardAccessorRW& shard, const UUID& client_id,
     const std::string& key, uint64_t value_length,
-    const ReplicateConfig& config,
+    const ReplicateConfig& config, const std::string& group_id,
     const std::chrono::system_clock::time_point& now)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
     std::vector<Replica> replicas;
@@ -1266,11 +1387,15 @@ auto MasterService::AllocateAndInsertMetadata(
         }
     }
 
+    // Publish the route before metadata while holding the target shard lock, so
+    // same-key callers serialize on this shard instead of missing the grouped
+    // object and writing a duplicate on the natural key shard.
+    RegisterGroupMember(shard.get(), key, group_id);
     shard->metadata.emplace(
         std::piecewise_construct, std::forward_as_tuple(key),
         std::forward_as_tuple(client_id, now, value_length, std::move(replicas),
                               config.with_soft_pin, config.with_hard_pin,
-                              config.data_type));
+                              config.data_type, group_id));
     shard->processing_keys.insert(key);
 
     return replica_list;
@@ -1316,19 +1441,36 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
     VLOG(1) << "key=" << key << ", value_length=" << slice_length
             << ", config=" << config << ", action=put_start_begin";
 
+    auto group_id_result = GetGroupIdForKey(config, 1, 0);
+    if (!group_id_result) {
+        return tl::make_unexpected(group_id_result.error());
+    }
+    const std::string group_id = group_id_result.value();
+
     auto alive_clients = getAliveClientsSnapshot();
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    // Lock the shard and check if object already exists
-    MetadataShardAccessorRW shard(this, getShardIndex(key));
-
     const auto now = std::chrono::system_clock::now();
-    auto it = shard->metadata.find(key);
-    if (it != shard->metadata.end() &&
-        !CleanupStaleHandles(it->second, alive_clients)) {
+
+    auto prepare_existing =
+        [this, &alive_clients, &key, &now](
+            MetadataShardAccessorRW& shard,
+            std::unordered_map<std::string, ObjectMetadata>::iterator& it)
+        -> tl::expected<void, ErrorCode> {
+        if (it == shard->metadata.end()) {
+            return {};
+        }
+
+        if (CleanupStaleHandles(it->second, alive_clients)) {
+            shard->processing_keys.erase(key);
+            shard->replication_tasks.erase(key);
+            shard->offloading_tasks.erase(key);
+            it = EraseMetadataEntry(shard.get(), it);
+            return {};
+        }
+
         auto& metadata = it->second;
-        // If the object's PutStart expired and has not completed any
-        // replicas, we can discard it and allow the new PutStart to
-        // go.
+        // If the object's PutStart expired and has not completed any replicas,
+        // discard it and allow the new PutStart to go.
         if (!metadata.HasReplica(&Replica::fn_is_completed) &&
             metadata.put_start_time + put_start_discard_timeout_sec_ < now) {
             auto replicas = metadata.PopReplicas(&Replica::fn_is_processing);
@@ -1339,15 +1481,65 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                     metadata.put_start_time + put_start_release_timeout_sec_);
             }
             shard->processing_keys.erase(key);
-            shard->metadata.erase(it);
-        } else {
-            LOG(INFO) << "key=" << key << ", info=object_already_exists";
-            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+            it = EraseMetadataEntry(shard.get(), it);
+            return {};
         }
-    }
 
-    return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                     config, now);
+        LOG(INFO) << "key=" << key << ", info=object_already_exists";
+        return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+    };
+
+    auto put_with_locked_target = [&](MetadataShardAccessorRW& target_shard)
+        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+        auto target_it = target_shard->metadata.find(key);
+        auto result = prepare_existing(target_shard, target_it);
+        if (!result) {
+            return tl::make_unexpected(result.error());
+        }
+        return AllocateAndInsertMetadata(target_shard, client_id, key,
+                                         slice_length, config, group_id, now);
+    };
+
+    auto put_with_locked_shards = [&](MetadataShardAccessorRW& existing_shard,
+                                      MetadataShardAccessorRW& target_shard)
+        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+        auto existing_it = existing_shard->metadata.find(key);
+        auto result = prepare_existing(existing_shard, existing_it);
+        if (!result) {
+            return tl::make_unexpected(result.error());
+        }
+        return put_with_locked_target(target_shard);
+    };
+
+    while (true) {
+        const size_t existing_shard_idx = getMetadataShardIndex(key);
+        const size_t target_shard_idx =
+            group_id.empty() ? getShardIndex(key) : getShardIndex(group_id);
+
+        if (existing_shard_idx == target_shard_idx) {
+            MetadataShardAccessorRW shard(this, target_shard_idx);
+            if (getMetadataShardIndex(key) != existing_shard_idx) {
+                continue;
+            }
+            return put_with_locked_target(shard);
+        }
+
+        if (existing_shard_idx < target_shard_idx) {
+            MetadataShardAccessorRW existing_shard(this, existing_shard_idx);
+            MetadataShardAccessorRW target_shard(this, target_shard_idx);
+            if (getMetadataShardIndex(key) != existing_shard_idx) {
+                continue;
+            }
+            return put_with_locked_shards(existing_shard, target_shard);
+        }
+
+        MetadataShardAccessorRW target_shard(this, target_shard_idx);
+        MetadataShardAccessorRW existing_shard(this, existing_shard_idx);
+        if (getMetadataShardIndex(key) != existing_shard_idx) {
+            continue;
+        }
+        return put_with_locked_shards(existing_shard, target_shard);
+    }
 }
 
 auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
@@ -1602,6 +1794,13 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     VLOG(1) << "key=" << key << ", value_length=" << slice_length
             << ", config=" << config << ", action=upsert_start_begin";
 
+    auto group_id_result = GetGroupIdForKey(config, 1, 0);
+    if (!group_id_result) {
+        return tl::make_unexpected(group_id_result.error());
+    }
+    const bool has_requested_group_id = config.group_ids.has_value();
+    const std::string requested_group_id = group_id_result.value();
+
     // --- Lock acquisition ---
     // snapshot_mutex_ (shared): allows concurrent reads/writes, blocks only
     //   during full metadata snapshots.
@@ -1609,151 +1808,229 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     //   operations on keys that hash to the same shard.
     auto alive_clients = getAliveClientsSnapshot();
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataShardAccessorRW shard(this, getShardIndex(key));
-
     const auto now = std::chrono::system_clock::now();
-    auto it = shard->metadata.find(key);
 
-    // --- Step 0: stale handle cleanup ---
-    // If all memory replicas point to unmounted segments (node crashed and
-    // restarted), the metadata is useless — erase it and treat as new key.
-    // Also clean up local_disk replicas whose owner client has expired.
-    if (it != shard->metadata.end() &&
-        CleanupStaleHandles(it->second, alive_clients)) {
-        shard->processing_keys.erase(key);
-        ErasePromotionTaskIfPresent(shard, key);
-        shard->metadata.erase(it);
-        it = shard->metadata.end();
-    }
+    auto cleanup_existing_if_stale =
+        [this, &alive_clients, &key](
+            MetadataShardAccessorRW& shard,
+            std::unordered_map<std::string, ObjectMetadata>::iterator& it)
+        -> bool {
+        if (it != shard->metadata.end() &&
+            CleanupStaleHandles(it->second, alive_clients)) {
+            shard->processing_keys.erase(key);
+            shard->replication_tasks.erase(key);
+            shard->offloading_tasks.erase(key);
+            EraseMetadataEntry(shard.get(), it);
+            it = shard->metadata.end();
+            return true;
+        }
+        return false;
+    };
 
-    // --- Step 1: safety checks and preemption (only if key exists) ---
-    if (it != shard->metadata.end()) {
+    while (true) {
+        const size_t existing_shard_idx = getMetadataShardIndex(key);
+        const size_t requested_shard_idx =
+            has_requested_group_id && !requested_group_id.empty()
+                ? getShardIndex(requested_group_id)
+                : getShardIndex(key);
+        const size_t target_shard_idx = requested_shard_idx;
+
+        std::optional<MetadataShardAccessorRW> first_shard_guard;
+        std::optional<MetadataShardAccessorRW> second_shard_guard;
+        MetadataShardAccessorRW* existing_shard = nullptr;
+        MetadataShardAccessorRW* target_shard = nullptr;
+        if (existing_shard_idx == target_shard_idx) {
+            first_shard_guard.emplace(this, target_shard_idx);
+            target_shard = &*first_shard_guard;
+        } else if (existing_shard_idx < target_shard_idx) {
+            first_shard_guard.emplace(this, existing_shard_idx);
+            second_shard_guard.emplace(this, target_shard_idx);
+            existing_shard = &*first_shard_guard;
+            target_shard = &*second_shard_guard;
+        } else {
+            first_shard_guard.emplace(this, target_shard_idx);
+            second_shard_guard.emplace(this, existing_shard_idx);
+            target_shard = &*first_shard_guard;
+            existing_shard = &*second_shard_guard;
+        }
+
+        if (getMetadataShardIndex(key) != existing_shard_idx) {
+            continue;
+        }
+
+        MetadataShardAccessorRW* shard_for_key = target_shard;
+        std::unordered_map<std::string, ObjectMetadata>::iterator it;
+
+        if (existing_shard != nullptr) {
+            auto existing_it = (*existing_shard)->metadata.find(key);
+            cleanup_existing_if_stale(*existing_shard, existing_it);
+            if (existing_it != (*existing_shard)->metadata.end()) {
+                if (has_requested_group_id) {
+                    LOG(ERROR) << "key=" << key
+                               << ", error=group_membership_is_immutable";
+                    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                }
+                shard_for_key = existing_shard;
+                it = existing_it;
+            } else {
+                it = (*target_shard)->metadata.find(key);
+                cleanup_existing_if_stale(*target_shard, it);
+            }
+        } else {
+            it = (*target_shard)->metadata.find(key);
+            cleanup_existing_if_stale(*target_shard, it);
+        }
+
+        MetadataShardAccessorRW& shard = *shard_for_key;
+
+        // --- Step 1: safety checks and preemption (only if key exists) ---
+        if (it != shard->metadata.end()) {
+            auto& metadata = it->second;
+
+            if (has_requested_group_id &&
+                metadata.group_id != requested_group_id) {
+                LOG(ERROR) << "key=" << key
+                           << ", error=group_membership_is_immutable";
+                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+            }
+
+            // Reject if a Copy/Move task is actively reading this key's
+            // replicas. Writing during replication would corrupt the copy.
+            if (shard->replication_tasks.count(key) > 0) {
+                LOG(INFO) << "key=" << key
+                          << ", error=object_has_replication_task";
+                return tl::make_unexpected(
+                    ErrorCode::OBJECT_HAS_REPLICATION_TASK);
+            }
+
+            // Reject if an offload-to-disk task is in progress (same reason).
+            if (shard->offloading_tasks.count(key) > 0) {
+                LOG(INFO) << "key=" << key
+                          << ", error=object_has_offloading_task";
+                return tl::make_unexpected(
+                    ErrorCode::OBJECT_HAS_REPLICATION_TASK);
+            }
+
+            // Preempt an in-progress Put/Upsert on the same key.  The previous
+            // writer's PROCESSING replicas are moved to discarded_replicas_
+            // with a TTL so they are not freed while the old writer may still
+            // be doing RDMA writes.  Unlike PutStart (which only preempts after
+            // a timeout), UpsertStart preempts immediately.
+            if (shard->processing_keys.count(key) > 0) {
+                auto processing_replicas =
+                    metadata.PopReplicas(&Replica::fn_is_processing);
+                if (!processing_replicas.empty()) {
+                    std::lock_guard lock(discarded_replicas_mutex_);
+                    discarded_replicas_.emplace_back(
+                        std::move(processing_replicas),
+                        now + put_start_release_timeout_sec_);
+                }
+                shard->processing_keys.erase(key);
+
+                // If no COMPLETE replicas survive the preemption, this key
+                // effectively does not exist — fall through to Case A.
+                if (!metadata.HasReplica(&Replica::fn_is_completed)) {
+                    it = EraseMetadataEntry(shard.get(), it);
+                    it = shard->metadata.end();
+                    if (!has_requested_group_id &&
+                        shard_for_key != target_shard) {
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // --- Case A: key does not exist (or was erased above) ---
+        // Allocate fresh buffers, identical to PutStart.
+        if (it == shard->metadata.end()) {
+            VLOG(1) << "key=" << key << ", action=upsert_start_case_a";
+            const std::string group_id =
+                has_requested_group_id ? requested_group_id : "";
+            return AllocateAndInsertMetadata(
+                shard, client_id, key, slice_length, config, group_id, now);
+        }
+
+        // --- Step 2: key exists with COMPLETE replicas → Case B or C ---
         auto& metadata = it->second;
 
-        // Reject if a Copy/Move task is actively reading this key's replicas.
-        // Writing during replication would corrupt the copy.
-        if (shard->replication_tasks.count(key) > 0) {
-            LOG(INFO) << "key=" << key << ", error=object_has_replication_task";
-            return tl::make_unexpected(ErrorCode::OBJECT_HAS_REPLICATION_TASK);
+        // Reject if any reader holds a reference (refcnt > 0).  Overwriting a
+        // buffer that an RDMA read is streaming from would cause data
+        // corruption. The client should retry after readers finish.
+        if (metadata.HasReplica(&Replica::fn_is_busy)) {
+            LOG(INFO) << "key=" << key << ", error=object_replica_busy";
+            return tl::make_unexpected(ErrorCode::OBJECT_REPLICA_BUSY);
         }
 
-        // Reject if an offload-to-disk task is in progress (same reason).
-        if (shard->offloading_tasks.count(key) > 0) {
-            LOG(INFO) << "key=" << key << ", error=object_has_offloading_task";
-            return tl::make_unexpected(ErrorCode::OBJECT_HAS_REPLICATION_TASK);
-        }
+        if (metadata.size == slice_length) {
+            // --- Case B: same size — in-place update ---
+            // Reuse existing buffer addresses.  No allocation or deallocation.
+            // The client will RDMA-write new data to the same addresses.
+            //
+            // hard_pinned is const and preserved automatically — upsert does
+            // not change the eviction protection level of an existing object.
+            metadata.client_id = client_id;
+            metadata.put_start_time = now;
 
-        // Preempt an in-progress Put/Upsert on the same key.  The previous
-        // writer's PROCESSING replicas are moved to discarded_replicas_ with a
-        // TTL so they are not freed while the old writer may still be doing
-        // RDMA writes.  Unlike PutStart (which only preempts after a timeout),
-        // UpsertStart preempts immediately.
-        if (shard->processing_keys.count(key) > 0) {
-            auto processing_replicas =
-                metadata.PopReplicas(&Replica::fn_is_processing);
-            if (!processing_replicas.empty()) {
-                std::lock_guard lock(discarded_replicas_mutex_);
-                discarded_replicas_.emplace_back(
-                    std::move(processing_replicas),
-                    now + put_start_release_timeout_sec_);
+            // Reconcile soft_pin state with the incoming config.
+            {
+                SpinLocker locker(&metadata.lock);
+                if (config.with_soft_pin && !metadata.soft_pin_timeout) {
+                    metadata.soft_pin_timeout.emplace();
+                    MasterMetricManager::instance().inc_soft_pin_key_count(1);
+                } else if (!config.with_soft_pin && metadata.soft_pin_timeout) {
+                    metadata.soft_pin_timeout.reset();
+                    MasterMetricManager::instance().dec_soft_pin_key_count(1);
+                }
             }
-            shard->processing_keys.erase(key);
 
-            // If no COMPLETE replicas survive the preemption, this key
-            // effectively does not exist — fall through to Case A.
-            if (!metadata.HasReplica(&Replica::fn_is_completed)) {
-                ErasePromotionTaskIfPresent(shard, key);
-                shard->metadata.erase(it);
-                it = shard->metadata.end();
+            // Mark COMPLETE → PROCESSING so readers won't see stale data
+            // mid-transfer.  The key becomes unreadable until UpsertEnd.
+            metadata.VisitReplicas(
+                &Replica::fn_is_completed,
+                [](Replica& replica) { replica.mark_processing(); });
+
+            shard->processing_keys.insert(key);
+
+            // Return the existing descriptors — same buffer addresses as
+            // before.
+            std::vector<Replica::Descriptor> replica_list;
+            const auto& all_replicas = metadata.GetAllReplicas();
+            replica_list.reserve(all_replicas.size());
+            for (const auto& replica : all_replicas) {
+                replica_list.emplace_back(replica.get_descriptor());
             }
+
+            VLOG(1) << "key=" << key << ", action=upsert_start_case_b_inplace";
+            return replica_list;
         }
-    }
 
-    // --- Case A: key does not exist (or was erased above) ---
-    // Allocate fresh buffers, identical to PutStart.
-    if (it == shard->metadata.end()) {
-        VLOG(1) << "key=" << key << ", action=upsert_start_case_a";
-        return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                         config, now);
-    }
-
-    // --- Step 2: key exists with COMPLETE replicas → Case B or C ---
-    auto& metadata = it->second;
-
-    // Reject if any reader holds a reference (refcnt > 0).  Overwriting a
-    // buffer that an RDMA read is streaming from would cause data corruption.
-    // The client should retry after readers finish.
-    if (metadata.HasReplica(&Replica::fn_is_busy)) {
-        LOG(INFO) << "key=" << key << ", error=object_replica_busy";
-        return tl::make_unexpected(ErrorCode::OBJECT_REPLICA_BUSY);
-    }
-
-    if (metadata.size == slice_length) {
-        // --- Case B: same size — in-place update ---
-        // Reuse existing buffer addresses.  No allocation or deallocation.
-        // The client will RDMA-write new data to the same addresses.
+        // --- Case C: different size — discard old replicas and reallocate ---
+        // Old buffers cannot be reused.  Move them to discarded_replicas_ for
+        // delayed release (readers may still hold descriptors without refcnt),
+        // then allocate fresh buffers at the new size.
         //
-        // hard_pinned is const and preserved automatically — upsert does not
-        // change the eviction protection level of an existing object.
-        metadata.client_id = client_id;
-        metadata.put_start_time = now;
+        // Preserve hard_pin and soft_pin from the old metadata so that eviction
+        // protection survives a size-changing upsert (RFC §2.2.2).
+        ReplicateConfig merged_config = config;
+        merged_config.with_hard_pin =
+            merged_config.with_hard_pin || metadata.IsHardPinned();
+        merged_config.with_soft_pin =
+            merged_config.with_soft_pin || metadata.IsSoftPinned();
+        const std::string group_id =
+            has_requested_group_id ? requested_group_id : metadata.group_id;
 
-        // Reconcile soft_pin state with the incoming config.
-        {
-            SpinLocker locker(&metadata.lock);
-            if (config.with_soft_pin && !metadata.soft_pin_timeout) {
-                metadata.soft_pin_timeout.emplace();
-                MasterMetricManager::instance().inc_soft_pin_key_count(1);
-            } else if (!config.with_soft_pin && metadata.soft_pin_timeout) {
-                metadata.soft_pin_timeout.reset();
-                MasterMetricManager::instance().dec_soft_pin_key_count(1);
-            }
+        auto old_replicas = metadata.PopReplicas();
+        if (!old_replicas.empty()) {
+            std::lock_guard lock(discarded_replicas_mutex_);
+            discarded_replicas_.emplace_back(
+                std::move(old_replicas), now + put_start_release_timeout_sec_);
         }
+        EraseMetadataEntry(shard.get(), it);
 
-        // Mark COMPLETE → PROCESSING so readers won't see stale data
-        // mid-transfer.  The key becomes unreadable until UpsertEnd.
-        metadata.VisitReplicas(&Replica::fn_is_completed, [](Replica& replica) {
-            replica.mark_processing();
-        });
-
-        shard->processing_keys.insert(key);
-
-        // Return the existing descriptors — same buffer addresses as before.
-        std::vector<Replica::Descriptor> replica_list;
-        const auto& all_replicas = metadata.GetAllReplicas();
-        replica_list.reserve(all_replicas.size());
-        for (const auto& replica : all_replicas) {
-            replica_list.emplace_back(replica.get_descriptor());
-        }
-
-        VLOG(1) << "key=" << key << ", action=upsert_start_case_b_inplace";
-        return replica_list;
+        VLOG(1) << "key=" << key << ", action=upsert_start_case_c_reallocate";
+        return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
+                                         merged_config, group_id, now);
     }
-
-    // --- Case C: different size — discard old replicas and reallocate ---
-    // Old buffers cannot be reused.  Move them to discarded_replicas_ for
-    // delayed release (readers may still hold descriptors without refcnt),
-    // then allocate fresh buffers at the new size.
-    //
-    // Preserve hard_pin and soft_pin from the old metadata so that eviction
-    // protection survives a size-changing upsert (RFC §2.2.2).
-    ReplicateConfig merged_config = config;
-    merged_config.with_hard_pin =
-        merged_config.with_hard_pin || metadata.IsHardPinned();
-    merged_config.with_soft_pin =
-        merged_config.with_soft_pin || metadata.IsSoftPinned();
-
-    auto old_replicas = metadata.PopReplicas();
-    if (!old_replicas.empty()) {
-        std::lock_guard lock(discarded_replicas_mutex_);
-        discarded_replicas_.emplace_back(std::move(old_replicas),
-                                         now + put_start_release_timeout_sec_);
-    }
-    shard->metadata.erase(it);
-
-    VLOG(1) << "key=" << key << ", action=upsert_start_case_c_reallocate";
-    return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                     merged_config, now);
 }
 
 auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
@@ -1780,12 +2057,22 @@ MasterService::BatchUpsertStart(const UUID& client_id,
             tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>(
             keys.size(), tl::make_unexpected(ErrorCode::INVALID_PARAMS));
     }
+    if (config.group_ids.has_value() &&
+        config.group_ids->size() != keys.size()) {
+        LOG(ERROR) << "BatchUpsertStart: group_ids.size()="
+                   << config.group_ids->size()
+                   << " != keys.size()=" << keys.size();
+        return std::vector<
+            tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>(
+            keys.size(), tl::make_unexpected(ErrorCode::INVALID_PARAMS));
+    }
     std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
         results;
     results.reserve(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
+        auto key_config = MakeSingleKeyConfig(config, i);
         results.emplace_back(
-            UpsertStart(client_id, keys[i], slice_lengths[i], config));
+            UpsertStart(client_id, keys[i], slice_lengths[i], key_config));
     }
     return results;
 }
@@ -2330,7 +2617,6 @@ auto MasterService::Remove(const std::string& key, bool force)
 
     // Remove object metadata
     accessor.Erase();
-    ErasePromotionTaskIfPresent(accessor.GetShard(), key);
     return {};
 }
 
@@ -2384,8 +2670,7 @@ auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
 
                 VLOG(1) << "key=" << it->first
                         << " matched by regex. Removing.";
-                ErasePromotionTaskIfPresent(shard, it->first);
-                it = shard->metadata.erase(it);
+                it = EraseMetadataEntry(shard.get(), it);
                 removed_count++;
             } else {
                 ++it;
@@ -2427,7 +2712,7 @@ long MasterService::RemoveAll(bool force) {
                 auto mem_rep_count =
                     it->second.CountReplicas(&Replica::fn_is_memory_replica);
                 total_freed_size += it->second.size * mem_rep_count;
-                it = shard->metadata.erase(it);
+                it = EraseMetadataEntry(shard.get(), it);
                 removed_count++;
             } else {
                 ++it;
@@ -2454,7 +2739,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
         std::min(keys.size(), static_cast<size_t>(kNumShards)));
 
     for (size_t i = 0; i < keys.size(); ++i) {
-        size_t shard_idx = getShardIndex(keys[i]);
+        size_t shard_idx = getMetadataShardIndex(keys[i]);
         keys_by_shard[shard_idx].emplace_back(i, &keys[i]);
     }
 
@@ -2483,7 +2768,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                 shard->processing_keys.erase(key);
                 shard->replication_tasks.erase(key);
                 shard->offloading_tasks.erase(key);
-                shard->metadata.erase(it);
+                EraseMetadataEntry(shard.get(), it);
                 results[original_idx] =
                     tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
                 continue;
@@ -2519,7 +2804,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
             }
 
             // Remove object metadata
-            shard->metadata.erase(it);
+            EraseMetadataEntry(shard.get(), it);
             results[original_idx] = {};  // Success
         }
     }
@@ -3242,7 +3527,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
         if (!metadata.IsValid() ||
             metadata.AllReplicas(&Replica::fn_is_completed)) {
             if (!metadata.IsValid()) {
-                shard->metadata.erase(it);
+                EraseMetadataEntry(shard.get(), it);
             }
             key_it = shard->processing_keys.erase(key_it);
             continue;
@@ -3264,7 +3549,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
             if (!metadata.IsValid()) {
                 // All replicas of this object are discarded, just
                 // remove the whole object.
-                shard->metadata.erase(it);
+                EraseMetadataEntry(shard.get(), it);
             }
 
             key_it = shard->processing_keys.erase(key_it);
@@ -3317,7 +3602,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
 
         // Check whether the object is still valid.
         if (!metadata.IsValid()) {
-            shard->metadata.erase(metadata_it);
+            EraseMetadataEntry(shard.get(), metadata_it);
         }
 
         task_it = shard->replication_tasks.erase(task_it);
@@ -4345,7 +4630,7 @@ bool MasterService::TryRestoreStateFromSnapshot(
                                                       .time_since_epoch())
                                                   .count())
                                         : "null");
-                            it = shard.metadata.erase(it);
+                            it = EraseMetadataEntry(shard, it);
                         } else {
                             ++it;
                         }
@@ -4496,6 +4781,11 @@ void MasterService::BatchEvict(double evict_ratio_target,
         });
     };
 
+    struct EvictionResult {
+        uint64_t freed_bytes{0};
+        long evicted_objects{0};
+    };
+
     // --- Offload-on-evict support ---
     long offload_queued_this_cycle = 0;
     long offload_deferred_count = 0;
@@ -4571,6 +4861,60 @@ void MasterService::BatchEvict(double evict_ratio_target,
         return 0;
     };
 
+    auto try_evict_group_or_object =
+        [&, this](const std::string& key, ObjectMetadata& metadata,
+                  MetadataShardAccessorRW& shard,
+                  bool allow_soft_pinned) -> EvictionResult {
+        if (!metadata.IsGrouped()) {
+            uint64_t freed = try_evict_or_offload(key, metadata, shard);
+            return {.freed_bytes = freed, .evicted_objects = freed > 0 ? 1 : 0};
+        }
+
+        auto group_it = shard->group_members.find(metadata.group_id);
+        if (group_it == shard->group_members.end()) {
+            uint64_t freed = try_evict_or_offload(key, metadata, shard);
+            return {.freed_bytes = freed, .evicted_objects = freed > 0 ? 1 : 0};
+        }
+
+        for (const auto& member_key : group_it->second) {
+            auto member_it = shard->metadata.find(member_key);
+            if (member_it != shard->metadata.end() &&
+                !member_it->second.IsLeaseExpired(now)) {
+                return {};
+            }
+        }
+
+        EvictionResult result;
+        std::vector<std::string> member_keys(group_it->second.begin(),
+                                             group_it->second.end());
+        for (const auto& member_key : member_keys) {
+            auto member_it = shard->metadata.find(member_key);
+            if (member_it == shard->metadata.end()) {
+                continue;
+            }
+            auto& member_metadata = member_it->second;
+            if (member_metadata.IsHardPinned() ||
+                !member_metadata.IsLeaseExpired(now) ||
+                (!allow_soft_pinned && member_metadata.IsSoftPinned(now)) ||
+                !can_evict_replicas(member_metadata)) {
+                continue;
+            }
+
+            uint64_t freed =
+                try_evict_or_offload(member_key, member_metadata, shard);
+            result.freed_bytes += freed;
+            if (freed > 0) {
+                result.evicted_objects++;
+            }
+            // The caller owns the iterator for the trigger key and erases it
+            // after this helper returns; erase only peer members here.
+            if (member_key != key && !member_metadata.IsValid()) {
+                EraseMetadataEntry(shard.get(), member_it);
+            }
+        }
+        return result;
+    };
+
     // Randomly select a starting shard to avoid imbalance eviction between
     // shards.
     size_t start_idx = RandomIndex(kNumShards);
@@ -4644,17 +4988,16 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 }
                 if (it->second.lease_timeout <= target_timeout) {
                     // Evict this object (or defer for offload)
-                    uint64_t freed =
-                        try_evict_or_offload(it->first, it->second, shard);
-                    total_freed_size += freed;
+                    auto evict_result =
+                        try_evict_group_or_object(it->first, it->second, shard,
+                                                  /*allow_soft_pinned=*/false);
+                    total_freed_size += evict_result.freed_bytes;
                     if (it->second.IsValid() == false) {
-                        it = shard->metadata.erase(it);
+                        it = EraseMetadataEntry(shard.get(), it);
                     } else {
                         ++it;
                     }
-                    if (freed > 0) {
-                        shard_evicted_count++;
-                    }
+                    shard_evicted_count += evict_result.evicted_objects;
                 } else {
                     // second pass candidates
                     no_pin_objects.push_back(it->second.lease_timeout);
@@ -4707,18 +5050,17 @@ void MasterService::BatchEvict(double evict_ratio_target,
                         !it->second.IsSoftPinned(now) &&
                         can_evict_replicas(it->second)) {
                         // Evict this object (or defer for offload)
-                        uint64_t freed =
-                            try_evict_or_offload(it->first, it->second, shard);
-                        total_freed_size += freed;
+                        auto evict_result = try_evict_group_or_object(
+                            it->first, it->second, shard,
+                            /*allow_soft_pinned=*/false);
+                        total_freed_size += evict_result.freed_bytes;
                         if (it->second.IsValid() == false) {
-                            it = shard->metadata.erase(it);
+                            it = EraseMetadataEntry(shard.get(), it);
                         } else {
                             ++it;
                         }
-                        if (freed > 0) {
-                            evicted_count++;
-                        }
-                        target_evict_num--;
+                        evicted_count += evict_result.evicted_objects;
+                        target_evict_num -= evict_result.evicted_objects;
                     } else {
                         ++it;
                     }
@@ -4760,18 +5102,17 @@ void MasterService::BatchEvict(double evict_ratio_target,
                     if (!it->second.IsSoftPinned(now) ||
                         it->second.lease_timeout <= soft_target_timeout) {
                         // Evict this object (or defer for offload)
-                        uint64_t freed =
-                            try_evict_or_offload(it->first, it->second, shard);
-                        total_freed_size += freed;
+                        auto evict_result = try_evict_group_or_object(
+                            it->first, it->second, shard,
+                            /*allow_soft_pinned=*/true);
+                        total_freed_size += evict_result.freed_bytes;
                         if (it->second.IsValid() == false) {
-                            it = shard->metadata.erase(it);
+                            it = EraseMetadataEntry(shard.get(), it);
                         } else {
                             ++it;
                         }
-                        if (freed > 0) {
-                            evicted_count++;
-                        }
-                        target_evict_num--;
+                        evicted_count += evict_result.evicted_objects;
+                        target_evict_num -= evict_result.evicted_objects;
                     } else {
                         ++it;
                     }
@@ -4884,7 +5225,7 @@ void MasterService::NoFBatchEvict(double evict_ratio_target,
             total_freed_size += metadata.size * erased;
             shard_evicted_count++;
             if (!metadata.IsValid()) {
-                it = shard->metadata.erase(it);
+                it = EraseMetadataEntry(shard.get(), it);
             } else {
                 ++it;
             }
@@ -5457,12 +5798,19 @@ MasterService::MetadataSerializer::Deserialize(
     Replica::next_id_.store(next_id);
     LOG(INFO) << "Restored Replica::next_id_ to " << next_id;
 
+    service_->RebuildGroupRoutingIndex();
     return {};
 }
 
 void MasterService::MetadataSerializer::Reset() {
     for (auto& shard : service_->metadata_shards_) {
         shard.metadata.clear();
+        shard.group_members.clear();
+    }
+    {
+        std::unique_lock<std::shared_mutex> lock(
+            service_->group_routing_mutex_);
+        service_->object_group_ids_.clear();
     }
     {
         std::lock_guard lock(service_->discarded_replicas_mutex_);
@@ -5531,6 +5879,7 @@ MasterService::MetadataSerializer::DeserializeShard(const msgpack::object& obj,
 
     // Clear existing data
     shard.metadata.clear();
+    shard.group_members.clear();
 
     // Deserialize metadata
     if (metadata_array == nullptr ||
@@ -5568,7 +5917,8 @@ MasterService::MetadataSerializer::DeserializeShard(const msgpack::object& obj,
                 metadata_ptr->client_id, metadata_ptr->put_start_time,
                 metadata_ptr->size, metadata_ptr->PopReplicas(),
                 metadata_ptr->soft_pin_timeout.has_value(),
-                metadata_ptr->IsHardPinned(), metadata_ptr->data_type));
+                metadata_ptr->IsHardPinned(), metadata_ptr->data_type,
+                metadata_ptr->group_id));
 
         it->second.lease_timeout = metadata_ptr->lease_timeout;
         it->second.soft_pin_timeout = metadata_ptr->soft_pin_timeout;
@@ -5584,11 +5934,11 @@ MasterService::MetadataSerializer::SerializeMetadata(
     // Pack ObjectMetadata using array structure for efficiency
     // Format: [client_id, put_start_time, size, lease_timeout,
     // has_soft_pin_timeout, soft_pin_timeout, replicas_count, data_type,
-    // replicas..., hard_pinned]
+    // replicas..., hard_pinned, group_id]
 
-    size_t array_size = 9;  // client_id, put_start_time, size, lease_timeout,
-                            // has_soft_pin_timeout, soft_pin_timeout,
-                            // replicas_count, data_type, hard_pinned
+    size_t array_size = 10;  // client_id, put_start_time, size, lease_timeout,
+                             // has_soft_pin_timeout, soft_pin_timeout,
+                             // replicas_count, data_type, hard_pinned, group_id
     array_size += metadata.CountReplicas();  // One element per replica
     packer.pack_array(array_size);
 
@@ -5641,6 +5991,7 @@ MasterService::MetadataSerializer::SerializeMetadata(
     }
 
     packer.pack(metadata.IsHardPinned());
+    packer.pack(metadata.group_id);
 
     return {};
 }
@@ -5656,7 +6007,9 @@ MasterService::MetadataSerializer::DeserializeMetadata(
     }
 
     // Need at least 7 elements: client_id, put_start_time, size, lease_timeout,
-    // has_soft_pin_timeout, soft_pin_timeout, replicas_count
+    // has_soft_pin_timeout, soft_pin_timeout, replicas_count.
+    // Optional fields are decoded by type for backward compatibility:
+    // data_type appears before replicas; hard_pinned and group_id trail them.
     if (obj.via.array.size < 7) {
         return tl::unexpected(SerializationError(
             ErrorCode::DESERIALIZE_FAIL,
@@ -5690,31 +6043,25 @@ MasterService::MetadataSerializer::DeserializeMetadata(
     uint32_t replicas_count = array[index++].as<uint32_t>();
 
     // Format detection:
-    //   v1: 7 + replicas_count, no data_type or hard_pinned
-    //   v2: 8 + replicas_count, either data_type or trailing hard_pinned
-    //   v3: 9 + replicas_count, data_type plus trailing hard_pinned
-    constexpr uint32_t kOldFieldCount = 7;
-    constexpr uint32_t kOneExtraFieldCount = 8;
-    constexpr uint32_t kCurrentFieldCount = 9;
+    //   v1: 7 + replicas_count, no optional fields
+    //   v2: 8 + replicas_count, either data_type or hard_pinned
+    //   v3: 9 + replicas_count, data_type + hard_pinned or
+    //       hard_pinned + group_id
+    //   v4: 10 + replicas_count, data_type + hard_pinned + group_id
+    constexpr uint32_t kBaseFieldCount = 7;
+    constexpr uint32_t kMaxOptionalFieldCount = 3;
     const uint32_t total_elements = obj.via.array.size;
-    const bool is_old_format =
-        (total_elements == kOldFieldCount + replicas_count);
-    const bool is_one_extra_format =
-        (total_elements == kOneExtraFieldCount + replicas_count);
-    const bool is_current_format =
-        (total_elements == kCurrentFieldCount + replicas_count);
-
-    if (!is_current_format && !is_one_extra_format && !is_old_format) {
+    const uint32_t min_elements = kBaseFieldCount + replicas_count;
+    if (total_elements < min_elements ||
+        total_elements > min_elements + kMaxOptionalFieldCount) {
         return tl::unexpected(SerializationError(
             ErrorCode::DESERIALIZE_FAIL,
             "deserialize ObjectMetadata array size mismatch"));
     }
 
     ObjectDataType data_type = ObjectDataType::UNKNOWN;
-    if (is_current_format) {
-        data_type = static_cast<ObjectDataType>(array[index++].as<uint8_t>());
-    } else if (is_one_extra_format &&
-               array[index].type == msgpack::type::POSITIVE_INTEGER) {
+    if (index < total_elements &&
+        array[index].type == msgpack::type::POSITIVE_INTEGER) {
         data_type = static_cast<ObjectDataType>(array[index++].as<uint8_t>());
     }
 
@@ -5733,8 +6080,19 @@ MasterService::MetadataSerializer::DeserializeMetadata(
 
     // Deserialize hard_pinned (if present, otherwise default to false)
     bool is_hard_pinned = false;
-    if (index < obj.via.array.size) {
+    if (index < obj.via.array.size &&
+        array[index].type == msgpack::type::BOOLEAN) {
         is_hard_pinned = array[index++].as<bool>();
+    }
+
+    std::string group_id;
+    if (index < obj.via.array.size && array[index].type == msgpack::type::STR) {
+        group_id = array[index++].as<std::string>();
+    }
+    if (index != obj.via.array.size) {
+        return tl::unexpected(SerializationError(
+            ErrorCode::DESERIALIZE_FAIL,
+            "deserialize ObjectMetadata optional field type mismatch"));
     }
 
     // Create ObjectMetadata instance
@@ -5743,7 +6101,8 @@ MasterService::MetadataSerializer::DeserializeMetadata(
         client_id,
         std::chrono::system_clock::time_point(
             std::chrono::milliseconds(put_start_time_timestamp)),
-        size, std::move(replicas), enable_soft_pin, is_hard_pinned, data_type);
+        size, std::move(replicas), enable_soft_pin, is_hard_pinned, data_type,
+        group_id);
     metadata->lease_timeout = std::chrono::system_clock::time_point(
         std::chrono::milliseconds(lease_timestamp));
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -75,6 +75,18 @@ void SetServiceUnavailable(coro_http::coro_http_response& resp,
     resp.set_status_and_content(coro_http::status_type::service_unavailable,
                                 payload);
 }
+
+ReplicateConfig MakeSingleKeyConfig(const ReplicateConfig& config,
+                                    size_t key_index) {
+    ReplicateConfig key_config = config;
+    if (config.group_ids.has_value()) {
+        key_config.group_ids = std::vector<std::string>{
+            config.group_ids->at(key_index),
+        };
+    }
+    return key_config;
+}
+
 struct HttpErrorResponse {
     bool success{false};
     int32_t error_code{0};
@@ -1005,11 +1017,24 @@ WrappedMasterService::BatchPutStart(const UUID& client_id,
         results;
     results.reserve(keys.size());
 
-    if (config.prefer_alloc_in_same_node) {
+    if (keys.size() != slice_lengths.size()) {
+        LOG(ERROR) << "BatchPutStart: keys.size()=" << keys.size()
+                   << " != slice_lengths.size()=" << slice_lengths.size();
+        results.assign(keys.size(),
+                       tl::make_unexpected(ErrorCode::INVALID_PARAMS));
+    } else if (config.group_ids.has_value() &&
+               config.group_ids->size() != keys.size()) {
+        LOG(ERROR) << "BatchPutStart: group_ids.size()="
+                   << config.group_ids->size()
+                   << " != keys.size()=" << keys.size();
+        results.assign(keys.size(),
+                       tl::make_unexpected(ErrorCode::INVALID_PARAMS));
+    } else if (config.prefer_alloc_in_same_node) {
         ReplicateConfig new_config = config;
         for (size_t i = 0; i < keys.size(); ++i) {
+            auto key_config = MakeSingleKeyConfig(new_config, i);
             auto result = master_service_.PutStart(
-                client_id, keys[i], slice_lengths[i], new_config);
+                client_id, keys[i], slice_lengths[i], key_config);
             results.emplace_back(result);
             if ((i == 0) && result.has_value()) {
                 std::string preferred_segment;
@@ -1029,8 +1054,9 @@ WrappedMasterService::BatchPutStart(const UUID& client_id,
         }
     } else {
         for (size_t i = 0; i < keys.size(); ++i) {
+            auto key_config = MakeSingleKeyConfig(config, i);
             results.emplace_back(master_service_.PutStart(
-                client_id, keys[i], slice_lengths[i], config));
+                client_id, keys[i], slice_lengths[i], key_config));
         }
     }
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -76,17 +76,6 @@ void SetServiceUnavailable(coro_http::coro_http_response& resp,
                                 payload);
 }
 
-ReplicateConfig MakeSingleKeyConfig(const ReplicateConfig& config,
-                                    size_t key_index) {
-    ReplicateConfig key_config = config;
-    if (config.group_ids.has_value()) {
-        key_config.group_ids = std::vector<std::string>{
-            config.group_ids->at(key_index),
-        };
-    }
-    return key_config;
-}
-
 struct HttpErrorResponse {
     bool success{false};
     int32_t error_code{0};
@@ -1032,7 +1021,7 @@ WrappedMasterService::BatchPutStart(const UUID& client_id,
     } else if (config.prefer_alloc_in_same_node) {
         ReplicateConfig new_config = config;
         for (size_t i = 0; i < keys.size(); ++i) {
-            auto key_config = MakeSingleKeyConfig(new_config, i);
+            auto key_config = new_config.ForSingleKey(i);
             auto result = master_service_.PutStart(
                 client_id, keys[i], slice_lengths[i], key_config);
             results.emplace_back(result);
@@ -1054,7 +1043,7 @@ WrappedMasterService::BatchPutStart(const UUID& client_id,
         }
     } else {
         for (size_t i = 0; i < keys.size(); ++i) {
-            auto key_config = MakeSingleKeyConfig(config, i);
+            auto key_config = config.ForSingleKey(i);
             results.emplace_back(master_service_.PutStart(
                 client_id, keys[i], slice_lengths[i], key_config));
         }

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -650,6 +651,82 @@ TEST_F(ClientIntegrationTest, BatchPutGetOperations) {
                   0);
         client_buffer_allocator_->deallocate(
             target_batched_slices[keys[i]][0].ptr, test_data_list[i].size());
+    }
+}
+
+TEST_F(ClientIntegrationTest, BatchPutMixedGroupIdsThroughClient) {
+    auto find_group_id_on_different_shard = [](const std::string& key) {
+        static constexpr size_t kMetadataShardCountForTest = 1024;
+        const size_t key_shard =
+            std::hash<std::string>{}(key) % kMetadataShardCountForTest;
+        for (int i = 0; i < 10000; ++i) {
+            std::string group_id = key + "_group_" + std::to_string(i);
+            if (std::hash<std::string>{}(group_id) %
+                    kMetadataShardCountForTest !=
+                key_shard) {
+                return group_id;
+            }
+        }
+        return key + "_fallback_group";
+    };
+
+    const std::vector<std::string> keys = {
+        "client_batch_grouped_a",
+        "client_batch_ungrouped",
+        "client_batch_grouped_b",
+    };
+    const std::vector<std::string> values = {
+        "grouped-value-a",
+        "ungrouped-value",
+        "grouped-value-b",
+    };
+
+    std::vector<void*> source_buffers;
+    std::vector<std::vector<Slice>> batched_slices;
+    source_buffers.reserve(values.size());
+    batched_slices.reserve(values.size());
+    for (const auto& value : values) {
+        void* buffer = client_buffer_allocator_->allocate(value.size());
+        memcpy(buffer, value.data(), value.size());
+        source_buffers.push_back(buffer);
+        batched_slices.push_back({Slice{buffer, value.size()}});
+    }
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.group_ids =
+        std::vector<std::string>{find_group_id_on_different_shard(keys[0]), "",
+                                 find_group_id_on_different_shard(keys[2])};
+
+    auto put_results = test_client_->BatchPut(keys, batched_slices, config);
+    ASSERT_EQ(put_results.size(), keys.size());
+    for (const auto& result : put_results) {
+        ASSERT_TRUE(result.has_value())
+            << "BatchPut failed: " << toString(result.error());
+    }
+
+    for (size_t i = 0; i < values.size(); ++i) {
+        client_buffer_allocator_->deallocate(source_buffers[i],
+                                             values[i].size());
+    }
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        void* target_buffer =
+            client_buffer_allocator_->allocate(values[i].size());
+        std::vector<Slice> slices{Slice{target_buffer, values[i].size()}};
+        auto get_result = test_client_->Get(keys[i], slices);
+        ASSERT_TRUE(get_result.has_value())
+            << "Get failed: " << toString(get_result.error());
+        EXPECT_EQ(slices[0].size, values[i].size());
+        EXPECT_EQ(memcmp(slices[0].ptr, values[i].data(), values[i].size()), 0);
+        client_buffer_allocator_->deallocate(target_buffer, values[i].size());
+    }
+
+    auto remove_results = test_client_->BatchRemove(keys, /*force=*/true);
+    ASSERT_EQ(remove_results.size(), keys.size());
+    for (const auto& result : remove_results) {
+        ASSERT_TRUE(result.has_value())
+            << "BatchRemove failed: " << toString(result.error());
     }
 }
 

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -2,6 +2,7 @@
 #include "master_metric_manager.h"
 #include "ha/snapshot/catalog/snapshot_catalog_store.h"
 #include "ha/snapshot/object/snapshot_object_store.h"
+#include "ha/snapshot/snapshot_test_utils.h"
 #ifdef STORE_USE_ETCD
 #include "etcd_helper.h"
 #include "ha/oplog/etcd_oplog_store.h"
@@ -159,6 +160,36 @@ class SnapshotChildProcessTest : public ::testing::Test {
         auto& shard = svc->metadata_shards_[shard_idx];
         SharedMutexLocker lock(&shard.mutex, shared_lock_t{});
         return shard.metadata.find(key) != shard.metadata.end();
+    }
+
+    uint32_t GetShardIndexForTest(const std::string& key) {
+        return static_cast<uint32_t>(service_->getShardIndex(key));
+    }
+
+    tl::expected<void, SerializationError> DeserializeMetadataForTest(
+        const std::vector<uint8_t>& data) {
+        MasterService::MetadataSerializer serializer(service_.get());
+        return serializer.Deserialize(data);
+    }
+
+    bool ObjectIsGroupedInMetadata(const std::string& key, size_t shard_idx) {
+        auto& shard = service_->metadata_shards_[shard_idx];
+        SharedMutexLocker lock(&shard.mutex, shared_lock_t{});
+        auto it = shard.metadata.find(key);
+        EXPECT_NE(it, shard.metadata.end());
+        return it != shard.metadata.end() && it->second.IsGrouped();
+    }
+
+    std::string FindGroupIdOnDifferentShard(MasterService* svc,
+                                            const std::string& key) {
+        const size_t key_shard = svc->getShardIndex(key);
+        for (int i = 0; i < 1024; ++i) {
+            std::string group_id = key + "_group_" + std::to_string(i);
+            if (svc->getShardIndex(group_id) != key_shard) {
+                return group_id;
+            }
+        }
+        return key + "_group";
     }
 
    private:
@@ -405,6 +436,109 @@ TEST_F(SnapshotChildProcessTest, PersistState_UsesFrozenSnapshotDescriptor) {
     EXPECT_EQ(latest->value().producer_view_version,
               descriptor.producer_view_version);
     EXPECT_EQ(latest->value().created_at_ms, descriptor.created_at_ms);
+}
+
+TEST_F(SnapshotChildProcessTest, RestoreRebuildsGroupedObjectRouting) {
+    auto make_config = [this]() {
+        return MasterServiceConfigBuilder()
+            .set_enable_snapshot(false)
+            .set_enable_snapshot_restore(true)
+            .set_snapshot_backup_dir(tmp_dir() + "/backup")
+            .set_snapshot_interval_seconds(100)
+            .set_snapshot_child_timeout_seconds(60)
+            .set_snapshot_retention_count(3)
+            .set_snapshot_object_store_type("local")
+            .set_default_kv_lease_ttl(600000)
+            .build();
+    };
+    service_ = std::make_unique<MasterService>(make_config());
+
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "grouped_snapshot_segment";
+    segment.base = 0x310000000;
+    segment.size = 1024 * 1024 * 16;
+    segment.te_endpoint = segment.name;
+    const UUID client_id = generate_uuid();
+    ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
+
+    const std::string key = "snapshot_grouped_route_key";
+    ReplicateConfig replicate_config;
+    replicate_config.replica_num = 1;
+    replicate_config.group_ids = std::vector<std::string>{
+        FindGroupIdOnDifferentShard(service_.get(), key)};
+
+    auto put_start = service_->PutStart(client_id, key, 1024, replicate_config);
+    ASSERT_TRUE(put_start.has_value()) << toString(put_start.error());
+    ASSERT_TRUE(
+        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    ASSERT_TRUE(service_->ExistKey(key).value_or(false));
+
+    auto persist_result = CallPersistState("20240701_130000_000");
+    ASSERT_TRUE(persist_result.has_value())
+        << "PersistState failed: " << persist_result.error().message;
+
+    service_.reset();
+    service_ = std::make_unique<MasterService>(make_config());
+
+    auto restored_replicas = service_->GetReplicaList(key);
+    ASSERT_TRUE(restored_replicas.has_value())
+        << "Grouped key should remain reachable by key after restore";
+    ASSERT_TRUE(service_->Remove(key, /*force=*/true).has_value());
+    EXPECT_FALSE(service_->ExistKey(key).value_or(true));
+}
+
+TEST_F(SnapshotChildProcessTest,
+       DeserializeLegacyMetadataWithoutGroupIdRestoresUngroupedObject) {
+    CreateDefaultService();
+    const std::string key = "legacy_snapshot_no_group_id_key";
+    const uint32_t shard_idx = GetShardIndexForTest(key);
+    const UUID client_id = generate_uuid();
+
+    msgpack::sbuffer shard_buffer;
+    MsgpackPacker shard_packer(&shard_buffer);
+    shard_packer.pack_map(1);
+    shard_packer.pack(std::string("metadata"));
+    shard_packer.pack_array(1);
+    shard_packer.pack_array(2);
+    shard_packer.pack(key);
+
+    shard_packer.pack_array(8);
+    shard_packer.pack(UuidToString(client_id));
+    shard_packer.pack(kDefaultTestPutStartTimeMs);
+    shard_packer.pack(kDefaultTestObjectSize);
+    shard_packer.pack(kDefaultTestLeaseTimeoutMs);
+    shard_packer.pack(false);
+    shard_packer.pack(uint64_t{0});
+    shard_packer.pack(uint32_t{1});
+    PackDiskReplica(shard_packer, kDefaultTestDiskFilePath,
+                    kDefaultTestObjectSize);
+
+    auto compressed_shard =
+        zstd_compress(reinterpret_cast<const uint8_t*>(shard_buffer.data()),
+                      shard_buffer.size(), 3);
+
+    msgpack::sbuffer root_buffer;
+    MsgpackPacker root_packer(&root_buffer);
+    root_packer.pack_map(3);
+    root_packer.pack(std::string("shards"));
+    root_packer.pack_map(1);
+    root_packer.pack(shard_idx);
+    root_packer.pack_bin(compressed_shard.size());
+    root_packer.pack_bin_body(
+        reinterpret_cast<const char*>(compressed_shard.data()),
+        compressed_shard.size());
+    root_packer.pack(std::string("discarded_replicas"));
+    root_packer.pack_array(0);
+    root_packer.pack(std::string("replica_next_id"));
+    root_packer.pack(uint64_t{10});
+
+    auto deserialize_result =
+        DeserializeMetadataForTest(ToByteVector(root_buffer));
+    ASSERT_TRUE(deserialize_result.has_value())
+        << deserialize_result.error().message;
+
+    EXPECT_FALSE(ObjectIsGroupedInMetadata(key, shard_idx));
 }
 
 TEST_F(SnapshotChildProcessTest, LegacyEtcdConnstringFallbackIsPreserved) {

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -647,9 +647,9 @@ TEST_F(MasterServiceTest, ExpiredGroupedPutCanBeReplacedByUngroupedPut) {
     EXPECT_TRUE(service_->ExistKey(key).value_or(false));
 }
 
-TEST_F(MasterServiceTest, GroupedLeaseRefreshProtectsCurrentMembers) {
+TEST_F(MasterServiceTest, GroupedLeaseRefreshNearExpiryProtectsCurrentMembers) {
     auto service_config =
-        MasterServiceConfig::builder().set_default_kv_lease_ttl(1000).build();
+        MasterServiceConfig::builder().set_default_kv_lease_ttl(200).build();
     std::unique_ptr<MasterService> service_(new MasterService(service_config));
     [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
     const UUID client_id = generate_uuid();
@@ -669,6 +669,47 @@ TEST_F(MasterServiceTest, GroupedLeaseRefreshProtectsCurrentMembers) {
     auto exists = service_->ExistKey(key_a);
     ASSERT_TRUE(exists.has_value());
     ASSERT_TRUE(exists.value());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(120));
+    exists = service_->ExistKey(key_a);
+    ASSERT_TRUE(exists.has_value());
+    ASSERT_TRUE(exists.value());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    auto remove_group_peer = service_->Remove(key_b);
+    ASSERT_FALSE(remove_group_peer.has_value());
+    EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_group_peer.error());
+
+    EXPECT_TRUE(service_->Remove(key_a, /*force=*/true).has_value());
+    EXPECT_TRUE(service_->Remove(key_b, /*force=*/true).has_value());
+}
+
+TEST_F(MasterServiceTest,
+       GroupedLeaseRefreshAfterMembershipChangeDoesNotWaitForTriggerExpiry) {
+    auto service_config =
+        MasterServiceConfig::builder().set_default_kv_lease_ttl(500).build();
+    std::unique_ptr<MasterService> service_(new MasterService(service_config));
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key_a = "lease_group_dirty_key_a";
+    const std::string key_b = "lease_group_dirty_key_b";
+    const std::string group_id = FindGroupIdOnDifferentShard(key_a);
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.group_ids = std::vector<std::string>{group_id};
+
+    PutCompletedObject(*service_, client_id, key_a, config);
+    ASSERT_TRUE(service_->ExistKey(key_a).value_or(false));
+
+    PutCompletedObject(*service_, client_id, key_b, config);
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+    auto exists = service_->ExistKey(key_a);
+    ASSERT_TRUE(exists.has_value());
+    ASSERT_TRUE(exists.value());
+    std::this_thread::sleep_for(std::chrono::milliseconds(390));
 
     auto remove_group_peer = service_->Remove(key_b);
     ASSERT_FALSE(remove_group_peer.has_value());

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -1,4 +1,5 @@
 #include "master_service.h"
+#include "rpc_service.h"
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
@@ -6,6 +7,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <random>
 #include <thread>
@@ -88,6 +90,33 @@ class MasterServiceTest : public ::testing::Test {
         EXPECT_TRUE(
             service.PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
         return key;
+    }
+
+    std::string FindGroupIdOnDifferentShard(const std::string& key) const {
+        static constexpr size_t kMetadataShardCountForTest = 1024;
+        const size_t key_shard =
+            std::hash<std::string>{}(key) % kMetadataShardCountForTest;
+        for (int i = 0; i < 10000; ++i) {
+            std::string group_id = key + "_group_" + std::to_string(i);
+            if (std::hash<std::string>{}(group_id) %
+                    kMetadataShardCountForTest !=
+                key_shard) {
+                return group_id;
+            }
+        }
+        return key + "_fallback_group";
+    }
+
+    void PutCompletedObject(MasterService& service, const UUID& client_id,
+                            const std::string& key,
+                            const ReplicateConfig& config,
+                            uint64_t slice_length = 1024) const {
+        auto put_start = service.PutStart(client_id, key, slice_length, config);
+        ASSERT_TRUE(put_start.has_value())
+            << "PutStart failed for key=" << key
+            << ", error=" << toString(put_start.error());
+        ASSERT_TRUE(
+            service.PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
     }
 
     bool ExecutePendingMoveTasks(MasterService& service,
@@ -533,6 +562,434 @@ TEST_F(MasterServiceTest, PutStartOnePlusOneAllowsSingleAllocatedReplica) {
     EXPECT_TRUE(put_start_result->front().is_memory_replica());
 }
 #endif
+
+TEST_F(MasterServiceTest, PutStartGroupIdsValidation) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    config.group_ids = std::vector<std::string>{};
+    auto empty_group_ids =
+        service_->PutStart(client_id, "empty_group_ids", 1024, config);
+    EXPECT_FALSE(empty_group_ids.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, empty_group_ids.error());
+
+    config.group_ids = std::vector<std::string>{"g0", "g1"};
+    auto too_many_group_ids =
+        service_->PutStart(client_id, "too_many_group_ids", 1024, config);
+    EXPECT_FALSE(too_many_group_ids.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, too_many_group_ids.error());
+
+    config.group_ids = std::vector<std::string>{""};
+    auto ungrouped =
+        service_->PutStart(client_id, "explicit_ungrouped", 1024, config);
+    ASSERT_TRUE(ungrouped.has_value());
+    ASSERT_TRUE(
+        service_->PutEnd(client_id, "explicit_ungrouped", ReplicaType::MEMORY)
+            .has_value());
+    auto exists = service_->ExistKey("explicit_ungrouped");
+    ASSERT_TRUE(exists.has_value());
+    EXPECT_TRUE(exists.value());
+}
+
+TEST_F(MasterServiceTest, GroupedObjectRoutesKeyLevelLookupAndRemove) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key = "grouped_route_key";
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
+
+    PutCompletedObject(*service_, client_id, key, config);
+
+    auto exists = service_->ExistKey(key);
+    ASSERT_TRUE(exists.has_value());
+    EXPECT_TRUE(exists.value());
+    EXPECT_TRUE(service_->GetReplicaList(key).has_value());
+
+    ASSERT_TRUE(service_->Remove(key, /*force=*/true).has_value());
+    auto exists_after_remove = service_->ExistKey(key);
+    ASSERT_TRUE(exists_after_remove.has_value());
+    EXPECT_FALSE(exists_after_remove.value());
+}
+
+TEST_F(MasterServiceTest, ExpiredGroupedPutCanBeReplacedByUngroupedPut) {
+    auto service_config = MasterServiceConfig::builder()
+                              .set_put_start_discard_timeout_sec(0)
+                              .set_put_start_release_timeout_sec(1)
+                              .build();
+    std::unique_ptr<MasterService> service_(new MasterService(service_config));
+    const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = context.client_id;
+
+    const std::string key = "expired_grouped_put_to_ungrouped";
+    ReplicateConfig grouped_config;
+    grouped_config.replica_num = 1;
+    grouped_config.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
+
+    ASSERT_TRUE(
+        service_->PutStart(client_id, key, 1024, grouped_config).has_value());
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+
+    ReplicateConfig ungrouped_config;
+    ungrouped_config.replica_num = 1;
+    auto put_start = service_->PutStart(client_id, key, 1024, ungrouped_config);
+    ASSERT_TRUE(put_start.has_value()) << toString(put_start.error());
+    ASSERT_TRUE(
+        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    EXPECT_TRUE(service_->ExistKey(key).value_or(false));
+}
+
+TEST_F(MasterServiceTest, GroupedLeaseRefreshProtectsCurrentMembers) {
+    auto service_config =
+        MasterServiceConfig::builder().set_default_kv_lease_ttl(1000).build();
+    std::unique_ptr<MasterService> service_(new MasterService(service_config));
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key_a = "lease_group_key_a";
+    const std::string key_b = "lease_group_key_b";
+    const std::string group_id = FindGroupIdOnDifferentShard(key_a);
+
+    ReplicateConfig config_a;
+    config_a.replica_num = 1;
+    config_a.group_ids = std::vector<std::string>{group_id};
+    ReplicateConfig config_b = config_a;
+
+    PutCompletedObject(*service_, client_id, key_a, config_a);
+    PutCompletedObject(*service_, client_id, key_b, config_b);
+
+    auto exists = service_->ExistKey(key_a);
+    ASSERT_TRUE(exists.has_value());
+    ASSERT_TRUE(exists.value());
+
+    auto remove_group_peer = service_->Remove(key_b);
+    ASSERT_FALSE(remove_group_peer.has_value());
+    EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_group_peer.error());
+
+    EXPECT_TRUE(service_->Remove(key_a, /*force=*/true).has_value());
+    EXPECT_TRUE(service_->Remove(key_b, /*force=*/true).has_value());
+}
+
+TEST_F(MasterServiceTest, RemoveGroupedMemberPreservesOtherMembers) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key_a = "remove_group_key_a";
+    const std::string key_b = "remove_group_key_b";
+    const std::string group_id = FindGroupIdOnDifferentShard(key_a);
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.group_ids = std::vector<std::string>{group_id};
+    PutCompletedObject(*service_, client_id, key_a, config);
+    PutCompletedObject(*service_, client_id, key_b, config);
+
+    ASSERT_TRUE(service_->Remove(key_a, /*force=*/true).has_value());
+
+    auto removed_exists = service_->ExistKey(key_a);
+    ASSERT_TRUE(removed_exists.has_value());
+    EXPECT_FALSE(removed_exists.value());
+    EXPECT_TRUE(service_->GetReplicaList(key_b).has_value());
+
+    ASSERT_TRUE(service_->Remove(key_b, /*force=*/true).has_value());
+    auto group_empty = service_->ExistKey(key_b);
+    ASSERT_TRUE(group_empty.has_value());
+    EXPECT_FALSE(group_empty.value());
+}
+
+TEST_F(MasterServiceTest, UpsertPreservesGroupMembership) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key = "upsert_group_key";
+    const std::string group_id = FindGroupIdOnDifferentShard(key);
+
+    ReplicateConfig grouped_config;
+    grouped_config.replica_num = 1;
+    grouped_config.group_ids = std::vector<std::string>{group_id};
+    PutCompletedObject(*service_, client_id, key, grouped_config);
+
+    ReplicateConfig unset_group_config;
+    unset_group_config.replica_num = 1;
+    auto preserve_result =
+        service_->UpsertStart(client_id, key, 1024, unset_group_config);
+    ASSERT_TRUE(preserve_result.has_value())
+        << "Unset group_ids should preserve existing group membership";
+    ASSERT_TRUE(
+        service_->UpsertEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key).has_value());
+
+    ReplicateConfig different_group_config;
+    different_group_config.replica_num = 1;
+    different_group_config.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(key + "_other")};
+    auto different_group_result =
+        service_->UpsertStart(client_id, key, 1024, different_group_config);
+    ASSERT_FALSE(different_group_result.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, different_group_result.error());
+
+    ReplicateConfig explicit_ungrouped_config;
+    explicit_ungrouped_config.replica_num = 1;
+    explicit_ungrouped_config.group_ids = std::vector<std::string>{""};
+    auto explicit_ungrouped_result =
+        service_->UpsertStart(client_id, key, 1024, explicit_ungrouped_config);
+    ASSERT_FALSE(explicit_ungrouped_result.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, explicit_ungrouped_result.error());
+}
+
+TEST_F(MasterServiceTest, IncompleteGroupedUpsertCanBecomeUngrouped) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = context.client_id;
+
+    const std::string key = "incomplete_grouped_upsert_to_ungrouped";
+    ReplicateConfig grouped_config;
+    grouped_config.replica_num = 1;
+    grouped_config.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
+
+    ASSERT_TRUE(
+        service_->PutStart(client_id, key, 1024, grouped_config).has_value());
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+
+    ReplicateConfig ungrouped_config;
+    ungrouped_config.replica_num = 1;
+    auto upsert_start =
+        service_->UpsertStart(client_id, key, 1024, ungrouped_config);
+    ASSERT_TRUE(upsert_start.has_value()) << toString(upsert_start.error());
+    ASSERT_TRUE(
+        service_->UpsertEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    EXPECT_TRUE(service_->ExistKey(key).value_or(false));
+}
+
+TEST_F(MasterServiceTest,
+       GroupedEvictionExpandsSafeMembersAndSkipsLeasedGroup) {
+    auto service_config =
+        MasterServiceConfig::builder().set_default_kv_lease_ttl(1000).build();
+    constexpr size_t kSegmentSize = 4 * 1024 * 1024;
+    constexpr size_t kObjectSize = 2 * 1024 * 1024;
+
+    {
+        std::unique_ptr<MasterService> service_(
+            new MasterService(service_config));
+        [[maybe_unused]] const auto context =
+            PrepareSimpleSegment(*service_, "grouped_evict_segment",
+                                 kDefaultSegmentBase, kSegmentSize);
+        const UUID client_id = generate_uuid();
+
+        const std::string evict_key_a = "grouped_evict_key_a";
+        const std::string evict_key_b = "grouped_evict_key_b";
+        ReplicateConfig evict_config;
+        evict_config.replica_num = 1;
+        evict_config.group_ids =
+            std::vector<std::string>{FindGroupIdOnDifferentShard(evict_key_a)};
+        PutCompletedObject(*service_, client_id, evict_key_a, evict_config,
+                           kObjectSize);
+        PutCompletedObject(*service_, client_id, evict_key_b, evict_config,
+                           kObjectSize);
+
+        ReplicateConfig trigger_config;
+        trigger_config.replica_num = 1;
+        auto trigger_result = service_->PutStart(
+            client_id, "trigger_grouped_eviction", kObjectSize, trigger_config);
+        ASSERT_FALSE(trigger_result.has_value());
+        EXPECT_EQ(ErrorCode::NO_AVAILABLE_HANDLE, trigger_result.error());
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+        EXPECT_FALSE(service_->ExistKey(evict_key_a).value_or(true));
+        EXPECT_FALSE(service_->ExistKey(evict_key_b).value_or(true));
+    }
+
+    {
+        std::unique_ptr<MasterService> service_(
+            new MasterService(service_config));
+        [[maybe_unused]] const auto context =
+            PrepareSimpleSegment(*service_, "grouped_lease_segment",
+                                 kDefaultSegmentBase, kSegmentSize);
+        const UUID client_id = generate_uuid();
+
+        const std::string leased_key_a = "grouped_leased_key_a";
+        const std::string leased_key_b = "grouped_leased_key_b";
+        ReplicateConfig leased_config;
+        leased_config.replica_num = 1;
+        leased_config.group_ids =
+            std::vector<std::string>{FindGroupIdOnDifferentShard(leased_key_a)};
+        PutCompletedObject(*service_, client_id, leased_key_a, leased_config,
+                           kObjectSize);
+        PutCompletedObject(*service_, client_id, leased_key_b, leased_config,
+                           kObjectSize);
+
+        auto exists = service_->ExistKey(leased_key_a);
+        ASSERT_TRUE(exists.has_value());
+        ASSERT_TRUE(exists.value());
+
+        ReplicateConfig trigger_config;
+        trigger_config.replica_num = 1;
+        auto trigger_result =
+            service_->PutStart(client_id, "trigger_leased_group_eviction",
+                               kObjectSize, trigger_config);
+        ASSERT_FALSE(trigger_result.has_value());
+        EXPECT_EQ(ErrorCode::NO_AVAILABLE_HANDLE, trigger_result.error());
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+        EXPECT_TRUE(service_->GetReplicaList(leased_key_a).has_value());
+        EXPECT_TRUE(service_->GetReplicaList(leased_key_b).has_value());
+    }
+}
+
+TEST_F(MasterServiceTest, GroupedEvictionSkipsUnsafeMembersAndEvictsSafePeers) {
+    constexpr size_t kSegmentSize = 4 * 1024 * 1024;
+    constexpr size_t kObjectSize = 2 * 1024 * 1024;
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context =
+        PrepareSimpleSegment(*service_, "grouped_mixed_safety_segment",
+                             kDefaultSegmentBase, kSegmentSize);
+    const UUID client_id = generate_uuid();
+
+    const std::string safe_key = "grouped_mixed_safe_key";
+    const std::string hard_pinned_key = "grouped_mixed_hard_pinned_key";
+    const std::string group_id = FindGroupIdOnDifferentShard(safe_key);
+
+    ReplicateConfig safe_config;
+    safe_config.replica_num = 1;
+    safe_config.group_ids = std::vector<std::string>{group_id};
+    PutCompletedObject(*service_, client_id, safe_key, safe_config,
+                       kObjectSize);
+
+    ReplicateConfig hard_pinned_config = safe_config;
+    hard_pinned_config.with_hard_pin = true;
+    PutCompletedObject(*service_, client_id, hard_pinned_key,
+                       hard_pinned_config, kObjectSize);
+
+    ReplicateConfig trigger_config;
+    trigger_config.replica_num = 1;
+    auto trigger_result =
+        service_->PutStart(client_id, "trigger_mixed_safety_group_eviction",
+                           kObjectSize, trigger_config);
+    ASSERT_FALSE(trigger_result.has_value());
+    EXPECT_EQ(ErrorCode::NO_AVAILABLE_HANDLE, trigger_result.error());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    EXPECT_FALSE(service_->ExistKey(safe_key).value_or(true));
+    EXPECT_TRUE(service_->GetReplicaList(hard_pinned_key).has_value());
+    EXPECT_TRUE(service_->Remove(hard_pinned_key, /*force=*/true).has_value());
+}
+
+TEST_F(MasterServiceTest, BatchUpsertStartMixedGroupIdsPreservesOrder) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::vector<std::string> keys = {
+        "batch_grouped_a",
+        "batch_ungrouped",
+        "batch_grouped_b",
+    };
+    const std::vector<uint64_t> sizes = {1024, 2048, 4096};
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(keys[0]), "",
+                                 FindGroupIdOnDifferentShard(keys[2])};
+
+    auto results = service_->BatchUpsertStart(client_id, keys, sizes, config);
+    ASSERT_EQ(results.size(), keys.size());
+    for (const auto& result : results) {
+        ASSERT_TRUE(result.has_value());
+    }
+
+    auto end_results = service_->BatchUpsertEnd(client_id, keys);
+    ASSERT_EQ(end_results.size(), keys.size());
+    for (const auto& result : end_results) {
+        ASSERT_TRUE(result.has_value());
+    }
+
+    for (const auto& key : keys) {
+        EXPECT_TRUE(service_->GetReplicaList(key).has_value());
+    }
+
+    ReplicateConfig invalid_config = config;
+    invalid_config.group_ids = std::vector<std::string>{"only_one"};
+    auto invalid_results =
+        service_->BatchUpsertStart(client_id, keys, sizes, invalid_config);
+    ASSERT_EQ(invalid_results.size(), keys.size());
+    for (const auto& result : invalid_results) {
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(ErrorCode::INVALID_PARAMS, result.error());
+    }
+}
+
+TEST_F(MasterServiceTest, WrappedBatchPutStartMixedGroupIdsPreservesOrder) {
+    WrappedMasterServiceConfig service_config;
+    service_config.default_kv_lease_ttl = 100;
+    service_config.enable_metric_reporting = false;
+    WrappedMasterService service_(service_config);
+
+    Segment segment = MakeSegment("wrapped_batch_group_segment");
+    const UUID client_id = generate_uuid();
+    ASSERT_TRUE(service_.MountSegment(segment, client_id).has_value());
+
+    const std::vector<std::string> keys = {
+        "wrapped_batch_grouped_a",
+        "wrapped_batch_ungrouped",
+        "wrapped_batch_grouped_b",
+    };
+    const std::vector<uint64_t> sizes = {1024, 2048, 4096};
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(keys[0]), "",
+                                 FindGroupIdOnDifferentShard(keys[2])};
+
+    auto results = service_.BatchPutStart(client_id, keys, sizes, config);
+    ASSERT_EQ(results.size(), keys.size());
+    for (const auto& result : results) {
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
+    }
+
+    auto end_results = service_.BatchPutEnd(client_id, keys);
+    ASSERT_EQ(end_results.size(), keys.size());
+    for (const auto& result : end_results) {
+        ASSERT_TRUE(result.has_value());
+    }
+
+    for (const auto& key : keys) {
+        EXPECT_TRUE(service_.GetReplicaList(key).has_value());
+    }
+
+    ReplicateConfig invalid_config = config;
+    invalid_config.group_ids = std::vector<std::string>{"only_one"};
+    auto invalid_group_results =
+        service_.BatchPutStart(client_id, keys, sizes, invalid_config);
+    ASSERT_EQ(invalid_group_results.size(), keys.size());
+    for (const auto& result : invalid_group_results) {
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(ErrorCode::INVALID_PARAMS, result.error());
+    }
+
+    auto invalid_size_results =
+        service_.BatchPutStart(client_id, keys, {1024}, config);
+    ASSERT_EQ(invalid_size_results.size(), keys.size());
+    for (const auto& result : invalid_size_results) {
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(ErrorCode::INVALID_PARAMS, result.error());
+    }
+}
 
 TEST_F(MasterServiceTest, PutStartEndFlow) {
     std::unique_ptr<MasterService> service_(new MasterService());

--- a/mooncake-wheel/tests/test_import_structure.py
+++ b/mooncake-wheel/tests/test_import_structure.py
@@ -16,12 +16,18 @@ class TestImportStructure(unittest.TestCase):
         # Verify direct access to TransferOpcode
         self.assertIsNotNone(mooncake.engine.TransferOpcode)
 
-        from mooncake.store import MooncakeDistributedStore
+        from mooncake.store import MooncakeDistributedStore, ReplicateConfig
 
         # Just verify we can create instances
         store = MooncakeDistributedStore()
+        config = ReplicateConfig()
+        config.group_ids = ["group-a", ""]
 
         self.assertIsNotNone(store)
+        self.assertEqual(config.group_ids, ["group-a", ""])
+
+        config.group_ids = None
+        self.assertIsNone(config.group_ids)
 
     def test_direct_import(self):
         """Test direct import of specific components."""


### PR DESCRIPTION
## Description

Refs #2127.

This PR adds opt-in grouped object semantics to Mooncake Store through `ReplicateConfig::group_ids`.

Grouped objects are routed by `hash(group_id)` while existing object-key APIs remain compatible. When grouping is enabled, the master tracks a lightweight object-to-group routing index, refreshes the current group members when any member is accessed, and expands eviction from a grouped candidate to currently safe-to-evict group members.

## Changes

- Add optional `ReplicateConfig::group_ids`.
- Validate `group_ids` only when explicitly provided.
- Treat empty string entries as ungrouped, allowing mixed grouped / ungrouped batch writes.
- Route grouped object metadata by `group_id` while preserving key-level lookup, remove, put, and upsert behavior.
- Keep group membership immutable while an object exists.
- Refresh lease protection for current group members when one member is accessed.
- Expand eviction from a grouped candidate to current group members while reusing existing object-level safety checks.
- Rebuild grouped routing state after snapshot restore.
- Preserve compatibility with legacy snapshots that do not contain `group_id`.
- Expose `group_ids` through the Python binding and preserve key-to-group ordering in batch/tensor paths.

## Scope

This PR intentionally keeps the first implementation lightweight and best-effort.

It does not add group completeness tracking, `group_size`, `group_index`, `RemoveGroup`, atomic group visibility, SGLang integration, or benchmark tooling. Those can be handled as follow-up work after the core Store semantics are reviewed.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

Ran on a Linux test host:

```bash
cmake --build build-noetcd --target master_service_test snapshot_child_process_test -j 8
./build-noetcd/mooncake-store/tests/master_service_test
./build-noetcd/mooncake-store/tests/snapshot_child_process_test

cmake --build build-noetcd --target client_integration_test -j 8
./build-noetcd/mooncake-store/tests/client_integration_test
```
Results:
- master_service_test: 109 tests passed.
- snapshot_child_process_test: 22 tests passed.
- client_integration_test: 17 tests passed, 1 existing disabled test.
- git diff --check passed before commit.
- `./scripts/code_format.sh` completed on the Linux test host (formatted 0 files).
- `python3 -m py_compile mooncake-wheel/tests/test_import_structure.py` passed.

Coverage added for:
- group_ids validation.
- grouped object routing and key-level lookup/remove.
- lease refresh across current group members.
- grouped eviction with leased, pinned, unsafe, and safe members.
- batch put/upsert group id ordering.
- client integration path for mixed group ids.
- snapshot restore route rebuild.
- legacy snapshot compatibility without group_id.
- Python binding smoke coverage for `ReplicateConfig.group_ids` property assignment and clearing.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using ./scripts/code_format.sh before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.


