### PR TITLE
[TE] Add transport terminal event progress

### DIFF
--- a/docs/source/design/tent/failover.md
+++ b/docs/source/design/tent/failover.md
@@ -3,12 +3,13 @@
 TENT hides transfer failures from the application by recovering inside the data path.
 This document describes how the recovery works, which knobs control it, and how it is tested.
 
-The design has two layers:
+The design has three layers:
 
-1. **Cross-transport failover** in `TransferEngineImpl`. When a transport fails a task at the completion stage, the engine moves that task to the next available transport (for example RDMA → TCP). Submit-stage failures are not retried today; see Known Gaps.
-2. **Intra-RDMA rail recovery** in `RailMonitor`. When a specific (local NIC, remote NIC) rail keeps failing, the monitor pauses it with exponential cooldown; a successful transfer or the cooldown expiry brings it back.
+1. **Cross-transport failover** in `TransferEngineImpl`. When a transport reports a recoverable completion-stage failure, the engine moves that task to the next available transport (for example RDMA → TCP). Submit-stage failures are not retried today; see Known Gaps.
+2. **Event-driven progress** through `ProgressWorker`. When supported transports write a terminal task status (`COMPLETED`, `FAILED`, or `TIMEOUT`), they notify the engine-side `BatchEventSink`, which wakes the background progress worker. This removes the old implicit requirement that an application must continuously poll `getTransferStatus()` before failover can advance.
+3. **Intra-RDMA rail recovery** in `RailMonitor`. When a specific (local NIC, remote NIC) rail keeps failing, the monitor pauses it with exponential cooldown; a successful transfer or the cooldown expiry brings it back.
 
-Application code submits a batch and polls `getTransferStatus`. It never sees a `FAILED` task as long as any healthy path remains and the failover budget is not exhausted.
+Application code submits a batch and either waits, polls `getTransferStatus`, or relies on the progress worker when it is enabled. It never sees a `FAILED` task as long as any healthy path remains and the failover budget is not exhausted.
 
 ## Fault Model
 
@@ -18,35 +19,83 @@ TENT focuses on three kinds of transient faults:
 |-------|---------|-----------------|
 | Work request completion error (WC error) | RDMA worker sees a bad completion | Rail-level `markFailed` + task-level resubmit |
 | QP / endpoint failure | `submitTransferTasks` returns non-OK | *Not retried today*: task surfaces as `FAILED`. See Known Gaps. |
-| Peer disconnect mid-transfer | `getTransferStatus` returns `FAILED` | Cross-transport failover |
+| Peer disconnect mid-transfer | Transport writes or reports `FAILED`/`TIMEOUT` | Cross-transport failover, driven either by polling or by the progress worker |
 
 Permanent or application-visible errors (invalid arguments, out-of-memory, segment not found) are *not* retried; they are returned to the caller as-is.
 
 ## Architecture
 
 ```
-                +-------------------------+
- submitTransfer |  TransferEngineImpl     |
- ---------------> classify by TransportType
-                |  submitTransferTasks    |----failure----+
-                +-------------------------+               |
-                      |                                   v
-                      |                       resubmitTransferTask
-                      |                       (bump priority, pick next
-                      |                        transport, resubmit)
-                      v
-         +---------------------------+
-         | RdmaTransport / workers   |
-         |   +---------------------+ |
-         |   | RailMonitor         | |
-         |   |  per-rail state     | |
-         |   |  cooldown / recover | |
-         |   +---------------------+ |
-         +---------------------------+
+Application
+    |
+    | submitTransfer(batch, requests)
+    v
++--------------------------------------------------------------+
+| TransferEngineImpl                                           |
+|  - classify requests by TransportType                        |
+|  - allocate one SubBatch per transport                       |
+|  - attach BatchEventSink(batch_id, generation) to each batch  |
++------------------------------+-------------------------------+
+                               |
+                               | submitTransferTasks()
+                               v
+                +--------------------------------+
+                | Supported terminal transports  |
+                | RDMA / TCP / SHM / bufio       |
+                +---------------+----------------+
+                                |
+                                | terminal status write
+                                | COMPLETED / FAILED / TIMEOUT
+                                v
+                +--------------------------------+
+                | BatchEventSink::notifyMaybeReady|
+                +---------------+----------------+
+                                |
+                                | enqueue (BatchID, generation)
+                                v
+                +--------------------------------+
+                | ProgressWorker                 |
+                | coalesce duplicate work items  |
+                +---------------+----------------+
+                                |
+                                | progressBatchIfAlive()
+                                v
+                +--------------------------------+
+                | Aggregate task status          |
+                | validate generation/lifetime   |
+                +---------------+----------------+
+                                |
+                                | recoverable terminal failure
+                                v
+                +--------------------------------+
+                | resubmitTransferTask           |
+                | bump priority, pick next path  |
+                +--------------------------------+
+
+RDMA also has an independent per-rail recovery loop:
+
+                +--------------------------------+
+                | RdmaTransport workers          |
+                | post / poll work completions   |
+                +---------------+----------------+
+                                |
+                                | WC success / WC error
+                                v
+                +--------------------------------+
+                | RailMonitor                    |
+                | per-rail state + cooldown      |
+                +---------------+----------------+
+                                |
+                                | available(local, remote)
+                                v
+                +--------------------------------+
+                | RDMA scheduler picks a rail    |
+                +--------------------------------+
 ```
 
 * Each request is owned by one `TaskInfo`. `type` names the transport currently executing the task; `xport_priority` is the index into the ranked fallback list; `failover_count` caps how many times we may re-resolve the transport.
 * The ranked fallback list comes from `getTransportType(req, priority)`. Priority 0 yields the best available transport; increasing priority walks down the list; `UNSPEC` means no transport left.
+* `BatchEventSink` is attached per sub-batch. A terminal transport event calls `notifyMaybeReady()`, and the engine forwards `(BatchID, generation)` to `ProgressWorker`.
 * RDMA rail state lives in `RailMonitor`. Its lifecycle is independent of the task-level state machine: a rail can be paused while tasks keep flowing on other rails.
 
 ## State Machine
