### PR TITLE
[Doc] add vLLM scenario-based landing pages and archive legacy docs

### DIFF
--- a/docs/source/design/architecture.md
+++ b/docs/source/design/architecture.md
@@ -12,7 +12,7 @@ Mooncake:
 
 ## Architectural Overview
 ![architecture](../image/mooncake-store.png)
-- Mooncake provides object-level operations, i.e. `Get/Put/List/Del`, and also supports dynamically configurating replication strategies (`Replicate` operations);
+- Mooncake provides object-level operations, i.e. `Get/Put/List/Del`, and also supports dynamically configuring replication strategies (`Replicate` operations);
 - Mooncake supports zero-copy and multi-NIC data transfer over VRAM/DRAM/NVMe SSD. This feature is supported by Transfer Engine, which has been open-sourced;
 - **The master node** centrally manages the mappings of objects to VRAM/DRAM/NVM buffers. The master node also drives **managed pool buffer nodes** to achieve data transfer by calling Transfer Engine's APIs;
 - **Managed pool buffer nodes** mainly provide DRAM space for storing objects.

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -6,7 +6,7 @@ Mooncake Store is a high-performance **distributed key-value (KV) cache storage 
 
 Unlike traditional caching systems such as Redis or Memcached, Mooncake Store is positioned as **a distributed KV cache rather than a generic caching system**. The key difference is that in the latter, the key is derived from the value through hashing, so value is immutable after inserting (although the key/value pair may be evicted).
 
-Mooncake Store provides low-level object storage and management capabilities, including configurable caching and eviction strategies that offers high memory efficiency and is specifically designed to accelerate LLM inference performance.
+Mooncake Store provides low-level object storage and management capabilities, including configurable caching and eviction strategies that offer high memory efficiency and is specifically designed to accelerate LLM inference performance.
 
 Key features of Mooncake Store include:
 - **Object-level storage operations**: Mooncake Store provides simple and easy-to-use object-level APIs, including `Put`, `Get`, and `Remove` operations.
