### PR TITLE
[Doc] restructure SGLang integration docs and add performance index

### DIFF
--- a/docs/source/design/tent/overview.md
+++ b/docs/source/design/tent/overview.md
@@ -109,14 +109,6 @@ qos
 slice-spraying
 :::
 
-## TENT Transport Selector
-
-:::{toctree}
-:maxdepth: 1
-
-transport-selector
-:::
-
 ## TENT Failover
 
 :::{toctree}

--- a/docs/source/design/tent/overview.md
+++ b/docs/source/design/tent/overview.md
@@ -109,6 +109,14 @@ qos
 slice-spraying
 :::
 
+## TENT Transport Selector
+
+:::{toctree}
+:maxdepth: 1
+
+transport-selector
+:::
+
 ## TENT Failover
 
 :::{toctree}

--- a/docs/source/getting_started/examples/lmcache-integration.md
+++ b/docs/source/getting_started/examples/lmcache-integration.md
@@ -1,4 +1,5 @@
-# Mooncake x LMCache: Unite to Pioneer KVCache-Centric LLM Serving System
+# Mooncake x LMCache Integration
+# Unite to Pioneer KVCache-Centric LLM Serving System
 
 Mooncake and LMCache have announced a strategic collaboration aimed at pioneering a KVCache-centric Large Language Model (LLM) serving system. This partnership seeks to significantly enhance the efficiency, scalability, and responsiveness of LLM applications.
 
@@ -68,3 +69,10 @@ Moving forward, LMCache and Mooncake plan to collaborate closely on several key 
 *   **Expanding caching strategies beyond simple prefix matching**, enhancing KVCache reusability by supporting more flexible matching patterns.
 
 This strategic partnership represents a significant advancement toward fully realizing the potential of next-generation LLM serving architectures.
+
+::: {toctree}
+:maxdepth: 1
+:hidden:
+
+vllm-integration/vllmv1-lmcache-integration
+:::

--- a/docs/source/getting_started/examples/sglang-integration-v1.md
+++ b/docs/source/getting_started/examples/sglang-integration-v1.md
@@ -1,43 +1,43 @@
 # SGLang Disaggregated Serving with MooncakeTransferEngine
 
 ## Overview
