### PR TITLE
[TE][Store] Fix IPv6 address parsing in connection endpoints

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -15,6 +15,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include "master_metric_manager.h"
+#include "common.h"
 #include "segment.h"
 #ifdef USE_NOF
 #include "spdk/spdk_wrapper.h"
@@ -486,7 +487,8 @@ auto MasterService::MountNoFSegment(const NoFSegment& segment,
     ScopedNoFSegmentAccess nof_segment_access =
         nof_segment_manager_.getNoFSegmentAccess();
 
-    LOG(INFO) << "NoF segment mount: " << "client_id=" << client_id
+    LOG(INFO) << "NoF segment mount: "
+              << "client_id=" << client_id
               << ", action=mount_segment, segment_name=" << segment.name;
 
     auto err = nof_segment_access.MountSegment(segment, client_id);
@@ -875,13 +877,7 @@ auto MasterService::QueryIp(const UUID& client_id)
     unique_ips.reserve(segments.size());
     for (const auto& segment : segments) {
         if (!segment.te_endpoint.empty()) {
-            size_t colon_pos = segment.te_endpoint.find(':');
-            if (colon_pos != std::string::npos) {
-                std::string ip = segment.te_endpoint.substr(0, colon_pos);
-                unique_ips.emplace(ip);
-            } else {
-                unique_ips.emplace(segment.te_endpoint);
-            }
+            unique_ips.emplace(getHostNameWithoutPort(segment.te_endpoint));
         }
     }
 
@@ -4809,7 +4805,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
         MasterMetricManager::instance().inc_eviction_fail();
         MasterMetricManager::instance().inc_mem_eviction_fail();
     }
-    VLOG(1) << "action=evict_objects" << ", evicted_count=" << evicted_count
+    VLOG(1) << "action=evict_objects"
+            << ", evicted_count=" << evicted_count
             << ", offload_deferred=" << offload_deferred_count
             << ", offload_cap_forced=" << offload_cap_forced_count
             << ", offload_push_failed_forced=" << offload_push_failed_forced

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -22,6 +22,7 @@
 
 #include "real_client.h"
 #include "client_buffer.hpp"
+#include "common.h"
 #include "config.h"
 #include "mutex.h"
 #include "types.h"
@@ -648,14 +649,13 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
 
     // Check if hostname already contains a port
     const std::string &hostname = local_hostname;
-    size_t colon_pos = hostname.find(':');
-    bool user_specified_port = (colon_pos != std::string::npos);
+    bool user_specified_port = hasExplicitPort(hostname);
 
     if (user_specified_port) {
         // User specified port, no retry needed
         this->local_hostname = local_hostname;
-        this->local_rpc_addr =
-            hostname.substr(0, colon_pos + 1) + std::to_string(local_rpc_port);
+        this->local_rpc_addr = buildHostNameWithPort(
+            getHostNameWithoutPort(hostname), local_rpc_port);
         auto client_opt = mooncake::Client::Create(
             this->local_hostname, metadata_server, protocol, device_name,
             master_server_addr, transfer_engine, {{"client_mode", "real"}});
@@ -688,9 +688,9 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 continue;
             }
 
-            this->local_hostname = hostname + ":" + std::to_string(port);
+            this->local_hostname = buildHostNameWithPort(hostname, port);
             this->local_rpc_addr =
-                hostname + ":" + std::to_string(local_rpc_port);
+                buildHostNameWithPort(hostname, local_rpc_port);
             auto client_opt = mooncake::Client::Create(
                 this->local_hostname, metadata_server, protocol, device_name,
                 master_server_addr, transfer_engine, {{"client_mode", "real"}});
@@ -876,13 +876,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         LOG(INFO) << "Offload RPC server started on port " << offload_rpc_port_;
 
         // Build local_rpc_addr from hostname + auto-allocated port