@@ -968,7 +968,7 @@ retcode = store.setup(
 The absence of error messages indicates successful data transfer.
 
 ### Starting the Client as Standalone Process and accessing via RPC
-To start a RPC type **real** `Client` as a standalone process, you can use the following command:
+To start an RPC type **real** `Client` as a standalone process, you can use the following command:
 
 ```bash
 ./build/mooncake-store/src/mooncake_client \

--- a/docs/source/design/tent/overview.md
+++ b/docs/source/design/tent/overview.md
@@ -113,6 +113,14 @@ qos
 slice-spraying
 :::
 
+## TENT Transport Selector
+
+:::{toctree}
+:maxdepth: 1
+
+transport-selector
+:::
+
 ## TENT Failover
 
 :::{toctree}

--- a/docs/source/design/tent/overview.md
+++ b/docs/source/design/tent/overview.md
@@ -113,14 +113,6 @@ qos
 slice-spraying
 :::
 
-## TENT Transport Selector
-
-:::{toctree}
-:maxdepth: 1
-
-transport-selector
-:::
-
 ## TENT Failover
 
 :::{toctree}

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -20,7 +20,7 @@ pip install mooncake-transfer-engine-non-cuda
 > **Note**: The CUDA version includes Mooncake-EP and GPU topology detection, requiring CUDA 12.1+. The non-CUDA version is for environments without CUDA dependencies.
 > **Note**: MLU support is currently source-build only. If you need Cambricon MLU memory support, install Neuware and build with `-DUSE_MLU=ON`.
 
-## Automatic
+## Automatic Build
 
 ### Recommended Version
 - OS: Ubuntu 22.04 LTS+
@@ -45,7 +45,7 @@ pip install mooncake-transfer-engine-non-cuda
    sudo make install
    ```
 
-## Manual
+## Manual Build
 
 ### Recommended Version
 - cmake: 3.22.x
@@ -105,7 +105,10 @@ pip install mooncake-transfer-engine-non-cuda
     export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda/lib64
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64
     ```
-    > **Note:** Mooncake could use the DMA-BUF path for GPU-Direct RDMA, which does **not** require the `nvidia-peermem` kernel module. If you prefer the DMA-BUF path, please set the runtime environment variable `WITH_NVIDIA_PEERMEM=0` before starting Mooncake. If you prefer the legacy `ibv_reg_mr` path (which requires `nvidia-peermem`), set the runtime environment variable `WITH_NVIDIA_PEERMEM=1`. See Section 3.7 of https://docs.nvidia.com/cuda/gpudirect-rdma/ for instructions on installing `nvidia-peermem`.
+    ```{admonition} GPU-Direct RDMA
+    :class: note
+    Mooncake could use the DMA-BUF path for GPU-Direct RDMA, which does **not** require the `nvidia-peermem` kernel module. If you prefer the DMA-BUF path, please set the runtime environment variable `WITH_NVIDIA_PEERMEM=0` before starting Mooncake. If you prefer the legacy `ibv_reg_mr` path (which requires `nvidia-peermem`), set the runtime environment variable `WITH_NVIDIA_PEERMEM=1`. See Section 3.7 of https://docs.nvidia.com/cuda/gpudirect-rdma/ for instructions on installing `nvidia-peermem`.
+    ```
 
 3. If you want to compile the Moore Mthreads GPUDirect support module, first follow the instructions in https://docs.mthreads.com/musa-sdk/musa-sdk-doc-online/install_guide to install MUSA. After that:
     1) Install `mthreads-peermem` for enabling GPU-Direct RDMA

--- a/docs/source/getting_started/examples/vllm-integration/disagg-prefill-decode.md
+++ b/docs/source/getting_started/examples/vllm-integration/disagg-prefill-decode.md
@@ -122,7 +122,7 @@ vllm serve Qwen/Qwen2.5-7B-Instruct \
     - `kv_producer`: For prefiller instances that generate KV caches
     - `kv_consumer`: For decoder instances that consume KV caches
     - `kv_both`: Enables symmetric functionality (experimental)
-    - `num_workers`: Thread pool size in each prefiller worker to send kvcache (default 10)
+  - `num_workers`: Thread pool size in each prefiller worker to send kvcache (default 10)
 
 ### Environment Variables
 

--- a/docs/source/getting_started/examples/vllm-integration/disagg-prefill-decode.md
+++ b/docs/source/getting_started/examples/vllm-integration/disagg-prefill-decode.md
@@ -1,0 +1,337 @@
+# Disaggregated Prefill-Decode with MooncakeConnector
+
+## Overview
+
+This guide demonstrates how to use `MooncakeConnector` with vLLM for disaggregated Prefill-Decode (PD) serving. `MooncakeConnector` enables direct cross-node KV cache transfer between prefill and decode instances using RDMA technology, achieving up to **142.25 GB/s** peak bandwidth (71.1% utilization of 8x RoCE).
+
+For more details about Mooncake, please refer to [Mooncake project](https://github.com/kvcache-ai/Mooncake) and [Mooncake documents](https://kvcache-ai.github.io/Mooncake/).
+
+---
+
+## Choose Your vLLM Backend
+
+| Backend | vLLM Version | Status | Guide |
+|---------|-------------|--------|-------|
+| **vLLM V1** | Latest | Recommended | [Jump to V1 guide](#using-vllm-v1-recommended) |
+| **vLLM V0** | ≤ v0.6.4.post1 | Legacy | [Jump to V0 guide](#using-vllm-v0-legacy) |
+
+```{admonition} New Users
+:class: tip
+If you are starting a new deployment, use the **vLLM V1** backend. V0 support is maintained for existing deployments only.
+```
+
+---
+
+## Using vLLM V1 (Recommended)
+
+This section covers `MooncakeConnector` integration with vLLM V1 backend. The integration enables efficient cross-node KV cache transfer via RDMA.
+
+### Installation
+
+#### Prerequisites
+
+Install mooncake-transfer-engine through pip:
+
+```bash
+pip install mooncake-transfer-engine
+```
+
+```{note}
+If you encounter problems such as missing `lib*.so`, uninstall this package by `pip3 uninstall mooncake-transfer-engine`, and build the binaries manually according to the [instructions](../../build.md).
+```
+
+#### Install vLLM
+
+Refer to [vLLM official installation guide](https://docs.vllm.ai/en/latest/getting_started/installation.html) for the latest installation instructions.
+
+### Usage
+
+#### Basic Setup (Different Nodes)
+
+**Prefiller Node** (192.168.0.2):
+
+```bash
+vllm serve Qwen/Qwen2.5-7B-Instruct \
+  --port 8010 \
+  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer"}'
+```
+
+**Decoder Node** (192.168.0.3):
+
+```bash
+vllm serve Qwen/Qwen2.5-7B-Instruct \
+  --port 8020 \
+  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer"}'
+```
+
+**Proxy Server:**
+
+```bash
+# In vllm root directory.
+python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
+  --prefiller-host 192.168.0.2 --prefiller-port 8010 \
+  --decoder-host 192.168.0.3 --decoder-port 8020
+```
+
+> NOTE: The Mooncake Connector currently uses the proxy from nixl_integration. This will be replaced with a self-developed proxy in the future.
+
+Now you can send requests to the proxy server through port 8000.
+
+**Test:**
+
+```bash
+curl http://127.0.0.1:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-7B-Instruct",
+    "messages": [
+      {"role": "user", "content": "Tell me a long story about artificial intelligence."}
+    ]
+  }'
+```
+
+#### Advanced Configuration
+
+**With Tensor Parallelism:**
+
+Prefiller:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+vllm serve Qwen/Qwen2.5-7B-Instruct \
+  --port 8010 \
+  --tensor-parallel-size 8 \
+  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer"}'
+```
+
+Decoder:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+vllm serve Qwen/Qwen2.5-7B-Instruct \
+  --port 8020 \
+  --tensor-parallel-size 8 \
+  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer"}'
+```
+
+#### Configuration Parameters
+
+- `--kv-transfer-config`: JSON string to configure the KV transfer connector
+  - `kv_connector`: Set to `"MooncakeConnector"`
+  - `kv_role`: Role of the instance
+    - `kv_producer`: For prefiller instances that generate KV caches
+    - `kv_consumer`: For decoder instances that consume KV caches
+    - `kv_both`: Enables symmetric functionality (experimental)
+    - `num_workers`: Thread pool size in each prefiller worker to send kvcache (default 10)
+
+### Environment Variables
+
+- `VLLM_MOONCAKE_BOOTSTRAP_PORT`: Port for Mooncake bootstrap server (default: 8998)
+  - Required only for prefiller instances
+  - Each vLLM worker needs a unique port on its host
+  - For TP/DP deployments, each worker's port is computed as: `base_port + dp_rank * tp_size + tp_rank`
+- `VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT`: Timeout (in seconds) for automatically releasing KV cache (default: 480)
+  - Used when a request is aborted to prevent holding resources indefinitely
+
+### Performance
+
+For detailed performance benchmarks and results, see the [vLLM Benchmark](../../../performance/vllm-v1-support-benchmark.md) documentation.
+
+---
+
+## Using vLLM V0 (Legacy)
+
+```{admonition} Legacy Backend
+:class: warning
+This section is for vLLM V0 backend (≤ v0.6.4.post1). For new deployments, use the [V1 backend](#using-vllm-v1-recommended) above.
+```
+
+This integration is based on [PR 10502](https://github.com/vllm-project/vllm/pull/10502) and [PR 10884](https://github.com/vllm-project/vllm/pull/10884). Preview benchmark results are available at [vLLM Benchmark Results V0.2](../../../performance/vllm-benchmark-results-v0.2.md).
+
+### Installation
+
+#### Prerequisite
+
+```bash
+pip3 install mooncake-transfer-engine
+```
+
+```{note}
+- If you encounter problems such as missing `lib*.so`, uninstall this package by `pip3 uninstall mooncake-transfer-engine`, and build the binaries manually according to the [instructions](../../build.md).
+- For vLLM version ≤ v0.8.4, it requires `mooncake-transfer-engine ≤ 0.3.3.post2`. In the latest release, the interface `mooncake_vllm_adaptor` has been deprecated.
+```
+
+#### Install vLLM
+
+**1. Clone vLLM from official repo:**
+
+```bash
+git clone git@github.com:vllm-project/vllm.git
+```
+
+**2. Build from source (Include C++ and CUDA code):**
+
+```bash
+cd vllm
+pip3 uninstall vllm -y
+pip3 install -e .
+```
+
+```{tip}
+If the build fails, try upgrading cmake: `pip3 install cmake --upgrade`.
+```
+
+If you encounter any problems, refer to the [vLLM official compilation guide](https://docs.vllm.ai/en/v0.6.4.post1/getting_started/installation.html#install-the-latest-code).
+
+### Configuration
+
+#### Prepare configuration file over RDMA
+
+Create a `mooncake.json` file for both Prefill and Decode instances. Use the identical config file on both sides.
+
+```json
+{
+  "prefill_url": "192.168.0.137:13003",
+  "decode_url": "192.168.0.139:13003",
+  "metadata_server": "192.168.0.139:2379",
+  "metadata_backend": "etcd",
+  "protocol": "rdma",
+  "device_name": "erdma_0"
+}
+```
+
+- `prefill_url`: The IP address and port of the Prefill node (port is used to communicate with metadata server).
+- `decode_url`: The IP address and port of the Decode node. If running prefill and decode on the same node, set a different port (at least 50 apart from `prefill_url` port) to avoid conflicts.
+- `metadata_server`: The metadata server address. Supports `etcd`, `redis`, and `http` backends. Example: `"etcd://192.168.0.137:2379"`, `"redis://192.168.0.137:6379"`, `"http://192.168.0.137:8080/metadata"`.
+- `metadata_backend`: Currently supports `"etcd"`, `"redis"`, and `"http"`. If absent and `metadata_server` has no prefix, defaults to `"etcd"`. This parameter will be deprecated in a future version.
+- `protocol`: `"rdma"` or `"tcp"`.
+- `device_name`: Required when protocol is `"rdma"`. Multiple NICs can be separated by commas (`"erdma_0,erdma_1"`).
+
+#### Prepare configuration file over TCP
+
+```json
+{
+  "prefill_url": "192.168.0.137:13003",
+  "decode_url": "192.168.0.139:13003",
+  "metadata_server": "192.168.0.139:2379",
+  "metadata_backend": "etcd",
+  "protocol": "tcp",
+  "device_name": ""
+}
+```
+
+### Run Example
+
+Change the IP addresses and ports according to your environment.
+
+```bash
+# Begin from root of your cloned repo!
+
+# 1. Start the etcd server
+etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://localhost:2379
+
+# 2. Run on the prefilling side (producer role)
+MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_MODELSCOPE=True python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8100 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer","kv_rank":0,"kv_parallel_size":2,"kv_buffer_size":2e9}'
+
+# 3. Run on the decoding side (consumer role)
+MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_MODELSCOPE=True python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8200 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer","kv_rank":1,"kv_parallel_size":2,"kv_buffer_size":2e9}'
+```
+
+**Key parameters:**
+- `MOONCAKE_CONFIG_PATH`: Path to the mooncake.json configuration file.
+- `VLLM_USE_MODELSCOPE`: Optional. Remove if you have HuggingFace access.
+- `--kv-transfer-config`: Connector configuration
+  - `kv_connector`: `"MooncakeConnector"`
+  - `kv_role`: `"kv_producer"` or `"kv_consumer"`
+  - `kv_rank`: 0 for producer, 1 for consumer
+  - `kv_parallel_size`: Fixed to 2 currently
+  - `kv_buffer_size`: KVCache lookup buffer size; increase for longer prompts. If OOM occurs, decrease `--gpu-memory-utilization`.
+  - `kv_ip` and `kv_port`: Used to specify the IP address and port of the master node for `"PyNcclConnector"` distributed setup. Not used for `"MooncakeConnector"` currently. Instead, `"MooncakeConnector"` uses a config file to set up the distributed connection.
+- `--tensor-parallel-size` / `-tp`: Supported. If running on the same node, set different `CUDA_VISIBLE_DEVICES`.
+
+```{note}
+If running prefill and decode on the same node, set a different port for `decode_url`. To avoid port conflicts, ensure the decode port differs by at least 50 from the `prefill_url` port (e.g., `"decode_url": "192.168.0.137:13103"`). If the same URL is set for both, the port of `decode_url` will be automatically incremented by 100.
+```
+
+**Proxy Server:**
+
+```bash
+python3 proxy_server.py
+```
+
+```python
+# proxy_server.py
+import os
+import aiohttp
+from quart import Quart, make_response, request
+
+AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
+app = Quart(__name__)
+
+async def forward_request(url, data):
+    async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
+        headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
+        async with session.post(url=url, json=data, headers=headers) as response:
+            if response.status == 200:
+                async for chunk_bytes in response.content.iter_chunked(1024):
+                    yield chunk_bytes
+
+@app.route('/v1/completions', methods=['POST'])
+async def handle_request():
+    try:
+        original_request_data = await request.get_json()
+        prefill_request = original_request_data.copy()
+        prefill_request['max_tokens'] = 1  # prefill only
+        async for _ in forward_request('http://localhost:8100/v1/completions', prefill_request):
+            continue
+        generator = forward_request('http://192.168.0.139:8200/v1/completions',  # Change IP
+                                    original_request_data)
+        response = await make_response(generator)
+        response.timeout = None
+        return response
+    except Exception as e:
+        import sys, traceback
+        exc_info = sys.exc_info()
+        print("Error occurred in disagg prefill proxy server")
+        print(e)
+        print("".join(traceback.format_exception(*exc_info)))
+
+if __name__ == '__main__':
+    app.run(host="0.0.0.0", port=8000)
+```
+
+> Be sure to change the IP address in the proxy server code.
+
+### Test
+
+```bash
+curl -s http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4",
+    "prompt": "San Francisco is a",
+    "max_tokens": 1000
+  }'
+```
+
+---
+
+## Troubleshooting
+
+- If you encounter connection issues, check that:
+  - All nodes can reach each other over the network
+  - Firewall rules allow traffic on the specified ports
+  - RDMA devices are properly configured and listed in `device_name`
+- For missing library errors, rebuild `mooncake-transfer-engine` from source
+- Enable debug logging with `VLLM_LOGGING_LEVEL=DEBUG` for detailed diagnostics
+- For production deployments, consider using a more robust proxy solution

--- a/docs/source/getting_started/examples/vllm-integration/index.md
+++ b/docs/source/getting_started/examples/vllm-integration/index.md
@@ -1,13 +1,64 @@
-# vLLM Disaggregated Serving
+# Mooncake x vLLM Integration
+
+## Overview
+
+Mooncake integrates with vLLM to accelerate large language model serving through high-performance KV cache transfer and shared storage. The integration supports two primary scenarios:
+
+- **Disaggregated Prefill-Decode Serving**: Seamlessly split prefill and decode across nodes using `MooncakeConnector`, with RDMA-powered cross-node KV cache transfer achieving up to **142.25 GB/s** peak bandwidth (71.1% utilization of 8x RoCE). Transfer overhead is negligible &mdash; for 32K-token prompts (4.50 GB of KV data), transfer takes only **31.65 ms**, accounting for just **4.2%** of total TTFT.
+- **KV Cache Storage & Sharing**: Extend effective KV cache capacity via `MooncakeStore` / `MooncakeStoreConnector`, with hash-based prefix caching that enables multiple vLLM instances to share cached KV blocks. Supports CPU/Disk offloading and dynamic XpYd topologies at runtime.
+
+| Scenario | Guide | vLLM Backend |
+|----------|-------|-------------|
+| PD Disaggregation (KV transfer) | [Disaggregated Prefill-Decode](disagg-prefill-decode) | V1 ✅ / V0 ⚠️ |
+| KV Cache Storage & Sharing | [KV Cache Storage with MooncakeStore](kv-cache-storage) | V1 ✅ / V0 ⚠️ |
+
+```{admonition} New to Mooncake + vLLM?
+:class: tip
+Start with the V1 guides above. Legacy V0 documentation is available for existing deployments only.
+```
+
+---
+
+## Getting Started
+
+### Disaggregated Prefill-Decode
+
+Direct KV cache transfer between prefill and decode nodes via `MooncakeConnector` using RDMA.
 
 ::::{toctree}
 :maxdepth: 1
 
-vllm-mooncakestoreconnector
-vllmv1-lmcache-integration
-vllmv1-lmcache-mp-integration
-vllm-integration-v0.2
-vllm-integration-v0.3
-vllm-integration-v1.0
+disagg-prefill-decode
 ::::
 
+### KV Cache Storage & Sharing
+
+Distributed KV cache storage via `MooncakeStore` / `MooncakeStoreConnector` for offloading, prefix caching, and cross-instance sharing.
+
+::::{toctree}
+:maxdepth: 1
+
+kv-cache-storage
+::::
+
+### LMCache-Based Disaggregated Serving
+
+Disaggregated prefill-decode using LMCache with Mooncake Store as the remote storage backend. Supports both non-MP (`LMCacheConnectorV1`) and MP (`LMCacheMPConnector`) paths.
+
+::::{toctree}
+:maxdepth: 1
+
+vllmv1-lmcache-integration
+vllmv1-lmcache-mp-integration
+::::
+
+---
+
+## Archived Documentation
+
+The following pages are from earlier versions of the integration and are no longer maintained. All content has been consolidated into the scenario-based guides above.
+
+- [MooncakeStoreConnector (Original)](vllm-mooncakestoreconnector)
+- [vLLM V0 PD Disaggregation Demo (Original)](vllm-integration-v0.2)
+- [vLLM V0 MooncakeStore (Original)](vllm-integration-v0.3)
+- [vLLM V1 PD Disaggregation (Original)](vllm-integration-v1.0)

--- a/docs/source/getting_started/examples/vllm-integration/kv-cache-storage.md
+++ b/docs/source/getting_started/examples/vllm-integration/kv-cache-storage.md
@@ -1,0 +1,409 @@
+# KV Cache Storage & Sharing with MooncakeStore
+
+## Overview
+
+This guide demonstrates how to use `MooncakeStore` / `MooncakeStoreConnector` with vLLM to build a distributed KV cache storage pool. It enables KV cache offloading to CPU/SSD, hash-based prefix caching across multiple vLLM instances, and flexible XpYd disaggregated deployment — where you can dynamically adjust prefill and decode group sizes at runtime.
+
+Compared to Redis-based backends, MooncakeStore achieves significantly lower TTFT (e.g., **~32% improvement** in mean TTFT for 2P2D tp=2 under RDMA). See [benchmark results](../../../performance/vllm-benchmark-results-v1.md) for details.
+
+---
+
+## Choose Your vLLM Backend
+
+| Backend | Connector | vLLM Version | Status | Guide |
+|---------|-----------|-------------|--------|-------|
+| **vLLM V1** | `MooncakeStoreConnector` | Latest | Recommended | [Jump to V1 guide](#using-vllm-v1-recommended) |
+| **vLLM V0** | `MooncakeStore` | ≤ v0.6.4.post1 | Legacy | [Jump to V0 guide](#using-vllm-v0-legacy) |
+
+```{admonition} New Users
+:class: tip
+If you are starting a new deployment, use the **vLLM V1** backend with `MooncakeStoreConnector`. V0 support is maintained for existing deployments only.
+```
+
+Key differences from v0.x to v1:
+- **XpYd support and orchestration**: Dynamically change the population of prefill and decode groups
+- **More stable and fault-tolerant**: A sudden crash of a single vLLM instance is tolerable; instance-to-instance connections are removed, so each instance works as a vanilla vLLM instance capable of handling requests independently
+
+---
+
+## Using vLLM V1 (Recommended)
+
+This section covers `MooncakeStoreConnector` — the new vLLM KV connector that uses `MooncakeDistributedStore` as a shared KV cache pool. It enables:
+
+- **CPU/Disk offloading**: Extend effective KV cache capacity by offloading to CPU memory or SSD via Mooncake's transfer engine.
+- **Hash-based prefix caching across instances**: Multiple vLLM instances share cached KV blocks through the store using block-hash deduplication.
+- **Flexible deployment**: Works as a single-node KV cache extension (`kv_both`), or in disaggregated prefill-decode setups (`kv_producer` / `kv_consumer`).
+
+### Deployment
+
+#### 1. Prerequisites
+
+- [vLLM](https://github.com/vllm-project/vllm) is installed
+- [Mooncake](https://github.com/kvcache-ai/Mooncake) is installed
+
+Refer to the [vLLM official repository](https://github.com/vllm-project/vllm) and [Mooncake official repository](https://github.com/kvcache-ai/Mooncake) for installation instructions and building from source.
+
+#### 2. Mooncake Master Server
+
+**Start:**
+
+```shell
+mooncake_master --port 50063
+```
+
+**Configure Mooncake**: Create a JSON configuration file (e.g., `mooncake_config.json`):
+
+```json
+{
+  "metadata_server": "http://127.0.0.1:8092/metadata",
+  "master_server_address": "127.0.0.1:50063",
+  "global_segment_size": "0",
+  "local_buffer_size": "2147483648",
+  "protocol": "rdma",
+  "device_name": ""
+}
+```
+
+**Set environment variable:**
+
+```shell
+export MOONCAKE_CONFIG_PATH=/path/to/mooncake_config.json
+```
+
+#### 3. Usage
+
+**3.1 Single-Node KV Cache Offloading** (`kv_both`):
+
+```shell
+MOONCAKE_CONFIG_PATH=mooncake_config.json \
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both"}'
+```
+
+**3.2 XpYd Disaggregated Prefill-Decode** (`kv_producer/kv_consumer`):
+
+Prefill Node:
+
+```shell
+MOONCAKE_CONFIG_PATH=mooncake_config.json \
+VLLM_MOONCAKE_BOOTSTRAP_PORT=50052 \
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
+    --port 8100 \
+    --kv-transfer-config '{
+        "kv_connector": "MultiConnector",
+        "kv_role": "kv_producer",
+        "kv_connector_extra_config": {
+            "connectors": [
+                {
+                    "kv_connector": "MooncakeConnector",
+                    "kv_role": "kv_producer"
+                },
+                {
+                    "kv_connector": "MooncakeStoreConnector",
+                    "kv_role": "kv_producer"
+                }
+            ]
+        }
+    }'
+```
+
+Decode Node:
+
+```shell
+MOONCAKE_CONFIG_PATH=mooncake_config.json \
+VLLM_MOONCAKE_BOOTSTRAP_PORT=50053 \
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
+    --port 8200 \
+    --kv-transfer-config '{
+        "kv_connector": "MultiConnector",
+        "kv_role": "kv_consumer",
+        "kv_connector_extra_config": {
+            "connectors": [
+                {
+                    "kv_connector": "MooncakeConnector",
+                    "kv_role": "kv_consumer"
+                },
+                {
+                    "kv_connector": "MooncakeStoreConnector",
+                    "kv_role": "kv_consumer"
+                }
+            ]
+        }
+    }'
+```
+
+Proxy:
+
+```shell
+python examples/disaggregated/disaggregated_serving/mooncake_connector/mooncake_connector_proxy.py \
+    --prefill http://192.168.0.2:8100 \
+    --decode http://192.168.0.3:8200
+```
+
+> When running with data parallelism, set a fixed `PYTHONHASHSEED` so that block hashes are consistent across DP ranks:
+>
+> ```shell
+> PYTHONHASHSEED=0 vllm serve ...
+> ```
+>
+> Without this, identical prompts may produce different block hashes on different DP ranks, preventing cross-instance prefix cache hits.
+
+---
+
+## Using vLLM V0 (Legacy)
+
+```{admonition} Legacy Backend
+:class: warning
+This section is for vLLM V0 backend with `MooncakeStore`. For new deployments, use the [V1 backend with `MooncakeStoreConnector`](#using-vllm-v1-recommended) above.
+```
+
+This integration is based on [PR 10502](https://github.com/vllm-project/vllm/pull/10502) and [PR 12957](https://github.com/vllm-project/vllm/pull/12957) to support KVCache transfer for intra-node and inter-node disaggregated serving.
+
+### Installation
+
+#### Prerequisite
+
+```bash
+pip3 install mooncake-transfer-engine
+```
+
+```{note}
+- If you encounter problems such as missing `lib*.so`, uninstall by `pip3 uninstall mooncake-transfer-engine`, and build manually according to the [instructions](../../build.md).
+- For vLLM version ≤ v0.8.4, it requires `mooncake-transfer-engine ≤ 0.3.3.post2`. The interface `mooncake_vllm_adaptor` has been deprecated in the latest release.
+```
+
+#### Install vLLM
+
+**1. Clone vLLM:**
+
+```bash
+git clone git@github.com:vllm-project/vllm.git
+```
+
+**2. Build from source:**
+
+```bash
+cd vllm
+pip3 install -e .
+```
+
+If you encounter problems, refer to the [vLLM official compilation guide](https://docs.vllm.ai/en/latest/getting_started/installation/index.html).
+
+### Configuration
+
+#### Prepare configuration for RDMA
+
+Create a `mooncake.json` file:
+
+```json
+{
+    "local_hostname": "192.168.0.137",
+    "metadata_server": "etcd://192.168.0.137:2379",
+    "protocol": "rdma",
+    "device_name": "erdma_0",
+    "master_server_address": "192.168.0.137:50001"
+}
+```
+
+- `local_hostname`: The IP address of the current node. All prefill and decode instances on the same node can share this config.
+- `metadata_server`: The metadata server. Supports `etcd`, `redis`, and `http` backends.
+- `protocol`: `"rdma"` or `"tcp"`.
+- `device_name`: Required for RDMA. Multiple NICs separated by commas (`"erdma_0,erdma_1"`).
+- `master_server_address`: The IP address and port of the MooncakeStore master daemon.
+
+#### Prepare configuration for TCP
+
+```json
+{
+    "local_hostname": "192.168.0.137",
+    "metadata_server": "etcd://192.168.0.137:2379",
+    "protocol": "tcp",
+    "device_name": "",
+    "master_server_address": "192.168.0.137:50001"
+}
+```
+
+### Run Example
+
+Change the IP addresses and ports according to your environment. `VLLM_USE_V1=0` is required for vLLM V0 backend.
+
+```bash
+# Begin from root of your cloned repo!
+
+# 1. Start the etcd server
+etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://localhost:2379
+# You may need to terminate other etcd processes before running the above command
+
+# 2. Start the mooncake_master server
+mooncake_master --port 50001
+# If some vllm instances exit unexpectedly, some connection metadata will be
+# corrupted since they are not properly cleaned. In that case, we recommend
+# you restart the mooncake_master before running another test.
+
+# 3. Run multiple vllm instances
+# kv_producer role
+MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8100 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
+
+CUDA_VISIBLE_DEVICES=1 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8101 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
+
+CUDA_VISIBLE_DEVICES=2 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8102 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
+
+CUDA_VISIBLE_DEVICES=3 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8103 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
+
+# kv_consumer role
+CUDA_VISIBLE_DEVICES=4 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8200 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
+
+CUDA_VISIBLE_DEVICES=5 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8201 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
+
+CUDA_VISIBLE_DEVICES=6 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8202 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
+
+CUDA_VISIBLE_DEVICES=7 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8203 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
+```
+
+**Key parameters:**
+- `MOONCAKE_CONFIG_PATH`: Path to the mooncake.json configuration file.
+- `VLLM_USE_MODELSCOPE`: Optional. Remove if you have HuggingFace access.
+- `VLLM_USE_V1=0`: Required since the disaggregated feature is currently only supported on V0 vLLM. You can also `export` this configuration to the env instead of putting it in front of every command.
+- `--model`: The model to use.
+- `--port`: The vllm service port on which to listen.
+- `--max-model-len`: The maximum length of the model.
+- `--tensor-parallel-size` / `-tp`: Supported. All instances should have the same tensor_parallel_size. If running prefill and decode on the same node, set different `CUDA_VISIBLE_DEVICES` (e.g., `CUDA_VISIBLE_DEVICES=0,1` for prefill and `CUDA_VISIBLE_DEVICES=2,3` for decode).
+- `--kv-transfer-config`: Set `kv_connector` to `"MooncakeStoreConnector"`, `kv_role` to `"kv_producer"`, `"kv_consumer"`, or `"kv_both"`.
+- If some vLLM instances exit unexpectedly, connection metadata may be corrupted. Restart `mooncake_master` before another test.
+
+```bash
+# 5. Start the proxy server
+cd vllm
+python3 examples/online_serving/disagg_examples/disagg_proxy_demo.py \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --prefill localhost:8100 localhost:8101 \
+    --decode localhost:8200 localhost:8201 \
+    --port 8000
+```
+
+- `--model`: The model and tokenizer used by the proxy server.
+- `--port`: The proxy server port on which to listen.
+- `--prefill` / `-p`: IP and port of the vllm prefill instances.
+- `--decode` / `-d`: IP and port of the vllm decode instances.
+
+#### Dynamic XpYd Adjustment
+
+To dynamically adjust prefill and decode instances at runtime:
+
+```bash
+export ADMIN_API_KEY="xxxxxxxx"
+
+# or add it before the command:
+ADMIN_API_KEY="xxxxxxxx" python3 vllm/examples/online_serving/disagg_examples/disagg_demo.py \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --prefill localhost:8100 localhost:8101 \
+    --decode localhost:8200 localhost:8201 \
+    --port 8000 \
+    --scheduling round_robin
+
+# Add instances to groups dynamically
+curl -X POST "http://localhost:8000/instances/add" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $ADMIN_API_KEY" \
+  -d '{"type": "prefill", "instance": "localhost:8102"}'
+
+curl -X POST "http://localhost:8000/instances/add" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $ADMIN_API_KEY" \
+  -d '{"type": "prefill", "instance": "localhost:8103"}'
+
+curl -X POST "http://localhost:8000/instances/add" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $ADMIN_API_KEY" \
+  -d '{"type": "decode", "instance": "localhost:8202"}'
+
+curl -X POST "http://localhost:8000/instances/add" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $ADMIN_API_KEY" \
+  -d '{"type": "decode", "instance": "localhost:8203"}'
+
+# Get proxy status
+curl localhost:8000/status | jq
+```
+
+```{note}
+Mooncake team provides this simple round-robin proxy as a demo. In production, you can implement custom global proxy strategies.
+```
+
+**Be sure to change the IP address in the commands.**
+
+### Test
+
+```bash
+curl -s http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4",
+    "prompt": "San Francisco is a",
+    "max_tokens": 1000
+  }'
+```
+
+- If you are not testing on the proxy server, change `localhost` to the IP address of the proxy server.
+
+---
+
+## Performance
+
+| Scenario | Document |
+|----------|----------|
+| V1 MooncakeStoreConnector vs Redis | [Benchmark V1](../../../performance/vllm-benchmark-results-v1.md) |
+| V0 MooncakeStore vs Redis | [Benchmark V0](../../../performance/vllm-benchmark-results-v0.2.md) |
+
+---
+
+## Troubleshooting
+
+- If you encounter connection issues, check that:
+  - All nodes can reach each other over the network
+  - Firewall rules allow traffic on the specified ports
+  - RDMA devices are properly configured
+  - `mooncake_master` is running and reachable
+- For missing library errors, rebuild `mooncake-transfer-engine` from source
+- If vLLM instances exit unexpectedly, restart `mooncake_master` to clean up corrupted metadata
+- Enable debug logging with `VLLM_LOGGING_LEVEL=DEBUG` for detailed diagnostics

--- a/docs/source/getting_started/examples/vllm-integration/vllm-integration-v0.2.md
+++ b/docs/source/getting_started/examples/vllm-integration/vllm-integration-v0.2.md
@@ -1,5 +1,10 @@
 # vLLM V0 Disaggregated Serving Demo
 
+```{admonition} Archived
+:class: warning
+This page has been **consolidated** into the unified [Disaggregated Prefill-Decode](disagg-prefill-decode) guide (see the V0 Legacy section). Please use that guide for up-to-date information.
+```
+
 ## Overview
 This is the latest version of mooncake-transfer-engine integration doc with the vLLM project based on [PR 10502](https://github.com/vllm-project/vllm/pull/10502) and [PR 10884](https://github.com/vllm-project/vllm/pull/10884) (vllm version: v0.6.4.post1/main) to accelerate KVCache transfer for inter-node disaggregated serving scenario. We have run some experiments to obtain some [preview benchmark results](../../../performance/vllm-benchmark-results-v0.2.md). More benchmark results will be released in due time.
 
@@ -89,10 +94,20 @@ etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://loc
 # You may need to terminate other etcd processes before running the above command
 
 # 2. Run on the prefilling side (producer role)
-MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_MODELSCOPE=True python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --port 8100 --max-model-len 10000 --gpu-memory-utilization 0.8 --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer","kv_rank":0,"kv_parallel_size":2,"kv_buffer_size":2e9}'
+MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_MODELSCOPE=True python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8100 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer","kv_rank":0,"kv_parallel_size":2,"kv_buffer_size":2e9}'
 
 # 3. Run on the decoding side (consumer role)
-MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_MODELSCOPE=True python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --port 8200 --max-model-len 10000 --gpu-memory-utilization 0.8 --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer","kv_rank":1,"kv_parallel_size":2,"kv_buffer_size":2e9}'
+MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_MODELSCOPE=True python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8200 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer","kv_rank":1,"kv_parallel_size":2,"kv_buffer_size":2e9}'
 ```
 
 - `MOONCAKE_CONFIG_PATH` is the path to the mooncake.json configuration file.

