### PR TITLE
[Store] rebuild offset-allocator metadata on restart

### DIFF
--- a/docs/source/design/ssd-offload.md
+++ b/docs/source/design/ssd-offload.md
@@ -148,7 +148,7 @@ Each object is stored as an individual file. The file path is derived from the k
 
 ### OffsetAllocatorStorageBackend
 
-A single pre-allocated file (`kv_cache.data`) is shared by all objects. Space within the file is managed by an `OffsetAllocator`. Metadata is sharded across 1024 independent maps to reduce lock contention under high concurrency. Records follow the layout `[key_len: u32 | value_len: u32 | key | value]`.
+A single pre-allocated file (`kv_cache.data`) is shared by all objects. Space within the file is managed by an `OffsetAllocator`. Metadata is sharded across 1024 independent maps to reduce lock contention under high concurrency. Records follow the layout `[key_len: u32 | value_len: u32 | key | value]`. Restart recovery persists generation-scoped allocator/index snapshots plus a manifest (`kv_cache.allocator.<generation>`, `kv_cache.index.<generation>`, `kv_cache.manifest`) next to the data file and rebuilds in-memory metadata from them on startup.
 
 ---
 
@@ -242,6 +242,6 @@ To prevent `io_uring`'s `FOLL_LONGTERM` page pinning from failing on systems wit
 
 ## Metadata Recovery on Restart
 
-On startup, `FileStorage::Init` calls `StorageBackend::ScanMeta`, which reads on-disk metadata and invokes a callback for each discovered object. The callback calls `MasterClient::NotifyOffloadSuccess` to re-register the objects with the master. This restores the full disk-replica view without any application-level intervention for the backends that preserve restart metadata, namely `BucketStorageBackend` and the file-per-key backend.
+On startup, `FileStorage::Init` calls `StorageBackend::ScanMeta`, which reports each discovered object through a callback. The callback calls `MasterClient::NotifyOffloadSuccess` to re-register the objects with the master. This restores the full disk-replica view without any application-level intervention for backends that preserve restart metadata, including `BucketStorageBackend`, the file-per-key backend, and `OffsetAllocatorStorageBackend`. For `OffsetAllocatorStorageBackend`, `ScanMeta` iterates the in-memory map rebuilt earlier from recovery snapshots rather than re-reading object metadata from the data file.
 