-        std::string rpc_host = this->local_hostname;
-        auto pos = rpc_host.find(':');
-        if (pos != std::string::npos) {
-            rpc_host = rpc_host.substr(0, pos);
-        }
-        this->local_rpc_addr =
-            rpc_host + ":" + std::to_string(offload_rpc_port_);
+        this->local_rpc_addr = buildHostNameWithPort(
+            getHostNameWithoutPort(this->local_hostname), offload_rpc_port_);
     }
     if (enable_ssd_offload) {
         auto file_storage_config = FileStorageConfig::FromEnvironment();

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
@@ -2156,6 +2156,117 @@ TEST_F(MasterServiceSnapshotTest,
         << "Client with all empty te_endpoints should have empty IP vector";
 }
 
+TEST_F(MasterServiceSnapshotTest, BatchQueryIpBracketedIpv6Test) {
+    service_.reset(new MasterService());
+    const UUID client_id = generate_uuid();
+
+    // Mount a segment with a bracketed IPv6 endpoint
+    constexpr size_t buffer = 0x300000000;
+    constexpr size_t size = 1024 * 1024 * 16;
+    Segment segment = MakeSegment("test_segment", buffer, size);
+    segment.te_endpoint = "[::1]:17813";
+    auto mount_result = service_->MountSegment(segment, client_id);
+    ASSERT_TRUE(mount_result.has_value());
+
+    std::vector<UUID> client_ids = {client_id};
+    auto query_result = service_->BatchQueryIp(client_ids);
+    ASSERT_TRUE(query_result.has_value());
+
+    const auto& results = query_result.value();
+    auto it = results.find(client_id);
+    ASSERT_NE(it, results.end());
+
+    const auto& ip_addresses = it->second;
+    ASSERT_EQ(1u, ip_addresses.size());
+    EXPECT_EQ("::1", ip_addresses[0]);
+}
+
+TEST_F(MasterServiceSnapshotTest, BatchQueryIpLinkLocalIpv6WithScopeTest) {
+    service_.reset(new MasterService());
+    const UUID client_id = generate_uuid();
+
+    // Mount a segment with a link-local IPv6 address with scope ID
+    constexpr size_t buffer = 0x300000000;
+    constexpr size_t size = 1024 * 1024 * 16;
+    Segment segment = MakeSegment("test_segment", buffer, size);
+    segment.te_endpoint = "fe80::a236:bcff:fecb:a1be%eno2:15773";
+    auto mount_result = service_->MountSegment(segment, client_id);
+    ASSERT_TRUE(mount_result.has_value());
+
+    std::vector<UUID> client_ids = {client_id};
+    auto query_result = service_->BatchQueryIp(client_ids);
+    ASSERT_TRUE(query_result.has_value());
+
+    const auto& results = query_result.value();
+    auto it = results.find(client_id);
+    ASSERT_NE(it, results.end());
+
+    const auto& ip_addresses = it->second;
+    ASSERT_EQ(1u, ip_addresses.size());
+    EXPECT_EQ("fe80::a236:bcff:fecb:a1be%eno2", ip_addresses[0]);
+}
+
+TEST_F(MasterServiceSnapshotTest, BatchQueryIpIpv6NoPortTest) {
+    service_.reset(new MasterService());
+    const UUID client_id = generate_uuid();
+
+    // Mount a segment with an IPv6 address without port
+    constexpr size_t buffer = 0x300000000;
+    constexpr size_t size = 1024 * 1024 * 16;
+    Segment segment = MakeSegment("test_segment", buffer, size);
+    segment.te_endpoint = "::1";
+    auto mount_result = service_->MountSegment(segment, client_id);
+    ASSERT_TRUE(mount_result.has_value());
+
+    std::vector<UUID> client_ids = {client_id};
+    auto query_result = service_->BatchQueryIp(client_ids);
+    ASSERT_TRUE(query_result.has_value());
+
+    const auto& results = query_result.value();
+    auto it = results.find(client_id);
+    ASSERT_NE(it, results.end());
+
+    const auto& ip_addresses = it->second;
+    ASSERT_EQ(1u, ip_addresses.size());
+    EXPECT_EQ("::1", ip_addresses[0]);
+}
+
+TEST_F(MasterServiceSnapshotTest, BatchQueryIpMixedIpv4AndIpv6Test) {
+    service_.reset(new MasterService());
+    const UUID client_id = generate_uuid();
+
+    // Mount segments with IPv4 and IPv6 endpoints for the same client
+    constexpr size_t buffer1 = 0x300000000;
+    constexpr size_t buffer2 = 0x400000000;
+    constexpr size_t size = 1024 * 1024 * 16;
+
+    Segment segment1 = MakeSegment("segment1", buffer1, size);
+    segment1.te_endpoint = "192.168.1.1:12345";
+    auto mount_result1 = service_->MountSegment(segment1, client_id);
+    ASSERT_TRUE(mount_result1.has_value());
+
+    Segment segment2 = MakeSegment("segment2", buffer2, size);
+    segment2.te_endpoint = "[::1]:17813";
+    auto mount_result2 = service_->MountSegment(segment2, client_id);
+    ASSERT_TRUE(mount_result2.has_value());
+
+    std::vector<UUID> client_ids = {client_id};
+    auto query_result = service_->BatchQueryIp(client_ids);
+    ASSERT_TRUE(query_result.has_value());
+
+    const auto& results = query_result.value();
+    auto it = results.find(client_id);
+    ASSERT_NE(it, results.end());
+
+    const auto& ip_addresses = it->second;
+    ASSERT_EQ(2u, ip_addresses.size());
+
+    std::unordered_set<std::string> ip_set(ip_addresses.begin(),
+                                           ip_addresses.end());
+    EXPECT_NE(ip_set.find("192.168.1.1"), ip_set.end());
+    EXPECT_NE(ip_set.find("::1"), ip_set.end());
+}
+
 TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
     // Reset storage space metrics.
     MasterMetricManager::instance().reset_allocated_mem_size();

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -3331,6 +3331,117 @@ TEST_F(MasterServiceTest, BatchQueryIpMultipleSegmentsEmptyTeEndpointTest) {
         << "Client with all empty te_endpoints should have empty IP vector";
 }
 
+TEST_F(MasterServiceTest, BatchQueryIpBracketedIpv6Test) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    const UUID client_id = generate_uuid();
+
+    // Mount a segment with a bracketed IPv6 endpoint
+    constexpr size_t buffer = 0x300000000;
+    constexpr size_t size = 1024 * 1024 * 16;
+    Segment segment = MakeSegment("test_segment", buffer, size);
+    segment.te_endpoint = "[::1]:17813";
+    auto mount_result = service_->MountSegment(segment, client_id);
+    ASSERT_TRUE(mount_result.has_value());
+
+    std::vector<UUID> client_ids = {client_id};
+    auto query_result = service_->BatchQueryIp(client_ids);
+    ASSERT_TRUE(query_result.has_value());
+
+    const auto& results = query_result.value();
+    auto it = results.find(client_id);
+    ASSERT_NE(it, results.end());
+
+    const auto& ip_addresses = it->second;
+    ASSERT_EQ(1u, ip_addresses.size());
+    EXPECT_EQ("::1", ip_addresses[0]);
+}
+
+TEST_F(MasterServiceTest, BatchQueryIpLinkLocalIpv6WithScopeTest) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    const UUID client_id = generate_uuid();
+
+    // Mount a segment with a link-local IPv6 address with scope ID
+    constexpr size_t buffer = 0x300000000;
+    constexpr size_t size = 1024 * 1024 * 16;
+    Segment segment = MakeSegment("test_segment", buffer, size);
+    segment.te_endpoint = "fe80::a236:bcff:fecb:a1be%eno2:15773";
+    auto mount_result = service_->MountSegment(segment, client_id);
+    ASSERT_TRUE(mount_result.has_value());
+
+    std::vector<UUID> client_ids = {client_id};
+    auto query_result = service_->BatchQueryIp(client_ids);
+    ASSERT_TRUE(query_result.has_value());
+
+    const auto& results = query_result.value();
+    auto it = results.find(client_id);
+    ASSERT_NE(it, results.end());
+
+    const auto& ip_addresses = it->second;
+    ASSERT_EQ(1u, ip_addresses.size());
+    EXPECT_EQ("fe80::a236:bcff:fecb:a1be%eno2", ip_addresses[0]);
+}
+
+TEST_F(MasterServiceTest, BatchQueryIpIpv6NoPortTest) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    const UUID client_id = generate_uuid();
+
+    // Mount a segment with an IPv6 address without port
+    constexpr size_t buffer = 0x300000000;
+    constexpr size_t size = 1024 * 1024 * 16;
+    Segment segment = MakeSegment("test_segment", buffer, size);
+    segment.te_endpoint = "::1";
+    auto mount_result = service_->MountSegment(segment, client_id);
+    ASSERT_TRUE(mount_result.has_value());
+
+    std::vector<UUID> client_ids = {client_id};
+    auto query_result = service_->BatchQueryIp(client_ids);
+    ASSERT_TRUE(query_result.has_value());
+
+    const auto& results = query_result.value();
+    auto it = results.find(client_id);
+    ASSERT_NE(it, results.end());
+
+    const auto& ip_addresses = it->second;
+    ASSERT_EQ(1u, ip_addresses.size());
+    EXPECT_EQ("::1", ip_addresses[0]);
+}
+
+TEST_F(MasterServiceTest, BatchQueryIpMixedIpv4AndIpv6Test) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    const UUID client_id = generate_uuid();
+
+    // Mount segments with IPv4 and IPv6 endpoints for the same client
+    constexpr size_t buffer1 = 0x300000000;
+    constexpr size_t buffer2 = 0x400000000;
+    constexpr size_t size = 1024 * 1024 * 16;
+
+    Segment segment1 = MakeSegment("segment1", buffer1, size);
+    segment1.te_endpoint = "192.168.1.1:12345";
+    auto mount_result1 = service_->MountSegment(segment1, client_id);
+    ASSERT_TRUE(mount_result1.has_value());
+
+    Segment segment2 = MakeSegment("segment2", buffer2, size);
+    segment2.te_endpoint = "[::1]:17813";
+    auto mount_result2 = service_->MountSegment(segment2, client_id);
+    ASSERT_TRUE(mount_result2.has_value());
+
+    std::vector<UUID> client_ids = {client_id};
+    auto query_result = service_->BatchQueryIp(client_ids);
+    ASSERT_TRUE(query_result.has_value());
+
+    const auto& results = query_result.value();
+    auto it = results.find(client_id);
+    ASSERT_NE(it, results.end());
+
+    const auto& ip_addresses = it->second;
+    ASSERT_EQ(2u, ip_addresses.size());
+
+    std::unordered_set<std::string> ip_set(ip_addresses.begin(),
+                                           ip_addresses.end());
+    EXPECT_NE(ip_set.find("192.168.1.1"), ip_set.end());
+    EXPECT_NE(ip_set.find("::1"), ip_set.end());
+}
+
 TEST_F(MasterServiceTest, PutStartExpiringTest) {
     // Reset storage space metrics.
     MasterMetricManager::instance().reset_allocated_mem_size();

--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -267,6 +267,33 @@ static inline std::pair<std::string, uint16_t> parseHostNameWithPort(
             getPortFromString(server_name.substr(colon_pos + 1), port)};
 }
 
