### PR TITLE
[Store] Revive HTTP metadata cleanup from #1219

### DIFF
--- a/mooncake-store/include/ha_helper.h
+++ b/mooncake-store/include/ha_helper.h
@@ -1,0 +1,90 @@
+#ifndef MOONCAKE_HA_HELPER_H_
+#define MOONCAKE_HA_HELPER_H_
+
+#include <csignal>
+#include <glog/logging.h>
+
+#include <string>
+#include <thread>
+#include <ylt/coro_rpc/coro_rpc_server.hpp>
+
+#include "types.h"
+#include "master_config.h"
+#include "http_metadata_server.h"
+
+namespace mooncake {
+
+/*
+ * @brief A helper class for maintain and monitor the master view change.
+ *        The cluster is assumed to have multiple master servers, but only
+ *        one master can be elected as leader to serve client requests.
+ *        Each master view is associated with a unique version id, which
+ *        is incremented monotonically each time the master view is changed.
+ */
+class MasterViewHelper {
+   public:
+    MasterViewHelper(const MasterViewHelper&) = delete;
+    MasterViewHelper& operator=(const MasterViewHelper&) = delete;
+    MasterViewHelper();
+
+    /*
+     * @brief Connect to the etcd cluster. This function should be called at
+     * first
+     * @param etcd_endpoints: The endpoints of the etcd store client.
+     *        Multiple endpoints are separated by semicolons.
+     * @return: Error code.
+     */
+    ErrorCode ConnectToEtcd(const std::string& etcd_endpoints);
+
+    /*
+     * @brief Elect the master to be the leader. This is a blocking function.
+     * @param master_address: The ip:port address of the master to be elected.
+     * @param version: Output param, the version of the new master view.
+     * @param lease_id: Output param, the lease id of the leader.
+     */
+    void ElectLeader(const std::string& master_address, ViewVersionId& version,
+                     EtcdLeaseId& lease_id);
+
+    /*
+     * @brief Keep the master to be the leader. This function blocks until the
+     * master is no longer the leader.
+     * @param lease_id: The lease id of the leader.
+     */
+    void KeepLeader(EtcdLeaseId lease_id);
+
+    /*
+     * @brief Get the current master view.
+     * @param master: Output param, the ip:port address of the master.
+     * @param version: Output param, the version of the master view.
+     * @return: Error code.
+     */
+    ErrorCode GetMasterView(std::string& master_address,
+                            ViewVersionId& version);
+
+   private:
+    std::string master_view_key_;
+};
+
+/*
+ * @brief A supervisor class for the master service, only used in HA mode.
+ *        This class will continuously do the following procedures after start:
+ *        1. Elect local master to be the leader.
+ *        2. Start the master service when it is elected as leader.
+ *        3. Stop the master service when it is no longer the leader.
+ */
+class MasterServiceSupervisor {
+   public:
+    MasterServiceSupervisor(const MasterServiceSupervisorConfig& config);
+    int Start();
+    ~MasterServiceSupervisor();
+
+   private:
+    // coro_rpc server thread
+    std::thread server_thread_;
+
+    MasterServiceSupervisorConfig config_;
+};
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_HA_HELPER_H_

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -189,6 +189,12 @@ class MasterServiceSupervisorConfig {
     uint32_t promotion_admission_threshold = 2;
     uint32_t promotion_queue_limit = 50000;
     uint32_t promotion_max_per_heartbeat = 1;
+
+    // HTTP metadata server configuration
+    bool enable_http_metadata_server = false;
+    uint32_t http_metadata_server_port = 8080;
+    std::string http_metadata_server_host = "0.0.0.0";
+
     MasterServiceSupervisorConfig() = default;
 
     // From MasterConfig
@@ -266,6 +272,12 @@ class MasterServiceSupervisorConfig {
         cxl_path = config.cxl_path;
         cxl_size = config.cxl_size;
         enable_cxl = config.enable_cxl;
+
+        // Set HTTP metadata server configuration
+        enable_http_metadata_server = config.enable_http_metadata_server;
+        http_metadata_server_port = config.http_metadata_server_port;
+        http_metadata_server_host = config.http_metadata_server_host;
+
         validate();
     }
 

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -1,0 +1,220 @@
+#include "ha_helper.h"
+#include "etcd_helper.h"
+#include "rpc_service.h"
+
+namespace mooncake {
+
+MasterViewHelper::MasterViewHelper() {
+    std::string cluster_id;
+    const char* cluster_id_env = std::getenv("MC_STORE_CLUSTER_ID");
+    if (cluster_id_env != nullptr && strlen(cluster_id_env) > 0) {
+        cluster_id = cluster_id_env;
+    } else {
+        cluster_id = "mooncake";
+    }
+    // Ensure the cluster_id ends with '/' if not empty
+    if (!cluster_id.empty() && cluster_id.back() != '/') {
+        cluster_id += '/';
+    }
+    master_view_key_ = "mooncake-store/" + cluster_id + "master_view";
+    LOG(INFO) << "Master view key: " << master_view_key_;
+}
+
+ErrorCode MasterViewHelper::ConnectToEtcd(const std::string& etcd_endpoints) {
+    return EtcdHelper::ConnectToEtcdStoreClient(etcd_endpoints);
+}
+
+void MasterViewHelper::ElectLeader(const std::string& master_address,
+                                   ViewVersionId& version,
+                                   EtcdLeaseId& lease_id) {
+    while (true) {
+        // Check if there is already a leader
+        ViewVersionId current_version = 0;
+        std::string current_master;
+        auto ret =
+            EtcdHelper::Get(master_view_key_.c_str(), master_view_key_.size(),
+                            current_master, current_version);
+        if (ret != ErrorCode::OK && ret != ErrorCode::ETCD_KEY_NOT_EXIST) {
+            LOG(ERROR) << "Failed to get current leader: " << ret;
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        } else if (ret != ErrorCode::ETCD_KEY_NOT_EXIST) {
+            LOG(INFO) << "CurrentLeader=" << current_master
+                      << ", CurrentVersion=" << current_version;
+            // In rare cases, the leader may be ourselves, but it does not
+            // matter. We will watch the key until it's deleted.
+            LOG(INFO) << "Waiting for leadership change...";
+            auto ret = EtcdHelper::WatchUntilDeleted(master_view_key_.c_str(),
+                                                     master_view_key_.size());
+            if (ret != ErrorCode::OK) {
+                LOG(ERROR) << "Etcd error when waiting for leadership change: "
+                           << ret;
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                continue;
+            }
+            // From now, the key is deleted
+        } else {
+            LOG(INFO) << "No leader found, trying to elect self as leader";
+        }
+
+        // Here, the key is either deleted or not set. We can
+        // try to elect ourselves as the leader. We vote ourselfves
+        // as the leader by trying to creating the key in a transaction.
+        // The one who successfully creates the key is the leader.
+        ret = EtcdHelper::GrantLease(ETCD_MASTER_VIEW_LEASE_TTL, lease_id);
+        if (ret != ErrorCode::OK) {
+            LOG(ERROR) << "Failed to grant lease: " << ret;
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+
+        ret = EtcdHelper::CreateWithLease(
+            master_view_key_.c_str(), master_view_key_.size(),
+            master_address.c_str(), master_address.size(), lease_id, version);
+        if (ret == ErrorCode::ETCD_TRANSACTION_FAIL) {
+            LOG(INFO) << "Failed to elect self as leader: " << ret;
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        } else if (ret != ErrorCode::OK) {
+            LOG(ERROR) << "Failed to create key with lease: " << ret;
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        } else {
+            LOG(INFO) << "Successfully elected self as leader";
+            return;
+        }
+    }
+}
+
+void MasterViewHelper::KeepLeader(EtcdLeaseId lease_id) {
+    EtcdHelper::KeepAlive(lease_id);
+}
+
+ErrorCode MasterViewHelper::GetMasterView(std::string& master_address,
+                                          ViewVersionId& version) {
+    auto err_code =
+        EtcdHelper::Get(master_view_key_.c_str(), master_view_key_.size(),
+                        master_address, version);
+    if (err_code != ErrorCode::OK) {
+        if (err_code == ErrorCode::ETCD_KEY_NOT_EXIST) {
+            LOG(ERROR) << "No master is available";
+        } else {
+            LOG(ERROR) << "Failed to get master address due to etcd error";
+        }
+        return err_code;
+    } else {
+        LOG(INFO) << "Get master address: " << master_address
+                  << ", version: " << version;
+        return ErrorCode::OK;
+    }
+}
+
+MasterServiceSupervisor::MasterServiceSupervisor(
+    const MasterServiceSupervisorConfig& config)
+    : config_(config) {}
+
+int MasterServiceSupervisor::Start() {
+    while (true) {
+        LOG(INFO) << "Init master service...";
+        coro_rpc::coro_rpc_server server(
+            config_.rpc_thread_num, config_.rpc_port, config_.rpc_address,
+            config_.rpc_conn_timeout, config_.rpc_enable_tcp_no_delay);
+        const char* value = std::getenv("MC_RPC_PROTOCOL");
+        if (value && std::string_view(value) == "rdma") {
+            server.init_ibv();
+        }
+
+        LOG(INFO) << "Init leader election helper...";
+        MasterViewHelper mv_helper;
+        if (mv_helper.ConnectToEtcd(config_.etcd_endpoints) != ErrorCode::OK) {
+            LOG(ERROR) << "Failed to connect to etcd endpoints: "
+                       << config_.etcd_endpoints;
+            return -1;
+        }
+        LOG(INFO) << "Trying to elect self as leader...";
+        EtcdLeaseId lease_id = 0;
+        // view_version will be updated by ElectLeader and then used in
+        // WrappedMasterService
+        ViewVersionId view_version = 0;
+        mv_helper.ElectLeader(config_.local_hostname, view_version, lease_id);
+
+        // Start a thread to keep the leader alive
+        auto keep_leader_thread =
+            std::thread([&server, &mv_helper, lease_id]() {
+                mv_helper.KeepLeader(lease_id);
+                LOG(INFO) << "Trying to stop server...";
+                server.stop();
+            });
+
+        // To prevent potential split-brain, wait long enough for the old leader
+        // to retire.
+        const int waiting_time = ETCD_MASTER_VIEW_LEASE_TTL;
+        std::this_thread::sleep_for(std::chrono::seconds(waiting_time));
+
+        LOG(INFO) << "Starting master service...";
+        mooncake::WrappedMasterService wrapped_master_service(
+            mooncake::WrappedMasterServiceConfig(config_, view_version));
+
+        // Start HTTP metadata server if enabled, passing the master service
+        std::unique_ptr<mooncake::HttpMetadataServer> http_metadata_server;
+        if (config_.enable_http_metadata_server) {
+            // Create a shared_ptr with a no-op deleter since
+            // wrapped_master_service is stack-allocated and will be cleaned up
+            // automatically
+            auto wrapped_service_ptr =
+                std::shared_ptr<mooncake::WrappedMasterService>(
+                    &wrapped_master_service,
+                    [](mooncake::WrappedMasterService*) {});
+            http_metadata_server =
+                std::make_unique<mooncake::HttpMetadataServer>(
+                    config_.http_metadata_server_port,
+                    config_.http_metadata_server_host, wrapped_service_ptr);
+            http_metadata_server->start();
+
+            if (!http_metadata_server->is_running()) {
+                LOG(ERROR) << "Failed to start HTTP metadata server";
+                return -1;
+            }
+
+            LOG(INFO) << "HTTP metadata server started successfully";
+        }
+
+        mooncake::RegisterRpcService(server, wrapped_master_service);
+        // Metric reporting is now handled by WrappedMasterService.
+
+        async_simple::Future<coro_rpc::err_code> ec =
+            server.async_start();  // won't block here
+        if (ec.hasResult()) {
+            LOG(ERROR) << "Failed to start master service: "
+                       << ec.result().value();
+            auto etcd_err = EtcdHelper::CancelKeepAlive(lease_id);
+            if (etcd_err != ErrorCode::OK) {
+                LOG(ERROR) << "Failed to cancel keep leader alive: "
+                           << etcd_err;
+            }
+            // Even if CancelKeepAlive fails, the keep alive context are closed.
+            // We can safely join the keep leader thread.
+            keep_leader_thread.join();
+            return -1;
+        }
+        // Block until the server is stopped
+        auto server_err = std::move(ec).get();
+        LOG(ERROR) << "Master service stopped: " << server_err;
+
+        // If the server is closed due to internal errors, we need to manually
+        // stop keep leader alive.
+        auto etcd_err = EtcdHelper::CancelKeepAlive(lease_id);
+        // The error here is predicatable, no need to log it as ERROR.
+        LOG(INFO) << "Cancel keep leader alive: " << etcd_err;
+        keep_leader_thread.join();
+    }
+    return 0;
+}
+
+MasterServiceSupervisor::~MasterServiceSupervisor() {
+    if (server_thread_.joinable()) {
+        server_thread_.join();
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/http_metadata_server.cpp
+++ b/mooncake-store/src/http_metadata_server.cpp
@@ -6,6 +6,9 @@
 
 #include <mutex>
 #include <string>
+#include <regex>
+#include <thread>
+#include <chrono>
 
 namespace mooncake {
 
@@ -13,6 +16,18 @@ HttpMetadataServer::HttpMetadataServer(uint16_t port, const std::string& host)
     : port_(port),
       host_(host),
       server_(std::make_unique<coro_http::coro_http_server>(4, port)),
+      wrapped_master_service_(nullptr),
+      running_(false) {
+    init_server();
+}
+
+HttpMetadataServer::HttpMetadataServer(
+    uint16_t port, const std::string& host,
+    std::shared_ptr<WrappedMasterService> wrapped_master_service)
+    : port_(port),
+      host_(host),
+      server_(std::make_unique<coro_http::coro_http_server>(4, port)),
+      wrapped_master_service_(wrapped_master_service),
       running_(false) {
     init_server();
 }
@@ -114,6 +129,14 @@ bool HttpMetadataServer::start() {
 
     server_->async_start();
     running_ = true;
+
+    // Start health monitoring thread if master service is provided
+    if (wrapped_master_service_) {
+        health_monitor_running_ = true;
+        health_monitor_thread_ =
+            std::thread(&HttpMetadataServer::health_monitor_thread_func, this);
+    }
+
     LOG(INFO) << "HTTP metadata server started on " << host_ << ":" << port_;
     return true;
 }
@@ -123,9 +146,93 @@ void HttpMetadataServer::stop() {
         return;
     }
 
+    // Stop health monitoring thread
+    health_monitor_running_ = false;
+    if (health_monitor_thread_.joinable()) {
+        health_monitor_thread_.join();
+    }
+
     server_->stop();
     running_ = false;
     LOG(INFO) << "HTTP metadata server stopped";
+}
+
+void HttpMetadataServer::health_monitor_thread_func() {
+    while (health_monitor_running_) {
+        check_and_cleanup_metadata();
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(kHealthMonitorSleepMs));
+    }
+}
+
+void HttpMetadataServer::check_and_cleanup_metadata() {
+    if (!wrapped_master_service_) {
+        return;
+    }
+
+    // Get all segments once from master service
+    auto segments_result = wrapped_master_service_->GetAllSegments();
+    if (!segments_result.has_value()) {
+        LOG(WARNING) << "Failed to get all segments for metadata cleanup";
+        return;
+    }
+    const auto& all_segments = segments_result.value();
+
+    // Convert to unordered_set for O(1) lookup
+    std::unordered_set<std::string> segment_set(all_segments.begin(),
+                                                all_segments.end());
+
+    // Get all current keys from the metadata store
+    std::vector<std::string> keys_to_check;
+    {
+        std::lock_guard<std::mutex> lock(store_mutex_);
+        for (const auto& pair : store_) {
+            keys_to_check.push_back(pair.first);
+        }
+    }
+
+    // Check each key to see if it corresponds to segment metadata
+    // that should be cleaned up
+    for (const auto& key : keys_to_check) {
+        // Check if this key corresponds to segment metadata (e.g., keys
+        // containing "segment")
+        if (key.find("segment") != std::string::npos) {
+            std::string segment_name = key;
+            // Extract segment name from key if needed
+            if (key.find("rpc_meta_") == 0) {
+                segment_name = key.substr(9);  // Remove "rpc_meta_" prefix
+            }
+            if (!is_segment_healthy(segment_name, segment_set)) {
+                cleanup_segment_metadata(segment_name);
+            }
+        }
+        // Note: Removed client health check as it has side effects.
+        // Client metadata cleanup should be handled by the master service
+        // based on actual client liveness tracking.
+    }
+}
+
+bool HttpMetadataServer::is_segment_healthy(
+    const std::string& segment_name,
+    const std::unordered_set<std::string>& all_segments) {
+    // Check if the segment exists in the provided set
+    return all_segments.find(segment_name) != all_segments.end();
+}
+
+void HttpMetadataServer::cleanup_segment_metadata(
+    const std::string& segment_name) {
+    std::lock_guard<std::mutex> lock(store_mutex_);
+
+    // Find and remove all metadata entries related to this segment
+    for (auto it = store_.begin(); it != store_.end();) {
+        if (it->first.find(segment_name) != std::string::npos) {
+            LOG(INFO) << "Cleaning up metadata for segment: " << segment_name
+                      << ", key: " << it->first;
+            it = store_.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
 KVPoll HttpMetadataServer::poll() const {

--- a/mooncake-store/src/http_metadata_server.cpp
+++ b/mooncake-store/src/http_metadata_server.cpp
@@ -171,7 +171,7 @@ void HttpMetadataServer::check_and_cleanup_metadata() {
     }
 
     // Get all segments once from master service
-    auto segments_result = wrapped_master_service_->GetAllSegments();
+    auto segments_result = wrapped_master_service_->GetAllSegmentsForAdmin();
     if (!segments_result.has_value()) {
         LOG(WARNING) << "Failed to get all segments for metadata cleanup";
         return;


### PR DESCRIPTION
## Summary
This PR revives and reapplies the HTTP metadata cleanup work from #1219 on top of current `main`.

## Context
- Source reference: #1219
- New branch from latest `main`
- Re-submitted for fresh review and CI on current baseline

## Notes
- Includes the metadata cleanup related updates for HTTP metadata server and related store-side wiring.
- Please review with #1219 context in mind.