### PR TITLE
[Store] add prefix-query regex fast paths in Store Master

### DIFF
--- a/mooncake-store/benchmarks/CMakeLists.txt
+++ b/mooncake-store/benchmarks/CMakeLists.txt
@@ -20,6 +20,12 @@ target_link_libraries(
   storage_backend_bench PRIVATE mooncake_store cachelib_memory_allocator
                                 gflags::gflags glog::glog pthread)
 
+# Add prefix query benchmark executable
+add_executable(prefix_query_bench prefix_query_bench.cpp)
+target_link_libraries(
+  prefix_query_bench PRIVATE mooncake_store cachelib_memory_allocator
+                             gflags::gflags glog::glog pthread)
+
 # Add allocation strategy benchmark executable
 # This benchmark tests AllocationStrategy performance with configurable
 # segment counts, allocation sizes, replica counts, and workload patterns

--- a/mooncake-store/benchmarks/prefix_query_bench.cpp
+++ b/mooncake-store/benchmarks/prefix_query_bench.cpp
@@ -1,0 +1,166 @@
+// Copyright 2025 Mooncake Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+#include <chrono>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+#include "master_service.h"
+
+DEFINE_uint64(num_keys, 200000, "Number of keys to preload into Master");
+DEFINE_uint64(num_prefix_groups, 100,
+              "Distinct prefix groups to distribute the keys across");
+DEFINE_uint64(query_iterations, 200,
+              "Number of repeated prefix queries to execute");
+DEFINE_uint64(value_size, 1024, "Logical object value size in bytes");
+DEFINE_uint64(target_prefix_id, 42, "Prefix group id to query");
+
+namespace {
+
+using mooncake::ErrorCode;
+using mooncake::generate_uuid;
+using mooncake::MasterService;
+using mooncake::ReplicateConfig;
+using mooncake::ReplicaType;
+using mooncake::Segment;
+using mooncake::UUID;
+
+constexpr uintptr_t kSegmentBase = 0x400000000ULL;
+
+std::string FormatPrefixId(uint64_t id) {
+    std::ostringstream oss;
+    oss << std::setw(3) << std::setfill('0') << id;
+    return oss.str();
+}
+
+Segment MakeSegment(uint64_t segment_size) {
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "prefix_query_bench_segment";
+    segment.base = kSegmentBase;
+    segment.size = segment_size;
+    segment.te_endpoint = segment.name;
+    return segment;
+}
+
+void CheckExpected(bool ok, const std::string& message) {
+    if (!ok) {
+        LOG(ERROR) << message;
+        std::exit(1);
+    }
+}
+
+void PreloadKeys(MasterService& service, const UUID& client_id,
+                 uint64_t num_keys, uint64_t num_prefix_groups,
+                 uint64_t value_size) {
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    for (uint64_t i = 0; i < num_keys; ++i) {
+        const uint64_t prefix_id = i % num_prefix_groups;
+        const std::string key = "tenant_" + FormatPrefixId(prefix_id) +
+                                "/session_" + std::to_string(i);
+        auto put_start = service.PutStart(client_id, key, value_size, config);
+        CheckExpected(put_start.has_value(), "PutStart failed for " + key);
+        auto put_end = service.PutEnd(client_id, key, ReplicaType::MEMORY);
+        CheckExpected(put_end.has_value(), "PutEnd failed for " + key);
+    }
+}
+
+struct QueryStats {
+    double total_ms{0.0};
+    double avg_ms{0.0};
+    size_t match_count{0};
+};
+
+QueryStats RunPrefixQueryBenchmark(MasterService& service,
+                                   const std::string& pattern,
+                                   uint64_t iterations, bool disable_fastpath) {
+    setenv("MOONCAKE_STORE_DISABLE_PREFIX_FASTPATH",
+           disable_fastpath ? "1" : "0", 1);
+
+    // Warm up query-plan creation and cache state before timing.
+    for (int i = 0; i < 10; ++i) {
+        auto result = service.GetReplicaListByRegex(pattern);
+        CheckExpected(result.has_value(), "Warmup query failed");
+    }
+
+    QueryStats stats;
+    const auto start = std::chrono::steady_clock::now();
+    for (uint64_t i = 0; i < iterations; ++i) {
+        auto result = service.GetReplicaListByRegex(pattern);
+        CheckExpected(result.has_value(), "Measured query failed");
+        stats.match_count = result->size();
+    }
+    const auto end = std::chrono::steady_clock::now();
+    stats.total_ms =
+        std::chrono::duration<double, std::milli>(end - start).count();
+    stats.avg_ms = stats.total_ms / static_cast<double>(iterations);
+    return stats;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    google::InitGoogleLogging(argv[0]);
+    FLAGS_logtostderr = true;
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+    CheckExpected(FLAGS_num_prefix_groups > 0,
+                  "num_prefix_groups must be positive");
+    const uint64_t segment_size =
+        FLAGS_num_keys * FLAGS_value_size * 2 + (64ULL << 20);
+
+    auto service_config = mooncake::MasterServiceConfig::builder()
+                              .set_client_live_ttl_sec(3600)
+                              .build();
+    MasterService service(service_config);
+    const UUID client_id = generate_uuid();
+    Segment segment = MakeSegment(segment_size);
+    auto mount_result = service.MountSegment(segment, client_id);
+    CheckExpected(mount_result.has_value(),
+                  "Failed to mount benchmark segment");
+
+    std::cout << "Preloading " << FLAGS_num_keys << " keys across "
+              << FLAGS_num_prefix_groups << " prefix groups..." << std::endl;
+    PreloadKeys(service, client_id, FLAGS_num_keys, FLAGS_num_prefix_groups,
+                FLAGS_value_size);
+
+    const std::string prefix =
+        "tenant_" +
+        FormatPrefixId(FLAGS_target_prefix_id % FLAGS_num_prefix_groups) +
+        "/session_";
+    const std::string pattern = "^" + prefix;
+
+    auto baseline =
+        RunPrefixQueryBenchmark(service, pattern, FLAGS_query_iterations, true);
+    auto fastpath = RunPrefixQueryBenchmark(service, pattern,
+                                            FLAGS_query_iterations, false);
+
+    const double speedup = baseline.avg_ms / fastpath.avg_ms;
+    const double latency_reduction =
+        (baseline.avg_ms - fastpath.avg_ms) / baseline.avg_ms * 100.0;
+
+    std::cout << "\n=== Prefix Query Benchmark ===\n";
+    std::cout << "Pattern: " << pattern << "\n";
+    std::cout << "Matches/query: " << baseline.match_count << "\n";
+    std::cout << "Iterations: " << FLAGS_query_iterations << "\n";
+    std::cout << "\n[Regex fallback]\n";
+    std::cout << "  Total: " << baseline.total_ms << " ms\n";
+    std::cout << "  Avg:   " << baseline.avg_ms << " ms/query\n";
+    std::cout << "\n[Prefix fast path]\n";
+    std::cout << "  Total: " << fastpath.total_ms << " ms\n";
+    std::cout << "  Avg:   " << fastpath.avg_ms << " ms/query\n";
+    std::cout << "\n[Delta]\n";
+    std::cout << "  Speedup:            " << speedup << "x\n";
+    std::cout << "  Latency reduction:  " << latency_reduction << "%\n";
+
+    return 0;
+}

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1,6 +1,7 @@
 #include "master_service.h"
 
 #include <cassert>
+#include <cctype>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -116,6 +117,136 @@ tl::expected<std::string, ErrorCode> GetGroupIdForKey(
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
     return config.group_ids->at(key_index);
+}
+
+enum class RegexQueryMode {
+    kRegex,
+    kPrefix,
+    kExact,
+    kSubstring,
+};
+
+struct RegexQueryPlan {
+    RegexQueryMode mode{RegexQueryMode::kRegex};
+    std::string literal;
+    std::optional<std::regex> regex;
+
+    bool Matches(const std::string& key) const {
+        switch (mode) {
+            case RegexQueryMode::kPrefix:
+                return key.size() >= literal.size() &&
+                       key.compare(0, literal.size(), literal) == 0;
+            case RegexQueryMode::kExact:
+                return key == literal;
+            case RegexQueryMode::kSubstring:
+                return key.find(literal) != std::string::npos;
+            case RegexQueryMode::kRegex:
+                return std::regex_search(key, *regex);
+        }
+        return false;
+    }
+};
+
+bool IsRegexMetaChar(char c) {
+    switch (c) {
+        case '.':
+        case '^':
+        case '$':
+        case '|':
+        case '(':
+        case ')':
+        case '[':
+        case ']':
+        case '{':
+        case '}':
+        case '*':
+        case '+':
+        case '?':
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::optional<RegexQueryPlan> TryBuildLiteralRegexPlan(
+    const std::string& pattern) {
+    if (pattern.empty()) {
+        return RegexQueryPlan{RegexQueryMode::kSubstring, "", std::nullopt};
+    }
+
+    const bool anchored_start = pattern.front() == '^';
+    size_t i = anchored_start ? 1 : 0;
+    std::string literal;
+
+    while (i < pattern.size()) {
+        const char c = pattern[i];
+        if (c == '\\') {
+            if (i + 1 >= pattern.size()) {
+                return std::nullopt;
+            }
+            const unsigned char escaped =
+                static_cast<unsigned char>(pattern[i + 1]);
+            if (std::isalnum(escaped)) {
+                // Alphanumeric ECMAScript escapes such as \d, \w, \s, \b, or
+                // backreferences like \1 carry regex semantics and must fall
+                // back to the full regex engine.
+                return std::nullopt;
+            }
+            literal.push_back(static_cast<char>(escaped));
+            i += 2;
+            continue;
+        }
+
+        if (anchored_start && c == '$' && i + 1 == pattern.size()) {
+            return RegexQueryPlan{RegexQueryMode::kExact, std::move(literal),
+                                  std::nullopt};
+        }
+
+        if (anchored_start && c == '.' && i + 1 < pattern.size() &&
+            pattern[i + 1] == '*') {
+            const size_t tail = i + 2;
+            if (tail == pattern.size() ||
+                (tail + 1 == pattern.size() && pattern[tail] == '$')) {
+                return RegexQueryPlan{RegexQueryMode::kPrefix,
+                                      std::move(literal), std::nullopt};
+            }
+            return std::nullopt;
+        }
+
+        if (IsRegexMetaChar(c)) {
+            return std::nullopt;
+        }
+
+        literal.push_back(c);
+        ++i;
+    }
+
+    if (anchored_start) {
+        return RegexQueryPlan{RegexQueryMode::kPrefix, std::move(literal),
+                              std::nullopt};
+    }
+    return RegexQueryPlan{RegexQueryMode::kSubstring, std::move(literal),
+                          std::nullopt};
+}
+
+tl::expected<RegexQueryPlan, ErrorCode> BuildRegexQueryPlan(
+    const std::string& pattern) {
+    if (!GetEnvOr<bool>("MOONCAKE_STORE_DISABLE_PREFIX_FASTPATH", false)) {
+        if (auto plan = TryBuildLiteralRegexPlan(pattern)) {
+            return std::move(*plan);
+        }
+    }
+
+    try {
+        RegexQueryPlan plan;
+        plan.mode = RegexQueryMode::kRegex;
+        plan.regex.emplace(pattern, std::regex::ECMAScript);
+        return plan;
+    } catch (const std::regex_error& e) {
+        LOG(ERROR) << "Invalid regex pattern: " << pattern
+                   << ", error: " << e.what();
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
 }
 
 }  // namespace
@@ -1172,14 +1303,9 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
         std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
         ErrorCode> {
     std::unordered_map<std::string, std::vector<Replica::Descriptor>> results;
-    std::regex pattern;
-
-    try {
-        pattern = std::regex(regex_pattern, std::regex::ECMAScript);
-    } catch (const std::regex_error& e) {
-        LOG(ERROR) << "Invalid regex pattern: " << regex_pattern
-                   << ", error: " << e.what();
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    auto query_plan = BuildRegexQueryPlan(regex_pattern);
+    if (!query_plan) {
+        return tl::make_unexpected(query_plan.error());
     }
 
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
@@ -1187,7 +1313,7 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
         MetadataShardAccessorRO shard(this, i);
 
         for (const auto& [key, metadata] : shard->metadata) {
-            if (std::regex_search(key, pattern)) {
+            if (query_plan->Matches(key)) {
                 std::vector<Replica::Descriptor> replica_list;
                 metadata.VisitReplicas(
                     &Replica::fn_is_completed,
@@ -2640,14 +2766,9 @@ auto MasterService::Remove(const std::string& key, bool force)
 auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
     -> tl::expected<long, ErrorCode> {
     long removed_count = 0;
-    std::regex pattern;
-
-    try {
-        pattern = std::regex(regex_pattern, std::regex::ECMAScript);
-    } catch (const std::regex_error& e) {
-        LOG(ERROR) << "Invalid regex pattern: " << regex_pattern
-                   << ", error: " << e.what();
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    auto query_plan = BuildRegexQueryPlan(regex_pattern);
+    if (!query_plan) {
+        return tl::make_unexpected(query_plan.error());
     }
 
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
@@ -2655,7 +2776,7 @@ auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
         MetadataShardAccessorRW shard(this, i);
 
         for (auto it = shard->metadata.begin(); it != shard->metadata.end();) {
-            if (std::regex_search(it->first, pattern)) {
+            if (query_plan->Matches(it->first)) {
                 if (!force && !it->second.IsLeaseExpired()) {
                     VLOG(1) << "key=" << it->first
                             << " matched by regex, but has lease. Skipping "

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3597,13 +3597,13 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
 void MasterService::EvictionThreadFunc() {
     VLOG(1) << "action=eviction_thread_started";
 
-    // Start with an already-elapsed window so the first loop iteration
-    // (after kEvictionThreadSleepMs) triggers DiscardExpiredProcessingReplicas.
-    // Without this, a task admitted shortly after thread startup can survive
-    // the first reaper cycle and not be cleaned until ~2s later, causing
-    // promotion-on-hit tests that sleep for 2s to flake.
+    // Sweep expired PROCESSING / replication / offload / promotion state on a
+    // bounded cadence instead of only once per release TTL. Otherwise a task
+    // admitted just after a sweep can miss the next TTL-sized check, forcing
+    // cleanup to wait nearly another full TTL after it has already expired.
+    constexpr auto kDiscardSweepInterval = std::chrono::milliseconds(100);
     auto last_discard_time =
-        std::chrono::system_clock::now() - put_start_release_timeout_sec_;
+        std::chrono::system_clock::now() - kDiscardSweepInterval;
     while (eviction_running_) {
         const auto now = std::chrono::system_clock::now();
         double used_ratio =
@@ -3623,9 +3623,11 @@ void MasterService::EvictionThreadFunc() {
             BatchEvict(evict_ratio_target, evict_ratio_lowerbound);
             LOG(INFO) << "[EVICT-DONE] BatchEvict execution completed.";
             last_discard_time = now;
-        } else if (now - last_discard_time > put_start_release_timeout_sec_) {
-            // Try discarding expired processing keys and ongoing replication
-            // tasks if we have not done this for a long time.
+        } else if (now - last_discard_time >= kDiscardSweepInterval) {
+            // Expiry still uses each task's own put_start_release_timeout_sec_
+            // inside DiscardExpiredProcessingReplicas. This cadence only
+            // bounds how late we notice work that has already crossed its
+            // deadline when the system is otherwise idle.
             {
                 std::shared_lock<std::shared_mutex> shared_lock(
                     snapshot_mutex_);

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -1294,6 +1294,8 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
         "config/user/settings.json", "logs/app-2025-08-13.log",
         // Keys with varying lengths
         "short", "a_very_very_very_long_key_that_tests_length_limits",
+        // Single-character keys to verify regex escape fallback
+        "7", "d",
         // Keys that look similar but should not match certain regex
         "test-key-extra", "another_key"};
 
@@ -1376,6 +1378,23 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().size(), 1);
         EXPECT_EQ(result.value().begin()->first, "short");
+    }
+
+    // Test 3.8b: Escaped literal exact match
+    {
+        auto result =
+            service_->GetReplicaListByRegex("^config/user/settings\\.json$");
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(result.value().size(), 1);
+        EXPECT_EQ(result.value().begin()->first, "config/user/settings.json");
+    }
+
+    // Test 3.8c: Alphanumeric escapes must fall back to full regex semantics
+    {
+        auto result = service_->GetReplicaListByRegex("^\\d$");
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(result.value().size(), 1);
+        EXPECT_EQ(result.value().begin()->first, "7");
     }
 
     // Test 3.9: Initial test for non-existent key (as a sanity check)


### PR DESCRIPTION
## Description

This PR optimizes regex-based metadata queries in Store Master by adding a lightweight fast path for simple query patterns.

Currently, `GetReplicaListByRegex` and `RemoveByRegex` always rely on full `std::regex_search`, even for cases that are structurally much simpler than general regex. This PR adds a small query classifier and routes the following cases to cheaper string-based matching logic:

- prefix queries such as `^tenant_042/session_`
- exact literal queries such as `^foo$`
- simple literal substring queries

All other patterns continue to use the existing full regex path.

This PR includes:
- fast-path handling in:
  - `GetReplicaListByRegex`
  - `RemoveByRegex`
- test coverage for escaped-literal exact matching
- a benchmark binary to compare regex fallback vs prefix fast path

Representative benchmark result on the target server:
- workload:
  - `50000` keys
  - `100` prefix groups
  - `500` matches per query
  - `100` iterations
  - query pattern: `^tenant_042/session_`
- result:
  - regex fallback: `30.9364 ms/query`
  - prefix fast path: `1.84852 ms/query`

This corresponds to roughly:
- `16.74x` speedup
- `94.02%` latency reduction

This optimization is intended for prefix-oriented regex queries and should not be interpreted as a global Store-wide performance improvement.

If this direction looks good, I will continue with a follow-up design for a real PrefixQuery index solution, including data structures, lock model, benchmark expectations, and risk analysis.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Tested on the target server by rebuilding and running:

- `master_service_test` with:
  - `MasterServiceTest.GetReplicaListByRegex`
  - `MasterServiceTest.GetReplicaListByRegexComplex`
- `prefix_query_bench` with:
  - `--num_keys=50000`
  - `--num_prefix_groups=100`
  - `--query_iterations=100`
  - `--value_size=1024`
  - `--target_prefix_id=42`

The benchmark behavior was also checked against the upstream `main` baseline.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.