### PR TITLE
[TransferEngine][MACA] Add missing CUDA-like type aliases for MACA compatibility

### DIFF
--- a/mooncake-transfer-engine/include/gpu_vendor/maca.h
+++ b/mooncake-transfer-engine/include/gpu_vendor/maca.h
@@ -42,6 +42,8 @@ const static std::string GPU_PREFIX = "maca:";
 #define CU_MEM_ALLOCATION_TYPE_PINNED mcMemAllocationTypePinned
 #define CU_MEM_LOCATION_TYPE_DEVICE mcMemLocationTypeDevice
 #define CU_MEM_HANDLE_TYPE_FABRIC mcMemHandleTypeFabric
+#define CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR \
+    mcMemHandleTypePosixFileDescriptor
 #define CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED \
     mcDeviceAttributeHandleTypeFabricSupported
 #define CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED \
@@ -52,6 +54,7 @@ const static std::string GPU_PREFIX = "maca:";
 #define CU_MEMORYTYPE_HOST mcMemoryTypeHost
 #define CU_MEMORYTYPE_DEVICE mcMemoryTypeDevice
 #define CU_POINTER_ATTRIBUTE_MEMORY_TYPE mcPointerAttributeMemoryType
+#define CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL mcPointerAttributeDevice
 #define CU_POINTER_ATTRIBUTE_RANGE_START_ADDR mcPointerAttributeRangeStartAddr
 #define CU_POINTER_ATTRIBUTE_RANGE_SIZE mcPointerAttributeRangeSize
 #define CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD mcMemHandleTypePosixFileDescriptor


### PR DESCRIPTION


Add missing mappings in gpu_vendor/maca.h:
- CUmemAllocationHandleType -> mcMemAllocationHandleType (follow-up to #2227)
- CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR -> mcMemHandleTypePosixFileDescriptor
- CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL -> mcPointerAttributeDevice

These aliases are used in nvlink_allocator.cpp and other components when building with -DUSE_MACA=ON.

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
