### PR TITLE
[Store] feat: scoped key isolation

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1852,7 +1852,8 @@ PYBIND11_MODULE(store, m) {
                const std::string &master_server_addr = "127.0.0.1:50051",
                const py::object &engine = py::none(),
                bool enable_ssd_offload = false,
-               const std::string &ssd_offload_path = "") {
+               const std::string &ssd_offload_path = "",
+               const std::string &tenant_id = "default") {
                 auto real_client = self.init_real_client();
                 std::shared_ptr<mooncake::TransferEngine> transfer_engine =
                     nullptr;
@@ -1864,14 +1865,14 @@ PYBIND11_MODULE(store, m) {
                     local_hostname, metadata_server, global_segment_size,
                     local_buffer_size, protocol, rdma_devices,
                     master_server_addr, transfer_engine, "", enable_ssd_offload,
-                    ssd_offload_path);
+                    ssd_offload_path, tenant_id);
             },
             py::arg("local_hostname"), py::arg("metadata_server"),
             py::arg("global_segment_size"), py::arg("local_buffer_size"),
             py::arg("protocol"), py::arg("rdma_devices"),
             py::arg("master_server_addr"), py::arg("engine") = py::none(),
             py::arg("enable_ssd_offload") = false,
-            py::arg("ssd_offload_path") = "")
+            py::arg("ssd_offload_path") = "", py::arg("tenant_id") = "default")
         .def(
             "setup",
             [](MooncakeStorePyWrapper &self, const py::dict &config_dict) {

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -151,6 +151,12 @@ class Client {
         const std::vector<std::string>& object_keys);
 
     /**
+     * @brief Batch query object metadata by already tenant-scoped storage keys.
+     */
+    std::vector<tl::expected<QueryResult, ErrorCode>> BatchQueryStorageKeys(
+        const std::vector<std::string>& storage_keys);
+
+    /**
      * @brief Batch clear KV cache for specified object keys on a specific
      * segment for a given client.
      * @param object_keys Vector of object key strings to clear.
@@ -284,8 +290,7 @@ class Client {
         const std::vector<std::string>& keys, ReplicaType replica_type);
 
     std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplicaStorageKeys(
-        const std::vector<std::string>& storage_keys,
-        ReplicaType replica_type);
+        const std::vector<std::string>& storage_keys, ReplicaType replica_type);
 
     /**
      * @brief Registers a memory segment to master for allocation

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -67,6 +67,9 @@ class Client {
     const UUID& getClientId() const { return client_id_; }
     const std::string& GetTenantId() const { return tenant_id_; }
     std::string BuildStorageKey(const std::string& object_key) const {
+        if (ParseTenantScopedKey(object_key)) {
+            return object_key;
+        }
         return BuildTenantScopedKey(tenant_id_, object_key);
     }
 

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -283,6 +283,10 @@ class Client {
     std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
         const std::vector<std::string>& keys, ReplicaType replica_type);
 
+    std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplicaStorageKeys(
+        const std::vector<std::string>& storage_keys,
+        ReplicaType replica_type);
+
     /**
      * @brief Registers a memory segment to master for allocation
      * @param buffer Memory buffer to register

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -67,9 +67,6 @@ class Client {
     const UUID& getClientId() const { return client_id_; }
     const std::string& GetTenantId() const { return tenant_id_; }
     std::string BuildStorageKey(const std::string& object_key) const {
-        if (ParseTenantScopedKey(object_key)) {
-            return object_key;
-        }
         return BuildTenantScopedKey(tenant_id_, object_key);
     }
 
@@ -851,7 +848,8 @@ class Client {
      */
     tl::expected<void, ErrorCode> Copy(const std::string& key,
                                        const std::string& source,
-                                       const std::vector<std::string>& targets);
+                                       const std::vector<std::string>& targets,
+                                       bool key_is_storage_key = false);
 
     /**
      * @brief Move an object's replica from source segment to target segment
@@ -862,7 +860,8 @@ class Client {
      */
     tl::expected<void, ErrorCode> Move(const std::string& key,
                                        const std::string& source,
-                                       const std::string& target);
+                                       const std::string& target,
+                                       bool key_is_storage_key = false);
 
     // Task thread pool for async task execution
     ThreadPool task_thread_pool_;

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -65,6 +65,10 @@ class Client {
     virtual ~Client();
 
     const UUID& getClientId() const { return client_id_; }
+    const std::string& GetTenantId() const { return tenant_id_; }
+    std::string BuildStorageKey(const std::string& object_key) const {
+        return BuildTenantScopedKey(tenant_id_, object_key);
+    }
 
     /**
      * @brief Creates and initializes a new Client instance
@@ -86,7 +90,8 @@ class Client {
         const std::optional<std::string>& device_names = std::nullopt,
         const std::string& master_server_entry = kDefaultMasterAddress,
         const std::shared_ptr<TransferEngine>& transfer_engine = nullptr,
-        std::map<std::string, std::string> labels = {});
+        std::map<std::string, std::string> labels = {},
+        std::string tenant_id = "default");
 
     /**
      * @brief Retrieves data for a given key
@@ -627,7 +632,8 @@ class Client {
      */
     Client(const std::string& local_hostname,
            const std::string& metadata_connstring, const std::string& protocol,
-           const std::map<std::string, std::string>& labels = {});
+           const std::map<std::string, std::string>& labels = {},
+           std::string tenant_id = "default");
 
    private:
     /**
@@ -744,6 +750,7 @@ class Client {
 
     // Client identification
     const UUID client_id_;
+    const std::string tenant_id_;
 
     // Client-side metrics
     std::unique_ptr<ClientMetric> metrics_;

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -29,7 +29,8 @@ class DummyClient : public PyClient {
                    const std::shared_ptr<TransferEngine> &transfer_engine,
                    const std::string &ipc_socket_path,
                    bool enable_ssd_offload = false,
-                   const std::string &ssd_offload_path = "") {
+                   const std::string &ssd_offload_path = "",
+                   const std::string &tenant_id = "default") {
         // Dummy client does not support real setup
         return -1;
     };

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -167,6 +167,10 @@ class MasterClient {
     [[nodiscard]] std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
     BatchGetReplicaList(const std::vector<std::string>& object_keys);
 
+    [[nodiscard]] std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+    BatchGetReplicaListStorageKeys(
+        const std::vector<std::string>& storage_keys);
+
     /**
      * @brief Starts a put operation
      * @param key Object key

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -582,6 +582,15 @@ class MasterClient {
                           ReplicaType replica_type);
 
    private:
+    [[nodiscard]] std::string BuildStorageKey(
+        const std::string& object_key) const;
+
+    [[nodiscard]] std::vector<std::string> BuildStorageKeys(
+        const std::vector<std::string>& object_keys) const;
+
+    [[nodiscard]] std::string BuildStorageRegex(
+        const std::string& object_regex) const;
+
     /**
      * @brief Generic RPC invocation helper for single-result operations
      * @tparam ServiceMethod Pointer to WrappedMasterService member function

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -581,15 +581,32 @@ class MasterClient {
     BatchEvictDiskReplica(const std::vector<std::string>& keys,
                           ReplicaType replica_type);
 
+    [[nodiscard]] tl::expected<CopyStartResponse, ErrorCode>
+    CopyStartStorageKey(const std::string& storage_key,
+                        const std::string& src_segment,
+                        const std::vector<std::string>& tgt_segments);
+    [[nodiscard]] tl::expected<void, ErrorCode> CopyEndStorageKey(
+        const std::string& storage_key);
+    [[nodiscard]] tl::expected<void, ErrorCode> CopyRevokeStorageKey(
+        const std::string& storage_key);
+    [[nodiscard]] tl::expected<MoveStartResponse, ErrorCode>
+    MoveStartStorageKey(const std::string& storage_key,
+                        const std::string& src_segment,
+                        const std::string& tgt_segment);
+    [[nodiscard]] tl::expected<void, ErrorCode> MoveEndStorageKey(
+        const std::string& storage_key);
+    [[nodiscard]] tl::expected<void, ErrorCode> MoveRevokeStorageKey(
+        const std::string& storage_key);
+    [[nodiscard]] std::vector<tl::expected<void, ErrorCode>>
+    BatchEvictDiskReplicaStorageKeys(
+        const std::vector<std::string>& storage_keys, ReplicaType replica_type);
+
    private:
     [[nodiscard]] std::string BuildStorageKey(
         const std::string& object_key) const;
 
     [[nodiscard]] std::vector<std::string> BuildStorageKeys(
         const std::vector<std::string>& object_keys) const;
-
-    [[nodiscard]] std::string BuildStorageRegex(
-        const std::string& object_regex) const;
 
     /**
      * @brief Generic RPC invocation helper for single-result operations

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 #include <variant>
 #include <cstdlib>
@@ -52,8 +53,11 @@ inline void MaybeEnableRdmaSocketConfig(SocketConfigVariant& socket_config) {
  */
 class MasterClient {
    public:
-    MasterClient(const UUID& client_id, MasterClientMetric* metrics = nullptr)
-        : client_id_(client_id), metrics_(metrics) {
+    MasterClient(const UUID& client_id, MasterClientMetric* metrics = nullptr,
+                 std::string tenant_id = "default")
+        : client_id_(client_id),
+          tenant_id_(tenant_id.empty() ? "default" : std::move(tenant_id)),
+          metrics_(metrics) {
         coro_io::client_pool<coro_rpc::coro_rpc_client>::pool_config
             pool_conf{};
 
@@ -632,6 +636,7 @@ class MasterClient {
 
     // The client identification.
     const UUID client_id_;
+    const std::string tenant_id_;
 
     // Metrics for tracking RPC operations
     MasterClientMetric* metrics_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -15,6 +15,7 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 #include <ylt/util/expected.hpp>
 #include <ylt/util/tl/expected.hpp>
@@ -162,9 +163,13 @@ class MasterService {
      * @return ErrorCode::OK if exists, otherwise return other ErrorCode
      */
     auto ExistKey(const std::string& key) -> tl::expected<bool, ErrorCode>;
+    auto ExistKey(const std::string& key, const std::string& tenant_id)
+        -> tl::expected<bool, ErrorCode>;
 
     std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
         const std::vector<std::string>& keys);
+    std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
+        const std::vector<std::string>& keys, const std::string& tenant_id);
 
     /**
      * @brief Fetch all keys
@@ -243,6 +248,11 @@ class MasterService {
                            const UUID& client_id,
                            const std::string& segment_name)
         -> tl::expected<std::vector<std::string>, ErrorCode>;
+    auto BatchReplicaClear(const std::vector<std::string>& object_keys,
+                           const UUID& client_id,
+                           const std::string& segment_name,
+                           const std::string& tenant_id)
+        -> tl::expected<std::vector<std::string>, ErrorCode>;
 
     /**
      * @brief Retrieves replica lists for object keys that match a regex
@@ -255,6 +265,11 @@ class MasterService {
         -> tl::expected<
             std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
             ErrorCode>;
+    auto GetReplicaListByRegex(const std::string& regex_pattern,
+                               const std::string& tenant_id)
+        -> tl::expected<
+            std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
+            ErrorCode>;
 
     /**
      * @brief Get list of replicas for an object
@@ -263,6 +278,8 @@ class MasterService {
      * ready
      */
     auto GetReplicaList(const std::string& key)
+        -> tl::expected<GetReplicaListResponse, ErrorCode>;
+    auto GetReplicaList(const std::string& key, const std::string& tenant_id)
         -> tl::expected<GetReplicaListResponse, ErrorCode>;
 
     /**
@@ -276,6 +293,10 @@ class MasterService {
     auto PutStart(const UUID& client_id, const std::string& key,
                   const uint64_t slice_length, const ReplicateConfig& config)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
+    auto PutStart(const UUID& client_id, const std::string& key,
+                  const uint64_t slice_length, const ReplicateConfig& config,
+                  const std::string& tenant_id)
+        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
 
     /**
      * @brief Complete a put operation, replica_type indicates the type of
@@ -285,12 +306,18 @@ class MasterService {
      */
     auto PutEnd(const UUID& client_id, const std::string& key,
                 ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
+    auto PutEnd(const UUID& client_id, const std::string& key,
+                ReplicaType replica_type, const std::string& tenant_id)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Adds a replica instance associated with the given client and key.
      */
     auto AddReplica(const UUID& client_id, const std::string& key,
                     Replica& replica) -> tl::expected<void, ErrorCode>;
+    auto AddReplica(const UUID& client_id, const std::string& key,
+                    Replica& replica, const std::string& tenant_id)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Revoke a put operation, replica_type indicates the type of
@@ -300,6 +327,9 @@ class MasterService {
      */
     auto PutRevoke(const UUID& client_id, const std::string& key,
                    ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
+    auto PutRevoke(const UUID& client_id, const std::string& key,
+                   ReplicaType replica_type, const std::string& tenant_id)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Complete a batch of put operations
@@ -309,6 +339,9 @@ class MasterService {
     std::vector<tl::expected<void, ErrorCode>> BatchPutEnd(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type = ReplicaType::ALL);
+    std::vector<tl::expected<void, ErrorCode>> BatchPutEnd(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        ReplicaType replica_type, const std::string& tenant_id);
 
     /**
      * @brief Revoke a batch of put operations
@@ -318,6 +351,9 @@ class MasterService {
     std::vector<tl::expected<void, ErrorCode>> BatchPutRevoke(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type = ReplicaType::ALL);
+    std::vector<tl::expected<void, ErrorCode>> BatchPutRevoke(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        ReplicaType replica_type, const std::string& tenant_id);
 
     /**
      * @brief Start an upsert operation. If the key does not exist, behaves
@@ -331,18 +367,28 @@ class MasterService {
     auto UpsertStart(const UUID& client_id, const std::string& key,
                      const uint64_t slice_length, const ReplicateConfig& config)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
+    auto UpsertStart(const UUID& client_id, const std::string& key,
+                     const uint64_t slice_length, const ReplicateConfig& config,
+                     const std::string& tenant_id)
+        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
 
     /**
      * @brief Complete an upsert operation. Delegates to PutEnd.
      */
     auto UpsertEnd(const UUID& client_id, const std::string& key,
                    ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
+    auto UpsertEnd(const UUID& client_id, const std::string& key,
+                   ReplicaType replica_type, const std::string& tenant_id)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Revoke an upsert operation. Delegates to PutRevoke.
      */
     auto UpsertRevoke(const UUID& client_id, const std::string& key,
                       ReplicaType replica_type)
+        -> tl::expected<void, ErrorCode>;
+    auto UpsertRevoke(const UUID& client_id, const std::string& key,
+                      ReplicaType replica_type, const std::string& tenant_id)
         -> tl::expected<void, ErrorCode>;
 
     /**
@@ -353,18 +399,30 @@ class MasterService {
                      const std::vector<std::string>& keys,
                      const std::vector<uint64_t>& slice_lengths,
                      const ReplicateConfig& config);
+    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+    BatchUpsertStart(const UUID& client_id,
+                     const std::vector<std::string>& keys,
+                     const std::vector<uint64_t>& slice_lengths,
+                     const ReplicateConfig& config,
+                     const std::string& tenant_id);
 
     /**
      * @brief Complete a batch of upsert operations. Delegates to BatchPutEnd.
      */
     std::vector<tl::expected<void, ErrorCode>> BatchUpsertEnd(
         const UUID& client_id, const std::vector<std::string>& keys);
+    std::vector<tl::expected<void, ErrorCode>> BatchUpsertEnd(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        const std::string& tenant_id);
 
     /**
      * @brief Revoke a batch of upsert operations. Delegates to BatchPutRevoke.
      */
     std::vector<tl::expected<void, ErrorCode>> BatchUpsertRevoke(
         const UUID& client_id, const std::vector<std::string>& keys);
+    std::vector<tl::expected<void, ErrorCode>> BatchUpsertRevoke(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        const std::string& tenant_id);
 
     /**
      * @brief Evict a disk replica for a key (triggered by client-side disk
@@ -377,6 +435,10 @@ class MasterService {
     auto EvictDiskReplica(const UUID& client_id, const std::string& key,
                           ReplicaType replica_type)
         -> tl::expected<void, ErrorCode>;
+    auto EvictDiskReplica(const UUID& client_id, const std::string& key,
+                          ReplicaType replica_type,
+                          const std::string& tenant_id)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Batch evict disk replicas for multiple keys.
@@ -388,6 +450,9 @@ class MasterService {
     std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type);
+    std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        ReplicaType replica_type, const std::string& tenant_id);
 
     /**
      * @brief Start a copy operation
@@ -406,12 +471,23 @@ class MasterService {
         const UUID& client_id, const std::string& key,
         const std::string& src_segment,
         const std::vector<std::string>& tgt_segments);
+    tl::expected<CopyStartResponse, ErrorCode> CopyStart(
+        const UUID& client_id, const std::string& key,
+        const std::string& src_segment,
+        const std::vector<std::string>& tgt_segments,
+        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> CopyEnd(const UUID& client_id,
                                           const std::string& key);
+    tl::expected<void, ErrorCode> CopyEnd(const UUID& client_id,
+                                          const std::string& key,
+                                          const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> CopyRevoke(const UUID& client_id,
                                              const std::string& key);
+    tl::expected<void, ErrorCode> CopyRevoke(const UUID& client_id,
+                                             const std::string& key,
+                                             const std::string& tenant_id);
 
     /**
      * @brief Start a move operation
@@ -429,12 +505,22 @@ class MasterService {
     tl::expected<MoveStartResponse, ErrorCode> MoveStart(
         const UUID& client_id, const std::string& key,
         const std::string& src_segment, const std::string& tgt_segment);
+    tl::expected<MoveStartResponse, ErrorCode> MoveStart(
+        const UUID& client_id, const std::string& key,
+        const std::string& src_segment, const std::string& tgt_segment,
+        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> MoveEnd(const UUID& client_id,
                                           const std::string& key);
+    tl::expected<void, ErrorCode> MoveEnd(const UUID& client_id,
+                                          const std::string& key,
+                                          const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> MoveRevoke(const UUID& client_id,
                                              const std::string& key);
+    tl::expected<void, ErrorCode> MoveRevoke(const UUID& client_id,
+                                             const std::string& key,
+                                             const std::string& tenant_id);
 
     /**
      * @brief Remove an object and its replicas
@@ -445,6 +531,8 @@ class MasterService {
      */
     auto Remove(const std::string& key, bool force = false)
         -> tl::expected<void, ErrorCode>;
+    auto Remove(const std::string& key, const std::string& tenant_id,
+                bool force = false) -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Removes objects from the master whose keys match a regex pattern.
@@ -455,6 +543,8 @@ class MasterService {
      */
     auto RemoveByRegex(const std::string& str, bool force = false)
         -> tl::expected<long, ErrorCode>;
+    auto RemoveByRegex(const std::string& str, const std::string& tenant_id,
+                       bool force = false) -> tl::expected<long, ErrorCode>;
 
     /**
      * @brief Remove all objects and their replicas
@@ -470,6 +560,9 @@ class MasterService {
      * @return Vector of expected results for each key.
      */
     auto BatchRemove(const std::vector<std::string>& keys, bool force = false)
+        -> std::vector<tl::expected<void, ErrorCode>>;
+    auto BatchRemove(const std::vector<std::string>& keys,
+                     const std::string& tenant_id, bool force = false)
         -> std::vector<tl::expected<void, ErrorCode>>;
 
     /**
@@ -596,6 +689,9 @@ class MasterService {
      */
     tl::expected<UUID, ErrorCode> CreateCopyTask(
         const std::string& key, const std::vector<std::string>& targets);
+    tl::expected<UUID, ErrorCode> CreateCopyTask(
+        const std::string& key, const std::vector<std::string>& targets,
+        const std::string& tenant_id);
 
     /**
      * @brief Create a move task to move an object's replica from source segment
@@ -605,6 +701,10 @@ class MasterService {
     tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
                                                  const std::string& source,
                                                  const std::string& target);
+    tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
+                                                 const std::string& source,
+                                                 const std::string& target,
+                                                 const std::string& tenant_id);
 
     /**
      * @brief Create a drain job to gracefully evacuate one or more segments.
@@ -741,11 +841,14 @@ class MasterService {
             const std::chrono::system_clock::time_point put_start_time_,
             size_t value_length, std::vector<Replica>&& reps,
             bool enable_soft_pin, bool enable_hard_pin = false,
-            ObjectDataType data_type_ = ObjectDataType::UNKNOWN)
+            ObjectDataType data_type_ = ObjectDataType::UNKNOWN,
+            std::string tenant_id_ = "default", std::string user_key_ = {})
             : client_id(client_id_),
               put_start_time(put_start_time_),
               size(value_length),
               data_type(data_type_),
+              tenant_id(std::move(tenant_id_)),
+              user_key(std::move(user_key_)),
               lease_timeout(),
               soft_pin_timeout(std::nullopt),
               hard_pinned(enable_hard_pin),
@@ -769,6 +872,12 @@ class MasterService {
         std::chrono::system_clock::time_point put_start_time;
         const size_t size;
         const ObjectDataType data_type{ObjectDataType::UNKNOWN};
+        const std::string tenant_id;
+        const std::string user_key;
+
+        const std::string& UserKeyOr(const std::string& fallback) const {
+            return user_key.empty() ? fallback : user_key;
+        }
 
         mutable SpinLock lock;
         // Default constructor, creates a time_point representing
@@ -1114,7 +1223,7 @@ class MasterService {
     auto AllocateAndInsertMetadata(
         MetadataShardAccessorRW& shard, const UUID& client_id,
         const std::string& key, uint64_t value_length,
-        const ReplicateConfig& config,
+        const ReplicateConfig& config, const std::string& tenant_id,
         const std::chrono::system_clock::time_point& now)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
 
@@ -1141,8 +1250,8 @@ class MasterService {
     bool ProbeNoFSegment(const std::string& te_endpoint,
                          std::string* error_reason);
 
-    tl::expected<void, ErrorCode> PushOffloadingQueue(const std::string& key,
-                                                      Replica& replica);
+    tl::expected<void, ErrorCode> PushOffloadingQueue(
+        const std::string& tenant_id, const std::string& key, Replica& replica);
 
     // Graceful unmount scheduler
     class GracefulUnmountScheduler {
@@ -1317,16 +1426,19 @@ class MasterService {
         void Create(const UUID& client_id, uint64_t total_length,
                     std::vector<Replica> replicas, bool enable_soft_pin,
                     bool enable_hard_pin = false,
-                    ObjectDataType data_type = ObjectDataType::UNKNOWN) {
+                    ObjectDataType data_type = ObjectDataType::UNKNOWN,
+                    std::string tenant_id = "default",
+                    std::string user_key = {}) {
             if (Exists()) {
                 throw std::logic_error("Already exists");
             }
             const auto now = std::chrono::system_clock::now();
             auto result = shard_guard_->metadata.emplace(
                 std::piecewise_construct, std::forward_as_tuple(key_),
-                std::forward_as_tuple(client_id, now, total_length,
-                                      std::move(replicas), enable_soft_pin,
-                                      enable_hard_pin, data_type));
+                std::forward_as_tuple(
+                    client_id, now, total_length, std::move(replicas),
+                    enable_soft_pin, enable_hard_pin, data_type,
+                    std::move(tenant_id), std::move(user_key)));
             it_ = result.first;
         }
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -163,13 +163,9 @@ class MasterService {
      * @return ErrorCode::OK if exists, otherwise return other ErrorCode
      */
     auto ExistKey(const std::string& key) -> tl::expected<bool, ErrorCode>;
-    auto ExistKey(const std::string& key, const std::string& tenant_id)
-        -> tl::expected<bool, ErrorCode>;
 
     std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
         const std::vector<std::string>& keys);
-    std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
-        const std::vector<std::string>& keys, const std::string& tenant_id);
 
     /**
      * @brief Fetch all keys
@@ -248,11 +244,6 @@ class MasterService {
                            const UUID& client_id,
                            const std::string& segment_name)
         -> tl::expected<std::vector<std::string>, ErrorCode>;
-    auto BatchReplicaClear(const std::vector<std::string>& object_keys,
-                           const UUID& client_id,
-                           const std::string& segment_name,
-                           const std::string& tenant_id)
-        -> tl::expected<std::vector<std::string>, ErrorCode>;
 
     /**
      * @brief Retrieves replica lists for object keys that match a regex
@@ -279,8 +270,6 @@ class MasterService {
      */
     auto GetReplicaList(const std::string& key)
         -> tl::expected<GetReplicaListResponse, ErrorCode>;
-    auto GetReplicaList(const std::string& key, const std::string& tenant_id)
-        -> tl::expected<GetReplicaListResponse, ErrorCode>;
 
     /**
      * @brief Start a put operation for an object
@@ -293,10 +282,6 @@ class MasterService {
     auto PutStart(const UUID& client_id, const std::string& key,
                   const uint64_t slice_length, const ReplicateConfig& config)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
-    auto PutStart(const UUID& client_id, const std::string& key,
-                  const uint64_t slice_length, const ReplicateConfig& config,
-                  const std::string& tenant_id)
-        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
 
     /**
      * @brief Complete a put operation, replica_type indicates the type of
@@ -306,18 +291,12 @@ class MasterService {
      */
     auto PutEnd(const UUID& client_id, const std::string& key,
                 ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
-    auto PutEnd(const UUID& client_id, const std::string& key,
-                ReplicaType replica_type, const std::string& tenant_id)
-        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Adds a replica instance associated with the given client and key.
      */
     auto AddReplica(const UUID& client_id, const std::string& key,
                     Replica& replica) -> tl::expected<void, ErrorCode>;
-    auto AddReplica(const UUID& client_id, const std::string& key,
-                    Replica& replica, const std::string& tenant_id)
-        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Revoke a put operation, replica_type indicates the type of
@@ -327,9 +306,6 @@ class MasterService {
      */
     auto PutRevoke(const UUID& client_id, const std::string& key,
                    ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
-    auto PutRevoke(const UUID& client_id, const std::string& key,
-                   ReplicaType replica_type, const std::string& tenant_id)
-        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Complete a batch of put operations
@@ -339,9 +315,6 @@ class MasterService {
     std::vector<tl::expected<void, ErrorCode>> BatchPutEnd(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type = ReplicaType::ALL);
-    std::vector<tl::expected<void, ErrorCode>> BatchPutEnd(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        ReplicaType replica_type, const std::string& tenant_id);
 
     /**
      * @brief Revoke a batch of put operations
@@ -351,9 +324,6 @@ class MasterService {
     std::vector<tl::expected<void, ErrorCode>> BatchPutRevoke(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type = ReplicaType::ALL);
-    std::vector<tl::expected<void, ErrorCode>> BatchPutRevoke(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        ReplicaType replica_type, const std::string& tenant_id);
 
     /**
      * @brief Start an upsert operation. If the key does not exist, behaves
@@ -367,28 +337,18 @@ class MasterService {
     auto UpsertStart(const UUID& client_id, const std::string& key,
                      const uint64_t slice_length, const ReplicateConfig& config)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
-    auto UpsertStart(const UUID& client_id, const std::string& key,
-                     const uint64_t slice_length, const ReplicateConfig& config,
-                     const std::string& tenant_id)
-        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
 
     /**
      * @brief Complete an upsert operation. Delegates to PutEnd.
      */
     auto UpsertEnd(const UUID& client_id, const std::string& key,
                    ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
-    auto UpsertEnd(const UUID& client_id, const std::string& key,
-                   ReplicaType replica_type, const std::string& tenant_id)
-        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Revoke an upsert operation. Delegates to PutRevoke.
      */
     auto UpsertRevoke(const UUID& client_id, const std::string& key,
                       ReplicaType replica_type)
-        -> tl::expected<void, ErrorCode>;
-    auto UpsertRevoke(const UUID& client_id, const std::string& key,
-                      ReplicaType replica_type, const std::string& tenant_id)
         -> tl::expected<void, ErrorCode>;
 
     /**
@@ -399,30 +359,18 @@ class MasterService {
                      const std::vector<std::string>& keys,
                      const std::vector<uint64_t>& slice_lengths,
                      const ReplicateConfig& config);
-    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-    BatchUpsertStart(const UUID& client_id,
-                     const std::vector<std::string>& keys,
-                     const std::vector<uint64_t>& slice_lengths,
-                     const ReplicateConfig& config,
-                     const std::string& tenant_id);
 
     /**
      * @brief Complete a batch of upsert operations. Delegates to BatchPutEnd.
      */
     std::vector<tl::expected<void, ErrorCode>> BatchUpsertEnd(
         const UUID& client_id, const std::vector<std::string>& keys);
-    std::vector<tl::expected<void, ErrorCode>> BatchUpsertEnd(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        const std::string& tenant_id);
 
     /**
      * @brief Revoke a batch of upsert operations. Delegates to BatchPutRevoke.
      */
     std::vector<tl::expected<void, ErrorCode>> BatchUpsertRevoke(
         const UUID& client_id, const std::vector<std::string>& keys);
-    std::vector<tl::expected<void, ErrorCode>> BatchUpsertRevoke(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        const std::string& tenant_id);
 
     /**
      * @brief Evict a disk replica for a key (triggered by client-side disk
@@ -435,10 +383,6 @@ class MasterService {
     auto EvictDiskReplica(const UUID& client_id, const std::string& key,
                           ReplicaType replica_type)
         -> tl::expected<void, ErrorCode>;
-    auto EvictDiskReplica(const UUID& client_id, const std::string& key,
-                          ReplicaType replica_type,
-                          const std::string& tenant_id)
-        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Batch evict disk replicas for multiple keys.
@@ -450,9 +394,6 @@ class MasterService {
     std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type);
-    std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        ReplicaType replica_type, const std::string& tenant_id);
 
     /**
      * @brief Start a copy operation
@@ -471,23 +412,12 @@ class MasterService {
         const UUID& client_id, const std::string& key,
         const std::string& src_segment,
         const std::vector<std::string>& tgt_segments);
-    tl::expected<CopyStartResponse, ErrorCode> CopyStart(
-        const UUID& client_id, const std::string& key,
-        const std::string& src_segment,
-        const std::vector<std::string>& tgt_segments,
-        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> CopyEnd(const UUID& client_id,
                                           const std::string& key);
-    tl::expected<void, ErrorCode> CopyEnd(const UUID& client_id,
-                                          const std::string& key,
-                                          const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> CopyRevoke(const UUID& client_id,
                                              const std::string& key);
-    tl::expected<void, ErrorCode> CopyRevoke(const UUID& client_id,
-                                             const std::string& key,
-                                             const std::string& tenant_id);
 
     /**
      * @brief Start a move operation
@@ -505,22 +435,12 @@ class MasterService {
     tl::expected<MoveStartResponse, ErrorCode> MoveStart(
         const UUID& client_id, const std::string& key,
         const std::string& src_segment, const std::string& tgt_segment);
-    tl::expected<MoveStartResponse, ErrorCode> MoveStart(
-        const UUID& client_id, const std::string& key,
-        const std::string& src_segment, const std::string& tgt_segment,
-        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> MoveEnd(const UUID& client_id,
                                           const std::string& key);
-    tl::expected<void, ErrorCode> MoveEnd(const UUID& client_id,
-                                          const std::string& key,
-                                          const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> MoveRevoke(const UUID& client_id,
                                              const std::string& key);
-    tl::expected<void, ErrorCode> MoveRevoke(const UUID& client_id,
-                                             const std::string& key,
-                                             const std::string& tenant_id);
 
     /**
      * @brief Remove an object and its replicas
@@ -531,8 +451,6 @@ class MasterService {
      */
     auto Remove(const std::string& key, bool force = false)
         -> tl::expected<void, ErrorCode>;
-    auto Remove(const std::string& key, const std::string& tenant_id,
-                bool force = false) -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Removes objects from the master whose keys match a regex pattern.
@@ -560,9 +478,6 @@ class MasterService {
      * @return Vector of expected results for each key.
      */
     auto BatchRemove(const std::vector<std::string>& keys, bool force = false)
-        -> std::vector<tl::expected<void, ErrorCode>>;
-    auto BatchRemove(const std::vector<std::string>& keys,
-                     const std::string& tenant_id, bool force = false)
         -> std::vector<tl::expected<void, ErrorCode>>;
 
     /**
@@ -689,9 +604,6 @@ class MasterService {
      */
     tl::expected<UUID, ErrorCode> CreateCopyTask(
         const std::string& key, const std::vector<std::string>& targets);
-    tl::expected<UUID, ErrorCode> CreateCopyTask(
-        const std::string& key, const std::vector<std::string>& targets,
-        const std::string& tenant_id);
 
     /**
      * @brief Create a move task to move an object's replica from source segment
@@ -701,10 +613,6 @@ class MasterService {
     tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
                                                  const std::string& source,
                                                  const std::string& target);
-    tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
-                                                 const std::string& source,
-                                                 const std::string& target,
-                                                 const std::string& tenant_id);
 
     /**
      * @brief Create a drain job to gracefully evacuate one or more segments.
@@ -757,6 +665,61 @@ class MasterService {
         const UUID& client_id, const TaskCompleteRequest& request);
 
    private:
+    struct ResolvedObjectKey {
+        std::string storage_key;
+        std::string tenant_id;
+        std::string user_key;
+    };
+
+    static ResolvedObjectKey ResolveObjectKey(const std::string& key);
+
+    tl::expected<UUID, ErrorCode> CreateCopyTaskResolved(
+        const ResolvedObjectKey& resolved_key,
+        const std::vector<std::string>& targets);
+    tl::expected<UUID, ErrorCode> CreateMoveTaskResolved(
+        const ResolvedObjectKey& resolved_key, const std::string& source,
+        const std::string& target);
+    tl::expected<CopyStartResponse, ErrorCode> CopyStartResolved(
+        const UUID& client_id, const ResolvedObjectKey& resolved_key,
+        const std::string& src_segment,
+        const std::vector<std::string>& tgt_segments);
+    tl::expected<void, ErrorCode> CopyEndResolved(
+        const UUID& client_id, const ResolvedObjectKey& resolved_key);
+    tl::expected<void, ErrorCode> CopyRevokeResolved(
+        const UUID& client_id, const ResolvedObjectKey& resolved_key);
+    tl::expected<MoveStartResponse, ErrorCode> MoveStartResolved(
+        const UUID& client_id, const ResolvedObjectKey& resolved_key,
+        const std::string& src_segment, const std::string& tgt_segment);
+    tl::expected<void, ErrorCode> MoveEndResolved(
+        const UUID& client_id, const ResolvedObjectKey& resolved_key);
+    tl::expected<void, ErrorCode> MoveRevokeResolved(
+        const UUID& client_id, const ResolvedObjectKey& resolved_key);
+    tl::expected<void, ErrorCode> PutEndResolved(
+        const UUID& client_id, const ResolvedObjectKey& resolved_key,
+        ReplicaType replica_type);
+    tl::expected<void, ErrorCode> PutRevokeResolved(
+        const UUID& client_id, const ResolvedObjectKey& resolved_key,
+        ReplicaType replica_type);
+    tl::expected<void, ErrorCode> AddReplicaResolved(
+        const UUID& client_id, const ResolvedObjectKey& resolved_key,
+        Replica& replica);
+    tl::expected<void, ErrorCode> EvictDiskReplicaResolved(
+        const UUID& client_id, const ResolvedObjectKey& resolved_key,
+        ReplicaType replica_type);
+    tl::expected<void, ErrorCode> RemoveResolved(
+        const ResolvedObjectKey& resolved_key, bool force);
+    tl::expected<bool, ErrorCode> ExistKeyResolved(
+        const ResolvedObjectKey& resolved_key);
+    tl::expected<GetReplicaListResponse, ErrorCode> GetReplicaListResolved(
+        const ResolvedObjectKey& resolved_key);
+    tl::expected<std::vector<Replica::Descriptor>, ErrorCode> PutStartResolved(
+        const UUID& client_id, const ResolvedObjectKey& resolved_key,
+        uint64_t slice_length, const ReplicateConfig& config);
+    tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+    UpsertStartResolved(const UUID& client_id,
+                        const ResolvedObjectKey& resolved_key,
+                        uint64_t slice_length, const ReplicateConfig& config);
+
     void SnapshotThreadFunc();
 
     // Persist master state
@@ -1289,28 +1252,28 @@ class MasterService {
      * Caller is responsible for refcnt-pinning the source replica and
      * recording the task in the shard's promotion_tasks map.
      */
-    tl::expected<void, ErrorCode> PushPromotionQueue(const std::string& key,
-                                                     Replica& source_replica);
+    tl::expected<void, ErrorCode> PushPromotionQueue(
+        const std::string& storage_key, Replica& source_replica);
 
     /**
-     * @brief Helper invoked from GetReplicaList when an only-LOCAL_DISK key is
-     * observed. Applies the gating chain (frequency / watermark / dedup /
-     * cap), refcnt-pins the source LOCAL_DISK replica, records a
-     * PromotionTask, and pushes onto the holder client's promotion_objects
-     * map. Acquires its own RW shard accessor; safe to call after
-     * GetReplicaList's RO accessor has been released.
+     * @brief Helper invoked from GetReplicaList when an only-LOCAL_DISK object
+     * is observed. The input must be the object's storage key. Applies the
+     * gating chain (frequency / watermark / dedup / cap), refcnt-pins the
+     * source LOCAL_DISK replica, records a PromotionTask, and pushes onto the
+     * holder client's promotion_objects map. Acquires its own RW shard
+     * accessor; safe to call after GetReplicaList's RO accessor is released.
      */
-    void TryPushPromotionQueue(const std::string& key);
+    void TryPushPromotionQueue(const std::string& storage_key);
 
-    // Erase any in-flight PromotionTask for `key` and decrement the
+    // Erase any in-flight PromotionTask for `storage_key` and decrement the
     // cluster-wide in-flight counter. Safe no-op if no task exists.
     // Call from any path that erases an ObjectMetadata entry, so the
     // task doesn't pin a promotion_in_flight_ slot for the full
     // put_start_release_timeout_sec_ until the reaper sweeps.
     void ErasePromotionTaskIfPresent(MetadataShardAccessorRW& shard,
-                                     const std::string& key)
+                                     const std::string& storage_key)
         NO_THREAD_SAFETY_ANALYSIS {
-        if (shard->promotion_tasks.erase(key) > 0) {
+        if (shard->promotion_tasks.erase(storage_key) > 0) {
             promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
         }
     }

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -215,7 +215,8 @@ class PyClient {
         const std::string &master_server_addr,
         const std::shared_ptr<TransferEngine> &transfer_engine,
         const std::string &ipc_socket_path, bool enable_ssd_offload = false,
-        const std::string &ssd_offload_path = "") = 0;
+        const std::string &ssd_offload_path = "",
+        const std::string &tenant_id = "default") = 0;
 
     virtual int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                             const std::string &server_address,

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -82,7 +82,8 @@ class RealClient : public PyClient {
         const std::shared_ptr<TransferEngine> &transfer_engine = nullptr,
         const std::string &ipc_socket_path = "",
         bool enable_ssd_offload = false,
-        const std::string &ssd_offload_path = "");
+        const std::string &ssd_offload_path = "",
+        const std::string &tenant_id = "default");
 
     int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                     const std::string &server_address,
@@ -503,7 +504,8 @@ class RealClient : public PyClient {
         const std::shared_ptr<TransferEngine> &transfer_engine = nullptr,
         const std::string &ipc_socket_path = "", int local_rpc_port = 50052,
         bool enable_ssd_offload = false, bool start_offload_rpc_server = false,
-        const std::string &ssd_offload_path = "");
+        const std::string &ssd_offload_path = "",
+        const std::string &tenant_id = "default");
 
     // Overload that accepts a configuration dictionary
     tl::expected<void, ErrorCode> setup_internal(const ConfigDict &config);

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -46,77 +46,145 @@ class WrappedMasterService {
     tl::expected<std::vector<std::string>, ErrorCode> BatchReplicaClear(
         const std::vector<std::string>& object_keys, const UUID& client_id,
         const std::string& segment_name);
+    tl::expected<std::vector<std::string>, ErrorCode> BatchReplicaClearInTenant(
+        const std::vector<std::string>& object_keys, const UUID& client_id,
+        const std::string& segment_name, const std::string& tenant_id);
 
     tl::expected<
         std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
         ErrorCode>
     GetReplicaListByRegex(const std::string& str);
+    tl::expected<
+        std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
+        ErrorCode>
+    GetReplicaListByRegexInTenant(const std::string& str,
+                                  const std::string& tenant_id);
 
     tl::expected<GetReplicaListResponse, ErrorCode> GetReplicaList(
         const std::string& key);
+    tl::expected<GetReplicaListResponse, ErrorCode> GetReplicaListInTenant(
+        const std::string& key, const std::string& tenant_id);
 
     std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
     BatchGetReplicaList(const std::vector<std::string>& keys);
+    std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+    BatchGetReplicaListInTenant(const std::vector<std::string>& keys,
+                                const std::string& tenant_id);
 
     tl::expected<std::vector<Replica::Descriptor>, ErrorCode> PutStart(
         const UUID& client_id, const std::string& key,
         const uint64_t slice_length, const ReplicateConfig& config);
+    tl::expected<std::vector<Replica::Descriptor>, ErrorCode> PutStartInTenant(
+        const UUID& client_id, const std::string& key,
+        const uint64_t slice_length, const ReplicateConfig& config,
+        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> PutEnd(
         const UUID& client_id, const std::string& key,
         ReplicaType replica_type = ReplicaType::ALL);
+    tl::expected<void, ErrorCode> PutEndInTenant(const UUID& client_id,
+                                                 const std::string& key,
+                                                 ReplicaType replica_type,
+                                                 const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> PutRevoke(
         const UUID& client_id, const std::string& key,
         ReplicaType replica_type = ReplicaType::ALL);
+    tl::expected<void, ErrorCode> PutRevokeInTenant(
+        const UUID& client_id, const std::string& key, ReplicaType replica_type,
+        const std::string& tenant_id);
 
     std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
     BatchPutStart(const UUID& client_id, const std::vector<std::string>& keys,
                   const std::vector<uint64_t>& slice_lengths,
                   const ReplicateConfig& config);
+    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+    BatchPutStartInTenant(const UUID& client_id,
+                          const std::vector<std::string>& keys,
+                          const std::vector<uint64_t>& slice_lengths,
+                          const ReplicateConfig& config,
+                          const std::string& tenant_id);
 
     std::vector<tl::expected<void, ErrorCode>> BatchPutEnd(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type = ReplicaType::ALL);
+    std::vector<tl::expected<void, ErrorCode>> BatchPutEndInTenant(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        ReplicaType replica_type, const std::string& tenant_id);
 
     std::vector<tl::expected<void, ErrorCode>> BatchPutRevoke(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type = ReplicaType::ALL);
+    std::vector<tl::expected<void, ErrorCode>> BatchPutRevokeInTenant(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        ReplicaType replica_type, const std::string& tenant_id);
 
     tl::expected<std::vector<Replica::Descriptor>, ErrorCode> UpsertStart(
         const UUID& client_id, const std::string& key,
         const uint64_t slice_length, const ReplicateConfig& config);
+    tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+    UpsertStartInTenant(const UUID& client_id, const std::string& key,
+                        const uint64_t slice_length,
+                        const ReplicateConfig& config,
+                        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> UpsertEnd(const UUID& client_id,
                                             const std::string& key,
                                             ReplicaType replica_type);
+    tl::expected<void, ErrorCode> UpsertEndInTenant(
+        const UUID& client_id, const std::string& key, ReplicaType replica_type,
+        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> UpsertRevoke(const UUID& client_id,
                                                const std::string& key,
                                                ReplicaType replica_type);
+    tl::expected<void, ErrorCode> UpsertRevokeInTenant(
+        const UUID& client_id, const std::string& key, ReplicaType replica_type,
+        const std::string& tenant_id);
 
     std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
     BatchUpsertStart(const UUID& client_id,
                      const std::vector<std::string>& keys,
                      const std::vector<uint64_t>& slice_lengths,
                      const ReplicateConfig& config);
+    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+    BatchUpsertStartInTenant(const UUID& client_id,
+                             const std::vector<std::string>& keys,
+                             const std::vector<uint64_t>& slice_lengths,
+                             const ReplicateConfig& config,
+                             const std::string& tenant_id);
 
     std::vector<tl::expected<void, ErrorCode>> BatchUpsertEnd(
         const UUID& client_id, const std::vector<std::string>& keys);
+    std::vector<tl::expected<void, ErrorCode>> BatchUpsertEndInTenant(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        const std::string& tenant_id);
 
     std::vector<tl::expected<void, ErrorCode>> BatchUpsertRevoke(
         const UUID& client_id, const std::vector<std::string>& keys);
+    std::vector<tl::expected<void, ErrorCode>> BatchUpsertRevokeInTenant(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> Remove(const std::string& key,
                                          bool force = false);
+    tl::expected<void, ErrorCode> RemoveInTenant(const std::string& key,
+                                                 const std::string& tenant_id,
+                                                 bool force = false);
 
     tl::expected<long, ErrorCode> RemoveByRegex(const std::string& str,
                                                 bool force = false);
+    tl::expected<long, ErrorCode> RemoveByRegexInTenant(
+        const std::string& str, const std::string& tenant_id,
+        bool force = false);
 
     long RemoveAll(bool force = false);
 
     std::vector<tl::expected<void, ErrorCode>> BatchRemove(
         const std::vector<std::string>& keys, bool force = false);
+    std::vector<tl::expected<void, ErrorCode>> BatchRemoveInTenant(
+        const std::vector<std::string>& keys, const std::string& tenant_id,
+        bool force = false);
 
     tl::expected<void, ErrorCode> MountSegment(const Segment& segment,
                                                const UUID& client_id);
@@ -201,10 +269,16 @@ class WrappedMasterService {
         const UUID& segment_id);
     tl::expected<UUID, ErrorCode> CreateCopyTask(
         const std::string& key, const std::vector<std::string>& targets);
+    tl::expected<UUID, ErrorCode> CreateCopyTaskInTenant(
+        const std::string& key, const std::vector<std::string>& targets,
+        const std::string& tenant_id);
 
     tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
                                                  const std::string& source,
                                                  const std::string& target);
+    tl::expected<UUID, ErrorCode> CreateMoveTaskInTenant(
+        const std::string& key, const std::string& source,
+        const std::string& target, const std::string& tenant_id);
 
     tl::expected<QueryTaskResponse, ErrorCode> QueryTask(const UUID& task_id);
 
@@ -218,30 +292,57 @@ class WrappedMasterService {
         const UUID& client_id, const std::string& key,
         const std::string& src_segment,
         const std::vector<std::string>& tgt_segments);
+    tl::expected<CopyStartResponse, ErrorCode> CopyStartInTenant(
+        const UUID& client_id, const std::string& key,
+        const std::string& src_segment,
+        const std::vector<std::string>& tgt_segments,
+        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> CopyEnd(const UUID& client_id,
                                           const std::string& key);
+    tl::expected<void, ErrorCode> CopyEndInTenant(const UUID& client_id,
+                                                  const std::string& key,
+                                                  const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> CopyRevoke(const UUID& client_id,
                                              const std::string& key);
+    tl::expected<void, ErrorCode> CopyRevokeInTenant(
+        const UUID& client_id, const std::string& key,
+        const std::string& tenant_id);
 
     tl::expected<MoveStartResponse, ErrorCode> MoveStart(
         const UUID& client_id, const std::string& key,
         const std::string& src_segment, const std::string& tgt_segment);
+    tl::expected<MoveStartResponse, ErrorCode> MoveStartInTenant(
+        const UUID& client_id, const std::string& key,
+        const std::string& src_segment, const std::string& tgt_segment,
+        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> MoveEnd(const UUID& client_id,
                                           const std::string& key);
+    tl::expected<void, ErrorCode> MoveEndInTenant(const UUID& client_id,
+                                                  const std::string& key,
+                                                  const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> MoveRevoke(const UUID& client_id,
                                              const std::string& key);
+    tl::expected<void, ErrorCode> MoveRevokeInTenant(
+        const UUID& client_id, const std::string& key,
+        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> EvictDiskReplica(const UUID& client_id,
                                                    const std::string& key,
                                                    ReplicaType replica_type);
+    tl::expected<void, ErrorCode> EvictDiskReplicaInTenant(
+        const UUID& client_id, const std::string& key, ReplicaType replica_type,
+        const std::string& tenant_id);
 
     std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type);
+    std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplicaInTenant(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        ReplicaType replica_type, const std::string& tenant_id);
 
    private:
     MasterService master_service_;

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -50,7 +50,7 @@ class WrappedMasterService {
     tl::expected<
         std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
         ErrorCode>
-    GetReplicaListByRegex(const std::string& str);
+    GetReplicaListByRegex(const std::string& str, const std::string& tenant_id);
 
     tl::expected<GetReplicaListResponse, ErrorCode> GetReplicaList(
         const std::string& key);
@@ -111,6 +111,7 @@ class WrappedMasterService {
                                          bool force = false);
 
     tl::expected<long, ErrorCode> RemoveByRegex(const std::string& str,
+                                                const std::string& tenant_id,
                                                 bool force = false);
 
     long RemoveAll(bool force = false);

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -46,145 +46,77 @@ class WrappedMasterService {
     tl::expected<std::vector<std::string>, ErrorCode> BatchReplicaClear(
         const std::vector<std::string>& object_keys, const UUID& client_id,
         const std::string& segment_name);
-    tl::expected<std::vector<std::string>, ErrorCode> BatchReplicaClearInTenant(
-        const std::vector<std::string>& object_keys, const UUID& client_id,
-        const std::string& segment_name, const std::string& tenant_id);
 
     tl::expected<
         std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
         ErrorCode>
     GetReplicaListByRegex(const std::string& str);
-    tl::expected<
-        std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
-        ErrorCode>
-    GetReplicaListByRegexInTenant(const std::string& str,
-                                  const std::string& tenant_id);
 
     tl::expected<GetReplicaListResponse, ErrorCode> GetReplicaList(
         const std::string& key);
-    tl::expected<GetReplicaListResponse, ErrorCode> GetReplicaListInTenant(
-        const std::string& key, const std::string& tenant_id);
 
     std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
     BatchGetReplicaList(const std::vector<std::string>& keys);
-    std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
-    BatchGetReplicaListInTenant(const std::vector<std::string>& keys,
-                                const std::string& tenant_id);
 
     tl::expected<std::vector<Replica::Descriptor>, ErrorCode> PutStart(
         const UUID& client_id, const std::string& key,
         const uint64_t slice_length, const ReplicateConfig& config);
-    tl::expected<std::vector<Replica::Descriptor>, ErrorCode> PutStartInTenant(
-        const UUID& client_id, const std::string& key,
-        const uint64_t slice_length, const ReplicateConfig& config,
-        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> PutEnd(
         const UUID& client_id, const std::string& key,
         ReplicaType replica_type = ReplicaType::ALL);
-    tl::expected<void, ErrorCode> PutEndInTenant(const UUID& client_id,
-                                                 const std::string& key,
-                                                 ReplicaType replica_type,
-                                                 const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> PutRevoke(
         const UUID& client_id, const std::string& key,
         ReplicaType replica_type = ReplicaType::ALL);
-    tl::expected<void, ErrorCode> PutRevokeInTenant(
-        const UUID& client_id, const std::string& key, ReplicaType replica_type,
-        const std::string& tenant_id);
 
     std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
     BatchPutStart(const UUID& client_id, const std::vector<std::string>& keys,
                   const std::vector<uint64_t>& slice_lengths,
                   const ReplicateConfig& config);
-    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-    BatchPutStartInTenant(const UUID& client_id,
-                          const std::vector<std::string>& keys,
-                          const std::vector<uint64_t>& slice_lengths,
-                          const ReplicateConfig& config,
-                          const std::string& tenant_id);
 
     std::vector<tl::expected<void, ErrorCode>> BatchPutEnd(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type = ReplicaType::ALL);
-    std::vector<tl::expected<void, ErrorCode>> BatchPutEndInTenant(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        ReplicaType replica_type, const std::string& tenant_id);
 
     std::vector<tl::expected<void, ErrorCode>> BatchPutRevoke(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type = ReplicaType::ALL);
-    std::vector<tl::expected<void, ErrorCode>> BatchPutRevokeInTenant(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        ReplicaType replica_type, const std::string& tenant_id);
 
     tl::expected<std::vector<Replica::Descriptor>, ErrorCode> UpsertStart(
         const UUID& client_id, const std::string& key,
         const uint64_t slice_length, const ReplicateConfig& config);
-    tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
-    UpsertStartInTenant(const UUID& client_id, const std::string& key,
-                        const uint64_t slice_length,
-                        const ReplicateConfig& config,
-                        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> UpsertEnd(const UUID& client_id,
                                             const std::string& key,
                                             ReplicaType replica_type);
-    tl::expected<void, ErrorCode> UpsertEndInTenant(
-        const UUID& client_id, const std::string& key, ReplicaType replica_type,
-        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> UpsertRevoke(const UUID& client_id,
                                                const std::string& key,
                                                ReplicaType replica_type);
-    tl::expected<void, ErrorCode> UpsertRevokeInTenant(
-        const UUID& client_id, const std::string& key, ReplicaType replica_type,
-        const std::string& tenant_id);
 
     std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
     BatchUpsertStart(const UUID& client_id,
                      const std::vector<std::string>& keys,
                      const std::vector<uint64_t>& slice_lengths,
                      const ReplicateConfig& config);
-    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-    BatchUpsertStartInTenant(const UUID& client_id,
-                             const std::vector<std::string>& keys,
-                             const std::vector<uint64_t>& slice_lengths,
-                             const ReplicateConfig& config,
-                             const std::string& tenant_id);
 
     std::vector<tl::expected<void, ErrorCode>> BatchUpsertEnd(
         const UUID& client_id, const std::vector<std::string>& keys);
-    std::vector<tl::expected<void, ErrorCode>> BatchUpsertEndInTenant(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        const std::string& tenant_id);
 
     std::vector<tl::expected<void, ErrorCode>> BatchUpsertRevoke(
         const UUID& client_id, const std::vector<std::string>& keys);
-    std::vector<tl::expected<void, ErrorCode>> BatchUpsertRevokeInTenant(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> Remove(const std::string& key,
                                          bool force = false);
-    tl::expected<void, ErrorCode> RemoveInTenant(const std::string& key,
-                                                 const std::string& tenant_id,
-                                                 bool force = false);
 
     tl::expected<long, ErrorCode> RemoveByRegex(const std::string& str,
                                                 bool force = false);
-    tl::expected<long, ErrorCode> RemoveByRegexInTenant(
-        const std::string& str, const std::string& tenant_id,
-        bool force = false);
 
     long RemoveAll(bool force = false);
 
     std::vector<tl::expected<void, ErrorCode>> BatchRemove(
         const std::vector<std::string>& keys, bool force = false);
-    std::vector<tl::expected<void, ErrorCode>> BatchRemoveInTenant(
-        const std::vector<std::string>& keys, const std::string& tenant_id,
-        bool force = false);
 
     tl::expected<void, ErrorCode> MountSegment(const Segment& segment,
                                                const UUID& client_id);
@@ -269,16 +201,10 @@ class WrappedMasterService {
         const UUID& segment_id);
     tl::expected<UUID, ErrorCode> CreateCopyTask(
         const std::string& key, const std::vector<std::string>& targets);
-    tl::expected<UUID, ErrorCode> CreateCopyTaskInTenant(
-        const std::string& key, const std::vector<std::string>& targets,
-        const std::string& tenant_id);
 
     tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
                                                  const std::string& source,
                                                  const std::string& target);
-    tl::expected<UUID, ErrorCode> CreateMoveTaskInTenant(
-        const std::string& key, const std::string& source,
-        const std::string& target, const std::string& tenant_id);
 
     tl::expected<QueryTaskResponse, ErrorCode> QueryTask(const UUID& task_id);
 
@@ -292,57 +218,30 @@ class WrappedMasterService {
         const UUID& client_id, const std::string& key,
         const std::string& src_segment,
         const std::vector<std::string>& tgt_segments);
-    tl::expected<CopyStartResponse, ErrorCode> CopyStartInTenant(
-        const UUID& client_id, const std::string& key,
-        const std::string& src_segment,
-        const std::vector<std::string>& tgt_segments,
-        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> CopyEnd(const UUID& client_id,
                                           const std::string& key);
-    tl::expected<void, ErrorCode> CopyEndInTenant(const UUID& client_id,
-                                                  const std::string& key,
-                                                  const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> CopyRevoke(const UUID& client_id,
                                              const std::string& key);
-    tl::expected<void, ErrorCode> CopyRevokeInTenant(
-        const UUID& client_id, const std::string& key,
-        const std::string& tenant_id);
 
     tl::expected<MoveStartResponse, ErrorCode> MoveStart(
         const UUID& client_id, const std::string& key,
         const std::string& src_segment, const std::string& tgt_segment);
-    tl::expected<MoveStartResponse, ErrorCode> MoveStartInTenant(
-        const UUID& client_id, const std::string& key,
-        const std::string& src_segment, const std::string& tgt_segment,
-        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> MoveEnd(const UUID& client_id,
                                           const std::string& key);
-    tl::expected<void, ErrorCode> MoveEndInTenant(const UUID& client_id,
-                                                  const std::string& key,
-                                                  const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> MoveRevoke(const UUID& client_id,
                                              const std::string& key);
-    tl::expected<void, ErrorCode> MoveRevokeInTenant(
-        const UUID& client_id, const std::string& key,
-        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> EvictDiskReplica(const UUID& client_id,
                                                    const std::string& key,
                                                    ReplicaType replica_type);
-    tl::expected<void, ErrorCode> EvictDiskReplicaInTenant(
-        const UUID& client_id, const std::string& key, ReplicaType replica_type,
-        const std::string& tenant_id);
 
     std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type);
-    std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplicaInTenant(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        ReplicaType replica_type, const std::string& tenant_id);
 
    private:
     MasterService master_service_;

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -246,10 +246,17 @@ inline std::optional<TenantScopedKey> ParseTenantScopedKey(
         if (ch < '0' || ch > '9') {
             return std::nullopt;
         }
-        tenant_len = tenant_len * 10 + static_cast<size_t>(ch - '0');
+        const size_t digit = static_cast<size_t>(ch - '0');
+        if (tenant_len > (std::numeric_limits<size_t>::max() - digit) / 10) {
+            return std::nullopt;
+        }
+        tenant_len = tenant_len * 10 + digit;
     }
 
     const size_t tenant_begin = first_sep + 1;
+    if (tenant_len > scoped_key.size() - tenant_begin) {
+        return std::nullopt;
+    }
     const size_t second_sep = tenant_begin + tenant_len;
     if (second_sep >= scoped_key.size() || scoped_key[second_sep] != ':') {
         return std::nullopt;

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -215,6 +215,50 @@ constexpr const char* CONFIG_KEY_PROTOCOL = "protocol";
 constexpr const char* CONFIG_KEY_RDMA_DEVICES = "rdma_devices";
 constexpr const char* CONFIG_KEY_MASTER_SERVER_ADDR = "master_server_addr";
 constexpr const char* CONFIG_KEY_IPC_SOCKET_PATH = "ipc_socket_path";
+constexpr const char* CONFIG_KEY_TENANT_ID = "tenant_id";
+
+inline std::string NormalizeTenantId(const std::string& tenant_id) {
+    return tenant_id.empty() ? "default" : tenant_id;
+}
+
+inline std::string BuildTenantScopedKey(const std::string& tenant_id,
+                                        const std::string& user_key) {
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    return std::to_string(normalized_tenant.size()) + ":" + normalized_tenant +
+           ":" + user_key;
+}
+
+struct TenantScopedKey {
+    std::string tenant_id;
+    std::string user_key;
+};
+
+inline std::optional<TenantScopedKey> ParseTenantScopedKey(
+    std::string_view scoped_key) {
+    const auto first_sep = scoped_key.find(':');
+    if (first_sep == std::string_view::npos || first_sep == 0) {
+        return std::nullopt;
+    }
+
+    size_t tenant_len = 0;
+    for (size_t i = 0; i < first_sep; ++i) {
+        const char ch = scoped_key[i];
+        if (ch < '0' || ch > '9') {
+            return std::nullopt;
+        }
+        tenant_len = tenant_len * 10 + static_cast<size_t>(ch - '0');
+    }
+
+    const size_t tenant_begin = first_sep + 1;
+    const size_t second_sep = tenant_begin + tenant_len;
+    if (second_sep >= scoped_key.size() || scoped_key[second_sep] != ':') {
+        return std::nullopt;
+    }
+
+    return TenantScopedKey{
+        std::string(scoped_key.substr(tenant_begin, tenant_len)),
+        std::string(scoped_key.substr(second_sep + 1))};
+}
 
 // Store client configuration defaults
 static constexpr size_t DEFAULT_GLOBAL_SEGMENT_SIZE = 1024 * 1024 * 16;  // 16MB

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2782,18 +2782,8 @@ void Client::PutToLocalFile(const std::string& key,
         // Notify master about any evicted disk replicas (batch)
         if (!store_result.value().empty()) {
             const auto& evicted_keys = store_result.value();
-            std::vector<std::string> evicted_object_keys;
-            evicted_object_keys.reserve(evicted_keys.size());
-            for (const auto& evicted_key : evicted_keys) {
-                if (auto parsed = ParseTenantScopedKey(evicted_key)) {
-                    evicted_object_keys.emplace_back(
-                        std::move(parsed->user_key));
-                } else {
-                    evicted_object_keys.emplace_back(evicted_key);
-                }
-            }
             auto evict_results = master_client_.BatchEvictDiskReplica(
-                evicted_object_keys, replica_type);
+                evicted_keys, replica_type);
             for (size_t i = 0; i < evict_results.size(); ++i) {
                 if (!evict_results[i]) {
                     LOG(WARNING)

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2596,12 +2596,15 @@ tl::expected<void, ErrorCode> Client::ExecuteReplicaTransfer(
 
 tl::expected<void, ErrorCode> Client::Copy(
     const std::string& key, const std::string& source,
-    const std::vector<std::string>& targets) {
+    const std::vector<std::string>& targets, bool key_is_storage_key) {
     LOG(INFO) << "action=replica_copy_start"
               << ", key=" << key << ", targets_count=" << targets.size();
 
     // Call CopyStart first - it validates existence and allocates replicas
-    auto start_result = master_client_.CopyStart(key, source, targets);
+    auto start_result =
+        key_is_storage_key
+            ? master_client_.CopyStartStorageKey(key, source, targets)
+            : master_client_.CopyStart(key, source, targets);
     if (!start_result.has_value()) {
         ErrorCode error = start_result.error();
         LOG(ERROR) << "action=replica_copy_failed"
@@ -2616,7 +2619,9 @@ tl::expected<void, ErrorCode> Client::Copy(
         LOG(INFO) << "action=replica_copy_skipped"
                   << ", key=" << key << ", info=target_replicas_already_exist";
         // Target replicas already exist, consider it success
-        auto copy_end_result = master_client_.CopyEnd(key);
+        auto copy_end_result = key_is_storage_key
+                                   ? master_client_.CopyEndStorageKey(key)
+                                   : master_client_.CopyEnd(key);
         if (!copy_end_result.has_value()) {
             ErrorCode error = copy_end_result.error();
             LOG(ERROR) << "action=replica_copy_failed"
@@ -2628,9 +2633,16 @@ tl::expected<void, ErrorCode> Client::Copy(
     }
 
     auto result = ExecuteReplicaTransfer(
-        key, "copy", [&]() { return master_client_.CopyEnd(key); },
-        [&]() { return master_client_.CopyRevoke(key); }, response.source,
-        response.targets);
+        key, "copy",
+        [&]() {
+            return key_is_storage_key ? master_client_.CopyEndStorageKey(key)
+                                      : master_client_.CopyEnd(key);
+        },
+        [&]() {
+            return key_is_storage_key ? master_client_.CopyRevokeStorageKey(key)
+                                      : master_client_.CopyRevoke(key);
+        },
+        response.source, response.targets);
 
     if (result.has_value()) {
         LOG(INFO) << "action=replica_copy_success"
@@ -2643,14 +2655,18 @@ tl::expected<void, ErrorCode> Client::Copy(
 
 tl::expected<void, ErrorCode> Client::Move(const std::string& key,
                                            const std::string& source,
-                                           const std::string& target) {
+                                           const std::string& target,
+                                           bool key_is_storage_key) {
     LOG(INFO) << "action=replica_move_start"
               << ", key=" << key << ", source_segment=" << source
               << ", target_segment=" << target;
 
     // Call MoveStart first - it validates existence and allocates replica if
     // needed
-    auto move_start_result = master_client_.MoveStart(key, source, target);
+    auto move_start_result =
+        key_is_storage_key
+            ? master_client_.MoveStartStorageKey(key, source, target)
+            : master_client_.MoveStart(key, source, target);
     if (!move_start_result.has_value()) {
         ErrorCode error = move_start_result.error();
         LOG(ERROR) << "action=replica_move_failed"
@@ -2665,7 +2681,9 @@ tl::expected<void, ErrorCode> Client::Move(const std::string& key,
         LOG(INFO) << "action=replica_move_skipped"
                   << ", key=" << key << ", info=target_replica_already_exists";
         // Target already exists, consider it success
-        auto move_end_result = master_client_.MoveEnd(key);
+        auto move_end_result = key_is_storage_key
+                                   ? master_client_.MoveEndStorageKey(key)
+                                   : master_client_.MoveEnd(key);
         if (!move_end_result.has_value()) {
             ErrorCode error = move_end_result.error();
             LOG(ERROR) << "action=replica_move_failed"
@@ -2679,9 +2697,16 @@ tl::expected<void, ErrorCode> Client::Move(const std::string& key,
     std::vector<Replica::Descriptor> targets = {response.target.value()};
 
     auto result = ExecuteReplicaTransfer(
-        key, "move", [&]() { return master_client_.MoveEnd(key); },
-        [&]() { return master_client_.MoveRevoke(key); }, response.source,
-        targets);
+        key, "move",
+        [&]() {
+            return key_is_storage_key ? master_client_.MoveEndStorageKey(key)
+                                      : master_client_.MoveEnd(key);
+        },
+        [&]() {
+            return key_is_storage_key ? master_client_.MoveRevokeStorageKey(key)
+                                      : master_client_.MoveRevoke(key);
+        },
+        response.source, targets);
 
     if (result.has_value()) {
         LOG(INFO) << "action=replica_move_success"
@@ -2782,8 +2807,9 @@ void Client::PutToLocalFile(const std::string& key,
         // Notify master about any evicted disk replicas (batch)
         if (!store_result.value().empty()) {
             const auto& evicted_keys = store_result.value();
-            auto evict_results = master_client_.BatchEvictDiskReplica(
-                evicted_keys, replica_type);
+            auto evict_results =
+                master_client_.BatchEvictDiskReplicaStorageKeys(evicted_keys,
+                                                                replica_type);
             for (size_t i = 0; i < evict_results.size(); ++i) {
                 if (!evict_results[i]) {
                     LOG(WARNING)
@@ -2934,7 +2960,8 @@ void Client::ExecuteTask(const ClientTask& client_task) {
                 ReplicaCopyPayload payload;
                 struct_json::from_json(payload, assignment.payload);
                 auto copy_result =
-                    Copy(payload.key, payload.source, payload.targets);
+                    Copy(payload.key, payload.source, payload.targets,
+                         /*key_is_storage_key=*/true);
                 if (copy_result.has_value()) {
                     result = ErrorCode::OK;
                 } else {
@@ -2946,7 +2973,8 @@ void Client::ExecuteTask(const ClientTask& client_task) {
                 ReplicaMovePayload payload;
                 struct_json::from_json(payload, assignment.payload);
                 auto move_result =
-                    Move(payload.key, payload.source, payload.target);
+                    Move(payload.key, payload.source, payload.target,
+                         /*key_is_storage_key=*/true);
                 if (move_result.has_value()) {
                     result = ErrorCode::OK;
                 } else {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -807,6 +807,37 @@ std::vector<tl::expected<QueryResult, ErrorCode>> Client::BatchQuery(
     return results;
 }
 
+std::vector<tl::expected<QueryResult, ErrorCode>> Client::BatchQueryStorageKeys(
+    const std::vector<std::string>& storage_keys) {
+    std::chrono::steady_clock::time_point start_time =
+        std::chrono::steady_clock::now();
+    auto response = master_client_.BatchGetReplicaListStorageKeys(storage_keys);
+
+    if (response.size() != storage_keys.size()) {
+        LOG(ERROR) << "BatchQueryStorageKeys response size mismatch. Expected: "
+                   << storage_keys.size() << ", Got: " << response.size();
+        std::vector<tl::expected<QueryResult, ErrorCode>> results;
+        results.reserve(storage_keys.size());
+        for (size_t i = 0; i < storage_keys.size(); ++i) {
+            results.emplace_back(tl::unexpected(ErrorCode::RPC_FAIL));
+        }
+        return results;
+    }
+    std::vector<tl::expected<QueryResult, ErrorCode>> results;
+    results.reserve(response.size());
+    for (size_t i = 0; i < response.size(); ++i) {
+        if (response[i]) {
+            results.emplace_back(QueryResult(
+                std::move(response[i].value().replicas),
+                start_time + std::chrono::milliseconds(
+                                 response[i].value().lease_ttl_ms)));
+        } else {
+            results.emplace_back(tl::unexpected(response[i].error()));
+        }
+    }
+    return results;
+}
+
 tl::expected<std::vector<std::string>, ErrorCode> Client::BatchReplicaClear(
     const std::vector<std::string>& object_keys, const UUID& client_id,
     const std::string& segment_name) {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -16,6 +16,7 @@
 #include <ranges>
 #include <thread>
 #include <set>
+#include <utility>
 #include <ylt/struct_json/json_reader.h>
 
 #include "transfer_engine.h"
@@ -56,11 +57,14 @@ using gpu_staging::SetDevice;
 Client::Client(const std::string& local_hostname,
                const std::string& metadata_connstring,
                const std::string& protocol,
-               const std::map<std::string, std::string>& labels)
+               const std::map<std::string, std::string>& labels,
+               std::string tenant_id)
     : client_id_(generate_uuid()),
+      tenant_id_(tenant_id.empty() ? "default" : std::move(tenant_id)),
       metrics_(ClientMetric::Create(merge_labels(labels))),
       master_client_(client_id_,
-                     metrics_ ? &metrics_->master_client_metric : nullptr),
+                     metrics_ ? &metrics_->master_client_metric : nullptr,
+                     tenant_id_),
       local_hostname_(local_hostname),
       metadata_connstring_(metadata_connstring),
       protocol_(protocol),
@@ -591,9 +595,10 @@ std::optional<std::shared_ptr<Client>> Client::Create(
     const std::string& protocol, const std::optional<std::string>& device_names,
     const std::string& master_server_entry,
     const std::shared_ptr<TransferEngine>& transfer_engine,
-    std::map<std::string, std::string> labels) {
+    std::map<std::string, std::string> labels, std::string tenant_id) {
     auto client = std::shared_ptr<Client>(
-        new Client(local_hostname, metadata_connstring, protocol, labels));
+        new Client(local_hostname, metadata_connstring, protocol, labels,
+                   std::move(tenant_id)));
 
     ErrorCode err = client->ConnectToMaster(master_server_entry);
     if (err != ErrorCode::OK) {
@@ -2592,29 +2597,31 @@ tl::expected<void, ErrorCode> Client::ExecuteReplicaTransfer(
 tl::expected<void, ErrorCode> Client::Copy(
     const std::string& key, const std::string& source,
     const std::vector<std::string>& targets) {
-    LOG(INFO) << "action=replica_copy_start" << ", key=" << key
-              << ", targets_count=" << targets.size();
+    LOG(INFO) << "action=replica_copy_start"
+              << ", key=" << key << ", targets_count=" << targets.size();
 
     // Call CopyStart first - it validates existence and allocates replicas
     auto start_result = master_client_.CopyStart(key, source, targets);
     if (!start_result.has_value()) {
         ErrorCode error = start_result.error();
-        LOG(ERROR) << "action=replica_copy_failed" << ", key=" << key
-                   << ", source=" << source << ", error=copy_start_failed"
+        LOG(ERROR) << "action=replica_copy_failed"
+                   << ", key=" << key << ", source=" << source
+                   << ", error=copy_start_failed"
                    << ", error_code=" << error;
         return tl::unexpected(error);
     }
 
     const auto& response = start_result.value();
     if (response.targets.empty()) {
-        LOG(INFO) << "action=replica_copy_skipped" << ", key=" << key
-                  << ", info=target_replicas_already_exist";
+        LOG(INFO) << "action=replica_copy_skipped"
+                  << ", key=" << key << ", info=target_replicas_already_exist";
         // Target replicas already exist, consider it success
         auto copy_end_result = master_client_.CopyEnd(key);
         if (!copy_end_result.has_value()) {
             ErrorCode error = copy_end_result.error();
-            LOG(ERROR) << "action=replica_copy_failed" << ", key=" << key
-                       << ", error=copy_end_failed" << ", error_code=" << error;
+            LOG(ERROR) << "action=replica_copy_failed"
+                       << ", key=" << key << ", error=copy_end_failed"
+                       << ", error_code=" << error;
             return tl::unexpected(error);
         }
         return {};
@@ -2626,7 +2633,8 @@ tl::expected<void, ErrorCode> Client::Copy(
         response.targets);
 
     if (result.has_value()) {
-        LOG(INFO) << "action=replica_copy_success" << ", key=" << key
+        LOG(INFO) << "action=replica_copy_success"
+                  << ", key=" << key
                   << ", target_count=" << response.targets.size();
     }
 
@@ -2636,30 +2644,33 @@ tl::expected<void, ErrorCode> Client::Copy(
 tl::expected<void, ErrorCode> Client::Move(const std::string& key,
                                            const std::string& source,
                                            const std::string& target) {
-    LOG(INFO) << "action=replica_move_start" << ", key=" << key
-              << ", source_segment=" << source << ", target_segment=" << target;
+    LOG(INFO) << "action=replica_move_start"
+              << ", key=" << key << ", source_segment=" << source
+              << ", target_segment=" << target;
 
     // Call MoveStart first - it validates existence and allocates replica if
     // needed
     auto move_start_result = master_client_.MoveStart(key, source, target);
     if (!move_start_result.has_value()) {
         ErrorCode error = move_start_result.error();
-        LOG(ERROR) << "action=replica_move_failed" << ", key=" << key
-                   << ", error=move_start_failed" << ", error_code=" << error;
+        LOG(ERROR) << "action=replica_move_failed"
+                   << ", key=" << key << ", error=move_start_failed"
+                   << ", error_code=" << error;
         // MoveStart already validated existence, so we just return the error
         return tl::unexpected(error);
     }
 
     const auto& response = move_start_result.value();
     if (!response.target.has_value()) {
-        LOG(INFO) << "action=replica_move_skipped" << ", key=" << key
-                  << ", info=target_replica_already_exists";
+        LOG(INFO) << "action=replica_move_skipped"
+                  << ", key=" << key << ", info=target_replica_already_exists";
         // Target already exists, consider it success
         auto move_end_result = master_client_.MoveEnd(key);
         if (!move_end_result.has_value()) {
             ErrorCode error = move_end_result.error();
-            LOG(ERROR) << "action=replica_move_failed" << ", key=" << key
-                       << ", error=move_end_failed" << ", error_code=" << error;
+            LOG(ERROR) << "action=replica_move_failed"
+                       << ", key=" << key << ", error=move_end_failed"
+                       << ", error_code=" << error;
             return tl::unexpected(error);
         }
         return {};
@@ -2673,8 +2684,8 @@ tl::expected<void, ErrorCode> Client::Move(const std::string& key,
         targets);
 
     if (result.has_value()) {
-        LOG(INFO) << "action=replica_move_success" << ", key=" << key
-                  << ", source_segment=" << source
+        LOG(INFO) << "action=replica_move_success"
+                  << ", key=" << key << ", source_segment=" << source
                   << ", target_segment=" << target;
     }
 
@@ -2752,9 +2763,10 @@ void Client::PutToLocalFile(const std::string& key,
 
     // Async StoreObject + PutEnd (unchanged from original)
     write_thread_pool_.enqueue([this, backend = storage_backend_, key,
+                                storage_key = BuildStorageKey(key),
                                 value = std::move(value), path] {
         // Store the object
-        auto store_result = backend->StoreObject(path, value, key);
+        auto store_result = backend->StoreObject(path, value, storage_key);
         ReplicaType replica_type = ReplicaType::DISK;
 
         if (!store_result) {
@@ -2770,8 +2782,18 @@ void Client::PutToLocalFile(const std::string& key,
         // Notify master about any evicted disk replicas (batch)
         if (!store_result.value().empty()) {
             const auto& evicted_keys = store_result.value();
+            std::vector<std::string> evicted_object_keys;
+            evicted_object_keys.reserve(evicted_keys.size());
+            for (const auto& evicted_key : evicted_keys) {
+                if (auto parsed = ParseTenantScopedKey(evicted_key)) {
+                    evicted_object_keys.emplace_back(
+                        std::move(parsed->user_key));
+                } else {
+                    evicted_object_keys.emplace_back(evicted_key);
+                }
+            }
             auto evict_results = master_client_.BatchEvictDiskReplica(
-                evicted_keys, replica_type);
+                evicted_object_keys, replica_type);
             for (size_t i = 0; i < evict_results.size(); ++i) {
                 if (!evict_results[i]) {
                     LOG(WARNING)
@@ -2879,8 +2901,8 @@ void Client::PollAndDispatchTasks() {
             // Only log if it's not an RPC failure (which is expected
             // during connection failures)
             if (error != ErrorCode::RPC_FAIL) {
-                LOG(WARNING)
-                    << "action=task_poll_failed" << ", error_code=" << error;
+                LOG(WARNING) << "action=task_poll_failed"
+                             << ", error_code=" << error;
             }
         }
     }
@@ -2897,7 +2919,8 @@ void Client::TaskPollThreadMain() {
 
 void Client::SubmitTask(const TaskAssignment& assignment) {
     if (!task_running_.load()) {
-        LOG(WARNING) << "action=task_rejected" << ", task_id=" << assignment.id
+        LOG(WARNING) << "action=task_rejected"
+                     << ", task_id=" << assignment.id
                      << ", reason=executor_stopped";
         return;
     }

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2117,6 +2117,13 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchEvictDiskReplica(
     return master_client_.BatchEvictDiskReplica(keys, replica_type);
 }
 
+std::vector<tl::expected<void, ErrorCode>>
+Client::BatchEvictDiskReplicaStorageKeys(
+    const std::vector<std::string>& storage_keys, ReplicaType replica_type) {
+    return master_client_.BatchEvictDiskReplicaStorageKeys(storage_keys,
+                                                           replica_type);
+}
+
 std::vector<int> Client::GetNicNumaNodes() const {
     std::set<int> nodes;
     if (!transfer_engine_) return {};

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -417,18 +417,8 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         auto eviction_handler = [this](const std::vector<std::string>&
                                            evicted_keys) {
             if (evicted_keys.empty()) return;
-            std::vector<std::string> evicted_object_keys;
-            evicted_object_keys.reserve(evicted_keys.size());
-            for (const auto& evicted_key : evicted_keys) {
-                if (auto parsed = ParseTenantScopedKey(evicted_key)) {
-                    evicted_object_keys.emplace_back(
-                        std::move(parsed->user_key));
-                } else {
-                    evicted_object_keys.emplace_back(evicted_key);
-                }
-            }
             auto results = client_->BatchEvictDiskReplica(
-                evicted_object_keys, ReplicaType::LOCAL_DISK);
+                evicted_keys, ReplicaType::LOCAL_DISK);
             for (size_t i = 0; i < results.size(); ++i) {
                 if (!results[i]) {
                     LOG(WARNING)

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -344,17 +344,10 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         return {};
     }
     std::unordered_map<std::string, int64_t> storage_offloading_objects;
-    std::unordered_map<std::string, std::string> storage_to_user_key;
-    std::unordered_map<std::string, std::string> user_to_storage_key;
     storage_offloading_objects.reserve(offloading_objects.size());
-    storage_to_user_key.reserve(offloading_objects.size());
-    user_to_storage_key.reserve(offloading_objects.size());
     for (const auto& [key, size] : offloading_objects) {
         auto parsed = ParseTenantScopedKey(key);
         std::string storage_key = parsed ? key : client_->BuildStorageKey(key);
-        std::string user_key = parsed ? parsed->user_key : key;
-        user_to_storage_key.emplace(user_key, storage_key);
-        storage_to_user_key.emplace(storage_key, std::move(user_key));
         storage_offloading_objects.emplace(std::move(storage_key), size);
     }
 
@@ -394,20 +387,8 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
     };
 
     for (const auto& storage_keys : buckets_keys) {
-        std::vector<std::string> user_keys;
-        user_keys.reserve(storage_keys.size());
-        for (const auto& storage_key : storage_keys) {
-            auto it = storage_to_user_key.find(storage_key);
-            if (it == storage_to_user_key.end()) {
-                LOG(ERROR) << "Missing user key for storage key: "
-                           << storage_key;
-                continue;
-            }
-            user_keys.emplace_back(it->second);
-        }
-
         std::unordered_map<std::string, std::vector<Slice>> batch_object;
-        auto query_result = BatchQuerySegmentSlices(user_keys, batch_object);
+        auto query_result = BatchQuerySegmentSlices(storage_keys, batch_object);
         if (!query_result) {
             LOG(ERROR) << "BatchQuerySlices failed with error: "
                        << query_result.error();
@@ -438,12 +419,6 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         for (auto& [obj_key, slices] : batch_object) {
             std::vector<Slice> host_slices;
             bool obj_success = true;
-            auto storage_key_it = user_to_storage_key.find(obj_key);
-            if (storage_key_it == user_to_storage_key.end()) {
-                LOG(ERROR) << "Missing storage key for user key: " << obj_key;
-                continue;
-            }
-            const std::string& storage_key = storage_key_it->second;
             for (const auto& slice : slices) {
                 int device_id = -1;
                 if (IsDevicePointer(slice.ptr, &device_id)) {
@@ -462,7 +437,7 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
                 }
             }
             if (obj_success) {
-                host_batch_object[storage_key] = std::move(host_slices);
+                host_batch_object[obj_key] = std::move(host_slices);
             }
         }
 
@@ -810,7 +785,7 @@ tl::expected<void, ErrorCode> FileStorage::BatchLoad(
 tl::expected<void, ErrorCode> FileStorage::BatchQuerySegmentSlices(
     const std::vector<std::string>& keys,
     std::unordered_map<std::string, std::vector<Slice>>& batched_slices) {
-    auto batched_query_results = client_->BatchQuery(keys);
+    auto batched_query_results = client_->BatchQueryStorageKeys(keys);
     if (batched_query_results.empty())
         return tl::make_unexpected(ErrorCode::INVALID_REPLICA);
     for (size_t i = 0; i < batched_query_results.size(); ++i) {

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -343,11 +343,26 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
     if (offloading_objects.empty()) {
         return {};
     }
+    std::unordered_map<std::string, int64_t> storage_offloading_objects;
+    std::unordered_map<std::string, std::string> storage_to_user_key;
+    std::unordered_map<std::string, std::string> user_to_storage_key;
+    storage_offloading_objects.reserve(offloading_objects.size());
+    storage_to_user_key.reserve(offloading_objects.size());
+    user_to_storage_key.reserve(offloading_objects.size());
+    for (const auto& [key, size] : offloading_objects) {
+        auto parsed = ParseTenantScopedKey(key);
+        std::string storage_key = parsed ? key : client_->BuildStorageKey(key);
+        std::string user_key = parsed ? parsed->user_key : key;
+        user_to_storage_key.emplace(user_key, storage_key);
+        storage_to_user_key.emplace(storage_key, std::move(user_key));
+        storage_offloading_objects.emplace(std::move(storage_key), size);
+    }
+
     std::vector<std::vector<std::string>> buckets_keys;
     if (auto bucket_backend =
             std::dynamic_pointer_cast<BucketStorageBackend>(storage_backend_)) {
         auto allocate_res = bucket_backend->AllocateOffloadingBuckets(
-            offloading_objects, buckets_keys);
+            storage_offloading_objects, buckets_keys);
         if (!allocate_res) {
             LOG(ERROR) << "AllocateOffloadingBuckets failed with error: "
                        << allocate_res.error();
@@ -355,8 +370,8 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         }
     } else {
         std::vector<std::string> keys;
-        keys.reserve(offloading_objects.size());
-        for (const auto& it : offloading_objects) {
+        keys.reserve(storage_offloading_objects.size());
+        for (const auto& it : storage_offloading_objects) {
             keys.emplace_back(it.first);
         }
         buckets_keys.emplace_back(std::move(keys));
@@ -378,9 +393,21 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         return ErrorCode::OK;
     };
 
-    for (const auto& keys : buckets_keys) {
+    for (const auto& storage_keys : buckets_keys) {
+        std::vector<std::string> user_keys;
+        user_keys.reserve(storage_keys.size());
+        for (const auto& storage_key : storage_keys) {
+            auto it = storage_to_user_key.find(storage_key);
+            if (it == storage_to_user_key.end()) {
+                LOG(ERROR) << "Missing user key for storage key: "
+                           << storage_key;
+                continue;
+            }
+            user_keys.emplace_back(it->second);
+        }
+
         std::unordered_map<std::string, std::vector<Slice>> batch_object;
-        auto query_result = BatchQuerySegmentSlices(keys, batch_object);
+        auto query_result = BatchQuerySegmentSlices(user_keys, batch_object);
         if (!query_result) {
             LOG(ERROR) << "BatchQuerySlices failed with error: "
                        << query_result.error();
@@ -390,8 +417,18 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         auto eviction_handler = [this](const std::vector<std::string>&
                                            evicted_keys) {
             if (evicted_keys.empty()) return;
+            std::vector<std::string> evicted_object_keys;
+            evicted_object_keys.reserve(evicted_keys.size());
+            for (const auto& evicted_key : evicted_keys) {
+                if (auto parsed = ParseTenantScopedKey(evicted_key)) {
+                    evicted_object_keys.emplace_back(
+                        std::move(parsed->user_key));
+                } else {
+                    evicted_object_keys.emplace_back(evicted_key);
+                }
+            }
             auto results = client_->BatchEvictDiskReplica(
-                evicted_keys, ReplicaType::LOCAL_DISK);
+                evicted_object_keys, ReplicaType::LOCAL_DISK);
             for (size_t i = 0; i < results.size(); ++i) {
                 if (!results[i]) {
                     LOG(WARNING)
@@ -411,6 +448,12 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         for (auto& [obj_key, slices] : batch_object) {
             std::vector<Slice> host_slices;
             bool obj_success = true;
+            auto storage_key_it = user_to_storage_key.find(obj_key);
+            if (storage_key_it == user_to_storage_key.end()) {
+                LOG(ERROR) << "Missing storage key for user key: " << obj_key;
+                continue;
+            }
+            const std::string& storage_key = storage_key_it->second;
             for (const auto& slice : slices) {
                 int device_id = -1;
                 if (IsDevicePointer(slice.ptr, &device_id)) {
@@ -429,7 +472,7 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
                 }
             }
             if (obj_success) {
-                host_batch_object[obj_key] = std::move(host_slices);
+                host_batch_object[storage_key] = std::move(host_slices);
             }
         }
 

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -417,7 +417,7 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         auto eviction_handler = [this](const std::vector<std::string>&
                                            evicted_keys) {
             if (evicted_keys.empty()) return;
-            auto results = client_->BatchEvictDiskReplica(
+            auto results = client_->BatchEvictDiskReplicaStorageKeys(
                 evicted_keys, ReplicaType::LOCAL_DISK);
             for (size_t i = 0; i < results.size(); ++i) {
                 if (!results[i]) {

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -553,6 +553,19 @@ MasterClient::BatchGetReplicaList(const std::vector<std::string>& object_keys) {
     return result;
 }
 
+std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+MasterClient::BatchGetReplicaListStorageKeys(
+    const std::vector<std::string>& storage_keys) {
+    ScopedVLogTimer timer(1, "MasterClient::BatchGetReplicaListStorageKeys");
+    timer.LogRequest("keys_count=", storage_keys.size());
+
+    auto result = invoke_batch_rpc<&WrappedMasterService::BatchGetReplicaList,
+                                   GetReplicaListResponse>(storage_keys.size(),
+                                                           storage_keys);
+    timer.LogResponse("result=", result.size(), " operations");
+    return result;
+}
+
 tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
 MasterClient::PutStart(const std::string& key,
                        const std::vector<size_t>& slice_lengths,

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -38,6 +38,11 @@ struct RpcNameTraits<&WrappedMasterService::GetReplicaList> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::GetReplicaListInTenant> {
+    static constexpr const char* value = "GetReplicaListInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::CalcCacheStats> {
     static constexpr const char* value = "CalcCacheStats";
 };
@@ -53,8 +58,18 @@ struct RpcNameTraits<&WrappedMasterService::BatchReplicaClear> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::BatchReplicaClearInTenant> {
+    static constexpr const char* value = "BatchReplicaClearInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::GetReplicaListByRegex> {
     static constexpr const char* value = "GetReplicaListByRegex";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::GetReplicaListByRegexInTenant> {
+    static constexpr const char* value = "GetReplicaListByRegexInTenant";
 };
 
 template <>
@@ -63,8 +78,18 @@ struct RpcNameTraits<&WrappedMasterService::BatchGetReplicaList> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::BatchGetReplicaListInTenant> {
+    static constexpr const char* value = "BatchGetReplicaListInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::PutStart> {
     static constexpr const char* value = "PutStart";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::PutStartInTenant> {
+    static constexpr const char* value = "PutStartInTenant";
 };
 
 template <>
@@ -73,8 +98,18 @@ struct RpcNameTraits<&WrappedMasterService::BatchPutStart> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::BatchPutStartInTenant> {
+    static constexpr const char* value = "BatchPutStartInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::PutEnd> {
     static constexpr const char* value = "PutEnd";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::PutEndInTenant> {
+    static constexpr const char* value = "PutEndInTenant";
 };
 
 template <>
@@ -83,8 +118,18 @@ struct RpcNameTraits<&WrappedMasterService::BatchPutEnd> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::BatchPutEndInTenant> {
+    static constexpr const char* value = "BatchPutEndInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::PutRevoke> {
     static constexpr const char* value = "PutRevoke";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::PutRevokeInTenant> {
+    static constexpr const char* value = "PutRevokeInTenant";
 };
 
 template <>
@@ -93,8 +138,18 @@ struct RpcNameTraits<&WrappedMasterService::BatchPutRevoke> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::BatchPutRevokeInTenant> {
+    static constexpr const char* value = "BatchPutRevokeInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::UpsertStart> {
     static constexpr const char* value = "UpsertStart";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::UpsertStartInTenant> {
+    static constexpr const char* value = "UpsertStartInTenant";
 };
 
 template <>
@@ -103,8 +158,18 @@ struct RpcNameTraits<&WrappedMasterService::BatchUpsertStart> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::BatchUpsertStartInTenant> {
+    static constexpr const char* value = "BatchUpsertStartInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::UpsertEnd> {
     static constexpr const char* value = "UpsertEnd";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::UpsertEndInTenant> {
+    static constexpr const char* value = "UpsertEndInTenant";
 };
 
 template <>
@@ -113,8 +178,18 @@ struct RpcNameTraits<&WrappedMasterService::BatchUpsertEnd> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::BatchUpsertEndInTenant> {
+    static constexpr const char* value = "BatchUpsertEndInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::UpsertRevoke> {
     static constexpr const char* value = "UpsertRevoke";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::UpsertRevokeInTenant> {
+    static constexpr const char* value = "UpsertRevokeInTenant";
 };
 
 template <>
@@ -123,13 +198,28 @@ struct RpcNameTraits<&WrappedMasterService::BatchUpsertRevoke> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::BatchUpsertRevokeInTenant> {
+    static constexpr const char* value = "BatchUpsertRevokeInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::Remove> {
     static constexpr const char* value = "Remove";
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::RemoveInTenant> {
+    static constexpr const char* value = "RemoveInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::RemoveByRegex> {
     static constexpr const char* value = "RemoveByRegex";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::RemoveByRegexInTenant> {
+    static constexpr const char* value = "RemoveByRegexInTenant";
 };
 
 template <>
@@ -140,6 +230,11 @@ struct RpcNameTraits<&WrappedMasterService::RemoveAll> {
 template <>
 struct RpcNameTraits<&WrappedMasterService::BatchRemove> {
     static constexpr const char* value = "BatchRemove";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::BatchRemoveInTenant> {
+    static constexpr const char* value = "BatchRemoveInTenant";
 };
 
 template <>
@@ -258,8 +353,18 @@ struct RpcNameTraits<&WrappedMasterService::CopyStart> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::CopyStartInTenant> {
+    static constexpr const char* value = "CopyStartInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::CopyEnd> {
     static constexpr const char* value = "CopyEnd";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::CopyEndInTenant> {
+    static constexpr const char* value = "CopyEndInTenant";
 };
 
 template <>
@@ -268,8 +373,18 @@ struct RpcNameTraits<&WrappedMasterService::CopyRevoke> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::CopyRevokeInTenant> {
+    static constexpr const char* value = "CopyRevokeInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::MoveStart> {
     static constexpr const char* value = "MoveStart";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::MoveStartInTenant> {
+    static constexpr const char* value = "MoveStartInTenant";
 };
 
 template <>
@@ -278,8 +393,18 @@ struct RpcNameTraits<&WrappedMasterService::MoveEnd> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::MoveEndInTenant> {
+    static constexpr const char* value = "MoveEndInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::MoveRevoke> {
     static constexpr const char* value = "MoveRevoke";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::MoveRevokeInTenant> {
+    static constexpr const char* value = "MoveRevokeInTenant";
 };
 
 template <>
@@ -288,8 +413,18 @@ struct RpcNameTraits<&WrappedMasterService::CreateCopyTask> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::CreateCopyTaskInTenant> {
+    static constexpr const char* value = "CreateCopyTaskInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::CreateMoveTask> {
     static constexpr const char* value = "CreateMoveTask";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::CreateMoveTaskInTenant> {
+    static constexpr const char* value = "CreateMoveTaskInTenant";
 };
 
 template <>
@@ -313,8 +448,18 @@ struct RpcNameTraits<&WrappedMasterService::EvictDiskReplica> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::EvictDiskReplicaInTenant> {
+    static constexpr const char* value = "EvictDiskReplicaInTenant";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::BatchEvictDiskReplica> {
     static constexpr const char* value = "BatchEvictDiskReplica";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::BatchEvictDiskReplicaInTenant> {
+    static constexpr const char* value = "BatchEvictDiskReplicaInTenant";
 };
 
 template <auto ServiceMethod, typename ReturnType, typename... Args>
@@ -489,11 +634,11 @@ MasterClient::BatchReplicaClear(const std::vector<std::string>& object_keys,
                                 const std::string& segment_name) {
     ScopedVLogTimer timer(1, "MasterClient::BatchReplicaClear");
     timer.LogRequest("object_keys_count=", object_keys.size(),
-                     ", client_id=", client_id,
-                     ", segment_name=", segment_name);
-    auto result = invoke_rpc<&WrappedMasterService::BatchReplicaClear,
-                             std::vector<std::string>>(object_keys, client_id,
-                                                       segment_name);
+                     ", client_id=", client_id, ", segment_name=", segment_name,
+                     ", tenant_id=", tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::BatchReplicaClearInTenant,
+                             std::vector<std::string>>(
+        object_keys, client_id, segment_name, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -502,11 +647,12 @@ tl::expected<std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
              ErrorCode>
 MasterClient::GetReplicaListByRegex(const std::string& str) {
     ScopedVLogTimer timer(1, "MasterClient::GetReplicaListByRegex");
-    timer.LogRequest("Regex=", str);
+    timer.LogRequest("Regex=", str, ", tenant_id=", tenant_id_);
 
     auto result = invoke_rpc<
-        &WrappedMasterService::GetReplicaListByRegex,
-        std::unordered_map<std::string, std::vector<Replica::Descriptor>>>(str);
+        &WrappedMasterService::GetReplicaListByRegexInTenant,
+        std::unordered_map<std::string, std::vector<Replica::Descriptor>>>(
+        str, tenant_id_);
 
     timer.LogResponseExpected(result);
     return result;
@@ -515,10 +661,10 @@ MasterClient::GetReplicaListByRegex(const std::string& str) {
 tl::expected<GetReplicaListResponse, ErrorCode> MasterClient::GetReplicaList(
     const std::string& object_key) {
     ScopedVLogTimer timer(1, "MasterClient::GetReplicaList");
-    timer.LogRequest("object_key=", object_key);
+    timer.LogRequest("object_key=", object_key, ", tenant_id=", tenant_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::GetReplicaList,
-                             GetReplicaListResponse>(object_key);
+    auto result = invoke_rpc<&WrappedMasterService::GetReplicaListInTenant,
+                             GetReplicaListResponse>(object_key, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -526,11 +672,13 @@ tl::expected<GetReplicaListResponse, ErrorCode> MasterClient::GetReplicaList(
 std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
 MasterClient::BatchGetReplicaList(const std::vector<std::string>& object_keys) {
     ScopedVLogTimer timer(1, "MasterClient::BatchGetReplicaList");
-    timer.LogRequest("keys_count=", object_keys.size());
+    timer.LogRequest("keys_count=", object_keys.size(),
+                     ", tenant_id=", tenant_id_);
 
-    auto result = invoke_batch_rpc<&WrappedMasterService::BatchGetReplicaList,
-                                   GetReplicaListResponse>(object_keys.size(),
-                                                           object_keys);
+    auto result =
+        invoke_batch_rpc<&WrappedMasterService::BatchGetReplicaListInTenant,
+                         GetReplicaListResponse>(object_keys.size(),
+                                                 object_keys, tenant_id_);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -547,9 +695,9 @@ MasterClient::PutStart(const std::string& key,
         total_slice_length += slice_length;
     }
 
-    auto result = invoke_rpc<&WrappedMasterService::PutStart,
+    auto result = invoke_rpc<&WrappedMasterService::PutStartInTenant,
                              std::vector<Replica::Descriptor>>(
-        client_id_, key, total_slice_length, config);
+        client_id_, key, total_slice_length, config, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -572,9 +720,9 @@ MasterClient::BatchPutStart(
         total_slice_lengths.emplace_back(total_slice_length);
     }
 
-    auto result = invoke_batch_rpc<&WrappedMasterService::BatchPutStart,
+    auto result = invoke_batch_rpc<&WrappedMasterService::BatchPutStartInTenant,
                                    std::vector<Replica::Descriptor>>(
-        keys.size(), client_id_, keys, total_slice_lengths, config);
+        keys.size(), client_id_, keys, total_slice_lengths, config, tenant_id_);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -582,10 +730,10 @@ MasterClient::BatchPutStart(
 tl::expected<void, ErrorCode> MasterClient::PutEnd(const std::string& key,
                                                    ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::PutEnd");
-    timer.LogRequest("key=", key);
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::PutEnd, void>(
-        client_id_, key, replica_type);
+    auto result = invoke_rpc<&WrappedMasterService::PutEndInTenant, void>(
+        client_id_, key, replica_type, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -593,10 +741,11 @@ tl::expected<void, ErrorCode> MasterClient::PutEnd(const std::string& key,
 std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchPutEnd(
     const std::vector<std::string>& keys, ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::BatchPutEnd");
-    timer.LogRequest("keys_count=", keys.size());
+    timer.LogRequest("keys_count=", keys.size(), ", tenant_id=", tenant_id_);
 
-    auto result = invoke_batch_rpc<&WrappedMasterService::BatchPutEnd, void>(
-        keys.size(), client_id_, keys, replica_type);
+    auto result =
+        invoke_batch_rpc<&WrappedMasterService::BatchPutEndInTenant, void>(
+            keys.size(), client_id_, keys, replica_type, tenant_id_);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -604,10 +753,10 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchPutEnd(
 tl::expected<void, ErrorCode> MasterClient::PutRevoke(
     const std::string& key, ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::PutRevoke");
-    timer.LogRequest("key=", key);
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::PutRevoke, void>(
-        client_id_, key, replica_type);
+    auto result = invoke_rpc<&WrappedMasterService::PutRevokeInTenant, void>(
+        client_id_, key, replica_type, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -615,10 +764,11 @@ tl::expected<void, ErrorCode> MasterClient::PutRevoke(
 std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchPutRevoke(
     const std::vector<std::string>& keys, ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::BatchPutRevoke");
-    timer.LogRequest("keys_count=", keys.size());
+    timer.LogRequest("keys_count=", keys.size(), ", tenant_id=", tenant_id_);
 
-    auto result = invoke_batch_rpc<&WrappedMasterService::BatchPutRevoke, void>(
-        keys.size(), client_id_, keys, replica_type);
+    auto result =
+        invoke_batch_rpc<&WrappedMasterService::BatchPutRevokeInTenant, void>(
+            keys.size(), client_id_, keys, replica_type, tenant_id_);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -635,9 +785,9 @@ MasterClient::UpsertStart(const std::string& key,
         total_slice_length += slice_length;
     }
 
-    auto result = invoke_rpc<&WrappedMasterService::UpsertStart,
+    auto result = invoke_rpc<&WrappedMasterService::UpsertStartInTenant,
                              std::vector<Replica::Descriptor>>(
-        client_id_, key, total_slice_length, config);
+        client_id_, key, total_slice_length, config, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -660,9 +810,11 @@ MasterClient::BatchUpsertStart(
         total_slice_lengths.emplace_back(total);
     }
 
-    auto result = invoke_batch_rpc<&WrappedMasterService::BatchUpsertStart,
-                                   std::vector<Replica::Descriptor>>(
-        keys.size(), client_id_, keys, total_slice_lengths, config);
+    auto result =
+        invoke_batch_rpc<&WrappedMasterService::BatchUpsertStartInTenant,
+                         std::vector<Replica::Descriptor>>(
+            keys.size(), client_id_, keys, total_slice_lengths, config,
+            tenant_id_);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -670,10 +822,10 @@ MasterClient::BatchUpsertStart(
 tl::expected<void, ErrorCode> MasterClient::UpsertEnd(
     const std::string& key, ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::UpsertEnd");
-    timer.LogRequest("key=", key);
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::UpsertEnd, void>(
-        client_id_, key, replica_type);
+    auto result = invoke_rpc<&WrappedMasterService::UpsertEndInTenant, void>(
+        client_id_, key, replica_type, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -681,10 +833,11 @@ tl::expected<void, ErrorCode> MasterClient::UpsertEnd(
 std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchUpsertEnd(
     const std::vector<std::string>& keys) {
     ScopedVLogTimer timer(1, "MasterClient::BatchUpsertEnd");
-    timer.LogRequest("keys_count=", keys.size());
+    timer.LogRequest("keys_count=", keys.size(), ", tenant_id=", tenant_id_);
 
-    auto result = invoke_batch_rpc<&WrappedMasterService::BatchUpsertEnd, void>(
-        keys.size(), client_id_, keys);
+    auto result =
+        invoke_batch_rpc<&WrappedMasterService::BatchUpsertEndInTenant, void>(
+            keys.size(), client_id_, keys, tenant_id_);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -692,10 +845,10 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchUpsertEnd(
 tl::expected<void, ErrorCode> MasterClient::UpsertRevoke(
     const std::string& key, ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::UpsertRevoke");
-    timer.LogRequest("key=", key);
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::UpsertRevoke, void>(
-        client_id_, key, replica_type);
+    auto result = invoke_rpc<&WrappedMasterService::UpsertRevokeInTenant, void>(
+        client_id_, key, replica_type, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -703,11 +856,11 @@ tl::expected<void, ErrorCode> MasterClient::UpsertRevoke(
 std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchUpsertRevoke(
     const std::vector<std::string>& keys) {
     ScopedVLogTimer timer(1, "MasterClient::BatchUpsertRevoke");
-    timer.LogRequest("keys_count=", keys.size());
+    timer.LogRequest("keys_count=", keys.size(), ", tenant_id=", tenant_id_);
 
     auto result =
-        invoke_batch_rpc<&WrappedMasterService::BatchUpsertRevoke, void>(
-            keys.size(), client_id_, keys);
+        invoke_batch_rpc<&WrappedMasterService::BatchUpsertRevokeInTenant,
+                         void>(keys.size(), client_id_, keys, tenant_id_);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -715,9 +868,11 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchUpsertRevoke(
 tl::expected<void, ErrorCode> MasterClient::Remove(const std::string& key,
                                                    bool force) {
     ScopedVLogTimer timer(1, "MasterClient::Remove");
-    timer.LogRequest("key=", key, ", force=", force);
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id_,
+                     ", force=", force);
 
-    auto result = invoke_rpc<&WrappedMasterService::Remove, void>(key, force);
+    auto result = invoke_rpc<&WrappedMasterService::RemoveInTenant, void>(
+        key, tenant_id_, force);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -725,10 +880,12 @@ tl::expected<void, ErrorCode> MasterClient::Remove(const std::string& key,
 tl::expected<long, ErrorCode> MasterClient::RemoveByRegex(
     const std::string& str, bool force) {
     ScopedVLogTimer timer(1, "MasterClient::RemoveByRegex");
-    timer.LogRequest("key=", str, ", force=", force);
+    timer.LogRequest("key=", str, ", tenant_id=", tenant_id_,
+                     ", force=", force);
 
     auto result =
-        invoke_rpc<&WrappedMasterService::RemoveByRegex, long>(str, force);
+        invoke_rpc<&WrappedMasterService::RemoveByRegexInTenant, long>(
+            str, tenant_id_, force);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -745,10 +902,12 @@ tl::expected<long, ErrorCode> MasterClient::RemoveAll(bool force) {
 std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchRemove(
     const std::vector<std::string>& keys, bool force) {
     ScopedVLogTimer timer(1, "MasterClient::BatchRemove");
-    timer.LogRequest("keys_count=", keys.size(), ", force=", force);
+    timer.LogRequest("keys_count=", keys.size(), ", tenant_id=", tenant_id_,
+                     ", force=", force);
 
-    auto result = invoke_batch_rpc<&WrappedMasterService::BatchRemove, void>(
-        keys.size(), keys, force);
+    auto result =
+        invoke_batch_rpc<&WrappedMasterService::BatchRemoveInTenant, void>(
+            keys.size(), keys, tenant_id_, force);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -921,7 +1080,8 @@ tl::expected<UUID, ErrorCode> MasterClient::CreateCopyTask(
     timer.LogRequest("key=", key, ", targets_size=", targets.size());
 
     auto result =
-        invoke_rpc<&WrappedMasterService::CreateCopyTask, UUID>(key, targets);
+        invoke_rpc<&WrappedMasterService::CreateCopyTaskInTenant, UUID>(
+            key, targets, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -932,8 +1092,9 @@ tl::expected<UUID, ErrorCode> MasterClient::CreateMoveTask(
     ScopedVLogTimer timer(1, "MasterClient::CreateMoveTask");
     timer.LogRequest("key=", key, ", source=", source, ", target=", target);
 
-    auto result = invoke_rpc<&WrappedMasterService::CreateMoveTask, UUID>(
-        key, source, target);
+    auto result =
+        invoke_rpc<&WrappedMasterService::CreateMoveTaskInTenant, UUID>(
+            key, source, target, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1025,8 +1186,8 @@ tl::expected<CopyStartResponse, ErrorCode> MasterClient::CopyStart(
                      ", tgt_segments_count=", tgt_segments.size());
 
     auto result =
-        invoke_rpc<&WrappedMasterService::CopyStart, CopyStartResponse>(
-            client_id_, key, src_segment, tgt_segments);
+        invoke_rpc<&WrappedMasterService::CopyStartInTenant, CopyStartResponse>(
+            client_id_, key, src_segment, tgt_segments, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1047,8 +1208,8 @@ tl::expected<void, ErrorCode> MasterClient::CopyEnd(const std::string& key) {
     ScopedVLogTimer timer(1, "MasterClient::CopyEnd");
     timer.LogRequest("key=", key);
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::CopyEnd, void>(client_id_, key);
+    auto result = invoke_rpc<&WrappedMasterService::CopyEndInTenant, void>(
+        client_id_, key, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1068,8 +1229,8 @@ tl::expected<void, ErrorCode> MasterClient::CopyRevoke(const std::string& key) {
     ScopedVLogTimer timer(1, "MasterClient::CopyRevoke");
     timer.LogRequest("key=", key);
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::CopyRevoke, void>(client_id_, key);
+    auto result = invoke_rpc<&WrappedMasterService::CopyRevokeInTenant, void>(
+        client_id_, key, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1082,8 +1243,8 @@ tl::expected<MoveStartResponse, ErrorCode> MasterClient::MoveStart(
                      ", tgt_segment=", tgt_segment);
 
     auto result =
-        invoke_rpc<&WrappedMasterService::MoveStart, MoveStartResponse>(
-            client_id_, key, src_segment, tgt_segment);
+        invoke_rpc<&WrappedMasterService::MoveStartInTenant, MoveStartResponse>(
+            client_id_, key, src_segment, tgt_segment, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1092,8 +1253,8 @@ tl::expected<void, ErrorCode> MasterClient::MoveEnd(const std::string& key) {
     ScopedVLogTimer timer(1, "MasterClient::MoveEnd");
     timer.LogRequest("key=", key);
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::MoveEnd, void>(client_id_, key);
+    auto result = invoke_rpc<&WrappedMasterService::MoveEndInTenant, void>(
+        client_id_, key, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1102,8 +1263,8 @@ tl::expected<void, ErrorCode> MasterClient::MoveRevoke(const std::string& key) {
     ScopedVLogTimer timer(1, "MasterClient::MoveRevoke");
     timer.LogRequest("key=", key);
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::MoveRevoke, void>(client_id_, key);
+    auto result = invoke_rpc<&WrappedMasterService::MoveRevokeInTenant, void>(
+        client_id_, key, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1121,10 +1282,12 @@ tl::expected<void, ErrorCode> MasterClient::MarkTaskToComplete(
 tl::expected<void, ErrorCode> MasterClient::EvictDiskReplica(
     const std::string& key, ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::EvictDiskReplica");
-    timer.LogRequest("key=", key, ", replica_type=", replica_type);
+    timer.LogRequest("key=", key, ", replica_type=", replica_type,
+                     ", tenant_id=", tenant_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::EvictDiskReplica, void>(
-        client_id_, key, replica_type);
+    auto result =
+        invoke_rpc<&WrappedMasterService::EvictDiskReplicaInTenant, void>(
+            client_id_, key, replica_type, tenant_id_);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1133,11 +1296,13 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchEvictDiskReplica(
     const std::vector<std::string>& keys, ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::BatchEvictDiskReplica");
     timer.LogRequest("keys_count=", keys.size(),
-                     ", replica_type=", replica_type);
+                     ", replica_type=", replica_type,
+                     ", tenant_id=", tenant_id_);
 
     auto result =
-        invoke_batch_rpc<&WrappedMasterService::BatchEvictDiskReplica, void>(
-            keys.size(), client_id_, keys, replica_type);
+        invoke_batch_rpc<&WrappedMasterService::BatchEvictDiskReplicaInTenant,
+                         void>(keys.size(), client_id_, keys, replica_type,
+                               tenant_id_);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -5,6 +5,7 @@
 #include <async_simple/coro/SyncAwait.h>
 
 #include <csignal>
+#include <regex>
 #include <string>
 #include <vector>
 #include <ylt/coro_rpc/impl/coro_rpc_client.hpp>
@@ -38,11 +39,6 @@ struct RpcNameTraits<&WrappedMasterService::GetReplicaList> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::GetReplicaListInTenant> {
-    static constexpr const char* value = "GetReplicaListInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::CalcCacheStats> {
     static constexpr const char* value = "CalcCacheStats";
 };
@@ -58,18 +54,8 @@ struct RpcNameTraits<&WrappedMasterService::BatchReplicaClear> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::BatchReplicaClearInTenant> {
-    static constexpr const char* value = "BatchReplicaClearInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::GetReplicaListByRegex> {
     static constexpr const char* value = "GetReplicaListByRegex";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::GetReplicaListByRegexInTenant> {
-    static constexpr const char* value = "GetReplicaListByRegexInTenant";
 };
 
 template <>
@@ -78,18 +64,8 @@ struct RpcNameTraits<&WrappedMasterService::BatchGetReplicaList> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::BatchGetReplicaListInTenant> {
-    static constexpr const char* value = "BatchGetReplicaListInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::PutStart> {
     static constexpr const char* value = "PutStart";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::PutStartInTenant> {
-    static constexpr const char* value = "PutStartInTenant";
 };
 
 template <>
@@ -98,18 +74,8 @@ struct RpcNameTraits<&WrappedMasterService::BatchPutStart> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::BatchPutStartInTenant> {
-    static constexpr const char* value = "BatchPutStartInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::PutEnd> {
     static constexpr const char* value = "PutEnd";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::PutEndInTenant> {
-    static constexpr const char* value = "PutEndInTenant";
 };
 
 template <>
@@ -118,18 +84,8 @@ struct RpcNameTraits<&WrappedMasterService::BatchPutEnd> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::BatchPutEndInTenant> {
-    static constexpr const char* value = "BatchPutEndInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::PutRevoke> {
     static constexpr const char* value = "PutRevoke";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::PutRevokeInTenant> {
-    static constexpr const char* value = "PutRevokeInTenant";
 };
 
 template <>
@@ -138,18 +94,8 @@ struct RpcNameTraits<&WrappedMasterService::BatchPutRevoke> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::BatchPutRevokeInTenant> {
-    static constexpr const char* value = "BatchPutRevokeInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::UpsertStart> {
     static constexpr const char* value = "UpsertStart";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::UpsertStartInTenant> {
-    static constexpr const char* value = "UpsertStartInTenant";
 };
 
 template <>
@@ -158,18 +104,8 @@ struct RpcNameTraits<&WrappedMasterService::BatchUpsertStart> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::BatchUpsertStartInTenant> {
-    static constexpr const char* value = "BatchUpsertStartInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::UpsertEnd> {
     static constexpr const char* value = "UpsertEnd";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::UpsertEndInTenant> {
-    static constexpr const char* value = "UpsertEndInTenant";
 };
 
 template <>
@@ -178,18 +114,8 @@ struct RpcNameTraits<&WrappedMasterService::BatchUpsertEnd> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::BatchUpsertEndInTenant> {
-    static constexpr const char* value = "BatchUpsertEndInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::UpsertRevoke> {
     static constexpr const char* value = "UpsertRevoke";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::UpsertRevokeInTenant> {
-    static constexpr const char* value = "UpsertRevokeInTenant";
 };
 
 template <>
@@ -198,28 +124,13 @@ struct RpcNameTraits<&WrappedMasterService::BatchUpsertRevoke> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::BatchUpsertRevokeInTenant> {
-    static constexpr const char* value = "BatchUpsertRevokeInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::Remove> {
     static constexpr const char* value = "Remove";
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::RemoveInTenant> {
-    static constexpr const char* value = "RemoveInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::RemoveByRegex> {
     static constexpr const char* value = "RemoveByRegex";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::RemoveByRegexInTenant> {
-    static constexpr const char* value = "RemoveByRegexInTenant";
 };
 
 template <>
@@ -230,11 +141,6 @@ struct RpcNameTraits<&WrappedMasterService::RemoveAll> {
 template <>
 struct RpcNameTraits<&WrappedMasterService::BatchRemove> {
     static constexpr const char* value = "BatchRemove";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::BatchRemoveInTenant> {
-    static constexpr const char* value = "BatchRemoveInTenant";
 };
 
 template <>
@@ -353,18 +259,8 @@ struct RpcNameTraits<&WrappedMasterService::CopyStart> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::CopyStartInTenant> {
-    static constexpr const char* value = "CopyStartInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::CopyEnd> {
     static constexpr const char* value = "CopyEnd";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::CopyEndInTenant> {
-    static constexpr const char* value = "CopyEndInTenant";
 };
 
 template <>
@@ -373,18 +269,8 @@ struct RpcNameTraits<&WrappedMasterService::CopyRevoke> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::CopyRevokeInTenant> {
-    static constexpr const char* value = "CopyRevokeInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::MoveStart> {
     static constexpr const char* value = "MoveStart";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::MoveStartInTenant> {
-    static constexpr const char* value = "MoveStartInTenant";
 };
 
 template <>
@@ -393,18 +279,8 @@ struct RpcNameTraits<&WrappedMasterService::MoveEnd> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::MoveEndInTenant> {
-    static constexpr const char* value = "MoveEndInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::MoveRevoke> {
     static constexpr const char* value = "MoveRevoke";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::MoveRevokeInTenant> {
-    static constexpr const char* value = "MoveRevokeInTenant";
 };
 
 template <>
@@ -413,18 +289,8 @@ struct RpcNameTraits<&WrappedMasterService::CreateCopyTask> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::CreateCopyTaskInTenant> {
-    static constexpr const char* value = "CreateCopyTaskInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::CreateMoveTask> {
     static constexpr const char* value = "CreateMoveTask";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::CreateMoveTaskInTenant> {
-    static constexpr const char* value = "CreateMoveTaskInTenant";
 };
 
 template <>
@@ -448,18 +314,8 @@ struct RpcNameTraits<&WrappedMasterService::EvictDiskReplica> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::EvictDiskReplicaInTenant> {
-    static constexpr const char* value = "EvictDiskReplicaInTenant";
-};
-
-template <>
 struct RpcNameTraits<&WrappedMasterService::BatchEvictDiskReplica> {
     static constexpr const char* value = "BatchEvictDiskReplica";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::BatchEvictDiskReplicaInTenant> {
-    static constexpr const char* value = "BatchEvictDiskReplicaInTenant";
 };
 
 template <auto ServiceMethod, typename ReturnType, typename... Args>
@@ -549,7 +405,39 @@ std::vector<tl::expected<ResultType, ErrorCode>> MasterClient::invoke_batch_rpc(
         }());
 }
 
+namespace {
+
+std::string EscapeRegexLiteral(const std::string& value) {
+    static const std::regex metacharacters(R"([.^$|()\\[\]{}*+?])");
+    return std::regex_replace(value, metacharacters, R"(\$&)");
+}
+
+}  // namespace
+
 MasterClient::~MasterClient() = default;
+
+std::string MasterClient::BuildStorageKey(const std::string& object_key) const {
+    return BuildTenantScopedKey(tenant_id_, object_key);
+}
+
+std::vector<std::string> MasterClient::BuildStorageKeys(
+    const std::vector<std::string>& object_keys) const {
+    std::vector<std::string> storage_keys;
+    storage_keys.reserve(object_keys.size());
+    for (const auto& object_key : object_keys) {
+        storage_keys.emplace_back(BuildStorageKey(object_key));
+    }
+    return storage_keys;
+}
+
+std::string MasterClient::BuildStorageRegex(
+    const std::string& object_regex) const {
+    const auto prefix = BuildTenantScopedKey(tenant_id_, "");
+    if (!object_regex.empty() && object_regex.front() == '^') {
+        return "^" + EscapeRegexLiteral(prefix) + object_regex.substr(1);
+    }
+    return "^" + EscapeRegexLiteral(prefix) + ".*(" + object_regex + ")";
+}
 
 ErrorCode MasterClient::Connect(const std::string& master_addr) {
     ScopedVLogTimer timer(1, "MasterClient::Connect");
@@ -590,7 +478,8 @@ tl::expected<bool, ErrorCode> MasterClient::ExistKey(
     ScopedVLogTimer timer(1, "MasterClient::ExistKey");
     timer.LogRequest("object_key=", object_key);
 
-    auto result = invoke_rpc<&WrappedMasterService::ExistKey, bool>(object_key);
+    auto result = invoke_rpc<&WrappedMasterService::ExistKey, bool>(
+        BuildStorageKey(object_key));
     timer.LogResponseExpected(result);
     return result;
 }
@@ -601,7 +490,7 @@ std::vector<tl::expected<bool, ErrorCode>> MasterClient::BatchExistKey(
     timer.LogRequest("keys_count=", object_keys.size());
 
     auto result = invoke_batch_rpc<&WrappedMasterService::BatchExistKey, bool>(
-        object_keys.size(), object_keys);
+        object_keys.size(), BuildStorageKeys(object_keys));
     timer.LogResponse("result=", result.size(), " keys");
     return result;
 }
@@ -636,9 +525,9 @@ MasterClient::BatchReplicaClear(const std::vector<std::string>& object_keys,
     timer.LogRequest("object_keys_count=", object_keys.size(),
                      ", client_id=", client_id, ", segment_name=", segment_name,
                      ", tenant_id=", tenant_id_);
-    auto result = invoke_rpc<&WrappedMasterService::BatchReplicaClearInTenant,
+    auto result = invoke_rpc<&WrappedMasterService::BatchReplicaClear,
                              std::vector<std::string>>(
-        object_keys, client_id, segment_name, tenant_id_);
+        BuildStorageKeys(object_keys), client_id, segment_name);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -650,9 +539,9 @@ MasterClient::GetReplicaListByRegex(const std::string& str) {
     timer.LogRequest("Regex=", str, ", tenant_id=", tenant_id_);
 
     auto result = invoke_rpc<
-        &WrappedMasterService::GetReplicaListByRegexInTenant,
+        &WrappedMasterService::GetReplicaListByRegex,
         std::unordered_map<std::string, std::vector<Replica::Descriptor>>>(
-        str, tenant_id_);
+        BuildStorageRegex(str));
 
     timer.LogResponseExpected(result);
     return result;
@@ -663,8 +552,9 @@ tl::expected<GetReplicaListResponse, ErrorCode> MasterClient::GetReplicaList(
     ScopedVLogTimer timer(1, "MasterClient::GetReplicaList");
     timer.LogRequest("object_key=", object_key, ", tenant_id=", tenant_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::GetReplicaListInTenant,
-                             GetReplicaListResponse>(object_key, tenant_id_);
+    auto result =
+        invoke_rpc<&WrappedMasterService::GetReplicaList,
+                   GetReplicaListResponse>(BuildStorageKey(object_key));
     timer.LogResponseExpected(result);
     return result;
 }
@@ -675,10 +565,9 @@ MasterClient::BatchGetReplicaList(const std::vector<std::string>& object_keys) {
     timer.LogRequest("keys_count=", object_keys.size(),
                      ", tenant_id=", tenant_id_);
 
-    auto result =
-        invoke_batch_rpc<&WrappedMasterService::BatchGetReplicaListInTenant,
-                         GetReplicaListResponse>(object_keys.size(),
-                                                 object_keys, tenant_id_);
+    auto result = invoke_batch_rpc<&WrappedMasterService::BatchGetReplicaList,
+                                   GetReplicaListResponse>(
+        object_keys.size(), BuildStorageKeys(object_keys));
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -695,9 +584,9 @@ MasterClient::PutStart(const std::string& key,
         total_slice_length += slice_length;
     }
 
-    auto result = invoke_rpc<&WrappedMasterService::PutStartInTenant,
+    auto result = invoke_rpc<&WrappedMasterService::PutStart,
                              std::vector<Replica::Descriptor>>(
-        client_id_, key, total_slice_length, config, tenant_id_);
+        client_id_, BuildStorageKey(key), total_slice_length, config);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -720,9 +609,10 @@ MasterClient::BatchPutStart(
         total_slice_lengths.emplace_back(total_slice_length);
     }
 
-    auto result = invoke_batch_rpc<&WrappedMasterService::BatchPutStartInTenant,
+    auto result = invoke_batch_rpc<&WrappedMasterService::BatchPutStart,
                                    std::vector<Replica::Descriptor>>(
-        keys.size(), client_id_, keys, total_slice_lengths, config, tenant_id_);
+        keys.size(), client_id_, BuildStorageKeys(keys), total_slice_lengths,
+        config);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -732,8 +622,8 @@ tl::expected<void, ErrorCode> MasterClient::PutEnd(const std::string& key,
     ScopedVLogTimer timer(1, "MasterClient::PutEnd");
     timer.LogRequest("key=", key, ", tenant_id=", tenant_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::PutEndInTenant, void>(
-        client_id_, key, replica_type, tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::PutEnd, void>(
+        client_id_, BuildStorageKey(key), replica_type);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -743,9 +633,8 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchPutEnd(
     ScopedVLogTimer timer(1, "MasterClient::BatchPutEnd");
     timer.LogRequest("keys_count=", keys.size(), ", tenant_id=", tenant_id_);
 
-    auto result =
-        invoke_batch_rpc<&WrappedMasterService::BatchPutEndInTenant, void>(
-            keys.size(), client_id_, keys, replica_type, tenant_id_);
+    auto result = invoke_batch_rpc<&WrappedMasterService::BatchPutEnd, void>(
+        keys.size(), client_id_, BuildStorageKeys(keys), replica_type);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -755,8 +644,8 @@ tl::expected<void, ErrorCode> MasterClient::PutRevoke(
     ScopedVLogTimer timer(1, "MasterClient::PutRevoke");
     timer.LogRequest("key=", key, ", tenant_id=", tenant_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::PutRevokeInTenant, void>(
-        client_id_, key, replica_type, tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::PutRevoke, void>(
+        client_id_, BuildStorageKey(key), replica_type);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -766,9 +655,8 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchPutRevoke(
     ScopedVLogTimer timer(1, "MasterClient::BatchPutRevoke");
     timer.LogRequest("keys_count=", keys.size(), ", tenant_id=", tenant_id_);
 
-    auto result =
-        invoke_batch_rpc<&WrappedMasterService::BatchPutRevokeInTenant, void>(
-            keys.size(), client_id_, keys, replica_type, tenant_id_);
+    auto result = invoke_batch_rpc<&WrappedMasterService::BatchPutRevoke, void>(
+        keys.size(), client_id_, BuildStorageKeys(keys), replica_type);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -785,9 +673,9 @@ MasterClient::UpsertStart(const std::string& key,
         total_slice_length += slice_length;
     }
 
-    auto result = invoke_rpc<&WrappedMasterService::UpsertStartInTenant,
+    auto result = invoke_rpc<&WrappedMasterService::UpsertStart,
                              std::vector<Replica::Descriptor>>(
-        client_id_, key, total_slice_length, config, tenant_id_);
+        client_id_, BuildStorageKey(key), total_slice_length, config);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -810,11 +698,10 @@ MasterClient::BatchUpsertStart(
         total_slice_lengths.emplace_back(total);
     }
 
-    auto result =
-        invoke_batch_rpc<&WrappedMasterService::BatchUpsertStartInTenant,
-                         std::vector<Replica::Descriptor>>(
-            keys.size(), client_id_, keys, total_slice_lengths, config,
-            tenant_id_);
+    auto result = invoke_batch_rpc<&WrappedMasterService::BatchUpsertStart,
+                                   std::vector<Replica::Descriptor>>(
+        keys.size(), client_id_, BuildStorageKeys(keys), total_slice_lengths,
+        config);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -824,8 +711,8 @@ tl::expected<void, ErrorCode> MasterClient::UpsertEnd(
     ScopedVLogTimer timer(1, "MasterClient::UpsertEnd");
     timer.LogRequest("key=", key, ", tenant_id=", tenant_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::UpsertEndInTenant, void>(
-        client_id_, key, replica_type, tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::UpsertEnd, void>(
+        client_id_, BuildStorageKey(key), replica_type);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -835,9 +722,8 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchUpsertEnd(
     ScopedVLogTimer timer(1, "MasterClient::BatchUpsertEnd");
     timer.LogRequest("keys_count=", keys.size(), ", tenant_id=", tenant_id_);
 
-    auto result =
-        invoke_batch_rpc<&WrappedMasterService::BatchUpsertEndInTenant, void>(
-            keys.size(), client_id_, keys, tenant_id_);
+    auto result = invoke_batch_rpc<&WrappedMasterService::BatchUpsertEnd, void>(
+        keys.size(), client_id_, BuildStorageKeys(keys));
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -847,8 +733,8 @@ tl::expected<void, ErrorCode> MasterClient::UpsertRevoke(
     ScopedVLogTimer timer(1, "MasterClient::UpsertRevoke");
     timer.LogRequest("key=", key, ", tenant_id=", tenant_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::UpsertRevokeInTenant, void>(
-        client_id_, key, replica_type, tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::UpsertRevoke, void>(
+        client_id_, BuildStorageKey(key), replica_type);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -859,8 +745,8 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchUpsertRevoke(
     timer.LogRequest("keys_count=", keys.size(), ", tenant_id=", tenant_id_);
 
     auto result =
-        invoke_batch_rpc<&WrappedMasterService::BatchUpsertRevokeInTenant,
-                         void>(keys.size(), client_id_, keys, tenant_id_);
+        invoke_batch_rpc<&WrappedMasterService::BatchUpsertRevoke, void>(
+            keys.size(), client_id_, BuildStorageKeys(keys));
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -871,8 +757,8 @@ tl::expected<void, ErrorCode> MasterClient::Remove(const std::string& key,
     timer.LogRequest("key=", key, ", tenant_id=", tenant_id_,
                      ", force=", force);
 
-    auto result = invoke_rpc<&WrappedMasterService::RemoveInTenant, void>(
-        key, tenant_id_, force);
+    auto result = invoke_rpc<&WrappedMasterService::Remove, void>(
+        BuildStorageKey(key), force);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -883,9 +769,8 @@ tl::expected<long, ErrorCode> MasterClient::RemoveByRegex(
     timer.LogRequest("key=", str, ", tenant_id=", tenant_id_,
                      ", force=", force);
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::RemoveByRegexInTenant, long>(
-            str, tenant_id_, force);
+    auto result = invoke_rpc<&WrappedMasterService::RemoveByRegex, long>(
+        BuildStorageRegex(str), force);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -905,9 +790,8 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchRemove(
     timer.LogRequest("keys_count=", keys.size(), ", tenant_id=", tenant_id_,
                      ", force=", force);
 
-    auto result =
-        invoke_batch_rpc<&WrappedMasterService::BatchRemoveInTenant, void>(
-            keys.size(), keys, tenant_id_, force);
+    auto result = invoke_batch_rpc<&WrappedMasterService::BatchRemove, void>(
+        keys.size(), BuildStorageKeys(keys), force);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -1079,9 +963,8 @@ tl::expected<UUID, ErrorCode> MasterClient::CreateCopyTask(
     ScopedVLogTimer timer(1, "MasterClient::CreateCopyTask");
     timer.LogRequest("key=", key, ", targets_size=", targets.size());
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::CreateCopyTaskInTenant, UUID>(
-            key, targets, tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::CreateCopyTask, UUID>(
+        BuildStorageKey(key), targets);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1092,9 +975,8 @@ tl::expected<UUID, ErrorCode> MasterClient::CreateMoveTask(
     ScopedVLogTimer timer(1, "MasterClient::CreateMoveTask");
     timer.LogRequest("key=", key, ", source=", source, ", target=", target);
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::CreateMoveTaskInTenant, UUID>(
-            key, source, target, tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::CreateMoveTask, UUID>(
+        BuildStorageKey(key), source, target);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1186,8 +1068,8 @@ tl::expected<CopyStartResponse, ErrorCode> MasterClient::CopyStart(
                      ", tgt_segments_count=", tgt_segments.size());
 
     auto result =
-        invoke_rpc<&WrappedMasterService::CopyStartInTenant, CopyStartResponse>(
-            client_id_, key, src_segment, tgt_segments, tenant_id_);
+        invoke_rpc<&WrappedMasterService::CopyStart, CopyStartResponse>(
+            client_id_, BuildStorageKey(key), src_segment, tgt_segments);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1208,8 +1090,8 @@ tl::expected<void, ErrorCode> MasterClient::CopyEnd(const std::string& key) {
     ScopedVLogTimer timer(1, "MasterClient::CopyEnd");
     timer.LogRequest("key=", key);
 
-    auto result = invoke_rpc<&WrappedMasterService::CopyEndInTenant, void>(
-        client_id_, key, tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::CopyEnd, void>(
+        client_id_, BuildStorageKey(key));
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1229,8 +1111,8 @@ tl::expected<void, ErrorCode> MasterClient::CopyRevoke(const std::string& key) {
     ScopedVLogTimer timer(1, "MasterClient::CopyRevoke");
     timer.LogRequest("key=", key);
 
-    auto result = invoke_rpc<&WrappedMasterService::CopyRevokeInTenant, void>(
-        client_id_, key, tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::CopyRevoke, void>(
+        client_id_, BuildStorageKey(key));
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1243,8 +1125,8 @@ tl::expected<MoveStartResponse, ErrorCode> MasterClient::MoveStart(
                      ", tgt_segment=", tgt_segment);
 
     auto result =
-        invoke_rpc<&WrappedMasterService::MoveStartInTenant, MoveStartResponse>(
-            client_id_, key, src_segment, tgt_segment, tenant_id_);
+        invoke_rpc<&WrappedMasterService::MoveStart, MoveStartResponse>(
+            client_id_, BuildStorageKey(key), src_segment, tgt_segment);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1253,8 +1135,8 @@ tl::expected<void, ErrorCode> MasterClient::MoveEnd(const std::string& key) {
     ScopedVLogTimer timer(1, "MasterClient::MoveEnd");
     timer.LogRequest("key=", key);
 
-    auto result = invoke_rpc<&WrappedMasterService::MoveEndInTenant, void>(
-        client_id_, key, tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::MoveEnd, void>(
+        client_id_, BuildStorageKey(key));
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1263,8 +1145,8 @@ tl::expected<void, ErrorCode> MasterClient::MoveRevoke(const std::string& key) {
     ScopedVLogTimer timer(1, "MasterClient::MoveRevoke");
     timer.LogRequest("key=", key);
 
-    auto result = invoke_rpc<&WrappedMasterService::MoveRevokeInTenant, void>(
-        client_id_, key, tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::MoveRevoke, void>(
+        client_id_, BuildStorageKey(key));
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1285,9 +1167,8 @@ tl::expected<void, ErrorCode> MasterClient::EvictDiskReplica(
     timer.LogRequest("key=", key, ", replica_type=", replica_type,
                      ", tenant_id=", tenant_id_);
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::EvictDiskReplicaInTenant, void>(
-            client_id_, key, replica_type, tenant_id_);
+    auto result = invoke_rpc<&WrappedMasterService::EvictDiskReplica, void>(
+        client_id_, BuildStorageKey(key), replica_type);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1300,9 +1181,8 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchEvictDiskReplica(
                      ", tenant_id=", tenant_id_);
 
     auto result =
-        invoke_batch_rpc<&WrappedMasterService::BatchEvictDiskReplicaInTenant,
-                         void>(keys.size(), client_id_, keys, replica_type,
-                               tenant_id_);
+        invoke_batch_rpc<&WrappedMasterService::BatchEvictDiskReplica, void>(
+            keys.size(), client_id_, BuildStorageKeys(keys), replica_type);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -5,7 +5,6 @@
 #include <async_simple/coro/SyncAwait.h>
 
 #include <csignal>
-#include <regex>
 #include <string>
 #include <vector>
 #include <ylt/coro_rpc/impl/coro_rpc_client.hpp>
@@ -405,21 +404,9 @@ std::vector<tl::expected<ResultType, ErrorCode>> MasterClient::invoke_batch_rpc(
         }());
 }
 
-namespace {
-
-std::string EscapeRegexLiteral(const std::string& value) {
-    static const std::regex metacharacters(R"([.^$|()\\[\]{}*+?])");
-    return std::regex_replace(value, metacharacters, R"(\$&)");
-}
-
-}  // namespace
-
 MasterClient::~MasterClient() = default;
 
 std::string MasterClient::BuildStorageKey(const std::string& object_key) const {
-    if (ParseTenantScopedKey(object_key)) {
-        return object_key;
-    }
     return BuildTenantScopedKey(tenant_id_, object_key);
 }
 
@@ -431,15 +418,6 @@ std::vector<std::string> MasterClient::BuildStorageKeys(
         storage_keys.emplace_back(BuildStorageKey(object_key));
     }
     return storage_keys;
-}
-
-std::string MasterClient::BuildStorageRegex(
-    const std::string& object_regex) const {
-    const auto prefix = BuildTenantScopedKey(tenant_id_, "");
-    if (!object_regex.empty() && object_regex.front() == '^') {
-        return "^" + EscapeRegexLiteral(prefix) + object_regex.substr(1);
-    }
-    return "^" + EscapeRegexLiteral(prefix) + ".*(" + object_regex + ")";
 }
 
 ErrorCode MasterClient::Connect(const std::string& master_addr) {
@@ -544,7 +522,7 @@ MasterClient::GetReplicaListByRegex(const std::string& str) {
     auto result = invoke_rpc<
         &WrappedMasterService::GetReplicaListByRegex,
         std::unordered_map<std::string, std::vector<Replica::Descriptor>>>(
-        BuildStorageRegex(str));
+        str, tenant_id_);
 
     timer.LogResponseExpected(result);
     return result;
@@ -773,7 +751,7 @@ tl::expected<long, ErrorCode> MasterClient::RemoveByRegex(
                      ", force=", force);
 
     auto result = invoke_rpc<&WrappedMasterService::RemoveByRegex, long>(
-        BuildStorageRegex(str), force);
+        str, tenant_id_, force);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1066,13 +1044,19 @@ tl::expected<void, ErrorCode> MasterClient::NotifyPromotionFailure(
 tl::expected<CopyStartResponse, ErrorCode> MasterClient::CopyStart(
     const std::string& key, const std::string& src_segment,
     const std::vector<std::string>& tgt_segments) {
+    return CopyStartStorageKey(BuildStorageKey(key), src_segment, tgt_segments);
+}
+
+tl::expected<CopyStartResponse, ErrorCode> MasterClient::CopyStartStorageKey(
+    const std::string& storage_key, const std::string& src_segment,
+    const std::vector<std::string>& tgt_segments) {
     ScopedVLogTimer timer(1, "MasterClient::CopyStart");
-    timer.LogRequest("key=", key, ", src_segment=", src_segment,
+    timer.LogRequest("key=", storage_key, ", src_segment=", src_segment,
                      ", tgt_segments_count=", tgt_segments.size());
 
     auto result =
         invoke_rpc<&WrappedMasterService::CopyStart, CopyStartResponse>(
-            client_id_, BuildStorageKey(key), src_segment, tgt_segments);
+            client_id_, storage_key, src_segment, tgt_segments);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1090,11 +1074,16 @@ tl::expected<QueryTaskResponse, ErrorCode> MasterClient::QueryTask(
 }
 
 tl::expected<void, ErrorCode> MasterClient::CopyEnd(const std::string& key) {
-    ScopedVLogTimer timer(1, "MasterClient::CopyEnd");
-    timer.LogRequest("key=", key);
+    return CopyEndStorageKey(BuildStorageKey(key));
+}
 
-    auto result = invoke_rpc<&WrappedMasterService::CopyEnd, void>(
-        client_id_, BuildStorageKey(key));
+tl::expected<void, ErrorCode> MasterClient::CopyEndStorageKey(
+    const std::string& storage_key) {
+    ScopedVLogTimer timer(1, "MasterClient::CopyEnd");
+    timer.LogRequest("key=", storage_key);
+
+    auto result = invoke_rpc<&WrappedMasterService::CopyEnd, void>(client_id_,
+                                                                   storage_key);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1111,11 +1100,16 @@ tl::expected<std::vector<TaskAssignment>, ErrorCode> MasterClient::FetchTasks(
 }
 
 tl::expected<void, ErrorCode> MasterClient::CopyRevoke(const std::string& key) {
+    return CopyRevokeStorageKey(BuildStorageKey(key));
+}
+
+tl::expected<void, ErrorCode> MasterClient::CopyRevokeStorageKey(
+    const std::string& storage_key) {
     ScopedVLogTimer timer(1, "MasterClient::CopyRevoke");
-    timer.LogRequest("key=", key);
+    timer.LogRequest("key=", storage_key);
 
     auto result = invoke_rpc<&WrappedMasterService::CopyRevoke, void>(
-        client_id_, BuildStorageKey(key));
+        client_id_, storage_key);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1123,33 +1117,49 @@ tl::expected<void, ErrorCode> MasterClient::CopyRevoke(const std::string& key) {
 tl::expected<MoveStartResponse, ErrorCode> MasterClient::MoveStart(
     const std::string& key, const std::string& src_segment,
     const std::string& tgt_segment) {
+    return MoveStartStorageKey(BuildStorageKey(key), src_segment, tgt_segment);
+}
+
+tl::expected<MoveStartResponse, ErrorCode> MasterClient::MoveStartStorageKey(
+    const std::string& storage_key, const std::string& src_segment,
+    const std::string& tgt_segment) {
     ScopedVLogTimer timer(1, "MasterClient::MoveStart");
-    timer.LogRequest("key=", key, ", src_segment=", src_segment,
+    timer.LogRequest("key=", storage_key, ", src_segment=", src_segment,
                      ", tgt_segment=", tgt_segment);
 
     auto result =
         invoke_rpc<&WrappedMasterService::MoveStart, MoveStartResponse>(
-            client_id_, BuildStorageKey(key), src_segment, tgt_segment);
+            client_id_, storage_key, src_segment, tgt_segment);
     timer.LogResponseExpected(result);
     return result;
 }
 
 tl::expected<void, ErrorCode> MasterClient::MoveEnd(const std::string& key) {
-    ScopedVLogTimer timer(1, "MasterClient::MoveEnd");
-    timer.LogRequest("key=", key);
+    return MoveEndStorageKey(BuildStorageKey(key));
+}
 
-    auto result = invoke_rpc<&WrappedMasterService::MoveEnd, void>(
-        client_id_, BuildStorageKey(key));
+tl::expected<void, ErrorCode> MasterClient::MoveEndStorageKey(
+    const std::string& storage_key) {
+    ScopedVLogTimer timer(1, "MasterClient::MoveEnd");
+    timer.LogRequest("key=", storage_key);
+
+    auto result = invoke_rpc<&WrappedMasterService::MoveEnd, void>(client_id_,
+                                                                   storage_key);
     timer.LogResponseExpected(result);
     return result;
 }
 
 tl::expected<void, ErrorCode> MasterClient::MoveRevoke(const std::string& key) {
+    return MoveRevokeStorageKey(BuildStorageKey(key));
+}
+
+tl::expected<void, ErrorCode> MasterClient::MoveRevokeStorageKey(
+    const std::string& storage_key) {
     ScopedVLogTimer timer(1, "MasterClient::MoveRevoke");
-    timer.LogRequest("key=", key);
+    timer.LogRequest("key=", storage_key);
 
     auto result = invoke_rpc<&WrappedMasterService::MoveRevoke, void>(
-        client_id_, BuildStorageKey(key));
+        client_id_, storage_key);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1178,14 +1188,21 @@ tl::expected<void, ErrorCode> MasterClient::EvictDiskReplica(
 
 std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchEvictDiskReplica(
     const std::vector<std::string>& keys, ReplicaType replica_type) {
+    return BatchEvictDiskReplicaStorageKeys(BuildStorageKeys(keys),
+                                            replica_type);
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+MasterClient::BatchEvictDiskReplicaStorageKeys(
+    const std::vector<std::string>& storage_keys, ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::BatchEvictDiskReplica");
-    timer.LogRequest("keys_count=", keys.size(),
+    timer.LogRequest("keys_count=", storage_keys.size(),
                      ", replica_type=", replica_type,
                      ", tenant_id=", tenant_id_);
 
     auto result =
         invoke_batch_rpc<&WrappedMasterService::BatchEvictDiskReplica, void>(
-            keys.size(), client_id_, BuildStorageKeys(keys), replica_type);
+            storage_keys.size(), client_id_, storage_keys, replica_type);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -417,6 +417,9 @@ std::string EscapeRegexLiteral(const std::string& value) {
 MasterClient::~MasterClient() = default;
 
 std::string MasterClient::BuildStorageKey(const std::string& object_key) const {
+    if (ParseTenantScopedKey(object_key)) {
+        return object_key;
+    }
     return BuildTenantScopedKey(tenant_id_, object_key);
 }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -104,6 +104,13 @@ bool HasExpectedReplicaAllocation(const ReplicateConfig& config,
            allocated_nof_replicas == config.nof_replica_num;
 }
 
+TenantScopedKey ResolveTenantScopedKey(const std::string& key) {
+    if (auto parsed = ParseTenantScopedKey(key)) {
+        return *parsed;
+    }
+    return TenantScopedKey{"default", key};
+}
+
 }  // namespace
 
 MasterService::MasterService() : MasterService(MasterServiceConfig()) {}
@@ -490,7 +497,8 @@ auto MasterService::MountNoFSegment(const NoFSegment& segment,
     ScopedNoFSegmentAccess nof_segment_access =
         nof_segment_manager_.getNoFSegmentAccess();
 
-    LOG(INFO) << "NoF segment mount: " << "client_id=" << client_id
+    LOG(INFO) << "NoF segment mount: "
+              << "client_id=" << client_id
               << ", action=mount_segment, segment_name=" << segment.name;
 
     auto err = nof_segment_access.MountSegment(segment, client_id);
@@ -755,7 +763,8 @@ auto MasterService::UnmountNoFSegment(const UUID& segment_id,
 
 auto MasterService::ExistKey(const std::string& key)
     -> tl::expected<bool, ErrorCode> {
-    return ExistKey(key, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return ExistKey(scoped_key.user_key, scoped_key.tenant_id);
 }
 
 auto MasterService::ExistKey(const std::string& key,
@@ -782,7 +791,12 @@ auto MasterService::ExistKey(const std::string& key,
 
 std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
     const std::vector<std::string>& keys) {
-    return BatchExistKey(keys, "default");
+    std::vector<tl::expected<bool, ErrorCode>> results;
+    results.reserve(keys.size());
+    for (const auto& key : keys) {
+        results.emplace_back(ExistKey(key));
+    }
+    return results;
 }
 
 std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
@@ -930,7 +944,18 @@ auto MasterService::BatchReplicaClear(
     const std::vector<std::string>& object_keys, const UUID& client_id,
     const std::string& segment_name)
     -> tl::expected<std::vector<std::string>, ErrorCode> {
-    return BatchReplicaClear(object_keys, client_id, segment_name, "default");
+    std::vector<std::string> cleared_keys;
+    cleared_keys.reserve(object_keys.size());
+    for (const auto& key : object_keys) {
+        const auto scoped_key = ResolveTenantScopedKey(key);
+        auto result = BatchReplicaClear({scoped_key.user_key}, client_id,
+                                        segment_name, scoped_key.tenant_id);
+        if (!result.has_value()) {
+            return result;
+        }
+        cleared_keys.insert(cleared_keys.end(), result->begin(), result->end());
+    }
+    return cleared_keys;
 }
 
 auto MasterService::BatchReplicaClear(
@@ -1056,7 +1081,47 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
     -> tl::expected<
         std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
         ErrorCode> {
-    return GetReplicaListByRegex(regex_pattern, "default");
+    std::unordered_map<std::string, std::vector<Replica::Descriptor>> results;
+    std::regex pattern;
+
+    try {
+        pattern = std::regex(regex_pattern, std::regex::ECMAScript);
+    } catch (const std::regex_error& e) {
+        LOG(ERROR) << "Invalid regex pattern: " << regex_pattern
+                   << ", error: " << e.what();
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    for (size_t i = 0; i < kNumShards; ++i) {
+        MetadataShardAccessorRO shard(this, i);
+
+        for (const auto& [key, metadata] : shard->metadata) {
+            const auto& user_key = metadata.UserKeyOr(key);
+            if (std::regex_search(key, pattern) ||
+                std::regex_search(user_key, pattern)) {
+                std::vector<Replica::Descriptor> replica_list;
+                metadata.VisitReplicas(
+                    &Replica::fn_is_completed,
+                    [&replica_list](const Replica& replica) {
+                        replica_list.emplace_back(replica.get_descriptor());
+                    });
+
+                if (replica_list.empty()) {
+                    LOG(WARNING)
+                        << "key=" << key
+                        << " matched by regex, but has no complete replicas.";
+                    continue;
+                }
+
+                results.emplace(user_key, std::move(replica_list));
+                metadata.GrantLease(default_kv_lease_ttl_,
+                                    default_kv_soft_pin_ttl_);
+            }
+        }
+    }
+
+    return results;
 }
 
 auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern,
@@ -1110,7 +1175,8 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern,
 
 auto MasterService::GetReplicaList(const std::string& key)
     -> tl::expected<GetReplicaListResponse, ErrorCode> {
-    return GetReplicaList(key, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return GetReplicaList(scoped_key.user_key, scoped_key.tenant_id);
 }
 
 auto MasterService::GetReplicaList(const std::string& key,
@@ -1325,7 +1391,9 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                              const uint64_t slice_length,
                              const ReplicateConfig& config)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
-    return PutStart(client_id, key, slice_length, config, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return PutStart(client_id, scoped_key.user_key, slice_length, config,
+                    scoped_key.tenant_id);
 }
 
 auto MasterService::PutStart(const UUID& client_id, const std::string& key,
@@ -1407,7 +1475,9 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
 auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
                            ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    return PutEnd(client_id, key, replica_type, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return PutEnd(client_id, scoped_key.user_key, replica_type,
+                  scoped_key.tenant_id);
 }
 
 auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
@@ -1489,7 +1559,9 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
 auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
                                Replica& replica)
     -> tl::expected<void, ErrorCode> {
-    return AddReplica(client_id, key, replica, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return AddReplica(client_id, scoped_key.user_key, replica,
+                      scoped_key.tenant_id);
 }
 
 auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
@@ -1543,7 +1615,9 @@ auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
 auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
                               ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    return PutRevoke(client_id, key, replica_type, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return PutRevoke(client_id, scoped_key.user_key, replica_type,
+                     scoped_key.tenant_id);
 }
 
 auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
@@ -1608,7 +1682,12 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutEnd(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
-    return BatchPutEnd(client_id, keys, replica_type, "default");
+    std::vector<tl::expected<void, ErrorCode>> results;
+    results.reserve(keys.size());
+    for (const auto& key : keys) {
+        results.emplace_back(PutEnd(client_id, key, replica_type));
+    }
+    return results;
 }
 
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutEnd(
@@ -1625,7 +1704,12 @@ std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutEnd(
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutRevoke(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
-    return BatchPutRevoke(client_id, keys, replica_type, "default");
+    std::vector<tl::expected<void, ErrorCode>> results;
+    results.reserve(keys.size());
+    for (const auto& key : keys) {
+        results.emplace_back(PutRevoke(client_id, key, replica_type));
+    }
+    return results;
 }
 
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutRevoke(
@@ -1658,7 +1742,9 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                                 const uint64_t slice_length,
                                 const ReplicateConfig& config)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
-    return UpsertStart(client_id, key, slice_length, config, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return UpsertStart(client_id, scoped_key.user_key, slice_length, config,
+                       scoped_key.tenant_id);
 }
 
 auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
@@ -1861,7 +1947,9 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
 auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
                               ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    return UpsertEnd(client_id, key, replica_type, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return UpsertEnd(client_id, scoped_key.user_key, replica_type,
+                     scoped_key.tenant_id);
 }
 
 auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
@@ -1874,7 +1962,9 @@ auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
 auto MasterService::UpsertRevoke(const UUID& client_id, const std::string& key,
                                  ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    return UpsertRevoke(client_id, key, replica_type, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return UpsertRevoke(client_id, scoped_key.user_key, replica_type,
+                        scoped_key.tenant_id);
 }
 
 auto MasterService::UpsertRevoke(const UUID& client_id, const std::string& key,
@@ -1889,7 +1979,19 @@ MasterService::BatchUpsertStart(const UUID& client_id,
                                 const std::vector<std::string>& keys,
                                 const std::vector<uint64_t>& slice_lengths,
                                 const ReplicateConfig& config) {
-    return BatchUpsertStart(client_id, keys, slice_lengths, config, "default");
+    if (keys.size() != slice_lengths.size()) {
+        return std::vector<
+            tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>(
+            keys.size(), tl::make_unexpected(ErrorCode::INVALID_PARAMS));
+    }
+    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+        results;
+    results.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results.emplace_back(
+            UpsertStart(client_id, keys[i], slice_lengths[i], config));
+    }
+    return results;
 }
 
 std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
@@ -2012,7 +2114,9 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment,
     const std::vector<std::string>& tgt_segments) {
-    return CopyStart(client_id, key, src_segment, tgt_segments, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return CopyStart(client_id, scoped_key.user_key, src_segment, tgt_segments,
+                     scoped_key.tenant_id);
 }
 
 tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
@@ -2115,7 +2219,8 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
 
 tl::expected<void, ErrorCode> MasterService::CopyEnd(const UUID& client_id,
                                                      const std::string& key) {
-    return CopyEnd(client_id, key, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return CopyEnd(client_id, scoped_key.user_key, scoped_key.tenant_id);
 }
 
 tl::expected<void, ErrorCode> MasterService::CopyEnd(
@@ -2193,7 +2298,8 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(
 
 tl::expected<void, ErrorCode> MasterService::CopyRevoke(
     const UUID& client_id, const std::string& key) {
-    return CopyRevoke(client_id, key, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return CopyRevoke(client_id, scoped_key.user_key, scoped_key.tenant_id);
 }
 
 tl::expected<void, ErrorCode> MasterService::CopyRevoke(
@@ -2254,7 +2360,9 @@ tl::expected<void, ErrorCode> MasterService::CopyRevoke(
 tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment, const std::string& tgt_segment) {
-    return MoveStart(client_id, key, src_segment, tgt_segment, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return MoveStart(client_id, scoped_key.user_key, src_segment, tgt_segment,
+                     scoped_key.tenant_id);
 }
 
 tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
@@ -2352,7 +2460,8 @@ tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
 
 tl::expected<void, ErrorCode> MasterService::MoveEnd(const UUID& client_id,
                                                      const std::string& key) {
-    return MoveEnd(client_id, key, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return MoveEnd(client_id, scoped_key.user_key, scoped_key.tenant_id);
 }
 
 tl::expected<void, ErrorCode> MasterService::MoveEnd(
@@ -2445,7 +2554,8 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
 
 tl::expected<void, ErrorCode> MasterService::MoveRevoke(
     const UUID& client_id, const std::string& key) {
-    return MoveRevoke(client_id, key, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return MoveRevoke(client_id, scoped_key.user_key, scoped_key.tenant_id);
 }
 
 tl::expected<void, ErrorCode> MasterService::MoveRevoke(
@@ -2505,7 +2615,8 @@ tl::expected<void, ErrorCode> MasterService::MoveRevoke(
 
 auto MasterService::Remove(const std::string& key, bool force)
     -> tl::expected<void, ErrorCode> {
-    return Remove(key, "default", force);
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return Remove(scoped_key.user_key, scoped_key.tenant_id, force);
 }
 
 auto MasterService::Remove(const std::string& key, const std::string& tenant_id,
@@ -2549,7 +2660,61 @@ auto MasterService::Remove(const std::string& key, const std::string& tenant_id,
 
 auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
     -> tl::expected<long, ErrorCode> {
-    return RemoveByRegex(regex_pattern, "default", force);
+    long removed_count = 0;
+    std::regex pattern;
+
+    try {
+        pattern = std::regex(regex_pattern, std::regex::ECMAScript);
+    } catch (const std::regex_error& e) {
+        LOG(ERROR) << "Invalid regex pattern: " << regex_pattern
+                   << ", error: " << e.what();
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    for (size_t i = 0; i < kNumShards; ++i) {
+        MetadataShardAccessorRW shard(this, i);
+
+        for (auto it = shard->metadata.begin(); it != shard->metadata.end();) {
+            const auto& user_key = it->second.UserKeyOr(it->first);
+            if (std::regex_search(it->first, pattern) ||
+                std::regex_search(user_key, pattern)) {
+                if (!force && !it->second.IsLeaseExpired()) {
+                    VLOG(1) << "key=" << it->first
+                            << " matched by regex, but has lease. Skipping "
+                            << "removal.";
+                    ++it;
+                    continue;
+                }
+                if (!it->second.AllReplicas(&Replica::fn_is_completed)) {
+                    LOG(WARNING) << "key=" << it->first
+                                 << " matched by regex, but not all replicas "
+                                    "are complete. Skipping removal.";
+                    ++it;
+                    continue;
+                }
+                if (metadata_shards_[i].replication_tasks.contains(it->first)) {
+                    LOG(WARNING) << "key=" << it->first
+                                 << ", matched by regex, but has replication "
+                                    "task. Skipping removal.";
+                    ++it;
+                    continue;
+                }
+
+                VLOG(1) << "key=" << it->first
+                        << " matched by regex. Removing.";
+                ErasePromotionTaskIfPresent(shard, it->first);
+                it = shard->metadata.erase(it);
+                removed_count++;
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    VLOG(1) << "action=remove_by_regex, pattern=" << regex_pattern
+            << ", removed_count=" << removed_count;
+    return removed_count;
 }
 
 auto MasterService::RemoveByRegex(const std::string& regex_pattern,
@@ -2666,7 +2831,12 @@ long MasterService::RemoveAll(bool force) {
 auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                                 bool force)
     -> std::vector<tl::expected<void, ErrorCode>> {
-    return BatchRemove(keys, "default", force);
+    std::vector<tl::expected<void, ErrorCode>> results;
+    results.reserve(keys.size());
+    for (const auto& key : keys) {
+        results.emplace_back(Remove(key, force));
+    }
+    return results;
 }
 
 auto MasterService::BatchRemove(const std::vector<std::string>& keys,
@@ -6059,7 +6229,8 @@ std::string MasterService::FormatTimestamp(
 
 tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
     const std::string& key, const std::vector<std::string>& targets) {
-    return CreateCopyTask(key, targets, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return CreateCopyTask(scoped_key.user_key, targets, scoped_key.tenant_id);
 }
 
 tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
@@ -6122,7 +6293,9 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
 tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
     const std::string& key, const std::string& source,
     const std::string& target) {
-    return CreateMoveTask(key, source, target, "default");
+    const auto scoped_key = ResolveTenantScopedKey(key);
+    return CreateMoveTask(scoped_key.user_key, source, target,
+                          scoped_key.tenant_id);
 }
 
 tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -6285,7 +6285,7 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
     }
     return task_manager_.get_write_access()
         .submit_task_typed<TaskType::REPLICA_COPY>(
-            select_client, {.key = key,
+            select_client, {.key = internal_key,
                             .source = selected_source_segment,
                             .targets = targets});
 }
@@ -6349,7 +6349,8 @@ tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
 
     return task_manager_.get_write_access()
         .submit_task_typed<TaskType::REPLICA_MOVE>(
-            select_client, {.key = key, .source = source, .target = target});
+            select_client,
+            {.key = internal_key, .source = source, .target = target});
 }
 
 tl::expected<QueryTaskResponse, ErrorCode> MasterService::QueryTask(
@@ -6673,10 +6674,8 @@ void MasterService::ScheduleDrainJobTasks(DrainJob& job) {
         for (size_t i = 0; i < kNumShards; ++i) {
             MetadataShardAccessorRO shard(this, i);
             for (const auto& [key, metadata] : shard->metadata) {
-                const std::string& user_key = metadata.UserKeyOr(key);
                 for (const auto& source_segment : job.request.segments) {
-                    const auto unit_key =
-                        MakeDrainUnitKey(user_key, source_segment);
+                    const auto unit_key = MakeDrainUnitKey(key, source_segment);
                     if (job.completed_unit_keys.contains(unit_key) ||
                         active_unit_keys.contains(unit_key) ||
                         job.terminal_failed_unit_keys.contains(unit_key)) {
@@ -6706,7 +6705,7 @@ void MasterService::ScheduleDrainJobTasks(DrainJob& job) {
                     }
 
                     if (plans.size() < slots) {
-                        plans.push_back({user_key, source_segment, *target,
+                        plans.push_back({key, source_segment, *target,
                                          metadata.size, unit_key});
                     }
                 }
@@ -6760,7 +6759,6 @@ bool MasterService::MaybeCompleteDrainJob(DrainJob& job) {
         for (size_t i = 0; i < kNumShards; ++i) {
             MetadataShardAccessorRO shard(this, i);
             for (const auto& [key, metadata] : shard->metadata) {
-                const std::string& user_key = metadata.UserKeyOr(key);
                 const auto replica_segments = metadata.GetReplicaSegmentNames();
                 for (const auto& source_segment : job.request.segments) {
                     if (std::find(replica_segments.begin(),
@@ -6768,7 +6766,7 @@ bool MasterService::MaybeCompleteDrainJob(DrainJob& job) {
                                   source_segment) != replica_segments.end()) {
                         remaining_segments.insert(source_segment);
                         remaining_unit_keys.insert(
-                            MakeDrainUnitKey(user_key, source_segment));
+                            MakeDrainUnitKey(key, source_segment));
                     }
                 }
             }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1055,47 +1055,7 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
     -> tl::expected<
         std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
         ErrorCode> {
-    std::unordered_map<std::string, std::vector<Replica::Descriptor>> results;
-    std::regex pattern;
-
-    try {
-        pattern = std::regex(regex_pattern, std::regex::ECMAScript);
-    } catch (const std::regex_error& e) {
-        LOG(ERROR) << "Invalid regex pattern: " << regex_pattern
-                   << ", error: " << e.what();
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    for (size_t i = 0; i < kNumShards; ++i) {
-        MetadataShardAccessorRO shard(this, i);
-
-        for (const auto& [key, metadata] : shard->metadata) {
-            const auto& user_key = metadata.UserKeyOr(key);
-            if (std::regex_search(key, pattern) ||
-                std::regex_search(user_key, pattern)) {
-                std::vector<Replica::Descriptor> replica_list;
-                metadata.VisitReplicas(
-                    &Replica::fn_is_completed,
-                    [&replica_list](const Replica& replica) {
-                        replica_list.emplace_back(replica.get_descriptor());
-                    });
-
-                if (replica_list.empty()) {
-                    LOG(WARNING)
-                        << "key=" << key
-                        << " matched by regex, but has no complete replicas.";
-                    continue;
-                }
-
-                results.emplace(user_key, std::move(replica_list));
-                metadata.GrantLease(default_kv_lease_ttl_,
-                                    default_kv_soft_pin_ttl_);
-            }
-        }
-    }
-
-    return results;
+    return GetReplicaListByRegex(regex_pattern, "default");
 }
 
 auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern,
@@ -1908,6 +1868,8 @@ MasterService::BatchUpsertStart(const UUID& client_id,
                                 const std::vector<uint64_t>& slice_lengths,
                                 const ReplicateConfig& config) {
     if (keys.size() != slice_lengths.size()) {
+        LOG(ERROR) << "BatchUpsertStart parameter size mismatch: keys="
+                   << keys.size() << ", slice_lengths=" << slice_lengths.size();
         return std::vector<
             tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>(
             keys.size(), tl::make_unexpected(ErrorCode::INVALID_PARAMS));
@@ -2531,61 +2493,7 @@ tl::expected<void, ErrorCode> MasterService::RemoveResolved(
 
 auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
     -> tl::expected<long, ErrorCode> {
-    long removed_count = 0;
-    std::regex pattern;
-
-    try {
-        pattern = std::regex(regex_pattern, std::regex::ECMAScript);
-    } catch (const std::regex_error& e) {
-        LOG(ERROR) << "Invalid regex pattern: " << regex_pattern
-                   << ", error: " << e.what();
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-    }
-
-    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    for (size_t i = 0; i < kNumShards; ++i) {
-        MetadataShardAccessorRW shard(this, i);
-
-        for (auto it = shard->metadata.begin(); it != shard->metadata.end();) {
-            const auto& user_key = it->second.UserKeyOr(it->first);
-            if (std::regex_search(it->first, pattern) ||
-                std::regex_search(user_key, pattern)) {
-                if (!force && !it->second.IsLeaseExpired()) {
-                    VLOG(1) << "key=" << it->first
-                            << " matched by regex, but has lease. Skipping "
-                            << "removal.";
-                    ++it;
-                    continue;
-                }
-                if (!it->second.AllReplicas(&Replica::fn_is_completed)) {
-                    LOG(WARNING) << "key=" << it->first
-                                 << " matched by regex, but not all replicas "
-                                    "are complete. Skipping removal.";
-                    ++it;
-                    continue;
-                }
-                if (metadata_shards_[i].replication_tasks.contains(it->first)) {
-                    LOG(WARNING) << "key=" << it->first
-                                 << ", matched by regex, but has replication "
-                                    "task. Skipping removal.";
-                    ++it;
-                    continue;
-                }
-
-                VLOG(1) << "key=" << it->first
-                        << " matched by regex. Removing.";
-                ErasePromotionTaskIfPresent(shard, it->first);
-                it = shard->metadata.erase(it);
-                removed_count++;
-            } else {
-                ++it;
-            }
-        }
-    }
-
-    VLOG(1) << "action=remove_by_regex, pattern=" << regex_pattern
-            << ", removed_count=" << removed_count;
-    return removed_count;
+    return RemoveByRegex(regex_pattern, "default", force);
 }
 
 auto MasterService::RemoveByRegex(const std::string& regex_pattern,
@@ -2925,14 +2833,12 @@ auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
     }
 
     for (auto& [key, size] : offloading_objects_copy) {
-        auto parsed = ParseTenantScopedKey(key);
-        const auto internal_key =
-            parsed ? BuildTenantScopedKey(parsed->tenant_id, parsed->user_key)
-                   : BuildTenantScopedKey("default", key);
-        MetadataAccessorRW accessor(this, internal_key);
+        const auto resolved_key = ResolveObjectKey(key);
+        MetadataAccessorRW accessor(this, resolved_key.storage_key);
         if (accessor.Exists()) {
             auto& shard = accessor.GetShard();
-            auto task_it = shard->offloading_tasks.find(internal_key);
+            auto task_it =
+                shard->offloading_tasks.find(resolved_key.storage_key);
             if (task_it != shard->offloading_tasks.end()) {
                 auto source =
                     accessor.Get().GetReplicaByID(task_it->second.source_id);
@@ -2986,11 +2892,10 @@ auto MasterService::NotifyOffloadSuccess(
     const std::vector<StorageObjectMetadata>& metadatas)
     -> tl::expected<void, ErrorCode> {
     for (size_t i = 0; i < keys.size(); ++i) {
-        const auto& storage_key = keys[i];
-        auto parsed = ParseTenantScopedKey(storage_key);
-        const std::string tenant_id = parsed ? parsed->tenant_id : "default";
-        const std::string user_key = parsed ? parsed->user_key : storage_key;
-        const auto internal_key = BuildTenantScopedKey(tenant_id, user_key);
+        const auto resolved_key = ResolveObjectKey(keys[i]);
+        const auto& internal_key = resolved_key.storage_key;
+        const auto& tenant_id = resolved_key.tenant_id;
+        const auto& user_key = resolved_key.user_key;
         const auto& metadata = metadatas[i];
 
         // Release refcnt and clear offloading task.

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -104,16 +104,18 @@ bool HasExpectedReplicaAllocation(const ReplicateConfig& config,
            allocated_nof_replicas == config.nof_replica_num;
 }
 
-TenantScopedKey ResolveTenantScopedKey(const std::string& key) {
-    if (auto parsed = ParseTenantScopedKey(key)) {
-        return *parsed;
-    }
-    return TenantScopedKey{"default", key};
-}
-
 }  // namespace
 
 MasterService::MasterService() : MasterService(MasterServiceConfig()) {}
+
+MasterService::ResolvedObjectKey MasterService::ResolveObjectKey(
+    const std::string& key) {
+    if (auto parsed = ParseTenantScopedKey(key)) {
+        return {BuildTenantScopedKey(parsed->tenant_id, parsed->user_key),
+                parsed->tenant_id, parsed->user_key};
+    }
+    return {BuildTenantScopedKey("default", key), "default", key};
+}
 
 MasterService::MasterService(const MasterServiceConfig& config)
     : graceful_unmount_scheduler_(this),
@@ -763,15 +765,14 @@ auto MasterService::UnmountNoFSegment(const UUID& segment_id,
 
 auto MasterService::ExistKey(const std::string& key)
     -> tl::expected<bool, ErrorCode> {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return ExistKey(scoped_key.user_key, scoped_key.tenant_id);
+    return ExistKeyResolved(ResolveObjectKey(key));
 }
 
-auto MasterService::ExistKey(const std::string& key,
-                             const std::string& tenant_id)
-    -> tl::expected<bool, ErrorCode> {
+tl::expected<bool, ErrorCode> MasterService::ExistKeyResolved(
+    const ResolvedObjectKey& resolved_key) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     MetadataAccessorRO accessor(this, internal_key);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";
@@ -795,16 +796,6 @@ std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
     results.reserve(keys.size());
     for (const auto& key : keys) {
         results.emplace_back(ExistKey(key));
-    }
-    return results;
-}
-
-std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
-    const std::vector<std::string>& keys, const std::string& tenant_id) {
-    std::vector<tl::expected<bool, ErrorCode>> results;
-    results.reserve(keys.size());
-    for (const auto& key : keys) {
-        results.emplace_back(ExistKey(key, tenant_id));
     }
     return results;
 }
@@ -944,24 +935,6 @@ auto MasterService::BatchReplicaClear(
     const std::vector<std::string>& object_keys, const UUID& client_id,
     const std::string& segment_name)
     -> tl::expected<std::vector<std::string>, ErrorCode> {
-    std::vector<std::string> cleared_keys;
-    cleared_keys.reserve(object_keys.size());
-    for (const auto& key : object_keys) {
-        const auto scoped_key = ResolveTenantScopedKey(key);
-        auto result = BatchReplicaClear({scoped_key.user_key}, client_id,
-                                        segment_name, scoped_key.tenant_id);
-        if (!result.has_value()) {
-            return result;
-        }
-        cleared_keys.insert(cleared_keys.end(), result->begin(), result->end());
-    }
-    return cleared_keys;
-}
-
-auto MasterService::BatchReplicaClear(
-    const std::vector<std::string>& object_keys, const UUID& client_id,
-    const std::string& segment_name, const std::string& tenant_id)
-    -> tl::expected<std::vector<std::string>, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     std::vector<std::string> cleared_keys;
     cleared_keys.reserve(object_keys.size());
@@ -972,7 +945,8 @@ auto MasterService::BatchReplicaClear(
             LOG(WARNING) << "BatchReplicaClear: empty key, skipping";
             continue;
         }
-        const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+        const auto resolved_key = ResolveObjectKey(key);
+        const auto& internal_key = resolved_key.storage_key;
         MetadataAccessorRW accessor(this, internal_key);
         if (!accessor.Exists()) {
             LOG(WARNING) << "BatchReplicaClear: key=" << key
@@ -1019,7 +993,7 @@ auto MasterService::BatchReplicaClear(
 
             // Erase the entire metadata (all replicas will be deallocated)
             accessor.Erase();
-            cleared_keys.emplace_back(key);
+            cleared_keys.emplace_back(resolved_key.user_key);
             VLOG(1) << "BatchReplicaClear: successfully cleared all replicas "
                        "for key="
                     << key << " for client_id=" << client_id;
@@ -1066,7 +1040,7 @@ auto MasterService::BatchReplicaClear(
                 accessor.Erase();
             }
 
-            cleared_keys.emplace_back(key);
+            cleared_keys.emplace_back(resolved_key.user_key);
             VLOG(1) << "BatchReplicaClear: successfully cleared replicas on "
                        "segment_name="
                     << segment_name << " for key=" << key
@@ -1175,15 +1149,14 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern,
 
 auto MasterService::GetReplicaList(const std::string& key)
     -> tl::expected<GetReplicaListResponse, ErrorCode> {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return GetReplicaList(scoped_key.user_key, scoped_key.tenant_id);
+    return GetReplicaListResolved(ResolveObjectKey(key));
 }
 
-auto MasterService::GetReplicaList(const std::string& key,
-                                   const std::string& tenant_id)
-    -> tl::expected<GetReplicaListResponse, ErrorCode> {
+tl::expected<GetReplicaListResponse, ErrorCode>
+MasterService::GetReplicaListResolved(const ResolvedObjectKey& resolved_key) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
 
     GetReplicaListResponse resp({}, default_kv_lease_ttl_);
     bool promotion_eligible = false;
@@ -1237,7 +1210,7 @@ auto MasterService::GetReplicaList(const std::string& key,
     }
     // RO accessor released. Safe to take a fresh RW accessor now.
     if (promotion_eligible) {
-        TryPushPromotionQueue(key);
+        TryPushPromotionQueue(internal_key);
     }
     return resp;
 }
@@ -1391,16 +1364,18 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                              const uint64_t slice_length,
                              const ReplicateConfig& config)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return PutStart(client_id, scoped_key.user_key, slice_length, config,
-                    scoped_key.tenant_id);
+    return PutStartResolved(client_id, ResolveObjectKey(key), slice_length,
+                            config);
 }
 
-auto MasterService::PutStart(const UUID& client_id, const std::string& key,
-                             const uint64_t slice_length,
-                             const ReplicateConfig& config,
-                             const std::string& tenant_id)
-    -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+MasterService::PutStartResolved(const UUID& client_id,
+                                const ResolvedObjectKey& resolved_key,
+                                const uint64_t slice_length,
+                                const ReplicateConfig& config) {
+    const auto& key = resolved_key.user_key;
+    const auto& tenant_id = resolved_key.tenant_id;
+    const auto& internal_key = resolved_key.storage_key;
     if ((config.replica_num == 0 && config.nof_replica_num == 0) ||
         key.empty() || slice_length == 0) {
         LOG(ERROR) << "key=" << key << ", replica_num=" << config.replica_num
@@ -1440,7 +1415,6 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
     auto alive_clients = getAliveClientsSnapshot();
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     // Lock the shard and check if object already exists
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
     MetadataShardAccessorRW shard(this, getShardIndex(internal_key));
 
     const auto now = std::chrono::system_clock::now();
@@ -1475,17 +1449,16 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
 auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
                            ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return PutEnd(client_id, scoped_key.user_key, replica_type,
-                  scoped_key.tenant_id);
+    return PutEndResolved(client_id, ResolveObjectKey(key), replica_type);
 }
 
-auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
-                           ReplicaType replica_type,
-                           const std::string& tenant_id)
-    -> tl::expected<void, ErrorCode> {
+tl::expected<void, ErrorCode> MasterService::PutEndResolved(
+    const UUID& client_id, const ResolvedObjectKey& resolved_key,
+    ReplicaType replica_type) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    const auto& key = resolved_key.user_key;
+    const auto& tenant_id = resolved_key.tenant_id;
+    const auto& internal_key = resolved_key.storage_key;
     MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
@@ -1559,24 +1532,21 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
 auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
                                Replica& replica)
     -> tl::expected<void, ErrorCode> {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return AddReplica(client_id, scoped_key.user_key, replica,
-                      scoped_key.tenant_id);
+    return AddReplicaResolved(client_id, ResolveObjectKey(key), replica);
 }
 
-auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
-                               Replica& replica, const std::string& tenant_id)
-    -> tl::expected<void, ErrorCode> {
+tl::expected<void, ErrorCode> MasterService::AddReplicaResolved(
+    const UUID& client_id, const ResolvedObjectKey& resolved_key,
+    Replica& replica) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    const auto normalized_tenant = NormalizeTenantId(tenant_id);
-    const auto internal_key = BuildTenantScopedKey(normalized_tenant, key);
+    const auto& internal_key = resolved_key.storage_key;
     MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         accessor.Create(
             client_id,
             replica.get_descriptor().get_local_disk_descriptor().object_size,
             std::vector<Replica>{}, false, false, ObjectDataType::UNKNOWN,
-            normalized_tenant, key);
+            resolved_key.tenant_id, resolved_key.user_key);
     }
     auto& metadata = accessor.Get();
     if (replica.type() != ReplicaType::LOCAL_DISK) {
@@ -1615,17 +1585,15 @@ auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
 auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
                               ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return PutRevoke(client_id, scoped_key.user_key, replica_type,
-                     scoped_key.tenant_id);
+    return PutRevokeResolved(client_id, ResolveObjectKey(key), replica_type);
 }
 
-auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
-                              ReplicaType replica_type,
-                              const std::string& tenant_id)
-    -> tl::expected<void, ErrorCode> {
+tl::expected<void, ErrorCode> MasterService::PutRevokeResolved(
+    const UUID& client_id, const ResolvedObjectKey& resolved_key,
+    ReplicaType replica_type) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(INFO) << "key=" << key << ", info=object_not_found";
@@ -1690,17 +1658,6 @@ std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutEnd(
     return results;
 }
 
-std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutEnd(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    ReplicaType replica_type, const std::string& tenant_id) {
-    std::vector<tl::expected<void, ErrorCode>> results;
-    results.reserve(keys.size());
-    for (const auto& key : keys) {
-        results.emplace_back(PutEnd(client_id, key, replica_type, tenant_id));
-    }
-    return results;
-}
-
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutRevoke(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
@@ -1708,18 +1665,6 @@ std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutRevoke(
     results.reserve(keys.size());
     for (const auto& key : keys) {
         results.emplace_back(PutRevoke(client_id, key, replica_type));
-    }
-    return results;
-}
-
-std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutRevoke(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    ReplicaType replica_type, const std::string& tenant_id) {
-    std::vector<tl::expected<void, ErrorCode>> results;
-    results.reserve(keys.size());
-    for (const auto& key : keys) {
-        results.emplace_back(
-            PutRevoke(client_id, key, replica_type, tenant_id));
     }
     return results;
 }
@@ -1742,16 +1687,18 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                                 const uint64_t slice_length,
                                 const ReplicateConfig& config)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return UpsertStart(client_id, scoped_key.user_key, slice_length, config,
-                       scoped_key.tenant_id);
+    return UpsertStartResolved(client_id, ResolveObjectKey(key), slice_length,
+                               config);
 }
 
-auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
-                                const uint64_t slice_length,
-                                const ReplicateConfig& config,
-                                const std::string& tenant_id)
-    -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+MasterService::UpsertStartResolved(const UUID& client_id,
+                                   const ResolvedObjectKey& resolved_key,
+                                   const uint64_t slice_length,
+                                   const ReplicateConfig& config) {
+    const auto& key = resolved_key.user_key;
+    const auto& tenant_id = resolved_key.tenant_id;
+    const auto& internal_key = resolved_key.storage_key;
     // --- Parameter validation (same as PutStart) ---
     if ((config.replica_num == 0 && config.nof_replica_num == 0) ||
         key.empty() || slice_length == 0) {
@@ -1796,7 +1743,6 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     //   operations on keys that hash to the same shard.
     auto alive_clients = getAliveClientsSnapshot();
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
     MetadataShardAccessorRW shard(this, getShardIndex(internal_key));
 
     const auto now = std::chrono::system_clock::now();
@@ -1850,7 +1796,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
             // If no COMPLETE replicas survive the preemption, this key
             // effectively does not exist — fall through to Case A.
             if (!metadata.HasReplica(&Replica::fn_is_completed)) {
-                ErasePromotionTaskIfPresent(shard, key);
+                ErasePromotionTaskIfPresent(shard, internal_key);
                 shard->metadata.erase(it);
                 it = shard->metadata.end();
             }
@@ -1947,31 +1893,13 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
 auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
                               ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return UpsertEnd(client_id, scoped_key.user_key, replica_type,
-                     scoped_key.tenant_id);
-}
-
-auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
-                              ReplicaType replica_type,
-                              const std::string& tenant_id)
-    -> tl::expected<void, ErrorCode> {
-    return PutEnd(client_id, key, replica_type, tenant_id);
+    return PutEnd(client_id, key, replica_type);
 }
 
 auto MasterService::UpsertRevoke(const UUID& client_id, const std::string& key,
                                  ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return UpsertRevoke(client_id, scoped_key.user_key, replica_type,
-                        scoped_key.tenant_id);
-}
-
-auto MasterService::UpsertRevoke(const UUID& client_id, const std::string& key,
-                                 ReplicaType replica_type,
-                                 const std::string& tenant_id)
-    -> tl::expected<void, ErrorCode> {
-    return PutRevoke(client_id, key, replica_type, tenant_id);
+    return PutRevoke(client_id, key, replica_type);
 }
 
 std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
@@ -1994,38 +1922,9 @@ MasterService::BatchUpsertStart(const UUID& client_id,
     return results;
 }
 
-std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-MasterService::BatchUpsertStart(const UUID& client_id,
-                                const std::vector<std::string>& keys,
-                                const std::vector<uint64_t>& slice_lengths,
-                                const ReplicateConfig& config,
-                                const std::string& tenant_id) {
-    if (keys.size() != slice_lengths.size()) {
-        LOG(ERROR) << "BatchUpsertStart: keys.size()=" << keys.size()
-                   << " != slice_lengths.size()=" << slice_lengths.size();
-        return std::vector<
-            tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>(
-            keys.size(), tl::make_unexpected(ErrorCode::INVALID_PARAMS));
-    }
-    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-        results;
-    results.reserve(keys.size());
-    for (size_t i = 0; i < keys.size(); ++i) {
-        results.emplace_back(UpsertStart(client_id, keys[i], slice_lengths[i],
-                                         config, tenant_id));
-    }
-    return results;
-}
-
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertEnd(
     const UUID& client_id, const std::vector<std::string>& keys) {
     return BatchPutEnd(client_id, keys, ReplicaType::ALL);
-}
-
-std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertEnd(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    const std::string& tenant_id) {
-    return BatchPutEnd(client_id, keys, ReplicaType::ALL, tenant_id);
 }
 
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertRevoke(
@@ -2033,29 +1932,19 @@ std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertRevoke(
     return BatchPutRevoke(client_id, keys, ReplicaType::ALL);
 }
 
-std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertRevoke(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    const std::string& tenant_id) {
-    return BatchPutRevoke(client_id, keys, ReplicaType::ALL, tenant_id);
-}
-
 auto MasterService::EvictDiskReplica(const UUID& client_id,
                                      const std::string& key,
                                      ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    if (auto parsed = ParseTenantScopedKey(key)) {
-        return EvictDiskReplica(client_id, parsed->user_key, replica_type,
-                                parsed->tenant_id);
-    }
-    return EvictDiskReplica(client_id, key, replica_type, "default");
+    return EvictDiskReplicaResolved(client_id, ResolveObjectKey(key),
+                                    replica_type);
 }
 
-auto MasterService::EvictDiskReplica(const UUID& client_id,
-                                     const std::string& key,
-                                     ReplicaType replica_type,
-                                     const std::string& tenant_id)
-    -> tl::expected<void, ErrorCode> {
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+tl::expected<void, ErrorCode> MasterService::EvictDiskReplicaResolved(
+    const UUID& client_id, const ResolvedObjectKey& resolved_key,
+    ReplicaType replica_type) {
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(INFO) << "key=" << key << ", info=object_not_found_for_eviction";
@@ -2098,34 +1987,21 @@ std::vector<tl::expected<void, ErrorCode>> MasterService::BatchEvictDiskReplica(
     return results;
 }
 
-std::vector<tl::expected<void, ErrorCode>> MasterService::BatchEvictDiskReplica(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    ReplicaType replica_type, const std::string& tenant_id) {
-    std::vector<tl::expected<void, ErrorCode>> results;
-    results.reserve(keys.size());
-    for (const auto& key : keys) {
-        results.push_back(
-            EvictDiskReplica(client_id, key, replica_type, tenant_id));
-    }
-    return results;
-}
-
 tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment,
     const std::vector<std::string>& tgt_segments) {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return CopyStart(client_id, scoped_key.user_key, src_segment, tgt_segments,
-                     scoped_key.tenant_id);
+    return CopyStartResolved(client_id, ResolveObjectKey(key), src_segment,
+                             tgt_segments);
 }
 
-tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
-    const UUID& client_id, const std::string& key,
+tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStartResolved(
+    const UUID& client_id, const ResolvedObjectKey& resolved_key,
     const std::string& src_segment,
-    const std::vector<std::string>& tgt_segments,
-    const std::string& tenant_id) {
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    const std::vector<std::string>& tgt_segments) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     {
         ScopedSegmentAccess segment_access =
             segment_manager_.getSegmentAccess();
@@ -2219,14 +2095,13 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
 
 tl::expected<void, ErrorCode> MasterService::CopyEnd(const UUID& client_id,
                                                      const std::string& key) {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return CopyEnd(client_id, scoped_key.user_key, scoped_key.tenant_id);
+    return CopyEndResolved(client_id, ResolveObjectKey(key));
 }
 
-tl::expected<void, ErrorCode> MasterService::CopyEnd(
-    const UUID& client_id, const std::string& key,
-    const std::string& tenant_id) {
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+tl::expected<void, ErrorCode> MasterService::CopyEndResolved(
+    const UUID& client_id, const ResolvedObjectKey& resolved_key) {
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
@@ -2298,14 +2173,13 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(
 
 tl::expected<void, ErrorCode> MasterService::CopyRevoke(
     const UUID& client_id, const std::string& key) {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return CopyRevoke(client_id, scoped_key.user_key, scoped_key.tenant_id);
+    return CopyRevokeResolved(client_id, ResolveObjectKey(key));
 }
 
-tl::expected<void, ErrorCode> MasterService::CopyRevoke(
-    const UUID& client_id, const std::string& key,
-    const std::string& tenant_id) {
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+tl::expected<void, ErrorCode> MasterService::CopyRevokeResolved(
+    const UUID& client_id, const ResolvedObjectKey& resolved_key) {
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
@@ -2360,17 +2234,16 @@ tl::expected<void, ErrorCode> MasterService::CopyRevoke(
 tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment, const std::string& tgt_segment) {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return MoveStart(client_id, scoped_key.user_key, src_segment, tgt_segment,
-                     scoped_key.tenant_id);
+    return MoveStartResolved(client_id, ResolveObjectKey(key), src_segment,
+                             tgt_segment);
 }
 
-tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
-    const UUID& client_id, const std::string& key,
-    const std::string& src_segment, const std::string& tgt_segment,
-    const std::string& tenant_id) {
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStartResolved(
+    const UUID& client_id, const ResolvedObjectKey& resolved_key,
+    const std::string& src_segment, const std::string& tgt_segment) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     if (src_segment == tgt_segment) {
         LOG(ERROR) << "key=" << key << ", move_tgt=" << tgt_segment
                    << " cannot be the same as move_src=" << src_segment;
@@ -2460,14 +2333,13 @@ tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
 
 tl::expected<void, ErrorCode> MasterService::MoveEnd(const UUID& client_id,
                                                      const std::string& key) {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return MoveEnd(client_id, scoped_key.user_key, scoped_key.tenant_id);
+    return MoveEndResolved(client_id, ResolveObjectKey(key));
 }
 
-tl::expected<void, ErrorCode> MasterService::MoveEnd(
-    const UUID& client_id, const std::string& key,
-    const std::string& tenant_id) {
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+tl::expected<void, ErrorCode> MasterService::MoveEndResolved(
+    const UUID& client_id, const ResolvedObjectKey& resolved_key) {
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
@@ -2554,14 +2426,13 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
 
 tl::expected<void, ErrorCode> MasterService::MoveRevoke(
     const UUID& client_id, const std::string& key) {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return MoveRevoke(client_id, scoped_key.user_key, scoped_key.tenant_id);
+    return MoveRevokeResolved(client_id, ResolveObjectKey(key));
 }
 
-tl::expected<void, ErrorCode> MasterService::MoveRevoke(
-    const UUID& client_id, const std::string& key,
-    const std::string& tenant_id) {
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+tl::expected<void, ErrorCode> MasterService::MoveRevokeResolved(
+    const UUID& client_id, const ResolvedObjectKey& resolved_key) {
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
@@ -2615,14 +2486,14 @@ tl::expected<void, ErrorCode> MasterService::MoveRevoke(
 
 auto MasterService::Remove(const std::string& key, bool force)
     -> tl::expected<void, ErrorCode> {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return Remove(scoped_key.user_key, scoped_key.tenant_id, force);
+    return RemoveResolved(ResolveObjectKey(key), force);
 }
 
-auto MasterService::Remove(const std::string& key, const std::string& tenant_id,
-                           bool force) -> tl::expected<void, ErrorCode> {
+tl::expected<void, ErrorCode> MasterService::RemoveResolved(
+    const ResolvedObjectKey& resolved_key, bool force) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", error=object_not_found";
@@ -2654,7 +2525,7 @@ auto MasterService::Remove(const std::string& key, const std::string& tenant_id,
 
     // Remove object metadata
     accessor.Erase();
-    ErasePromotionTaskIfPresent(accessor.GetShard(), key);
+    ErasePromotionTaskIfPresent(accessor.GetShard(), internal_key);
     return {};
 }
 
@@ -2831,17 +2702,6 @@ long MasterService::RemoveAll(bool force) {
 auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                                 bool force)
     -> std::vector<tl::expected<void, ErrorCode>> {
-    std::vector<tl::expected<void, ErrorCode>> results;
-    results.reserve(keys.size());
-    for (const auto& key : keys) {
-        results.emplace_back(Remove(key, force));
-    }
-    return results;
-}
-
-auto MasterService::BatchRemove(const std::vector<std::string>& keys,
-                                const std::string& tenant_id, bool force)
-    -> std::vector<tl::expected<void, ErrorCode>> {
     std::vector<tl::expected<void, ErrorCode>> results(keys.size());
 
     // Group keys by shard to reduce lock contention
@@ -2852,8 +2712,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
         std::min(keys.size(), static_cast<size_t>(kNumShards)));
 
     for (size_t i = 0; i < keys.size(); ++i) {
-        size_t shard_idx =
-            getShardIndex(BuildTenantScopedKey(tenant_id, keys[i]));
+        size_t shard_idx = getShardIndex(ResolveObjectKey(keys[i]).storage_key);
         keys_by_shard[shard_idx].emplace_back(i, &keys[i]);
     }
 
@@ -2868,7 +2727,8 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
 
         for (const auto& [original_idx, key_ptr] : key_group) {
             const std::string& key = *key_ptr;
-            const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+            const auto resolved_key = ResolveObjectKey(key);
+            const auto& internal_key = resolved_key.storage_key;
             auto it = shard->metadata.find(internal_key);
 
             if (it == shard->metadata.end()) {
@@ -3154,7 +3014,7 @@ auto MasterService::NotifyOffloadSuccess(
         // Add LOCAL_DISK replica.
         Replica replica(client_id, metadata.data_size,
                         metadata.transport_endpoint, ReplicaStatus::COMPLETE);
-        auto res = AddReplica(client_id, user_key, replica, tenant_id);
+        auto res = AddReplica(client_id, internal_key, replica);
         if (!res && res.error() != ErrorCode::OBJECT_NOT_FOUND) {
             LOG(ERROR) << "Failed to add replica: error=" << res.error()
                        << ", client_id=" << client_id << ", key=" << user_key
@@ -3213,11 +3073,11 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
 
 // Promotion-on-hit
 
-// Push a key onto the holder client's promotion_objects map. Resolves the
-// holder via the LOCAL_DISK replica's embedded client_id rather than via
+// Push a storage key onto the holder client's promotion_objects map. Resolves
+// the holder via the LOCAL_DISK replica's embedded client_id rather than via
 // the segment-name reverse lookup.
 tl::expected<void, ErrorCode> MasterService::PushPromotionQueue(
-    const std::string& key, Replica& source_replica) {
+    const std::string& storage_key, Replica& source_replica) {
     auto holder_id = source_replica.get_local_disk_client_id();
     if (!holder_id.has_value()) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -3236,16 +3096,16 @@ tl::expected<void, ErrorCode> MasterService::PushPromotionQueue(
     }
     MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
     auto res = local_disk_segment_it->second->promotion_objects.emplace(
-        key, static_cast<int64_t>(source_replica.get_descriptor()
-                                      .get_local_disk_descriptor()
-                                      .object_size));
+        storage_key, static_cast<int64_t>(source_replica.get_descriptor()
+                                              .get_local_disk_descriptor()
+                                              .object_size));
     if (!res.second) {
         return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
     }
     return {};
 }
 
-void MasterService::TryPushPromotionQueue(const std::string& key) {
+void MasterService::TryPushPromotionQueue(const std::string& storage_key) {
     if (!promotion_on_hit_ || !promotion_sketch_) {
         return;
     }
@@ -3255,7 +3115,7 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
     // is clamped into [1, 255] at config parse time (see master.cpp), so
     // direct comparison is well-defined and threshold=0 (which would
     // bypass the gate entirely since freq is uint8_t) cannot reach here.
-    const uint8_t freq = promotion_sketch_->increment(key);
+    const uint8_t freq = promotion_sketch_->increment(storage_key);
     if (freq < promotion_admission_threshold_) {
         return;
     }
@@ -3272,7 +3132,7 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
     // Acquire a fresh RW shard accessor for dedup, refcnt-pin, and task
     // record. Safe to call here because GetReplicaList has already released
     // its RO accessor.
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, storage_key);
     if (!accessor.Exists()) {
         return;
     }
@@ -3281,7 +3141,7 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
 
     // Dedup: don't queue twice if a promotion is already in flight or if a
     // MEMORY replica has appeared since GetReplicaList observed only-disk.
-    if (shard->promotion_tasks.count(key) > 0) {
+    if (shard->promotion_tasks.count(storage_key) > 0) {
         return;
     }
     if (metadata.HasReplica(&Replica::fn_is_memory_replica)) {
@@ -3316,10 +3176,10 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
         source->get_descriptor().get_local_disk_descriptor().object_size;
 
     // Try to enqueue on the holder client. On failure, drop the refcnt back.
-    auto push_result = PushPromotionQueue(key, *source);
+    auto push_result = PushPromotionQueue(storage_key, *source);
     if (!push_result) {
         source->dec_refcnt();
-        VLOG(1) << "promotion_push_failed key=" << key
+        VLOG(1) << "promotion_push_failed key=" << storage_key
                 << " error=" << push_result.error();
         return;
     }
@@ -3332,13 +3192,15 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
     // Record the in-flight task. alloc_id is filled in by
     // PromotionAllocStart once the new MEMORY replica is staged.
     shard->promotion_tasks.emplace(
-        key, PromotionTask{.source_id = source->id(),
-                           .alloc_id = 0,
-                           .object_size = object_size,
-                           .start_time = std::chrono::system_clock::now(),
-                           .holder_id = holder_id});
+        storage_key,
+        PromotionTask{.source_id = source->id(),
+                      .alloc_id = 0,
+                      .object_size = object_size,
+                      .start_time = std::chrono::system_clock::now(),
+                      .holder_id = holder_id});
     promotion_in_flight_.fetch_add(1, std::memory_order_relaxed);
-    VLOG(1) << "promotion_queued key=" << key << " size=" << object_size;
+    VLOG(1) << "promotion_queued key=" << storage_key
+            << " size=" << object_size;
 }
 
 auto MasterService::PromotionObjectHeartbeat(const UUID& client_id)
@@ -3374,8 +3236,10 @@ auto MasterService::PromotionAllocStart(
     const UUID& client_id, const std::string& key, uint64_t size,
     const std::vector<std::string>& preferred_segments)
     -> tl::expected<PromotionAllocStartResponse, ErrorCode> {
+    const auto resolved_key = ResolveObjectKey(key);
+    const auto& storage_key = resolved_key.storage_key;
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, storage_key);
     if (!accessor.Exists()) {
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -3393,7 +3257,7 @@ auto MasterService::PromotionAllocStart(
     // removed or evicted. The shard mutex is held for the rest of this
     // function, so the iterator stays valid across the allocation step.
     auto& shard = accessor.GetShard();
-    auto task_it = shard->promotion_tasks.find(key);
+    auto task_it = shard->promotion_tasks.find(storage_key);
     if (task_it == shard->promotion_tasks.end()) {
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
     }
@@ -3466,8 +3330,10 @@ auto MasterService::PromotionAllocStart(
 auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
                                            const std::string& key)
     -> tl::expected<void, ErrorCode> {
+    const auto resolved_key = ResolveObjectKey(key);
+    const auto& storage_key = resolved_key.storage_key;
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, storage_key);
     if (!accessor.Exists()) {
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -3479,7 +3345,7 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
     // replicas, so we must not just "mark first PROCESSING memory
     // complete" — that would risk committing someone else's half-written
     // replica.
-    auto task_it = shard->promotion_tasks.find(key);
+    auto task_it = shard->promotion_tasks.find(storage_key);
     if (task_it == shard->promotion_tasks.end() ||
         task_it->second.alloc_id == 0) {
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
@@ -3516,7 +3382,7 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
         auto it = client_local_disk_segment.find(client_id);
         if (it != client_local_disk_segment.end()) {
             MutexLocker locker(&it->second->offloading_mutex_);
-            it->second->promotion_objects.erase(key);
+            it->second->promotion_objects.erase(storage_key);
         }
     }
 
@@ -3529,15 +3395,17 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
 auto MasterService::NotifyPromotionFailure(const UUID& client_id,
                                            const std::string& key)
     -> tl::expected<void, ErrorCode> {
+    const auto resolved_key = ResolveObjectKey(key);
+    const auto& storage_key = resolved_key.storage_key;
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, storage_key);
     if (!accessor.Exists()) {
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
     auto& metadata = accessor.Get();
     auto& shard = accessor.GetShard();
 
-    auto task_it = shard->promotion_tasks.find(key);
+    auto task_it = shard->promotion_tasks.find(storage_key);
     if (task_it == shard->promotion_tasks.end()) {
         // No task to release. Either the reaper already swept it, or the
         // client never had a task here. Return OK to keep this RPC
@@ -3574,7 +3442,7 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
         auto it = client_local_disk_segment.find(client_id);
         if (it != client_local_disk_segment.end()) {
             MutexLocker locker(&it->second->offloading_mutex_);
-            it->second->promotion_objects.erase(key);
+            it->second->promotion_objects.erase(storage_key);
         }
     }
 
@@ -6229,15 +6097,16 @@ std::string MasterService::FormatTimestamp(
 
 tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
     const std::string& key, const std::vector<std::string>& targets) {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return CreateCopyTask(scoped_key.user_key, targets, scoped_key.tenant_id);
+    const auto resolved_key = ResolveObjectKey(key);
+    return CreateCopyTaskResolved(resolved_key, targets);
 }
 
-tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
-    const std::string& key, const std::vector<std::string>& targets,
-    const std::string& tenant_id) {
+tl::expected<UUID, ErrorCode> MasterService::CreateCopyTaskResolved(
+    const ResolvedObjectKey& resolved_key,
+    const std::vector<std::string>& targets) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     if (targets.empty()) {
         LOG(ERROR) << "key=" << key << ", error=empty_targets";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -6293,16 +6162,16 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
 tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
     const std::string& key, const std::string& source,
     const std::string& target) {
-    const auto scoped_key = ResolveTenantScopedKey(key);
-    return CreateMoveTask(scoped_key.user_key, source, target,
-                          scoped_key.tenant_id);
+    const auto resolved_key = ResolveObjectKey(key);
+    return CreateMoveTaskResolved(resolved_key, source, target);
 }
 
-tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
-    const std::string& key, const std::string& source,
-    const std::string& target, const std::string& tenant_id) {
+tl::expected<UUID, ErrorCode> MasterService::CreateMoveTaskResolved(
+    const ResolvedObjectKey& resolved_key, const std::string& source,
+    const std::string& target) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    const auto& key = resolved_key.user_key;
+    const auto& internal_key = resolved_key.storage_key;
     MetadataAccessorRO accessor(this, internal_key);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -755,8 +755,15 @@ auto MasterService::UnmountNoFSegment(const UUID& segment_id,
 
 auto MasterService::ExistKey(const std::string& key)
     -> tl::expected<bool, ErrorCode> {
+    return ExistKey(key, "default");
+}
+
+auto MasterService::ExistKey(const std::string& key,
+                             const std::string& tenant_id)
+    -> tl::expected<bool, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRO accessor(this, key);
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    MetadataAccessorRO accessor(this, internal_key);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";
         return false;
@@ -775,10 +782,15 @@ auto MasterService::ExistKey(const std::string& key)
 
 std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
     const std::vector<std::string>& keys) {
+    return BatchExistKey(keys, "default");
+}
+
+std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
+    const std::vector<std::string>& keys, const std::string& tenant_id) {
     std::vector<tl::expected<bool, ErrorCode>> results;
     results.reserve(keys.size());
     for (const auto& key : keys) {
-        results.emplace_back(ExistKey(key));
+        results.emplace_back(ExistKey(key, tenant_id));
     }
     return results;
 }
@@ -789,7 +801,7 @@ auto MasterService::GetAllKeys()
     for (size_t i = 0; i < kNumShards; i++) {
         MetadataShardAccessorRO shard(this, i);
         for (const auto& item : shard->metadata) {
-            all_keys.push_back(item.first);
+            all_keys.push_back(item.second.UserKeyOr(item.first));
         }
     }
     return all_keys;
@@ -918,6 +930,13 @@ auto MasterService::BatchReplicaClear(
     const std::vector<std::string>& object_keys, const UUID& client_id,
     const std::string& segment_name)
     -> tl::expected<std::vector<std::string>, ErrorCode> {
+    return BatchReplicaClear(object_keys, client_id, segment_name, "default");
+}
+
+auto MasterService::BatchReplicaClear(
+    const std::vector<std::string>& object_keys, const UUID& client_id,
+    const std::string& segment_name, const std::string& tenant_id)
+    -> tl::expected<std::vector<std::string>, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     std::vector<std::string> cleared_keys;
     cleared_keys.reserve(object_keys.size());
@@ -928,7 +947,8 @@ auto MasterService::BatchReplicaClear(
             LOG(WARNING) << "BatchReplicaClear: empty key, skipping";
             continue;
         }
-        MetadataAccessorRW accessor(this, key);
+        const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+        MetadataAccessorRW accessor(this, internal_key);
         if (!accessor.Exists()) {
             LOG(WARNING) << "BatchReplicaClear: key=" << key
                          << " not found, skipping";
@@ -1036,6 +1056,14 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
     -> tl::expected<
         std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
         ErrorCode> {
+    return GetReplicaListByRegex(regex_pattern, "default");
+}
+
+auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern,
+                                          const std::string& tenant_id)
+    -> tl::expected<
+        std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
+        ErrorCode> {
     std::unordered_map<std::string, std::vector<Replica::Descriptor>> results;
     std::regex pattern;
 
@@ -1048,11 +1076,14 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
     }
 
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
     for (size_t i = 0; i < kNumShards; ++i) {
         MetadataShardAccessorRO shard(this, i);
 
         for (const auto& [key, metadata] : shard->metadata) {
-            if (std::regex_search(key, pattern)) {
+            const auto& user_key = metadata.UserKeyOr(key);
+            if (metadata.tenant_id == normalized_tenant &&
+                std::regex_search(user_key, pattern)) {
                 std::vector<Replica::Descriptor> replica_list;
                 metadata.VisitReplicas(
                     &Replica::fn_is_completed,
@@ -1067,7 +1098,7 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
                     continue;
                 }
 
-                results.emplace(key, std::move(replica_list));
+                results.emplace(user_key, std::move(replica_list));
                 metadata.GrantLease(default_kv_lease_ttl_,
                                     default_kv_soft_pin_ttl_);
             }
@@ -1079,12 +1110,19 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
 
 auto MasterService::GetReplicaList(const std::string& key)
     -> tl::expected<GetReplicaListResponse, ErrorCode> {
+    return GetReplicaList(key, "default");
+}
+
+auto MasterService::GetReplicaList(const std::string& key,
+                                   const std::string& tenant_id)
+    -> tl::expected<GetReplicaListResponse, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
 
     GetReplicaListResponse resp({}, default_kv_lease_ttl_);
     bool promotion_eligible = false;
     {
-        MetadataAccessorRO accessor(this, key);
+        MetadataAccessorRO accessor(this, internal_key);
 
         MasterMetricManager::instance().inc_total_get_nums();
 
@@ -1141,9 +1179,12 @@ auto MasterService::GetReplicaList(const std::string& key)
 auto MasterService::AllocateAndInsertMetadata(
     MetadataShardAccessorRW& shard, const UUID& client_id,
     const std::string& key, uint64_t value_length,
-    const ReplicateConfig& config,
+    const ReplicateConfig& config, const std::string& tenant_id_param,
     const std::chrono::system_clock::time_point& now)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+    const std::string tenant_id = NormalizeTenantId(tenant_id_param);
+    const std::string user_key = key;
+    const std::string internal_key = BuildTenantScopedKey(tenant_id, user_key);
     std::vector<Replica> replicas;
     const auto write_mode = DetermineReplicaWriteMode(config);
     size_t allocated_memory_replicas = 0;
@@ -1241,7 +1282,7 @@ auto MasterService::AllocateAndInsertMetadata(
 
     if (use_disk_replica_) {
         std::string file_path =
-            ResolvePathFromKey(key, root_fs_dir_, cluster_id_);
+            ResolvePathFromKey(internal_key, root_fs_dir_, cluster_id_);
         replicas.emplace_back(file_path, value_length,
                               ReplicaStatus::PROCESSING);
     }
@@ -1271,11 +1312,11 @@ auto MasterService::AllocateAndInsertMetadata(
     }
 
     shard->metadata.emplace(
-        std::piecewise_construct, std::forward_as_tuple(key),
+        std::piecewise_construct, std::forward_as_tuple(internal_key),
         std::forward_as_tuple(client_id, now, value_length, std::move(replicas),
                               config.with_soft_pin, config.with_hard_pin,
-                              config.data_type));
-    shard->processing_keys.insert(key);
+                              config.data_type, tenant_id, user_key));
+    shard->processing_keys.insert(internal_key);
 
     return replica_list;
 }
@@ -1283,6 +1324,14 @@ auto MasterService::AllocateAndInsertMetadata(
 auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                              const uint64_t slice_length,
                              const ReplicateConfig& config)
+    -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+    return PutStart(client_id, key, slice_length, config, "default");
+}
+
+auto MasterService::PutStart(const UUID& client_id, const std::string& key,
+                             const uint64_t slice_length,
+                             const ReplicateConfig& config,
+                             const std::string& tenant_id)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
     if ((config.replica_num == 0 && config.nof_replica_num == 0) ||
         key.empty() || slice_length == 0) {
@@ -1323,10 +1372,11 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
     auto alive_clients = getAliveClientsSnapshot();
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     // Lock the shard and check if object already exists
-    MetadataShardAccessorRW shard(this, getShardIndex(key));
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    MetadataShardAccessorRW shard(this, getShardIndex(internal_key));
 
     const auto now = std::chrono::system_clock::now();
-    auto it = shard->metadata.find(key);
+    auto it = shard->metadata.find(internal_key);
     if (it != shard->metadata.end() &&
         !CleanupStaleHandles(it->second, alive_clients)) {
         auto& metadata = it->second;
@@ -1342,7 +1392,7 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                     std::move(replicas),
                     metadata.put_start_time + put_start_release_timeout_sec_);
             }
-            shard->processing_keys.erase(key);
+            shard->processing_keys.erase(internal_key);
             shard->metadata.erase(it);
         } else {
             LOG(INFO) << "key=" << key << ", info=object_already_exists";
@@ -1351,14 +1401,22 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
     }
 
     return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                     config, now);
+                                     config, tenant_id, now);
 }
 
 auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
                            ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
+    return PutEnd(client_id, key, replica_type, "default");
+}
+
+auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
+                           ReplicaType replica_type,
+                           const std::string& tenant_id)
+    -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -1397,13 +1455,14 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
             [](const Replica& replica) {
                 return replica.is_completed() && replica.is_memory_replica();
             },
-            [this, &key, &shard](Replica& replica) {
-                auto result = PushOffloadingQueue(key, replica);
+            [this, &key, &tenant_id, &internal_key, &shard](Replica& replica) {
+                auto result = PushOffloadingQueue(tenant_id, key, replica);
                 if (result) {
                     replica.inc_refcnt();
                     shard->offloading_tasks.emplace(
-                        key, OffloadingTask{replica.id(),
-                                            std::chrono::system_clock::now()});
+                        internal_key,
+                        OffloadingTask{replica.id(),
+                                       std::chrono::system_clock::now()});
                 }
             });
     }
@@ -1430,13 +1489,22 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
 auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
                                Replica& replica)
     -> tl::expected<void, ErrorCode> {
+    return AddReplica(client_id, key, replica, "default");
+}
+
+auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
+                               Replica& replica, const std::string& tenant_id)
+    -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    const auto internal_key = BuildTenantScopedKey(normalized_tenant, key);
+    MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         accessor.Create(
             client_id,
             replica.get_descriptor().get_local_disk_descriptor().object_size,
-            std::vector<Replica>{}, false);
+            std::vector<Replica>{}, false, false, ObjectDataType::UNKNOWN,
+            normalized_tenant, key);
     }
     auto& metadata = accessor.Get();
     if (replica.type() != ReplicaType::LOCAL_DISK) {
@@ -1475,8 +1543,16 @@ auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
 auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
                               ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
+    return PutRevoke(client_id, key, replica_type, "default");
+}
+
+auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
+                              ReplicaType replica_type,
+                              const std::string& tenant_id)
+    -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(INFO) << "key=" << key << ", info=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -1532,10 +1608,16 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutEnd(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
+    return BatchPutEnd(client_id, keys, replica_type, "default");
+}
+
+std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutEnd(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    ReplicaType replica_type, const std::string& tenant_id) {
     std::vector<tl::expected<void, ErrorCode>> results;
     results.reserve(keys.size());
     for (const auto& key : keys) {
-        results.emplace_back(PutEnd(client_id, key, replica_type));
+        results.emplace_back(PutEnd(client_id, key, replica_type, tenant_id));
     }
     return results;
 }
@@ -1543,10 +1625,17 @@ std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutEnd(
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutRevoke(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
+    return BatchPutRevoke(client_id, keys, replica_type, "default");
+}
+
+std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutRevoke(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    ReplicaType replica_type, const std::string& tenant_id) {
     std::vector<tl::expected<void, ErrorCode>> results;
     results.reserve(keys.size());
     for (const auto& key : keys) {
-        results.emplace_back(PutRevoke(client_id, key, replica_type));
+        results.emplace_back(
+            PutRevoke(client_id, key, replica_type, tenant_id));
     }
     return results;
 }
@@ -1568,6 +1657,14 @@ std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutRevoke(
 auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                                 const uint64_t slice_length,
                                 const ReplicateConfig& config)
+    -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+    return UpsertStart(client_id, key, slice_length, config, "default");
+}
+
+auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
+                                const uint64_t slice_length,
+                                const ReplicateConfig& config,
+                                const std::string& tenant_id)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
     // --- Parameter validation (same as PutStart) ---
     if ((config.replica_num == 0 && config.nof_replica_num == 0) ||
@@ -1613,10 +1710,11 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     //   operations on keys that hash to the same shard.
     auto alive_clients = getAliveClientsSnapshot();
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataShardAccessorRW shard(this, getShardIndex(key));
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    MetadataShardAccessorRW shard(this, getShardIndex(internal_key));
 
     const auto now = std::chrono::system_clock::now();
-    auto it = shard->metadata.find(key);
+    auto it = shard->metadata.find(internal_key);
 
     // --- Step 0: stale handle cleanup ---
     // If all memory replicas point to unmounted segments (node crashed and
@@ -1624,8 +1722,8 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     // Also clean up local_disk replicas whose owner client has expired.
     if (it != shard->metadata.end() &&
         CleanupStaleHandles(it->second, alive_clients)) {
-        shard->processing_keys.erase(key);
-        ErasePromotionTaskIfPresent(shard, key);
+        shard->processing_keys.erase(internal_key);
+        ErasePromotionTaskIfPresent(shard, internal_key);
         shard->metadata.erase(it);
         it = shard->metadata.end();
     }
@@ -1636,13 +1734,13 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
 
         // Reject if a Copy/Move task is actively reading this key's replicas.
         // Writing during replication would corrupt the copy.
-        if (shard->replication_tasks.count(key) > 0) {
+        if (shard->replication_tasks.count(internal_key) > 0) {
             LOG(INFO) << "key=" << key << ", error=object_has_replication_task";
             return tl::make_unexpected(ErrorCode::OBJECT_HAS_REPLICATION_TASK);
         }
 
         // Reject if an offload-to-disk task is in progress (same reason).
-        if (shard->offloading_tasks.count(key) > 0) {
+        if (shard->offloading_tasks.count(internal_key) > 0) {
             LOG(INFO) << "key=" << key << ", error=object_has_offloading_task";
             return tl::make_unexpected(ErrorCode::OBJECT_HAS_REPLICATION_TASK);
         }
@@ -1652,7 +1750,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
         // TTL so they are not freed while the old writer may still be doing
         // RDMA writes.  Unlike PutStart (which only preempts after a timeout),
         // UpsertStart preempts immediately.
-        if (shard->processing_keys.count(key) > 0) {
+        if (shard->processing_keys.count(internal_key) > 0) {
             auto processing_replicas =
                 metadata.PopReplicas(&Replica::fn_is_processing);
             if (!processing_replicas.empty()) {
@@ -1661,7 +1759,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                     std::move(processing_replicas),
                     now + put_start_release_timeout_sec_);
             }
-            shard->processing_keys.erase(key);
+            shard->processing_keys.erase(internal_key);
 
             // If no COMPLETE replicas survive the preemption, this key
             // effectively does not exist — fall through to Case A.
@@ -1678,7 +1776,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     if (it == shard->metadata.end()) {
         VLOG(1) << "key=" << key << ", action=upsert_start_case_a";
         return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                         config, now);
+                                         config, tenant_id, now);
     }
 
     // --- Step 2: key exists with COMPLETE replicas → Case B or C ---
@@ -1720,7 +1818,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
             replica.mark_processing();
         });
 
-        shard->processing_keys.insert(key);
+        shard->processing_keys.insert(internal_key);
 
         // Return the existing descriptors — same buffer addresses as before.
         std::vector<Replica::Descriptor> replica_list;
@@ -1757,19 +1855,33 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
 
     VLOG(1) << "key=" << key << ", action=upsert_start_case_c_reallocate";
     return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                     merged_config, now);
+                                     merged_config, tenant_id, now);
 }
 
 auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
                               ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    return PutEnd(client_id, key, replica_type);
+    return UpsertEnd(client_id, key, replica_type, "default");
+}
+
+auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
+                              ReplicaType replica_type,
+                              const std::string& tenant_id)
+    -> tl::expected<void, ErrorCode> {
+    return PutEnd(client_id, key, replica_type, tenant_id);
 }
 
 auto MasterService::UpsertRevoke(const UUID& client_id, const std::string& key,
                                  ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    return PutRevoke(client_id, key, replica_type);
+    return UpsertRevoke(client_id, key, replica_type, "default");
+}
+
+auto MasterService::UpsertRevoke(const UUID& client_id, const std::string& key,
+                                 ReplicaType replica_type,
+                                 const std::string& tenant_id)
+    -> tl::expected<void, ErrorCode> {
+    return PutRevoke(client_id, key, replica_type, tenant_id);
 }
 
 std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
@@ -1777,6 +1889,15 @@ MasterService::BatchUpsertStart(const UUID& client_id,
                                 const std::vector<std::string>& keys,
                                 const std::vector<uint64_t>& slice_lengths,
                                 const ReplicateConfig& config) {
+    return BatchUpsertStart(client_id, keys, slice_lengths, config, "default");
+}
+
+std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+MasterService::BatchUpsertStart(const UUID& client_id,
+                                const std::vector<std::string>& keys,
+                                const std::vector<uint64_t>& slice_lengths,
+                                const ReplicateConfig& config,
+                                const std::string& tenant_id) {
     if (keys.size() != slice_lengths.size()) {
         LOG(ERROR) << "BatchUpsertStart: keys.size()=" << keys.size()
                    << " != slice_lengths.size()=" << slice_lengths.size();
@@ -1788,27 +1909,52 @@ MasterService::BatchUpsertStart(const UUID& client_id,
         results;
     results.reserve(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
-        results.emplace_back(
-            UpsertStart(client_id, keys[i], slice_lengths[i], config));
+        results.emplace_back(UpsertStart(client_id, keys[i], slice_lengths[i],
+                                         config, tenant_id));
     }
     return results;
 }
 
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertEnd(
     const UUID& client_id, const std::vector<std::string>& keys) {
-    return BatchPutEnd(client_id, keys);
+    return BatchPutEnd(client_id, keys, ReplicaType::ALL);
+}
+
+std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertEnd(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    const std::string& tenant_id) {
+    return BatchPutEnd(client_id, keys, ReplicaType::ALL, tenant_id);
 }
 
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertRevoke(
     const UUID& client_id, const std::vector<std::string>& keys) {
-    return BatchPutRevoke(client_id, keys);
+    return BatchPutRevoke(client_id, keys, ReplicaType::ALL);
+}
+
+std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertRevoke(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    const std::string& tenant_id) {
+    return BatchPutRevoke(client_id, keys, ReplicaType::ALL, tenant_id);
 }
 
 auto MasterService::EvictDiskReplica(const UUID& client_id,
                                      const std::string& key,
                                      ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    MetadataAccessorRW accessor(this, key);
+    if (auto parsed = ParseTenantScopedKey(key)) {
+        return EvictDiskReplica(client_id, parsed->user_key, replica_type,
+                                parsed->tenant_id);
+    }
+    return EvictDiskReplica(client_id, key, replica_type, "default");
+}
+
+auto MasterService::EvictDiskReplica(const UUID& client_id,
+                                     const std::string& key,
+                                     ReplicaType replica_type,
+                                     const std::string& tenant_id)
+    -> tl::expected<void, ErrorCode> {
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(INFO) << "key=" << key << ", info=object_not_found_for_eviction";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -1850,10 +1996,31 @@ std::vector<tl::expected<void, ErrorCode>> MasterService::BatchEvictDiskReplica(
     return results;
 }
 
+std::vector<tl::expected<void, ErrorCode>> MasterService::BatchEvictDiskReplica(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    ReplicaType replica_type, const std::string& tenant_id) {
+    std::vector<tl::expected<void, ErrorCode>> results;
+    results.reserve(keys.size());
+    for (const auto& key : keys) {
+        results.push_back(
+            EvictDiskReplica(client_id, key, replica_type, tenant_id));
+    }
+    return results;
+}
+
 tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment,
     const std::vector<std::string>& tgt_segments) {
+    return CopyStart(client_id, key, src_segment, tgt_segments, "default");
+}
+
+tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
+    const UUID& client_id, const std::string& key,
+    const std::string& src_segment,
+    const std::vector<std::string>& tgt_segments,
+    const std::string& tenant_id) {
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     {
         ScopedSegmentAccess segment_access =
@@ -1872,7 +2039,7 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
             }
         }
     }
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", object not found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -1931,7 +2098,7 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
     // Create replication task for tracking.
     auto& shard = accessor.GetShard();
     shard->replication_tasks.emplace(
-        std::piecewise_construct, std::forward_as_tuple(key),
+        std::piecewise_construct, std::forward_as_tuple(internal_key),
         std::forward_as_tuple(client_id, std::chrono::system_clock::now(),
                               ReplicationTask::Type::COPY, source->id(),
                               std::move(replica_ids)));
@@ -1948,8 +2115,15 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
 
 tl::expected<void, ErrorCode> MasterService::CopyEnd(const UUID& client_id,
                                                      const std::string& key) {
+    return CopyEnd(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> MasterService::CopyEnd(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2019,8 +2193,15 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(const UUID& client_id,
 
 tl::expected<void, ErrorCode> MasterService::CopyRevoke(
     const UUID& client_id, const std::string& key) {
+    return CopyRevoke(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> MasterService::CopyRevoke(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2073,6 +2254,14 @@ tl::expected<void, ErrorCode> MasterService::CopyRevoke(
 tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment, const std::string& tgt_segment) {
+    return MoveStart(client_id, key, src_segment, tgt_segment, "default");
+}
+
+tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
+    const UUID& client_id, const std::string& key,
+    const std::string& src_segment, const std::string& tgt_segment,
+    const std::string& tenant_id) {
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     if (src_segment == tgt_segment) {
         LOG(ERROR) << "key=" << key << ", move_tgt=" << tgt_segment
@@ -2095,7 +2284,7 @@ tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
         }
     }
 
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", object not found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2146,7 +2335,7 @@ tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
     // Create replication task for tracking.
     auto& shard = accessor.GetShard();
     shard->replication_tasks.emplace(
-        std::piecewise_construct, std::forward_as_tuple(key),
+        std::piecewise_construct, std::forward_as_tuple(internal_key),
         std::forward_as_tuple(client_id, std::chrono::system_clock::now(),
                               ReplicationTask::Type::MOVE, source->id(),
                               std::move(replica_ids)));
@@ -2163,8 +2352,15 @@ tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
 
 tl::expected<void, ErrorCode> MasterService::MoveEnd(const UUID& client_id,
                                                      const std::string& key) {
+    return MoveEnd(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> MasterService::MoveEnd(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2249,8 +2445,15 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(const UUID& client_id,
 
 tl::expected<void, ErrorCode> MasterService::MoveRevoke(
     const UUID& client_id, const std::string& key) {
+    return MoveRevoke(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> MasterService::MoveRevoke(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2302,8 +2505,14 @@ tl::expected<void, ErrorCode> MasterService::MoveRevoke(
 
 auto MasterService::Remove(const std::string& key, bool force)
     -> tl::expected<void, ErrorCode> {
+    return Remove(key, "default", force);
+}
+
+auto MasterService::Remove(const std::string& key, const std::string& tenant_id,
+                           bool force) -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    MetadataAccessorRW accessor(this, internal_key);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2340,6 +2549,12 @@ auto MasterService::Remove(const std::string& key, bool force)
 
 auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
     -> tl::expected<long, ErrorCode> {
+    return RemoveByRegex(regex_pattern, "default", force);
+}
+
+auto MasterService::RemoveByRegex(const std::string& regex_pattern,
+                                  const std::string& tenant_id, bool force)
+    -> tl::expected<long, ErrorCode> {
     long removed_count = 0;
     std::regex pattern;
 
@@ -2352,11 +2567,14 @@ auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
     }
 
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
     for (size_t i = 0; i < kNumShards; ++i) {
         MetadataShardAccessorRW shard(this, i);
 
         for (auto it = shard->metadata.begin(); it != shard->metadata.end();) {
-            if (std::regex_search(it->first, pattern)) {
+            const auto& user_key = it->second.UserKeyOr(it->first);
+            if (it->second.tenant_id == normalized_tenant &&
+                std::regex_search(user_key, pattern)) {
                 if (!force && !it->second.IsLeaseExpired()) {
                     VLOG(1) << "key=" << it->first
                             << " matched by regex, but has lease. Skipping "
@@ -2448,6 +2666,12 @@ long MasterService::RemoveAll(bool force) {
 auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                                 bool force)
     -> std::vector<tl::expected<void, ErrorCode>> {
+    return BatchRemove(keys, "default", force);
+}
+
+auto MasterService::BatchRemove(const std::vector<std::string>& keys,
+                                const std::string& tenant_id, bool force)
+    -> std::vector<tl::expected<void, ErrorCode>> {
     std::vector<tl::expected<void, ErrorCode>> results(keys.size());
 
     // Group keys by shard to reduce lock contention
@@ -2458,7 +2682,8 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
         std::min(keys.size(), static_cast<size_t>(kNumShards)));
 
     for (size_t i = 0; i < keys.size(); ++i) {
-        size_t shard_idx = getShardIndex(keys[i]);
+        size_t shard_idx =
+            getShardIndex(BuildTenantScopedKey(tenant_id, keys[i]));
         keys_by_shard[shard_idx].emplace_back(i, &keys[i]);
     }
 
@@ -2473,7 +2698,8 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
 
         for (const auto& [original_idx, key_ptr] : key_group) {
             const std::string& key = *key_ptr;
-            auto it = shard->metadata.find(key);
+            const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+            auto it = shard->metadata.find(internal_key);
 
             if (it == shard->metadata.end()) {
                 VLOG(1) << "key=" << key << ", error=object_not_found";
@@ -2484,9 +2710,9 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
 
             // Clean up stale replica handles (consistent with single Remove)
             if (CleanupStaleHandles(it->second, alive_clients)) {
-                shard->processing_keys.erase(key);
-                shard->replication_tasks.erase(key);
-                shard->offloading_tasks.erase(key);
+                shard->processing_keys.erase(internal_key);
+                shard->replication_tasks.erase(internal_key);
+                shard->offloading_tasks.erase(internal_key);
                 shard->metadata.erase(it);
                 results[original_idx] =
                     tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2514,7 +2740,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                 continue;
             }
 
-            if (shard->replication_tasks.contains(key)) {
+            if (shard->replication_tasks.contains(internal_key)) {
                 LOG(ERROR) << "key=" << key
                            << ", error=object_has_replication_task";
                 results[original_idx] =
@@ -2669,10 +2895,14 @@ auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
     }
 
     for (auto& [key, size] : offloading_objects_copy) {
-        MetadataAccessorRW accessor(this, key);
+        auto parsed = ParseTenantScopedKey(key);
+        const auto internal_key =
+            parsed ? BuildTenantScopedKey(parsed->tenant_id, parsed->user_key)
+                   : BuildTenantScopedKey("default", key);
+        MetadataAccessorRW accessor(this, internal_key);
         if (accessor.Exists()) {
             auto& shard = accessor.GetShard();
-            auto task_it = shard->offloading_tasks.find(key);
+            auto task_it = shard->offloading_tasks.find(internal_key);
             if (task_it != shard->offloading_tasks.end()) {
                 auto source =
                     accessor.Get().GetReplicaByID(task_it->second.source_id);
@@ -2726,16 +2956,20 @@ auto MasterService::NotifyOffloadSuccess(
     const std::vector<StorageObjectMetadata>& metadatas)
     -> tl::expected<void, ErrorCode> {
     for (size_t i = 0; i < keys.size(); ++i) {
-        const auto& key = keys[i];
+        const auto& storage_key = keys[i];
+        auto parsed = ParseTenantScopedKey(storage_key);
+        const std::string tenant_id = parsed ? parsed->tenant_id : "default";
+        const std::string user_key = parsed ? parsed->user_key : storage_key;
+        const auto internal_key = BuildTenantScopedKey(tenant_id, user_key);
         const auto& metadata = metadatas[i];
 
         // Release refcnt and clear offloading task.
         {
-            MetadataAccessorRW accessor(this, key);
+            MetadataAccessorRW accessor(this, internal_key);
             if (accessor.Exists()) {
                 auto& obj_metadata = accessor.Get();
                 auto& shard = accessor.GetShard();
-                auto task_it = shard->offloading_tasks.find(key);
+                auto task_it = shard->offloading_tasks.find(internal_key);
                 if (task_it != shard->offloading_tasks.end()) {
                     auto source =
                         obj_metadata.GetReplicaByID(task_it->second.source_id);
@@ -2750,10 +2984,11 @@ auto MasterService::NotifyOffloadSuccess(
         // Add LOCAL_DISK replica.
         Replica replica(client_id, metadata.data_size,
                         metadata.transport_endpoint, ReplicaStatus::COMPLETE);
-        auto res = AddReplica(client_id, key, replica);
+        auto res = AddReplica(client_id, user_key, replica, tenant_id);
         if (!res && res.error() != ErrorCode::OBJECT_NOT_FOUND) {
             LOG(ERROR) << "Failed to add replica: error=" << res.error()
-                       << ", client_id=" << client_id << ", key=" << key;
+                       << ", client_id=" << client_id << ", key=" << user_key
+                       << ", tenant_id=" << tenant_id;
             return tl::make_unexpected(res.error());
         }
     }
@@ -2761,7 +2996,8 @@ auto MasterService::NotifyOffloadSuccess(
 }
 
 tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
-    const std::string& key, Replica& replica) {
+    const std::string& tenant_id, const std::string& key, Replica& replica) {
+    const auto storage_key = BuildTenantScopedKey(tenant_id, key);
     const auto& segment_names = replica.get_segment_names();
     if (segment_names.empty()) {
         return {};
@@ -2795,9 +3031,9 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
             return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
         }
         auto res = local_disk_segment_it->second->offloading_objects.emplace(
-            key, replica.get_descriptor()
-                     .get_memory_descriptor()
-                     .buffer_descriptor.size_);
+            storage_key, replica.get_descriptor()
+                             .get_memory_descriptor()
+                             .buffer_descriptor.size_);
         if (!res.second) {
             return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
         }
@@ -4553,14 +4789,17 @@ void MasterService::BatchEvict(double evict_ratio_target,
 
         // Queue one MEMORY replica for offload; others will be evicted below.
         bool queued = false;
+        const std::string& user_key = metadata.UserKeyOr(key);
         metadata.VisitReplicas(
             [](const Replica& r) {
                 return r.is_memory_replica() && r.is_completed() &&
                        r.get_refcnt() == 0;
             },
-            [this, &key, &shard, &queued, &now](Replica& replica) {
+            [this, &key, &metadata, &user_key, &shard, &queued,
+             &now](Replica& replica) {
                 if (queued) return;  // only need to pin one replica for offload
-                auto result = PushOffloadingQueue(key, replica);
+                auto result =
+                    PushOffloadingQueue(metadata.tenant_id, user_key, replica);
                 if (result) {
                     replica.inc_refcnt();
                     shard->offloading_tasks.emplace(
@@ -4827,7 +5066,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
         MasterMetricManager::instance().inc_eviction_fail();
         MasterMetricManager::instance().inc_mem_eviction_fail();
     }
-    VLOG(1) << "action=evict_objects" << ", evicted_count=" << evicted_count
+    VLOG(1) << "action=evict_objects"
+            << ", evicted_count=" << evicted_count
             << ", offload_deferred=" << offload_deferred_count
             << ", offload_cap_forced=" << offload_cap_forced_count
             << ", offload_push_failed_forced=" << offload_push_failed_forced
@@ -5580,13 +5820,20 @@ MasterService::MetadataSerializer::DeserializeShard(const msgpack::object& obj,
         }
 
         auto metadata_ptr = std::move(metadata_result.value());
+        std::string restored_user_key = metadata_ptr->UserKeyOr(key);
+        if (metadata_ptr->user_key.empty()) {
+            if (auto parsed = ParseTenantScopedKey(key)) {
+                restored_user_key = std::move(parsed->user_key);
+            }
+        }
         auto [it, inserted] = shard.metadata.emplace(
             std::piecewise_construct, std::forward_as_tuple(std::move(key)),
             std::forward_as_tuple(
                 metadata_ptr->client_id, metadata_ptr->put_start_time,
                 metadata_ptr->size, metadata_ptr->PopReplicas(),
                 metadata_ptr->soft_pin_timeout.has_value(),
-                metadata_ptr->IsHardPinned(), metadata_ptr->data_type));
+                metadata_ptr->IsHardPinned(), metadata_ptr->data_type,
+                metadata_ptr->tenant_id, std::move(restored_user_key)));
 
         it->second.lease_timeout = metadata_ptr->lease_timeout;
         it->second.soft_pin_timeout = metadata_ptr->soft_pin_timeout;
@@ -5602,11 +5849,12 @@ MasterService::MetadataSerializer::SerializeMetadata(
     // Pack ObjectMetadata using array structure for efficiency
     // Format: [client_id, put_start_time, size, lease_timeout,
     // has_soft_pin_timeout, soft_pin_timeout, replicas_count, data_type,
-    // replicas..., hard_pinned]
+    // tenant_id, user_key, replicas..., hard_pinned]
 
-    size_t array_size = 9;  // client_id, put_start_time, size, lease_timeout,
-                            // has_soft_pin_timeout, soft_pin_timeout,
-                            // replicas_count, data_type, hard_pinned
+    size_t array_size = 11;  // client_id, put_start_time, size, lease_timeout,
+                             // has_soft_pin_timeout, soft_pin_timeout,
+                             // replicas_count, data_type, tenant_id, user_key,
+                             // hard_pinned
     array_size += metadata.CountReplicas();  // One element per replica
     packer.pack_array(array_size);
 
@@ -5648,6 +5896,10 @@ MasterService::MetadataSerializer::SerializeMetadata(
 
     // Serialize data_type
     packer.pack(static_cast<uint8_t>(metadata.data_type));
+
+    // Serialize tenant scope
+    packer.pack(metadata.tenant_id);
+    packer.pack(metadata.user_key);
 
     // Serialize replicas
     for (const auto& replica : metadata.GetAllReplicas()) {
@@ -5711,9 +5963,11 @@ MasterService::MetadataSerializer::DeserializeMetadata(
     //   v1: 7 + replicas_count, no data_type or hard_pinned
     //   v2: 8 + replicas_count, either data_type or trailing hard_pinned
     //   v3: 9 + replicas_count, data_type plus trailing hard_pinned
+    //   v4: 11 + replicas_count, data_type, tenant_id, user_key, hard_pinned
     constexpr uint32_t kOldFieldCount = 7;
     constexpr uint32_t kOneExtraFieldCount = 8;
     constexpr uint32_t kCurrentFieldCount = 9;
+    constexpr uint32_t kTenantFieldCount = 11;
     const uint32_t total_elements = obj.via.array.size;
     const bool is_old_format =
         (total_elements == kOldFieldCount + replicas_count);
@@ -5721,19 +5975,29 @@ MasterService::MetadataSerializer::DeserializeMetadata(
         (total_elements == kOneExtraFieldCount + replicas_count);
     const bool is_current_format =
         (total_elements == kCurrentFieldCount + replicas_count);
+    const bool is_tenant_format =
+        (total_elements == kTenantFieldCount + replicas_count);
 
-    if (!is_current_format && !is_one_extra_format && !is_old_format) {
+    if (!is_tenant_format && !is_current_format && !is_one_extra_format &&
+        !is_old_format) {
         return tl::unexpected(SerializationError(
             ErrorCode::DESERIALIZE_FAIL,
             "deserialize ObjectMetadata array size mismatch"));
     }
 
     ObjectDataType data_type = ObjectDataType::UNKNOWN;
-    if (is_current_format) {
+    if (is_current_format || is_tenant_format) {
         data_type = static_cast<ObjectDataType>(array[index++].as<uint8_t>());
     } else if (is_one_extra_format &&
                array[index].type == msgpack::type::POSITIVE_INTEGER) {
         data_type = static_cast<ObjectDataType>(array[index++].as<uint8_t>());
+    }
+
+    std::string tenant_id = "default";
+    std::string user_key;
+    if (is_tenant_format) {
+        tenant_id = array[index++].as<std::string>();
+        user_key = array[index++].as<std::string>();
     }
 
     // Deserialize replicas
@@ -5761,7 +6025,8 @@ MasterService::MetadataSerializer::DeserializeMetadata(
         client_id,
         std::chrono::system_clock::time_point(
             std::chrono::milliseconds(put_start_time_timestamp)),
-        size, std::move(replicas), enable_soft_pin, is_hard_pinned, data_type);
+        size, std::move(replicas), enable_soft_pin, is_hard_pinned, data_type,
+        tenant_id, user_key);
     metadata->lease_timeout = std::chrono::system_clock::time_point(
         std::chrono::milliseconds(lease_timestamp));
 
@@ -5794,12 +6059,19 @@ std::string MasterService::FormatTimestamp(
 
 tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
     const std::string& key, const std::vector<std::string>& targets) {
+    return CreateCopyTask(key, targets, "default");
+}
+
+tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
+    const std::string& key, const std::vector<std::string>& targets,
+    const std::string& tenant_id) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
     if (targets.empty()) {
         LOG(ERROR) << "key=" << key << ", error=empty_targets";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
-    MetadataAccessorRO accessor(this, key);
+    MetadataAccessorRO accessor(this, internal_key);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -5850,8 +6122,15 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
 tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
     const std::string& key, const std::string& source,
     const std::string& target) {
+    return CreateMoveTask(key, source, target, "default");
+}
+
+tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
+    const std::string& key, const std::string& source,
+    const std::string& target, const std::string& tenant_id) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRO accessor(this, key);
+    const auto internal_key = BuildTenantScopedKey(tenant_id, key);
+    MetadataAccessorRO accessor(this, internal_key);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -6221,8 +6500,10 @@ void MasterService::ScheduleDrainJobTasks(DrainJob& job) {
         for (size_t i = 0; i < kNumShards; ++i) {
             MetadataShardAccessorRO shard(this, i);
             for (const auto& [key, metadata] : shard->metadata) {
+                const std::string& user_key = metadata.UserKeyOr(key);
                 for (const auto& source_segment : job.request.segments) {
-                    const auto unit_key = MakeDrainUnitKey(key, source_segment);
+                    const auto unit_key =
+                        MakeDrainUnitKey(user_key, source_segment);
                     if (job.completed_unit_keys.contains(unit_key) ||
                         active_unit_keys.contains(unit_key) ||
                         job.terminal_failed_unit_keys.contains(unit_key)) {
@@ -6252,7 +6533,7 @@ void MasterService::ScheduleDrainJobTasks(DrainJob& job) {
                     }
 
                     if (plans.size() < slots) {
-                        plans.push_back({key, source_segment, *target,
+                        plans.push_back({user_key, source_segment, *target,
                                          metadata.size, unit_key});
                     }
                 }
@@ -6306,6 +6587,7 @@ bool MasterService::MaybeCompleteDrainJob(DrainJob& job) {
         for (size_t i = 0; i < kNumShards; ++i) {
             MetadataShardAccessorRO shard(this, i);
             for (const auto& [key, metadata] : shard->metadata) {
+                const std::string& user_key = metadata.UserKeyOr(key);
                 const auto replica_segments = metadata.GetReplicaSegmentNames();
                 for (const auto& source_segment : job.request.segments) {
                     if (std::find(replica_segments.begin(),
@@ -6313,7 +6595,7 @@ bool MasterService::MaybeCompleteDrainJob(DrainJob& job) {
                                   source_segment) != replica_segments.end()) {
                         remaining_segments.insert(source_segment);
                         remaining_unit_keys.insert(
-                            MakeDrainUnitKey(key, source_segment));
+                            MakeDrainUnitKey(user_key, source_segment));
                     }
                 }
             }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -620,7 +620,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     const std::shared_ptr<TransferEngine> &transfer_engine,
     const std::string &ipc_socket_path, int local_rpc_port,
     bool enable_ssd_offload, bool start_offload_rpc_server,
-    const std::string &ssd_offload_path) {
+    const std::string &ssd_offload_path, const std::string &tenant_id) {
     this->protocol = protocol;
     this->ipc_socket_path_ = ipc_socket_path;
     const bool should_use_hugepage =
@@ -658,7 +658,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             hostname.substr(0, colon_pos + 1) + std::to_string(local_rpc_port);
         auto client_opt = mooncake::Client::Create(
             this->local_hostname, metadata_server, protocol, device_name,
-            master_server_addr, transfer_engine, {{"client_mode", "real"}});
+            master_server_addr, transfer_engine, {{"client_mode", "real"}},
+            tenant_id);
         if (!client_opt) {
             LOG(ERROR) << "Failed to create client";
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -693,7 +694,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 hostname + ":" + std::to_string(local_rpc_port);
             auto client_opt = mooncake::Client::Create(
                 this->local_hostname, metadata_server, protocol, device_name,
-                master_server_addr, transfer_engine, {{"client_mode", "real"}});
+                master_server_addr, transfer_engine, {{"client_mode", "real"}},
+                tenant_id);
             if (client_opt) {
                 client_ = *client_opt;
                 success = true;
@@ -917,11 +919,12 @@ int RealClient::setup_real(
     const std::string &master_server_addr,
     const std::shared_ptr<TransferEngine> &transfer_engine,
     const std::string &ipc_socket_path, bool enable_ssd_offload,
-    const std::string &ssd_offload_path) {
+    const std::string &ssd_offload_path, const std::string &tenant_id) {
     return to_py_ret(setup_internal(
         local_hostname, metadata_server, global_segment_size, local_buffer_size,
         protocol, rdma_devices, master_server_addr, transfer_engine,
-        ipc_socket_path, 50052, enable_ssd_offload, true, ssd_offload_path));
+        ipc_socket_path, 50052, enable_ssd_offload, true, ssd_offload_path,
+        tenant_id));
 }
 
 namespace {
@@ -988,6 +991,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         config, CONFIG_KEY_MASTER_SERVER_ADDR, DEFAULT_MASTER_SERVER_ADDR);
     std::string ipc_socket_path =
         get_config(config, CONFIG_KEY_IPC_SOCKET_PATH);
+    std::string tenant_id = get_config(config, CONFIG_KEY_TENANT_ID, "default");
 
     // Validate size parameters are within acceptable ranges
     if (global_segment_size < MIN_SEGMENT_SIZE ||
@@ -1022,10 +1026,10 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     bool enable_ssd_offload =
         (enable_ssd_offload_str == "true" || enable_ssd_offload_str == "1");
 
-    return setup_internal(local_hostname, metadata_server, global_segment_size,
-                          local_buffer_size, protocol, rdma_devices,
-                          master_server_addr, nullptr, ipc_socket_path, 50052,
-                          enable_ssd_offload, true, ssd_offload_path);
+    return setup_internal(
+        local_hostname, metadata_server, global_segment_size, local_buffer_size,
+        protocol, rdma_devices, master_server_addr, nullptr, ipc_socket_path,
+        50052, enable_ssd_offload, true, ssd_offload_path, tenant_id);
 }
 
 tl::expected<void, ErrorCode> RealClient::initAll_internal(
@@ -5458,11 +5462,14 @@ RealClient::batch_get_into_offload_object_internal(
     auto start_time = std::chrono::steady_clock::now();
     std::vector<std::string> keys;
     std::vector<int64_t> sizes;
+    std::unordered_map<std::string, std::vector<Slice>> storage_objects;
     for (const auto &object_it : objects) {
-        keys.emplace_back(object_it.first);
+        std::string storage_key = client_->BuildStorageKey(object_it.first);
+        keys.emplace_back(storage_key);
         int64_t total = 0;
         for (const auto &s : object_it.second) total += s.size;
         sizes.emplace_back(total);
+        storage_objects.emplace(std::move(storage_key), object_it.second);
     }
     auto batchGetResp = client_requester_->batch_get_offload_object(
         target_rpc_service_addr, keys, sizes);
@@ -5478,7 +5485,7 @@ RealClient::batch_get_into_offload_object_internal(
     }
     auto result =
         client_->BatchGetOffloadObject(batchGetResp->transfer_engine_addr, keys,
-                                       batchGetResp->pointers, objects);
+                                       batchGetResp->pointers, storage_objects);
     auto end_time = std::chrono::steady_clock::now();
     auto elapsed_time = static_cast<uint64_t>(
         std::chrono::duration_cast<std::chrono::milliseconds>(end_time -

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -838,16 +838,24 @@ tl::expected<std::vector<std::string>, ErrorCode>
 WrappedMasterService::BatchReplicaClear(
     const std::vector<std::string>& object_keys, const UUID& client_id,
     const std::string& segment_name) {
+    return BatchReplicaClearInTenant(object_keys, client_id, segment_name,
+                                     "default");
+}
+
+tl::expected<std::vector<std::string>, ErrorCode>
+WrappedMasterService::BatchReplicaClearInTenant(
+    const std::vector<std::string>& object_keys, const UUID& client_id,
+    const std::string& segment_name, const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchReplicaClear");
     const size_t total_keys = object_keys.size();
     timer.LogRequest("object_keys_count=", total_keys,
-                     ", client_id=", client_id,
-                     ", segment_name=", segment_name);
+                     ", client_id=", client_id, ", segment_name=", segment_name,
+                     ", tenant_id=", tenant_id);
     MasterMetricManager::instance().inc_batch_replica_clear_requests(
         total_keys);
 
-    auto result =
-        master_service_.BatchReplicaClear(object_keys, client_id, segment_name);
+    auto result = master_service_.BatchReplicaClear(object_keys, client_id,
+                                                    segment_name, tenant_id);
 
     size_t failure_count = 0;
     if (!result.has_value()) {
@@ -890,6 +898,26 @@ WrappedMasterService::GetReplicaListByRegex(const std::string& str) {
         });
 }
 
+tl::expected<std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
+             ErrorCode>
+WrappedMasterService::GetReplicaListByRegexInTenant(
+    const std::string& str, const std::string& tenant_id) {
+    return execute_rpc(
+        "GetReplicaListByRegexInTenant",
+        [&] { return master_service_.GetReplicaListByRegex(str, tenant_id); },
+        [&](auto& timer) {
+            timer.LogRequest("Regex=", str, ", tenant_id=", tenant_id);
+        },
+        [] {
+            MasterMetricManager::instance()
+                .inc_get_replica_list_by_regex_requests();
+        },
+        [] {
+            MasterMetricManager::instance()
+                .inc_get_replica_list_by_regex_failures();
+        });
+}
+
 tl::expected<GetReplicaListResponse, ErrorCode>
 WrappedMasterService::GetReplicaList(const std::string& key) {
     return execute_rpc(
@@ -901,12 +929,33 @@ WrappedMasterService::GetReplicaList(const std::string& key) {
         });
 }
 
+tl::expected<GetReplicaListResponse, ErrorCode>
+WrappedMasterService::GetReplicaListInTenant(const std::string& key,
+                                             const std::string& tenant_id) {
+    return execute_rpc(
+        "GetReplicaListInTenant",
+        [&] { return master_service_.GetReplicaList(key, tenant_id); },
+        [&](auto& timer) {
+            timer.LogRequest("key=", key, ", tenant_id=", tenant_id);
+        },
+        [] { MasterMetricManager::instance().inc_get_replica_list_requests(); },
+        [] {
+            MasterMetricManager::instance().inc_get_replica_list_failures();
+        });
+}
+
 std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
 WrappedMasterService::BatchGetReplicaList(
     const std::vector<std::string>& keys) {
+    return BatchGetReplicaListInTenant(keys, "default");
+}
+
+std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+WrappedMasterService::BatchGetReplicaListInTenant(
+    const std::vector<std::string>& keys, const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchGetReplicaList");
     const size_t total_keys = keys.size();
-    timer.LogRequest("keys_count=", total_keys);
+    timer.LogRequest("keys_count=", total_keys, ", tenant_id=", tenant_id);
     MasterMetricManager::instance().inc_batch_get_replica_list_requests(
         total_keys);
 
@@ -914,7 +963,7 @@ WrappedMasterService::BatchGetReplicaList(
     results.reserve(keys.size());
 
     for (const auto& key : keys) {
-        results.emplace_back(master_service_.GetReplicaList(key));
+        results.emplace_back(master_service_.GetReplicaList(key, tenant_id));
     }
 
     size_t failure_count = 0;
@@ -951,15 +1000,25 @@ tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
 WrappedMasterService::PutStart(const UUID& client_id, const std::string& key,
                                const uint64_t slice_length,
                                const ReplicateConfig& config) {
+    return PutStartInTenant(client_id, key, slice_length, config, "default");
+}
+
+tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+WrappedMasterService::PutStartInTenant(const UUID& client_id,
+                                       const std::string& key,
+                                       const uint64_t slice_length,
+                                       const ReplicateConfig& config,
+                                       const std::string& tenant_id) {
     return execute_rpc(
         "PutStart",
         [&] {
             return master_service_.PutStart(client_id, key, slice_length,
-                                            config);
+                                            config, tenant_id);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", slice_length=", slice_length);
+                             ", slice_length=", slice_length,
+                             ", tenant_id=", tenant_id);
         },
         [&] { MasterMetricManager::instance().inc_put_start_requests(); },
         [] { MasterMetricManager::instance().inc_put_start_failures(); });
@@ -967,12 +1026,22 @@ WrappedMasterService::PutStart(const UUID& client_id, const std::string& key,
 
 tl::expected<void, ErrorCode> WrappedMasterService::PutEnd(
     const UUID& client_id, const std::string& key, ReplicaType replica_type) {
+    return PutEndInTenant(client_id, key, replica_type, "default");
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::PutEndInTenant(
+    const UUID& client_id, const std::string& key, ReplicaType replica_type,
+    const std::string& tenant_id) {
     return execute_rpc(
         "PutEnd",
-        [&] { return master_service_.PutEnd(client_id, key, replica_type); },
+        [&] {
+            return master_service_.PutEnd(client_id, key, replica_type,
+                                          tenant_id);
+        },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", replica_type=", replica_type);
+                             ", replica_type=", replica_type,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_put_end_requests(); },
         [] { MasterMetricManager::instance().inc_put_end_failures(); });
@@ -980,12 +1049,22 @@ tl::expected<void, ErrorCode> WrappedMasterService::PutEnd(
 
 tl::expected<void, ErrorCode> WrappedMasterService::PutRevoke(
     const UUID& client_id, const std::string& key, ReplicaType replica_type) {
+    return PutRevokeInTenant(client_id, key, replica_type, "default");
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::PutRevokeInTenant(
+    const UUID& client_id, const std::string& key, ReplicaType replica_type,
+    const std::string& tenant_id) {
     return execute_rpc(
         "PutRevoke",
-        [&] { return master_service_.PutRevoke(client_id, key, replica_type); },
+        [&] {
+            return master_service_.PutRevoke(client_id, key, replica_type,
+                                             tenant_id);
+        },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", replica_type=", replica_type);
+                             ", replica_type=", replica_type,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_put_revoke_requests(); },
         [] { MasterMetricManager::instance().inc_put_revoke_failures(); });
@@ -996,9 +1075,19 @@ WrappedMasterService::BatchPutStart(const UUID& client_id,
                                     const std::vector<std::string>& keys,
                                     const std::vector<uint64_t>& slice_lengths,
                                     const ReplicateConfig& config) {
+    return BatchPutStartInTenant(client_id, keys, slice_lengths, config,
+                                 "default");
+}
+
+std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+WrappedMasterService::BatchPutStartInTenant(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    const std::vector<uint64_t>& slice_lengths, const ReplicateConfig& config,
+    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchPutStart");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
+                     ", tenant_id=", tenant_id);
     MasterMetricManager::instance().inc_batch_put_start_requests(total_keys);
 
     std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
@@ -1009,7 +1098,7 @@ WrappedMasterService::BatchPutStart(const UUID& client_id,
         ReplicateConfig new_config = config;
         for (size_t i = 0; i < keys.size(); ++i) {
             auto result = master_service_.PutStart(
-                client_id, keys[i], slice_lengths[i], new_config);
+                client_id, keys[i], slice_lengths[i], new_config, tenant_id);
             results.emplace_back(result);
             if ((i == 0) && result.has_value()) {
                 std::string preferred_segment;
@@ -1030,7 +1119,7 @@ WrappedMasterService::BatchPutStart(const UUID& client_id,
     } else {
         for (size_t i = 0; i < keys.size(); ++i) {
             results.emplace_back(master_service_.PutStart(
-                client_id, keys[i], slice_lengths[i], config));
+                client_id, keys[i], slice_lengths[i], config, tenant_id));
         }
     }
 
@@ -1074,9 +1163,18 @@ WrappedMasterService::BatchPutStart(const UUID& client_id,
 std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchPutEnd(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
+    return BatchPutEndInTenant(client_id, keys, replica_type, "default");
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+WrappedMasterService::BatchPutEndInTenant(const UUID& client_id,
+                                          const std::vector<std::string>& keys,
+                                          ReplicaType replica_type,
+                                          const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchPutEnd");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
+                     ", tenant_id=", tenant_id);
     MasterMetricManager::instance().inc_batch_put_end_requests(total_keys);
 
     std::vector<tl::expected<void, ErrorCode>> results;
@@ -1084,7 +1182,7 @@ std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchPutEnd(
 
     for (const auto& key : keys) {
         results.emplace_back(
-            master_service_.PutEnd(client_id, key, replica_type));
+            master_service_.PutEnd(client_id, key, replica_type, tenant_id));
     }
 
     size_t failure_count = 0;
@@ -1114,9 +1212,17 @@ std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchPutEnd(
 std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchPutRevoke(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
+    return BatchPutRevokeInTenant(client_id, keys, replica_type, "default");
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+WrappedMasterService::BatchPutRevokeInTenant(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    ReplicaType replica_type, const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchPutRevoke");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
+                     ", tenant_id=", tenant_id);
     MasterMetricManager::instance().inc_batch_put_revoke_requests(total_keys);
 
     std::vector<tl::expected<void, ErrorCode>> results;
@@ -1124,7 +1230,7 @@ std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchPutRevoke(
 
     for (const auto& key : keys) {
         results.emplace_back(
-            master_service_.PutRevoke(client_id, key, replica_type));
+            master_service_.PutRevoke(client_id, key, replica_type, tenant_id));
     }
 
     size_t failure_count = 0;
@@ -1155,15 +1261,25 @@ tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
 WrappedMasterService::UpsertStart(const UUID& client_id, const std::string& key,
                                   const uint64_t slice_length,
                                   const ReplicateConfig& config) {
+    return UpsertStartInTenant(client_id, key, slice_length, config, "default");
+}
+
+tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
+WrappedMasterService::UpsertStartInTenant(const UUID& client_id,
+                                          const std::string& key,
+                                          const uint64_t slice_length,
+                                          const ReplicateConfig& config,
+                                          const std::string& tenant_id) {
     return execute_rpc(
         "UpsertStart",
         [&] {
             return master_service_.UpsertStart(client_id, key, slice_length,
-                                               config);
+                                               config, tenant_id);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", slice_length=", slice_length);
+                             ", slice_length=", slice_length,
+                             ", tenant_id=", tenant_id);
         },
         [&] { MasterMetricManager::instance().inc_put_start_requests(); },
         [] { MasterMetricManager::instance().inc_put_start_failures(); });
@@ -1171,12 +1287,22 @@ WrappedMasterService::UpsertStart(const UUID& client_id, const std::string& key,
 
 tl::expected<void, ErrorCode> WrappedMasterService::UpsertEnd(
     const UUID& client_id, const std::string& key, ReplicaType replica_type) {
+    return UpsertEndInTenant(client_id, key, replica_type, "default");
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::UpsertEndInTenant(
+    const UUID& client_id, const std::string& key, ReplicaType replica_type,
+    const std::string& tenant_id) {
     return execute_rpc(
         "UpsertEnd",
-        [&] { return master_service_.UpsertEnd(client_id, key, replica_type); },
+        [&] {
+            return master_service_.UpsertEnd(client_id, key, replica_type,
+                                             tenant_id);
+        },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", replica_type=", replica_type);
+                             ", replica_type=", replica_type,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_put_end_requests(); },
         [] { MasterMetricManager::instance().inc_put_end_failures(); });
@@ -1184,14 +1310,22 @@ tl::expected<void, ErrorCode> WrappedMasterService::UpsertEnd(
 
 tl::expected<void, ErrorCode> WrappedMasterService::UpsertRevoke(
     const UUID& client_id, const std::string& key, ReplicaType replica_type) {
+    return UpsertRevokeInTenant(client_id, key, replica_type, "default");
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::UpsertRevokeInTenant(
+    const UUID& client_id, const std::string& key, ReplicaType replica_type,
+    const std::string& tenant_id) {
     return execute_rpc(
         "UpsertRevoke",
         [&] {
-            return master_service_.UpsertRevoke(client_id, key, replica_type);
+            return master_service_.UpsertRevoke(client_id, key, replica_type,
+                                                tenant_id);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", replica_type=", replica_type);
+                             ", replica_type=", replica_type,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_put_revoke_requests(); },
         [] { MasterMetricManager::instance().inc_put_revoke_failures(); });
@@ -1201,13 +1335,23 @@ std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
 WrappedMasterService::BatchUpsertStart(
     const UUID& client_id, const std::vector<std::string>& keys,
     const std::vector<uint64_t>& slice_lengths, const ReplicateConfig& config) {
+    return BatchUpsertStartInTenant(client_id, keys, slice_lengths, config,
+                                    "default");
+}
+
+std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
+WrappedMasterService::BatchUpsertStartInTenant(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    const std::vector<uint64_t>& slice_lengths, const ReplicateConfig& config,
+    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchUpsertStart");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
+                     ", tenant_id=", tenant_id);
     MasterMetricManager::instance().inc_batch_put_start_requests(total_keys);
 
-    auto results = master_service_.BatchUpsertStart(client_id, keys,
-                                                    slice_lengths, config);
+    auto results = master_service_.BatchUpsertStart(
+        client_id, keys, slice_lengths, config, tenant_id);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
@@ -1235,12 +1379,20 @@ WrappedMasterService::BatchUpsertStart(
 
 std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchUpsertEnd(
     const UUID& client_id, const std::vector<std::string>& keys) {
+    return BatchUpsertEndInTenant(client_id, keys, "default");
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+WrappedMasterService::BatchUpsertEndInTenant(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchUpsertEnd");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
+                     ", tenant_id=", tenant_id);
     MasterMetricManager::instance().inc_batch_put_end_requests(total_keys);
 
-    auto results = master_service_.BatchUpsertEnd(client_id, keys);
+    auto results = master_service_.BatchUpsertEnd(client_id, keys, tenant_id);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
@@ -1269,12 +1421,21 @@ std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchUpsertEnd(
 std::vector<tl::expected<void, ErrorCode>>
 WrappedMasterService::BatchUpsertRevoke(const UUID& client_id,
                                         const std::vector<std::string>& keys) {
+    return BatchUpsertRevokeInTenant(client_id, keys, "default");
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+WrappedMasterService::BatchUpsertRevokeInTenant(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchUpsertRevoke");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
+                     ", tenant_id=", tenant_id);
     MasterMetricManager::instance().inc_batch_put_revoke_requests(total_keys);
 
-    auto results = master_service_.BatchUpsertRevoke(client_id, keys);
+    auto results =
+        master_service_.BatchUpsertRevoke(client_id, keys, tenant_id);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
@@ -1302,20 +1463,35 @@ WrappedMasterService::BatchUpsertRevoke(const UUID& client_id,
 
 tl::expected<void, ErrorCode> WrappedMasterService::Remove(
     const std::string& key, bool force) {
+    return RemoveInTenant(key, "default", force);
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::RemoveInTenant(
+    const std::string& key, const std::string& tenant_id, bool force) {
     return execute_rpc(
-        "Remove", [&] { return master_service_.Remove(key, force); },
-        [&](auto& timer) { timer.LogRequest("key=", key, ", force=", force); },
+        "RemoveInTenant",
+        [&] { return master_service_.Remove(key, tenant_id, force); },
+        [&](auto& timer) {
+            timer.LogRequest("key=", key, ", tenant_id=", tenant_id,
+                             ", force=", force);
+        },
         [] { MasterMetricManager::instance().inc_remove_requests(); },
         [] { MasterMetricManager::instance().inc_remove_failures(); });
 }
 
 tl::expected<long, ErrorCode> WrappedMasterService::RemoveByRegex(
     const std::string& str, bool force) {
+    return RemoveByRegexInTenant(str, "default", force);
+}
+
+tl::expected<long, ErrorCode> WrappedMasterService::RemoveByRegexInTenant(
+    const std::string& str, const std::string& tenant_id, bool force) {
     return execute_rpc(
-        "RemoveByRegex",
-        [&] { return master_service_.RemoveByRegex(str, force); },
+        "RemoveByRegexInTenant",
+        [&] { return master_service_.RemoveByRegex(str, tenant_id, force); },
         [&](auto& timer) {
-            timer.LogRequest("regex=", str, ", force=", force);
+            timer.LogRequest("regex=", str, ", tenant_id=", tenant_id,
+                             ", force=", force);
         },
         [] { MasterMetricManager::instance().inc_remove_by_regex_requests(); },
         [] { MasterMetricManager::instance().inc_remove_by_regex_failures(); });
@@ -1332,12 +1508,20 @@ long WrappedMasterService::RemoveAll(bool force) {
 
 std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchRemove(
     const std::vector<std::string>& keys, bool force) {
+    return BatchRemoveInTenant(keys, "default", force);
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+WrappedMasterService::BatchRemoveInTenant(const std::vector<std::string>& keys,
+                                          const std::string& tenant_id,
+                                          bool force) {
     ScopedVLogTimer timer(1, "BatchRemove");
     const size_t total_keys = keys.size();
-    timer.LogRequest("keys_count=", total_keys, ", force=", force);
+    timer.LogRequest("keys_count=", total_keys, ", tenant_id=", tenant_id,
+                     ", force=", force);
     MasterMetricManager::instance().inc_remove_requests(total_keys);
 
-    auto results = master_service_.BatchRemove(keys, force);
+    auto results = master_service_.BatchRemove(keys, tenant_id, force);
 
     size_t failure_count = 0;
     for (const auto& result : results) {
@@ -1493,16 +1677,27 @@ tl::expected<CopyStartResponse, ErrorCode> WrappedMasterService::CopyStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment,
     const std::vector<std::string>& tgt_segments) {
+    return CopyStartInTenant(client_id, key, src_segment, tgt_segments,
+                             "default");
+}
+
+tl::expected<CopyStartResponse, ErrorCode>
+WrappedMasterService::CopyStartInTenant(
+    const UUID& client_id, const std::string& key,
+    const std::string& src_segment,
+    const std::vector<std::string>& tgt_segments,
+    const std::string& tenant_id) {
     return execute_rpc(
-        "CopyStart",
+        "CopyStartInTenant",
         [&] {
             return master_service_.CopyStart(client_id, key, src_segment,
-                                             tgt_segments);
+                                             tgt_segments, tenant_id);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
                              ", src_segment=", src_segment,
-                             ", tgt_segments_count=", tgt_segments.size());
+                             ", tgt_segments_count=", tgt_segments.size(),
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_copy_start_requests(); },
         [] { MasterMetricManager::instance().inc_copy_start_failures(); });
@@ -1510,10 +1705,18 @@ tl::expected<CopyStartResponse, ErrorCode> WrappedMasterService::CopyStart(
 
 tl::expected<void, ErrorCode> WrappedMasterService::CopyEnd(
     const UUID& client_id, const std::string& key) {
+    return CopyEndInTenant(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::CopyEndInTenant(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     return execute_rpc(
-        "CopyEnd", [&] { return master_service_.CopyEnd(client_id, key); },
+        "CopyEndInTenant",
+        [&] { return master_service_.CopyEnd(client_id, key, tenant_id); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key);
+            timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_copy_end_requests(); },
         [] { MasterMetricManager::instance().inc_copy_end_failures(); });
@@ -1521,11 +1724,18 @@ tl::expected<void, ErrorCode> WrappedMasterService::CopyEnd(
 
 tl::expected<void, ErrorCode> WrappedMasterService::CopyRevoke(
     const UUID& client_id, const std::string& key) {
+    return CopyRevokeInTenant(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::CopyRevokeInTenant(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     return execute_rpc(
-        "CopyRevoke",
-        [&] { return master_service_.CopyRevoke(client_id, key); },
+        "CopyRevokeInTenant",
+        [&] { return master_service_.CopyRevoke(client_id, key, tenant_id); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key);
+            timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_copy_revoke_requests(); },
         [] { MasterMetricManager::instance().inc_copy_revoke_failures(); });
@@ -1534,16 +1744,27 @@ tl::expected<void, ErrorCode> WrappedMasterService::CopyRevoke(
 tl::expected<MoveStartResponse, ErrorCode> WrappedMasterService::MoveStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment, const std::string& tgt_segment) {
+    return MoveStartInTenant(client_id, key, src_segment, tgt_segment,
+                             "default");
+}
+
+tl::expected<MoveStartResponse, ErrorCode>
+WrappedMasterService::MoveStartInTenant(const UUID& client_id,
+                                        const std::string& key,
+                                        const std::string& src_segment,
+                                        const std::string& tgt_segment,
+                                        const std::string& tenant_id) {
     return execute_rpc(
-        "MoveStart",
+        "MoveStartInTenant",
         [&] {
             return master_service_.MoveStart(client_id, key, src_segment,
-                                             tgt_segment);
+                                             tgt_segment, tenant_id);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
                              ", src_segment=", src_segment,
-                             ", tgt_segment=", tgt_segment);
+                             ", tgt_segment=", tgt_segment,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_move_start_requests(); },
         [] { MasterMetricManager::instance().inc_move_start_failures(); });
@@ -1551,10 +1772,18 @@ tl::expected<MoveStartResponse, ErrorCode> WrappedMasterService::MoveStart(
 
 tl::expected<void, ErrorCode> WrappedMasterService::MoveEnd(
     const UUID& client_id, const std::string& key) {
+    return MoveEndInTenant(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::MoveEndInTenant(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     return execute_rpc(
-        "MoveEnd", [&] { return master_service_.MoveEnd(client_id, key); },
+        "MoveEndInTenant",
+        [&] { return master_service_.MoveEnd(client_id, key, tenant_id); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key);
+            timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_move_end_requests(); },
         [] { MasterMetricManager::instance().inc_move_end_failures(); });
@@ -1562,11 +1791,18 @@ tl::expected<void, ErrorCode> WrappedMasterService::MoveEnd(
 
 tl::expected<void, ErrorCode> WrappedMasterService::MoveRevoke(
     const UUID& client_id, const std::string& key) {
+    return MoveRevokeInTenant(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::MoveRevokeInTenant(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     return execute_rpc(
-        "MoveRevoke",
-        [&] { return master_service_.MoveRevoke(client_id, key); },
+        "MoveRevokeInTenant",
+        [&] { return master_service_.MoveRevoke(client_id, key, tenant_id); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key);
+            timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_move_revoke_requests(); },
         [] { MasterMetricManager::instance().inc_move_revoke_failures(); });
@@ -1574,15 +1810,22 @@ tl::expected<void, ErrorCode> WrappedMasterService::MoveRevoke(
 
 tl::expected<void, ErrorCode> WrappedMasterService::EvictDiskReplica(
     const UUID& client_id, const std::string& key, ReplicaType replica_type) {
+    return EvictDiskReplicaInTenant(client_id, key, replica_type, "default");
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::EvictDiskReplicaInTenant(
+    const UUID& client_id, const std::string& key, ReplicaType replica_type,
+    const std::string& tenant_id) {
     return execute_rpc(
-        "EvictDiskReplica",
+        "EvictDiskReplicaInTenant",
         [&] {
             return master_service_.EvictDiskReplica(client_id, key,
-                                                    replica_type);
+                                                    replica_type, tenant_id);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", replica_type=", replica_type);
+                             ", replica_type=", replica_type,
+                             ", tenant_id=", tenant_id);
         },
         [] {
             MasterMetricManager::instance().inc_evict_disk_replica_requests();
@@ -1596,14 +1839,23 @@ std::vector<tl::expected<void, ErrorCode>>
 WrappedMasterService::BatchEvictDiskReplica(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
+    return BatchEvictDiskReplicaInTenant(client_id, keys, replica_type,
+                                         "default");
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+WrappedMasterService::BatchEvictDiskReplicaInTenant(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    ReplicaType replica_type, const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchEvictDiskReplica");
     const size_t total_keys = keys.size();
     timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
-                     ", replica_type=", replica_type);
+                     ", replica_type=", replica_type,
+                     ", tenant_id=", tenant_id);
     MasterMetricManager::instance().inc_evict_disk_replica_requests();
 
-    auto results =
-        master_service_.BatchEvictDiskReplica(client_id, keys, replica_type);
+    auto results = master_service_.BatchEvictDiskReplica(
+        client_id, keys, replica_type, tenant_id);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
@@ -1626,11 +1878,18 @@ WrappedMasterService::BatchEvictDiskReplica(
 
 tl::expected<UUID, ErrorCode> WrappedMasterService::CreateCopyTask(
     const std::string& key, const std::vector<std::string>& targets) {
+    return CreateCopyTaskInTenant(key, targets, "default");
+}
+
+tl::expected<UUID, ErrorCode> WrappedMasterService::CreateCopyTaskInTenant(
+    const std::string& key, const std::vector<std::string>& targets,
+    const std::string& tenant_id) {
     return execute_rpc(
-        "CreateCopyTask",
-        [&] { return master_service_.CreateCopyTask(key, targets); },
+        "CreateCopyTaskInTenant",
+        [&] { return master_service_.CreateCopyTask(key, targets, tenant_id); },
         [&](auto& timer) {
-            timer.LogRequest("key=", key, ", targets_size=", targets.size());
+            timer.LogRequest("key=", key, ", targets_size=", targets.size(),
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_create_copy_task_requests(); },
         [] {
@@ -1641,12 +1900,21 @@ tl::expected<UUID, ErrorCode> WrappedMasterService::CreateCopyTask(
 tl::expected<UUID, ErrorCode> WrappedMasterService::CreateMoveTask(
     const std::string& key, const std::string& source,
     const std::string& target) {
+    return CreateMoveTaskInTenant(key, source, target, "default");
+}
+
+tl::expected<UUID, ErrorCode> WrappedMasterService::CreateMoveTaskInTenant(
+    const std::string& key, const std::string& source,
+    const std::string& target, const std::string& tenant_id) {
     return execute_rpc(
-        "CreateMoveTask",
-        [&] { return master_service_.CreateMoveTask(key, source, target); },
+        "CreateMoveTaskInTenant",
+        [&] {
+            return master_service_.CreateMoveTask(key, source, target,
+                                                  tenant_id);
+        },
         [&](auto& timer) {
             timer.LogRequest("key=", key, ", source=", source,
-                             ", target=", target);
+                             ", target=", target, ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_create_move_task_requests(); },
         [] {
@@ -1858,45 +2126,97 @@ void RegisterRpcService(
     server.register_handler<&mooncake::WrappedMasterService::BatchReplicaClear>(
         &wrapped_master_service);
     server.register_handler<
+        &mooncake::WrappedMasterService::BatchReplicaClearInTenant>(
+        &wrapped_master_service);
+    server.register_handler<
         &mooncake::WrappedMasterService::GetReplicaListByRegex>(
         &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::GetReplicaListByRegexInTenant>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::GetReplicaList>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::GetReplicaListInTenant>(
         &wrapped_master_service);
     server
         .register_handler<&mooncake::WrappedMasterService::BatchGetReplicaList>(
             &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::BatchGetReplicaListInTenant>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::PutStart>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::PutStartInTenant>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::PutEnd>(
         &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::PutEndInTenant>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::PutRevoke>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::PutRevokeInTenant>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchPutStart>(
         &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::BatchPutStartInTenant>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchPutEnd>(
         &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::BatchPutEndInTenant>(
+            &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchPutRevoke>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::BatchPutRevokeInTenant>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::UpsertStart>(
         &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::UpsertStartInTenant>(
+            &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::UpsertEnd>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::UpsertEndInTenant>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::UpsertRevoke>(
         &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::UpsertRevokeInTenant>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchUpsertStart>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::BatchUpsertStartInTenant>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchUpsertEnd>(
         &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::BatchUpsertEndInTenant>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchUpsertRevoke>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::BatchUpsertRevokeInTenant>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::Remove>(
         &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::RemoveInTenant>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::RemoveByRegex>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::RemoveByRegexInTenant>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::RemoveAll>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchRemove>(
         &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::BatchRemoveInTenant>(
+            &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::MountSegment>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::MountNoFSegment>(
@@ -1958,24 +2278,50 @@ void RegisterRpcService(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::CopyStart>(
         &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::CopyStartInTenant>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::CopyEnd>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::CopyEndInTenant>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::CopyRevoke>(
         &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::CopyRevokeInTenant>(
+            &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::MoveStart>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::MoveStartInTenant>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::MoveEnd>(
         &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::MoveEndInTenant>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::MoveRevoke>(
         &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::MoveRevokeInTenant>(
+            &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::EvictDiskReplica>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::EvictDiskReplicaInTenant>(
         &wrapped_master_service);
     server.register_handler<
         &mooncake::WrappedMasterService::BatchEvictDiskReplica>(
         &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::BatchEvictDiskReplicaInTenant>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::CreateCopyTask>(
         &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::CreateCopyTaskInTenant>(
+        &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::CreateMoveTask>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::CreateMoveTaskInTenant>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::QueryTask>(
         &wrapped_master_service);

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -875,11 +875,14 @@ WrappedMasterService::BatchReplicaClear(
 
 tl::expected<std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
              ErrorCode>
-WrappedMasterService::GetReplicaListByRegex(const std::string& str) {
+WrappedMasterService::GetReplicaListByRegex(const std::string& str,
+                                            const std::string& tenant_id) {
     return execute_rpc(
         "GetReplicaListByRegex",
-        [&] { return master_service_.GetReplicaListByRegex(str); },
-        [&](auto& timer) { timer.LogRequest("Regex=", str); },
+        [&] { return master_service_.GetReplicaListByRegex(str, tenant_id); },
+        [&](auto& timer) {
+            timer.LogRequest("Regex=", str, ", tenant_id=", tenant_id);
+        },
         [] {
             MasterMetricManager::instance()
                 .inc_get_replica_list_by_regex_requests();
@@ -1294,12 +1297,13 @@ tl::expected<void, ErrorCode> WrappedMasterService::Remove(
 }
 
 tl::expected<long, ErrorCode> WrappedMasterService::RemoveByRegex(
-    const std::string& str, bool force) {
+    const std::string& str, const std::string& tenant_id, bool force) {
     return execute_rpc(
         "RemoveByRegex",
-        [&] { return master_service_.RemoveByRegex(str, force); },
+        [&] { return master_service_.RemoveByRegex(str, tenant_id, force); },
         [&](auto& timer) {
-            timer.LogRequest("regex=", str, ", force=", force);
+            timer.LogRequest("regex=", str, ", tenant_id=", tenant_id,
+                             ", force=", force);
         },
         [] { MasterMetricManager::instance().inc_remove_by_regex_requests(); },
         [] { MasterMetricManager::instance().inc_remove_by_regex_failures(); });

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -838,24 +838,16 @@ tl::expected<std::vector<std::string>, ErrorCode>
 WrappedMasterService::BatchReplicaClear(
     const std::vector<std::string>& object_keys, const UUID& client_id,
     const std::string& segment_name) {
-    return BatchReplicaClearInTenant(object_keys, client_id, segment_name,
-                                     "default");
-}
-
-tl::expected<std::vector<std::string>, ErrorCode>
-WrappedMasterService::BatchReplicaClearInTenant(
-    const std::vector<std::string>& object_keys, const UUID& client_id,
-    const std::string& segment_name, const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchReplicaClear");
     const size_t total_keys = object_keys.size();
     timer.LogRequest("object_keys_count=", total_keys,
-                     ", client_id=", client_id, ", segment_name=", segment_name,
-                     ", tenant_id=", tenant_id);
+                     ", client_id=", client_id,
+                     ", segment_name=", segment_name);
     MasterMetricManager::instance().inc_batch_replica_clear_requests(
         total_keys);
 
-    auto result = master_service_.BatchReplicaClear(object_keys, client_id,
-                                                    segment_name, tenant_id);
+    auto result =
+        master_service_.BatchReplicaClear(object_keys, client_id, segment_name);
 
     size_t failure_count = 0;
     if (!result.has_value()) {
@@ -898,26 +890,6 @@ WrappedMasterService::GetReplicaListByRegex(const std::string& str) {
         });
 }
 
-tl::expected<std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
-             ErrorCode>
-WrappedMasterService::GetReplicaListByRegexInTenant(
-    const std::string& str, const std::string& tenant_id) {
-    return execute_rpc(
-        "GetReplicaListByRegexInTenant",
-        [&] { return master_service_.GetReplicaListByRegex(str, tenant_id); },
-        [&](auto& timer) {
-            timer.LogRequest("Regex=", str, ", tenant_id=", tenant_id);
-        },
-        [] {
-            MasterMetricManager::instance()
-                .inc_get_replica_list_by_regex_requests();
-        },
-        [] {
-            MasterMetricManager::instance()
-                .inc_get_replica_list_by_regex_failures();
-        });
-}
-
 tl::expected<GetReplicaListResponse, ErrorCode>
 WrappedMasterService::GetReplicaList(const std::string& key) {
     return execute_rpc(
@@ -929,33 +901,12 @@ WrappedMasterService::GetReplicaList(const std::string& key) {
         });
 }
 
-tl::expected<GetReplicaListResponse, ErrorCode>
-WrappedMasterService::GetReplicaListInTenant(const std::string& key,
-                                             const std::string& tenant_id) {
-    return execute_rpc(
-        "GetReplicaListInTenant",
-        [&] { return master_service_.GetReplicaList(key, tenant_id); },
-        [&](auto& timer) {
-            timer.LogRequest("key=", key, ", tenant_id=", tenant_id);
-        },
-        [] { MasterMetricManager::instance().inc_get_replica_list_requests(); },
-        [] {
-            MasterMetricManager::instance().inc_get_replica_list_failures();
-        });
-}
-
 std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
 WrappedMasterService::BatchGetReplicaList(
     const std::vector<std::string>& keys) {
-    return BatchGetReplicaListInTenant(keys, "default");
-}
-
-std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
-WrappedMasterService::BatchGetReplicaListInTenant(
-    const std::vector<std::string>& keys, const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchGetReplicaList");
     const size_t total_keys = keys.size();
-    timer.LogRequest("keys_count=", total_keys, ", tenant_id=", tenant_id);
+    timer.LogRequest("keys_count=", total_keys);
     MasterMetricManager::instance().inc_batch_get_replica_list_requests(
         total_keys);
 
@@ -963,7 +914,7 @@ WrappedMasterService::BatchGetReplicaListInTenant(
     results.reserve(keys.size());
 
     for (const auto& key : keys) {
-        results.emplace_back(master_service_.GetReplicaList(key, tenant_id));
+        results.emplace_back(master_service_.GetReplicaList(key));
     }
 
     size_t failure_count = 0;
@@ -973,11 +924,11 @@ WrappedMasterService::BatchGetReplicaListInTenant(
             auto error = results[i].error();
             if (error == ErrorCode::OBJECT_NOT_FOUND ||
                 error == ErrorCode::REPLICA_IS_NOT_READY) {
-                VLOG(1) << "BatchGetReplicaList failed for key[" << i << "] '"
-                        << keys[i] << "': " << toString(error);
+                VLOG(1) << "BatchGetReplicaList failed for key[" << i << "] "
+                        << keys[i] << ": " << toString(error);
             } else {
-                LOG(ERROR) << "BatchGetReplicaList failed for key[" << i
-                           << "] '" << keys[i] << "': " << toString(error);
+                LOG(ERROR) << "BatchGetReplicaList failed for key[" << i << "] "
+                           << keys[i] << ": " << toString(error);
             }
         }
     }
@@ -1000,25 +951,15 @@ tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
 WrappedMasterService::PutStart(const UUID& client_id, const std::string& key,
                                const uint64_t slice_length,
                                const ReplicateConfig& config) {
-    return PutStartInTenant(client_id, key, slice_length, config, "default");
-}
-
-tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
-WrappedMasterService::PutStartInTenant(const UUID& client_id,
-                                       const std::string& key,
-                                       const uint64_t slice_length,
-                                       const ReplicateConfig& config,
-                                       const std::string& tenant_id) {
     return execute_rpc(
         "PutStart",
         [&] {
             return master_service_.PutStart(client_id, key, slice_length,
-                                            config, tenant_id);
+                                            config);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", slice_length=", slice_length,
-                             ", tenant_id=", tenant_id);
+                             ", slice_length=", slice_length);
         },
         [&] { MasterMetricManager::instance().inc_put_start_requests(); },
         [] { MasterMetricManager::instance().inc_put_start_failures(); });
@@ -1026,22 +967,12 @@ WrappedMasterService::PutStartInTenant(const UUID& client_id,
 
 tl::expected<void, ErrorCode> WrappedMasterService::PutEnd(
     const UUID& client_id, const std::string& key, ReplicaType replica_type) {
-    return PutEndInTenant(client_id, key, replica_type, "default");
-}
-
-tl::expected<void, ErrorCode> WrappedMasterService::PutEndInTenant(
-    const UUID& client_id, const std::string& key, ReplicaType replica_type,
-    const std::string& tenant_id) {
     return execute_rpc(
         "PutEnd",
-        [&] {
-            return master_service_.PutEnd(client_id, key, replica_type,
-                                          tenant_id);
-        },
+        [&] { return master_service_.PutEnd(client_id, key, replica_type); },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", replica_type=", replica_type,
-                             ", tenant_id=", tenant_id);
+                             ", replica_type=", replica_type);
         },
         [] { MasterMetricManager::instance().inc_put_end_requests(); },
         [] { MasterMetricManager::instance().inc_put_end_failures(); });
@@ -1049,22 +980,12 @@ tl::expected<void, ErrorCode> WrappedMasterService::PutEndInTenant(
 
 tl::expected<void, ErrorCode> WrappedMasterService::PutRevoke(
     const UUID& client_id, const std::string& key, ReplicaType replica_type) {
-    return PutRevokeInTenant(client_id, key, replica_type, "default");
-}
-
-tl::expected<void, ErrorCode> WrappedMasterService::PutRevokeInTenant(
-    const UUID& client_id, const std::string& key, ReplicaType replica_type,
-    const std::string& tenant_id) {
     return execute_rpc(
         "PutRevoke",
-        [&] {
-            return master_service_.PutRevoke(client_id, key, replica_type,
-                                             tenant_id);
-        },
+        [&] { return master_service_.PutRevoke(client_id, key, replica_type); },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", replica_type=", replica_type,
-                             ", tenant_id=", tenant_id);
+                             ", replica_type=", replica_type);
         },
         [] { MasterMetricManager::instance().inc_put_revoke_requests(); },
         [] { MasterMetricManager::instance().inc_put_revoke_failures(); });
@@ -1075,19 +996,9 @@ WrappedMasterService::BatchPutStart(const UUID& client_id,
                                     const std::vector<std::string>& keys,
                                     const std::vector<uint64_t>& slice_lengths,
                                     const ReplicateConfig& config) {
-    return BatchPutStartInTenant(client_id, keys, slice_lengths, config,
-                                 "default");
-}
-
-std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-WrappedMasterService::BatchPutStartInTenant(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    const std::vector<uint64_t>& slice_lengths, const ReplicateConfig& config,
-    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchPutStart");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
-                     ", tenant_id=", tenant_id);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
     MasterMetricManager::instance().inc_batch_put_start_requests(total_keys);
 
     std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
@@ -1098,7 +1009,7 @@ WrappedMasterService::BatchPutStartInTenant(
         ReplicateConfig new_config = config;
         for (size_t i = 0; i < keys.size(); ++i) {
             auto result = master_service_.PutStart(
-                client_id, keys[i], slice_lengths[i], new_config, tenant_id);
+                client_id, keys[i], slice_lengths[i], new_config);
             results.emplace_back(result);
             if ((i == 0) && result.has_value()) {
                 std::string preferred_segment;
@@ -1119,7 +1030,7 @@ WrappedMasterService::BatchPutStartInTenant(
     } else {
         for (size_t i = 0; i < keys.size(); ++i) {
             results.emplace_back(master_service_.PutStart(
-                client_id, keys[i], slice_lengths[i], config, tenant_id));
+                client_id, keys[i], slice_lengths[i], config));
         }
     }
 
@@ -1163,35 +1074,19 @@ WrappedMasterService::BatchPutStartInTenant(
 std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchPutEnd(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
-    return BatchPutEndInTenant(client_id, keys, replica_type, "default");
-}
-
-std::vector<tl::expected<void, ErrorCode>>
-WrappedMasterService::BatchPutEndInTenant(const UUID& client_id,
-                                          const std::vector<std::string>& keys,
-                                          ReplicaType replica_type,
-                                          const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchPutEnd");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
-                     ", tenant_id=", tenant_id);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
     MasterMetricManager::instance().inc_batch_put_end_requests(total_keys);
 
-    std::vector<tl::expected<void, ErrorCode>> results;
-    results.reserve(keys.size());
-
-    for (const auto& key : keys) {
-        results.emplace_back(
-            master_service_.PutEnd(client_id, key, replica_type, tenant_id));
-    }
+    auto results = master_service_.BatchPutEnd(client_id, keys, replica_type);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
         if (!results[i].has_value()) {
             failure_count++;
-            auto error = results[i].error();
             LOG(ERROR) << "BatchPutEnd failed for key[" << i << "] '" << keys[i]
-                       << "': " << toString(error);
+                       << "': " << toString(results[i].error());
         }
     }
 
@@ -1212,34 +1107,20 @@ WrappedMasterService::BatchPutEndInTenant(const UUID& client_id,
 std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchPutRevoke(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
-    return BatchPutRevokeInTenant(client_id, keys, replica_type, "default");
-}
-
-std::vector<tl::expected<void, ErrorCode>>
-WrappedMasterService::BatchPutRevokeInTenant(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    ReplicaType replica_type, const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchPutRevoke");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
-                     ", tenant_id=", tenant_id);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
     MasterMetricManager::instance().inc_batch_put_revoke_requests(total_keys);
 
-    std::vector<tl::expected<void, ErrorCode>> results;
-    results.reserve(keys.size());
-
-    for (const auto& key : keys) {
-        results.emplace_back(
-            master_service_.PutRevoke(client_id, key, replica_type, tenant_id));
-    }
+    auto results =
+        master_service_.BatchPutRevoke(client_id, keys, replica_type);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
         if (!results[i].has_value()) {
             failure_count++;
-            auto error = results[i].error();
             LOG(ERROR) << "BatchPutRevoke failed for key[" << i << "] '"
-                       << keys[i] << "': " << toString(error);
+                       << keys[i] << "': " << toString(results[i].error());
         }
     }
 
@@ -1261,25 +1142,15 @@ tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
 WrappedMasterService::UpsertStart(const UUID& client_id, const std::string& key,
                                   const uint64_t slice_length,
                                   const ReplicateConfig& config) {
-    return UpsertStartInTenant(client_id, key, slice_length, config, "default");
-}
-
-tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
-WrappedMasterService::UpsertStartInTenant(const UUID& client_id,
-                                          const std::string& key,
-                                          const uint64_t slice_length,
-                                          const ReplicateConfig& config,
-                                          const std::string& tenant_id) {
     return execute_rpc(
         "UpsertStart",
         [&] {
             return master_service_.UpsertStart(client_id, key, slice_length,
-                                               config, tenant_id);
+                                               config);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", slice_length=", slice_length,
-                             ", tenant_id=", tenant_id);
+                             ", slice_length=", slice_length);
         },
         [&] { MasterMetricManager::instance().inc_put_start_requests(); },
         [] { MasterMetricManager::instance().inc_put_start_failures(); });
@@ -1287,22 +1158,12 @@ WrappedMasterService::UpsertStartInTenant(const UUID& client_id,
 
 tl::expected<void, ErrorCode> WrappedMasterService::UpsertEnd(
     const UUID& client_id, const std::string& key, ReplicaType replica_type) {
-    return UpsertEndInTenant(client_id, key, replica_type, "default");
-}
-
-tl::expected<void, ErrorCode> WrappedMasterService::UpsertEndInTenant(
-    const UUID& client_id, const std::string& key, ReplicaType replica_type,
-    const std::string& tenant_id) {
     return execute_rpc(
         "UpsertEnd",
-        [&] {
-            return master_service_.UpsertEnd(client_id, key, replica_type,
-                                             tenant_id);
-        },
+        [&] { return master_service_.UpsertEnd(client_id, key, replica_type); },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", replica_type=", replica_type,
-                             ", tenant_id=", tenant_id);
+                             ", replica_type=", replica_type);
         },
         [] { MasterMetricManager::instance().inc_put_end_requests(); },
         [] { MasterMetricManager::instance().inc_put_end_failures(); });
@@ -1310,22 +1171,14 @@ tl::expected<void, ErrorCode> WrappedMasterService::UpsertEndInTenant(
 
 tl::expected<void, ErrorCode> WrappedMasterService::UpsertRevoke(
     const UUID& client_id, const std::string& key, ReplicaType replica_type) {
-    return UpsertRevokeInTenant(client_id, key, replica_type, "default");
-}
-
-tl::expected<void, ErrorCode> WrappedMasterService::UpsertRevokeInTenant(
-    const UUID& client_id, const std::string& key, ReplicaType replica_type,
-    const std::string& tenant_id) {
     return execute_rpc(
         "UpsertRevoke",
         [&] {
-            return master_service_.UpsertRevoke(client_id, key, replica_type,
-                                                tenant_id);
+            return master_service_.UpsertRevoke(client_id, key, replica_type);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", replica_type=", replica_type,
-                             ", tenant_id=", tenant_id);
+                             ", replica_type=", replica_type);
         },
         [] { MasterMetricManager::instance().inc_put_revoke_requests(); },
         [] { MasterMetricManager::instance().inc_put_revoke_failures(); });
@@ -1335,31 +1188,20 @@ std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
 WrappedMasterService::BatchUpsertStart(
     const UUID& client_id, const std::vector<std::string>& keys,
     const std::vector<uint64_t>& slice_lengths, const ReplicateConfig& config) {
-    return BatchUpsertStartInTenant(client_id, keys, slice_lengths, config,
-                                    "default");
-}
-
-std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-WrappedMasterService::BatchUpsertStartInTenant(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    const std::vector<uint64_t>& slice_lengths, const ReplicateConfig& config,
-    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchUpsertStart");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
-                     ", tenant_id=", tenant_id);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
     MasterMetricManager::instance().inc_batch_put_start_requests(total_keys);
 
-    auto results = master_service_.BatchUpsertStart(
-        client_id, keys, slice_lengths, config, tenant_id);
+    auto results = master_service_.BatchUpsertStart(client_id, keys,
+                                                    slice_lengths, config);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
         if (!results[i].has_value()) {
             failure_count++;
-            auto error = results[i].error();
             LOG(ERROR) << "BatchUpsertStart failed for key[" << i << "] '"
-                       << keys[i] << "': " << toString(error);
+                       << keys[i] << "': " << toString(results[i].error());
         }
     }
 
@@ -1379,28 +1221,19 @@ WrappedMasterService::BatchUpsertStartInTenant(
 
 std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchUpsertEnd(
     const UUID& client_id, const std::vector<std::string>& keys) {
-    return BatchUpsertEndInTenant(client_id, keys, "default");
-}
-
-std::vector<tl::expected<void, ErrorCode>>
-WrappedMasterService::BatchUpsertEndInTenant(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchUpsertEnd");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
-                     ", tenant_id=", tenant_id);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
     MasterMetricManager::instance().inc_batch_put_end_requests(total_keys);
 
-    auto results = master_service_.BatchUpsertEnd(client_id, keys, tenant_id);
+    auto results = master_service_.BatchUpsertEnd(client_id, keys);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
         if (!results[i].has_value()) {
             failure_count++;
-            auto error = results[i].error();
             LOG(ERROR) << "BatchUpsertEnd failed for key[" << i << "] '"
-                       << keys[i] << "': " << toString(error);
+                       << keys[i] << "': " << toString(results[i].error());
         }
     }
 
@@ -1421,29 +1254,19 @@ WrappedMasterService::BatchUpsertEndInTenant(
 std::vector<tl::expected<void, ErrorCode>>
 WrappedMasterService::BatchUpsertRevoke(const UUID& client_id,
                                         const std::vector<std::string>& keys) {
-    return BatchUpsertRevokeInTenant(client_id, keys, "default");
-}
-
-std::vector<tl::expected<void, ErrorCode>>
-WrappedMasterService::BatchUpsertRevokeInTenant(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchUpsertRevoke");
     const size_t total_keys = keys.size();
-    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
-                     ", tenant_id=", tenant_id);
+    timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys);
     MasterMetricManager::instance().inc_batch_put_revoke_requests(total_keys);
 
-    auto results =
-        master_service_.BatchUpsertRevoke(client_id, keys, tenant_id);
+    auto results = master_service_.BatchUpsertRevoke(client_id, keys);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
         if (!results[i].has_value()) {
             failure_count++;
-            auto error = results[i].error();
             LOG(ERROR) << "BatchUpsertRevoke failed for key[" << i << "] '"
-                       << keys[i] << "': " << toString(error);
+                       << keys[i] << "': " << toString(results[i].error());
         }
     }
 
@@ -1463,35 +1286,20 @@ WrappedMasterService::BatchUpsertRevokeInTenant(
 
 tl::expected<void, ErrorCode> WrappedMasterService::Remove(
     const std::string& key, bool force) {
-    return RemoveInTenant(key, "default", force);
-}
-
-tl::expected<void, ErrorCode> WrappedMasterService::RemoveInTenant(
-    const std::string& key, const std::string& tenant_id, bool force) {
     return execute_rpc(
-        "RemoveInTenant",
-        [&] { return master_service_.Remove(key, tenant_id, force); },
-        [&](auto& timer) {
-            timer.LogRequest("key=", key, ", tenant_id=", tenant_id,
-                             ", force=", force);
-        },
+        "Remove", [&] { return master_service_.Remove(key, force); },
+        [&](auto& timer) { timer.LogRequest("key=", key, ", force=", force); },
         [] { MasterMetricManager::instance().inc_remove_requests(); },
         [] { MasterMetricManager::instance().inc_remove_failures(); });
 }
 
 tl::expected<long, ErrorCode> WrappedMasterService::RemoveByRegex(
     const std::string& str, bool force) {
-    return RemoveByRegexInTenant(str, "default", force);
-}
-
-tl::expected<long, ErrorCode> WrappedMasterService::RemoveByRegexInTenant(
-    const std::string& str, const std::string& tenant_id, bool force) {
     return execute_rpc(
-        "RemoveByRegexInTenant",
-        [&] { return master_service_.RemoveByRegex(str, tenant_id, force); },
+        "RemoveByRegex",
+        [&] { return master_service_.RemoveByRegex(str, force); },
         [&](auto& timer) {
-            timer.LogRequest("regex=", str, ", tenant_id=", tenant_id,
-                             ", force=", force);
+            timer.LogRequest("regex=", str, ", force=", force);
         },
         [] { MasterMetricManager::instance().inc_remove_by_regex_requests(); },
         [] { MasterMetricManager::instance().inc_remove_by_regex_failures(); });
@@ -1508,20 +1316,12 @@ long WrappedMasterService::RemoveAll(bool force) {
 
 std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchRemove(
     const std::vector<std::string>& keys, bool force) {
-    return BatchRemoveInTenant(keys, "default", force);
-}
-
-std::vector<tl::expected<void, ErrorCode>>
-WrappedMasterService::BatchRemoveInTenant(const std::vector<std::string>& keys,
-                                          const std::string& tenant_id,
-                                          bool force) {
     ScopedVLogTimer timer(1, "BatchRemove");
     const size_t total_keys = keys.size();
-    timer.LogRequest("keys_count=", total_keys, ", tenant_id=", tenant_id,
-                     ", force=", force);
+    timer.LogRequest("keys_count=", total_keys, ", force=", force);
     MasterMetricManager::instance().inc_remove_requests(total_keys);
 
-    auto results = master_service_.BatchRemove(keys, tenant_id, force);
+    auto results = master_service_.BatchRemove(keys, force);
 
     size_t failure_count = 0;
     for (const auto& result : results) {
@@ -1677,27 +1477,16 @@ tl::expected<CopyStartResponse, ErrorCode> WrappedMasterService::CopyStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment,
     const std::vector<std::string>& tgt_segments) {
-    return CopyStartInTenant(client_id, key, src_segment, tgt_segments,
-                             "default");
-}
-
-tl::expected<CopyStartResponse, ErrorCode>
-WrappedMasterService::CopyStartInTenant(
-    const UUID& client_id, const std::string& key,
-    const std::string& src_segment,
-    const std::vector<std::string>& tgt_segments,
-    const std::string& tenant_id) {
     return execute_rpc(
-        "CopyStartInTenant",
+        "CopyStart",
         [&] {
             return master_service_.CopyStart(client_id, key, src_segment,
-                                             tgt_segments, tenant_id);
+                                             tgt_segments);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
                              ", src_segment=", src_segment,
-                             ", tgt_segments_count=", tgt_segments.size(),
-                             ", tenant_id=", tenant_id);
+                             ", tgt_segments_count=", tgt_segments.size());
         },
         [] { MasterMetricManager::instance().inc_copy_start_requests(); },
         [] { MasterMetricManager::instance().inc_copy_start_failures(); });
@@ -1705,18 +1494,10 @@ WrappedMasterService::CopyStartInTenant(
 
 tl::expected<void, ErrorCode> WrappedMasterService::CopyEnd(
     const UUID& client_id, const std::string& key) {
-    return CopyEndInTenant(client_id, key, "default");
-}
-
-tl::expected<void, ErrorCode> WrappedMasterService::CopyEndInTenant(
-    const UUID& client_id, const std::string& key,
-    const std::string& tenant_id) {
     return execute_rpc(
-        "CopyEndInTenant",
-        [&] { return master_service_.CopyEnd(client_id, key, tenant_id); },
+        "CopyEnd", [&] { return master_service_.CopyEnd(client_id, key); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", tenant_id=", tenant_id);
+            timer.LogRequest("client_id=", client_id, ", key=", key);
         },
         [] { MasterMetricManager::instance().inc_copy_end_requests(); },
         [] { MasterMetricManager::instance().inc_copy_end_failures(); });
@@ -1724,18 +1505,11 @@ tl::expected<void, ErrorCode> WrappedMasterService::CopyEndInTenant(
 
 tl::expected<void, ErrorCode> WrappedMasterService::CopyRevoke(
     const UUID& client_id, const std::string& key) {
-    return CopyRevokeInTenant(client_id, key, "default");
-}
-
-tl::expected<void, ErrorCode> WrappedMasterService::CopyRevokeInTenant(
-    const UUID& client_id, const std::string& key,
-    const std::string& tenant_id) {
     return execute_rpc(
-        "CopyRevokeInTenant",
-        [&] { return master_service_.CopyRevoke(client_id, key, tenant_id); },
+        "CopyRevoke",
+        [&] { return master_service_.CopyRevoke(client_id, key); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", tenant_id=", tenant_id);
+            timer.LogRequest("client_id=", client_id, ", key=", key);
         },
         [] { MasterMetricManager::instance().inc_copy_revoke_requests(); },
         [] { MasterMetricManager::instance().inc_copy_revoke_failures(); });
@@ -1744,27 +1518,16 @@ tl::expected<void, ErrorCode> WrappedMasterService::CopyRevokeInTenant(
 tl::expected<MoveStartResponse, ErrorCode> WrappedMasterService::MoveStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment, const std::string& tgt_segment) {
-    return MoveStartInTenant(client_id, key, src_segment, tgt_segment,
-                             "default");
-}
-
-tl::expected<MoveStartResponse, ErrorCode>
-WrappedMasterService::MoveStartInTenant(const UUID& client_id,
-                                        const std::string& key,
-                                        const std::string& src_segment,
-                                        const std::string& tgt_segment,
-                                        const std::string& tenant_id) {
     return execute_rpc(
-        "MoveStartInTenant",
+        "MoveStart",
         [&] {
             return master_service_.MoveStart(client_id, key, src_segment,
-                                             tgt_segment, tenant_id);
+                                             tgt_segment);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
                              ", src_segment=", src_segment,
-                             ", tgt_segment=", tgt_segment,
-                             ", tenant_id=", tenant_id);
+                             ", tgt_segment=", tgt_segment);
         },
         [] { MasterMetricManager::instance().inc_move_start_requests(); },
         [] { MasterMetricManager::instance().inc_move_start_failures(); });
@@ -1772,18 +1535,10 @@ WrappedMasterService::MoveStartInTenant(const UUID& client_id,
 
 tl::expected<void, ErrorCode> WrappedMasterService::MoveEnd(
     const UUID& client_id, const std::string& key) {
-    return MoveEndInTenant(client_id, key, "default");
-}
-
-tl::expected<void, ErrorCode> WrappedMasterService::MoveEndInTenant(
-    const UUID& client_id, const std::string& key,
-    const std::string& tenant_id) {
     return execute_rpc(
-        "MoveEndInTenant",
-        [&] { return master_service_.MoveEnd(client_id, key, tenant_id); },
+        "MoveEnd", [&] { return master_service_.MoveEnd(client_id, key); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", tenant_id=", tenant_id);
+            timer.LogRequest("client_id=", client_id, ", key=", key);
         },
         [] { MasterMetricManager::instance().inc_move_end_requests(); },
         [] { MasterMetricManager::instance().inc_move_end_failures(); });
@@ -1791,18 +1546,11 @@ tl::expected<void, ErrorCode> WrappedMasterService::MoveEndInTenant(
 
 tl::expected<void, ErrorCode> WrappedMasterService::MoveRevoke(
     const UUID& client_id, const std::string& key) {
-    return MoveRevokeInTenant(client_id, key, "default");
-}
-
-tl::expected<void, ErrorCode> WrappedMasterService::MoveRevokeInTenant(
-    const UUID& client_id, const std::string& key,
-    const std::string& tenant_id) {
     return execute_rpc(
-        "MoveRevokeInTenant",
-        [&] { return master_service_.MoveRevoke(client_id, key, tenant_id); },
+        "MoveRevoke",
+        [&] { return master_service_.MoveRevoke(client_id, key); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", tenant_id=", tenant_id);
+            timer.LogRequest("client_id=", client_id, ", key=", key);
         },
         [] { MasterMetricManager::instance().inc_move_revoke_requests(); },
         [] { MasterMetricManager::instance().inc_move_revoke_failures(); });
@@ -1810,22 +1558,15 @@ tl::expected<void, ErrorCode> WrappedMasterService::MoveRevokeInTenant(
 
 tl::expected<void, ErrorCode> WrappedMasterService::EvictDiskReplica(
     const UUID& client_id, const std::string& key, ReplicaType replica_type) {
-    return EvictDiskReplicaInTenant(client_id, key, replica_type, "default");
-}
-
-tl::expected<void, ErrorCode> WrappedMasterService::EvictDiskReplicaInTenant(
-    const UUID& client_id, const std::string& key, ReplicaType replica_type,
-    const std::string& tenant_id) {
     return execute_rpc(
-        "EvictDiskReplicaInTenant",
+        "EvictDiskReplica",
         [&] {
             return master_service_.EvictDiskReplica(client_id, key,
-                                                    replica_type, tenant_id);
+                                                    replica_type);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
-                             ", replica_type=", replica_type,
-                             ", tenant_id=", tenant_id);
+                             ", replica_type=", replica_type);
         },
         [] {
             MasterMetricManager::instance().inc_evict_disk_replica_requests();
@@ -1839,23 +1580,14 @@ std::vector<tl::expected<void, ErrorCode>>
 WrappedMasterService::BatchEvictDiskReplica(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
-    return BatchEvictDiskReplicaInTenant(client_id, keys, replica_type,
-                                         "default");
-}
-
-std::vector<tl::expected<void, ErrorCode>>
-WrappedMasterService::BatchEvictDiskReplicaInTenant(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    ReplicaType replica_type, const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "BatchEvictDiskReplica");
     const size_t total_keys = keys.size();
     timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
-                     ", replica_type=", replica_type,
-                     ", tenant_id=", tenant_id);
+                     ", replica_type=", replica_type);
     MasterMetricManager::instance().inc_evict_disk_replica_requests();
 
-    auto results = master_service_.BatchEvictDiskReplica(
-        client_id, keys, replica_type, tenant_id);
+    auto results =
+        master_service_.BatchEvictDiskReplica(client_id, keys, replica_type);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
@@ -1878,18 +1610,11 @@ WrappedMasterService::BatchEvictDiskReplicaInTenant(
 
 tl::expected<UUID, ErrorCode> WrappedMasterService::CreateCopyTask(
     const std::string& key, const std::vector<std::string>& targets) {
-    return CreateCopyTaskInTenant(key, targets, "default");
-}
-
-tl::expected<UUID, ErrorCode> WrappedMasterService::CreateCopyTaskInTenant(
-    const std::string& key, const std::vector<std::string>& targets,
-    const std::string& tenant_id) {
     return execute_rpc(
-        "CreateCopyTaskInTenant",
-        [&] { return master_service_.CreateCopyTask(key, targets, tenant_id); },
+        "CreateCopyTask",
+        [&] { return master_service_.CreateCopyTask(key, targets); },
         [&](auto& timer) {
-            timer.LogRequest("key=", key, ", targets_size=", targets.size(),
-                             ", tenant_id=", tenant_id);
+            timer.LogRequest("key=", key, ", targets_size=", targets.size());
         },
         [] { MasterMetricManager::instance().inc_create_copy_task_requests(); },
         [] {
@@ -1900,21 +1625,12 @@ tl::expected<UUID, ErrorCode> WrappedMasterService::CreateCopyTaskInTenant(
 tl::expected<UUID, ErrorCode> WrappedMasterService::CreateMoveTask(
     const std::string& key, const std::string& source,
     const std::string& target) {
-    return CreateMoveTaskInTenant(key, source, target, "default");
-}
-
-tl::expected<UUID, ErrorCode> WrappedMasterService::CreateMoveTaskInTenant(
-    const std::string& key, const std::string& source,
-    const std::string& target, const std::string& tenant_id) {
     return execute_rpc(
-        "CreateMoveTaskInTenant",
-        [&] {
-            return master_service_.CreateMoveTask(key, source, target,
-                                                  tenant_id);
-        },
+        "CreateMoveTask",
+        [&] { return master_service_.CreateMoveTask(key, source, target); },
         [&](auto& timer) {
             timer.LogRequest("key=", key, ", source=", source,
-                             ", target=", target, ", tenant_id=", tenant_id);
+                             ", target=", target);
         },
         [] { MasterMetricManager::instance().inc_create_move_task_requests(); },
         [] {
@@ -2125,98 +1841,65 @@ void RegisterRpcService(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchReplicaClear>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::BatchReplicaClearInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<
         &mooncake::WrappedMasterService::GetReplicaListByRegex>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::GetReplicaListByRegexInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::GetReplicaList>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::GetReplicaListInTenant>(
-        &wrapped_master_service);
+
     server
         .register_handler<&mooncake::WrappedMasterService::BatchGetReplicaList>(
             &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::BatchGetReplicaListInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::PutStart>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::PutStartInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::PutEnd>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::PutEndInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::PutRevoke>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::PutRevokeInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::BatchPutStart>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::BatchPutStartInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::BatchPutEnd>(
         &wrapped_master_service);
-    server
-        .register_handler<&mooncake::WrappedMasterService::BatchPutEndInTenant>(
-            &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::BatchPutRevoke>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::BatchPutRevokeInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::UpsertStart>(
         &wrapped_master_service);
-    server
-        .register_handler<&mooncake::WrappedMasterService::UpsertStartInTenant>(
-            &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::UpsertEnd>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::UpsertEndInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::UpsertRevoke>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::UpsertRevokeInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::BatchUpsertStart>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::BatchUpsertStartInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::BatchUpsertEnd>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::BatchUpsertEndInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::BatchUpsertRevoke>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::BatchUpsertRevokeInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::Remove>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::RemoveInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::RemoveByRegex>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::RemoveByRegexInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::RemoveAll>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchRemove>(
         &wrapped_master_service);
-    server
-        .register_handler<&mooncake::WrappedMasterService::BatchRemoveInTenant>(
-            &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::MountSegment>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::MountNoFSegment>(
@@ -2278,51 +1961,35 @@ void RegisterRpcService(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::CopyStart>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::CopyStartInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::CopyEnd>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::CopyEndInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::CopyRevoke>(
         &wrapped_master_service);
-    server
-        .register_handler<&mooncake::WrappedMasterService::CopyRevokeInTenant>(
-            &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::MoveStart>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::MoveStartInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::MoveEnd>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::MoveEndInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::MoveRevoke>(
         &wrapped_master_service);
-    server
-        .register_handler<&mooncake::WrappedMasterService::MoveRevokeInTenant>(
-            &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::EvictDiskReplica>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::EvictDiskReplicaInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<
         &mooncake::WrappedMasterService::BatchEvictDiskReplica>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::BatchEvictDiskReplicaInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::CreateCopyTask>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::CreateCopyTaskInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::CreateMoveTask>(
         &wrapped_master_service);
-    server.register_handler<
-        &mooncake::WrappedMasterService::CreateMoveTaskInTenant>(
-        &wrapped_master_service);
+
     server.register_handler<&mooncake::WrappedMasterService::QueryTask>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::FetchTasks>(

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
@@ -2369,8 +2369,14 @@ TEST_F(MasterServiceSnapshotTest, OffloadObjectHeartbeat) {
     }
     ASSERT_EQ(res->size(), keys.size());
     for (auto& key : keys) {
-        ASSERT_TRUE(res.value().find(key) != res.value().end());
-        ASSERT_EQ(res.value().find(key)->second, 1024);
+        const auto storage_key = BuildTenantScopedKey("default", key);
+        auto it = res.value().find(storage_key);
+        ASSERT_TRUE(it != res.value().end());
+        ASSERT_EQ(it->second, 1024);
+        auto parsed = ParseTenantScopedKey(storage_key);
+        ASSERT_TRUE(parsed.has_value());
+        ASSERT_EQ(parsed->tenant_id, "default");
+        ASSERT_EQ(parsed->user_key, key);
     }
 
     keys.clear();
@@ -2386,8 +2392,10 @@ TEST_F(MasterServiceSnapshotTest, OffloadObjectHeartbeat) {
     }
     ASSERT_EQ(res->size(), keys.size());
     for (auto& key : keys) {
-        ASSERT_TRUE(res.value().find(key) != res.value().end());
-        ASSERT_EQ(res.value().find(key)->second, 1024);
+        const auto storage_key = BuildTenantScopedKey("default", key);
+        auto it = res.value().find(storage_key);
+        ASSERT_TRUE(it != res.value().end());
+        ASSERT_EQ(it->second, 1024);
     }
 }
 

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -155,10 +155,12 @@ class SnapshotChildProcessTest : public ::testing::Test {
 
     // Check if a key exists in raw metadata (regardless of replica status)
     bool KeyExistsInMetadata(MasterService* svc, const std::string& key) {
-        size_t shard_idx = svc->getShardIndex(key);
+        const auto resolved_key = MasterService::ResolveObjectKey(key);
+        size_t shard_idx = svc->getShardIndex(resolved_key.storage_key);
         auto& shard = svc->metadata_shards_[shard_idx];
         SharedMutexLocker lock(&shard.mutex, shared_lock_t{});
-        return shard.metadata.find(key) != shard.metadata.end();
+        return shard.metadata.find(resolved_key.storage_key) !=
+               shard.metadata.end();
     }
 
    private:

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -176,28 +176,27 @@ TEST_F(MasterServiceTest, TenantScopedKeysAllowSameUserKeyIsolation) {
     const UUID client_a = generate_uuid();
     const UUID client_b = generate_uuid();
     const std::string key = "shared_user_key";
+    const std::string tenant_a_key = BuildTenantScopedKey("tenant_a", key);
+    const std::string tenant_b_key = BuildTenantScopedKey("tenant_b", key);
     const uint64_t value_length = 1024;
 
     ReplicateConfig config;
     config.replica_num = 1;
 
-    ASSERT_TRUE(
-        service->PutStart(client_a, key, value_length, config, "tenant_a")
-            .has_value());
-    ASSERT_TRUE(service->PutEnd(client_a, key, ReplicaType::MEMORY, "tenant_a")
+    ASSERT_TRUE(service->PutStart(client_a, tenant_a_key, value_length, config)
+                    .has_value());
+    ASSERT_TRUE(service->PutEnd(client_a, tenant_a_key, ReplicaType::MEMORY)
                     .has_value());
 
-    ASSERT_FALSE(
-        service->PutStart(client_a, key, value_length, config, "tenant_a")
-            .has_value());
-    ASSERT_TRUE(
-        service->PutStart(client_b, key, value_length, config, "tenant_b")
-            .has_value());
-    ASSERT_TRUE(service->PutEnd(client_b, key, ReplicaType::MEMORY, "tenant_b")
+    ASSERT_FALSE(service->PutStart(client_a, tenant_a_key, value_length, config)
+                     .has_value());
+    ASSERT_TRUE(service->PutStart(client_b, tenant_b_key, value_length, config)
+                    .has_value());
+    ASSERT_TRUE(service->PutEnd(client_b, tenant_b_key, ReplicaType::MEMORY)
                     .has_value());
 
-    EXPECT_TRUE(service->GetReplicaList(key, "tenant_a").has_value());
-    EXPECT_TRUE(service->GetReplicaList(key, "tenant_b").has_value());
+    EXPECT_TRUE(service->GetReplicaList(tenant_a_key).has_value());
+    EXPECT_TRUE(service->GetReplicaList(tenant_b_key).has_value());
     EXPECT_EQ(service->GetReplicaList(key).error(),
               ErrorCode::OBJECT_NOT_FOUND);
 
@@ -206,10 +205,10 @@ TEST_F(MasterServiceTest, TenantScopedKeysAllowSameUserKeyIsolation) {
     ASSERT_EQ(regex_a->size(), 1);
     EXPECT_TRUE(regex_a->contains(key));
 
-    ASSERT_TRUE(service->Remove(key, "tenant_a", true).has_value());
-    EXPECT_EQ(service->GetReplicaList(key, "tenant_a").error(),
+    ASSERT_TRUE(service->Remove(tenant_a_key, true).has_value());
+    EXPECT_EQ(service->GetReplicaList(tenant_a_key).error(),
               ErrorCode::OBJECT_NOT_FOUND);
-    EXPECT_TRUE(service->GetReplicaList(key, "tenant_b").has_value());
+    EXPECT_TRUE(service->GetReplicaList(tenant_b_key).has_value());
 }
 
 TEST_F(MasterServiceTest, TenantScopedCopyMoveUseClientTenant) {
@@ -220,44 +219,39 @@ TEST_F(MasterServiceTest, TenantScopedCopyMoveUseClientTenant) {
 
     const UUID client_id = generate_uuid();
     const std::string tenant_id = "tenant_a";
+    const std::string copy_key = BuildTenantScopedKey(tenant_id, "copy_key");
+    const std::string move_key = BuildTenantScopedKey(tenant_id, "move_key");
 
     ReplicateConfig config;
     config.replica_num = 1;
     config.preferred_segment = "segment_1";
 
     ASSERT_TRUE(
-        service->PutStart(client_id, "copy_key", 1024, config, tenant_id)
-            .has_value());
+        service->PutStart(client_id, copy_key, 1024, config).has_value());
     ASSERT_TRUE(
-        service->PutEnd(client_id, "copy_key", ReplicaType::MEMORY, tenant_id)
-            .has_value());
+        service->PutEnd(client_id, copy_key, ReplicaType::MEMORY).has_value());
     EXPECT_EQ(
         service->CopyStart(client_id, "copy_key", "segment_1", {"segment_2"})
             .error(),
         ErrorCode::OBJECT_NOT_FOUND);
-    ASSERT_TRUE(service
-                    ->CopyStart(client_id, "copy_key", "segment_1",
-                                {"segment_2"}, tenant_id)
-                    .has_value());
-    ASSERT_TRUE(service->CopyEnd(client_id, "copy_key", tenant_id).has_value());
+    ASSERT_TRUE(
+        service->CopyStart(client_id, copy_key, "segment_1", {"segment_2"})
+            .has_value());
+    ASSERT_TRUE(service->CopyEnd(client_id, copy_key).has_value());
 
     ASSERT_TRUE(
-        service->PutStart(client_id, "move_key", 1024, config, tenant_id)
-            .has_value());
+        service->PutStart(client_id, move_key, 1024, config).has_value());
     ASSERT_TRUE(
-        service->PutEnd(client_id, "move_key", ReplicaType::MEMORY, tenant_id)
-            .has_value());
+        service->PutEnd(client_id, move_key, ReplicaType::MEMORY).has_value());
     EXPECT_EQ(
         service->CreateMoveTask("move_key", "segment_1", "segment_3").error(),
         ErrorCode::OBJECT_NOT_FOUND);
-    ASSERT_TRUE(
-        service->CreateMoveTask("move_key", "segment_1", "segment_3", tenant_id)
-            .has_value());
-    ASSERT_TRUE(service
-                    ->MoveStart(client_id, "move_key", "segment_1", "segment_3",
-                                tenant_id)
+    ASSERT_TRUE(service->CreateMoveTask(move_key, "segment_1", "segment_3")
                     .has_value());
-    ASSERT_TRUE(service->MoveEnd(client_id, "move_key", tenant_id).has_value());
+    ASSERT_TRUE(
+        service->MoveStart(client_id, move_key, "segment_1", "segment_3")
+            .has_value());
+    ASSERT_TRUE(service->MoveEnd(client_id, move_key).has_value());
 }
 
 TEST_F(MasterServiceTest, TenantScopedReplicaTasksCarryStorageKey) {
@@ -277,16 +271,13 @@ TEST_F(MasterServiceTest, TenantScopedReplicaTasksCarryStorageKey) {
     config.replica_num = 1;
     config.preferred_segment = "segment_1";
 
+    ASSERT_TRUE(service->PutStart(client_id, expected_copy_key, 1024, config)
+                    .has_value());
     ASSERT_TRUE(
-        service->PutStart(client_id, "copy_task_key", 1024, config, tenant_id)
+        service->PutEnd(client_id, expected_copy_key, ReplicaType::MEMORY)
             .has_value());
     ASSERT_TRUE(
-        service
-            ->PutEnd(client_id, "copy_task_key", ReplicaType::MEMORY, tenant_id)
-            .has_value());
-    ASSERT_TRUE(
-        service->CreateCopyTask("copy_task_key", {"segment_2"}, tenant_id)
-            .has_value());
+        service->CreateCopyTask(expected_copy_key, {"segment_2"}).has_value());
 
     auto copy_tasks = service->FetchTasks(ctx1.client_id, 1);
     ASSERT_TRUE(copy_tasks.has_value());
@@ -300,17 +291,14 @@ TEST_F(MasterServiceTest, TenantScopedReplicaTasksCarryStorageKey) {
                     .has_value());
     EXPECT_TRUE(service->CopyEnd(ctx1.client_id, copy_payload.key).has_value());
 
-    ASSERT_TRUE(
-        service->PutStart(client_id, "move_task_key", 1024, config, tenant_id)
-            .has_value());
-    ASSERT_TRUE(
-        service
-            ->PutEnd(client_id, "move_task_key", ReplicaType::MEMORY, tenant_id)
-            .has_value());
-    ASSERT_TRUE(service
-                    ->CreateMoveTask("move_task_key", "segment_1", "segment_3",
-                                     tenant_id)
+    ASSERT_TRUE(service->PutStart(client_id, expected_move_key, 1024, config)
                     .has_value());
+    ASSERT_TRUE(
+        service->PutEnd(client_id, expected_move_key, ReplicaType::MEMORY)
+            .has_value());
+    ASSERT_TRUE(
+        service->CreateMoveTask(expected_move_key, "segment_1", "segment_3")
+            .has_value());
 
     auto move_tasks = service->FetchTasks(ctx1.client_id, 1);
     ASSERT_TRUE(move_tasks.has_value());
@@ -4610,10 +4598,10 @@ TEST_F(MasterServiceTest, TenantScopedDrainJobSchedulesScopedMoveTask) {
     ReplicateConfig config;
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
-    ASSERT_TRUE(service_->PutStart(put_client_id, key, 1024, config, tenant_id)
+    ASSERT_TRUE(service_->PutStart(put_client_id, storage_key, 1024, config)
                     .has_value());
     ASSERT_TRUE(
-        service_->PutEnd(put_client_id, key, ReplicaType::MEMORY, tenant_id)
+        service_->PutEnd(put_client_id, storage_key, ReplicaType::MEMORY)
             .has_value());
 
     CreateDrainJobRequest request;
@@ -4656,7 +4644,7 @@ TEST_F(MasterServiceTest, TenantScopedDrainJobSchedulesScopedMoveTask) {
         return query.has_value() && query->status == JobStatus::SUCCEEDED;
     });
 
-    auto replicas = service_->GetReplicaList(key, tenant_id);
+    auto replicas = service_->GetReplicaList(storage_key);
     ASSERT_TRUE(replicas.has_value());
     std::unordered_set<std::string> segment_names;
     for (const auto& replica : replicas->replicas) {

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <limits>
 #include <memory>
 #include <random>
 #include <thread>
@@ -169,6 +170,22 @@ class MasterServiceTest : public ::testing::Test {
     void TearDown() override { google::ShutdownGoogleLogging(); }
 };
 
+TEST_F(MasterServiceTest, ParseTenantScopedKeyRejectsMalformedPrefixes) {
+    const auto normal =
+        ParseTenantScopedKey(BuildTenantScopedKey("tenant_a", "user:key"));
+    ASSERT_TRUE(normal.has_value());
+    EXPECT_EQ(normal->tenant_id, "tenant_a");
+    EXPECT_EQ(normal->user_key, "user:key");
+
+    EXPECT_FALSE(
+        ParseTenantScopedKey("999999999999999999999999999999:x").has_value());
+    EXPECT_FALSE(ParseTenantScopedKey(
+                     std::to_string(std::numeric_limits<size_t>::max()) + "0:x")
+                     .has_value());
+    EXPECT_FALSE(ParseTenantScopedKey("8:tenant_a").has_value());
+    EXPECT_FALSE(ParseTenantScopedKey("8:tenant").has_value());
+}
+
 TEST_F(MasterServiceTest, TenantScopedKeysAllowSameUserKeyIsolation) {
     auto service = std::make_unique<MasterService>();
     PrepareSimpleSegment(*service);
@@ -264,6 +281,48 @@ TEST_F(MasterServiceTest, TenantRegexAlternationDoesNotCrossTenants) {
     EXPECT_EQ(service->GetReplicaList(tenant_a_foo).error(),
               ErrorCode::OBJECT_NOT_FOUND);
     EXPECT_TRUE(service->GetReplicaList(tenant_b_bar).has_value());
+}
+
+TEST_F(MasterServiceTest, LegacyRegexOnlyMatchesDefaultTenantUserKeys) {
+    auto service = std::make_unique<MasterService>();
+    PrepareSimpleSegment(*service);
+
+    const UUID client_id = generate_uuid();
+    const std::string default_key = "default_key";
+    const std::string tenant_key = BuildTenantScopedKey("tenantA", "foo");
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    ASSERT_TRUE(
+        service->PutStart(client_id, default_key, 1024, config).has_value());
+    ASSERT_TRUE(service->PutEnd(client_id, default_key, ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(
+        service->PutStart(client_id, tenant_key, 1024, config).has_value());
+    ASSERT_TRUE(service->PutEnd(client_id, tenant_key, ReplicaType::MEMORY)
+                    .has_value());
+
+    auto legacy_matches = service->GetReplicaListByRegex("^7:tenantA:");
+    ASSERT_TRUE(legacy_matches.has_value());
+    EXPECT_TRUE(legacy_matches->empty());
+
+    auto tenant_matches = service->GetReplicaListByRegex("^foo$", "tenantA");
+    ASSERT_TRUE(tenant_matches.has_value());
+    ASSERT_EQ(tenant_matches->size(), 1);
+    EXPECT_TRUE(tenant_matches->contains("foo"));
+
+    auto legacy_removed = service->RemoveByRegex("^7:tenantA:", true);
+    ASSERT_TRUE(legacy_removed.has_value());
+    EXPECT_EQ(*legacy_removed, 0);
+    EXPECT_TRUE(service->GetReplicaList(tenant_key).has_value());
+
+    auto default_removed = service->RemoveByRegex("^default_key$", true);
+    ASSERT_TRUE(default_removed.has_value());
+    EXPECT_EQ(*default_removed, 1);
+    EXPECT_EQ(service->GetReplicaList(default_key).error(),
+              ErrorCode::OBJECT_NOT_FOUND);
+    EXPECT_TRUE(service->GetReplicaList(tenant_key).has_value());
 }
 
 TEST_F(MasterServiceTest, TenantScopedCopyMoveUseClientTenant) {
@@ -5295,6 +5354,14 @@ TEST_F(MasterServiceTest, BatchUpsertStart) {
     ASSERT_EQ(2, end_results.size());
     EXPECT_TRUE(end_results[0].has_value());
     EXPECT_TRUE(end_results[1].has_value());
+
+    auto mismatch_results =
+        service_->BatchUpsertStart(client_id, keys, {1024}, config);
+    ASSERT_EQ(keys.size(), mismatch_results.size());
+    for (const auto& result : mismatch_results) {
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
+    }
 }
 
 TEST_F(MasterServiceTest, UpsertPreemptsInProgressUpsert) {

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -211,6 +211,61 @@ TEST_F(MasterServiceTest, TenantScopedKeysAllowSameUserKeyIsolation) {
     EXPECT_TRUE(service->GetReplicaList(tenant_b_key).has_value());
 }
 
+TEST_F(MasterServiceTest, TenantScopedUserKeyMayLookLikeStorageKey) {
+    auto service = std::make_unique<MasterService>();
+    PrepareSimpleSegment(*service);
+
+    const UUID client_id = generate_uuid();
+    const std::string user_key = "1:a:b";
+    const std::string storage_key = BuildTenantScopedKey("tenant_x", user_key);
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    ASSERT_TRUE(
+        service->PutStart(client_id, storage_key, 1024, config).has_value());
+    ASSERT_TRUE(service->PutEnd(client_id, storage_key, ReplicaType::MEMORY)
+                    .has_value());
+
+    EXPECT_TRUE(service->GetReplicaList(storage_key).has_value());
+    EXPECT_EQ(service->GetReplicaList(user_key).error(),
+              ErrorCode::OBJECT_NOT_FOUND);
+}
+
+TEST_F(MasterServiceTest, TenantRegexAlternationDoesNotCrossTenants) {
+    auto service = std::make_unique<MasterService>();
+    PrepareSimpleSegment(*service);
+
+    const UUID client_a = generate_uuid();
+    const UUID client_b = generate_uuid();
+    const std::string tenant_a_foo = BuildTenantScopedKey("tenant_a", "foo");
+    const std::string tenant_b_bar = BuildTenantScopedKey("tenant_b", "bar");
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    ASSERT_TRUE(
+        service->PutStart(client_a, tenant_a_foo, 1024, config).has_value());
+    ASSERT_TRUE(service->PutEnd(client_a, tenant_a_foo, ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(
+        service->PutStart(client_b, tenant_b_bar, 1024, config).has_value());
+    ASSERT_TRUE(service->PutEnd(client_b, tenant_b_bar, ReplicaType::MEMORY)
+                    .has_value());
+
+    auto matches = service->GetReplicaListByRegex("^foo|bar", "tenant_a");
+    ASSERT_TRUE(matches.has_value());
+    EXPECT_TRUE(matches->contains("foo"));
+    EXPECT_FALSE(matches->contains("bar"));
+
+    auto removed = service->RemoveByRegex("^foo|bar", "tenant_a", true);
+    ASSERT_TRUE(removed.has_value());
+    EXPECT_EQ(*removed, 1);
+    EXPECT_EQ(service->GetReplicaList(tenant_a_foo).error(),
+              ErrorCode::OBJECT_NOT_FOUND);
+    EXPECT_TRUE(service->GetReplicaList(tenant_b_bar).has_value());
+}
+
 TEST_F(MasterServiceTest, TenantScopedCopyMoveUseClientTenant) {
     auto service = std::make_unique<MasterService>();
     PrepareSimpleSegment(*service, "segment_1");

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -169,6 +169,97 @@ class MasterServiceTest : public ::testing::Test {
     void TearDown() override { google::ShutdownGoogleLogging(); }
 };
 
+TEST_F(MasterServiceTest, TenantScopedKeysAllowSameUserKeyIsolation) {
+    auto service = std::make_unique<MasterService>();
+    PrepareSimpleSegment(*service);
+
+    const UUID client_a = generate_uuid();
+    const UUID client_b = generate_uuid();
+    const std::string key = "shared_user_key";
+    const uint64_t value_length = 1024;
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    ASSERT_TRUE(
+        service->PutStart(client_a, key, value_length, config, "tenant_a")
+            .has_value());
+    ASSERT_TRUE(service->PutEnd(client_a, key, ReplicaType::MEMORY, "tenant_a")
+                    .has_value());
+
+    ASSERT_FALSE(
+        service->PutStart(client_a, key, value_length, config, "tenant_a")
+            .has_value());
+    ASSERT_TRUE(
+        service->PutStart(client_b, key, value_length, config, "tenant_b")
+            .has_value());
+    ASSERT_TRUE(service->PutEnd(client_b, key, ReplicaType::MEMORY, "tenant_b")
+                    .has_value());
+
+    EXPECT_TRUE(service->GetReplicaList(key, "tenant_a").has_value());
+    EXPECT_TRUE(service->GetReplicaList(key, "tenant_b").has_value());
+    EXPECT_EQ(service->GetReplicaList(key).error(),
+              ErrorCode::OBJECT_NOT_FOUND);
+
+    auto regex_a = service->GetReplicaListByRegex("shared_.*", "tenant_a");
+    ASSERT_TRUE(regex_a.has_value());
+    ASSERT_EQ(regex_a->size(), 1);
+    EXPECT_TRUE(regex_a->contains(key));
+
+    ASSERT_TRUE(service->Remove(key, "tenant_a", true).has_value());
+    EXPECT_EQ(service->GetReplicaList(key, "tenant_a").error(),
+              ErrorCode::OBJECT_NOT_FOUND);
+    EXPECT_TRUE(service->GetReplicaList(key, "tenant_b").has_value());
+}
+
+TEST_F(MasterServiceTest, TenantScopedCopyMoveUseClientTenant) {
+    auto service = std::make_unique<MasterService>();
+    PrepareSimpleSegment(*service, "segment_1");
+    PrepareSimpleSegment(*service, "segment_2");
+    PrepareSimpleSegment(*service, "segment_3");
+
+    const UUID client_id = generate_uuid();
+    const std::string tenant_id = "tenant_a";
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.preferred_segment = "segment_1";
+
+    ASSERT_TRUE(
+        service->PutStart(client_id, "copy_key", 1024, config, tenant_id)
+            .has_value());
+    ASSERT_TRUE(
+        service->PutEnd(client_id, "copy_key", ReplicaType::MEMORY, tenant_id)
+            .has_value());
+    EXPECT_EQ(
+        service->CopyStart(client_id, "copy_key", "segment_1", {"segment_2"})
+            .error(),
+        ErrorCode::OBJECT_NOT_FOUND);
+    ASSERT_TRUE(service
+                    ->CopyStart(client_id, "copy_key", "segment_1",
+                                {"segment_2"}, tenant_id)
+                    .has_value());
+    ASSERT_TRUE(service->CopyEnd(client_id, "copy_key", tenant_id).has_value());
+
+    ASSERT_TRUE(
+        service->PutStart(client_id, "move_key", 1024, config, tenant_id)
+            .has_value());
+    ASSERT_TRUE(
+        service->PutEnd(client_id, "move_key", ReplicaType::MEMORY, tenant_id)
+            .has_value());
+    EXPECT_EQ(
+        service->CreateMoveTask("move_key", "segment_1", "segment_3").error(),
+        ErrorCode::OBJECT_NOT_FOUND);
+    ASSERT_TRUE(
+        service->CreateMoveTask("move_key", "segment_1", "segment_3", tenant_id)
+            .has_value());
+    ASSERT_TRUE(service
+                    ->MoveStart(client_id, "move_key", "segment_1", "segment_3",
+                                tenant_id)
+                    .has_value());
+    ASSERT_TRUE(service->MoveEnd(client_id, "move_key", tenant_id).has_value());
+}
+
 std::string GenerateKeyForSegment(const UUID& client_id,
                                   const std::unique_ptr<MasterService>& service,
                                   const std::string& segment_name) {
@@ -3544,8 +3635,14 @@ TEST_F(MasterServiceTest, OffloadObjectHeartbeat) {
     }
     ASSERT_EQ(res->size(), keys.size());
     for (auto& key : keys) {
-        ASSERT_TRUE(res.value().find(key) != res.value().end());
-        ASSERT_EQ(res.value().find(key)->second, 1024);
+        const auto storage_key = BuildTenantScopedKey("default", key);
+        auto it = res.value().find(storage_key);
+        ASSERT_TRUE(it != res.value().end());
+        ASSERT_EQ(it->second, 1024);
+        auto parsed = ParseTenantScopedKey(storage_key);
+        ASSERT_TRUE(parsed.has_value());
+        ASSERT_EQ(parsed->tenant_id, "default");
+        ASSERT_EQ(parsed->user_key, key);
     }
 
     keys.clear();
@@ -3561,8 +3658,10 @@ TEST_F(MasterServiceTest, OffloadObjectHeartbeat) {
     }
     ASSERT_EQ(res->size(), keys.size());
     for (auto& key : keys) {
-        ASSERT_TRUE(res.value().find(key) != res.value().end());
-        ASSERT_EQ(res.value().find(key)->second, 1024);
+        const auto storage_key = BuildTenantScopedKey("default", key);
+        auto it = res.value().find(storage_key);
+        ASSERT_TRUE(it != res.value().end());
+        ASSERT_EQ(it->second, 1024);
     }
 }
 

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -260,6 +260,71 @@ TEST_F(MasterServiceTest, TenantScopedCopyMoveUseClientTenant) {
     ASSERT_TRUE(service->MoveEnd(client_id, "move_key", tenant_id).has_value());
 }
 
+TEST_F(MasterServiceTest, TenantScopedReplicaTasksCarryStorageKey) {
+    auto service = std::make_unique<MasterService>();
+    const auto ctx1 = PrepareSimpleSegment(*service, "segment_1");
+    PrepareSimpleSegment(*service, "segment_2");
+    PrepareSimpleSegment(*service, "segment_3");
+
+    const UUID client_id = generate_uuid();
+    const std::string tenant_id = "tenant_a";
+    const std::string expected_copy_key =
+        BuildTenantScopedKey(tenant_id, "copy_task_key");
+    const std::string expected_move_key =
+        BuildTenantScopedKey(tenant_id, "move_task_key");
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.preferred_segment = "segment_1";
+
+    ASSERT_TRUE(
+        service->PutStart(client_id, "copy_task_key", 1024, config, tenant_id)
+            .has_value());
+    ASSERT_TRUE(
+        service
+            ->PutEnd(client_id, "copy_task_key", ReplicaType::MEMORY, tenant_id)
+            .has_value());
+    ASSERT_TRUE(
+        service->CreateCopyTask("copy_task_key", {"segment_2"}, tenant_id)
+            .has_value());
+
+    auto copy_tasks = service->FetchTasks(ctx1.client_id, 1);
+    ASSERT_TRUE(copy_tasks.has_value());
+    ASSERT_EQ(copy_tasks->size(), 1u);
+    ReplicaCopyPayload copy_payload;
+    struct_json::from_json(copy_payload, copy_tasks->front().payload);
+    EXPECT_EQ(copy_payload.key, expected_copy_key);
+    EXPECT_TRUE(service
+                    ->CopyStart(ctx1.client_id, copy_payload.key,
+                                copy_payload.source, copy_payload.targets)
+                    .has_value());
+    EXPECT_TRUE(service->CopyEnd(ctx1.client_id, copy_payload.key).has_value());
+
+    ASSERT_TRUE(
+        service->PutStart(client_id, "move_task_key", 1024, config, tenant_id)
+            .has_value());
+    ASSERT_TRUE(
+        service
+            ->PutEnd(client_id, "move_task_key", ReplicaType::MEMORY, tenant_id)
+            .has_value());
+    ASSERT_TRUE(service
+                    ->CreateMoveTask("move_task_key", "segment_1", "segment_3",
+                                     tenant_id)
+                    .has_value());
+
+    auto move_tasks = service->FetchTasks(ctx1.client_id, 1);
+    ASSERT_TRUE(move_tasks.has_value());
+    ASSERT_EQ(move_tasks->size(), 1u);
+    ReplicaMovePayload move_payload;
+    struct_json::from_json(move_payload, move_tasks->front().payload);
+    EXPECT_EQ(move_payload.key, expected_move_key);
+    EXPECT_TRUE(service
+                    ->MoveStart(ctx1.client_id, move_payload.key,
+                                move_payload.source, move_payload.target)
+                    .has_value());
+    EXPECT_TRUE(service->MoveEnd(ctx1.client_id, move_payload.key).has_value());
+}
+
 std::string GenerateKeyForSegment(const UUID& client_id,
                                   const std::unique_ptr<MasterService>& service,
                                   const std::string& segment_name) {
@@ -4517,6 +4582,81 @@ TEST_F(MasterServiceTest, DrainJobSchedulesMoveTaskAndConvergesToDrained) {
     EXPECT_EQ(segment_status.value(), SegmentStatus::DRAINED);
 
     auto replicas = service_->GetReplicaList(key);
+    ASSERT_TRUE(replicas.has_value());
+    std::unordered_set<std::string> segment_names;
+    for (const auto& replica : replicas->replicas) {
+        segment_names.insert(replica.get_memory_descriptor()
+                                 .buffer_descriptor.transport_endpoint_);
+    }
+    EXPECT_TRUE(segment_names.contains("segment_1"));
+    EXPECT_FALSE(segment_names.contains("segment_0"));
+}
+
+TEST_F(MasterServiceTest, TenantScopedDrainJobSchedulesScopedMoveTask) {
+    auto service_config =
+        MasterServiceConfig::builder().set_default_kv_lease_ttl(0).build();
+    auto service_ = std::make_unique<MasterService>(service_config);
+
+    const auto ctx0 = PrepareSimpleSegment(*service_, "segment_0", 0x300000000,
+                                           kDefaultSegmentSize);
+    PrepareSimpleSegment(*service_, "segment_1", 0x400000000,
+                         kDefaultSegmentSize);
+
+    const UUID put_client_id = generate_uuid();
+    const std::string key = "tenant_drain_key";
+    const std::string tenant_id = "tenant_drain";
+    const std::string storage_key = BuildTenantScopedKey(tenant_id, key);
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.preferred_segment = "segment_0";
+    ASSERT_TRUE(service_->PutStart(put_client_id, key, 1024, config, tenant_id)
+                    .has_value());
+    ASSERT_TRUE(
+        service_->PutEnd(put_client_id, key, ReplicaType::MEMORY, tenant_id)
+            .has_value());
+
+    CreateDrainJobRequest request;
+    request.segments = {"segment_0"};
+    request.target_segments = {"segment_1"};
+    request.max_concurrency = 1;
+
+    auto job_id = service_->CreateDrainJob(request);
+    ASSERT_TRUE(job_id.has_value());
+
+    std::vector<TaskAssignment> fetched_tasks;
+    WaitUntil([&] {
+        auto fetched = service_->FetchTasks(ctx0.client_id, 1);
+        if (!fetched.has_value() || fetched->empty()) {
+            return false;
+        }
+        fetched_tasks = std::move(fetched.value());
+        return true;
+    });
+    ASSERT_EQ(fetched_tasks.size(), 1u);
+
+    ReplicaMovePayload payload;
+    struct_json::from_json(payload, fetched_tasks.front().payload);
+    EXPECT_EQ(payload.key, storage_key);
+    ASSERT_TRUE(service_
+                    ->MoveStart(ctx0.client_id, payload.key, payload.source,
+                                payload.target)
+                    .has_value());
+    ASSERT_TRUE(service_->MoveEnd(ctx0.client_id, payload.key).has_value());
+
+    TaskCompleteRequest complete_request;
+    complete_request.id = fetched_tasks.front().id;
+    complete_request.status = TaskStatus::SUCCESS;
+    complete_request.message = "move_done";
+    ASSERT_TRUE(service_->MarkTaskToComplete(ctx0.client_id, complete_request)
+                    .has_value());
+
+    WaitUntil([&] {
+        auto query = service_->QueryDrainJob(job_id.value());
+        return query.has_value() && query->status == JobStatus::SUCCEEDED;
+    });
+
+    auto replicas = service_->GetReplicaList(key, tenant_id);
     ASSERT_TRUE(replicas.has_value());
     std::unordered_set<std::string> segment_names;
     for (const auto& replica : replicas->replicas) {

--- a/mooncake-store/tests/offload_on_evict_test.cpp
+++ b/mooncake-store/tests/offload_on_evict_test.cpp
@@ -71,6 +71,10 @@ class OffloadOnEvictTest : public ::testing::Test {
         return std::move(res.value());
     }
 
+    std::string DefaultStorageKey(const std::string& key) const {
+        return BuildTenantScopedKey("default", key);
+    }
+
     template <typename Predicate>
     void WaitUntil(
         Predicate&& predicate,
@@ -138,9 +142,9 @@ TEST_F(OffloadOnEvictTest, ComboA_OffloadAtPutEnd) {
     auto queued = DrainOffloadQueue(*service, ctx.client_id);
     EXPECT_EQ(queued.size(), 3u)
         << "Default: all 3 objects should be in offload queue after PutEnd";
-    EXPECT_TRUE(queued.count("key_a1"));
-    EXPECT_TRUE(queued.count("key_a2"));
-    EXPECT_TRUE(queued.count("key_a3"));
+    EXPECT_TRUE(queued.count(DefaultStorageKey("key_a1")));
+    EXPECT_TRUE(queued.count(DefaultStorageKey("key_a2")));
+    EXPECT_TRUE(queued.count(DefaultStorageKey("key_a3")));
 
     service->RemoveAll();
 }

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -104,6 +104,10 @@ class PromotionOnHitTest : public ::testing::Test {
         EXPECT_TRUE(mount_ld.has_value());
         return client_id;
     }
+
+    std::string DefaultStorageKey(const std::string& key) const {
+        return BuildTenantScopedKey("default", key);
+    }
 };
 
 // Sanity: with promotion disabled, no path mutates promotion_objects.
@@ -275,7 +279,7 @@ TEST_F(PromotionOnHitTest, RacingReadersDedup) {
     EXPECT_EQ(pending->size(), 1u)
         << "Concurrent readers (" << kThreads << " x " << kReadsPerThread
         << ") must dedupe to a single promotion task";
-    ASSERT_TRUE(pending->count("k_cold"));
+    ASSERT_TRUE(pending->count(DefaultStorageKey("k_cold")));
 
     service->RemoveAll();
 }
@@ -564,9 +568,9 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
     EXPECT_EQ(heartbeat->size(), 1u)
         << "promotion_queue_limit=1 should admit only the first task "
         << "globally; k2's enqueue must be dropped";
-    EXPECT_EQ(heartbeat->count(k1), 1u)
+    EXPECT_EQ(heartbeat->count(DefaultStorageKey(k1)), 1u)
         << "k1 was read first and should be the surviving task";
-    EXPECT_EQ(heartbeat->count(k2), 0u)
+    EXPECT_EQ(heartbeat->count(DefaultStorageKey(k2)), 0u)
         << "k2 was rejected by the cap gate; should not appear";
 
     service->RemoveAll();
@@ -594,7 +598,10 @@ TEST_F(PromotionOnHitTest, HeartbeatBoundedBatchPreservesLeftovers) {
     // first GetReplicaList per key crosses the admission threshold (=1)
     // and TryPushPromotionQueue enqueues a task.
     const std::vector<std::string> keys{"hb_k1", "hb_k2", "hb_k3"};
+    std::vector<std::string> storage_keys;
+    storage_keys.reserve(keys.size());
     for (const auto& k : keys) {
+        storage_keys.emplace_back(DefaultStorageKey(k));
         ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, k, 1024,
                                            seg.segment_name));
         auto r = service->GetReplicaList(k);
@@ -607,7 +614,8 @@ TEST_F(PromotionOnHitTest, HeartbeatBoundedBatchPreservesLeftovers) {
     EXPECT_EQ(tick1->size(), 1u)
         << "heartbeat should return at most kMaxPerHeartbeat=1 entry";
     std::string first_key = tick1->begin()->first;
-    EXPECT_TRUE(std::find(keys.begin(), keys.end(), first_key) != keys.end());
+    EXPECT_TRUE(std::find(storage_keys.begin(), storage_keys.end(),
+                          first_key) != storage_keys.end());
 
     // Second heartbeat returns another key (a different one).
     auto tick2 = service->PromotionObjectHeartbeat(seg.client_id);
@@ -787,8 +795,8 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsCrossShard) {
         << " must be rejected by the global gate. A per-shard heuristic "
         << "would admit it here since the destination shard's local "
         << "count is 0.";
-    EXPECT_EQ(heartbeat->count(k1), 1u);
-    EXPECT_EQ(heartbeat->count(k2), 0u);
+    EXPECT_EQ(heartbeat->count(DefaultStorageKey(k1)), 1u);
+    EXPECT_EQ(heartbeat->count(DefaultStorageKey(k2)), 0u);
 
     service->RemoveAll();
 }
@@ -963,7 +971,7 @@ TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
         << "in-flight counter must decrement on the NotifyPromotionSuccess "
         << "success path. Without fetch_sub, the cap stays saturated and "
         << "k_second is silently dropped.";
-    EXPECT_EQ(pending->count("k_second"), 1u);
+    EXPECT_EQ(pending->count(DefaultStorageKey("k_second")), 1u);
 
     service->RemoveAll();
 }
@@ -1175,7 +1183,7 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
     }
     auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
     ASSERT_TRUE(heartbeat.has_value());
-    EXPECT_EQ(heartbeat->count("k_b"), 1u)
+    EXPECT_EQ(heartbeat->count(DefaultStorageKey("k_b")), 1u)
         << "k_b admission must succeed after k_a's failure released the "
         << "slot. If this fires, NotifyPromotionFailure did not decrement "
         << "promotion_in_flight_, and transient client-side errors "
@@ -1423,7 +1431,7 @@ TEST_F(PromotionOnHitTest, ClientExpiryClearsPromotionTask) {
     auto pending_pre =
         service->PromotionObjectHeartbeat(second_holder.client_id);
     ASSERT_TRUE(pending_pre.has_value());
-    EXPECT_EQ(pending_pre->count("k_other"), 0u)
+    EXPECT_EQ(pending_pre->count(DefaultStorageKey("k_other")), 0u)
         << "Sanity: queue_limit=1 should block the second admission "
         << "while the first task is in flight.";
 
@@ -1457,7 +1465,7 @@ TEST_F(PromotionOnHitTest, ClientExpiryClearsPromotionTask) {
     auto pending_post =
         service->PromotionObjectHeartbeat(second_holder.client_id);
     ASSERT_TRUE(pending_post.has_value());
-    EXPECT_EQ(pending_post->count("k_other"), 1u)
+    EXPECT_EQ(pending_post->count(DefaultStorageKey("k_other")), 1u)
         << "After the holder expired, ClearInvalidHandles must have "
         << "erased its promotion_tasks entry and decremented "
         << "promotion_in_flight_. Otherwise the global cap remains "
@@ -1535,7 +1543,7 @@ TEST_F(PromotionOnHitTest, RemoveErasesPromotionTask) {
     {
         auto pending = service->PromotionObjectHeartbeat(holder.client_id);
         ASSERT_TRUE(pending.has_value());
-        EXPECT_EQ(pending->count("k_first"), 1u);
+        EXPECT_EQ(pending->count(DefaultStorageKey("k_first")), 1u);
     }
 
     // Remove k_first with force=true. With the fix, this also wipes
@@ -1554,7 +1562,7 @@ TEST_F(PromotionOnHitTest, RemoveErasesPromotionTask) {
     }
     auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
     ASSERT_TRUE(pending_post.has_value());
-    EXPECT_EQ(pending_post->count("k_second"), 1u)
+    EXPECT_EQ(pending_post->count(DefaultStorageKey("k_second")), 1u)
         << "k_second must be admittable after Remove of k_first — Remove "
         << "must erase the in-flight promotion_tasks entry and decrement "
         << "promotion_in_flight_, otherwise queue_limit=1 stays saturated.";
@@ -1604,7 +1612,7 @@ TEST_F(PromotionOnHitTest, RemoveByRegexErasesPromotionTask) {
     }
     auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
     ASSERT_TRUE(pending_post.has_value());
-    EXPECT_EQ(pending_post->count("other_k2"), 1u)
+    EXPECT_EQ(pending_post->count(DefaultStorageKey("other_k2")), 1u)
         << "other_k2 must be admittable after RemoveByRegex of regex_k1 "
         << "— RemoveByRegex must erase the in-flight promotion_tasks "
         << "entry. Otherwise queue_limit=1 stays saturated.";


### PR DESCRIPTION
## Description

This PR implements the base tenant-isolation model for Mooncake Store object operations.

The core design binds `tenant_id` to each client and scopes user object keys in `MasterClient` before sending requests to the master. The master stores and indexes objects by scoped storage key, while parsing tenant/user key metadata only when needed for filtering, task handling, metrics, and user-facing responses.

The implementation also fixes background paths that previously could lose tenant context, including copy/move tasks, drain-triggered moves, offload, promotion, and disk eviction. Regex operations now pass `tenant_id` explicitly and filter by tenant on the master before applying the user regex, avoiding cross-tenant regex matches. User keys that look like internal scoped keys are always treated as normal user keys at client boundaries.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- Built with CMake/Make after the tenant scoped key changes.
- Ran the relevant Mooncake Store tests, including `master_service_test` and `master_service_test_for_snapshot`.
- Added regression coverage for same user key isolation across tenants, background copy/move task storage keys, drain-triggered scoped move tasks, user keys that resemble scoped storage keys, and regex alternation isolation.
- Ran formatting and `git diff --check`.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.