### PR TITLE
[PG][EP] Fix engine.so runtime dependency

### DIFF
--- a/mooncake-ep/setup.py
+++ b/mooncake-ep/setup.py
@@ -50,7 +50,9 @@ setup(
             extra_link_args=[
                 "-Wl,-rpath,$ORIGIN",
                 "-L" + os.path.join(current_dir, "../mooncake-wheel/mooncake"),
+                "-Wl,--push-state,--no-as-needed",
                 "-l:engine.so",
+                "-Wl,--pop-state",
             ],
         )
     ],

--- a/mooncake-pg/setup.py
+++ b/mooncake-pg/setup.py
@@ -64,7 +64,9 @@ setup(
             extra_link_args=[
                 "-Wl,-rpath,$ORIGIN",
                 "-L" + os.path.join(current_dir, "../mooncake-wheel/mooncake"),
+                "-Wl,--push-state,--no-as-needed",
                 "-l:engine.so",
+                "-Wl,--pop-state",
             ],
         )
     ],


### PR DESCRIPTION
## Description

This fixes the torch 2.12 Mooncake EP import failure where the built `ep_2_12_0` extension does not record `engine.so` as a direct runtime dependency.

The failure mode is an import-time unresolved symbol from glog:

```text
undefined symbol: _ZN6google10LogMessageC1EPKcii
```

I checked the installed Mooncake `0.3.11.post1` wheel and found that the torch 2.12 EP artifact is the only EP artifact missing the direct `engine.so` dependency:

```text
ep_2_9_1.cpython-312-x86_64-linux-gnu.so
  engine.so: True
  torch libs: ['libc10.so', 'libtorch.so', 'libtorch_cpu.so', 'libtorch_python.so', 'libc10_cuda.so']

ep_2_10_0.cpython-312-x86_64-linux-gnu.so
  engine.so: True
  torch libs: ['libc10.so', 'libtorch.so', 'libtorch_cpu.so', 'libtorch_python.so', 'libc10_cuda.so']

ep_2_11_0.cpython-312-x86_64-linux-gnu.so
  engine.so: True
  torch libs: ['libc10.so', 'libtorch.so', 'libtorch_cpu.so', 'libtorch_python.so', 'libc10_cuda.so']

ep_2_12_0.cpython-312-x86_64-linux-gnu.so
  engine.so: False
  torch libs: ['libc10.so', 'libtorch_cpu.so', 'libtorch_python.so', 'libc10_cuda.so']
```

`ep_2_12_0` still has unresolved glog references:

```text
U _ZN6google10LogMessage6streamEv
U _ZN6google10LogMessageC1EPKci
U _ZN6google10LogMessageC1EPKcii
U _ZN6google10LogMessageD1Ev
```

Directly importing the exact torch 2.12 EP module fails:

```text
ImportError: .../mooncake/ep_2_12_0.cpython-312-x86_64-linux-gnu.so: undefined symbol: _ZN6google10LogMessageC1EPKcii
```

Preloading `mooncake.engine` with `RTLD_GLOBAL` makes the same import pass, which confirms the missing dependency is the issue:

```text
preload then import mooncake.ep_2_12_0 OK
```

Mooncake already links EP/PG with `-l:engine.so`, but in torch 2.12 builds that dependency can be dropped by linker `--as-needed` behavior. This PR wraps only `-l:engine.so` with:

```text
-Wl,--push-state,--no-as-needed
-l:engine.so
-Wl,--pop-state
```

This preserves the existing linker state for all other libraries while forcing `engine.so` to remain a direct `DT_NEEDED` dependency, matching the working EP wheel contract from torch 2.9/2.10/2.11.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [x] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Verified the current installed wheel behavior before the fix:

```bash
readelf -d ep_2_9_1*.so
readelf -d ep_2_10_0*.so
readelf -d ep_2_11_0*.so
readelf -d ep_2_12_0*.so
```

Observed that `ep_2_12_0` is missing `NEEDED engine.so`, while `ep_2_9_1`, `ep_2_10_0`, and `ep_2_11_0` include it.

Verified the import failure and workaround:

```python
import importlib
import torch

print("torch", torch.__version__)
importlib.import_module("mooncake.ep_2_12_0")
```

fails with:

```text
undefined symbol: _ZN6google10LogMessageC1EPKcii
```

and:

```python
import importlib
import os
import sys
import torch

print("torch", torch.__version__)
old = sys.getdlopenflags()
sys.setdlopenflags(old | os.RTLD_GLOBAL)
try:
    importlib.import_module("mooncake.engine")
finally:
    sys.setdlopenflags(old)

importlib.import_module("mooncake.ep_2_12_0")
print("preload then import mooncake.ep_2_12_0 OK")
```

passes.

Expected post-build verification:

```bash
readelf -d mooncake/ep_2_12_0*.so | grep engine.so
```

should include:

```text
Shared library: [engine.so]
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.