### PR TITLE
[Store] Implement tenant metadata map isolation

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <boost/functional/hash.hpp>
 #include <boost/lockfree/queue.hpp>
@@ -1134,17 +1135,16 @@ class MasterService {
         GUARDED_BY(group_routing_mutex_);
     mutable std::shared_mutex group_routing_mutex_;
 
+    static constexpr size_t kObjectOperationLockStripes = 4096;
+
     struct ObjectOperationLock {
-        std::shared_ptr<std::mutex> mutex;
         std::unique_lock<std::mutex> lock;
     };
 
     ObjectOperationLock AcquireObjectOperationLock(const std::string& tenant_id,
                                                    const std::string& key);
 
-    std::mutex object_operation_locks_mutex_;
-    std::unordered_map<std::string, std::weak_ptr<std::mutex>>
-        object_operation_locks_;
+    std::array<std::mutex, kObjectOperationLockStripes> object_operation_locks_;
 
     // For accessing a metadata shard with read-write permission
     class MetadataShardAccessorRW {

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1177,6 +1177,17 @@ class MasterService {
         return {NormalizeTenantId(tenant_id), user_key};
     }
 
+    static std::string MakeTenantScopedKey(const std::string& tenant_id,
+                                           const std::string& key) {
+        const auto normalized_tenant = NormalizeTenantId(tenant_id);
+        std::string scoped_key;
+        scoped_key.reserve(normalized_tenant.size() + key.size() + 1);
+        scoped_key.append(normalized_tenant);
+        scoped_key.push_back('\0');
+        scoped_key.append(key);
+        return scoped_key;
+    }
+
     // Helper to get shard index from tenant-scoped object identity.
     size_t getShardIndex(const std::string& tenant_id,
                          const std::string& user_key) const {
@@ -1197,11 +1208,18 @@ class MasterService {
     size_t getMetadataShardIndex(const std::string& key) const;
     size_t getMetadataShardIndex(const std::string& tenant_id,
                                  const std::string& key) const;
-    void RegisterGroupMember(TenantState& tenant_state, const std::string& key,
+    void RegisterGroupMember(TenantState& tenant_state,
+                             const std::string& tenant_id,
+                             const std::string& key,
                              const std::string& group_id);
     void UnregisterGroupMember(TenantState& tenant_state,
+                               const std::string& tenant_id,
                                const std::string& key,
                                const std::string& group_id);
+    std::unordered_map<std::string, ObjectMetadata>::iterator EraseMetadata(
+        TenantState& tenant_state,
+        std::unordered_map<std::string, ObjectMetadata>::iterator it,
+        const std::string& tenant_id);
     void RebuildGroupRoutingIndex();
     void GrantLeaseForGroup(const TenantState& tenant_state,
                             const std::string& key,
@@ -1435,11 +1453,8 @@ class MasterService {
 
         // Delete current metadata (for PutRevoke or Remove operations)
         void Erase() NO_THREAD_SAFETY_ANALYSIS {
-            const std::string group_id = it_->second.group_id;
-            tenant_state_->metadata.erase(it_);
+            service_->EraseMetadata(*tenant_state_, it_, object_id_.tenant_id);
             it_ = tenant_state_->metadata.end();
-            service_->UnregisterGroupMember(*tenant_state_, object_id_.user_key,
-                                            group_id);
             MaybeEraseEmptyTenant();
         }
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1134,6 +1134,18 @@ class MasterService {
         GUARDED_BY(group_routing_mutex_);
     mutable std::shared_mutex group_routing_mutex_;
 
+    struct ObjectOperationLock {
+        std::shared_ptr<std::mutex> mutex;
+        std::unique_lock<std::mutex> lock;
+    };
+
+    ObjectOperationLock AcquireObjectOperationLock(const std::string& tenant_id,
+                                                   const std::string& key);
+
+    std::mutex object_operation_locks_mutex_;
+    std::unordered_map<std::string, std::weak_ptr<std::mutex>>
+        object_operation_locks_;
+
     // For accessing a metadata shard with read-write permission
     class MetadataShardAccessorRW {
        public:
@@ -1208,6 +1220,8 @@ class MasterService {
     size_t getMetadataShardIndex(const std::string& key) const;
     size_t getMetadataShardIndex(const std::string& tenant_id,
                                  const std::string& key) const;
+    std::optional<std::string> GetGroupRoute(const std::string& tenant_id,
+                                             const std::string& key) const;
     void RegisterGroupMember(TenantState& tenant_state,
                              const std::string& tenant_id,
                              const std::string& key,

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1195,6 +1195,8 @@ class MasterService {
     }
 
     size_t getMetadataShardIndex(const std::string& key) const;
+    size_t getMetadataShardIndex(const std::string& tenant_id,
+                                 const std::string& key) const;
     void RegisterGroupMember(TenantState& tenant_state, const std::string& key,
                              const std::string& group_id);
     void UnregisterGroupMember(TenantState& tenant_state,
@@ -1349,7 +1351,8 @@ class MasterService {
                            const ObjectIdentity& object_id)
             : service_(service),
               object_id_(object_id),
-              shard_idx_(service_->getMetadataShardIndex(object_id_.user_key)),
+              shard_idx_(service_->getMetadataShardIndex(object_id_.tenant_id,
+                                                         object_id_.user_key)),
               shard_guard_(service_, shard_idx_),
               tenant_it_(shard_guard_->tenants.find(object_id_.tenant_id)),
               tenant_state_(tenant_it_ == shard_guard_->tenants.end()
@@ -1562,7 +1565,8 @@ class MasterService {
                            const ObjectIdentity& object_id)
             : service_(service),
               object_id_(object_id),
-              shard_idx_(service_->getMetadataShardIndex(object_id_.user_key)),
+              shard_idx_(service_->getMetadataShardIndex(object_id_.tenant_id,
+                                                         object_id_.user_key)),
               shard_guard_(service_, shard_idx_),
               tenant_it_(shard_guard_->tenants.find(object_id_.tenant_id)),
               tenant_state_(tenant_it_ == shard_guard_->tenants.end()

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -163,6 +163,8 @@ class MasterService {
      * @return ErrorCode::OK if exists, otherwise return other ErrorCode
      */
     auto ExistKey(const std::string& key) -> tl::expected<bool, ErrorCode>;
+    auto ExistKey(const std::string& key, const std::string& tenant_id)
+        -> tl::expected<bool, ErrorCode>;
 
     std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
         const std::vector<std::string>& keys);
@@ -256,6 +258,11 @@ class MasterService {
         -> tl::expected<
             std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
             ErrorCode>;
+    auto GetReplicaListByRegex(const std::string& regex_pattern,
+                               const std::string& tenant_id)
+        -> tl::expected<
+            std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
+            ErrorCode>;
 
     /**
      * @brief Get list of replicas for an object
@@ -264,6 +271,8 @@ class MasterService {
      * ready
      */
     auto GetReplicaList(const std::string& key)
+        -> tl::expected<GetReplicaListResponse, ErrorCode>;
+    auto GetReplicaList(const std::string& key, const std::string& tenant_id)
         -> tl::expected<GetReplicaListResponse, ErrorCode>;
 
     /**
@@ -277,6 +286,10 @@ class MasterService {
     auto PutStart(const UUID& client_id, const std::string& key,
                   const uint64_t slice_length, const ReplicateConfig& config)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
+    auto PutStart(const UUID& client_id, const std::string& key,
+                  const std::string& tenant_id, const uint64_t slice_length,
+                  const ReplicateConfig& config)
+        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
 
     /**
      * @brief Complete a put operation, replica_type indicates the type of
@@ -286,6 +299,9 @@ class MasterService {
      */
     auto PutEnd(const UUID& client_id, const std::string& key,
                 ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
+    auto PutEnd(const UUID& client_id, const std::string& key,
+                const std::string& tenant_id, ReplicaType replica_type)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Adds a replica instance associated with the given client and key.
@@ -331,6 +347,10 @@ class MasterService {
      */
     auto UpsertStart(const UUID& client_id, const std::string& key,
                      const uint64_t slice_length, const ReplicateConfig& config)
+        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
+    auto UpsertStart(const UUID& client_id, const std::string& key,
+                     const std::string& tenant_id, const uint64_t slice_length,
+                     const ReplicateConfig& config)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
 
     /**
@@ -446,6 +466,8 @@ class MasterService {
      */
     auto Remove(const std::string& key, bool force = false)
         -> tl::expected<void, ErrorCode>;
+    auto Remove(const std::string& key, const std::string& tenant_id,
+                bool force = false) -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Removes objects from the master whose keys match a regex pattern.
@@ -456,6 +478,8 @@ class MasterService {
      */
     auto RemoveByRegex(const std::string& str, bool force = false)
         -> tl::expected<long, ErrorCode>;
+    auto RemoveByRegex(const std::string& str, const std::string& tenant_id,
+                       bool force = false) -> tl::expected<long, ErrorCode>;
 
     /**
      * @brief Remove all objects and their replicas
@@ -726,6 +750,11 @@ class MasterService {
     void JobDispatchThreadFunc();
 
     // Internal data structures
+    struct ObjectIdentity {
+        std::string tenant_id;
+        std::string user_key;
+    };
+
     struct ObjectMetadata {
         // RAII-style metric management
         ~ObjectMetadata() {
@@ -743,12 +772,15 @@ class MasterService {
             size_t value_length, std::vector<Replica>&& reps,
             bool enable_soft_pin, bool enable_hard_pin = false,
             ObjectDataType data_type_ = ObjectDataType::UNKNOWN,
-            std::string group_id_ = "")
+            std::string group_id_ = "", std::string tenant_id_ = "default",
+            std::string user_key_ = {})
             : client_id(client_id_),
               put_start_time(put_start_time_),
               size(value_length),
               data_type(data_type_),
               group_id(std::move(group_id_)),
+              tenant_id(std::move(tenant_id_)),
+              user_key(std::move(user_key_)),
               lease_timeout(),
               soft_pin_timeout(std::nullopt),
               hard_pinned(enable_hard_pin),
@@ -773,6 +805,8 @@ class MasterService {
         const size_t size;
         const ObjectDataType data_type{ObjectDataType::UNKNOWN};
         const std::string group_id;
+        const std::string tenant_id;
+        const std::string user_key;
 
         mutable SpinLock lock;
         // Default constructor, creates a time_point representing
@@ -1069,20 +1103,28 @@ class MasterService {
 
     static constexpr size_t kNumShards = 1024;  // Number of metadata shards
 
+    struct TenantState {
+        std::unordered_map<std::string, ObjectMetadata> metadata;
+        std::unordered_set<std::string> processing_keys;
+        std::unordered_map<std::string, const ReplicationTask>
+            replication_tasks;
+        std::unordered_map<std::string, const OffloadingTask> offloading_tasks;
+        std::unordered_map<std::string, PromotionTask> promotion_tasks;
+
+        std::unordered_map<std::string, std::unordered_set<std::string>>
+            group_members;  // group_id → set of keys
+
+        bool Empty() const {
+            return metadata.empty() && processing_keys.empty() &&
+                   replication_tasks.empty() && offloading_tasks.empty() &&
+                   promotion_tasks.empty() && group_members.empty();
+        }
+    };
+
     // Sharded metadata maps and their mutexes
     struct MetadataShard {
         mutable SharedMutex mutex;
-        std::unordered_map<std::string, ObjectMetadata> metadata
-            GUARDED_BY(mutex);
-        std::unordered_set<std::string> processing_keys GUARDED_BY(mutex);
-        std::unordered_map<std::string, const ReplicationTask> replication_tasks
-            GUARDED_BY(mutex);
-        std::unordered_map<std::string, const OffloadingTask> offloading_tasks
-            GUARDED_BY(mutex);
-        std::unordered_map<std::string, PromotionTask> promotion_tasks
-            GUARDED_BY(mutex);
-        std::unordered_map<std::string, std::unordered_set<std::string>>
-            group_members GUARDED_BY(mutex);
+        std::unordered_map<std::string, TenantState> tenants GUARDED_BY(mutex);
     };
     std::array<MetadataShard, kNumShards> metadata_shards_;
 
@@ -1130,22 +1172,37 @@ class MasterService {
         SharedMutexLocker lock_;
     };
 
-    // Helper to get shard index from key
+    static ObjectIdentity MakeObjectIdentity(
+        const std::string& user_key, const std::string& tenant_id = "default") {
+        return {NormalizeTenantId(tenant_id), user_key};
+    }
+
+    // Helper to get shard index from tenant-scoped object identity.
+    size_t getShardIndex(const std::string& tenant_id,
+                         const std::string& user_key) const {
+        const auto normalized_tenant = NormalizeTenantId(tenant_id);
+        if (normalized_tenant == "default") {
+            return std::hash<std::string>{}(user_key) % kNumShards;
+        }
+        size_t seed = std::hash<std::string>{}(normalized_tenant);
+        boost::hash_combine(seed, user_key);
+        return seed % kNumShards;
+    }
+
+    // Legacy helper routes plain keys to the default tenant.
     size_t getShardIndex(const std::string& key) const {
         return std::hash<std::string>{}(key) % kNumShards;
     }
 
     size_t getMetadataShardIndex(const std::string& key) const;
-    void RegisterGroupMember(MetadataShard& shard, const std::string& key,
+    void RegisterGroupMember(TenantState& tenant_state, const std::string& key,
                              const std::string& group_id);
-    void UnregisterGroupMember(MetadataShard& shard, const std::string& key,
+    void UnregisterGroupMember(TenantState& tenant_state,
+                               const std::string& key,
                                const std::string& group_id);
-    std::unordered_map<std::string, ObjectMetadata>::iterator
-    EraseMetadataEntry(
-        MetadataShard& shard,
-        std::unordered_map<std::string, ObjectMetadata>::iterator it);
     void RebuildGroupRoutingIndex();
-    void GrantLeaseForGroup(const MetadataShard& shard, const std::string& key,
+    void GrantLeaseForGroup(const TenantState& tenant_state,
+                            const std::string& key,
                             const ObjectMetadata& metadata) const;
 
     // Helper to clean up stale handles pointing to unmounted segments
@@ -1160,6 +1217,7 @@ class MasterService {
         MetadataShardAccessorRW& shard, const UUID& client_id,
         const std::string& key, uint64_t value_length,
         const ReplicateConfig& config, const std::string& group_id,
+        const std::string& tenant_id,
         const std::chrono::system_clock::time_point& now)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
 
@@ -1186,8 +1244,8 @@ class MasterService {
     bool ProbeNoFSegment(const std::string& te_endpoint,
                          std::string* error_reason);
 
-    tl::expected<void, ErrorCode> PushOffloadingQueue(const std::string& key,
-                                                      Replica& replica);
+    tl::expected<void, ErrorCode> PushOffloadingQueue(
+        const ObjectIdentity& object_id, Replica& replica);
 
     // Graceful unmount scheduler
     class GracefulUnmountScheduler {
@@ -1225,8 +1283,8 @@ class MasterService {
      * Caller is responsible for refcnt-pinning the source replica and
      * recording the task in the shard's promotion_tasks map.
      */
-    tl::expected<void, ErrorCode> PushPromotionQueue(const std::string& key,
-                                                     Replica& source_replica);
+    tl::expected<void, ErrorCode> PushPromotionQueue(
+        const ObjectIdentity& object_id, Replica& source_replica);
 
     /**
      * @brief Helper invoked from GetReplicaList when an only-LOCAL_DISK key is
@@ -1236,7 +1294,17 @@ class MasterService {
      * map. Acquires its own RW shard accessor; safe to call after
      * GetReplicaList's RO accessor has been released.
      */
-    void TryPushPromotionQueue(const std::string& key);
+    void TryPushPromotionQueue(const ObjectIdentity& object_id);
+
+    // Erase any in-flight PromotionTask for `key` and decrement the
+    // cluster-wide in-flight counter. Safe no-op if no task exists.
+    void ErasePromotionTaskIfPresent(TenantState& tenant_state,
+                                     const std::string& key)
+        NO_THREAD_SAFETY_ANALYSIS {
+        if (tenant_state.promotion_tasks.erase(key) > 0) {
+            promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+        }
+    }
 
     // Lease related members
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
@@ -1275,19 +1343,36 @@ class MasterService {
     class MetadataAccessorRW {
        public:
         MetadataAccessorRW(MasterService* service, const std::string& key)
+            : MetadataAccessorRW(service, MakeObjectIdentity(key)) {}
+
+        MetadataAccessorRW(MasterService* service,
+                           const ObjectIdentity& object_id)
             : service_(service),
-              key_(key),
-              shard_idx_(service_->getMetadataShardIndex(key)),
+              object_id_(object_id),
+              shard_idx_(service_->getMetadataShardIndex(object_id_.user_key)),
               shard_guard_(service_, shard_idx_),
-              it_(shard_guard_->metadata.find(key)),
-              processing_it_(shard_guard_->processing_keys.find(key)),
-              replication_task_it_(shard_guard_->replication_tasks.find(key)) {
+              tenant_it_(shard_guard_->tenants.find(object_id_.tenant_id)),
+              tenant_state_(tenant_it_ == shard_guard_->tenants.end()
+                                ? nullptr
+                                : &tenant_it_->second),
+              it_(tenant_state_ == nullptr
+                      ? ObjectMetadataIterator{}
+                      : tenant_state_->metadata.find(object_id_.user_key)),
+              processing_it_(tenant_state_ == nullptr
+                                 ? ProcessingIterator{}
+                                 : tenant_state_->processing_keys.find(
+                                       object_id_.user_key)),
+              replication_task_it_(tenant_state_ == nullptr
+                                       ? ReplicationTaskIterator{}
+                                       : tenant_state_->replication_tasks.find(
+                                             object_id_.user_key)) {
             // Automatically clean up invalid handles (memory replicas only).
             // Note: We only check memory replicas here to avoid lock order
             // violation (client_mutex_ must be acquired before metadata shard).
             // local_disk replicas are cleaned up by ClearInvalidHandles() in
             // ClientMonitorFunc.
-            if (it_ != shard_guard_->metadata.end()) {
+            if (tenant_state_ != nullptr &&
+                it_ != tenant_state_->metadata.end()) {
                 // Erase invalid memory replicas (those with unmounted
                 // segments). No client_mutex_ needed since we only check memory
                 // replicas.
@@ -1296,9 +1381,16 @@ class MasterService {
                 });
                 // If no valid replicas remain, delete the whole object.
                 if (!it_->second.IsValid()) {
+                    const bool had_processing =
+                        processing_it_ != tenant_state_->processing_keys.end();
                     this->Erase();
-                    if (processing_it_ != shard_guard_->processing_keys.end()) {
+                    if (tenant_state_ != nullptr && had_processing) {
                         this->EraseFromProcessing();
+                    }
+                    if (tenant_state_ != nullptr) {
+                        service_->ErasePromotionTaskIfPresent(
+                            *tenant_state_, object_id_.user_key);
+                        MaybeEraseEmptyTenant();
                     }
                 }
             }
@@ -1306,20 +1398,29 @@ class MasterService {
 
         // Check if metadata exists
         bool Exists() const NO_THREAD_SAFETY_ANALYSIS {
-            return it_ != shard_guard_->metadata.end() && it_->second.IsValid();
+            return tenant_state_ != nullptr &&
+                   it_ != tenant_state_->metadata.end() &&
+                   it_->second.IsValid();
         }
 
         bool InProcessing() const NO_THREAD_SAFETY_ANALYSIS {
-            return processing_it_ != shard_guard_->processing_keys.end();
+            return tenant_state_ != nullptr &&
+                   processing_it_ != tenant_state_->processing_keys.end();
         }
 
         bool HasReplicationTask() const NO_THREAD_SAFETY_ANALYSIS {
-            return replication_task_it_ !=
-                   shard_guard_->replication_tasks.end();
+            return tenant_state_ != nullptr &&
+                   replication_task_it_ !=
+                       tenant_state_->replication_tasks.end();
         }
 
         MetadataShardAccessorRW& GetShard() NO_THREAD_SAFETY_ANALYSIS {
             return shard_guard_;
+        }
+
+        TenantState& GetTenantState() NO_THREAD_SAFETY_ANALYSIS {
+            EnsureTenantState();
+            return *tenant_state_;
         }
 
         // Get metadata (only call when Exists() is true)
@@ -1331,44 +1432,83 @@ class MasterService {
 
         // Delete current metadata (for PutRevoke or Remove operations)
         void Erase() NO_THREAD_SAFETY_ANALYSIS {
-            it_ = service_->EraseMetadataEntry(shard_guard_.get(), it_);
+            const std::string group_id = it_->second.group_id;
+            tenant_state_->metadata.erase(it_);
+            it_ = tenant_state_->metadata.end();
+            service_->UnregisterGroupMember(*tenant_state_, object_id_.user_key,
+                                            group_id);
+            MaybeEraseEmptyTenant();
         }
 
         void EraseFromProcessing() NO_THREAD_SAFETY_ANALYSIS {
-            shard_guard_->processing_keys.erase(processing_it_);
-            processing_it_ = shard_guard_->processing_keys.end();
+            tenant_state_->processing_keys.erase(processing_it_);
+            processing_it_ = tenant_state_->processing_keys.end();
+            MaybeEraseEmptyTenant();
         }
 
         void EraseReplicationTask() NO_THREAD_SAFETY_ANALYSIS {
-            shard_guard_->replication_tasks.erase(replication_task_it_);
-            replication_task_it_ = shard_guard_->replication_tasks.end();
+            tenant_state_->replication_tasks.erase(replication_task_it_);
+            replication_task_it_ = tenant_state_->replication_tasks.end();
+            MaybeEraseEmptyTenant();
         }
 
         void Create(const UUID& client_id, uint64_t total_length,
                     std::vector<Replica> replicas, bool enable_soft_pin,
                     bool enable_hard_pin = false,
-                    ObjectDataType data_type = ObjectDataType::UNKNOWN) {
+                    ObjectDataType data_type = ObjectDataType::UNKNOWN,
+                    std::string group_id = "") {
             if (Exists()) {
                 throw std::logic_error("Already exists");
             }
             const auto now = std::chrono::system_clock::now();
-            auto result = shard_guard_->metadata.emplace(
-                std::piecewise_construct, std::forward_as_tuple(key_),
-                std::forward_as_tuple(client_id, now, total_length,
-                                      std::move(replicas), enable_soft_pin,
-                                      enable_hard_pin, data_type));
+            EnsureTenantState();
+            auto result = tenant_state_->metadata.emplace(
+                std::piecewise_construct,
+                std::forward_as_tuple(object_id_.user_key),
+                std::forward_as_tuple(
+                    client_id, now, total_length, std::move(replicas),
+                    enable_soft_pin, enable_hard_pin, data_type, group_id,
+                    object_id_.tenant_id, object_id_.user_key));
             it_ = result.first;
         }
 
        private:
+        using ObjectMetadataIterator =
+            std::unordered_map<std::string, ObjectMetadata>::iterator;
+        using ProcessingIterator = std::unordered_set<std::string>::iterator;
+        using ReplicationTaskIterator =
+            std::unordered_map<std::string, const ReplicationTask>::iterator;
+
+        void EnsureTenantState() NO_THREAD_SAFETY_ANALYSIS {
+            if (tenant_state_ != nullptr) {
+                return;
+            }
+            auto result =
+                shard_guard_->tenants.try_emplace(object_id_.tenant_id);
+            tenant_it_ = result.first;
+            tenant_state_ = &tenant_it_->second;
+            it_ = tenant_state_->metadata.end();
+            processing_it_ = tenant_state_->processing_keys.end();
+            replication_task_it_ = tenant_state_->replication_tasks.end();
+        }
+
+        void MaybeEraseEmptyTenant() NO_THREAD_SAFETY_ANALYSIS {
+            if (tenant_state_ == nullptr || !tenant_state_->Empty()) {
+                return;
+            }
+            shard_guard_->tenants.erase(tenant_it_);
+            tenant_state_ = nullptr;
+        }
+
         MasterService* service_;
-        std::string key_;
+        ObjectIdentity object_id_;
         size_t shard_idx_;
         MetadataShardAccessorRW shard_guard_;
-        std::unordered_map<std::string, ObjectMetadata>::iterator it_;
-        std::unordered_set<std::string>::iterator processing_it_;
-        std::unordered_map<std::string, const ReplicationTask>::iterator
-            replication_task_it_;
+        std::unordered_map<std::string, TenantState>::iterator tenant_it_;
+        TenantState* tenant_state_;
+        ObjectMetadataIterator it_;
+        ProcessingIterator processing_it_;
+        ReplicationTaskIterator replication_task_it_;
     };
 
     class MetadataSerializer {
@@ -1416,20 +1556,36 @@ class MasterService {
     class MetadataAccessorRO {
        public:
         MetadataAccessorRO(const MasterService* service, const std::string& key)
+            : MetadataAccessorRO(service, MakeObjectIdentity(key)) {}
+
+        MetadataAccessorRO(const MasterService* service,
+                           const ObjectIdentity& object_id)
             : service_(service),
-              key_(key),
-              shard_idx_(service_->getMetadataShardIndex(key)),
+              object_id_(object_id),
+              shard_idx_(service_->getMetadataShardIndex(object_id_.user_key)),
               shard_guard_(service_, shard_idx_),
-              it_(shard_guard_->metadata.find(key)),
-              processing_it_(shard_guard_->processing_keys.find(key)) {}
+              tenant_it_(shard_guard_->tenants.find(object_id_.tenant_id)),
+              tenant_state_(tenant_it_ == shard_guard_->tenants.end()
+                                ? nullptr
+                                : &tenant_it_->second),
+              it_(tenant_state_ == nullptr
+                      ? ObjectMetadataConstIterator{}
+                      : tenant_state_->metadata.find(object_id_.user_key)),
+              processing_it_(tenant_state_ == nullptr
+                                 ? ProcessingConstIterator{}
+                                 : tenant_state_->processing_keys.find(
+                                       object_id_.user_key)) {}
 
         // Check if metadata exists
         bool Exists() const NO_THREAD_SAFETY_ANALYSIS {
-            return it_ != shard_guard_->metadata.end() && it_->second.IsValid();
+            return tenant_state_ != nullptr &&
+                   it_ != tenant_state_->metadata.end() &&
+                   it_->second.IsValid();
         }
 
         bool InProcessing() const NO_THREAD_SAFETY_ANALYSIS {
-            return processing_it_ != shard_guard_->processing_keys.end();
+            return tenant_state_ != nullptr &&
+                   processing_it_ != tenant_state_->processing_keys.end();
         }
 
         // Get metadata (only call when Exists() is true)
@@ -1441,13 +1597,24 @@ class MasterService {
             return shard_guard_;
         }
 
+        const TenantState* GetTenantState() const NO_THREAD_SAFETY_ANALYSIS {
+            return tenant_state_;
+        }
+
        private:
+        using ObjectMetadataConstIterator =
+            std::unordered_map<std::string, ObjectMetadata>::const_iterator;
+        using ProcessingConstIterator =
+            std::unordered_set<std::string>::const_iterator;
+
         const MasterService* service_;
-        const std::string key_;
+        const ObjectIdentity object_id_;
         const size_t shard_idx_;
         MetadataShardAccessorRO shard_guard_;
-        std::unordered_map<std::string, ObjectMetadata>::const_iterator it_;
-        std::unordered_set<std::string>::const_iterator processing_it_;
+        std::unordered_map<std::string, TenantState>::const_iterator tenant_it_;
+        const TenantState* tenant_state_;
+        ObjectMetadataConstIterator it_;
+        ProcessingConstIterator processing_it_;
     };
 
     friend class MetadataAccessorRW;
@@ -1658,8 +1825,13 @@ class MasterService {
     std::optional<std::string> SelectDrainTargetForKey(
         const ObjectMetadata& metadata, const std::string& source_segment,
         const std::vector<std::string>& requested_targets);
-    std::string MakeDrainUnitKey(const std::string& key,
+    std::string MakeDrainUnitKey(const std::string& tenant_id,
+                                 const std::string& key,
                                  const std::string& source_segment) const;
+    std::string MakeDrainUnitKey(const std::string& key,
+                                 const std::string& source_segment) const {
+        return MakeDrainUnitKey("default", key, source_segment);
+    }
 
     std::thread job_dispatch_thread_;
     std::atomic<bool> job_dispatch_running_{false};

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -222,6 +222,10 @@ static constexpr size_t DEFAULT_LOCAL_BUFFER_SIZE = 1024 * 1024 * 16;    // 16MB
 constexpr const char* DEFAULT_PROTOCOL = "tcp";
 constexpr const char* DEFAULT_MASTER_SERVER_ADDR = "127.0.0.1:50051";
 
+inline std::string NormalizeTenantId(const std::string& tenant_id) {
+    return tenant_id.empty() ? "default" : tenant_id;
+}
+
 // Store client configuration validation limits
 static constexpr size_t MIN_SEGMENT_SIZE = 1024;                          // 1KB
 static constexpr size_t MAX_SEGMENT_SIZE = 1024ULL * 1024 * 1024 * 1024;  // 1TB

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -165,10 +165,10 @@ MasterService::MasterService(const MasterServiceConfig& config)
           config.snapshot_catalog_store_connstring),
       put_start_discard_timeout_sec_(config.put_start_discard_timeout_sec),
       put_start_release_timeout_sec_(config.put_start_release_timeout_sec),
+      task_manager_(config.task_manager_config),
       cxl_path_(config.cxl_path),
       cxl_size_(config.cxl_size),
-      enable_cxl_(config.enable_cxl),
-      task_manager_(config.task_manager_config) {
+      enable_cxl_(config.enable_cxl) {
     if (enable_snapshot_ || enable_snapshot_restore_) {
         try {
             auto object_store_type =
@@ -598,7 +598,7 @@ size_t MasterService::getMetadataShardIndex(const std::string& key) const {
     return getShardIndex(it->second);
 }
 
-void MasterService::RegisterGroupMember(MetadataShard& shard,
+void MasterService::RegisterGroupMember(TenantState& tenant_state,
                                         const std::string& key,
                                         const std::string& group_id) {
     if (group_id.empty()) {
@@ -607,22 +607,20 @@ void MasterService::RegisterGroupMember(MetadataShard& shard,
     std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
     object_group_ids_[key] = group_id;
     groups_needing_lease_refresh_.insert(group_id);
-    shard.group_members[group_id].insert(key);
+    tenant_state.group_members[group_id].insert(key);
 }
 
-void MasterService::UnregisterGroupMember(MetadataShard& shard,
+void MasterService::UnregisterGroupMember(TenantState& tenant_state,
                                           const std::string& key,
                                           const std::string& group_id) {
     if (group_id.empty()) {
         return;
     }
-    bool group_empty = false;
-    auto group_it = shard.group_members.find(group_id);
-    if (group_it != shard.group_members.end()) {
+    auto group_it = tenant_state.group_members.find(group_id);
+    if (group_it != tenant_state.group_members.end()) {
         group_it->second.erase(key);
         if (group_it->second.empty()) {
-            shard.group_members.erase(group_it);
-            group_empty = true;
+            tenant_state.group_members.erase(group_it);
         }
     }
     std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
@@ -630,50 +628,25 @@ void MasterService::UnregisterGroupMember(MetadataShard& shard,
     if (route_it != object_group_ids_.end() && route_it->second == group_id) {
         object_group_ids_.erase(route_it);
     }
-    if (group_empty) {
-        groups_needing_lease_refresh_.erase(group_id);
-    }
-}
-
-std::unordered_map<std::string, MasterService::ObjectMetadata>::iterator
-MasterService::EraseMetadataEntry(
-    MetadataShard& shard,
-    std::unordered_map<std::string, ObjectMetadata>::iterator it) {
-    if (it == shard.metadata.end()) {
-        return it;
-    }
-    const std::string key = it->first;
-    const std::string group_id = it->second.group_id;
-    // Keep the route visible until metadata is gone. Concurrent writers that
-    // saw the old route will either serialize on this shard or retry after the
-    // route changes, instead of creating a second copy on the key shard.
-    auto next = shard.metadata.erase(it);
-    if (shard.promotion_tasks.erase(key) > 0) {
-        promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
-    }
-    UnregisterGroupMember(shard, key, group_id);
-    return next;
 }
 
 void MasterService::RebuildGroupRoutingIndex() {
     std::unordered_map<std::string, std::string> rebuilt_group_ids;
     std::unordered_set<std::string> groups_needing_refresh;
-    // Snapshot restore rebuilds this derived index after all metadata shards
-    // have been deserialized. Take shard locks here so the helper does not
-    // depend on callers touching guarded shard state directly.
     for (size_t shard_idx = 0; shard_idx < kNumShards; ++shard_idx) {
         MetadataShardAccessorRW shard(this, shard_idx);
-        shard->group_members.clear();
-        for (const auto& [key, metadata] : shard->metadata) {
-            if (!metadata.IsGrouped()) {
-                continue;
+        for (auto& [tenant_id, tenant_state] : shard->tenants) {
+            tenant_state.group_members.clear();
+            for (const auto& [key, metadata] : tenant_state.metadata) {
+                if (!metadata.IsGrouped()) {
+                    continue;
+                }
+                tenant_state.group_members[metadata.group_id].insert(key);
+                rebuilt_group_ids[key] = metadata.group_id;
+                groups_needing_refresh.insert(metadata.group_id);
             }
-            shard->group_members[metadata.group_id].insert(key);
-            rebuilt_group_ids[key] = metadata.group_id;
-            groups_needing_refresh.insert(metadata.group_id);
         }
     }
-
     {
         std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
         object_group_ids_ = std::move(rebuilt_group_ids);
@@ -681,7 +654,7 @@ void MasterService::RebuildGroupRoutingIndex() {
     }
 }
 
-void MasterService::GrantLeaseForGroup(const MetadataShard& shard,
+void MasterService::GrantLeaseForGroup(const TenantState& tenant_state,
                                        const std::string& key,
                                        const ObjectMetadata& metadata) const {
     if (!metadata.IsGrouped()) {
@@ -700,21 +673,18 @@ void MasterService::GrantLeaseForGroup(const MetadataShard& shard,
         return;
     }
 
-    auto group_it = shard.group_members.find(metadata.group_id);
-    if (group_it == shard.group_members.end()) {
+    auto group_it = tenant_state.group_members.find(metadata.group_id);
+    if (group_it == tenant_state.group_members.end()) {
         metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
         return;
     }
 
     for (const auto& member_key : group_it->second) {
-        auto member_it = shard.metadata.find(member_key);
-        if (member_it != shard.metadata.end()) {
-            member_it->second.GrantLease(default_kv_lease_ttl_,
-                                         default_kv_soft_pin_ttl_);
+        auto mit = tenant_state.metadata.find(member_key);
+        if (mit != tenant_state.metadata.end()) {
+            mit->second.GrantLease(default_kv_lease_ttl_,
+                                   default_kv_soft_pin_ttl_);
         }
-    }
-    if (group_it->second.find(key) == group_it->second.end()) {
-        metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
     }
     {
         std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
@@ -730,18 +700,28 @@ void MasterService::ClearInvalidHandles(
     const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients) {
     for (size_t i = 0; i < kNumShards; i++) {
         MetadataShardAccessorRW shard(this, i);
-        auto it = shard->metadata.begin();
-        while (it != shard->metadata.end()) {
-            if (CleanupStaleHandles(it->second, alive_clients)) {
-                // If the object is empty, we need to erase the iterator and
-                // also erase the key from processing_keys,
-                // replication_tasks, offloading_tasks, and promotion_tasks.
-                shard->processing_keys.erase(it->first);
-                shard->replication_tasks.erase(it->first);
-                shard->offloading_tasks.erase(it->first);
-                it = EraseMetadataEntry(shard.get(), it);
+        for (auto tenant_it = shard->tenants.begin();
+             tenant_it != shard->tenants.end();) {
+            auto& tenant_state = tenant_it->second;
+            auto it = tenant_state.metadata.begin();
+            while (it != tenant_state.metadata.end()) {
+                if (CleanupStaleHandles(it->second, alive_clients)) {
+                    tenant_state.processing_keys.erase(it->first);
+                    tenant_state.replication_tasks.erase(it->first);
+                    tenant_state.offloading_tasks.erase(it->first);
+                    if (tenant_state.promotion_tasks.erase(it->first) > 0) {
+                        promotion_in_flight_.fetch_sub(
+                            1, std::memory_order_relaxed);
+                    }
+                    it = tenant_state.metadata.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+            if (tenant_state.Empty()) {
+                tenant_it = shard->tenants.erase(tenant_it);
             } else {
-                ++it;
+                ++tenant_it;
             }
         }
     }
@@ -890,8 +870,14 @@ auto MasterService::UnmountNoFSegment(const UUID& segment_id,
 
 auto MasterService::ExistKey(const std::string& key)
     -> tl::expected<bool, ErrorCode> {
+    return ExistKey(key, "default");
+}
+
+auto MasterService::ExistKey(const std::string& key,
+                             const std::string& tenant_id)
+    -> tl::expected<bool, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRO accessor(this, key);
+    MetadataAccessorRO accessor(this, MakeObjectIdentity(key, tenant_id));
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";
         return false;
@@ -901,7 +887,13 @@ auto MasterService::ExistKey(const std::string& key)
     if (metadata.HasReplica(&Replica::fn_is_completed)) {
         // Grant a lease to the object as it may be further used by the
         // client.
-        GrantLeaseForGroup(accessor.GetShard().get(), key, metadata);
+        auto* ts = accessor.GetTenantState();
+        if (ts) {
+            GrantLeaseForGroup(*ts, key, metadata);
+        } else {
+            metadata.GrantLease(default_kv_lease_ttl_,
+                                default_kv_soft_pin_ttl_);
+        }
         return true;
     }
 
@@ -923,8 +915,14 @@ auto MasterService::GetAllKeys()
     std::vector<std::string> all_keys;
     for (size_t i = 0; i < kNumShards; i++) {
         MetadataShardAccessorRO shard(this, i);
-        for (const auto& item : shard->metadata) {
-            all_keys.push_back(item.first);
+        auto tenant_it = shard->tenants.find("default");
+        if (tenant_it == shard->tenants.end()) {
+            continue;
+        }
+        for (const auto& item : tenant_it->second.metadata) {
+            all_keys.push_back(item.second.user_key.empty()
+                                   ? item.first
+                                   : item.second.user_key);
         }
     }
     return all_keys;
@@ -1171,6 +1169,14 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
     -> tl::expected<
         std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
         ErrorCode> {
+    return GetReplicaListByRegex(regex_pattern, "default");
+}
+
+auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern,
+                                          const std::string& tenant_id)
+    -> tl::expected<
+        std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
+        ErrorCode> {
     std::unordered_map<std::string, std::vector<Replica::Descriptor>> results;
     std::regex pattern;
 
@@ -1183,10 +1189,14 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
     }
 
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
     for (size_t i = 0; i < kNumShards; ++i) {
         MetadataShardAccessorRO shard(this, i);
-
-        for (const auto& [key, metadata] : shard->metadata) {
+        auto tenant_it = shard->tenants.find(normalized_tenant);
+        if (tenant_it == shard->tenants.end()) {
+            continue;
+        }
+        for (const auto& [key, metadata] : tenant_it->second.metadata) {
             if (std::regex_search(key, pattern)) {
                 std::vector<Replica::Descriptor> replica_list;
                 metadata.VisitReplicas(
@@ -1203,7 +1213,7 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
                 }
 
                 results.emplace(key, std::move(replica_list));
-                GrantLeaseForGroup(shard.get(), key, metadata);
+                GrantLeaseForGroup(tenant_it->second, key, metadata);
             }
         }
     }
@@ -1213,12 +1223,19 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
 
 auto MasterService::GetReplicaList(const std::string& key)
     -> tl::expected<GetReplicaListResponse, ErrorCode> {
+    return GetReplicaList(key, "default");
+}
+
+auto MasterService::GetReplicaList(const std::string& key,
+                                   const std::string& tenant_id)
+    -> tl::expected<GetReplicaListResponse, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
 
     GetReplicaListResponse resp({}, default_kv_lease_ttl_);
     bool promotion_eligible = false;
     {
-        MetadataAccessorRO accessor(this, key);
+        MetadataAccessorRO accessor(this, object_id);
 
         MasterMetricManager::instance().inc_total_get_nums();
 
@@ -1248,7 +1265,13 @@ auto MasterService::GetReplicaList(const std::string& key)
         MasterMetricManager::instance().inc_valid_get_nums();
         // Grant a lease to the object so it will not be removed
         // when the client is reading it.
-        GrantLeaseForGroup(accessor.GetShard().get(), key, metadata);
+        auto* ts = accessor.GetTenantState();
+        if (ts) {
+            GrantLeaseForGroup(*ts, key, metadata);
+        } else {
+            metadata.GrantLease(default_kv_lease_ttl_,
+                                default_kv_soft_pin_ttl_);
+        }
 
         // Promotion-on-hit eligibility: only when no MEMORY replica is
         // present but at least one LOCAL_DISK replica is. Decided here while
@@ -1267,7 +1290,7 @@ auto MasterService::GetReplicaList(const std::string& key)
     }
     // RO accessor released. Safe to take a fresh RW accessor now.
     if (promotion_eligible) {
-        TryPushPromotionQueue(key);
+        TryPushPromotionQueue(object_id);
     }
     return resp;
 }
@@ -1276,8 +1299,10 @@ auto MasterService::AllocateAndInsertMetadata(
     MetadataShardAccessorRW& shard, const UUID& client_id,
     const std::string& key, uint64_t value_length,
     const ReplicateConfig& config, const std::string& group_id,
+    const std::string& tenant_id,
     const std::chrono::system_clock::time_point& now)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+    auto& tenant_state = shard->tenants[tenant_id];
     std::vector<Replica> replicas;
     const auto write_mode = DetermineReplicaWriteMode(config);
     size_t allocated_memory_replicas = 0;
@@ -1404,16 +1429,14 @@ auto MasterService::AllocateAndInsertMetadata(
         }
     }
 
-    // Publish the route before metadata while holding the target shard lock, so
-    // same-key callers serialize on this shard instead of missing the grouped
-    // object and writing a duplicate on the natural key shard.
-    RegisterGroupMember(shard.get(), key, group_id);
-    shard->metadata.emplace(
+    // Publish the route before inserting metadata for grouped objects.
+    RegisterGroupMember(tenant_state, key, group_id);
+    tenant_state.metadata.emplace(
         std::piecewise_construct, std::forward_as_tuple(key),
         std::forward_as_tuple(client_id, now, value_length, std::move(replicas),
                               config.with_soft_pin, config.with_hard_pin,
-                              config.data_type, group_id));
-    shard->processing_keys.insert(key);
+                              config.data_type, group_id, tenant_id, key));
+    tenant_state.processing_keys.insert(key);
 
     return replica_list;
 }
@@ -1422,6 +1445,15 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                              const uint64_t slice_length,
                              const ReplicateConfig& config)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+    return PutStart(client_id, key, "default", slice_length, config);
+}
+
+auto MasterService::PutStart(const UUID& client_id, const std::string& key,
+                             const std::string& tenant_id,
+                             const uint64_t slice_length,
+                             const ReplicateConfig& config)
+    -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
     if ((config.replica_num == 0 && config.nof_replica_num == 0) ||
         key.empty() || slice_length == 0) {
         LOG(ERROR) << "key=" << key << ", replica_num=" << config.replica_num
@@ -1466,28 +1498,23 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
 
     auto alive_clients = getAliveClientsSnapshot();
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    // Lock the shard and check if object already exists.
+    // For new grouped objects, route to the group's target shard directly
+    // since the routing table hasn't been populated yet.
+    const size_t target_shard_idx =
+        group_id.empty() ? getMetadataShardIndex(object_id.user_key)
+                         : getShardIndex(group_id);
+    MetadataShardAccessorRW shard(this, target_shard_idx);
+    auto& tenant_state = shard->tenants[object_id.tenant_id];
+
     const auto now = std::chrono::system_clock::now();
-
-    auto prepare_existing =
-        [this, &alive_clients, &key, &now](
-            MetadataShardAccessorRW& shard,
-            std::unordered_map<std::string, ObjectMetadata>::iterator& it)
-        -> tl::expected<void, ErrorCode> {
-        if (it == shard->metadata.end()) {
-            return {};
-        }
-
-        if (CleanupStaleHandles(it->second, alive_clients)) {
-            shard->processing_keys.erase(key);
-            shard->replication_tasks.erase(key);
-            shard->offloading_tasks.erase(key);
-            it = EraseMetadataEntry(shard.get(), it);
-            return {};
-        }
-
+    auto it = tenant_state.metadata.find(key);
+    if (it != tenant_state.metadata.end() &&
+        !CleanupStaleHandles(it->second, alive_clients)) {
         auto& metadata = it->second;
-        // If the object's PutStart expired and has not completed any replicas,
-        // discard it and allow the new PutStart to go.
+        // If the object's PutStart expired and has not completed any
+        // replicas, we can discard it and allow the new PutStart to
+        // go.
         if (!metadata.HasReplica(&Replica::fn_is_completed) &&
             metadata.put_start_time + put_start_discard_timeout_sec_ < now) {
             auto replicas = metadata.PopReplicas(&Replica::fn_is_processing);
@@ -1497,73 +1524,32 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                     std::move(replicas),
                     metadata.put_start_time + put_start_release_timeout_sec_);
             }
-            shard->processing_keys.erase(key);
-            it = EraseMetadataEntry(shard.get(), it);
-            return {};
+            tenant_state.processing_keys.erase(key);
+            tenant_state.metadata.erase(it);
+        } else {
+            LOG(INFO) << "key=" << key << ", info=object_already_exists";
+            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
         }
-
-        LOG(INFO) << "key=" << key << ", info=object_already_exists";
-        return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
-    };
-
-    auto put_with_locked_target = [&](MetadataShardAccessorRW& target_shard)
-        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
-        auto target_it = target_shard->metadata.find(key);
-        auto result = prepare_existing(target_shard, target_it);
-        if (!result) {
-            return tl::make_unexpected(result.error());
-        }
-        return AllocateAndInsertMetadata(target_shard, client_id, key,
-                                         slice_length, config, group_id, now);
-    };
-
-    auto put_with_locked_shards = [&](MetadataShardAccessorRW& existing_shard,
-                                      MetadataShardAccessorRW& target_shard)
-        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
-        auto existing_it = existing_shard->metadata.find(key);
-        auto result = prepare_existing(existing_shard, existing_it);
-        if (!result) {
-            return tl::make_unexpected(result.error());
-        }
-        return put_with_locked_target(target_shard);
-    };
-
-    while (true) {
-        const size_t existing_shard_idx = getMetadataShardIndex(key);
-        const size_t target_shard_idx =
-            group_id.empty() ? getShardIndex(key) : getShardIndex(group_id);
-
-        if (existing_shard_idx == target_shard_idx) {
-            MetadataShardAccessorRW shard(this, target_shard_idx);
-            if (getMetadataShardIndex(key) != existing_shard_idx) {
-                continue;
-            }
-            return put_with_locked_target(shard);
-        }
-
-        if (existing_shard_idx < target_shard_idx) {
-            MetadataShardAccessorRW existing_shard(this, existing_shard_idx);
-            MetadataShardAccessorRW target_shard(this, target_shard_idx);
-            if (getMetadataShardIndex(key) != existing_shard_idx) {
-                continue;
-            }
-            return put_with_locked_shards(existing_shard, target_shard);
-        }
-
-        MetadataShardAccessorRW target_shard(this, target_shard_idx);
-        MetadataShardAccessorRW existing_shard(this, existing_shard_idx);
-        if (getMetadataShardIndex(key) != existing_shard_idx) {
-            continue;
-        }
-        return put_with_locked_shards(existing_shard, target_shard);
     }
+
+    return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
+                                     config, group_id, object_id.tenant_id,
+                                     now);
 }
 
 auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
                            ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
+    return PutEnd(client_id, key, "default", replica_type);
+}
+
+auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
+                           const std::string& tenant_id,
+                           ReplicaType replica_type)
+    -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
+    MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -1597,18 +1583,19 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
         [](Replica& replica) { replica.mark_complete(); });
 
     if (enable_offload_ && !offload_on_evict_) {
-        auto& shard = accessor.GetShard();
+        auto& tenant_state = accessor.GetTenantState();
         metadata.VisitReplicas(
             [](const Replica& replica) {
                 return replica.is_completed() && replica.is_memory_replica();
             },
-            [this, &key, &shard](Replica& replica) {
-                auto result = PushOffloadingQueue(key, replica);
+            [this, &object_id, &tenant_state](Replica& replica) {
+                auto result = PushOffloadingQueue(object_id, replica);
                 if (result) {
                     replica.inc_refcnt();
-                    shard->offloading_tasks.emplace(
-                        key, OffloadingTask{replica.id(),
-                                            std::chrono::system_clock::now()});
+                    tenant_state.offloading_tasks.emplace(
+                        object_id.user_key,
+                        OffloadingTask{replica.id(),
+                                       std::chrono::system_clock::now()});
                 }
             });
     }
@@ -1774,6 +1761,15 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                                 const uint64_t slice_length,
                                 const ReplicateConfig& config)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+    return UpsertStart(client_id, key, "default", slice_length, config);
+}
+
+auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
+                                const std::string& tenant_id,
+                                const uint64_t slice_length,
+                                const ReplicateConfig& config)
+    -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
     // --- Parameter validation (same as PutStart) ---
     if ((config.replica_num == 0 && config.nof_replica_num == 0) ||
         key.empty() || slice_length == 0) {
@@ -1815,239 +1811,189 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     if (!group_id_result) {
         return tl::make_unexpected(group_id_result.error());
     }
-    const bool has_requested_group_id = config.group_ids.has_value();
-    const std::string requested_group_id = group_id_result.value();
+    const std::string group_id = group_id_result.value();
 
     // --- Lock acquisition ---
-    // snapshot_mutex_ (shared): allows concurrent reads/writes, blocks only
-    //   during full metadata snapshots.
-    // shard lock (exclusive via MetadataShardAccessorRW): serializes all
-    //   operations on keys that hash to the same shard.
     auto alive_clients = getAliveClientsSnapshot();
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    // Use getMetadataShardIndex to find the object at its current shard
+    // (handles both grouped and ungrouped routing).
+    const size_t lookup_shard_idx = getMetadataShardIndex(object_id.user_key);
+    MetadataShardAccessorRW shard(this, lookup_shard_idx);
+    auto& tenant_state = shard->tenants[object_id.tenant_id];
+
     const auto now = std::chrono::system_clock::now();
+    auto it = tenant_state.metadata.find(key);
 
-    auto cleanup_existing_if_stale =
-        [this, &alive_clients, &key](
-            MetadataShardAccessorRW& shard,
-            std::unordered_map<std::string, ObjectMetadata>::iterator& it)
-        -> bool {
-        if (it != shard->metadata.end() &&
-            CleanupStaleHandles(it->second, alive_clients)) {
-            shard->processing_keys.erase(key);
-            shard->replication_tasks.erase(key);
-            shard->offloading_tasks.erase(key);
-            EraseMetadataEntry(shard.get(), it);
-            it = shard->metadata.end();
-            return true;
-        }
-        return false;
-    };
+    // --- Step 0: stale handle cleanup ---
+    if (it != tenant_state.metadata.end() &&
+        CleanupStaleHandles(it->second, alive_clients)) {
+        tenant_state.processing_keys.erase(key);
+        ErasePromotionTaskIfPresent(tenant_state, key);
+        tenant_state.metadata.erase(it);
+        it = tenant_state.metadata.end();
+    }
 
-    while (true) {
-        const size_t existing_shard_idx = getMetadataShardIndex(key);
-        const size_t requested_shard_idx =
-            has_requested_group_id && !requested_group_id.empty()
-                ? getShardIndex(requested_group_id)
-                : getShardIndex(key);
-        const size_t target_shard_idx = requested_shard_idx;
+    // --- Step 1: safety checks and preemption (only if key exists) ---
+    if (it != tenant_state.metadata.end()) {
+        auto& metadata = it->second;
 
-        std::optional<MetadataShardAccessorRW> first_shard_guard;
-        std::optional<MetadataShardAccessorRW> second_shard_guard;
-        MetadataShardAccessorRW* existing_shard = nullptr;
-        MetadataShardAccessorRW* target_shard = nullptr;
-        if (existing_shard_idx == target_shard_idx) {
-            first_shard_guard.emplace(this, target_shard_idx);
-            target_shard = &*first_shard_guard;
-        } else if (existing_shard_idx < target_shard_idx) {
-            first_shard_guard.emplace(this, existing_shard_idx);
-            second_shard_guard.emplace(this, target_shard_idx);
-            existing_shard = &*first_shard_guard;
-            target_shard = &*second_shard_guard;
-        } else {
-            first_shard_guard.emplace(this, target_shard_idx);
-            second_shard_guard.emplace(this, existing_shard_idx);
-            target_shard = &*first_shard_guard;
-            existing_shard = &*second_shard_guard;
-        }
-
-        if (getMetadataShardIndex(key) != existing_shard_idx) {
-            continue;
-        }
-
-        MetadataShardAccessorRW* shard_for_key = target_shard;
-        std::unordered_map<std::string, ObjectMetadata>::iterator it;
-
-        if (existing_shard != nullptr) {
-            auto existing_it = (*existing_shard)->metadata.find(key);
-            cleanup_existing_if_stale(*existing_shard, existing_it);
-            if (existing_it != (*existing_shard)->metadata.end()) {
-                if (has_requested_group_id) {
-                    LOG(ERROR) << "key=" << key
-                               << ", error=group_membership_is_immutable";
-                    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-                }
-                shard_for_key = existing_shard;
-                it = existing_it;
-            } else {
-                it = (*target_shard)->metadata.find(key);
-                cleanup_existing_if_stale(*target_shard, it);
-            }
-        } else {
-            it = (*target_shard)->metadata.find(key);
-            cleanup_existing_if_stale(*target_shard, it);
-        }
-
-        MetadataShardAccessorRW& shard = *shard_for_key;
-
-        // --- Step 1: safety checks and preemption (only if key exists) ---
-        if (it != shard->metadata.end()) {
-            auto& metadata = it->second;
-
-            if (has_requested_group_id &&
-                metadata.group_id != requested_group_id) {
+        // Reject if the caller tries to change group membership.
+        // Group membership is immutable while an object exists.
+        if (config.group_ids.has_value() && metadata.IsGrouped()) {
+            const bool has_requested_group_id =
+                config.group_ids.has_value() && !group_id.empty();
+            if (has_requested_group_id && metadata.group_id != group_id) {
                 LOG(ERROR) << "key=" << key
                            << ", error=group_membership_is_immutable";
                 return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
             }
-
-            // Reject if a Copy/Move task is actively reading this key's
-            // replicas. Writing during replication would corrupt the copy.
-            if (shard->replication_tasks.count(key) > 0) {
-                LOG(INFO) << "key=" << key
-                          << ", error=object_has_replication_task";
-                return tl::make_unexpected(
-                    ErrorCode::OBJECT_HAS_REPLICATION_TASK);
-            }
-
-            // Reject if an offload-to-disk task is in progress (same reason).
-            if (shard->offloading_tasks.count(key) > 0) {
-                LOG(INFO) << "key=" << key
-                          << ", error=object_has_offloading_task";
-                return tl::make_unexpected(
-                    ErrorCode::OBJECT_HAS_REPLICATION_TASK);
-            }
-
-            // Preempt an in-progress Put/Upsert on the same key.  The previous
-            // writer's PROCESSING replicas are moved to discarded_replicas_
-            // with a TTL so they are not freed while the old writer may still
-            // be doing RDMA writes.  Unlike PutStart (which only preempts after
-            // a timeout), UpsertStart preempts immediately.
-            if (shard->processing_keys.count(key) > 0) {
-                auto processing_replicas =
-                    metadata.PopReplicas(&Replica::fn_is_processing);
-                if (!processing_replicas.empty()) {
-                    std::lock_guard lock(discarded_replicas_mutex_);
-                    discarded_replicas_.emplace_back(
-                        std::move(processing_replicas),
-                        now + put_start_release_timeout_sec_);
-                }
-                shard->processing_keys.erase(key);
-
-                // If no COMPLETE replicas survive the preemption, this key
-                // effectively does not exist — fall through to Case A.
-                if (!metadata.HasReplica(&Replica::fn_is_completed)) {
-                    it = EraseMetadataEntry(shard.get(), it);
-                    it = shard->metadata.end();
-                    if (!has_requested_group_id &&
-                        shard_for_key != target_shard) {
-                        continue;
-                    }
+            if (!has_requested_group_id && metadata.IsGrouped()) {
+                // Explicitly ungrouping a grouped object is not allowed.
+                if (config.group_ids.has_value() &&
+                    config.group_ids->at(0).empty()) {
+                    LOG(ERROR) << "key=" << key
+                               << ", error=group_membership_is_immutable";
+                    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
                 }
             }
         }
 
-        // --- Case A: key does not exist (or was erased above) ---
-        // Allocate fresh buffers, identical to PutStart.
-        if (it == shard->metadata.end()) {
-            VLOG(1) << "key=" << key << ", action=upsert_start_case_a";
-            const std::string group_id =
-                has_requested_group_id ? requested_group_id : "";
-            return AllocateAndInsertMetadata(
-                shard, client_id, key, slice_length, config, group_id, now);
+        // Reject if a Copy/Move task is actively reading this key's replicas.
+        if (tenant_state.replication_tasks.count(key) > 0) {
+            LOG(INFO) << "key=" << key << ", error=object_has_replication_task";
+            return tl::make_unexpected(ErrorCode::OBJECT_HAS_REPLICATION_TASK);
         }
 
-        // --- Step 2: key exists with COMPLETE replicas → Case B or C ---
-        auto& metadata = it->second;
-
-        // Reject if any reader holds a reference (refcnt > 0).  Overwriting a
-        // buffer that an RDMA read is streaming from would cause data
-        // corruption. The client should retry after readers finish.
-        if (metadata.HasReplica(&Replica::fn_is_busy)) {
-            LOG(INFO) << "key=" << key << ", error=object_replica_busy";
-            return tl::make_unexpected(ErrorCode::OBJECT_REPLICA_BUSY);
+        // Reject if an offload-to-disk task is in progress (same reason).
+        if (tenant_state.offloading_tasks.count(key) > 0) {
+            LOG(INFO) << "key=" << key << ", error=object_has_offloading_task";
+            return tl::make_unexpected(ErrorCode::OBJECT_HAS_REPLICATION_TASK);
         }
 
-        if (metadata.size == slice_length) {
-            // --- Case B: same size — in-place update ---
-            // Reuse existing buffer addresses.  No allocation or deallocation.
-            // The client will RDMA-write new data to the same addresses.
-            //
-            // hard_pinned is const and preserved automatically — upsert does
-            // not change the eviction protection level of an existing object.
-            metadata.client_id = client_id;
-            metadata.put_start_time = now;
-
-            // Reconcile soft_pin state with the incoming config.
-            {
-                SpinLocker locker(&metadata.lock);
-                if (config.with_soft_pin && !metadata.soft_pin_timeout) {
-                    metadata.soft_pin_timeout.emplace();
-                    MasterMetricManager::instance().inc_soft_pin_key_count(1);
-                } else if (!config.with_soft_pin && metadata.soft_pin_timeout) {
-                    metadata.soft_pin_timeout.reset();
-                    MasterMetricManager::instance().dec_soft_pin_key_count(1);
-                }
+        // Preempt an in-progress Put/Upsert on the same key.  The previous
+        // writer's PROCESSING replicas are moved to discarded_replicas_ with a
+        // TTL so they are not freed while the old writer may still be doing
+        // RDMA writes.  Unlike PutStart (which only preempts after a timeout),
+        // UpsertStart preempts immediately.
+        if (tenant_state.processing_keys.count(key) > 0) {
+            auto processing_replicas =
+                metadata.PopReplicas(&Replica::fn_is_processing);
+            if (!processing_replicas.empty()) {
+                std::lock_guard lock(discarded_replicas_mutex_);
+                discarded_replicas_.emplace_back(
+                    std::move(processing_replicas),
+                    now + put_start_release_timeout_sec_);
             }
+            tenant_state.processing_keys.erase(key);
 
-            // Mark COMPLETE → PROCESSING so readers won't see stale data
-            // mid-transfer.  The key becomes unreadable until UpsertEnd.
-            metadata.VisitReplicas(
-                &Replica::fn_is_completed,
-                [](Replica& replica) { replica.mark_processing(); });
-
-            shard->processing_keys.insert(key);
-
-            // Return the existing descriptors — same buffer addresses as
-            // before.
-            std::vector<Replica::Descriptor> replica_list;
-            const auto& all_replicas = metadata.GetAllReplicas();
-            replica_list.reserve(all_replicas.size());
-            for (const auto& replica : all_replicas) {
-                replica_list.emplace_back(replica.get_descriptor());
+            // If no COMPLETE replicas survive the preemption, this key
+            // effectively does not exist — fall through to Case A.
+            if (!metadata.HasReplica(&Replica::fn_is_completed)) {
+                ErasePromotionTaskIfPresent(tenant_state, key);
+                tenant_state.metadata.erase(it);
+                it = tenant_state.metadata.end();
             }
-
-            VLOG(1) << "key=" << key << ", action=upsert_start_case_b_inplace";
-            return replica_list;
         }
-
-        // --- Case C: different size — discard old replicas and reallocate ---
-        // Old buffers cannot be reused.  Move them to discarded_replicas_ for
-        // delayed release (readers may still hold descriptors without refcnt),
-        // then allocate fresh buffers at the new size.
-        //
-        // Preserve hard_pin and soft_pin from the old metadata so that eviction
-        // protection survives a size-changing upsert (RFC §2.2.2).
-        ReplicateConfig merged_config = config;
-        merged_config.with_hard_pin =
-            merged_config.with_hard_pin || metadata.IsHardPinned();
-        merged_config.with_soft_pin =
-            merged_config.with_soft_pin || metadata.IsSoftPinned();
-        const std::string group_id =
-            has_requested_group_id ? requested_group_id : metadata.group_id;
-
-        auto old_replicas = metadata.PopReplicas();
-        if (!old_replicas.empty()) {
-            std::lock_guard lock(discarded_replicas_mutex_);
-            discarded_replicas_.emplace_back(
-                std::move(old_replicas), now + put_start_release_timeout_sec_);
-        }
-        EraseMetadataEntry(shard.get(), it);
-
-        VLOG(1) << "key=" << key << ", action=upsert_start_case_c_reallocate";
-        return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                         merged_config, group_id, now);
     }
+
+    // --- Case A: key does not exist (or was erased above) ---
+    // Allocate fresh buffers, identical to PutStart.
+    if (it == tenant_state.metadata.end()) {
+        VLOG(1) << "key=" << key << ", action=upsert_start_case_a";
+        const size_t case_a_shard_idx =
+            group_id.empty() ? lookup_shard_idx : getShardIndex(group_id);
+        if (case_a_shard_idx != lookup_shard_idx) {
+            MetadataShardAccessorRW target_shard(this, case_a_shard_idx);
+            return AllocateAndInsertMetadata(target_shard, client_id, key,
+                                             slice_length, config, group_id,
+                                             object_id.tenant_id, now);
+        }
+        return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
+                                         config, group_id, object_id.tenant_id,
+                                         now);
+    }
+
+    // --- Step 2: key exists with COMPLETE replicas → Case B or C ---
+    auto& metadata = it->second;
+
+    // Reject if any reader holds a reference (refcnt > 0).  Overwriting a
+    // buffer that an RDMA read is streaming from would cause data corruption.
+    // The client should retry after readers finish.
+    if (metadata.HasReplica(&Replica::fn_is_busy)) {
+        LOG(INFO) << "key=" << key << ", error=object_replica_busy";
+        return tl::make_unexpected(ErrorCode::OBJECT_REPLICA_BUSY);
+    }
+
+    if (metadata.size == slice_length) {
+        // --- Case B: same size — in-place update ---
+        // Reuse existing buffer addresses.  No allocation or deallocation.
+        // The client will RDMA-write new data to the same addresses.
+        //
+        // hard_pinned is const and preserved automatically — upsert does not
+        // change the eviction protection level of an existing object.
+        metadata.client_id = client_id;
+        metadata.put_start_time = now;
+
+        // Reconcile soft_pin state with the incoming config.
+        {
+            SpinLocker locker(&metadata.lock);
+            if (config.with_soft_pin && !metadata.soft_pin_timeout) {
+                metadata.soft_pin_timeout.emplace();
+                MasterMetricManager::instance().inc_soft_pin_key_count(1);
+            } else if (!config.with_soft_pin && metadata.soft_pin_timeout) {
+                metadata.soft_pin_timeout.reset();
+                MasterMetricManager::instance().dec_soft_pin_key_count(1);
+            }
+        }
+
+        // Mark COMPLETE → PROCESSING so readers won't see stale data
+        // mid-transfer.  The key becomes unreadable until UpsertEnd.
+        metadata.VisitReplicas(&Replica::fn_is_completed, [](Replica& replica) {
+            replica.mark_processing();
+        });
+
+        tenant_state.processing_keys.insert(key);
+
+        // Return the existing descriptors — same buffer addresses as before.
+        std::vector<Replica::Descriptor> replica_list;
+        const auto& all_replicas = metadata.GetAllReplicas();
+        replica_list.reserve(all_replicas.size());
+        for (const auto& replica : all_replicas) {
+            replica_list.emplace_back(replica.get_descriptor());
+        }
+
+        VLOG(1) << "key=" << key << ", action=upsert_start_case_b_inplace";
+        return replica_list;
+    }
+
+    // --- Case C: different size — discard old replicas and reallocate ---
+    // Old buffers cannot be reused.  Move them to discarded_replicas_ for
+    // delayed release (readers may still hold descriptors without refcnt),
+    // then allocate fresh buffers at the new size.
+    //
+    // Preserve hard_pin and soft_pin from the old metadata so that eviction
+    // protection survives a size-changing upsert (RFC §2.2.2).
+    ReplicateConfig merged_config = config;
+    merged_config.with_hard_pin =
+        merged_config.with_hard_pin || metadata.IsHardPinned();
+    merged_config.with_soft_pin =
+        merged_config.with_soft_pin || metadata.IsSoftPinned();
+
+    auto old_replicas = metadata.PopReplicas();
+    if (!old_replicas.empty()) {
+        std::lock_guard lock(discarded_replicas_mutex_);
+        discarded_replicas_.emplace_back(std::move(old_replicas),
+                                         now + put_start_release_timeout_sec_);
+    }
+    tenant_state.metadata.erase(it);
+
+    VLOG(1) << "key=" << key << ", action=upsert_start_case_c_reallocate";
+    const std::string effective_group_id =
+        metadata.IsGrouped() ? metadata.group_id : group_id;
+    return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
+                                     merged_config, effective_group_id,
+                                     object_id.tenant_id, now);
 }
 
 auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
@@ -2229,8 +2175,8 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
     }
 
     // Create replication task for tracking.
-    auto& shard = accessor.GetShard();
-    shard->replication_tasks.emplace(
+    auto& tenant_state = accessor.GetTenantState();
+    tenant_state.replication_tasks.emplace(
         std::piecewise_construct, std::forward_as_tuple(key),
         std::forward_as_tuple(client_id, std::chrono::system_clock::now(),
                               ReplicationTask::Type::COPY, source->id(),
@@ -2444,8 +2390,8 @@ tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
     }
 
     // Create replication task for tracking.
-    auto& shard = accessor.GetShard();
-    shard->replication_tasks.emplace(
+    auto& tenant_state = accessor.GetTenantState();
+    tenant_state.replication_tasks.emplace(
         std::piecewise_construct, std::forward_as_tuple(key),
         std::forward_as_tuple(client_id, std::chrono::system_clock::now(),
                               ReplicationTask::Type::MOVE, source->id(),
@@ -2602,8 +2548,14 @@ tl::expected<void, ErrorCode> MasterService::MoveRevoke(
 
 auto MasterService::Remove(const std::string& key, bool force)
     -> tl::expected<void, ErrorCode> {
+    return Remove(key, "default", force);
+}
+
+auto MasterService::Remove(const std::string& key, const std::string& tenant_id,
+                           bool force) -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
+    MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2632,12 +2584,19 @@ auto MasterService::Remove(const std::string& key, bool force)
         return tl::make_unexpected(ErrorCode::OBJECT_HAS_REPLICATION_TASK);
     }
 
-    // Remove object metadata
+    auto& tenant_state = accessor.GetTenantState();
+    ErasePromotionTaskIfPresent(tenant_state, key);
     accessor.Erase();
     return {};
 }
 
 auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
+    -> tl::expected<long, ErrorCode> {
+    return RemoveByRegex(regex_pattern, "default", force);
+}
+
+auto MasterService::RemoveByRegex(const std::string& regex_pattern,
+                                  const std::string& tenant_id, bool force)
     -> tl::expected<long, ErrorCode> {
     long removed_count = 0;
     std::regex pattern;
@@ -2651,10 +2610,17 @@ auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
     }
 
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
     for (size_t i = 0; i < kNumShards; ++i) {
         MetadataShardAccessorRW shard(this, i);
+        auto tenant_it = shard->tenants.find(normalized_tenant);
+        if (tenant_it == shard->tenants.end()) {
+            continue;
+        }
+        auto& tenant_state = tenant_it->second;
 
-        for (auto it = shard->metadata.begin(); it != shard->metadata.end();) {
+        for (auto it = tenant_state.metadata.begin();
+             it != tenant_state.metadata.end();) {
             if (std::regex_search(it->first, pattern)) {
                 if (!force && !it->second.IsLeaseExpired()) {
                     VLOG(1) << "key=" << it->first
@@ -2677,7 +2643,7 @@ auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
                     ++it;
                     continue;
                 }
-                if (metadata_shards_[i].replication_tasks.contains(it->first)) {
+                if (tenant_state.replication_tasks.contains(it->first)) {
                     LOG(WARNING) << "key=" << it->first
                                  << ", matched by regex, but has replication "
                                     "task. Skipping removal.";
@@ -2687,11 +2653,15 @@ auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
 
                 VLOG(1) << "key=" << it->first
                         << " matched by regex. Removing.";
-                it = EraseMetadataEntry(shard.get(), it);
+                ErasePromotionTaskIfPresent(tenant_state, it->first);
+                it = tenant_state.metadata.erase(it);
                 removed_count++;
             } else {
                 ++it;
             }
+        }
+        if (tenant_state.Empty()) {
+            shard->tenants.erase(tenant_it);
         }
     }
 
@@ -2710,29 +2680,28 @@ long MasterService::RemoveAll(bool force) {
 
     for (size_t i = 0; i < kNumShards; i++) {
         MetadataShardAccessorRW shard(this, i);
-        if (shard->metadata.empty()) {
-            continue;
-        }
-
-        // Only remove completed objects with expired leases (unless force=true)
-        auto it = shard->metadata.begin();
-        while (it != shard->metadata.end()) {
-            /**
-             * The reason the force operation here does not bypass the replica
-             * check is that put operations (which could also be copy or move)
-             * and remove operations might be happening concurrently, making it
-             * extremely dangerous to perform a direct removal at this point.
-             */
-            if ((force || it->second.IsLeaseExpired(now)) &&
-                it->second.AllReplicas(&Replica::fn_is_completed) &&
-                !shard->replication_tasks.contains(it->first)) {
-                auto mem_rep_count =
-                    it->second.CountReplicas(&Replica::fn_is_memory_replica);
-                total_freed_size += it->second.size * mem_rep_count;
-                it = EraseMetadataEntry(shard.get(), it);
-                removed_count++;
+        for (auto tenant_it = shard->tenants.begin();
+             tenant_it != shard->tenants.end();) {
+            auto& tenant_state = tenant_it->second;
+            auto it = tenant_state.metadata.begin();
+            while (it != tenant_state.metadata.end()) {
+                if ((force || it->second.IsLeaseExpired(now)) &&
+                    it->second.AllReplicas(&Replica::fn_is_completed) &&
+                    !tenant_state.replication_tasks.contains(it->first)) {
+                    auto mem_rep_count = it->second.CountReplicas(
+                        &Replica::fn_is_memory_replica);
+                    total_freed_size += it->second.size * mem_rep_count;
+                    ErasePromotionTaskIfPresent(tenant_state, it->first);
+                    it = tenant_state.metadata.erase(it);
+                    removed_count++;
+                } else {
+                    ++it;
+                }
+            }
+            if (tenant_state.Empty()) {
+                tenant_it = shard->tenants.erase(tenant_it);
             } else {
-                ++it;
+                ++tenant_it;
             }
         }
     }
@@ -2756,7 +2725,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
         std::min(keys.size(), static_cast<size_t>(kNumShards)));
 
     for (size_t i = 0; i < keys.size(); ++i) {
-        size_t shard_idx = getMetadataShardIndex(keys[i]);
+        size_t shard_idx = getShardIndex(keys[i]);
         keys_by_shard[shard_idx].emplace_back(i, &keys[i]);
     }
 
@@ -2771,9 +2740,17 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
 
         for (const auto& [original_idx, key_ptr] : key_group) {
             const std::string& key = *key_ptr;
-            auto it = shard->metadata.find(key);
+            auto tenant_it = shard->tenants.find("default");
+            if (tenant_it == shard->tenants.end()) {
+                VLOG(1) << "key=" << key << ", error=object_not_found";
+                results[original_idx] =
+                    tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+                continue;
+            }
+            auto& tenant_state = tenant_it->second;
+            auto it = tenant_state.metadata.find(key);
 
-            if (it == shard->metadata.end()) {
+            if (it == tenant_state.metadata.end()) {
                 VLOG(1) << "key=" << key << ", error=object_not_found";
                 results[original_idx] =
                     tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2782,10 +2759,11 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
 
             // Clean up stale replica handles (consistent with single Remove)
             if (CleanupStaleHandles(it->second, alive_clients)) {
-                shard->processing_keys.erase(key);
-                shard->replication_tasks.erase(key);
-                shard->offloading_tasks.erase(key);
-                EraseMetadataEntry(shard.get(), it);
+                tenant_state.processing_keys.erase(key);
+                tenant_state.replication_tasks.erase(key);
+                tenant_state.offloading_tasks.erase(key);
+                ErasePromotionTaskIfPresent(tenant_state, key);
+                tenant_state.metadata.erase(it);
                 results[original_idx] =
                     tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
                 continue;
@@ -2812,7 +2790,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                 continue;
             }
 
-            if (shard->replication_tasks.contains(key)) {
+            if (tenant_state.replication_tasks.contains(key)) {
                 LOG(ERROR) << "key=" << key
                            << ", error=object_has_replication_task";
                 results[original_idx] =
@@ -2821,7 +2799,11 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
             }
 
             // Remove object metadata
-            EraseMetadataEntry(shard.get(), it);
+            ErasePromotionTaskIfPresent(tenant_state, key);
+            tenant_state.metadata.erase(it);
+            if (tenant_state.Empty()) {
+                shard->tenants.erase(tenant_it);
+            }
             results[original_idx] = {};  // Success
         }
     }
@@ -2849,7 +2831,9 @@ size_t MasterService::GetKeyCount() const {
     size_t total = 0;
     for (size_t i = 0; i < kNumShards; i++) {
         MetadataShardAccessorRO shard(this, i);
-        total += shard->metadata.size();
+        for (const auto& [tenant_id, tenant_state] : shard->tenants) {
+            total += tenant_state.metadata.size();
+        }
     }
     return total;
 }
@@ -2969,15 +2953,15 @@ auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
     for (auto& [key, size] : offloading_objects_copy) {
         MetadataAccessorRW accessor(this, key);
         if (accessor.Exists()) {
-            auto& shard = accessor.GetShard();
-            auto task_it = shard->offloading_tasks.find(key);
-            if (task_it != shard->offloading_tasks.end()) {
+            auto& tenant_state = accessor.GetTenantState();
+            auto task_it = tenant_state.offloading_tasks.find(key);
+            if (task_it != tenant_state.offloading_tasks.end()) {
                 auto source =
                     accessor.Get().GetReplicaByID(task_it->second.source_id);
                 if (source) {
                     source->dec_refcnt();
                 }
-                shard->offloading_tasks.erase(task_it);
+                tenant_state.offloading_tasks.erase(task_it);
             }
         }
     }
@@ -3032,15 +3016,15 @@ auto MasterService::NotifyOffloadSuccess(
             MetadataAccessorRW accessor(this, key);
             if (accessor.Exists()) {
                 auto& obj_metadata = accessor.Get();
-                auto& shard = accessor.GetShard();
-                auto task_it = shard->offloading_tasks.find(key);
-                if (task_it != shard->offloading_tasks.end()) {
+                auto& tenant_state = accessor.GetTenantState();
+                auto task_it = tenant_state.offloading_tasks.find(key);
+                if (task_it != tenant_state.offloading_tasks.end()) {
                     auto source =
                         obj_metadata.GetReplicaByID(task_it->second.source_id);
                     if (source != nullptr) {
                         source->dec_refcnt();
                     }
-                    shard->offloading_tasks.erase(task_it);
+                    tenant_state.offloading_tasks.erase(task_it);
                 }
             }
         }
@@ -3059,7 +3043,13 @@ auto MasterService::NotifyOffloadSuccess(
 }
 
 tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
-    const std::string& key, Replica& replica) {
+    const ObjectIdentity& object_id, Replica& replica) {
+    if (object_id.tenant_id != "default") {
+        VLOG(1) << "key=" << object_id.user_key
+                << ", tenant_id=" << object_id.tenant_id
+                << ", action=skip_offload_for_non_default_tenant";
+        return tl::make_unexpected(ErrorCode::UNABLE_OFFLOADING);
+    }
     const auto& segment_names = replica.get_segment_names();
     if (segment_names.empty()) {
         return {};
@@ -3093,9 +3083,9 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
             return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
         }
         auto res = local_disk_segment_it->second->offloading_objects.emplace(
-            key, replica.get_descriptor()
-                     .get_memory_descriptor()
-                     .buffer_descriptor.size_);
+            object_id.user_key, replica.get_descriptor()
+                                    .get_memory_descriptor()
+                                    .buffer_descriptor.size_);
         if (!res.second) {
             return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
         }
@@ -3109,7 +3099,7 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
 // holder via the LOCAL_DISK replica's embedded client_id rather than via
 // the segment-name reverse lookup.
 tl::expected<void, ErrorCode> MasterService::PushPromotionQueue(
-    const std::string& key, Replica& source_replica) {
+    const ObjectIdentity& object_id, Replica& source_replica) {
     auto holder_id = source_replica.get_local_disk_client_id();
     if (!holder_id.has_value()) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -3128,19 +3118,21 @@ tl::expected<void, ErrorCode> MasterService::PushPromotionQueue(
     }
     MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
     auto res = local_disk_segment_it->second->promotion_objects.emplace(
-        key, static_cast<int64_t>(source_replica.get_descriptor()
-                                      .get_local_disk_descriptor()
-                                      .object_size));
+        object_id.user_key,
+        static_cast<int64_t>(source_replica.get_descriptor()
+                                 .get_local_disk_descriptor()
+                                 .object_size));
     if (!res.second) {
         return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
     }
     return {};
 }
 
-void MasterService::TryPushPromotionQueue(const std::string& key) {
+void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
     if (!promotion_on_hit_ || !promotion_sketch_) {
         return;
     }
+    const auto& key = object_id.user_key;
 
     // Frequency gate: bump and compare against the threshold. The sketch
     // returns uint8_t (saturating at 255); promotion_admission_threshold_
@@ -3164,16 +3156,16 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
     // Acquire a fresh RW shard accessor for dedup, refcnt-pin, and task
     // record. Safe to call here because GetReplicaList has already released
     // its RO accessor.
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
         return;
     }
     auto& metadata = accessor.Get();
-    auto& shard = accessor.GetShard();
+    auto& tenant_state = accessor.GetTenantState();
 
     // Dedup: don't queue twice if a promotion is already in flight or if a
     // MEMORY replica has appeared since GetReplicaList observed only-disk.
-    if (shard->promotion_tasks.count(key) > 0) {
+    if (tenant_state.promotion_tasks.count(key) > 0) {
         return;
     }
     if (metadata.HasReplica(&Replica::fn_is_memory_replica)) {
@@ -3208,7 +3200,7 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
         source->get_descriptor().get_local_disk_descriptor().object_size;
 
     // Try to enqueue on the holder client. On failure, drop the refcnt back.
-    auto push_result = PushPromotionQueue(key, *source);
+    auto push_result = PushPromotionQueue(object_id, *source);
     if (!push_result) {
         source->dec_refcnt();
         VLOG(1) << "promotion_push_failed key=" << key
@@ -3223,7 +3215,7 @@ void MasterService::TryPushPromotionQueue(const std::string& key) {
 
     // Record the in-flight task. alloc_id is filled in by
     // PromotionAllocStart once the new MEMORY replica is staged.
-    shard->promotion_tasks.emplace(
+    tenant_state.promotion_tasks.emplace(
         key, PromotionTask{.source_id = source->id(),
                            .alloc_id = 0,
                            .object_size = object_size,
@@ -3279,14 +3271,14 @@ auto MasterService::PromotionAllocStart(
     // stall AllocStart past put_start_release_timeout_sec_). If we
     // allocated and AddReplicas'd anyway, the staged PROCESSING MEMORY
     // replica would have no PromotionTask pointing at it: the generic
-    // PROCESSING reaper iterates shard->processing_keys (never
+    // PROCESSING reaper iterates tenant_state.processing_keys (never
     // populated by promotion) and the promotion-task reaper would have
     // nothing left to iterate, leaking the buffer until the object is
     // removed or evicted. The shard mutex is held for the rest of this
     // function, so the iterator stays valid across the allocation step.
-    auto& shard = accessor.GetShard();
-    auto task_it = shard->promotion_tasks.find(key);
-    if (task_it == shard->promotion_tasks.end()) {
+    auto& tenant_state = accessor.GetTenantState();
+    auto task_it = tenant_state.promotion_tasks.find(key);
+    if (task_it == tenant_state.promotion_tasks.end()) {
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
     }
 
@@ -3364,15 +3356,15 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
     auto& metadata = accessor.Get();
-    auto& shard = accessor.GetShard();
+    auto& tenant_state = accessor.GetTenantState();
 
     // Look up the in-flight task to find the exact replica we staged. A
     // concurrent Put on this key may have created other PROCESSING MEMORY
     // replicas, so we must not just "mark first PROCESSING memory
     // complete" — that would risk committing someone else's half-written
     // replica.
-    auto task_it = shard->promotion_tasks.find(key);
-    if (task_it == shard->promotion_tasks.end() ||
+    auto task_it = tenant_state.promotion_tasks.find(key);
+    if (task_it == tenant_state.promotion_tasks.end() ||
         task_it->second.alloc_id == 0) {
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
     }
@@ -3395,7 +3387,7 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
     if (source != nullptr) {
         source->dec_refcnt();
     }
-    shard->promotion_tasks.erase(task_it);
+    tenant_state.promotion_tasks.erase(task_it);
     promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
 
     // Erase the per-client promotion_objects entry (best-effort; the
@@ -3427,10 +3419,10 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
     auto& metadata = accessor.Get();
-    auto& shard = accessor.GetShard();
+    auto& tenant_state = accessor.GetTenantState();
 
-    auto task_it = shard->promotion_tasks.find(key);
-    if (task_it == shard->promotion_tasks.end()) {
+    auto task_it = tenant_state.promotion_tasks.find(key);
+    if (task_it == tenant_state.promotion_tasks.end()) {
         // No task to release. Either the reaper already swept it, or the
         // client never had a task here. Return OK to keep this RPC
         // idempotent — repeated failure notifications on the same key
@@ -3452,7 +3444,7 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
     if (task_it->second.alloc_id != 0) {
         metadata.EraseReplicaByID(task_it->second.alloc_id);
     }
-    shard->promotion_tasks.erase(task_it);
+    tenant_state.promotion_tasks.erase(task_it);
     promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
 
     // Clear the holder's per-client promotion_objects entry. Same
@@ -3476,13 +3468,7 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
 void MasterService::EvictionThreadFunc() {
     VLOG(1) << "action=eviction_thread_started";
 
-    // Start with an already-elapsed window so the first loop iteration
-    // (after kEvictionThreadSleepMs) triggers DiscardExpiredProcessingReplicas.
-    // Without this, a task admitted shortly after thread startup can survive
-    // the first reaper cycle and not be cleaned until ~2s later, causing
-    // promotion-on-hit tests that sleep for 2s to flake.
-    auto last_discard_time =
-        std::chrono::system_clock::now() - put_start_release_timeout_sec_;
+    auto last_discard_time = std::chrono::system_clock::now();
     while (eviction_running_) {
         const auto now = std::chrono::system_clock::now();
         double used_ratio =
@@ -3545,166 +3531,138 @@ void MasterService::DiscardExpiredProcessingReplicas(
     const std::chrono::system_clock::time_point& now) {
     std::list<DiscardedReplicas> discarded_replicas;
 
-    // Part 1: Discard expired PutStart operations.
-    for (auto key_it = shard->processing_keys.begin();
-         key_it != shard->processing_keys.end();) {
-        auto it = shard->metadata.find(*key_it);
-        if (it == shard->metadata.end()) {
-            // The key has been removed from metadata. This should be
-            // impossible.
-            LOG(ERROR) << "Key " << *key_it
-                       << " was removed while in processing";
-            key_it = shard->processing_keys.erase(key_it);
-            continue;
-        }
+    for (auto tenant_it = shard->tenants.begin();
+         tenant_it != shard->tenants.end();) {
+        auto& tenant_state = tenant_it->second;
 
-        auto& metadata = it->second;
-        // If the object is not valid or not in processing state, just
-        // remove it from the processing set.
-        if (!metadata.IsValid() ||
-            metadata.AllReplicas(&Replica::fn_is_completed)) {
-            if (!metadata.IsValid()) {
-                EraseMetadataEntry(shard.get(), it);
+        for (auto key_it = tenant_state.processing_keys.begin();
+             key_it != tenant_state.processing_keys.end();) {
+            auto it = tenant_state.metadata.find(*key_it);
+            if (it == tenant_state.metadata.end()) {
+                LOG(ERROR) << "Key " << *key_it
+                           << " was removed while in processing";
+                key_it = tenant_state.processing_keys.erase(key_it);
+                continue;
             }
-            key_it = shard->processing_keys.erase(key_it);
-            continue;
+
+            auto& metadata = it->second;
+            if (!metadata.IsValid() ||
+                metadata.AllReplicas(&Replica::fn_is_completed)) {
+                if (!metadata.IsValid()) {
+                    tenant_state.metadata.erase(it);
+                }
+                key_it = tenant_state.processing_keys.erase(key_it);
+                continue;
+            }
+
+            const auto ttl =
+                metadata.put_start_time + put_start_release_timeout_sec_;
+            if (ttl < now) {
+                auto replicas =
+                    metadata.PopReplicas(&Replica::fn_is_processing);
+                if (!replicas.empty()) {
+                    discarded_replicas.emplace_back(std::move(replicas), ttl);
+                }
+                if (!metadata.IsValid()) {
+                    tenant_state.metadata.erase(it);
+                }
+                key_it = tenant_state.processing_keys.erase(key_it);
+                continue;
+            }
+            key_it++;
         }
 
-        // If the object's PutStart timedout, discard and release it's
-        // space. Note that instead of releasing the space directly, we
-        // insert the replicas into the discarded list so that the
-        // discarding and releasing operations can be recorded in
-        // statistics.
-        const auto ttl =
-            metadata.put_start_time + put_start_release_timeout_sec_;
-        if (ttl < now) {
-            auto replicas = metadata.PopReplicas(&Replica::fn_is_processing);
+        for (auto task_it = tenant_state.replication_tasks.begin();
+             task_it != tenant_state.replication_tasks.end();) {
+            auto metadata_it = tenant_state.metadata.find(task_it->first);
+            if (metadata_it == tenant_state.metadata.end()) {
+                LOG(ERROR) << "Key " << task_it->first
+                           << " was removed with ongoing replication task";
+                task_it = tenant_state.replication_tasks.erase(task_it);
+                continue;
+            }
+
+            const auto ttl =
+                task_it->second.start_time + put_start_release_timeout_sec_;
+            if (ttl > now) {
+                task_it++;
+                continue;
+            }
+
+            auto& metadata = metadata_it->second;
+            auto source = metadata.GetReplicaByID(task_it->second.source_id);
+            if (source != nullptr) {
+                source->dec_refcnt();
+            }
+
+            auto& replica_ids = task_it->second.replica_ids;
+            auto replicas =
+                metadata.PopReplicas([&replica_ids](const Replica& replica) {
+                    auto it = std::find(replica_ids.begin(), replica_ids.end(),
+                                        replica.id());
+                    return it != replica_ids.end();
+                });
             if (!replicas.empty()) {
                 discarded_replicas.emplace_back(std::move(replicas), ttl);
             }
-
             if (!metadata.IsValid()) {
-                // All replicas of this object are discarded, just
-                // remove the whole object.
-                EraseMetadataEntry(shard.get(), it);
+                tenant_state.metadata.erase(metadata_it);
             }
-
-            key_it = shard->processing_keys.erase(key_it);
-            continue;
+            task_it = tenant_state.replication_tasks.erase(task_it);
         }
 
-        key_it++;
-    }
-
-    // Part 2: Discard expired CopyStart/MoveStart operations.
-    for (auto task_it = shard->replication_tasks.begin();
-         task_it != shard->replication_tasks.end();) {
-        auto metadata_it = shard->metadata.find(task_it->first);
-        if (metadata_it == shard->metadata.end()) {
-            // The key has been removed from metadata. This should be
-            // impossible.
-            LOG(ERROR) << "Key " << task_it->first
-                       << " was removed with ongoing replication task";
-            task_it = shard->replication_tasks.erase(task_it);
-            continue;
-        }
-
-        const auto ttl =
-            task_it->second.start_time + put_start_release_timeout_sec_;
-        if (ttl > now) {
-            // The task is not expired, skip it.
-            task_it++;
-            continue;
-        }
-
-        auto& metadata = metadata_it->second;
-
-        // Release source refcnt.
-        auto source = metadata.GetReplicaByID(task_it->second.source_id);
-        if (source != nullptr) {
-            source->dec_refcnt();
-        }
-
-        // Discard allocated replicas.
-        auto& replica_ids = task_it->second.replica_ids;
-        auto replicas =
-            metadata.PopReplicas([&replica_ids](const Replica& replica) {
-                auto it = std::find(replica_ids.begin(), replica_ids.end(),
-                                    replica.id());
-                return it != replica_ids.end();
-            });
-        if (!replicas.empty()) {
-            discarded_replicas.emplace_back(std::move(replicas), ttl);
-        }
-
-        // Check whether the object is still valid.
-        if (!metadata.IsValid()) {
-            EraseMetadataEntry(shard.get(), metadata_it);
-        }
-
-        task_it = shard->replication_tasks.erase(task_it);
-    }
-
-    // Part 3: Discard expired offloading operations.
-    for (auto task_it = shard->offloading_tasks.begin();
-         task_it != shard->offloading_tasks.end();) {
-        const auto ttl =
-            task_it->second.start_time + put_start_release_timeout_sec_;
-        if (ttl > now) {
-            task_it++;
-            continue;
-        }
-
-        auto metadata_it = shard->metadata.find(task_it->first);
-        if (metadata_it != shard->metadata.end()) {
-            auto source =
-                metadata_it->second.GetReplicaByID(task_it->second.source_id);
-            if (source != nullptr) {
-                source->dec_refcnt();
+        for (auto task_it = tenant_state.offloading_tasks.begin();
+             task_it != tenant_state.offloading_tasks.end();) {
+            const auto ttl =
+                task_it->second.start_time + put_start_release_timeout_sec_;
+            if (ttl > now) {
+                task_it++;
+                continue;
             }
+            auto metadata_it = tenant_state.metadata.find(task_it->first);
+            if (metadata_it != tenant_state.metadata.end()) {
+                auto source = metadata_it->second.GetReplicaByID(
+                    task_it->second.source_id);
+                if (source != nullptr) {
+                    source->dec_refcnt();
+                }
+            }
+            LOG(WARNING) << "Offloading task expired for key: "
+                         << task_it->first;
+            task_it = tenant_state.offloading_tasks.erase(task_it);
         }
 
-        LOG(WARNING) << "Offloading task expired for key: " << task_it->first;
-        task_it = shard->offloading_tasks.erase(task_it);
-    }
+        for (auto task_it = tenant_state.promotion_tasks.begin();
+             task_it != tenant_state.promotion_tasks.end();) {
+            const auto ttl =
+                task_it->second.start_time + put_start_release_timeout_sec_;
+            if (ttl > now) {
+                task_it++;
+                continue;
+            }
+            auto metadata_it = tenant_state.metadata.find(task_it->first);
+            if (metadata_it != tenant_state.metadata.end()) {
+                auto source = metadata_it->second.GetReplicaByID(
+                    task_it->second.source_id);
+                if (source != nullptr) {
+                    source->dec_refcnt();
+                }
+                if (task_it->second.alloc_id != 0) {
+                    metadata_it->second.EraseReplicaByID(
+                        task_it->second.alloc_id);
+                }
+            }
+            LOG(WARNING) << "Promotion task expired for key: "
+                         << task_it->first;
+            task_it = tenant_state.promotion_tasks.erase(task_it);
+            promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+        }
 
-    // Part 4: Discard expired promotion-on-hit tasks. For each:
-    //   - Drop the source LOCAL_DISK refcnt so the source can be
-    //     evicted normally.
-    //   - If a PROCESSING MEMORY replica was staged (alloc_id != 0),
-    //     pop it via EraseReplicaByID. The staged replica is not in
-    //     shard->processing_keys, so this is the only place (besides
-    //     NotifyPromotionFailure) that reaps it; without this the
-    //     buffer leaks until the object is removed or evicted.
-    //   - Erase the task entry and decrement the in-flight counter.
-    // task.start_time is set at admission and reset at AllocStart, so
-    // queue-wait (alloc_id == 0) and active-transfer (alloc_id != 0)
-    // phases each get a full put_start_release_timeout_sec_ window.
-    // The per-client promotion_objects map is GC'd on the next
-    // heartbeat (entries for vanished tasks are harmless — Notify will
-    // return REPLICA_IS_NOT_READY since the task entry is gone).
-    for (auto task_it = shard->promotion_tasks.begin();
-         task_it != shard->promotion_tasks.end();) {
-        const auto ttl =
-            task_it->second.start_time + put_start_release_timeout_sec_;
-        if (ttl > now) {
-            task_it++;
-            continue;
+        if (tenant_state.Empty()) {
+            tenant_it = shard->tenants.erase(tenant_it);
+        } else {
+            ++tenant_it;
         }
-        auto metadata_it = shard->metadata.find(task_it->first);
-        if (metadata_it != shard->metadata.end()) {
-            auto source =
-                metadata_it->second.GetReplicaByID(task_it->second.source_id);
-            if (source != nullptr) {
-                source->dec_refcnt();
-            }
-            if (task_it->second.alloc_id != 0) {
-                metadata_it->second.EraseReplicaByID(task_it->second.alloc_id);
-            }
-        }
-        LOG(WARNING) << "Promotion task expired for key: " << task_it->first;
-        task_it = shard->promotion_tasks.erase(task_it);
-        promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
     }
 
     if (!discarded_replicas.empty()) {
@@ -4643,33 +4601,25 @@ bool MasterService::TryRestoreStateFromSnapshot(
             if (!skip_cleanup) {
                 auto cleanup_now = now;
                 for (auto& shard : metadata_shards_) {
-                    for (auto it = shard.metadata.begin();
-                         it != shard.metadata.end();) {
-                        if (it->second.HasDiffRepStatus(
-                                ReplicaStatus::COMPLETE) ||
-                            (it->second.IsLeaseExpired(cleanup_now) &&
-                             !it->second.IsSoftPinned(cleanup_now))) {
-                            VLOG(1)
-                                << "clear metadata key=" << it->first
-                                << " ,lease_timeout="
-                                << std::chrono::duration_cast<
-                                       std::chrono::milliseconds>(
-                                       it->second.lease_timeout
-                                           .time_since_epoch())
-                                       .count()
-                                << " ,soft_pin_timeout="
-                                << (it->second.soft_pin_timeout.has_value()
-                                        ? std::to_string(
-                                              std::chrono::duration_cast<
-                                                  std::chrono::milliseconds>(
-                                                  it->second.soft_pin_timeout
-                                                      .value()
-                                                      .time_since_epoch())
-                                                  .count())
-                                        : "null");
-                            it = EraseMetadataEntry(shard, it);
+                    for (auto tenant_it = shard.tenants.begin();
+                         tenant_it != shard.tenants.end();) {
+                        auto& tenant_state = tenant_it->second;
+                        for (auto it = tenant_state.metadata.begin();
+                             it != tenant_state.metadata.end();) {
+                            if (it->second.HasDiffRepStatus(
+                                    ReplicaStatus::COMPLETE) ||
+                                (it->second.IsLeaseExpired(cleanup_now) &&
+                                 !it->second.IsSoftPinned(cleanup_now))) {
+                                VLOG(1) << "clear metadata key=" << it->first;
+                                it = tenant_state.metadata.erase(it);
+                            } else {
+                                ++it;
+                            }
+                        }
+                        if (tenant_state.Empty()) {
+                            tenant_it = shard.tenants.erase(tenant_it);
                         } else {
-                            ++it;
+                            ++tenant_it;
                         }
                     }
                 }
@@ -4682,30 +4632,33 @@ bool MasterService::TryRestoreStateFromSnapshot(
             }
 
             for (auto& shard : metadata_shards_) {
-                for (auto it = shard.metadata.begin();
-                     it != shard.metadata.end();) {
-                    for (auto& replica : it->second.GetAllReplicas()) {
-                        if (!replica.get_descriptor().is_memory_replica()) {
-                            continue;
+                for (auto& [tenant_id, tenant_state] : shard.tenants) {
+                    for (auto it = tenant_state.metadata.begin();
+                         it != tenant_state.metadata.end();) {
+                        for (auto& replica : it->second.GetAllReplicas()) {
+                            if (!replica.get_descriptor().is_memory_replica()) {
+                                continue;
+                            }
+                            auto temp_segment_names =
+                                replica.get_segment_names();
+                            if (temp_segment_names.empty()) {
+                                continue;
+                            }
+                            if (!temp_segment_names[0].has_value()) {
+                                continue;
+                            }
+                            auto buffer_descriptor =
+                                replica.get_descriptor()
+                                    .get_memory_descriptor()
+                                    .buffer_descriptor;
+                            MasterMetricManager::instance()
+                                .inc_allocated_mem_size(
+                                    temp_segment_names[0].value(),
+                                    static_cast<int64_t>(
+                                        buffer_descriptor.size_));
                         }
-                        auto temp_segment_names = replica.get_segment_names();
-                        if (temp_segment_names.empty()) {
-                            continue;
-                        }
-
-                        std::string temp_segment_name;
-                        if (temp_segment_names[0].has_value()) {
-                            temp_segment_name = temp_segment_names[0].value();
-                        }
-
-                        auto buffer_descriptor = replica.get_descriptor()
-                                                     .get_memory_descriptor()
-                                                     .buffer_descriptor;
-                        MasterMetricManager::instance().inc_allocated_mem_size(
-                            temp_segment_name,
-                            static_cast<int64_t>(buffer_descriptor.size_));
+                        ++it;
                     }
-                    ++it;
                 }
             }
 
@@ -4818,11 +4771,6 @@ void MasterService::BatchEvict(double evict_ratio_target,
         });
     };
 
-    struct EvictionResult {
-        uint64_t freed_bytes{0};
-        long evicted_objects{0};
-    };
-
     // --- Offload-on-evict support ---
     long offload_queued_this_cycle = 0;
     long offload_deferred_count = 0;
@@ -4840,11 +4788,16 @@ void MasterService::BatchEvict(double evict_ratio_target,
     // Returns freed bytes. Returns 0 if offload-queued and no additional
     // replicas were evicted (all MEMORY replicas of the key are now pinned).
     auto try_evict_or_offload =
-        [&, this](const std::string& key, ObjectMetadata& metadata,
-                  MetadataShardAccessorRW& shard) -> uint64_t {
+        [&, this](const std::string& tenant_id, const std::string& key,
+                  ObjectMetadata& metadata,
+                  TenantState& tenant_state) -> uint64_t {
         if (!offload_on_evict_) {
             // Original behavior
             return metadata.size * evict_replicas(metadata);
+        }
+
+        if (tenant_id != "default") {
+            return 0;
         }
 
         // LOCAL_DISK replica already exists — safe to delete MEMORY immediately
@@ -4867,12 +4820,14 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 return r.is_memory_replica() && r.is_completed() &&
                        r.get_refcnt() == 0;
             },
-            [this, &key, &shard, &queued, &now](Replica& replica) {
+            [this, &tenant_id, &key, &tenant_state, &queued,
+             &now](Replica& replica) {
                 if (queued) return;  // only need to pin one replica for offload
-                auto result = PushOffloadingQueue(key, replica);
+                auto result = PushOffloadingQueue(
+                    MakeObjectIdentity(key, tenant_id), replica);
                 if (result) {
                     replica.inc_refcnt();
-                    shard->offloading_tasks.emplace(
+                    tenant_state.offloading_tasks.emplace(
                         key, OffloadingTask{replica.id(), now});
                     queued = true;
                 }
@@ -4898,24 +4853,32 @@ void MasterService::BatchEvict(double evict_ratio_target,
         return 0;
     };
 
+    struct EvictionResult {
+        uint64_t freed_bytes{0};
+        long evicted_objects{0};
+    };
+
     auto try_evict_group_or_object =
-        [&, this](const std::string& key, ObjectMetadata& metadata,
-                  MetadataShardAccessorRW& shard,
+        [&, this](const std::string& tenant_id, const std::string& key,
+                  ObjectMetadata& metadata, MetadataShardAccessorRW& shard,
+                  TenantState& tenant_state,
                   bool allow_soft_pinned) -> EvictionResult {
         if (!metadata.IsGrouped()) {
-            uint64_t freed = try_evict_or_offload(key, metadata, shard);
+            uint64_t freed =
+                try_evict_or_offload(tenant_id, key, metadata, tenant_state);
             return {.freed_bytes = freed, .evicted_objects = freed > 0 ? 1 : 0};
         }
 
-        auto group_it = shard->group_members.find(metadata.group_id);
-        if (group_it == shard->group_members.end()) {
-            uint64_t freed = try_evict_or_offload(key, metadata, shard);
+        auto group_it = tenant_state.group_members.find(metadata.group_id);
+        if (group_it == tenant_state.group_members.end()) {
+            uint64_t freed =
+                try_evict_or_offload(tenant_id, key, metadata, tenant_state);
             return {.freed_bytes = freed, .evicted_objects = freed > 0 ? 1 : 0};
         }
 
         for (const auto& member_key : group_it->second) {
-            auto member_it = shard->metadata.find(member_key);
-            if (member_it != shard->metadata.end() &&
+            auto member_it = tenant_state.metadata.find(member_key);
+            if (member_it != tenant_state.metadata.end() &&
                 !member_it->second.IsLeaseExpired(now)) {
                 return {};
             }
@@ -4925,8 +4888,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
         std::vector<std::string> member_keys(group_it->second.begin(),
                                              group_it->second.end());
         for (const auto& member_key : member_keys) {
-            auto member_it = shard->metadata.find(member_key);
-            if (member_it == shard->metadata.end()) {
+            auto member_it = tenant_state.metadata.find(member_key);
+            if (member_it == tenant_state.metadata.end()) {
                 continue;
             }
             auto& member_metadata = member_it->second;
@@ -4937,16 +4900,14 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 continue;
             }
 
-            uint64_t freed =
-                try_evict_or_offload(member_key, member_metadata, shard);
+            uint64_t freed = try_evict_or_offload(
+                tenant_id, member_key, member_metadata, tenant_state);
             result.freed_bytes += freed;
             if (freed > 0) {
                 result.evicted_objects++;
             }
-            // The caller owns the iterator for the trigger key and erases it
-            // after this helper returns; erase only peer members here.
             if (member_key != key && !member_metadata.IsValid()) {
-                EraseMetadataEntry(shard.get(), member_it);
+                tenant_state.metadata.erase(member_it);
             }
         }
         return result;
@@ -4965,9 +4926,11 @@ void MasterService::BatchEvict(double evict_ratio_target,
         // in later evictions.
         DiscardExpiredProcessingReplicas(shard, now);
 
-        // object_count must be updated at beginning as it will be used later
-        // to compute ideal_evict_num
-        object_count += shard->metadata.size();
+        size_t shard_object_count = 0;
+        for (const auto& [tenant_id, tenant_state] : shard->tenants) {
+            shard_object_count += tenant_state.metadata.size();
+        }
+        object_count += shard_object_count;
 
         // To achieve evicted_count / object_count = evict_ratio_target,
         // ideally how many object should be evicted in this shard
@@ -4976,30 +4939,25 @@ void MasterService::BatchEvict(double evict_ratio_target,
 
         std::vector<std::chrono::system_clock::time_point>
             candidates;  // can be removed
-        for (auto it = shard->metadata.begin(); it != shard->metadata.end();
-             it++) {
-            // Hard-pinned objects are never evicted
-            if (it->second.IsHardPinned()) {
-                continue;
-            }
-            // Skip objects that are not expired or have incomplete replicas
-            if (!it->second.IsLeaseExpired(now) ||
-                !can_evict_replicas(it->second)) {
-                continue;
-            }
-            if (!it->second.IsSoftPinned(now)) {
-                if (ideal_evict_num > 0) {
-                    // first pass candidates
-                    candidates.push_back(it->second.lease_timeout);
-                } else {
-                    // No need to evict any object in this shard, put to
-                    // second pass candidates
-                    no_pin_objects.push_back(it->second.lease_timeout);
+        for (const auto& [tenant_id, tenant_state] : shard->tenants) {
+            for (auto it = tenant_state.metadata.begin();
+                 it != tenant_state.metadata.end(); it++) {
+                if (it->second.IsHardPinned()) {
+                    continue;
                 }
-            } else if (allow_evict_soft_pinned_objects_) {
-                // second pass candidates, only if
-                // allow_evict_soft_pinned_objects_ is true
-                soft_pin_objects.push_back(it->second.lease_timeout);
+                if (!it->second.IsLeaseExpired(now) ||
+                    !can_evict_replicas(it->second)) {
+                    continue;
+                }
+                if (!it->second.IsSoftPinned(now)) {
+                    if (ideal_evict_num > 0) {
+                        candidates.push_back(it->second.lease_timeout);
+                    } else {
+                        no_pin_objects.push_back(it->second.lease_timeout);
+                    }
+                } else if (allow_evict_soft_pinned_objects_) {
+                    soft_pin_objects.push_back(it->second.lease_timeout);
+                }
             }
         }
 
@@ -5011,34 +4969,38 @@ void MasterService::BatchEvict(double evict_ratio_target,
                              candidates.begin() + (evict_num - 1),
                              candidates.end());
             auto target_timeout = candidates[evict_num - 1];
-            // Evict objects with lease timeout less than or equal to target.
-            auto it = shard->metadata.begin();
-            while (it != shard->metadata.end()) {
-                // Skip objects that are not allowed to be evicted in the first
-                // pass
-                if (it->second.IsHardPinned() ||
-                    !it->second.IsLeaseExpired(now) ||
-                    it->second.IsSoftPinned(now) ||
-                    !can_evict_replicas(it->second)) {
-                    ++it;
-                    continue;
-                }
-                if (it->second.lease_timeout <= target_timeout) {
-                    // Evict this object (or defer for offload)
-                    auto evict_result =
-                        try_evict_group_or_object(it->first, it->second, shard,
-                                                  /*allow_soft_pinned=*/false);
-                    total_freed_size += evict_result.freed_bytes;
-                    if (it->second.IsValid() == false) {
-                        it = EraseMetadataEntry(shard.get(), it);
+            for (auto tenant_it = shard->tenants.begin();
+                 tenant_it != shard->tenants.end();) {
+                auto& tenant_state = tenant_it->second;
+                auto it = tenant_state.metadata.begin();
+                while (it != tenant_state.metadata.end()) {
+                    if (it->second.IsHardPinned() ||
+                        !it->second.IsLeaseExpired(now) ||
+                        it->second.IsSoftPinned(now) ||
+                        !can_evict_replicas(it->second)) {
+                        ++it;
+                        continue;
+                    }
+                    if (it->second.lease_timeout <= target_timeout) {
+                        auto evict_result = try_evict_group_or_object(
+                            tenant_it->first, it->first, it->second, shard,
+                            tenant_state, /*allow_soft_pinned=*/false);
+                        total_freed_size += evict_result.freed_bytes;
+                        if (it->second.IsValid() == false) {
+                            it = tenant_state.metadata.erase(it);
+                        } else {
+                            ++it;
+                        }
+                        shard_evicted_count += evict_result.evicted_objects;
                     } else {
+                        no_pin_objects.push_back(it->second.lease_timeout);
                         ++it;
                     }
-                    shard_evicted_count += evict_result.evicted_objects;
+                }
+                if (tenant_state.Empty()) {
+                    tenant_it = shard->tenants.erase(tenant_it);
                 } else {
-                    // second pass candidates
-                    no_pin_objects.push_back(it->second.lease_timeout);
-                    ++it;
+                    ++tenant_it;
                 }
             }
             evicted_count += shard_evicted_count;
@@ -5079,27 +5041,37 @@ void MasterService::BatchEvict(double evict_ratio_target,
             for (size_t i = 0; i < kNumShards && target_evict_num > 0; i++) {
                 MetadataShardAccessorRW shard(this,
                                               (start_idx + i) % kNumShards);
-                auto it = shard->metadata.begin();
-                while (it != shard->metadata.end() && target_evict_num > 0) {
-                    if (!it->second.IsHardPinned() &&
-                        it->second.IsLeaseExpired(now) &&
-                        it->second.lease_timeout <= target_timeout &&
-                        !it->second.IsSoftPinned(now) &&
-                        can_evict_replicas(it->second)) {
-                        // Evict this object (or defer for offload)
-                        auto evict_result = try_evict_group_or_object(
-                            it->first, it->second, shard,
-                            /*allow_soft_pinned=*/false);
-                        total_freed_size += evict_result.freed_bytes;
-                        if (it->second.IsValid() == false) {
-                            it = EraseMetadataEntry(shard.get(), it);
+                for (auto tenant_it = shard->tenants.begin();
+                     tenant_it != shard->tenants.end() &&
+                     target_evict_num > 0;) {
+                    auto& tenant_state = tenant_it->second;
+                    auto it = tenant_state.metadata.begin();
+                    while (it != tenant_state.metadata.end() &&
+                           target_evict_num > 0) {
+                        if (!it->second.IsHardPinned() &&
+                            it->second.IsLeaseExpired(now) &&
+                            it->second.lease_timeout <= target_timeout &&
+                            !it->second.IsSoftPinned(now) &&
+                            can_evict_replicas(it->second)) {
+                            auto evict_result = try_evict_group_or_object(
+                                tenant_it->first, it->first, it->second, shard,
+                                tenant_state, /*allow_soft_pinned=*/false);
+                            total_freed_size += evict_result.freed_bytes;
+                            if (!it->second.IsValid()) {
+                                it = tenant_state.metadata.erase(it);
+                            } else {
+                                ++it;
+                            }
+                            evicted_count += evict_result.evicted_objects;
+                            target_evict_num -= evict_result.evicted_objects;
                         } else {
                             ++it;
                         }
-                        evicted_count += evict_result.evicted_objects;
-                        target_evict_num -= evict_result.evicted_objects;
+                    }
+                    if (tenant_state.Empty()) {
+                        tenant_it = shard->tenants.erase(tenant_it);
                     } else {
-                        ++it;
+                        ++tenant_it;
                     }
                 }
             }
@@ -5125,33 +5097,40 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 MetadataShardAccessorRW shard(this,
                                               (start_idx + i) % kNumShards);
 
-                auto it = shard->metadata.begin();
-                while (it != shard->metadata.end() && target_evict_num > 0) {
-                    // Skip hard-pinned or not-yet-expired objects
-                    if (it->second.IsHardPinned() ||
-                        !it->second.IsLeaseExpired(now) ||
-                        !can_evict_replicas(it->second)) {
-                        ++it;
-                        continue;
-                    }
-                    // Evict objects with 1). no soft pin OR 2). with soft pin
-                    // and lease timeout less than or equal to target.
-                    if (!it->second.IsSoftPinned(now) ||
-                        it->second.lease_timeout <= soft_target_timeout) {
-                        // Evict this object (or defer for offload)
-                        auto evict_result = try_evict_group_or_object(
-                            it->first, it->second, shard,
-                            /*allow_soft_pinned=*/true);
-                        total_freed_size += evict_result.freed_bytes;
-                        if (it->second.IsValid() == false) {
-                            it = EraseMetadataEntry(shard.get(), it);
+                for (auto tenant_it = shard->tenants.begin();
+                     tenant_it != shard->tenants.end() &&
+                     target_evict_num > 0;) {
+                    auto& tenant_state = tenant_it->second;
+                    auto it = tenant_state.metadata.begin();
+                    while (it != tenant_state.metadata.end() &&
+                           target_evict_num > 0) {
+                        if (it->second.IsHardPinned() ||
+                            !it->second.IsLeaseExpired(now) ||
+                            !can_evict_replicas(it->second)) {
+                            ++it;
+                            continue;
+                        }
+                        if (!it->second.IsSoftPinned(now) ||
+                            it->second.lease_timeout <= soft_target_timeout) {
+                            auto evict_result = try_evict_group_or_object(
+                                tenant_it->first, it->first, it->second, shard,
+                                tenant_state, /*allow_soft_pinned=*/true);
+                            total_freed_size += evict_result.freed_bytes;
+                            if (!it->second.IsValid()) {
+                                it = tenant_state.metadata.erase(it);
+                            } else {
+                                ++it;
+                            }
+                            evicted_count += evict_result.evicted_objects;
+                            target_evict_num -= evict_result.evicted_objects;
                         } else {
                             ++it;
                         }
-                        evicted_count += evict_result.evicted_objects;
-                        target_evict_num -= evict_result.evicted_objects;
+                    }
+                    if (tenant_state.Empty()) {
+                        tenant_it = shard->tenants.erase(tenant_it);
                     } else {
-                        ++it;
+                        ++tenant_it;
                     }
                 }
             }
@@ -5230,7 +5209,9 @@ void MasterService::NoFBatchEvict(double evict_ratio_target,
         MetadataShardAccessorRW shard(
             this, (start_idx + i) % metadata_shards_.size());
         DiscardExpiredProcessingReplicas(shard, now);
-        object_count += shard->metadata.size();
+        for (const auto& [tenant_id, tenant_state] : shard->tenants) {
+            object_count += tenant_state.metadata.size();
+        }
 
         const long ideal_evict_num =
             std::ceil(object_count * evict_ratio_target) - evicted_count;
@@ -5239,32 +5220,43 @@ void MasterService::NoFBatchEvict(double evict_ratio_target,
         }
 
         long shard_evicted_count = 0;
-        for (auto it = shard->metadata.begin();
-             it != shard->metadata.end() &&
+        for (auto tenant_it = shard->tenants.begin();
+             tenant_it != shard->tenants.end() &&
              shard_evicted_count < ideal_evict_num;) {
-            auto& metadata = it->second;
-            if (metadata.IsHardPinned() || !metadata.IsLeaseExpired(now) ||
-                metadata.IsSoftPinned(now)) {
-                ++it;
-                continue;
-            }
+            auto& tenant_state = tenant_it->second;
+            for (auto it = tenant_state.metadata.begin();
+                 it != tenant_state.metadata.end() &&
+                 shard_evicted_count < ideal_evict_num;) {
+                auto& metadata = it->second;
+                if (metadata.IsHardPinned() || !metadata.IsLeaseExpired(now) ||
+                    metadata.IsSoftPinned(now)) {
+                    ++it;
+                    continue;
+                }
 
-            const size_t erased =
-                metadata.EraseReplicas([](const Replica& replica) {
-                    return replica.is_nof_replica() && replica.is_completed() &&
-                           replica.get_refcnt() == 0;
-                });
-            if (erased == 0) {
-                ++it;
-                continue;
-            }
+                const size_t erased =
+                    metadata.EraseReplicas([](const Replica& replica) {
+                        return replica.is_nof_replica() &&
+                               replica.is_completed() &&
+                               replica.get_refcnt() == 0;
+                    });
+                if (erased == 0) {
+                    ++it;
+                    continue;
+                }
 
-            total_freed_size += metadata.size * erased;
-            shard_evicted_count++;
-            if (!metadata.IsValid()) {
-                it = EraseMetadataEntry(shard.get(), it);
+                total_freed_size += metadata.size * erased;
+                shard_evicted_count++;
+                if (!metadata.IsValid()) {
+                    it = tenant_state.metadata.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+            if (tenant_state.Empty()) {
+                tenant_it = shard->tenants.erase(tenant_it);
             } else {
-                ++it;
+                ++tenant_it;
             }
         }
         evicted_count += shard_evicted_count;
@@ -5650,7 +5642,7 @@ MasterService::MetadataSerializer::Serialize() {
     // First count non-empty shards
     size_t valid_shards = 0;
     for (size_t i = 0; i < kNumShards; ++i) {
-        if (!service_->metadata_shards_[i].metadata.empty()) {
+        if (!service_->metadata_shards_[i].tenants.empty()) {
             valid_shards++;
         }
     }
@@ -5663,7 +5655,7 @@ MasterService::MetadataSerializer::Serialize() {
         const auto& shard = service_->metadata_shards_[shard_idx];
 
         // Skip if shard is empty
-        if (shard.metadata.empty()) {
+        if (shard.tenants.empty()) {
             continue;
         }
 
@@ -5834,15 +5826,13 @@ MasterService::MetadataSerializer::Deserialize(
     auto next_id = replica_next_id_obj->as<uint64_t>();
     Replica::next_id_.store(next_id);
     LOG(INFO) << "Restored Replica::next_id_ to " << next_id;
-
     service_->RebuildGroupRoutingIndex();
     return {};
 }
 
 void MasterService::MetadataSerializer::Reset() {
     for (auto& shard : service_->metadata_shards_) {
-        shard.metadata.clear();
-        shard.group_members.clear();
+        shard.tenants.clear();
     }
     {
         std::unique_lock<std::shared_mutex> lock(
@@ -5865,29 +5855,46 @@ MasterService::MetadataSerializer::SerializeShard(const MetadataShard& shard,
 
     // Serialize metadata
     packer.pack("metadata");
-    packer.pack_array(shard.metadata.size());
-
-    // Sort keys to ensure consistent serialization order.
-    // NOTE: sort may be slow for large shards.
-    std::vector<std::string> sorted_keys;
-    sorted_keys.reserve(shard.metadata.size());
-    for (const auto& [key, metadata] : shard.metadata) {
-        sorted_keys.push_back(key);
+    size_t metadata_count = 0;
+    for (const auto& [tenant_id, tenant_state] : shard.tenants) {
+        metadata_count += tenant_state.metadata.size();
     }
-    std::sort(sorted_keys.begin(), sorted_keys.end());
+    packer.pack_array(metadata_count);
 
-    for (const auto& key : sorted_keys) {
-        const auto& metadata = shard.metadata.at(key);
-        // Each metadata item format: [key, metadata_object]
-        packer.pack_array(2);
-        packer.pack(key);
+    // Sort tenant/key pairs to ensure consistent serialization order.
+    // NOTE: sort may be slow for large shards.
+    struct SortedEntry {
+        std::string tenant_id;
+        std::string key;
+        const ObjectMetadata* metadata;
+    };
+    std::vector<SortedEntry> sorted_entries;
+    sorted_entries.reserve(metadata_count);
+    for (const auto& [tenant_id, tenant_state] : shard.tenants) {
+        for (const auto& [key, metadata] : tenant_state.metadata) {
+            sorted_entries.push_back({tenant_id, key, &metadata});
+        }
+    }
+    std::sort(sorted_entries.begin(), sorted_entries.end(),
+              [](const SortedEntry& lhs, const SortedEntry& rhs) {
+                  if (lhs.tenant_id != rhs.tenant_id) {
+                      return lhs.tenant_id < rhs.tenant_id;
+                  }
+                  return lhs.key < rhs.key;
+              });
 
-        auto result = SerializeMetadata(metadata, packer);
+    for (const auto& entry : sorted_entries) {
+        // Each metadata item format: [tenant_id, key, metadata_object].
+        packer.pack_array(3);
+        packer.pack(entry.tenant_id);
+        packer.pack(entry.key);
+
+        auto result = SerializeMetadata(*entry.metadata, packer);
         if (!result) {
             return tl::make_unexpected(SerializationError(
                 result.error().code,
                 fmt::format("Failed to serialize metadata for key '{}': {}",
-                            key, result.error().message)));
+                            entry.key, result.error().message)));
         }
     }
 
@@ -5916,8 +5923,7 @@ MasterService::MetadataSerializer::DeserializeShard(const msgpack::object& obj,
     }
 
     // Clear existing data
-    shard.metadata.clear();
-    shard.group_members.clear();
+    shard.tenants.clear();
 
     // Deserialize metadata
     if (metadata_array == nullptr ||
@@ -5927,21 +5933,33 @@ MasterService::MetadataSerializer::DeserializeShard(const msgpack::object& obj,
                                "Missing or invalid 'metadata' field in shard"));
     }
 
-    shard.metadata.reserve(metadata_array->via.array.size);
+    shard.tenants.reserve(metadata_array->via.array.size);
 
     for (uint32_t j = 0; j < metadata_array->via.array.size; ++j) {
         const msgpack::object& item = metadata_array->via.array.ptr[j];
 
-        if (item.type != msgpack::type::ARRAY || item.via.array.size != 2) {
+        if (item.type != msgpack::type::ARRAY ||
+            (item.via.array.size != 2 && item.via.array.size != 3)) {
             return tl::make_unexpected(SerializationError(
                 ErrorCode::DESERIALIZE_FAIL,
-                "Invalid metadata item format: expected [key, metadata]"));
+                "Invalid metadata item format: expected [key, metadata] or "
+                "[tenant_id, key, metadata]"));
         }
 
-        std::string key = item.via.array.ptr[0].as<std::string>();
-        const msgpack::object& value_obj = item.via.array.ptr[1];
+        std::string tenant_id = "default";
+        std::string key;
+        const msgpack::object* value_obj = nullptr;
+        if (item.via.array.size == 2) {
+            key = item.via.array.ptr[0].as<std::string>();
+            value_obj = &item.via.array.ptr[1];
+        } else {
+            tenant_id =
+                NormalizeTenantId(item.via.array.ptr[0].as<std::string>());
+            key = item.via.array.ptr[1].as<std::string>();
+            value_obj = &item.via.array.ptr[2];
+        }
 
-        auto metadata_result = DeserializeMetadata(value_obj);
+        auto metadata_result = DeserializeMetadata(*value_obj);
         if (!metadata_result) {
             LOG(ERROR) << "Failed to deserialize metadata for key: " << key
                        << ": " << metadata_result.error().message;
@@ -5949,14 +5967,16 @@ MasterService::MetadataSerializer::DeserializeShard(const msgpack::object& obj,
         }
 
         auto metadata_ptr = std::move(metadata_result.value());
-        auto [it, inserted] = shard.metadata.emplace(
+        auto& tenant_state = shard.tenants[tenant_id];
+        const std::string user_key = key;
+        auto [it, inserted] = tenant_state.metadata.emplace(
             std::piecewise_construct, std::forward_as_tuple(std::move(key)),
             std::forward_as_tuple(
                 metadata_ptr->client_id, metadata_ptr->put_start_time,
                 metadata_ptr->size, metadata_ptr->PopReplicas(),
                 metadata_ptr->soft_pin_timeout.has_value(),
                 metadata_ptr->IsHardPinned(), metadata_ptr->data_type,
-                metadata_ptr->group_id));
+                metadata_ptr->group_id, tenant_id, user_key));
 
         it->second.lease_timeout = metadata_ptr->lease_timeout;
         it->second.soft_pin_timeout = metadata_ptr->soft_pin_timeout;
@@ -6045,9 +6065,7 @@ MasterService::MetadataSerializer::DeserializeMetadata(
     }
 
     // Need at least 7 elements: client_id, put_start_time, size, lease_timeout,
-    // has_soft_pin_timeout, soft_pin_timeout, replicas_count.
-    // Optional fields are decoded by type for backward compatibility:
-    // data_type appears before replicas; hard_pinned and group_id trail them.
+    // has_soft_pin_timeout, soft_pin_timeout, replicas_count
     if (obj.via.array.size < 7) {
         return tl::unexpected(SerializationError(
             ErrorCode::DESERIALIZE_FAIL,
@@ -6083,9 +6101,8 @@ MasterService::MetadataSerializer::DeserializeMetadata(
     // Format detection:
     //   v1: 7 + replicas_count, no optional fields
     //   v2: 8 + replicas_count, either data_type or hard_pinned
-    //   v3: 9 + replicas_count, data_type + hard_pinned or
-    //       hard_pinned + group_id
-    //   v4: 10 + replicas_count, data_type + hard_pinned + group_id
+    //   v3: 9 + replicas_count, data_type + hard_pinned or hard_pinned +
+    //   group_id v4: 10 + replicas_count, data_type + hard_pinned + group_id
     constexpr uint32_t kBaseFieldCount = 7;
     constexpr uint32_t kMaxOptionalFieldCount = 3;
     const uint32_t total_elements = obj.via.array.size;
@@ -6126,11 +6143,6 @@ MasterService::MetadataSerializer::DeserializeMetadata(
     std::string group_id;
     if (index < obj.via.array.size && array[index].type == msgpack::type::STR) {
         group_id = array[index++].as<std::string>();
-    }
-    if (index != obj.via.array.size) {
-        return tl::unexpected(SerializationError(
-            ErrorCode::DESERIALIZE_FAIL,
-            "deserialize ObjectMetadata optional field type mismatch"));
     }
 
     // Create ObjectMetadata instance
@@ -6483,8 +6495,11 @@ tl::expected<void, ErrorCode> MasterService::CancelDrainJob(
 }
 
 std::string MasterService::MakeDrainUnitKey(
-    const std::string& key, const std::string& source_segment) const {
-    return std::to_string(key.size()) + ":" + key + ":" + source_segment;
+    const std::string& tenant_id, const std::string& key,
+    const std::string& source_segment) const {
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    return std::to_string(normalized_tenant.size()) + ":" + normalized_tenant +
+           ":" + std::to_string(key.size()) + ":" + key + ":" + source_segment;
 }
 
 std::optional<std::string> MasterService::SelectDrainTargetForKey(
@@ -6599,40 +6614,45 @@ void MasterService::ScheduleDrainJobTasks(DrainJob& job) {
         std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
         for (size_t i = 0; i < kNumShards; ++i) {
             MetadataShardAccessorRO shard(this, i);
-            for (const auto& [key, metadata] : shard->metadata) {
-                for (const auto& source_segment : job.request.segments) {
-                    const auto unit_key = MakeDrainUnitKey(key, source_segment);
-                    if (job.completed_unit_keys.contains(unit_key) ||
-                        active_unit_keys.contains(unit_key) ||
-                        job.terminal_failed_unit_keys.contains(unit_key)) {
-                        continue;
-                    }
+            for (const auto& [tenant_id, tenant_state] : shard->tenants) {
+                for (const auto& [key, metadata] : tenant_state.metadata) {
+                    for (const auto& source_segment : job.request.segments) {
+                        const auto unit_key =
+                            MakeDrainUnitKey(tenant_id, key, source_segment);
+                        if (job.completed_unit_keys.contains(unit_key) ||
+                            active_unit_keys.contains(unit_key) ||
+                            job.terminal_failed_unit_keys.contains(unit_key)) {
+                            continue;
+                        }
 
-                    const auto replica_segments =
-                        metadata.GetReplicaSegmentNames();
-                    if (std::find(replica_segments.begin(),
-                                  replica_segments.end(),
-                                  source_segment) == replica_segments.end()) {
-                        continue;
-                    }
+                        const auto replica_segments =
+                            metadata.GetReplicaSegmentNames();
+                        if (std::find(replica_segments.begin(),
+                                      replica_segments.end(), source_segment) ==
+                            replica_segments.end()) {
+                            continue;
+                        }
 
-                    if (metadata.IsHardPinned() || !metadata.IsLeaseExpired() ||
-                        !metadata.AllReplicas(&Replica::fn_is_completed) ||
-                        shard->replication_tasks.contains(key)) {
-                        blocked_unit_keys.insert(unit_key);
-                        continue;
-                    }
+                        if (tenant_id != "default" || metadata.IsHardPinned() ||
+                            !metadata.IsLeaseExpired() ||
+                            !metadata.AllReplicas(&Replica::fn_is_completed) ||
+                            tenant_state.replication_tasks.contains(key)) {
+                            blocked_unit_keys.insert(unit_key);
+                            continue;
+                        }
 
-                    auto target = SelectDrainTargetForKey(
-                        metadata, source_segment, job.request.target_segments);
-                    if (!target.has_value()) {
-                        blocked_unit_keys.insert(unit_key);
-                        continue;
-                    }
+                        auto target = SelectDrainTargetForKey(
+                            metadata, source_segment,
+                            job.request.target_segments);
+                        if (!target.has_value()) {
+                            blocked_unit_keys.insert(unit_key);
+                            continue;
+                        }
 
-                    if (plans.size() < slots) {
-                        plans.push_back({key, source_segment, *target,
-                                         metadata.size, unit_key});
+                        if (plans.size() < slots) {
+                            plans.push_back({key, source_segment, *target,
+                                             metadata.size, unit_key});
+                        }
                     }
                 }
             }
@@ -6684,15 +6704,18 @@ bool MasterService::MaybeCompleteDrainJob(DrainJob& job) {
         std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
         for (size_t i = 0; i < kNumShards; ++i) {
             MetadataShardAccessorRO shard(this, i);
-            for (const auto& [key, metadata] : shard->metadata) {
-                const auto replica_segments = metadata.GetReplicaSegmentNames();
-                for (const auto& source_segment : job.request.segments) {
-                    if (std::find(replica_segments.begin(),
-                                  replica_segments.end(),
-                                  source_segment) != replica_segments.end()) {
-                        remaining_segments.insert(source_segment);
-                        remaining_unit_keys.insert(
-                            MakeDrainUnitKey(key, source_segment));
+            for (const auto& [tenant_id, tenant_state] : shard->tenants) {
+                for (const auto& [key, metadata] : tenant_state.metadata) {
+                    const auto replica_segments =
+                        metadata.GetReplicaSegmentNames();
+                    for (const auto& source_segment : job.request.segments) {
+                        if (std::find(replica_segments.begin(),
+                                      replica_segments.end(), source_segment) !=
+                            replica_segments.end()) {
+                            remaining_segments.insert(source_segment);
+                            remaining_unit_keys.insert(MakeDrainUnitKey(
+                                tenant_id, key, source_segment));
+                        }
                     }
                 }
             }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1534,51 +1534,60 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
     }
     const std::string group_id = group_id_result.value();
 
-    auto alive_clients = getAliveClientsSnapshot();
-    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    // Lock the shard and check if object already exists.
-    // For new grouped objects, route to the group's target shard directly
-    // since the routing table hasn't been populated yet.
-    const size_t target_shard_idx =
-        group_id.empty()
-            ? getMetadataShardIndex(object_id.tenant_id, object_id.user_key)
-            : getShardIndex(group_id);
-    MetadataShardAccessorRW shard(this, target_shard_idx);
-    auto& tenant_state = shard->tenants[object_id.tenant_id];
-
     const auto now = std::chrono::system_clock::now();
-    auto it = tenant_state.metadata.find(key);
-    if (it != tenant_state.metadata.end() &&
-        !CleanupStaleHandles(it->second, alive_clients)) {
-        auto& metadata = it->second;
-        if (!metadata.HasReplica(&Replica::fn_is_completed) &&
-            metadata.put_start_time + put_start_discard_timeout_sec_ < now) {
-            auto replicas = metadata.PopReplicas(&Replica::fn_is_processing);
-            if (!replicas.empty()) {
-                std::lock_guard lock(discarded_replicas_mutex_);
-                discarded_replicas_.emplace_back(
-                    std::move(replicas),
-                    metadata.put_start_time + put_start_release_timeout_sec_);
-            }
-            tenant_state.processing_keys.erase(key);
-            EraseMetadata(tenant_state, it, object_id.tenant_id);
-            if (group_id.empty()) {
-                const size_t ungrouped_shard_idx =
-                    getShardIndex(object_id.tenant_id, object_id.user_key);
-                if (ungrouped_shard_idx != target_shard_idx) {
-                    MetadataShardAccessorRW ungrouped_shard(
-                        this, ungrouped_shard_idx);
-                    return AllocateAndInsertMetadata(
-                        ungrouped_shard, client_id, key, slice_length, config,
-                        group_id, object_id.tenant_id, now);
+    std::optional<size_t> retry_shard_idx;
+    {
+        auto alive_clients = getAliveClientsSnapshot();
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        // Lock the shard and check if object already exists.
+        // For new grouped objects, route to the group's target shard directly
+        // since the routing table hasn't been populated yet.
+        const size_t target_shard_idx =
+            group_id.empty()
+                ? getMetadataShardIndex(object_id.tenant_id, object_id.user_key)
+                : getShardIndex(group_id);
+        MetadataShardAccessorRW shard(this, target_shard_idx);
+        auto& tenant_state = shard->tenants[object_id.tenant_id];
+
+        auto it = tenant_state.metadata.find(key);
+        if (it != tenant_state.metadata.end() &&
+            !CleanupStaleHandles(it->second, alive_clients)) {
+            auto& metadata = it->second;
+            if (!metadata.HasReplica(&Replica::fn_is_completed) &&
+                metadata.put_start_time + put_start_discard_timeout_sec_ <
+                    now) {
+                auto replicas =
+                    metadata.PopReplicas(&Replica::fn_is_processing);
+                if (!replicas.empty()) {
+                    std::lock_guard lock(discarded_replicas_mutex_);
+                    discarded_replicas_.emplace_back(
+                        std::move(replicas),
+                        metadata.put_start_time +
+                            put_start_release_timeout_sec_);
                 }
+                tenant_state.processing_keys.erase(key);
+                EraseMetadata(tenant_state, it, object_id.tenant_id);
+                if (group_id.empty()) {
+                    const size_t ungrouped_shard_idx =
+                        getShardIndex(object_id.tenant_id, object_id.user_key);
+                    if (ungrouped_shard_idx != target_shard_idx) {
+                        retry_shard_idx = ungrouped_shard_idx;
+                    }
+                }
+            } else {
+                LOG(INFO) << "key=" << key << ", info=object_already_exists";
+                return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
             }
-        } else {
-            LOG(INFO) << "key=" << key << ", info=object_already_exists";
-            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+        }
+
+        if (!retry_shard_idx.has_value()) {
+            return AllocateAndInsertMetadata(shard, client_id, key,
+                                             slice_length, config, group_id,
+                                             object_id.tenant_id, now);
         }
     }
-
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    MetadataShardAccessorRW shard(this, retry_shard_idx.value());
     return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
                                      config, group_id, object_id.tenant_id,
                                      now);
@@ -1860,176 +1869,197 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     }
     const std::string group_id = group_id_result.value();
 
-    // --- Lock acquisition ---
-    auto alive_clients = getAliveClientsSnapshot();
-    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    // Use getMetadataShardIndex to find the object at its current shard
-    // (handles both grouped and ungrouped routing).
-    const size_t lookup_shard_idx =
-        getMetadataShardIndex(object_id.tenant_id, object_id.user_key);
-    MetadataShardAccessorRW shard(this, lookup_shard_idx);
-    auto& tenant_state = shard->tenants[object_id.tenant_id];
-
     const auto now = std::chrono::system_clock::now();
-    auto it = tenant_state.metadata.find(key);
+    std::optional<size_t> case_a_retry_shard_idx;
+    {
+        // --- Lock acquisition ---
+        auto alive_clients = getAliveClientsSnapshot();
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        // Use getMetadataShardIndex to find the object at its current shard
+        // (handles both grouped and ungrouped routing).
+        const size_t lookup_shard_idx =
+            getMetadataShardIndex(object_id.tenant_id, object_id.user_key);
+        MetadataShardAccessorRW shard(this, lookup_shard_idx);
+        auto& tenant_state = shard->tenants[object_id.tenant_id];
 
-    // --- Step 0: stale handle cleanup ---
-    if (it != tenant_state.metadata.end() &&
-        CleanupStaleHandles(it->second, alive_clients)) {
-        tenant_state.processing_keys.erase(key);
-        ErasePromotionTaskIfPresent(tenant_state, key);
-        EraseMetadata(tenant_state, it, object_id.tenant_id);
-        it = tenant_state.metadata.end();
-    }
+        auto it = tenant_state.metadata.find(key);
 
-    // --- Step 1: safety checks and preemption (only if key exists) ---
-    if (it != tenant_state.metadata.end()) {
-        auto& metadata = it->second;
-
-        // Reject if the caller tries to change group membership.
-        // Group membership is immutable while an object exists.
-        if (config.group_ids.has_value() && metadata.group_id != group_id) {
-            LOG(ERROR) << "key=" << key
-                       << ", error=group_membership_is_immutable";
-            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        // --- Step 0: stale handle cleanup ---
+        if (it != tenant_state.metadata.end() &&
+            CleanupStaleHandles(it->second, alive_clients)) {
+            tenant_state.processing_keys.erase(key);
+            ErasePromotionTaskIfPresent(tenant_state, key);
+            EraseMetadata(tenant_state, it, object_id.tenant_id);
+            it = tenant_state.metadata.end();
         }
 
-        // Reject if a Copy/Move task is actively reading this key's replicas.
-        if (tenant_state.replication_tasks.count(key) > 0) {
-            LOG(INFO) << "key=" << key << ", error=object_has_replication_task";
-            return tl::make_unexpected(ErrorCode::OBJECT_HAS_REPLICATION_TASK);
+        // --- Step 1: safety checks and preemption (only if key exists) ---
+        if (it != tenant_state.metadata.end()) {
+            auto& metadata = it->second;
+
+            // Reject if the caller tries to change group membership.
+            // Group membership is immutable while an object exists.
+            if (config.group_ids.has_value() && metadata.group_id != group_id) {
+                LOG(ERROR) << "key=" << key
+                           << ", error=group_membership_is_immutable";
+                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+            }
+
+            // Reject if a Copy/Move task is actively reading this key's
+            // replicas.
+            if (tenant_state.replication_tasks.count(key) > 0) {
+                LOG(INFO) << "key=" << key
+                          << ", error=object_has_replication_task";
+                return tl::make_unexpected(
+                    ErrorCode::OBJECT_HAS_REPLICATION_TASK);
+            }
+
+            // Reject if an offload-to-disk task is in progress (same reason).
+            if (tenant_state.offloading_tasks.count(key) > 0) {
+                LOG(INFO) << "key=" << key
+                          << ", error=object_has_offloading_task";
+                return tl::make_unexpected(
+                    ErrorCode::OBJECT_HAS_REPLICATION_TASK);
+            }
+
+            // Preempt an in-progress Put/Upsert on the same key.  The previous
+            // writer's PROCESSING replicas are moved to discarded_replicas_
+            // with a TTL so they are not freed while the old writer may still
+            // be doing RDMA writes.  Unlike PutStart (which only preempts after
+            // a timeout), UpsertStart preempts immediately.
+            if (tenant_state.processing_keys.count(key) > 0) {
+                auto processing_replicas =
+                    metadata.PopReplicas(&Replica::fn_is_processing);
+                if (!processing_replicas.empty()) {
+                    std::lock_guard lock(discarded_replicas_mutex_);
+                    discarded_replicas_.emplace_back(
+                        std::move(processing_replicas),
+                        now + put_start_release_timeout_sec_);
+                }
+                tenant_state.processing_keys.erase(key);
+
+                // If no COMPLETE replicas survive the preemption, this key
+                // effectively does not exist — fall through to Case A.
+                if (!metadata.HasReplica(&Replica::fn_is_completed)) {
+                    ErasePromotionTaskIfPresent(tenant_state, key);
+                    EraseMetadata(tenant_state, it, object_id.tenant_id);
+                    it = tenant_state.metadata.end();
+                }
+            }
         }
 
-        // Reject if an offload-to-disk task is in progress (same reason).
-        if (tenant_state.offloading_tasks.count(key) > 0) {
-            LOG(INFO) << "key=" << key << ", error=object_has_offloading_task";
-            return tl::make_unexpected(ErrorCode::OBJECT_HAS_REPLICATION_TASK);
-        }
+        // --- Case A: key does not exist (or was erased above) ---
+        // Allocate fresh buffers, identical to PutStart.
+        if (it == tenant_state.metadata.end()) {
+            VLOG(1) << "key=" << key << ", action=upsert_start_case_a";
+            const size_t case_a_shard_idx =
+                group_id.empty()
+                    ? getShardIndex(object_id.tenant_id, object_id.user_key)
+                    : getShardIndex(group_id);
+            if (case_a_shard_idx != lookup_shard_idx) {
+                case_a_retry_shard_idx = case_a_shard_idx;
+            } else {
+                return AllocateAndInsertMetadata(shard, client_id, key,
+                                                 slice_length, config, group_id,
+                                                 object_id.tenant_id, now);
+            }
+        } else {
+            // --- Step 2: key exists with COMPLETE replicas → Case B or C ---
+            auto& metadata = it->second;
 
-        // Preempt an in-progress Put/Upsert on the same key.  The previous
-        // writer's PROCESSING replicas are moved to discarded_replicas_ with a
-        // TTL so they are not freed while the old writer may still be doing
-        // RDMA writes.  Unlike PutStart (which only preempts after a timeout),
-        // UpsertStart preempts immediately.
-        if (tenant_state.processing_keys.count(key) > 0) {
-            auto processing_replicas =
-                metadata.PopReplicas(&Replica::fn_is_processing);
-            if (!processing_replicas.empty()) {
+            // Reject if any reader holds a reference (refcnt > 0).  Overwriting
+            // a buffer that an RDMA read is streaming from would cause data
+            // corruption. The client should retry after readers finish.
+            if (metadata.HasReplica(&Replica::fn_is_busy)) {
+                LOG(INFO) << "key=" << key << ", error=object_replica_busy";
+                return tl::make_unexpected(ErrorCode::OBJECT_REPLICA_BUSY);
+            }
+
+            if (metadata.size == slice_length) {
+                // --- Case B: same size — in-place update ---
+                // Reuse existing buffer addresses.  No allocation or
+                // deallocation. The client will RDMA-write new data to the same
+                // addresses.
+                //
+                // hard_pinned is const and preserved automatically — upsert
+                // does not change the eviction protection level of an existing
+                // object.
+                metadata.client_id = client_id;
+                metadata.put_start_time = now;
+
+                // Reconcile soft_pin state with the incoming config.
+                {
+                    SpinLocker locker(&metadata.lock);
+                    if (config.with_soft_pin && !metadata.soft_pin_timeout) {
+                        metadata.soft_pin_timeout.emplace();
+                        MasterMetricManager::instance().inc_soft_pin_key_count(
+                            1);
+                    } else if (!config.with_soft_pin &&
+                               metadata.soft_pin_timeout) {
+                        metadata.soft_pin_timeout.reset();
+                        MasterMetricManager::instance().dec_soft_pin_key_count(
+                            1);
+                    }
+                }
+
+                // Mark COMPLETE → PROCESSING so readers won't see stale data
+                // mid-transfer.  The key becomes unreadable until UpsertEnd.
+                metadata.VisitReplicas(
+                    &Replica::fn_is_completed,
+                    [](Replica& replica) { replica.mark_processing(); });
+
+                tenant_state.processing_keys.insert(key);
+
+                // Return the existing descriptors — same buffer addresses as
+                // before.
+                std::vector<Replica::Descriptor> replica_list;
+                const auto& all_replicas = metadata.GetAllReplicas();
+                replica_list.reserve(all_replicas.size());
+                for (const auto& replica : all_replicas) {
+                    replica_list.emplace_back(replica.get_descriptor());
+                }
+
+                VLOG(1) << "key=" << key
+                        << ", action=upsert_start_case_b_inplace";
+                return replica_list;
+            }
+
+            // --- Case C: different size — discard old replicas and reallocate
+            // --- Old buffers cannot be reused.  Move them to
+            // discarded_replicas_ for delayed release (readers may still hold
+            // descriptors without refcnt), then allocate fresh buffers at the
+            // new size.
+            //
+            // Preserve hard_pin and soft_pin from the old metadata so that
+            // eviction protection survives a size-changing upsert (RFC §2.2.2).
+            ReplicateConfig merged_config = config;
+            merged_config.with_hard_pin =
+                merged_config.with_hard_pin || metadata.IsHardPinned();
+            merged_config.with_soft_pin =
+                merged_config.with_soft_pin || metadata.IsSoftPinned();
+
+            const std::string existing_group_id = metadata.group_id;
+            auto old_replicas = metadata.PopReplicas();
+            if (!old_replicas.empty()) {
                 std::lock_guard lock(discarded_replicas_mutex_);
                 discarded_replicas_.emplace_back(
-                    std::move(processing_replicas),
+                    std::move(old_replicas),
                     now + put_start_release_timeout_sec_);
             }
-            tenant_state.processing_keys.erase(key);
+            EraseMetadata(tenant_state, it, object_id.tenant_id);
 
-            // If no COMPLETE replicas survive the preemption, this key
-            // effectively does not exist — fall through to Case A.
-            if (!metadata.HasReplica(&Replica::fn_is_completed)) {
-                ErasePromotionTaskIfPresent(tenant_state, key);
-                EraseMetadata(tenant_state, it, object_id.tenant_id);
-                it = tenant_state.metadata.end();
-            }
+            VLOG(1) << "key=" << key
+                    << ", action=upsert_start_case_c_reallocate";
+            return AllocateAndInsertMetadata(
+                shard, client_id, key, slice_length, merged_config,
+                existing_group_id, object_id.tenant_id, now);
         }
     }
-
-    // --- Case A: key does not exist (or was erased above) ---
-    // Allocate fresh buffers, identical to PutStart.
-    if (it == tenant_state.metadata.end()) {
-        VLOG(1) << "key=" << key << ", action=upsert_start_case_a";
-        const size_t case_a_shard_idx =
-            group_id.empty()
-                ? getShardIndex(object_id.tenant_id, object_id.user_key)
-                : getShardIndex(group_id);
-        if (case_a_shard_idx != lookup_shard_idx) {
-            MetadataShardAccessorRW target_shard(this, case_a_shard_idx);
-            return AllocateAndInsertMetadata(target_shard, client_id, key,
-                                             slice_length, config, group_id,
-                                             object_id.tenant_id, now);
-        }
-        return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                         config, group_id, object_id.tenant_id,
-                                         now);
-    }
-
-    // --- Step 2: key exists with COMPLETE replicas → Case B or C ---
-    auto& metadata = it->second;
-
-    // Reject if any reader holds a reference (refcnt > 0).  Overwriting a
-    // buffer that an RDMA read is streaming from would cause data corruption.
-    // The client should retry after readers finish.
-    if (metadata.HasReplica(&Replica::fn_is_busy)) {
-        LOG(INFO) << "key=" << key << ", error=object_replica_busy";
-        return tl::make_unexpected(ErrorCode::OBJECT_REPLICA_BUSY);
-    }
-
-    if (metadata.size == slice_length) {
-        // --- Case B: same size — in-place update ---
-        // Reuse existing buffer addresses.  No allocation or deallocation.
-        // The client will RDMA-write new data to the same addresses.
-        //
-        // hard_pinned is const and preserved automatically — upsert does not
-        // change the eviction protection level of an existing object.
-        metadata.client_id = client_id;
-        metadata.put_start_time = now;
-
-        // Reconcile soft_pin state with the incoming config.
-        {
-            SpinLocker locker(&metadata.lock);
-            if (config.with_soft_pin && !metadata.soft_pin_timeout) {
-                metadata.soft_pin_timeout.emplace();
-                MasterMetricManager::instance().inc_soft_pin_key_count(1);
-            } else if (!config.with_soft_pin && metadata.soft_pin_timeout) {
-                metadata.soft_pin_timeout.reset();
-                MasterMetricManager::instance().dec_soft_pin_key_count(1);
-            }
-        }
-
-        // Mark COMPLETE → PROCESSING so readers won't see stale data
-        // mid-transfer.  The key becomes unreadable until UpsertEnd.
-        metadata.VisitReplicas(&Replica::fn_is_completed, [](Replica& replica) {
-            replica.mark_processing();
-        });
-
-        tenant_state.processing_keys.insert(key);
-
-        // Return the existing descriptors — same buffer addresses as before.
-        std::vector<Replica::Descriptor> replica_list;
-        const auto& all_replicas = metadata.GetAllReplicas();
-        replica_list.reserve(all_replicas.size());
-        for (const auto& replica : all_replicas) {
-            replica_list.emplace_back(replica.get_descriptor());
-        }
-
-        VLOG(1) << "key=" << key << ", action=upsert_start_case_b_inplace";
-        return replica_list;
-    }
-
-    // --- Case C: different size — discard old replicas and reallocate ---
-    // Old buffers cannot be reused.  Move them to discarded_replicas_ for
-    // delayed release (readers may still hold descriptors without refcnt),
-    // then allocate fresh buffers at the new size.
-    //
-    // Preserve hard_pin and soft_pin from the old metadata so that eviction
-    // protection survives a size-changing upsert (RFC §2.2.2).
-    ReplicateConfig merged_config = config;
-    merged_config.with_hard_pin =
-        merged_config.with_hard_pin || metadata.IsHardPinned();
-    merged_config.with_soft_pin =
-        merged_config.with_soft_pin || metadata.IsSoftPinned();
-
-    const std::string existing_group_id = metadata.group_id;
-    auto old_replicas = metadata.PopReplicas();
-    if (!old_replicas.empty()) {
-        std::lock_guard lock(discarded_replicas_mutex_);
-        discarded_replicas_.emplace_back(std::move(old_replicas),
-                                         now + put_start_release_timeout_sec_);
-    }
-    EraseMetadata(tenant_state, it, object_id.tenant_id);
-
-    VLOG(1) << "key=" << key << ", action=upsert_start_case_c_reallocate";
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    MetadataShardAccessorRW shard(this, case_a_retry_shard_idx.value());
     return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                     merged_config, existing_group_id,
-                                     object_id.tenant_id, now);
+                                     config, group_id, object_id.tenant_id,
+                                     now);
 }
 
 auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -590,42 +590,44 @@ MasterService::getAliveClientsSnapshot() const {
 }
 
 size_t MasterService::getMetadataShardIndex(const std::string& key) const {
-    std::shared_lock<std::shared_mutex> lock(group_routing_mutex_);
-    auto it = object_group_ids_.find(key);
-    if (it == object_group_ids_.end()) {
-        return getShardIndex(key);
-    }
-    return getShardIndex(it->second);
+    return getMetadataShardIndex("default", key);
 }
 
 size_t MasterService::getMetadataShardIndex(const std::string& tenant_id,
                                             const std::string& key) const {
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
     std::shared_lock<std::shared_mutex> lock(group_routing_mutex_);
-    auto it = object_group_ids_.find(key);
+    auto it =
+        object_group_ids_.find(MakeTenantScopedKey(normalized_tenant, key));
     if (it == object_group_ids_.end()) {
-        return getShardIndex(tenant_id, key);
+        return getShardIndex(normalized_tenant, key);
     }
     return getShardIndex(it->second);
 }
 
 void MasterService::RegisterGroupMember(TenantState& tenant_state,
+                                        const std::string& tenant_id,
                                         const std::string& key,
                                         const std::string& group_id) {
     if (group_id.empty()) {
         return;
     }
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
     std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
-    object_group_ids_[key] = group_id;
-    groups_needing_lease_refresh_.insert(group_id);
+    object_group_ids_[MakeTenantScopedKey(normalized_tenant, key)] = group_id;
+    groups_needing_lease_refresh_.insert(
+        MakeTenantScopedKey(normalized_tenant, group_id));
     tenant_state.group_members[group_id].insert(key);
 }
 
 void MasterService::UnregisterGroupMember(TenantState& tenant_state,
+                                          const std::string& tenant_id,
                                           const std::string& key,
                                           const std::string& group_id) {
     if (group_id.empty()) {
         return;
     }
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
     bool group_empty = false;
     auto group_it = tenant_state.group_members.find(group_id);
     if (group_it != tenant_state.group_members.end()) {
@@ -636,13 +638,27 @@ void MasterService::UnregisterGroupMember(TenantState& tenant_state,
         }
     }
     std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
-    auto route_it = object_group_ids_.find(key);
+    auto route_it =
+        object_group_ids_.find(MakeTenantScopedKey(normalized_tenant, key));
     if (route_it != object_group_ids_.end() && route_it->second == group_id) {
         object_group_ids_.erase(route_it);
     }
     if (group_empty) {
-        groups_needing_lease_refresh_.erase(group_id);
+        groups_needing_lease_refresh_.erase(
+            MakeTenantScopedKey(normalized_tenant, group_id));
     }
+}
+
+std::unordered_map<std::string, MasterService::ObjectMetadata>::iterator
+MasterService::EraseMetadata(
+    TenantState& tenant_state,
+    std::unordered_map<std::string, ObjectMetadata>::iterator it,
+    const std::string& tenant_id) {
+    const std::string key = it->first;
+    const std::string group_id = it->second.group_id;
+    auto next = tenant_state.metadata.erase(it);
+    UnregisterGroupMember(tenant_state, tenant_id, key, group_id);
+    return next;
 }
 
 void MasterService::RebuildGroupRoutingIndex() {
@@ -657,8 +673,10 @@ void MasterService::RebuildGroupRoutingIndex() {
                     continue;
                 }
                 tenant_state.group_members[metadata.group_id].insert(key);
-                rebuilt_group_ids[key] = metadata.group_id;
-                groups_needing_refresh.insert(metadata.group_id);
+                rebuilt_group_ids[MakeTenantScopedKey(tenant_id, key)] =
+                    metadata.group_id;
+                groups_needing_refresh.insert(
+                    MakeTenantScopedKey(tenant_id, metadata.group_id));
             }
         }
     }
@@ -681,7 +699,8 @@ void MasterService::GrantLeaseForGroup(const TenantState& tenant_state,
                                                     default_kv_soft_pin_ttl_);
     if (!needs_refresh) {
         std::shared_lock<std::shared_mutex> lock(group_routing_mutex_);
-        needs_refresh = groups_needing_lease_refresh_.find(metadata.group_id) !=
+        needs_refresh = groups_needing_lease_refresh_.find(MakeTenantScopedKey(
+                            metadata.tenant_id, metadata.group_id)) !=
                         groups_needing_lease_refresh_.end();
     }
     if (!needs_refresh) {
@@ -706,7 +725,8 @@ void MasterService::GrantLeaseForGroup(const TenantState& tenant_state,
     }
     {
         std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
-        groups_needing_lease_refresh_.erase(metadata.group_id);
+        groups_needing_lease_refresh_.erase(
+            MakeTenantScopedKey(metadata.tenant_id, metadata.group_id));
     }
 }
 
@@ -731,7 +751,7 @@ void MasterService::ClearInvalidHandles(
                         promotion_in_flight_.fetch_sub(
                             1, std::memory_order_relaxed);
                     }
-                    it = tenant_state.metadata.erase(it);
+                    it = EraseMetadata(tenant_state, it, tenant_it->first);
                 } else {
                     ++it;
                 }
@@ -1448,7 +1468,7 @@ auto MasterService::AllocateAndInsertMetadata(
     }
 
     // Publish the route before inserting metadata for grouped objects.
-    RegisterGroupMember(tenant_state, key, group_id);
+    RegisterGroupMember(tenant_state, tenant_id, key, group_id);
     tenant_state.metadata.emplace(
         std::piecewise_construct, std::forward_as_tuple(key),
         std::forward_as_tuple(client_id, now, value_length, std::move(replicas),
@@ -1541,7 +1561,18 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                     metadata.put_start_time + put_start_release_timeout_sec_);
             }
             tenant_state.processing_keys.erase(key);
-            tenant_state.metadata.erase(it);
+            EraseMetadata(tenant_state, it, object_id.tenant_id);
+            if (group_id.empty()) {
+                const size_t ungrouped_shard_idx =
+                    getShardIndex(object_id.tenant_id, object_id.user_key);
+                if (ungrouped_shard_idx != target_shard_idx) {
+                    MetadataShardAccessorRW ungrouped_shard(
+                        this, ungrouped_shard_idx);
+                    return AllocateAndInsertMetadata(
+                        ungrouped_shard, client_id, key, slice_length, config,
+                        group_id, object_id.tenant_id, now);
+                }
+            }
         } else {
             LOG(INFO) << "key=" << key << ", info=object_already_exists";
             return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
@@ -1847,7 +1878,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
         CleanupStaleHandles(it->second, alive_clients)) {
         tenant_state.processing_keys.erase(key);
         ErasePromotionTaskIfPresent(tenant_state, key);
-        tenant_state.metadata.erase(it);
+        EraseMetadata(tenant_state, it, object_id.tenant_id);
         it = tenant_state.metadata.end();
     }
 
@@ -1857,23 +1888,10 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
 
         // Reject if the caller tries to change group membership.
         // Group membership is immutable while an object exists.
-        if (config.group_ids.has_value() && metadata.IsGrouped()) {
-            const bool has_requested_group_id =
-                config.group_ids.has_value() && !group_id.empty();
-            if (has_requested_group_id && metadata.group_id != group_id) {
-                LOG(ERROR) << "key=" << key
-                           << ", error=group_membership_is_immutable";
-                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-            }
-            if (!has_requested_group_id && metadata.IsGrouped()) {
-                // Explicitly ungrouping a grouped object is not allowed.
-                if (config.group_ids.has_value() &&
-                    config.group_ids->at(0).empty()) {
-                    LOG(ERROR) << "key=" << key
-                               << ", error=group_membership_is_immutable";
-                    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-                }
-            }
+        if (config.group_ids.has_value() && metadata.group_id != group_id) {
+            LOG(ERROR) << "key=" << key
+                       << ", error=group_membership_is_immutable";
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
 
         // Reject if a Copy/Move task is actively reading this key's replicas.
@@ -1908,7 +1926,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
             // effectively does not exist — fall through to Case A.
             if (!metadata.HasReplica(&Replica::fn_is_completed)) {
                 ErasePromotionTaskIfPresent(tenant_state, key);
-                tenant_state.metadata.erase(it);
+                EraseMetadata(tenant_state, it, object_id.tenant_id);
                 it = tenant_state.metadata.end();
             }
         }
@@ -1919,7 +1937,9 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     if (it == tenant_state.metadata.end()) {
         VLOG(1) << "key=" << key << ", action=upsert_start_case_a";
         const size_t case_a_shard_idx =
-            group_id.empty() ? lookup_shard_idx : getShardIndex(group_id);
+            group_id.empty()
+                ? getShardIndex(object_id.tenant_id, object_id.user_key)
+                : getShardIndex(group_id);
         if (case_a_shard_idx != lookup_shard_idx) {
             MetadataShardAccessorRW target_shard(this, case_a_shard_idx);
             return AllocateAndInsertMetadata(target_shard, client_id, key,
@@ -1997,20 +2017,18 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     merged_config.with_soft_pin =
         merged_config.with_soft_pin || metadata.IsSoftPinned();
 
-    const std::string effective_group_id =
-        metadata.IsGrouped() ? metadata.group_id : group_id;
-
+    const std::string existing_group_id = metadata.group_id;
     auto old_replicas = metadata.PopReplicas();
     if (!old_replicas.empty()) {
         std::lock_guard lock(discarded_replicas_mutex_);
         discarded_replicas_.emplace_back(std::move(old_replicas),
                                          now + put_start_release_timeout_sec_);
     }
-    tenant_state.metadata.erase(it);
+    EraseMetadata(tenant_state, it, object_id.tenant_id);
 
     VLOG(1) << "key=" << key << ", action=upsert_start_case_c_reallocate";
     return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                     merged_config, effective_group_id,
+                                     merged_config, existing_group_id,
                                      object_id.tenant_id, now);
 }
 
@@ -2672,7 +2690,7 @@ auto MasterService::RemoveByRegex(const std::string& regex_pattern,
                 VLOG(1) << "key=" << it->first
                         << " matched by regex. Removing.";
                 ErasePromotionTaskIfPresent(tenant_state, it->first);
-                it = tenant_state.metadata.erase(it);
+                it = EraseMetadata(tenant_state, it, normalized_tenant);
                 removed_count++;
             } else {
                 ++it;
@@ -2710,7 +2728,7 @@ long MasterService::RemoveAll(bool force) {
                         &Replica::fn_is_memory_replica);
                     total_freed_size += it->second.size * mem_rep_count;
                     ErasePromotionTaskIfPresent(tenant_state, it->first);
-                    it = tenant_state.metadata.erase(it);
+                    it = EraseMetadata(tenant_state, it, tenant_it->first);
                     removed_count++;
                 } else {
                     ++it;
@@ -2781,7 +2799,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                 tenant_state.replication_tasks.erase(key);
                 tenant_state.offloading_tasks.erase(key);
                 ErasePromotionTaskIfPresent(tenant_state, key);
-                tenant_state.metadata.erase(it);
+                EraseMetadata(tenant_state, it, "default");
                 results[original_idx] =
                     tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
                 continue;
@@ -2818,7 +2836,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
 
             // Remove object metadata
             ErasePromotionTaskIfPresent(tenant_state, key);
-            tenant_state.metadata.erase(it);
+            EraseMetadata(tenant_state, it, "default");
             if (tenant_state.Empty()) {
                 shard->tenants.erase(tenant_it);
             }
@@ -3567,7 +3585,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
             if (!metadata.IsValid() ||
                 metadata.AllReplicas(&Replica::fn_is_completed)) {
                 if (!metadata.IsValid()) {
-                    tenant_state.metadata.erase(it);
+                    EraseMetadata(tenant_state, it, tenant_it->first);
                 }
                 key_it = tenant_state.processing_keys.erase(key_it);
                 continue;
@@ -3582,7 +3600,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
                     discarded_replicas.emplace_back(std::move(replicas), ttl);
                 }
                 if (!metadata.IsValid()) {
-                    tenant_state.metadata.erase(it);
+                    EraseMetadata(tenant_state, it, tenant_it->first);
                 }
                 key_it = tenant_state.processing_keys.erase(key_it);
                 continue;
@@ -3624,7 +3642,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
                 discarded_replicas.emplace_back(std::move(replicas), ttl);
             }
             if (!metadata.IsValid()) {
-                tenant_state.metadata.erase(metadata_it);
+                EraseMetadata(tenant_state, metadata_it, tenant_it->first);
             }
             task_it = tenant_state.replication_tasks.erase(task_it);
         }
@@ -4629,7 +4647,8 @@ bool MasterService::TryRestoreStateFromSnapshot(
                                 (it->second.IsLeaseExpired(cleanup_now) &&
                                  !it->second.IsSoftPinned(cleanup_now))) {
                                 VLOG(1) << "clear metadata key=" << it->first;
-                                it = tenant_state.metadata.erase(it);
+                                it = EraseMetadata(tenant_state, it,
+                                                   tenant_it->first);
                             } else {
                                 ++it;
                             }
@@ -4925,7 +4944,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 result.evicted_objects++;
             }
             if (member_key != key && !member_metadata.IsValid()) {
-                tenant_state.metadata.erase(member_it);
+                EraseMetadata(tenant_state, member_it, tenant_id);
             }
         }
         return result;
@@ -5005,7 +5024,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
                             tenant_state, /*allow_soft_pinned=*/false);
                         total_freed_size += evict_result.freed_bytes;
                         if (it->second.IsValid() == false) {
-                            it = tenant_state.metadata.erase(it);
+                            it = EraseMetadata(tenant_state, it,
+                                               tenant_it->first);
                         } else {
                             ++it;
                         }
@@ -5076,7 +5096,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                 tenant_state, /*allow_soft_pinned=*/false);
                             total_freed_size += evict_result.freed_bytes;
                             if (!it->second.IsValid()) {
-                                it = tenant_state.metadata.erase(it);
+                                it = EraseMetadata(tenant_state, it,
+                                                   tenant_it->first);
                             } else {
                                 ++it;
                             }
@@ -5135,7 +5156,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                 tenant_state, /*allow_soft_pinned=*/true);
                             total_freed_size += evict_result.freed_bytes;
                             if (!it->second.IsValid()) {
-                                it = tenant_state.metadata.erase(it);
+                                it = EraseMetadata(tenant_state, it,
+                                                   tenant_it->first);
                             } else {
                                 ++it;
                             }
@@ -5266,7 +5288,7 @@ void MasterService::NoFBatchEvict(double evict_ratio_target,
                 total_freed_size += metadata.size * erased;
                 shard_evicted_count++;
                 if (!metadata.IsValid()) {
-                    it = tenant_state.metadata.erase(it);
+                    it = EraseMetadata(tenant_state, it, tenant_it->first);
                 } else {
                     ++it;
                 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -605,6 +605,46 @@ size_t MasterService::getMetadataShardIndex(const std::string& tenant_id,
     return getShardIndex(it->second);
 }
 
+std::optional<std::string> MasterService::GetGroupRoute(
+    const std::string& tenant_id, const std::string& key) const {
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    std::shared_lock<std::shared_mutex> lock(group_routing_mutex_);
+    auto it =
+        object_group_ids_.find(MakeTenantScopedKey(normalized_tenant, key));
+    if (it == object_group_ids_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+MasterService::ObjectOperationLock MasterService::AcquireObjectOperationLock(
+    const std::string& tenant_id, const std::string& key) {
+    auto object_mutex = std::shared_ptr<std::mutex>();
+    const auto scoped_key = MakeTenantScopedKey(tenant_id, key);
+    {
+        std::lock_guard<std::mutex> lock(object_operation_locks_mutex_);
+        auto it = object_operation_locks_.find(scoped_key);
+        if (it != object_operation_locks_.end()) {
+            object_mutex = it->second.lock();
+        }
+        if (object_mutex == nullptr) {
+            object_mutex = std::make_shared<std::mutex>();
+            object_operation_locks_[scoped_key] = object_mutex;
+        }
+        if (object_operation_locks_.size() > kNumShards * 4) {
+            for (auto cleanup_it = object_operation_locks_.begin();
+                 cleanup_it != object_operation_locks_.end();) {
+                if (cleanup_it->second.expired()) {
+                    cleanup_it = object_operation_locks_.erase(cleanup_it);
+                } else {
+                    ++cleanup_it;
+                }
+            }
+        }
+    }
+    return {object_mutex, std::unique_lock<std::mutex>(*object_mutex)};
+}
+
 void MasterService::RegisterGroupMember(TenantState& tenant_state,
                                         const std::string& tenant_id,
                                         const std::string& key,
@@ -1341,6 +1381,15 @@ auto MasterService::AllocateAndInsertMetadata(
     const std::chrono::system_clock::time_point& now)
     -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
     auto& tenant_state = shard->tenants[tenant_id];
+    if (tenant_state.metadata.contains(key)) {
+        LOG(INFO) << "key=" << key << ", info=object_already_exists";
+        return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+    }
+    if (GetGroupRoute(tenant_id, key).has_value()) {
+        LOG(INFO) << "key=" << key << ", info=object_already_exists";
+        return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+    }
+
     std::vector<Replica> replicas;
     const auto write_mode = DetermineReplicaWriteMode(config);
     size_t allocated_memory_replicas = 0;
@@ -1467,13 +1516,16 @@ auto MasterService::AllocateAndInsertMetadata(
         }
     }
 
-    // Publish the route before inserting metadata for grouped objects.
-    RegisterGroupMember(tenant_state, tenant_id, key, group_id);
-    tenant_state.metadata.emplace(
+    auto [it, inserted] = tenant_state.metadata.emplace(
         std::piecewise_construct, std::forward_as_tuple(key),
         std::forward_as_tuple(client_id, now, value_length, std::move(replicas),
                               config.with_soft_pin, config.with_hard_pin,
                               config.data_type, group_id, tenant_id, key));
+    if (!inserted) {
+        LOG(INFO) << "key=" << key << ", info=object_already_exists";
+        return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+    }
+    RegisterGroupMember(tenant_state, tenant_id, key, group_id);
     tenant_state.processing_keys.insert(key);
 
     return replica_list;
@@ -1534,28 +1586,37 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
     }
     const std::string group_id = group_id_result.value();
 
+    [[maybe_unused]] auto object_operation_lock =
+        AcquireObjectOperationLock(object_id.tenant_id, object_id.user_key);
     const auto now = std::chrono::system_clock::now();
     std::optional<size_t> retry_shard_idx;
     {
         auto alive_clients = getAliveClientsSnapshot();
         std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-        // Lock the shard and check if object already exists.
-        // For new grouped objects, route to the group's target shard directly
-        // since the routing table hasn't been populated yet.
-        const size_t target_shard_idx =
-            group_id.empty()
-                ? getMetadataShardIndex(object_id.tenant_id, object_id.user_key)
-                : getShardIndex(group_id);
-        MetadataShardAccessorRW shard(this, target_shard_idx);
+        const size_t lookup_shard_idx =
+            getMetadataShardIndex(object_id.tenant_id, object_id.user_key);
+        MetadataShardAccessorRW shard(this, lookup_shard_idx);
         auto& tenant_state = shard->tenants[object_id.tenant_id];
 
         auto it = tenant_state.metadata.find(key);
-        if (it != tenant_state.metadata.end() &&
-            !CleanupStaleHandles(it->second, alive_clients)) {
-            auto& metadata = it->second;
-            if (!metadata.HasReplica(&Replica::fn_is_completed) &&
-                metadata.put_start_time + put_start_discard_timeout_sec_ <
-                    now) {
+        if (it != tenant_state.metadata.end()) {
+            if (CleanupStaleHandles(it->second, alive_clients)) {
+                tenant_state.processing_keys.erase(key);
+                tenant_state.replication_tasks.erase(key);
+                tenant_state.offloading_tasks.erase(key);
+                ErasePromotionTaskIfPresent(tenant_state, key);
+                EraseMetadata(tenant_state, it, object_id.tenant_id);
+                it = tenant_state.metadata.end();
+            } else {
+                auto& metadata = it->second;
+                if (metadata.HasReplica(&Replica::fn_is_completed) ||
+                    metadata.put_start_time + put_start_discard_timeout_sec_ >=
+                        now) {
+                    LOG(INFO)
+                        << "key=" << key << ", info=object_already_exists";
+                    return tl::make_unexpected(
+                        ErrorCode::OBJECT_ALREADY_EXISTS);
+                }
                 auto replicas =
                     metadata.PopReplicas(&Replica::fn_is_processing);
                 if (!replicas.empty()) {
@@ -1567,27 +1628,35 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                 }
                 tenant_state.processing_keys.erase(key);
                 EraseMetadata(tenant_state, it, object_id.tenant_id);
-                if (group_id.empty()) {
-                    const size_t ungrouped_shard_idx =
-                        getShardIndex(object_id.tenant_id, object_id.user_key);
-                    if (ungrouped_shard_idx != target_shard_idx) {
-                        retry_shard_idx = ungrouped_shard_idx;
-                    }
-                }
-            } else {
-                LOG(INFO) << "key=" << key << ", info=object_already_exists";
-                return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+                it = tenant_state.metadata.end();
             }
         }
 
-        if (!retry_shard_idx.has_value()) {
-            return AllocateAndInsertMetadata(shard, client_id, key,
-                                             slice_length, config, group_id,
-                                             object_id.tenant_id, now);
+        if (it == tenant_state.metadata.end()) {
+            const size_t target_shard_idx =
+                group_id.empty()
+                    ? getShardIndex(object_id.tenant_id, object_id.user_key)
+                    : getShardIndex(group_id);
+            if (target_shard_idx != lookup_shard_idx) {
+                retry_shard_idx = target_shard_idx;
+                if (tenant_state.Empty()) {
+                    shard->tenants.erase(object_id.tenant_id);
+                }
+            } else {
+                return AllocateAndInsertMetadata(shard, client_id, key,
+                                                 slice_length, config, group_id,
+                                                 object_id.tenant_id, now);
+            }
         }
     }
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataShardAccessorRW shard(this, retry_shard_idx.value());
+    auto& retry_tenant_state = shard->tenants[object_id.tenant_id];
+    if (GetGroupRoute(object_id.tenant_id, object_id.user_key).has_value() ||
+        retry_tenant_state.metadata.contains(key)) {
+        LOG(INFO) << "key=" << key << ", info=object_already_exists";
+        return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+    }
     return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
                                      config, group_id, object_id.tenant_id,
                                      now);
@@ -1869,6 +1938,8 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     }
     const std::string group_id = group_id_result.value();
 
+    [[maybe_unused]] auto object_operation_lock =
+        AcquireObjectOperationLock(object_id.tenant_id, object_id.user_key);
     const auto now = std::chrono::system_clock::now();
     std::optional<size_t> case_a_retry_shard_idx;
     {
@@ -1958,6 +2029,9 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                     : getShardIndex(group_id);
             if (case_a_shard_idx != lookup_shard_idx) {
                 case_a_retry_shard_idx = case_a_shard_idx;
+                if (tenant_state.Empty()) {
+                    shard->tenants.erase(object_id.tenant_id);
+                }
             } else {
                 return AllocateAndInsertMetadata(shard, client_id, key,
                                                  slice_length, config, group_id,
@@ -2057,6 +2131,14 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     }
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataShardAccessorRW shard(this, case_a_retry_shard_idx.value());
+    auto& retry_tenant_state = shard->tenants[object_id.tenant_id];
+    const auto current_route =
+        GetGroupRoute(object_id.tenant_id, object_id.user_key);
+    if (current_route.has_value() ||
+        retry_tenant_state.metadata.contains(key)) {
+        LOG(INFO) << "key=" << key << ", info=object_already_exists";
+        return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+    }
     return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
                                      config, group_id, object_id.tenant_id,
                                      now);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -619,30 +619,10 @@ std::optional<std::string> MasterService::GetGroupRoute(
 
 MasterService::ObjectOperationLock MasterService::AcquireObjectOperationLock(
     const std::string& tenant_id, const std::string& key) {
-    auto object_mutex = std::shared_ptr<std::mutex>();
     const auto scoped_key = MakeTenantScopedKey(tenant_id, key);
-    {
-        std::lock_guard<std::mutex> lock(object_operation_locks_mutex_);
-        auto it = object_operation_locks_.find(scoped_key);
-        if (it != object_operation_locks_.end()) {
-            object_mutex = it->second.lock();
-        }
-        if (object_mutex == nullptr) {
-            object_mutex = std::make_shared<std::mutex>();
-            object_operation_locks_[scoped_key] = object_mutex;
-        }
-        if (object_operation_locks_.size() > kNumShards * 4) {
-            for (auto cleanup_it = object_operation_locks_.begin();
-                 cleanup_it != object_operation_locks_.end();) {
-                if (cleanup_it->second.expired()) {
-                    cleanup_it = object_operation_locks_.erase(cleanup_it);
-                } else {
-                    ++cleanup_it;
-                }
-            }
-        }
-    }
-    return {object_mutex, std::unique_lock<std::mutex>(*object_mutex)};
+    const auto stripe_idx =
+        std::hash<std::string>{}(scoped_key) % kObjectOperationLockStripes;
+    return {std::unique_lock<std::mutex>(object_operation_locks_[stripe_idx])};
 }
 
 void MasterService::RegisterGroupMember(TenantState& tenant_state,

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -598,6 +598,16 @@ size_t MasterService::getMetadataShardIndex(const std::string& key) const {
     return getShardIndex(it->second);
 }
 
+size_t MasterService::getMetadataShardIndex(const std::string& tenant_id,
+                                            const std::string& key) const {
+    std::shared_lock<std::shared_mutex> lock(group_routing_mutex_);
+    auto it = object_group_ids_.find(key);
+    if (it == object_group_ids_.end()) {
+        return getShardIndex(tenant_id, key);
+    }
+    return getShardIndex(it->second);
+}
+
 void MasterService::RegisterGroupMember(TenantState& tenant_state,
                                         const std::string& key,
                                         const std::string& group_id) {
@@ -616,17 +626,22 @@ void MasterService::UnregisterGroupMember(TenantState& tenant_state,
     if (group_id.empty()) {
         return;
     }
+    bool group_empty = false;
     auto group_it = tenant_state.group_members.find(group_id);
     if (group_it != tenant_state.group_members.end()) {
         group_it->second.erase(key);
         if (group_it->second.empty()) {
             tenant_state.group_members.erase(group_it);
+            group_empty = true;
         }
     }
     std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
     auto route_it = object_group_ids_.find(key);
     if (route_it != object_group_ids_.end() && route_it->second == group_id) {
         object_group_ids_.erase(route_it);
+    }
+    if (group_empty) {
+        groups_needing_lease_refresh_.erase(group_id);
     }
 }
 
@@ -685,6 +700,9 @@ void MasterService::GrantLeaseForGroup(const TenantState& tenant_state,
             mit->second.GrantLease(default_kv_lease_ttl_,
                                    default_kv_soft_pin_ttl_);
         }
+    }
+    if (group_it->second.find(key) == group_it->second.end()) {
+        metadata.GrantLease(default_kv_lease_ttl_, default_kv_soft_pin_ttl_);
     }
     {
         std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
@@ -1502,8 +1520,9 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
     // For new grouped objects, route to the group's target shard directly
     // since the routing table hasn't been populated yet.
     const size_t target_shard_idx =
-        group_id.empty() ? getMetadataShardIndex(object_id.user_key)
-                         : getShardIndex(group_id);
+        group_id.empty()
+            ? getMetadataShardIndex(object_id.tenant_id, object_id.user_key)
+            : getShardIndex(group_id);
     MetadataShardAccessorRW shard(this, target_shard_idx);
     auto& tenant_state = shard->tenants[object_id.tenant_id];
 
@@ -1512,9 +1531,6 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
     if (it != tenant_state.metadata.end() &&
         !CleanupStaleHandles(it->second, alive_clients)) {
         auto& metadata = it->second;
-        // If the object's PutStart expired and has not completed any
-        // replicas, we can discard it and allow the new PutStart to
-        // go.
         if (!metadata.HasReplica(&Replica::fn_is_completed) &&
             metadata.put_start_time + put_start_discard_timeout_sec_ < now) {
             auto replicas = metadata.PopReplicas(&Replica::fn_is_processing);
@@ -1818,7 +1834,8 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     // Use getMetadataShardIndex to find the object at its current shard
     // (handles both grouped and ungrouped routing).
-    const size_t lookup_shard_idx = getMetadataShardIndex(object_id.user_key);
+    const size_t lookup_shard_idx =
+        getMetadataShardIndex(object_id.tenant_id, object_id.user_key);
     MetadataShardAccessorRW shard(this, lookup_shard_idx);
     auto& tenant_state = shard->tenants[object_id.tenant_id];
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1997,6 +1997,9 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     merged_config.with_soft_pin =
         merged_config.with_soft_pin || metadata.IsSoftPinned();
 
+    const std::string effective_group_id =
+        metadata.IsGrouped() ? metadata.group_id : group_id;
+
     auto old_replicas = metadata.PopReplicas();
     if (!old_replicas.empty()) {
         std::lock_guard lock(discarded_replicas_mutex_);
@@ -2006,8 +2009,6 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     tenant_state.metadata.erase(it);
 
     VLOG(1) << "key=" << key << ", action=upsert_start_case_c_reallocate";
-    const std::string effective_group_id =
-        metadata.IsGrouped() ? metadata.group_id : group_id;
     return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
                                      merged_config, effective_group_id,
                                      object_id.tenant_id, now);
@@ -2742,7 +2743,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
         std::min(keys.size(), static_cast<size_t>(kNumShards)));
 
     for (size_t i = 0; i < keys.size(); ++i) {
-        size_t shard_idx = getShardIndex(keys[i]);
+        size_t shard_idx = getMetadataShardIndex(keys[i]);
         keys_by_shard[shard_idx].emplace_back(i, &keys[i]);
     }
 

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -159,7 +159,10 @@ class SnapshotChildProcessTest : public ::testing::Test {
         size_t shard_idx = svc->getShardIndex(key);
         auto& shard = svc->metadata_shards_[shard_idx];
         SharedMutexLocker lock(&shard.mutex, shared_lock_t{});
-        return shard.metadata.find(key) != shard.metadata.end();
+        auto tenant_it = shard.tenants.find("default");
+        return tenant_it != shard.tenants.end() &&
+               tenant_it->second.metadata.find(key) !=
+                   tenant_it->second.metadata.end();
     }
 
     uint32_t GetShardIndexForTest(const std::string& key) {
@@ -175,9 +178,13 @@ class SnapshotChildProcessTest : public ::testing::Test {
     bool ObjectIsGroupedInMetadata(const std::string& key, size_t shard_idx) {
         auto& shard = service_->metadata_shards_[shard_idx];
         SharedMutexLocker lock(&shard.mutex, shared_lock_t{});
-        auto it = shard.metadata.find(key);
-        EXPECT_NE(it, shard.metadata.end());
-        return it != shard.metadata.end() && it->second.IsGrouped();
+        for (const auto& [tenant_id, tenant_state] : shard.tenants) {
+            auto it = tenant_state.metadata.find(key);
+            if (it != tenant_state.metadata.end()) {
+                return it->second.IsGrouped();
+            }
+        }
+        return false;
     }
 
     std::string FindGroupIdOnDifferentShard(MasterService* svc,

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <ylt/struct_json/json_reader.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <functional>
@@ -661,6 +662,136 @@ TEST_F(MasterServiceTest, GroupRoutingIsTenantScopedForSameUserKey) {
     ASSERT_TRUE(service_->Remove(key, tenant_a, /*force=*/true).has_value());
     EXPECT_FALSE(service_->GetReplicaList(key, tenant_a).has_value());
     EXPECT_TRUE(service_->GetReplicaList(key, tenant_b).has_value());
+}
+
+TEST_F(MasterServiceTest,
+       ConcurrentGroupedAndUngroupedFirstCreateDoesNotDuplicateMetadata) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key = "concurrent_grouped_ungrouped_first_create";
+    const std::string tenant_id = "tenant_concurrent_first_create";
+    ReplicateConfig ungrouped_config;
+    ungrouped_config.replica_num = 1;
+    ReplicateConfig grouped_config;
+    grouped_config.replica_num = 1;
+    grouped_config.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
+
+    static constexpr size_t kThreadCount = 16;
+    std::atomic<size_t> ready{0};
+    std::atomic<bool> start{false};
+    std::vector<int> put_start_success(kThreadCount, 0);
+    std::vector<int> put_end_success(kThreadCount, 0);
+    std::vector<std::thread> threads;
+    threads.reserve(kThreadCount);
+
+    for (size_t i = 0; i < kThreadCount; ++i) {
+        threads.emplace_back([&, i]() {
+            ready.fetch_add(1, std::memory_order_acq_rel);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            const auto& config =
+                (i % 2 == 0) ? grouped_config : ungrouped_config;
+            auto put_start =
+                service_->PutStart(client_id, key, tenant_id, 1024, config);
+            put_start_success[i] = put_start.has_value() ? 1 : 0;
+            if (put_start.has_value()) {
+                put_end_success[i] = service_->PutEnd(client_id, key, tenant_id,
+                                                      ReplicaType::MEMORY)
+                                             .has_value()
+                                         ? 1
+                                         : 0;
+            } else {
+                EXPECT_EQ(ErrorCode::OBJECT_ALREADY_EXISTS, put_start.error());
+            }
+        });
+    }
+
+    while (ready.load(std::memory_order_acquire) < kThreadCount) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(std::count(put_start_success.begin(), put_start_success.end(), 1),
+              1);
+    EXPECT_EQ(std::count(put_end_success.begin(), put_end_success.end(), 1), 1);
+    EXPECT_EQ(service_->GetKeyCount(), 1u);
+    EXPECT_TRUE(service_->GetReplicaList(key, tenant_id).has_value());
+}
+
+TEST_F(MasterServiceTest,
+       ConcurrentDifferentGroupedFirstCreateDoesNotDuplicateMetadata) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key = "concurrent_different_grouped_first_create";
+    const std::string tenant_id = "tenant_concurrent_grouped_first_create";
+    const std::string group_a = FindGroupIdOnDifferentShard(key);
+    std::string group_b;
+    for (int i = 0; i < 10000; ++i) {
+        group_b = key + "_other_group_" + std::to_string(i);
+        if (std::hash<std::string>{}(group_b) % 1024 !=
+            std::hash<std::string>{}(group_a) % 1024) {
+            break;
+        }
+    }
+    ReplicateConfig config_a;
+    config_a.replica_num = 1;
+    config_a.group_ids = std::vector<std::string>{group_a};
+    ReplicateConfig config_b;
+    config_b.replica_num = 1;
+    config_b.group_ids = std::vector<std::string>{group_b};
+
+    static constexpr size_t kThreadCount = 16;
+    std::atomic<size_t> ready{0};
+    std::atomic<bool> start{false};
+    std::vector<int> put_start_success(kThreadCount, 0);
+    std::vector<int> put_end_success(kThreadCount, 0);
+    std::vector<std::thread> threads;
+    threads.reserve(kThreadCount);
+
+    for (size_t i = 0; i < kThreadCount; ++i) {
+        threads.emplace_back([&, i]() {
+            ready.fetch_add(1, std::memory_order_acq_rel);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            const auto& config = (i % 2 == 0) ? config_a : config_b;
+            auto put_start =
+                service_->PutStart(client_id, key, tenant_id, 1024, config);
+            put_start_success[i] = put_start.has_value() ? 1 : 0;
+            if (put_start.has_value()) {
+                put_end_success[i] = service_->PutEnd(client_id, key, tenant_id,
+                                                      ReplicaType::MEMORY)
+                                             .has_value()
+                                         ? 1
+                                         : 0;
+            } else {
+                EXPECT_EQ(ErrorCode::OBJECT_ALREADY_EXISTS, put_start.error());
+            }
+        });
+    }
+
+    while (ready.load(std::memory_order_acquire) < kThreadCount) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(std::count(put_start_success.begin(), put_start_success.end(), 1),
+              1);
+    EXPECT_EQ(std::count(put_end_success.begin(), put_end_success.end(), 1), 1);
+    EXPECT_EQ(service_->GetKeyCount(), 1u);
+    EXPECT_TRUE(service_->GetReplicaList(key, tenant_id).has_value());
 }
 
 TEST_F(MasterServiceTest, ExpiredGroupedPutCanBeReplacedByUngroupedPut) {

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -1084,6 +1084,83 @@ TEST_F(MasterServiceTest, PutStartEndFlow) {
     EXPECT_EQ(ReplicaStatus::COMPLETE, replica_list[0].status);
 }
 
+TEST_F(MasterServiceTest, TenantPutGetRemoveIsolatesSameUserKey) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key = "shared_user_key";
+    const std::string tenant_a = "tenant_a";
+    const std::string tenant_b = "tenant_b";
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    ASSERT_TRUE(
+        service_->PutStart(client_id, key, tenant_a, 1024, config).has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, tenant_a, ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(
+        service_->PutStart(client_id, key, tenant_b, 2048, config).has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, tenant_b, ReplicaType::MEMORY)
+                    .has_value());
+
+    EXPECT_FALSE(service_->GetReplicaList(key).has_value());
+    EXPECT_FALSE(service_->ExistKey(key).value());
+    EXPECT_TRUE(service_->ExistKey(key, tenant_a).value());
+    EXPECT_TRUE(service_->ExistKey(key, tenant_b).value());
+    EXPECT_TRUE(service_->GetReplicaList(key, tenant_a).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, tenant_b).has_value());
+    EXPECT_EQ(service_->GetKeyCount(), 2u);
+
+    ASSERT_TRUE(service_->Remove(key, tenant_a, /*force=*/true).has_value());
+    EXPECT_FALSE(service_->GetReplicaList(key, tenant_a).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, tenant_b).has_value());
+    EXPECT_EQ(service_->GetKeyCount(), 1u);
+}
+
+TEST_F(MasterServiceTest, RegexOperationsAreTenantScoped) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key = "regex_shared_key";
+    const std::string tenant_a = "tenant_regex_a";
+    const std::string tenant_b = "tenant_regex_b";
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    ASSERT_TRUE(service_->PutStart(client_id, key, 1024, config).has_value());
+    ASSERT_TRUE(
+        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    ASSERT_TRUE(
+        service_->PutStart(client_id, key, tenant_a, 1024, config).has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, tenant_a, ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(
+        service_->PutStart(client_id, key, tenant_b, 1024, config).has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, tenant_b, ReplicaType::MEMORY)
+                    .has_value());
+
+    auto default_matches = service_->GetReplicaListByRegex("^regex_shared");
+    ASSERT_TRUE(default_matches.has_value());
+    EXPECT_EQ(default_matches->size(), 1);
+
+    auto remove_default =
+        service_->RemoveByRegex("^regex_shared", /*force=*/true);
+    ASSERT_TRUE(remove_default.has_value());
+    EXPECT_EQ(remove_default.value(), 1);
+    EXPECT_FALSE(service_->GetReplicaList(key).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, tenant_a).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, tenant_b).has_value());
+
+    auto remove_tenant_a =
+        service_->RemoveByRegex("^regex_shared", tenant_a, /*force=*/true);
+    ASSERT_TRUE(remove_tenant_a.has_value());
+    EXPECT_EQ(remove_tenant_a.value(), 1);
+    EXPECT_FALSE(service_->GetReplicaList(key, tenant_a).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, tenant_b).has_value());
+}
+
 TEST_F(MasterServiceTest, PutWithPreferredSegment) {
     // For backward compatibility, test the deprecated single preferred_segment
     std::unique_ptr<MasterService> service_(new MasterService());

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -619,6 +619,50 @@ TEST_F(MasterServiceTest, GroupedObjectRoutesKeyLevelLookupAndRemove) {
     EXPECT_FALSE(exists_after_remove.value());
 }
 
+TEST_F(MasterServiceTest, GroupRoutingIsTenantScopedForSameUserKey) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key = "tenant_grouped_shared_user_key";
+    const std::string tenant_a = "tenant_group_route_a";
+    const std::string tenant_b = "tenant_group_route_b";
+    const std::string group_a = FindGroupIdOnDifferentShard(key);
+    std::string group_b;
+    for (int i = 0; i < 10000; ++i) {
+        group_b = key + "_tenant_b_group_" + std::to_string(i);
+        if (std::hash<std::string>{}(group_b) % 1024 !=
+            std::hash<std::string>{}(group_a) % 1024) {
+            break;
+        }
+    }
+
+    ReplicateConfig config_a;
+    config_a.replica_num = 1;
+    config_a.group_ids = std::vector<std::string>{group_a};
+    ReplicateConfig config_b;
+    config_b.replica_num = 1;
+    config_b.group_ids = std::vector<std::string>{group_b};
+
+    ASSERT_TRUE(service_->PutStart(client_id, key, tenant_a, 1024, config_a)
+                    .has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, tenant_a, ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service_->PutStart(client_id, key, tenant_b, 2048, config_b)
+                    .has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, tenant_b, ReplicaType::MEMORY)
+                    .has_value());
+
+    EXPECT_TRUE(service_->ExistKey(key, tenant_a).value_or(false));
+    EXPECT_TRUE(service_->ExistKey(key, tenant_b).value_or(false));
+    EXPECT_TRUE(service_->GetReplicaList(key, tenant_a).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, tenant_b).has_value());
+
+    ASSERT_TRUE(service_->Remove(key, tenant_a, /*force=*/true).has_value());
+    EXPECT_FALSE(service_->GetReplicaList(key, tenant_a).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, tenant_b).has_value());
+}
+
 TEST_F(MasterServiceTest, ExpiredGroupedPutCanBeReplacedByUngroupedPut) {
     auto service_config = MasterServiceConfig::builder()
                               .set_put_start_discard_timeout_sec(0)
@@ -645,6 +689,52 @@ TEST_F(MasterServiceTest, ExpiredGroupedPutCanBeReplacedByUngroupedPut) {
     ASSERT_TRUE(
         service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
     EXPECT_TRUE(service_->ExistKey(key).value_or(false));
+}
+
+TEST_F(MasterServiceTest, BatchRemoveUnregistersGroupedRoute) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key = "batch_remove_grouped_route";
+    ReplicateConfig grouped_config;
+    grouped_config.replica_num = 1;
+    grouped_config.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
+    PutCompletedObject(*service_, client_id, key, grouped_config);
+
+    auto remove_results =
+        service_->BatchRemove(std::vector<std::string>{key}, /*force=*/true);
+    ASSERT_EQ(remove_results.size(), 1u);
+    ASSERT_TRUE(remove_results[0].has_value());
+
+    ReplicateConfig ungrouped_config;
+    ungrouped_config.replica_num = 1;
+    PutCompletedObject(*service_, client_id, key, ungrouped_config);
+    EXPECT_TRUE(service_->GetReplicaList(key).has_value());
+}
+
+TEST_F(MasterServiceTest, RemoveByRegexUnregistersGroupedRoute) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key = "regex_remove_grouped_route";
+    ReplicateConfig grouped_config;
+    grouped_config.replica_num = 1;
+    grouped_config.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
+    PutCompletedObject(*service_, client_id, key, grouped_config);
+
+    auto removed = service_->RemoveByRegex("^regex_remove_grouped_route$",
+                                           /*force=*/true);
+    ASSERT_TRUE(removed.has_value());
+    EXPECT_EQ(removed.value(), 1);
+
+    ReplicateConfig ungrouped_config;
+    ungrouped_config.replica_num = 1;
+    PutCompletedObject(*service_, client_id, key, ungrouped_config);
+    EXPECT_TRUE(service_->GetReplicaList(key).has_value());
 }
 
 TEST_F(MasterServiceTest, GroupedLeaseRefreshNearExpiryProtectsCurrentMembers) {
@@ -811,6 +901,28 @@ TEST_F(MasterServiceTest, IncompleteGroupedUpsertCanBecomeUngrouped) {
     ASSERT_TRUE(
         service_->UpsertEnd(client_id, key, ReplicaType::MEMORY).has_value());
     EXPECT_TRUE(service_->ExistKey(key).value_or(false));
+}
+
+TEST_F(MasterServiceTest, UpsertRejectsExistingUngroupedToGrouped) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key = "upsert_ungrouped_to_grouped";
+    ReplicateConfig ungrouped_config;
+    ungrouped_config.replica_num = 1;
+    PutCompletedObject(*service_, client_id, key, ungrouped_config);
+
+    ReplicateConfig grouped_config;
+    grouped_config.replica_num = 1;
+    grouped_config.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
+    auto upsert_start =
+        service_->UpsertStart(client_id, key, 2048, grouped_config);
+    ASSERT_FALSE(upsert_start.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, upsert_start.error());
+
+    EXPECT_TRUE(service_->GetReplicaList(key).has_value());
 }
 
 TEST_F(MasterServiceTest,


### PR DESCRIPTION
## Description

This PR introduces the first stage of tenant-aware metadata isolation in Mooncake Store.

The main change is to refactor `MasterService` metadata from a single-level `key -> ObjectMetadata` map into a tenant-aware namespace:

```text
MetadataShard -> tenant_id -> user_key -> ObjectMetadata
```

This provides the internal metadata foundation needed for multi-tenancy while preserving legacy/default-tenant behavior. The default tenant keeps the old shard mapping so snapshots written before this change can still restore keys that are reachable by legacy APIs.

This PR also updates related master paths to avoid incorrect cross-tenant behavior:

- Adds tenant-aware internal overloads for put/get/exist/regex/remove paths.
- Keeps no-tenant APIs scoped to the `default` tenant.
- Serializes tenant IDs in new metadata snapshots while remaining compatible with old snapshot entries.
- Prevents non-default tenant objects from entering the existing offload queue until the offload callback protocol carries tenant identity.
- Makes drain completion account for replicas from all tenants so a segment is not incorrectly marked as drained while non-default tenant replicas remain.
- Adds focused tests for same-user-key tenant isolation and tenant-scoped regex behavior.

This PR does not implement full server-side tenant authorization. In particular, client-to-tenant binding, RPC-level tenant identity propagation, and tenant validation will be implemented in follow-up PRs. The planned staging is:

1. This PR: stabilize the tenant-aware metadata data model and preserve legacy behavior.
2. Follow-up PR: pass tenant identity from client/MasterClient through RPC and establish a trusted `client_id -> tenant_id` binding in master.
3. Follow-up PR: make async/cross-component flows such as offload, promotion, copy/move, and drain fully tenant-aware with authorization checks.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Built the focused test targets with Ninja:

```bash
ninja -C build master_service_test offload_on_evict_test promotion_on_hit_test snapshot_child_process_test
```

Ran the focused CTest suite:

```bash
ctest --test-dir build -R "^(master_service_test|offload_on_evict_test|promotion_on_hit_test|snapshot_child_process_test)$" --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 4
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