--- a/docs/source/getting_started/examples/vllm-integration/vllm-integration-v0.3.md
+++ b/docs/source/getting_started/examples/vllm-integration/vllm-integration-v0.3.md
@@ -1,5 +1,10 @@
 # vLLM V0 Disaggregated Serving with MooncakeStore
 
+```{admonition} Archived
+:class: warning
+This page has been **consolidated** into the unified [KV Cache Storage & Sharing](kv-cache-storage) guide (see the V0 Legacy section). Please use that guide for up-to-date information.
+```
+
 ## Overview
 This is the latest version of the MooncakeStore integration doc with the vLLM project based on [PR 10502](https://github.com/vllm-project/vllm/pull/10502) and [PR 12957](https://github.com/vllm-project/vllm/pull/12957) to support KVCache transfer for intra-node and inter-node disaggregated serving scenario. Benchmark results will be released soon.
 
@@ -91,22 +96,62 @@ mooncake_master --port 50001
 
 # 3. Run multiple vllm instances
 # kv_producer role
-MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --port 8100 --max-model-len 10000 --gpu-memory-utilization 0.8 --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
+MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8100 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
 
-CUDA_VISIBLE_DEVICES=1 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --port 8101 --max-model-len 10000 --gpu-memory-utilization 0.8 --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
+CUDA_VISIBLE_DEVICES=1 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8101 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
 
-CUDA_VISIBLE_DEVICES=2 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --port 8102 --max-model-len 10000 --gpu-memory-utilization 0.8 --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
+CUDA_VISIBLE_DEVICES=2 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8102 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
 
-CUDA_VISIBLE_DEVICES=3 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --port 8103 --max-model-len 10000 --gpu-memory-utilization 0.8 --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
+CUDA_VISIBLE_DEVICES=3 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8103 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}'
 
 # kv_consumer role
