### PR TITLE
[Store] BatchExistKey reads per shard instead of per key

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -910,11 +910,48 @@ auto MasterService::ExistKey(const std::string& key)
 
 std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
     const std::vector<std::string>& keys) {
-    std::vector<tl::expected<bool, ErrorCode>> results;
-    results.reserve(keys.size());
-    for (const auto& key : keys) {
-        results.emplace_back(ExistKey(key));
+    std::vector<tl::expected<bool, ErrorCode>> results(keys.size());
+
+    // Group key indices by their target metadata shard so each shard lock is
+    // acquired once per batch instead of once per key (as repeated ExistKey
+    // calls would do). Keys that hash to the same shard are processed together
+    // under a single shared lock. This only consults the group-routing index
+    // (via getMetadataShardIndex), so it runs before taking snapshot_mutex_ to
+    // keep that critical section limited to the shard reads below.
+    std::unordered_map<size_t, std::vector<size_t>> indices_by_shard;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        indices_by_shard[getMetadataShardIndex(keys[i])].push_back(i);
     }
+
+    // Take snapshot_mutex_ per shard rather than across the whole batch: exist
+    // results are independent per key, so no cross-shard snapshot consistency
+    // is required, and this lets a pending snapshot (which needs the unique
+    // lock) interleave between shards instead of waiting for the full batch.
+    for (const auto& [shard_idx, key_indices] : indices_by_shard) {
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        MetadataShardAccessorRO shard(this, shard_idx);
+        for (size_t i : key_indices) {
+            const auto& key = keys[i];
+            auto it = shard->metadata.find(key);
+            if (it == shard->metadata.end() || !it->second.IsValid()) {
+                VLOG(1) << "key=" << key << ", info=object_not_found";
+                results[i] = false;
+                continue;
+            }
+
+            const auto& metadata = it->second;
+            if (metadata.HasReplica(&Replica::fn_is_completed)) {
+                // Grant a lease to the object as it may be further used by the
+                // client.
+                GrantLeaseForGroup(shard.get(), key, metadata);
+                results[i] = true;
+            } else {
+                // If no complete replica is found, the key does not exist.
+                results[i] = false;
+            }
+        }
+    }
+
     return results;
 }
 

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -3687,6 +3687,59 @@ TEST_F(MasterServiceTest, BatchExistKeyTest) {
     ASSERT_FALSE(exist_resp[test_object_num].value());
 }
 
+// Covers the branches BatchExistKey reimplements inline (rather than calling
+// ExistKey per key): group-id routing through getMetadataShardIndex, the
+// grouped-lease path, the started-but-incomplete replica case, and result
+// ordering across a mix of key kinds.
+TEST_F(MasterServiceTest, BatchExistKeyGroupedAndIncomplete) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    const UUID client_id = generate_uuid();
+
+    constexpr size_t buffer = 0x300000000;
+    constexpr size_t size = 1024 * 1024 * 128;
+    [[maybe_unused]] const auto context =
+        PrepareSimpleSegment(*service_, "test_segment", buffer, size);
+
+    // Two grouped keys sharing a group id that routes to a shard different from
+    // grouped_key_a's own shard. BatchExistKey must route both via the group id
+    // so they land on the same shard and are processed under a single lock,
+    // exercising getMetadataShardIndex's group path and GrantLeaseForGroup.
+    const std::string grouped_key_a = "batch_grouped_key_a";
+    const std::string grouped_key_b = "batch_grouped_key_b";
+    const std::string group_id = FindGroupIdOnDifferentShard(grouped_key_a);
+    ReplicateConfig grouped_config;
+    grouped_config.replica_num = 1;
+    grouped_config.group_ids = std::vector<std::string>{group_id};
+    PutCompletedObject(*service_, client_id, grouped_key_a, grouped_config);
+    PutCompletedObject(*service_, client_id, grouped_key_b, grouped_config);
+
+    // An ungrouped, fully-completed key.
+    const std::string completed_key = "batch_completed_key";
+    ReplicateConfig config;
+    config.replica_num = 1;
+    PutCompletedObject(*service_, client_id, completed_key, config);
+
+    // A key that started but never completed: it exists in metadata but has no
+    // complete replica, so it must report as not existing.
+    const std::string incomplete_key = "batch_incomplete_key";
+    ASSERT_TRUE(service_->PutStart(client_id, incomplete_key, 1024, config)
+                    .has_value());
+
+    // A key that was never put at all.
+    const std::string missing_key = "batch_missing_key";
+
+    std::vector<std::string> keys = {grouped_key_a, completed_key,
+                                     incomplete_key, missing_key,
+                                     grouped_key_b};
+    auto resp = service_->BatchExistKey(keys);
+    ASSERT_EQ(resp.size(), keys.size());
+    EXPECT_TRUE(resp[0].value());   // grouped_key_a
+    EXPECT_TRUE(resp[1].value());   // completed_key
+    EXPECT_FALSE(resp[2].value());  // incomplete_key: started, not completed
+    EXPECT_FALSE(resp[3].value());  // missing_key: never put
+    EXPECT_TRUE(resp[4].value());   // grouped_key_b
+}
+
 TEST_F(MasterServiceTest, BatchQueryIpTest) {
     std::unique_ptr<MasterService> service_(new MasterService());
     const UUID client_id = generate_uuid();


### PR DESCRIPTION
## What

`MasterService::BatchExistKey` previously looped over the keys and called `ExistKey` once per key. Each `ExistKey` call independently acquires `snapshot_mutex_` (shared) and the target shard's mutex (shared) — so a batch of N keys took N snapshot-lock and N shard-lock acquisitions, even when many keys map to the same shard.

This PR makes `BatchExistKey` batch its reads per shard:

1. Bucket each key's input index by its target metadata shard via `getMetadataShardIndex` (which respects group routing). This consults only the group-routing index, so it runs before taking `snapshot_mutex_`.
2. For each touched shard, take the shard lock once and process all of that shard's keys together.

Lock acquisitions drop from O(num keys) to O(num distinct shards touched).

The per-key logic is unchanged from `ExistKey`: validity check, completed-replica check, and `GrantLeaseForGroup`. Results are written back by original input index, so output ordering is preserved.

`snapshot_mutex_` is taken per shard rather than across the whole batch. Exist results are independent per key, so no cross-shard snapshot consistency is required, and a pending snapshot (which needs the unique lock) can interleave between shards instead of waiting for the entire batch.

## Tests

Extended `BatchExistKeyTest` with a focused `BatchExistKeyGroupedAndIncomplete` case covering the branches `BatchExistKey` now reimplements inline rather than delegating to `ExistKey`:
- group-id routing through `getMetadataShardIndex` (two grouped keys sharing a group id that routes to a different shard) and the grouped-lease path,
- a started-but-incomplete replica (`PutStart` without `PutEnd`) reporting as not existing,
- result ordering across a mix of grouped / completed / incomplete / missing keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)