+static inline bool hasExplicitPort(const std::string &server_name) {
+    auto result = extractIPv6HostAndPort(server_name);
+    if (result.matched) {
+        return !result.port.empty();
+    }
+    return server_name.rfind(':') != std::string::npos;
+}
+
+static inline std::string getHostNameWithoutPort(
+    const std::string &server_name) {
+    auto result = extractIPv6HostAndPort(server_name);
+    if (result.matched) {
+        return std::move(result.host);
+    }
+
+    const size_t colon_pos = server_name.rfind(':');
+    if (colon_pos == std::string::npos) {
+        return server_name;
+    }
+    return server_name.substr(0, colon_pos);
+}
+
+static inline std::string buildHostNameWithPort(const std::string &host,
+                                                uint16_t port) {
+    return maybeWrapIpV6(host) + ":" + std::to_string(port);
+}
+
 static inline uint16_t parsePortAndDevice(std::string_view suffix,
                                           uint16_t default_port,
                                           int *device_id) {

--- a/mooncake-transfer-engine/tent/src/common/ip.cpp
+++ b/mooncake-transfer-engine/tent/src/common/ip.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "tent/common/utils/ip.h"
+#include "common.h"
+
 #include <glog/logging.h>
 
 namespace mooncake {
@@ -92,42 +94,60 @@ Status checkLocalIpAddress(std::string &hostname, bool &ipv6) {
 std::pair<std::string, uint16_t> parseHostNameWithPort(const std::string &url,
                                                        uint16_t default_port) {
     uint16_t port = default_port;
+    if (url.empty()) return std::make_pair(url, port);
 
-    // Check if url is valid IPv6 address
-    in6_addr addr;
-    if (inet_pton(AF_INET6, url.c_str(), &addr) == 1) return {url, port};
-
-    // Check if url is valid IPv6 address with port
-    size_t start_pos = 0;
-    size_t end_pos = url.find_last_of(']');
-    size_t port_pos = url.find_last_of(':');
-    if (url.front() == '[' && end_pos != std::string::npos &&
-        port_pos > end_pos) {
-        auto ip = url.substr(start_pos + 1, end_pos - start_pos - 1);
-        std::string port_str = url.substr(port_pos + 1);
-        int val = std::atoi(port_str.c_str());
-        if (val <= 0 || val > 65535) {
-            LOG(WARNING) << "Illegal port number in " << url
-                         << ". Use default port " << port << " instead";
-        } else {
-            port = static_cast<uint16_t>(val);
+    // Helper: check if a string is a valid numeric IP (IPv4 or IPv6),
+    // automatically stripping scope IDs (e.g., %eth0) before validation
+    auto isNumericAddress = [](const std::string &host) -> bool {
+        std::string check = host;
+        auto pct = host.find('%');
+        if (pct != std::string::npos) {
+            if (host.find(':', pct) != std::string::npos) {
+                return false;
+            }
+            check = host.substr(0, pct);
         }
-        return std::make_pair(port_str, port);
+        struct addrinfo hints, *res;
+        memset(&hints, 0, sizeof(hints));
+        hints.ai_flags = AI_NUMERICHOST;
+        hints.ai_family = AF_UNSPEC;
+        hints.ai_socktype = SOCK_STREAM;
+        int ret = getaddrinfo(check.c_str(), nullptr, &hints, &res);
+        if (ret == 0) freeaddrinfo(res);
+        return ret == 0;
+    };
+
+    if (isNumericAddress(url)) return {url, port};
+
+    size_t end_pos = url.find_last_of(']');
+    if (url.front() == '[' && end_pos != std::string::npos) {
+        std::string ip = url.substr(1, end_pos - 1);
+        if (!isNumericAddress(ip)) {
+            LOG(WARNING) << "Illegal bracketed IPv6 address: " << ip;
+            return std::make_pair(std::string(), port);
+        }
+        if (end_pos + 1 < url.size() && url[end_pos + 1] == ':') {
+            port = getPortFromString(url.substr(end_pos + 2), default_port);
+        }
+        return std::make_pair(ip, port);
     }
 
-    // Check if url has port field
-    auto pos = url.find(':');
-    if (pos == url.npos) return std::make_pair(url, port);
-    auto trimmed_server_name = url.substr(0, pos);
-    auto port_str = url.substr(pos + 1);
-    int val = std::atoi(port_str.c_str());
-    if (val <= 0 || val > 65535)
-        LOG(WARNING) << "Illegal port number in " << url
-                     << ". Use default port " << port << " instead";
-    else
-        port = (uint16_t)val;
+    auto pos = url.rfind(':');
+    if (pos != std::string::npos) {
+        std::string host_part = url.substr(0, pos);
+        std::string port_str = url.substr(pos + 1);
 
-    return std::make_pair(trimmed_server_name, port);
+        if (!isNumericAddress(host_part) &&
+            host_part.find(':') != std::string::npos) {
+            LOG(WARNING) << "Illegal IPv6 address: " << host_part;
+            return std::make_pair(std::string(), port);
+        }
+
+        return std::make_pair(host_part,
+                              getPortFromString(port_str, default_port));
+    }
+
+    return std::make_pair(url, port);
 }
 
 std::string buildIpAddrWithPort(const std::string &hostname, uint16_t port,

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -20,6 +20,12 @@ target_include_directories(metrics_config_loader_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME metrics_config_loader_test COMMAND metrics_config_loader_test)
 
+add_executable(tent_ip_utils_test ip_utils_test.cpp)
+target_link_libraries(tent_ip_utils_test PRIVATE tent_common gtest gtest_main)
+target_include_directories(tent_ip_utils_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_ip_utils_test COMMAND tent_ip_utils_test)
+
 add_executable(request_merge_test request_merge_test.cpp)
 target_link_libraries(request_merge_test PRIVATE gtest gtest_main
                                                  tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/ip_utils_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/ip_utils_test.cpp
@@ -1,0 +1,125 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "tent/common/utils/ip.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+TEST(TentIpUtilsTest, ParsesBracketedIpv6WithPort) {
+    auto [host, port] = parseHostNameWithPort("[2001:db8::1]:9000", 1234);
+
+    EXPECT_EQ(host, "2001:db8::1");
+    EXPECT_EQ(port, 9000);
+}
+
+TEST(TentIpUtilsTest, ParsesBracketedIpv6WithoutPort) {
+    auto [host, port] = parseHostNameWithPort("[2001:db8::1]", 1234);
+
+    EXPECT_EQ(host, "2001:db8::1");
+    EXPECT_EQ(port, 1234);
+}
+
+TEST(TentIpUtilsTest, ParsesRawIpv6WithoutPort) {
+    auto [host, port] = parseHostNameWithPort("2001:db8::1", 1234);
+
+    EXPECT_EQ(host, "2001:db8::1");
+    EXPECT_EQ(port, 1234);
+}
+
+TEST(TentIpUtilsTest, ParsesIpv4WithPort) {
+    auto [host, port] = parseHostNameWithPort("192.168.1.10:9000", 1234);
+
+    EXPECT_EQ(host, "192.168.1.10");
+    EXPECT_EQ(port, 9000);
+}
+
+TEST(TentIpUtilsTest, ParsesHostnameWithPort) {
+    auto [host, port] = parseHostNameWithPort("example.com:9000", 1234);
+
+    EXPECT_EQ(host, "example.com");
+    EXPECT_EQ(port, 9000);
+}
+
+TEST(TentIpUtilsTest, InvalidBracketedIpv6UsesDefaultPort) {
+    auto [host, port] = parseHostNameWithPort("[2001::db8::1]:9000", 1234);
+
+    EXPECT_TRUE(host.empty());
+    EXPECT_EQ(port, 1234);
+}
+
+TEST(TentIpUtilsTest, InvalidRawIpv6UsesDefaultPort) {
+    auto [host, port] = parseHostNameWithPort("2001::db8::1", 1234);
+
+    EXPECT_TRUE(host.empty());
+    EXPECT_EQ(port, 1234);
+}
+
+TEST(TentIpUtilsTest, BracketedIpv6WithInvalidPortUsesDefaultPort) {
+    auto [host, port] = parseHostNameWithPort("[2001:db8::1]:bad", 1234);
+
+    EXPECT_EQ(host, "2001:db8::1");
+    EXPECT_EQ(port, 1234);
+}
+
+TEST(TentIpUtilsTest, EmptyInputUsesDefaultPort) {
+    auto [host, port] = parseHostNameWithPort("", 1234);
+
+    EXPECT_TRUE(host.empty());
+    EXPECT_EQ(port, 1234);
+}
+
+TEST(TentIpUtilsTest, BuildsBracketedIpv6Endpoint) {
+    EXPECT_EQ(buildIpAddrWithPort("2001:db8::1", 9000, true),
+              "[2001:db8::1]:9000");
+}
+
+TEST(TentIpUtilsTest, ParsesScopeIdWithoutPort) {
+    auto [host, port] =
+        parseHostNameWithPort("fe80::a236:bcff:fecb:a1be%eno2", 1234);
+
+    EXPECT_EQ(host, "fe80::a236:bcff:fecb:a1be%eno2");
+    EXPECT_EQ(port, 1234);
+}
+
+TEST(TentIpUtilsTest, ParsesScopeIdWithPort) {
+    auto [host, port] =
+        parseHostNameWithPort("fe80::a236:bcff:fecb:a1be%eno2:15773", 1234);
+
+    EXPECT_EQ(host, "fe80::a236:bcff:fecb:a1be%eno2");
+    EXPECT_EQ(port, 15773);
+}
+
+TEST(TentIpUtilsTest, ParsesBracketedScopeIdWithPort) {
+    auto [host, port] =
+        parseHostNameWithPort("[fe80::a236:bcff:fecb:a1be%eno2]:15773", 1234);
+
+    EXPECT_EQ(host, "fe80::a236:bcff:fecb:a1be%eno2");
+    EXPECT_EQ(port, 15773);
+}
+
+TEST(TentIpUtilsTest, ScopeIdWithInvalidPortUsesDefault) {
+    auto [host, port] =
+        parseHostNameWithPort("fe80::a236:bcff:fecb:a1be%eno2:bad", 1234);
+
+    EXPECT_EQ(host, "fe80::a236:bcff:fecb:a1be%eno2");
+    EXPECT_EQ(port, 1234);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tests/common_test.cpp
+++ b/mooncake-transfer-engine/tests/common_test.cpp
@@ -112,6 +112,27 @@ TEST(ParseHostNameWithPort, HostWithoutPort) {
     EXPECT_EQ(port, kDefaultPort);
 }
 
+TEST(HostPortHelpers, DetectsExplicitPort) {
+    EXPECT_TRUE(hasExplicitPort("8.8.8.8:4321"));
+    EXPECT_TRUE(hasExplicitPort("example.com:4321"));
+    EXPECT_TRUE(hasExplicitPort("[2001:db8::1]:4321"));
+    EXPECT_FALSE(hasExplicitPort("2001:db8::1"));
+    EXPECT_FALSE(hasExplicitPort("[2001:db8::1]"));
+}
+
+TEST(HostPortHelpers, ExtractsHostWithoutPort) {
+    EXPECT_EQ(getHostNameWithoutPort("8.8.8.8:4321"), "8.8.8.8");
+    EXPECT_EQ(getHostNameWithoutPort("example.com:4321"), "example.com");
+    EXPECT_EQ(getHostNameWithoutPort("[2001:db8::1]:4321"), "2001:db8::1");
+    EXPECT_EQ(getHostNameWithoutPort("[2001:db8::1]"), "2001:db8::1");
+    EXPECT_EQ(getHostNameWithoutPort("2001:db8::1"), "2001:db8::1");
+}
+
+TEST(HostPortHelpers, BuildsBracketedIpv6Endpoint) {
+    EXPECT_EQ(buildHostNameWithPort("2001:db8::1", 4321), "[2001:db8::1]:4321");
+    EXPECT_EQ(buildHostNameWithPort("8.8.8.8", 4321), "8.8.8.8:4321");
+}
+
 //------------------------------------------------------------------------------
 // parsePortAndDevice
 //------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Problem:

IPv6 addresses contain colons (:), but the code used naive find(':') / rfind(':') to split host and port, which breaks on IPv6. For example:
- parseHostNameWithPort("2001:db8::1") splits at the first : and tries to parse db8::1 as a port.
- parseHostNameWithPort("[2001:db8::1]:9000") returned the port string as the host (make_pair(port_str, port)).
- In the Store, find(':') for extracting the hostname from local_hostname or in QueryIp chopped IPv6 addresses into garbage.

Solution:

The core idea: distinguish colons inside IPv6 addresses from the colon that separates host and port, and handle host:port operations uniformly.
1. ip.cpp - parseHostNameWithPort:
- Bracketed IPv6 [::]:port: validate the inner IP with inet_pton, then only look for a : after the closing ].
- Raw IPv6 ::1: if multiple colons are detected, treat it as a port-less IPv6 and use the default port.
- Return the actual IP address (not the port string) as the host part.
2. common.h — three new helpers:
- hasExplicitPort() — correctly checks whether a host string has an explicit port (IPv6: check after ]; IPv4/hostname: check last :).
- getHostNameWithoutPort() — safely strips the port, returning the bare host.
- buildHostNameWithPort() — auto-wraps IPv6 in [...] before appending :port.
3. Store side: Replaced all ad-hoc find(':') logic in master_service.cpp (QueryIp) and real_client.cpp (setup_internal) with the three helpers above.
## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

These changes are covered by tests in 3 files — all 21 tests pass:
1. mooncake-transfer-engine/tent/tests/ip_utils_test.cpp (new) — 10/10 passed
Tests parseHostNameWithPort and buildIpAddrWithPort:
- Bracketed IPv6 with/without port, raw IPv6 without port, IPv4, hostname, invalid bracketed IPv6, invalid raw IPv6, invalid port, empty input, endpoint building
2. mooncake-transfer-engine/tests/common_test.cpp (modified) — 3/3 passed
Tests the three new helpers in common.h:
- DetectsExplicitPort, ExtractsHostWithoutPort, BuildsBracketedIpv6Endpoint
3. mooncake-store/tests/master_service_test.cpp + mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp (modified) — 8/8 passed (4 in each)
Tests Store's BatchQueryIp (master_service.cpp:QueryIp):
- BatchQueryIpBracketedIpv6Test, BatchQueryIpLinkLocalIpv6WithScopeTest, BatchQueryIpIpv6NoPortTest, BatchQueryIpMixedIpv4AndIpv6Test
## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