-CUDA_VISIBLE_DEVICES=4 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --port 8200 --max-model-len 10000 --gpu-memory-utilization 0.8 --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
+CUDA_VISIBLE_DEVICES=4 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8200 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
 
-CUDA_VISIBLE_DEVICES=5 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --port 8201 --max-model-len 10000 --gpu-memory-utilization 0.8 --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
+CUDA_VISIBLE_DEVICES=5 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8201 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
 
-CUDA_VISIBLE_DEVICES=6 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --port 8202 --max-model-len 10000 --gpu-memory-utilization 0.8 --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
+CUDA_VISIBLE_DEVICES=6 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8202 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
 
-CUDA_VISIBLE_DEVICES=7 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --port 8203 --max-model-len 10000 --gpu-memory-utilization 0.8 --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
+CUDA_VISIBLE_DEVICES=7 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python3 -m vllm.entrypoints.openai.api_server \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --port 8203 \
+    --max-model-len 10000 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}'
 ```
 
 - `MOONCAKE_CONFIG_PATH` is the path to the mooncake.json configuration file.
@@ -127,7 +172,11 @@ CUDA_VISIBLE_DEVICES=7 MOONCAKE_CONFIG_PATH=./mooncake.json VLLM_USE_V1=0 python
 ```bash
 # 4. Start the proxy server
 cd vllm