@@ -66,13 +115,46 @@ if type == UNSPEC                          -> return error (no transport)
 transport_list_[type]->submitTransferTasks(...)
 ```
 
-It has two callers, one per recoverable failure surface:
+It has two recovery drivers plus one terminal exhaustion outcome:
 
-1. **Completion-stage failure.** `getTransferStatus(batch_id, task_id, status)` and the batch-form overload call `resubmitTransferTask` once per `FAILED` completion. On success the task is re-marked `PENDING` so the aggregated batch status does not latch to `FAILED` because of a task that is actually retrying.
+1. **Completion-stage failure observed by polling.** `getTransferStatus(batch_id, task_id, status)` and the batch-form overload call `resubmitTransferTask` once per `FAILED` completion when `enable_auto_failover_on_poll` is true. On success the task is re-marked `PENDING` so the aggregated batch status does not latch to `FAILED` because of a task that is actually retrying.
 
-2. **Exhaustion.** When the budget is hit, `resubmitTransferTask` sets the returned status to `InvalidEntry("Failover limit exceeded, all transports exhausted")`. Callers leave `task.type` unchanged; the task then reports `FAILED` through the normal status flow.
+2. **Completion-stage failure observed by `ProgressWorker`.** When `enable_progress_worker` is true, a supported transport terminal-status write wakes the background worker through `BatchEventSink`. The worker calls `progressBatchIfAlive`, which validates the batch generation and then runs the same aggregation/resubmit path as polling. This path is what allows `waitTransferCompletion` or an idle application thread to make progress without a tight polling loop.
+
+3. **Exhaustion.** When the budget is hit, `resubmitTransferTask` sets the returned status to `InvalidEntry("Failover limit exceeded, all transports exhausted")`. Callers leave `task.type` unchanged; the task then reports `FAILED` through the normal status flow.
 
 Submit-stage failures (`submitTransferTasks` returning non-OK) are **not** retried today. They mark the task as `UNSPEC`, and `getTransferStatus` short-circuits to `FAILED`. See Known Gaps for why.
+
+### Event-driven progress worker
+
+The progress worker is a coalescing notification path, not a second state machine:
+
+1. `submitTransfer` allocates a transport `SubBatch` and attaches an engine-owned `BatchEventSink` to it.
+2. A supported transport writes a terminal task status and calls the sink.
+3. `TransferEngineImpl::notifyBatchMaybeReady(batch_id, generation)` pushes one work item into `ProgressWorker`.
+4. `ProgressWorker` deduplicates work by `(BatchID, generation)` and wakes its worker thread.
+5. The worker calls `progressBatchIfAlive(batch_id, generation, status)`. If the batch is still alive and the generation matches, the engine aggregates sub-task status and performs any needed failover/resubmit.
+
+The generation check prevents ABA bugs when a batch slab address is freed and later reused. A late terminal event from the old batch carries the old generation and is ignored instead of progressing the new batch that happens to have the same `BatchID` pointer value.
+
+The sink lifetime is also protected against late transport callbacks:
+
+* Transports store a `std::shared_ptr<BatchEventSink>` rather than a raw owner pointer.
+* `freeBatch` closes attached sinks before sub-batches are freed, so any late notification becomes a no-op.
+* `TransferEngineImpl::deconstruct` closes sinks, drains transport async workers, and only then frees the remaining sub-batches.
+
+### Supported terminal-event transports
+
+Only transports with a clear active terminal status write are wired into the event path in this PR:
+
+| Transport | Terminal event source | Notes |
+|-----------|-----------------------|-------|
+| RDMA | `updateSliceStatus` changes the task `status_word` from `PENDING` to a final status | The notify is emitted only when the whole task reaches a terminal status, not per slice. |
+| TCP | `startTransfer` stores `COMPLETED` or `FAILED` | The task keeps a shared sink copied from the TCP sub-batch. |
+| SHM | `startTransfer` stores `COMPLETED` or `FAILED` | Uses the sub-batch helper after the final status write. |
+| bufio | `submitTransferTasks` finishes the synchronous file operation and writes the final status | Emits one terminal notification after the operation result is known. |
+
+B-class transports such as io_uring, nvlink, mnnvl, sunrise_link, gds, and ascend_direct are intentionally out of scope here because they do not all expose the same active terminal-write moment. They need a separate ticker/event-hook design.
 
 ### RDMA rail recovery
 
@@ -96,6 +178,7 @@ All knobs live in the top-level `transfer-engine.json`. Defaults are safe for pr
 | Key | Default | Meaning |
 |-----|---------|---------|
 | `enable_auto_failover_on_poll` | `true` | Controls whether `getTransferStatus` automatically resubmits tasks that report a recoverable `FAILED` completion. Set to `false` to make status polling observational only; internal completion paths can still trigger failover/resubmit. |
+| `enable_progress_worker` | `false` | Enables the background progress worker. When enabled, supported transport terminal events can advance batch aggregation and failover without requiring an application polling loop. |
 | `max_failover_attempts` | `3` | Upper bound on `resubmitTransferTask` calls per task. `0` disables cross-transport failover entirely. `1` allows exactly one switch. |
 | `transports/rdma/rail_error_threshold` | `3` | Number of failures inside `rail_error_window_secs` that trips a rail into the paused state. |
 | `transports/rdma/rail_error_window_secs` | `10` | Sliding window for counting rail errors. A failure older than the window resets `error_count` to 1. |
@@ -106,6 +189,7 @@ The RDMA keys are read by `RailMonitor::load`. Example:
 ```json
 {
   "enable_auto_failover_on_poll": true,
+  "enable_progress_worker": true,
   "max_failover_attempts": 3,
   "transports": {
     "rdma": {
@@ -132,12 +216,13 @@ The counter is only built when TENT is compiled with `-DTENT_METRICS_ENABLED=ON`
 | `Transport failover: X -> Y (attempt N/M)` | A task has successfully switched transports. |
 | `Task failover limit reached (M), last transport=X` | Task exhausted its budget and will surface `FAILED`. |
 | `No more transports available after X failed` | `resolveTransport` returned `UNSPEC`; no further fallback exists for this request. |
+| `ProgressWorker started` | Background progress worker is enabled and ready to consume terminal-event work items. |
 | `Rail recovered: local_nic=... remote_nic=... (cooldown expired)` | Cooldown elapsed and the rail is back in service. |
 | `Rail recovered: ... (un-paused by successful transfer)` | Live success on a previously paused rail brought it back early. |
 
 ## Testing
 
-Real hardware faults are hard to stage, so TENT tests the failover machinery with decorator-style fault injection.
+Real hardware faults are hard to stage, so TENT tests the failover machinery with decorator-style fault injection and progress-worker unit tests.
 
 ### FaultProxyTransport
 
@@ -148,7 +233,7 @@ Real hardware faults are hard to stage, so TENT tests the failover machinery wit
 * `fail_after_n_submits` — deterministic variant: succeed the first N submits, then always fail.
 * `fail_install` — make `install()` fail, simulating a transport that cannot come up.
 
-Because it implements the `Transport` interface, the engine sees an ordinary transport. All failover paths (`submitTransfer`, `getTransferStatus`, `resubmitTransferTask`) run unmodified.
+Because it implements the `Transport` interface, the engine sees an ordinary transport. All failover paths (`submitTransfer`, `getTransferStatus`, `ProgressWorker`, `resubmitTransferTask`) run unmodified.
 
 ### Test-only injection hook
 
@@ -171,20 +256,33 @@ Current cases:
 
 A test-local `PerRequestFaultProxy` (in the same file) subclasses `FaultProxyTransport` to take a `std::function` predicate, remembers which sub-task ids it marked as "poisoned" at submit time, and flips only those completions from `COMPLETED` to `FAILED` at status-query time.
 
+### Progress-worker and terminal-event tests
+
+`tent_progress_worker_test` covers the worker and transport-terminal integration directly:
+
+| Test area | What it exercises |
+|-----------|-------------------|
+| Event-driven completion | A terminal transport event wakes `ProgressWorker` and advances a batch without a user polling loop. |
+| Event-driven failover | A failed terminal status wakes the worker, which calls the same resubmit path used by poll-driven failover. |
+| Disabled worker | Terminal notifies are harmless when `enable_progress_worker=false`. |
+| Free/late-notify races | Closing sinks and generation checks prevent late transport callbacks from progressing freed or reused batches. |
+| Deduplication | Multiple terminal events for the same `(BatchID, generation)` coalesce into one queued work item. |
+
 ### Running manually
 
 The TENT tests are **not** in CI today (the upstream workflow builds with `USE_TENT=OFF`). Run them locally:
 
 ```bash
-cmake -S . -B build-tent -DUSE_TENT=ON -DUSE_CUDA=OFF
-cmake --build build-tent --target tent_failover_test tent_engine_failover_e2e_test -j
+cmake -S . -B build-tent -DUSE_TENT=ON -DUSE_CUDA=OFF -DBUILD_UNIT_TESTS=ON
+cmake --build build-tent --target tent_failover_test tent_engine_failover_e2e_test tent_progress_worker_test -j
 ./build-tent/mooncake-transfer-engine/tent/tests/tent_failover_test
 ./build-tent/mooncake-transfer-engine/tent/tests/tent_engine_failover_e2e_test
+./build-tent/mooncake-transfer-engine/tent/tests/tent_progress_worker_test
 ```
 
 Setting `USE_CUDA=OFF` forces `CpuPlatform`, which always reports `MTYPE_CPU`. With `USE_CUDA=ON` on a host without a GPU, `cudaPointerGetAttributes` fails, `getMemoryType` returns `MTYPE_UNKNOWN`, every transport reports unavailable, and `resolveTransport` returns `UNSPEC` before the fault injection ever runs.
 
-Companion unit tests cover the rail monitor and related building blocks: `tent_rail_monitor_test`, `tent_failover_test`, `tent_fault_proxy_test`.
+Companion unit tests cover the rail monitor and related building blocks: `tent_rail_monitor_test`, `tent_failover_test`, `tent_fault_proxy_test`, and `tent_progress_worker_test`.
 
 ## Known Gaps
 
@@ -192,6 +290,7 @@ Companion unit tests cover the rail monitor and related building blocks: `tent_r
   1. **Merged requests.** When `merge_requests` is enabled (default), `task_id_list[type]` contains both the real merged task and its derived aliases. Resubmitting per task-id re-posts one logical transfer multiple times on the fallback transport, breaking the deduplication the merge pass established.
   2. **Partial enqueue.** Some transports (for example `ShmTransport::submitTransferTasks`, `NVLinkTransport::submitTransferTasks`) enqueue or start work for earlier requests in `request_list` before returning an error on a later one. The return status alone does not tell us which tasks partially succeeded, so a blanket resubmit would duplicate already-started transfers.
   A safe submit-stage recovery needs either (a) a transport-level "atomic submit" capability flag plus per-task skip of derived ids, or (b) per-request status returned from `submitTransferTasks`. Neither exists today.
+* **B-class transport terminal events are not wired yet.** io_uring, nvlink, mnnvl, sunrise_link, gds, and ascend_direct need a separate progress source before they can participate in event-driven progress.
 * `markRecovered` (and cooldown expiry in `available`) clears the exponential-backoff memory entirely. A rail that flaps repeatedly therefore does not accumulate a growing cooldown across recovery cycles. If this becomes a problem the fix is to decay rather than reset.
 * Cross-transport failover is driven purely by return status; there is no latency-based "this transport is healthy but too slow, try another" signal. That belongs to the scheduler, not this document.
-* TENT tests are not exercised by CI. A follow-up can add a CI job that builds with `-DUSE_TENT=ON -DUSE_CUDA=OFF` and runs the `tent_*` test targets; none of the code in this document changes in that case.
+* TENT tests are not exercised by CI. A follow-up can add a CI job that builds with `-DUSE_TENT=ON -DUSE_CUDA=OFF -DBUILD_UNIT_TESTS=ON` and runs the `tent_*` test targets; none of the code in this document changes in that case.

--- a/mooncake-transfer-engine/tent/include/tent/runtime/progress_worker.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/progress_worker.h
@@ -53,9 +53,24 @@ class ProgressWorker {
     // Safe from any thread. De-duplicates: enqueueing a batch that is already
     // queued is a no-op. No-op if the worker has been stopped or never
     // started.
-    void notifyBatchMaybeReady(BatchID batch_id);
+    void notifyBatchMaybeReady(BatchID batch_id, uint64_t generation = 0);
 
    private:
+    struct WorkItem {
+        BatchID batch_id{0};
+        uint64_t generation{0};
+        bool operator==(const WorkItem& other) const {
+            return batch_id == other.batch_id && generation == other.generation;
+        }
+    };
+
+    struct WorkItemHash {
+        size_t operator()(const WorkItem& item) const {
+            return std::hash<BatchID>{}(item.batch_id) ^
+                   (std::hash<uint64_t>{}(item.generation) << 1);
+        }
+    };
+
     void runner();
 
     TransferEngineImpl* impl_;
@@ -64,8 +79,8 @@ class ProgressWorker {
 
     std::mutex mu_;
     std::condition_variable cv_;
-    std::unordered_set<BatchID> queued_;
-    std::deque<BatchID> order_;
+    std::unordered_set<WorkItem, WorkItemHash> queued_;
+    std::deque<WorkItem> order_;
 };
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -155,6 +155,9 @@ class TransferEngineImpl {
 
     Status progressBatch(BatchID batch_id, TransferStatus& overall_status);
 
+    Status progressBatchIfAlive(BatchID batch_id, uint64_t generation,
+                                TransferStatus& overall_status);
+
     Status waitTransferCompletion(BatchID batch_id);
 
     Status transferSync(const std::vector<Request>& request_list);
@@ -180,6 +183,8 @@ class TransferEngineImpl {
     // hooks; transports will be migrated to call this in a follow-up PR.
     void notifyBatchMaybeReady(BatchID batch_id);
 
+    void notifyBatchMaybeReady(BatchID batch_id, uint64_t generation);
+
    private:
     Status construct();
 
@@ -196,6 +201,10 @@ class TransferEngineImpl {
         TransportType request_type);
 
     Status resubmitTransferTask(Batch* batch, size_t task_id);
+
+    void attachBatchEventSink(Batch* batch, TransportType type);
+
+    void closeBatchEventSinks(Batch* batch);
 
     Status pollTaskStatus(Batch* batch, size_t task_id,
                           TransferStatus& task_status);
@@ -261,12 +270,13 @@ class TransferEngineImpl {
     bool enable_auto_failover_on_poll_{true};
     bool enable_progress_worker_{false};
 
-    // Guards alive_batches_ and serializes pollTaskStatus /
+    // Guards alive_batch_generations_ and serializes pollTaskStatus /
     // updateTaskStatusAfterPoll / lazyFreeBatch against the optional
     // ProgressWorker thread. Recursive because freeBatch -> lazyFreeBatch ->
-    // getTransferStatus can re-enter on the same thread. See issue #2116.
+    // getTransferStatus can re-enter on the same thread.
     std::recursive_mutex progress_mutex_;
-    std::unordered_set<BatchID> alive_batches_;
+    std::unordered_map<BatchID, uint64_t> alive_batch_generations_;
+    std::atomic<uint64_t> next_batch_generation_{1};
     std::unique_ptr<ProgressWorker> progress_worker_;
 };
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transport.h
@@ -28,6 +28,7 @@
 #include <string>
 
 #include "tent/common/status.h"
+#include "tent/common/types.h"
 #include "tent/runtime/platform.h"
 #include "tent/runtime/control_plane.h"
 
@@ -42,6 +43,12 @@ struct Capabilities {
     bool gpu_to_file = false;
 };
 
+struct BatchEventSink {
+    virtual ~BatchEventSink() = default;
+    virtual void notifyMaybeReady() noexcept = 0;
+    virtual void close() noexcept = 0;
+};
+
 class Transport {
    public:
     struct SubBatch {
@@ -49,6 +56,12 @@ class Transport {
         virtual ~SubBatch() {}
         virtual size_t size() const = 0;
         uint64_t device_mask;  // Device mask for transport selection
+        std::shared_ptr<BatchEventSink> sink;
+        BatchID batch_id = 0;
+        inline void notifyTerminal() noexcept {
+            auto s = sink;
+            if (s) s->notifyMaybeReady();
+        }
     };
 
     using SubBatchRef = SubBatch *;
@@ -66,6 +79,11 @@ class Transport {
     }
 
     virtual Status uninstall() { return Status::OK(); }
+
+    // Stop transport-owned async workers while keeping enough state alive for
+    // freeSubBatch(). Used by TransferEngineImpl teardown to quiesce terminal
+    // callbacks before SubBatch memory is reclaimed.
+    virtual Status drain() { return Status::OK(); }
 
     virtual const Capabilities capabilities() const { return caps; }
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -69,6 +69,8 @@ class RdmaTransport : public Transport {
 
     virtual Status uninstall();
 
+    virtual Status drain() override;
+
     virtual Status allocateSubBatch(SubBatchRef& batch, size_t max_size);
 
     virtual Status freeSubBatch(SubBatchRef& batch);

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -58,6 +58,7 @@ struct RdmaTask {
 
     // Reference counting for UAF protection
     std::atomic<int> ref_count{0};
+    std::shared_ptr<BatchEventSink> terminal_sink;
 
     void ref() { ref_count.fetch_add(1, std::memory_order_relaxed); }
     void deref() {
@@ -116,7 +117,11 @@ static inline void updateSliceStatus(RdmaSlice* slice,
                                           ? COMPLETED
                                           : task->first_error;
         if (final_st == PENDING) final_st = FAILED;
-        __sync_bool_compare_and_swap(&task->status_word, PENDING, final_st);
+        auto terminal_sink = task->terminal_sink;
+        if (__sync_bool_compare_and_swap(&task->status_word, PENDING,
+                                         final_st)) {
+            if (terminal_sink) terminal_sink->notifyMaybeReady();
+        }
     }
     task->deref();
 }

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
@@ -41,6 +41,7 @@ struct TcpTask {
     std::atomic<TransferStatusEnum> status_word{TransferStatusEnum::PENDING};
     std::atomic<size_t> transferred_bytes{0};
     uint64_t target_addr = 0;
+    std::shared_ptr<BatchEventSink> terminal_sink;
 
     TcpTask() = default;
     TcpTask(TcpTask &&other) noexcept
@@ -48,7 +49,8 @@ struct TcpTask {
           status_word(other.status_word.load(std::memory_order_relaxed)),
           transferred_bytes(
               other.transferred_bytes.load(std::memory_order_relaxed)),
-          target_addr(other.target_addr) {}
+          target_addr(other.target_addr),
+          terminal_sink(std::move(other.terminal_sink)) {}
     TcpTask(const TcpTask &) = delete;
     TcpTask &operator=(const TcpTask &) = delete;
 };
@@ -71,6 +73,8 @@ class TcpTransport : public Transport {
                            std::shared_ptr<Config> conf = nullptr);
 
     virtual Status uninstall();
+
+    virtual Status drain() override;
 
     virtual Status allocateSubBatch(SubBatchRef &batch, size_t max_size);
 

--- a/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
@@ -42,20 +42,22 @@ void ProgressWorker::stop() {
     if (thread_.joinable()) thread_.join();
 }
 
-void ProgressWorker::notifyBatchMaybeReady(BatchID batch_id) {
+void ProgressWorker::notifyBatchMaybeReady(BatchID batch_id,
+                                           uint64_t generation) {
     if (!batch_id) return;
     if (!running_.load(std::memory_order_acquire)) return;
+    WorkItem item{batch_id, generation};
     {
         std::lock_guard<std::mutex> lk(mu_);
-        if (!queued_.insert(batch_id).second) return;
-        order_.push_back(batch_id);
+        if (!queued_.insert(item).second) return;
+        order_.push_back(item);
     }
     cv_.notify_one();
 }
 
 void ProgressWorker::runner() {
     while (true) {
-        BatchID batch_id = 0;
+        WorkItem item;
         {
             std::unique_lock<std::mutex> lk(mu_);
             cv_.wait(lk, [&] {
@@ -63,9 +65,9 @@ void ProgressWorker::runner() {
                        !order_.empty();
             });
             if (!running_.load(std::memory_order_acquire)) return;
-            batch_id = order_.front();
+            item = order_.front();
             order_.pop_front();
-            queued_.erase(batch_id);
+            queued_.erase(item);
         }
         // progressBatch acquires the engine's progress_mutex_ and silently
         // returns InvalidArgument if the batch was freed before we got here.
@@ -73,7 +75,7 @@ void ProgressWorker::runner() {
         // Terminal states leave the batch alone — freeBatch on the user
         // thread is responsible for reclamation.
         TransferStatus s;
-        (void)impl_->progressBatch(batch_id, s);
+        (void)impl_->progressBatchIfAlive(item.batch_id, item.generation, s);
     }
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -19,6 +19,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <limits>
+#include <memory>
 #include <map>
 #include <optional>
 #include <random>
@@ -46,14 +47,42 @@ namespace tent {
 namespace {
 constexpr uint8_t kRedisMaxDbIndex = 255;
 constexpr uint8_t kRedisDefaultDbIndex = 0;
+
+class EngineBatchSink final : public BatchEventSink {
+   public:
+    EngineBatchSink(TransferEngineImpl* impl, BatchID batch_id,
+                    uint64_t generation)
+        : impl_(impl), batch_id_(batch_id), generation_(generation) {}
+
+    void notifyMaybeReady() noexcept override {
+        if (closed_.load(std::memory_order_acquire)) return;
+        impl_->notifyBatchMaybeReady(batch_id_, generation_);
+    }
+
+    void close() noexcept override {
+        closed_.store(true, std::memory_order_release);
+    }
+
+   private:
+    TransferEngineImpl* impl_;
+    BatchID batch_id_;
+    uint64_t generation_;
+    std::atomic<bool> closed_{false};
+};
 }  // namespace
 
 struct Batch {
-    Batch() : max_size(0) { sub_batch.fill(nullptr); }
+    Batch() : max_size(0) {
+        sub_batch.fill(nullptr);
+        sinks.fill(nullptr);
+    }
 
     ~Batch() {}
 
+    uint64_t generation{0};
     std::array<Transport::SubBatchRef, kSupportedTransportTypes> sub_batch;
+    std::array<std::shared_ptr<EngineBatchSink>, kSupportedTransportTypes>
+        sinks;
     std::vector<TaskInfo> task_list;
     size_t max_size;
 
@@ -435,6 +464,17 @@ Status TransferEngineImpl::deconstruct() {
     // local_segment_tracker_ and metadata_ to be alive.
     staging_proxy_.reset();
 
+    // Quiesce terminal-event callbacks before freeing any SubBatch memory.
+    // Closing sinks makes already-running callbacks no-op; drain() joins
+    // transport-owned workers while preserving enough state for freeSubBatch().
+    batch_set_.forEach([&](BatchSet& entry) {
+        for (auto& batch : entry.active) closeBatchEventSinks(batch);
+        for (auto& batch : entry.freelist) closeBatchEventSinks(batch);
+    });
+    for (auto& transport : transport_list_) {
+        if (transport) transport->drain();
+    }
+
     if (local_segment_tracker_) {
         local_segment_tracker_->forEach([&](BufferDesc& desc) -> Status {
             for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
@@ -459,8 +499,10 @@ Status TransferEngineImpl::deconstruct() {
                 auto& transport = transport_list_[type];
                 auto& sub_batch = batch->sub_batch[type];
                 if (!transport || !sub_batch) continue;
+                closeBatchEventSinks(batch);
                 transport->freeSubBatch(sub_batch);
             }
+            alive_batch_generations_.erase((BatchID)batch);
             Slab<Batch>::Get().deallocate(batch);
         }
         for (auto& batch : entry.freelist) {
@@ -468,8 +510,10 @@ Status TransferEngineImpl::deconstruct() {
                 auto& transport = transport_list_[type];
                 auto& sub_batch = batch->sub_batch[type];
                 if (!transport || !sub_batch) continue;
+                closeBatchEventSinks(batch);
                 transport->freeSubBatch(sub_batch);
             }
+            alive_batch_generations_.erase((BatchID)batch);
             Slab<Batch>::Get().deallocate(batch);
         }
         entry.active.clear();
@@ -767,22 +811,55 @@ BatchID TransferEngineImpl::allocateBatch(size_t batch_size) {
     Batch* batch = Slab<Batch>::Get().allocate();
     if (!batch) return (BatchID)0;
     batch->max_size = batch_size;
+    batch->generation =
+        next_batch_generation_.fetch_add(1, std::memory_order_relaxed);
+    if (batch->generation == 0) {
+        batch->generation =
+            next_batch_generation_.fetch_add(1, std::memory_order_relaxed);
+    }
     batch_set_.get().active.insert(batch);
     BatchID batch_id = (BatchID)batch;
     {
         std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-        alive_batches_.insert(batch_id);
+        alive_batch_generations_[batch_id] = batch->generation;
     }
     return batch_id;
 }
 
 Status TransferEngineImpl::freeBatch(BatchID batch_id) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
-    Batch* batch = (Batch*)(batch_id);
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    if (!alive_batch_generations_.count(batch_id))
+        return Status::InvalidArgument("Batch is not alive" LOC_MARK);
+    Batch* batch = (Batch*)(batch_id);
+    closeBatchEventSinks(batch);
     batch_set_.get().freelist.push_back(batch);
     lazyFreeBatch();
     return Status::OK();
+}
+
+void TransferEngineImpl::attachBatchEventSink(Batch* batch,
+                                              TransportType type) {
+    if (!enable_progress_worker_ || !batch || type < 0 ||
+        type >= (TransportType)kSupportedTransportTypes ||
+        !batch->sub_batch[type]) {
+        return;
+    }
+    if (!batch->sinks[type]) {
+        batch->sinks[type] = std::make_shared<EngineBatchSink>(
+            this, (BatchID)batch, batch->generation);
+    }
+    auto& sub_batch = batch->sub_batch[type];
+    sub_batch->batch_id = (BatchID)batch;
+    sub_batch->sink = batch->sinks[type];
+}
+
+void TransferEngineImpl::closeBatchEventSinks(Batch* batch) {
+    if (!batch) return;
+    for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
+        if (batch->sinks[type]) batch->sinks[type]->close();
+        if (batch->sub_batch[type]) batch->sub_batch[type]->sink.reset();
+    }
 }
 
 Status TransferEngineImpl::lazyFreeBatch() {
@@ -800,10 +877,13 @@ Status TransferEngineImpl::lazyFreeBatch() {
         for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
             auto& transport = transport_list_[type];
             auto& sub_batch = batch->sub_batch[type];
-            if (transport && sub_batch) transport->freeSubBatch(sub_batch);
+            if (transport && sub_batch) {
+                closeBatchEventSinks(batch);
+                transport->freeSubBatch(sub_batch);
+            }
         }
         batch_set.active.erase(batch);
-        alive_batches_.erase((BatchID)batch);
+        alive_batch_generations_.erase((BatchID)batch);
         Slab<Batch>::Get().deallocate(batch);
         it = batch_set.freelist.erase(it);
     }
@@ -1205,6 +1285,9 @@ SelectionResult TransferEngineImpl::resolveTransport(const Request& req,
 Status TransferEngineImpl::submitTransfer(
     BatchID batch_id, const std::vector<Request>& request_list) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    if (!alive_batch_generations_.count(batch_id))
+        return Status::InvalidArgument("Batch is not alive" LOC_MARK);
     Batch* batch = (Batch*)(batch_id);
 
     std::vector<Request> classified_request_list[kSupportedTransportTypes];
@@ -1274,6 +1357,7 @@ Status TransferEngineImpl::submitTransfer(
                 merged_task_id_map[merged_task_id] = task;
                 continue;
             }
+            attachBatchEventSink(batch, task.type);
         }
 
         if (!next_sub_task_id.count(task.type))
@@ -1350,6 +1434,9 @@ Status TransferEngineImpl::submitTransfer(
     BatchID batch_id, const std::vector<Request>& request_list,
     const Notification& notifi) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    if (!alive_batch_generations_.count(batch_id))
+        return Status::InvalidArgument("Batch is not alive" LOC_MARK);
     Batch* batch = (Batch*)(batch_id);
     const size_t start_task_id = batch->task_list.size();
     CHECK_STATUS(submitTransfer(batch_id, request_list));
@@ -1399,6 +1486,7 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
     if (!batch->sub_batch[type])
         CHECK_STATUS(transport->allocateSubBatch(batch->sub_batch[type],
                                                  batch->max_size));
+    attachBatchEventSink(batch, type);
     auto& sub_batch = batch->sub_batch[type];
     task.sub_task_id = sub_batch->size();
     task.type = type;
@@ -1484,7 +1572,7 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
                                              TransferStatus& task_status) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-    if (!alive_batches_.count(batch_id))
+    if (!alive_batch_generations_.count(batch_id))
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
     Batch* batch = (Batch*)(batch_id);
     if (task_id >= batch->task_list.size())
@@ -1507,7 +1595,7 @@ Status TransferEngineImpl::getTransferStatus(
     BatchID batch_id, std::vector<TransferStatus>& status_list) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-    if (!alive_batches_.count(batch_id))
+    if (!alive_batch_generations_.count(batch_id))
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
     Batch* batch = (Batch*)(batch_id);
     status_list.clear();
@@ -1524,7 +1612,7 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
                                           bool allow_failover) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-    if (!alive_batches_.count(batch_id))
+    if (!alive_batch_generations_.count(batch_id))
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
     Batch* batch = (Batch*)(batch_id);
     overall_status.s = PENDING;
@@ -1597,8 +1685,26 @@ Status TransferEngineImpl::progressBatch(BatchID batch_id,
     return getBatchStatus(batch_id, overall_status, true);
 }
 
+Status TransferEngineImpl::progressBatchIfAlive(
+    BatchID batch_id, uint64_t generation, TransferStatus& overall_status) {
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    if (generation != 0) {
+        auto it = alive_batch_generations_.find(batch_id);
+        if (it == alive_batch_generations_.end() || it->second != generation) {
+            return Status::InvalidArgument("Stale batch generation" LOC_MARK);
+        }
+    }
+    return getBatchStatus(batch_id, overall_status, true);
+}
+
 void TransferEngineImpl::notifyBatchMaybeReady(BatchID batch_id) {
     if (progress_worker_) progress_worker_->notifyBatchMaybeReady(batch_id);
+}
+
+void TransferEngineImpl::notifyBatchMaybeReady(BatchID batch_id,
+                                               uint64_t generation) {
+    if (progress_worker_)
+        progress_worker_->notifyBatchMaybeReady(batch_id, generation);
 }
 
 Status TransferEngineImpl::waitTransferCompletion(BatchID batch_id) {

--- a/mooncake-transfer-engine/tent/src/transport/bufio/bufio_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/bufio/bufio_transport.cpp
@@ -274,6 +274,8 @@ Status BufIoTransport::submitTransferTasks(
                                         : TransferStatusEnum::COMPLETED;
     }
 
+    buf_batch->notifyTerminal();
+
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -265,19 +265,22 @@ Status RdmaTransport::install(std::string& local_segment_name,
 
 Status RdmaTransport::uninstall() {
     if (installed_) {
-        // Stop notification worker thread
-        notify_worker_running_ = false;
-        if (notify_worker_.joinable()) {
-            notify_worker_.join();
-        }
-
-        workers_.reset();
+        drain();
         metadata_.reset();
         local_buffer_manager_.clear();
         context_set_.clear();
         context_name_lookup_.clear();
         installed_ = false;
     }
+    return Status::OK();
+}
+
+Status RdmaTransport::drain() {
+    notify_worker_running_ = false;
+    if (notify_worker_.joinable()) {
+        notify_worker_.join();
+    }
+    workers_.reset();
     return Status::OK();
 }
 
@@ -344,6 +347,7 @@ Status RdmaTransport::submitTransferTasks(
         auto* task = RdmaTaskStorage::Get().allocate();
         rdma_batch->task_list.push_back(task);
         task->request = request;
+        task->terminal_sink = rdma_batch->sink;
         task->num_slices = 0;
         task->status_word = PENDING;
         task->transferred_bytes = 0;

--- a/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
@@ -132,6 +132,7 @@ void ShmTransport::startTransfer(ShmTask *task, ShmSubBatch *batch) {
     } else {
         task->status_word = TransferStatusEnum::FAILED;
     }
+    if (batch) batch->notifyTerminal();
 }
 
 Status ShmTransport::getTransferStatus(SubBatchRef batch, int task_id,

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -110,11 +110,16 @@ Status TcpTransport::install(std::string &local_segment_name,
 Status TcpTransport::uninstall() {
     if (installed_) {
         if (metadata_) metadata_->setNotifyCallback(nullptr);
-        shutting_down_.store(true, std::memory_order_release);
-        thread_pool_.reset();
+        drain();
         metadata_.reset();
         installed_ = false;
     }
+    return Status::OK();
+}
+
+Status TcpTransport::drain() {
+    shutting_down_.store(true, std::memory_order_release);
+    thread_pool_.reset();
     return Status::OK();
 }
 
@@ -152,6 +157,7 @@ Status TcpTransport::submitTransferTasks(
         tcp_batch->task_list.emplace_back();
         auto &task = tcp_batch->task_list.back();
         task.request = request;
+        task.terminal_sink = tcp_batch->sink;
         task.status_word.store(TransferStatusEnum::PENDING,
                                std::memory_order_release);
     }
@@ -211,6 +217,8 @@ void TcpTransport::startTransfer(TcpTask *task) {
         task->status_word.store(TransferStatusEnum::FAILED,
                                 std::memory_order_release);
     }
+    auto terminal_sink = task->terminal_sink;
+    if (terminal_sink) terminal_sink->notifyMaybeReady();
 }
 
 Status TcpTransport::doTransferWithRetry(TcpTask *task) {

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -81,6 +81,10 @@ class FakeTransport : public Transport {
     std::atomic<int> submit_calls{0};
     std::atomic<int> status_calls{0};
     std::atomic<int> add_mem_calls{0};
+    std::atomic<int> notify_calls{0};
+    std::shared_ptr<BatchEventSink> last_sink;
+
+    void setNotifyOnSubmit(bool ok) { notify_on_submit_ = ok; }
 
     Status install(std::string& /*local_segment_name*/,
                    std::shared_ptr<ControlService> /*metadata*/,
@@ -105,6 +109,7 @@ class FakeTransport : public Transport {
         SubBatchRef batch, const std::vector<Request>& request_list) override {
         ++submit_calls;
         auto* fb = static_cast<FakeSubBatch*>(batch);
+        last_sink = batch->sink;
         for (const auto& req : request_list) {
             if (status_factory_) {
                 fb->statuses.push_back(status_factory_(req));
@@ -115,6 +120,10 @@ class FakeTransport : public Transport {
             fb->requests.push_back(req);
             fb->poll_counts.push_back(0);
             fb->task_count++;
+        }
+        if (notify_on_submit_) {
+            ++notify_calls;
+            batch->notifyTerminal();
         }
         return Status::OK();
     }
@@ -180,6 +189,7 @@ class FakeTransport : public Transport {
     TransportType self_type_;
     StatusFactory status_factory_;
     PollStatusFactory poll_status_factory_;
+    bool notify_on_submit_ = false;
 };
 
 std::shared_ptr<Config> makeMinimalP2PConfig() {
@@ -389,7 +399,7 @@ TEST(ProgressWorker, SingleNotifyAdvancesOneStep) {
 
 // ---------------------------------------------------------------------------
 // 4. freeBatch races with worker notifications. With ASAN/UBSAN this
-// catches missing alive_batches_ / progress_mutex_ coverage.
+// catches missing alive_batch_generations_ / progress_mutex_ coverage.
 // ---------------------------------------------------------------------------
 
 TEST(ProgressWorker, FreeBatchRacesWithWorker) {
@@ -440,8 +450,8 @@ TEST(ProgressWorker, FreeBatchRacesWithWorker) {
         engine.notifyBatchMaybeReady(batch_id);
 
         // Free immediately; the worker may pick the notification up after
-        // free. The progress_mutex_ + alive_batches_ guard must keep this
-        // safe.
+        // free. The progress_mutex_ + alive_batch_generations_ guard must keep
+        // this safe.
         EXPECT_TRUE(engine.freeBatch(batch_id).ok());
     }
 
@@ -472,7 +482,7 @@ TEST(ProgressWorker, EngineDestructorJoinsWorker) {
         engine.swapTransportForTest(TCP, fake_tcp);
 
         // Push some notifies for non-existent batches; worker must reject
-        // them via alive_batches_ check and stay alive.
+        // them via alive_batch_generations_ check and stay alive.
         for (int i = 0; i < 8; ++i) {
             engine.notifyBatchMaybeReady((BatchID)(uintptr_t)0xdeadbeef);
         }
@@ -480,6 +490,292 @@ TEST(ProgressWorker, EngineDestructorJoinsWorker) {
     // If teardown hangs or crashes here, gtest fails this test on timeout
     // / signal — no further assert needed.
     SUCCEED();
+}
+
+// ---------------------------------------------------------------------------
+// 6. Transport-driven progress
+// ---------------------------------------------------------------------------
+
+TEST(TransportTerminalEvent, NotifyDrivesProgressWithoutManualPoke) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    cfg->set("enable_progress_worker", true);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    // The primary transport publishes terminal events itself; mirrors the
+    // SHM / bufio integration done in PR 3.
+    fake_rdma->setNotifyOnSubmit(true);
+
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(seg, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0xD1);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(1);
+    ASSERT_NE(batch_id, (BatchID)0);
+
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+    req.length = kBufLen;
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {req}).ok());
+    ASSERT_GE(fake_rdma->notify_calls.load(), 1)
+        << "transport must have invoked notifyTerminal()";
+
+    // Caller never calls notifyBatchMaybeReady, progressBatch, or
+    // getTransferStatus in the wait loop below. The worker should observe the
+    // transport-published terminal event and poll the transport on its own.
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(2000);
+    while (std::chrono::steady_clock::now() < deadline &&
+           fake_rdma->status_calls.load() == 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    EXPECT_GT(fake_rdma->status_calls.load(), 0)
+        << "transport notifyTerminal() must drive ProgressWorker to poll";
+
+    TransferStatus status{};
+    ASSERT_TRUE(engine.getTransferStatus(batch_id, status).ok());
+    EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED)
+        << "transport notifyTerminal() must drive ProgressWorker to terminal";
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// 7. Transport-driven failover .
+// ---------------------------------------------------------------------------
+
+TEST(TransportTerminalEvent, NotifyDrivesAutoFailover) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    cfg->set("enable_progress_worker", true);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    fake_rdma->setNotifyOnSubmit(true);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    fake_tcp->setNotifyOnSubmit(true);
+
+    FaultPolicy rdma_policy;
+    rdma_policy.status_corrupt_rate = 1.0;
+    auto proxied_rdma =
+        std::make_shared<FaultProxyTransport>(fake_rdma, rdma_policy);
+
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(proxied_rdma->install(seg, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, proxied_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0xD2);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(1);
+    ASSERT_NE(batch_id, (BatchID)0);
+
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+    req.length = kBufLen;
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {req}).ok());
+
+    // Observation-only loop: getTransferStatus runs with auto-failover-on-poll
+    // disabled, so the only thing that can drive the batch through failover
+    // is the worker, woken by notifyTerminal from the (real) inner transport
+    // beneath the FaultProxy.
+    TransferStatus status{};
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(2000);
+    while (std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        if (fake_tcp->submit_calls.load() == 0) continue;
+        status = {};
+        ASSERT_TRUE(engine.getTransferStatus(batch_id, status).ok());
+        if (status.s == TransferStatusEnum::COMPLETED) break;
+    }
+    EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED)
+        << "worker must drive failover via transport terminal events";
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+    EXPECT_GE(fake_tcp->submit_calls.load(), 1);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// 8. Worker disabled: notifyTerminal is benign.
+// ---------------------------------------------------------------------------
+
+TEST(TransportTerminalEvent, WorkerDisabledNotifyIsNoop) {
+    auto cfg = makeMinimalP2PConfig();
+    // Default: enable_progress_worker not set → worker is off.
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    fake_rdma->setNotifyOnSubmit(true);  // call notifyTerminal anyway
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(seg, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0xD3);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(1);
+    ASSERT_NE(batch_id, (BatchID)0);
+
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+    req.length = kBufLen;
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {req}).ok());
+
+    // The transport invoked notifyTerminal; sink should be null because
+    // enable_progress_worker=false. We can't read SubBatch::sink directly
+    // from the test, but a benign no-op manifests as: status is observable
+    // via the regular getTransferStatus path and nothing crashed.
+    EXPECT_GE(fake_rdma->notify_calls.load(), 1);
+    TransferStatus status{};
+    ASSERT_TRUE(engine.getTransferStatus(batch_id, status).ok());
+    EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// 9. Free-batch races a transport terminal event (PR 3 detach correctness).
+//    Submit + free + concurrent terminal notifications must remain UAF-safe;
+//    detach (sink=nullptr before freeSubBatch) plus single-load semantics in
+//    notifyTerminal guarantee at-most-one-missed-notify, no crash.
+// ---------------------------------------------------------------------------
+
+TEST(TransportTerminalEvent, FreeBatchRaceWithTransportTerminal) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    cfg->set("enable_progress_worker", true);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    fake_rdma->setNotifyOnSubmit(true);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(seg, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0xD4);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    constexpr int kRounds = 200;
+    for (int i = 0; i < kRounds; ++i) {
+        BatchID batch_id = engine.allocateBatch(1);
+        ASSERT_NE(batch_id, (BatchID)0);
+
+        Request req;
+        req.opcode = Request::WRITE;
+        req.source = buf.data();
+        req.target_id = LOCAL_SEGMENT_ID;
+        req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+        req.length = kBufLen;
+        ASSERT_TRUE(engine.submitTransfer(batch_id, {req}).ok());
+
+        // Free immediately. The transport already invoked notifyTerminal()
+        // synchronously inside submit; the worker may still be picking the
+        // notification up. detach + alive_batch_generations_ guard must keep
+        // this safe.
+        EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    }
+
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// 10. A late transport-owned sink from a freed batch must not be able to
+//     progress a new batch even if the allocator reuses the same BatchID
+//     address. This covers the PR3 ABA/UAF review blocker at the event source.
+// ---------------------------------------------------------------------------
+
+TEST(TransportTerminalEvent, LateSinkAfterFreeDoesNotProgressReusedBatch) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_auto_failover_on_poll", false);
+    cfg->set("enable_progress_worker", true);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(seg, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0xD5);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+    req.length = kBufLen;
+
+    BatchID old_batch = engine.allocateBatch(1);
+    ASSERT_NE(old_batch, (BatchID)0);
+    ASSERT_TRUE(engine.submitTransfer(old_batch, {req}).ok());
+    auto old_sink = fake_rdma->last_sink;
+    ASSERT_TRUE(old_sink != nullptr);
+    ASSERT_TRUE(engine.freeBatch(old_batch).ok());
+
+    BatchID new_batch = engine.allocateBatch(1);
+    ASSERT_NE(new_batch, (BatchID)0);
+    ASSERT_TRUE(engine.submitTransfer(new_batch, {req}).ok());
+
+    // Let any worker item that might have been queued before the reset drain;
+    // the assertion below is specifically about the late old sink notify.
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    fake_rdma->status_calls.store(0, std::memory_order_release);
+    old_sink->notifyMaybeReady();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    EXPECT_EQ(fake_rdma->status_calls.load(), 0)
+        << "late notify from a freed batch must be closed/generation-stale";
+
+    TransferStatus status{};
+    ASSERT_TRUE(engine.getTransferStatus(new_batch, status).ok());
+    EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);
+
+    EXPECT_TRUE(engine.freeBatch(new_batch).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

This PR wires supported transport terminal events into TENT `ProgressWorker`, so transfer progress/failover no longer depends on an application-side tight `getTransferStatus()` polling loop when `enable_progress_worker=true`.

Part of #2116.

cc @KMSorSMS @alogfans

## What changed

- Add `BatchEventSink` and attach it to transport `SubBatch` objects.
- Forward terminal transport events to `ProgressWorker`.
- Make progress work items generation-aware with `(BatchID, generation)` to avoid ABA when slab addresses are reused.
- Close sinks before freeing sub-batches so late transport callbacks become no-op.
- Add `Transport::drain()` and call it during engine teardown before reclaiming `SubBatch` memory.
- Wire terminal-event notification for:
  - RDMA
  - TCP
  - SHM
  - bufio
- Keep B-class transports out of scope for this PR.
- Add progress-worker / terminal-event tests.
- Update TENT failover design docs.

## Safety notes

This PR handles the main lifetime and concurrency risks from the terminal-event path:

- Transports hold `std::shared_ptr<BatchEventSink>` instead of raw `SubBatch*` owners.
- `freeBatch()` closes attached sinks before lazy sub-batch reclamation.
- `deconstruct()` closes sinks, drains transports, then frees sub-batches.
- `ProgressWorker` deduplicates by `(BatchID, generation)`.
- `progressBatchIfAlive()` validates the generation under `progress_mutex_` and progresses the batch in the same critical section.

## Tests

### Build

```bash
ninja -C build -j8 tent_progress_worker_test
```

Result:

```text
[27/27] Linking CXX executable mooncake-transfer-engine/tent/tests/tent_progress_worker_test
```

### Progress worker / terminal-event tests

```bash
./build/mooncake-transfer-engine/tent/tests/tent_progress_worker_test --gtest_color=no
```

Result:

```text
[==========] Running 10 tests from 2 test suites.
[----------] 5 tests from ProgressWorker
[ RUN      ] ProgressWorker.DisabledByDefaultLeavesBehaviorUnchanged
[       OK ] ProgressWorker.DisabledByDefaultLeavesBehaviorUnchanged (3 ms)
[ RUN      ] ProgressWorker.ProgressesWithoutPollAutoFailover
[       OK ] ProgressWorker.ProgressesWithoutPollAutoFailover (7 ms)
[ RUN      ] ProgressWorker.SingleNotifyAdvancesOneStep
[       OK ] ProgressWorker.SingleNotifyAdvancesOneStep (54 ms)
[ RUN      ] ProgressWorker.FreeBatchRacesWithWorker
[       OK ] ProgressWorker.FreeBatchRacesWithWorker (2 ms)
[ RUN      ] ProgressWorker.EngineDestructorJoinsWorker
[       OK ] ProgressWorker.EngineDestructorJoinsWorker (2 ms)
[----------] 5 tests from ProgressWorker (70 ms total)

[----------] 5 tests from TransportTerminalEvent
[ RUN      ] TransportTerminalEvent.NotifyDrivesProgressWithoutManualPoke
[       OK ] TransportTerminalEvent.NotifyDrivesProgressWithoutManualPoke (7 ms)
[ RUN      ] TransportTerminalEvent.NotifyDrivesAutoFailover
[       OK ] TransportTerminalEvent.NotifyDrivesAutoFailover (7 ms)
[ RUN      ] TransportTerminalEvent.WorkerDisabledNotifyIsNoop
[       OK ] TransportTerminalEvent.WorkerDisabledNotifyIsNoop (2 ms)
[ RUN      ] TransportTerminalEvent.FreeBatchRaceWithTransportTerminal
[       OK ] TransportTerminalEvent.FreeBatchRaceWithTransportTerminal (2 ms)
[ RUN      ] TransportTerminalEvent.LateSinkAfterFreeDoesNotProgressReusedBatch
[       OK ] TransportTerminalEvent.LateSinkAfterFreeDoesNotProgressReusedBatch (72 ms)
[----------] 5 tests from TransportTerminalEvent (91 ms total)

[==========] 10 tests from 2 test suites ran. (162 ms total)
[  PASSED  ] 10 tests.
```

### Failover unit tests

```bash
./build/mooncake-transfer-engine/tent/tests/tent_failover_test --gtest_color=no
```

Result:

```text
[==========] Running 14 tests from 5 test suites.
[  PASSED  ] 14 tests.
```

### Failover e2e tests

```bash
./build/mooncake-transfer-engine/tent/tests/tent_engine_failover_e2e_test --gtest_color=no
```

Result:

```text
[==========] Running 16 tests from 1 test suite.
[  PASSED  ] 16 tests.
```