-`OffsetAllocatorStorageBackend` is the exception. It truncates its pre-allocated data file during initialization and clears its in-memory metadata, so previously offloaded objects are not recoverable after a real client restart.
+For `OffsetAllocatorStorageBackend`, restart recovery depends on generation-scoped allocator/index snapshots plus `kv_cache.manifest`. Startup fails fast if manifest-referenced snapshot deserialization fails, if persisted allocation state does not match the allocator snapshot, if recovery snapshot files exist without a manifest, or if the backing `kv_cache.data` file is missing/truncated relative to the configured capacity.

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1182,6 +1182,8 @@ class MasterService {
      */
     tl::expected<void, ErrorCode> PushPromotionQueue(const std::string& key,
                                                      Replica& source_replica);
+    void ClearPromotionQueueEntry(const UUID& client_id,
+                                  const std::string& key);
 
     /**
      * @brief Helper invoked from GetReplicaList when an only-LOCAL_DISK key is
@@ -1192,6 +1194,14 @@ class MasterService {
      * GetReplicaList's RO accessor has been released.
      */
     void TryPushPromotionQueue(const std::string& key);
+
+    [[nodiscard]] bool IsPromotionTaskExpired(
+        const PromotionTask& task,
+        const std::chrono::system_clock::time_point& now) const;
+    void CleanupPromotionTask(ObjectMetadata* metadata,
+                              MetadataShardAccessorRW& shard,
+                              const std::string& key, const PromotionTask& task)
+        NO_THREAD_SAFETY_ANALYSIS;
 
     // Erase any in-flight PromotionTask for `key` and decrement the
     // cluster-wide in-flight counter. Safe no-op if no task exists.

--- a/mooncake-store/include/offset_allocator/offset_allocator.hpp
+++ b/mooncake-store/include/offset_allocator/offset_allocator.hpp
@@ -42,12 +42,20 @@ struct OffsetAllocation {
     bool isNoSpace() const { return offset == NO_SPACE; }
 
     friend class __Allocator;
+    friend class OffsetAllocator;
     friend class Serializer<OffsetAllocationHandle>;
 };
 
 struct OffsetAllocStorageReport {
     uint64_t totalFreeSpace;
     uint64_t largestFreeRegion;
+};
+
+struct PersistedAllocationState {
+    uint32 allocation_offset;
+    NodeIndex allocation_metadata;
+    uint64_t real_base;
+    uint64_t requested_size;
 };
 
 struct OffsetAllocStorageReportFull {
@@ -106,6 +114,7 @@ class OffsetAllocationHandle {
     uint64_t requested_size;
 
     friend class OffsetAllocatorTest;  // for unit tests
+    friend class OffsetAllocator;
     friend class Serializer<OffsetAllocationHandle>;
 };
 
@@ -167,6 +176,15 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
     // Get comprehensive metrics including fragmentation analysis (thread-safe)
     [[nodiscard]]
     OffsetAllocatorMetrics get_metrics() const;
+
+    [[nodiscard]] PersistedAllocationState GetPersistedAllocationState(
+        const OffsetAllocationHandle& handle) const;
+
+    [[nodiscard]] OffsetAllocationHandle RestoreAllocationHandle(
+        const PersistedAllocationState& state);
+
+    [[nodiscard]] bool ValidatePersistedAllocationState(
+        const PersistedAllocationState& state) const;
 
     // Serialize the allocator with serializer.
     template <typename T>

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -3,6 +3,7 @@
 #include <glog/logging.h>
 
 #include <atomic>
+#include <cstdint>
 #include <filesystem>
 #include <map>
 #include <memory>
@@ -1133,6 +1134,38 @@ class OffsetAllocatorStorageBackend : public StorageBackendInterface {
     // alive until all readers release their references
     using AllocationPtr = std::shared_ptr<RefCountedAllocationHandle>;
 
+    struct PersistedObjectEntry {
+        std::string key;
+        uint64_t offset;
+        uint32_t total_size;
+        uint32_t value_size;
+        uint32_t allocation_offset;
+        uint32_t allocation_metadata;
+        uint64_t allocation_real_base;
+        uint64_t allocation_requested_size;
+    };
+
+    struct PersistedSnapshot {
+        uint32_t version = 1;
+        uint64_t capacity = 0;
+        int64_t total_size = 0;
+        int64_t total_keys = 0;
+        std::vector<PersistedObjectEntry> entries;
+        std::vector<offset_allocator::PersistedAllocationState>
+            stale_allocations;
+    };
+
+    struct RecoveryManifest {
+        uint32_t version = 1;
+        uint64_t generation = 0;
+    };
+    YLT_REFL(PersistedObjectEntry, key, offset, total_size, value_size,
+             allocation_offset, allocation_metadata, allocation_real_base,
+             allocation_requested_size);
+    YLT_REFL(PersistedSnapshot, version, capacity, total_size, total_keys,
+             entries, stale_allocations);
+    YLT_REFL(RecoveryManifest, version, generation);
+
     // Metadata entry for a stored object. Protected by stripe lock for the key.
     struct ObjectEntry {
         // Byte offset in data file where record is stored
@@ -1144,18 +1177,25 @@ class OffsetAllocatorStorageBackend : public StorageBackendInterface {
         // Value size only (excluding header and key)
         uint32_t value_size;
 
+        offset_allocator::PersistedAllocationState allocation_state;
+
         // Refcounted handle keeps physical extent alive during reads
         AllocationPtr allocation;
         ObjectEntry(uint64_t off, uint32_t total, uint32_t val,
+                    offset_allocator::PersistedAllocationState persisted_state,
                     AllocationPtr alloc_ptr)
             : offset(off),
               total_size(total),
               value_size(val),
+              allocation_state(std::move(persisted_state)),
               allocation(std::move(alloc_ptr)) {}
     };
 
     // Returns full path to data file: {storage_path_}/kv_cache.data
     std::string GetDataFilePath() const;
+    std::string GetRecoveryManifestPath() const;
+    std::string GetAllocatorSnapshotPath(uint64_t generation) const;
+    std::string GetIndexSnapshotPath(uint64_t generation) const;
 
     static constexpr size_t kNumShards =
         1024;  // Number of shards (must be power of 2 for bitwise optimization)
@@ -1215,9 +1255,53 @@ class OffsetAllocatorStorageBackend : public StorageBackendInterface {
     // counting)
     std::atomic<int64_t> total_keys_{0};
 
+    tl::expected<void, ErrorCode> PersistRecoverySnapshots(
+        const PersistedSnapshot& snapshot, uint64_t generation);
+    tl::expected<void, ErrorCode> PersistAllocatorSnapshot(
+        const std::shared_ptr<offset_allocator::OffsetAllocator>& allocator,
+        uint64_t generation) const;
+    tl::expected<void, ErrorCode> PersistIndexSnapshot(
+        const PersistedSnapshot& snapshot, uint64_t generation) const;
+    tl::expected<RecoveryManifest, ErrorCode> LoadRecoveryManifest() const;
+    tl::expected<std::shared_ptr<offset_allocator::OffsetAllocator>, ErrorCode>
+    LoadAllocatorSnapshot(uint64_t generation) const;
+    tl::expected<PersistedSnapshot, ErrorCode> LoadIndexSnapshot(
+        uint64_t generation) const;
+    tl::expected<void, ErrorCode> LoadRecoverySnapshots();
+    tl::expected<void, ErrorCode> ValidateSnapshot(
+        const PersistedSnapshot& snapshot) const;
+    tl::expected<void, ErrorCode> WriteFileAtomically(
+        const std::string& path,
+        const std::vector<SerializedByte>& bytes) const;
+    tl::expected<std::vector<SerializedByte>, ErrorCode> ReadFileBytes(
+        const std::string& path) const;
+    tl::expected<void, ErrorCode> RebuildInMemoryState(
+        const PersistedSnapshot& snapshot);
+    void ClearInMemoryState();
+    void ResetRecoverySnapshotState();
+    void SetRecoverySnapshotState(const PersistedSnapshot& snapshot);
+    PersistedObjectEntry BuildPersistedObjectEntry(
+        const std::string& key, const ObjectEntry& entry) const;
+    static offset_allocator::PersistedAllocationState ToAllocationState(
+        const PersistedObjectEntry& entry);
+    void UpsertRecoverySnapshotEntry(const PersistedObjectEntry& entry,
+                                     int64_t size_delta, bool is_new_key);
+    void RemoveRecoverySnapshotEntry(const std::string& key, int64_t size_delta,
+                                     bool was_new_key);
+    void CleanupObsoleteRecoverySnapshots(uint64_t live_generation) const;
+    static constexpr uint32_t kSnapshotVersion = 1;
+    static constexpr uint32_t kManifestVersion = 1;
+
     // Test-only: Predicate to determine which keys should fail in BatchOffload.
     // Used for deterministic testing of partial success behavior.
     std::function<bool(const std::string& key)> test_failure_predicate_;
+
+    std::string recovery_manifest_path_;
+    std::atomic<uint64_t> next_snapshot_generation_{1};
+    mutable SharedMutex recovery_state_mutex_;
+    mutable Mutex recovery_snapshot_io_mutex_;
+    PersistedSnapshot recovery_snapshot_state_;
+    std::unordered_map<std::string, size_t> recovery_snapshot_index_;
 };
 
 tl::expected<std::shared_ptr<StorageBackendInterface>, ErrorCode>

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2821,6 +2821,44 @@ tl::expected<void, ErrorCode> MasterService::PushPromotionQueue(
     return {};
 }
 
+void MasterService::ClearPromotionQueueEntry(const UUID& client_id,
+                                             const std::string& key) {
+    ScopedLocalDiskSegmentAccess local_disk_segment_access =
+        segment_manager_.getLocalDiskSegmentAccess();
+    auto& client_local_disk_segment =
+        local_disk_segment_access.getClientLocalDiskSegment();
+    auto it = client_local_disk_segment.find(client_id);
+    if (it == client_local_disk_segment.end()) {
+        return;
+    }
+    MutexLocker locker(&it->second->offloading_mutex_);
+    it->second->promotion_objects.erase(key);
+}
+
+bool MasterService::IsPromotionTaskExpired(
+    const PromotionTask& task,
+    const std::chrono::system_clock::time_point& now) const {
+    return task.start_time + put_start_release_timeout_sec_ <= now;
+}
+
+void MasterService::CleanupPromotionTask(ObjectMetadata* metadata,
+                                         MetadataShardAccessorRW& shard,
+                                         const std::string& key,
+                                         const PromotionTask& task) {
+    if (metadata != nullptr) {
+        auto* source = metadata->GetReplicaByID(task.source_id);
+        if (source != nullptr) {
+            source->dec_refcnt();
+        }
+        if (task.alloc_id != 0) {
+            metadata->EraseReplicaByID(task.alloc_id);
+        }
+    }
+    shard->promotion_tasks.erase(key);
+    promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+    ClearPromotionQueueEntry(task.holder_id, key);
+}
+
 void MasterService::TryPushPromotionQueue(const std::string& key) {
     if (!promotion_on_hit_ || !promotion_sketch_) {
         return;
@@ -2974,6 +3012,13 @@ auto MasterService::PromotionAllocStart(
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
     }
 
+    const auto now = std::chrono::system_clock::now();
+    if (IsPromotionTaskExpired(task_it->second, now)) {
+        const PromotionTask expired_task = task_it->second;
+        CleanupPromotionTask(&metadata, shard, key, expired_task);
+        return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    }
+
     // Holder-only gate (see PromotionTask::holder_id doc).
     if (task_it->second.holder_id != client_id) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -3061,6 +3106,13 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
     }
 
+    const auto now = std::chrono::system_clock::now();
+    if (IsPromotionTaskExpired(task_it->second, now)) {
+        const PromotionTask expired_task = task_it->second;
+        CleanupPromotionTask(&metadata, shard, key, expired_task);
+        return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    }
+
     // Holder-only gate (see PromotionTask::holder_id doc).
     if (task_it->second.holder_id != client_id) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -3084,17 +3136,7 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
 
     // Erase the per-client promotion_objects entry (best-effort; the
     // heartbeat may have already drained it).
-    {
-        ScopedLocalDiskSegmentAccess local_disk_segment_access =
-            segment_manager_.getLocalDiskSegmentAccess();
-        auto& client_local_disk_segment =
-            local_disk_segment_access.getClientLocalDiskSegment();
-        auto it = client_local_disk_segment.find(client_id);
-        if (it != client_local_disk_segment.end()) {
-            MutexLocker locker(&it->second->offloading_mutex_);
-            it->second->promotion_objects.erase(key);
-        }
-    }
+    ClearPromotionQueueEntry(client_id, key);
 
     if (!committed) {
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
@@ -3122,6 +3164,13 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
         return {};
     }
 
+    const auto now = std::chrono::system_clock::now();
+    if (IsPromotionTaskExpired(task_it->second, now)) {
+        const PromotionTask expired_task = task_it->second;
+        CleanupPromotionTask(&metadata, shard, key, expired_task);
+        return {};
+    }
+
     // Holder-only gate (see PromotionTask::holder_id doc).
     if (task_it->second.holder_id != client_id) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -3142,17 +3191,7 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
     // Clear the holder's per-client promotion_objects entry. Same
     // best-effort cleanup pattern as NotifyPromotionSuccess — the
     // heartbeat may have already drained it.
-    {
-        ScopedLocalDiskSegmentAccess local_disk_segment_access =
-            segment_manager_.getLocalDiskSegmentAccess();
-        auto& client_local_disk_segment =
-            local_disk_segment_access.getClientLocalDiskSegment();
-        auto it = client_local_disk_segment.find(client_id);
-        if (it != client_local_disk_segment.end()) {
-            MutexLocker locker(&it->second->offloading_mutex_);
-            it->second->promotion_objects.erase(key);
-        }
-    }
+    ClearPromotionQueueEntry(client_id, key);
 
     return {};
 }
@@ -3363,26 +3402,19 @@ void MasterService::DiscardExpiredProcessingReplicas(
     // return REPLICA_IS_NOT_READY since the task entry is gone).
     for (auto task_it = shard->promotion_tasks.begin();
          task_it != shard->promotion_tasks.end();) {
-        const auto ttl =
-            task_it->second.start_time + put_start_release_timeout_sec_;
-        if (ttl > now) {
-            task_it++;
+        if (!IsPromotionTaskExpired(task_it->second, now)) {
+            ++task_it;
             continue;
         }
-        auto metadata_it = shard->metadata.find(task_it->first);
-        if (metadata_it != shard->metadata.end()) {
-            auto source =
-                metadata_it->second.GetReplicaByID(task_it->second.source_id);
-            if (source != nullptr) {
-                source->dec_refcnt();
-            }
-            if (task_it->second.alloc_id != 0) {
-                metadata_it->second.EraseReplicaByID(task_it->second.alloc_id);
-            }
-        }
-        LOG(WARNING) << "Promotion task expired for key: " << task_it->first;
-        task_it = shard->promotion_tasks.erase(task_it);
-        promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+        const std::string expired_key = task_it->first;
+        const PromotionTask expired_task = task_it->second;
+        auto metadata_it = shard->metadata.find(expired_key);
+        ObjectMetadata* metadata = metadata_it != shard->metadata.end()
+                                       ? &metadata_it->second
+                                       : nullptr;
+        ++task_it;
+        LOG(WARNING) << "Promotion task expired for key: " << expired_key;
+        CleanupPromotionTask(metadata, shard, expired_key, expired_task);
     }
 
     if (!discarded_replicas.empty()) {

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -652,6 +652,51 @@ OffsetAllocatorMetrics OffsetAllocator::get_metrics() const {
     return get_metrics_internal();
 }
 
+PersistedAllocationState OffsetAllocator::GetPersistedAllocationState(
+    const OffsetAllocationHandle& handle) const {
+    return PersistedAllocationState{
+        .allocation_offset =
+            static_cast<uint32_t>(handle.m_allocation.getOffset()),
+        .allocation_metadata = handle.m_allocation.metadata,
+        .real_base = handle.real_base,
+        .requested_size = handle.requested_size,
+    };
+}
+
+OffsetAllocationHandle OffsetAllocator::RestoreAllocationHandle(
+    const PersistedAllocationState& state) {
+    return OffsetAllocationHandle(
+        shared_from_this(),
+        OffsetAllocation(state.allocation_offset, state.allocation_metadata),
+        state.real_base, state.requested_size);
+}
+
+bool OffsetAllocator::ValidatePersistedAllocationState(
+    const PersistedAllocationState& state) const {
+    if (state.requested_size == 0) {
+        return false;
+    }
+
+    MutexLocker guard(&m_mutex);
+    if (!m_allocator) {
+        return false;
+    }
+
+    OffsetAllocation allocation(state.allocation_offset,
+                                state.allocation_metadata);
+    uint64_t allocated_size =
+        static_cast<uint64_t>(m_allocator->allocationSize(allocation))
+        << m_multiplier_bits;
+    if (allocated_size == 0 || state.requested_size > allocated_size) {
+        return false;
+    }
+
+    uint64_t expected_base =
+        m_base +
+        (static_cast<uint64_t>(state.allocation_offset) << m_multiplier_bits);
+    return state.real_base == expected_base;
+}
+
 void OffsetAllocator::freeAllocation(const OffsetAllocation& allocation,
                                      uint64_t size) {
     MutexLocker lock(&m_mutex);

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -13,16 +13,77 @@
 #include <vector>
 #include <algorithm>
 #include <chrono>
+#include <system_error>
 #include <unordered_set>
 
+#include <ylt/struct_pack.hpp>
 #include <ylt/struct_pb.hpp>
 
 #include "mutex.h"
+#include "serializer.h"
 #include "utils.h"
 
 #include <ylt/util/tl/expected.hpp>
 
 namespace mooncake {
+namespace {
+
+constexpr std::string_view kRecoveryManifestFilename = "kv_cache.manifest";
+constexpr std::string_view kAllocatorSnapshotPrefix = "kv_cache.allocator.";
+constexpr std::string_view kIndexSnapshotPrefix = "kv_cache.index.";
+
+struct FdGuard {
+    int fd;
+    explicit FdGuard(int fd) : fd(fd) {}
+    ~FdGuard() {
+        if (fd >= 0) close(fd);
+    }
+    int release() {
+        int ret = fd;
+        fd = -1;
+        return ret;
+    }
+    int get() const { return fd; }
+};
+
+std::string BuildRecoverySnapshotPath(const std::string& storage_path,
+                                      std::string_view prefix,
+                                      uint64_t generation) {
+    return (std::filesystem::path(storage_path) /
+            (std::string(prefix) + std::to_string(generation)))
+        .string();
+}
+
+struct AllocationStateKey {
+    uint32_t allocation_offset;
+    uint32_t allocation_metadata;
+    uint64_t real_base;
+    uint64_t requested_size;
+
+    bool operator==(const AllocationStateKey& other) const = default;
+};
+
+AllocationStateKey MakeAllocationStateKey(
+    const offset_allocator::PersistedAllocationState& state) {
+    return AllocationStateKey{state.allocation_offset,
+                              state.allocation_metadata, state.real_base,
+                              state.requested_size};
+}
+
+struct AllocationStateKeyHash {
+    size_t operator()(const AllocationStateKey& key) const {
+        size_t seed = std::hash<uint32_t>{}(key.allocation_offset);
+        seed ^= std::hash<uint32_t>{}(key.allocation_metadata) + 0x9e3779b9 +
+                (seed << 6) + (seed >> 2);
+        seed ^= std::hash<uint64_t>{}(key.real_base) + 0x9e3779b9 +
+                (seed << 6) + (seed >> 2);
+        seed ^= std::hash<uint64_t>{}(key.requested_size) + 0x9e3779b9 +
+                (seed << 6) + (seed >> 2);
+        return seed;
+    }
+};
+
+}  // namespace
 
 bool FilePerKeyConfig::Validate() const {
     if (fsdir.empty()) {
@@ -2658,6 +2719,560 @@ std::string OffsetAllocatorStorageBackend::GetDataFilePath() const {
     return (std::filesystem::path(storage_path_) / "kv_cache.data").string();
 }
 
+std::string OffsetAllocatorStorageBackend::GetRecoveryManifestPath() const {
+    return (std::filesystem::path(storage_path_) / kRecoveryManifestFilename)
+        .string();
+}
+
+std::string OffsetAllocatorStorageBackend::GetAllocatorSnapshotPath(
+    uint64_t generation) const {
+    return BuildRecoverySnapshotPath(storage_path_, kAllocatorSnapshotPrefix,
+                                     generation);
+}
+
+std::string OffsetAllocatorStorageBackend::GetIndexSnapshotPath(
+    uint64_t generation) const {
+    return BuildRecoverySnapshotPath(storage_path_, kIndexSnapshotPrefix,
+                                     generation);
+}
+
+tl::expected<void, ErrorCode>
+OffsetAllocatorStorageBackend::WriteFileAtomically(
+    const std::string& path, const std::vector<SerializedByte>& bytes) const {
+    const std::string tmp_path = path + ".tmp";
+    unlink(tmp_path.c_str());
+    int fd = open(tmp_path.c_str(),
+                  O_CLOEXEC | O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0600);
+    if (fd < 0) {
+        LOG(ERROR) << "Failed to open temp snapshot file: " << tmp_path;
+        return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+    }
+
+    FdGuard fd_guard(fd);
+
+    size_t total_written = 0;
+    while (total_written < bytes.size()) {
+        ssize_t n = write(fd, bytes.data() + total_written,
+                          bytes.size() - total_written);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            LOG(ERROR) << "Failed to write temp snapshot file: " << tmp_path
+                       << ", error: " << strerror(errno);
+            unlink(tmp_path.c_str());
+            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        }
+        total_written += static_cast<size_t>(n);
+    }
+
+    if (fsync(fd) != 0) {
+        LOG(ERROR) << "Failed to fsync temp snapshot file: " << tmp_path
+                   << ", error: " << strerror(errno);
+        unlink(tmp_path.c_str());
+        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
+
+    if (rename(tmp_path.c_str(), path.c_str()) != 0) {
+        LOG(ERROR) << "Failed to rename snapshot file from " << tmp_path
+                   << " to " << path << ", error: " << strerror(errno);
+        unlink(tmp_path.c_str());
+        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
+
+    std::string parent_dir = std::filesystem::path(path).parent_path().string();
+    int dir_fd = open(parent_dir.c_str(), O_RDONLY | O_DIRECTORY);
+    if (dir_fd >= 0) {
+        if (fsync(dir_fd) != 0) {
+            LOG(ERROR) << "Failed to fsync snapshot directory: " << parent_dir
+                       << ", error: " << strerror(errno);
+            close(dir_fd);
+            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        }
+        close(dir_fd);
+    }
+
+    return {};
+}
+
+tl::expected<std::vector<SerializedByte>, ErrorCode>
+OffsetAllocatorStorageBackend::ReadFileBytes(const std::string& path) const {
+    int fd = open(path.c_str(), O_CLOEXEC | O_RDONLY | O_NOFOLLOW);
+    if (fd < 0) {
+        LOG(ERROR) << "Failed to open snapshot file: " << path;
+        return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+    }
+
+    FdGuard fd_guard(fd);
+
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        LOG(ERROR) << "Failed to stat snapshot file: " << path;
+        return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+    }
+    if (st.st_size < 0) {
+        LOG(ERROR) << "Snapshot file has invalid size: " << path;
+        return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+    }
+
+    const uint64_t max_snapshot_bytes =
+        std::max<uint64_t>(capacity_ * 2, 64ULL * 1024 * 1024);
+    if (static_cast<uint64_t>(st.st_size) > max_snapshot_bytes) {
+        LOG(ERROR) << "Snapshot file is too large: " << path
+                   << ", size=" << st.st_size
+                   << ", limit=" << max_snapshot_bytes;
+        return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+    }
+
+    std::vector<SerializedByte> bytes(st.st_size);
+    size_t total_read = 0;
+    while (total_read < bytes.size()) {
+        ssize_t n =
+            read(fd, bytes.data() + total_read, bytes.size() - total_read);
+        if (n < 0) {
+            LOG(ERROR) << "Failed to read snapshot file: " << path
+                       << ", error: " << strerror(errno);
+            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        }
+        if (n == 0) {
+            break;
+        }
+        total_read += static_cast<size_t>(n);
+    }
+
+    if (total_read != bytes.size()) {
+        LOG(ERROR) << "Short read for snapshot file: " << path;
+        return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+    }
+
+    return bytes;
+}
+
+void OffsetAllocatorStorageBackend::ResetRecoverySnapshotState() {
+    recovery_snapshot_state_ = PersistedSnapshot{};
+    recovery_snapshot_state_.version = kSnapshotVersion;
+    recovery_snapshot_state_.capacity = capacity_;
+    recovery_snapshot_index_.clear();
+}
+
+void OffsetAllocatorStorageBackend::SetRecoverySnapshotState(
+    const PersistedSnapshot& snapshot) {
+    recovery_snapshot_state_ = snapshot;
+    recovery_snapshot_state_.version = kSnapshotVersion;
+    recovery_snapshot_state_.capacity = capacity_;
+    recovery_snapshot_state_.stale_allocations.clear();
+    recovery_snapshot_index_.clear();
+    recovery_snapshot_index_.reserve(recovery_snapshot_state_.entries.size());
+    for (size_t i = 0; i < recovery_snapshot_state_.entries.size(); ++i) {
+        recovery_snapshot_index_.emplace(
+            recovery_snapshot_state_.entries[i].key, i);
+    }
+}
+
+OffsetAllocatorStorageBackend::PersistedObjectEntry
+OffsetAllocatorStorageBackend::BuildPersistedObjectEntry(
+    const std::string& key, const ObjectEntry& entry) const {
+    return PersistedObjectEntry{
+        .key = key,
+        .offset = entry.offset,
+        .total_size = entry.total_size,
+        .value_size = entry.value_size,
+        .allocation_offset = entry.allocation_state.allocation_offset,
+        .allocation_metadata = entry.allocation_state.allocation_metadata,
+        .allocation_real_base = entry.allocation_state.real_base,
+        .allocation_requested_size = entry.allocation_state.requested_size,
+    };
+}
+
+offset_allocator::PersistedAllocationState
+OffsetAllocatorStorageBackend::ToAllocationState(
+    const PersistedObjectEntry& entry) {
+    return offset_allocator::PersistedAllocationState{
+        .allocation_offset = entry.allocation_offset,
+        .allocation_metadata = entry.allocation_metadata,
+        .real_base = entry.allocation_real_base,
+        .requested_size = entry.allocation_requested_size,
+    };
+}
+
+void OffsetAllocatorStorageBackend::UpsertRecoverySnapshotEntry(
+    const PersistedObjectEntry& entry, int64_t size_delta, bool is_new_key) {
+    auto it = recovery_snapshot_index_.find(entry.key);
+    if (it == recovery_snapshot_index_.end()) {
+        recovery_snapshot_index_.emplace(
+            entry.key, recovery_snapshot_state_.entries.size());
+        recovery_snapshot_state_.entries.push_back(entry);
+    } else {
+        recovery_snapshot_state_.entries[it->second] = entry;
+    }
+    recovery_snapshot_state_.total_size += size_delta;
+    if (is_new_key) {
+        recovery_snapshot_state_.total_keys++;
+    }
+}
+
+void OffsetAllocatorStorageBackend::RemoveRecoverySnapshotEntry(
+    const std::string& key, int64_t size_delta, bool was_new_key) {
+    auto it = recovery_snapshot_index_.find(key);
+    if (it == recovery_snapshot_index_.end()) {
+        return;
+    }
+
+    const size_t idx = it->second;
+    const size_t last_idx = recovery_snapshot_state_.entries.size() - 1;
+    if (idx != last_idx) {
+        recovery_snapshot_state_.entries[idx] =
+            std::move(recovery_snapshot_state_.entries[last_idx]);
+        recovery_snapshot_index_[recovery_snapshot_state_.entries[idx].key] =
+            idx;
+    }
+    recovery_snapshot_state_.entries.pop_back();
+    recovery_snapshot_index_.erase(it);
+    recovery_snapshot_state_.total_size -= size_delta;
+    if (was_new_key) {
+        recovery_snapshot_state_.total_keys--;
+    }
+}
+
+void OffsetAllocatorStorageBackend::ClearInMemoryState() {
+    std::vector<std::unique_ptr<SharedMutexLocker>> shard_locks;
+    shard_locks.reserve(kNumShards);
+    for (size_t i = 0; i < kNumShards; ++i) {
+        shard_locks.emplace_back(
+            std::make_unique<SharedMutexLocker>(&shards_[i].mutex));
+        shards_[i].map.clear();
+    }
+    total_size_.store(0, std::memory_order_relaxed);
+    total_keys_.store(0, std::memory_order_relaxed);
+    ResetRecoverySnapshotState();
+}
+
+void OffsetAllocatorStorageBackend::CleanupObsoleteRecoverySnapshots(
+    uint64_t live_generation) const {
+    namespace fs = std::filesystem;
+
+    std::error_code ec;
+    for (const auto& entry : fs::directory_iterator(storage_path_, ec)) {
+        if (ec) {
+            LOG(WARNING) << "Failed to iterate recovery snapshot directory: "
+                         << storage_path_ << ", error: " << ec.message();
+            return;
+        }
+        if (!entry.is_regular_file(ec)) {
+            ec.clear();
+            continue;
+        }
+
+        const auto filename = entry.path().filename().string();
+        auto cleanup_generation = [&](std::string_view prefix) {
+            if (filename.rfind(prefix, 0) != 0) {
+                return;
+            }
+            const std::string generation_str(filename.substr(prefix.size()));
+            if (generation_str.empty()) {
+                return;
+            }
+            char* end = nullptr;
+            errno = 0;
+            uint64_t generation = strtoull(generation_str.c_str(), &end, 10);
+            if (errno != 0 || end == generation_str.c_str() || *end != '\0') {
+                LOG(WARNING) << "Skipping malformed recovery snapshot file: "
+                             << filename;
+                return;
+            }
+            if (generation == live_generation) {
+                return;
+            }
+            std::error_code remove_ec;
+            if (!fs::remove(entry.path(), remove_ec) && remove_ec) {
+                LOG(WARNING)
+                    << "Failed to remove obsolete recovery snapshot: "
+                    << entry.path() << ", error: " << remove_ec.message();
+            }
+        };
+
+        cleanup_generation(kAllocatorSnapshotPrefix);
+        cleanup_generation(kIndexSnapshotPrefix);
+    }
+}
+
+tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::ValidateSnapshot(
+    const PersistedSnapshot& snapshot) const {
+    if (snapshot.version != kSnapshotVersion) {
+        LOG(ERROR) << "Unsupported snapshot version: " << snapshot.version;
+        return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+    }
+    if (snapshot.capacity != capacity_) {
+        LOG(ERROR) << "Snapshot capacity mismatch: expected " << capacity_
+                   << ", got " << snapshot.capacity;
+        return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+    }
+    if (snapshot.total_size < 0 || snapshot.total_keys < 0) {
+        LOG(ERROR) << "Snapshot has negative aggregate counters: total_size="
+                   << snapshot.total_size
+                   << ", total_keys=" << snapshot.total_keys;
+        return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+    }
+    if (snapshot.total_keys != static_cast<int64_t>(snapshot.entries.size())) {
+        LOG(ERROR) << "Snapshot key count mismatch: expected "
+                   << snapshot.total_keys << ", got "
+                   << snapshot.entries.size();
+        return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+    }
+
+    std::unordered_set<std::string> seen_keys;
+    seen_keys.reserve(snapshot.entries.size());
+    std::unordered_set<AllocationStateKey, AllocationStateKeyHash>
+        seen_allocations;
+    seen_allocations.reserve(snapshot.entries.size() +
+                             snapshot.stale_allocations.size());
+
+    int64_t recomputed_total_size = 0;
+    for (const auto& entry : snapshot.entries) {
+        if (!seen_keys.insert(entry.key).second) {
+            LOG(ERROR) << "Snapshot contains duplicate key: " << entry.key;
+            return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+        }
+        if (entry.total_size <
+            RecordHeader::SIZE + entry.key.size() + entry.value_size) {
+            LOG(ERROR) << "Snapshot entry has invalid total size for key: "
+                       << entry.key;
+            return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+        }
+        if (entry.offset + entry.total_size > capacity_) {
+            LOG(ERROR) << "Snapshot entry range exceeds capacity for key: "
+                       << entry.key;
+            return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+        }
+        auto allocation_state = ToAllocationState(entry);
+        if (!allocator_ ||
+            !allocator_->ValidatePersistedAllocationState(allocation_state)) {
+            LOG(ERROR) << "Snapshot has invalid allocation state for key: "
+                       << entry.key;
+            return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+        }
+        if (!seen_allocations.insert(MakeAllocationStateKey(allocation_state))
+                 .second) {
+            LOG(ERROR) << "Snapshot reuses an allocation state for key: "
+                       << entry.key;
+            return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+        }
+        recomputed_total_size += entry.total_size;
+    }
+    for (const auto& stale : snapshot.stale_allocations) {
+        if (!allocator_ ||
+            !allocator_->ValidatePersistedAllocationState(stale)) {
+            LOG(ERROR) << "Snapshot has invalid stale allocation state";
+            return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+        }
+        if (!seen_allocations.insert(MakeAllocationStateKey(stale)).second) {
+            LOG(ERROR) << "Snapshot stale allocation overlaps a live or stale "
+                          "allocation";
+            return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+        }
+    }
+
+    if (snapshot.total_size != recomputed_total_size) {
+        LOG(ERROR) << "Snapshot total size mismatch: expected "
+                   << snapshot.total_size << ", got " << recomputed_total_size;
+        return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+    }
+    return {};
+}
+
+tl::expected<void, ErrorCode>
+OffsetAllocatorStorageBackend::RebuildInMemoryState(
+    const PersistedSnapshot& snapshot) {
+    std::array<std::vector<std::pair<std::string, ObjectEntry>>, kNumShards>
+        rebuilt_shards;
+    std::vector<offset_allocator::OffsetAllocationHandle> stale_handles;
+    stale_handles.reserve(snapshot.stale_allocations.size());
+
+    for (const auto& entry : snapshot.entries) {
+        auto allocation_state = ToAllocationState(entry);
+        if (!allocator_->ValidatePersistedAllocationState(allocation_state)) {
+            LOG(ERROR)
+                << "Snapshot has invalid allocation state during rebuild "
+                   "for key: "
+                << entry.key;
+            return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+        }
+        auto restored_handle =
+            allocator_->RestoreAllocationHandle(allocation_state);
+        auto allocation_ptr = std::make_shared<RefCountedAllocationHandle>(
+            std::move(restored_handle));
+        auto& rebuilt_shard = rebuilt_shards[ShardForKey(entry.key)];
+        rebuilt_shard.emplace_back(
+            entry.key,
+            ObjectEntry(entry.offset, entry.total_size, entry.value_size,
+                        allocation_state, std::move(allocation_ptr)));
+    }
+    for (const auto& stale : snapshot.stale_allocations) {
+        stale_handles.push_back(allocator_->RestoreAllocationHandle(stale));
+    }
+
+    std::vector<std::unique_ptr<SharedMutexLocker>> shard_locks;
+    shard_locks.reserve(kNumShards);
+    for (size_t i = 0; i < kNumShards; ++i) {
+        shard_locks.emplace_back(
+            std::make_unique<SharedMutexLocker>(&shards_[i].mutex));
+    }
+
+    for (size_t i = 0; i < kNumShards; ++i) {
+        shards_[i].map.clear();
+        shards_[i].map.reserve(rebuilt_shards[i].size());
+        for (auto& [key, entry] : rebuilt_shards[i]) {
+            shards_[i].map.emplace(std::move(key), std::move(entry));
+        }
+    }
+
+    total_size_.store(snapshot.total_size, std::memory_order_relaxed);
+    total_keys_.store(snapshot.total_keys, std::memory_order_relaxed);
+    SetRecoverySnapshotState(snapshot);
+    return {};
+}
+
+tl::expected<void, ErrorCode>
+OffsetAllocatorStorageBackend::PersistAllocatorSnapshot(
+    const std::shared_ptr<offset_allocator::OffsetAllocator>& allocator,
+    uint64_t generation) const {
+    std::vector<SerializedByte> buffer;
+    auto error = serialize_to(allocator, buffer);
+    if (error != ErrorCode::OK) {
+        LOG(ERROR) << "Failed to serialize allocator snapshot: " << error;
+        return tl::make_unexpected(error);
+    }
+    return WriteFileAtomically(GetAllocatorSnapshotPath(generation), buffer);
+}
+
+tl::expected<void, ErrorCode>
+OffsetAllocatorStorageBackend::PersistIndexSnapshot(
+    const PersistedSnapshot& snapshot, uint64_t generation) const {
+    auto packed = struct_pack::serialize(snapshot);
+    std::vector<SerializedByte> buffer(packed.begin(), packed.end());
+    return WriteFileAtomically(GetIndexSnapshotPath(generation), buffer);
+}
+
+tl::expected<OffsetAllocatorStorageBackend::RecoveryManifest, ErrorCode>
+OffsetAllocatorStorageBackend::LoadRecoveryManifest() const {
+    auto bytes_result = ReadFileBytes(recovery_manifest_path_);
+    if (!bytes_result) {
+        return tl::make_unexpected(bytes_result.error());
+    }
+
+    RecoveryManifest manifest;
+    const auto& buffer = bytes_result.value();
+    auto deserialize_result = struct_pack::deserialize_to(
+        manifest, std::string_view(reinterpret_cast<const char*>(buffer.data()),
+                                   buffer.size()));
+    if (deserialize_result != struct_pack::errc::ok) {
+        LOG(ERROR) << "Failed to deserialize recovery manifest, error_code="
+                   << static_cast<int>(deserialize_result);
+        return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+    }
+    if (manifest.version != kManifestVersion || manifest.generation == 0) {
+        LOG(ERROR) << "Invalid recovery manifest: version=" << manifest.version
+                   << ", generation=" << manifest.generation;
+        return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+    }
+    return manifest;
+}
+
+tl::expected<std::shared_ptr<offset_allocator::OffsetAllocator>, ErrorCode>
+OffsetAllocatorStorageBackend::LoadAllocatorSnapshot(
+    uint64_t generation) const {
+    auto bytes_result = ReadFileBytes(GetAllocatorSnapshotPath(generation));
+    if (!bytes_result) {
+        return tl::make_unexpected(bytes_result.error());
+    }
+    auto allocator = deserialize_from<offset_allocator::OffsetAllocator>(
+        bytes_result.value());
+    if (!allocator) {
+        LOG(ERROR) << "Failed to deserialize allocator snapshot";
+        return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+    }
+    return allocator;
+}
+
+tl::expected<OffsetAllocatorStorageBackend::PersistedSnapshot, ErrorCode>
+OffsetAllocatorStorageBackend::LoadIndexSnapshot(uint64_t generation) const {
+    auto bytes_result = ReadFileBytes(GetIndexSnapshotPath(generation));
+    if (!bytes_result) {
+        return tl::make_unexpected(bytes_result.error());
+    }
+
+    const auto& buffer = bytes_result.value();
+    PersistedSnapshot snapshot;
+    auto deserialize_result = struct_pack::deserialize_to(
+        snapshot, std::string_view(reinterpret_cast<const char*>(buffer.data()),
+                                   buffer.size()));
+    if (deserialize_result != struct_pack::errc::ok) {
+        LOG(ERROR) << "Failed to deserialize index snapshot, error_code="
+                   << static_cast<int>(deserialize_result);
+        return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+    }
+
+    auto validate_result = ValidateSnapshot(snapshot);
+    if (!validate_result) {
+        return tl::make_unexpected(validate_result.error());
+    }
+    return snapshot;
+}
+
+tl::expected<void, ErrorCode>
+OffsetAllocatorStorageBackend::PersistRecoverySnapshots(
+    const PersistedSnapshot& snapshot, uint64_t generation) {
+    MutexLocker persist_lock(&recovery_snapshot_io_mutex_);
+
+    auto allocator_result = PersistAllocatorSnapshot(allocator_, generation);
+    if (!allocator_result) {
+        return allocator_result;
+    }
+    auto index_result = PersistIndexSnapshot(snapshot, generation);
+    if (!index_result) {
+        return index_result;
+    }
+
+    RecoveryManifest manifest{.version = kManifestVersion,
+                              .generation = generation};
+    auto packed = struct_pack::serialize(manifest);
+    std::vector<SerializedByte> buffer(packed.begin(), packed.end());
+    auto manifest_result = WriteFileAtomically(recovery_manifest_path_, buffer);
+    if (!manifest_result) {
+        return manifest_result;
+    }
+
+    CleanupObsoleteRecoverySnapshots(generation);
+    return {};
+}
+
+tl::expected<void, ErrorCode>
+OffsetAllocatorStorageBackend::LoadRecoverySnapshots() {
+    auto manifest_result = LoadRecoveryManifest();
+    if (!manifest_result) {
+        return tl::make_unexpected(manifest_result.error());
+    }
+
+    uint64_t generation = manifest_result->generation;
+    auto allocator_result = LoadAllocatorSnapshot(generation);
+    if (!allocator_result) {
+        return tl::make_unexpected(allocator_result.error());
+    }
+    allocator_ = std::move(allocator_result.value());
+
+    auto snapshot_result = LoadIndexSnapshot(generation);
+    if (!snapshot_result) {
+        return tl::make_unexpected(snapshot_result.error());
+    }
+
+    auto rebuild_result = RebuildInMemoryState(snapshot_result.value());
+    if (!rebuild_result) {
+        return rebuild_result;
+    }
+    next_snapshot_generation_.store(generation + 1, std::memory_order_relaxed);
+    return {};
+}
+
 //-----------------------------------------------------------------------------
 
 tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::Init() {
@@ -2675,60 +3290,61 @@ tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::Init() {
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
 
-        // Clear in-memory maps (V1: no persistence, start fresh)
-        // Lock all shards to ensure exclusive access during initialization
-        {
-            std::vector<std::unique_ptr<SharedMutexLocker>> shard_locks;
-            shard_locks.reserve(kNumShards);
-            for (size_t i = 0; i < kNumShards; ++i) {
-                shard_locks.emplace_back(
-                    std::make_unique<SharedMutexLocker>(&shards_[i].mutex));
-                shards_[i].map.clear();
-            }
-            total_size_.store(0, std::memory_order_relaxed);
-            total_keys_.store(0, std::memory_order_relaxed);
-        }
+        ClearInMemoryState();
 
-        // Get data file path
+        // Get data and snapshot file paths
         data_file_path_ = GetDataFilePath();
+        recovery_manifest_path_ = GetRecoveryManifestPath();
 
-        // RAII wrapper to ensure fd is closed on all error paths
-        struct FdGuard {
-            int fd;
-            explicit FdGuard(int fd) : fd(fd) {}
-            ~FdGuard() {
-                if (fd >= 0) {
-                    close(fd);
+        const bool recovery_mode = fs::exists(recovery_manifest_path_);
+        if (!recovery_mode) {
+            for (const auto& entry : fs::directory_iterator(storage_path_)) {
+                if (!entry.is_regular_file()) {
+                    continue;
+                }
+                const auto filename = entry.path().filename().string();
+                if (filename.rfind(kAllocatorSnapshotPrefix, 0) == 0 ||
+                    filename.rfind(kIndexSnapshotPrefix, 0) == 0) {
+                    LOG(ERROR) << "Recovery snapshot mismatch: manifest "
+                                  "missing but recovery snapshot file exists: "
+                               << filename;
+                    return tl::make_unexpected(ErrorCode::FILE_NOT_FOUND);
                 }
             }
-            // Release ownership (caller takes responsibility)
-            int release() {
-                int ret = fd;
-                fd = -1;
-                return ret;
-            }
-            // Get fd without releasing (for operations)
-            int get() const { return fd; }
-        };
-
-        // Open/truncate data file in read-write mode
-        // We need raw fd for fallocate, so open directly
-        int flags = O_CLOEXEC | O_RDWR | O_CREAT | O_TRUNC;
-        int raw_fd = open(data_file_path_.c_str(), flags, 0644);
+        }
+        int flags = O_CLOEXEC | O_RDWR;
+        if (!recovery_mode) {
+            flags |= O_CREAT | O_TRUNC;
+        }
+        int raw_fd = open(data_file_path_.c_str(), flags | O_NOFOLLOW, 0600);
         if (raw_fd < 0) {
             LOG(ERROR) << "Failed to open data file: " << data_file_path_;
             return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
         }
         FdGuard fd_guard(raw_fd);
 
-        // Use fallocate if available, otherwise ftruncate
-        if (fallocate(fd_guard.get(), 0, 0, capacity_) != 0) {
-            // Fallback to ftruncate
-            if (ftruncate(fd_guard.get(), capacity_) != 0) {
-                LOG(ERROR) << "Failed to preallocate file: " << data_file_path_
-                           << ", capacity: " << capacity_
-                           << ", error: " << strerror(errno);
-                return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        if (!recovery_mode) {
+            if (fallocate(fd_guard.get(), 0, 0, capacity_) != 0) {
+                if (ftruncate(fd_guard.get(), capacity_) != 0) {
+                    LOG(ERROR)
+                        << "Failed to preallocate file: " << data_file_path_
+                        << ", capacity: " << capacity_
+                        << ", error: " << strerror(errno);
+                    return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+                }
+            }
+        } else {
+            struct stat data_stat;
+            if (fstat(fd_guard.get(), &data_stat) != 0) {
+                LOG(ERROR) << "Failed to stat data file: " << data_file_path_;
+                return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+            }
+            if (data_stat.st_size < 0 ||
+                static_cast<uint64_t>(data_stat.st_size) < capacity_) {
+                LOG(ERROR) << "Recovered data file is truncated: "
+                           << data_file_path_ << ", size=" << data_stat.st_size
+                           << ", expected_at_least=" << capacity_;
+                return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
             }
         }
 
@@ -2744,16 +3360,32 @@ tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::Init() {
                                                      fd_guard.release());
         }
 
-        // Create allocator with base=0, size=capacity
-        allocator_ = offset_allocator::OffsetAllocator::create(0, capacity_);
-        if (!allocator_) {
-            LOG(ERROR) << "Failed to create OffsetAllocator";
-            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        if (recovery_mode) {
+            auto load_result = LoadRecoverySnapshots();
+            if (!load_result) {
+                return load_result;
+            }
+        } else {
+            allocator_ =
+                offset_allocator::OffsetAllocator::create(0, capacity_);
+            if (!allocator_) {
+                LOG(ERROR) << "Failed to create OffsetAllocator";
+                return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+            }
+            ResetRecoverySnapshotState();
+            auto persist_result = PersistRecoverySnapshots(
+                recovery_snapshot_state_,
+                next_snapshot_generation_.load(std::memory_order_relaxed));
+            if (!persist_result) {
+                return persist_result;
+            }
+            next_snapshot_generation_.fetch_add(1, std::memory_order_relaxed);
         }
 
         initialized_.store(true, std::memory_order_release);
         LOG(INFO) << "OffsetAllocatorStorageBackend initialized, capacity: "
-                  << capacity_ << " bytes, data file: " << data_file_path_;
+                  << capacity_ << " bytes, data file: " << data_file_path_
+                  << (recovery_mode ? " (recovered)" : " (fresh)");
     } catch (const std::exception& e) {
         LOG(ERROR) << "OffsetAllocatorStorageBackend initialize error: "
                    << e.what();
@@ -2790,10 +3422,35 @@ tl::expected<int64_t, ErrorCode> OffsetAllocatorStorageBackend::BatchOffload(
         return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
     }
 
+    struct PendingWrite {
+        std::string key;
+        uint64_t offset;
+        uint32_t record_size;
+        uint32_t value_size;
+        offset_allocator::PersistedAllocationState allocation_state;
+        AllocationPtr allocation_ptr;
+        size_t shard_idx;
+    };
+
+    struct PublishedUpdate {
+        size_t shard_idx;
+        std::string key;
+        int64_t size_delta;
+        bool is_new_key;
+        std::optional<ObjectEntry> old_entry;
+        PersistedObjectEntry persisted_entry;
+    };
+
+    std::vector<PendingWrite> pending_writes;
     std::vector<std::string> keys;
     std::vector<StorageObjectMetadata> metadatas;
+    std::vector<offset_allocator::PersistedAllocationState> stale_allocations;
+    std::vector<PublishedUpdate> published_updates;
+    pending_writes.reserve(batch_object.size());
     keys.reserve(batch_object.size());
     metadatas.reserve(batch_object.size());
+    stale_allocations.reserve(batch_object.size());
+    published_updates.reserve(batch_object.size());
 
     // Process each object in the batch; continue on individual failures to
     // support partial success
@@ -2879,50 +3536,109 @@ tl::expected<int64_t, ErrorCode> OffsetAllocatorStorageBackend::BatchOffload(
             continue;  // Continue processing other keys
         }
 
-        // Step 3: Wrap allocation in refcounted handle
+        // Step 3: Stage metadata update; publish it only after the batch has
+        // finished its allocation and I/O work.
+        auto allocation_state =
+            allocator_->GetPersistedAllocationState(allocation.value());
         auto allocation_ptr = std::make_shared<RefCountedAllocationHandle>(
             std::move(allocation.value()));
+        pending_writes.push_back(PendingWrite{
+            .key = key,
+            .offset = offset,
+            .record_size = static_cast<uint32_t>(record_size),
+            .value_size = value_size,
+            .allocation_state = allocation_state,
+            .allocation_ptr = std::move(allocation_ptr),
+            .shard_idx = ShardForKey(key),
+        });
+    }
 
-        // Step 4: Update metadata map under exclusive shard lock
-        // Lock only the shard for this key (other shards can proceed in
-        // parallel)
-        {
-            size_t shard_idx = ShardForKey(key);
-            auto& shard = shards_[shard_idx];
-            SharedMutexLocker lock(&shard.mutex);
+    if (!pending_writes.empty()) {
+        SharedMutexLocker recovery_lock(&recovery_state_mutex_);
 
-            // Check if key exists to update size accounting
-            auto it = shard.map.find(key);
-            int64_t size_delta = static_cast<int64_t>(record_size);
-            bool is_new_key = (it == shard.map.end());
+        for (auto& pending : pending_writes) {
+            auto& shard = shards_[pending.shard_idx];
+            int64_t size_delta = static_cast<int64_t>(pending.record_size);
+            bool is_new_key = false;
+            std::optional<ObjectEntry> old_entry;
+            {
+                SharedMutexLocker lock(&shard.mutex);
+                auto it = shard.map.find(pending.key);
+                is_new_key = (it == shard.map.end());
+                if (!is_new_key) {
+                    size_delta -= static_cast<int64_t>(it->second.total_size);
+                    old_entry.emplace(it->second.offset, it->second.total_size,
+                                      it->second.value_size,
+                                      it->second.allocation_state,
+                                      it->second.allocation);
+                }
 
-            if (!is_new_key) {
-                // Overwrite: subtract old size
-                size_delta -= static_cast<int64_t>(it->second.total_size);
-                // Old AllocationPtr will be dropped, refcount decremented
-                // Physical extent freed when last reader releases it
+                shard.map.insert_or_assign(
+                    pending.key,
+                    ObjectEntry(pending.offset, pending.record_size,
+                                pending.value_size, pending.allocation_state,
+                                pending.allocation_ptr));
+                total_size_.fetch_add(size_delta, std::memory_order_relaxed);
+                if (is_new_key) {
+                    total_keys_.fetch_add(1, std::memory_order_relaxed);
+                }
             }
 
-            // Update map (insert_or_assign handles both insert and overwrite)
-            shard.map.insert_or_assign(
-                key, ObjectEntry(offset, record_size, value_size,
-                                 std::move(allocation_ptr)));
-
-            // Update total size atomically (lock-free, separate from map
-            // updates)
-            total_size_.fetch_add(size_delta, std::memory_order_relaxed);
-
-            // Update total keys only if inserting a new key
-            if (is_new_key) {
-                total_keys_.fetch_add(1, std::memory_order_relaxed);
+            if (old_entry.has_value()) {
+                stale_allocations.push_back(old_entry->allocation_state);
             }
+            published_updates.push_back(PublishedUpdate{
+                .shard_idx = pending.shard_idx,
+                .key = pending.key,
+                .size_delta = size_delta,
+                .is_new_key = is_new_key,
+                .old_entry = std::move(old_entry),
+                .persisted_entry = BuildPersistedObjectEntry(
+                    pending.key, shard.map.at(pending.key)),
+            });
+
+            keys.push_back(pending.key);
+            metadatas.push_back(StorageObjectMetadata{
+                0, static_cast<int64_t>(pending.offset),
+                static_cast<int64_t>(pending.key.size()),
+                static_cast<int64_t>(pending.value_size), ""});
         }
 
-        keys.push_back(key);
-        metadatas.push_back(StorageObjectMetadata{
-            0,  // bucket_id not used for this backend
-            static_cast<int64_t>(offset), static_cast<int64_t>(header.key_len),
-            static_cast<int64_t>(value_size), ""});
+        for (const auto& update : published_updates) {
+            UpsertRecoverySnapshotEntry(update.persisted_entry,
+                                        update.size_delta, update.is_new_key);
+        }
+
+        PersistedSnapshot snapshot = recovery_snapshot_state_;
+        snapshot.stale_allocations = std::move(stale_allocations);
+        uint64_t generation =
+            next_snapshot_generation_.load(std::memory_order_relaxed);
+        auto persist_result = PersistRecoverySnapshots(snapshot, generation);
+        if (!persist_result) {
+            for (auto it = published_updates.rbegin();
+                 it != published_updates.rend(); ++it) {
+                auto& shard = shards_[it->shard_idx];
+                SharedMutexLocker rollback_lock(&shard.mutex);
+                if (it->is_new_key) {
+                    shard.map.erase(it->key);
+                    total_keys_.fetch_sub(1, std::memory_order_relaxed);
+                } else {
+                    shard.map.insert_or_assign(it->key,
+                                               std::move(*it->old_entry));
+                }
+                total_size_.fetch_sub(it->size_delta,
+                                      std::memory_order_relaxed);
+                RemoveRecoverySnapshotEntry(it->key, it->size_delta,
+                                            it->is_new_key);
+                if (!it->is_new_key && it->old_entry.has_value()) {
+                    UpsertRecoverySnapshotEntry(
+                        BuildPersistedObjectEntry(it->key, *it->old_entry),
+                        -it->size_delta, false);
+                }
+            }
+            return tl::make_unexpected(persist_result.error());
+        }
+        next_snapshot_generation_.fetch_add(1, std::memory_order_relaxed);
     }
 
     // Invoke complete handler only if we have successful keys to report

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -2781,7 +2781,8 @@ OffsetAllocatorStorageBackend::WriteFileAtomically(
     }
 
     std::string parent_dir = std::filesystem::path(path).parent_path().string();
-    int dir_fd = open(parent_dir.c_str(), O_RDONLY | O_DIRECTORY);
+    int dir_fd = open(parent_dir.empty() ? "." : parent_dir.c_str(),
+                      O_RDONLY | O_DIRECTORY);
     if (dir_fd >= 0) {
         if (fsync(dir_fd) != 0) {
             LOG(ERROR) << "Failed to fsync snapshot directory: " << parent_dir
@@ -2815,8 +2816,7 @@ OffsetAllocatorStorageBackend::ReadFileBytes(const std::string& path) const {
         return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
     }
 
-    const uint64_t max_snapshot_bytes =
-        std::max<uint64_t>(capacity_ * 2, 64ULL * 1024 * 1024);
+    const uint64_t max_snapshot_bytes = 4ULL * 1024 * 1024 * 1024;
     if (static_cast<uint64_t>(st.st_size) > max_snapshot_bytes) {
         LOG(ERROR) << "Snapshot file is too large: " << path
                    << ", size=" << st.st_size
@@ -3298,8 +3298,17 @@ tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::Init() {
 
         const bool recovery_mode = fs::exists(recovery_manifest_path_);
         if (!recovery_mode) {
-            for (const auto& entry : fs::directory_iterator(storage_path_)) {
-                if (!entry.is_regular_file()) {
+            std::error_code ec_dir;
+            for (const auto& entry :
+                 fs::directory_iterator(storage_path_, ec_dir)) {
+                if (ec_dir) {
+                    LOG(ERROR)
+                        << "Failed to iterate storage directory: "
+                        << storage_path_ << ", error: " << ec_dir.message();
+                    return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+                }
+                if (!entry.is_regular_file(ec_dir)) {
+                    ec_dir.clear();
                     continue;
                 }
                 const auto filename = entry.path().filename().string();
@@ -3310,6 +3319,11 @@ tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::Init() {
                                << filename;
                     return tl::make_unexpected(ErrorCode::FILE_NOT_FOUND);
                 }
+            }
+            if (ec_dir) {
+                LOG(ERROR) << "Failed to iterate storage directory: "
+                           << storage_path_ << ", error: " << ec_dir.message();
+                return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
             }
         }
         int flags = O_CLOEXEC | O_RDWR;
@@ -3609,11 +3623,13 @@ tl::expected<int64_t, ErrorCode> OffsetAllocatorStorageBackend::BatchOffload(
                                         update.size_delta, update.is_new_key);
         }
 
-        PersistedSnapshot snapshot = recovery_snapshot_state_;
-        snapshot.stale_allocations = std::move(stale_allocations);
+        recovery_snapshot_state_.stale_allocations =
+            std::move(stale_allocations);
         uint64_t generation =
             next_snapshot_generation_.load(std::memory_order_relaxed);
-        auto persist_result = PersistRecoverySnapshots(snapshot, generation);
+        auto persist_result =
+            PersistRecoverySnapshots(recovery_snapshot_state_, generation);
+        recovery_snapshot_state_.stale_allocations.clear();
         if (!persist_result) {
             for (auto it = published_updates.rbegin();
                  it != published_updates.rend(); ++it) {

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -34,6 +34,55 @@ class PromotionOnHitTest : public ::testing::Test {
         return service->promotion_admission_threshold_;
     }
 
+    static bool HasPromotionTaskForTesting(MasterService* service,
+                                           const std::string& key) {
+        MasterService::MetadataShardAccessorRO shard(
+            service, service->getShardIndex(key));
+        return shard->promotion_tasks.count(key) > 0;
+    }
+
+    template <typename Predicate>
+    static bool WaitUntil(
+        Predicate&& predicate,
+        std::chrono::milliseconds timeout = std::chrono::seconds(5),
+        std::chrono::milliseconds interval = std::chrono::milliseconds(10)) {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (predicate()) {
+                return true;
+            }
+            std::this_thread::sleep_for(interval);
+        }
+        return predicate();
+    }
+
+    static bool WaitForPromotionTaskReapedForTesting(
+        MasterService* service, const std::string& key,
+        std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+        return WaitUntil(
+            [&] { return !HasPromotionTaskForTesting(service, key); }, timeout);
+    }
+
+    static bool BackdatePromotionTaskForTesting(MasterService* service,
+                                                const std::string& key,
+                                                std::chrono::seconds age) {
+        MasterService::MetadataShardAccessorRW shard(
+            service, service->getShardIndex(key));
+        auto it = shard->promotion_tasks.find(key);
+        if (it == shard->promotion_tasks.end()) {
+            return false;
+        }
+        it->second.start_time = std::chrono::system_clock::now() - age;
+        return true;
+    }
+
+    static void StopEvictionThreadForTesting(MasterService* service) {
+        service->eviction_running_.store(false, std::memory_order_relaxed);
+        if (service->eviction_thread_.joinable()) {
+            service->eviction_thread_.join();
+        }
+    }
+
     static constexpr size_t kDefaultSegmentBase = 0x300000000;
 
     Segment MakeSegment(std::string name, size_t base, size_t size) const {
@@ -329,9 +378,8 @@ TEST_F(PromotionOnHitTest, StalePromotionReaper) {
     }
 
     // Wait past the staleness window; the eviction thread reaps the task.
-    // Eviction loop sleeps for kEvictionThreadSleepMs (10 ms), so 2s wall
-    // clock gives ~200 attempts — plenty.
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    ASSERT_TRUE(WaitForPromotionTaskReapedForTesting(service.get(), "k_cold"))
+        << "promotion task should be reaped after the release timeout";
 
     // Trigger #3: with the task reaped, dedup is unblocked and a fresh
     // GetReplicaList must enqueue again.
@@ -390,7 +438,8 @@ TEST_F(PromotionOnHitTest, RemoveDuringPromotion) {
 
     // Wait for the reaper; it must tolerate the missing metadata entry
     // (the source replica it would dec_refcnt is already gone).
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    ASSERT_TRUE(WaitForPromotionTaskReapedForTesting(service.get(), "k_cold"))
+        << "promotion task should be reaped even after metadata removal";
 
     // Re-injecting the key and re-triggering must work end-to-end, proving
     // the per-shard PromotionTask was reaped (not stuck).
@@ -702,17 +751,18 @@ TEST_F(PromotionOnHitTest, ReaperPopsStagedMemoryReplicaOnExpiry) {
     // Poll instead of a fixed sleep — the eviction thread cadence and
     // the test runner's scheduling jitter (especially under suite load)
     // both vary, so a hard 2s sleep is flaky here.
-    constexpr auto kPollDeadline = std::chrono::seconds(5);
-    constexpr auto kPollInterval = std::chrono::milliseconds(50);
-    const auto poll_start = std::chrono::steady_clock::now();
     size_t used_after_reap = 0;
-    while (std::chrono::steady_clock::now() - poll_start < kPollDeadline) {
-        auto q = service->QuerySegments(ctx.segment_name);
-        ASSERT_TRUE(q.has_value());
-        used_after_reap = q->first;
-        if (used_after_reap == used_baseline) break;
-        std::this_thread::sleep_for(kPollInterval);
-    }
+    ASSERT_TRUE(WaitUntil(
+        [&] {
+            auto q = service->QuerySegments(ctx.segment_name);
+            EXPECT_TRUE(q.has_value());
+            if (!q.has_value()) {
+                return false;
+            }
+            used_after_reap = q->first;
+            return used_after_reap == used_baseline;
+        },
+        std::chrono::seconds(5), std::chrono::milliseconds(50)));
     EXPECT_EQ(used_after_reap, used_baseline)
         << "after reap: staged PROCESSING MEMORY replica's buffer must "
         << "be freed back to the DRAM allocator. If this fires, the "
@@ -968,6 +1018,68 @@ TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
     service->RemoveAll();
 }
 
+// PromotionAllocStart must also defend against expired tasks before the
+// async reaper thread gets a chance to sweep them. Otherwise a holder
+// that stalls past the release TTL can still allocate a PROCESSING MEMORY
+// replica in the stale task window, and that orphaned buffer lives until
+// object removal or eviction.
+TEST_F(PromotionOnHitTest, AllocStartRejectsExpiredTaskBeforeReaperRuns) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 2000;
+    config.put_start_discard_timeout_sec = 0;
+    config.put_start_release_timeout_sec = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_cold", 1024,
+                                       ctx.segment_name));
+
+    auto seg_baseline = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_baseline.has_value());
+    const size_t used_baseline = seg_baseline->first;
+
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
+    ASSERT_TRUE(HasPromotionTaskForTesting(service.get(), "k_cold"));
+
+    // Freeze out the background reaper so the next AllocStart call itself
+    // must notice and clean up the expired task.
+    StopEvictionThreadForTesting(service.get());
+    ASSERT_TRUE(BackdatePromotionTaskForTesting(service.get(), "k_cold",
+                                                std::chrono::seconds(5)));
+    ASSERT_TRUE(HasPromotionTaskForTesting(service.get(), "k_cold"));
+
+    auto alloc =
+        service->PromotionAllocStart(ctx.client_id, "k_cold", 1024, {});
+    ASSERT_FALSE(alloc.has_value());
+    EXPECT_EQ(alloc.error(), ErrorCode::REPLICA_IS_NOT_READY);
+    EXPECT_FALSE(HasPromotionTaskForTesting(service.get(), "k_cold"));
+
+    auto seg_after = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_after.has_value());
+    EXPECT_EQ(seg_after->first, used_baseline)
+        << "expired AllocStart must not stage a PROCESSING MEMORY replica";
+
+    // The synchronous cleanup path must fully release the slot so a fresh
+    // read can re-admit the same key even with eviction disabled.
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+        auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(pending->size(), 1u);
+        EXPECT_EQ(pending->count("k_cold"), 1u);
+    }
+
+    service->RemoveAll();
+}
+
 // PromotionAllocStart must reject when the in-flight task has been
 // reaped between the holder's heartbeat and the AllocStart RPC arriving
 // (e.g. client stall past put_start_release_timeout_sec_). Without the
@@ -1005,12 +1117,9 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsReapedTask) {
     // Wait past the TTL so the reaper sweeps the task. AllocStart has
     // not yet been called, so alloc_id is 0; the reaper's
     // EraseReplicaByID branch is a no-op and only the task entry is
-    // removed. We can't easily poll for reap externally (the only
-    // user-facing observable would be re-admitting through the gate,
-    // which would create a fresh task and defeat the test), so use a
-    // fixed sleep with margin. Matches the StalePromotionReaper pattern
-    // (TTL=1s, sleep=2s).
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    // removed.
+    ASSERT_TRUE(WaitForPromotionTaskReapedForTesting(service.get(), "k_cold"))
+        << "promotion task should be reaped before AllocStart arrives";
 
     // AllocStart on a reaped task must reject without allocating.
     // Allocating would leave an orphaned PROCESSING MEMORY replica
@@ -1030,6 +1139,54 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsReapedTask) {
         << "grew here, AllocStart got to AddReplicas before the task-"
         << "existence check and the staged buffer is now orphaned (no "
         << "reaper iterates it).";
+
+    service->RemoveAll();
+}
+
+// NotifyPromotionSuccess must also reject expired tasks even if the async
+// reaper has not run yet. Otherwise a late success RPC can still commit a
+// MEMORY replica after its transfer window expired.
+TEST_F(PromotionOnHitTest, NotifySuccessRejectsExpiredTaskBeforeReaperRuns) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 2000;
+    config.put_start_discard_timeout_sec = 0;
+    config.put_start_release_timeout_sec = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_cold", 1024,
+                                       ctx.segment_name));
+
+    auto seg_baseline = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_baseline.has_value());
+    const size_t used_baseline = seg_baseline->first;
+
+    {
+        auto r = service->GetReplicaList("k_cold");
+        ASSERT_TRUE(r.has_value());
+    }
+    auto alloc =
+        service->PromotionAllocStart(ctx.client_id, "k_cold", 1024, {});
+    ASSERT_TRUE(alloc.has_value());
+    ASSERT_TRUE(HasPromotionTaskForTesting(service.get(), "k_cold"));
+
+    StopEvictionThreadForTesting(service.get());
+    ASSERT_TRUE(BackdatePromotionTaskForTesting(service.get(), "k_cold",
+                                                std::chrono::seconds(5)));
+
+    auto notify = service->NotifyPromotionSuccess(ctx.client_id, "k_cold");
+    ASSERT_FALSE(notify.has_value());
+    EXPECT_EQ(notify.error(), ErrorCode::REPLICA_IS_NOT_READY);
+    EXPECT_FALSE(HasPromotionTaskForTesting(service.get(), "k_cold"));
+
+    auto seg_after = service->QuerySegments(ctx.segment_name);
+    ASSERT_TRUE(seg_after.has_value());
+    EXPECT_EQ(seg_after->first, used_baseline)
+        << "expired NotifyPromotionSuccess must release the staged buffer";
 
     service->RemoveAll();
 }

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <fcntl.h>
 #include <unistd.h>
+#include <ylt/struct_pack.hpp>
 #include <ylt/util/tl/expected.hpp>
 
 #include "allocator.h"
@@ -19,10 +20,131 @@
 
 namespace fs = std::filesystem;
 namespace mooncake::test {
+namespace {
+
+struct PersistedObjectEntryMirror {
+    std::string key;
+    uint64_t offset;
+    uint32_t total_size;
+    uint32_t value_size;
+    uint32_t allocation_offset;
+    uint32_t allocation_metadata;
+    uint64_t allocation_real_base;
+    uint64_t allocation_requested_size;
+};
+
+struct PersistedSnapshotMirror {
+    uint32_t version = 1;
+    uint64_t capacity = 0;
+    int64_t total_size = 0;
+    int64_t total_keys = 0;
+    std::vector<PersistedObjectEntryMirror> entries;
+    std::vector<offset_allocator::PersistedAllocationState> stale_allocations;
+};
+
+YLT_REFL(PersistedObjectEntryMirror, key, offset, total_size, value_size,
+         allocation_offset, allocation_metadata, allocation_real_base,
+         allocation_requested_size);
+YLT_REFL(PersistedSnapshotMirror, version, capacity, total_size, total_keys,
+         entries, stale_allocations);
+
+PersistedSnapshotMirror ReadPersistedSnapshot(const fs::path& path) {
+    PersistedSnapshotMirror snapshot;
+    int fd = open(path.c_str(), O_RDONLY);
+    EXPECT_GE(fd, 0);
+    if (fd < 0) {
+        return snapshot;
+    }
+
+    struct stat st;
+    int stat_result = fstat(fd, &st);
+    EXPECT_EQ(stat_result, 0);
+    if (stat_result != 0) {
+        close(fd);
+        return snapshot;
+    }
+
+    std::string bytes(st.st_size, '\0');
+    EXPECT_EQ(read(fd, bytes.data(), bytes.size()),
+              static_cast<ssize_t>(bytes.size()));
+    close(fd);
+
+    auto result = struct_pack::deserialize_to(snapshot, bytes);
+    EXPECT_EQ(result, struct_pack::errc::ok);
+    return snapshot;
+}
+
+void WritePersistedSnapshot(const fs::path& path,
+                            const PersistedSnapshotMirror& snapshot) {
+    auto packed = struct_pack::serialize(snapshot);
+    int fd = open(path.c_str(), O_WRONLY | O_TRUNC);
+    ASSERT_GE(fd, 0);
+    ASSERT_EQ(write(fd, packed.data(), packed.size()),
+              static_cast<ssize_t>(packed.size()));
+    close(fd);
+}
+
+fs::path RecoveryManifestPath(const std::string& data_path) {
+    return fs::path(data_path) / "kv_cache.manifest";
+}
+
+fs::path IndexSnapshotPath(const std::string& data_path, uint64_t generation) {
+    return fs::path(data_path) /
+           ("kv_cache.index." + std::to_string(generation));
+}
+
+fs::path AllocatorSnapshotPath(const std::string& data_path,
+                               uint64_t generation) {
+    return fs::path(data_path) /
+           ("kv_cache.allocator." + std::to_string(generation));
+}
+
+}  // namespace
 
 class StorageBackendTest : public ::testing::Test {
    protected:
     std::string data_path;
+
+    static FileStorageConfig MakeOffsetAllocatorConfig(
+        const std::string& storage_path,
+        int64_t total_size_limit = 100 * 1024 * 1024,
+        int64_t total_keys_limit = 10000,
+        int64_t scanmeta_iterator_keys_limit = 20000) {
+        FileStorageConfig config;
+        config.storage_filepath = storage_path;
+        config.storage_backend_type = StorageBackendType::kOffsetAllocator;
+        config.total_size_limit = total_size_limit;
+        config.total_keys_limit = total_keys_limit;
+        config.scanmeta_iterator_keys_limit = scanmeta_iterator_keys_limit;
+        return config;
+    }
+
+    static void PutSingleValue(OffsetAllocatorStorageBackend& backend,
+                               const std::string& key,
+                               const std::string& value) {
+        auto buf = std::make_unique<char[]>(value.size());
+        std::memcpy(buf.get(), value.data(), value.size());
+        std::unordered_map<std::string, std::vector<Slice>> batch_object;
+        batch_object.emplace(
+            key, std::vector<Slice>{Slice{buf.get(), value.size()}});
+        auto offload_res = backend.BatchOffload(
+            batch_object,
+            [](const std::vector<std::string>&,
+               std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+        ASSERT_TRUE(offload_res);
+        ASSERT_EQ(offload_res.value(), 1);
+    }
+
+    static std::string LoadSingleValue(OffsetAllocatorStorageBackend& backend,
+                                       const std::string& key,
+                                       size_t value_size) {
+        auto buf = std::make_unique<char[]>(value_size);
+        std::unordered_map<std::string, Slice> load_slices;
+        load_slices.emplace(key, Slice{buf.get(), value_size});
+        auto load_res = backend.BatchLoad(load_slices);
+        EXPECT_TRUE(load_res);
+        return std::string(buf.get(), value_size);
+    }
 
     // Helper function to test partial success behavior for any
     // StorageBackendInterface. Uses deterministic failure injection on a batch
@@ -1512,6 +1634,325 @@ TEST_F(StorageBackendTest, OffsetAllocatorStorageBackend_ScanMetaEmpty) {
     ASSERT_TRUE(scan_res);
     EXPECT_FALSE(handler_called)
         << "Handler should not be called for empty backend";
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(StorageBackendTest, OffsetAllocatorStorageBackend_RestartRecovery) {
+    auto config = MakeOffsetAllocatorConfig(data_path);
+    {
+        OffsetAllocatorStorageBackend storage_backend(config);
+        ASSERT_TRUE(storage_backend.Init());
+        PutSingleValue(storage_backend, "key1", "value1");
+        PutSingleValue(storage_backend, "key2", "value2-longer");
+    }
+
+    OffsetAllocatorStorageBackend recovered_backend(config);
+    ASSERT_TRUE(recovered_backend.Init());
+    EXPECT_EQ(LoadSingleValue(recovered_backend, "key1", 6), "value1");
+    EXPECT_EQ(LoadSingleValue(recovered_backend, "key2", 13), "value2-longer");
+
+    std::vector<std::string> scan_keys;
+    auto scan_res = recovered_backend.ScanMeta(
+        [&](const std::vector<std::string>& keys,
+            std::vector<StorageObjectMetadata>& metas) {
+            scan_keys.insert(scan_keys.end(), keys.begin(), keys.end());
+            EXPECT_EQ(keys.size(), metas.size());
+            return ErrorCode::OK;
+        });
+    ASSERT_TRUE(scan_res);
+    EXPECT_EQ(scan_keys.size(), 2);
+    EXPECT_NE(std::find(scan_keys.begin(), scan_keys.end(), "key1"),
+              scan_keys.end());
+    EXPECT_NE(std::find(scan_keys.begin(), scan_keys.end(), "key2"),
+              scan_keys.end());
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(StorageBackendTest,
+       OffsetAllocatorStorageBackend_RestartOverwriteRecovery) {
+    auto config = MakeOffsetAllocatorConfig(data_path);
+    {
+        OffsetAllocatorStorageBackend storage_backend(config);
+        ASSERT_TRUE(storage_backend.Init());
+        PutSingleValue(storage_backend, "dup", "before");
+    }
+
+    {
+        OffsetAllocatorStorageBackend recovered_backend(config);
+        ASSERT_TRUE(recovered_backend.Init());
+        PutSingleValue(recovered_backend, "dup", "after-update");
+    }
+
+    OffsetAllocatorStorageBackend second_recovered_backend(config);
+    ASSERT_TRUE(second_recovered_backend.Init());
+    EXPECT_EQ(LoadSingleValue(second_recovered_backend, "dup", 12),
+              "after-update");
+
+    std::vector<std::string> scan_keys;
+    auto scan_res = second_recovered_backend.ScanMeta(
+        [&](const std::vector<std::string>& keys,
+            std::vector<StorageObjectMetadata>& metas) {
+            scan_keys.insert(scan_keys.end(), keys.begin(), keys.end());
+            EXPECT_EQ(keys.size(), metas.size());
+            return ErrorCode::OK;
+        });
+    ASSERT_TRUE(scan_res);
+    EXPECT_EQ(std::count(scan_keys.begin(), scan_keys.end(), "dup"), 1);
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(
+    StorageBackendTest,
+    OffsetAllocatorStorageBackend_RestartRecoveryAfterOverwriteBatchFailure) {
+    auto config = MakeOffsetAllocatorConfig(data_path);
+
+    OffsetAllocatorStorageBackend backend(config);
+    ASSERT_TRUE(backend.Init());
+    PutSingleValue(backend, "same_key", std::string(1024, 'a'));
+
+    backend.SetTestFailurePredicate(
+        [](const std::string& key) { return key == "fail_key"; });
+
+    std::string overwrite_value(2048, 'b');
+    std::string fail_value(512, 'c');
+    auto overwrite_buf = std::make_unique<char[]>(overwrite_value.size());
+    auto fail_buf = std::make_unique<char[]>(fail_value.size());
+    std::memcpy(overwrite_buf.get(), overwrite_value.data(),
+                overwrite_value.size());
+    std::memcpy(fail_buf.get(), fail_value.data(), fail_value.size());
+
+    std::unordered_map<std::string, std::vector<Slice>> batch_object;
+    batch_object.emplace(
+        "same_key",
+        std::vector<Slice>{Slice{overwrite_buf.get(), overwrite_value.size()}});
+    batch_object.emplace("fail_key", std::vector<Slice>{Slice{
+                                         fail_buf.get(), fail_value.size()}});
+
+    auto offload_res = backend.BatchOffload(
+        batch_object,
+        [](const std::vector<std::string>&,
+           std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+    ASSERT_TRUE(offload_res);
+    ASSERT_EQ(offload_res.value(), 1);
+
+    OffsetAllocatorStorageBackend recovered_backend(config);
+    ASSERT_TRUE(recovered_backend.Init());
+    EXPECT_EQ(
+        LoadSingleValue(recovered_backend, "same_key", overwrite_value.size()),
+        overwrite_value);
+    auto fail_exist_res = recovered_backend.IsExist("fail_key");
+    ASSERT_TRUE(fail_exist_res);
+    EXPECT_FALSE(fail_exist_res.value());
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(StorageBackendTest, OffsetAllocatorStorageBackend_RestartEmptyBaseline) {
+    auto config = MakeOffsetAllocatorConfig(data_path);
+    {
+        OffsetAllocatorStorageBackend storage_backend(config);
+        ASSERT_TRUE(storage_backend.Init());
+    }
+
+    OffsetAllocatorStorageBackend recovered_backend(config);
+    ASSERT_TRUE(recovered_backend.Init());
+    bool handler_called = false;
+    auto scan_res = recovered_backend.ScanMeta(
+        [&](const std::vector<std::string>& keys,
+            std::vector<StorageObjectMetadata>& metas) {
+            handler_called = true;
+            EXPECT_TRUE(keys.empty());
+            EXPECT_TRUE(metas.empty());
+            return ErrorCode::OK;
+        });
+    ASSERT_TRUE(scan_res);
+    EXPECT_FALSE(handler_called);
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(StorageBackendTest,
+       OffsetAllocatorStorageBackend_CleansObsoleteRecoverySnapshots) {
+    auto config = MakeOffsetAllocatorConfig(data_path);
+    {
+        OffsetAllocatorStorageBackend storage_backend(config);
+        ASSERT_TRUE(storage_backend.Init());
+        ASSERT_TRUE(fs::exists(AllocatorSnapshotPath(data_path, 1)));
+        ASSERT_TRUE(fs::exists(IndexSnapshotPath(data_path, 1)));
+
+        PutSingleValue(storage_backend, "key1", "value1");
+        ASSERT_FALSE(fs::exists(AllocatorSnapshotPath(data_path, 1)));
+        ASSERT_FALSE(fs::exists(IndexSnapshotPath(data_path, 1)));
+        ASSERT_TRUE(fs::exists(AllocatorSnapshotPath(data_path, 2)));
+        ASSERT_TRUE(fs::exists(IndexSnapshotPath(data_path, 2)));
+
+        PutSingleValue(storage_backend, "key2", "value2");
+        ASSERT_FALSE(fs::exists(AllocatorSnapshotPath(data_path, 2)));
+        ASSERT_FALSE(fs::exists(IndexSnapshotPath(data_path, 2)));
+        ASSERT_TRUE(fs::exists(AllocatorSnapshotPath(data_path, 3)));
+        ASSERT_TRUE(fs::exists(IndexSnapshotPath(data_path, 3)));
+    }
+
+    OffsetAllocatorStorageBackend recovered_backend(config);
+    ASSERT_TRUE(recovered_backend.Init());
+    EXPECT_EQ(LoadSingleValue(recovered_backend, "key1", 6), "value1");
+    EXPECT_EQ(LoadSingleValue(recovered_backend, "key2", 6), "value2");
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(StorageBackendTest,
+       OffsetAllocatorStorageBackend_InitFailsWhenSnapshotPairMissing) {
+    auto config = MakeOffsetAllocatorConfig(data_path);
+    {
+        OffsetAllocatorStorageBackend storage_backend(config);
+        ASSERT_TRUE(storage_backend.Init());
+        PutSingleValue(storage_backend, "key", "value");
+    }
+
+    ASSERT_TRUE(fs::remove(RecoveryManifestPath(data_path)));
+
+    OffsetAllocatorStorageBackend recovered_backend(config);
+    auto init_res = recovered_backend.Init();
+    EXPECT_FALSE(init_res.has_value());
+    EXPECT_EQ(init_res.error(), ErrorCode::FILE_NOT_FOUND);
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(StorageBackendTest,
+       OffsetAllocatorStorageBackend_InitFailsOnCorruptedIndexSnapshot) {
+    auto config = MakeOffsetAllocatorConfig(data_path);
+    {
+        OffsetAllocatorStorageBackend storage_backend(config);
+        ASSERT_TRUE(storage_backend.Init());
+        PutSingleValue(storage_backend, "key", "value");
+    }
+
+    auto index_path = IndexSnapshotPath(data_path, 2);
+    std::string corrupted = "not-a-valid-snapshot";
+    {
+        int fd = open(index_path.c_str(), O_WRONLY | O_TRUNC);
+        ASSERT_GE(fd, 0);
+        ASSERT_EQ(write(fd, corrupted.data(), corrupted.size()),
+                  static_cast<ssize_t>(corrupted.size()));
+        close(fd);
+    }
+
+    OffsetAllocatorStorageBackend recovered_backend(config);
+    auto init_res = recovered_backend.Init();
+    EXPECT_FALSE(init_res.has_value());
+    EXPECT_EQ(init_res.error(), ErrorCode::DESERIALIZE_FAIL);
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(StorageBackendTest,
+       OffsetAllocatorStorageBackend_InitFailsOnDuplicateSnapshotKeys) {
+    auto config = MakeOffsetAllocatorConfig(data_path);
+    {
+        OffsetAllocatorStorageBackend storage_backend(config);
+        ASSERT_TRUE(storage_backend.Init());
+        PutSingleValue(storage_backend, "key", "value");
+    }
+
+    auto index_path = IndexSnapshotPath(data_path, 2);
+    auto snapshot = ReadPersistedSnapshot(index_path);
+    ASSERT_EQ(snapshot.entries.size(), 1U);
+    snapshot.entries.push_back(snapshot.entries.front());
+    snapshot.total_keys += 1;
+    snapshot.total_size += snapshot.entries.front().total_size;
+    WritePersistedSnapshot(index_path, snapshot);
+
+    OffsetAllocatorStorageBackend recovered_backend(config);
+    auto init_res = recovered_backend.Init();
+    EXPECT_FALSE(init_res.has_value());
+    EXPECT_EQ(init_res.error(), ErrorCode::DESERIALIZE_FAIL);
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(StorageBackendTest,
+       OffsetAllocatorStorageBackend_InitFailsOnDuplicateSnapshotAllocations) {
+    auto config = MakeOffsetAllocatorConfig(data_path);
+    {
+        OffsetAllocatorStorageBackend storage_backend(config);
+        ASSERT_TRUE(storage_backend.Init());
+        PutSingleValue(storage_backend, "key", "value");
+    }
+
+    auto index_path = IndexSnapshotPath(data_path, 2);
+    auto snapshot = ReadPersistedSnapshot(index_path);
+    ASSERT_EQ(snapshot.entries.size(), 1U);
+    auto duplicated = snapshot.entries.front();
+    duplicated.key = "foo";
+    snapshot.entries.push_back(duplicated);
+    snapshot.total_keys += 1;
+    snapshot.total_size += duplicated.total_size;
+    WritePersistedSnapshot(index_path, snapshot);
+
+    OffsetAllocatorStorageBackend recovered_backend(config);
+    auto init_res = recovered_backend.Init();
+    EXPECT_FALSE(init_res.has_value());
+    EXPECT_EQ(init_res.error(), ErrorCode::DESERIALIZE_FAIL);
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(StorageBackendTest,
+       OffsetAllocatorStorageBackend_ScanMetaBatchesAfterRecovery) {
+    auto config =
+        MakeOffsetAllocatorConfig(data_path, 100 * 1024 * 1024, 10000, 2);
+    {
+        OffsetAllocatorStorageBackend storage_backend(config);
+        ASSERT_TRUE(storage_backend.Init());
+        PutSingleValue(storage_backend, "key1", "v1");
+        PutSingleValue(storage_backend, "key2", "v2");
+        PutSingleValue(storage_backend, "key3", "v3");
+    }
+
+    OffsetAllocatorStorageBackend recovered_backend(config);
+    ASSERT_TRUE(recovered_backend.Init());
+
+    int callback_count = 0;
+    size_t total_keys = 0;
+    auto scan_res = recovered_backend.ScanMeta(
+        [&](const std::vector<std::string>& keys,
+            std::vector<StorageObjectMetadata>& metas) {
+            callback_count++;
+            total_keys += keys.size();
+            EXPECT_EQ(keys.size(), metas.size());
+            EXPECT_LE(keys.size(), 2);
+            return ErrorCode::OK;
+        });
+    ASSERT_TRUE(scan_res);
+    EXPECT_EQ(total_keys, 3);
+    EXPECT_EQ(callback_count, 2);
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(StorageBackendTest,
+       OffsetAllocatorStorageBackend_IsEnableOffloadingRestoredAfterRecovery) {
+    auto config = MakeOffsetAllocatorConfig(data_path, 100 * 1024 * 1024, 2);
+    {
+        OffsetAllocatorStorageBackend storage_backend(config);
+        ASSERT_TRUE(storage_backend.Init());
+        PutSingleValue(storage_backend, "key1", "value1");
+        PutSingleValue(storage_backend, "key2", "value2");
+        auto enabled = storage_backend.IsEnableOffloading();
+        ASSERT_TRUE(enabled);
+        EXPECT_FALSE(enabled.value());
+    }
+
+    OffsetAllocatorStorageBackend recovered_backend(config);
+    ASSERT_TRUE(recovered_backend.Init());
+    auto enabled = recovered_backend.IsEnableOffloading();
+    ASSERT_TRUE(enabled);
+    EXPECT_FALSE(enabled.value());
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
  ## Motivation                                                                                                                                                                      
                                                                                                                                                                                     
  `OffsetAllocatorStorageBackend` stores all objects in one shared data file and relies on in-memory metadata plus allocator state to locate objects. Before this change, that backend did not have a complete restart-recovery path: process restart could preserve `kv_cache.data`, but it could not reliably reconstruct the allocator state and key index needed to serve reads and replay local-disk metadata back to the master.                                                                                                           
                                                                                                                                                                                     
  This PR closes that gap by persisting recovery metadata alongside the data file and rebuilding the backend's in-memory state during startup. The goal is to make `OffsetAllocatorStorageBackend` follow the existing synchronous startup recovery model already used by the storage stack, instead of introducing a new async rebuild path in this PR.                                  
                                               
  ## Scenario                                       
                                                                                                                                                                                     
  This PR targets the existing startup flow for local-disk recovery:                                                                                                                 
                                                                                                                                                                                     
  1. `FileStorage::Init()` starts the backend.                                                                                                                                       
  2. `OffsetAllocatorStorageBackend::Init()` restores local allocator/index state from persisted recovery metadata.                                                                  
  3. `ScanMeta()` iterates the rebuilt in-memory object view.                                                                                                                        
  4. `NotifyOffloadSuccess()` re-registers recovered objects with the master.                                                                                                        
                                                                                                                                                                                     
  With this change, restart recovery for offset-allocator-backed storage works the same way as the existing synchronous startup recovery skeleton: startup succeeds only after the backend's local readable state is rebuilt.                                                                                                                                         
                                                                                                                                                                                     
  ## Description                                                                                                                                                                     
                                                                                                                                                                                     
  This PR adds restart recovery for `OffsetAllocatorStorageBackend` through three pieces:                                                                                            
                                                                                                                                                                                     
  ### Recovery metadata persistence                                                                                                                                                  
                                                                                                                                                                                     
  - Persist generation-scoped recovery files next to `kv_cache.data`:                                                                                                                
    - `kv_cache.allocator.<generation>`                                                                                                                                              
    - `kv_cache.index.<generation>`                                                                                                                                                  
    - `kv_cache.manifest`                                                                                                                                                            
  - Persist allocator state separately from object index state.                                                                                                                      
  - Use the manifest as the authoritative pointer to the active recovery generation.                                                                                                 
  - Remove obsolete allocator/index snapshot generations after a successful manifest update.                                                                                         
                                                                                                                                                                                     
  ### Restart validation and rebuild                                                                                                                                                 
                                                                                                                                                                                     
  - Load manifest, allocator snapshot, and index snapshot during backend init.                                                                                                       
  - Fail fast when:                                                                                                                                                                  
    - the manifest is missing but snapshot files exist,                                                                                                                              
    - manifest-referenced snapshot files are missing,                                                                                                                                
    - allocator/index snapshots cannot be deserialized,                                                                                                                              
    - persisted allocation state is invalid,                                                                                                                                         
    - duplicate keys or duplicate allocation states appear in the snapshot,                                                                                                          
    - the backing data file is missing or truncated relative to configured capacity.                                                                                                 
  - Rebuild shard maps, object metadata, aggregate counters, and allocator-backed handles from persisted recovery state.                                                             
  - Keep the startup flow synchronous; this PR does not introduce background async rebuild.                                                                                          
                                                                                                                                                                                     
  ### Write-path integration and recovery correctness                                                                                                                                
                                                                                                                                                                                     
  - Update recovery metadata on successful batch offload so restart state tracks overwrites and partial-success batches.                                                             
  - Preserve overwrite recovery correctness through stale-allocation tracking.                                                                                                       
  - Keep recovery snapshot state rollback-safe when recovery persistence fails during publish.                                                                                       
  - Reduce reviewer-facing failure ambiguity by tightening snapshot validation and rebuild invariants.                                                                               
                                                                                                                                                                                     
  ## Documentation                                                                                                                                                                   
                                                                                                                                                                                     
  - Update `docs/source/design/ssd-offload.md` to describe:                                                                                                                          
    - the recovery file layout,                                                                                                                                                      
    - the startup rebuild path,                                                                                                                                                      
    - fail-fast recovery semantics for the offset-allocator backend.                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## How Has This Been Tested?                                                                                                                                                       
 - `/root/Mooncake/build-min-check/mooncake-store/tests/storage_backend_test --gtest_filter="StorageBackendTest.OffsetAllocatorStorageBackend_RestartRecovery:StorageBackendTest.OffsetAllocatorStorageBackend_RestartOverwriteRecovery:StorageBackendTest.OffsetAllocatorStorageBackend_RestartRecoveryAfterOverwriteBatchFailure:StorageBackendTest.OffsetAllocatorStorageBackend_RestartEmptyBaseline:StorageBackendTest.OffsetAllocatorStorageBackend_CleansObsoleteRecoverySnapshots:StorageBackendTest.OffsetAllocatorStorageBackend_InitFailsWhenSnapshotPairMissing:StorageBackendTest.OffsetAllocatorStorageBackend_InitFailsOnCorruptedIndexSnapshot:StorageBackendTest.OffsetAllocatorStorageBackend_InitFailsOnDuplicateSnapshotKeys:StorageBackendTest.OffsetAllocatorStorageBackend_InitFailsOnDuplicateSnapshotAllocations:StorageBackendTest.OffsetAllocatorStorageBackend_ScanMetaBatchesAfterRecovery:StorageBackendTest.OffsetAllocatorStorageBackend_IsEnableOffloadingRestoredAfterRecovery"`                                                                                                 
  - `/root/Mooncake/build-min-check/mooncake-store/tests/storage_backend_test`                                                                                                   
                                                                                                                                                                                     
  ## Notes                                                                                                                                                                           
                                                                                                                                                                                     
  - This PR intentionally keeps rebuild synchronous during startup to match the existing storage recovery model.                                                                     
  - **Async/background rebuild is intentionally deferred to a follow-up PR.** 
  - **A pre-existing stale-task gap was exposed in the promotion-on-hit path: PromotionAllocStart and NotifyPromotionSuccess only checked whether a promotion task still existed, not whether it had already expired. In the window before the async reaper swept the task, late RPCs could still allocate or commit stale promotions, potentially leaving orphaned staged memory replicas.**                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                        
  ---                                                       
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