-python3 examples/online_serving/disagg_examples/disagg_proxy_demo.py --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --prefill localhost:8100 localhost:8101  --decode localhost:8200 localhost:8201  --port 8000
+python3 examples/online_serving/disagg_examples/disagg_proxy_demo.py \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --prefill localhost:8100 localhost:8101 \
+    --decode localhost:8200 localhost:8201 \
+    --port 8000
 ```
 
 - The `--model` parameter specifies the model to use, also specifies the tokenizer used by the proxy server.
@@ -139,7 +188,12 @@ python3 examples/online_serving/disagg_examples/disagg_proxy_demo.py --model Qwe
 # If you want to dynamically adjust the instances of p-nodes and d-nodes during runtime, you need to configure this environment variables.
 export ADMIN_API_KEY="xxxxxxxx"
 # or add it before the command:
-ADMIN_API_KEY="xxxxxxxx" python3 vllm/examples/online_serving/disagg_examples/disagg_demo.py --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --prefill localhost:8100 localhost:8101  --decode localhost:8200 localhost:8201  --port 8000 --scheduling round_robin
+ADMIN_API_KEY="xxxxxxxx" python3 vllm/examples/online_serving/disagg_examples/disagg_demo.py \
+    --model Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+    --prefill localhost:8100 localhost:8101 \
+    --decode localhost:8200 localhost:8201 \
+    --port 8000 \
+    --scheduling round_robin
 
 # Then use this command to add instances into prefill group or decode group
 curl -X POST "http://localhost:8000/instances/add" -H "Content-Type: application/json" -H "X-API-Key: $ADMIN_API_KEY" -d '{"type": "prefill", "instance": "localhost:8102"}'

--- a/docs/source/getting_started/examples/vllm-integration/vllm-integration-v1.0.md
+++ b/docs/source/getting_started/examples/vllm-integration/vllm-integration-v1.0.md
@@ -1,5 +1,10 @@
 # vLLM v1 backend Disaggregated Serving with MooncakeConnector
 
+```{admonition} Archived
+:class: warning
+This page has been **consolidated** into the unified [Disaggregated Prefill-Decode](disagg-prefill-decode) guide. Please use that guide for up-to-date information.
+```
+
 ## Overview
 
 This guide demonstrates how to use the MooncakeConnector with vLLM v1 backend for disaggregated serving in Prefill-Decode separation architecture. The integration enables efficient cross-node KV cache transfer using RDMA technology.

--- a/docs/source/getting_started/examples/vllm-integration/vllm-integration-v1.0.md
+++ b/docs/source/getting_started/examples/vllm-integration/vllm-integration-v1.0.md
@@ -105,7 +105,7 @@ vllm serve Qwen/Qwen2.5-7B-Instruct \
     - `kv_producer`: For prefiller instances that generate KV caches
     - `kv_consumer`: For decoder instances that consume KV caches
     - `kv_both`: Enables symmetric functionality (experimental)
-    - `num_workers`: Thread pool size in each prefiller worker to send kvcache (default 10)
+  - `num_workers`: Thread pool size in each prefiller worker to send kvcache (default 10)
 
 ## Environment Variables
 

--- a/docs/source/getting_started/examples/vllm-integration/vllm-mooncakestoreconnector.md
+++ b/docs/source/getting_started/examples/vllm-integration/vllm-mooncakestoreconnector.md
@@ -1,5 +1,10 @@
 # Guide: vLLM MooncakeStoreConnector
 
+```{admonition} Archived
+:class: warning
+This page has been **consolidated** into the unified [KV Cache Storage & Sharing](kv-cache-storage) guide (see the V1 Recommended section). Please use that guide for up-to-date information.
+```
+
 ## Overview
 
 This document describes how to deploy vLLM's `MooncakeStoreConnector`. `MooncakeStoreConnector`  is a new vLLM's KV connector that uses `MooncakeDistributedStore` as a shared KV cache pool. It enables:
@@ -114,7 +119,9 @@ vllm serve meta-llama/Llama-3.1-8B-Instruct \
 Proxy：
 
 ```shell
