### PR TITLE
feat(store): add NoF SSD deployment tools and e2e coverage

### DIFF
--- a/docs/source/deployment/nvmf-ssd-deployment-guide.md
+++ b/docs/source/deployment/nvmf-ssd-deployment-guide.md
@@ -1,0 +1,286 @@
+# Mooncake NVMe-oF SSD Pool Deployment Guide
+
+## Overview
+
+This guide shows how to attach an NVMe-oF SSD pool to Mooncake Store. The
+deployment has two main phases:
+
+- Start Mooncake services built with NoF support enabled.
+- Create SPDK NVMe-oF targets on SSD pool nodes and register their namespaces
+  with the Mooncake master.
+
+After registration, the master reports the registered NVMe-oF namespaces as a
+remote SSD pool in its metrics, and clients can place NoF replicas through
+Mooncake Store.
+
+## 1. Build Mooncake with NoF Support
+
+Follow the "Build with NVMe-oF SSD Pool" section in the
+[Build Guide](../getting_started/build.md) to install SPDK dependencies and
+build Mooncake with `-DUSE_NOF=ON`.
+
+## 2. Deploy Mooncake Services
+
+### 2.1 Node Topology
+
+- **Mooncake service node**: 192.168.65.81. This node runs the master, metadata, and store services.
+- **SSD pool nodes**: 192.168.65.56 and 192.168.65.57. These nodes provide SSD storage resources.
+
+### 2.2 Deploy the Master Service
+
+```bash
+mooncake_master --rpc_address=192.168.65.81
+```
+
+### 2.3 Deploy the Metadata Service
+
+```bash
+python3 -m mooncake.http_metadata_server --host=192.168.65.81 --port=8080
+```
+
+If an aiohttp-related error occurs during startup, install aiohttp:
+
+```bash
+pip3 install aiohttp
+```
+
+### 2.4 Deploy the Store Service
+
+#### Configure `store_service.json`
+
+Create `store_service.json` under `/home`:
+
+```json
+{
+  "local_hostname": "localhost",
+  "metadata_server": "http://192.168.65.81:8080/metadata",
+  "master_server_address": "192.168.65.81:50051",
+  "protocol": "rdma",
+  "device_name": "mlx5_0",
+  "global_segment_size": "50gb",
+  "local_buffer_size": 0
+}
+```
+
+**Notes**:
+
+- `device_name`: Run `ibv_devices` on node 192.168.65.81 to check the RDMA device name.
+
+#### Start the Service
+
+The store service initializes the SPDK environment during startup. Configure hugepages on the store service node, 192.168.65.81:
+
+```bash
+echo 512 > /proc/sys/vm/nr_hugepages
+```
+
+Only a small number of hugepages is required during startup. In most cases, 512 hugepages are sufficient.
+
+Start the store service:
+
+```bash
+python3 -m mooncake.mooncake_store_service --config=/home/store_service.json --port=8081
+```
+
+If a timeout error occurs during startup, check whether a proxy is configured on node 192.168.65.81. If a proxy is configured, unset the proxy configuration and try again.
+
+## 3. Deploy the NVMe-oF SSD Pool
+
+### 3.1 Prerequisites
+
+1. Configure passwordless SSH login from the Mooncake node, 192.168.65.81, to the SSD pool nodes, 192.168.65.56 and 192.168.65.57.
+   See [OpenSSH key-based authentication](https://help.ubuntu.com/community/SSH/OpenSSH/Keys).
+2. Build SPDK on each SSD pool node in advance.
+   See [SPDK build instructions](https://github.com/spdk/spdk/blob/master/README.md#build).
+
+### 3.2 Install SSH Dependencies
+
+```bash
+python3 -m pip install "paramiko>=3.4.0"
+```
+
+### 3.3 Deploy the SSD Pool
+
+#### Deployment Command
+
+```bash
+python3 -m mooncake.spdk_tgt_create \
+    --spdk_target_info="ip:192.168.65.56 path:/home/spdk pci:0000:01:00.0,0000:02:00.0" \
+    --spdk_target_info="ip:192.168.65.57 path:/home/spdk" \
+    --core-mask=0xff \
+    --transport-type=RDMA \
+    --max-queue-depth=128 \
+    --max-io-qpairs-per-ctrlr=127 \
+    --max-io-size=4096 \
+    --in-capsule-data-size=131072 \
+    --io-unit-size=131072 \
+    --max-aq-depth=128 \
+    --num-shared-buffers=4096 \
+    --buf-cache-size=32
+```
+
+#### Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `ip` | IP address of the target node. |
+| `path` | SPDK installation path on the target node. |
+| `pci` | PCI addresses of SSDs to register with the target. Use commas to separate multiple PCI addresses. If this field is omitted, SPDK-ready or unmounted NVMe devices on the target node are registered. |
+| `--core-mask` | CPU core mask used to start `nvmf_tgt` with `-m`. The default value is `0xff`. |
+
+**Tip**: Run `/path/scripts/setup.sh status` on a target node to list available PCI addresses.
+
+#### Transport Options
+
+The transport options are passed to the SPDK `nvmf_create_transport` RPC. If an option is not specified, the tool uses the default value listed below.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--transport-type` | `RDMA` | NVMe-oF transport type. |
+| `--max-queue-depth` | `128` | Maximum number of outstanding I/O operations per queue. |
+| `--max-io-qpairs-per-ctrlr` | `127` | Maximum number of I/O queue pairs per controller. |
+| `--max-io-size` | `4096` | Maximum I/O size, in bytes. |
+| `--in-capsule-data-size` | `131072` | Maximum in-capsule data size, in bytes. |
+| `--io-unit-size` | `131072` | I/O unit size, in bytes. |
+| `--max-aq-depth` | `128` | Maximum number of admin commands per admin queue. |
+| `--num-shared-buffers` | `4096` | Number of pooled data buffers available to the transport. |
+| `--buf-cache-size` | `32` | Number of shared buffers reserved for each poll group. |
+
+## 4. Register the NVMe-oF SSD Pool
+
+### 4.1 Register All SSDs
+
+```bash
+python3 -m mooncake.mooncake_ssd_register \
+    --master_server_address=192.168.65.81:50051 \
+    --spdk_target_info="ip:192.168.65.56 path:/home/spdk" \
+    --spdk_target_info="ip:192.168.65.57 path:/root/spdk"
+```
+
+#### Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--master_server_address` | IP address and port of the master service node. The default port is 50051. |
+| `--spdk_target_info` | Target node information, including `ip`, the node IP address, and `path`, the SPDK installation path. |
+| `--username` | SSH username used to connect to target nodes. The default value is `root`. |
+| `--port` | SSH port used to connect to target nodes. The default value is `22`. |
+| `--password` | SSH password used to connect to target nodes. |
+| `--key-file` | SSH private key file used to connect to target nodes. |
+
+## 5. Unregister the NVMe-oF SSD Pool
+
+### 5.1 Unregister a Specific SSD
+
+```bash
+python3 -m mooncake.mooncake_ssd_unregister \
+    --master_server_address=192.168.65.81:50051 \
+    --spdk_target_info="ip:192.168.65.56 ns:1 nqn:nqn.2016-06.io.spdk:cnode1"
+```
+
+#### Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--master_server_address` | IP address and port of the master service node. The default port is 50051. |
+| `--spdk_target_info` | Disk information to unregister, including `ip`, the node IP address, `ns`, the namespace ID, and `nqn`, the subsystem NQN. |
+| `--username` | SSH username used to connect to target nodes. The default value is `root`. |
+| `--port` | SSH port used to connect to target nodes. The default value is `22`. |
+| `--password` | SSH password used to connect to target nodes. |
+| `--key-file` | SSH private key file used to connect to target nodes. |
+
+### 5.2 Get Target Disk Information
+
+Enter the SPDK directory on the target node and run the following commands.
+
+1. Show subsystem information, including NQN and namespace IDs:
+
+```bash
+./scripts/rpc.py nvmf_get_subsystems
+```
+
+2. Show disk details, including block size and PCI address:
+
+```bash
+./scripts/rpc.py bdev_get_bdevs
+```
+
+## 6. Performance Tests
+
+### 6.1 Use the Built-in Benchmark Tool
+
+```bash
+./build/mooncake-store/benchmarks/nof_worker_pool_bench \
+    --endpoints='traddr:192.168.65.56 trsvcid:4420 subnqn:nqn.2016-06.io.spdk:cnode1 trtype:RDMA adrfam:IPv4 ns:1, traddr:192.168.65.56 trsvcid:4420 subnqn:nqn.2016-06.io.spdk:cnode1 trtype:RDMA adrfam:IPv4 ns:2' \
+    --op=read \
+    --io_size=1048576 \
+    --iodepth=8 \
+    --warmup_sec=3 \
+    --duration_sec=30
+```
+
+#### Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--endpoints` | Disk information used for the test. |
+| `--op` | I/O operation type, either `read` or `write`. |
+| `--io_size` | Block size in bytes. |
+| `--iodepth` | Read/write queue depth. |
+| `--warmup_sec` | Warmup duration in seconds. |
+| `--duration_sec` | Test duration in seconds. |
+
+### 6.2 Use NoF with vLLM + LMCache
+
+For the general VLLM + LMCache + Mooncake deployment flow, see
+[vLLM V1 Disaggregated Serving with Mooncake Store and LMCache](../getting_started/examples/vllm-integration/vllmv1-lmcache-integration.md).
+After the NVMe-oF SSD pool is registered with Mooncake, add the NoF-specific
+Mooncake configuration below.
+
+#### NoF Environment Variables
+
+```bash
+export LMCACHE_CONFIG_FILE="/path/vllm-lmcache-mooncake-config.yaml"
+export MC_NOF_WORKERS=4
+export MC_NOF_SUBMIT_CHUNK_BYTES=$((1 << 17))  # 128KB
+export MC_NOF_INFLIGHT_BYTES_LIMIT=$((1 << 25))  # 32MB
+```
+
+#### NoF LMCache Configuration
+
+```yaml
+chunk_size: 256
+remote_url: "mooncakestore://192.168.65.81:50051/"
+remote_serde: "naive"
+local_cpu: True
+max_local_cpu_size: 8
+enable_mooncake_nof_pool: True
+
+extra_config:
+  local_hostname: "localhost"
+  metadata_server: "http://192.168.65.81:8080/metadata"
+  master_server_address: "192.168.65.81:50051"
+  global_segment_size: 0
+  local_buffer_size: 1073741824
+  protocol: "rdma"
+  device_name: "mlx5_0"
+```
+
+**Notes**:
+
+- `enable_mooncake_nof_pool=True` enables writing KV cache objects to the
+  registered NoF pool.
+- `global_segment_size: 0` means the inference process does not contribute a
+  memory segment to the Mooncake cluster.
+- Keep `local_buffer_size` non-zero because the client still needs local
+  staging buffers for Mooncake transfers.
+- The parameters in `extra_config` should use the same Mooncake master,
+  metadata server, protocol, and RDMA device as the store service.
+
+| Environment Variable | Description | Default |
+|----------------------|-------------|---------|
+| `MC_NOF_WORKERS` | Number of worker threads used to process SPDK NoF I/O operations. | 4 |
+| `MC_NOF_SUBMIT_CHUNK_BYTES` | Size of each I/O operation submitted to SPDK. | 128KB |
+| `MC_NOF_INFLIGHT_BYTES_LIMIT` | Maximum number of in-flight I/O bytes allowed in the system. | 32MB |
+
+These three parameters together provide QoS control for SPDK NoF I/O.

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -45,6 +45,24 @@ pip install mooncake-transfer-engine-non-cuda
    sudo make install
    ```
 
+### Build with NVMe-oF SSD Pool
+
+To enable the NVMe-oF SSD pool, install the SPDK dependencies and build
+Mooncake with `USE_NOF` enabled:
+
+```bash
+bash dependencies.sh --with-spdk
+
+mkdir build
+cd build
+cmake .. -DUSE_NOF=ON
+make -j
+sudo make install
+```
+
+`-DUSE_NOF=ON` builds the NoF registration APIs and deployment tools. Use
+`-DUSE_NOF=OFF` or omit the option when the NVMe-oF SSD pool is not needed.
+
 ## Manual Build
 
 ### Recommended Version

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -142,6 +142,7 @@ troubleshooting/troubleshooting
 :maxdepth: 2
 
 deployment/mooncake-store-deployment-guide
+deployment/nvmf-ssd-deployment-guide
 :::
 
 % Community

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -161,6 +161,15 @@ if(WITH_STORE)
       "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_config.py"
       "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/cli.py"
     DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
+
+  if(USE_NOF)
+    install(
+      FILES
+        "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_ssd_register.py"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_ssd_unregister.py"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/spdk_tgt_create.py"
+      DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
+  endif()
 endif()
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_PACKAGE_NAME}/

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -11,6 +11,8 @@
 #include "dummy_client.h"
 #include "real_client.h"
 #include "types.h"
+#include "memory_alloc.h"
+#include "ssd_register_client.h"
 
 #include <cstdlib>  // for atexit
 #include <memory>
@@ -1642,6 +1644,21 @@ class MooncakeHostMemAllocatorPyWrapper {
     ~MooncakeHostMemAllocatorPyWrapper() { shm_helper_ = nullptr; }
 };
 
+uintptr_t get_alloc_func_addr() {
+    return reinterpret_cast<uintptr_t>(&hugepage_memory_alloc);
+}
+
+uintptr_t get_free_func_addr() {
+    return reinterpret_cast<uintptr_t>(&hugepage_memory_free);
+}
+
+class MooncakeDistributedNoFRegisterPyWrapper {
+   public:
+    std::shared_ptr<NoFRegisterClient> register_{nullptr};
+
+    MooncakeDistributedNoFRegisterPyWrapper() = default;
+};
+
 PYBIND11_MODULE(store, m) {
     // Object data type classification
     py::enum_<ObjectDataType>(m, "ObjectDataType")
@@ -1661,10 +1678,13 @@ PYBIND11_MODULE(store, m) {
     py::class_<ReplicateConfig>(m, "ReplicateConfig")
         .def(py::init<>())
         .def_readwrite("replica_num", &ReplicateConfig::replica_num)
+        .def_readwrite("nof_replica_num", &ReplicateConfig::nof_replica_num)
         .def_readwrite("with_soft_pin", &ReplicateConfig::with_soft_pin)
         .def_readwrite("with_hard_pin", &ReplicateConfig::with_hard_pin)
         .def_readwrite("preferred_segments",
                        &ReplicateConfig::preferred_segments)
+        .def_readwrite("preferred_nof_segments",
+                       &ReplicateConfig::preferred_nof_segments)
         .def_readwrite("preferred_segment", &ReplicateConfig::preferred_segment)
         .def_readwrite("prefer_alloc_in_same_node",
                        &ReplicateConfig::prefer_alloc_in_same_node)
@@ -1871,6 +1891,29 @@ PYBIND11_MODULE(store, m) {
             })
         .def_readwrite("parallelism", &ReadTargetSpec::parallelism);
 
+    py::class_<MooncakeDistributedNoFRegisterPyWrapper>(
+        m, "MooncakeDistributedNoFRegister")
+        .def(py::init<>())
+        .def("real_register",
+             [](MooncakeDistributedNoFRegisterPyWrapper &self,
+                const std::string &nqn = "", size_t nsid = 1,
+                const std::string &traddr = "", size_t trsvcid = 4420,
+                uintptr_t base = 0x0, size_t size = 1024,
+                const std::string &master_server_addr = "127.0.0.1:50051") {
+                 self.register_ = std::make_shared<NoFRegisterClient>();
+                 return self.register_->set_register(nqn, nsid, traddr, trsvcid,
+                                                     base, size,
+                                                     master_server_addr);
+             })
+        .def("real_unregister_by_endpoint",
+             [](MooncakeDistributedNoFRegisterPyWrapper &self,
+                const std::string &nqn = "", size_t nsid = 1,
+                const std::string &traddr = "", size_t trsvcid = 4420,
+                const std::string &master_server_addr = "127.0.0.1:50051") {
+                 self.register_ = std::make_shared<NoFRegisterClient>();
+                 return self.register_->set_unregister_by_endpoint(
+                     nqn, nsid, traddr, trsvcid, master_server_addr);
+             });
     // Create a wrapper that exposes DistributedObjectStore with Python-specific
     // methods
     // Helper function to extract PyClient shared_ptr from
@@ -2844,6 +2887,9 @@ PYBIND11_MODULE(store, m) {
         py::arg("node"),
         "Bind the current thread and memory allocation preference to the "
         "specified NUMA node");
+
+    m.def("get_alloc_func_addr", &get_alloc_func_addr);
+    m.def("get_free_func_addr", &get_free_func_addr);
 
     // Add EngramStore bindings
     mooncake::engram::bind_engram_store(m);

--- a/mooncake-store/benchmarks/store_kv_bench.md
+++ b/mooncake-store/benchmarks/store_kv_bench.md
@@ -1,0 +1,204 @@
+# `store_kv_bench.py`
+
+`store_kv_bench.py` is a Mooncake Store end-to-end KV benchmark tool. It talks
+to a real Mooncake cluster through the Python `store` binding and can exercise
+`put/get` as well as zero-copy `put_from/get_into` style APIs.
+
+## Scope
+
+This tool focuses on object-semantic benchmark scenarios:
+
+- Functional verification with read-after-write validation
+- Dataset fill for eviction / capacity tests
+- Pure write performance
+- Pure read performance
+- Read/write mixed mode with "existing-object read + new-object write"
+
+Fault injection, NoF register / unregister, heartbeat trigger, memory segment
+unmount, and target-side operations are intentionally out of scope. The tool
+supports phase gaps so external tools can finish those operations before the
+next phase continues.
+
+## Supported Scenarios
+
+- `verify_write`
+  - Fixed-count write followed by full readback verification
+- `fill`
+  - Fixed-count write used for filling a dataset / eviction watermark
+- `write_perf`
+  - Time-based or fixed-count write benchmark
+- `read_perf`
+  - Optional prepare-write phase, then read performance benchmark
+- `mixed_rw`
+  - Optional prepare-write phase, then mixed "read prepared objects + write new objects"
+
+## APIs
+
+- `--io-api=plain`
+  - Single object:
+    - `put`
+    - `get`
+  - Batch:
+    - `put_batch`
+    - `get_batch`
+- `--io-api=zcopy`
+  - Single object:
+    - `put_from`
+    - `get_into`
+  - Batch:
+    - `batch_put_from`
+    - `batch_get_into`
+
+`zcopy` mode automatically allocates temporary user buffers and registers them
+with `register_buffer`.
+
+## Key Rules
+
+- Keys are generated deterministically:
+  - `{prefix padded/truncated to fit}{16-digit object id}`
+- The same `key-prefix`, `key-size`, and `object-id-start` produce the same key sequence
+- `verify` currently requires `pattern`
+- Any write-involved scenario requires `value-size` to be 512-byte aligned
+- `memory-replica-num` and `nof-replica-num` cannot both be `0`
+- `prepare-objects`
+  - Controls how many objects are written by the prepare phase
+  - `0` means reuse `nr-objects`
+
+## Phase Gap
+
+Phase gaps are used when an external tool needs time to inject a fault or do an
+unmount / remount operation.
+
+- `--phase-gap-mode=none`
+  - Continue immediately
+- `--phase-gap-mode=sleep --phase-gap-sec=N`
+  - Sleep before the next phase
+- `--phase-gap-mode=manual`
+  - Wait for Enter
+- `--phase-gap-mode=file --phase-gap-file=/tmp/bench.ready`
+  - Wait until the file exists
+
+If `file` mode is used, make sure the marker file does not already exist before
+starting the benchmark.
+
+## Common Examples
+
+### 1. Functional verification (`1+0`)
+
+```bash
+python3 mooncake-store/benchmarks/store_kv_bench.py \
+  --scenario verify_write \
+  --io-api plain \
+  --local-hostname 127.0.0.1:50071 \
+  --metadata-server http://127.0.0.1:8080/metadata \
+  --master-server 127.0.0.1:50051 \
+  --protocol tcp \
+  --global-segment-size $((64*1024*1024)) \
+  --local-buffer-size $((32*1024*1024)) \
+  --nr-objects 16 \
+  --batch-size 4 \
+  --key-prefix verify \
+  --key-size 20 \
+  --value-size 4096 \
+  --memory-replica-num 1 \
+  --nof-replica-num 0 \
+  --verify \
+  --pattern 0xab
+```
+
+### 2. NoF-only functional verification (`0+1`)
+
+```bash
+python3 mooncake-store/benchmarks/store_kv_bench.py \
+  --scenario verify_write \
+  --io-api plain \
+  --local-hostname 127.0.0.1:50071 \
+  --metadata-server http://127.0.0.1:8080/metadata \
+  --master-server 127.0.0.1:50051 \
+  --protocol tcp \
+  --global-segment-size 0 \
+  --local-buffer-size $((8*1024*1024)) \
+  --nr-objects 8 \
+  --batch-size 2 \
+  --key-prefix nofonly \
+  --key-size 20 \
+  --value-size 4096 \
+  --memory-replica-num 0 \
+  --nof-replica-num 1 \
+  --verify \
+  --pattern 0xcd
+```
+
+### 3. Read performance with automatic prepare phase
+
+```bash
+python3 mooncake-store/benchmarks/store_kv_bench.py \
+  --scenario read_perf \
+  --prepare-mode auto \
+  --phase-gap-mode sleep \
+  --phase-gap-sec 1 \
+  --io-api plain \
+  --local-hostname 127.0.0.1:50071 \
+  --metadata-server http://127.0.0.1:8080/metadata \
+  --master-server 127.0.0.1:50051 \
+  --protocol tcp \
+  --nr-objects 32 \
+  --batch-size 4 \
+  --runtime 5 \
+  --key-prefix readperf \
+  --key-size 20 \
+  --value-size 4096 \
+  --memory-replica-num 1 \
+  --nof-replica-num 0 \
+  --verify \
+  --pattern 0xee
+```
+
+### 4. Mixed read/write with initial dataset
+
+```bash
+python3 mooncake-store/benchmarks/store_kv_bench.py \
+  --scenario mixed_rw \
+  --prepare-mode auto \
+  --io-api zcopy \
+  --local-hostname 127.0.0.1:50071 \
+  --metadata-server http://127.0.0.1:8080/metadata \
+  --master-server 127.0.0.1:50051 \
+  --protocol tcp \
+  --nr-objects 64 \
+  --write-objects 4096 \
+  --batch-size 4 \
+  --runtime 10 \
+  --rwmixread 70 \
+  --key-prefix mixed \
+  --key-size 20 \
+  --value-size 4096 \
+  --memory-replica-num 1 \
+  --nof-replica-num 1 \
+  --verify \
+  --pattern 0x5a
+```
+
+In `mixed_rw`, reads are served from the prepared object set, while writes
+always use fresh object ids. This keeps the workload as "existing-object read +
+new-object write" and avoids key overlap between the read and write streams.
+
+## Output
+
+Each phase prints:
+
+- request counts
+- KV counts
+- miss / verify-failure counts
+- bytes processed
+- duration
+- `req/s`
+- `kv/s`
+- `MiB/s`
+- `lat_mean`
+- `lat_p50`
+- `lat_p95`
+- `lat_p99`
+- aggregated error counts
+
+An overall summary is printed after all phases complete.

--- a/mooncake-store/benchmarks/store_kv_bench.py
+++ b/mooncake-store/benchmarks/store_kv_bench.py
@@ -1,0 +1,1028 @@
+#!/usr/bin/env python3
+"""Mooncake Store end-to-end KV benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import logging
+import math
+import os
+import random
+import statistics
+import threading
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, List, Optional
+from mooncake.store import MooncakeDistributedStore, ReplicateConfig, get_alloc_func_addr, get_free_func_addr
+
+
+LOG = logging.getLogger("store_kv_bench")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Mooncake Store end-to-end KV benchmark",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--scenario",
+        required=True,
+        choices=["verify_write", "fill", "write_perf", "read_perf", "mixed_rw"],
+        help="Benchmark scenario to execute.",
+    )
+
+    parser.add_argument("--local-hostname", default="127.0.0.1:50071")
+    parser.add_argument("--metadata-server", default="http://127.0.0.1:8080/metadata")
+    parser.add_argument("--master-server", default="127.0.0.1:50051")
+    parser.add_argument("--protocol", default="tcp")
+    parser.add_argument("--device-name", default="")
+    parser.add_argument("--global-segment-size", type=int, default=64 * 1024 * 1024)
+    parser.add_argument("--local-buffer-size", type=int, default=32 * 1024 * 1024)
+    parser.add_argument(
+        "--io-api",
+        choices=["plain", "zcopy"],
+        default="plain",
+        help="plain uses put/get/put_batch/get_batch, zcopy uses put_from/get_into/batch_put_from/batch_get_into",
+    )
+
+    parser.add_argument("--numjobs", type=int, default=1)
+    parser.add_argument("--iodepth", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--runtime", type=int, default=0, help="Seconds. 0 means object-count based.")
+    parser.add_argument("--nr-objects", type=int, default=128)
+    parser.add_argument("--write-objects", type=int, default=0)
+    parser.add_argument(
+        "--prepare-objects",
+        type=int,
+        default=0,
+        help="Object count used by the prepare phase. 0 means reuse nr-objects.",
+    )
+    parser.add_argument("--object-id-start", type=int, default=0)
+    parser.add_argument("--key-prefix", default="kvbench")
+    parser.add_argument("--key-size", type=int, default=20)
+    parser.add_argument("--value-size", type=int, default=4096)
+    parser.add_argument("--rand-seed", type=int, default=1)
+
+    parser.add_argument("--memory-replica-num", type=int, default=1)
+    parser.add_argument("--nof-replica-num", type=int, default=0)
+
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--pattern", default="")
+    parser.add_argument("--prepare-mode", choices=["auto", "none", "write"], default="auto")
+    parser.add_argument("--rwmixread", type=int, default=70)
+
+    parser.add_argument(
+        "--phase-gap-mode",
+        choices=["none", "sleep", "manual", "file"],
+        default="none",
+    )
+    parser.add_argument("--phase-gap-sec", type=int, default=0)
+    parser.add_argument("--phase-gap-file", default="")
+    parser.add_argument("--phase-gap-timeout-sec", type=int, default=600)
+    parser.add_argument("--log-level", default="INFO")
+    return parser
+
+
+def setup_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+@dataclass
+class PhaseStats:
+    name: str
+    request_latencies: List[float] = field(default_factory=list)
+    requests: int = 0
+    successful_requests: int = 0
+    failed_requests: int = 0
+    kvs: int = 0
+    successful_kvs: int = 0
+    failed_kvs: int = 0
+    misses: int = 0
+    verify_failures: int = 0
+    bytes_processed: int = 0
+    error_counts: Counter = field(default_factory=Counter)
+    start_time: float = 0.0
+    end_time: float = 0.0
+    dataset_exhausted: bool = False
+
+
+@dataclass
+class RequestResult:
+    request_ok: bool
+    kv_successes: int
+    kv_failures: int
+    bytes_processed: int
+    successful_object_ids: List[int] = field(default_factory=list)
+    misses: int = 0
+    verify_failures: int = 0
+    error_counts: Counter = field(default_factory=Counter)
+
+
+class PayloadFactory:
+    def __init__(self, value_size: int, pattern: bytes):
+        self.value_size = value_size
+        self.pattern = pattern
+        self._default_cache: dict[int, bytes] = {}
+        self._pattern_payload = self._repeat(pattern) if pattern else b""
+
+    def _repeat(self, token: bytes) -> bytes:
+        repeat = (self.value_size + len(token) - 1) // len(token)
+        return (token * repeat)[: self.value_size]
+
+    def build(self, object_id: int) -> bytes:
+        if self.pattern:
+            return self._pattern_payload
+        fill_byte = object_id & 0xFF
+        payload = self._default_cache.get(fill_byte)
+        if payload is None:
+            payload = bytes([fill_byte]) * self.value_size
+            self._default_cache[fill_byte] = payload
+        return payload
+
+    def verify_payload(self, object_id: int, payload: bytes) -> bool:
+        return payload == self.build(object_id)
+
+
+class DatasetState:
+    def __init__(self, object_id_start: int):
+        self.write_lock = threading.Lock()
+        self.ids_lock = threading.Lock()
+        self.cursor_lock = threading.Lock()
+        self.next_write_id = object_id_start
+        self.prepared_ids: tuple[int, ...] = ()
+        self.written_ids: tuple[int, ...] = ()
+        self.read_cursor = 0
+
+    def reserve_write_ids(self, count: int, upper_bound: int) -> List[int]:
+        with self.write_lock:
+            if self.next_write_id >= upper_bound:
+                return []
+            end = min(self.next_write_id + count, upper_bound)
+            ids = list(range(self.next_write_id, end))
+            self.next_write_id = end
+            return ids
+
+    def mark_prepared(self, ids: Iterable[int]) -> None:
+        ids = tuple(ids)
+        if not ids:
+            return
+        with self.ids_lock:
+            self.prepared_ids = self.prepared_ids + ids
+            self.written_ids = self.written_ids + ids
+
+    def mark_runtime_written(self, ids: Iterable[int]) -> None:
+        ids = tuple(ids)
+        if not ids:
+            return
+        with self.ids_lock:
+            self.written_ids = self.written_ids + ids
+
+    def written_count(self) -> int:
+        with self.ids_lock:
+            return len(self.written_ids)
+
+    def snapshot_written_ids(self) -> List[int]:
+        with self.ids_lock:
+            return list(self.written_ids)
+
+    def next_read_ids(
+        self,
+        count: int,
+        *,
+        loop: bool,
+        sequential: bool,
+        rng,
+        source: str = "written",
+    ) -> List[int]:
+        with self.ids_lock:
+            readable_ids = self.prepared_ids if source == "prepared" else self.written_ids
+        if not readable_ids:
+            return []
+        if sequential:
+            with self.cursor_lock:
+                result = []
+                for _ in range(count):
+                    if self.read_cursor >= len(readable_ids):
+                        if not loop:
+                            break
+                        self.read_cursor = 0
+                    result.append(readable_ids[self.read_cursor])
+                    self.read_cursor += 1
+                return result
+        return [readable_ids[rng.randrange(len(readable_ids))] for _ in range(count)]
+
+
+def parse_pattern(pattern_text: str) -> bytes:
+    if not pattern_text:
+        return b""
+    if pattern_text.startswith("0x"):
+        hex_text = pattern_text[2:]
+        if len(hex_text) % 2 != 0:
+            raise ValueError("hex pattern length must be even")
+        return bytes.fromhex(hex_text)
+    return pattern_text.encode("utf-8")
+
+
+def make_key(prefix: str, key_size: int, object_id: int) -> str:
+    suffix = f"{object_id:016d}"
+    if key_size < len(suffix):
+        raise ValueError(f"key_size={key_size} is smaller than suffix length {len(suffix)}")
+    prefix_space = key_size - len(suffix)
+    prefix_part = prefix[:prefix_space].ljust(prefix_space, "_")
+    return f"{prefix_part}{suffix}"
+
+
+class StoreSession:
+    def __init__(
+        self,
+        args: argparse.Namespace,
+        lane_id: int,
+        payload_factory: PayloadFactory,
+        store_obj,
+        zcopy: Optional["ZcopyBufferView"] = None,
+    ):
+        self.args = args
+        self.lane_id = lane_id
+        self.payload_factory = payload_factory
+        self.store = store_obj
+        self.config = ReplicateConfig()
+        self.config.replica_num = args.memory_replica_num
+        self.config.nof_replica_num = args.nof_replica_num
+        self._zcopy = zcopy
+
+    def close(self) -> None:
+        self._zcopy = None
+
+    def put_ids(self, object_ids: List[int]) -> RequestResult:
+        keys = [make_key(self.args.key_prefix, self.args.key_size, object_id) for object_id in object_ids]
+        ret_codes = self._put_keys(keys, object_ids)
+
+        errors: Counter = Counter()
+        success_ids: List[int] = []
+        if self.args.io_api == "plain" and not (len(object_ids) == 1 and self.args.batch_size == 1):
+            ret = ret_codes[0]
+            if ret == 0:
+                success_ids.extend(object_ids)
+            else:
+                errors[ret] += 1
+        else:
+            for object_id, ret in zip(object_ids, ret_codes):
+                if ret == 0:
+                    success_ids.append(object_id)
+                else:
+                    errors[ret] += 1
+        request_ok = len(success_ids) == len(object_ids)
+        return RequestResult(
+            request_ok=request_ok,
+            kv_successes=len(success_ids),
+            kv_failures=len(object_ids) - len(success_ids),
+            bytes_processed=len(success_ids) * self.args.value_size,
+            successful_object_ids=success_ids,
+            error_counts=errors,
+        )
+
+    def get_ids(self, object_ids: List[int], verify: bool) -> RequestResult:
+        keys = [make_key(self.args.key_prefix, self.args.key_size, object_id) for object_id in object_ids]
+        errors: Counter = Counter()
+        kv_successes = 0
+        misses = 0
+        verify_failures = 0
+        if self.args.io_api == "plain":
+            payloads = self._get_payloads_plain(keys)
+            for object_id, payload in zip(object_ids, payloads):
+                if payload in (None, b""):
+                    misses += 1
+                    errors["MISS"] += 1
+                    continue
+                if verify and not self.payload_factory.verify_payload(object_id, payload):
+                    verify_failures += 1
+                    errors["VERIFY_FAIL"] += 1
+                    continue
+                kv_successes += 1
+        else:
+            assert self._zcopy is not None
+            lengths = self._get_lengths_zcopy(keys, len(object_ids))
+            for slot, (object_id, length) in enumerate(zip(object_ids, lengths)):
+                if length < 0:
+                    if self.store.isExist(keys[slot]) == 0:
+                        misses += 1
+                        errors["MISS"] += 1
+                    else:
+                        errors[length] += 1
+                    continue
+                payload = self._zcopy.read_bytes(slot, length)
+                if verify:
+                    if length != self.args.value_size:
+                        verify_failures += 1
+                        errors["VERIFY_SIZE_MISMATCH"] += 1
+                        continue
+                    if not self.payload_factory.verify_payload(object_id, payload):
+                        verify_failures += 1
+                        errors["VERIFY_FAIL"] += 1
+                        continue
+                kv_successes += 1
+
+        kv_failures = len(object_ids) - kv_successes
+        return RequestResult(
+            request_ok=(kv_failures == 0),
+            kv_successes=kv_successes,
+            kv_failures=kv_failures,
+            bytes_processed=kv_successes * self.args.value_size,
+            misses=misses,
+            verify_failures=verify_failures,
+            error_counts=errors,
+        )
+
+    def _put_keys(self, keys: List[str], object_ids: List[int]) -> List[int]:
+        values = [self.payload_factory.build(object_id) for object_id in object_ids]
+        if self.args.io_api == "plain":
+            if len(object_ids) == 1 and self.args.batch_size == 1:
+                return [self.store.put(keys[0], values[0], self.config)]
+            return [self.store.put_batch(keys, values, self.config)]
+
+        assert self._zcopy is not None
+        ptrs = self._zcopy.fill_write_buffers(values)
+        sizes = [len(value) for value in values]
+        if len(object_ids) == 1 and self.args.batch_size == 1:
+            return [self.store.put_from(keys[0], ptrs[0], sizes[0], self.config)]
+        return list(self.store.batch_put_from(keys, ptrs, sizes, self.config))
+
+    def _get_payloads_plain(self, keys: List[str]) -> List[bytes]:
+        if len(keys) == 1 and self.args.batch_size == 1:
+            return [self.store.get(keys[0])]
+        return list(self.store.get_batch(keys))
+
+    def _get_lengths_zcopy(self, keys: List[str], slot_count: int) -> List[int]:
+        assert self._zcopy is not None
+        ptrs = self._zcopy.prepare_read_buffers(slot_count)
+        sizes = [self.args.value_size] * slot_count
+        if slot_count == 1 and self.args.batch_size == 1:
+            return [self.store.get_into(keys[0], ptrs[0], sizes[0])]
+        return list(self.store.batch_get_into(keys, ptrs, sizes))
+
+
+class ZcopyBufferPool:
+    def __init__(self, store_obj, value_size: int, slots: int):
+        self.store = store_obj
+        self.value_size = value_size
+        self.slots = slots
+        self.total_size = self.value_size * self.slots
+        self._alloc_fn = None
+        self._free_fn = None
+        self._registered = False
+        self.base_ptr = 0
+
+        alloc_addr = get_alloc_func_addr()
+        free_addr = get_free_func_addr()
+        if alloc_addr is None or free_addr is None:
+            raise RuntimeError("store module does not expose hugepage alloc/free helpers")
+
+        self._alloc_fn = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_size_t)(
+            get_alloc_func_addr()
+        )
+        self._free_fn = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(
+            get_free_func_addr()
+        )
+
+        raw_ptr = self._alloc_fn(self.total_size)
+        self.base_ptr = ctypes.cast(raw_ptr, ctypes.c_void_p).value or 0
+        if self.base_ptr == 0:
+            raise RuntimeError(
+                f"direct hugepage alloc failed for zcopy pool: size={self.total_size}"
+            )
+        ret = self.store.register_buffer(self.base_ptr, self.total_size)
+        if ret != 0:
+            failed_ptr = self.base_ptr
+            self._free_fn(ctypes.c_void_p(self.base_ptr))
+            self.base_ptr = 0
+            raise RuntimeError(
+                f"register_buffer failed for direct zcopy pool ptr={failed_ptr}: {ret}"
+            )
+        self._registered = True
+        self._buffer = (ctypes.c_ubyte * self.total_size).from_address(self.base_ptr)
+
+    def close(self) -> None:
+        self._buffer = None
+        if self.base_ptr:
+            if self._registered:
+                try:
+                    self.store.unregister_buffer(self.base_ptr)
+                except Exception:
+                    LOG.debug("unregister_buffer failed for direct zcopy pool ptr=%s", self.base_ptr, exc_info=True)
+                self._registered = False
+            if self._free_fn is not None:
+                self._free_fn(ctypes.c_void_p(self.base_ptr))
+            self.base_ptr = 0
+
+    def slot_ptr(self, slot: int) -> int:
+        if slot < 0 or slot >= self.slots:
+            raise IndexError(f"zcopy slot {slot} is out of range [0, {self.slots})")
+        return self.base_ptr + slot * self.value_size
+
+
+class ZcopyBufferView:
+    def __init__(self, pool: ZcopyBufferPool, slot_offset: int, slots: int):
+        self.pool = pool
+        self.slot_offset = slot_offset
+        self.slots = slots
+
+    def _slot_ptr(self, slot: int) -> int:
+        if slot < 0 or slot >= self.slots:
+            raise IndexError(f"zcopy view slot {slot} is out of range [0, {self.slots})")
+        return self.pool.slot_ptr(self.slot_offset + slot)
+
+    def fill_write_buffers(self, payloads: List[bytes]) -> List[int]:
+        ptrs: List[int] = []
+        for slot, payload in enumerate(payloads):
+            if len(payload) > self.pool.value_size:
+                raise ValueError(
+                    f"Payload size {len(payload)} exceeds slot size {self.pool.value_size}"
+                )
+            ptr = self._slot_ptr(slot)
+            ctypes.memmove(ptr, payload, len(payload))
+            ptrs.append(ptr)
+        return ptrs
+
+    def prepare_read_buffers(self, slot_count: int) -> List[int]:
+        ptrs: List[int] = []
+        for slot in range(slot_count):
+            ptr = self._slot_ptr(slot)
+            ctypes.memset(ptr, 0, self.pool.value_size)
+            ptrs.append(ptr)
+        return ptrs
+
+    def read_bytes(self, slot: int, size: int) -> bytes:
+        if size > self.pool.value_size:
+            raise ValueError(
+                f"Read size {size} exceeds slot size {self.pool.value_size}"
+            )
+        return ctypes.string_at(self._slot_ptr(slot), size)
+
+
+class StoreRuntime:
+    def __init__(self, args: argparse.Namespace, lane_count: int):
+
+        self.lane_count = lane_count
+        self.store = MooncakeDistributedStore()
+        setup_ret = self.store.setup(
+            args.local_hostname,
+            args.metadata_server,
+            args.global_segment_size,
+            args.local_buffer_size,
+            args.protocol,
+            args.device_name,
+            args.master_server,
+        )
+        if setup_ret != 0:
+            raise RuntimeError(f"setup failed: {setup_ret}")
+
+        self.zcopy_pool: Optional[ZcopyBufferPool] = None
+        if args.io_api == "zcopy":
+            slots = max(1, args.batch_size) * lane_count
+            self.zcopy_pool = ZcopyBufferPool(
+                self.store, args.value_size, slots
+            )
+
+    def make_session(
+        self,
+        args: argparse.Namespace,
+        lane_id: int,
+        payload_factory: PayloadFactory,
+    ) -> StoreSession:
+        zcopy_view: Optional[ZcopyBufferView] = None
+        if self.zcopy_pool is not None:
+            slots_per_lane = max(1, args.batch_size)
+            zcopy_view = ZcopyBufferView(
+                self.zcopy_pool, lane_id * slots_per_lane, slots_per_lane
+            )
+        return StoreSession(
+            args,
+            lane_id,
+            payload_factory,
+            self.store,
+            zcopy_view,
+        )
+
+    def close(self) -> None:
+        if self.zcopy_pool is not None:
+            self.zcopy_pool.close()
+            self.zcopy_pool = None
+        if hasattr(self.store, "close"):
+            try:
+                self.store.close()
+            except Exception:
+                LOG.debug("shared store close failed", exc_info=True)
+        elif hasattr(self.store, "tearDownAll"):
+            try:
+                self.store.tearDownAll()
+            except Exception:
+                LOG.debug("shared tearDownAll failed", exc_info=True)
+
+
+def merge_stats(name: str, stats_list: List[PhaseStats]) -> PhaseStats:
+    merged = PhaseStats(name=name)
+    if not stats_list:
+        return merged
+    merged.start_time = min((s.start_time for s in stats_list if s.start_time), default=0.0)
+    merged.end_time = max((s.end_time for s in stats_list if s.end_time), default=0.0)
+    for stats in stats_list:
+        merged.request_latencies.extend(stats.request_latencies)
+        merged.requests += stats.requests
+        merged.successful_requests += stats.successful_requests
+        merged.failed_requests += stats.failed_requests
+        merged.kvs += stats.kvs
+        merged.successful_kvs += stats.successful_kvs
+        merged.failed_kvs += stats.failed_kvs
+        merged.misses += stats.misses
+        merged.verify_failures += stats.verify_failures
+        merged.bytes_processed += stats.bytes_processed
+        merged.error_counts.update(stats.error_counts)
+        merged.dataset_exhausted = merged.dataset_exhausted or stats.dataset_exhausted
+    return merged
+
+
+def percentile(values: List[float], p: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * p
+    low = math.floor(rank)
+    high = math.ceil(rank)
+    if low == high:
+        return ordered[low]
+    return ordered[low] + (ordered[high] - ordered[low]) * (rank - low)
+
+
+def summarize_stats(stats: PhaseStats) -> dict:
+    duration = max(stats.end_time - stats.start_time, 0.0)
+    return {
+        "requests": stats.requests,
+        "successful_requests": stats.successful_requests,
+        "failed_requests": stats.failed_requests,
+        "kvs": stats.kvs,
+        "successful_kvs": stats.successful_kvs,
+        "failed_kvs": stats.failed_kvs,
+        "misses": stats.misses,
+        "verify_failures": stats.verify_failures,
+        "bytes": stats.bytes_processed,
+        "duration_sec": duration,
+        "req_per_sec": (stats.requests / duration) if duration > 0 else 0.0,
+        "kv_per_sec": (stats.kvs / duration) if duration > 0 else 0.0,
+        "MiB_per_sec": (stats.bytes_processed / duration / (1024 * 1024)) if duration > 0 else 0.0,
+        "lat_mean_ms": statistics.mean(stats.request_latencies) * 1000 if stats.request_latencies else 0.0,
+        "lat_p50_ms": percentile(stats.request_latencies, 0.50) * 1000,
+        "lat_p95_ms": percentile(stats.request_latencies, 0.95) * 1000,
+        "lat_p99_ms": percentile(stats.request_latencies, 0.99) * 1000,
+        "dataset_exhausted": stats.dataset_exhausted,
+        "error_counts": dict(stats.error_counts),
+    }
+
+
+def log_phase_stats(stats: PhaseStats) -> None:
+    summary = summarize_stats(stats)
+    LOG.info("=== phase %s ===", stats.name)
+    LOG.info(
+        "requests=%d successful_requests=%d failed_requests=%d kvs=%d successful_kvs=%d failed_kvs=%d",
+        summary["requests"],
+        summary["successful_requests"],
+        summary["failed_requests"],
+        summary["kvs"],
+        summary["successful_kvs"],
+        summary["failed_kvs"],
+    )
+    LOG.info(
+        "misses=%d verify_failures=%d bytes=%d duration=%.3fs req/s=%.2f kv/s=%.2f MiB/s=%.2f",
+        summary["misses"],
+        summary["verify_failures"],
+        summary["bytes"],
+        summary["duration_sec"],
+        summary["req_per_sec"],
+        summary["kv_per_sec"],
+        summary["MiB_per_sec"],
+    )
+    LOG.info(
+        "lat_mean=%.3fms lat_p50=%.3fms lat_p95=%.3fms lat_p99=%.3fms dataset_exhausted=%s",
+        summary["lat_mean_ms"],
+        summary["lat_p50_ms"],
+        summary["lat_p95_ms"],
+        summary["lat_p99_ms"],
+        summary["dataset_exhausted"],
+    )
+    if summary["error_counts"]:
+        LOG.info("errors=%s", summary["error_counts"])
+
+
+class BenchmarkRunner:
+    def __init__(self, args: argparse.Namespace):
+        self.args = args
+        self.pattern = parse_pattern(args.pattern)
+        self.payload_factory = PayloadFactory(args.value_size, self.pattern)
+        self.dataset = DatasetState(args.object_id_start)
+        self.lane_count = args.numjobs * args.iodepth
+        self._sessions: Optional[List[StoreSession]] = None
+        self._runtime: Optional[StoreRuntime] = None
+        self._validate_args()
+
+    def _validate_args(self) -> None:
+        if self.args.numjobs <= 0 or self.args.iodepth <= 0:
+            raise ValueError("numjobs and iodepth must be > 0")
+        if self.args.batch_size <= 0:
+            raise ValueError("batch-size must be > 0")
+        if self.args.value_size <= 0:
+            raise ValueError("value-size must be > 0")
+        if self.args.key_size <= 0:
+            raise ValueError("key-size must be > 0")
+        if self.args.nr_objects <= 0:
+            raise ValueError("nr-objects must be > 0")
+        if self.args.write_objects < 0:
+            raise ValueError("write-objects must be >= 0")
+        if self.args.prepare_objects < 0:
+            raise ValueError("prepare-objects must be >= 0")
+        if self.args.rwmixread < 0 or self.args.rwmixread > 100:
+            raise ValueError("rwmixread must be within [0, 100]")
+        if self.args.verify and not self.pattern:
+            raise ValueError("verify mode currently requires --pattern")
+        if self.args.memory_replica_num == 0 and self.args.nof_replica_num == 0:
+            raise ValueError("memory_replica_num and nof_replica_num cannot both be 0")
+        if self.args.phase_gap_mode == "sleep" and self.args.phase_gap_sec <= 0:
+            raise ValueError("phase-gap-sec must be > 0 when phase-gap-mode=sleep")
+        if self.args.phase_gap_mode == "file" and not self.args.phase_gap_file:
+            raise ValueError("phase-gap-file must be set when phase-gap-mode=file")
+        if self.args.scenario == "mixed_rw" and self.args.runtime <= 0:
+            raise ValueError("mixed_rw requires --runtime > 0")
+        if self._scenario_has_write() and self.args.value_size % 512 != 0:
+            raise ValueError("write-involved scenarios require value-size to be 512B aligned")
+        make_key(self.args.key_prefix, self.args.key_size, self.args.object_id_start)
+
+    def _scenario_has_write(self) -> bool:
+        return self.args.scenario in {"verify_write", "fill", "write_perf", "mixed_rw"}
+
+    def _write_budget(self) -> int:
+        return self.args.write_objects if self.args.write_objects > 0 else self.args.nr_objects
+
+    def _prepare_budget(self) -> int:
+        return self.args.prepare_objects if self.args.prepare_objects > 0 else self.args.nr_objects
+
+    def _make_sessions(self) -> List[StoreSession]:
+        if self._sessions is None:
+            self._runtime = StoreRuntime(self.args, self.lane_count)
+            self._sessions = [
+                self._runtime.make_session(self.args, lane_id, self.payload_factory)
+                for lane_id in range(self.lane_count)
+            ]
+        return self._sessions
+
+    def close(self) -> None:
+        if self._sessions is not None:
+            for session in self._sessions:
+                session.close()
+            self._sessions = None
+        if self._runtime is not None:
+            self._runtime.close()
+            self._runtime = None
+
+    def _phase_gap(self, label: str) -> None:
+        mode = self.args.phase_gap_mode
+        if mode == "none":
+            return
+        LOG.info("phase gap before %s, mode=%s", label, mode)
+        if mode == "sleep":
+            LOG.info("sleeping %d seconds before %s", self.args.phase_gap_sec, label)
+            time.sleep(self.args.phase_gap_sec)
+            return
+        if mode == "manual":
+            input(f"phase '{label}' is waiting, finish external operations then press Enter to continue...")
+            return
+        deadline = time.time() + self.args.phase_gap_timeout_sec
+        while time.time() < deadline:
+            if os.path.exists(self.args.phase_gap_file):
+                LOG.info("detected phase gap file %s, continuing to %s", self.args.phase_gap_file, label)
+                return
+            time.sleep(1.0)
+        raise TimeoutError(f"timed out waiting for phase gap file {self.args.phase_gap_file}")
+
+    def _run_threads(self, phase_name: str, worker_builder: Callable[[StoreSession, int], Callable[[PhaseStats], None]]) -> PhaseStats:
+        sessions = self._make_sessions()
+        per_lane_stats: List[Optional[PhaseStats]] = [None] * self.lane_count
+        threads: List[threading.Thread] = []
+
+        def runner(index: int, session: StoreSession) -> None:
+            stats = PhaseStats(name=f"{phase_name}/lane{index}")
+            stats.start_time = time.perf_counter()
+            worker_builder(session, index)(stats)
+            stats.end_time = time.perf_counter()
+            per_lane_stats[index] = stats
+
+        for lane_id, session in enumerate(sessions):
+            thread = threading.Thread(target=runner, args=(lane_id, session), name=f"{phase_name}-lane{lane_id}")
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        merged = merge_stats(phase_name, [s for s in per_lane_stats if s is not None])
+        log_phase_stats(merged)
+        return merged
+
+    def _record(self, stats: PhaseStats, latency: float, request: RequestResult, kv_count: int) -> None:
+        stats.request_latencies.append(latency)
+        stats.requests += 1
+        stats.kvs += kv_count
+        if request.request_ok:
+            stats.successful_requests += 1
+        else:
+            stats.failed_requests += 1
+        stats.successful_kvs += request.kv_successes
+        stats.failed_kvs += request.kv_failures
+        stats.misses += request.misses
+        stats.verify_failures += request.verify_failures
+        stats.bytes_processed += request.bytes_processed
+        stats.error_counts.update(request.error_counts)
+
+    def _run_fixed_write(
+        self,
+        phase_name: str,
+        total_objects: int,
+        *,
+        strict: bool,
+        write_scope: str = "runtime",
+    ) -> PhaseStats:
+        write_upper = self.dataset.next_write_id + total_objects
+
+        def worker(session: StoreSession, _lane_id: int) -> Callable[[PhaseStats], None]:
+            def run(stats: PhaseStats) -> None:
+                while True:
+                    object_ids = self.dataset.reserve_write_ids(self.args.batch_size, write_upper)
+                    if not object_ids:
+                        break
+                    start = time.perf_counter()
+                    result = session.put_ids(object_ids)
+                    latency = time.perf_counter() - start
+                    self._record(stats, latency, result, len(object_ids))
+                    if result.successful_object_ids:
+                        if write_scope == "prepared":
+                            self.dataset.mark_prepared(result.successful_object_ids)
+                        else:
+                            self.dataset.mark_runtime_written(result.successful_object_ids)
+            return run
+
+        stats = self._run_threads(phase_name, worker)
+        expected = total_objects
+        if stats.successful_kvs < expected:
+            stats.dataset_exhausted = True
+        if strict and (stats.failed_kvs > 0 or stats.successful_kvs != expected):
+            raise RuntimeError(
+                f"{phase_name} strict write failed: expected {expected} objects, "
+                f"got success={stats.successful_kvs}, failed={stats.failed_kvs}"
+            )
+        return stats
+
+    def _run_time_based_write(self, phase_name: str, total_objects: int) -> PhaseStats:
+        deadline = time.time() + self.args.runtime
+        write_upper = self.dataset.next_write_id + total_objects
+        stop_event = threading.Event()
+
+        def worker(session: StoreSession, _lane_id: int) -> Callable[[PhaseStats], None]:
+            def run(stats: PhaseStats) -> None:
+                while time.time() < deadline and not stop_event.is_set():
+                    object_ids = self.dataset.reserve_write_ids(self.args.batch_size, write_upper)
+                    if not object_ids:
+                        stats.dataset_exhausted = True
+                        stop_event.set()
+                        break
+                    start = time.perf_counter()
+                    result = session.put_ids(object_ids)
+                    latency = time.perf_counter() - start
+                    self._record(stats, latency, result, len(object_ids))
+                    if result.successful_object_ids:
+                        self.dataset.mark_runtime_written(result.successful_object_ids)
+            return run
+
+        return self._run_threads(phase_name, worker)
+
+    def _run_read_phase(
+        self,
+        phase_name: str,
+        *,
+        verify: bool,
+        sequential: bool,
+        loop: bool,
+        runtime_sec: int = 0,
+    ) -> PhaseStats:
+        seed_base = self.args.rand_seed
+        if runtime_sec > 0:
+            deadline = time.time() + runtime_sec
+
+            def worker(session: StoreSession, lane_id: int) -> Callable[[PhaseStats], None]:
+                rng = random.Random(seed_base + lane_id)
+
+                def run(stats: PhaseStats) -> None:
+                    while time.time() < deadline:
+                        object_ids = self.dataset.next_read_ids(
+                            self.args.batch_size,
+                            loop=True,
+                            sequential=sequential,
+                            rng=rng,
+                            source="prepared",
+                        )
+                        if not object_ids:
+                            stats.dataset_exhausted = True
+                            break
+                        start = time.perf_counter()
+                        result = session.get_ids(object_ids, verify)
+                        latency = time.perf_counter() - start
+                        self._record(stats, latency, result, len(object_ids))
+
+                return run
+
+            return self._run_threads(phase_name, worker)
+
+        def worker(session: StoreSession, lane_id: int) -> Callable[[PhaseStats], None]:
+            rng = random.Random(seed_base + lane_id)
+
+            def run(stats: PhaseStats) -> None:
+                while True:
+                    object_ids = self.dataset.next_read_ids(
+                        self.args.batch_size,
+                        loop=loop,
+                        sequential=sequential,
+                        rng=rng,
+                        source="prepared",
+                    )
+                    if not object_ids:
+                        break
+                    start = time.perf_counter()
+                    result = session.get_ids(object_ids, verify)
+                    latency = time.perf_counter() - start
+                    self._record(stats, latency, result, len(object_ids))
+
+            return run
+
+        return self._run_threads(phase_name, worker)
+
+    def _run_mixed_phase(self, phase_name: str, extra_write_budget: int) -> PhaseStats:
+        deadline = time.time() + self.args.runtime
+        write_upper = self.dataset.next_write_id + extra_write_budget
+        stop_event = threading.Event()
+        seed_base = self.args.rand_seed
+
+        def worker(session: StoreSession, lane_id: int) -> Callable[[PhaseStats], None]:
+            rng = random.Random(seed_base + lane_id)
+
+            def run(stats: PhaseStats) -> None:
+                while time.time() < deadline and not stop_event.is_set():
+                    do_read = rng.randrange(100) < self.args.rwmixread
+                    if do_read:
+                        object_ids = self.dataset.next_read_ids(
+                            self.args.batch_size,
+                            loop=True,
+                            sequential=False,
+                            rng=rng,
+                            source="prepared",
+                        )
+                        if not object_ids:
+                            continue
+                        start = time.perf_counter()
+                        result = session.get_ids(object_ids, verify=self.args.verify)
+                        latency = time.perf_counter() - start
+                        self._record(stats, latency, result, len(object_ids))
+                        continue
+
+                    object_ids = self.dataset.reserve_write_ids(self.args.batch_size, write_upper)
+                    if not object_ids:
+                        stats.dataset_exhausted = True
+                        stop_event.set()
+                        break
+                    start = time.perf_counter()
+                    result = session.put_ids(object_ids)
+                    latency = time.perf_counter() - start
+                    self._record(stats, latency, result, len(object_ids))
+                    if result.successful_object_ids:
+                        self.dataset.mark_runtime_written(result.successful_object_ids)
+
+            return run
+
+        return self._run_threads(phase_name, worker)
+
+    def _maybe_prepare_dataset(self) -> Optional[PhaseStats]:
+        if self.args.prepare_mode == "none":
+            return None
+        if self.args.prepare_mode == "write" or self.args.scenario in {"read_perf", "mixed_rw"}:
+            stats = self._run_fixed_write(
+                "prepare_write",
+                self._prepare_budget(),
+                strict=True,
+                write_scope="prepared",
+            )
+            self._phase_gap("main_run")
+            return stats
+        return None
+
+    def run(self) -> List[PhaseStats]:
+        LOG.info(
+            "scenario=%s io_api=%s numjobs=%d iodepth=%d lanes=%d batch_size=%d value_size=%d nr_objects=%d prepare_objects=%d write_objects=%d memory_replica_num=%d nof_replica_num=%d verify=%s",
+            self.args.scenario,
+            self.args.io_api,
+            self.args.numjobs,
+            self.args.iodepth,
+            self.lane_count,
+            self.args.batch_size,
+            self.args.value_size,
+            self.args.nr_objects,
+            self._prepare_budget(),
+            self.args.write_objects,
+            self.args.memory_replica_num,
+            self.args.nof_replica_num,
+            self.args.verify,
+        )
+
+        phases: List[PhaseStats] = []
+        if self.args.scenario == "verify_write":
+            phases.append(
+                self._run_fixed_write(
+                    "write_verify",
+                    self._write_budget(),
+                    strict=True,
+                    write_scope="prepared",
+                )
+            )
+            self._phase_gap("verify_read")
+            phases.append(self._run_read_phase("verify_read", verify=True, sequential=True, loop=False))
+            return phases
+
+        if self.args.scenario == "fill":
+            phases.append(self._run_fixed_write("fill_write", self._write_budget(), strict=False))
+            return phases
+
+        if self.args.scenario == "write_perf":
+            total_objects = self._write_budget()
+            if self.args.runtime > 0:
+                phases.append(self._run_time_based_write("write_perf", total_objects))
+            else:
+                phases.append(self._run_fixed_write("write_perf", total_objects, strict=False))
+            return phases
+
+        if self.args.scenario == "read_perf":
+            prepared = self._maybe_prepare_dataset()
+            if prepared is not None:
+                phases.append(prepared)
+            phases.append(
+                self._run_read_phase(
+                    "read_perf",
+                    verify=self.args.verify,
+                    sequential=True,
+                    loop=(self.args.runtime > 0),
+                    runtime_sec=self.args.runtime,
+                )
+            )
+            return phases
+
+        prepared = self._maybe_prepare_dataset()
+        if prepared is not None:
+            phases.append(prepared)
+        phases.append(self._run_mixed_phase("mixed_rw", self._write_budget()))
+        return phases
+
+
+def log_overall_summary(phases: List[PhaseStats]) -> None:
+    overall = merge_stats("overall", phases)
+    LOG.info("=== overall summary ===")
+    log_phase_stats(overall)
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    setup_logging(args.log_level)
+    runner: Optional[BenchmarkRunner] = None
+    try:
+        runner = BenchmarkRunner(args)
+        phases = runner.run()
+        log_overall_summary(phases)
+        if any(phase.verify_failures > 0 for phase in phases):
+            return 20
+        if args.verify and any(phase.misses > 0 for phase in phases if "read" in phase.name):
+            return 21
+        return 0
+    except KeyboardInterrupt:
+        LOG.warning("benchmark interrupted")
+        return 130
+    except Exception as exc:  # pragma: no cover - CLI entry path
+        LOG.exception("benchmark failed: %s", exc)
+        return 1
+    finally:
+        if runner is not None:
+            runner.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mooncake-store/include/ssd_register_client.h
+++ b/mooncake-store/include/ssd_register_client.h
@@ -1,0 +1,39 @@
+#ifndef MOONCAKE_SSD_REGISTER_CLIENT_H
+#define MOONCAKE_SSD_REGISTER_CLIENT_H
+
+#include "master_client.h"
+#include "types.h"
+#include <string>
+
+namespace mooncake {
+#define OPERATION_OK 0
+#define OPERATION_FAILED -1
+
+class NoFRegisterClient {
+   public:
+    NoFRegisterClient();
+    ~NoFRegisterClient();
+
+    int set_register(const std::string &nqn, size_t nsid,
+                     const std::string &traddr, size_t trsvcid, uintptr_t base,
+                     size_t size, const std::string &master_server_addr);
+
+    /**
+     * @brief Unregister a NoF SSD segment by its te_endpoint
+     * @param nqn NQN of the SSD
+     * @param nsid Namespace ID
+     * @param traddr Transport address
+     * @param trsvcid Transport service ID
+     * @param master_server_addr Master server address
+     * @return int OPERATION_OK or OPERATION_FAILED
+     */
+    int set_unregister_by_endpoint(const std::string &nqn, size_t nsid,
+                                   const std::string &traddr, size_t trsvcid,
+                                   const std::string &master_server_addr);
+
+   private:
+    MasterClient master_client_;
+};
+}  // namespace mooncake
+
+#endif  // MOONCAKE_SSD_REGISTER_CLIENT_H

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -58,6 +58,7 @@ set(MOONCAKE_STORE_SOURCES
     ha_metric_manager.cpp
     store_c.cpp
     memory_alloc.cpp
+    ssd_register_client.cpp
     engram/engram_store.cpp
 )
 

--- a/mooncake-store/src/ssd_register_client.cpp
+++ b/mooncake-store/src/ssd_register_client.cpp
@@ -1,0 +1,138 @@
+#include "ssd_register_client.h"
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+
+namespace mooncake {
+
+NoFRegisterClient::NoFRegisterClient()
+    : master_client_(generate_uuid(), nullptr) {}
+
+NoFRegisterClient::~NoFRegisterClient() = default;
+
+int NoFRegisterClient::set_register(const std::string &nqn, size_t nsid,
+                                    const std::string &traddr, size_t trsvcid,
+                                    uintptr_t base, size_t size,
+                                    const std::string &master_server_addr) {
+    LOG(INFO) << "Registering SSD: nqn=" << nqn << ",nsid=" << nsid
+              << ",traddr=" << traddr << ",trsvcid=" << trsvcid
+              << ",master=" << master_server_addr << ",base=" << base
+              << ",size=" << size;
+
+    auto err = master_client_.Connect(master_server_addr);
+    if (err != ErrorCode::OK) {
+        LOG(ERROR) << "Failed to connect to master";
+        return OPERATION_FAILED;
+    }
+
+    const char *trtype_env = std::getenv("MC_NOF_TRTYPE");
+    std::string trtype = trtype_env ? trtype_env : "RDMA";
+    std::transform(
+        trtype.begin(), trtype.end(), trtype.begin(),
+        [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    if (trtype != "RDMA" && trtype != "TCP") {
+        LOG(WARNING) << "Invalid MC_NOF_TRTYPE=" << trtype
+                     << ", fallback to RDMA";
+        trtype = "RDMA";
+    }
+
+    std::string te_endpoint = "traddr:" + traddr +
+                              " trsvcid:" + std::to_string(trsvcid) +
+                              " subnqn:" + nqn + " trtype:" + trtype +
+                              " adrfam:IPv4 ns:" + std::to_string(nsid);
+
+    NoFSegment segment;
+    segment.base = base;
+    segment.size = size;
+    segment.id = generate_uuid();
+    segment.name = te_endpoint;
+    segment.te_endpoint = te_endpoint;
+    auto mount_result = master_client_.MountNoFSegment(segment);
+    if (!mount_result) {
+        LOG(ERROR) << "mount_segment_to_master_failed ";
+        return OPERATION_FAILED;
+    }
+
+    return OPERATION_OK;
+}
+
+int NoFRegisterClient::set_unregister_by_endpoint(
+    const std::string &nqn, size_t nsid, const std::string &traddr,
+    size_t trsvcid, const std::string &master_server_addr) {
+    LOG(INFO) << "Unregistering SSD by endpoint: nqn=" << nqn
+              << ",nsid=" << nsid << ",traddr=" << traddr
+              << ",trsvcid=" << trsvcid << ",master=" << master_server_addr;
+
+    // Connect to master server
+    auto err = master_client_.Connect(master_server_addr);
+    if (err != ErrorCode::OK) {
+        LOG(ERROR) << "Failed to connect to master: " << static_cast<int>(err);
+        return OPERATION_FAILED;
+    }
+
+    const char *trtype_env = std::getenv("MC_NOF_TRTYPE");
+    std::string trtype = trtype_env ? trtype_env : "RDMA";
+    std::transform(
+        trtype.begin(), trtype.end(), trtype.begin(),
+        [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    if (trtype != "RDMA" && trtype != "TCP") {
+        LOG(WARNING) << "Invalid MC_NOF_TRTYPE=" << trtype
+                     << ", fallback to RDMA";
+        trtype = "RDMA";
+    }
+
+    // Build the te_endpoint string to match registered segments
+    std::string te_endpoint = "traddr:" + traddr +
+                              " trsvcid:" + std::to_string(trsvcid) +
+                              " subnqn:" + nqn + " trtype:" + trtype +
+                              " adrfam:IPv4 ns:" + std::to_string(nsid);
+
+    LOG(INFO) << "Built te_endpoint: " << te_endpoint;
+
+    auto matching_segments_result =
+        master_client_.GetNoFSegmentsByName(te_endpoint);
+    if (!matching_segments_result) {
+        LOG(ERROR) << "Failed to get NoF segments by name: "
+                   << static_cast<int>(matching_segments_result.error());
+        return OPERATION_FAILED;
+    }
+
+    std::vector<NoFSegmentOwnerInfo> matching_segments =
+        matching_segments_result.value();
+    LOG(INFO) << "Retrieved " << matching_segments.size()
+              << " mounted NoF segments for te_endpoint";
+    if (matching_segments.empty()) {
+        LOG(ERROR) << "No segment found for te_endpoint: " << te_endpoint;
+        return OPERATION_FAILED;
+    }
+
+    // Unmount all matching segments
+    bool all_unmounted = true;
+    for (const auto &segment : matching_segments) {
+        LOG(INFO) << "Found matching segment: id=" << segment.segment_id
+                  << ", owner_client_id=" << segment.client_id;
+        MasterClient owner_master_client(segment.client_id, nullptr);
+        err = owner_master_client.Connect(master_server_addr);
+        if (err != ErrorCode::OK) {
+            LOG(ERROR) << "Failed to connect owner master client for segment "
+                       << segment.segment_id << ": " << static_cast<int>(err);
+            all_unmounted = false;
+            continue;
+        }
+
+        auto unmount_result =
+            owner_master_client.UnmountNoFSegment(segment.segment_id);
+        if (!unmount_result) {
+            LOG(ERROR) << "Failed to unmount segment " << segment.segment_id
+                       << ": " << static_cast<int>(unmount_result.error());
+            all_unmounted = false;
+        } else {
+            LOG(INFO) << "Successfully unmounted segment " << segment.segment_id
+                      << ", owner_client_id=" << segment.client_id;
+        }
+    }
+
+    return all_unmounted ? OPERATION_OK : OPERATION_FAILED;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/tests/e2e/readme.md
+++ b/mooncake-store/tests/e2e/readme.md
@@ -11,6 +11,8 @@ The E2E test suite includes several executable programs designed to test differe
 - **e2e_rand_test**: Long-term randomized end-to-end testing.
 - **chaos_test**: Short-term chaos testing with predefined scenarios.
 - **chaos_rand_test**: Long-term randomized chaos testing with configurable parameters.
+- **store_client_e2e.py**: Python `MooncakeDistributedStore` client that continuously issues `put/get` operations.
+- **run_nof_heartbeat_tcp_e2e.sh**: Scripted NoF heartbeat end-to-end test using a TCP SPDK target.
 
 ## Parameters
 
@@ -73,3 +75,77 @@ Currently it only has few test cases. Will add more in the future.
 
 **[WIP]**:
 Currently it only has few test cases. Will add more in the future.
+
+### run_nof_heartbeat_tcp_e2e.sh
+
+**Brief**: Launches a real four-component path for NoF heartbeat validation:
+
+- `mooncake_master`
+- standalone Python HTTP metadata server
+- SPDK `nvmf_tgt` with TCP transport
+- Python client built on `MooncakeDistributedStore`
+
+The script first verifies steady-state `put/get` success with `memory + nof` replicas. It then kills the SPDK target, waits for the master heartbeat thread to emit `action=unmount_nof_segment_by_heartbeat`, and finally verifies that the client still observes successful I/O after the NoF segment is removed.
+
+**Prerequisites**:
+
+- `BUILD_DIR` points to a build tree that already contains:
+  - `mooncake-store/src/mooncake_master`
+  - `mooncake-integration/store*.so`
+- SPDK has already been built under `extern/spdk`
+- Python environment contains `aiohttp` because the script launches a standalone metadata process with `mooncake-wheel/mooncake/http_metadata_server.py`
+- The script uses `sudo -n` to set hugepages and mount `/dev/hugepages`, so the current user must have passwordless sudo
+
+**Usage**:
+
+```bash
+cd mooncake-store/tests/e2e
+BUILD_DIR=/path/to/build ./run_nof_heartbeat_tcp_e2e.sh
+```
+
+To run in **NoF-only** mode (do not mount a local memory segment), set:
+
+```bash
+CLIENT_GLOBAL_SEGMENT_SIZE=0 BUILD_DIR=/path/to/build ./run_nof_heartbeat_tcp_e2e.sh
+```
+
+To increase the amount of steady-state traffic before killing the target, set:
+
+```bash
+PRE_FAULT_SUCCESS_TARGET=10 BUILD_DIR=/path/to/build ./run_nof_heartbeat_tcp_e2e.sh
+```
+
+**Notes**:
+
+- The client payload size defaults to `4096` bytes because the current NoF path requires 4K-aligned I/O.
+- The script uses a standalone metadata server process (`mooncake-wheel/mooncake/http_metadata_server.py`) instead of the embedded master metadata server so all four components remain explicit during the test.
+- In default mode, the script verifies **service continuity** after NoF unmount by checking that post-fault I/O still succeeds.
+- In `CLIENT_GLOBAL_SEGMENT_SIZE=0` mode, the script verifies **NoF-only failure behavior** by checking that post-fault I/O starts failing after the NoF segment is removed.
+- Logs are written under `LOG_DIR` (default `/tmp/mooncake_nof_heartbeat_e2e`) and the final pass/fail summary is printed from `summary.log`.
+
+### store_client_e2e.py
+
+**Brief**: A standalone Python workload generator built on `MooncakeDistributedStore`. It continuously issues `put/get` against the configured master/metadata pair and prints `put_ok/get_ok/put_fail/get_fail` lines that can be consumed by shell scripts.
+
+**Standalone Usage**:
+
+```bash
+PYTHONPATH=/path/to/build/mooncake-integration \
+python3 store_client_e2e.py \
+  --local-hostname 127.0.0.1:50071 \
+  --metadata-server http://127.0.0.1:8080/metadata \
+  --master-server 127.0.0.1:50051 \
+  --global-segment-size 67108864 \
+  --local-buffer-size 33554432 \
+  --payload-size 4096 \
+  --duration-sec 20 \
+  --sleep-ms 200 \
+  --key-prefix demo
+```
+
+**Key Parameters**:
+
+- `--global-segment-size 0`: run in NoF-only mode
+- `--payload-size 4096`: keep NoF writes 4K aligned
+- `--duration-sec`: total workload duration
+- `--sleep-ms`: interval between operations

--- a/mooncake-store/tests/e2e/run_nof_heartbeat_tcp_e2e.sh
+++ b/mooncake-store/tests/e2e/run_nof_heartbeat_tcp_e2e.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
+BUILD_DIR=${BUILD_DIR:-"$REPO_ROOT/build"}
+LOG_DIR=${LOG_DIR:-/tmp/mooncake_nof_heartbeat_e2e}
+MASTER_RPC=${MASTER_RPC:-127.0.0.1:50051}
+MASTER_HOST=${MASTER_RPC%:*}
+MASTER_PORT=${MASTER_RPC##*:}
+METADATA_HOST=${METADATA_HOST:-127.0.0.1}
+METADATA_PORT=${METADATA_PORT:-8080}
+METADATA_SERVER="http://$METADATA_HOST:$METADATA_PORT/metadata"
+TARGET_HOST=${TARGET_HOST:-127.0.0.1}
+TARGET_PORT=${TARGET_PORT:-4420}
+TARGET_NQN=${TARGET_NQN:-nqn.2016-06.io.spdk:cnode1}
+NOF_SIZE=${NOF_SIZE:-67108864}
+PAYLOAD_SIZE=${PAYLOAD_SIZE:-4096}
+CLIENT_DURATION=${CLIENT_DURATION:-0}
+CLIENT_SLEEP_MS=${CLIENT_SLEEP_MS:-200}
+HEARTBEAT_INTERVAL=${HEARTBEAT_INTERVAL:-2}
+HEARTBEAT_TIMEOUT_MS=${HEARTBEAT_TIMEOUT_MS:-500}
+HEARTBEAT_FAILURES=${HEARTBEAT_FAILURES:-3}
+CLIENT_GLOBAL_SEGMENT_SIZE=${CLIENT_GLOBAL_SEGMENT_SIZE:-67108864}
+CLIENT_LOCAL_BUFFER_SIZE=${CLIENT_LOCAL_BUFFER_SIZE:-33554432}
+CLIENT_MEMORY_REPLICA_NUM=${CLIENT_MEMORY_REPLICA_NUM:-1}
+CLIENT_NOF_REPLICA_NUM=${CLIENT_NOF_REPLICA_NUM:-1}
+PRE_FAULT_SUCCESS_TARGET=${PRE_FAULT_SUCCESS_TARGET:-3}
+
+TARGET_PID=""
+MASTER_PID=""
+META_PID=""
+CLIENT_PID=""
+
+cleanup() {
+  [[ -n "$CLIENT_PID" ]] && kill "$CLIENT_PID" >/dev/null 2>&1 || true
+  [[ -n "$MASTER_PID" ]] && kill "$MASTER_PID" >/dev/null 2>&1 || true
+  [[ -n "$TARGET_PID" ]] && kill "$TARGET_PID" >/dev/null 2>&1 || true
+  [[ -n "$META_PID" ]] && kill "$META_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+wait_for_pattern() {
+  local file=$1
+  local pattern=$2
+  local timeout=$3
+  local waited=0
+  while (( waited < timeout )); do
+    if grep -q "$pattern" "$file" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
+}
+
+count_pattern() {
+  local file=$1
+  local pattern=$2
+  grep -c "$pattern" "$file" 2>/dev/null || true
+}
+
+rm -rf "$LOG_DIR"
+mkdir -p "$LOG_DIR"
+
+sudo -n sh -c 'echo 512 > /proc/sys/vm/nr_hugepages'
+sudo -n umount /dev/hugepages >/dev/null 2>&1 || true
+sudo -n mkdir -p /dev/hugepages
+sudo -n mount -t hugetlbfs -o pagesize=2M,mode=1777 none /dev/hugepages
+grep -E 'HugePages_Total|HugePages_Free|Hugepagesize' /proc/meminfo >"$LOG_DIR/hugepages.log"
+
+pkill -f '/nvmf_tgt' >/dev/null 2>&1 || true
+pkill -f 'mooncake_master' >/dev/null 2>&1 || true
+pkill -f 'http_metadata_server.py' >/dev/null 2>&1 || true
+sleep 1
+
+"$REPO_ROOT/extern/spdk/build/bin/nvmf_tgt" -m 0x1 -u --iova-mode=va --wait-for-rpc >"$LOG_DIR/target.log" 2>&1 &
+TARGET_PID=$!
+sleep 3
+
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" framework_start_init >/dev/null
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" framework_wait_init >/dev/null
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" bdev_malloc_create -b Malloc0 64 4096 >/dev/null
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_create_transport -t TCP >/dev/null || true
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_create_subsystem "$TARGET_NQN" -a -s SPDK00000000000001 >/dev/null || true
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_subsystem_add_ns "$TARGET_NQN" Malloc0 >/dev/null || true
+python3 "$REPO_ROOT/extern/spdk/scripts/rpc.py" nvmf_subsystem_add_listener "$TARGET_NQN" -t tcp -a "$TARGET_HOST" -s "$TARGET_PORT" >/dev/null || true
+
+python3 "$REPO_ROOT/mooncake-wheel/mooncake/http_metadata_server.py" --host "$METADATA_HOST" --port "$METADATA_PORT" >"$LOG_DIR/metadata.log" 2>&1 &
+META_PID=$!
+sleep 2
+
+"$BUILD_DIR/mooncake-store/src/mooncake_master" \
+  --rpc_address="$MASTER_HOST" \
+  --rpc_port="$MASTER_PORT" \
+  --enable_http_metadata_server=false \
+  --logtostderr=true \
+  --nof_heartbeat_interval_sec="$HEARTBEAT_INTERVAL" \
+  --nof_heartbeat_probe_timeout_ms="$HEARTBEAT_TIMEOUT_MS" \
+  --nof_heartbeat_failures_threshold="$HEARTBEAT_FAILURES" >"$LOG_DIR/master.log" 2>&1 &
+MASTER_PID=$!
+sleep 3
+
+PYTHONPATH="$BUILD_DIR/mooncake-integration" MC_NOF_TRTYPE=TCP python3 - <<PY >"$LOG_DIR/register.log" 2>&1
+import store
+ret = store.MooncakeDistributedNoFRegister().real_register(
+    "$TARGET_NQN",
+    1,
+    "$TARGET_HOST",
+    int("$TARGET_PORT"),
+    0,
+    int("$NOF_SIZE"),
+    "$MASTER_RPC",
+)
+print(f"register_ret {ret}", flush=True)
+raise SystemExit(0 if ret == 0 else 1)
+PY
+
+PYTHONPATH="$BUILD_DIR/mooncake-integration" python3 "$SCRIPT_DIR/store_client_e2e.py" \
+  --local-hostname "127.0.0.1:50071" \
+  --metadata-server "$METADATA_SERVER" \
+  --master-server "$MASTER_RPC" \
+  --global-segment-size "$CLIENT_GLOBAL_SEGMENT_SIZE" \
+  --local-buffer-size "$CLIENT_LOCAL_BUFFER_SIZE" \
+  --memory-replica-num "$CLIENT_MEMORY_REPLICA_NUM" \
+  --nof-replica-num "$CLIENT_NOF_REPLICA_NUM" \
+  --payload-size "$PAYLOAD_SIZE" \
+  --duration-sec "$CLIENT_DURATION" \
+  --sleep-ms "$CLIENT_SLEEP_MS" \
+  --key-prefix "nof-heartbeat" >"$LOG_DIR/client.log" 2>&1 &
+CLIENT_PID=$!
+
+deadline=$((SECONDS + 30))
+while (( SECONDS < deadline )); do
+  put_ok_count=$(count_pattern "$LOG_DIR/client.log" 'put_ok')
+  get_ok_count=$(count_pattern "$LOG_DIR/client.log" 'get_ok')
+  if (( put_ok_count >= PRE_FAULT_SUCCESS_TARGET && get_ok_count >= PRE_FAULT_SUCCESS_TARGET )); then
+    break
+  fi
+  sleep 1
+done
+
+put_ok_count=$(count_pattern "$LOG_DIR/client.log" 'put_ok')
+get_ok_count=$(count_pattern "$LOG_DIR/client.log" 'get_ok')
+if (( put_ok_count < PRE_FAULT_SUCCESS_TARGET || get_ok_count < PRE_FAULT_SUCCESS_TARGET )); then
+  echo "client did not reach enough initial success: put_ok=$put_ok_count get_ok=$get_ok_count"
+  exit 1
+fi
+
+pre_fault_line_count=$(wc -l <"$LOG_DIR/client.log")
+
+kill "$TARGET_PID" >/dev/null 2>&1 || true
+TARGET_PID=""
+
+if ! wait_for_pattern "$LOG_DIR/master.log" 'action=unmount_nof_segment_by_heartbeat' $((HEARTBEAT_INTERVAL * HEARTBEAT_FAILURES + 20)); then
+  echo "master did not unmount nof segment by heartbeat"
+  exit 1
+fi
+
+post_unmount_line_count=$(wc -l <"$LOG_DIR/client.log")
+
+observation_deadline=$((SECONDS + 10))
+while (( SECONDS < observation_deadline )); do
+  post_unmount_successes=$(awk -v start="$post_unmount_line_count" '
+    NR > start && ($0 ~ /put_ok/ || $0 ~ /get_ok/) { count++ }
+    END { print count + 0 }
+  ' "$LOG_DIR/client.log")
+  post_unmount_failures=$(awk -v start="$post_unmount_line_count" '
+    NR > start && ($0 ~ /put_fail/ || $0 ~ /get_fail/) { count++ }
+    END { print count + 0 }
+  ' "$LOG_DIR/client.log")
+
+  if [[ "$CLIENT_GLOBAL_SEGMENT_SIZE" -eq 0 ]]; then
+    (( post_unmount_failures > 0 )) && break
+  else
+    (( post_unmount_successes > 0 )) && break
+  fi
+  sleep 1
+done
+
+kill "$CLIENT_PID" >/dev/null 2>&1 || true
+wait "$CLIENT_PID" >/dev/null 2>&1 || true
+CLIENT_PID=""
+
+post_fault_successes=$(awk -v start="$pre_fault_line_count" '
+  NR > start && ($0 ~ /put_ok/ || $0 ~ /get_ok/) { count++ }
+  END { print count + 0 }
+' "$LOG_DIR/client.log")
+
+post_fault_failures=$(awk -v start="$pre_fault_line_count" '
+  NR > start && ($0 ~ /put_fail/ || $0 ~ /get_fail/) { count++ }
+  END { print count + 0 }
+' "$LOG_DIR/client.log")
+
+post_unmount_successes=$(awk -v start="$post_unmount_line_count" '
+  NR > start && ($0 ~ /put_ok/ || $0 ~ /get_ok/) { count++ }
+  END { print count + 0 }
+' "$LOG_DIR/client.log")
+
+post_unmount_failures=$(awk -v start="$post_unmount_line_count" '
+  NR > start && ($0 ~ /put_fail/ || $0 ~ /get_fail/) { count++ }
+  END { print count + 0 }
+' "$LOG_DIR/client.log")
+
+if [[ "$CLIENT_GLOBAL_SEGMENT_SIZE" -eq 0 ]]; then
+  if [[ "$post_unmount_failures" -le 0 ]]; then
+    echo "expected IO failures after target down in nof-only mode"
+    exit 1
+  fi
+else
+  if [[ "$post_unmount_successes" -le 0 ]]; then
+    echo "no successful IO observed after target down"
+    exit 1
+  fi
+fi
+
+{
+  echo "=== hugepages ==="
+  cat "$LOG_DIR/hugepages.log"
+  echo "=== register ==="
+  cat "$LOG_DIR/register.log"
+  echo "=== client ==="
+  cat "$LOG_DIR/client.log"
+  echo "=== master tail ==="
+  tail -n 200 "$LOG_DIR/master.log"
+  echo "=== metadata tail ==="
+  tail -n 80 "$LOG_DIR/metadata.log"
+  echo "=== target tail ==="
+  tail -n 120 "$LOG_DIR/target.log"
+  echo "=== verdict ==="
+  echo "post_fault_successes=$post_fault_successes"
+  echo "post_fault_failures=$post_fault_failures"
+  echo "post_unmount_successes=$post_unmount_successes"
+  echo "post_unmount_failures=$post_unmount_failures"
+  echo "pre_fault_put_ok=$put_ok_count"
+  echo "pre_fault_get_ok=$get_ok_count"
+  echo "pre_fault_line_count=$pre_fault_line_count"
+  echo "post_unmount_line_count=$post_unmount_line_count"
+  echo "client_global_segment_size=$CLIENT_GLOBAL_SEGMENT_SIZE"
+  echo "client_memory_replica_num=$CLIENT_MEMORY_REPLICA_NUM"
+  echo "client_nof_replica_num=$CLIENT_NOF_REPLICA_NUM"
+} >"$LOG_DIR/summary.log"
+
+cat "$LOG_DIR/summary.log"

--- a/mooncake-store/tests/e2e/store_client_e2e.py
+++ b/mooncake-store/tests/e2e/store_client_e2e.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+import time
+
+
+def make_payload(seq: int, size: int) -> bytes:
+    seed = f"value{seq}".encode()
+    repeat = (size // len(seed)) + 1
+    return (seed * repeat)[:size]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Continuous MooncakeDistributedStore put/get workload"
+    )
+    parser.add_argument("--local-hostname", default="127.0.0.1:50071")
+    parser.add_argument("--metadata-server", default="http://127.0.0.1:8080/metadata")
+    parser.add_argument("--master-server", default="127.0.0.1:50051")
+    parser.add_argument("--protocol", default="tcp")
+    parser.add_argument("--device-name", default="")
+    parser.add_argument("--global-segment-size", type=int, default=64 * 1024 * 1024)
+    parser.add_argument("--local-buffer-size", type=int, default=32 * 1024 * 1024)
+    parser.add_argument("--payload-size", type=int, default=4096)
+    parser.add_argument("--duration-sec", type=int, default=20)
+    parser.add_argument("--sleep-ms", type=int, default=200)
+    parser.add_argument("--key-prefix", default="nof-e2e")
+    parser.add_argument("--memory-replica-num", type=int, default=1)
+    parser.add_argument("--nof-replica-num", type=int, default=1)
+    args = parser.parse_args()
+
+    try:
+        import store  # type: ignore
+    except Exception as exc:
+        print(f"import_fail {exc}", flush=True)
+        return 10
+
+    mc = store.MooncakeDistributedStore()
+    setup_ret = mc.setup(
+        args.local_hostname,
+        args.metadata_server,
+        args.global_segment_size,
+        args.local_buffer_size,
+        args.protocol,
+        args.device_name,
+        args.master_server,
+    )
+    print(f"setup_ret {setup_ret}", flush=True)
+    if setup_ret != 0:
+        return setup_ret
+
+    replicate_config = store.ReplicateConfig()
+    replicate_config.replica_num = args.memory_replica_num
+    replicate_config.nof_replica_num = args.nof_replica_num
+
+    deadline = time.time() + args.duration_sec if args.duration_sec > 0 else None
+    seq = 0
+    put_ok = 0
+    get_ok = 0
+    put_fail = 0
+    get_fail = 0
+    mismatch = 0
+
+    while deadline is None or time.time() < deadline:
+        seq += 1
+        key = f"{args.key_prefix}-{seq}"
+        expected = make_payload(seq, args.payload_size)
+
+        put_ret = mc.put(key, expected, replicate_config)
+        if put_ret == 0:
+            put_ok += 1
+            print(f"put_ok seq={seq} key={key} len={len(expected)}", flush=True)
+        else:
+            put_fail += 1
+            print(f"put_fail seq={seq} key={key} ret={put_ret}", flush=True)
+            time.sleep(args.sleep_ms / 1000.0)
+            continue
+
+        actual = mc.get(key)
+        if actual == expected:
+            get_ok += 1
+            print(f"get_ok seq={seq} key={key} len={len(actual)}", flush=True)
+        elif actual in (b"", None):
+            get_fail += 1
+            actual_len = 0 if actual in (b"", None) else len(actual)
+            print(f"get_fail seq={seq} key={key} len={actual_len}", flush=True)
+        else:
+            mismatch += 1
+            print(
+                f"data_mismatch seq={seq} key={key} expected_len={len(expected)} actual_len={len(actual)}",
+                flush=True,
+            )
+            return 20
+
+        time.sleep(args.sleep_ms / 1000.0)
+
+    print(
+        "summary "
+        f"put_ok={put_ok} put_fail={put_fail} "
+        f"get_ok={get_ok} get_fail={get_fail} mismatch={mismatch}",
+        flush=True,
+    )
+    return 0 if mismatch == 0 else 20
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mooncake-wheel/mooncake/mooncake_ssd_register.py
+++ b/mooncake-wheel/mooncake/mooncake_ssd_register.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+# python3 -m mooncake.mooncake_ssd_register --master_server_address=192.168.65.81:50051 --spdk_target_info="ip:192.168.65.56 path:/home/spdk" --spdk_target_info="ip:192.168.65.57 path:/root/spdk"
+
+import argparse
+import json
+import logging
+import time
+import re
+import shlex
+from typing import List, Dict, Any
+
+import paramiko
+
+from mooncake.store import MooncakeDistributedNoFRegister
+from mooncake.mooncake_config import MooncakeConfig
+
+
+class MooncakeNoFRegister:
+    """
+    Registers SSDs from remote SPDK targets to Mooncake master server.
+    """
+
+    def __init__(self, cli_config: dict = None, spdk_targets: List[str] = None):
+        self.register = None
+        self.config_list: List[Dict[str, Any]] = []
+        self.cli_config = cli_config or {}
+        self.spdk_targets = spdk_targets or []
+        self._setup_logging()
+
+        try:
+            # Only support getting SSD info from remote SPDK targets
+            if self.spdk_targets:
+                # Get SSD info from remote SPDK targets
+                master_server_address = self.cli_config.get('master_server_address')
+                if not master_server_address:
+                    raise ValueError("master_server_address is required when using spdk_target_info")
+                self.config_list = self._get_remote_ssd_info(master_server_address)
+            else:
+                raise ValueError("spdk_target_info is required")
+
+            # Apply CLI overrides to every config (if key exists)
+            for config in self.config_list:
+                for key, value in self.cli_config.items():
+                    if key in config:
+                        # Convert trsvcid/nsid to int if needed
+                        if key in ("trsvcid", "nsid"):
+                            try:
+                                config[key] = int(value)
+                            except ValueError:
+                                logging.warning(f"Invalid integer for {key}: {value}")
+                        else:
+                            config[key] = value
+
+            # Remove duplicate SSDs based on their unique identifiers
+            self._remove_duplicate_ssds()
+
+            logging.info("Loaded %d SSD configuration(s)", len(self.config_list))
+        except Exception as e:
+            logging.error("Configuration load failed: %s", e)
+            raise
+
+
+
+    def _remove_duplicate_ssds(self):
+        """
+        Remove duplicate SSD configurations from the config list
+        """
+        unique_configs = []
+        seen_keys = set()
+
+        for config in self.config_list:
+            # Generate unique key directly without calling _get_ssd_unique_key
+            key = (config['nqn'], config['nsid'], config['traddr'], config['trsvcid'])
+            if key not in seen_keys:
+                seen_keys.add(key)
+                unique_configs.append(config)
+
+        if len(unique_configs) < len(self.config_list):
+            logging.info(f"Removed {len(self.config_list) - len(unique_configs)} duplicate SSD configuration(s)")
+
+        self.config_list = unique_configs
+
+
+
+    def _parse_spdk_target_info(self, target_info: str) -> Dict[str, str]:
+        """
+        Parse spdk target info string like "ip:192.168.65.56 path:/home"
+        """
+        result = {}
+        parts = re.findall(r'(\w+):([^\s]+)', target_info)
+        for key, value in parts:
+            result[key] = value
+        return result
+
+    def _execute_ssh_command(self, ip: str, command: str, path: str) -> str:
+        """
+        Execute command on remote server via SSH
+        """
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+            ssh.connect(
+                ip,
+                port=int(self.cli_config.get('port', 22)),
+                username=self.cli_config.get('username', 'root'),
+                password=self.cli_config.get('password'),
+                key_filename=self.cli_config.get('key_file'),
+                timeout=10
+            )
+
+            # Try multiple possible paths to find the RPC script
+            possible_paths = [
+                path,  # Direct path provided by user
+                f"{path}/spdk"  # Common case: spdk is a subdirectory
+            ]
+
+            for test_path in possible_paths:
+                full_command = f"cd {shlex.quote(test_path)} && test -f scripts/rpc.py"
+                stdin, stdout, stderr = ssh.exec_command(full_command, timeout=5)
+                if stdout.channel.recv_exit_status() == 0:
+                    # Found the script, execute the actual command
+                    full_command = f"cd {shlex.quote(test_path)} && {command}"
+                    stdin, stdout, stderr = ssh.exec_command(full_command, timeout=30)
+                    exit_status = stdout.channel.recv_exit_status()
+                    output = stdout.read().decode('utf-8')
+                    error = stderr.read().decode('utf-8')
+                    if exit_status != 0:
+                        logging.error(f"SSH command error on {ip}: {error}")
+                        raise RuntimeError(f"SSH command failed: {error or output}")
+                    return output
+
+            # If we get here, none of the paths worked
+            raise RuntimeError(f"Could not find scripts/rpc.py in any of the possible paths: {possible_paths}")
+        finally:
+            ssh.close()
+
+    def _get_remote_ssd_info(self, master_server_address: str) -> List[Dict[str, Any]]:
+        """
+        Get SSD info from remote SPDK targets
+        """
+        ssd_configs = []
+
+        for target_info in self.spdk_targets:
+            target = self._parse_spdk_target_info(target_info)
+            ip = target.get('ip')
+            path = target.get('path')
+
+            if not ip or not path:
+                logging.error(f"Invalid target info: {target_info}")
+                continue
+
+            logging.info(f"Getting SSD info from target: {ip} (path: {path})")
+
+            try:
+                # Get subsystems info
+                subsystems_cmd = "./scripts/rpc.py nvmf_get_subsystems"
+                subsystems_output = self._execute_ssh_command(ip, subsystems_cmd, path)
+                subsystems = json.loads(subsystems_output)
+
+                # Process each subsystem
+                for subsystem in subsystems:
+                    if subsystem.get('subtype') != 'NVMe':
+                        continue
+
+                    nqn = subsystem.get('nqn')
+                    listen_addresses = subsystem.get('listen_addresses', [])
+
+                    if not nqn or not listen_addresses:
+                        continue
+
+                    # Get transport info from first listen address
+                    traddr = listen_addresses[0].get('traddr')
+                    trsvcid = listen_addresses[0].get('trsvcid')
+
+                    if not traddr or not trsvcid:
+                        continue
+
+                    # Process each namespace
+                    namespaces = subsystem.get('namespaces', [])
+                    for namespace in namespaces:
+                        nsid = namespace.get('nsid')
+                        bdev_name = namespace.get('bdev_name')
+
+                        if not nsid or not bdev_name:
+                            continue
+
+                        # Get bdev info to calculate size
+                        bdev_cmd = f"./scripts/rpc.py bdev_get_bdevs -b {shlex.quote(bdev_name)}"
+                        bdev_output = self._execute_ssh_command(ip, bdev_cmd, path)
+                        bdevs = json.loads(bdev_output)
+
+                        if not bdevs:
+                            continue
+
+                        bdev = bdevs[0]
+                        block_size = bdev.get('block_size', 512)
+                        num_blocks = bdev.get('num_blocks', 0)
+                        size = block_size * num_blocks
+
+                        # Create SSD config
+                        ssd_config = {
+                            'nqn': nqn,
+                            'nsid': nsid,
+                            'traddr': traddr,
+                            'trsvcid': int(trsvcid),  # Ensure trsvcid is integer
+                            'base': 0,
+                            'size': size,
+                            'master_server_address': master_server_address,
+                            'metadata_server': ''
+                        }
+
+                        ssd_configs.append(ssd_config)
+                        logging.info(f"Found SSD: nqn={nqn}, nsid={nsid}, traddr={traddr}, size={size}")
+
+            except Exception as e:
+                logging.error(f"Failed to get SSD info from {ip}: {e}")
+                continue
+
+        if not ssd_configs:
+            raise RuntimeError("No SSD information found from remote targets")
+
+        return ssd_configs
+
+    def _setup_logging(self):
+        logging.basicConfig(
+            level=logging.INFO,
+            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        )
+
+    def start_ssd_service(self):
+        success_count = 0
+        skipped_count = 0
+        failed_count = 0
+        total = len(self.config_list)
+
+        for i, cfg in enumerate(self.config_list):
+            try:
+                logging.info("Registering SSD %d/%d: nqn=%s, traddr=%s", i + 1, total, cfg.get("nqn"), cfg.get("traddr"))
+
+                # Create register instance and register SSD
+                self.register = MooncakeDistributedNoFRegister()
+                ret = self.register.real_register(
+                    cfg["nqn"],
+                    cfg["nsid"],
+                    cfg["traddr"],
+                    cfg["trsvcid"],
+                    cfg["base"],
+                    cfg["size"],
+                    cfg["master_server_address"]
+                )
+
+                if ret != 0:
+                    raise RuntimeError(f"Registration failed with code {ret}")
+
+                logging.info("Register SSD %d/%d succeeded", i + 1, total)
+                success_count += 1
+
+            except Exception as e:
+                # Check if the error is due to the segment already existing on the server
+                if "SEGMENT_ALREADY_EXISTS" in str(e) or "segment already exists" in str(e):
+                    logging.info("SSD %d/%d (nqn=%s, traddr=%s) already registered on server, skipping",
+                                i + 1, total, cfg.get("nqn"), cfg.get("traddr"))
+                    skipped_count += 1
+                else:
+                    logging.error("Failed to register SSD %d/%d: %s", i + 1, total, e)
+                    failed_count += 1
+
+        # Summary
+        logging.info("SSD registration summary:")
+        logging.info("- Total SSDs: %d", total)
+        logging.info("- Successfully registered: %d", success_count)
+        logging.info("- Already registered (skipped): %d", skipped_count)
+        logging.info("- Failed: %d", failed_count)
+
+        # Return success if all SSDs were either registered or already existed
+        return failed_count == 0
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='Mooncake SSD Register with REST API')
+    parser.add_argument('--master_server_address', type=str,
+                        help='Master server address (e.g., 192.168.65.81:50051)',
+                        required=True)
+    parser.add_argument('--spdk_target_info', action='append',
+                        help='SPDK target information (e.g., "ip:192.168.65.56 path:/home")',
+                        required=True)
+    parser.add_argument('--username', type=str, default='root',
+                        help='SSH username for target nodes (default: root)')
+    parser.add_argument('--port', type=int, default=22,
+                        help='SSH port for target nodes (default: 22)')
+    parser.add_argument('--password', type=str,
+                        help='SSH password for target nodes')
+    parser.add_argument('--key-file', type=str,
+                        help='SSH private key file path')
+    parser.add_argument('-D', '--define', action='append',
+                        help='Override configuration fields globally (e.g., -Dtrsvcid=4420)',
+                        default=[])
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+
+    cli_config = {}
+    for item in args.define:
+        if '=' in item:
+            key, value = item.split('=', 1)
+            cli_config[key] = value
+        else:
+            logging.warning(f"Ignoring invalid CLI config: {item}")
+
+    # Add master_server_address to cli_config if provided
+    if args.master_server_address:
+        cli_config['master_server_address'] = args.master_server_address
+    cli_config['username'] = args.username
+    cli_config['port'] = args.port
+    if args.password:
+        cli_config['password'] = args.password
+    if args.key_file:
+        cli_config['key_file'] = args.key_file
+
+    register = MooncakeNoFRegister(cli_config, args.spdk_target_info)
+    success = register.start_ssd_service()
+    if not success:
+        exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/mooncake-wheel/mooncake/mooncake_ssd_unregister.py
+++ b/mooncake-wheel/mooncake/mooncake_ssd_unregister.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+# python3 -m mooncake.mooncake_ssd_unregister --master_server_address=192.168.65.81:50051 --spdk_target_info="ip:192.168.65.56 ns:1 nqn:nqn.2016-06.io.spdk:cnode1"
+
+import argparse
+import logging
+import json
+import re
+import shlex
+from typing import List, Dict, Any
+
+import paramiko
+
+from mooncake.store import MooncakeDistributedNoFRegister
+from mooncake.mooncake_config import MooncakeConfig
+
+
+class MooncakeNoFUnregister:
+    """
+    Unregisters SSDs from Mooncake master server by endpoint information.
+    """
+
+    def __init__(self, cli_config: dict = None, spdk_targets: List[str] = None):
+        self.register = None
+        self.config_list: List[Dict[str, Any]] = []
+        self.cli_config = cli_config or {}
+        self.spdk_targets = spdk_targets or []
+        self._setup_logging()
+
+        try:
+            # Only support getting SSD info from command line
+            if self.spdk_targets:
+                # Get SSD info from command line parameters
+                master_server_address = self.cli_config.get('master_server_address')
+                if not master_server_address:
+                    raise ValueError("master_server_address is required when using spdk_target_info")
+                self.config_list = self._parse_spdk_targets(master_server_address)
+            else:
+                raise ValueError("spdk_target_info is required")
+
+            # Apply CLI overrides to every config (if key exists)
+            for config in self.config_list:
+                for key, value in self.cli_config.items():
+                    if key in config:
+                        # Convert trsvcid/nsid to int if needed
+                        if key in ("trsvcid", "nsid"):
+                            try:
+                                config[key] = int(value)
+                            except ValueError:
+                                logging.warning(f"Invalid integer for {key}: {value}")
+                        else:
+                            config[key] = value
+
+            # Remove duplicate SSDs based on their unique identifiers
+            self._remove_duplicate_ssds()
+
+            logging.info("Loaded %d SSD configuration(s) to unregister", len(self.config_list))
+        except Exception as e:
+            logging.error("Configuration load failed: %s", e)
+            raise
+
+    def _remove_duplicate_ssds(self):
+        """
+        Remove duplicate SSD configurations from the config list
+        """
+        unique_configs = []
+        seen_keys = set()
+
+        for config in self.config_list:
+            # Generate unique key directly
+            key = (config['nqn'], config['nsid'], config['traddr'], config['trsvcid'])
+            if key not in seen_keys:
+                seen_keys.add(key)
+                unique_configs.append(config)
+
+        if len(unique_configs) < len(self.config_list):
+            logging.info(f"Removed {len(self.config_list) - len(unique_configs)} duplicate SSD configuration(s)")
+
+        self.config_list = unique_configs
+
+    def _execute_ssh_command(self, ip: str, command: str, path: str) -> str:
+        """
+        Execute command on remote server via SSH
+        """
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+            ssh.connect(
+                ip,
+                port=int(self.cli_config.get('port', 22)),
+                username=self.cli_config.get('username', 'root'),
+                password=self.cli_config.get('password'),
+                key_filename=self.cli_config.get('key_file'),
+                timeout=10
+            )
+
+            # Try multiple possible paths to find the RPC script
+            possible_paths = [
+                path,  # Direct path provided by user
+                f"{path}/spdk"  # Common case: spdk is a subdirectory
+            ]
+
+            for test_path in possible_paths:
+                full_command = f"cd {shlex.quote(test_path)} && test -f scripts/rpc.py"
+                stdin, stdout, stderr = ssh.exec_command(full_command, timeout=5)
+                if stdout.channel.recv_exit_status() == 0:
+                    # Found the script, execute the actual command
+                    full_command = f"cd {shlex.quote(test_path)} && {command}"
+                    stdin, stdout, stderr = ssh.exec_command(full_command, timeout=30)
+                    exit_status = stdout.channel.recv_exit_status()
+                    output = stdout.read().decode('utf-8')
+                    error = stderr.read().decode('utf-8')
+                    if exit_status != 0:
+                        logging.error(f"SSH command error on {ip}: {error}")
+                        raise RuntimeError(f"SSH command failed: {error or output}")
+                    return output
+
+            # If we get here, none of the paths worked
+            raise RuntimeError(f"Could not find scripts/rpc.py in any of the possible paths: {possible_paths}")
+        finally:
+            ssh.close()
+
+    def _parse_spdk_targets(self, master_server_address: str) -> List[Dict[str, Any]]:
+        """
+        Parse spdk target info strings like "ip:192.168.65.56" or "ip:192.168.65.56 ns:2"
+        or "ip:192.168.65.56 path:/home/spdk" to get actual namespaces from SPDK target
+        """
+        ssd_configs = []
+
+        for target_info in self.spdk_targets:
+            # Parse target info
+            target = {}
+            parts = target_info.split()
+            for part in parts:
+                if ':' in part:
+                    key, value = part.split(':', 1)
+                    target[key.strip()] = value.strip()
+
+            # Validate required fields
+            if 'ip' not in target:
+                raise ValueError("spdk_target_info must contain 'ip' field")
+
+            ip = target['ip']
+            specified_ns = int(target['ns']) if 'ns' in target else None
+            path = target.get('path')
+
+            # We need to know the NQN to build the te_endpoint
+            # For now, we'll use a default NQN pattern (this should be improved)
+            default_nqn = "nqn.2016-06.io.spdk:cnode1"
+            nqn = target.get('nqn', default_nqn)
+
+            # Default transport parameters
+            trsvcid = int(target.get('port', '4420'))
+            trtype = target.get('trtype', 'RDMA')
+
+            # Create SSD config for each namespace (or specified ns only)
+            if specified_ns is not None:
+                # Unregister specific namespace
+                ssd_config = {
+                    'nqn': nqn,
+                    'nsid': specified_ns,
+                    'traddr': ip,
+                    'trsvcid': trsvcid,
+                    'base': 0,
+                    'size': 0,  # Size is not needed for unregister
+                    'master_server_address': master_server_address,
+                    'metadata_server': ''
+                }
+                ssd_configs.append(ssd_config)
+                logging.info(f"Will unregister SSD: nqn={nqn}, nsid={specified_ns}, traddr={ip}")
+            elif path is not None:
+                # Get actual namespaces from SPDK target
+                logging.info(f"Getting namespace info from target: {ip} (path: {path})")
+                try:
+                    # Get subsystems info
+                    subsystems_cmd = "./scripts/rpc.py nvmf_get_subsystems"
+                    subsystems_output = self._execute_ssh_command(ip, subsystems_cmd, path)
+                    subsystems = json.loads(subsystems_output)
+
+                    # Process each subsystem
+                    for subsystem in subsystems:
+                        if subsystem.get('subtype') != 'NVMe':
+                            continue
+
+                        subsystem_nqn = subsystem.get('nqn')
+                        listen_addresses = subsystem.get('listen_addresses', [])
+
+                        if not subsystem_nqn or not listen_addresses:
+                            continue
+
+                        # Get transport info from first listen address
+                        traddr = listen_addresses[0].get('traddr')
+                        target_trsvcid = listen_addresses[0].get('trsvcid')
+
+                        if not traddr or not target_trsvcid:
+                            continue
+
+                        # Use the nqn from the subsystem if not specified
+                        current_nqn = nqn if nqn != default_nqn else subsystem_nqn
+                        current_trsvcid = int(target_trsvcid) if target_trsvcid else trsvcid
+
+                        # Process each namespace
+                        namespaces = subsystem.get('namespaces', [])
+                        for namespace in namespaces:
+                            nsid = namespace.get('nsid')
+
+                            if not nsid:
+                                continue
+
+                            # Create SSD config
+                            ssd_config = {
+                                'nqn': current_nqn,
+                                'nsid': nsid,
+                                'traddr': traddr,
+                                'trsvcid': current_trsvcid,
+                                'base': 0,
+                                'size': 0,  # Size is not needed for unregister
+                                'master_server_address': master_server_address,
+                                'metadata_server': ''
+                            }
+                            ssd_configs.append(ssd_config)
+                            logging.info(f"Will unregister SSD: nqn={current_nqn}, nsid={nsid}, traddr={traddr}")
+
+                except Exception as e:
+                    logging.error(f"Failed to get namespace info from {ip}: {e}")
+                    logging.warning("Falling back to unregistering default namespace (nsid=1)")
+                    # Fall back to unregistering default namespace
+                    ssd_config = {
+                        'nqn': nqn,
+                        'nsid': 1,
+                        'traddr': ip,
+                        'trsvcid': trsvcid,
+                        'base': 0,
+                        'size': 0,
+                        'master_server_address': master_server_address,
+                        'metadata_server': ''
+                    }
+                    ssd_configs.append(ssd_config)
+                    logging.info(f"Will unregister SSD (fallback): nqn={nqn}, nsid=1, traddr={ip}")
+            else:
+                # No path provided, unregister default namespace only
+                logging.warning("No 'path' provided in spdk_target_info, cannot query actual namespaces from SPDK target")
+                logging.warning("Will unregister default namespace (nsid=1) only")
+                ssd_config = {
+                    'nqn': nqn,
+                    'nsid': 1,
+                    'traddr': ip,
+                    'trsvcid': trsvcid,
+                    'base': 0,
+                    'size': 0,
+                    'master_server_address': master_server_address,
+                    'metadata_server': ''
+                }
+                ssd_configs.append(ssd_config)
+                logging.info(f"Will unregister SSD: nqn={nqn}, nsid=1, traddr={ip}")
+
+        if not ssd_configs:
+            raise RuntimeError("No SSD configuration generated from target info")
+
+        return ssd_configs
+
+    def _setup_logging(self):
+        logging.basicConfig(
+            level=logging.INFO,
+            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        )
+
+    def start_ssd_unregister_service(self):
+        success_count = 0
+        failed_count = 0
+        total = len(self.config_list)
+
+        for i, cfg in enumerate(self.config_list):
+            try:
+                logging.info("Unregistering SSD %d/%d: nqn=%s, traddr=%s, nsid=%d", i + 1, total, cfg.get("nqn"), cfg.get("traddr"), cfg.get("nsid"))
+
+                # Create register instance and unregister SSD
+                self.register = MooncakeDistributedNoFRegister()
+                ret = self.register.real_unregister_by_endpoint(
+                    cfg["nqn"],
+                    cfg["nsid"],
+                    cfg["traddr"],
+                    cfg["trsvcid"],
+                    cfg["master_server_address"]
+                )
+
+                if ret != 0:
+                    raise RuntimeError(f"Unregistration failed with code {ret}")
+
+                logging.info("Unregister SSD %d/%d succeeded", i + 1, total)
+                success_count += 1
+
+            except Exception as e:
+                logging.error("Failed to unregister SSD %d/%d: %s", i + 1, total, e)
+                failed_count += 1
+
+        # Summary
+        logging.info("SSD unregistration summary:")
+        logging.info("- Total SSDs: %d", total)
+        logging.info("- Successfully unregistered: %d", success_count)
+        logging.info("- Failed: %d", failed_count)
+
+        # Return success if all SSDs were unregistered successfully
+        return failed_count == 0
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='Mooncake SSD Unregister with REST API')
+    parser.add_argument('--master_server_address', type=str,
+                        help='Master server address (e.g., 192.168.65.81:50051)',
+                        default='192.168.65.81:50051')
+    parser.add_argument('--spdk_target_info', action='append',
+                        help='SPDK target information (e.g., "ip:192.168.65.56 ns:2 nqn:nqn.2016-06.io.spdk:cnode1" or "ip:192.168.65.56 path:/home/spdk")',
+                        default=None)
+    parser.add_argument('--username', type=str, default='root',
+                        help='SSH username for target nodes (default: root)')
+    parser.add_argument('--port', type=int, default=22,
+                        help='SSH port for target nodes (default: 22)')
+    parser.add_argument('--password', type=str,
+                        help='SSH password for target nodes')
+    parser.add_argument('--key-file', type=str,
+                        help='SSH private key file path')
+    parser.add_argument('-D', '--define', action='append',
+                        help='Override configuration fields globally (e.g., -Dtrsvcid=4420)',
+                        default=[])
+    args = parser.parse_args()
+
+    # If no spdk_target_info is provided, use default
+    if args.spdk_target_info is None:
+        args.spdk_target_info = ['ip:192.168.65.56 ns:1 nqn:nqn.2016-06.io.spdk:cnode1']
+
+    return args
+
+
+def main():
+    args = parse_arguments()
+
+    cli_config = {}
+    for item in args.define:
+        if '=' in item:
+            key, value = item.split('=', 1)
+            cli_config[key] = value
+        else:
+            logging.warning(f"Ignoring invalid CLI config: {item}")
+
+    # Add master_server_address to cli_config if provided
+    if args.master_server_address:
+        cli_config['master_server_address'] = args.master_server_address
+    cli_config['username'] = args.username
+    cli_config['port'] = args.port
+    if args.password:
+        cli_config['password'] = args.password
+    if args.key_file:
+        cli_config['key_file'] = args.key_file
+
+    unregister = MooncakeNoFUnregister(cli_config, args.spdk_target_info)
+    success = unregister.start_ssd_unregister_service()
+    if not success:
+        exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/mooncake-wheel/mooncake/spdk_tgt_create.py
+++ b/mooncake-wheel/mooncake/spdk_tgt_create.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+# Tool to remotely create SPDK targets on multiple nodes
+# Usage: python3 -m mooncake.spdk_tgt_create --spdk_target_info="ip:192.168.65.56 path:/home/spdk pci:0000:01:00.0,0000:02:00.0" --spdk_target_info="ip:192.168.65.57 path:/home/spdk"
+
+import argparse
+import logging
+import paramiko
+import re
+import shlex
+import time
+from typing import List, Dict, Any, Optional
+
+
+class SPDKTgtCreator:
+    """
+    Remotely creates SPDK targets on multiple nodes via SSH.
+    """
+
+    DEFAULT_TRANSPORT_OPTIONS = {
+        'trtype': 'RDMA',
+        'max_queue_depth': 128,
+        'max_io_qpairs_per_ctrlr': 127,
+        'max_io_size': 4096,
+        'in_capsule_data_size': 131072,
+        'io_unit_size': 131072,
+        'max_aq_depth': 128,
+        'num_shared_buffers': 4096,
+        'buf_cache_size': 32,
+    }
+
+    TRANSPORT_RPC_FLAGS = {
+        'trtype': '-t',
+        'max_queue_depth': '-q',
+        'max_io_qpairs_per_ctrlr': '-m',
+        'max_io_size': '-c',
+        'in_capsule_data_size': '-i',
+        'io_unit_size': '-u',
+        'max_aq_depth': '-a',
+        'num_shared_buffers': '-n',
+        'buf_cache_size': '-b',
+    }
+
+    def __init__(self, spdk_targets: List[str], transport_options: Dict[str, Any] = None, core_mask: str = '0xff'):
+        self.spdk_targets = spdk_targets
+        self.core_mask = core_mask
+        self.transport_options = dict(self.DEFAULT_TRANSPORT_OPTIONS)
+        if transport_options:
+            self.transport_options.update(transport_options)
+        self._setup_logging()
+        self.target_configs = self._parse_spdk_targets()
+
+    def _setup_logging(self):
+        logging.basicConfig(
+            level=logging.INFO,
+            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        )
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def _parse_spdk_targets(self) -> List[Dict[str, Any]]:
+        """
+        Parse SPDK target information from command line arguments.
+        Format: "ip:<ip> path:<spdk_path> [pci:<pci1>,<pci2> ...]"
+        """
+        target_configs = []
+
+        for target_info in self.spdk_targets:
+            target = {
+                'ip': None,
+                'path': None,
+                'pci_devices': []
+            }
+
+            # Split the target info by spaces
+            parts = target_info.split()
+
+            # Simple state machine to parse the target info
+            state = None  # Can be 'ip', 'path', or 'pci'
+
+            for part in parts:
+                if ':' in part:
+                    # This is a key-value pair
+                    key, value = part.split(':', 1)
+                    key = key.strip()
+                    value = value.strip()
+
+                    if key == 'ip':
+                        target['ip'] = value
+                        state = 'ip'
+                    elif key == 'path':
+                        target['path'] = value
+                        state = 'path'
+                    elif key == 'pci':
+                        # Parse PCI devices separated by commas
+                        if value:
+                            # Split by commas and strip whitespace
+                            pci_list = [dev.strip() for dev in value.split(',') if dev.strip()]
+                            target['pci_devices'].extend(pci_list)
+                        state = 'pci'
+                    elif state == 'pci':
+                        pci_list = [dev.strip() for dev in part.split(',') if dev.strip()]
+                        target['pci_devices'].extend(pci_list)
+                else:
+                    # This is a continuation of the current state
+                    if state == 'path':
+                        # Path might contain spaces (unlikely but possible)
+                        target['path'] += ' ' + part
+                    elif state == 'pci':
+                        pci_list = [dev.strip() for dev in part.split(',') if dev.strip()]
+                        target['pci_devices'].extend(pci_list)
+
+            # Validate required fields
+            if not target['ip']:
+                raise ValueError("Each spdk_target_info must contain 'ip' field")
+            if not target['path']:
+                raise ValueError("Each spdk_target_info must contain 'path' field")
+
+            target_configs.append(target)
+            pci_info = target['pci_devices'] if target['pci_devices'] else 'auto-discover'
+            self.logger.info(f"Parsed target: IP={target['ip']}, Path={target['path']}, PCI devices={pci_info}")
+
+        return target_configs
+
+    def _ssh_connect(self, ip: str, username: str = 'root', password: str = None, key_file: str = None) -> paramiko.SSHClient:
+        """
+        Establish an SSH connection to the target host.
+        """
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        try:
+            if key_file:
+                self.logger.info(f"Connecting to {ip} using key file {key_file}")
+                ssh.connect(ip, username=username, key_filename=key_file)
+            else:
+                self.logger.info(f"Connecting to {ip} using password authentication")
+                ssh.connect(ip, username=username, password=password)
+            return ssh
+        except Exception as e:
+            self.logger.error(f"Failed to connect to {ip}: {e}")
+            raise
+
+    def _execute_command(self, ssh: paramiko.SSHClient, command: str, working_dir: str = None, sudo: bool = False, log_errors: bool = True, timeout: Optional[int] = 30) -> tuple:
+        """
+        Execute a command on the remote host via SSH.
+        """
+        if working_dir:
+            command = f"cd {working_dir} && {command}"
+
+        if sudo:
+            command = f"sudo {command}"
+
+        self.logger.debug(f"Executing command: {command}")
+
+        stdin, stdout, stderr = ssh.exec_command(command, timeout=timeout)
+        exit_status = stdout.channel.recv_exit_status()
+        output = stdout.read().decode('utf-8')
+        error = stderr.read().decode('utf-8')
+
+        if output:
+            self.logger.debug(f"Command output: {output}")
+        if error:
+            self.logger.debug(f"Command error: {error}")
+        if exit_status != 0:
+            if log_errors:
+                self.logger.error(f"Command failed with exit code {exit_status}: {command}")
+                if output:
+                    self.logger.error(f"Command output: {output}")
+                self.logger.error(f"Error output: {error}")
+            raise RuntimeError(f"Command execution failed: {error or output}")
+
+        return output, error
+
+    def _discover_nvme_pci_devices(self, ssh: paramiko.SSHClient) -> List[str]:
+        """
+        Discover SPDK-ready or unmounted NVMe controller PCI addresses on the target host.
+        """
+        self.logger.info("No PCI devices specified, discovering SPDK-ready or unmounted NVMe PCI devices")
+        output, _ = self._execute_command(
+            ssh,
+            r"""for dev in /sys/bus/pci/devices/*; do
+  class=$(cat "$dev/class" 2>/dev/null || true)
+  case "$class" in
+    0x0108*) ;;
+    *) continue ;;
+  esac
+  pci=$(basename "$dev")
+  driver=$(basename "$(readlink "$dev/driver" 2>/dev/null)" 2>/dev/null || true)
+  case "$driver" in
+    vfio-pci|uio_pci_generic|igb_uio)
+      echo "USE $pci $driver"
+      continue
+      ;;
+  esac
+  has_block=0
+  mounted=0
+  for block in /sys/block/nvme*n*; do
+    [ -e "$block" ] || continue
+    real_device=$(readlink -f "$block/device" 2>/dev/null || true)
+    case "$real_device" in
+      *"/$pci"/*|*"/$pci") ;;
+      *) continue ;;
+    esac
+    has_block=1
+    disk=$(basename "$block")
+    if lsblk -nr -o MOUNTPOINT "/dev/$disk" 2>/dev/null | grep -q '[^[:space:]]'; then
+        mounted=1
+    fi
+  done
+  if [ "$has_block" -eq 0 ]; then
+    echo "SKIP $pci no_block_device"
+  elif [ "$mounted" -eq 0 ]; then
+    echo "USE $pci"
+  else
+    echo "SKIP $pci mounted"
+  fi
+done"""
+        )
+
+        pci_devices = []
+        pci_pattern = re.compile(
+            r'^(?:[0-9a-fA-F]{4}:)?[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$'
+        )
+        for line in output.splitlines():
+            fields = line.split()
+            if len(fields) < 2:
+                continue
+            action, pci = fields[0], fields[1]
+            if action == 'USE' and pci_pattern.match(pci):
+                pci_devices.append(pci)
+            elif action == 'SKIP' and pci_pattern.match(pci):
+                reason = ' '.join(fields[2:]) or 'not eligible'
+                self.logger.warning(f"Skipping NVMe PCI device {pci}: {reason}")
+
+        if not pci_devices:
+            raise RuntimeError("No SPDK-ready or unmounted NVMe PCI devices found on the target host")
+
+        self.logger.info(f"Selected NVMe PCI devices for SPDK setup: {', '.join(pci_devices)}")
+        return pci_devices
+
+    def _filter_spdk_ready_pci_devices(self, ssh: paramiko.SSHClient, pci_devices: List[str], strict: bool) -> List[str]:
+        """
+        Keep PCI devices that are bound to an SPDK-compatible userspace driver.
+        """
+        if not pci_devices:
+            return []
+
+        pci_args = ' '.join(shlex.quote(pci) for pci in pci_devices)
+        output, _ = self._execute_command(
+            ssh,
+            f"""for pci in {pci_args}; do
+  driver=$(basename "$(readlink "/sys/bus/pci/devices/$pci/driver" 2>/dev/null)" 2>/dev/null || true)
+  case "$driver" in
+    vfio-pci|uio_pci_generic|igb_uio) echo "READY $pci $driver" ;;
+    "") echo "NOT_READY $pci no_driver" ;;
+    *) echo "NOT_READY $pci $driver" ;;
+  esac
+done"""
+        )
+
+        ready_devices = []
+        not_ready_devices = []
+        for line in output.splitlines():
+            fields = line.split()
+            if len(fields) < 3:
+                continue
+            state, pci, driver = fields[0], fields[1], fields[2]
+            if state == 'READY':
+                ready_devices.append(pci)
+            elif state == 'NOT_READY':
+                not_ready_devices.append((pci, driver))
+
+        if not_ready_devices:
+            details = ', '.join(f"{pci} ({driver})" for pci, driver in not_ready_devices)
+            if strict:
+                raise RuntimeError(
+                    "Some PCI devices are not available to SPDK after setup.sh: "
+                    f"{details}. Check whether they are mounted or still bound to the kernel driver."
+                )
+            self.logger.warning(f"Skipping PCI devices not available to SPDK after setup.sh: {details}")
+
+        if not ready_devices:
+            raise RuntimeError("No PCI devices are available to SPDK after setup.sh")
+
+        self.logger.info(f"PCI devices available to SPDK: {', '.join(ready_devices)}")
+        return ready_devices
+
+    def _start_spdk_tgt(self, ssh: paramiko.SSHClient, spdk_path: str) -> None:
+        """
+        Start the SPDK NVMF target service in the background.
+        """
+        # Check if tgt is already running
+        try:
+            self._execute_command(ssh, "pgrep -x nvmf_tgt", log_errors=False)
+            self.logger.info("SPDK tgt service is already running, stopping it first")
+            self._execute_command(ssh, "pkill -x nvmf_tgt")
+            time.sleep(2)  # Give it time to stop
+        except RuntimeError:
+            self.logger.debug("SPDK tgt service is not running, will start it")
+
+        # Start tgt in the background using absolute path
+        self.logger.info(f"Starting SPDK tgt service with core mask {self.core_mask}")
+        tgt_binary = f"{spdk_path}/build/bin/nvmf_tgt"
+        log_file = f"{spdk_path}/tgt.log"
+        self._execute_command(
+            ssh,
+            f"nohup {tgt_binary} -m {shlex.quote(self.core_mask)} > {log_file} 2>&1 &",
+            timeout=None
+        )
+        time.sleep(3)  # Give it time to start
+
+    def _setup_spdk(self, ssh: paramiko.SSHClient, spdk_path: str, pci_devices: List[str]) -> None:
+        """
+        Setup SPDK with the specified PCI devices.
+        """
+        self.logger.info(f"Setting up SPDK with PCI devices: {', '.join(pci_devices)}")
+        pci_allowed = ' '.join(pci_devices)
+        setup_script = f"{spdk_path}/scripts/setup.sh"
+        self._execute_command(ssh, f"PCI_ALLOWED='{pci_allowed}' {setup_script}", sudo=True)
+
+    def _format_transport_options(self) -> str:
+        """
+        Format transport options for the SPDK nvmf_create_transport RPC.
+        """
+        formatted_options = []
+        for option, flag in self.TRANSPORT_RPC_FLAGS.items():
+            value = self.transport_options[option]
+            formatted_options.extend([flag, shlex.quote(str(value))])
+        return ' '.join(formatted_options)
+
+    def _create_transport(self, ssh: paramiko.SSHClient, spdk_path: str) -> None:
+        """
+        Create NVMe-oF transport for SPDK.
+        """
+        self.logger.info(f"Creating {self.transport_options['trtype']} transport")
+        rpc_script = f"{spdk_path}/scripts/rpc.py"
+        transport_options = self._format_transport_options()
+        self._execute_command(ssh, f"{rpc_script} nvmf_create_transport {transport_options}")
+
+    def _create_bdevs(self, ssh: paramiko.SSHClient, spdk_path: str, pci_devices: List[str]) -> List[str]:
+        """
+        Create block devices for the specified PCI devices.
+        """
+        bdevs = []
+        rpc_script = f"{spdk_path}/scripts/rpc.py"
+        for i, pci in enumerate(pci_devices):
+            bdev_name = f"Nvme{i}"
+            self.logger.info(f"Creating bdev {bdev_name} for PCI {pci}")
+            self._execute_command(ssh, f"{rpc_script} bdev_nvme_attach_controller -b {bdev_name} -t PCIe -a {pci}")
+            bdevs.append(f"{bdev_name}n1")
+            self.logger.info(f"Attached PCI {pci} as bdev {bdev_name}n1")
+        return bdevs
+
+    def _create_subsystem(self, ssh: paramiko.SSHClient, spdk_path: str) -> str:
+        """
+        Create an NVMF subsystem.
+        """
+        subsystem_nqn = "nqn.2016-06.io.spdk:cnode1"
+        self.logger.info(f"Creating subsystem {subsystem_nqn}")
+        rpc_script = f"{spdk_path}/scripts/rpc.py"
+        self._execute_command(ssh, f"{rpc_script} nvmf_create_subsystem {subsystem_nqn} -a -s SPDK00000000000001 -m 12")
+        return subsystem_nqn
+
+    def _add_namespaces(self, ssh: paramiko.SSHClient, spdk_path: str, subsystem_nqn: str, bdevs: List[str]) -> None:
+        """
+        Add namespaces to the subsystem.
+        """
+        rpc_script = f"{spdk_path}/scripts/rpc.py"
+        for bdev in bdevs:
+            self.logger.info(f"Adding namespace {bdev} to subsystem {subsystem_nqn}")
+            self._execute_command(ssh, f"{rpc_script} nvmf_subsystem_add_ns {subsystem_nqn} {bdev}")
+
+    def _add_listener(self, ssh: paramiko.SSHClient, spdk_path: str, subsystem_nqn: str, ip: str) -> None:
+        """
+        Add a listener to the subsystem.
+        """
+        trtype = self.transport_options['trtype']
+        self.logger.info(f"Adding {trtype} listener on {ip}:4420")
+        rpc_script = f"{spdk_path}/scripts/rpc.py"
+        self._execute_command(ssh, f"{rpc_script} nvmf_subsystem_add_listener {subsystem_nqn} -t {shlex.quote(str(trtype))} -a {ip} -s 4420")
+
+    def deploy_target(self, target_config: Dict[str, Any]) -> bool:
+        """
+        Deploy SPDK target on a single node.
+        """
+        ip = target_config['ip']
+        spdk_path = target_config['path']
+        pci_devices = target_config['pci_devices']
+
+        self.logger.info(f"Deploying SPDK target on {ip}")
+
+        try:
+            # Establish SSH connection
+            ssh = self._ssh_connect(ip)
+
+            try:
+                auto_discovered = not pci_devices
+                if not pci_devices:
+                    pci_devices = self._discover_nvme_pci_devices(ssh)
+                else:
+                    self.logger.info(f"Using explicitly specified PCI devices for {ip}: {', '.join(pci_devices)}")
+
+                # Setup SPDK
+                self._setup_spdk(ssh, spdk_path, pci_devices)
+                pci_devices = self._filter_spdk_ready_pci_devices(
+                    ssh,
+                    pci_devices,
+                    strict=not auto_discovered
+                )
+                self.logger.info(f"Target {ip} will expose PCI devices: {', '.join(pci_devices)}")
+
+                # Start tgt service
+                self._start_spdk_tgt(ssh, spdk_path)
+
+                # Create transport
+                self._create_transport(ssh, spdk_path)
+
+                # Create bdevs
+                bdevs = self._create_bdevs(ssh, spdk_path, pci_devices)
+
+                # Create subsystem
+                subsystem_nqn = self._create_subsystem(ssh, spdk_path)
+
+                # Add namespaces
+                self._add_namespaces(ssh, spdk_path, subsystem_nqn, bdevs)
+
+                # Add listener
+                self._add_listener(ssh, spdk_path, subsystem_nqn, ip)
+
+                self.logger.info(f"Successfully deployed SPDK target on {ip}")
+                return True
+            finally:
+                ssh.close()
+        except Exception as e:
+            self.logger.error(f"Failed to deploy SPDK target on {ip}: {e}")
+            return False
+
+    def deploy_all_targets(self) -> bool:
+        """
+        Deploy SPDK targets on all specified nodes.
+        """
+        success_count = 0
+        total_count = len(self.target_configs)
+
+        for i, target_config in enumerate(self.target_configs):
+            self.logger.info(f"=== Deploying target {i+1}/{total_count} ===")
+            if self.deploy_target(target_config):
+                success_count += 1
+
+        self.logger.info("=== Deployment Summary ===")
+        self.logger.info(f"Total targets: {total_count}")
+        self.logger.info(f"Successfully deployed: {success_count}")
+        self.logger.info(f"Failed: {total_count - success_count}")
+
+        return success_count == total_count
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='SPDK Target Creator Tool')
+    parser.add_argument(
+        '--spdk_target_info',
+        action='append',
+        help=('SPDK target information (e.g., "ip:192.168.65.56 '
+              'path:/home/spdk pci:0000:01:00.0,0000:02:00.0"). If pci is '
+              'omitted, SPDK-ready or unmounted NVMe devices on the target are used.'),
+        required=True
+    )
+    parser.add_argument('--core-mask', type=str, default='0xff',
+                        help='CPU core mask used to start nvmf_tgt with -m (default: 0xff)')
+    parser.add_argument('--transport-type', type=str, default='RDMA',
+                        help='NVMe-oF transport type for nvmf_create_transport (default: RDMA)')
+    parser.add_argument('--max-queue-depth', type=int, default=128,
+                        help='Max number of outstanding I/O per queue (default: 128)')
+    parser.add_argument('--max-io-qpairs-per-ctrlr', type=int, default=127,
+                        help='Max number of I/O qpairs per controller (default: 127)')
+    parser.add_argument('--max-io-size', type=int, default=4096,
+                        help='Max I/O size in bytes (default: 4096)')
+    parser.add_argument('--in-capsule-data-size', type=int, default=131072,
+                        help='Max in-capsule data size in bytes (default: 131072)')
+    parser.add_argument('--io-unit-size', type=int, default=131072,
+                        help='I/O unit size in bytes (default: 131072)')
+    parser.add_argument('--max-aq-depth', type=int, default=128,
+                        help='Max number of admin commands per admin queue (default: 128)')
+    parser.add_argument('--num-shared-buffers', type=int, default=4096,
+                        help='Number of pooled data buffers available to the transport (default: 4096)')
+    parser.add_argument('--buf-cache-size', type=int, default=32,
+                        help='Number of shared buffers reserved for each poll group (default: 32)')
+    parser.add_argument('--username', type=str, default='root',
+                        help='SSH username for target nodes (default: root)')
+    parser.add_argument('--password', type=str,
+                        help='SSH password for target nodes')
+    parser.add_argument('--key-file', type=str,
+                        help='SSH private key file path')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    transport_options = {
+        'trtype': args.transport_type,
+        'max_queue_depth': args.max_queue_depth,
+        'max_io_qpairs_per_ctrlr': args.max_io_qpairs_per_ctrlr,
+        'max_io_size': args.max_io_size,
+        'in_capsule_data_size': args.in_capsule_data_size,
+        'io_unit_size': args.io_unit_size,
+        'max_aq_depth': args.max_aq_depth,
+        'num_shared_buffers': args.num_shared_buffers,
+        'buf_cache_size': args.buf_cache_size,
+    }
+
+    try:
+        creator = SPDKTgtCreator(args.spdk_target_info, transport_options, args.core_mask)
+        success = creator.deploy_all_targets()
+        exit(0 if success else 1)
+    except Exception as e:
+        logging.error(f"Error: {e}")
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description

This PR is the fourth split-out part of the original NVMe-oF SSD cache support patch.

It builds on #2143, #2172, and #2247. #2143 introduced master-side NoF segment metadata and control-plane support, #2172 added the SPDK/NVMe-oF worker pool and low-level data-plane primitives, and #2247 routed NoF replicas through the regular Store put/get paths.

This PR adds the remaining NoF SSD test coverage and deployment tooling, including end-to-end test scripts, benchmark helpers, SPDK target creation, SSD registration/unregistration utilities, Python bindings, and deployment documentation.

## Changes

* Add NoF heartbeat TCP end-to-end test coverage.
* Add Store client e2e test helpers for NoF SSD workflows.
* Add NoF KV benchmark script and benchmark documentation.
* Add `SSDRegisterClient` for registering and unregistering NoF SSD resources with the master.
* Expose SSD registration support through the Python integration layer.
* Add `mooncake.spdk_tgt_create` for remote SPDK NVMe-oF target deployment.
* Add `mooncake.mooncake_ssd_register` for registering target SSD namespaces into Mooncake.
* Add `mooncake.mooncake_ssd_unregister` for unregistering target SSD namespaces.
* Support optional PCI auto-discovery in `spdk_tgt_create`.
* Support configurable SPDK target core mask and NVMe-oF transport parameters.
* Improve deployment logs so users can see which PCI devices are selected, skipped, attached, and exposed by each target node.
* Add NVMe-oF SSD pool deployment documentation.

## Scope

This PR only adds NoF SSD e2e coverage, benchmark helpers, deployment utilities, SSD registration tools, Python integration, and documentation.

The core NoF metadata, worker pool, and put/get data-path support were introduced in previous PRs.

Related: #2084, #2143, #2172, #2247, #1940

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
