### PR TITLE
fix: unify default cluster_namespace to match master's DEFAULT_CLUSTE…

### DIFF
--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -836,7 +836,7 @@ The HTTP metadata server can be configured using the following parameters:
 - **`http_metadata_server_port`** (integer, default: `8080`): Specifies the TCP port on which the HTTP metadata server will listen for incoming connections. This port must be available and not conflict with other services.
 - **`http_metadata_server_host`** (string, default: `"0.0.0.0"`): Specifies the host address for the HTTP metadata server to bind to. Use `"0.0.0.0"` to listen on all available network interfaces, or specify a specific IP address for security purposes.
 #### Environment Variables
-- MC_STORE_CLUSTER_ID: Identify the metadata when multiple cluster share the same master, default 'mooncake'.
+- MC_STORE_CLUSTER_ID: Identify the metadata when multiple cluster share the same master, default 'mooncake_cluster'.
 - MC_STORE_MEMCPY: Enables or disables local memcpy optimization, set to 1/true to enable, 0/false to disable.
 - MC_STORE_CLIENT_METRIC: Enables client metric reporting, enabled by default; set to 0/false to disable.
 - MC_STORE_CLIENT_METRIC_INTERVAL: Reporting interval in seconds, default 0 (collects but does not report).

--- a/docs/source/zh_archive/mooncake-store.md
+++ b/docs/source/zh_archive/mooncake-store.md
@@ -721,7 +721,7 @@ HTTP 元数据服务器可通过以下参数进行配置：
 
 #### 环境变量说明
 
-- **MC_STORE_CLUSTER_ID**: 在多集群复用 master 场景下标识元数据, 默认 'mooncake'
+- **MC_STORE_CLUSTER_ID**: 在多集群复用 master 场景下标识元数据, 默认 'mooncake_cluster'
 - **MC_STORE_MEMCPY**: 控制是否启用本地 memcpy 优化, 1/true 启用, 0/false 禁用
 - **MC_STORE_CLIENT_METRIC**: 启用客户端指标上报, 默认启用；设为 0/false 禁用
 - **MC_STORE_CLIENT_METRIC_INTERVAL**: 指标上报间隔(秒), 默认 0(仅收集不上报)

--- a/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
+++ b/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
@@ -11,6 +11,8 @@
 #include <glog/logging.h>
 #include <ylt/util/tl/expected.hpp>
 
+#include "types.h"
+
 namespace mooncake {
 namespace ha {
 namespace backends {
@@ -369,7 +371,7 @@ ClusterNamespace EtcdLeaderCoordinator::ResolveClusterNamespace(
     if (env_cluster_id != nullptr && std::strlen(env_cluster_id) > 0) {
         resolved_namespace = env_cluster_id;
     } else {
-        resolved_namespace = "mooncake";
+        resolved_namespace = DEFAULT_CLUSTER_ID;
     }
     return resolved_namespace;
 }

--- a/mooncake-store/src/ha/leadership/backends/redis/redis_leader_coordinator.cpp
+++ b/mooncake-store/src/ha/leadership/backends/redis/redis_leader_coordinator.cpp
@@ -11,6 +11,8 @@
 #include <thread>
 
 #include <glog/logging.h>
+
+#include "types.h"
 #ifdef STORE_USE_REDIS
 #include <hiredis/hiredis.h>
 #endif
@@ -665,7 +667,7 @@ ClusterNamespace RedisLeaderCoordinator::ResolveClusterNamespace(
     if (env_cluster_id != nullptr && std::strlen(env_cluster_id) > 0) {
         resolved_namespace = env_cluster_id;
     } else {
-        resolved_namespace = "mooncake";
+        resolved_namespace = DEFAULT_CLUSTER_ID;
     }
     return resolved_namespace;
 }

--- a/mooncake-store/src/ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.cpp
+++ b/mooncake-store/src/ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.cpp
@@ -1,11 +1,14 @@
 #include "ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.h"
 
+#include <cstdlib>
 #include <exception>
 #include <memory>
 #include <optional>
 #include <string_view>
 
 #include <glog/logging.h>
+
+#include "types.h"
 #ifdef STORE_USE_REDIS
 #include <hiredis/hiredis.h>
 #endif
@@ -315,10 +318,15 @@ ErrorCode RedisSnapshotCatalogStore::Delete(const SnapshotId& snapshot_id) {
 
 ClusterNamespace RedisSnapshotCatalogStore::ResolveClusterNamespace(
     const ClusterNamespace& cluster_namespace) {
-    if (cluster_namespace.empty()) {
-        return "mooncake";
+    if (!cluster_namespace.empty()) {
+        return cluster_namespace;
     }
-    return cluster_namespace;
+
+    const char* env_cluster_id = std::getenv("MC_STORE_CLUSTER_ID");
+    if (env_cluster_id != nullptr && *env_cluster_id != '\0') {
+        return env_cluster_id;
+    }
+    return DEFAULT_CLUSTER_ID;
 }
 
 std::string RedisSnapshotCatalogStore::BuildLatestKey(


### PR DESCRIPTION
## Description

The client-side `ResolveClusterNamespace()` in etcd leader coordinator, redis leader coordinator, and redis snapshot catalog store all used `"mooncake"` as the fallback default, while the master-side `--cluster_id` flag defaults to `"mooncake_cluster"` (`DEFAULT_CLUSTER_ID`). This inconsistency caused clients to look up a different etcd/redis key than what the master registered, making them unable to discover the master when both sides use defaults.

Fix by replacing the hardcoded `"mooncake"` fallback with the `DEFAULT_CLUSTER_ID` constant (`"mooncake_cluster"`) so that client and master use the same namespace out of the box.

Also update documentation to reflect the corrected default value.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

Verified that after the change, both master (using default `--cluster_id`) and client (without setting `MC_STORE_CLUSTER_ID`) resolve to the same namespace `"mooncake_cluster"`, allowing successful master discovery via etcd/redis.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
