### PR TITLE
[Doc] finalize navigation restructure and update build/design docs

### DIFF
--- a/docs/source/api-reference/http/index.md
+++ b/docs/source/api-reference/http/index.md
@@ -10,4 +10,5 @@
 :hidden:
 
 ../../http-api-reference/http-service
+../../design/conductor/indexer-api-design
 :::

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -1,4 +1,4 @@
-# Mooncake Store Deployment & Tunnig Guide
+# Mooncake Store Deployment & Tuning Guide
 
 This guide covers minimal deployment, and operational tuning of Mooncake Store.
 

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -1,6 +1,8 @@
-# Mooncake Store Deployment & Operations Guide
+# Mooncake Store Deployment & Tunnig Guide
 
 This page summarizes useful flags, environment variables, and HTTP endpoints to help advanced users tune Mooncake Master and observe metrics.
+
+For benchmark context on storage performance, allocator behavior, allocation strategies, and SSD offload, see [Mooncake Performance Benchmarks](../performance/mooncake/index).
 
 ## Master Startup Flags (with defaults)
 
@@ -99,6 +101,8 @@ mooncake_master \
   --http_metadata_server_port=8080
 ```
 
+For measured allocation-routing overhead and utilization behavior, see [AllocationStrategy Performance](../performance/allocation-strategy-benchmark-result).
+
 **Tips:**
 
 In addition to command-line flags, the Master also supports configuration via JSON and YAML files. For example:
@@ -186,6 +190,8 @@ grep -E 'HugePages_Total|HugePages_Free|Hugepagesize' /proc/meminfo
 
 The `64gb` / `56gb` inputs above are tuned examples for large HiCache deployments, not defaults. The arena remains disabled unless you explicitly enable it. If you enable it via gflag without an env override, the default pool size is `8gb`. On smaller hosts, start with `8gb` or `16gb` and size upward with the helper.
 
+For allocator utilization and mmap arena behavior, see [Allocator Performance](../performance/allocator-benchmark-result).
+
 ## Set the Log Level for yalantinglibs coro_rpc and coro_http
 By default, the log level is set to warning. You can customize it using the following environment variable:
 
@@ -204,9 +210,13 @@ Available log levels: trace, debug, info, warn (or warning), error, and critical
 
 ---
 
+## Advanced Topics
+
 :::{toctree}
-:caption: Advanced Topics
 :maxdepth: 1
 
 ssd-offload
+NvMe-Of SSD Pool<nvmf-ssd-deployment-guide>
+HF3FS Plugin (Experimental)<../getting_started/plugin-usage/3FS-USRBIO-Plugin>
+../getting_started/observability
 :::

--- a/docs/source/deployment/ssd-offload.md
+++ b/docs/source/deployment/ssd-offload.md
@@ -4,6 +4,8 @@
 
 Mooncake Store supports offloading KV cache objects from distributed memory to local SSD. When memory pressure is high, the master instructs clients to persist selected objects to disk. On a cache miss, the client automatically falls back to reading from SSD.
 
+For measured TTFT and throughput impact in multi-turn workloads, see [Mooncake SSD Offload Benchmark](../performance/ssd-offload-benchmark-results.md).
+
 SSD offload requires the **Real Client** and supports two deployment modes:
 
 - **Mode A: Embedded Real Client** — the Python process embeds the Real Client, and SSD offload runs inside the Python process.

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -435,6 +435,8 @@ Mooncake Store provides two concrete implementations of `BufferAllocatorBase`:
 
 **OffsetBufferAllocator (default and recommended)**: This allocator is derived from [OffsetAllocator](https://github.com/sebbbi/OffsetAllocator), which uses a custom bin-based allocation strategy that supports fast hard realtime `O(1)` offset allocation with minimal fragmentation. Mooncake Store optimizes this allocator based on the specific memory usage characteristics of LLM inference workloads, thereby enhancing memory utilization in LLM scenarios.
 
+For measured utilization and allocation latency across LLM-style workloads, see [Allocator Performance](../performance/allocator-benchmark-result.md).
+
 **CachelibBufferAllocator (deprecated)**: This allocator leverages Facebook's [CacheLib](https://github.com/facebook/CacheLib) to manage memory using a slab-based allocation strategy. It provides efficient memory allocation with good fragmentation resistance and is well-suited for high-performance scenarios. However, in our modified version, it does not handle workloads with highly variable object sizes effectively, so it is currently marked as deprecated.
 
 Users can choose the allocator that best matches their performance and memory usage requirements through the `--memory-allocator` startup parameter of `master_service`.
@@ -520,6 +522,8 @@ Valid values are: `random` (default), `free_ratio_first`, `cxl` (case-sensitive)
 - New segments are dynamically added at runtime and you need them to absorb load quickly. With `random`, convergence to a well-balanced state can be slow on large or dynamic clusters; `free_ratio_first` accelerates this by preferentially filling emptier segments, substantially increasing the likelihood that newly joined segments are selected for allocations (see details below).
 
 **Use `cxl`** only when your hardware includes CXL (Compute Express Link) memory devices and you want to allocate data exclusively on CXL segments.
+
+For benchmark data comparing `random` and `free_ratio_first` across segment counts, replica counts, and skewed capacities, see [AllocationStrategy Performance](../performance/allocation-strategy-benchmark-result.md).
 
 #### Strategy Details
 

--- a/docs/source/design/ssd-offload.md
+++ b/docs/source/design/ssd-offload.md
@@ -6,6 +6,8 @@ Mooncake Store supports offloading KV cache objects from distributed memory to l
 
 SSD offload is implemented as a background subsystem within the **real client** process. It is transparent to the application: a `Put` that would otherwise be evicted from memory is persisted to disk, and a `Get` that finds no memory replica automatically falls back to reading from SSD.
 
+For multi-turn conversation benchmark results, see [Mooncake SSD Offload Benchmark](../performance/ssd-offload-benchmark-results.md).
+
 ---
 
 ## Architecture

--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -318,6 +318,14 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 
 For the complete C++ API reference, see [Transfer Engine C++ API](../../api-reference/cpp/index).
 
+## Supported Protocols
+
+:::{toctree}
+:maxdepth: 1
+
+../../getting_started/supported-protocols
+:::
+
 ## EFA Transport (AWS)
 
 :::{toctree}
@@ -343,14 +351,6 @@ heterogeneous_ascend
 
 kunpeng_ub_transport
 sunrise_link_transport
-:::
-
-## Supported Protocols
-
-:::{toctree}
-:maxdepth: 1
-
-../../getting_started/supported-protocols
 :::
 
 ## Benchmark and Tuning Guide

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -45,7 +45,7 @@ pip install mooncake-transfer-engine-non-cuda
    sudo make install
    ```
 
