### PR TITLE
[Store] Robustify ConfigDict size parsing

### DIFF
--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -207,6 +207,9 @@ std::string expected_to_str(const tl::expected<T, ErrorCode>& expected) {
     } catch (const std::exception&) {
         return std::nullopt;  // Failed to parse number
     }
+    if (value < 0) {
+        return std::nullopt;
+    }
 
     if (pos >= s.length()) {
         // No unit specified, assume bytes

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -171,14 +171,15 @@ std::string expected_to_str(const tl::expected<T, ErrorCode>& expected) {
 }
 
 /**
- * @brief Convert a string representation of size to bytes
+ * @brief Parse a string representation of size to bytes
  * @param str String representation of size (e.g., "1.5 GB", "1024 MB",
  * "1048576")
- * @return uint64_t Number of bytes, or 0 if parsing fails
+ * @return Parsed byte size, or std::nullopt if parsing fails
  */
-[[nodiscard]] inline uint64_t string_to_byte_size(const std::string& str) {
+[[nodiscard]] inline std::optional<uint64_t> try_string_to_byte_size(
+    const std::string& str) {
     if (str.empty()) {
-        return 0;
+        return std::nullopt;
     }
 
     // Create a copy for manipulation
@@ -189,7 +190,7 @@ std::string expected_to_str(const tl::expected<T, ErrorCode>& expected) {
     s.erase(s.find_last_not_of(" \t\r\n") + 1);
 
     if (s.empty()) {
-        return 0;
+        return std::nullopt;
     }
 
     // Handle special case for "infinite"
@@ -204,7 +205,7 @@ std::string expected_to_str(const tl::expected<T, ErrorCode>& expected) {
     try {
         value = std::stod(s, &pos);
     } catch (const std::exception&) {
-        return 0;  // Failed to parse number
+        return std::nullopt;  // Failed to parse number
     }
 
     if (pos >= s.length()) {
@@ -238,8 +239,19 @@ std::string expected_to_str(const tl::expected<T, ErrorCode>& expected) {
         return static_cast<uint64_t>(value);
     } else {
         // Unknown unit
-        return 0;
+        return std::nullopt;
     }
+}
+
+/**
+ * @brief Convert a string representation of size to bytes
+ * @param str String representation of size (e.g., "1.5 GB", "1024 MB",
+ * "1048576")
+ * @return uint64_t Number of bytes, or 0 if parsing fails
+ */
+[[nodiscard]] inline uint64_t string_to_byte_size(const std::string& str) {
+    auto parsed = try_string_to_byte_size(str);
+    return parsed.value_or(0);
 }
 
 /**

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -932,17 +932,6 @@ inline std::string get_config(const ConfigDict &config, const std::string &key,
     return (it != config.end()) ? it->second : default_value;
 }
 
-inline std::string trim_config_value(std::string value) {
-    value.erase(0, value.find_first_not_of(" \t\r\n"));
-    auto last = value.find_last_not_of(" \t\r\n");
-    if (last == std::string::npos) {
-        value.clear();
-    } else {
-        value.erase(last + 1);
-    }
-    return value;
-}
-
 inline std::optional<size_t> get_config_size(const ConfigDict &config,
                                              const std::string &key,
                                              size_t default_value) {
@@ -950,26 +939,14 @@ inline std::optional<size_t> get_config_size(const ConfigDict &config,
     if (it == config.end()) {
         return default_value;
     }
-    const std::string value = trim_config_value(it->second);
-    if (value.empty() || value[0] == '-') {
-        LOG(ERROR) << "Invalid value for config key '" << key
-                   << "': " << it->second;
-        return std::nullopt;
-    }
 
-    auto parsed_size_opt = try_string_to_byte_size(value);
+    auto parsed_size_opt = try_string_to_byte_size(it->second);
     if (!parsed_size_opt.has_value()) {
         LOG(ERROR) << "Invalid size value for config key '" << key
                    << "': " << it->second;
         return std::nullopt;
     }
-    uint64_t parsed_size = parsed_size_opt.value();
-    if (parsed_size > std::numeric_limits<size_t>::max()) {
-        LOG(ERROR) << "Value out of range for config key '" << key
-                   << "': " << it->second;
-        return std::nullopt;
-    }
-    return static_cast<size_t>(parsed_size);
+    return static_cast<size_t>(parsed_size_opt.value());
 }
 }  // namespace
 
@@ -1011,19 +988,19 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     std::string ipc_socket_path =
         get_config(config, CONFIG_KEY_IPC_SOCKET_PATH);
 
-    // Validate size parameters are within acceptable ranges
-    if ((global_segment_size != 0 && global_segment_size < MIN_SEGMENT_SIZE) ||
-        global_segment_size > MAX_SEGMENT_SIZE) {
-        LOG(ERROR) << "Invalid " << CONFIG_KEY_GLOBAL_SEGMENT_SIZE << ": "
-                   << global_segment_size << ", must be 0 or between "
-                   << MIN_SEGMENT_SIZE << " and " << MAX_SEGMENT_SIZE;
-        return tl::unexpected(ErrorCode::INVALID_PARAMS);
-    }
-    if ((local_buffer_size != 0 && local_buffer_size < MIN_SEGMENT_SIZE) ||
-        local_buffer_size > MAX_SEGMENT_SIZE) {
-        LOG(ERROR) << "Invalid " << CONFIG_KEY_LOCAL_BUFFER_SIZE << ": "
-                   << local_buffer_size << ", must be 0 or between "
-                   << MIN_SEGMENT_SIZE << " and " << MAX_SEGMENT_SIZE;
+    // A size of 0 keeps the pure client/server setup semantics.
+    auto validate_size = [](const char *key, size_t value) {
+        if ((value != 0 && value < MIN_SEGMENT_SIZE) ||
+            value > MAX_SEGMENT_SIZE) {
+            LOG(ERROR) << "Invalid " << key << ": " << value
+                       << ", must be 0 or between " << MIN_SEGMENT_SIZE
+                       << " and " << MAX_SEGMENT_SIZE;
+            return false;
+        }
+        return true;
+    };
+    if (!validate_size(CONFIG_KEY_GLOBAL_SEGMENT_SIZE, global_segment_size) ||
+        !validate_size(CONFIG_KEY_LOCAL_BUFFER_SIZE, local_buffer_size)) {
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -932,30 +932,44 @@ inline std::string get_config(const ConfigDict &config, const std::string &key,
     return (it != config.end()) ? it->second : default_value;
 }
 
-inline size_t get_config_size(const ConfigDict &config, const std::string &key,
-                              size_t default_value) {
+inline std::string trim_config_value(std::string value) {
+    value.erase(0, value.find_first_not_of(" \t\r\n"));
+    auto last = value.find_last_not_of(" \t\r\n");
+    if (last == std::string::npos) {
+        value.clear();
+    } else {
+        value.erase(last + 1);
+    }
+    return value;
+}
+
+inline std::optional<size_t> get_config_size(const ConfigDict &config,
+                                             const std::string &key,
+                                             size_t default_value) {
     auto it = config.find(key);
     if (it == config.end()) {
         return default_value;
     }
-    const std::string &value = it->second;
-    // Check for negative numbers (stoull incorrectly parses "-1" as large val)
-    if (!value.empty() && value[0] == '-') {
-        LOG(WARNING) << "Invalid negative value for config key '" << key
-                     << "': " << value << ", using default: " << default_value;
-        return default_value;
+    const std::string value = trim_config_value(it->second);
+    if (value.empty() || value[0] == '-') {
+        LOG(ERROR) << "Invalid value for config key '" << key
+                   << "': " << it->second;
+        return std::nullopt;
     }
-    try {
-        return std::stoull(value);
-    } catch (const std::invalid_argument &e) {
-        LOG(WARNING) << "Invalid non-numeric value for config key '" << key
-                     << "': " << value << ", using default: " << default_value;
-        return default_value;
-    } catch (const std::out_of_range &e) {
-        LOG(WARNING) << "Value out of range for config key '" << key
-                     << "': " << value << ", using default: " << default_value;
-        return default_value;
+
+    auto parsed_size_opt = try_string_to_byte_size(value);
+    if (!parsed_size_opt.has_value()) {
+        LOG(ERROR) << "Invalid size value for config key '" << key
+                   << "': " << it->second;
+        return std::nullopt;
     }
+    uint64_t parsed_size = parsed_size_opt.value();
+    if (parsed_size > std::numeric_limits<size_t>::max()) {
+        LOG(ERROR) << "Value out of range for config key '" << key
+                   << "': " << it->second;
+        return std::nullopt;
+    }
+    return static_cast<size_t>(parsed_size);
 }
 }  // namespace
 
@@ -977,10 +991,18 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     }
 
     // Extract optional parameters with defaults
-    size_t global_segment_size = get_config_size(
+    auto global_segment_size_opt = get_config_size(
         config, CONFIG_KEY_GLOBAL_SEGMENT_SIZE, DEFAULT_GLOBAL_SEGMENT_SIZE);
-    size_t local_buffer_size = get_config_size(
+    if (!global_segment_size_opt.has_value()) {
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    auto local_buffer_size_opt = get_config_size(
         config, CONFIG_KEY_LOCAL_BUFFER_SIZE, DEFAULT_LOCAL_BUFFER_SIZE);
+    if (!local_buffer_size_opt.has_value()) {
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    size_t global_segment_size = global_segment_size_opt.value();
+    size_t local_buffer_size = local_buffer_size_opt.value();
     std::string protocol =
         get_config(config, CONFIG_KEY_PROTOCOL, DEFAULT_PROTOCOL);
     std::string rdma_devices = get_config(config, CONFIG_KEY_RDMA_DEVICES);
@@ -990,17 +1012,17 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         get_config(config, CONFIG_KEY_IPC_SOCKET_PATH);
 
     // Validate size parameters are within acceptable ranges
-    if (global_segment_size < MIN_SEGMENT_SIZE ||
+    if ((global_segment_size != 0 && global_segment_size < MIN_SEGMENT_SIZE) ||
         global_segment_size > MAX_SEGMENT_SIZE) {
         LOG(ERROR) << "Invalid " << CONFIG_KEY_GLOBAL_SEGMENT_SIZE << ": "
-                   << global_segment_size << ", must be between "
+                   << global_segment_size << ", must be 0 or between "
                    << MIN_SEGMENT_SIZE << " and " << MAX_SEGMENT_SIZE;
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
-    if (local_buffer_size < MIN_SEGMENT_SIZE ||
+    if ((local_buffer_size != 0 && local_buffer_size < MIN_SEGMENT_SIZE) ||
         local_buffer_size > MAX_SEGMENT_SIZE) {
         LOG(ERROR) << "Invalid " << CONFIG_KEY_LOCAL_BUFFER_SIZE << ": "
-                   << local_buffer_size << ", must be between "
+                   << local_buffer_size << ", must be 0 or between "
                    << MIN_SEGMENT_SIZE << " and " << MAX_SEGMENT_SIZE;
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -85,6 +85,23 @@ class RealClientTest : public ::testing::Test {
                   0);
     }
 
+    ConfigDict MakeConfigDict(const std::string& local_hostname,
+                              const std::string& global_segment_size,
+                              const std::string& local_buffer_size) const {
+        const std::string rdma_devices = (FLAGS_protocol == std::string("rdma"))
+                                             ? FLAGS_device_name
+                                             : std::string("");
+        ConfigDict config;
+        config[CONFIG_KEY_LOCAL_HOSTNAME] = local_hostname;
+        config[CONFIG_KEY_METADATA_SERVER] = "P2PHANDSHAKE";
+        config[CONFIG_KEY_GLOBAL_SEGMENT_SIZE] = global_segment_size;
+        config[CONFIG_KEY_LOCAL_BUFFER_SIZE] = local_buffer_size;
+        config[CONFIG_KEY_PROTOCOL] = FLAGS_protocol;
+        config[CONFIG_KEY_RDMA_DEVICES] = rdma_devices;
+        config[CONFIG_KEY_MASTER_SERVER_ADDR] = master_address_;
+        return config;
+    }
+
     std::string CreateTempSegmentFile(size_t size) {
         std::string path = "/tmp/mooncake_real_client_segment_XXXXXX";
         int fd = mkstemp(path.data());
@@ -889,22 +906,12 @@ TEST_F(RealClientTest, SetupWithConfigDict) {
     master_address_ = master_.master_address();
     LOG(INFO) << "Started in-proc master at " << master_address_;
 
-    // Setup the client using ConfigDict
-    const std::string rdma_devices = (FLAGS_protocol == std::string("rdma"))
-                                         ? FLAGS_device_name
-                                         : std::string("");
-
     ConfigDict config;
     auto result = py_client_->setup_internal(config);
     ASSERT_FALSE(result.has_value()) << "Setup with empty config should fail";
 
-    config[CONFIG_KEY_LOCAL_HOSTNAME] = "localhost:17813";
-    config[CONFIG_KEY_METADATA_SERVER] = "P2PHANDSHAKE";
-    config[CONFIG_KEY_GLOBAL_SEGMENT_SIZE] = std::to_string(16 * 1024 * 1024);
-    config[CONFIG_KEY_LOCAL_BUFFER_SIZE] = std::to_string(16 * 1024 * 1024);
-    config[CONFIG_KEY_PROTOCOL] = FLAGS_protocol;
-    config[CONFIG_KEY_RDMA_DEVICES] = rdma_devices;
-    config[CONFIG_KEY_MASTER_SERVER_ADDR] = master_address_;
+    config = MakeConfigDict("localhost:17813", std::to_string(16 * 1024 * 1024),
+                            std::to_string(16 * 1024 * 1024));
 
     result = py_client_->setup_internal(config);
     ASSERT_TRUE(result.has_value()) << "Setup with ConfigDict should succeed";
@@ -927,6 +934,56 @@ TEST_F(RealClientTest, SetupWithConfigDict) {
     std::string retrieved_data(static_cast<const char*>(buffer_handle->ptr()),
                                buffer_handle->size());
     EXPECT_EQ(retrieved_data, test_data) << "Retrieved data should match";
+}
+
+TEST_F(RealClientTest, SetupWithConfigDictHumanReadableSizes) {
+    ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder().build()))
+        << "Failed to start in-proc master";
+    master_address_ = master_.master_address();
+
+    ConfigDict config = MakeConfigDict("localhost:17814", "16MB", "16 MB");
+    auto result = py_client_->setup_internal(config);
+    ASSERT_TRUE(result.has_value())
+        << "Setup should accept human-readable size strings";
+}
+
+TEST_F(RealClientTest, SetupWithConfigDictAllowsZeroSizes) {
+    ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder().build()))
+        << "Failed to start in-proc master";
+    master_address_ = master_.master_address();
+
+    ConfigDict config = MakeConfigDict("localhost:17815", "0", "0");
+    auto result = py_client_->setup_internal(config);
+    ASSERT_TRUE(result.has_value())
+        << "Setup should preserve zero-size pure client/server semantics";
+}
+
+TEST_F(RealClientTest, ErrSetupWithInvalidConfigDictSize) {
+    GLogMuter muter;
+    ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder().build()))
+        << "Failed to start in-proc master";
+    master_address_ = master_.master_address();
+
+    struct InvalidSizeCase {
+        const char* local_hostname;
+        const char* global_segment_size;
+        const char* local_buffer_size;
+    };
+
+    const InvalidSizeCase invalid_size_cases[] = {
+        {"localhost:17816", "50%", "16MB"},
+        {"localhost:17817", "16MB", "16XB"},
+    };
+
+    for (const auto& test_case : invalid_size_cases) {
+        ConfigDict config = MakeConfigDict(test_case.local_hostname,
+                                           test_case.global_segment_size,
+                                           test_case.local_buffer_size);
+        auto result = py_client_->setup_internal(config);
+        EXPECT_FALSE(result.has_value())
+            << "Invalid explicit size values should fail instead of being "
+               "partially parsed or silently defaulted";
+    }
 }
 
 TEST_F(RealClientTest, ErrSetupWithInvalidArgument) {

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -973,6 +973,7 @@ TEST_F(RealClientTest, ErrSetupWithInvalidConfigDictSize) {
     const InvalidSizeCase invalid_size_cases[] = {
         {"localhost:17816", "50%", "16MB"},
         {"localhost:17817", "16MB", "16XB"},
+        {"localhost:17818", "-5", "16MB"},
     };
 
     for (const auto& test_case : invalid_size_cases) {

--- a/mooncake-store/tests/utils_test.cpp
+++ b/mooncake-store/tests/utils_test.cpp
@@ -23,6 +23,20 @@ TEST(UtilsTest, ByteSizeToString) {
     EXPECT_EQ(byte_size_to_string(15 * 1024 * 1024 + 44048), "15.04 MB");
 }
 
+TEST(UtilsTest, StringToByteSize) {
+    auto parsed = try_string_to_byte_size("16 MB");
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(parsed.value(), 16ULL * 1024 * 1024);
+
+    parsed = try_string_to_byte_size("0");
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(parsed.value(), 0);
+
+    EXPECT_FALSE(try_string_to_byte_size("-5").has_value());
+    EXPECT_FALSE(try_string_to_byte_size("16XB").has_value());
+    EXPECT_EQ(string_to_byte_size("-5"), 0);
+}
+
 TEST(UtilsTest, StringToBool) {
     EXPECT_EQ(string_to_bool("1"), true);
     EXPECT_EQ(string_to_bool("true"), true);

--- a/mooncake-wheel/tests/test_distributed_object_store.py
+++ b/mooncake-wheel/tests/test_distributed_object_store.py
@@ -38,6 +38,46 @@ def get_client(store, local_buffer_size_param=None):
     if retcode:
         raise RuntimeError(f"Failed to setup store client. Return code: {retcode}")
 
+
+def get_config_dict(global_segment_size, local_buffer_size):
+    """Build a config dictionary for the MooncakeDistributedStore setup wrapper."""
+    return {
+        "local_hostname": os.getenv("LOCAL_HOSTNAME", "localhost"),
+        "metadata_server": os.getenv(
+            "MC_METADATA_SERVER", "http://127.0.0.1:8080/metadata"
+        ),
+        "global_segment_size": global_segment_size,
+        "local_buffer_size": local_buffer_size,
+        "protocol": os.getenv("PROTOCOL", "tcp"),
+        "rdma_devices": os.getenv("DEVICE_NAME", "ibp6s0"),
+        "master_server_addr": os.getenv("MASTER_SERVER", "127.0.0.1:50051"),
+    }
+
+
+class TestConfigDictSetup(unittest.TestCase):
+    """Test configuration-dictionary setup through the Python store wrapper."""
+
+    def test_human_readable_sizes(self):
+        store = MooncakeDistributedStore()
+        self.addCleanup(store.close)
+
+        retcode = store.setup(get_config_dict("16MB", "16 MB"))
+        self.assertEqual(retcode, 0)
+
+        test_data = b"test_config_dict_human_readable_value"
+        key = f"test_config_dict_human_readable_key_{os.getpid()}"
+
+        self.assertEqual(store.put(key, test_data), 0)
+        self.assertEqual(store.get(key), test_data)
+
+    def test_unsupported_percentage_size(self):
+        store = MooncakeDistributedStore()
+        self.addCleanup(store.close)
+
+        retcode = store.setup(get_config_dict("50%", "16MB"))
+        self.assertNotEqual(retcode, 0)
+
+
 class TestZeroLocalBufferSize(unittest.TestCase):
     """Test class for zero local buffer size scenarios."""
     


### PR DESCRIPTION
## Description

Robustify the Store `ConfigDict` setup path for `global_segment_size` and `local_buffer_size`.

This PR keeps the existing numeric setup APIs unchanged and only updates `RealClient::setup_internal(ConfigDict)` to reuse the shared byte-size parser. Direct `store.setup({...})` calls now accept human-readable size strings such as `16MB` and `16 MB`, while explicit unsupported values such as `50%`, unknown units, and negative sizes fail fast with `INVALID_PARAMS`.

This also tightens the shared parser by rejecting negative size strings before conversion, so existing `string_to_byte_size()` callers no longer silently cast values such as `-5` into a huge unsigned integer.

This PR does not change the numeric pybind setup path: `store.setup(host, meta, global_segment_size, local_buffer_size, ...)` still takes `size_t` arguments, so string inputs there are rejected before reaching C++. Higher-level callers such as SGLang that use the numeric setup path still need to parse their own string config before calling Mooncake.

Percentage-based sizes remain out of scope for this PR.

Refs #903

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- `git diff --check`
- `clang-format-20 --dry-run -Werror mooncake-store/include/utils.h mooncake-store/src/real_client.cpp mooncake-store/tests/utils_test.cpp mooncake-store/tests/pybind_client_test.cpp`
- `cmake --build build-issue903 --target utils_test pybind_client_test store mooncake_master -j 32`
- `MC_FORCE_TCP=true ctest --test-dir build-issue903 -R "^(utils_test|pybind_client_test)$" --output-on-failure`
- Real Python e2e on a remote Linux host:
  - `MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 MC_FORCE_TCP=true python3 mooncake-wheel/tests/test_distributed_object_store.py -v`

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `clang-format-20` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.