### PR TITLE
[Security] Fix Go vulnerabilities in libetcd_wrapper.so

### DIFF
--- a/mooncake-common/etcd/go.mod
+++ b/mooncake-common/etcd/go.mod
@@ -2,7 +2,7 @@ module github.com/kvcache-ai/Mooncake/mooncake-common/etcd
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	go.etcd.io/etcd/api/v3 v3.5.21
@@ -18,7 +18,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
-	golang.org/x/net v0.48.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect


### PR DESCRIPTION
## Description

Update Go toolchain and dependencies to address CVEs:
- Go 1.25.9 → 1.25.10 (fixes CVE-2026-33814, CVE-2026-39836, CVE-2026-42499, CVE-2026-33811, CVE-2026-39820, CVE-2026-42501)
- golang.org/x/net v0.48.0 → v0.55.0 (fixes CVE-2026-39821, CVE-2026-33814)

This rebuilds libetcd_wrapper.so with patched Go stdlib and golang.org/x/net to resolve downstream vulnerability scanner findings.

Fixes #2239

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