-python examples/disaggregated/disaggregated_serving/mooncake_connector/mooncake_connector_proxy.py --prefill http://192.168.0.2:8100 --decode http://192.168.0.3:8200
+python examples/disaggregated/disaggregated_serving/mooncake_connector/mooncake_connector_proxy.py \
+    --prefill http://192.168.0.2:8100 \
+    --decode http://192.168.0.3:8200
 ```
 
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -83,6 +83,7 @@ getting_started/examples/vllm-integration/index
 :caption: Performance
 :maxdepth: 1
 
+performance/vllm/index
 performance/sglang-benchmark-results-v1
 performance/vllm-benchmark-results-v0.2
 performance/vllm-benchmark-results-v1
@@ -151,4 +152,17 @@ deployment/mooncake-store-deployment-guide
 :maxdepth: 1
 
 community/governance
+:::
+
+% Archived content
+
+:::{toctree}
+:caption: Archived
+:maxdepth: 1
+
+getting_started/examples/vllm-integration/vllm-mooncakestoreconnector
+getting_started/examples/vllm-integration/vllm-integration-v0.2
+getting_started/examples/vllm-integration/vllm-integration-v0.3
+getting_started/examples/vllm-integration/vllm-integration-v1.0
+getting_started/examples/vllm-integration/vllmv1-lmcache-integration
 :::

--- a/docs/source/performance/vllm/index.md
+++ b/docs/source/performance/vllm/index.md
@@ -5,7 +5,7 @@ Benchmarks evaluating Mooncake's integration with vLLM across different backends
 | Document | Backend | Key Findings |
 |----------|---------|---------------|
 | [vLLM V1 + MooncakeConnector](../vllm-v1-support-benchmark) | vLLM V1 | 1P1D PD disaggregation on H800 with 8x RoCE: **142.25 GB/s** peak transfer bandwidth (71.1% of theoretical), KV transfer overhead just **4.2%** of total TTFT at 32K tokens |
-| [vLLM V0 + MooncakeStore vs Redis](../vllm-benchmark-results-v1) | vLLM V0 | MooncakeStore RDMA consistently outperforms Redis across all XpYd topologies — e.g., **~32% lower** mean TTFT in 2P2D tp=2 |
+| [vLLM V1 + MooncakeStore vs Redis](../vllm-benchmark-results-v1) | vLLM V1 | MooncakeStore RDMA consistently outperforms Redis across all XpYd topologies — e.g., **~32% lower** mean TTFT in 2P2D tp=2 |
 | [vLLM V0 + MooncakeConnector (Legacy)](../vllm-benchmark-results-v0.2) | vLLM V0 | TP=4 reduces TTFT by ~80% vs TP=1; RDMA provides significant latency advantage over TCP across varying QPS and input lengths |
 
 :::{toctree}

--- a/docs/source/performance/vllm/index.md
+++ b/docs/source/performance/vllm/index.md
@@ -1,0 +1,18 @@
+# vLLM Performance Benchmarks
+
+Benchmarks evaluating Mooncake's integration with vLLM across different backends and scenarios.
+
+| Document | Backend | Key Findings |
+|----------|---------|---------------|
+| [vLLM V1 + MooncakeConnector](../vllm-v1-support-benchmark) | vLLM V1 | 1P1D PD disaggregation on H800 with 8x RoCE: **142.25 GB/s** peak transfer bandwidth (71.1% of theoretical), KV transfer overhead just **4.2%** of total TTFT at 32K tokens |
+| [vLLM V0 + MooncakeStore vs Redis](../vllm-benchmark-results-v1) | vLLM V0 | MooncakeStore RDMA consistently outperforms Redis across all XpYd topologies — e.g., **~32% lower** mean TTFT in 2P2D tp=2 |
+| [vLLM V0 + MooncakeConnector (Legacy)](../vllm-benchmark-results-v0.2) | vLLM V0 | TP=4 reduces TTFT by ~80% vs TP=1; RDMA provides significant latency advantage over TCP across varying QPS and input lengths |
+
+:::{toctree}
+:maxdepth: 1
+:hidden:
+
+../vllm-v1-support-benchmark
+../vllm-benchmark-results-v1
+../vllm-benchmark-results-v0.2
+:::


### PR DESCRIPTION
## Description
As described in https://github.com/kvcache-ai/Mooncake/issues/2258. This is the first PR mainly focus on vLLM related documentations.

This PR restructures the vLLM integration documentation from version-fragmented pages into task-oriented scenario guides, and adds a vLLM performance benchmark overview page.

Two new scenario-based guides are introduced:

- **`disagg-prefill-decode.md`** — Unified PD disaggregation guide covering V1 (recommended) and V0 (legacy) backends, with installation, configuration, run examples, and proxy server implementation.
- **`kv-cache-storage.md`** — Unified KV cache storage guide covering MooncakeStore / MooncakeStoreConnector, including single-node offloading, XpYd disaggregated deployment with MultiConnector, and dynamic instance adjustment.

The `vllm-integration/index.md` landing page is rewritten so users choose a scenario first, then a backend. Legacy V0/V1 pages are preserved with Archived banners and moved to a dedicated Archived toctree section. A new `performance/vllm/index.md` provides a benchmark overview table with key findings per scenario.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

- Built locally with `make clean && make html -W` — zero warnings.
- Verified all new pages are registered in toctrees and render correctly.
- Preview deployed at https://aionw.github.io/

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.