### PR TITLE
[Store] Support SSD offload configuration in standalone store service

### DIFF
--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -85,6 +85,8 @@ class MooncakeConfig:
             (e.g., "mlx5_0", "erdma_0", or "auto-discovery").
             Required when protocol is "rdma", optional for other protocols.
         master_server_address (str): The address of the master server.
+        enable_ssd_offload (bool): Enable SSD offload. Default is False.
+        ssd_offload_path (str): The path to the SSD directory for offloading.
 
     Example of configuration file:
         {
@@ -94,7 +96,9 @@ class MooncakeConfig:
             "local_buffer_size": 1073741824,
             "protocol": "tcp",
             "device_name": "",
-            "master_server_address": "localhost:8081"
+            "master_server_address": "localhost:8081",
+            "enable_ssd_offload": true,
+            "ssd_offload_path": "/nvme/mooncake_offload"
         }
         
         For RDMA:
@@ -105,7 +109,9 @@ class MooncakeConfig:
             "local_buffer_size": 1073741824,
             "protocol": "rdma",
             "device_name": "mlx5_0",
-            "master_server_address": "master:8081"
+            "master_server_address": "master:8081",
+            "enable_ssd_offload": true,
+            "ssd_offload_path": "/nvme/mooncake_offload"
         }
     """
     local_hostname: str
@@ -115,6 +121,8 @@ class MooncakeConfig:
     protocol: str
     device_name: Optional[str]
     master_server_address: str
+    enable_ssd_offload: bool = False
+    ssd_offload_path: str = ""
 
     @staticmethod
     def from_file(file_path: str) -> 'MooncakeConfig':
@@ -141,6 +149,8 @@ class MooncakeConfig:
             protocol=config.get("protocol", "tcp"),
             device_name=config.get("device_name", ""),
             master_server_address=config.get("master_server_address"),
+            enable_ssd_offload=bool(config.get("enable_ssd_offload", False)),
+            ssd_offload_path=str(config.get("ssd_offload_path", "")),
         )
 
     @staticmethod
@@ -167,5 +177,7 @@ class MooncakeConfig:
                 protocol=os.getenv("MOONCAKE_PROTOCOL", "tcp"),
                 device_name=os.getenv("MOONCAKE_DEVICE", ""),
                 master_server_address=os.getenv("MOONCAKE_MASTER"),
+                enable_ssd_offload=os.getenv("MOONCAKE_OFFLOAD_ENABLED", "false").lower() in ("true", "1"),
+                ssd_offload_path=os.getenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", ""),
             )
         return MooncakeConfig.from_file(config_file_path)

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -128,7 +128,10 @@ class MooncakeStoreService:
                     self.config.local_buffer_size,
                     self.config.protocol,
                     self.config.device_name,
-                    self.config.master_server_address
+                    self.config.master_server_address,
+                    None,
+                    self.config.enable_ssd_offload,
+                    self.config.ssd_offload_path
                 )
 
                 if ret != 0:

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -19,7 +19,9 @@ class TestMooncakeConfig(unittest.TestCase):
             "global_segment_size": 3355443200,
             "local_buffer_size": 1073741824,
             "protocol": "tcp",
-            "device_name": "eth0"
+            "device_name": "eth0",
+            "enable_ssd_offload": True,
+            "ssd_offload_path": "/nvme/mooncake_offload"
         }
 
     def tearDown(self):
@@ -42,6 +44,8 @@ class TestMooncakeConfig(unittest.TestCase):
         self.assertEqual(config.local_buffer_size, 1073741824)
         self.assertEqual(config.protocol, "tcp")
         self.assertEqual(config.device_name, "eth0")
+        self.assertEqual(config.enable_ssd_offload, True)
+        self.assertEqual(config.ssd_offload_path, "/nvme/mooncake_offload")
 
     def test_load_with_default_values(self):
         """Test loading configuration with default values"""
@@ -57,6 +61,8 @@ class TestMooncakeConfig(unittest.TestCase):
         self.assertEqual(config.local_buffer_size, DEFAULT_LOCAL_BUFFER_SIZE)
         self.assertEqual(config.protocol, "tcp")
         self.assertEqual(config.device_name, "")
+        self.assertEqual(config.enable_ssd_offload, False)
+        self.assertEqual(config.ssd_offload_path, "")
 
     def test_missing_required_field(self):
         """Test missing required field"""
@@ -93,6 +99,8 @@ class TestMooncakeConfig(unittest.TestCase):
         os.environ['MOONCAKE_GLOBAL_SEGMENT_SIZE'] = str(self.valid_config["global_segment_size"])
         os.environ['MOONCAKE_PROTOCOL'] = self.valid_config["protocol"]
         os.environ['MOONCAKE_DEVICE'] = self.valid_config["device_name"]
+        os.environ['MOONCAKE_OFFLOAD_ENABLED'] = str(self.valid_config["enable_ssd_offload"])
+        os.environ['MOONCAKE_OFFLOAD_FILE_STORAGE_PATH'] = self.valid_config["ssd_offload_path"]
 
         try:
             config = MooncakeConfig.load_from_env()
@@ -102,6 +110,8 @@ class TestMooncakeConfig(unittest.TestCase):
             self.assertEqual(config.global_segment_size, self.valid_config["global_segment_size"])
             self.assertEqual(config.protocol, self.valid_config["protocol"])
             self.assertEqual(config.device_name, self.valid_config["device_name"])
+            self.assertEqual(config.enable_ssd_offload, self.valid_config["enable_ssd_offload"])
+            self.assertEqual(config.ssd_offload_path, self.valid_config["ssd_offload_path"])
 
         finally:
             # Clean up environment variable
@@ -111,6 +121,8 @@ class TestMooncakeConfig(unittest.TestCase):
             del os.environ['MOONCAKE_GLOBAL_SEGMENT_SIZE']
             del os.environ['MOONCAKE_PROTOCOL']
             del os.environ['MOONCAKE_DEVICE']
+            del os.environ['MOONCAKE_OFFLOAD_ENABLED']
+            del os.environ['MOONCAKE_OFFLOAD_FILE_STORAGE_PATH']
 
     def test_load_from_env_missing(self):
         """Test loading configuration from environment variable when not set"""


### PR DESCRIPTION
## Description

This PR fixes an issue where the standalone store service (`MooncakeStoreService`) could not leverage local SSD offloading due to missing offload parameter setups in Python configurations and service initialization.

### Key Changes
- **Configuration Parsing**: Fixed `MooncakeConfig` by adding `enable_ssd_offload` and `ssd_offload_path` parsing from both JSON files and environment variables (`MOONCAKE_OFFLOAD_ENABLED` & `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`) to support the **local SSD offloading** method.
- **Store Service Integration**: Passed the missing local SSD offload parameters into the Mooncake Store backend engine constructor in `MooncakeStoreService` to successfully enable the local SSD directory offloading.
- **Unit Tests**: Added test cases in `tests/test_mooncake_config.py` to cover config loading behavior.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- **Functional Verification**: Tested the standalone store service mode using the **local SSD offloading** method (configured with `enable_ssd_offload=True` and a designated `ssd_offload_path` directory). Verified that KV cache data chunks are successfully and correctly offloaded to the local SSD directory.
- **Unit Tests**: Ran `mooncake-wheel/tests/test_mooncake_config.py` to verify:
  - Configuration file loading (`test_load_from_config_file`, `test_load_with_default_values`).
  - Environment variable configuration parsing (`test_load_from_config_env`).
  - All unit tests passed.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
