### PR TITLE
[Store] RemoveAll not deleting SSD offload files, enable storage_backend_->RemoveAll() in Client::RemoveAll

### DIFF
--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2511,10 +2511,11 @@ tl::expected<long, ErrorCode> Client::RemoveByRegex(const ObjectKey& str,
 }
 
 tl::expected<long, ErrorCode> Client::RemoveAll(bool force) {
-    if (storage_backend_) {
+    auto result = master_client_.RemoveAll(force);
+    if (result && storage_backend_) {
         storage_backend_->RemoveAll();
     }
-    return master_client_.RemoveAll(force);
+    return result;
 }
 
 std::vector<tl::expected<void, ErrorCode>> Client::BatchRemove(

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2511,9 +2511,9 @@ tl::expected<long, ErrorCode> Client::RemoveByRegex(const ObjectKey& str,
 }
 
 tl::expected<long, ErrorCode> Client::RemoveAll(bool force) {
-    // if (storage_backend_) {
-    //     storage_backend_->RemoveAll();
-    // }
+    if (storage_backend_) {
+        storage_backend_->RemoveAll();
+    }
     return master_client_.RemoveAll(force);
 }
 


### PR DESCRIPTION
## Description

`Client::RemoveAll` previously only removed metadata from MasterService, leaving SSD offload files as orphans on disk. Enable `storage_backend_->RemoveAll()` to delete both metadata and actual disk files, preventing disk space leak.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [X] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
