### PR TITLE
[build] Strip shared libraries to reduce NPU wheel size

### DIFF
--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -137,6 +137,11 @@ if [ "$CI" = "true" ] || [ "$FREE_BUILD_DIR" = "1" ]; then
     fi
 fi
 
+if [ "$NPU_BUILD" = "1" ]; then
+    echo "Stripping shared libraries to reduce wheel size..."
+    find mooncake-wheel/mooncake -name "*.so" -exec strip --strip-unneeded {} \;
+fi
+
 echo "Building wheel package..."
 # Build the wheel package
 cd mooncake-wheel


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->
Strip shared libraries (*.so) in NPU builds to reduce wheel package size. The NPU wheel currently exceeds 200MB due to unstripped debug symbols in shared libraries, preventing PyPI publication (100MB limit).

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->
- Verified strip reduces .so file size by approximately 50-80% on NPU build environment
- Only applies when NPU_BUILD=1, no impact on CUDA/non-CUDA builds

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
