### PR TITLE
[Store] (CI run_tests_with_ssd failed / promotion-on-hit failed) eliminate race conditions

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3178,7 +3178,13 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
 void MasterService::EvictionThreadFunc() {
     VLOG(1) << "action=eviction_thread_started";
 
-    auto last_discard_time = std::chrono::system_clock::now();
+    // Start with an already-elapsed window so the first loop iteration
+    // (after kEvictionThreadSleepMs) triggers DiscardExpiredProcessingReplicas.
+    // Without this, a task admitted shortly after thread startup can survive
+    // the first reaper cycle and not be cleaned until ~2s later, causing
+    // promotion-on-hit tests that sleep for 2s to flake.
+    auto last_discard_time =
+        std::chrono::system_clock::now() - put_start_release_timeout_sec_;
     while (eviction_running_) {
         const auto now = std::chrono::system_clock::now();
         double used_ratio =

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -1128,7 +1128,7 @@ int TransferMetadata::addRpcMetaEntry(const std::string &server_name,
 
     Json::Value rpcMetaJSON;
     rpcMetaJSON["ip_or_host_name"] = desc.ip_or_host_name;
-    rpcMetaJSON["rpc_port"] = static_cast<Json::UInt64>(desc.rpc_port);
+    rpcMetaJSON["rpc_port"] = static_cast<Json::UInt>(desc.rpc_port);
     if (!storage_plugin_->set(rpc_meta_prefix_ + server_name, rpcMetaJSON)) {
         LOG(ERROR) << "Failed to set location of " << server_name;
         return ERR_METADATA;
@@ -1157,19 +1157,16 @@ int TransferMetadata::rePublishRpcMetaEntry(const std::string &server_name) {
     if (storage_plugin_->get(full_key, existing)) {
         Json::Value desired;
         desired["ip_or_host_name"] = local_rpc_meta_.ip_or_host_name;
-        desired["rpc_port"] =
-            static_cast<Json::UInt64>(local_rpc_meta_.rpc_port);
+        desired["rpc_port"] = static_cast<Json::UInt>(local_rpc_meta_.rpc_port);
         if (existing == desired) {
             return 0;
         }
-        storage_plugin_->remove(full_key);
     }
 
     LOG(INFO) << "Re-publishing RPC meta entry for " << server_name;
     Json::Value rpcMetaJSON;
     rpcMetaJSON["ip_or_host_name"] = local_rpc_meta_.ip_or_host_name;
-    rpcMetaJSON["rpc_port"] =
-        static_cast<Json::UInt64>(local_rpc_meta_.rpc_port);
+    rpcMetaJSON["rpc_port"] = static_cast<Json::UInt>(local_rpc_meta_.rpc_port);
     if (!storage_plugin_->set(full_key, rpcMetaJSON)) {
         LOG(ERROR) << "Failed to re-publish RPC meta entry for " << server_name;
         return ERR_METADATA;


### PR DESCRIPTION
## CI Failure Timeline

I queried the GitHub Actions API for all "Build & Test (Linux)" workflow runs and checked each failed run's "Run tests with ssd" step conclusion.

| Date (UTC) | Run ID | Branch | Failed job (OS, Python) |
|---|---|---|---|
| **Before 5/25 03:44** | — | — | **No SSD failures found** (checked all failed runs from 5/22 onward; SSD step was always `success`) |
| 5/25 03:44 | 26382059305 | main | ubuntu-22.04, 3.10 |
| 5/25 09:30 | 26393564472 | cruz/data-rebuild | ubuntu-22.04, 3.12 |
| 5/26 00:02 | 26424780365 | feat/rocm-dmabuf-mr-registration | ubuntu-24.04, 3.12 |
| 5/26 01:47 | 26427640427 | dev_nof_ssd_split | ubuntu-22.04, 3.10 |
| 5/26 05:25 | 26434052055 | feat/part-2-batch-fast-path-pr | ubuntu-24.04, 3.10 |
| 5/26 06:13 | 26435666690 | main | ubuntu-24.04, 3.10 |

**Key observation:** All SSD failures occur on **different branches** (main, cruz/data-rebuild, feat/rocm-dmabuf-mr-registration, etc.), confirming the bug is in the shared codebase, not in any specific PR. The first failure appeared at **2026-05-25 03:44 UTC**, which correlates with when `rePublishRpcMetaEntry()` was introduced (PR #2077, commit `788c1c73`).

## Description

Fix a race condition in `TransferMetadata::rePublishRpcMetaEntry()` that causes intermittent CI failures in the "Run tests with ssd" step.

**Root cause:** A `Json::Value` type mismatch caused the content-comparison shortcut to always fail, forcing every call to take the remove-then-set path:

1. `addRpcMetaEntry()` and `rePublishRpcMetaEntry()` wrote `rpc_port` as `Json::UInt64`.
2. When reading back from the HTTP metadata server, JSON deserialization returns the same value as a different `Json::Value` type (e.g. `Json::UInt`).
3. `Json::Value::operator==()` is **type-sensitive** — `Json::UInt64(8080) == Json::UInt(8080)` returns `false`.
4. Therefore `existing == desired` always returned `false`, even when the entry was identical.
5. The code always fell through to `storage_plugin_->remove(full_key)` followed by `set()`, creating a window where concurrent readers find no entry and return error -800 (`TRANSFER_FAIL`).

**Fix:** Unify `rpc_port` serialization to `Json::UInt` (consistent with the type returned by JSON deserialization) so that `existing == desired` correctly returns `true` when the entry is unchanged. With the early-return path working, the `remove()` call becomes dead code and is deleted.


### Additional fix: eviction-thread startup race in promotion-on-hit tests

  While investigating the SSD failures we discovered a second, independent race window in `MasterService::EvictionThreadFunc()`.

  `last_discard_time` was initialised to `std::chrono::system_clock::now()`, so the first loop iteration (after `kEvictionThreadSleepMs`, typically 1 s) computed a discard-elapsed time of only ~1 s.  If a task was admitted shortly after the eviction thread started, it could survive that first reaper cycle because `put_start_release_timeout_sec_` (2 s) had not yet elapsed.  The task would then linger for another full sleep interval, being cleaned only after ~2–3 s total.

  The promotion-on-hit tests sleep for exactly 2 s and then assert that the replica has been promoted.  When the test scheduler unluckily overlap with the eviction thread’s initial window, the replica is still in the `PROCESSING` state and the assertion fails.  This explains the intermittent “promotion on hit” flakes observed in CI.

  **Fix:** Initialise `last_discard_time` to `now() - put_start_release_timeout_sec_`, so the first loop iteration
  already treats the timeout as elapsed and immediately invokes `DiscardExpiredProcessingReplicas()`.

## Root Cause Analysis

### The type mismatch

`rePublishRpcMetaEntry()` attempts an optimization: compare the existing entry with the desired entry, and skip the write if they are identical. However, the comparison never succeeds because of a `Json::Value` type mismatch:

```cpp
// Writing (in both addRpcMetaEntry and rePublishRpcMetaEntry):
rpcMetaJSON["rpc_port"] = static_cast<Json::UInt64>(local_rpc_meta_.rpc_port);

// Reading (via storage_plugin_->get → HTTP server → JSON parse):
// The HTTP metadata server stores and returns JSON numbers without
// preserving the original Json::Value subtype.  On deserialization,
// "rpc_port" comes back as a different numeric type (e.g. Json::UInt).

// Comparison (type-sensitive):
existing == desired  // always false due to type mismatch
```

Because the comparison always fails, the code always executes:

```cpp
storage_plugin_->remove(full_key);   // entry is gone
// ← race window: concurrent get() returns empty / 404
storage_plugin_->set(full_key, ...); // entry is back
```

### Call chain leading to the race

1. `StorageHeartbeatThreadMain()` sends the first `Ping()` to master.
2. Because `MountSegment()` does **not** insert the client into `ok_client_` (only `ReMountSegment()` does), the first ping returns `NEED_REMOUNT`.
3. The heartbeat thread spawns an async `remount_segment` task.
4. `remount_segment` calls `rePublishRpcMetaEntry()`, which always takes the remove-then-set path (due to the type mismatch).
5. Any concurrent `getRpcMetaEntry()` call during the gap gets no result and returns -800.

### Why the race is probabilistic

- The `rePublishRpcMetaEntry()` call is triggered by an async `std::future` from the heartbeat thread.
- Whether a concurrent reader hits the gap depends on scheduling: how long the metadata server takes to process the remove, and whether another thread happens to call `getRpcMetaEntry()` at that exact moment.
- Under CI load (multiple test processes, shared runners), the timing varies, making the failure intermittent.

## Changes

1. **`addRpcMetaEntry()`**: `static_cast<Json::UInt64>` → `static_cast<Json::UInt>` (line 1131)
2. **`rePublishRpcMetaEntry()` desired construction**: `static_cast<Json::UInt64>` → `static_cast<Json::UInt>` (line 1160)
3. **`rePublishRpcMetaEntry()` rpcMetaJSON construction**: `static_cast<Json::UInt64>` → `static_cast<Json::UInt>` (line 1171)
4. **`rePublishRpcMetaEntry()`**: removed `storage_plugin_->remove(full_key)` (line 1165)

Changes 1-3 ensure `existing == desired` correctly returns `true` when the entry is unchanged, so the code takes the early-return path and never reaches `remove()`. Change 4 deletes the now-dead remove call.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other
