### PR TITLE
[Store] fix: reset MasterMetricManager on MasterService recreation in HA mode

### DIFF
--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -343,6 +343,25 @@ class MasterMetricManager {
     int64_t get_update_task_requests();
     int64_t get_update_task_failures();
 
+    // --- Term-scoped Metrics Reset ---
+    /**
+     * @brief Reset metrics whose lifetime is tied to a single MasterService
+     * instance / leader term. Must be called when a new MasterService is
+     * constructed in HA mode, before state restoration runs.
+     *
+     * Why: MasterMetricManager is a process-level singleton, but in HA mode
+     * MasterService is destroyed and recreated on every etcd reconnect /
+     * leader transition. Without this reset, the new instance's restore path
+     * re-increments gauges that still hold values from the previous instance
+     * (e.g. active_clients doubling after etcd reconnect — issue #2210), and
+     * per-term counters silently accumulate across leader terms (issue #1186).
+     *
+     * Resets both gauges (current-state) and counters (per-term). Histograms
+     * summarize distributions and ylt exposes no reset API for them, so they
+     * are left untouched.
+     */
+    void ResetTermScopedMetrics();
+
     // --- Serialization ---
     /**
      * @brief Serializes all managed metrics into Prometheus text format.

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -532,6 +532,175 @@ void MasterMetricManager::update_metrics_for_zero_output() {
     // actual segment names.
 }
 
+void MasterMetricManager::ResetTermScopedMetrics() {
+    // --- Static gauges (current-state) ---
+    // Must reset: otherwise state restore re-inc's on top of stale values
+    // from the previous MasterService instance. This is the root cause of
+    // issue #2210 (active_clients).
+    mem_allocated_size_.reset();
+    mem_total_capacity_.reset();
+    nof_allocated_size_.reset();
+    nof_total_capacity_.reset();
+    file_allocated_size_.reset();
+    file_total_capacity_.reset();
+    key_count_.reset();
+    soft_pin_key_count_.reset();
+    active_clients_.reset();
+    mem_cache_nums_.reset();
+    file_cache_nums_.reset();
+    put_start_discarded_staging_size_.reset();
+
+    // --- Per-segment dynamic gauges ---
+    // Zero out any labels left over from the previous term. State restore
+    // will re-populate via inc_* with the current segment names; labels for
+    // segments that no longer exist remain at 0 (ylt has no public API to
+    // erase label entries from dynamic counters).
+    auto zero_all_labels = [](auto& dyn_gauge) {
+        for (auto& entry : dyn_gauge.copy()) {
+            dyn_gauge.update(entry->label, 0);
+        }
+    };
+    zero_all_labels(mem_allocated_size_per_segment_);
+    zero_all_labels(mem_total_capacity_per_segment_);
+    zero_all_labels(nof_allocated_size_per_segment_);
+    zero_all_labels(nof_total_capacity_per_segment_);
+
+    // --- Counters (per-term) ---
+    // Per the design discussion in issue #1186, treat counters as
+    // per-leader-term so each term's stats stand alone. External aggregation
+    // can sum across instances if a cluster-lifetime view is needed.
+    put_start_requests_.reset();
+    put_start_failures_.reset();
+    put_start_alloc_failures_.reset();
+    put_end_requests_.reset();
+    put_end_failures_.reset();
+    put_revoke_requests_.reset();
+    put_revoke_failures_.reset();
+    get_replica_list_requests_.reset();
+    get_replica_list_failures_.reset();
+    get_replica_list_by_regex_requests_.reset();
+    get_replica_list_by_regex_failures_.reset();
+    exist_key_requests_.reset();
+    exist_key_failures_.reset();
+    remove_requests_.reset();
+    remove_failures_.reset();
+    remove_by_regex_requests_.reset();
+    remove_by_regex_failures_.reset();
+    remove_all_requests_.reset();
+    remove_all_failures_.reset();
+    mount_segment_requests_.reset();
+    mount_segment_failures_.reset();
+    unmount_segment_requests_.reset();
+    unmount_segment_failures_.reset();
+    remount_segment_requests_.reset();
+    remount_segment_failures_.reset();
+    mount_nof_segment_requests_.reset();
+    mount_nof_segment_failures_.reset();
+    unmount_nof_segment_requests_.reset();
+    unmount_nof_segment_failures_.reset();
+    remount_nof_segment_requests_.reset();
+    remount_nof_segment_failures_.reset();
+    ping_requests_.reset();
+    ping_failures_.reset();
+    nof_heartbeat_success_total_.reset();
+    nof_heartbeat_failure_total_.reset();
+    nof_heartbeat_timeout_total_.reset();
+    nof_segments_unmounted_by_heartbeat_total_.reset();
+
+    batch_exist_key_requests_.reset();
+    batch_exist_key_failures_.reset();
+    batch_exist_key_partial_successes_.reset();
+    batch_exist_key_items_.reset();
+    batch_exist_key_failed_items_.reset();
+    batch_query_ip_requests_.reset();
+    batch_query_ip_failures_.reset();
+    batch_query_ip_partial_successes_.reset();
+    batch_query_ip_items_.reset();
+    batch_query_ip_failed_items_.reset();
+    batch_replica_clear_requests_.reset();
+    batch_replica_clear_failures_.reset();
+    batch_replica_clear_partial_successes_.reset();
+    batch_replica_clear_items_.reset();
+    batch_replica_clear_failed_items_.reset();
+    batch_get_replica_list_requests_.reset();
+    batch_get_replica_list_failures_.reset();
+    batch_get_replica_list_partial_successes_.reset();
+    batch_get_replica_list_items_.reset();
+    batch_get_replica_list_failed_items_.reset();
+    batch_put_start_requests_.reset();
+    batch_put_start_failures_.reset();
+    batch_put_start_partial_successes_.reset();
+    batch_put_start_items_.reset();
+    batch_put_start_failed_items_.reset();
+    batch_put_end_requests_.reset();
+    batch_put_end_failures_.reset();
+    batch_put_end_partial_successes_.reset();
+    batch_put_end_items_.reset();
+    batch_put_end_failed_items_.reset();
+    batch_put_revoke_requests_.reset();
+    batch_put_revoke_failures_.reset();
+    batch_put_revoke_partial_successes_.reset();
+    batch_put_revoke_items_.reset();
+    batch_put_revoke_failed_items_.reset();
+
+    mem_cache_hit_nums_.reset();
+    file_cache_hit_nums_.reset();
+    valid_get_nums_.reset();
+    total_get_nums_.reset();
+
+    eviction_success_.reset();
+    eviction_attempts_.reset();
+    evicted_key_count_.reset();
+    evicted_size_.reset();
+    mem_eviction_success_.reset();
+    mem_eviction_attempts_.reset();
+    mem_evicted_key_count_.reset();
+    mem_evicted_size_.reset();
+    nof_eviction_success_.reset();
+    nof_eviction_attempts_.reset();
+    nof_evicted_key_count_.reset();
+    nof_evicted_size_.reset();
+
+    put_start_discard_cnt_.reset();
+    put_start_release_cnt_.reset();
+
+    snapshot_success_.reset();
+    snapshot_fail_.reset();
+
+    copy_start_requests_.reset();
+    copy_start_failures_.reset();
+    copy_end_requests_.reset();
+    copy_end_failures_.reset();
+    copy_revoke_requests_.reset();
+    copy_revoke_failures_.reset();
+    move_start_requests_.reset();
+    move_start_failures_.reset();
+    move_end_requests_.reset();
+    move_end_failures_.reset();
+    move_revoke_requests_.reset();
+    move_revoke_failures_.reset();
+    evict_disk_replica_requests_.reset();
+    evict_disk_replica_failures_.reset();
+
+    create_copy_task_requests_.reset();
+    create_copy_task_failures_.reset();
+    create_move_task_requests_.reset();
+    create_move_task_failures_.reset();
+    query_task_requests_.reset();
+    query_task_failures_.reset();
+    fetch_tasks_requests_.reset();
+    fetch_tasks_failures_.reset();
+    mark_task_to_complete_requests_.reset();
+    mark_task_to_complete_failures_.reset();
+
+    // Drop the cached summary baseline; otherwise rate calculations would
+    // mix the previous term's counter deltas with the new term's zero base.
+    {
+        std::lock_guard<std::mutex> lock(summary_snapshot_mutex_);
+        summary_snapshot_ = SummarySnapshot{};
+    }
+}
+
 // Memory Storage Metrics
 void MasterMetricManager::inc_allocated_mem_size(const std::string& segment,
                                                  int64_t val) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -155,6 +155,14 @@ MasterService::MasterService(const MasterServiceConfig& config)
       cxl_size_(config.cxl_size),
       enable_cxl_(config.enable_cxl),
       task_manager_(config.task_manager_config) {
+    // HA mode rebuilds MasterService on every etcd reconnect / leader
+    // transition, but MasterMetricManager is a process-level singleton, so
+    // gauges and per-term counters would otherwise carry over from the
+    // previous instance and either double-count (gauges, after the restore
+    // path re-inc's them) or accumulate silently (counters). Reset here so
+    // restore starts from a clean slate. See issues #2210 and #1186.
+    MasterMetricManager::instance().ResetTermScopedMetrics();
+
     if (enable_snapshot_ || enable_snapshot_restore_) {
         try {
             auto object_store_type =


### PR DESCRIPTION
## Description

Fixes #2210.

In HA mode, `MasterService` is destroyed and recreated on every etcd reconnect / leader transition, but `MasterMetricManager` is a process-level singleton that outlives those transitions. The destructor of the old `MasterService` does not clear the singleton, so values registered during the previous term remain. When the new `MasterService` runs its restore path and calls `inc_*` on top of those stale values, gauges double-count and per-term counters silently accumulate across leader terms.

This PR adds `MasterMetricManager::ResetTermScopedMetrics()` and calls it at the very top of the `MasterService` constructor, before `RestoreState()` or any `inc_*` runs. The new instance starts from a clean baseline and restore re-populates gauges with the actual current state.

Non-HA mode is unaffected: `MasterService` is constructed exactly once, metrics are already 0, so the reset call is a safe no-op.

### Relation to #1186

#1186 raises the same singleton-lifecycle root cause but in more general terms, and it leaves open whether counters should be cleared or synced across leader terms. This PR's scope is just the gauge-class symptom (active_clients, mem/file cache nums, capacities, soft-pin count). The reset helper also clears per-term counters as the simpler default, but that choice is not load-bearing for the bug being fixed here and can be revisited if the project prefers the sync-to-follower alternative.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
