### PR TITLE
[Store] fix batch tensor allocation error code

### DIFF
--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -45,7 +45,7 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
             if (!alloc_result) {
                 LOG(ERROR) << "Failed to allocate buffer for " << operation_name
                            << " key: " << keys[i];
-                results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
+                results[i] = to_py_ret(ErrorCode::NO_AVAILABLE_HANDLE);
                 continue;
             }
 


### PR DESCRIPTION
## Description

Fix the error code returned by `batch_write_tensor_impl` when client buffer allocation fails. This path now returns `ErrorCode::NO_AVAILABLE_HANDLE` instead of `ErrorCode::INVALID_PARAMS`, matching the actual failure reason: no available buffer handle / insufficient allocation capacity, not invalid user input.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Not run locally. The change is limited to correcting the returned error code for an existing allocation-failure branch.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.