### PR TITLE
[CI] Add docs-check job to validate Sphinx build with -W

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -765,6 +765,48 @@ jobs:
       shell: bash
 
 
+  docs-check:
+    name: Check Sphinx docs build
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event.action == 'opened' ||
+      contains(github.event.pull_request.labels.*.name, 'run-ci')
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+        persist-credentials: false
+
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          docs:
+            - 'docs/**'
+            - 'requirements_docs.txt'
+
+    - name: Set up Python
+      if: steps.filter.outputs.docs == 'true'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install documentation dependencies
+      if: steps.filter.outputs.docs == 'true'
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements_docs.txt
+
+    - name: Build docs with strict mode
+      if: steps.filter.outputs.docs == 'true'
+      run: |
+        cd docs
+        make html SPHINXOPTS=-W
+      shell: bash
+
+
   check-paths:
     if: >-
       github.event_name == 'push' ||
@@ -828,6 +870,7 @@ jobs:
     needs:
       - spell-check
       - clang-format
+      - docs-check
       - build
       - build-musa
       - build-flags


### PR DESCRIPTION
## Description

In PR https://github.com/kvcache-ai/Mooncake/pull/2218, we fixed several bugs in HTML generation so that make html no longer reports warnings. This PR also adds CI checks to ensure this behavior is preserved and to prevent future documentation-related regressions.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

No need.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
