### PR TITLE
[CP][Store] Add retry logic for auto port binding in client setup (#1328)

### DIFF
--- a/mooncake-store/include/centralized_client_service.h
+++ b/mooncake-store/include/centralized_client_service.h
@@ -41,7 +41,6 @@ class CentralizedClientService
       public std::enable_shared_from_this<CentralizedClientService> {
    public:
     CentralizedClientService(
-        const std::string& local_ip, uint16_t te_port,
         const std::string& metadata_connstring, uint16_t metrics_port = 9003,
         bool enable_metrics_http = true,
         const std::map<std::string, std::string>& labels = {});

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -376,6 +376,9 @@ class ClientService {
     virtual std::string GetHealthStatus() const { return "OK"; }
 
    public:
+    std::string local_endpoint() const {
+        return local_ip_ + ":" + std::to_string(te_port_);
+    }
     /**
      * @brief Gets the local transport endpoint (IP and port).
      * @return The transport endpoint string.
@@ -416,8 +419,7 @@ class ClientService {
     /**
      * @brief Private constructor to enforce creation through Create() method
      */
-    ClientService(const std::string& local_ip, uint16_t te_port,
-                  const std::string& metadata_connstring,
+    ClientService(const std::string& metadata_connstring,
                   uint16_t metrics_port = 9003, bool enable_metrics_http = true,
                   const std::map<std::string, std::string>& labels = {});
 
@@ -449,11 +451,14 @@ class ClientService {
      * @return ErrorCode indicating success or failure.
      */
     ErrorCode InitTransferEngine(
-        const std::string& endpoint, const std::string& metadata_connstring,
-        const std::string& protocol,
+        const std::string& local_ip, uint16_t te_port,
+        const std::string& metadata_connstring, const std::string& protocol,
         const std::optional<std::string>& device_names);
 
    protected:
+    ErrorCode InnerInitTransferEngine(
+        bool auto_discover, const std::string& protocol,
+        const std::optional<std::string>& device_names);
     // Heartbeat-related function
 
     /**
@@ -587,15 +592,13 @@ class ClientService {
     std::shared_ptr<TransferEngine> transfer_engine_;
 
     // Configuration
-    const std::string local_ip_;
-    const uint16_t te_port_;
-    std::string local_endpoint() const {
-        return local_ip_ + ":" + std::to_string(te_port_);
-    }
+    std::string local_ip_;
+    uint16_t te_port_ = 0;
 
     // The segment endpoint that the transfer engine registered with the
     // metadata backend.
     std::string te_endpoint_;
+    std::unique_ptr<AutoPortBinder> port_binder_;
     void initTeEndpoint();
     const std::string& get_te_endpoint() const { return te_endpoint_; }
 

--- a/mooncake-store/include/mutex.h
+++ b/mooncake-store/include/mutex.h
@@ -1,7 +1,6 @@
 #ifndef THREAD_SAFETY_ANALYSIS_MUTEX_H
 #define THREAD_SAFETY_ANALYSIS_MUTEX_H
 
-#include <atomic>
 #include <mutex>
 #include <shared_mutex>
 #include <atomic>

--- a/mooncake-store/include/p2p_client_service.h
+++ b/mooncake-store/include/p2p_client_service.h
@@ -37,8 +37,7 @@ class P2PClientService final : public ClientService {
      * @param enable_metrics_http Whether to enable metrics HTTP server.
      * @param labels Optional labels for client metrics.
      */
-    P2PClientService(const std::string& local_ip, uint16_t te_port,
-                     const std::string& metadata_connstring,
+    P2PClientService(const std::string& metadata_connstring,
                      uint16_t metrics_port = 9003,
                      bool enable_metrics_http = true,
                      const std::map<std::string, std::string>& labels = {});

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -449,12 +449,8 @@ class RealClient : public PyClient {
 
     tl::expected<HeartbeatResponse, ErrorCode> ping(const UUID& client_id);
 
-    std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
-
     std::string protocol;
     std::string device_name;
-    std::string local_ip;
-    uint16_t te_port = 0;
 
     struct MappedShm {
         std::string shm_name;

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -378,9 +378,15 @@ class AutoPortBinder {
 
     int getPort() const { return port_; }
 
+    int rebind();
+
    private:
+    int tryBindPort();
+
     int socket_fd_;
     int port_;
+    int min_port_;
+    int max_port_;
 };
 
 // HTTP utility: simple GET, returns body on 200, otherwise error code

--- a/mooncake-store/src/centralized_client_service.cpp
+++ b/mooncake-store/src/centralized_client_service.cpp
@@ -22,11 +22,10 @@
 namespace mooncake {
 
 CentralizedClientService::CentralizedClientService(
-    const std::string& local_ip, uint16_t te_port,
     const std::string& metadata_connstring, uint16_t metrics_port,
     bool enable_metrics_http, const std::map<std::string, std::string>& labels)
-    : ClientService(local_ip, te_port, metadata_connstring, metrics_port,
-                    enable_metrics_http, labels),
+    : ClientService(metadata_connstring, metrics_port, enable_metrics_http,
+                    labels),
       metrics_(ClientMetric::Create(labels)),
       master_client_(client_id_,
                      metrics_ ? &metrics_->master_client_metric : nullptr),
@@ -148,9 +147,9 @@ ErrorCode CentralizedClientService::Init(
 
     // Initialize transfer engine
     if (config.transfer_engine == nullptr) {
-        transfer_engine_ = std::make_shared<TransferEngine>();
-        err = InitTransferEngine(local_endpoint(), metadata_connstring_,
-                                 config.protocol, config.rdma_devices);
+        err = InitTransferEngine(config.local_ip, config.te_port,
+                                 metadata_connstring_, config.protocol,
+                                 config.rdma_devices);
         if (err != ErrorCode::OK) {
             LOG(ERROR) << "Failed to initialize transfer engine";
             return err;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -46,13 +46,10 @@ size_t ClientService::CalculateSliceSize(std::span<const Slice> slices) {
     return slice_size;
 }
 
-ClientService::ClientService(const std::string& local_ip, uint16_t te_port,
-                             const std::string& metadata_connstring,
+ClientService::ClientService(const std::string& metadata_connstring,
                              uint16_t metrics_port, bool enable_metrics_http,
                              const std::map<std::string, std::string>& labels)
     : client_id_(generate_uuid()),
-      local_ip_(local_ip),
-      te_port_(te_port),
       metadata_connstring_(metadata_connstring),
       metrics_port_(metrics_port),
       enable_metrics_http_(enable_metrics_http) {
@@ -63,8 +60,8 @@ ClientService::ClientService(const std::string& local_ip, uint16_t te_port,
 std::optional<std::shared_ptr<ClientService>> ClientService::Create(
     const CentralizedClientConfig& config) {
     auto client = std::make_shared<CentralizedClientService>(
-        config.local_ip, config.te_port, config.metadata_connstring,
-        config.metrics_port, config.enable_metrics_http, config.labels);
+        config.metadata_connstring, config.metrics_port,
+        config.enable_metrics_http, config.labels);
 
     auto err = client->Init(config);
     if (err != ErrorCode::OK) {
@@ -79,8 +76,8 @@ std::optional<std::shared_ptr<ClientService>> ClientService::Create(
 std::optional<std::shared_ptr<ClientService>> ClientService::Create(
     const P2PClientConfig& config) {
     auto client = std::make_shared<P2PClientService>(
-        config.local_ip, config.te_port, config.metadata_connstring,
-        config.metrics_port, config.enable_metrics_http, config.labels);
+        config.metadata_connstring, config.metrics_port,
+        config.enable_metrics_http, config.labels);
 
     auto err = client->Init(config);
     if (err != ErrorCode::OK) {
@@ -265,14 +262,9 @@ tl::expected<void, ErrorCode> ClientService::CheckRegisterMemoryParams(
 }
 
 ErrorCode ClientService::InitTransferEngine(
-    const std::string& endpoint, const std::string& metadata_connstring,
-    const std::string& protocol,
+    const std::string& local_ip, uint16_t te_port,
+    const std::string& metadata_connstring, const std::string& protocol,
     const std::optional<std::string>& device_names) {
-    if (!transfer_engine_) {
-        LOG(ERROR) << "Transfer engine pointer is null";
-        return ErrorCode::INVALID_PARAMS;
-    }
-
     // get auto_discover and filters from env
     std::optional<bool> env_auto_discover = get_auto_discover();
     bool auto_discover = false;
@@ -288,15 +280,7 @@ ErrorCode ClientService::InitTransferEngine(
             auto_discover = true;
         }
     }
-    transfer_engine_->setAutoDiscover(auto_discover);
-
-    // Honor filters when auto-discovery is enabled; otherwise warn once
-    if (auto_discover) {
-        LOG(INFO) << "Transfer engine auto discovery is enabled for protocol: "
-                  << protocol;
-        auto filters = get_auto_discover_filters();
-        transfer_engine_->setWhitelistFilters(std::move(filters));
-    } else {
+    if (!auto_discover) {
         const char* env_filters = std::getenv("MC_MS_FILTERS");
         if (env_filters && *env_filters != '\0') {
             LOG(WARNING)
@@ -312,9 +296,72 @@ ErrorCode ClientService::InitTransferEngine(
             globalConfig().ascend_use_fabric_mem = true;
         }
     }
-    auto [hostname, port] = parseHostNameWithPort(endpoint);
-    int rc =
-        transfer_engine_->init(metadata_connstring, endpoint, hostname, port);
+
+    local_ip_ = local_ip;
+    te_port_ = te_port;
+    const bool is_auto_port = (te_port_ == 0);
+    ErrorCode err = ErrorCode::OK;
+
+    const int kMaxRetries =
+        is_auto_port ? GetEnvOr<int>("MC_STORE_CLIENT_SETUP_RETRIES", 20) : 1;
+
+    for (int attempt = 0; attempt < kMaxRetries; ++attempt) {
+        if (attempt > 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            int new_port = port_binder_->rebind();
+            if (new_port < 0) {
+                LOG(WARNING)
+                    << "Failed to rebind port"
+                    << ", port=" << std::to_string(new_port)
+                    << ", retry=" << (attempt + 1) << "/" << kMaxRetries;
+                continue;
+            }
+            te_port_ = static_cast<uint16_t>(new_port);
+        } else if (is_auto_port) {
+            port_binder_ = std::make_unique<AutoPortBinder>();
+            int new_port = port_binder_->getPort();
+            if (new_port < 0) {
+                LOG(ERROR) << "Failed to bind available port"
+                           << ", port=" << std::to_string(new_port);
+                continue;
+            }
+            te_port_ = static_cast<uint16_t>(new_port);
+        }
+
+        err = InnerInitTransferEngine(auto_discover, protocol, device_names);
+        if (err == ErrorCode::OK) {
+            if (attempt > 0) {
+                LOG(INFO) << "TE init succeeded on port " << te_port_
+                          << " after " << (attempt + 1) << " attempt(s)";
+            }
+            return ErrorCode::OK;
+        }
+
+        if (is_auto_port) {
+            LOG(WARNING) << "TE init failed on port " << te_port_ << ", retry "
+                         << (attempt + 1) << "/" << kMaxRetries;
+        }
+    }
+
+    LOG(ERROR) << "Failed to initialize transfer engine"
+               << (is_auto_port ? " after all retries" : "") << ", err=" << err;
+    return err;
+}
+
+ErrorCode ClientService::InnerInitTransferEngine(
+    bool auto_discover, const std::string& protocol,
+    const std::optional<std::string>& device_names) {
+    transfer_engine_ = std::make_shared<TransferEngine>();
+    transfer_engine_->setAutoDiscover(auto_discover);
+    if (auto_discover) {
+        LOG(INFO) << "Transfer engine auto discovery is enabled for protocol: "
+                  << protocol;
+        auto filters = get_auto_discover_filters();
+        transfer_engine_->setWhitelistFilters(std::move(filters));
+    }
+
+    int rc = transfer_engine_->init(metadata_connstring_, local_endpoint(),
+                                    local_ip_, te_port_);
     if (rc != 0) {
         LOG(ERROR) << "Failed to initialize transfer engine, rc=" << rc;
         return ErrorCode::INTERNAL_ERROR;

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -1779,6 +1779,13 @@ std::string MasterMetricManager::get_summary_string() {
        << batch_replica_clear_requests << ", Item="
        << batch_replica_clear_items - batch_replica_clear_failed_items << "/"
        << batch_replica_clear_items << "), ";
+    ss << "RemoveReplica:(Req="
+       << batch_remove_replica_requests - batch_remove_replica_fails -
+              batch_remove_replica_partial_successes
+       << "/" << batch_remove_replica_partial_successes << "/"
+       << batch_remove_replica_requests << ", Item="
+       << batch_remove_replica_items - batch_remove_replica_failed_items << "/"
+       << batch_remove_replica_items << "), ";
 
     ss << "CreateMoveTask:(Req=" << create_move_tasks - create_move_task_fails
        << "/" << create_move_tasks << "), ";

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -22,11 +22,10 @@ namespace mooncake {
 // ============================================================================
 
 P2PClientService::P2PClientService(
-    const std::string& local_ip, uint16_t te_port,
     const std::string& metadata_connstring, uint16_t metrics_port,
     bool enable_metrics_http, const std::map<std::string, std::string>& labels)
-    : ClientService(local_ip, te_port, metadata_connstring, metrics_port,
-                    enable_metrics_http, labels),
+    : ClientService(metadata_connstring, metrics_port, enable_metrics_http,
+                    labels),
       metrics_(P2PClientMetric::Create(labels)),
       master_client_(client_id_,
                      metrics_ ? &metrics_->master_client_metric : nullptr) {}
@@ -139,9 +138,9 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
 
     // 5. Initialize transfer engine (local operation, no master dependency)
     if (config.transfer_engine == nullptr) {
-        transfer_engine_ = std::make_shared<TransferEngine>();
-        err = InitTransferEngine(local_endpoint(), metadata_connstring_,
-                                 config.protocol, config.rdma_devices);
+        err = InitTransferEngine(config.local_ip, config.te_port,
+                                 metadata_connstring_, config.protocol,
+                                 config.rdma_devices);
         if (err != ErrorCode::OK) {
             LOG(ERROR) << "Failed to initialize transfer engine";
             return err;

--- a/mooncake-store/src/p2p_rpc_service.cpp
+++ b/mooncake-store/src/p2p_rpc_service.cpp
@@ -141,6 +141,13 @@ BatchSyncReplicaResponse WrappedP2PMasterService::BatchSyncReplica(
         if (ec != ErrorCode::OK) remove_failures++;
     }
 
+    MasterMetricManager::instance().inc_add_replica_requests(
+        req.add_keys.size());
+    MasterMetricManager::instance().inc_add_replica_failures(add_failures);
+    MasterMetricManager::instance().inc_remove_replica_requests(
+        req.remove_keys.size());
+    MasterMetricManager::instance().inc_remove_replica_failures(
+        remove_failures);
     timer.LogResponse("add_failures=", add_failures,
                       ", remove_failures=", remove_failures);
     return response;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -185,19 +185,6 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(ConfigT& config) {
         (std::getenv("MC_STORE_USE_HUGEPAGE") != nullptr) &&
         this->protocol != "ascend";
 
-    if (config.te_port == 0) {
-        // Create port binder to hold a port
-        port_binder_ = std::make_unique<AutoPortBinder>();
-        int port = port_binder_->getPort();
-        if (port < 0) {
-            LOG(ERROR) << "Failed to bind available port";
-            return tl::unexpected(ErrorCode::INVALID_PARAMS);
-        }
-        config.te_port = static_cast<uint16_t>(port);
-    }
-    this->local_ip = config.local_ip;
-    this->te_port = config.te_port;
-
     auto client_opt = mooncake::ClientService::Create(config);
     if (!client_opt) {
         LOG(ERROR) << "Failed to create client";
@@ -288,9 +275,6 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
     // Reset all resources
     client_service_.reset();
     client_buffer_allocator_.reset();
-    port_binder_.reset();
-    local_ip = "";
-    te_port = 0;
     device_name = "";
     protocol = "";
     std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);
@@ -1007,7 +991,7 @@ int64_t RealClient::get_into(const std::string& key, void* buffer, size_t size,
 }
 
 std::string RealClient::get_hostname() const {
-    return local_ip + ":" + std::to_string(te_port);
+    return client_service_ ? client_service_->local_endpoint() : "";
 }
 
 std::vector<int> RealClient::batch_put_from(

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -41,10 +41,14 @@ bool isPortAvailable(int port) {
 
 // AutoPortBinder implementation
 AutoPortBinder::AutoPortBinder(int min_port, int max_port)
-    : socket_fd_(-1), port_(-1) {
+    : socket_fd_(-1), port_(-1), min_port_(min_port), max_port_(max_port) {
+    tryBindPort();
+}
+
+int AutoPortBinder::tryBindPort() {
     static std::random_device rand_gen;
     std::mt19937 gen(rand_gen());
-    std::uniform_int_distribution<> rand_dist(min_port, max_port);
+    std::uniform_int_distribution<> rand_dist(min_port_, max_port_);
 
     for (int attempt = 0; attempt < 20; ++attempt) {
         int port = rand_dist(gen);
@@ -59,12 +63,22 @@ AutoPortBinder::AutoPortBinder(int min_port, int max_port)
 
         if (bind(socket_fd_, (sockaddr *)&addr, sizeof(addr)) == 0) {
             port_ = port;
-            break;
+            return port;
         } else {
             close(socket_fd_);
             socket_fd_ = -1;
         }
     }
+    return -1;
+}
+
+int AutoPortBinder::rebind() {
+    if (socket_fd_ >= 0) {
+        close(socket_fd_);
+        socket_fd_ = -1;
+    }
+    port_ = -1;
+    return tryBindPort();
 }
 
 AutoPortBinder::~AutoPortBinder() {

--- a/mooncake-store/tests/ha_integration_test.cpp
+++ b/mooncake-store/tests/ha_integration_test.cpp
@@ -62,8 +62,8 @@ class HAIntegrationTest : public ::testing::Test {
             /*labels=*/{}, async_sender_thread_count);
 
         auto client = std::make_shared<P2PClientService>(
-            config.local_ip, config.te_port, config.metadata_connstring,
-            config.metrics_port, config.enable_metrics_http, config.labels);
+            config.metadata_connstring, config.metrics_port,
+            config.enable_metrics_http, config.labels);
 
         auto err = client->Init(config);
         EXPECT_EQ(err, ErrorCode::OK)

--- a/mooncake-store/tests/p2p_client_integration_test.cpp
+++ b/mooncake-store/tests/p2p_client_integration_test.cpp
@@ -49,8 +49,8 @@ class P2PClientIntegrationTest : public ::testing::Test {
         }
 
         auto client = std::make_shared<P2PClientService>(
-            config.local_ip, config.te_port, config.metadata_connstring,
-            config.metrics_port, config.enable_metrics_http, config.labels);
+            config.metadata_connstring, config.metrics_port,
+            config.enable_metrics_http, config.labels);
 
         auto err = client->Init(config);
         EXPECT_EQ(err, ErrorCode::OK)


### PR DESCRIPTION
## Description

1. cherry-pick (refactor) the #1328 PR
2. fix some compile warning

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
