### PR TITLE
[Build] Fix Python package path detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ option(USE_NOF "build mooncake store with NoF SSD pool support" OFF)
 include(${CMAKE_CURRENT_SOURCE_DIR}/mooncake-common/SetupPython.cmake)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extern/pybind11)
 execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import sys; print(sys.path[-1])"
+    COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib'))"
     OUTPUT_VARIABLE PYTHON_SYS_PATH
 )
 string(STRIP ${PYTHON_SYS_PATH} PYTHON_SYS_PATH)

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -2,7 +2,7 @@ file(GLOB SOURCES "*.cpp")
 include(${CMAKE_CURRENT_LIST_DIR}/../mooncake-common/SetupPython.cmake)
 execute_process(
   COMMAND ${PYTHON_EXECUTABLE} -c
-          "import sys; print([s for s in sys.path if 'packages' in s][0])"
+          "import sysconfig; print(sysconfig.get_path('platlib'))"
   OUTPUT_VARIABLE PYTHON_SYS_PATH)
 string(STRIP ${PYTHON_SYS_PATH} PYTHON_SYS_PATH)
 

--- a/mooncake-transfer-engine/tent/src/python/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/python/CMakeLists.txt
@@ -2,7 +2,7 @@ file(GLOB SOURCES "*.cpp")
 include(${CMAKE_CURRENT_LIST_DIR}/../../../../mooncake-common/SetupPython.cmake)
 execute_process(
   COMMAND ${PYTHON_EXECUTABLE} -c
-          "import sys; print([s for s in sys.path if 'packages' in s][0])"
+          "import sysconfig; print(sysconfig.get_path('platlib'))"
   OUTPUT_VARIABLE PYTHON_SYS_PATH)
 string(STRIP ${PYTHON_SYS_PATH} PYTHON_SYS_PATH)
 


### PR DESCRIPTION
## Description

  Fix Python package path detection in CMake.

  The previous logic inferred the Python package directory from `sys.path`, using either `sys.path[-1]` or the first entry    containing `packages`. In environments where packages inject extra paths into `sys.path`, this can select an unrelated               vendored path, for example:

  ```text
  /usr/local/lib/python3.10/dist-packages/tilelang/3rdparty/tvm/python

  This change uses sysconfig.get_path('platlib') instead, which returns the
  platform-specific Python package installation directory suitable for compiled
  extension modules.

  ## Module

  - [ ] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [x] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] PyTorch Backend (mooncake-pg)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [x] Other

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Other

  ## How Has This Been Tested?

  Configured the project with HIP enabled:

  cmake .. -DUSE_HIP=ON

  Verified that CMake now detects the expected Python package path:

  /usr/local/lib/python3.10/dist-packages

  instead of the incorrect vendored path:

  /usr/local/lib/python3.10/dist-packages/tilelang/3rdparty/tvm/python

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [ ] I have formatted my own code using ./scripts/code_format.sh before submitting.
  - [ ] I have updated the documentation.
  - [ ] I have added tests to prove my changes are effective.