### PR TITLE
[Build] Fix compile warnings across multiple components

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -50,7 +50,7 @@ struct PyTensorInfo {
         // Check dtype is within valid range (0 to TensorDtype::NR_DTYPES,
         // excluding UNKNOWN=-1)
         if (validated.header.dtype >=
-            static_cast<uint32_t>(TensorDtype::NR_DTYPES)) {
+            static_cast<int32_t>(TensorDtype::NR_DTYPES)) {
             return false;
         }
 

--- a/mooncake-integration/store/store_py_internal.h
+++ b/mooncake-integration/store/store_py_internal.h
@@ -526,7 +526,7 @@ std::optional<py::object> materialize_shard_tensor(const py::handle &tensor,
         .attr("contiguous")();
 }
 
-std::optional<std::vector<PyTensorInfo>> build_tp_shard_infos(
+[[maybe_unused]] std::optional<std::vector<PyTensorInfo>> build_tp_shard_infos(
     const py::handle &tensor, int tp_size, int split_dim,
     const std::function<std::string(int)> &key_for_rank,
     const std::vector<ParallelAxisSpec> &axes = {}) {
@@ -1334,9 +1334,10 @@ std::pair<int64_t, int64_t> calculate_shard_range(int64_t dim_size, int rank,
     return {start, end - start};
 }
 
-std::optional<ParsedTensorMetadata> parse_tensor_metadata_from_buffer(
-    BufferHandle *buffer_handle, char *usr_buffer, int64_t data_length,
-    bool *take_ownership, char **exported_data, size_t *total_length) {
+[[maybe_unused]] std::optional<ParsedTensorMetadata>
+parse_tensor_metadata_from_buffer(BufferHandle *buffer_handle, char *usr_buffer,
+                                  int64_t data_length, bool *take_ownership,
+                                  char **exported_data, size_t *total_length) {
     if (!buffer_handle && !usr_buffer) return std::nullopt;
     if (buffer_handle && usr_buffer) return std::nullopt;
 

--- a/mooncake-store/include/client_buffer.hpp
+++ b/mooncake-store/include/client_buffer.hpp
@@ -57,6 +57,7 @@ class ClientBufferAllocator
     ClientBufferAllocator(void* addr, size_t size, const std::string& protocol);
 
     void* buffer_;
+    size_t buffer_size_;
     bool use_hugepage_ = false;
 
    private:
@@ -66,7 +67,6 @@ class ClientBufferAllocator
     std::shared_ptr<offset_allocator::OffsetAllocator> allocator_;
 
     std::string protocol;
-    size_t buffer_size_;
     bool is_external_memory_ = false;
 };
 

--- a/mooncake-store/include/ha/snapshot/snapshot_logger.h
+++ b/mooncake-store/include/ha/snapshot/snapshot_logger.h
@@ -16,7 +16,7 @@ inline void SnapshotLogWrite(const char* level, const std::string& msg) {
     if (g_snapshot_log_pipe_fd < 0) return;
     std::string line = std::string("[") + level + "] " + msg + "\n";
     // write() is async-signal-safe, won't deadlock after fork
-    ::write(g_snapshot_log_pipe_fd, line.c_str(), line.size());
+    std::ignore = ::write(g_snapshot_log_pipe_fd, line.c_str(), line.size());
 }
 
 // Macros for child process logging - writes to pipe instead of glog

--- a/mooncake-store/src/client_buffer.cpp
+++ b/mooncake-store/src/client_buffer.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<ClientBufferAllocator> ClientBufferAllocator::create(
 ClientBufferAllocator::ClientBufferAllocator(size_t size,
                                              const std::string& protocol,
                                              bool use_hugepage)
-    : protocol(protocol), buffer_size_(size), use_hugepage_(use_hugepage) {
+    : buffer_size_(size), use_hugepage_(use_hugepage), protocol(protocol) {
     if (size == 0) {
         buffer_ = nullptr;
         allocator_ = nullptr;
@@ -50,7 +50,7 @@ ClientBufferAllocator::ClientBufferAllocator(size_t size,
 
 ClientBufferAllocator::ClientBufferAllocator(void* addr, size_t size,
                                              const std::string& protocol)
-    : protocol(protocol), buffer_size_(size) {
+    : buffer_size_(size), protocol(protocol) {
     buffer_ = addr;
     is_external_memory_ = true;
     allocator_ = mooncake::offset_allocator::OffsetAllocator::create(

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2,6 +2,7 @@
 
 #include <glog/logging.h>
 
+#include "allocator.h"
 #include "segment.h"
 
 #include <csignal>
@@ -2735,7 +2736,12 @@ void Client::PutToLocalFile(const std::string& key,
                            << ", triggering PutRevoke for disk replica";
                 pinned_buffer_pool_->Release(buf);
                 // Must revoke to avoid phantom replica in master
-                master_client_.PutRevoke(key, ReplicaType::DISK);
+                auto revoke_result =
+                    master_client_.PutRevoke(key, ReplicaType::DISK);
+                if (!revoke_result) {
+                    LOG(ERROR)
+                        << "Failed to revoke put operation for key: " << key;
+                }
                 return;
             }
             value.append(buf.data, slice.size);

--- a/mooncake-store/src/ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.cpp
+++ b/mooncake-store/src/ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.cpp
@@ -24,6 +24,8 @@ using common::redis::IsStringReply;
 using common::redis::RedisReplyPtr;
 using common::redis::SanitizeHashTagComponent;
 
+#ifdef STORE_USE_REDIS
+
 tl::expected<long long, ErrorCode> ParseSnapshotScore(
     std::string_view snapshot_id) {
     if (!snapshot_catalog_store_detail::IsValidSnapshotId(snapshot_id)) {
@@ -67,8 +69,6 @@ tl::expected<SnapshotDescriptor, ErrorCode> LoadSnapshotDescriptor(
     }
     return descriptor.value();
 }
-
-#ifdef STORE_USE_REDIS
 
 constexpr char kPublishSnapshotScript[] = R"LUA(
 redis.call('ZADD', KEYS[1], ARGV[1], ARGV[2])

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -151,10 +151,10 @@ MasterService::MasterService(const MasterServiceConfig& config)
           config.snapshot_catalog_store_connstring),
       put_start_discard_timeout_sec_(config.put_start_discard_timeout_sec),
       put_start_release_timeout_sec_(config.put_start_release_timeout_sec),
-      task_manager_(config.task_manager_config),
       cxl_path_(config.cxl_path),
       cxl_size_(config.cxl_size),
-      enable_cxl_(config.enable_cxl) {
+      enable_cxl_(config.enable_cxl),
+      task_manager_(config.task_manager_config) {
     if (enable_snapshot_ || enable_snapshot_restore_) {
         try {
             auto object_store_type =

--- a/mooncake-store/tests/ha/oplog/ha_recovery_test.cpp
+++ b/mooncake-store/tests/ha/oplog/ha_recovery_test.cpp
@@ -259,6 +259,7 @@ TEST_F(HaRecoveryTest, GC_NoSnapshot_IncompleteRecovery) {
     // This demonstrates data incompleteness without snapshot protection:
     // the applier sees a gap it cannot fill (seq 1~9 are GC'd).
     size_t applied = applier_->ApplyOpLogEntries(entries);
+    EXPECT_EQ(applied, 0);
 
     // Wait for gap timeout so pending entries eventually drain
     std::this_thread::sleep_for(std::chrono::seconds(4));

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -4431,8 +4431,8 @@ TEST_F(MasterServiceTest, DrainJobSchedulesMoveTaskAndConvergesToDrained) {
 TEST_F(MasterServiceTest, CancelDrainJobRestoresSegmentStatus) {
     auto service_ = std::make_unique<MasterService>();
 
-    const auto ctx0 = PrepareSimpleSegment(*service_, "segment_0", 0x300000000,
-                                           kDefaultSegmentSize);
+    [[maybe_unused]] const auto ctx0 = PrepareSimpleSegment(
+        *service_, "segment_0", 0x300000000, kDefaultSegmentSize);
     [[maybe_unused]] const auto ctx1 = PrepareSimpleSegment(
         *service_, "segment_1", 0x400000000, kDefaultSegmentSize);
 

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -2343,7 +2343,7 @@ TEST_F(StorageBackendTest,
     // Deleter thread: calls DeleteBucket
     std::thread deleter_thread([&]() {
         delete_started.store(true);
-        auto delete_result = storage_backend.DeleteBucket(bucket_id);
+        std::ignore = storage_backend.DeleteBucket(bucket_id);
         delete_completed.store(true);
     });
 

--- a/mooncake-store/tests/task_manager_test.cpp
+++ b/mooncake-store/tests/task_manager_test.cpp
@@ -269,7 +269,7 @@ TEST_F(ClientTaskManagerTest, PruneExpiredTasksProcessingTimeoutFreesSlot) {
 }
 
 TEST_F(ClientTaskManagerTest, SerializerRoundTrip) {
-    ClientTaskManager manager({10000, 10000, 10000, 0, 0});
+    ClientTaskManager manager({10000, 10000, 10000, 0, 0, 0});
     UUID client_id1 = generate_uuid();
     UUID client_id2 = generate_uuid();
 
@@ -277,11 +277,13 @@ TEST_F(ClientTaskManagerTest, SerializerRoundTrip) {
     auto t1 =
         manager.get_write_access().submit_task_typed<TaskType::REPLICA_COPY>(
             client_id1,
-            ReplicaCopyPayload{.key = "pending_key", .targets = {"seg1"}});
+            ReplicaCopyPayload{
+                .key = "pending_key", .source = "", .targets = {"seg1"}});
     auto t2 =
         manager.get_write_access().submit_task_typed<TaskType::REPLICA_COPY>(
             client_id2,
-            ReplicaCopyPayload{.key = "processing_key", .targets = {"seg2"}});
+            ReplicaCopyPayload{
+                .key = "processing_key", .source = "", .targets = {"seg2"}});
     auto t3 =
         manager.get_write_access().submit_task_typed<TaskType::REPLICA_MOVE>(
             client_id1, ReplicaMovePayload{
@@ -303,9 +305,9 @@ TEST_F(ClientTaskManagerTest, SerializerRoundTrip) {
     manager.get_write_access().pop_tasks(client_id2, 2);
 
     // Complete t1 as SUCCESS, t2 as FAILED
-    auto ec1 = manager.get_write_access().complete_task(
+    std::ignore = manager.get_write_access().complete_task(
         client_id1, t1.value(), TaskStatus::SUCCESS, "Done");
-    auto ec2 = manager.get_write_access().complete_task(
+    std::ignore = manager.get_write_access().complete_task(
         client_id2, t2.value(), TaskStatus::FAILED, "Failed");
 
     // Get original tasks
@@ -320,7 +322,7 @@ TEST_F(ClientTaskManagerTest, SerializerRoundTrip) {
     ASSERT_TRUE(serialized.has_value());
 
     // Deserialize into new manager
-    ClientTaskManager manager2({10000, 10000, 10000, 0, 0});
+    ClientTaskManager manager2({10000, 10000, 10000, 0, 0, 0});
     TaskManagerSerializer serializer2(&manager2);
     auto result = serializer2.Deserialize(serialized.value());
     ASSERT_TRUE(result.has_value());
@@ -377,13 +379,13 @@ TEST_F(ClientTaskManagerTest, SerializerRoundTrip) {
 }
 
 TEST_F(ClientTaskManagerTest, SerializerEmptyManager) {
-    ClientTaskManager manager({10000, 10000, 10000, 0, 0});
+    ClientTaskManager manager({10000, 10000, 10000, 0, 0, 0});
 
     TaskManagerSerializer serializer(&manager);
     auto serialized = serializer.Serialize();
     ASSERT_TRUE(serialized.has_value());
 
-    ClientTaskManager manager2({10000, 10000, 10000, 0, 0});
+    ClientTaskManager manager2({10000, 10000, 10000, 0, 0, 0});
     TaskManagerSerializer serializer2(&manager2);
     auto result = serializer2.Deserialize(serialized.value());
     ASSERT_TRUE(result.has_value());
@@ -394,12 +396,13 @@ TEST_F(ClientTaskManagerTest, SerializerEmptyManager) {
 }
 
 TEST_F(ClientTaskManagerTest, SerializerReset) {
-    ClientTaskManager manager({10000, 10000, 10000, 0, 0});
+    ClientTaskManager manager({10000, 10000, 10000, 0, 0, 0});
     UUID client_id = generate_uuid();
 
     auto t1 =
         manager.get_write_access().submit_task_typed<TaskType::REPLICA_COPY>(
-            client_id, ReplicaCopyPayload{.key = "key1", .targets = {"seg1"}});
+            client_id, ReplicaCopyPayload{
+                           .key = "key1", .source = "", .targets = {"seg1"}});
     ASSERT_TRUE(t1.has_value());
 
     TaskManagerSerializer serializer(&manager);

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -311,8 +311,8 @@ int TransferEngineImpl::init(const std::string& metadata_conn_string,
         }
 
 #else
-        if (local_topology_->getHcaList().size() > 0 &&
-                !getenv("MC_FORCE_TCP") ||
+        if ((local_topology_->getHcaList().size() > 0 &&
+             !getenv("MC_FORCE_TCP")) ||
             getenv("MC_FORCE_HCA")) {
             // only install RDMA transport when there is at least one HCA
             Transport* rdma_transport = nullptr;

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -945,7 +945,8 @@ void TcpTransport::startTransfer(Slice* slice) {
         }
         if (enable_connection_pool_) {
             // Remove the connection from pool if it was pooled
-            ConnectionKey key{meta_entry.ip_or_host_name, desc->tcp_data_port};
+            ConnectionKey key{meta_entry.ip_or_host_name,
+                              static_cast<uint16_t>(desc->tcp_data_port)};
             std::lock_guard<std::mutex> lock(pool_mutex_);
             auto it = connection_pool_.find(key);
             if (it != connection_pool_.end()) {

--- a/mooncake-transfer-engine/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test.cpp
@@ -171,7 +171,7 @@ bool validateTransferSizes() {
     return true;
 }
 
-void setBackendDevice(const std::string &backend) {
+[[maybe_unused]] void setBackendDevice(const std::string &backend) {
     if (!usesDeviceMemory(backend)) {
         return;
     }


### PR DESCRIPTION
## Description

Fix some build warnings caused by type cast, unused function/variable

- mooncake-transfer-engine: add parentheses around && within ||, add static_cast for narrowing, mark unused function [[maybe_unused]]
- mooncake-store: fix member reorder warnings, add std::ignore for unused results, fix missing field initializers, mark unused variables
- mooncake-integration: fix sign-compare comparison, mark unused functions [[maybe_unused]]

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

By existing test suites.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
