### PR TITLE
[Store] Remove HAMetricManager::Init()

### DIFF
--- a/mooncake-store/include/ha_metric_manager.h
+++ b/mooncake-store/include/ha_metric_manager.h
@@ -27,13 +27,6 @@ class HAMetricManager {
     // --- Singleton Access ---
     static HAMetricManager& instance();
 
-    /**
-     * @brief Explicitly initialize the singleton instance.
-     * Use this at startup (e.g. main) to ensure thread-safe initialization
-     * of the underlying metric library components.
-     */
-    static void Init() { instance(); }
-
     HAMetricManager(const HAMetricManager&) = delete;
     HAMetricManager& operator=(const HAMetricManager&) = delete;
     HAMetricManager(HAMetricManager&&) = delete;

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -16,10 +16,6 @@ namespace mooncake {
 
 HotStandbyService::HotStandbyService(const HotStandbyConfig& config)
     : config_(config) {
-    // Explicitly initialize HA metric manager to ensure thread safety
-    // during metric registration.
-    HAMetricManager::Init();
-
     metadata_store_ = std::make_unique<StandbyMetadataStore>();
     // OpLogApplier will be re-created in Start() with the resolved cluster_id
     // to enable etcd-based operations (e.g. requesting missing OpLog entries).

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -11,6 +11,7 @@
 #include "default_config.h"
 #include "duration_utils.h"
 #include "ha/leadership/master_service_supervisor.h"
+#include "ha_metric_manager.h"
 #include "http_metadata_server.h"
 #include "rpc_service.h"
 #include "types.h"
@@ -1092,6 +1093,8 @@ int main(int argc, char* argv[]) {
         // Give the server some time to start
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
+
+    mooncake::HAMetricManager::Init();
 
     if (master_config.enable_ha) {
         mooncake::ha::MasterServiceSupervisor supervisor(

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -11,7 +11,7 @@
 #include "default_config.h"
 #include "duration_utils.h"
 #include "ha/leadership/master_service_supervisor.h"
-#include "ha_metric_manager.h"
+
 #include "http_metadata_server.h"
 #include "rpc_service.h"
 #include "types.h"
@@ -1093,8 +1093,6 @@ int main(int argc, char* argv[]) {
         // Give the server some time to start
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
-
-    mooncake::HAMetricManager::Init();
 
     if (master_config.enable_ha) {
         mooncake::ha::MasterServiceSupervisor supervisor(

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -227,7 +227,6 @@ MasterAdminServer::MasterAdminServer(uint16_t http_port,
 MasterAdminServer::~MasterAdminServer() { Stop(); }
 
 bool MasterAdminServer::Start() {
-    HAMetricManager::Init();
     InitHttpServer();
 
     auto ec = http_server_.async_start();


### PR DESCRIPTION
## Description

HAMetricManager::Init() was called from two places — MasterAdminServer::Start()
and HotStandbyService constructor — neither of which owns the HA metrics
lifecycle. Both HA and standalone code paths depend on HAMetricManager via the
/metrics endpoint's serialization, so initialize it once in main() before
either path diverges.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Refactor

## How Has This Been Tested?

CI ctest suite; manual /metrics endpoint verification in both HA and
standalone modes.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.