### PR TITLE
feat(store): scope S3 snapshot path by cluster_id to support multi-cl…

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1230,6 +1230,13 @@ class MasterService {
 
     // cluster id for persistent sub directory
     const std::string cluster_id_;
+
+    // Returns the S3 snapshot root path, scoped by cluster_id to support
+    // multiple clusters sharing a single S3 bucket.
+    std::string GetSnapshotRoot() const {
+        return "mooncake_master_snapshot/" + cluster_id_;
+    }
+
     // root filesystem directory for persistent storage
     const std::string root_fs_dir_;
     // global 3fs/nfs segment size

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -36,7 +36,8 @@ static const std::string SNAPSHOT_SEGMENTS_FILE = "segments";
 static const std::string SNAPSHOT_TASK_MANAGER_FILE = "task_manager";
 static const std::string SNAPSHOT_MANIFEST_FILE = "manifest.txt";
 static const std::string SNAPSHOT_LATEST_FILE = "latest.txt";
-static const std::string SNAPSHOT_ROOT = "mooncake_master_snapshot";
+// SNAPSHOT_ROOT is now replaced by MasterService::GetSnapshotRoot()
+// to support multiple clusters sharing a single S3 bucket.
 static const std::string SNAPSHOT_BACKUP_SAVE_DIR =
     "mooncake_snapshot_save_backup";
 static const std::string SNAPSHOT_BACKUP_RESTORE_DIR =
@@ -2566,7 +2567,8 @@ void MasterService::SnapshotThreadFunc() {
             continue;
         }
 
-        const std::string path_prefix = SNAPSHOT_ROOT + "/" + snapshot_id + "/";
+        const std::string path_prefix =
+            GetSnapshotRoot() + "/" + snapshot_id + "/";
         const std::string manifest_path = path_prefix + SNAPSHOT_MANIFEST_FILE;
         auto descriptor =
             BuildSnapshotDescriptor(snapshot_id, manifest_path, path_prefix);
@@ -2886,7 +2888,7 @@ MasterService::BuildSnapshotDescriptor(const std::string& snapshot_id,
 
 tl::expected<void, SerializationError> MasterService::PersistState(
     const std::string& snapshot_id) {
-    const std::string path_prefix = SNAPSHOT_ROOT + "/" + snapshot_id + "/";
+    const std::string path_prefix = GetSnapshotRoot() + "/" + snapshot_id + "/";
     const std::string manifest_path = path_prefix + SNAPSHOT_MANIFEST_FILE;
     auto descriptor =
         BuildSnapshotDescriptor(snapshot_id, manifest_path, path_prefix);
@@ -3054,7 +3056,8 @@ tl::expected<void, SerializationError> MasterService::PersistState(
         }
 
         // Publish snapshot catalog entry and advance the latest marker.
-        std::string latest_path = SNAPSHOT_ROOT + "/" + SNAPSHOT_LATEST_FILE;
+        std::string latest_path =
+            GetSnapshotRoot() + "/" + SNAPSHOT_LATEST_FILE;
         std::string latest_content = snapshot_id;
 
         auto publish_result = snapshot_catalog_store->Publish(descriptor);
@@ -3284,7 +3287,7 @@ bool MasterService::TryRestoreStateFromSnapshot(
     const std::string& state_id = snapshot.snapshot_id;
     std::string path_prefix = snapshot.object_prefix;
     if (path_prefix.empty()) {
-        path_prefix = SNAPSHOT_ROOT + "/" + state_id + "/";
+        path_prefix = GetSnapshotRoot() + "/" + state_id + "/";
     }
 
     std::string manifest_path = snapshot.manifest_key;

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
@@ -188,7 +188,8 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
 
     // Get msgpack snapshot directory path
     std::string GetSnapshotDir(const std::string& snapshot_id) const {
-        return tmp_dir() + "/mooncake_master_snapshot/" + snapshot_id + "/";
+        return tmp_dir() + "/mooncake_master_snapshot/" +
+               std::string(DEFAULT_CLUSTER_ID) + "/" + snapshot_id + "/";
     }
 
     // Get backup directory path

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -261,10 +261,12 @@ TEST_F(SnapshotChildProcessTest, CleanupOldSnapshot_KeepsRecentDeletesOld) {
         "20240104_000000_000", "20240105_000000_000"};
 
     for (const auto& id : snapshot_ids) {
-        std::string key = "mooncake_master_snapshot/" + id + "/metadata";
+        std::string key = std::string("mooncake_master_snapshot/") +
+                          DEFAULT_CLUSTER_ID + "/" + id + "/metadata";
         backend->UploadString(key, "dummy_metadata");
-        std::string manifest_key =
-            "mooncake_master_snapshot/" + id + "/manifest.txt";
+        std::string manifest_key = std::string("mooncake_master_snapshot/") +
+                                   DEFAULT_CLUSTER_ID + "/" + id +
+                                   "/manifest.txt";
         backend->UploadString(manifest_key, "messagepack|1.0.0|" + id);
 
         auto descriptor =
@@ -282,7 +284,9 @@ TEST_F(SnapshotChildProcessTest, CleanupOldSnapshot_KeepsRecentDeletesOld) {
 
     // Verify: list remaining objects
     std::vector<std::string> remaining;
-    backend->ListObjectsWithPrefix("mooncake_master_snapshot/", remaining);
+    backend->ListObjectsWithPrefix(
+        std::string("mooncake_master_snapshot/") + DEFAULT_CLUSTER_ID + "/",
+        remaining);
 
     // Only the 2 newest (20240104, 20240105) should remain
     for (const auto& key : remaining) {
@@ -298,7 +302,8 @@ TEST_F(SnapshotChildProcessTest, CleanupOldSnapshot_KeepsRecentDeletesOld) {
 TEST_F(SnapshotChildProcessTest, UploadSnapshotPayloadFile_Success) {
     CreateDefaultService();
     std::vector<uint8_t> data = {10, 20, 30, 40, 50};
-    std::string path = "mooncake_master_snapshot/test_upload/metadata";
+    std::string path = std::string("mooncake_master_snapshot/") +
+                       DEFAULT_CLUSTER_ID + "/test_upload/metadata";
     auto result =
         CallUploadSnapshotPayloadFile(data, path, "metadata", "test_upload");
     ASSERT_TRUE(result.has_value())
@@ -331,8 +336,8 @@ TEST_F(SnapshotChildProcessTest, AutoSnapshot_GeneratesFiles) {
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
     // Check if latest.txt was generated
-    std::string latest_path =
-        tmp_dir() + "/mooncake_master_snapshot/latest.txt";
+    std::string latest_path = tmp_dir() + "/mooncake_master_snapshot/" +
+                              std::string(DEFAULT_CLUSTER_ID) + "/latest.txt";
     bool found = fs::exists(latest_path);
 
     // Destroy service to stop snapshot thread before assertions
@@ -365,9 +370,11 @@ TEST_F(SnapshotChildProcessTest, PersistState_PublishesSnapshotDescriptor) {
 
     EXPECT_EQ(latest->value().snapshot_id, snapshot_id);
     EXPECT_EQ(latest->value().manifest_key,
-              "mooncake_master_snapshot/" + snapshot_id + "/manifest.txt");
+              std::string("mooncake_master_snapshot/") + DEFAULT_CLUSTER_ID +
+                  "/" + snapshot_id + "/manifest.txt");
     EXPECT_EQ(latest->value().object_prefix,
-              "mooncake_master_snapshot/" + snapshot_id + "/");
+              std::string("mooncake_master_snapshot/") + DEFAULT_CLUSTER_ID +
+                  "/" + snapshot_id + "/");
     EXPECT_EQ(latest->value().last_included_seq, 0u);
     EXPECT_EQ(latest->value().producer_view_version, kViewVersion);
     const auto created_at_ms = latest->value().created_at_ms;
@@ -383,9 +390,11 @@ TEST_F(SnapshotChildProcessTest, PersistState_UsesFrozenSnapshotDescriptor) {
         ha::snapshot_catalog_store_detail::MakeSnapshotDescriptor(snapshot_id);
     descriptor.last_included_seq = 123;
     descriptor.producer_view_version = 41;
-    descriptor.manifest_key =
-        "mooncake_master_snapshot/" + snapshot_id + "/manifest.txt";
-    descriptor.object_prefix = "mooncake_master_snapshot/" + snapshot_id + "/";
+    descriptor.manifest_key = std::string("mooncake_master_snapshot/") +
+                              DEFAULT_CLUSTER_ID + "/" + snapshot_id +
+                              "/manifest.txt";
+    descriptor.object_prefix = std::string("mooncake_master_snapshot/") +
+                               DEFAULT_CLUSTER_ID + "/" + snapshot_id + "/";
     descriptor.created_at_ms = 1717243200123;
 
     auto persist_result = CallPersistState(descriptor);
@@ -592,9 +601,9 @@ TEST_F(SnapshotChildProcessTest,
         << "PersistState for snapshot2 failed: "
         << persist_result.error().message;
 
-    const fs::path corrupted_metadata = fs::path(tmp_dir()) /
-                                        "mooncake_master_snapshot" /
-                                        snapshot_id2 / "metadata";
+    const fs::path corrupted_metadata =
+        fs::path(tmp_dir()) / "mooncake_master_snapshot" / DEFAULT_CLUSTER_ID /
+        snapshot_id2 / "metadata";
     std::ofstream corrupt_stream(corrupted_metadata, std::ios::binary);
     ASSERT_TRUE(corrupt_stream.is_open())
         << "Failed to corrupt latest snapshot metadata";


### PR DESCRIPTION
## Description

Previously, all clusters sharing a single S3 bucket used the same hardcoded path prefix `"mooncake_master_snapshot"` for snapshots. When multiple Mooncake Store clusters point to the same bucket, their snapshot files would collide, causing data corruption or restore failures.

This PR introduces `MasterService::GetSnapshotRoot()` which returns `"mooncake_master_snapshot/{cluster_id}"` as the S3 path prefix, scoping each cluster's snapshots into its own directory. This allows multiple independent clusters to safely share one S3 bucket without path conflicts.

Changes:
- Add `GetSnapshotRoot()` helper method to `MasterService`
- Remove the static `SNAPSHOT_ROOT` constant
- Replace all usages of `SNAPSHOT_ROOT` with `GetSnapshotRoot()`

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Verified that when two clusters (with different `cluster_id` values) share the same S3 bucket, their snapshots are stored under separate prefixes (`mooncake_master_snapshot/cluster_a/` and `mooncake_master_snapshot/cluster_b/`), with no path collision during save and restore operations.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
