### PR TITLE
Fix MACA nvlink allocator build by mapping CUmemAllocationHandleType

### DIFF
--- a/mooncake-transfer-engine/include/gpu_vendor/maca.h
+++ b/mooncake-transfer-engine/include/gpu_vendor/maca.h
@@ -36,6 +36,7 @@ const static std::string GPU_PREFIX = "maca:";
 #define CUmemFabricHandle mcMemFabricHandle_t
 #define CUmemGenericAllocationHandle mcMemGenericAllocationHandle
 #define CUmemAllocationProp mcMemAllocationProp
+#define CUmemAllocationHandleType mcMemAllocationHandleType
 #define CUmemAccessDesc mcMemAccessDesc
 #define CUmemAllocationType mcMemAllocationType
 #define CU_MEM_ALLOCATION_TYPE_PINNED mcMemAllocationTypePinned


### PR DESCRIPTION
## Summary
- Add missing `CUmemAllocationHandleType` → `mcMemAllocationHandleType` alias in `gpu_vendor/maca.h`
- Fixes `nvlink_allocator.cpp` compile failure when building Mooncake with `-DUSE_MACA=ON`

## Context
`nvlink_allocator.cpp` uses `static_cast<CUmemAllocationHandleType>(...)` when retrying `cuMemCreate` without fabric handles. The MUSA backend already maps this type in `musa.h`, but the MACA compatibility header was missing the equivalent mapping.

## Test plan
- [ ] Build with `-DUSE_MACA=ON` on a host with MACA SDK installed
- [ ] Confirm `build_nvlink_allocator` completes and `nvlink_allocator.so` is produced


Made with [Cursor](https://cursor.com)