-### Build with NVMe-oF SSD Pool
+**Build with NVMe-oF SSD Pool**
 
 To enable the NVMe-oF SSD pool, install the SPDK dependencies and build
 Mooncake with `USE_NOF` enabled:
@@ -95,7 +95,7 @@ sudo make install
                        libhiredis-dev \
                        pkg-config \
                        patchelf
-    
+
     # For centos/alibaba linux os
     yum install cmake \
                 gflags-devel \
@@ -290,5 +290,5 @@ The following options can be used during `cmake ..` to specify whether to compil
 - `-DBUILD_SHARED_LIBS=[ON|OFF]`: Build Transfer Engine as shared library, default is OFF
 - `-DBUILD_UNIT_TESTS=[ON|OFF]`: Build unit tests, default is ON
 - `-DBUILD_EXAMPLES=[ON|OFF]`: Build examples, default is ON
-- `-DUSE_ASCEND_DIRECT=[ON|OFF]`: Enable Ascend Direct transport and HCCS support via the ADXL engine (**recommended**). 
+- `-DUSE_ASCEND_DIRECT=[ON|OFF]`: Enable Ascend Direct transport and HCCS support via the ADXL engine (**recommended**).
 - `-DUSE_UBSHMEM=[ON|OFF]`: Enable Huawei Ascend NPU shared memory transport via CANN VMM APIs.

--- a/docs/source/getting_started/examples/lmcache-integration.md
+++ b/docs/source/getting_started/examples/lmcache-integration.md
@@ -1,5 +1,6 @@
 # Mooncake x LMCache Integration
-# Unite to Pioneer KVCache-Centric LLM Serving System
+
+Mooncake and LMCache unite to pioneer KVCache-centric LLM serving systems.
 
 Mooncake and LMCache have announced a strategic collaboration aimed at pioneering a KVCache-centric Large Language Model (LLM) serving system. This partnership seeks to significantly enhance the efficiency, scalability, and responsiveness of LLM applications.
 
@@ -69,10 +70,3 @@ Moving forward, LMCache and Mooncake plan to collaborate closely on several key 
 *   **Expanding caching strategies beyond simple prefix matching**, enhancing KVCache reusability by supporting more flexible matching patterns.
 
 This strategic partnership represents a significant advancement toward fully realizing the potential of next-generation LLM serving architectures.
-
-::: {toctree}
-:maxdepth: 1
-:hidden:
-
-vllm-integration/vllmv1-lmcache-integration
-:::

--- a/docs/source/getting_started/examples/sglang-integration/index.md
+++ b/docs/source/getting_started/examples/sglang-integration/index.md
@@ -17,6 +17,8 @@ SGLang uses Mooncake's Transfer Engine for direct zero-copy KV cache transfer be
 
 **Related:** [Full PD Disaggregation Guide](../sglang-integration-v1) — installation, cross-node/same-node setup, XpYd topology, EP backend for MoE models, and EPD backend for multimodal models.
 