-This is the latest version of the MooncakeTransferEngine integration doc with the SGLang project based on [PR 4654](https://github.com/sgl-project/sglang/pull/4654) and [PR 4880](https://github.com/sgl-project/sglang/pull/4880) to support KVCache transfer for intra-node and inter-node disaggregated serving scenarios.
 
+SGLang uses Mooncake's Transfer Engine to enable disaggregated prefill-decode (PD) serving across nodes via RDMA, with support for EP and EPD backends. This integration is based on [PR 4654](https://github.com/sgl-project/sglang/pull/4654) and [PR 4880](https://github.com/sgl-project/sglang/pull/4880).
 
-**_Please note that this is still an experimental version and will be modified anytime based on feedback from the SGLang community._**
+In benchmarks, PD disaggregation with Mooncake achieves **~30% lower ITL** while maintaining comparable throughput ([details](../../performance/sglang-benchmark-results-v1)).
 
-## Installation
-### Prerequisite
+```
+  +-----------+   Transfer Engine (RDMA)    +-----------+
+  | SGLang    | ◄━━━━━━━━━━━━━━━━━━━━━━► | SGLang     |
+  | Prefill   |     KV cache blocks        | Decode     |
+  +-----------+                            +-----------+
+```
+
+## Prerequisites
+
 ```bash
 pip3 install mooncake-transfer-engine
 ```
 
-Note: If you encounter problems such as missing `lib*.so`, you should uninstall this package by `pip3 uninstall mooncake-transfer-engine`, and build the binaries manually according to the [instructions](../build.md).
+If you encounter missing `lib*.so` errors, uninstall and build from source instead:
 
-### Install the latest version of SGLang
-#### 1. Clone SGLang from official repo
+```bash
+pip3 uninstall mooncake-transfer-engine
+# Build from source — see build instructions
+```
+
+### Install SGLang
+
 ```bash
 git clone git@github.com:sgl-project/sglang.git
-```
-#### 2. Build
-##### 2.1 Build from source
-```bash
 cd sglang
 pip install --upgrade pip
 pip install -e "python[all]" --find-links https://flashinfer.ai/whl/cu124/torch2.5/flashinfer-python
 ```
 
-#####  If running on AMD GPU, tried below steps to install sglang for rocm or just run in rocm docker from https://hub.docker.com/r/rocm/sgl-dev directly
+For AMD GPUs, use the ROCm docker image:
+
 ```bash
-
-pip install --upgrade pip
-cd sgl-kernel
-python setup_rocm.py install
-cd ..
-pip install -e "python[all_hip]"
-
-or
-
 docker run -it --rm --network=host \
     --device=/dev/kfd --device=/dev/dri \
     --ipc=host --shm-size 16G \
@@ -48,128 +48,168 @@ docker run -it --rm --network=host \
    rocm/sgl-dev:20250707
 
 pip3 install mooncake-transfer-engine
-sudo apt update
-sudo apt install libibverbs1 libibverbs-dev -y
+sudo apt update && sudo apt install libibverbs1 libibverbs-dev -y
 sudo apt-get install lsof net-tools iputils-ping -y
-
 ```
 
- - If you encounter any problems that you cannot solve, please refer to the [SGLang official compilation guide](https://docs.sglang.ai/start/install.html).
+See the [SGLang official compilation guide](https://docs.sglang.ai/start/install.html) if you encounter issues.
 
 ## Configuration
 
- - **Update(Apr 10, 2025)** Good news: The configuration file requirement has been removed since [PR 5460](https://github.com/sgl-project/sglang/pull/5460). There is no need to prepare the _mooncake.json_ file anymore.
+Since [PR 5460](https://github.com/sgl-project/sglang/pull/5460), no `mooncake.json` configuration file is needed — Mooncake auto-detects RDMA devices.
 
+Key arguments:
 
+| Argument | Description |
+|----------|-------------|
+| `--disaggregation-mode` | `prefill` or `decode` — node role |
+| `--disaggregation-ib-device` | RDMA device(s). Auto-detected, comma-separated for multi-NIC |
+| `--tp-size` | Tensor parallelism size (optional) |
+| `--base-gpu-id` | Starting GPU index for same-node deployments |
+| `--host` / `--port` | SGLang service address |
 
-### To run prefill instance and decode instance on different node
+## Run PD Disaggregation
 
-Prefill: 
+### Cross-Node
+
 ```bash
-python -m sglang.launch_server --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --disaggregation-mode prefill --port 30000 --host 192.168.0.137 --tp-size 2
-```
- - The `--model-path` parameter specifies the model to use.
- - The `--host` parameter specifies the SGLang service host.
- - The `--port` parameter specifies the SGLang service port on which to listen.
- - The `--disaggregation-mode` is the node's role, either 'prefill' or 'decode'.
- - The `--disaggregation-ib-device` is the device to be used for data transmission, it is optional since we will detect this config automatically. Or you can still explicitly specify devices if needed. If multiple NIC devices are used, they can be separated by commas, such as "erdma_0,erdma_1". Please note that there are no spaces between them.
- - Option `--tp-size` is supported. Example: append `--tp-size 2` to the run command to run SGLang with multiple GPUs.
+# Prefill node (192.168.0.137)
+python -m sglang.launch_server \
+  --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+  --disaggregation-mode prefill \
+  --port 30000 --host 192.168.0.137 --tp-size 2
 
-Decode:
-```bash
-python -m sglang.launch_server --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --disaggregation-mode decode --port 30001 --host 192.168.0.140 --tp-size 2
-```
+# Decode node (192.168.0.140)
+python -m sglang.launch_server \
+  --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+  --disaggregation-mode decode \
+  --port 30001 --host 192.168.0.140 --tp-size 2
 
-Proxy:
-```bash
-python3 -m sglang.srt.disaggregation.mini_lb --prefill http://192.168.0.137:30000 --decode http://192.168.0.140:30001 --host 0.0.0.0 --port 8000
+# Router
+python3 -m sglang_router.launch_router \
+  --pd-disaggregation \
+  --prefill "http://192.168.0.137:30000" 8998 \
+  --decode  "http://192.168.0.140:30001" \
+  --policy round_robin \
+  --host 0.0.0.0 --port 8000
 ```
 
 Test:
+
 ```bash
-curl -X POST http://127.0.0.1:8000/generate -H "Content-Type: application/json" -d '{
-  "text": "Let me tell you a long story ",
-  "sampling_params": {
-    "temperature": 0
-  }
-}'
+curl -X POST http://127.0.0.1:8000/generate \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Tell me a long story", "sampling_params": {"temperature": 0}}'
 ```
 
-### To run prefill instance and decode instance on the same node
+### Same-Node
 
-Prefill: 
 ```bash
-python -m sglang.launch_server --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --disaggregation-mode prefill --port 30000 --host 192.168.0.137 --tp-size 2
-```
-
-Decode:
-```bash
-python -m sglang.launch_server --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 --disaggregation-mode decode --port 30001 --base-gpu-id 2 --host 192.168.0.137 --tp-size 2
-```
- - The function of `--base-gpu-id` is similar to env var`CUDA_VISIBLE_DEVICES`, which is used to avoid reusing the 0th GPU card. The difference is that it is used to specify the starting number of the GPU. If it is set to 2, the first and second cards will be skipped, and the third card will be used directly.
-
-Proxy:
-```bash
-python3 -m sglang.srt.disaggregation.mini_lb --prefill http://192.168.0.137:30000 --decode http://192.168.0.137:30001 --host 0.0.0.0 --port 8000
-```
-
-Test:
-```bash
-curl -X POST http://127.0.0.1:8000/generate -H "Content-Type: application/json" -d '{
-  "text": "Let me tell you a long story ",
-  "sampling_params": {
-    "temperature": 0
-  }
-}'
-```
-
-Note:
- - TP is supported but not required, you can remove `--tp-size 2` if you want.
- - The `--disaggregation-ib-device` is the device to be used for data transmission, it is optional since we will detect this config automatically. Or you can still explicitly specify devices if needed. If multiple NIC devices are used, they can be separated by commas, such as "erdma_0,erdma_1". Please note that there are no spaces between them.
- - XpYd is supported. It is ok to run one prefill and multiple decode instances on the same node, however, multiple prefill instances on the same node are not supported due to the port conflict of bootstrap server.
-   - e.g., `python3 -m sglang.srt.disaggregation.mini_lb --prefill http://192.168.0.137:30000,http://192.168.0.140:30000 --decode http://192.168.0.137:30001,http://192.168.0.140:30001 --host 0.0.0.0 --port 8000`
- - HuggingFace timeout can be addressed by `export SGLANG_USE_MODELSCOPE=true`
-
-### To enable Mooncake EP Backend
-
-
-Prefill:
-```bash
-python -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3-0324 --disaggregation-mode prefill --port 30000 --host 192.168.0.137 --tp-size 8 --dp-size 8 --elastic-ep-backend mooncake --mooncake-ib-device <mooncake-ib-device> --moe-a2a-backend mooncake
-```
-
-Decode:
-```bash
-python -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3-0324 --disaggregation-mode decode --port 30001 --host 192.168.0.140 --tp-size 8 --dp-size 8 --elastic-ep-backend mooncake --mooncake-ib-device <mooncake-ib-device> --moe-a2a-backend mooncake
-```
-- Set `--elastic-ep-backend` and `--moe-a2a-backend` to "mooncake" to enable Mooncake EP Backend.
-- The value of `--mooncake-ib-device` should be the same as `--disaggregation-ib-device`.
-
-
-### To enable Mooncake EPD Backend
-
-Encoder:
-```bash
+# Prefill
 python -m sglang.launch_server \
-    --model-path $MODEL \
-    --encoder-only \
-    --encoder-transfer-backend mooncake \
-    --port $PORT
-```
+  --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+  --disaggregation-mode prefill \
+  --port 30000 --host 192.168.0.137 --tp-size 2
 
-Prefill:
-```bash
+# Decode (skip first 2 GPUs, use cards 2+)
 python -m sglang.launch_server \
-    --model-path $MODEL \
-    --disaggregation-mode prefill \
-    --disaggregation-transfer-backend mooncake \
-    --encoder-transfer-backend mooncake \
-    --tp $TP \
-    --mem-fraction-static $MEM_FRACTION \
-    --chunked-prefill-size $CHUNK_SIZE \
-    --language-only \
-    --encoder-urls http://127.0.0.1:30002 http://127.0.0.1:30003 http://127.0.0.1:30004 http://127.0.0.1:30005 http://127.0.0.1:30006 http://127.0.0.1:30007 \
-    --port $PORT
+  --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+  --disaggregation-mode decode \
+  --port 30001 --base-gpu-id 2 --host 192.168.0.137 --tp-size 2
+
+# Router
+python3 -m sglang_router.launch_router \
+  --pd-disaggregation \
+  --prefill "http://192.168.0.137:30000" 8998 \
+  --decode  "http://192.168.0.137:30001" \
+  --policy round_robin \
+  --host 0.0.0.0 --port 8000
 ```
 
-- Set `--encoder-transfer-backend` to "mooncake" to enable Mooncake Backend.
+TP is supported but not required — omit `--tp-size 2` for single-GPU setups.
+
+### XpYd Topology
+
+Multiple decode instances per prefill are supported. Multiple prefills on the same node are not supported due to bootstrap server port conflicts.
+
+```bash
+python3 -m sglang_router.launch_router \
+  --pd-disaggregation \
+  --prefill "http://192.168.0.137:30000" 8998 \
+  --decode "http://192.168.0.137:30001,http://192.168.0.140:30001" \
+  --policy round_robin \
+  --host 0.0.0.0 --port 8000
+```
+
+```{tip}
+If you encounter HuggingFace timeouts, set `export SGLANG_USE_MODELSCOPE=true`.
+```
+
+## Advanced Backends
+
+### EP Backend — Expert Parallelism for MoE Models
+
+For Mixture-of-Experts models (e.g., DeepSeek-V3), different nodes hold different expert weights. During inference, Mooncake transfers expert activations between prefill and decode nodes via RDMA, replacing the NCCL-based all-to-all with a faster, disaggregation-aware transfer path.
+
+```bash
+# Prefill
+python -m sglang.launch_server \
+  --model-path deepseek-ai/DeepSeek-V3-0324 \
+  --disaggregation-mode prefill \
+  --port 30000 --host 192.168.0.137 \
+  --tp-size 8 --dp-size 8 \
+  --elastic-ep-backend mooncake \
+  --moe-a2a-backend mooncake
+
+# Decode
+python -m sglang.launch_server \
+  --model-path deepseek-ai/DeepSeek-V3-0324 \
+  --disaggregation-mode decode \
+  --port 30001 --host 192.168.0.140 \
+  --tp-size 8 --dp-size 8 \
+  --elastic-ep-backend mooncake \
+  --moe-a2a-backend mooncake
+```
+
+Set `--mooncake-ib-device` to the same value as `--disaggregation-ib-device` if explicit device specification is needed.
+
+### EPD Backend — Encoder-Prefill-Decode for Multimodal Models
+
+For multimodal models (e.g., LLaVA, InternVL), the **encoder** (Vision Transformer) processes images, the **prefill** node handles text + encoded visual tokens, and the **decode** node generates output. Mooncake transfers encoder outputs (visual embeddings) between these nodes via RDMA.
+
+The three node roles are:
+
+| Role | Flag | Responsibility |
+|------|------|----------------|
+| Encoder | `--encoder-only` | Processes images, produces visual embeddings. Mooncake sends embeddings to prefill via `--encoder-transfer-backend mooncake` |
+| Prefill | `--disaggregation-mode prefill` | Receives encoder embeddings, runs prefill with text + visual context. Mooncake transfers KV cache to decode |
+| Decode | `--disaggregation-mode decode` | Receives KV cache from prefill, generates output tokens |
+
+```bash
+# Encoder-only node
+python -m sglang.launch_server \
+  --model-path $MODEL \
+  --encoder-only \
+  --encoder-transfer-backend mooncake \
+  --port 30002
+
+# Prefill node
+python -m sglang.launch_server \
+  --model-path $MODEL \
+  --disaggregation-mode prefill \
+  --disaggregation-transfer-backend mooncake \
+  --encoder-transfer-backend mooncake \
+  --tp $TP \
+  --mem-fraction-static $MEM_FRACTION \
+  --chunked-prefill-size $CHUNK_SIZE \
+  --language-only \
+  --encoder-urls http://127.0.0.1:30002 http://127.0.0.1:30003 \
+  --port $PORT
+
+# Decode node
+python -m sglang.launch_server \
+  --model-path $MODEL \
+  --disaggregation-mode decode \
+  --disaggregation-transfer-backend mooncake \
+  --port $PORT
+```

--- a/docs/source/getting_started/examples/sglang-integration-v1.md
+++ b/docs/source/getting_started/examples/sglang-integration-v1.md
@@ -28,28 +28,23 @@ pip3 uninstall mooncake-transfer-engine
 
 ### Install SGLang
 
+It is recommended to use uv for faster installation:
+
 ```bash
-git clone git@github.com:sgl-project/sglang.git
-cd sglang
 pip install --upgrade pip
-pip install -e "python[all]" --find-links https://flashinfer.ai/whl/cu124/torch2.5/flashinfer-python
+pip install uv
+uv pip install sglang
 ```
 
-For AMD GPUs, use the ROCm docker image:
+The major version of Cuda is 13 by default. To install sglang under Cuda 12 with pip or uv, please try the following commands:
 
 ```bash
-docker run -it --rm --network=host \
-    --device=/dev/kfd --device=/dev/dri \
-    --ipc=host --shm-size 16G \
-    --group-add video \
-    --cap-add=SYS_PTRACE \
-    --security-opt seccomp=unconfined \
-    -v /home/workspace:/workspace \
-   rocm/sgl-dev:20250707
-
-pip3 install mooncake-transfer-engine
-sudo apt update && sudo apt install libibverbs1 libibverbs-dev -y
-sudo apt-get install lsof net-tools iputils-ping -y
+pip install --upgrade pip
+pip install uv
+uv pip install sglang
+uv pip install --force-reinstall  torch==2.11.0 torchaudio==2.11.0 torchvision --index-url https://download.pytorch.org/whl/cu129
+uv pip install --force-reinstall sglang-kernel --index-url https://docs.sglang.ai/whl/cu129/
+uv pip install --force-reinstall sgl-deep-gemm --index-url https://docs.sglang.ai/whl/cu129/ --no-deps
 ```
 
 See the [SGLang official compilation guide](https://docs.sglang.ai/start/install.html) if you encounter issues.

--- a/docs/source/getting_started/examples/sglang-integration-v1.md
+++ b/docs/source/getting_started/examples/sglang-integration-v1.md
@@ -56,8 +56,6 @@ See the [SGLang official compilation guide](https://docs.sglang.ai/start/install
 
 ## Configuration
 
-Since [PR 5460](https://github.com/sgl-project/sglang/pull/5460), no `mooncake.json` configuration file is needed — Mooncake auto-detects RDMA devices.
-
 Key arguments:
 
 | Argument | Description |

--- a/docs/source/getting_started/examples/sglang-integration-v1.md
+++ b/docs/source/getting_started/examples/sglang-integration-v1.md
@@ -68,7 +68,7 @@ Key arguments:
 
 ## Run PD Disaggregation
 
-### Cross-Node
+### Multi-Node
 
 ```bash
 # Prefill node (192.168.0.137)
@@ -100,7 +100,7 @@ curl -X POST http://127.0.0.1:8000/generate \
   -d '{"text": "Tell me a long story", "sampling_params": {"temperature": 0}}'
 ```
 
-### Same-Node
+### Single-Node
 
 ```bash
 # Prefill
@@ -122,15 +122,9 @@ python3 -m sglang_router.launch_router \
   --decode  "http://192.168.0.137:30001" \
   --policy round_robin \
   --host 0.0.0.0 --port 8000
-```
 
-TP is supported but not required — omit `--tp-size 2` for single-GPU setups.
-
-### XpYd Topology
-
-Multiple decode instances per prefill are supported. Multiple prefills on the same node are not supported due to bootstrap server port conflicts.
-
-```bash
+# Router for multi node.
+# Here is an example for 2 decode node running on 192.168.0.137 and 192.168.0.140
 python3 -m sglang_router.launch_router \
   --pd-disaggregation \
   --prefill "http://192.168.0.137:30000" 8998 \
@@ -138,6 +132,10 @@ python3 -m sglang_router.launch_router \
   --policy round_robin \
   --host 0.0.0.0 --port 8000
 ```
+
+TP is supported but not required — omit `--tp-size 2` for single-GPU setups.
+
+Multiple decode instances per prefill are supported. Multiple prefills on the same node are not supported due to bootstrap server port conflicts.
 
 ```{tip}
 If you encounter HuggingFace timeouts, set `export SGLANG_USE_MODELSCOPE=true`.

--- a/docs/source/getting_started/examples/sglang-integration/hicache-integration-v1.md
+++ b/docs/source/getting_started/examples/sglang-integration/hicache-integration-v1.md
@@ -26,21 +26,26 @@ This integration is particularly valuable for production deployments involving l
 
 ### Install SGLang
 
-1. Clone SGLang from official repo
+It is recommended to use uv for faster installation:
 
 ```bash
-git clone git@github.com:sgl-project/sglang.git
-```
-
-2. Build
-
-```bash
-cd sglang
 pip install --upgrade pip
-pip install -e "python[all]"
+pip install uv
+uv pip install sglang
 ```
 
-For more details, please refer to [SGLang official installation guide](https://docs.sglang.ai/get_started/install.html).
+The major version of Cuda is 13 by default. To install sglang under Cuda 12 with pip or uv, please try the following commands:
+
+```bash
+pip install --upgrade pip
+pip install uv
+uv pip install sglang
+uv pip install --force-reinstall  torch==2.11.0 torchaudio==2.11.0 torchvision --index-url https://download.pytorch.org/whl/cu129
+uv pip install --force-reinstall sglang-kernel --index-url https://docs.sglang.ai/whl/cu129/
+uv pip install --force-reinstall sgl-deep-gemm --index-url https://docs.sglang.ai/whl/cu129/ --no-deps
+```
+
+See the [SGLang official compilation guide](https://docs.sglang.ai/start/install.html) if you encounter issues.
 
 ### Install Mooncake
 
@@ -50,37 +55,7 @@ For more details, please refer to [SGLang official installation guide](https://d
 pip install mooncake-transfer-engine
 ```
 
-**Method 2: from source**
-
-Clone Mooncake project:
-
-```bash
-git clone https://github.com/kvcache-ai/Mooncake --recursive
-```
-
-Install dependencies:
-
-```bash
-cd Mooncake
-bash dependencies.sh
-```
-
-Build the project:
-
-```bash
-mkdir build
-cd build
-cmake ..
-make -j
-```
-
-Install Mooncake:
-
-```bash
-sudo make install
-```
-
-For more details, please refer to [Mooncake official installation guide](https://kvcache-ai.github.io/Mooncake/getting_started/build.html).
+If you want to build from source or using some other advanced features which not contained in prebuilt pip package, please refer to [Mooncake official installation guide](https://kvcache-ai.github.io/Mooncake/getting_started/build.html).
 
 ## Deployment
 

--- a/docs/source/getting_started/examples/sglang-integration/hicache-integration-v1.md
+++ b/docs/source/getting_started/examples/sglang-integration/hicache-integration-v1.md
@@ -349,54 +349,14 @@ python -m sglang.launch_server \
 
 ### Prefill/Decode Disaggregation
 
-In **PD disaggregation**, the configurations for the `metadata service`, `mooncake master`, and the optional `store service` remain the same as described above. The difference is that SGLang introduces three distinct roles: `prefill worker`, `decode worker`, and `router`.
+Mooncake HiCache works with SGLang's **PD disaggregation** mode. The `master service`, `metadata service`, and optional `store service` configurations are the same as described above.
 
-Among these, the `prefill worker` supports enabling **HiCache**. To run with PD disaggregation, start from the [PD configuration](https://kvcache-ai.github.io/Mooncake/getting_started/examples/sglang-integration-v1.html), and add the HiCache-related parameters (as previously described for the `SGLang server`) to the `prefill worker`.
+Among SGLang's three PD roles (`prefill worker`, `decode worker`, `router`), only the `prefill worker` supports enabling HiCache. To combine both features:
 
-In the example below, one `prefill worker`, one `decode worker`, and one `router` are launched. HiCache is enabled on the `prefill worker` to optimize prefill performance.
+1. Follow the [PD Disaggregation Guide](../sglang-integration-v1) to set up the prefill, decode, and router workers.
+2. Add the HiCache-related parameters (`--enable-hierarchical-cache`, `--hicache-storage-backend mooncake`, `--hicache-storage-prefetch-policy`, etc.) to the **prefill worker** only, as described in the HiCache sections above.
 
-**Prefill worker**:
-
-```bash
-MOONCAKE_TE_META_DATA_SERVER="http://127.0.0.1:8080/metadata" \
-MOONCAKE_MASTER=127.0.0.1:50051 \
-MOONCAKE_PROTOCOL="rdma" \
-MOONCAKE_DEVICE="mlx5_1" \
-MOONCAKE_GLOBAL_SEGMENT_SIZE=4294967296 \
-python -m sglang.launch_server \
-    --model-path [model_path] \
-    --page-size 64 \
-    --enable-hierarchical-cache \
-    --hicache-storage-prefetch-policy timeout \
-    --hicache-storage-backend mooncake \
-    --disaggregation-mode prefill \
-    --disaggregation-ib-device "mlx5_1" \
-    --base-gpu-id 0 \
-    --port 30000
-```
-
-**Decode worker**:
-
-```bash
-python -m sglang.launch_server \
-    --model-path [model_path] \
-    --page-size 64 \
-    --disaggregation-mode decode \
-    --disaggregation-ib-device "mlx5_1" \
-    --base-gpu-id 1 \
-    --port 30001
-```
-
-**Router**:
-
-```bash
-python -m sglang_router.launch_router \
-    --pd-disaggregation \
-    --prefill "http://127.0.0.1:30000" \
-    --decode "http://127.0.0.1:30001" \
-    --host 0.0.0.0 \
-    --port 8000
-```
+The Mooncake and HiCache configuration (environment variables or JSON config) is applied identically to the prefill worker — no changes are needed on the decode worker or router.
 
 ## Troubleshooting
 

--- a/docs/source/getting_started/examples/sglang-integration/hicache-integration-v1.md
+++ b/docs/source/getting_started/examples/sglang-integration/hicache-integration-v1.md
@@ -6,22 +6,6 @@ This document describes how to use Mooncake as the storage backend for SGLang Hi
 
 ## Introduction
 
-### About Mooncake
-
-Mooncake aims to enhance the inference efficiency of large language models (LLMs), especially in slow object storage environments, by constructing a multi-level caching pool on high-speed interconnected DRAM/SSD resources. Compared to traditional caching systems, Mooncake utilizes (GPUDirect) RDMA technology to transfer data directly in a zero-copy manner, while maximizing the use of multi-NIC resources on a single machine.
-
-For more details about Mooncake, please refer to [Mooncake project](https://github.com/kvcache-ai/Mooncake) and [Mooncake documents](https://kvcache-ai.github.io/Mooncake/).
-
-### About SGLang HiCache
-
-SGLang HiCache is a hierarchical KV caching system that extends SGLang's RadixAttention with advanced multi-tier memory management capabilities. It implements a scalable hierarchical storage architecture that spans GPU memory, CPU memory, and external storage layers, delivering significant performance improvements for large language model inference.
-
-HiCache introduces a **HiRadixTree** that acts as a page table for referencing KV caches across different memory tiers: **GPU Memory (L1)**, **CPU Memory (L2)**, **Mooncake and other Storage Backends (L3)**.
-
-The system includes an intelligent cache controller that automatically manages data movement between tiers, implementing optimized prefetching strategies and multiple write policies (write-through, write-through-selective, and write-back).
-
-For more details about SGLang HiCache, please refer to [HiCache system design document](https://docs.sglang.ai/advanced_features/hicache_design.html) and [this blog](https://lmsys.org/blog/2025-09-10-sglang-hicache/).
-
 ### Mooncake & SGLang HiCache
 
 Mooncake serves as a high-performance L3 storage backend for SGLang HiCache, enabling distributed KV cache storage across multiple servers with RDMA-accelerated data transfer. This integration addresses the capacity limitations of traditional GPU-only or GPU+CPU caching by providing virtually unlimited cache storage through a distributed memory pool.

--- a/docs/source/getting_started/examples/sglang-integration/hicache-integration-v1.md
+++ b/docs/source/getting_started/examples/sglang-integration/hicache-integration-v1.md
@@ -351,8 +351,6 @@ python -m sglang.launch_server \
 
 Mooncake HiCache works with SGLang's **PD disaggregation** mode. The `master service`, `metadata service`, and optional `store service` configurations are the same as described above.
 
-Among SGLang's three PD roles (`prefill worker`, `decode worker`, `router`), only the `prefill worker` supports enabling HiCache. To combine both features:
-
 1. Follow the [PD Disaggregation Guide](../sglang-integration-v1) to set up the prefill, decode, and router workers.
 2. Add the HiCache-related parameters (`--enable-hierarchical-cache`, `--hicache-storage-backend mooncake`, `--hicache-storage-prefetch-policy`, etc.) to the **prefill worker** only, as described in the HiCache sections above.
 

--- a/docs/source/getting_started/examples/sglang-integration/hicache-quick-start.md
+++ b/docs/source/getting_started/examples/sglang-integration/hicache-quick-start.md
@@ -1,6 +1,6 @@
 # Quick Start: SGLang HiCache with Mooncake Backend
 
-Follow this streamlined workflow to get SGLang HiCache running with Mooncake as the L3 storage backend.
+Follow this streamlined workflow to get SGLang HiCache running with Mooncake as the L3 storage backend. In benchmarks, pre-populated Mooncake achieves **best TTFT** across all tiers, maintaining high cache hit rates as conversation rounds grow ([details](../../../performance/sglang-hicache-benchmark-results-v1)).
 
 > Need more background or tuning options? See the [Complete Guide](hicache-integration-v1.md).
 

--- a/docs/source/getting_started/examples/sglang-integration/index.md
+++ b/docs/source/getting_started/examples/sglang-integration/index.md
@@ -1,8 +1,95 @@
-# SGLang HiCache with Mooncake Backend
+# SGLang x Mooncake Integration
+
+Mooncake integrates with SGLang through two paths — **PD Disaggregation** for cross-instance KV cache transfer via the Transfer Engine, and **HiCache L3 Backend** for hierarchical KV cache storage with Mooncake Store.
+
+---
+
+## PD Disaggregation
+
+SGLang uses Mooncake's Transfer Engine for direct zero-copy KV cache transfer between prefill and decode instances over RDMA.
+
+```
+  +-----------+   Transfer Engine (RDMA)    +-----------+
+  | SGLang    | ◄━━━━━━━━━━━━━━━━━━━━━━► | SGLang     |
+  | Prefill   |     KV cache blocks        | Decode     |
+  +-----------+                            +-----------+
+```
+
+Since [PR 5460](https://github.com/sgl-project/sglang/pull/5460), no `mooncake.json` is needed — devices are auto-detected.
+
+```bash
+# Prefill node
+python -m sglang.launch_server \
+  --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+  --disaggregation-mode prefill \
+  --port 30000 --host 192.168.0.137 --tp-size 2
+
+# Decode node
+python -m sglang.launch_server \
+  --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
+  --disaggregation-mode decode \
+  --port 30001 --host 192.168.0.140 --tp-size 2
+
+# Router (front the pair with sglang_router)
+python3 -m sglang_router.launch_router \
+  --pd-disaggregation \
+  --prefill "http://192.168.0.137:30000" \
+  --decode  "http://192.168.0.140:30001" \
+  --policy round_robin \
+  --host 0.0.0.0 --port 8000
+```
+
+Both prefill and decode can run on the same node with `--base-gpu-id` to avoid GPU conflicts. XpYd topology (multiple prefills, multiple decodes) is supported.
+
+**Related:** [Full PD Disaggregation Guide](../sglang-integration-v1) — installation, EP/EPD backends, and advanced configuration.
+
+---
+
+## HiCache with Mooncake Store
+
+HiCache extends SGLang's RadixAttention with three memory tiers, using Mooncake Store as the distributed L3 backend.
+
+```
+  +----------------------------------------------+
+  | SGLang + HiCache                             |
+  |  ┌─────────┐  ┌─────────┐  ┌──────────────┐ |
+  |  │ L1(GPU) │  │ L2(CPU) │  │ L3(Mooncake) │ |
+  |  └─────────┘  └─────────┘  └──────┬───────┘ |
+  +------------------------------------+----------+
+                                      |
+                             +--------+--------+
+                             | Mooncake Store  |
+                             | Distributed Pool |
+                             +-----------------+
+```
+
+When local cache misses, HiCache automatically prefetches KV blocks from remote storage via RDMA.
+
+```bash
+# 1. Start Mooncake Store master
+mooncake_master --enable_http_metadata_server=true
+
+# 2. Launch SGLang with HiCache + Mooncake L3
+export MOONCAKE_MASTER=127.0.0.1:50051
+export MC_STORE_USE_HUGEPAGE="1"
+
+python -m sglang.launch_server \
+  --model-path [model_path] \
+  --page-size 64 \
+  --enable-hierarchical-cache \
+  --hicache-storage-prefetch-policy timeout \
+  --hicache-storage-backend mooncake
+```
+
+**Related:**
+- [HiCache Quick Start](hicache-quick-start) — comprehensive setup including hugepage sizing
+- [HiCache Complete Guide](hicache-integration-v1) — prefetch strategies, tuning, and architecture deep dive
 
 ::::{toctree}
 :maxdepth: 1
+:hidden:
 
+../sglang-integration-v1
 hicache-quick-start
 hicache-integration-v1
 ::::

--- a/docs/source/getting_started/examples/sglang-integration/index.md
+++ b/docs/source/getting_started/examples/sglang-integration/index.md
@@ -6,7 +6,7 @@ Mooncake integrates with SGLang through two paths — **PD Disaggregation** for 
 
 ## PD Disaggregation
 
-SGLang uses Mooncake's Transfer Engine for direct zero-copy KV cache transfer between prefill and decode instances over RDMA.
+SGLang uses Mooncake's Transfer Engine for direct zero-copy KV cache transfer between prefill and decode instances over RDMA, with support for EP and EPD backends. In benchmarks, PD disaggregation with Mooncake achieves **~30% lower ITL** while maintaining comparable throughput.
 
 ```
   +-----------+   Transfer Engine (RDMA)   +------------+
@@ -15,37 +15,13 @@ SGLang uses Mooncake's Transfer Engine for direct zero-copy KV cache transfer be
   +-----------+                            +------------+
 ```
 
-```bash
-# Prefill node
-python -m sglang.launch_server \
-  --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
-  --disaggregation-mode prefill \
-  --port 30000 --host 192.168.0.137 --tp-size 2
-
-# Decode node
-python -m sglang.launch_server \
-  --model-path Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4 \
-  --disaggregation-mode decode \
-  --port 30001 --host 192.168.0.140 --tp-size 2
-
-# Router (front the pair with sglang_router)
-python3 -m sglang_router.launch_router \
-  --pd-disaggregation \
-  --prefill "http://192.168.0.137:30000" \
-  --decode  "http://192.168.0.140:30001" \
-  --policy round_robin \
-  --host 0.0.0.0 --port 8000
-```
-
-Both prefill and decode can run on the same node with `--base-gpu-id` to avoid GPU conflicts. XpYd topology (multiple prefills, multiple decodes) is supported.
-
-**Related:** [Full PD Disaggregation Guide](../sglang-integration-v1) — installation, EP/EPD backends, and advanced configuration.
+**Related:** [Full PD Disaggregation Guide](../sglang-integration-v1) — installation, cross-node/same-node setup, XpYd topology, EP backend for MoE models, and EPD backend for multimodal models.
 
 ---
 
 ## HiCache with Mooncake Store
 
-HiCache extends SGLang's RadixAttention with three memory tiers, using Mooncake Store as the distributed L3 backend.
+HiCache extends SGLang's RadixAttention with three memory tiers, using Mooncake Store as the distributed L3 backend. When local cache misses, HiCache automatically prefetches KV blocks from remote storage via RDMA.
 
 ```
   +----------------------------------------------+
@@ -61,26 +37,9 @@ HiCache extends SGLang's RadixAttention with three memory tiers, using Mooncake 
                              +------------------+
 ```
 
-When local cache misses, HiCache automatically prefetches KV blocks from remote storage via RDMA.
-
-```bash
-# 1. Start Mooncake Store master
-mooncake_master --enable_http_metadata_server=true
-
-# 2. Launch SGLang with HiCache + Mooncake L3
-export MOONCAKE_MASTER=127.0.0.1:50051
-
-python -m sglang.launch_server \
-  --model-path [model_path] \
-  --page-size 64 \
-  --enable-hierarchical-cache \
-  --hicache-storage-prefetch-policy timeout \
-  --hicache-storage-backend mooncake
-```
-
 **Related:**
-- [HiCache Quick Start](hicache-quick-start) — comprehensive setup including hugepage sizing
-- [HiCache Complete Guide](hicache-integration-v1) — prefetch strategies, tuning, and architecture deep dive
+- [HiCache Quick Start](hicache-quick-start) — minimal setup steps with hugepage sizing
+- [HiCache Complete Guide](hicache-integration-v1) — full deployment, prefetch strategies, memory tuning, and architecture deep dive
 
 ::::{toctree}
 :maxdepth: 1

--- a/docs/source/getting_started/examples/sglang-integration/index.md
+++ b/docs/source/getting_started/examples/sglang-integration/index.md
@@ -1,4 +1,4 @@
-# SGLang x Mooncake Integration
+# Mooncake x SGLang Integration
 
 Mooncake integrates with SGLang through two paths — **PD Disaggregation** for cross-instance KV cache transfer via the Transfer Engine, and **HiCache L3 Backend** for hierarchical KV cache storage with Mooncake Store.
 
@@ -9,13 +9,11 @@ Mooncake integrates with SGLang through two paths — **PD Disaggregation** for 
 SGLang uses Mooncake's Transfer Engine for direct zero-copy KV cache transfer between prefill and decode instances over RDMA.
 
 ```
-  +-----------+   Transfer Engine (RDMA)    +-----------+
-  | SGLang    | ◄━━━━━━━━━━━━━━━━━━━━━━► | SGLang     |
+  +-----------+   Transfer Engine (RDMA)   +------------+
+  | SGLang    | ◄━━━━━━━━━━━━━━━━━━━━━━►   | SGLang     |
   | Prefill   |     KV cache blocks        | Decode     |
-  +-----------+                            +-----------+
+  +-----------+                            +------------+
 ```
-
-Since [PR 5460](https://github.com/sgl-project/sglang/pull/5460), no `mooncake.json` is needed — devices are auto-detected.
 
 ```bash
 # Prefill node
@@ -52,15 +50,15 @@ HiCache extends SGLang's RadixAttention with three memory tiers, using Mooncake 
 ```
   +----------------------------------------------+
   | SGLang + HiCache                             |
-  |  ┌─────────┐  ┌─────────┐  ┌──────────────┐ |
-  |  │ L1(GPU) │  │ L2(CPU) │  │ L3(Mooncake) │ |
-  |  └─────────┘  └─────────┘  └──────┬───────┘ |
-  +------------------------------------+----------+
+  |  ┌─────────┐  ┌─────────┐  ┌──────────────┐  |
+  |  │ L1(GPU) │  │ L2(CPU) │  │ L3(Mooncake) │  |
+  |  └─────────┘  └─────────┘  └──────┬───────┘  |
+  +-----------------------------------+----------+
                                       |
-                             +--------+--------+
-                             | Mooncake Store  |
+                             +--------+---------+
+                             | Mooncake Store   |
                              | Distributed Pool |
-                             +-----------------+
+                             +------------------+
 ```
 
 When local cache misses, HiCache automatically prefetches KV blocks from remote storage via RDMA.
@@ -71,7 +69,6 @@ mooncake_master --enable_http_metadata_server=true
 
 # 2. Launch SGLang with HiCache + Mooncake L3
 export MOONCAKE_MASTER=127.0.0.1:50051
-export MC_STORE_USE_HUGEPAGE="1"
 
 python -m sglang.launch_server \
   --model-path [model_path] \

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -69,7 +69,6 @@ getting_started/build
 getting_started/quick-start
 getting_started/supported-protocols
 getting_started/observability
-getting_started/examples/sglang-integration-v1
 getting_started/examples/sglang-integration/index
 getting_started/examples/vllm-integration/index
 Mooncake x LMCache Integration<getting_started/examples/lmcache-integration>

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -84,6 +84,7 @@ getting_started/plugin-usage/3FS-USRBIO-Plugin
 :maxdepth: 1
 
 performance/vllm/index
+performance/sglang/index
 performance/sglang-benchmark-results-v1
 performance/vllm-benchmark-results-v0.2
 performance/vllm-benchmark-results-v1

--- a/docs/source/performance/sglang/index.md
+++ b/docs/source/performance/sglang/index.md
@@ -1,0 +1,9 @@
+# SGLang Performance Benchmarks
+
+:::{toctree}
+:maxdepth: 1
+:hidden:
+
+../sglang-benchmark-results-v1
+../sglang-hicache-benchmark-results-v1
+:::


### PR DESCRIPTION
## Description
As [3/N] of https://github.com/kvcache-ai/Mooncake/issues/2258

This PR restructures the SGLang integration documentation to follow the same task-oriented pattern introduced for vLLM, and adds an SGLang performance benchmark overview page.

- **`sglang-integration-v1.md`** — Rewritten with an architecture diagram showing the prefill-decode data flow via Transfer Engine, reorganized prerequisites (pip install, source build fallback), and updated syntax using `sglang_router` instead of deprecated `mini_lb`.
- **`sglang-integration/index.md`** — Rewritten as a HiCache scenario landing page. Presents a quick-start path and a deep-dive path, with clear links to the PD disaggregation guide, HiCache quick-start, and benchmark results.
- **`sglang-integration/hicache-integration-v1.md`** — Trimmed stale content; consolidated into the new index page.
- **`sglang-integration/hicache-quick-start.md`** — Fixed cross-reference links.
- **`lmcache-integration.md`** — Renamed to "Mooncake x LMCache Integration" and embedded the `vllmv1-lmcache-integration` toctree under the Mooncake × LMCache section.
- **`performance/sglang/index.md`** (new) — SGLang benchmark overview table summarizing key findings: ~30% lower ITL for PD disaggregation, and pre-populated Mooncake achieving best TTFT in multi-turn HiCache benchmarks.
- **`index.md`** — Added `performance/sglang/index` to the Performance toctree.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

- Built locally with `make clean && make html -W` — zero warnings.
- Verified all cross-references resolve correctly and the new SGLang performance page is accessible from the sidebar.
- Preview deployed at https://aionw.github.io/

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
