### PR TITLE
fix(wheel): exclude libfabric/libefa from auditwheel bundle to avoid dual-libfabric EFA conflict

### DIFF
--- a/docs/source/design/transfer-engine/efa_transport.md
+++ b/docs/source/design/transfer-engine/efa_transport.md
@@ -80,6 +80,34 @@ cp mooncake-common/libasio.so ../mooncake-wheel/mooncake/
 pip install -e ../mooncake-wheel --no-build-isolation
 ```
 
+### 3. Building a Distributable Wheel (optional)
+
+To produce a relocatable wheel for distribution (instead of the editable
+install above), use `scripts/build_wheel.sh`, which runs `auditwheel
+repair` to bundle non-system dependencies:
+
+```bash
+# After the cmake/make build above completes:
+PYTHON_VERSION=3.13 BUILD_DIR=build bash scripts/build_wheel.sh 3.13 dist
+pip install dist/mooncake_transfer_engine-*.whl
+```
+
+> **Important (EFA builds):** `auditwheel repair` excludes `libfabric`
+> and `libefa` from the wheel so they resolve to the system EFA
+> installation (`/opt/amazon/efa/lib`) at runtime. This is required
+> because the in-process `aws-ofi-nccl` plugin (loaded by NCCL) links the
+> **same** system `libfabric`. If the wheel bundled its own copy, the
+> process would load two independent libfabric instances — Mooncake's
+> bundled one and NCCL's system one — and whichever initializes first
+> claims the EFA device, leaving the other with an empty provider list
+> (`fi_getinfo: provider efa output empty list`). NCCL then silently
+> falls back to the TCP provider and cross-node collectives such as
+> `all_gather_object` hang. Excluding libfabric/libefa (see
+> `scripts/build_wheel.sh`) keeps a single shared libfabric in the
+> process. If you are on an older Mooncake build whose wheel still bundles
+> libfabric, force the system copy with
+> `export LD_PRELOAD=/opt/amazon/efa/lib/libfabric.so.1` as a workaround.
+
 ## Verification
 
 Test EFA transport initialization:
@@ -495,9 +523,9 @@ SGLang's PD-disaggregation Mooncake integration reads the transport from `MOONCA
 
 ### 1. Apply EFA Patch (only if SGLang version predates PR #25083)
 
-Older SGLang releases hardcode `"rdma"` in the transfer engine init. Since [SGLang PR #25083](https://github.com/sgl-project/sglang/pull/25083) the protocol is read from `MOONCAKE_PROTOCOL`, so once that PR is in your build (or upstream `main`) **this step is unnecessary** — skip to step 2.
+Older SGLang releases hardcode `"rdma"` in the transfer engine init. [SGLang PR #25083](https://github.com/sgl-project/sglang/pull/25083) has been **merged into SGLang `main`**, so the protocol is now read from `MOONCAKE_PROTOCOL`. If your SGLang build includes that PR (any recent `main` or release built after it), **this step is unnecessary** — skip to step 2.
 
-If you are pinned to an older release, apply the [patch script](https://github.com/whn09/kimi-k2-sglang):
+Only if you are pinned to an older release that predates PR #25083, apply the [patch script](https://github.com/whn09/kimi-k2-sglang):
 
 ```bash
 bash patch_sglang_efa.sh

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -280,6 +280,8 @@ else
 fi
 ${AUDITWHEEL_CMD} repair ${OUTPUT_DIR}/*.whl \
     --exclude libcurl.so* \
+    --exclude libfabric.so* \
+    --exclude libefa.so* \
     --exclude libibverbs.so* \
     --exclude libmlx5.so* \
     --exclude libnuma.so* \


### PR DESCRIPTION
## Description

The wheel build runs `auditwheel repair`, which by default grafts every non-excluded shared library the extension links against into the wheel's `mooncake_transfer_engine.libs/` directory and rewrites `engine.so`'s RPATH to prefer the bundled copy. The exclude list already carves out the system RDMA/EFA/CUDA stack (`libibverbs`, `libmlx5`, `libnuma`, `libcuda`, `libcudart`, ...) but **missed `libfabric` and `libefa`**.

As a result a pip-installed wheel ships its own `mooncake_transfer_engine.libs/libfabric-<hash>.so.1` and `engine.so` loads that instead of the system `/opt/amazon/efa/lib/libfabric.so.1`.

On AWS EFA hosts this places **two independent libfabric instances in one process**:
- Mooncake's `engine.so` uses the bundled libfabric (forced by RPATH `$ORIGIN/../mooncake_transfer_engine.libs`),
- `aws-ofi-nccl` (loaded by NCCL/PyTorch) uses the system `/opt/amazon/efa/lib/libfabric.so.1`.

Each instance runs its own `ofi_hmem_init` and opens EFA devices independently. When Mooncake initializes first (e.g. checkpoint-engine P2P, where `TransferEngine.initialize("efa", ...)` runs before `dist.init_process_group("nccl")`), it claims the EFA device context. aws-ofi-nccl's later `fi_getinfo` then returns `provider efa output empty list`, NCCL silently falls back to the TCP provider (`169.254.170.x`), and cross-node collectives such as `all_gather_object` hang.

`libfabric` is the one library that **must** be shared with the system `aws-ofi-nccl` plugin, exactly like `libibverbs`/`libmlx5` already are. Excluding it (and `libefa`) makes the wheel load the same libfabric the rest of the EFA stack uses, eliminating the dual-instance conflict.

## Module

- [x] Python Wheel (`mooncake-wheel`)
- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Reproduced and verified on 2× AWS EFA hosts (8× GPU, 16 EFA NICs each, `/opt/amazon/efa` libfabric 2.4, aws-ofi-nccl, PyTorch with bundled NCCL):

**Before (default `build_wheel.sh`):** the produced wheel contained `mooncake_transfer_engine.libs/libfabric-<hash>.so.1.30.0` and `libefa-<hash>.so.*`. With the wheel installed:
- `ldd .../mooncake/engine.so | grep fabric` → bundled `libfabric-<hash>.so` (via RPATH)
- `ldd /opt/amazon/ofi-nccl/lib/libnccl-net.so | grep fabric` → system `/opt/amazon/efa/lib/libfabric.so.1`
- `/proc/<pid>/maps` of the running job showed **both** libfabric paths loaded simultaneously.
- Running Mooncake-init-then-NCCL: `mooncake initialized on rdmapXXs0`, then NCCL logs `fi_getinfo: provider efa output empty list` → `NET/OFI aws-ofi-nccl initialization failed` → `Using network Socket` (falls off EFA).

**After (this change):** rebuilt the wheel; `mooncake_transfer_engine.libs/` no longer contains libfabric/libefa. The same run shows NCCL `Selected provider is efa, fabric is efa-direct (found 16 nics)` → `Using network Libfabric` — EFA is used, no fallback. (`LD_PRELOAD=/opt/amazon/efa/lib/libfabric.so.1` on the unfixed wheel produces the identical good result, confirming the single-instance fix.)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
