### PR TITLE
fix(metrics): show actual client-reported SSD capacity instead of infinite

### DIFF
--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -2037,10 +2037,7 @@ std::string MasterMetricManager::get_summary_string(
         ss << " (" << std::fixed << std::setprecision(1)
            << ((double)mem_allocated / (double)mem_capacity * 100.0) << "%)";
     }
-    int64_t file_display_capacity =
-        (dfs_capacity_unlimited_ && file_capacity == 0)
-            ? std::numeric_limits<int64_t>::max()
-            : file_capacity;
+    int64_t file_display_capacity = get_total_file_capacity();
     ss << " | NVMe-oF SSD: " << byte_size_to_string(nof_allocated) << " / "
        << byte_size_to_string(nof_capacity);
     if (nof_capacity > 0) {

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -715,14 +715,14 @@ int64_t MasterMetricManager::get_allocated_file_size() {
 }
 
 int64_t MasterMetricManager::get_total_file_capacity() {
-    if (dfs_capacity_unlimited_) {
+    if (dfs_capacity_unlimited_ && file_total_capacity_.value() == 0) {
         return std::numeric_limits<int64_t>::max();
     }
     return file_total_capacity_.value();
 }
 
 double MasterMetricManager::get_global_file_used_ratio(void) {
-    if (dfs_capacity_unlimited_) {
+    if (dfs_capacity_unlimited_ && file_total_capacity_.value() == 0) {
         return 0.0;
     }
     double allocated = file_allocated_size_.value();

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -2037,9 +2037,10 @@ std::string MasterMetricManager::get_summary_string(
         ss << " (" << std::fixed << std::setprecision(1)
            << ((double)mem_allocated / (double)mem_capacity * 100.0) << "%)";
     }
-    int64_t file_display_capacity = dfs_capacity_unlimited_
-                                        ? std::numeric_limits<int64_t>::max()
-                                        : file_capacity;
+    int64_t file_display_capacity =
+        (dfs_capacity_unlimited_ && file_capacity == 0)
+            ? std::numeric_limits<int64_t>::max()
+            : file_capacity;
     ss << " | NVMe-oF SSD: " << byte_size_to_string(nof_allocated) << " / "
        << byte_size_to_string(nof_capacity);
     if (nof_capacity > 0) {


### PR DESCRIPTION
## Description

Fixes #2276.

When no global file segment size limit is configured, `dfs_capacity_unlimited_` is set to true. This caused the metrics display to always show "infinite" for SSD Storage capacity (`std::numeric_limits<int64_t>::max()`) regardless of actual capacity reported by clients via `ReportSsdCapacity`.

**Root cause**: In `master_service.cpp:316-317`, if `global_file_segment_size_ == max()`, `dfs_capacity_unlimited_` is set to true. Then in `master_metric_manager.cpp:2040-2042`, the display unconditionally shows "infinite" when this flag is set, ignoring `file_total_capacity_` which contains the actual capacity reported by clients.

**Fix**: Only show "infinite" when both `dfs_capacity_unlimited_` is true AND no client has reported any capacity (`file_capacity == 0`). If clients have reported their actual SSD capacity via `ReportSsdCapacity` (stored in `file_total_capacity_`), use that value instead.

### Before
`SSD Storage: 309.25 GB / infinite`

### After
`SSD Storage: 309.25 GB / 107.37 GB` (shows actual reported capacity)

## Changes
- `mooncake-store/src/master_metric_manager.cpp`: Modified `file_display_capacity` logic to account for both `dfs_capacity_unlimited_` and whether actual client capacity has been reported.