### PR TITLE
[Fix] Fix duplicate service append on re-registration and add tests

### DIFF
--- a/mooncake-conductor/conductor-ctrl/kvevent/event_manager.go
+++ b/mooncake-conductor/conductor-ctrl/kvevent/event_manager.go
@@ -388,8 +388,10 @@ func (m *EventManager) StartHTTPServer() error {
 			AdditionalSalt: additionalSalt,
 		}
 
+		m.mu.Lock()
 		isNew, err := m.subscribeToService(svc)
 		if err != nil {
+			m.mu.Unlock()
 			slog.Error("Dynamic register failed", "instance_id", req.InstanceID, "err", err)
 			http.Error(w, fmt.Sprintf("Failed to subscribe: %v", err), http.StatusInternalServerError)
 			return
@@ -406,6 +408,7 @@ func (m *EventManager) StartHTTPServer() error {
 			}
 			m.indexer.AddDpSize(modelContext, int64(svc.DPRank))
 		}
+		m.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{
@@ -436,12 +439,15 @@ func (m *EventManager) StartHTTPServer() error {
 		targetKey := makeServiceKey(req.InstanceID, targetTenant, req.DPRank)
 
 		// Direct lookup and removal
+		m.mu.Lock()
 		if _, exists := m.activeConfigs.Load(targetKey); !exists {
+			m.mu.Unlock()
 			http.Error(w, fmt.Sprintf("service not found: %s", targetKey), http.StatusNotFound)
 			return
 		}
 
 		m.unsubscribeFromService(req.InstanceID, targetTenant, req.DPRank)
+		m.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{

--- a/mooncake-conductor/conductor-ctrl/kvevent/event_manager.go
+++ b/mooncake-conductor/conductor-ctrl/kvevent/event_manager.go
@@ -90,7 +90,10 @@ func NewEventManager(
 func (m *EventManager) Start() error {
 	slog.Info("Starting KV Event Manager...")
 
-	// Subscribe to all services concurrently
+	// Subscribe to all services concurrently.
+	// m.mu serialises the check-then-act inside subscribeToService and
+	// serialises with concurrent /register HTTP handlers so that
+	// m.subscribers, m.activeConfigs, and m.services stay consistent.
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(m.services))
 
@@ -98,7 +101,10 @@ func (m *EventManager) Start() error {
 		wg.Add(1)
 		go func(service common.ServiceConfig) {
 			defer wg.Done()
-			if _, err := m.subscribeToService(service); err != nil {
+			m.mu.Lock()
+			_, err := m.subscribeToService(service)
+			m.mu.Unlock()
+			if err != nil {
 				slog.Error("Failed to initiate subscription",
 					"service_type", service.Type,
 					"instance_id", service.InstanceID,
@@ -226,23 +232,39 @@ func (m *EventManager) subscribeToService(svc common.ServiceConfig) (bool, error
 
 func (m *EventManager) unsubscribeFromService(instanceID string, tenantID string, dpRank int) {
 	svcKey := makeServiceKey(instanceID, tenantID, dpRank)
-	if client, exists := m.subscribers.Load(svcKey); exists {
-		client.Stop()
-		m.subscribers.Delete(svcKey)
-		m.activeConfigs.Delete(svcKey)
 
-		// Remove engine_instance from tenant's instance set
-		m.tenantMutex.Lock()
-		if instanceSet, exists := m.tenantInstanceMap[tenantID]; exists {
-			delete(instanceSet, instanceID)
-		}
-		m.tenantMutex.Unlock()
-		slog.Info("Successfully unsubscribed from service",
-			"service_key", svcKey,
-			"instance_id", instanceID,
-			"tenant_id", tenantID,
-		)
+	// Atomically remove from tracking maps under m.mu so that a
+	// concurrent /register sees a consistent (empty) state.
+	m.mu.Lock()
+	client, exists := m.subscribers.LoadAndDelete(svcKey)
+	if exists {
+		m.activeConfigs.Delete(svcKey)
 	}
+	m.mu.Unlock()
+
+	if client == nil {
+		return
+	}
+
+	// Stop the ZMQ client OUTSIDE m.mu to avoid deadlock:
+	// HandleEvent acquires m.mu.RLock().  If the ZMQ event-loop
+	// goroutine is currently inside HandleEvent (or about to
+	// enter it), holding m.mu while waiting for that goroutine to
+	// exit via client.Stop() → wg.Wait() would deadlock.
+	client.Stop()
+
+	// Remove engine_instance from tenant's instance set
+	m.tenantMutex.Lock()
+	if instanceSet, exists := m.tenantInstanceMap[tenantID]; exists {
+		delete(instanceSet, instanceID)
+	}
+	m.tenantMutex.Unlock()
+
+	slog.Info("Successfully unsubscribed from service",
+		"service_key", svcKey,
+		"instance_id", instanceID,
+		"tenant_id", tenantID,
+	)
 }
 
 func (m *EventManager) getIndexer() *prefixindex.PrefixCacheTable {
@@ -438,16 +460,20 @@ func (m *EventManager) StartHTTPServer() error {
 		}
 		targetKey := makeServiceKey(req.InstanceID, targetTenant, req.DPRank)
 
-		// Direct lookup and removal
+		// Direct lookup and removal.
+		// Hold m.mu only for the existence check; unsubscribeFromService
+		// handles map removal under its own m.mu and calls client.Stop()
+		// outside the lock to avoid deadlock with HandleEvent's RLock.
 		m.mu.Lock()
-		if _, exists := m.activeConfigs.Load(targetKey); !exists {
-			m.mu.Unlock()
+		_, exists := m.activeConfigs.Load(targetKey)
+		m.mu.Unlock()
+
+		if !exists {
 			http.Error(w, fmt.Sprintf("service not found: %s", targetKey), http.StatusNotFound)
 			return
 		}
 
 		m.unsubscribeFromService(req.InstanceID, targetTenant, req.DPRank)
-		m.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{

--- a/mooncake-conductor/conductor-ctrl/kvevent/event_manager.go
+++ b/mooncake-conductor/conductor-ctrl/kvevent/event_manager.go
@@ -98,7 +98,7 @@ func (m *EventManager) Start() error {
 		wg.Add(1)
 		go func(service common.ServiceConfig) {
 			defer wg.Done()
-			if err := m.subscribeToService(service); err != nil {
+			if _, err := m.subscribeToService(service); err != nil {
 				slog.Error("Failed to initiate subscription",
 					"service_type", service.Type,
 					"instance_id", service.InstanceID,
@@ -151,7 +151,7 @@ func makeServiceKey(instanceID string, tenantID string, dpRank int) string {
 	return fmt.Sprintf("%s|%s|%d", instanceID, tenantID, dpRank)
 }
 
-func (m *EventManager) subscribeToService(svc common.ServiceConfig) error {
+func (m *EventManager) subscribeToService(svc common.ServiceConfig) (bool, error) {
 	// Use (instance_id, tenant_id) as composite key to support multi-tenant replicas
 	svcKey := makeServiceKey(svc.InstanceID, svc.TenantID, svc.DPRank)
 	if svc.InstanceID == "" {
@@ -159,12 +159,12 @@ func (m *EventManager) subscribeToService(svc common.ServiceConfig) error {
 	}
 
 	if _, exists := m.subscribers.Load(svcKey); exists {
-		return nil
+		return false, nil
 	}
 
 	// Validate endpoint
 	if svc.Endpoint == "" {
-		return fmt.Errorf("endpoint is required")
+		return false, fmt.Errorf("endpoint is required")
 	}
 
 	// Use ReplayEndpoint directly, fallback to empty if not provided
@@ -192,12 +192,12 @@ func (m *EventManager) subscribeToService(svc common.ServiceConfig) error {
 	}
 
 	if err := zmq.ValidateConfig(zmqConfig); err != nil {
-		return fmt.Errorf("invalid ZMQ config: %w", err)
+		return false, fmt.Errorf("invalid ZMQ config: %w", err)
 	}
 
 	client := zmq.NewZMQClient(zmqConfig, handler)
 	if err := client.Start(); err != nil {
-		return fmt.Errorf("failed to start ZMQ client: %w", err)
+		return false, fmt.Errorf("failed to start ZMQ client: %w", err)
 	}
 
 	m.subscribers.Store(svcKey, client)
@@ -221,7 +221,7 @@ func (m *EventManager) subscribeToService(svc common.ServiceConfig) error {
 		"replay_endpoint", replayEndpoint,
 	)
 
-	return nil
+	return true, nil
 }
 
 func (m *EventManager) unsubscribeFromService(instanceID string, tenantID string, dpRank int) {
@@ -388,22 +388,24 @@ func (m *EventManager) StartHTTPServer() error {
 			AdditionalSalt: additionalSalt,
 		}
 
-		if err := m.subscribeToService(svc); err != nil {
+		isNew, err := m.subscribeToService(svc)
+		if err != nil {
 			slog.Error("Dynamic register failed", "instance_id", req.InstanceID, "err", err)
 			http.Error(w, fmt.Sprintf("Failed to subscribe: %v", err), http.StatusInternalServerError)
 			return
 		}
-		m.services = append(m.services, svc)
-		modelContext := &prefixindex.ModelContext{
-			TenantID:       tenantID,
-			ModelName:      req.ModelName,
-			LoraName:       loraName,
-			BlockSize:      req.BlockSize,
-			AdditionalSalt: additionalSalt,
-			InstanceID:     svc.InstanceID,
+		if isNew {
+			m.services = append(m.services, svc)
+			modelContext := &prefixindex.ModelContext{
+				TenantID:       tenantID,
+				ModelName:      req.ModelName,
+				LoraName:       loraName,
+				BlockSize:      req.BlockSize,
+				AdditionalSalt: additionalSalt,
+				InstanceID:     svc.InstanceID,
+			}
+			m.indexer.AddDpSize(modelContext, int64(svc.DPRank))
 		}
-
-		m.indexer.AddDpSize(modelContext, int64(svc.DPRank))
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{

--- a/mooncake-conductor/conductor-ctrl/kvevent/event_manager_test.go
+++ b/mooncake-conductor/conductor-ctrl/kvevent/event_manager_test.go
@@ -1,0 +1,190 @@
+package kvevent
+
+import (
+	"testing"
+
+	"conductor/common"
+	"conductor/zmq"
+)
+
+func TestSubscribeToService_DuplicateReturnsFalse(t *testing.T) {
+	mgr := NewEventManager(nil, 0)
+
+	svc := common.ServiceConfig{
+		Endpoint:   "tcp://127.0.0.1:5557",
+		Type:       common.ServiceTypeVLLM,
+		ModelName:  "test-model",
+		InstanceID: "instance-1",
+		TenantID:   "tenant-1",
+		BlockSize:  16,
+	}
+
+	// Pre-populate subscribers to simulate an existing subscription,
+	// so subscribeToService hits the early-return path (line 161).
+	svcKey := makeServiceKey(svc.InstanceID, svc.TenantID, svc.DPRank)
+	mgr.subscribers.Store(svcKey, &zmq.ZMQClient{})
+
+	isNew, err := mgr.subscribeToService(svc)
+	if err != nil {
+		t.Fatalf("duplicate subscribeToService() unexpected error: %v", err)
+	}
+	if isNew {
+		t.Error("duplicate subscribeToService() should return false")
+	}
+}
+
+func TestSubscribeToService_MissingEndpoint(t *testing.T) {
+	mgr := NewEventManager(nil, 0)
+
+	svc := common.ServiceConfig{
+		Endpoint:   "",
+		Type:       common.ServiceTypeVLLM,
+		ModelName:  "test-model",
+		InstanceID: "instance-1",
+		TenantID:   "tenant-1",
+	}
+
+	isNew, err := mgr.subscribeToService(svc)
+	if err == nil {
+		t.Error("subscribeToService with empty endpoint should return error")
+	}
+	if isNew {
+		t.Error("subscribeToService on error should return false")
+	}
+}
+
+func TestSubscribeToService_DifferentDPRankIsNew(t *testing.T) {
+	mgr := NewEventManager(nil, 0)
+
+	svc0 := common.ServiceConfig{
+		Endpoint:   "tcp://127.0.0.1:5557",
+		Type:       common.ServiceTypeVLLM,
+		ModelName:  "test-model",
+		InstanceID: "instance-1",
+		TenantID:   "tenant-1",
+		DPRank:     0,
+		BlockSize:  16,
+	}
+	svc1 := common.ServiceConfig{
+		Endpoint:   "tcp://127.0.0.1:5557",
+		Type:       common.ServiceTypeVLLM,
+		ModelName:  "test-model",
+		InstanceID: "instance-1",
+		TenantID:   "tenant-1",
+		DPRank:     1,
+		BlockSize:  16,
+	}
+
+	// Pre-populate dp_rank 0, so dp_rank 1 is treated as new
+	svcKey0 := makeServiceKey(svc0.InstanceID, svc0.TenantID, svc0.DPRank)
+	mgr.subscribers.Store(svcKey0, &zmq.ZMQClient{})
+
+	isNew1, err1 := mgr.subscribeToService(svc1)
+	if err1 == nil {
+		// If no error, must be because it hit the validation before ZMQ connect
+		// Actually it will fail at zmq connect since no server exists.
+		// The key assertion is: svc1 (dp_rank=1) should NOT be treated as duplicate
+		// of svc0 (dp_rank=0), because their service keys differ.
+		t.Skip("requires running ZMQ server to complete the full path")
+	}
+	_ = isNew1
+}
+
+func TestSubscribeToService_DifferentTenantIsNew(t *testing.T) {
+	mgr := NewEventManager(nil, 0)
+
+	svcA := common.ServiceConfig{
+		Endpoint:   "tcp://127.0.0.1:5557",
+		Type:       common.ServiceTypeVLLM,
+		ModelName:  "test-model",
+		InstanceID: "instance-1",
+		TenantID:   "tenant-a",
+		BlockSize:  16,
+	}
+	svcB := common.ServiceConfig{
+		Endpoint:   "tcp://127.0.0.1:5557",
+		Type:       common.ServiceTypeVLLM,
+		ModelName:  "test-model",
+		InstanceID: "instance-1",
+		TenantID:   "tenant-b",
+		BlockSize:  16,
+	}
+
+	// Pre-populate tenant-a, so tenant-b is treated as new
+	svcKeyA := makeServiceKey(svcA.InstanceID, svcA.TenantID, svcA.DPRank)
+	mgr.subscribers.Store(svcKeyA, &zmq.ZMQClient{})
+
+	isNewB, errB := mgr.subscribeToService(svcB)
+	if errB == nil {
+		t.Skip("requires running ZMQ server to complete the full path")
+	}
+	_ = isNewB
+}
+
+func TestServicesSlice_NoDuplicateOnReRegister(t *testing.T) {
+	mgr := NewEventManager(nil, 0)
+
+	svc := common.ServiceConfig{
+		Endpoint:   "tcp://127.0.0.1:5557",
+		Type:       common.ServiceTypeVLLM,
+		ModelName:  "test-model",
+		InstanceID: "instance-1",
+		TenantID:   "tenant-1",
+		BlockSize:  16,
+	}
+
+	// Simulate the /register handler logic with isNew guard.
+	// First registration: subscribeToService will fail on zmq connect,
+	// so we pre-populate instead to test the guarded-append pattern.
+	svcKey := makeServiceKey(svc.InstanceID, svc.TenantID, svc.DPRank)
+	mgr.subscribers.Store(svcKey, &zmq.ZMQClient{})
+
+	// First call: duplicate → isNew=false
+	isNew, err := mgr.subscribeToService(svc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isNew {
+		mgr.services = append(mgr.services, svc)
+	}
+	if len(mgr.services) != 0 {
+		t.Errorf("services len = %d after duplicate, want 0", len(mgr.services))
+	}
+
+	// Second call: still duplicate → isNew=false
+	isNew2, err2 := mgr.subscribeToService(svc)
+	if err2 != nil {
+		t.Fatalf("unexpected error: %v", err2)
+	}
+	if isNew2 {
+		mgr.services = append(mgr.services, svc)
+	}
+	if len(mgr.services) != 0 {
+		t.Errorf("services len = %d after second duplicate, want 0", len(mgr.services))
+	}
+}
+
+func TestNewEventManager_InitialState(t *testing.T) {
+	mgr := NewEventManager(nil, 13333)
+
+	if mgr.indexer == nil {
+		t.Error("indexer should not be nil")
+	}
+	if mgr.tenantInstanceMap == nil {
+		t.Error("tenantInstanceMap should not be nil")
+	}
+	if len(mgr.services) != 0 {
+		t.Errorf("services should be empty, got %d", len(mgr.services))
+	}
+	if mgr.httpserverport != 13333 {
+		t.Errorf("httpserverport = %d, want 13333", mgr.httpserverport)
+	}
+}
+
+func TestMakeServiceKey(t *testing.T) {
+	key := makeServiceKey("instance-1", "tenant-1", 0)
+	expected := "instance-1|tenant-1|0"
+	if key != expected {
+		t.Errorf("makeServiceKey = %q, want %q", key, expected)
+	}
+}


### PR DESCRIPTION
subscribeToService now returns (bool, error) where the bool indicates whether a new subscription was actually created. The /register handler uses this flag to guard m.services append and AddDpSize, preventing the services slice from growing unboundedly on repeated registrations of the same worker.

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [x] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<img width="671" height="353" alt="image" src="https://github.com/user-attachments/assets/0766fa9b-1186-4ede-9eba-51fbf6eae3a9" />
## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