+**Benchmark:** [PD Disaggregation Performance](../../../performance/sglang-benchmark-results-v1) — compares 1P1D disaggregation with regular SGLang instances.
+
 ---
 
 ## HiCache with Mooncake Store
@@ -40,6 +42,7 @@ HiCache extends SGLang's RadixAttention with three memory tiers, using Mooncake 
 **Related:**
 - [HiCache Quick Start](hicache-quick-start) — minimal setup steps with hugepage sizing
 - [HiCache Complete Guide](hicache-integration-v1) — full deployment, prefetch strategies, memory tuning, and architecture deep dive
+- [SGLang Performance Benchmarks](../../../performance/sglang/index) — benchmark overview for PD disaggregation and HiCache with Mooncake
 
 ::::{toctree}
 :maxdepth: 1

--- a/docs/source/getting_started/examples/vllm-integration/index.md
+++ b/docs/source/getting_started/examples/vllm-integration/index.md
@@ -12,6 +12,8 @@ Mooncake integrates with vLLM to accelerate large language model serving through
 | PD Disaggregation (KV transfer) | [Disaggregated Prefill-Decode](disagg-prefill-decode) | V1 ✅ / V0 ⚠️ |
 | KV Cache Storage & Sharing | [KV Cache Storage with MooncakeStore](kv-cache-storage) | V1 ✅ / V0 ⚠️ |
 
+For detailed benchmark coverage across these scenarios, see [vLLM Integration Performance Benchmarks](../../../performance/vllm/index).
+
 ```{admonition} New to Mooncake + vLLM?
 :class: tip
 Start with the V1 guides above. Legacy V0 documentation is available for existing deployments only.

--- a/docs/source/getting_started/quick-start.md
+++ b/docs/source/getting_started/quick-start.md
@@ -42,7 +42,7 @@ def main():
     METADATA_SERVER = "P2PHANDSHAKE" # [ETCD_SERVER_URL, P2PHANDSHAKE, ...]
     PROTOCOL = "rdma" # [rdma, tcp, ...]
     DEVICE_NAME = "" # auto discovery if empty
-    
+
     # Initialize server engine
     server_engine = TransferEngine()
     server_engine.initialize(
@@ -52,12 +52,12 @@ def main():
         DEVICE_NAME
     )
     session_id = f"{HOSTNAME}:{server_engine.get_rpc_port()}"
-    
+
     # Allocate memory on server side (1MB buffer)
     server_buffer = np.zeros(1024 * 1024, dtype=np.uint8)
     server_ptr = server_buffer.ctypes.data
     server_len = server_buffer.nbytes
-    
+
     # Register memory with Mooncake
     if PROTOCOL == "rdma":
         ret_value = server_engine.register_memory(server_ptr, server_len)
@@ -67,7 +67,7 @@ def main():
 
     print(f"Server initialized with session ID: {session_id}")
     print(f"Server buffer address: {server_ptr}, length: {server_len}")
-    
+
     # Send buffer info to client
     buffer_info = {
         "session_id": session_id,
@@ -76,7 +76,7 @@ def main():
     }
     socket.send_json(buffer_info)
     print("Buffer information sent to client")
-    
+
     # Keep server running
     try:
         while True:
@@ -95,8 +95,8 @@ def main():
         context.term()
 
 if __name__ == "__main__":
-    main() 
- 
+    main()
+
 ```
 
 ### Start Transfer Engine Sender (Client)
@@ -113,7 +113,7 @@ def main():
     context = zmq.Context()
     socket = context.socket(zmq.PULL)
     socket.connect(f"tcp://localhost:5555")
-    
+
     # Wait for buffer info from server
     print("Waiting for server buffer information...")
     buffer_info = socket.recv_json()
@@ -122,7 +122,7 @@ def main():
     server_len = buffer_info["len"]
     print(f"Received server info - Session ID: {server_session_id}")
     print(f"Server buffer address: {server_ptr}, length: {server_len}")
-    
+
     # Initialize client engine
     HOSTNAME = "localhost" # localhost for simple demo
     METADATA_SERVER = "P2PHANDSHAKE" # [ETCD_SERVER_URL, P2PHANDSHAKE, ...]
@@ -137,12 +137,12 @@ def main():
         DEVICE_NAME
     )
     session_id = f"{HOSTNAME}:{client_engine.get_rpc_port()}"
-    
+
     # Allocate and initialize client buffer (1MB)
     client_buffer = np.ones(1024 * 1024, dtype=np.uint8)  # Fill with ones
     client_ptr = client_buffer.ctypes.data
     client_len = client_buffer.nbytes
