### PR TITLE
[TE] fix: pass default port when parsing TENT RDMA bind a…

### DIFF
--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -914,8 +914,7 @@ std::shared_ptr<TransferMetadata::SegmentDesc> TransferMetadata::getSegmentDesc(
     // the TCP-routable segment_name. Cache the mapping so subsequent
     // sendHandshake() calls can resolve the peer's TCP address from the
     // RDMA server name extracted from NIC paths.
-    if (p2p_handshake_mode_ && result &&
-        !result->rdma_server_name.empty() &&
+    if (p2p_handshake_mode_ && result && !result->rdma_server_name.empty() &&
         result->rdma_server_name != segment_name) {
         auto [tcp_ip, tcp_port] = parseHostNameWithPort(segment_name);
         RWSpinlock::WriteGuard guard(rpc_meta_lock_);
@@ -926,8 +925,8 @@ std::shared_ptr<TransferMetadata::SegmentDesc> TransferMetadata::getSegmentDesc(
             meta.sockfd = -1;
             rpc_meta_map_[result->rdma_server_name] = meta;
             LOG(INFO) << "P2P: cached RDMA->TCP mapping: "
-                      << result->rdma_server_name << " -> " << tcp_ip
-                      << ":" << tcp_port;
+                      << result->rdma_server_name << " -> " << tcp_ip << ":"
+                      << tcp_port;
         }
     }
 

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -665,9 +665,9 @@ int EfaContext::submitPostSend(
         slice->rdma.dest_rkey =
             peer_segment_desc->buffers[buffer_id].rkey[device_id];
 
-        std::string peer_nic_path =
-            peer_segment_desc->nicPathServerName() + "@" +
-            peer_segment_desc->devices[device_id].name;
+        std::string peer_nic_path = peer_segment_desc->nicPathServerName() +
+                                    "@" +
+                                    peer_segment_desc->devices[device_id].name;
         slice->peer_nic_path = peer_nic_path;
         slices_by_peer[peer_nic_path].push_back(slice);
     }

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -85,6 +85,7 @@ Status ConfigHelper::loadFromEnv(Config& config) {
     }
 
     // Legacy keys for backward compatibility (MC_* env vars)
+    setConfig(config, "MC_RDMA_BIND_ADDRESS", "transports/rdma/bind_address");
     setConfig(config, "MC_NUM_CQ_PER_CTX",
               "transports/rdma/device/num_cq_list");
     setConfig(config, "MC_NUM_COMP_CHANNELS_PER_CTX",

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -219,9 +219,12 @@ Status RdmaTransport::install(std::string& local_segment_name,
     // In dual-NIC environments (e.g. separate TCP and RDMA interfaces),
     // MC_RDMA_BIND_ADDRESS allows NIC paths to use an RDMA-reachable IP
     // while local_segment_name_ keeps the TCP-reachable address for P2P.
-    const char *rdma_bind_addr = std::getenv("MC_RDMA_BIND_ADDRESS");
+    const char* rdma_bind_addr = std::getenv("MC_RDMA_BIND_ADDRESS");
     if (rdma_bind_addr && rdma_bind_addr[0] != '\0') {
-        auto [host_name, port] = parseHostNameWithPort(local_segment_name);
+        const auto default_port =
+            conf_->get("rpc_server_port", static_cast<uint16_t>(0));
+        auto [host_name, port] =
+            parseHostNameWithPort(local_segment_name, default_port);
         rdma_server_name_ =
             std::string(rdma_bind_addr) + ":" + std::to_string(port);
         LOG(INFO) << "RdmaTransport(TENT): using RDMA bind address "
@@ -599,7 +602,8 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
         return nullptr;
     }
     std::shared_ptr<RdmaEndPoint> endpoint;
-    std::string peer_name = MakeNicPath(segment_desc->nicPathServerName(), target_dev_name);
+    std::string peer_name =
+        MakeNicPath(segment_desc->nicPathServerName(), target_dev_name);
     endpoint = context->endpointStore()->getOrInsert(peer_name);
     if (!endpoint) {
         LOG(ERROR) << "Cannot allocate endpoint " << peer_name;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -217,16 +217,15 @@ Status RdmaTransport::install(std::string& local_segment_name,
     local_topology_ = local_topology;
 
     // In dual-NIC environments (e.g. separate TCP and RDMA interfaces),
-    // MC_RDMA_BIND_ADDRESS allows NIC paths to use an RDMA-reachable IP
-    // while local_segment_name_ keeps the TCP-reachable address for P2P.
-    const char* rdma_bind_addr = std::getenv("MC_RDMA_BIND_ADDRESS");
-    if (rdma_bind_addr && rdma_bind_addr[0] != '\0') {
+    // transports/rdma/bind_address allows NIC paths to use an RDMA-reachable
+    // IP while local_segment_name_ keeps the TCP-reachable address for P2P.
+    const auto rdma_bind_addr = conf_->get("transports/rdma/bind_address", "");
+    if (!rdma_bind_addr.empty()) {
         const auto default_port =
             conf_->get("rpc_server_port", static_cast<uint16_t>(0));
         auto [host_name, port] =
             parseHostNameWithPort(local_segment_name, default_port);
-        rdma_server_name_ =
-            std::string(rdma_bind_addr) + ":" + std::to_string(port);
+        rdma_server_name_ = rdma_bind_addr + ":" + std::to_string(port);
         LOG(INFO) << "RdmaTransport(TENT): using RDMA bind address "
                   << rdma_server_name_
                   << " (TCP address: " << local_segment_name_ << ")";

--- a/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
@@ -261,6 +261,29 @@ class TestHttpMetadataServer {
 #endif
 
 TEST(TransferEngineConfigOverrideTest,
+     LegacyRdmaBindAddressEnvLoadsIntoTentConfig) {
+    EnvVarGuard guard("MC_RDMA_BIND_ADDRESS", "10.0.0.2");
+
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+
+    EXPECT_EQ(config.get("transports/rdma/bind_address", ""), "10.0.0.2");
+}
+
+TEST(TransferEngineConfigOverrideTest,
+     LegacyRdmaBindAddressEnvOverridesMcTentConf) {
+    EnvVarGuard conf_guard(
+        "MC_TENT_CONF",
+        R"({"transports":{"rdma":{"bind_address":"10.0.0.1"}}})");
+    EnvVarGuard bind_guard("MC_RDMA_BIND_ADDRESS", "10.0.0.2");
+
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+
+    EXPECT_EQ(config.get("transports/rdma/bind_address", ""), "10.0.0.2");
+}
+
+TEST(TransferEngineConfigOverrideTest,
      ExplicitMetadataOverridesDriveSuccessfulHttpInitialization) {
 #ifdef _WIN32
     GTEST_SKIP() << "Requires local HTTP metadata server support";


### PR DESCRIPTION
## Description

Fix a TENT RDMA build failure introduced by calling `parseHostNameWithPort()` with only the segment name after its signature requires a default port. When `MC_RDMA_BIND_ADDRESS` is set, RDMA now parses `local_segment_name` with the configured `rpc_server_port` fallback before constructing `rdma_server_name_`.

This also includes formatting updates from `./scripts/code_format.sh`.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