-    
+
     # Register memory with Mooncake
     if PROTOCOL == "rdma":
         ret_value = client_engine.register_memory(client_ptr, client_len)
@@ -161,12 +161,12 @@ def main():
             server_ptr,
             min(client_len, server_len)  # Transfer minimum of both lengths
         )
-    
+
         if ret >= 0:
             print("Transfer successful!")
         else:
             print("Transfer failed!")
-    
+
     # Cleanup
     if PROTOCOL == "rdma":
         ret_value = client_engine.unregister_memory(client_ptr)
@@ -178,7 +178,7 @@ def main():
     context.term()
 
 if __name__ == "__main__":
-    main() 
+    main()
 
 ```
 
@@ -245,4 +245,4 @@ store.close()
 
 ### More Examples and Documentation
 
-Please refer to the [Mooncake Store Python API](../python-api-reference/mooncake-store.md), [Mooncake Store](../design/mooncake-store.md) and [Mooncake Store Deployment & Operations Guide](../deployment/mooncake-store-deployment-guide.md) for more examples and documentation.
+Please refer to the [Mooncake Store Python API](../python-api-reference/mooncake-store.md), [Mooncake Store](../design/mooncake-store.md) and [Mooncake Store Deployment & Tuning Guide](../deployment/mooncake-store-deployment-guide.md) for more examples and documentation.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -67,14 +67,22 @@ This repository also hosts its technical report and the open-sourced traces.
 
 getting_started/build
 getting_started/quick-start
-getting_started/supported-protocols
-getting_started/observability
+
+:::
+
+% Deployment docs
+
+:::{toctree}
+:caption: Deployment
+:maxdepth: 2
+
+deployment/mooncake-store-deployment-guide
 getting_started/examples/sglang-integration/index
 getting_started/examples/vllm-integration/index
 Mooncake x LMCache Integration<getting_started/examples/lmcache-integration>
-getting_started/examples/lmdeploy-integration-v0.9
-getting_started/plugin-usage/3FS-USRBIO-Plugin
+Mooncake x LMDeploy Integration<getting_started/examples/lmdeploy-integration-v0.9>
 :::
+
 
 % Making the most out of Mooncake
 
@@ -84,15 +92,7 @@ getting_started/plugin-usage/3FS-USRBIO-Plugin
 
 performance/vllm/index
 performance/sglang/index
-performance/sglang-benchmark-results-v1
-performance/vllm-benchmark-results-v0.2
-performance/vllm-benchmark-results-v1
-performance/sglang-hicache-benchmark-results-v1
-performance/vllm-v1-support-benchmark
-performance/allocator-benchmark-result
-performance/allocation-strategy-benchmark-result
-performance/ssd-offload-benchmark-results
-performance/storage-benchmark
+performance/mooncake/index
 :::
 
 % Explanation of Mooncake internals
@@ -111,7 +111,6 @@ design/unified-parallel-tensor-io
 design/tent/overview
 design/tent/tebench
 design/conductor/conductor-architecture-design
-design/conductor/indexer-api-design
 :::
 
 % API Documentation
@@ -135,15 +134,6 @@ troubleshooting/error-code
 troubleshooting/troubleshooting
 :::
 
-% Deployment docs
-
-:::{toctree}
-:caption: Deployment
-:maxdepth: 2
-
-deployment/mooncake-store-deployment-guide
-deployment/nvmf-ssd-deployment-guide
-:::
 
 % Community
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -25,37 +25,60 @@ Mooncake is the serving platform for <a href="https://kimi.ai/">Kimi</a>, a lead
 Now both the Transfer Engine and Mooncake Store are open-sourced!
 This repository also hosts its technical report and the open-sourced traces.
 
+<h2 id="overview">🎉 Overview</h2>
+
+Mooncake features a KVCache-centric disaggregated architecture that separates prefill and decode clusters. It also leverages underutilized CPU, DRAM, and SSD resources in GPU clusters to build a disaggregated KVCache pool.
+
+:::{figure} ./image/architecture.png
+:align: center
+:alt: Mooncake architecture
+:width: 88%
+:::
+
+At the center of Mooncake is a KVCache-centric scheduler that balances effective throughput with latency-related Service Level Objectives (SLOs). In highly overloaded scenarios, Mooncake uses prediction-based early rejection to avoid wasting computation on requests that cannot meet their SLOs. Experiments show that Mooncake is especially effective for long-context workloads, achieving up to a 525% throughput increase in simulated scenarios while meeting SLOs. Under real workloads, Mooncake's architecture enables <a href="https://kimi.ai/">Kimi</a> to handle 75% more requests.
+
 <h2 id="updates">🔄 Updates</h2>
 
 - **May 7, 2026**: 🚀 [vLLM officially features Mooncake Store](https://vllm.ai/blog/mooncake-store) — a deep dive into how Mooncake's distributed KVCache engine supercharges vLLM inference with high-throughput, memory-efficient, cross-instance KV cache sharing!
 - **Apr 29, 2026**: SGLang introduces [RDMA-based P2P weight transfer for large-scale distributed RL](https://lmsys.org/blog/2026-04-29-p2p-update/) using Mooncake TransferEngine, achieving 7x faster weight updates for the 1T-parameter Kimi-K2 model (53s → 7.2s) with zero-copy RDMA transfer across thousands of GPUs.
- - **Mar 19, 2026**: [TorchSpec: Speculative Decoding Training at Scale](https://pytorch.org/blog/torchspec-speculative-decoding-training-at-scale) is [open sourced](https://github.com/torchspec-project/TorchSpec), using Mooncake to decouple inference and training via efficient hidden states management.
- - **Feb 12, 2026**: [Mooncake Joins PyTorch Ecosystem](https://pytorch.org/blog/mooncake-joins-pytorch-ecosystem/) We are thrilled to announce that Mooncake has officially joined the PyTorch Ecosystem!
- - **Jan 28, 2026**: [FlexKV](https://github.com/taco-project/FlexKV), a distributed KV store and cache system from Tencent and NVIDIA in collaboration with the community, now supports [distributed KVCache reuse](https://github.com/taco-project/FlexKV/blob/main/docs/dist_reuse/README_en.md) with the Mooncake Transfer Engine.
- - **Dec 23, 2025**: SGLang introduces [Encode-Prefill-Decode (EPD) Disaggregation](https://lmsys.org/blog/2026-01-12-epd/) with Mooncake as a transfer backend. This integration allows decoupling compute-intensive multimodal encoders (e.g., Vision Transformers) from language model nodes, utilizing Mooncake's RDMA engine for zero-copy transfer of large multimodal embeddings.
- - **Dec 19, 2025**: Mooncake Transfer Engine has been [integrated into TensorRT LLM](https://github.com/NVIDIA/TensorRT-LLM/tree/main/cpp/tensorrt_llm/executor/cache_transmission/mooncake_utils) for KVCache transfer in PD-disaggregated inference.
- - **Dec 19, 2025**: Mooncake Transfer Engine has been directly integrated into vLLM v1 as a [KV Connector](https://docs.vllm.ai/en/latest/features/mooncake_connector_usage/) in PD-disaggregated setups.
- - **Nov 07, 2025**: [RBG + SGLang HiCache + Mooncake](https://github.com/sgl-project/rbg/blob/main/keps/74-mooncake-integration/README.md), a role-based out-of-the-box solution for cloud native deployment, which is elastic, scalable, and high-performance.
- - **Sept 18, 2025**: Mooncake Store empowers vLLM Ascend by serving as [the distributed KV cache pool backend](https://docs.vllm.ai/projects/ascend/zh-cn/main/user_guide/feature_guide/kv_pool.html).
- - **Sept 10, 2025**: SGLang officially supports Mooncake Store as a [hierarchical KV caching storage backend](https://lmsys.org/blog/2025-09-10-sglang-hicache/). The integration extends RadixAttention with multi-tier KV cache storage across device, host, and remote storage layers.
- - **Sept 10, 2025**: The official & high-performance version of Mooncake P2P Store is open-sourced as [checkpoint-engine](https://github.com/MoonshotAI/checkpoint-engine/). It has been successfully applied in K1.5 and K2 production training, updating Kimi-K2 model (1T parameters) across thousands of GPUs in ~20s.
- - **Aug 23, 2025**: [xLLM](https://github.com/jd-opensource/xllm) high-performance inference engine builds hybrid KV cache management based on Mooncake, supporting global KV cache management with intelligent offloading and prefetching.
- - **Aug 18, 2025**: vLLM-Ascend [integrates Mooncake Transfer Engine](https://docs.vllm.ai/projects/ascend/en/latest/developer_guide/feature_guide/disaggregated_prefill.html) for KV cache register and disaggregate prefill, enabling efficient distributed inference on Ascend NPUs.
- - **Jul 20, 2025**: Mooncake powers [the deployment of Kimi K2](https://lmsys.org/blog/2025-07-20-k2-large-scale-ep/) on 128 H200 GPUs with PD disaggregation and large-scale expert parallelism, achieving 224k tokens/sec prefill throughput and 288k tokens/sec decode throughput.
- - **Jun 20, 2025**: Mooncake becomes a PD disaggregation [backend](https://kvcache-ai.github.io/Mooncake/getting_started/examples/lmdeploy-integration-v0.9.html) for LMDeploy.
- - **May 9, 2025**: NIXL officially supports Mooncake Transfer Engine as [a backend plugin](https://github.com/ai-dynamo/nixl/blob/main/src/plugins/mooncake/README.md).
- - **May 8, 2025**: Mooncake x LMCache <a href="https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/lmcache-integration.md" target="_blank">unite</a> to pioneer KVCache-centric LLM serving system.
- - **May 5, 2025**: Supported by Mooncake Team, SGLang release <a href="https://lmsys.org/blog/2025-05-05-large-scale-ep/" target="_blank">guidance</a> to deploy DeepSeek with PD Disaggregation on 96 H100 GPUs.
- - **Apr 22, 2025**: LMCache officially supports Mooncake Store as a <a href="https://blog.lmcache.ai/2025-04-22-tencent/" target="_blank">remote connector</a>.
- - **Apr 10, 2025**: SGLang officially supports Mooncake Transfer Engine for disaggregated prefilling and KV cache transfer.
- - **Mar 7, 2025**: We open-sourced the Mooncake Store, a distributed KVCache based on Transfer Engine. vLLM's xPyD disaggregated prefilling & decoding based on Mooncake Store will be released soon.
- - **Feb 25, 2025**: Mooncake receives the **Best Paper Award** at **FAST 2025**!
- - **Feb 21, 2025**: The updated <a href="https://github.com/kvcache-ai/Mooncake/tree/main/FAST25-release/traces" target="_blank">traces</a> used in our FAST'25 paper have been released.
- - **Dec 16, 2024**: vLLM officially supports Mooncake Transfer Engine for disaggregated prefilling and KV cache transfer.
- - **Nov 28, 2024**: We open-sourced the Transfer Engine, the central component of Mooncake. We also provide two demonstrations of Transfer Engine: a P2P Store and vLLM integration.
- - **July 9, 2024**: We open-sourced the trace as a <a href="https://github.com/kvcache-ai/Mooncake/blob/main/FAST25-release/arxiv-trace/mooncake_trace.jsonl" target="_blank">JSONL file</a>.
- - **June 27, 2024**: We present a series of Chinese blogs with more discussions on <a href="https://zhuanlan.zhihu.com/p/705754254">zhihu 1</a>, <a href="https://zhuanlan.zhihu.com/p/705910725">2</a>, <a href="https://zhuanlan.zhihu.com/p/706204757">3</a>, <a href="https://zhuanlan.zhihu.com/p/707997501">4</a>, <a href="https://zhuanlan.zhihu.com/p/9461861451">5</a>, <a href="https://zhuanlan.zhihu.com/p/1939988652114580803">6</a>, <a href="https://zhuanlan.zhihu.com/p/1959366095443064318">7</a>.
- - **June 26, 2024**: Initial technical report release.
+- **Mar 19, 2026**: [TorchSpec: Speculative Decoding Training at Scale](https://pytorch.org/blog/torchspec-speculative-decoding-training-at-scale) is [open sourced](https://github.com/torchspec-project/TorchSpec), using Mooncake to decouple inference and training via efficient hidden states management.
+- **Mar 5, 2026**: [LightX2V](https://github.com/ModelTC/LightX2V/pull/893) now supports disaggregated deployment based on Mooncake, enabling encoder/transformer service decoupling with Mooncake Transfer Engine for high-performance cross-device and cross-machine data transfer.
+- **Feb 25, 2026**: [SGLang](https://github.com/sgl-project/sglang) merged [Encoder Global Cache Manager](https://github.com/sgl-project/sglang/pull/16137), introducing a Mooncake-powered global multimodal embedding cache that enables cross-instance sharing of ViT embeddings to avoid redundant GPU computation.
+- **Feb 24, 2026**: [vLLM-Omni](https://docs.vllm.ai/projects/vllm-omni/en/latest/design/feature/disaggregated_inference/) introduces disaggregated inference connectors with support for both `MooncakeStoreConnector` and `MooncakeTransferEngineConnector` for multi-node omni-modality pipelines.
+- **Feb 12, 2026**: [Mooncake Joins PyTorch Ecosystem](https://pytorch.org/blog/mooncake-joins-pytorch-ecosystem/) We are thrilled to announce that Mooncake has officially joined the PyTorch Ecosystem!
+- **Jan 28, 2026**: [FlexKV](https://github.com/taco-project/FlexKV), a distributed KV store and cache system from Tencent and NVIDIA in collaboration with the community, now supports [distributed KVCache reuse](https://github.com/taco-project/FlexKV/blob/main/docs/dist_reuse/README_en.md) with the Mooncake Transfer Engine.
+
+:::{dropdown} Older updates
+:animate: fade-in
+
+- **Dec 27, 2025**: Collaboration with [ROLL](https://github.com/alibaba/ROLL)! Check out the paper [here](https://arxiv.org/abs/2512.22560).
+- **Dec 23, 2025**: SGLang introduces [Encode-Prefill-Decode (EPD) Disaggregation](https://lmsys.org/blog/2026-01-12-epd/) with Mooncake as a transfer backend. This integration allows decoupling compute-intensive multimodal encoders (e.g., Vision Transformers) from language model nodes, utilizing Mooncake's RDMA engine for zero-copy transfer of large multimodal embeddings.
+- **Dec 19, 2025**: Mooncake Transfer Engine has been [integrated into TensorRT LLM](https://github.com/NVIDIA/TensorRT-LLM/tree/main/cpp/tensorrt_llm/executor/cache_transmission/mooncake_utils) for KVCache transfer in PD-disaggregated inference.
+- **Dec 19, 2025**: Mooncake Transfer Engine has been directly integrated into vLLM v1 as a [KV Connector](https://docs.vllm.ai/en/latest/features/mooncake_connector_usage/) in PD-disaggregated setups.
+- **Nov 07, 2025**: [RBG + SGLang HiCache + Mooncake](https://github.com/sgl-project/rbg/blob/main/keps/74-mooncake-integration/README.md), a role-based out-of-the-box solution for cloud native deployment, which is elastic, scalable, and high-performance.
+- **Sept 18, 2025**: Mooncake Store empowers vLLM Ascend by serving as [the distributed KV cache pool backend](https://docs.vllm.ai/projects/ascend/zh-cn/main/user_guide/feature_guide/kv_pool.html).
+- **Sept 10, 2025**: SGLang officially supports Mooncake Store as a [hierarchical KV caching storage backend](https://lmsys.org/blog/2025-09-10-sglang-hicache/). The integration extends RadixAttention with multi-tier KV cache storage across device, host, and remote storage layers.
+- **Sept 10, 2025**: The official & high-performance version of Mooncake P2P Store is open-sourced as [checkpoint-engine](https://github.com/MoonshotAI/checkpoint-engine/). It has been successfully applied in K1.5 and K2 production training, updating Kimi-K2 model (1T parameters) across thousands of GPUs in ~20s.
+- **Aug 23, 2025**: [xLLM](https://github.com/jd-opensource/xllm) high-performance inference engine builds hybrid KV cache management based on Mooncake, supporting global KV cache management with intelligent offloading and prefetching.
+- **Aug 18, 2025**: vLLM-Ascend [integrates Mooncake Transfer Engine](https://docs.vllm.ai/projects/ascend/en/latest/developer_guide/feature_guide/disaggregated_prefill.html) for KV cache register and disaggregate prefill, enabling efficient distributed inference on Ascend NPUs.
+- **Jul 20, 2025**: Mooncake powers [the deployment of Kimi K2](https://lmsys.org/blog/2025-07-20-k2-large-scale-ep/) on 128 H200 GPUs with PD disaggregation and large-scale expert parallelism, achieving 224k tokens/sec prefill throughput and 288k tokens/sec decode throughput.
+- **Jun 20, 2025**: Mooncake becomes a PD disaggregation [backend](getting_started/examples/lmdeploy-integration-v0.9) for LMDeploy.
+
+- **May 9, 2025**: NIXL officially supports Mooncake Transfer Engine as [a backend plugin](https://github.com/ai-dynamo/nixl/blob/main/src/plugins/mooncake/README.md).
+- **May 8, 2025**: [Mooncake x LMCache](getting_started/examples/lmcache-integration) unite to pioneer KVCache-centric LLM serving system.
+- **May 5, 2025**: Supported by Mooncake Team, SGLang release <a href="https://lmsys.org/blog/2025-05-05-large-scale-ep/" target="_blank">guidance</a> to deploy DeepSeek with PD Disaggregation on 96 H100 GPUs.
+- **Apr 22, 2025**: LMCache officially supports Mooncake Store as a <a href="https://blog.lmcache.ai/2025-04-22-tencent/" target="_blank">remote connector</a>.
+- **Apr 10, 2025**: SGLang officially supports Mooncake Transfer Engine for disaggregated prefilling and KV cache transfer.
+- **Mar 7, 2025**: We open-sourced the Mooncake Store, a distributed KVCache based on Transfer Engine. vLLM's xPyD disaggregated prefilling & decoding based on Mooncake Store will be released soon.
+- **Feb 25, 2025**: Mooncake receives the **Best Paper Award** at **FAST 2025**!
+- **Feb 21, 2025**: The updated <a href="https://github.com/kvcache-ai/Mooncake/tree/main/FAST25-release/traces" target="_blank">traces</a> used in our FAST'25 paper have been released.
+- **Dec 16, 2024**: vLLM officially supports Mooncake Transfer Engine for disaggregated prefilling and KV cache transfer.
+- **Nov 28, 2024**: We open-sourced the Transfer Engine, the central component of Mooncake. We also provide two demonstrations of Transfer Engine: a P2P Store and vLLM integration.
+- **July 9, 2024**: We open-sourced the trace as a <a href="https://github.com/kvcache-ai/Mooncake/blob/main/FAST25-release/arxiv-trace/mooncake_trace.jsonl" target="_blank">JSONL file</a>.
+- **June 27, 2024**: We present a series of Chinese blogs with more discussions on <a href="https://zhuanlan.zhihu.com/p/705754254">zhihu 1</a>, <a href="https://zhuanlan.zhihu.com/p/705910725">2</a>, <a href="https://zhuanlan.zhihu.com/p/706204757">3</a>, <a href="https://zhuanlan.zhihu.com/p/707997501">4</a>, <a href="https://zhuanlan.zhihu.com/p/9461861451">5</a>, <a href="https://zhuanlan.zhihu.com/p/1939988652114580803">6</a>, <a href="https://zhuanlan.zhihu.com/p/1959366095443064318">7</a>.
+- **June 26, 2024**: Initial technical report release.
+
+:::
 
 ## Documentation
 

--- a/docs/source/performance/mooncake/index.md
+++ b/docs/source/performance/mooncake/index.md
@@ -1,0 +1,20 @@
+# Mooncake Performance Benchmarks
+
+Benchmarks evaluating Mooncake Store's core storage, allocation, and cache hierarchy behavior.
+
+| Document | Area | Key Findings |
+|----------|------|---------------|
+| [Storage Benchmark](../storage-benchmark) | Mooncake Store storage | Measures end-to-end storage performance across Mooncake Store operations and deployment configurations. |
+| [Allocator Benchmark](../allocator-benchmark-result) | Segment allocation | The optimized OffsetAllocator significantly improves utilization for uniform-size LLM KV cache allocation patterns. |
+| [Allocation Strategy Benchmark](../allocation-strategy-benchmark-result) | Allocation routing | Compares random and free-ratio-first allocation across segments, replicas, skewed capacity, and DSA-style KV+indexer workloads. |
+| [SSD Offload Benchmark](../ssd-offload-benchmark-results) | Cache hierarchy | SSD offload extends the KV cache hierarchy with NVMe, reducing the performance cliff after DRAM cache capacity is exhausted in long multi-turn conversations. |
+
+:::{toctree}
+:maxdepth: 1
+:hidden:
+
+../storage-benchmark
+../allocator-benchmark-result
+../allocation-strategy-benchmark-result
+../ssd-offload-benchmark-results
+:::

--- a/docs/source/performance/sglang/index.md
+++ b/docs/source/performance/sglang/index.md
@@ -1,4 +1,11 @@
-# SGLang Performance Benchmarks
+# SGLang Integration Performance Benchmarks
+
+Benchmarks evaluating Mooncake's integration with SGLang across PD disaggregation and HiCache hierarchical KV cache storage.
+
+| Document | Scenario | Key Findings |
+|----------|----------|---------------|
+| [PD Disaggregation Performance](../sglang-benchmark-results-v1) | SGLang PD disaggregation with Mooncake Transfer Engine | 1P1D PD disaggregation achieves approximately **30% lower ITL** while maintaining comparable throughput against two regular instances. |
+| [HiCache with Mooncake Backend Benchmark](../sglang-hicache-benchmark-results-v1) | SGLang HiCache using Mooncake Store as L3 storage | Mooncake-backed HiCache improves prefill performance in multi-turn workloads by maintaining higher KV cache hit rates as conversation rounds grow. |
 
 :::{toctree}
 :maxdepth: 1

--- a/docs/source/performance/vllm/index.md
+++ b/docs/source/performance/vllm/index.md
@@ -1,4 +1,4 @@
-# vLLM Performance Benchmarks
+# vLLM Integration Performance Benchmarks
 
 Benchmarks evaluating Mooncake's integration with vLLM across different backends and scenarios.
 


### PR DESCRIPTION
## Description
As final part of https://github.com/kvcache-ai/Mooncake/issues/2258

This PR improves the documentation structure around performance content and refreshes the homepage.

**Changes**
- Adds landing pages for Mooncake and SGLang performance benchmarks.
- Links benchmark results back from the relevant SGLang, vLLM, Mooncake Store, allocator, allocation-strategy, and SSD offload docs.
- Updates the homepage with the README overview and limits the visible Updates section to recent items and collapses older entries.

New document sites after this PR merged can be previewed on https://aionw.github.io/index.html
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

- Built locally with `make clean && make html -W` — zero warnings.
- Verified the new sidebar sections and cross-references resolve correctly.
- Preview deployed at https://aionw.github.io/

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.